### PR TITLE
fix wav output, add normalize patch method

### DIFF
--- a/dascore/__init__.py
+++ b/dascore/__init__.py
@@ -4,9 +4,8 @@ DASCore - A library for fiber optic sensing.
 # set xarray settings
 from xarray import set_options
 
-from dascore.clients.dirspool import DirectorySpool
 from dascore.core.patch import Patch
-from dascore.core.spool import MemorySpool, spool
+from dascore.core.spool import BaseSpool, spool
 from dascore.examples import get_example_patch, get_example_spool
 from dascore.io.core import get_format, read, scan, scan_to_df, write
 from dascore.utils.patch import patch_function

--- a/dascore/core/__init__.py
+++ b/dascore/core/__init__.py
@@ -2,4 +2,3 @@
 Core routines and functionality for processing distributed fiber data.
 """
 from .patch import Patch  # noqa
-from .spool import MemorySpool

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -1,7 +1,7 @@
 """
 A 2D trace object.
 """
-from typing import Mapping, Optional, Tuple, Union
+from typing import Mapping, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -28,7 +28,7 @@ class Patch:
         self,
         data: Union[ArrayLike, DataArray] = None,
         coords: Mapping[str, ArrayLike] = None,
-        dims: Tuple[str] = None,
+        dims: Sequence[str] = None,
         attrs: Optional[Mapping] = None,
     ):
         if isinstance(data, DataArray):
@@ -148,7 +148,7 @@ class Patch:
         return Coords(self._data_array.coords)
 
     @property
-    def dims(self) -> Tuple[str, ...]:
+    def dims(self) -> tuple[str, ...]:
         """Return the data array."""
         return self._data_array.dims
 
@@ -156,6 +156,11 @@ class Patch:
     def attrs(self) -> FrozenDict:
         """Return the attributes of the trace."""
         return FrozenDict(self._data_array.attrs)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Return the shape of the data array."""
+        return self._data_array.shape
 
     def to_xarray(self):
         """
@@ -180,6 +185,7 @@ class Patch:
     resample = dascore.proc.resample
     iresample = dascore.proc.iresample
     interpolate = dascore.proc.interpolate
+    normalize = dascore.proc.normalize
 
     # --- Method Namespaces
     # Note: these can't be cached_property (from functools) or references

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -341,3 +341,9 @@ def spool_from_spool(spool, **kwargs):
 def spool_from_patch_list(patch_list, **kwargs):
     """Return a spool from a sequence of patches."""
     return MemorySpool(patch_list)
+
+
+@spool.register(dc.Patch)
+def spool_from_patch(patch):
+    """Get a spool from a single patch."""
+    return MemorySpool([patch])

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -522,6 +522,6 @@ def write(
     dascore.exceptions.UnknownFiberFormat - Could not determine the fiber format.
     """
     formatter = FiberIO.manager.get_fiberio(file_format, file_version)
-    if not isinstance(patch_or_spool, dascore.MemorySpool):
-        patch_or_spool = dascore.MemorySpool([patch_or_spool])
+    if not isinstance(patch_or_spool, dascore.BaseSpool):
+        patch_or_spool = dascore.spool([patch_or_spool])
     formatter.write(patch_or_spool, path, **kwargs)

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -114,10 +114,10 @@ class DASDAEV1(FiberIO):
             try:
                 waveform_group = fi.root["/waveforms"]
             except KeyError:
-                return dc.MemorySpool([])
+                return dc.spool([])
             for patch_group in waveform_group:
                 patches.append(_read_patch(patch_group, **kwargs))
-        return dc.MemorySpool(patches)
+        return dc.spool(patches)
 
     def scan(self, path):
         """

--- a/dascore/io/pickle/core.py
+++ b/dascore/io/pickle/core.py
@@ -52,7 +52,7 @@ class PickleIO(FiberIO):
         """Read a Patch/Stream from disk."""
         with open(path, "rb") as fi:
             out = pickle.load(fi)
-        return dascore.MemorySpool(out)
+        return dascore.spool(out)
 
     def write(self, patch, path, **kwargs):
         """Read a Patch/Stream from disk."""

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -6,8 +6,9 @@ from typing import List, Optional, Union
 
 import numpy as np
 
+import dascore as dc
 from dascore.constants import timeable_types
-from dascore.core import MemorySpool, Patch
+from dascore.core import Patch
 from dascore.core.schema import PatchFileSummary
 from dascore.io.core import FiberIO
 from dascore.utils.time import to_datetime64
@@ -69,7 +70,7 @@ class TDMSFormatterV4713(FiberIO):
         time: Optional[tuple[timeable_types, timeable_types]] = None,
         distance: Optional[tuple[float, float]] = None,
         **kwargs
-    ) -> MemorySpool:
+    ) -> dc.BaseSpool:
         """
         Read a silixa tdms file, return a DataArray.
 
