### PR TITLE
decimate api fix

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -153,6 +153,14 @@ class Patch:
         """Return the attributes of the trace."""
         return FrozenDict(self._data_array.attrs)
 
+    def to_xarray(self):
+        """
+        Return a data array with patch contents.
+        """
+        # Note this is here in case we decide to remove xarray there will
+        # still be a way to get a DataArray object with an optional import
+        return self._data_array
+
     squeeze = dascore.proc.squeeze
     rename = dascore.proc.rename
     transpose = dascore.proc.transpose

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -34,7 +34,7 @@ def aggregate(
     method: Literal["mean", "median", "min", "max", "first", "last"] = "mean",
 ) -> PatchType:
     """
-    Aggregate values patch along a specified dimension.
+    Aggregate values along a specified dimension.
 
     Parameters
     ----------
@@ -43,9 +43,6 @@ def aggregate(
     method
         The aggregation to apply along dimension. Options are:
             mean, min, max, median, first, last
-
-    Notes
-    -----
     """
     axis = patch.dims.index(dim)
     func = _AGG_FUNCS[method]

--- a/dascore/proc/detrend.py
+++ b/dascore/proc/detrend.py
@@ -8,7 +8,7 @@ from dascore.utils.patch import patch_function
 
 
 @patch_function()
-def detrend(patch: PatchType, dim="time", type="linear") -> PatchType:
+def detrend(patch: PatchType, dim, type="linear") -> PatchType:
     """Perform detrending along a given dimension."""
     assert dim in patch.dims
     axis = patch.dims.index(dim)

--- a/dascore/proc/finitediff.py
+++ b/dascore/proc/finitediff.py
@@ -1,3 +1,0 @@
-"""
-Module for performing finite differences.
-"""

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -282,7 +282,7 @@ class TestReleaseMemory:
         memory.
         """
         patch = get_simple_patch()
-        new = patch.decimate(10)
+        new = patch.decimate(time=10)
         wr = weakref.ref(patch.data)
         del patch
         assert isinstance(new, Patch)
@@ -298,3 +298,16 @@ class TestReleaseMemory:
         del patch
         assert isinstance(new, Patch)
         assert wr() is None
+
+
+class TestXarray:
+    """Tests"""
+
+    pytest.importorskip("xarray")
+
+    def test_convert_to_xarray(self, random_patch):
+        """Tests for converting to xarray object."""
+        import xarray as xr
+
+        da = random_patch.to_xarray()
+        assert isinstance(da, xr.DataArray)

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -68,7 +68,7 @@ class TestDecimate:
         old_time = p1.coords["time"]
         old_dt = old_time[1:] - old_time[:-1]
         # apply decimation,
-        pa2 = random_patch.decimate(2)
+        pa2 = random_patch.decimate(time=2)
         new_time = pa2.coords["time"]
         new_dt = new_time[1:] - new_time[:-1]
         # ensure distance between time samples and shapes have changed
@@ -79,7 +79,7 @@ class TestDecimate:
 
     def test_update_time_max(self, random_patch):
         """Ensure the time_max is updated after decimation."""
-        out = random_patch.decimate(10)
+        out = random_patch.decimate(time=10)
         assert out.attrs["time_max"] == out.coords["time"].max()
 
     def test_update_delta_dim(self, random_patch):
@@ -87,7 +87,7 @@ class TestDecimate:
         Since decimate changes the spacing of dimension this should be updated.
         """
         dt1 = random_patch.attrs["d_time"]
-        out = random_patch.decimate(10)
+        out = random_patch.decimate(time=10)
         assert out.attrs["d_time"] == dt1 * 10
 
 


### PR DESCRIPTION
Before, `patch.decimate` didn't use kwargs to specify decimation dimension and value as other processing functions do. This PR corrects the issue.

Also added a `Patch.to_xarray` method to get an `xarray.DataArray` object from a patch. This will allow us to always support interoperability while, perhaps, one day making xarray an optional dependency. 