### PR TITLE
Support for generic coords

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -3,7 +3,7 @@ A 2D trace object.
 """
 from __future__ import annotations
 
-from typing import Callable, Mapping, Optional, Sequence, Union
+from typing import Callable, Mapping, Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -14,37 +14,59 @@ import dascore.proc
 from dascore.constants import DEFAULT_PATCH_ATTRS, PatchType
 from dascore.io import PatchIO
 from dascore.transform import TransformPatchNameSpace
-from dascore.utils.coords import add_coords
+from dascore.utils.coords import Coords, add_coords
 from dascore.utils.mapping import FrozenDict
-from dascore.utils.patch import Coords, _AttrsCoordsMixer
+from dascore.utils.patch import _AttrsCoordsMixer
 from dascore.viz import VizPatchNameSpace
 
 
 class Patch:
     """
-    A Class for storing and accessing 2D fiber data.
-    """
+    A Class for managing data and metadata.
 
-    # --- Dunder methods
+    Parameters
+    ----------
+    data
+        An array-like containing data, an xarray DataArray object, or a Patch.
+    coords
+        The coordinates, or dimensional labels for the data. These can be
+        passed in three forms:
+        {coord_name: data}
+        {coord_name: ((dimensions,), data)}
+        {coord_name: (dimensions, data)}
+    dims
+        A sequence of dimension strings. The first entry cooresponds to the
+        first axis of data, the second to the second dimension, and so on.
+    attrs
+        Optional attributes (non-coordinate metadata) passed as a dict.
+
+    Notes
+    -----
+    Unless data is a DataArray or Patch, data, coords, and dims are required.
+    """
 
     def __init__(
         self,
-        data: Union[ArrayLike, DataArray] = None,
-        coords: Mapping[str, ArrayLike] = None,
-        dims: Sequence[str] = None,
+        data: ArrayLike | DataArray | None = None,
+        coords: Mapping[str, ArrayLike] | None = None,
+        dims: Sequence[str] | None = None,
         attrs: Optional[Mapping] = None,
     ):
-        if isinstance(data, DataArray):
-            self._data_array = data
+        non_attrs = [x is None for x in [data, coords, dims]]
+        if isinstance(data, (DataArray, self.__class__)):
+            dar = data if isinstance(data, DataArray) else data._data_array
+            self._data_array = dar
             return
-        coords = {} if coords is None else coords
-        dims = dims if dims is not None else coords
+        elif any(non_attrs) and not all(non_attrs):
+            msg = "data, coords, and dims must be defined to init Patch."
+            raise ValueError(msg)
         mixer = _AttrsCoordsMixer(attrs, coords, dims)
         attrs, coords = mixer()
         # get xarray coords from custom coords object
-        if isinstance(coords, Coords):
-            coords = coords._coords
-        self._data_array = DataArray(data=data, dims=dims, coords=coords, attrs=attrs)
+        xr_coords = coords.to_nested_dict()
+        self._data_array = DataArray(
+            data=data, dims=dims, coords=xr_coords, attrs=attrs
+        )
 
     def __eq__(self, other):
         """
@@ -157,12 +179,17 @@ class Patch:
 
     @property
     def coords(self):
-        """Return the data array."""
-        return Coords(self._data_array.coords, data_shape=self._data_array.shape)
+        """Return a dict of coordinate data {coord_name: data}"""
+        return Coords(self._data_array.coords, dims=self.dims).array_dict
+
+    @property
+    def coord_dims(self):
+        """Return a dict of coordinate dimensions {coord_name: (**dims)}"""
+        return Coords(self._data_array.coords, dims=self.dims).dims_dict
 
     @property
     def dims(self) -> tuple[str, ...]:
-        """Return the data array."""
+        """Return the dimensions contained in patch."""
         return self._data_array.dims
 
     @property

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -14,7 +14,7 @@ import dascore.proc
 from dascore.constants import DEFAULT_PATCH_ATTRS, PatchType
 from dascore.io import PatchIO
 from dascore.transform import TransformPatchNameSpace
-from dascore.utils.coords import Coords, add_coords
+from dascore.utils.coords import Coords, assign_coords
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.patch import _AttrsCoordsMixer
 from dascore.viz import VizPatchNameSpace
@@ -266,5 +266,5 @@ class Patch:
         """
         return func(self, *args, **kwargs)
 
-    # Bind add_coords as method
-    add_coords = add_coords
+    # Bind assign_coords as method
+    assign_coords = assign_coords

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -38,7 +38,7 @@ class Patch:
             self._data_array = data
             return
         coords = {} if coords is None else coords
-        dims = dims if dims is not None else list(coords)
+        dims = dims if dims is not None else coords
         mixer = _AttrsCoordsMixer(attrs, coords, dims)
         attrs, coords = mixer()
         # get xarray coords from custom coords object
@@ -158,7 +158,7 @@ class Patch:
     @property
     def coords(self):
         """Return the data array."""
-        return Coords(self._data_array.coords)
+        return Coords(self._data_array.coords, data_shape=self._data_array.shape)
 
     @property
     def dims(self) -> tuple[str, ...]:

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -1,6 +1,8 @@
 """
 A 2D trace object.
 """
+from __future__ import annotations
+
 from typing import Callable, Mapping, Optional, Sequence, Union
 
 import numpy as np
@@ -12,6 +14,7 @@ import dascore.proc
 from dascore.constants import DEFAULT_PATCH_ATTRS, PatchType
 from dascore.io import PatchIO
 from dascore.transform import TransformPatchNameSpace
+from dascore.utils.coords import add_coords
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.patch import Coords, _AttrsCoordsMixer
 from dascore.viz import VizPatchNameSpace
@@ -109,9 +112,19 @@ class Patch:
             other = other.transpose(*self.dims)
         return np.equal(self.data, other.data).all()
 
-    def new(self: PatchType, data=None, coords=None, attrs=None) -> PatchType:
+    def new(
+        self: PatchType,
+        data: None | ArrayLike = None,
+        coords: None | dict[str | Sequence[str], ArrayLike] = None,
+        attrs: None | Mapping = None,
+        dims: None | Sequence[str] = None,
+    ) -> PatchType:
         """
-        Return a copy of the trace with data, coords, or attrs updated.
+        Return a copy of the Patch with updated data.
+
+        Parameters
+        ----------
+
         """
         data = data if data is not None else self.data
         attrs = attrs if attrs is not None else self.attrs
@@ -119,7 +132,7 @@ class Patch:
             coords = getattr(self.coords, "_coords", self.coords)
             dims = self.dims
         else:
-            dims = list(coords)
+            dims = dims or list(coords)
         return self.__class__(data=data, coords=coords, attrs=attrs, dims=dims)
 
     def update_attrs(self: PatchType, **attrs) -> PatchType:
