### PR TITLE
Better error message for non-existent spool file/directory

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -11,6 +11,7 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.constants import PatchType, SpoolType, numeric_types, timeable_types
+from dascore.exceptions import InvalidSpoolError
 from dascore.utils.chunk import ChunkManager
 from dascore.utils.docs import compose_docstring
 from dascore.utils.mapping import FrozenDict
@@ -318,7 +319,6 @@ def spool_from_str(path, **kwargs):
         from dascore.clients.dirspool import DirectorySpool
 
         return DirectorySpool(path, **kwargs)
-
     # A single file was passed. If the file format supports quick scanning
     # Return a FileSpool (lazy file reader), else return DirectorySpool.
     elif path.exists():  # a single file path was passed.
@@ -334,7 +334,11 @@ def spool_from_str(path, **kwargs):
         else:
             return MemorySpool(dc.read(path, _format, _version))
     else:
-        raise ValueError(f"could not get spool from {path}")
+        msg = (
+            f"could not get spool from argument: {path}. "
+            f"If it is a path, it may not exist."
+        )
+        raise InvalidSpoolError(msg)
 
 
 @spool.register(BaseSpool)

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -67,3 +67,7 @@ class InvalidIndexVersionError(ValueError, DASCoreError):
 
 class MissingOptionalDependency(ImportError, DASCoreError):
     """Raised when an optional package needed for some functionality is missing."""
+
+
+class InvalidSpoolError(ValueError, DASCoreError):
+    """Raised when something is wrong with a spool."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -9,6 +9,7 @@ import pytest
 import dascore as dc
 from dascore.clients.filespool import FileSpool
 from dascore.core.spool import BaseSpool, MemorySpool
+from dascore.exceptions import InvalidSpoolError
 from dascore.utils.time import to_datetime64, to_timedelta64
 
 
@@ -405,3 +406,8 @@ class TestMisc:
         # get first patch, assert it has no history
         out = spool[0]
         assert not out.attrs.history
+
+    def test_nice_non_exist_message(self):
+        """Ensure a nice message is raised for nonexistent paths. See #126."""
+        with pytest.raises(InvalidSpoolError, match="may not exist"):
+            dc.spool("Bad/file/path.h5")


### PR DESCRIPTION

## Description

Adds a better error message and a custom exception when `dascore.spool` fails to create a spool from a string input. Closes #126.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
