### PR TITLE
support float in resample, add test

### DIFF
--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -12,7 +12,7 @@ from dascore.exceptions import FilterValueError
 from dascore.proc.filter import _get_sampling_rate, _lowpass_cheby_2
 from dascore.utils.misc import check_evenly_sampled, get_dim_value_from_kwargs
 from dascore.utils.patch import get_start_stop_step, patch_function
-from dascore.utils.time import to_number
+from dascore.utils.time import to_number, to_timedelta64
 
 
 @patch_function()
@@ -168,6 +168,9 @@ def resample(
     """
     dim, axis, new_d_dim = get_dim_value_from_kwargs(patch, kwargs)
     d_dim = patch.attrs[f"d_{dim}"]  # current sampling rate
+    # nasty hack so that ints/floats get converted to seconds.
+    if isinstance(d_dim, np.timedelta64):
+        new_d_dim = to_timedelta64(new_d_dim)
     # dim_range = int(compat.floor((dim_stop - dim_start) / val))
     current_sig_len = patch.data.shape[axis]
     new_len = current_sig_len * (d_dim / new_d_dim)

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -114,11 +114,26 @@ class TestResample:
                 assert len1 == len2
 
     def test_upsample_time(self, random_patch):
-        """Test decreasing the temporal sampling rate"""
+        """Test increasing the temporal sampling rate"""
         current_dt = random_patch.attrs["d_time"]
         axis = random_patch.dims.index("time")
         new_dt = current_dt / 2
         new = random_patch.resample(time=new_dt)
+        assert new_dt == new.attrs["d_time"]
+        assert np.all(np.diff(new.coords["time"]) == new_dt)
+        shape1, shape2 = random_patch.data.shape, new.data.shape
+        for ax, (len1, len2) in enumerate(zip(shape1, shape2)):
+            if ax == axis:  # Only resampled axis should have changed len
+                assert len1 < len2
+            else:
+                assert len1 == len2
+
+    def test_upsample_time_float(self, random_patch):
+        """Test int as time sampling rate."""
+        current_dt = random_patch.attrs["d_time"]
+        axis = random_patch.dims.index("time")
+        new_dt = current_dt / 2
+        new = random_patch.resample(time=new_dt / np.timedelta64(1, "s"))
         assert new_dt == new.attrs["d_time"]
         assert np.all(np.diff(new.coords["time"]) == new_dt)
         shape1, shape2 = random_patch.data.shape, new.data.shape


### PR DESCRIPTION
Adds support for float/ints being converted to appropriate timedelta types. 

Eg the following are now equivalent:
```python
out = patch.resample(time=20)
out = patch.resample(time=np.timedelta64(20, 's'))
```