### PR TITLE
fix indexing version issues

### DIFF
--- a/dascore/version.py
+++ b/dascore/version.py
@@ -7,4 +7,4 @@ except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"
 
-__last_version__ = __version__.split("+")[0].split("-")[0].replace("v", "")
+__last_version__ = ".".join(__version__.split(".")[:3])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "xarray",
     "pydantic>=1.9.0",
     "rich",
+    "packaging",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_io/test_indexer.py
+++ b/tests/test_io/test_indexer.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from packaging.version import parse as get_version
 
+import dascore as dc
 from dascore.io.indexer import DirectoryIndexer
 from dascore.utils.patch import get_default_patch_name
 
@@ -62,6 +64,13 @@ class TestBasics:
         """Ensure a useful (not the default) str/repr is implemented"""
         out = str(basic_indexer)
         assert "object at" not in out
+
+    def test_version(self, basic_indexer):
+        """Ensure the version written to file is correct."""
+        updated = basic_indexer.update()
+        index_version = updated._index_version
+        assert index_version == dc.__last_version__
+        assert get_version(index_version) > get_version("0.0.1")
 
 
 class TestGetContents:


### PR DESCRIPTION
This PR fixes an issue where the index version was always less than the minimum version, forcing a re-indexing every time of a DAS archive. 