### PR TITLE
Allow update to skip non-das files, add ignore to scan

### DIFF
--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -11,6 +11,10 @@ class InvalidFileFormatter(ValueError, DASCoreError):
     """Raised when an invalid file formatter is defined or used."""
 
 
+class InvalidFiberFile(IOError, DASCoreError):
+    """Raised when a fiber operation is called on an invalid file."""
+
+
 class UnknownFiberFormat(IOError, DASCoreError):
     """Raised when the format of an alleged fiber file is not recognized."""
 

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -15,7 +15,12 @@ import pandas as pd
 import dascore
 from dascore.constants import SpoolType, timeable_types
 from dascore.core.schema import PatchFileSummary
-from dascore.exceptions import DASCoreError, InvalidFileFormatter, UnknownFiberFormat
+from dascore.exceptions import (
+    DASCoreError,
+    InvalidFiberFile,
+    InvalidFileFormatter,
+    UnknownFiberFormat,
+)
 from dascore.utils.docs import compose_docstring
 from dascore.utils.hdf5 import HDF5ExtError
 from dascore.utils.misc import suppress_warnings
@@ -357,6 +362,9 @@ def scan(
     The summary dictionaries contain the following fields:
         {fields}
     """
+    if not os.path.exists(path) or os.path.isdir(path):
+        msg = f"{path} does not exist or is a directory"
+        raise InvalidFiberFile(msg)
     # dispatch to file format handlers
     if not file_format or not file_version:
         try:

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -175,10 +175,12 @@ class _FiberIOManager:
     def _yield_format_version(self, format, version):
         """Yield file format/version prioritized formatters."""
         if format is not None:
-            formatters = self._format_version.get(format.upper(), None)
+            format = format.upper()
+            self.load_plugins(format)
+            formatters = self._format_version.get(format, None)
             # no format found
             if not formatters:
-                format_list = list(self._format_version)
+                format_list = list(self.known_formats)
                 msg = f"Unknown format {format}, " f"known formats are {format_list}"
                 raise UnknownFiberFormat(msg)
             # a version is specified
@@ -335,6 +337,7 @@ def scan(
     path: Union[Path, str],
     file_format: Optional[str] = None,
     file_version: Optional[str] = None,
+    ignore: bool = False,
 ) -> List[PatchFileSummary]:
     """
     Scan a file, return the summary dictionary.
@@ -345,6 +348,9 @@ def scan(
         The path the to file to scan
     file_format
         Format of the file. If not provided DASCore will try to determine it.
+    ignore
+        If True, ignore non-DAS files by returning an empty list, else raise
+        UnknownFiberFormat if unreadable file encountered.
 
     Notes
     -----
@@ -353,11 +359,18 @@ def scan(
     """
     # dispatch to file format handlers
     if not file_format or not file_version:
-        file_format, file_version = get_format(
-            path,
-            file_format=file_format,
-            file_version=file_version,
-        )
+        try:
+            file_format, file_version = get_format(
+                path,
+                file_format=file_format,
+                file_version=file_version,
+            )
+        except UnknownFiberFormat as e:
+            if ignore:
+                return []
+            else:
+                raise e
+
     formatter = FiberIO.manager.get_fiberio(file_format, file_version)
     out = formatter.scan(path)
     return out

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -467,7 +467,7 @@ class DirectoryIndexer(AbstractIndexer):
         update_time = time.time()
         new_files = list(self._get_file_iterator(paths=paths, only_new=True))
         smooth_iterator = track(new_files, f"Indexing {self.path.name}")
-        data_list = [y.dict() for x in smooth_iterator for y in dc.scan(x)]
+        data_list = [y.dict() for x in smooth_iterator for y in dc.scan(x, ignore=True)]
         df = pd.DataFrame(data_list)
         if not df.empty:
             self._write_update(df, update_time)

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -175,5 +175,5 @@ class TestScan:
 
     def test_scan_directory(self, tmp_path):
         """Trying to scan a directory should raise a nice error"""
-        with pytest.raises(IsADirectoryError):
+        with pytest.raises(OSError, match="a directory"):
             _ = dascore.scan(tmp_path)

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -161,3 +161,19 @@ class TestScan:
         out = dascore.scan(terra15_das_example_path)
         assert isinstance(out, list)
         assert len(out)
+
+    def test_scan_with_ignore(self, tmp_path):
+        """ignore option should make scan return []"""
+        # no ignore should still raise
+        dummy_file = tmp_path / "data.txt"
+        dummy_file.touch()
+        with pytest.raises(UnknownFiberFormat):
+            _ = dascore.scan(dummy_file)
+        out = dascore.scan(dummy_file, ignore=True)
+        assert not len(out)
+        assert out == []
+
+    def test_scan_directory(self, tmp_path):
+        """Trying to scan a directory should raise a nice error"""
+        with pytest.raises(IsADirectoryError):
+            _ = dascore.scan(tmp_path)

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -7,7 +7,11 @@ import numpy as np
 import pytest
 
 import dascore
-from dascore.exceptions import InvalidFileFormatter, UnknownFiberFormat
+from dascore.exceptions import (
+    InvalidFiberFile,
+    InvalidFileFormatter,
+    UnknownFiberFormat,
+)
 from dascore.io.core import FiberIO
 from dascore.io.dasdae.core import DASDAEV1
 
@@ -175,5 +179,5 @@ class TestScan:
 
     def test_scan_directory(self, tmp_path):
         """Trying to scan a directory should raise a nice error"""
-        with pytest.raises(OSError, match="a directory"):
+        with pytest.raises(InvalidFiberFile, match="a directory"):
             _ = dascore.scan(tmp_path)


### PR DESCRIPTION
Currently the file indexer raises a `UknownFiberFormat` error if even one file in the directory is not readable. This PR makes it simply ignore files it can't read as often there are unrelated files in a data directory (lock files, .open files, etc.). Also adds the `ignore` keyword to `dacore.scan` as to return an empty list when an unreadable file is scanned (default value is False).