### PR TITLE
Fix time formatting in waterfall plot

### DIFF
--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -2,13 +2,11 @@
 Utilities for plotting with matplotlib.
 """
 
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 
-import dascore as dc
-from dascore.constants import ONE_BILLION
-from dascore.utils.time import to_number
+from dascore.utils.misc import suppress_warnings
 
 
 def _get_dim_label(patch, dim):
@@ -33,20 +31,6 @@ def _get_ax(ax):
     return ax
 
 
-def _get_format_string(time_array):
-    """Determine the best format string."""
-    default_formatter = ("%Y-", "%m-", "%dT", "%H:", "%M:", "%S.%f")
-    td = time_array.max() - time_array.min()
-    dt = dc.to_datetime64(td / dc.to_timedelta64(1))
-    dt_str = str(dt).replace(":", "-").replace("T", "-").split("-")
-    base = dc.to_datetime64(0)
-    base_str = str(base).replace(":", "-").replace("T", "-").split("-")
-    diffs = np.array([x != y for x, y in zip(dt_str, base_str)])
-    ind_min = np.argmax(diffs)
-    fmter = "".join(default_formatter[ind_min:])
-    return fmter
-
-
 def _get_extents(dims_r, coords):
     """Get the extents used for each dimension."""
     # need to reverse dims since extent is [left, right, bottom, top]
@@ -56,71 +40,35 @@ def _get_extents(dims_r, coords):
         array = coords[dim]
         lims[dim] += [array.min(), array.max()]
     # special handling for time
-    if "time" in coords:  # convert dates to float in seconds
-        denom = ONE_BILLION
-        time_min = to_number(lims["time"][0]) / denom
-        time_max = to_number(lims["time"][1]) / denom
+    if "time" in coords:
+        # We can get a warning about loss of precision in ns, doesn't matter.
+        with suppress_warnings(UserWarning):
+            time_min = pd.to_datetime(lims["time"][0]).to_pydatetime()
+            time_max = pd.to_datetime(lims["time"][1]).to_pydatetime()
         # convert to julian date to appease matplotlib
-
-        lims["time"] = [time_min, time_max]
+        lims["time"] = [mdates.date2num(time_min), mdates.date2num(time_max)]
     out = [x for dim in dims_r for x in lims[dim]]
     return out
 
 
-def _strip_labels(labels, redundants=("0", ":", "T", ".")):
-    """Strip all the trailing zeros from labels."""
-    ar = np.array([list(x) for x in labels])
-    redundant = (np.isin(ar, redundants)).all(axis=0)
-    ind2keep = np.argmax(np.cumsum((~redundant).astype(np.int64))) + 1
-    return labels.str[:ind2keep].str.rstrip(".").str.rstrip(":").str.rstrip("T")
-
-
-def _get_labels(ticks, time_fmt, dt_ns):
-    """Get sensible labels for plots."""
-    ticks_ns = dc.to_datetime64(ticks).astype(np.int64)
-    out = np.round(ticks_ns / dt_ns).astype(np.int64) * dt_ns
-    labels = pd.to_datetime(out.astype("datetime64[ns]")).strftime(time_fmt)
-    return labels
-
-
-def _format_time_axis(ax, patch, dims_r, time_fmt, extents=None):
+def _format_time_axis(ax, dims_r):
     """
     Function to handle formatting time axis for image-type plots.
 
     Tries to snape all axis labels to "nice" values and adds reference
     start time.
     """
-    time = patch.coords["time"]
-    if not time_fmt:
-        time_fmt = _get_format_string(time)
-    approx_dt = ((time[1:] - time[:-1]) / dc.to_timedelta64(1)).mean()
-    dt_ns = np.round(approx_dt * ONE_BILLION, 6).astype(np.int64)
-    # determine which axis is x, tell mpl it's a date, get date axis
     axis_name = "x" if dims_r[0] == "time" else "y"
-    # getattr(ax, f"{axis_name}axis_date")()
-    ticks = getattr(ax, f"get_{axis_name}ticks")()
-    labels = _get_labels(ticks, time_fmt, dt_ns)
-    trimmed_labels = _strip_labels(labels)
-    getattr(ax, f"set_{axis_name}ticks")(ticks, trimmed_labels, rotation=-20)
-    # next add time label
-    _add_time_axis_label(ax, patch, dims_r, dt_ns)
-    # reset limits as these can get messed up when using custom labels.
-    if extents is not None:
-        ax.set_xlim(extents[0], extents[1])
-        ax.set_ylim(extents[2], extents[3])
-
-
-def _add_time_axis_label(ax, patch, dims_r, dt_ns):
-    """Add a time axis label to plot."""
-    # set time label with start/end time of trace
-    start, end = patch.attrs["time_min"], patch.attrs["time_max"]
-    if pd.isnull(start) or pd.isnull(end):
-        return  # nothing to do if no start/end times in attrs
-    # round start label to within 1 dt.
-    start_ns = start.astype(np.int64)
-    new_start_ns = np.round(start_ns / dt_ns).astype(np.int64) * dt_ns
-    ser = pd.Series(str(new_start_ns.astype("datetime64[ns]")))
-    new_start = _strip_labels(ser).iloc[0]
-    x_or_y = ["x", "y"][dims_r.index("time")]
-    time_label = f"Time\n (start: {new_start})"
-    getattr(ax, f"set_{x_or_y}label")(time_label)
+    # set date time formatting so MPL knows this axis is a date
+    getattr(ax, f"{axis_name}axis_date")()
+    # Set number of date ticks, even when zooming in
+    getattr(ax, f"{axis_name}axis").set_major_locator(plt.MaxNLocator(4))
+    # Set intelligent, zoom-in-able date formatter
+    locator = getattr(ax, f"{axis_name}axis").get_major_locator()
+    off_formats = ["", "%Y", "%Y-%m", "%Y-%m-%d", "%Y-%m-%d", "%Y-%m-%dT%H:%M"]
+    date_format = mdates.ConciseDateFormatter(locator, offset_formats=off_formats)
+    getattr(ax, f"{axis_name}axis").set_major_formatter(date_format)
+    # Set a custom function for when mouse hovers to display full precision
+    # see https://stackoverflow.com/a/32824933/3645626
+    format_name = f"format_{axis_name}data"
+    setattr(ax, format_name, lambda d: str(mdates.num2date(d)).split("+")[0][:-3])

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -39,12 +39,10 @@ def waterfall(
     patch: PatchType,
     ax: Optional[plt.Axes] = None,
     cmap="bwr",
-    timefmt=None,
     scale: Optional[Union[float, Sequence[float]]] = None,
     scale_type: Literal["relative", "absolute"] = "relative",
-    colorbar=True,
     show=False,
-) -> plt.Figure:
+) -> plt.Axes:
     """
     Parameters
     ----------