@@ -225,3 +238,6 @@ class Patch:
             Keyword arguments passed to func.
         """
         return func(self, *args, **kwargs)
+
+    # Bind add_coords as method
+    add_coords = add_coords

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -116,7 +116,7 @@ def _random_patch_lat_lon():
     lat = np.arange(0, len(dist)) * 0.001 - 109.857952
     lon = np.arange(0, len(dist)) * 0.001 + 41.544654
     # add a single coord
-    out = random_patch.add_coords(
+    out = random_patch.assign_coords(
         latitude=("distance", lat), longitude=("distance", lon)
     )
     return out

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -53,7 +53,7 @@ def _random_patch(starttime="2017-09-18", network="", station="", tag="random"):
         distance=np.arange(array.shape[0]) * attrs["d_distance"],
         time=np.arange(array.shape[1]) * attrs["d_time"],
     )
-    out = dict(data=array, coords=coords, attrs=attrs)
+    out = dict(data=array, coords=coords, attrs=attrs, dims=("distance", "time"))
     return dc.Patch(**out)
 
 
@@ -111,7 +111,7 @@ def _random_patch_lat_lon():
     Create a patch with latitude/longitude coords attached to
     the distance dimension.
     """
-    random_patch = get_example_patch("random")
+    random_patch = get_example_patch("random_das")
     dist = random_patch.coords["distance"]
     lat = np.arange(0, len(dist)) * 0.001 - 109.857952
     lon = np.arange(0, len(dist)) * 0.001 + 41.544654

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -105,6 +105,23 @@ def sin_wave_patch(
     return patch
 
 
+@register_func(EXAMPLE_PATCHES, key="random_patch_with_lat_lon")
+def _random_patch_lat_lon():
+    """
+    Create a patch with latitude/longitude coords attached to
+    the distance dimension.
+    """
+    random_patch = get_example_patch("random")
+    dist = random_patch.coords["distance"]
+    lat = np.arange(0, len(dist)) * 0.001 - 109.857952
+    lon = np.arange(0, len(dist)) * 0.001 + 41.544654
+    # add a single coord
+    out = random_patch.add_coords(
+        latitude=("distance", lat), longitude=("distance", lon)
+    )
+    return out
+
+
 @register_func(EXAMPLE_SPOOLS, key="random_das")
 def _random_spool(
     d_time=0,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -130,11 +130,6 @@ class _FiberIOManager:
         )
         for formatter in iterator:
             return formatter
-        msg = (
-            f"No fiberio instance found for format: {format} "
-            f"version: {version} and extension: {extension}"
-        )
-        raise UnknownFiberFormat(msg)
 
     def yield_fiberio(
         self,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -503,7 +503,7 @@ def write(
     file_format: str,
     file_version: Optional[str] = None,
     **kwargs,
-):
+) -> Path:
     """
     Write a Patch or Spool to disk.
 
@@ -525,3 +525,4 @@ def write(
     if not isinstance(patch_or_spool, dascore.BaseSpool):
         patch_or_spool = dascore.spool([patch_or_spool])
     formatter.write(patch_or_spool, path, **kwargs)
+    return path

--- a/dascore/io/dasdae/__init__.py
+++ b/dascore/io/dasdae/__init__.py
@@ -5,6 +5,3 @@ Note
 ----
 This is an experimental format and is subject to change.
 """
-# Current version of the dasdae writer. Bump this when the format
-# changes and consider a path for backward compatiblity.
-__version__ = "0.0.1"

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -1,5 +1,5 @@
 """
-Core module for reading and writing pickle format.
+Core module for reading and writing DASDAE format.
 """
 import contextlib
 from typing import Union

--- a/dascore/io/pickle/core.py
+++ b/dascore/io/pickle/core.py
@@ -24,8 +24,8 @@ class PickleIO(FiberIO):
     def _header_is_dascore(self, byte_stream):
         """Return True if the first few bytes mention dascore classes."""
         has_dascore = b"dascore.core" in byte_stream
-        spool_or_stream = b"Spool" in byte_stream or b"Patch" in byte_stream
-        return has_dascore and spool_or_stream
+        spool_or_patch = b"Spool" in byte_stream or b"Patch" in byte_stream
+        return has_dascore and spool_or_patch
 
     def get_format(self, path: Union[str, Path]) -> Union[tuple[str, str], bool]:
         """
@@ -49,12 +49,12 @@ class PickleIO(FiberIO):
                 return False
 
     def read(self, path, **kwargs):
-        """Read a Patch/Stream from disk."""
+        """Read a Patch/Spool from disk."""
         with open(path, "rb") as fi:
             out = pickle.load(fi)
         return dascore.spool(out)
 
     def write(self, patch, path, **kwargs):
-        """Read a Patch/Stream from disk."""
+        """Read a Patch/Spool from disk."""
         with open(path, "wb") as fi:
             pickle.dump(patch, fi)

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -97,6 +97,7 @@ class TDMSFormatterV4713(FiberIO):
             # Get data in distance and time requested and assoociated time
             # and distance arrays
             data, tar, dar = _get_data(time, distance, time_ar, dist_ar, data_node)
+            dims = ("time", "distance")
             _coords = {"time": tar, "distance": dar}
             attrs = _get_default_attrs(tdms_file, attrs)
 
@@ -106,5 +107,5 @@ class TDMSFormatterV4713(FiberIO):
             attrs["distance_min"] = dar.min()
             attrs["distance_max"] = dar.max()
             # get slices of data and read
-            patch = Patch(data=data, coords=_coords, attrs=attrs)
+            patch = Patch(data=data, coords=_coords, attrs=attrs, dims=dims)
             return dc.spool(patch)

--- a/dascore/io/terra15/utils.py
+++ b/dascore/io/terra15/utils.py
@@ -114,7 +114,7 @@ def _read_terra15(
     attrs["time_max"] = tar.max()
     attrs["distance_min"] = dar.min()
     attrs["distance_max"] = dar.max()
-    return Patch(data=data, coords=_coords, attrs=attrs)
+    return Patch(data=data, coords=_coords, attrs=attrs, dims=("time", "distance"))
 
 
 def _get_data(time, distance, time_array, dist_array, data_node):

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -63,4 +63,6 @@ def aggregate(
     new_attrs[f"{dim}_min"] = new_coord_val
     new_attrs[f"{dim}_max"] = new_coord_val
     new_attrs[f"d_{dim}"] = np.NaN
-    return patch.__class__(new_data, attrs=new_attrs, coords=new_coords)
+    return patch.__class__(
+        new_data, attrs=new_attrs, coords=new_coords, dims=list(new_coords)
+    )

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -123,7 +123,9 @@ def pass_filter(patch: PatchType, corners=4, zerophase=True, **kwargs) -> PatchT
         out = sosfiltfilt(sos, patch.data, axis=axis)
     else:
         out = sosfilt(sos, patch.data, axis=axis)
-    return dascore.Patch(data=out, coords=patch.coords, attrs=patch.attrs)
+    return dascore.Patch(
+        data=out, coords=patch.coords, attrs=patch.attrs, dims=patch.dims
+    )
 
 
 #

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -10,8 +10,12 @@ import dascore.compat as compat
 from dascore.constants import PatchType
 from dascore.exceptions import FilterValueError
 from dascore.proc.filter import _get_sampling_rate, _lowpass_cheby_2
-from dascore.utils.misc import check_evenly_sampled, get_dim_value_from_kwargs
-from dascore.utils.patch import get_start_stop_step, patch_function
+from dascore.utils.misc import check_evenly_sampled
+from dascore.utils.patch import (
+    get_dim_value_from_kwargs,
+    get_start_stop_step,
+    patch_function,
+)
 from dascore.utils.time import to_number, to_timedelta64
 
 

--- a/dascore/utils/coords.py
+++ b/dascore/utils/coords.py
@@ -1,0 +1,47 @@
+"""
+Utilities for working with coordinates on Patches.
+"""
+
+from dascore.constants import PatchType
+
+
+def add_coords(patch: PatchType, **kwargs) -> PatchType:
+    """
+    Add non-dimensional coordinates to a patch.
+
+    Parameters
+    ----------
+    patch
+        The patch to which coordinates will be added.
+    **kwargs
+        Used to specify the name, dimension, and values of the new
+        coordinates.
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import dascore as dc
+    >>> patch_1 = dc.get_example_patch()
+    >>> coords = patch_1.coords
+    >>> dist = coords['distance']
+    >>> time = coords['time']
+    >>> # Add a single coordinate associated with distance dimension
+    >>> lat = np.arange(0, len(dist)) * .001 -109.857952
+    >>> out_1 = patch_1.add_coords(latitude=('distance', lat))
+    >>> # Add multiple coordinates associated with distance dimension
+    >>> lon = np.arange(0, len(dist)) *.001 + 41.544654
+    >>> out_2 = patch_1.add_coords(
+    >>>     latitude=('distance', lat),
+    >>>     longitude=('distance', lon),
+    >>> )
+    >>> # Add multi-dimensional coordinates
+    >>> quality = np.ones(len(lat), len(lon))
+    >>> out_3 = patch_1.add_coords(
+    >>>     quality=(('latitude', 'longitude'), quality)
+    >>> )
+    """
+    coords = {x: patch.coords[x] for x in patch.coords}
+    for coord_key, (dimension, value) in kwargs.items():
+        coords[coord_key] = (dimension, value)
+    return patch.new(coords=coords, dims=patch.dims)

--- a/dascore/utils/coords.py
+++ b/dascore/utils/coords.py
@@ -9,7 +9,7 @@ from dascore.constants import PatchType
 from dascore.utils.mapping import FrozenDict
 
 
-def add_coords(patch: PatchType, **kwargs) -> PatchType:
+def assign_coords(patch: PatchType, **kwargs) -> PatchType:
     """
     Add non-dimensional coordinates to a patch.
 
@@ -32,18 +32,18 @@ def add_coords(patch: PatchType, **kwargs) -> PatchType:
     >>> time = coords['time']
     >>> # Add a single coordinate associated with distance dimension
     >>> lat = np.arange(0, len(dist)) * .001 -109.857952
-    >>> out_1 = patch_1.add_coords(latitude=('distance', lat))
+    >>> out_1 = patch_1.assign_coords(latitude=('distance', lat))
     >>> # Add multiple coordinates associated with distance dimension
     >>> lon = np.arange(0, len(dist)) *.001 + 41.544654
-    >>> out_2 = patch_1.add_coords(
-    >>>     latitude=('distance', lat),
-    >>>     longitude=('distance', lon),
-    >>> )
+    >>> out_2 = patch_1.assign_coords(
+    ...     latitude=('distance', lat),
+    ...     longitude=('distance', lon),
+    ... )
     >>> # Add multi-dimensional coordinates
-    >>> quality = np.ones(len(lat), len(lon))
-    >>> out_3 = patch_1.add_coords(
-    >>>     quality=(('latitude', 'longitude'), quality)
-    >>> )
+    >>> quality = np.ones_like(patch_1.data)
+    >>> out_3 = patch_1.assign_coords(
+    ...     quality=(patch_1.dims, quality)
+    ... )
     """
     coords = {x: patch.coords[x] for x in patch.coords}
     for coord_key, (dimension, value) in kwargs.items():

--- a/dascore/utils/coords.py
+++ b/dascore/utils/coords.py
@@ -1,8 +1,12 @@
 """
 Utilities for working with coordinates on Patches.
 """
+from __future__ import annotations
+
+from typing_extensions import Self
 
 from dascore.constants import PatchType
+from dascore.utils.mapping import FrozenDict
 
 
 def add_coords(patch: PatchType, **kwargs) -> PatchType:
@@ -45,3 +49,107 @@ def add_coords(patch: PatchType, **kwargs) -> PatchType:
     for coord_key, (dimension, value) in kwargs.items():
         coords[coord_key] = (dimension, value)
     return patch.new(coords=coords, dims=patch.dims)
+
+
+class Coords:
+    """
+    A class to simplify the handling of coordinates.
+
+    Also helps in supporting non-dimensional coordinates and inferring
+    dimensions.
+
+    Attributes
+    ----------
+    array_dict
+        A dict of {coord_name: array}.
+    dims_dict
+        A dict of {coord_name: tuple[dim_1, dim_2...]}.
+    dims
+        A tuple of the dimensions for the coordinates.
+    """
+
+    # --- Init stuff
+    dims = ()
+    array_dict = FrozenDict()
+    dims_dict = FrozenDict()
+
+    def __init__(self, coords, dims=None):
+        if coords is None:
+            return
+        # Another coord as input
+        if isinstance(coords, Coords):
+            self.__dict__.update(coords.__dict__)
+            return
+        # hande a dict being passed
+        if isinstance(coords, (dict, FrozenDict)):
+            array_dict, dim_dict = self._coord_dict_from_dict(coords)
+            self.dims = dims
+        # handle xarray coordinate
+        else:
+            array_dict, dim_dict = self._coord_dict_from_xr(coords)
+            self.dims = coords.dims
+        self.array_dict = FrozenDict(array_dict)
+        self.dims_dict = FrozenDict(dim_dict)
+
+    def _coord_dict_from_xr(self, coord):
+        """Get the coordinates from an xarray coordinate object."""
+        array_dict = {}
+        dim_dict = {}
+        for i, v in coord.items():
+            array_dict[i] = v.data
+            dims = v.dims
+            dim_dict[i] = (dims,) if isinstance(dims, str) else tuple(dims)
+        return array_dict, dim_dict
+
+    def _coord_dict_from_dict(self, coord_dict):
+        """Get the coordinate dict from a dictionary"""
+        arrays = {}
+        dimensions = {}
+        for i, v in coord_dict.items():
+            # determine if of the form (dim_name(s), value) or just value
+            if len(v) and isinstance(v[0], (str, tuple, list)):
+                assert len(v) == 2  # should be a sequence of dims, array
+                arrays[i] = v[1]
+                dims = v[0]
+                dimensions[i] = (dims,) if isinstance(dims, str) else tuple(dims)
+            else:
+                arrays[i] = v
+                dimensions[i] = (i,)
+        return arrays, dimensions
+
+    def __str__(self):
+        # TODO: Once I am convinced Coords will stay we need a better str
+        msg = f"Coords managing {list(self.dims_dict)}"
+        return msg
+
+    __repr__ = __str__
+
+    def get(self, item, default=None):
+        """Return item or None if not in coord. Same as dict.get"""
+        return self.array_dict.get(item, default=default)
+
+    def __iter__(self):
+        return self.array_dict.__iter__()
+
+    def __getitem__(self, item):
+        return self.array_dict[item]
+
+    def to_nested_dict(self):
+        """
+        Return a dict of {coord_name: ((*dims), data)}.
+
+        This is useful for input into xarray.
+        """
+        out = {i: (self.dims_dict[i], self.array_dict[i]) for i in self.dims_dict}
+        return out
+
+    def update(self, **kwargs) -> Self:
+        """Set the data of an existing coordinate."""
+        assert set(kwargs).issubset(set(self.array_dict))
+        coords = self.to_nested_dict()
+        for item, val in kwargs.items():
+            data_list = list(coords[item])
+            data_list[1] = val
+            coords[item] = data_list
+        out = self.__class__(coords)
+        return out

--- a/dascore/utils/mapping.py
+++ b/dascore/utils/mapping.py
@@ -14,7 +14,7 @@ class FrozenDict(collections.abc.Mapping):
 
     Notes
     -----
-    This implimentation was Inspired by the no-longer maintained package
+    This implementation was Inspired by the no-longer maintained package
     frozen-dict (https://github.com/slezica/python-frozendict)
 
     By design, changes in the original dict are not reflected in the frozen

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -11,7 +11,7 @@ import numpy as np
 import numpy.typing as nt
 import pandas as pd
 
-from dascore.exceptions import ParameterError, PatchDimError
+from dascore.exceptions import ParameterError
 
 
 def register_func(list_or_dict: Union[list, dict], key: Optional[str] = None):
@@ -148,29 +148,6 @@ def _get_sampling_rate(sampling_period):
     else:
         num = 1
     return num / sampling_period
-
-
-def get_dim_value_from_kwargs(patch, kwargs):
-    """
-    Assert that kwargs contain one value and it is a dimension of patch.
-
-    Several patch functions allow passing values via kwargs which are dimension
-    specific. This function allows for some sane validation of such functions.
-
-    Return the name of the dimension, its axis position, and its value.
-    """
-    dims = patch.dims
-    overlap = set(dims) & set(kwargs)
-    if len(kwargs) != 1 or not overlap:
-        msg = (
-            "You must use exactly one dimension name in kwargs. "
-            f"You passed the following kwargs: {kwargs} to a patch with "
-            f"dimensions {patch.dims}"
-        )
-        raise PatchDimError(msg)
-    dim = list(overlap)[0]
-    axis = dims.index(dim)
-    return dim, axis, kwargs[dim]
 
 
 def all_close(ar1, ar2):

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -523,7 +523,7 @@ def merge_patches(
     tolerance: float = 1.5,
 ) -> Sequence[PatchType]:
     """
-    Merge all compatible patches in stream together.
+    Merge all compatible patches in spool or patch list together.
 
     Parameters
     ----------

--- a/docs/contributing/code_of_conduct.qmd
+++ b/docs/contributing/code_of_conduct.qmd
@@ -60,15 +60,15 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders via email. The current 
+reported to the community leaders via email. The current
 community leaders responsible for enforcement of standards of acceptable
-behavior are [Ge Jin](https://people.mines.edu/gjin/) and 
+behavior are [Ge Jin](https://people.mines.edu/gjin/) and
 [Eileen Martin](https://eileenrmartin.github.io/).
 
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
-reporter of any incident. 
+reporter of any incident.
 
 ## Enforcement Guidelines
 

--- a/docs/contributing/contributing.qmd
+++ b/docs/contributing/contributing.qmd
@@ -20,41 +20,41 @@ Development planning and prioritization takes place [here](https://github.com/DA
 
 # DASCore or other DASDAE packages
 
-You may wonder whether a new feature you'd like to add belongs in DASCore, or if it should be 
+You may wonder whether a new feature you'd like to add belongs in DASCore, or if it should be
 part of another [DASDAE](https://github.com/DASDAE) package. The guiding principle is that
 if it does not require additional dependencies and is not particularly specialized to
-one sub-area of applied seismology, then it can be part of DASCore. What if the feature 
-you're interested in adding is generally applicable for many kinds of DAS data analysis, but 
+one sub-area of applied seismology, then it can be part of DASCore. What if the feature
+you're interested in adding is generally applicable for many kinds of DAS data analysis, but
 requires some additional package dependency? If this is the case, open a discussion describing
 the feature, the additional dependency, and (optional but encouraged) other future
-features that may also share this dependency. Typically we'll try to come to a clear consensus, then you can 
-move ahead with development. If the proposed DASCore dependency addition appears to be controversial, then you will 
+features that may also share this dependency. Typically we'll try to come to a clear consensus, then you can
+move ahead with development. If the proposed DASCore dependency addition appears to be controversial, then you will
 deliver a short presentation at one of the bi-weekly DASDAE developer team check-ins that should
-descrive the feature, the additional dependency (including approximate added size of the software 
-required to be installed), and ideas for other features that could be enabled by this dependency. 
+descrive the feature, the additional dependency (including approximate added size of the software
+required to be installed), and ideas for other features that could be enabled by this dependency.
 Then the developer community in attendance will discuss the proposed change and take a vote (majority
 approval required).
 
-If you are interested in creating a new [DASDAE](https://github.com/DASDAE) package which uses 
-DASCore as a dependency, you are not required to hold it to the same style and testing guidelines 
+If you are interested in creating a new [DASDAE](https://github.com/DASDAE) package which uses
+DASCore as a dependency, you are not required to hold it to the same style and testing guidelines
 as DASCore, but you are encouraged to do so, and can use DASCore's setup as an example. Following
-a common set of style and contributor workflows will make it easier for us to develop a 
-community of DASDAE developers who can easily move between using and developing any of the 
+a common set of style and contributor workflows will make it easier for us to develop a
+community of DASDAE developers who can easily move between using and developing any of the
 DASDAE packages.
 
-# Leadership 
+# Leadership
 
-Currently DASCore operates in BDFL mode during its initial construction phase, 
-with Derrick Chambers leading the oversight of the master branch, but this is 
-not intended to be the mode of operation in the future. In October 2023 at a 
-DASDAE developer team check-in, the team will review the additions provided by 
+Currently DASCore operates in BDFL mode during its initial construction phase,
+with Derrick Chambers leading the oversight of the master branch, but this is
+not intended to be the mode of operation in the future. In October 2023 at a
+DASDAE developer team check-in, the team will review the additions provided by
 contributors, and will nominate and approve a leadership team with a record of
-contribution to share the code management leadership responsibility. 
+contribution to share the code management leadership responsibility.
 
-Currently Eileen Martin and Ge Jin lead organizational activities (e.g. organize 
+Currently Eileen Martin and Ge Jin lead organizational activities (e.g. organize
 team meetings, coordinate logistics of training and tutorial activities, enforcement
 of community standards, approving travel and research assistantships for some contributors
-at Colorado School of Mines) as PI and co-PI of the NSF Geoinformatics grant that is 
-supporting initial development of DASDAE packages. However, as the contributor 
-community grows beyond Colorado School of Mines, after the life of the grant, these 
+at Colorado School of Mines) as PI and co-PI of the NSF Geoinformatics grant that is
+supporting initial development of DASDAE packages. However, as the contributor
+community grows beyond Colorado School of Mines, after the life of the grant, these
 roles are intended to be rotating among community members.

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -13,16 +13,17 @@ The `Patch` design was heavily inspired by
 
 Patches can be generated in a few ways.
 
-## Load an example patch (for simple demonstrations)
+## Load an Example Patch
 
-This example patch contains some artificially generated data.
+This example patch contains some artificially generated data. They are mostly used
+for simple demonstrations or testing.
 
 ```{python}
 import dascore as dc
 pa = dc.get_example_patch()
 ```
 
-## Load a file
+## Load a File
 
 We first download a small example fiber file from a URL in the DASCore library (you need an internet connection).
 Next, we simply read it into a [spool](spool.qmd) object then get the first (and only) patch.
@@ -46,7 +47,7 @@ depending on the file support for scanning, often load data lazily.
 Usually `dc.spool` is the function you want.
 :::
 
-## Create from Arrays
+## Create from Scratch
 
 Patches can also be created from NumPy arrays and dictionaries. This requires:
 
@@ -127,7 +128,7 @@ Because patches should be treated as immutable objects, you can't just modify
 them with normal item assignment. There are a few methods that return new
 patches with modifications, however, that are functionally the same.
 
-## new
+## New
 
 Often you may wish to modify one aspect of the patch. [`Patch.new`](`dascore.core.patch.Patch.new`)
 is designed for this purpose:
@@ -140,7 +141,7 @@ pa = dc.get_example_patch()
 new = pa.new(data=pa.data * 10)
 ```
 
-## update attrs
+## Update Attrs
 [`Patch.update_attrs`](`dascore.core.patch.Patch.update_attrs`) is for making small changes
 to the patch attrs (metadata) while keeping the unaffected metadata (`Patch.new` would require
 you replace the entirety of attrs).
@@ -208,7 +209,7 @@ It is common to have additional coordinates, such as latitude/longitude,
 attached to a particular dimension (e.g., distance). There are two ways
 to add coordinates to a patch:
 
-## Assign_coordinates
+## Assign Coordinates
 
 The [assign_coordinates](`dascore.utils.coords.assign_coords`) method will
 add the requested coordinates and return a new patch instance.
@@ -239,7 +240,7 @@ out_3 = pa.assign_coords(
 )
 ```
 
-## Include Coords in Patch Init
+## Coords in Patch Init
 
 Any number of coordinates can also be assigned when the patch is initiated. For
 coordinates other than those of the patch dimensions, the associated dimensions

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -197,3 +197,5 @@ patch = (
     .pipe(func, arg1=3)
 )
 ```
+
+# Adding dimensional coordinates

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -176,7 +176,7 @@ For example:
 ```{.python}
 import dascore as dc
 
-patch = (
+pa = (
     dc.get_example_patch()  # load the patch
     .pass_filter(time=(1, 10)  # apply bandpass filter
     .detrend(dim='time')  # detrend along time dimension
@@ -194,7 +194,7 @@ def func(patch, arg1=1):
     """Example non-patch method"""
     return patch.update_attrs(arg1=1)
 
-patch = (
+pa = (
     dc.get_example_patch()
     .pass_filter(time=(None, 10))
     .detrend('time', 'linear')
@@ -216,29 +216,31 @@ add the requested coordinates and return a new patch instance.
 ```{python}
 import numpy as np
 import dascore as dc
-patch_1 = dc.get_example_patch()
-coords = patch_1.coords
+pa = dc.get_example_patch()
+coords = pa.coords
 dist = coords['distance']
 time = coords['time']
 
 # Add a single coordinate associated with distance dimension
 lat = np.arange(0, len(dist)) * .001 -109.857952
-out_1 = patch_1.assign_coords(latitude=('distance', lat))
+out_1 = pa.assign_coords(latitude=('distance', lat))
+
 # Add multiple coordinates associated with distance dimension
 lon = np.arange(0, len(dist)) *.001 + 41.544654
-out_2 = patch_1.assign_coords(
+out_2 = pa.assign_coords(
     latitude=('distance', lat),
     longitude=('distance', lon),
 )
 
 # Add multi-dimensional coordinates
-quality = np.ones_like(patch_1.data)
-out_3 = patch_1.assign_coords(
-    quality=(patch_1.dims, quality)
+quality = np.ones_like(pa.data)
+out_3 = pa.assign_coords(
+    quality=(pa.dims, quality)
 )
 ```
 
 ## Include Coords in Patch Init
+
 Any number of coordinates can also be assigned when the patch is initiated. For
 coordinates other than those of the patch dimensions, the associated dimensions
 must be specified. For exampel:
@@ -247,12 +249,12 @@ must be specified. For exampel:
 import dascore as dc
 import numpy as np
 
-# create fake data
+# create data for patch
 rand = np.random.RandomState(13)
 array = rand.random(size=(20, 100))
 time1 = np.datetime64("2020-01-01")
 
-# create attributes of patch
+# create patch attrs
 attrs = dict(dx=1, d_time=1 / 250.0, category="DAS", id="test_data1")
 time_deltas = dc.to_timedelta64(np.arange(array.shape[1]) * attrs["d_time"])
 
@@ -260,7 +262,7 @@ time_deltas = dc.to_timedelta64(np.arange(array.shape[1]) * attrs["d_time"])
 distance = np.arange(array.shape[0]) * attrs["dx"]
 time = time1 + time_deltas
 quality = np.ones_like(array)
-latitude = np.arange(array.shape[1]) * .001 - 111.00
+latitude = np.arange(array.shape[0]) * .001 - 111.00
 
 # create coord dict
 coords = dict(
@@ -272,5 +274,5 @@ coords = dict(
 
 # Define dimensions of array and init Patch
 dims = ("distance", "time")
-out = dict(data=array, coords=coords, attrs=attrs, dims=dims)
+out = dc.Patch(data=array, coords=coords, attrs=attrs, dims=dims)
 ```

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -80,7 +80,11 @@ coords = dict(
     distance=np.arange(array.shape[0]) * attrs["d_distance"],
     time=np.arange(array.shape[1]) * attrs["d_time"],
 )
-pa = dc.Patch(data=array, coords=coords, attrs=attrs)
+
+# define dimensions (first label corresponds to data axis 0)
+dims = ('distance', 'time')
+
+pa = dc.Patch(data=array, coords=coords, attrs=attrs, dims=dims)
 print(pa)
 ```
 
@@ -198,4 +202,75 @@ patch = (
 )
 ```
 
-# Adding dimensional coordinates
+# Adding Coordinates
+
+It is common to have additional coordinates, such as latitude/longitude,
+attached to a particular dimension (e.g., distance). There are two ways
+to add coordinates to a patch:
+
+## Assign_coordinates
+
+The [assign_coordinates](`dascore.utils.coords.assign_coords`) method will
+add the requested coordinates and return a new patch instance.
+
+```{python}
+import numpy as np
+import dascore as dc
+patch_1 = dc.get_example_patch()
+coords = patch_1.coords
+dist = coords['distance']
+time = coords['time']
+
+# Add a single coordinate associated with distance dimension
+lat = np.arange(0, len(dist)) * .001 -109.857952
+out_1 = patch_1.assign_coords(latitude=('distance', lat))
+# Add multiple coordinates associated with distance dimension
+lon = np.arange(0, len(dist)) *.001 + 41.544654
+out_2 = patch_1.assign_coords(
+    latitude=('distance', lat),
+    longitude=('distance', lon),
+)
+
+# Add multi-dimensional coordinates
+quality = np.ones_like(patch_1.data)
+out_3 = patch_1.assign_coords(
+    quality=(patch_1.dims, quality)
+)
+```
+
+## Include Coords in Patch Init
+Any number of coordinates can also be assigned when the patch is initiated. For
+coordinates other than those of the patch dimensions, the associated dimensions
+must be specified. For exampel:
+
+```{python}
+import dascore as dc
+import numpy as np
+
+# create fake data
+rand = np.random.RandomState(13)
+array = rand.random(size=(20, 100))
+time1 = np.datetime64("2020-01-01")
+
+# create attributes of patch
+attrs = dict(dx=1, d_time=1 / 250.0, category="DAS", id="test_data1")
+time_deltas = dc.to_timedelta64(np.arange(array.shape[1]) * attrs["d_time"])
+
+# create coordinate data
+distance = np.arange(array.shape[0]) * attrs["dx"]
+time = time1 + time_deltas
+quality = np.ones_like(array)
+latitude = np.arange(array.shape[1]) * .001 - 111.00
+
+# create coord dict
+coords = dict(
+    distance=distance,
+    time=time,
+    latitude=("distance", latitude),  # Note distance is attached dimension
+    quality=(("distance", "time"), quality),  # Two attached dimensions here
+)
+
+# Define dimensions of array and init Patch
+dims = ("distance", "time")
+out = dict(data=array, coords=coords, attrs=attrs, dims=dims)
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,16 +143,8 @@ def random_patch() -> Patch:
 @pytest.fixture(scope="class")
 @register_func(PATCH_FIXTURES)
 def random_patch_with_lat_lon(random_patch):
-    """Create a random patch with added lat/lon coordinates."""
-
-    dist = random_patch.coords["distance"]
-    lat = np.arange(0, len(dist)) * 0.001 - 109.857952
-    lon = np.arange(0, len(dist)) * 0.001 + 41.544654
-    # add a single coord
-    out = random_patch.add_coords(
-        latitude=("distance", lat), longitude=("distance", lon)
-    )
-    return out
+    """Get a random patch with added lat/lon coordinates."""
+    return dc.get_example_patch("random_patch_with_lat_lon")
 
 
 @pytest.fixture(scope="class")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def terra15_das_example_path():
 @pytest.fixture(scope="session")
 @register_func(SPOOL_FIXTURES)
 def terra15_das_unfinished_path() -> Path:
-    """Return the stream of Terra15 Das Array"""
+    """Return the spool of Terra15 Das Array"""
     out = fetch("terra15_das_unfinished.hdf5")
     assert out.exists()
     return out
@@ -113,7 +113,7 @@ def terra15_v5_path():
 @pytest.fixture()
 @register_func(SPOOL_FIXTURES)
 def terra15_das_spool(terra15_das_example_path) -> SpoolType:
-    """Return the stream of Terra15 Das Array"""
+    """Return the spool of Terra15 Das Array"""
     return read(terra15_das_example_path, file_format="terra15")
 
 
@@ -231,7 +231,7 @@ def random_spool() -> SpoolType:
 @register_func(SPOOL_FIXTURES)
 def adjacent_spool_no_overlap(random_patch) -> dc.BaseSpool:
     """
-    Create a stream with several patches within one time sample but not
+    Create a spool with several patches within one time sample but not
     overlapping.
     """
     pa1 = random_patch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,7 @@ def multi_dim_coords_patch(random_patch):
     dist = random_patch.coords["distance"]
     time = random_patch.coords["time"]
     quality = np.ones((len(dist), len(time)))
-    out = random_patch.add_coords(quality=(("distance", "time"), quality))
+    out = random_patch.assign_coords(quality=(("distance", "time"), quality))
     return out
 
 

--- a/tests/test_clients/test_filespool.py
+++ b/tests/test_clients/test_filespool.py
@@ -44,3 +44,8 @@ class TestBasic:
         assert HDFPatchIndexManager(path).has_index
         new_contents = new_spool.get_contents()
         assert contents.equals(new_contents)
+
+    def test_raises_bad_file(self):
+        """Simply ensures a bad file will raise."""
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            FileSpool("/not/a/directory")

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -384,7 +384,7 @@ class TestAddCoords:
         dist = random_patch.coords["distance"]
         lat = np.arange(0, len(dist)) * 0.001 - 109.857952
         # add a single coord
-        out = random_patch.add_coords(latitude=("distance", lat))
+        out = random_patch.assign_coords(latitude=("distance", lat))
         return out
 
     def test_add_single_dim_one_coord(self, random_patch_with_lat):

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -143,6 +143,12 @@ class TestInit:
         assert "quality" in patch.coords
         assert np.all(patch.coords["quality"] == patch.data)
 
+    def test_incomplete_raises(self):
+        """An incomplete patch should raise an error."""
+        data = np.ones((10, 10))
+        with pytest.raises(ValueError, match="data, coords, and dims"):
+            Patch(data=data)
+
 
 class TestEmptyPatch:
     """Tests for empty patch objects."""

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -342,3 +342,35 @@ class TestPipe:
         out = random_patch.pipe(self.pipe_func, 2, keyword_arg="bob")
         assert out.attrs["positional_arg"] == 2
         assert out.attrs["keyword_arg"] == "bob"
+
+
+class TestAddCoords:
+    """Tests for adding non-standard coords to traces."""
+
+    @pytest.fixture(scope="class")
+    def random_patch_with_lat(self, random_patch):
+        """Create a random patch with added lat/lon coordinates."""
+
+        dist = random_patch.coords["distance"]
+        lat = np.arange(0, len(dist)) * 0.001 - 109.857952
+        # add a single coord
+        out = random_patch.add_coords(latitude=("distance", lat))
+        return out
+
+    def test_add_single_dim_one_coord(self, random_patch_with_lat):
+        """Tests that one coordinate can be added to a patch"""
+        assert "latitude" in random_patch_with_lat.coords
+
+    def test_add_single_dim_two_coord2(self, random_patch_with_lat_lon):
+        """Ensure multiple coords can be added to patch."""
+        out2 = random_patch_with_lat_lon
+        assert {"latitude", "longitude"}.issubset(set(out2.coords))
+        assert out2.coords["longitude"].shape
+        assert out2.coords["latitude"].shape
+
+    def test_add_multi_dim_coords(self, multi_dim_coords_patch):
+        """Ensure coords with multiple dimensions works."""
+        out1 = multi_dim_coords_patch
+        assert "quality" in out1.coords
+        assert out1.coords["quality"].shape
+        assert np.all(out1.coords["quality"] == 1)

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -1,5 +1,5 @@
 """
-Test for stream functions.
+Test for spool functions.
 """
 import numpy as np
 import pandas as pd
@@ -46,11 +46,11 @@ class TestSpoolIterablity:
     """Tests for indexing/iterating Spools"""
 
     def test_len(self, random_spool):
-        """Ensure the stream has a length"""
+        """Ensure the spool has a length"""
         assert len(random_spool) == len(list(random_spool))
 
     def test_index(self, random_spool):
-        """Ensure the stream can be indexed."""
+        """Ensure the spool can be indexed."""
         assert isinstance(random_spool[0], dc.Patch)
 
     def test_list_o_patches(self, random_spool):
@@ -210,7 +210,7 @@ class TestMergePatchesWithChunk:
     @pytest.fixture()
     def desperate_spool_no_overlap(self, random_patch) -> dc.BaseSpool:
         """
-        Create streams that do not overlap at all.
+        Create spool that do not overlap at all.
         Ensure the patches are not sorted in temporal order.
         """
         pa1 = random_patch
@@ -224,14 +224,14 @@ class TestMergePatchesWithChunk:
     @pytest.fixture()
     def spool_complete_overlap(self, random_patch) -> dc.BaseSpool:
         """
-        Create a stream which overlaps each other completely.
+        Create a spool which overlaps each other completely.
         """
         return dc.spool([random_patch, random_patch])
 
     @pytest.fixture()
     def spool_slight_gap(self, random_patch) -> dc.BaseSpool:
         """
-        Create a stream which has a 1.1 * dt gap.
+        Create a spool which has a 1.1 * dt gap.
         """
         pa1 = random_patch
         t2 = random_patch.attrs["time_max"]
@@ -244,10 +244,10 @@ class TestMergePatchesWithChunk:
     def test_merge_adjacent(self, adjacent_spool_no_overlap):
         """Test simple merge of patches."""
         len_1 = len(adjacent_spool_no_overlap)
-        out_stream = adjacent_spool_no_overlap.chunk(time=None)
-        assert len(out_stream) < len_1
-        assert len(out_stream) == 1
-        out_patch = out_stream[0]
+        out_spool = adjacent_spool_no_overlap.chunk(time=None)
+        assert len(out_spool) < len_1
+        assert len(out_spool) == 1
+        out_patch = out_spool[0]
         # make sure coords are consistent with attrs
         assert out_patch.attrs["time_max"] == out_patch.coords["time"].max()
         assert out_patch.attrs["time_min"] == out_patch.coords["time"].min()
@@ -259,7 +259,7 @@ class TestMergePatchesWithChunk:
         assert unique_spacing[0] == out_patch.attrs["d_time"]
 
     def test_no_overlap(self, desperate_spool_no_overlap):
-        """streams with no overlap should not be merged."""
+        """Spools with no overlap should not be merged."""
         len_1 = len(desperate_spool_no_overlap)
         out = desperate_spool_no_overlap.chunk(time=None)
         assert len_1 == len(out)

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -186,5 +186,7 @@ class TestRoundTrips:
         new_path = tmp_path_factory.mktemp("dasdae_append") / "tmp.h5"
         patch = random_patch_with_lat_lon
         dc.write(patch, new_path, "DASDAE")
-        # new = dc.read(new_path, file_format="DASDAE")
-        # breakpoint()
+        spool = dc.read(new_path, file_format="DASDAE")
+        assert len(spool) == 1
+        new_patch = spool[0]
+        assert patch.equals(new_patch)

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -123,9 +123,9 @@ class TestReadDasdae:
 
     def test_round_trip_empty_patch(self, written_dascore_v1_empty):
         """Ensure an emtpy patch can be deserialize."""
-        stream = dc.read(written_dascore_v1_empty)
-        assert len(stream) == 1
-        stream[0].equals(dc.Patch())
+        spool = dc.read(written_dascore_v1_empty)
+        assert len(spool) == 1
+        spool[0].equals(dc.Patch())
 
     def test_datetimes(self, tmp_path_factory, random_patch):
         """Ensure the datetimes in the attrs come back as datetimes"""

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -52,7 +52,7 @@ def dasdae_v1_file_path(request):
     return request.getfixturevalue(request.param)
 
 
-class TestWrite:
+class TestWriteDASDAE:
     """Ensure the format can be written."""
 
     def test_file_exists(self, dasdae_v1_file_path):
@@ -94,7 +94,7 @@ class TestWrite:
         assert (df["time_min"] == to_datetime64("1990-01-01")).any()
 
 
-class TestGetVersion:
+class TestGetVersionDASDAE:
     """Test for version gathering from files."""
 
     def test_version_tuple_returned(self, dasdae_v1_file_path):
@@ -108,7 +108,7 @@ class TestGetVersion:
         assert format_ver == (ex_format, ex_version)
 
 
-class TestReadDasdae:
+class TestReadDASDAE:
     """
     Test for reading a dasdae format.
     """
@@ -144,7 +144,7 @@ class TestReadDasdae:
             assert isinstance(patch_2.attrs[name], np.datetime64)
 
 
-class TestScanDasDae:
+class TestScanDASDAE:
     """Tests for scanning the dasdae format."""
 
     def test_scan_returns_info(self, written_dascore_v1_random, random_patch):
@@ -171,3 +171,20 @@ class TestScanDasDae:
         df1 = dc.scan_to_df(written_dascore_v1_random)
         df2 = dc.scan_to_df(written_dascore_v1_random_indexed)
         assert df1.drop(columns="path").equals(df2.drop(columns="path"))
+
+
+class TestRoundTrips:
+    """Tests for round-tripping various patches/spools"""
+
+    def test_write_patch_with_lat_lon(
+        self, random_patch_with_lat_lon, tmp_path_factory
+    ):
+        """
+        DASDAE should support writing patches with non-dimensional
+        coords.
+        """
+        new_path = tmp_path_factory.mktemp("dasdae_append") / "tmp.h5"
+        patch = random_patch_with_lat_lon
+        dc.write(patch, new_path, "DASDAE")
+        # new = dc.read(new_path, file_format="DASDAE")
+        # breakpoint()

--- a/tests/test_io/test_tdms/test_tdms_v4713.py
+++ b/tests/test_io/test_tdms/test_tdms_v4713.py
@@ -42,8 +42,8 @@ def tdms_das_example_path(request):
 def tdms_das_patch(tdms_das_example_path):
     """Make patch for test data"""
     ft = TDMSFormatterV4713()
-    stream_data = ft.read(tdms_das_example_path)
-    return stream_data[0]
+    spool = ft.read(tdms_das_example_path)
+    return spool[0]
 
 
 class TestReadTDMS:

--- a/tests/test_utils/test_coord_utils.py
+++ b/tests/test_utils/test_coord_utils.py
@@ -1,0 +1,71 @@
+"""
+Tests for coordinate utilities.
+"""
+import numpy as np
+import pytest
+
+from dascore.utils.coords import Coords
+from dascore.utils.misc import register_func
+
+
+class TestCoords:
+    """Tests for DASCore's custom coord class."""
+
+    coord_fixtures = []
+    time = [1, 2, 3]
+    distance = [1, 2, 3, 4, 5]
+    shape = (len(time), len(distance))
+    dims = ("time", "distance")
+
+    @pytest.fixture(scope="class")
+    @register_func(coord_fixtures)
+    def simple_dict_coords(self):
+        """Create a simple version of coords from dict."""
+        cdict = {"time": self.time, "distance": self.distance}
+        return Coords(cdict, self.dims)
+
+    @pytest.fixture(scope="class")
+    @register_func(coord_fixtures)
+    def simple_dict_coords_dim_name_tuple(self):
+        """Create a simple version of coords from dict."""
+        input_dict = {
+            "time": ("time", self.time),
+            "distance": ("distance", self.distance),
+        }
+        return Coords(input_dict, self.dims)
+
+    @pytest.fixture(scope="class")
+    @register_func(coord_fixtures)
+    def simple_dict_coords_other_coords(self):
+        """Create a simple version of coords from dict."""
+        input_dict = {
+            "time": ("time", self.time),
+            "distance": self.distance,
+            "latitude": ("distance", np.ones_like(self.distance)),
+        }
+        return Coords(input_dict, self.dims)
+
+    @pytest.fixture(scope="class")
+    @register_func(coord_fixtures)
+    def coord_from_xarray(self, random_patch):
+        """Return a Coord instance from xarray coords."""
+        dar = random_patch.to_xarray().transpose("time", "distance")
+        return Coords(dar.coords)
+
+    @pytest.fixture(scope="class", params=coord_fixtures)
+    def coord(self, request):
+        """meta-fixture to aggregate all coords."""
+        return request.getfixturevalue(request.param)
+
+    def test_dims_inferred(self, coord):
+        """Ensure dimensions can be inferred."""
+        assert coord.dims == ("time", "distance")
+
+    def test_update(self, coord_from_xarray):
+        """ensure update returns a new coord with updated values"""
+        time = coord_from_xarray["time"]
+        new_time = time + np.timedelta64(1, "s")
+        out = coord_from_xarray.update(time=new_time)
+        assert np.all(new_time == out["time"])
+        assert isinstance(out, Coords)
+        assert out is not coord_from_xarray

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -7,8 +7,7 @@ import pytest
 
 import dascore
 from dascore.exceptions import PatchAttributeError, PatchDimError
-from dascore.utils.misc import register_func
-from dascore.utils.patch import Coords, _AttrsCoordsMixer
+from dascore.utils.patch import _AttrsCoordsMixer
 
 
 @dascore.patch_function(required_dims=("time", "distance"))
@@ -228,64 +227,10 @@ class TestAttrsCoordsMixer:
         new_attrs, new_coords = mixer()
         assert new_attrs["d_time"] == td_new
         # first ensure new time coords are approximately new time delta
-        new_time = new_coords["time"].values
+        new_time = new_coords["time"]
         tdiff = (new_time[1:] - new_time[:-1]) / one_sec
         assert np.allclose(tdiff, td_new / one_sec)
         # also ensure the endtime has increased proportionately.
         old_duration = attrs["time_max"] - attrs["time_min"]
         new_duration = new_attrs["time_max"] - new_attrs["time_min"]
         assert np.isclose(old_duration / new_duration, td_old / td_new)
-
-
-class TestCoords:
-    """Tests for DASCore's custom coord class."""
-
-    coord_fixtures = []
-    time = [1, 2, 3]
-    distance = [1, 2, 3, 4, 5]
-    shape = (len(time), len(distance))
-
-    @pytest.fixture(scope="class")
-    @register_func(coord_fixtures)
-    def simple_dict_coords(self):
-        """Create a simple version of coords from dict."""
-        cdict = {"time": self.time, "distance": self.distance}
-        return Coords(cdict, self.shape)
-
-    @pytest.fixture(scope="class")
-    @register_func(coord_fixtures)
-    def simple_dict_coords_dim_name_tuple(self):
-        """Create a simple version of coords from dict."""
-        input_dict = {
-            "time": ("time", self.time),
-            "distance": ("distance", self.distance),
-        }
-        return Coords(input_dict, self.shape)
-
-    @pytest.fixture(scope="class")
-    @register_func(coord_fixtures)
-    def simple_dict_coords_other_coords(self):
-        """Create a simple version of coords from dict."""
-        input_dict = {
-            "time": ("time", self.time),
-            "distance": self.distance,
-            "latitude": ("distance", np.ones_like(self.distance)),
-        }
-        return Coords(input_dict, self.shape)
-
-    @pytest.fixture(scope="class")
-    @register_func(coord_fixtures)
-    def coord_from_xarray(self, random_patch):
-        """Return a Coord instance from xarray coords."""
-        xr_coord = random_patch.to_xarray().coords
-        shape = random_patch.data.shape
-        return Coords(xr_coord, shape)
-
-    @pytest.fixture(scope="class", params=coord_fixtures)
-    def coord(self, request):
-        """metafixture to aggregate all coords."""
-        return request.getfixturevalue(request.param)
-
-    def test_dims_inferred(self, coord):
-        """Ensure dimensions can be inferred."""
-        assert coord.dims == ("time", "distance")


### PR DESCRIPTION
In addition to some minor code cleanup/refactoring, this PR adds support for assigning generic coordinates to patches, associated documentation on how to do this in the Patch tutorial, and a test to ensure DASDAE format supports these (but doesn't break backwards compatibility)