### PR TITLE
add support for specifying spool index

### DIFF
--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -22,6 +22,19 @@ class DirectorySpool(DataFrameSpool):
 
     FileSpool creates and index of all files then allows for simple querying
     and bulk processing of the files.
+
+    Parameters
+    ----------
+    base_path
+        The path to the directory to index.
+    index_path
+        The path to the index file containing the contents of the directory.
+        By default it will be created in the top-level of the data directory.
+    preferred_format
+        A string to specify the format of the data. Specifying this parameter
+        will save time in indexing.
+    select_kwargs
+        Dict of keyword arguments to restrict output contents.
     """
 
     _drop_columns = ("file_format", "file_version", "path")
@@ -29,6 +42,8 @@ class DirectorySpool(DataFrameSpool):
     def __init__(
         self,
         base_path: Union[str, Path, Self, AbstractIndexer] = ".",
+        *,
+        index_path: Optional[Path] = None,
         preferred_format: Optional[str] = None,
         select_kwargs: Optional[dict] = None,
     ):
@@ -41,7 +56,7 @@ class DirectorySpool(DataFrameSpool):
         elif isinstance(base_path, AbstractIndexer):
             self.indexer = base_path
         elif isinstance(base_path, (Path, str)):
-            self.indexer = DirectoryIndexer(base_path)
+            self.indexer = DirectoryIndexer(base_path, index_path=index_path)
         self._preferred_format = preferred_format
         self._select_kwargs = {} if select_kwargs is None else select_kwargs
 

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -56,6 +56,9 @@ class DirectoryIndexer(AbstractIndexer):
     cache_size
         The number of queries to store in memory to avoid frequent reads
         of the index file. It is rare this needs to be modified.
+    index_path
+        The path to the index. By default, the index will be created on the
+        top level of the data directory.
     """
 
     # hdf5 compression defaults
@@ -64,10 +67,10 @@ class DirectoryIndexer(AbstractIndexer):
     index_name = ".dascore_index.h5"  # name of index file
     executor = None  # an executor for using parallelism
 
-    def __init__(self, path: Union[str, Path], cache_size: int = 5):
+    def __init__(self, path: Union[str, Path], cache_size: int = 5, index_path=None):
         self.max_size = cache_size
         self.path = Path(path).absolute()
-        self.index_path = self.path / self.index_name
+        self.index_path = Path(index_path or self.path / self.index_name)
         self.cache = pd.DataFrame(
             index=range(cache_size), columns="t1 t2 kwargs cindex".split()
         )

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -40,10 +40,31 @@ spool2 = dc.spool(path_to_das_file)
 import dascore as dc
 from dascore.utils.downloader import fetch
 
+# we use the fetch to make sure the file is downloaded. You would
+# just need to replace directory_path with your data directory path.
 path_to_das_file = fetch("terra15_das_1_trimmed.hdf5")
 directory_path = path_to_das_file.parent
 
+# update will create an index of the contents for fast querying/access
 spool3 = dc.spool(directory_path).update()
+```
+
+If you want the index file to exist somewhere else, for example if you can't
+write to the data directory, you can specify an index path.
+
+```{python}
+#| warning: false
+#| output: false
+import tempfile
+from pathlib import Path
+
+index_path = Path(tempfile.mkdtemp()) / "index.h5"
+
+# update will create an index of the contents for fast querying/access
+spool = dc.spool(directory_path, index_path=index_path).update()
+
+# new spools will also need to specify the index path
+spool_new = dc.spool(directory_path, index_path=index_path).update()
 ```
 
 Despite some implementation differences, all spools have common behavior/methods.


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

This PR adds support for a separate index file, as requested in #129. The parameter `index_path` can now be passed directly to `dascore.spool`.

```python
import dascore as dc

# normal logic, simply creates index at the top of the data directory
spool = dc.spool(directory_path).update()

# specifying an index
spool = dc.spool(directory_path, index_path=index_path).update()
```

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
