### PR TITLE
Optional deps

### DIFF
--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -59,3 +59,7 @@ class InvalidFileHandler(TypeError, DASCoreError):
 
 class InvalidIndexVersionError(ValueError, DASCoreError):
     """Raised when a version mismatch occurs in index."""
+
+
+class MissingOptionalDependency(ImportError, DASCoreError):
+    """Raised when an optional package needed for some functionality is missing."""

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -4,7 +4,6 @@ Module to Patch Processing.
 from .aggregate import aggregate
 from .basic import abs, normalize, rename, squeeze, standardize, transpose
 from .detrend import detrend
-from .filter import pass_filter, sobel_filter
-from .filter import median_filter, pass_filter
+from .filter import median_filter, pass_filter, sobel_filter
 from .resample import decimate, interpolate, iresample, resample
 from .select import select

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -3,15 +3,17 @@ Misc Utilities.
 """
 import contextlib
 import functools
+import importlib
 import os
 import warnings
+from types import ModuleType
 from typing import Iterable, Optional, Union
 
 import numpy as np
 import numpy.typing as nt
 import pandas as pd
 
-from dascore.exceptions import ParameterError
+from dascore.exceptions import MissingOptionalDependency, ParameterError
 
 
 def register_func(list_or_dict: Union[list, dict], key: Optional[str] = None):
@@ -266,3 +268,28 @@ class CacheDescriptor:
         """Set the cache contents."""
         cache = getattr(instance, self._cache_name)
         cache[self._name] = value
+
+
+def optional_import(package_name: str) -> ModuleType:
+    """
+    Import a module and return the module object if installed, else raise error.
+
+    Parameters
+    ----------
+    package_name
+        The name of the package which may or may not be installed. Can
+        also be sub-packages/modules (eg dascore.core).
+
+    Raises
+    ------
+    MissingOptionalDependency if the package is not installed.
+    """
+    try:
+        mod = importlib.import_module(package_name)
+    except ImportError:
+        msg = (
+            f"{package_name} is not installed but is required for the "
+            f"requested functionality"
+        )
+        raise MissingOptionalDependency(msg)
+    return mod

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -283,6 +283,17 @@ def optional_import(package_name: str) -> ModuleType:
     Raises
     ------
     MissingOptionalDependency if the package is not installed.
+
+    Examples
+    --------
+    >>> from dascore.utils.misc import optional_import
+    >>> from dascore.exceptions import MissingOptionalDependency
+    >>> # import a module (this is the same as import dascore as dc)
+    >>> dc = optional_import('dascore')
+    >>> try:
+    ...     optional_import('boblib5')  # doesn't exist so this raises
+    ... except MissingOptionalDependency:
+    ...     pass
     """
     try:
         mod = importlib.import_module(package_name)

--- a/docs/contributing/dev_install.qmd
+++ b/docs/contributing/dev_install.qmd
@@ -57,8 +57,4 @@ pip install -e ".[dev]"
 
 The first line ensures you are on the master branch, the second line will pull the latest changes and tags, and the last line
 will install again in developer mode. This is only required if DASCore's entry points or requirements have changed, but
-won't hurt anything if not. 
-
-
-
-
+won't hurt anything if not.

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -8,13 +8,14 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from dascore.exceptions import ParameterError
+from dascore.exceptions import MissingOptionalDependency, ParameterError
 from dascore.utils.misc import (
     MethodNameSpace,
     check_evenly_sampled,
     get_slice,
     iter_files,
     iterate,
+    optional_import,
 )
 
 
@@ -253,3 +254,21 @@ class TestIterate:
     def test_str(self):
         """A single string object should be returned as a tuple"""
         assert iterate("hey") == ("hey",)
+
+
+class TestOptionalImport:
+    """Ensure the optional import works."""
+
+    def test_import_installed_module(self):
+        """Test to ensure an installed module imports."""
+        import dascore as dc
+
+        mod = optional_import("dascore")
+        assert mod is dc
+        sub_mod = optional_import("dascore.core")
+        assert sub_mod is dc.core
+
+    def test_missing_module_raises(self):
+        """Ensure a module which is missing raises the appropriate Error."""
+        with pytest.raises(MissingOptionalDependency, match="boblib4"):
+            optional_import("boblib4")


### PR DESCRIPTION

## Description

Adds `optional_import` to dascore.utils.misc for specifying an optional library.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
