### PR TITLE
Windows compatibility tweak: astype(int)

### DIFF
--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -50,7 +50,7 @@ def aggregate(
     # update coords with new dimension (use mean)
     coords = patch.coords
     if dim == "time":  # need to convert time to ints
-        ns = patch.coords[dim].astype(int) / 1_000_000_000
+        ns = patch.coords[dim].astype(np.int64) / 1_000_000_000
         new_coord_val = to_datetime64(np.mean(ns))
     else:
         new_coord_val = np.mean(patch.coords[dim])

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -150,7 +150,7 @@ class ChunkManager:
         stop_cum_max = stop_sorted.cummax()
         end_markers = stop_cum_max.shift() + step_sorted * self._tolerance
         has_gap = start_sorted > end_markers
-        group_num = has_gap.astype(int).cumsum()
+        group_num = has_gap.astype(np.int64).cumsum()
         return group_num[start.index]
 
     def _get_duration_overlap(self, duration, start, step, overlap=None):

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -582,7 +582,7 @@ def _merge_patches(
         no_merge = ~(dist_to_previous <= merge_dist)
         sub_df["_dist_to_previous"] = dist_to_previous
         # determine if each patch should be merged with the previous one
-        for _, merge_patch_df in sub_df.groupby(no_merge.astype(int).cumsum()):
+        for _, merge_patch_df in sub_df.groupby(no_merge.astype(np.int64).cumsum()):
             out.append(_merge_compatible_patches(merge_patch_df))
     return out
 

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -3,6 +3,7 @@ Utilities for plotting with matplotlib.
 """
 
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
 import numpy as np
 import pandas as pd
 
@@ -60,6 +61,8 @@ def _get_extents(dims_r, coords):
         denom = ONE_BILLION
         time_min = to_number(lims["time"][0]) / denom
         time_max = to_number(lims["time"][1]) / denom
+        # convert to julian date to appease matplotlib
+
         lims["time"] = [time_min, time_max]
     out = [x for dim in dims_r for x in lims[dim]]
     return out
@@ -76,7 +79,7 @@ def _strip_labels(labels, redundants=("0", ":", "T", ".")):
 def _get_labels(ticks, time_fmt, dt_ns):
     """Get sensible labels for plots."""
     ticks_ns = dc.to_datetime64(ticks).astype(np.int64)
-    out = np.round(ticks_ns / dt_ns).astype(int) * dt_ns
+    out = np.round(ticks_ns / dt_ns).astype(np.int64) * dt_ns
     labels = pd.to_datetime(out.astype("datetime64[ns]")).strftime(time_fmt)
     return labels
 
@@ -115,8 +118,8 @@ def _add_time_axis_label(ax, patch, dims_r, dt_ns):
     if pd.isnull(start) or pd.isnull(end):
         return  # nothing to do if no start/end times in attrs
     # round start label to within 1 dt.
-    start_ns = start.astype(int)
-    new_start_ns = np.round(start_ns / dt_ns).astype(int) * dt_ns
+    start_ns = start.astype(np.int64)
+    new_start_ns = np.round(start_ns / dt_ns).astype(np.int64) * dt_ns
     ser = pd.Series(str(new_start_ns.astype("datetime64[ns]")))
     new_start = _strip_labels(ser).iloc[0]
     x_or_y = ["x", "y"][dims_r.index("time")]

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -3,7 +3,6 @@ Utilities for plotting with matplotlib.
 """
 
 import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
 import numpy as np
 import pandas as pd
 
@@ -72,7 +71,7 @@ def _strip_labels(labels, redundants=("0", ":", "T", ".")):
     """Strip all the trailing zeros from labels."""
     ar = np.array([list(x) for x in labels])
     redundant = (np.isin(ar, redundants)).all(axis=0)
-    ind2keep = np.argmax(np.cumsum((~redundant).astype(int))) + 1
+    ind2keep = np.argmax(np.cumsum((~redundant).astype(np.int64))) + 1
     return labels.str[:ind2keep].str.rstrip(".").str.rstrip(":").str.rstrip("T")
 
 
@@ -95,7 +94,7 @@ def _format_time_axis(ax, patch, dims_r, time_fmt, extents=None):
     if not time_fmt:
         time_fmt = _get_format_string(time)
     approx_dt = ((time[1:] - time[:-1]) / dc.to_timedelta64(1)).mean()
-    dt_ns = np.round(approx_dt * ONE_BILLION, 6).astype(int)
+    dt_ns = np.round(approx_dt * ONE_BILLION, 6).astype(np.int64)
     # determine which axis is x, tell mpl it's a date, get date axis
     axis_name = "x" if dims_r[0] == "time" else "y"
     # getattr(ax, f"{axis_name}axis_date")()

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -137,14 +137,14 @@ class TestFilterDfAdvanced:
         tmax = to_datetime64(example_df_2["time_max"].max() - np.timedelta64(1, "ns"))
         out = filter_df(example_df_2, time=(tmax, None))
         # just the last row should have been selected
-        assert out.iloc[-1] and out.astype(int).sum() == 1
+        assert out.iloc[-1] and out.astype(np.int64).sum() == 1
 
     def test_time_query_with_string(self, example_df_2):
         """Test for time query with a string."""
         tmax = to_datetime64(example_df_2["time_max"].max() - np.timedelta64(1, "ns"))
         out1 = filter_df(example_df_2, time=(str(tmax), None))
         # just the last row should have been selected
-        assert out1.iloc[-1] and out1.astype(int).sum() == 1
+        assert out1.iloc[-1] and out1.astype(np.int64).sum() == 1
         # also ensure the string can be second element, all rows should be selected
         out2 = filter_df(example_df_2, time=(None, str(tmax)))
         assert len(out2) == len(example_df_2)

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -2,6 +2,7 @@
 Tests for waterfall plots.
 """
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
 import dascore as dc
@@ -58,3 +59,14 @@ class TestWaterfall:
         patch = event_patch_1.pass_filter(time=(None, 300))
         _ = patch.viz.waterfall(scale=0.04)
         _ = patch.transpose("distance", "time").viz.waterfall(scale=0.04)
+
+    def test_time_axis_label_int_overflow(self, random_patch):
+        """Make sure the time axis labels are correct (windows compatibility)"""
+        ax = random_patch.viz.waterfall()
+        expected_starttime = random_patch.attrs["time_min"]
+        xtext = ax.xaxis.get_label_text()
+        # Get the piece of the label corresponding to the starttime
+        # A little bit on the brittle side, but better than nothing
+        starttime = xtext.split()[-1][:-1]
+        starttime = np.datetime64(starttime)
+        assert abs(starttime - expected_starttime) < np.timedelta64(1, "ns")


### PR DESCRIPTION
## Description

This PR makes some small compatibility tweaks for Windows by replacing any instances of `.astype(int)` with `.astype(np.int64)`. This is necessary because numpy will assume a smaller-sized int by default on Windows which leads to overflow errors (ex., when dealing with dates).

It should be noted that I just assumed that np.int64 was appropriate in all cases where I came across it, but because I'm not at all familiar with the codebase I don't know if it would be more appropriate to use something smaller (ex., for something memory intensive).

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