@@ -54,9 +52,6 @@ def waterfall(
         A matplotlib object, if None create one.
     cmap
         A matplotlib colormap string or instance.
-    timefmt
-        The format for the time axis (e.g., "%H:%M:%S"). If None,
-        try to automatically determine the most clear format.
     scale
         If not None, controls the saturation level of the colorbar.
         Values can either be a float, to set upper and lower limit to the same
@@ -68,8 +63,6 @@ def waterfall(
         are:
             relative - scale based on half the dynamic range in patch
             absolute - scale based on absolute values provided to `scale`
-    colorbar
-        If True, show the color bar.
     show
         If True, show the plot, else just return axis.
 
@@ -95,10 +88,9 @@ def waterfall(
     for dim, x in zip(dims_r, ["x", "y"]):
         getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
     if "time" in dims_r:
-        _format_time_axis(ax, patch, dims_r, timefmt, extents)
+        _format_time_axis(ax, dims_r)
     # add color bar
-    if colorbar:
-        ax.get_figure().colorbar(im)
+    ax.get_figure().colorbar(im)
     ax.invert_yaxis()  # invert y axis so origin is at top
     if show:
         plt.show()

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -92,7 +92,7 @@ def wiggle(
     for dim, x in zip(dims_r, ["x", "y"]):
         getattr(ax, f"set_{x}label")(str(dim).capitalize())
     if "time" in dims_r:
-        _format_time_axis(ax, patch, dims_r, timefmt)
+        _format_time_axis(ax, dims_r)
     ax.invert_yaxis()  # invert y axis so origin is at top
     if show:
         plt.show()

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -2,7 +2,6 @@
 Tests for waterfall plots.
 """
 import matplotlib.pyplot as plt
-import numpy as np
 import pytest
 
 import dascore as dc
@@ -63,10 +62,15 @@ class TestWaterfall:
     def test_time_axis_label_int_overflow(self, random_patch):
         """Make sure the time axis labels are correct (windows compatibility)"""
         ax = random_patch.viz.waterfall()
-        expected_starttime = random_patch.attrs["time_min"]
-        xtext = ax.xaxis.get_label_text()
+        name = ["y", "x"][random_patch.dims.index("time")]
         # Get the piece of the label corresponding to the starttime
-        # A little bit on the brittle side, but better than nothing
-        starttime = xtext.split()[-1][:-1]
-        starttime = np.datetime64(starttime)
-        assert abs(starttime - expected_starttime) < np.timedelta64(1, "ns")
+        # WE can just grab the offset text.
+        sub_ax = getattr(ax, f"{name}axis")
+        plt.tight_layout()  # need to call this to get offset to show up.
+        offset_str = sub_ax.get_major_formatter().get_offset()
+        min_time = random_patch.coords["time"].min()
+        assert str(min_time).startswith(offset_str)
+
+
+class TestTimeFormatting:
+    """Tests for formatting time axis."""


### PR DESCRIPTION
## Description

This PR fixes an issue where the time axis was not well labeled in the waterfall plots. The interactive mode was also not very useful as a float, rather than formatted time, was displayed when the cursor hovered over a point.

These changes use matplotlib's [ConciseDateFormatter ](https://matplotlib.org/stable/gallery/ticks/date_concise_formatter.html) to show a single offset time with concise tick labels. I also implemented a function to display standard datetime formatting with ms precision when the mouse is hovered over a point in interactive mode. 

Here is a simple example: 
![image](https://github.com/DASDAE/dascore/assets/11671536/b53be9a5-0f62-4dae-b338-c92f68800b05)


## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.

