### PR TITLE
Faster min/max time fetching for indexing terra15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: mixed-line-ending
         args: ['--fix=lf']
 -   repo: https://github.com/psf/black
-    rev: 21.10b0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -65,8 +65,8 @@ class Terra15Formatter(FiberIO):
                 time = time[:]
                 time_filtered = time[time > 0]
                 tmin, tmax = np.min(time_filtered), np.max(time_filtered)
-            out["time_min"] = tmin
-            out["time_max"] = tmax
+            out["time_min"] = to_datetime64(tmin)
+            out["time_max"] = to_datetime64(tmax)
             return [out]
 
     def read(

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,7 @@ extend_ignore =
     D412
     D414
     W605
+    BLK100
 ; exclude certain files
 exclude =
     .git

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -86,13 +86,13 @@ class TestToTimeDelta:
     def test_float_array(self):
         """Ensure an array of flaots can be converted to ns timedelta"""
         ar = [1.0, 0.000000001, 0.001]
-        expected = np.array([1 * 10 ** 9, 1, 1 * 10 ** 6], "timedelta64")
+        expected = np.array([1 * 10**9, 1, 1 * 10**6], "timedelta64")
         out = to_timedelta64(ar)
         assert np.all(out == expected)
 
     def test_timedelta64_array(self):
         """Ensure passing timedelta array works."""
-        expected = np.array([1 * 10 ** 9, 1, 1 * 10 ** 6], "timedelta64")
+        expected = np.array([1 * 10**9, 1, 1 * 10**6], "timedelta64")
         out = to_timedelta64(expected)
         assert np.equal(out, expected).all()
 


### PR DESCRIPTION
This PR improves the terra15 time indexing mechanism by just taking the first (min) and last (max) values of the time index. However, since an unfinished block can exist at the end of the terra15 file, this scenario is checked for and handled appropriately.

Also updated pre-commit black version as the pinned version has a conflict with newer versions of click.