### PR TITLE
Get spool to spool

### DIFF
--- a/dascore/__init__.py
+++ b/dascore/__init__.py
@@ -6,7 +6,7 @@ from xarray import set_options
 
 from dascore.clients.filespool import FileSpool
 from dascore.core.patch import Patch
-from dascore.core.spool import MemorySpool, load
+from dascore.core.spool import MemorySpool, spool
 from dascore.examples import get_example_patch, get_example_spool
 from dascore.io.core import get_format, read, scan, write
 from dascore.utils.patch import patch_function

--- a/dascore/__init__.py
+++ b/dascore/__init__.py
@@ -6,7 +6,7 @@ from xarray import set_options
 
 from dascore.clients.filespool import FileSpool
 from dascore.core.patch import Patch
-from dascore.core.spool import MemorySpool, get_spool
+from dascore.core.spool import MemorySpool, load
 from dascore.examples import get_example_patch, get_example_spool
 from dascore.io.core import get_format, read, scan, write
 from dascore.utils.patch import patch_function

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -285,7 +285,7 @@ class MemorySpool(DataFrameSpool):
 
 
 @singledispatch
-def load(obj: Union[Path, str, BaseSpool, Sequence[PatchType]], **kwargs) -> SpoolType:
+def spool(obj: Union[Path, str, BaseSpool, Sequence[PatchType]], **kwargs) -> SpoolType:
     """
     Load a spool from some data source.
 
@@ -298,8 +298,8 @@ def load(obj: Union[Path, str, BaseSpool, Sequence[PatchType]], **kwargs) -> Spo
     raise ValueError(msg)
 
 
-@load.register(str)
-@load.register(Path)
+@spool.register(str)
+@spool.register(Path)
 def spool_from_str(path, **kwargs):
     """Get a spool from a path."""
     path = Path(path)
@@ -313,14 +313,14 @@ def spool_from_str(path, **kwargs):
         raise ValueError(f"could not get spool from {path}")
 
 
-@load.register(BaseSpool)
+@spool.register(BaseSpool)
 def spool_from_spool(spool, **kwargs):
     """Return a spool from a spool."""
     return spool
 
 
-@load.register(list)
-@load.register(tuple)
+@spool.register(list)
+@spool.register(tuple)
 def spool_from_patch_list(patch_list, **kwargs):
     """Return a spool from a sequence of patches."""
     return MemorySpool(patch_list)

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -285,11 +285,9 @@ class MemorySpool(DataFrameSpool):
 
 
 @singledispatch
-def get_spool(
-    obj: Union[Path, str, BaseSpool, Sequence[PatchType]], **kwargs
-) -> SpoolType:
+def load(obj: Union[Path, str, BaseSpool, Sequence[PatchType]], **kwargs) -> SpoolType:
     """
-    Get a spool from an object.
+    Load a spool from some data source.
 
     Parameters
     ----------
