### PR TITLE
Empty spool/patch, small doc tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-# DasCore
+# DASCore
 
 A python library for distributed fiber optic sensing
 
 [![coverage](https://codecov.io/gh/dasdae/dascore/branch/master/graph/badge.svg)](https://codecov.io/gh/dasdae/dascore)
 [![supported versions](https://img.shields.io/pypi/pyversions/dascore.svg)](https://pypi.python.org/pypi/dascore)
-[![Licence](https://www.gnu.org/graphics/lgplv3-88x31.png)](https://www.gnu.org/licenses/lgpl.html)
 [![PyPI](https://pepy.tech/badge/dascore)](https://pepy.tech/project/dascore)
 [![Connda](https://img.shields.io/conda/dn/conda-forge/dascore?label=conda%20downloads)](https://github.com/conda-forge/dascore-feedstock)
-
+[![Licence](https://www.gnu.org/graphics/lgplv3-88x31.png)](https://www.gnu.org/licenses/lgpl.html)
 
 [Documentation](https://dasdae.github.io/dascore/)
 
-> **WARNING**: dascore is very new and not yet ready for public (non-development) use.
+> **WARNING**: dascore is still very new and not yet ready for public (non-development) use.

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -224,7 +224,10 @@ class DataFrameSpool(BaseSpool):
             **kwargs,
         )
         in_df, out_df = chunker.chunk(df)
-        instructions = chunker.get_instruction_df(in_df, out_df)
+        if df.empty:
+            instructions = None
+        else:
+            instructions = chunker.get_instruction_df(in_df, out_df)
         return self.new_from_df(out_df, source_df=self._df, instruction_df=instructions)
 
     def new_from_df(self, df, source_df=None, instruction_df=None):

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -257,6 +257,8 @@ class ChunkManager:
         output dataframe with column '_group'. The _group column is used
         to link the two dataframes together.
         """
+        if df.empty:  # empy df, do nothing
+            return df.assign(_group=None), df.assign(_group=None)
         # get series of start/stop along requested dimension
         start, stop, step = get_interval_columns(df, self._name)
         dur, overlap = self._get_duration_overlap(self._value, start, step)

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -1,7 +1,7 @@
 """
 Simple interface for progress markers.
 """
-from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
+from rich.progress import MofNCompleteColumn, Progress, SpinnerColumn, TimeElapsedColumn
 
 import dascore as dc
 
@@ -21,6 +21,7 @@ def track(sequence, description):
         SpinnerColumn(),
         *Progress.get_default_columns(),
         TimeElapsedColumn(),
+        MofNCompleteColumn(),
     )
     total = len(sequence)
     with progress:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 DASCore
 =======
 
-A python library for working with distributed fiber optic sensing data.
+A python library for distributed fiber optic sensing
 
 .. toctree::
    :maxdepth: 1

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -201,6 +201,11 @@ class TestEquals:
         patch2 = random_patch.new(attrs=attrs2)
         assert patch1.equals(patch2)
 
+    def test_transposed_patches_equal(self, random_patch):
+        """Transposed patches are still equal."""
+        transposed = random_patch.transpose()
+        assert random_patch.equals(transposed)
+
 
 class TestTranspose:
     """Tests for switching dimensions."""


### PR DESCRIPTION
This PR adds tests/support for empty spool/patches (particularly for `Spool.chunk` and `Patch.transpose`) and makes a couple of minor changes to the readme and index page.