@@ -106,4 +107,4 @@ class TDMSFormatterV4713(FiberIO):
             attrs["distance_max"] = dar.max()
             # get slices of data and read
             patch = Patch(data=data, coords=_coords, attrs=attrs)
-            return MemorySpool([patch])
+            return dc.spool(patch)

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -4,8 +4,8 @@ IO module for reading Terra15 DAS data.
 from pathlib import Path
 from typing import List, Optional, Union
 
+import dascore as dc
 from dascore.constants import timeable_types
-from dascore.core import MemorySpool
 from dascore.core.schema import PatchFileSummary
 from dascore.io.core import FiberIO
 from dascore.utils.hdf5 import HDF5ExtError, NoSuchNodeError, open_hdf5_file
@@ -52,7 +52,7 @@ class Terra15FormatterV4(FiberIO):
         time: Optional[tuple[timeable_types, timeable_types]] = None,
         distance: Optional[tuple[float, float]] = None,
         **kwargs
-    ) -> MemorySpool:
+    ) -> dc.BaseSpool:
         """
         Read a terra15 file.
         """
@@ -60,7 +60,7 @@ class Terra15FormatterV4(FiberIO):
         # TODO need to create h5 file decorator to avoid too many open/close files.
         with open_hdf5_file(path) as fi:
             patch = _read_terra15(fi.root, time, distance)
-        return MemorySpool([patch])
+        return dc.spool(patch)
 
 
 class Terra15FormatterV5(Terra15FormatterV4):

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -1,33 +1,15 @@
 """
 Core module for wave format.
 """
-
 from pathlib import Path
 from typing import Union
 
 import numpy as np
 from scipy.io.wavfile import write
 
-from dascore.constants import PatchType, SpoolType
+from dascore.constants import ONE_SECOND, SpoolType
 from dascore.io.core import FiberIO
-from dascore.utils.docs import compose_docstring
-from dascore.utils.patch import patch_function
-
-write_docstring = """
-Write the contents of the patch to wavefiles in a folder.
-
-Each distance channel is writen as its own file.
-
-Parameters
-----------
-path
-    The *directory* path to which the wave files are written.
-
-Notes
------
-The sampling rate in the wav format must be an int, so the patch's sampling
-rate is cast to an integer before writing wav file.
-"""
+from dascore.utils.patch import check_patch_dims
 
 
 class WavIO(FiberIO):
@@ -37,33 +19,62 @@ class WavIO(FiberIO):
 
     name = "WAV"
 
-    @compose_docstring(doc=write_docstring)
-    def write(self, spool: SpoolType, path: Union[str, Path], **kwargs):
+    def write(self, spool: SpoolType, path: Union[str, Path], resample_frequency=44100):
         """
-        {doc}
+        Write the contents of the patch to one or more wav files.
+
+        Parameters
+        ----------
+        path
+            If a path that ends with .wav, write all the distance channels
+            to a single file. If not, assume the path is a directory and write
+            each distance channel to its own wav file.
+        resample_frequency
+            A resample frequency in Hz. If None, do not perform resampling.
+            Often DAS has non-int sampling rates, so the default resampling
+            rate is usually safe.
+
+        Notes
+        -----
+            - The sampling rate in the wav format must be an int, so the
+            patch's sampling rate is cast to an integer before writing wav file.
+            This may cause some distortion (but it isn't likely to be noticeable).
+
+            - The array data type is converted to np.float32 before writing. This
+            requires values to be between (-1, 1) so the data are detrended
+            and normalized before writing.
+
+            - If a single wavefile is specified with the path argument, and
+            the output the patch has more than one len along the distance
+            dimension, a multi-channel wavefile is created. There may be some
+            players that do not support multi-channel wavefiles.
         """
