### PR TITLE
fix quarto version

### DIFF
--- a/.github/workflows/build_deploy_docs.yaml
+++ b/.github/workflows/build_deploy_docs.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: pre-release
+          version: 1.2.335
           tinytex: true
 
       - name: print quarto version

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -262,11 +262,11 @@ out_3 = pa.assign_coords(
 )
 ```
 
-## Coords in Patch Init
+## Coords in Patch Initialization
 
 Any number of coordinates can also be assigned when the patch is initiated. For
 coordinates other than those of the patch dimensions, the associated dimensions
-must be specified. For exampel:
+must be specified. For example:
 
 ```{python}
 import dascore as dc


### PR DESCRIPTION


## Description

Currently the cross-links aren't working to the API documentation, This PR attempts to fix this by fixing the quarto version to the one which works when I run it locally. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
