### PR TITLE
add patch.pipe method

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -1,7 +1,7 @@
 """
 A 2D trace object.
 """
-from typing import Mapping, Optional, Sequence, Union
+from typing import Callable, Mapping, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -205,3 +205,23 @@ class Patch:
     def io(self) -> PatchIO:
         """Return a patch IO object for saving patches to various formats."""
         return PatchIO(self)
+
+    def pipe(self, func: Callable[["Patch", ...], "Patch"], *args, **kwargs) -> "Patch":
+        """
+        Pipe the patch to a function.
+
+        This is primarily useful for maintaining a chain of patch calls for
+        a function.
+
+        Parameters
+        ----------
+        func
+            The function to pipe the patch. It must take a patch instance as
+            the first argument followed by any number of positional or keyword
+            arguments, then return a patch.
+        *args
+            Positional arguments that get passed to func.
+        **kwargs
+            Keyword arguments passed to func.
+        """
+        return func(self, *args, **kwargs)

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -162,3 +162,38 @@ pa1 = pa.update_attrs(time_min='2000-01-01')
 print(pa.attrs['time_min'])
 print(pa1.attrs['time_min'])
 ```
+
+# Method Chaining
+
+In most cases, you should use method chaining as part of a
+[fluent interface](https://en.wikipedia.org/wiki/Fluent_interface) when working with patches.
+
+For example:
+```{.python}
+import dascore as dc
+
+patch = (
+    dc.get_example_patch()  # load the patch
+    .pass_filter(time=(1, 10)  # apply bandpass filter
+    .detrend(dim='time')  # detrend along time dimension
+)
+```
+
+Similar to Pandas, `Patch` has a [pipe method](`dascore.core.patch.Patch.pipe`) so non-patch methods
+can still be used in a method chain.
+
+
+```{.python}
+import dascore as dc
+
+def func(patch, arg1=1):
+    """Example non-patch method"""
+    return patch.update_attrs(arg1=1)
+
+patch = (
+    dc.get_example_patch()
+    .pass_filter(time=(None, 10))
+    .detrend('time', 'linear')
+    .pipe(func, arg1=3)
+)
+```

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -320,3 +320,25 @@ class TestXarray:
 
         da = random_patch.to_xarray()
         assert isinstance(da, xr.DataArray)
+
+
+class TestPipe:
+    """Tests for piping Patch to other functions."""
+
+    @staticmethod
+    def pipe_func(patch, positional_arg, keyword_arg=None):
+        """Just add passed arguments to stats, return new patch."""
+        out = patch.update_attrs(positional_arg=positional_arg, keyword_arg=keyword_arg)
+        return out
+
+    def test_pipe_basic(self, random_patch):
+        """Test simple application of pipe."""
+        out = random_patch.pipe(self.pipe_func, 2)
+        assert out.attrs["positional_arg"] == 2
+        assert out.attrs["keyword_arg"] is None
+
+    def test_keyword_arg(self, random_patch):
+        """Ensure passing a keyword arg works."""
+        out = random_patch.pipe(self.pipe_func, 2, keyword_arg="bob")
+        assert out.attrs["positional_arg"] == 2
+        assert out.attrs["keyword_arg"] == "bob"


### PR DESCRIPTION
This works exactly the same as pandas' `Dataframe.pipe` method and allows none-patch methods to be used in method chaining. 

E.G. 

```python
import dascore as dc

patch = dc.get_example_patch()

def func(patch, arg1=1):
    """Example non-patch method"""
    return patch.update_attrs(arg1=1)

processed = (
    patch.filter(time=(None, 10))
    .detrend('time', 'linear')
    .pipe(func, arg1=3)
)
```