-        assert len(spool) == 1
-        _write_wavfolder(spool[0], path)
+        path = Path(path)
+        assert len(spool) == 1, "Only single patch spools can be written to wav"
+        patch = spool[0]
+        # write a single wav file, maybe multi-channeled.
+        data, sr = self._get_wav_data(patch, resample_frequency)
+        if path.name.endswith(".wav"):
+            write(filename=str(path), rate=int(sr), data=data)
+        else:  # write data to directory, one file for each distance
+            path.mkdir(exist_ok=True, parents=True)
+            distances = patch.coords["distance"]
+            for ind, dist in enumerate(distances):
+                sub_data = np.take(data, ind, axis=1)
+                sub_path = path / f"{dist}.wav"
+                write(filename=str(sub_path), rate=int(sr), data=sub_data)
 
-
-@patch_function(required_dims=("time", "distance"))
-@compose_docstring(doc=write_docstring)
-def _write_wavfolder(patch: PatchType, path: Union[str, Path]):
-    """
-    {doc}
-    """
-
-    path = Path(path)
-    path.mkdir(exist_ok=True, parents=True)
-    assert len(patch.dims) == 2, "only 2D patches supported for this function."
-    axis = patch.dims.index("distance")
-    data = patch.data
-
-    distance = patch.coords["distance"]
-    sr = 1 / (patch.attrs["d_time"] / np.timedelta64(1, "s"))
-    inds = np.arange(len(distance))
-
-    for ind, dist in enumerate(patch.coords["distance"]):
-        data = np.take(data, inds, axis=axis)
-        sub_path = path / f"{dist}.wav"
-        write(filename=str(sub_path), rate=int(sr), data=data)
+    @staticmethod
+    def _get_wav_data(patch, resample):
+        """Pre-condition patch data for writing. Return array and sample rate."""
+        check_patch_dims(patch, ("time", "distance"))
+        assert len(patch.dims) == 2, "only 2D patches supported for this function."
+        # handle resampling and normalization
+        pat = patch.transpose("time", "distance")
+        if resample is not None:
+            pat = pat.resample(time=1 / resample)
+        # normalize and detrend
+        pat = pat.detrend("distance", "linear").normalize("distance", norm="max")
+        data = pat.data
+        sample_rate = resample or int(np.round(ONE_SECOND / pat.attrs["d_time"]))
+        return data.astype(np.float32), sample_rate

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -19,7 +19,7 @@ class WavIO(FiberIO):
 
     name = "WAV"
 
-    def write(self, spool: SpoolType, path: Union[str, Path], resample_frequency=44100):
+    def write(self, spool: SpoolType, path: Union[str, Path], resample_frequency=None):
         """
         Write the contents of the patch to one or more wav files.
 
@@ -48,6 +48,10 @@ class WavIO(FiberIO):
             the output the patch has more than one len along the distance
             dimension, a multi-channel wavefile is created. There may be some
             players that do not support multi-channel wavefiles.
+
+            - If using VLC, often it won't play the file unless the sampling
+            rate is 44100, in this case just set resample_frequency=44100 to
+            see if this fixes the issue.
         """
         path = Path(path)
         assert len(spool) == 1, "Only single patch spools can be written to wav"
@@ -74,7 +78,7 @@ class WavIO(FiberIO):
         if resample is not None:
             pat = pat.resample(time=1 / resample)
         # normalize and detrend
-        pat = pat.detrend("distance", "linear").normalize("distance", norm="max")
+        pat = pat.detrend("time", "linear").normalize("time", norm="max")
         data = pat.data
-        sample_rate = resample or int(np.round(ONE_SECOND / pat.attrs["d_time"]))
-        return data.astype(np.float32), sample_rate
+        sample_rate = resample or np.round(ONE_SECOND / pat.attrs["d_time"])
+        return data.astype(np.float32), int(sample_rate)

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -2,7 +2,7 @@
 Module to Patch Processing.
 """
 from .aggregate import aggregate
-from .basic import abs, rename, squeeze, transpose
+from .basic import abs, normalize, rename, squeeze, transpose
 from .detrend import detrend
 from .filter import pass_filter
 from .resample import decimate, interpolate, iresample, resample

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -1,6 +1,8 @@
 """
 Basic operations for patches.
 """
+from typing import Literal
+
 import numpy as np
 
 from dascore.constants import PatchType
@@ -73,3 +75,40 @@ def rename(self: PatchType, **names) -> PatchType:
     """
     new_data_array = self._data_array.rename(**names)
     return self.__class__(new_data_array)