@@ -300,8 +298,8 @@ def get_spool(
     raise ValueError(msg)
 
 
-@get_spool.register(str)
-@get_spool.register(Path)
+@load.register(str)
+@load.register(Path)
 def spool_from_str(path, **kwargs):
     """Get a spool from a path."""
     path = Path(path)
@@ -315,14 +313,14 @@ def spool_from_str(path, **kwargs):
         raise ValueError(f"could not get spool from {path}")
 
 
-@get_spool.register(BaseSpool)
+@load.register(BaseSpool)
 def spool_from_spool(spool, **kwargs):
     """Return a spool from a spool."""
     return spool
 
 
-@get_spool.register(list)
-@get_spool.register(tuple)
+@load.register(list)
+@load.register(tuple)
 def spool_from_patch_list(patch_list, **kwargs):
     """Return a spool from a sequence of patches."""
     return MemorySpool(patch_list)

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -13,11 +13,10 @@ def track(sequence, description):
     # This is a dirty hack to allow debugging while running tests.
     # Otherwise, pdb doesn't work in any tracking scope.
     # See: https://github.com/Textualize/rich/issues/1053
-    if getattr(dc, "_debug"):
+    if getattr(dc, "_debug") or not len(sequence):
         yield from sequence
         return
-
-        # Normal progress bar behavior
+    # Normal progress bar behavior
     progress = Progress(
         SpinnerColumn(),
         *Progress.get_default_columns(),

--- a/docs/markdown/executable/quickstart.md
+++ b/docs/markdown/executable/quickstart.md
@@ -92,7 +92,7 @@ import dascore as dc
 pa = dc.get_example_patch()
 
 out = (
-    pa.decimate(8)  # decimate to reduce data volume by 8 along time dimension
+    pa.decimate(time=8)  # decimate to reduce data volume by 8 along time dimension
     .detrend(dim='distance')  # detrend along distance dimension
     .pass_filter(time=(None, 10))  # apply a low-pass 10 Hz butterworth filter
 )
@@ -162,7 +162,7 @@ can manage a group of patches loaded into memory, archives of local files,
 and (in the future) a variety of clients for accessing remote resources.
 
 The simplest way to get the appropriate spool for a specified input is to use
-the `get_spool` method, which should just work in the vast majority of cases.
+the `load` method, which should just work in the vast majority of cases.
 
 
 ```{code-cell}
@@ -172,16 +172,16 @@ import dascore as dc
 patch_list = [dc.get_example_patch()]
 
 # get a spool for managing in-memory patches
-spool1 = dc.get_spool(patch_list)
+spool1 = dc.load(patch_list)
 
 # get a spool from a das file
 from dascore.utils.downloader import fetch
 path_to_das_file = fetch("terra15_das_1_trimmed.hdf5")
-spool2 = dc.get_spool(path_to_das_file)
+spool2 = dc.load(path_to_das_file)
 
 # get a spool from a directory of DAS files
 directory_path = path_to_das_file.parent
-spool3 = dc.get_spool(directory_path)
+spool3 = dc.load(directory_path)
 ```
 
 Despite some implementation differences, all spools have common behavior/methods.

--- a/docs/markdown/executable/quickstart.md
+++ b/docs/markdown/executable/quickstart.md
@@ -172,16 +172,16 @@ import dascore as dc
 patch_list = [dc.get_example_patch()]
 
 # get a spool for managing in-memory patches
-spool1 = dc.load(patch_list)
+spool1 = dc.spool(patch_list)
 
 # get a spool from a das file
 from dascore.utils.downloader import fetch
 path_to_das_file = fetch("terra15_das_1_trimmed.hdf5")
-spool2 = dc.load(path_to_das_file)
+spool2 = dc.spool(path_to_das_file)
 
 # get a spool from a directory of DAS files
 directory_path = path_to_das_file.parent
-spool3 = dc.load(directory_path)
+spool3 = dc.spool(directory_path)
 ```
 
 Despite some implementation differences, all spools have common behavior/methods.

--- a/docs/markdown/executable/working_with_files.md
+++ b/docs/markdown/executable/working_with_files.md
@@ -32,15 +32,15 @@ path = ex.spool_to_directory(diverse_spool)
 
 # Create a spool for interacting with the files in the directory.
 spool = (
-    dascore.load(path)
-    .select(network='das2')  # sub-select das2 network
-    .select(time=(None, '2022-01-01'))  # unselect anything after 2022
-    .chunk(time=2, overlap=0.5)  # change the chunking of the patches
+  dascore.spool(path)
+  .select(network='das2')  # sub-select das2 network
+  .select(time=(None, '2022-01-01'))  # unselect anything after 2022
+  .chunk(time=2, overlap=0.5)  # change the chunking of the patches
 )
 
 # Iterate each patch and do something with it
 for patch in spool:
-    ...
+  ...
 ```
 
 ## Directory Indexer

--- a/docs/markdown/executable/working_with_files.md
+++ b/docs/markdown/executable/working_with_files.md
@@ -32,7 +32,7 @@ path = ex.spool_to_directory(diverse_spool)
 
 # Create a spool for interacting with the files in the directory.
 spool = (
-    dascore.get_spool(path)
+    dascore.load(path)
     .select(network='das2')  # sub-select das2 network
     .select(time=(None, '2022-01-01'))  # unselect anything after 2022
     .chunk(time=2, overlap=0.5)  # change the chunking of the patches

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,7 +225,7 @@ def diverse_spool_directory(diverse_spool):
 @pytest.fixture(scope="class")
 def diverse_file_spool(diverse_spool_directory):
     """Save the diverse spool contents to a directory."""
-    out = dascore.load(diverse_spool_directory).update()
+    out = dascore.spool(diverse_spool_directory).update()
     return out
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,7 +225,7 @@ def diverse_spool_directory(diverse_spool):
 @pytest.fixture(scope="class")
 def diverse_file_spool(diverse_spool_directory):
     """Save the diverse spool contents to a directory."""
-    out = dascore.get_spool(diverse_spool_directory).update()
+    out = dascore.load(diverse_spool_directory).update()
     return out
 
 

--- a/tests/test_clients/test_file_spool.py
+++ b/tests/test_clients/test_file_spool.py
@@ -195,7 +195,7 @@ class TestFileSpoolIntegrations:
         endtime = np.datetime64("2022-01-01")
         duration = 3
         spool = (
-            dc.load(diverse_spool_directory)
+            dc.spool(diverse_spool_directory)
             .select(network=network)  # sub-select das2 network
             .select(time=(None, endtime))  # unselect anything after 2022
             .chunk(time=duration, overlap=0.5)  # change the chunking of the patches

--- a/tests/test_clients/test_file_spool.py
+++ b/tests/test_clients/test_file_spool.py
@@ -195,7 +195,7 @@ class TestFileSpoolIntegrations:
         endtime = np.datetime64("2022-01-01")
         duration = 3
         spool = (
-            dc.get_spool(diverse_spool_directory)
+            dc.load(diverse_spool_directory)
             .select(network=network)  # sub-select das2 network
             .select(time=(None, endtime))  # unselect anything after 2022
             .chunk(time=duration, overlap=0.5)  # change the chunking of the patches

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -243,33 +243,33 @@ class TestGetSpool:
 
     def test_spool_from_spool(self, random_spool):
         """Ensure a spool is valid input to get spool."""
-        out = dascore.get_spool(random_spool)
+        out = dascore.load(random_spool)
         for p1, p2 in zip(out, random_spool):
             assert p1.equals(p2)
 
     def test_spool_from_patch_sequence(self, random_spool):
         """Ensure a list of patches returns a spool"""
-        spool_list = dascore.get_spool(list(random_spool))
-        spool_tuple = dascore.get_spool(tuple(random_spool))
+        spool_list = dascore.load(list(random_spool))
+        spool_tuple = dascore.load(tuple(random_spool))
         for p1, p2, p3 in zip(spool_tuple, spool_list, random_spool):
             assert p1.equals(p2)
             assert p2.equals(p3)
 
     def test_spool_from_single_file(self, terra15_das_example_path):
         """Ensure a single file path returns a spool."""
-        out1 = dascore.get_spool(terra15_das_example_path)
+        out1 = dascore.load(terra15_das_example_path)
         assert isinstance(out1, BaseSpool)
         # ensure format works.
-        out2 = dascore.get_spool(terra15_das_example_path, file_format="terra15")
+        out2 = dascore.load(terra15_das_example_path, file_format="terra15")
         assert isinstance(out2, BaseSpool)
         assert len(out1) == len(out2)
 
     def test_non_existent_file_raises(self):
         """A path that doesn't exist should raise."""
         with pytest.raises(Exception, match="get spool from"):
-            dascore.get_spool("here_or_there?")
+            dascore.load("here_or_there?")
 
     def test_non_supported_type_raises(self):
         """A type that can't contain patches should raise."""
         with pytest.raises(Exception, match="not get spool from"):
-            dascore.get_spool(1.2)
+            dascore.load(1.2)

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -243,33 +243,33 @@ class TestGetSpool:
 
     def test_spool_from_spool(self, random_spool):
         """Ensure a spool is valid input to get spool."""
-        out = dascore.load(random_spool)
+        out = dascore.spool(random_spool)
         for p1, p2 in zip(out, random_spool):
             assert p1.equals(p2)
 
     def test_spool_from_patch_sequence(self, random_spool):
         """Ensure a list of patches returns a spool"""
-        spool_list = dascore.load(list(random_spool))
-        spool_tuple = dascore.load(tuple(random_spool))
+        spool_list = dascore.spool(list(random_spool))
+        spool_tuple = dascore.spool(tuple(random_spool))
         for p1, p2, p3 in zip(spool_tuple, spool_list, random_spool):
             assert p1.equals(p2)
             assert p2.equals(p3)
 
     def test_spool_from_single_file(self, terra15_das_example_path):
         """Ensure a single file path returns a spool."""
-        out1 = dascore.load(terra15_das_example_path)
+        out1 = dascore.spool(terra15_das_example_path)
         assert isinstance(out1, BaseSpool)
         # ensure format works.
-        out2 = dascore.load(terra15_das_example_path, file_format="terra15")
+        out2 = dascore.spool(terra15_das_example_path, file_format="terra15")
         assert isinstance(out2, BaseSpool)
         assert len(out1) == len(out2)
 
     def test_non_existent_file_raises(self):
         """A path that doesn't exist should raise."""
         with pytest.raises(Exception, match="get spool from"):
-            dascore.load("here_or_there?")
+            dascore.spool("here_or_there?")
 
     def test_non_supported_type_raises(self):
         """A type that can't contain patches should raise."""
         with pytest.raises(Exception, match="not get spool from"):
-            dascore.load(1.2)
+            dascore.spool(1.2)


### PR DESCRIPTION
Renames the function `dacore.get_spool` to just `dascore.spool`. There is a few reasons for this:

1) It's shorter
2) numpy.array does something similar
3) spool is still a verb, and makes clear what kind of object will be returned

Since `get_spool` is very new I suspect the change wont affect any real code-bases.
