### PR TITLE
fix environment file

### DIFF
--- a/.github/workflows/get_coverage.yml
+++ b/.github/workflows/get_coverage.yml
@@ -16,8 +16,10 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: 'latest'
-          python-version: 3.10
-          channels: conda-forge
+          python-version: "3.10"
+          activate-environment: dascore
+          environment-file: environment.yml
+          condarc-file: .github/test_condarc.yml
 
       - name: install dascore
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pre-commit
   - pytables
   - matplotlib
-  - scipy
+  - scipy>1.10.0
   - findiff
   - jupyter
   - nbformat

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pre-commit
   - pytables
   - matplotlib
-  - scipy>1.10.0
+  - scipy>=1.10.0
   - findiff
   - jupyter
   - nbformat


### PR DESCRIPTION

## Description

This PR fixes the conda environment file by pinning scipy>=1.10.0. It also (hopefully) fixes the calc coverage job by using the conda environment.