+
+
+@patch_function()
+def normalize(
+    self: PatchType,
+    dim: str,
+    norm: Literal["l1", "l2", "max"] = "l2",
+) -> PatchType:
+    """
+    Normalize a patch along a specified dimension.
+
+    Parameters
+    ----------
+    dim
+        The dimension along which the normalization takes place.
+    norm
+        Determines the value to divide each sample by along a given axis.
+        Options are:
+            l1 - divide each sample by the l1 of the axis.
+            l2 - divide each sample by the l2 of the axis.
+            max - divide each sample by the maximum of the absolute value of the axis.
+    """
+    axis = self.dims.index(dim)
+    data = self.data
+    if norm in {"l1", "l2"}:
+        order = int(norm[-1])
+        norm_values = np.linalg.norm(self.data, axis=axis, ord=order)
+    elif norm == "max":
+        norm_values = np.max(data, axis=axis)
+    else:
+        msg = (
+            f"Norm value of {norm} is not supported. "
+            f"Supported values are {('l1', 'l2', 'max')}"
+        )
+        raise ValueError(msg)
+    new_data = data / np.expand_dims(norm_values, axis=axis)
+    return self.new(data=new_data)

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -51,7 +51,9 @@ def decimate(
         sr = _get_sampling_rate(patch, dim)
         freq = sr * 0.5 / float(factor)
         fdata = _lowpass_cheby_2(patch.data, freq, sr, axis=axis)
-        patch = dascore.Patch(fdata, coords=patch.coords, attrs=patch.attrs)
+        patch = dascore.Patch(
+            fdata, coords=patch.coords, attrs=patch.attrs, dims=patch.dims
+        )
 
     kwargs = {dim: slice(None, None, factor)}
     dar = patch._data_array.sel(**kwargs)
@@ -63,7 +65,7 @@ def decimate(
     d_attr = f"d_{dim}"
     attrs[d_attr] = patch.attrs[d_attr] * factor
 
-    return dascore.Patch(data=data, coords=dar.coords, attrs=dar.attrs)
+    return dascore.Patch(data=data, coords=dar.coords, attrs=dar.attrs, dims=dar.dims)
 
 
 @patch_function()

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -501,7 +501,7 @@ def patches_to_df(
         {fields}
     plus a field called 'patch' which contains a reference to each patch.
     """
-    if isinstance(patches, dascore.MemorySpool):
+    if isinstance(patches, dascore.BaseSpool):
         df = patches._df
     elif isinstance(patches, pd.DataFrame):
         return patches

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,8 @@ import tables as tb
 import dascore
 import dascore.examples as ex
 from dascore.clients.dirspool import DirectorySpool
-from dascore.core import MemorySpool, Patch
+from dascore.constants import SpoolType
+from dascore.core import Patch
 from dascore.io.core import read
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import register_func
@@ -102,7 +103,7 @@ def terra15_das_example_path():
 
 @pytest.fixture()
 @register_func(STREAM_FIXTURES)
-def terra15_das_stream(terra15_das_example_path) -> MemorySpool:
+def terra15_das_stream(terra15_das_example_path) -> SpoolType:
     """Return the stream of Terra15 Das Array"""
     return read(terra15_das_example_path, file_format="terra15")
 
@@ -144,7 +145,7 @@ def random_patch() -> Patch:
 
 @pytest.fixture(scope="session")
 @register_func(STREAM_FIXTURES)
-def random_spool() -> MemorySpool:
+def random_spool() -> SpoolType:
     """Init a random array."""
     from dascore.examples import get_example_spool
 
@@ -167,7 +168,7 @@ def dummy_text_file(tmp_path_factory):
 
 
 @pytest.fixture(scope="class")
-def adjacent_spool_no_overlap(random_patch) -> dascore.MemorySpool:
+def adjacent_spool_no_overlap(random_patch) -> dascore.BaseSpool:
     """
     Create a stream with several patches within one time sample but not
     overlapping.
@@ -184,14 +185,14 @@ def adjacent_spool_no_overlap(random_patch) -> dascore.MemorySpool:
     expected_time = pa3.attrs["time_max"] - pa1.attrs["time_min"]
     actual_time = pa3.coords["time"].max() - pa1.coords["time"].min()
     assert expected_time == actual_time
-    return dascore.MemorySpool([pa2, pa1, pa3])
+    return dascore.spool([pa2, pa1, pa3])
 
 
 @pytest.fixture(scope="class")
 def one_file_dir(tmp_path_factory, random_patch):
     """Create a directory with a single DAS file."""
     out = Path(tmp_path_factory.mktemp("one_file_file_spool"))
-    spool = dascore.MemorySpool([random_patch])
+    spool = dascore.spool(random_patch)
     return ex.spool_to_directory(spool, path=out)
 
 

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 import dascore as dc
+from dascore.clients.dirspool import DirectorySpool
 from dascore.constants import ONE_SECOND
 from dascore.core.schema import PatchFileSummary
 from dascore.utils.hdf5 import HDFPatchIndexManager
@@ -20,7 +21,7 @@ FILE_SPOOLS = []
 @register_func(FILE_SPOOLS)
 def one_file_spool(one_file_dir):
     """Create a directory with a single DAS file."""
-    spool = dc.DirectorySpool(one_file_dir)
+    spool = DirectorySpool(one_file_dir)
     return spool.update()
 
 
@@ -35,7 +36,7 @@ class TestFileSpool:
 
     def test_isinstance(self, file_spool):
         """Simply ensure expected type was returned."""
-        assert isinstance(file_spool, dc.DirectorySpool)
+        assert isinstance(file_spool, DirectorySpool)
 
 
 class TestFileIndex:

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -109,6 +109,10 @@ class TestInit:
         ar = get_simple_patch()
         assert not np.any(pd.isnull(ar.coords["time"]))
 
+    def test_shape(self, random_patch):
+        """Ensure shape returns the shape of the data array."""
+        assert random_patch.shape == random_patch.data.shape
+
 
 class TestEmptyPatch:
     """Tests for empty patch objects."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -189,7 +189,7 @@ class TestChunk:
         # get contents of chunked spool
         chunk_df = new.get_contents()
         new_patches = list(new)
-        new_patch = dc.MemorySpool(new_patches)
+        new_patch = dc.spool(new_patches)
         # get content of spool created from patches in chunked spool.
         new_content = new_patch.get_contents()
         # these should be (nearly) identical.
@@ -208,7 +208,7 @@ class TestMergePatchesWithChunk:
     """Tests for merging patches together using chunk method."""
 
     @pytest.fixture()
-    def desperate_spool_no_overlap(self, random_patch) -> dc.MemorySpool:
+    def desperate_spool_no_overlap(self, random_patch) -> dc.BaseSpool:
         """
         Create streams that do not overlap at all.
         Ensure the patches are not sorted in temporal order.
@@ -219,17 +219,17 @@ class TestMergePatchesWithChunk:
         pa2 = random_patch.update_attrs(time_min=t2 + d_time)
         t3 = pa2.attrs["time_max"]
         pa3 = pa2.update_attrs(time_min=t3 + d_time)
-        return dc.MemorySpool([pa2, pa1, pa3])
+        return dc.spool([pa2, pa1, pa3])
 
     @pytest.fixture()
-    def spool_complete_overlap(self, random_patch) -> dc.MemorySpool:
+    def spool_complete_overlap(self, random_patch) -> dc.BaseSpool:
         """
         Create a stream which overlaps each other completely.
         """
-        return dc.MemorySpool([random_patch, random_patch])
+        return dc.spool([random_patch, random_patch])
 
     @pytest.fixture()
-    def spool_slight_gap(self, random_patch) -> dc.MemorySpool:
+    def spool_slight_gap(self, random_patch) -> dc.BaseSpool:
         """
         Create a stream which has a 1.1 * dt gap.
         """
@@ -239,7 +239,7 @@ class TestMergePatchesWithChunk:
         pa2 = random_patch.update_attrs(time_min=t2 + dt * 1.1)
         t3 = pa2.attrs["time_max"]
         pa3 = pa2.update_attrs(time_min=t3 + dt * 1.1)
-        return dc.MemorySpool([pa2, pa1, pa3])
+        return dc.spool([pa2, pa1, pa3])
 
     def test_merge_adjacent(self, adjacent_spool_no_overlap):
         """Test simple merge of patches."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -152,7 +152,7 @@ class TestRead:
     def test_read_terra15(self, terra15_das_example_path, terra15_das_patch):
         """Ensure terra15 can be read."""
         out = dascore.read(terra15_das_example_path)
-        assert isinstance(out, dascore.MemorySpool)
+        assert isinstance(out, dascore.BaseSpool)
         assert len(out) == 1
         assert out[0].equals(terra15_das_patch)
 

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -14,6 +14,7 @@ from dascore.exceptions import (
 )
 from dascore.io.core import FiberIO
 from dascore.io.dasdae.core import DASDAEV1
+from dascore.utils.time import to_datetime64
 
 
 class FiberFormatTestV1(FiberIO):
@@ -188,8 +189,8 @@ class TestScan:
         attrs = random_patch.attrs
         assert len(out) == 1
         ser = out.iloc[0]
-        assert ser["time_min"] == attrs["time_min"]
-        assert ser["time_max"] == attrs["time_max"]
+        assert to_datetime64(ser["time_min"]) == to_datetime64(attrs["time_min"])
+        assert to_datetime64(ser["time_max"]) == to_datetime64(attrs["time_max"])
 
     def test_implements_scan(self):
         """Test for checking is subclass implements_scan"""

--- a/tests/test_io/test_pickle/test_pickle.py
+++ b/tests/test_io/test_pickle/test_pickle.py
@@ -28,7 +28,7 @@ class TestIsPickle:
     def test_read_pickle(self, pickle_patch_path, random_patch):
         """Ensure a pickle file can be read."""
         out = dascore.read(pickle_patch_path)
-        assert isinstance(out, dascore.MemorySpool)
+        assert isinstance(out, dascore.BaseSpool)
         assert len(out) == 1
         assert isinstance(out[0], dascore.Patch)
         assert random_patch == out[0]

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pytest
 
-import dascore
+import dascore as dc
+from dascore.constants import ONE_SECOND
 
 
 class TestWriteWav:
@@ -15,14 +16,17 @@ class TestWriteWav:
     def trimmed_down_patch(self, random_patch):
         """Trim down the random patch for a faster test."""
         dists = random_patch.coords["distance"]
-        out = random_patch.select(distance=(dists[0], dists[2]))
+        time = random_patch.coords["time"]
+        out = random_patch.select(
+            distance=(dists[0], dists[2]), time=(time[0], time[0] + ONE_SECOND)
+        )
         return out
 
     @pytest.fixture(scope="class")
     def wave_dir(self, trimmed_down_patch, tmp_path_factory):
         """Create a wave directory, return path."""
         new = Path(tmp_path_factory.mktemp("wavs"))
-        dascore.write(trimmed_down_patch, new, "wav")
+        dc.write(trimmed_down_patch, new, "wav")
         return new
 
     def test_directory(self, wave_dir, trimmed_down_patch):
@@ -30,3 +34,9 @@ class TestWriteWav:
         assert wave_dir.exists()
         wavs = list(wave_dir.rglob("*.wav"))
         assert len(wavs) == len(trimmed_down_patch.coords["distance"])
+
+    def test_write_single_file(self, trimmed_down_patch, tmp_path_factory):
+        """Ensure a single file can be written"""
+        path = tmp_path_factory.mktemp("wave_temp") / "temp.wav"
+        dc.write(trimmed_down_patch, path, "wav")
+        assert path.exists()

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -6,37 +6,31 @@ from pathlib import Path
 import pytest
 
 import dascore as dc
-from dascore.constants import ONE_SECOND
 
 
 class TestWriteWav:
     """Tests for writing wav format to disk."""
 
     @pytest.fixture(scope="class")
-    def trimmed_down_patch(self, random_patch):
-        """Trim down the random patch for a faster test."""
-        dists = random_patch.coords["distance"]
-        time = random_patch.coords["time"]
-        out = random_patch.select(
-            distance=(dists[0], dists[2]), time=(time[0], time[0] + ONE_SECOND)
-        )
-        return out
+    def audio_patch(self):
+        """Return the example sin wave patch"""
+        return dc.get_example_patch("sin_wav", sample_rate=500)
 
     @pytest.fixture(scope="class")
-    def wave_dir(self, trimmed_down_patch, tmp_path_factory):
+    def wave_dir(self, audio_patch, tmp_path_factory):
         """Create a wave directory, return path."""
         new = Path(tmp_path_factory.mktemp("wavs"))
-        dc.write(trimmed_down_patch, new, "wav")
+        dc.write(audio_patch, new, "wav")
         return new
 
-    def test_directory(self, wave_dir, trimmed_down_patch):
+    def test_directory(self, wave_dir, audio_patch):
         """Sanity checks on wav directory"""
         assert wave_dir.exists()
         wavs = list(wave_dir.rglob("*.wav"))
-        assert len(wavs) == len(trimmed_down_patch.coords["distance"])
+        assert len(wavs) == len(audio_patch.coords["distance"])
 
-    def test_write_single_file(self, trimmed_down_patch, tmp_path_factory):
+    def test_write_single_file(self, audio_patch, tmp_path_factory):
         """Ensure a single file can be written"""
         path = tmp_path_factory.mktemp("wave_temp") / "temp.wav"
-        dc.write(trimmed_down_patch, path, "wav")
+        dc.write(audio_patch, path, "wav")
         assert path.exists()

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -4,6 +4,7 @@ Tests module for wave format.
 from pathlib import Path
 
 import pytest
+from scipy.io.wavfile import read as read_wav
 
 import dascore as dc
 
@@ -34,3 +35,10 @@ class TestWriteWav:
         path = tmp_path_factory.mktemp("wave_temp") / "temp.wav"
         dc.write(audio_patch, path, "wav")
         assert path.exists()
+
+    def test_resample(self, audio_patch, tmp_path_factory):
+        """Ensure resampling changes sampling rate in file"""
+        path = tmp_path_factory.mktemp("wav_resample") / "resampled.wav"
+        dc.write(audio_patch, path, "wav", resample_frequency=1000)
+        (sr, ar) = read_wav(str(path))
+        assert sr == 1000

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -2,6 +2,7 @@
 Tests for basic patch functions.
 """
 import numpy as np
+import pytest
 
 
 class TestAbs:
@@ -15,3 +16,54 @@ class TestAbs:
         new = random_patch.new(data=data)
         out = new.abs()
         assert np.all(out.data >= 0)
+
+
+class TestNormalize:
+    """Tests for normalization."""
+
+    def test_bad_norm_raises(self, random_patch):
+        """Ensure an unsupported norm raises"""
+        with pytest.raises(ValueError):
+            random_patch.normalize("time", norm="bob_norm")
+
+    def test_l2(self, random_patch):
+        """Ensure after operation norms are 1."""
+        dims = random_patch.dims
+        # test along distance axis
+        dist_norm = random_patch.normalize("distance", norm="l2")
+        axis = dims.index("distance")
+        norm = np.linalg.norm(dist_norm.data, axis=axis)
+        assert np.allclose(norm, 1)
+        # tests along time axis
+        time_norm = random_patch.normalize("time", norm="l2")
+        axis = dims.index("time")
+        norm = np.linalg.norm(time_norm.data, axis=axis)
+        assert np.allclose(norm, 1)
+
+    def test_l1(self, random_patch):
+        """Ensure after operation norms are 1."""
+        dims = random_patch.dims
+        # test along distance axis
+        dist_norm = random_patch.normalize("distance", norm="l1")
+        axis = dims.index("distance")
+        norm = np.abs(np.sum(dist_norm.data, axis=axis))
+        assert np.allclose(norm, 1)
+        # tests along time axis
+        time_norm = random_patch.normalize("time", norm="l1")
+        axis = dims.index("time")
+        norm = np.abs(np.sum(time_norm.data, axis=axis))
+        assert np.allclose(norm, 1)
+
+    def test_max(self, random_patch):
+        """Ensure after operation norms are 1."""
+        dims = random_patch.dims
+        # test along distance axis
+        dist_norm = random_patch.normalize("distance", norm="l1")
+        axis = dims.index("distance")
+        norm = np.abs(np.sum(dist_norm.data, axis=axis))
+        assert np.allclose(norm, 1)
+        # tests along time axis
+        time_norm = random_patch.normalize("time", norm="l1")
+        axis = dims.index("time")
+        norm = np.abs(np.sum(time_norm.data, axis=axis))
+        assert np.allclose(norm, 1)


### PR DESCRIPTION
This PR tweaks how the wav format output works by:

1. Automatically scaling the outputs to min/max volume range
2. Support for multichannel wave files

Also added a `Patch.normalize` method.