### PR TITLE
Dascore format

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -43,13 +43,14 @@ class PatchSummaryDict(TypedDict):
     distance_max: float
     instrument_id: str
     dims: str
+    tag: str
 
 
 # The expected attributes for the Patch
 DEFAULT_PATCH_ATTRS = {
     "d_time": np.NaN,
     "d_distance": np.NaN,
-    "data_type": "",
+    "data_type": "DAS",
     "data_units": "",
     "category": "",
     "time_min": np.datetime64("NaT"),
@@ -63,6 +64,7 @@ DEFAULT_PATCH_ATTRS = {
     "instrument_id": "",
     "history": lambda: [],
     "dims": "",
+    "tag": "",
 }
 
 # Methods FileFormatter needs to support

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -65,6 +65,7 @@ DEFAULT_PATCH_ATTRS = {
     "history": lambda: [],
     "dims": "",
     "tag": "",
+    "label": "",
 }
 
 # Methods FileFormatter needs to support

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -73,12 +73,14 @@ class Patch:
         other
             A Trace2D object
         only_required_attrs
-            If True, only compare required attributes.
+            If True, only compare required attributes. This helps avoid issues
+            with comparing histories or custom attrs of patches, for example.
         """
 
         if only_required_attrs:
-            attrs1 = {x: patch.attrs.get(x, None) for x in DEFAULT_PATCH_ATTRS}
-            attrs2 = {x: other.attrs.get(x, None) for x in DEFAULT_PATCH_ATTRS}
+            attrs_to_compare = set(DEFAULT_PATCH_ATTRS) - {"history"}
+            attrs1 = {x: patch.attrs.get(x, None) for x in attrs_to_compare}
+            attrs2 = {x: other.attrs.get(x, None) for x in attrs_to_compare}
         else:
             attrs1, attrs2 = dict(patch.attrs), dict(other.attrs)
         if set(attrs1) != set(attrs2):  # attrs don't have same keys; not equal

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -61,7 +61,7 @@ class FiberIO(ABC):
         msg = f"FileFormatter: {self.name} has no write method"
         raise NotImplementedError(msg)
 
-    def get_format(self, path) -> tuple[str, str]:
+    def get_format(self, path) -> Union[tuple[str, str], bool]:
         """
         Return a tuple of (format_name, version_numbers).
 

--- a/dascore/io/dasdae/__init__.py
+++ b/dascore/io/dasdae/__init__.py
@@ -1,0 +1,10 @@
+"""
+Experimental Support for the DASDAE format.
+
+Note
+----
+This is an experimental format and is subject to change.
+"""
+# Current version of the dasdae writer. Bump this when the format
+# changes and consider a path for backward compatiblity.
+__version__ = "0.0.1"

--- a/dascore/io/dasdae/__init__.py
+++ b/dascore/io/dasdae/__init__.py
@@ -1,5 +1,5 @@
 """
-Experimental Support for the DASDAE format.
+Support for the DASDAE format.
 
 Note
 ----

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -1,0 +1,59 @@
+"""
+Core module for reading and writing pickle format.
+"""
+import numpy as np
+import tables
+
+import dascore as dc
+from dascore.io.core import FiberIO
+
+
+def write_meta(hfile):
+    """Write metadata to hdf5 file."""
+    attrs = hfile.root._v_attrs
+    attrs["__format__"] = "DASDAE"
+    attrs["__DASDAE_version__"] = dc.io.dasdae.__version__
+
+
+def generate_patch_node_name(patch):
+    """Generates the name of the node."""
+
+    def _format_datetime64(dt):
+        """Format the datetime string in a sensible way."""
+        out = str(np.datetime64(dt).astype("datetime64[ns]"))
+        return out.replace(":", "_").replace("-", "_").replace(".", "_")
+
+    attrs = patch.attrs
+    start = _format_datetime64(attrs.get("time_min", ""))
+    end = _format_datetime64(attrs.get("time_max", ""))
+    net = attrs.get("network", "")
+    sta = attrs.get("station", "")
+    tag = attrs.get("tag", "")
+    return f"DAS__{net}__{sta}__{tag}__{start}__{end}"
+
+
+def save_patch(patch, wave_group, h5):
+    """Save the patch to disk."""
+    name = generate_patch_node_name(patch)
+    patch_group = h5.create_group(wave_group, name)
+    for i, v in patch.attrs.items():
+        patch_group._v_attrs[i] = v
+
+
+class DASDAEIO(FiberIO):
+    """
+    Provides IO support for the DASDAE format.
+    """
+
+    name = "DASDAE"
+    preferred_extensions = ("h5", "hdf5")
+
+    def write(self, patch, path, **kwargs):
+        """Read a Patch/Stream from disk."""
+        with tables.open_file(path, mode="a") as h5:
+            write_meta(h5)
+            # get an iterable of patches and save them
+            patches = [patch] if isinstance(patch, dc.Patch) else patch
+            waveforms = h5.create_group(h5.root, "waveforms")
+            for patch in patches:
+                save_patch(patch, waveforms, h5)

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -32,12 +32,53 @@ def generate_patch_node_name(patch):
     return f"DAS__{net}__{sta}__{tag}__{start}__{end}"
 
 
-def save_patch(patch, wave_group, h5):
+def _save_attrs_and_dim(patch, patch_group):
+    """Save the attributes."""
+    # copy attrs to group attrs
+    # TODO will need to test if objects are serializable
+    for i, v in patch.attrs.items():
+        patch_group._v_attrs[i] = v
+    patch_group._v_attrs["dims"] = ",".join(patch.dims)
+
+
+def _save_array(data, name, group, h5):
+    """Save an array to a group, handle datetime flubbery."""
+    # handle datetime conversions
+    is_dt = np.issubdtype(data, np.datetime64)
+    is_td = np.issubdtype(data, np.timedelta64)
+    if is_dt or is_td:
+        data = data
+
+    # out = h5.create_array(
+    #     group,
+    #     f"coord_{name}",
+    #     data,
+    # )
+
+
+def _save_coords(patch, patch_group, h5):
+    """Save coordinates"""
+    for name, coord in patch._data_array.coords.items():
+        _save_array(coord, name, patch_group, h5)
+
+        # array = patch.coords[name]
+        # out = h5.create_array(
+        #     patch_group,
+        #     f"coord_{name}",
+        #     array,
+        # )
+        # # breakpoint()
+
+
+def _save_patch(patch, wave_group, h5):
     """Save the patch to disk."""
     name = generate_patch_node_name(patch)
     patch_group = h5.create_group(wave_group, name)
-    for i, v in patch.attrs.items():
-        patch_group._v_attrs[i] = v
+    _save_attrs_and_dim(patch, patch_group)
+    _save_coords(patch, patch_group, h5)
+
+    # add data
+    h5.create_array(patch_group, "data", patch.data)
 
 
 class DASDAEIO(FiberIO):
@@ -56,4 +97,4 @@ class DASDAEIO(FiberIO):
             patches = [patch] if isinstance(patch, dc.Patch) else patch
             waveforms = h5.create_group(h5.root, "waveforms")
             for patch in patches:
-                save_patch(patch, waveforms, h5)
+                _save_patch(patch, waveforms, h5)

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -15,6 +15,22 @@ from dascore.io.dasdae.utils import _read_patch, _save_patch, _write_meta
 class DASDAEIO(FiberIO):
     """
     Provides IO support for the DASDAE format.
+
+    DASDAE format is loosely based on the Adaptable Seismic Data Format (ASDF)
+    which uses hdf5. The hdf5 structure looks like the following:
+
+    /root
+    /root.attrs
+        __format__ = "DASDAE"
+        __DASDAE_version__ = 'x.y.z'  # version str
+    /root/waveforms/
+        DAS__{net}__{sta}__{tag}__{start}__{end}
+            data   # patch data array
+            data.attrs
+            _coords_{coord_name}  # each coordinate array is saved here
+        DAS__{net}__{sta}__{tag}__{start}__{end}.attrs
+            _attrs_{attr_nme}  # each patch attribute
+            _dims  # a str of 'dim1, dim2, dim3'
     """
 
     name = "DASDAE"

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -1,84 +1,15 @@
 """
 Core module for reading and writing pickle format.
 """
-import numpy as np
+import contextlib
+from typing import Union
+
 import tables
 
 import dascore as dc
+from dascore.constants import StreamType
 from dascore.io.core import FiberIO
-
-
-def write_meta(hfile):
-    """Write metadata to hdf5 file."""
-    attrs = hfile.root._v_attrs
-    attrs["__format__"] = "DASDAE"
-    attrs["__DASDAE_version__"] = dc.io.dasdae.__version__
-
-
-def generate_patch_node_name(patch):
-    """Generates the name of the node."""
-
-    def _format_datetime64(dt):
-        """Format the datetime string in a sensible way."""
-        out = str(np.datetime64(dt).astype("datetime64[ns]"))
-        return out.replace(":", "_").replace("-", "_").replace(".", "_")
-
-    attrs = patch.attrs
-    start = _format_datetime64(attrs.get("time_min", ""))
-    end = _format_datetime64(attrs.get("time_max", ""))
-    net = attrs.get("network", "")
-    sta = attrs.get("station", "")
-    tag = attrs.get("tag", "")
-    return f"DAS__{net}__{sta}__{tag}__{start}__{end}"
-
-
-def _save_attrs_and_dim(patch, patch_group):
-    """Save the attributes."""
-    # copy attrs to group attrs
-    # TODO will need to test if objects are serializable
-    for i, v in patch.attrs.items():
-        patch_group._v_attrs[i] = v
-    patch_group._v_attrs["dims"] = ",".join(patch.dims)
-
-
-def _save_array(data, name, group, h5):
-    """Save an array to a group, handle datetime flubbery."""
-    # handle datetime conversions
-    is_dt = np.issubdtype(data, np.datetime64)
-    is_td = np.issubdtype(data, np.timedelta64)
-    if is_dt or is_td:
-        data = data
-
-    # out = h5.create_array(
-    #     group,
-    #     f"coord_{name}",
-    #     data,
-    # )
-
-
-def _save_coords(patch, patch_group, h5):
-    """Save coordinates"""
-    for name, coord in patch._data_array.coords.items():
-        _save_array(coord, name, patch_group, h5)
-
-        # array = patch.coords[name]
-        # out = h5.create_array(
-        #     patch_group,
-        #     f"coord_{name}",
-        #     array,
-        # )
-        # # breakpoint()
-
-
-def _save_patch(patch, wave_group, h5):
-    """Save the patch to disk."""
-    name = generate_patch_node_name(patch)
-    patch_group = h5.create_group(wave_group, name)
-    _save_attrs_and_dim(patch, patch_group)
-    _save_coords(patch, patch_group, h5)
-
-    # add data
-    h5.create_array(patch_group, "data", patch.data)
+from dascore.io.dasdae.utils import _read_patch, _save_patch, _write_meta
 
 
 class DASDAEIO(FiberIO):
@@ -92,9 +23,34 @@ class DASDAEIO(FiberIO):
     def write(self, patch, path, **kwargs):
         """Read a Patch/Stream from disk."""
         with tables.open_file(path, mode="a") as h5:
-            write_meta(h5)
+            _write_meta(h5)
             # get an iterable of patches and save them
             patches = [patch] if isinstance(patch, dc.Patch) else patch
             waveforms = h5.create_group(h5.root, "waveforms")
             for patch in patches:
                 _save_patch(patch, waveforms, h5)
+
+    def get_format(self, path) -> Union[tuple[str, str], bool]:
+        """Return the format from a dasdae file."""
+        with tables.open_file(path, mode="r") as fi:
+            is_dasdae, version = False, ""  # NOQA
+            with contextlib.suppress(KeyError):
+                is_dasdue = fi.root._v_attrs["__format__"] == "DASDAE"
+                dasdae_version = fi.root._v_attrs["__DASDAE_version__"]
+            if is_dasdue:
+                return (self.name, dasdae_version)
+            return False
+
+    def read(self, path, **kwargs) -> StreamType:
+        """
+        Read a dascore file.
+        """
+        patches = []
+        with tables.open_file(path, mode="r") as fi:
+            try:
+                waveform_group = fi.root["/waveforms"]
+            except KeyError:
+                return dc.Stream([])
+            for patch_group in waveform_group:
+                patches.append(_read_patch(patch_group, **kwargs))
+        return dc.Stream(patches)

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -1,0 +1,131 @@
+"""
+DASDAE format utilities
+"""
+import numpy as np
+
+import dascore as dc
+from dascore.utils.time import to_number, to_timedelta64
+
+# --- Functions for writing
+
+
+def _write_meta(hfile):
+    """Write metadata to hdf5 file."""
+    attrs = hfile.root._v_attrs
+    attrs["__format__"] = "DASDAE"
+    attrs["__DASDAE_version__"] = dc.io.dasdae.__version__
+
+
+def _generate_patch_node_name(patch):
+    """Generates the name of the node."""
+
+    def _format_datetime64(dt):
+        """Format the datetime string in a sensible way."""
+        out = str(np.datetime64(dt).astype("datetime64[ns]"))
+        return out.replace(":", "_").replace("-", "_").replace(".", "_")
+
+    attrs = patch.attrs
+    start = _format_datetime64(attrs.get("time_min", ""))
+    end = _format_datetime64(attrs.get("time_max", ""))
+    net = attrs.get("network", "")
+    sta = attrs.get("station", "")
+    tag = attrs.get("tag", "")
+    return f"DAS__{net}__{sta}__{tag}__{start}__{end}"
+
+
+def _save_attrs_and_dim(patch, patch_group):
+    """Save the attributes."""
+    # copy attrs to group attrs
+    # TODO will need to test if objects are serializable
+    for i, v in patch.attrs.items():
+        patch_group._v_attrs[f"_attrs_{i}"] = v
+    patch_group._v_attrs["_dims"] = ",".join(patch.dims)
+
+
+def _save_array(data, name, group, h5):
+    """Save an array to a group, handle datetime flubbery."""
+    # handle datetime conversions
+    is_dt = np.issubdtype(data.dtype, np.datetime64)
+    is_td = np.issubdtype(data.dtype, np.timedelta64)
+    if is_dt or is_td:
+        data = to_number(data)
+    out = h5.create_array(
+        group,
+        name,
+        data,
+    )
+    out._v_attrs["is_datetime64"] = is_dt
+    out._v_attrs["is_timedelta64"] = is_td
+
+
+def _save_coords(patch, patch_group, h5):
+    """Save coordinates"""
+    for name, coord in patch._data_array.coords.items():
+        data = coord.values
+        save_name = f"_coord_{name}"
+        _save_array(data, save_name, patch_group, h5)
+
+
+def _save_patch(patch, wave_group, h5):
+    """Save the patch to disk."""
+    name = _generate_patch_node_name(patch)
+    patch_group = h5.create_group(wave_group, name)
+    _save_attrs_and_dim(patch, patch_group)
+    _save_coords(patch, patch_group, h5)
+    # add data
+    if patch.data.shape:
+        h5.create_array(patch_group, "data", patch.data)
+
+
+# --- Functions for reading
+
+
+def _get_attrs(patch_group):
+    """Get the saved attributes form the group attrs."""
+    out = {}
+    attrs = [x for x in patch_group._v_attrs._f_list() if x.startswith("_attrs_")]
+    for attr_name in attrs:
+        key = attr_name.replace("_attrs_", "")
+        out[key] = patch_group._v_attrs[attr_name]
+    return out
+
+
+def _read_array(table_array):
+    """Read an array into numpy."""
+    data = table_array[:]
+    if table_array._v_attrs["is_datetime64"]:
+        data = data.astype("datetime64[ns]")
+    if table_array._v_attrs["is_timedelta64"]:
+        data = to_timedelta64(data)
+    return data
+
+
+def _get_coords(patch_group):
+    """Get the coordinates from a patch group."""
+    out = {}
+    for coord in [x for x in patch_group if x.name.startswith("_coord_")]:
+        name = coord.name.replace("_coord_", "")
+        out[name] = _read_array(coord)
+    return out
+
+
+def _get_dims(patch_group):
+    """Get the dims tuple from the patch group."""
+    dims = patch_group._v_attrs["_dims"]
+    if not dims:
+        out = ()
+    else:
+        out = tuple(dims.split(","))
+    return out
+
+
+def _read_patch(patch_group, **kwargs):
+    """Read a patch group, return Patch."""
+    attrs = _get_attrs(patch_group)
+    dims = _get_dims(patch_group)
+    coords = _get_coords(patch_group)
+    try:
+        data = patch_group["data"][:]
+    except (IndexError, KeyError):
+        data = np.array(None)
+    return dc.Patch(data=data, coords=coords, dims=dims, attrs=attrs)

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -26,7 +26,7 @@ class Terra15Formatter(FiberIO):
     Support for Terra15 data format.
     """
 
-    name = "terra15"
+    name = "TERRA15"
     preferred_extensions = ("hdf5", "hf")
 
     def get_format(self, path: Union[str, Path]) -> Union[tuple[str, str], bool]:

--- a/dascore/utils/plugin.py
+++ b/dascore/utils/plugin.py
@@ -37,7 +37,11 @@ class FiberIOManager(MutableMapping):
                 self.loaded_eps[item] = self.eps[item]()()
             return self.loaded_eps[item]
         else:
-            msg = f"File format {item} is unknown to DASCore."
+            known_formats = set(self.loaded_eps) | set(self.eps)
+            msg = (
+                f"File format {item} is unknown to DASCore. Known formats "
+                f"are: [{', '.join(sorted(known_formats))}]"
+            )
             raise UnknownFiberFormat(msg)
 
     def __setitem__(self, key, value):

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -69,6 +69,7 @@ def _pass_datetime(datetime):
 
 
 @to_datetime64.register(type(None))
+@to_datetime64.register(type(pd.NaT))
 def _return_NaT(datetime):
     """Convert non to NaT"""
     return np.datetime64("NaT")

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ dascore.plugin.fiber_io =
     TERRA15 = dascore.io.terra15.core:Terra15Formatter
     PICKLE = dascore.io.pickle.core:PickleIO
     WAV = dascore.io.wav.core:WavIO
+    DASDAE = dascore.io.dasdae.core:DASDAEIO
 
 [options.extras_require]
 docs =

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -146,14 +146,58 @@ class TestEquals:
         new = random_patch.new(data=new_data)
         assert not new.equals(random_patch)
 
+    def test_coords_named_differently(self, random_patch):
+        """Ensure if the coords are not equal neither are the arrays."""
+        dims = random_patch.dims
+        new_coords = {x: random_patch.coords[x] for x in random_patch.coords}
+        new_coords["bob"] = new_coords.pop(dims[-1])
+        patch_2 = random_patch.new(coords=new_coords)
+        assert not patch_2.equals(random_patch)
+
     def test_coords_not_equal(self, random_patch):
-        """Ensure if the coords are not equal neither is the array."""
+        """Ensure if the coords are not equal neither are the arrays."""
+        new_coords = {x: random_patch.coords[x] for x in random_patch.coords}
+        new_coords["distance"] = new_coords["distance"] + 10
+        patch_2 = random_patch.new(coords=new_coords)
+        assert not patch_2.equals(random_patch)
 
     def test_attrs_not_equal(self, random_patch):
         """Ensure if the attributes are not equal the arrays are not equal"""
+        attrs = dict(random_patch.attrs)
+        attrs["d_time"] = attrs["d_time"] - np.timedelta64(10, "s")
+        patch2 = random_patch.new(attrs=attrs)
+        assert not patch2.equals(random_patch)
 
-    def test_non_default_attrs(self, random_patch):
-        """Ensure non default attrs don't effect equality unless specified."""
+    def test_one_null_value_in_attrs(self, random_patch):
+        """ "Ensure setting a value to null in attrs still works."""
+        attrs = dict(random_patch.attrs)
+        attrs["label"] = None
+        patch2 = random_patch.new(attrs=attrs)
+        patch2.equals(random_patch)
+        assert not patch2.equals(random_patch)
+
+    def test_extra_attrs(self, random_patch):
+        """
+        Ensure extra attrs in one patch still eval equal unless only_required
+        is used.
+        """
+        attrs = dict(random_patch.attrs)
+        attrs["new_label"] = "fun4eva"
+        patch2 = random_patch.new(attrs=attrs)
+        # they should be equal
+        assert patch2.equals(random_patch)
+        # until extra labels are allowed
+        assert not patch2.equals(random_patch, only_required_attrs=False)
+
+    def test_both_attrs_nan(self, random_patch):
+        """If Both Attrs are some type of NaN the patches should be equal."""
+        attrs1 = dict(random_patch.attrs)
+        attrs1["label"] = np.NaN
+        patch1 = random_patch.new(attrs=attrs1)
+        attrs2 = dict(attrs1)
+        attrs2["label"] = None
+        patch2 = random_patch.new(attrs=attrs2)
+        assert patch1.equals(patch2)
 
 
 class TestTranspose:

--- a/tests/test_io/test_dasdae.py
+++ b/tests/test_io/test_dasdae.py
@@ -4,30 +4,77 @@ Tests for DASDAE format.
 from pathlib import Path
 
 import pytest
-import tables
 
 import dascore as dc
 from dascore.io.dasdae import __version__ as DASDAE_file_version
+from dascore.io.dasdae.core import DASDAEIO
+from dascore.utils.misc import register_func
+
+# a list of fixture names for written DASDAE files
+WRITTEN_FILES = []
 
 
-@pytest.fixture(scope="session")
-def written_dascore(random_patch, tmp_path_factory):
+@pytest.fixture(scope="class")
+@register_func(WRITTEN_FILES)
+def written_dascore_random(random_patch, tmp_path_factory):
     """write the example patch to disk."""
     path = tmp_path_factory.mktemp("dascore_file") / "test.hdf5"
     dc.write(random_patch, path, "dasdae")
     return path
 
 
+@pytest.fixture(scope="class")
+@register_func(WRITTEN_FILES)
+def written_dasscore_empty(tmp_path_factory):
+    """Write an empty patch to the dascore format."""
+    path = tmp_path_factory.mktemp("empty_patcc") / "empty.hdf5"
+    patch = dc.Patch()
+    dc.write(patch, path, "DASDAE")
+    return path
+
+
+@pytest.fixture(params=WRITTEN_FILES, scope="class")
+def dasdae_file_path(request):
+    """Gatherer fixture to iterate through each written dasedae format."""
+    return request.getfixturevalue(request.param)
+
+
 class TestWrite:
     """Ensure the format can be written."""
 
-    def test_file_exists(self, written_dascore):
+    def test_file_exists(self, dasdae_file_path):
         """The file should *of course* exist."""
-        assert Path(written_dascore).exists()
+        assert Path(dasdae_file_path).exists()
 
-    def test_format_and_version_written(self, written_dascore):
-        """Ensure both version and format are in the file."""
-        with tables.open_file(written_dascore) as hf:
-            attr = hf.root._v_attrs
-            assert attr["__DASDAE_version__"] == DASDAE_file_version
-            assert attr["__format__"] == "DASDAE"
+
+class TestGetVersion:
+    """Test for version gathering from files."""
+
+    def test_version_tuple_returned(self, dasdae_file_path):
+        """Ensure the expected version str is returned."""
+        # format_version_tuple = dc.get_format(written_dascore)
+        dasie_format_ver = DASDAEIO().get_format(dasdae_file_path)
+        format_ver = dc.get_format(dasdae_file_path)
+        expected = ("DASDAE", DASDAE_file_version)
+        assert dasie_format_ver == format_ver
+        assert format_ver == expected
+
+
+class TestReadDasdae:
+    """
+    Test for reading a dasdae format.
+    """
+
+    def test_round_trip_random_patch(self, random_patch, tmp_path_factory):
+        """Ensure the random patch can be round-tripped"""
+        path = tmp_path_factory.mktemp("dasedae_round_trip") / "rt.h5"
+        dc.write(random_patch, path, "DASDAE")
+        out = dc.read(path)
+        assert len(out) == 1
+        assert out[0].equals(random_patch)
+
+    def test_round_trip_empty_patch(self, written_dasscore_empty):
+        """Ensure an emtpy patch can be deserialize."""
+        stream = dc.read(written_dasscore_empty)
+        assert len(stream) == 1
+        assert stream[0].equals(dc.Patch())

--- a/tests/test_io/test_dasdae.py
+++ b/tests/test_io/test_dasdae.py
@@ -1,0 +1,33 @@
+"""
+Tests for DASDAE format.
+"""
+from pathlib import Path
+
+import pytest
+import tables
+
+import dascore as dc
+from dascore.io.dasdae import __version__ as DASDAE_file_version
+
+
+@pytest.fixture(scope="session")
+def written_dascore(random_patch, tmp_path_factory):
+    """write the example patch to disk."""
+    path = tmp_path_factory.mktemp("dascore_file") / "test.hdf5"
+    dc.write(random_patch, path, "dasdae")
+    return path
+
+
+class TestWrite:
+    """Ensure the format can be written."""
+
+    def test_file_exists(self, written_dascore):
+        """The file should *of course* exist."""
+        assert Path(written_dascore).exists()
+
+    def test_format_and_version_written(self, written_dascore):
+        """Ensure both version and format are in the file."""
+        with tables.open_file(written_dascore) as hf:
+            attr = hf.root._v_attrs
+            assert attr["__DASDAE_version__"] == DASDAE_file_version
+            assert attr["__format__"] == "DASDAE"


### PR DESCRIPTION
This PR adds support for the dasdae format. The format is experimental and loosely based on the [adaptable seismic data format](https://academic.oup.com/gji/article/207/2/1003/2583765) 

As it stands now the format looks like the following:
```
/root
/root.attrs
    __format__ = "DASDAE"  
    __DASDAE_version__ = 'x.y.z'  # version str
/root/waveforms/
    DAS__{net}__{sta}__{tag}__{start}__{end}
        data   # patch data array
        data.attrs
        _coords_{coord_name}  # each coordinate array is saved here
    DAS__{net}__{sta}__{tag}__{start}__{end}.attrs
        _attrs_{attr_nme}  # each patch attribute
        _dims  # a str of 'dim1, dim2, dim3'
 ```
following asdf convention, we can then add event information, station metadata, etc under different name spaces (eg `/root/events`) .

Of course these are all implementation details; all the user sees is this:

```python
import dascore 

patch = dascore.get_example_patch()
patch.io.write('some_path.h5', 'dasdae')
patch2 = dascore.read('some_path.h5')
```

The internal DASDAE format version string will allow us to iterate quickly while maintaining backwards compatibility (if we really need to).



