### PR TITLE
Use scipy's decimate.

### DIFF
--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -10,15 +10,7 @@ from typing import Sequence
 import numpy as np
 import pandas as pd
 from scipy import ndimage
-from scipy.signal import (
-    cheb2ord,
-    cheby2,
-    iirfilter,
-    medfilt2d,
-    sosfilt,
-    sosfiltfilt,
-    zpk2sos,
-)
+from scipy.signal import iirfilter, medfilt2d, sosfilt, sosfiltfilt, zpk2sos
 
 import dascore
 from dascore.constants import PatchType
@@ -222,29 +214,6 @@ def sobel_filter(patch: PatchType, dim: str, mode="reflect", cval=0.0) -> PatchT
 #     if zerophase:
 #         out = sosfilt(sos, out[::-1])[::-1]
 #     return dascore.Patch(data=out, coords=patch.coords, attrs=patch.attrs)
-
-
-def _lowpass_cheby_2(data, freq, df, maxorder=12, axis=0):
-    """
-    Cheby2-Lowpass Filter used for pre-conditioning decimation.
-
-    Based on Obspy's implementation found here:
-    https://docs.obspy.org/master/_modules/obspy/signal/filter.html#lowpass_cheby_2
-    """
-    nyquist = df * 0.5
-    # rp - maximum ripple of passband, rs - attenuation of stopband
-    rp, rs, order = 1, 96, 1e99
-    ws = freq / nyquist  # stop band frequency
-    wp = ws  # pass band frequency
-    # raise for some bad scenarios
-    while True:
-        if order <= maxorder:
-            break
-        wp = wp * 0.99
-        order, wn = cheb2ord(wp, ws, rp, rs, analog=0)
-    z, p, k = cheby2(order, rs, wn, btype="low", analog=0, output="zpk")
-    sos = zpk2sos(z, p, k)
-    return sosfilt(sos, data, axis=axis)
 
 
 @patch_function()

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -48,6 +48,15 @@ def decimate(
     -----
     Simply uses scipy.signal.decimate if filter_type is specified. Otherwise,
     just slice data long specified dimension only including every n samples.
+
+    Examples
+    --------
+    # Simple example using iir
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>> decimated_irr = patch.decimate(time=10, filter_type='iir')
+    # Example using fir
+    >>> decimated_fir = patch.decimate(time=10, filter_type='fir')
     """
     dim, axis, factor = get_dim_value_from_kwargs(patch, kwargs)
     # Apply scipy

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -1,3 +1,57 @@
 ---
 title: Processing
 ---
+The following shows some simple examples of patch processing. See the
+[proc module documentation](`dascore.proc`) for a list of processing functions.
+
+# Decimate
+
+The [decimate patch function](`dascore.Patch.decimate`) decimates a `Patch`
+along a given axis while by default performing low-pass filtering to avoid
+[aliasing](https://en.wikipedia.org/wiki/Aliasing).
+
+## Data creation
+
+First, we create a patch composed of two sine waves; one above the new
+decimation frequency and one below.
+
+```{python}
+import dascore as dc
+
+patch = dc.examples.sin_wave_patch(
+    sample_rate=1000,
+    frequency=[200, 10],
+    channel_count=2,
+)
+_ = patch.viz.wiggle(show=True)
+```
+
+## IIR filter
+
+Next we decimate by 10x using IIR filter
+
+```{python}
+decimated_iir = patch.decimate(time=10, filter_type='iir')
+_ = decimated_iir.viz.wiggle(show=True)
+```
+
+Notice the lowpass filter removed the 200 Hz signal and only
+the 10Hz wave remains.
+
+## FIR filter
+
+Next we decimate by 10x using FIR filter.
+
+```{python}
+decimated_fir = patch.decimate(time=10, filter_type='fir')
+_ = decimated_fir.viz.wiggle(show=True)
+```
+
+## No Filter
+
+Next, we decimate without a filter to purposely induce aliasing.
+
+```{python}
+decimated_no_filt = patch.decimate(time=10, filter_type=None)
+_ = decimated_no_filt.viz.wiggle(show=True)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
      "pooch>=1.2",
      "pydantic>=1.9.0",
      "rich",
-     "scipy",
+     "scipy>=1.10.0",
      "tables",
      "typing_extensions",
      "xarray",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 pytest configuration for dascore
 """
+import os
 import shutil
 from pathlib import Path
 
@@ -20,7 +21,7 @@ from dascore.utils.misc import register_func
 test_data_path = Path(__file__).parent.absolute() / "test_data"
 
 # A list to register functions that return general spools or patches
-# These are to be used for running many different patches/spools through
+# These are to be used for running many patches/spools through
 # Generic tests.
 SPOOL_FIXTURES = []
 PATCH_FIXTURES = []
@@ -80,7 +81,11 @@ def pytest_sessionstart(session):
 
     import dascore as dc
 
-    matplotlib.use("Agg")
+    # If running in CI make sure to turn off matplotlib.
+    if os.environ.get("CI", False):
+        matplotlib.use("Agg")
+
+    # Ensure debug is set. This disables progress bars which disrupt debugging.
     dc._debug = True
 
 


### PR DESCRIPTION
## Description

This PR removes the old implementation of `Patch.decimate` and replaces it with `scipy.signal.decimate` which is much faster. There was an issue that caused `scipy.signal.decimate` to be unstable for large float32 arrays, but this was resolved in release 1.10.0. 

This also pins DASCore's scipy requirement to > 1.10.0 and adds a page in the tutorials about the decimate function.

Closes #10.

## Checklist

I have (if applicable):

- [X] referenced the GitHub issue this PR closes.
- [X] documented the new feature with docstrings or appropriate doc page.
- [X] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] your name has been added to the contributors page (docs/contributors.md).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.
