### PR TITLE
patch.select to no longer generate history entry

### DIFF
--- a/dascore/proc/select.py
+++ b/dascore/proc/select.py
@@ -2,7 +2,7 @@
 Function for querying Patchs
 """
 from dascore.constants import PatchType
-from dascore.utils.patch import _AttrsCoordsMixer, _get_history_str, patch_function
+from dascore.utils.patch import _AttrsCoordsMixer, patch_function
 from dascore.utils.time import get_select_time
 
 
@@ -62,6 +62,7 @@ def select(patch: PatchType, *, copy=False, **kwargs) -> PatchType:
     # prepare outputs
     data = new.data if not copy else new.data.copy()
     attrs = dict(new.attrs)
-    attrs["history"] = _get_history_str(patch, select, **kwargs)
+    # Select should no longer show up in the history attribute.
+    # attrs["history"] = _get_history_str(patch, select, **kwargs)
     attrs, coords = _AttrsCoordsMixer(attrs, new.coords, new.dims)()
     return patch.__class__(data, attrs=attrs, coords=coords, dims=patch.dims)

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -11,6 +11,7 @@ import dascore as dc
 from dascore.clients.dirspool import DirectorySpool
 from dascore.constants import ONE_SECOND
 from dascore.core.schema import PatchFileSummary
+from dascore.exceptions import ParameterError
 from dascore.utils.hdf5 import HDFPatchIndexManager
 from dascore.utils.misc import register_func
 
@@ -193,6 +194,23 @@ class TestSelect:
         assert len(sub) == 1
         patch = sub[0]
         assert isinstance(patch, dc.Patch)
+
+    def test_nice_error_message_bad_select(self, diverse_directory_spool):
+        """Ensure a nice error message is raised for bad"""
+        with pytest.raises(ParameterError, match="Bad filter parameter"):
+            _ = diverse_directory_spool.select(time=None)[0]
+
+    def test_select_correct_history_str(self, diverse_directory_spool):
+        """
+        Ensure no history string is added for selecting. See #142/#147.
+        """
+        spool = diverse_directory_spool
+        t1 = spool[0].attrs.time_min
+        dt = spool[0].attrs.d_time
+        selected_spool = spool.select(time=(t1, t1 + 30 * dt))
+        patch = selected_spool[0]
+        history = patch.attrs.history
+        assert len(history) <= 1
 
 
 class TestBasicChunk:

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pydantic
 import pytest
 
+from dascore.exceptions import ParameterError
 from dascore.utils.pd import adjust_segments, fill_defaults_from_pydantic, filter_df
 from dascore.utils.time import to_datetime64, to_timedelta64
 
@@ -78,7 +79,7 @@ class TestFilterDfBasic:
 
     def test_bad_parameter_raises(self, example_df):
         """ensure passing a parameter that doesn't have a column raises."""
-        with pytest.raises(KeyError, match="not found in df"):
+        with pytest.raises(ParameterError, match="the column does not"):
             filter_df(example_df, bad_column=2)
 
     def test_bad_parameter_doesnt_raise(self, example_df):
@@ -198,7 +199,7 @@ class TestAdjustSegments:
     def test_missing_interval_col_raises_keyerro(self, adjacent_df):
         """Ensure if an interval column is missing a KeyError is raised."""
         df = adjacent_df.drop(columns=["distance_min"])
-        with pytest.raises(KeyError):
+        with pytest.raises(ParameterError):
             _ = adjust_segments(df, distance=(100, 200))
 
     class TestFillDefaultsFromPydantic:


### PR DESCRIPTION
## Description

This PR modifies the `select` method to no longer include a history string. Here are the reasons:

1. `history` should show a record of processing, methods that might change the patch in a way that wouldn't be obvious. In the case of `select` the coordinates are updated so a history string is redundant.

2.  The select history strings can be quite long as floats and date times are common

3. Doing this fixes #142 and #147.


There was also a non-descriptive error message when using code like: `spool.select(time=None)[0]` so I added that here as well.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
