### PR TITLE
cable_id

### DIFF
--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -123,6 +123,8 @@ class HDFPatchIndexManager:
         "station": 8,
         "dims": 40,
         "file_version": 9,
+        "cable_id": 40,
+        "instrument_id": 40,
     }
     # columns which should be indexed for fast querying
     _query_columns = ("time_min", "time_max", "distance_min", "distance_max")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ def diverse_spool_directory(diverse_spool):
 
 
 @pytest.fixture(scope="class")
-def diverse_file_spool(diverse_spool_directory):
+def diverse_directory_spool(diverse_spool_directory):
     """Save the diverse spool contents to a directory."""
     out = dascore.spool(diverse_spool_directory).update()
     return out


### PR DESCRIPTION
Add cable/instrument ids to min_size for directory spool. This will ensure they get included in the index.

Also adds test to directory spool that all str columns are included. 