### PR TITLE
add support for ProdML

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -1,6 +1,6 @@
 """Constants used throughout obsplus."""
 from pathlib import Path
-from typing import TypeVar, Union
+from typing import Optional, TypeVar, Union
 
 import numpy as np
 import pandas as pd
@@ -16,6 +16,7 @@ DATA_VERSION = "0.0.0"
 
 # Types dascore can convert into time representations
 timeable_types = Union[int, float, str, np.datetime64, pd.Timestamp]
+opt_timeable_types = Optional[timeable_types]
 
 # Number types
 numeric_types = Union[int, float]

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -59,14 +59,18 @@ class Patch:
         dims: Sequence[str] | None = None,
         attrs: Optional[Mapping] = None,
     ):
-        non_attrs = [x is None for x in [data, coords, dims]]
         if isinstance(data, (DataArray, self.__class__)):
             dar = data if isinstance(data, DataArray) else data._data_array
             self._data_array = dar
             return
-        elif any(non_attrs) and not all(non_attrs):
+        # Try to generate coords from ranges in attrs
+        if coords is None and attrs is not None:
+            coords = PatchAttrs(**dict(attrs)).coords_from_dims()
+        non_attrs = [x is None for x in [data, coords, dims]]
+        if any(non_attrs) and not all(non_attrs):
             msg = "data, coords, and dims must be defined to init Patch."
             raise ValueError(msg)
+
         mixer = _AttrsCoordsMixer(attrs, coords, dims)
         attrs, coords = mixer()
         # get xarray coords from custom coords object

--- a/dascore/core/schema.py
+++ b/dascore/core/schema.py
@@ -1,6 +1,6 @@
 """Pydantic schemas used by DASCore."""
 from pathlib import Path
-from typing import Literal, Sequence, Union
+from typing import Literal, Mapping, Sequence, Union
 
 import numpy as np
 from pydantic import BaseModel, Field
@@ -116,6 +116,21 @@ class PatchAttrs(BaseModel):
         """return a dict of default values"""
         new = cls()
         return new.dict()
+
+    def coords_from_dims(self) -> Mapping[str, np.ndarray]:
+        """Return coordinates from dimensions assuming evenly sampled."""
+        out = {}
+        for dim in self.dims:
+            # TODO replace this with simple coords
+            start, stop = self[f"{dim}_min"], self[f"{dim}_max"]
+            step = self[f"d_{dim}"]
+            ar = np.arange(start, stop + step, step)
+            # due to float imprecision the last value can be slightly larger
+            # than stop, just trim
+            if ar[-1] > stop:
+                ar = ar[:-1]
+            out[dim] = ar
+        return out
 
     class Config:
         """Configuration for Patch Summary"""

--- a/dascore/data_registry.txt
+++ b/dascore/data_registry.txt
@@ -8,3 +8,5 @@ iDAS005_tdms_example.626.tdms 0c31f75015bc671d958967c7fdf32e2e64fdb467f997d331ae
 sample_tdms_file_v4713.tdms 22a79c4c3166ce3cc8467265540cdb3ad2b54460209d39641c1e8f20e64eca65 https://github.com/dasdae/test_data/raw/master/das/sample_tdms_file_v4713.tdms
 example_dasdae_event_1.h5 854530af7ea10bab54dd0f6458c5d67d8b334ee6e4032b75702fa408352b5007 https://github.com/dasdae/test_data/raw/master/das/example_dasdae_event_1.h5
 opta_sense_quantx_v2.h5 fca8c8b19a9e253f9252c14de3f2a7778391a763f39142fffc63ab0cc3fa9cc7 https://github.com/dasdae/test_data/raw/master/das/opta_sense_quantx_v2.h5
+prodml_2.0.h5 8f8eded106acab0b4266c5c752cc702363cb09391f5fddf1534429e94e4e9ab2 https://github.com/dasdae/test_data/raw/master/das/prodml_2.0.h5
+prodml_2.1.h5 47875ae1fa17d99849cdb595e9fa6853d162605c1556be90225f37aaa123dded https://github.com/dasdae/test_data/raw/master/das/prodml_2.1.h5

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -27,7 +27,7 @@ from dascore.utils.docs import compose_docstring
 from dascore.utils.hdf5 import HDF5ExtError
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch import scan_patches
-from dascore.utils.pd import list_ser_to_str
+from dascore.utils.pd import _model_list_to_df
 
 
 class _FiberIOManager:
@@ -377,9 +377,7 @@ def scan_to_df(
         file_version=file_version,
         ignore=ignore,
     )
-    df = pd.DataFrame([dict(x) for x in info]).assign(
-        dims=lambda x: list_ser_to_str(x["dims"])
-    )
+    df = _model_list_to_df(info)
     return df[list(PatchFileSummary.get_index_columns())]
 
 

--- a/dascore/io/prodml/__init__.py
+++ b/dascore/io/prodml/__init__.py
@@ -1,0 +1,9 @@
+"""
+Support for prodML format.
+
+This is used by Silixa's iDAS as an HDF5 format and perhaps other interrogators.
+
+More info about ProdML can be found here:
+https://www.energistics.org/prodml-developers-users
+"""
+from .core import ProdMLV2_0, ProdMLV2_1

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -1,0 +1,80 @@
+"""
+IO module for reading prodML data.
+"""
+from pathlib import Path
+from typing import List, Optional, Union
+
+import dascore as dc
+from dascore.constants import opt_timeable_types
+from dascore.core.schema import PatchFileSummary
+from dascore.io.core import FiberIO
+from dascore.utils.hdf5 import HDF5ExtError, NoSuchNodeError, open_hdf5_file
+
+from .utils import _get_prodml_attrs, _get_prodml_version_str, _read_prodml
+
+
+class ProdMLV2_0(FiberIO):
+    """
+    Support for ProdML V 2.0.
+    """
+
+    name = "PRODML"
+    preferred_extensions = ("hdf5", "h5")
+    version = "2.0"
+
+    def get_format(self, path: Union[str, Path]) -> Union[tuple[str, str], bool]:
+        """
+        Return True if file contains terra15 version 2 data else False.
+
+        Parameters
+        ----------
+        path
+            A path to the file which may contain terra15 data.
+        """
+        try:
+            with open_hdf5_file(path, "r") as fi:
+                version_str = _get_prodml_version_str(fi)
+                if version_str:
+                    return (self.name, version_str)
+        except (HDF5ExtError, OSError, IndexError, KeyError, NoSuchNodeError):
+            return False
+
+    def scan(self, path: Union[str, Path]) -> List[PatchFileSummary]:
+        """
+        Scan a prodml file, return summary information about the file's contents.
+        """
+        with open_hdf5_file(path) as fi:
+            file_version = _get_prodml_version_str(fi)
+            extras = {
+                "path": path,
+                "file_format": self.name,
+                "file_version": str(file_version),
+            }
+            return _get_prodml_attrs(fi, extras=extras, cls=PatchFileSummary)
+
+    def read(
+        self,
+        path: Union[str, Path],
+        time: Optional[tuple[opt_timeable_types, opt_timeable_types]] = None,
+        distance: Optional[tuple[Optional[float], Optional[float]]] = None,
+        **kwargs
+    ) -> dc.BaseSpool:
+        """
+        Read a ProdML file.
+        """
+        kwargs = {}
+        if time is not None:
+            kwargs["time"] = time
+        if distance is not None:
+            kwargs["distance"] = distance
+        with open_hdf5_file(path) as fi:
+            patches = _read_prodml(fi, **kwargs)
+        return dc.spool(patches)
+
+
+class ProdMLV2_1(ProdMLV2_0):
+    """
+    Support for ProdML V 2.1.
+    """
+
+    version = "2.1"

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -1,0 +1,126 @@
+"""Utilities for terra15."""
+
+import numpy as np
+
+import dascore as dc
+from dascore.core.schema import PatchAttrs
+from dascore.utils.misc import trim_attrs_get_inds
+
+# --- Getting format/version
+
+
+def _get_prodml_version_str(hdf_fi) -> str:
+    """
+    Return the version string for prodml file.
+    """
+
+    # define a few root attrs that act as a "fingerprint" for terra15 files
+
+    acquisition = getattr(hdf_fi.root, "Acquisition", None)
+    if acquisition is None:
+        return ""
+    acq_attrs = acquisition._v_attrs
+    expected_attrs = (
+        "AcquisitionDescription",
+        "GaugeLength",
+        "PulseRate",
+        "PulseWidth",
+        "NumberOfLoci",
+        "schemaVersion",
+        "uuid",
+    )
+    is_prodml = all([hasattr(acq_attrs, x) for x in expected_attrs])
+    return str(acq_attrs.schemaVersion.decode()) if is_prodml else ""
+
+
+def _get_raw_node_dict(acquisition_node):
+    """Get a dict of {Raw[x]: node}"""
+    out = {
+        x._v_name: x
+        for x in acquisition_node._f_iter_nodes()
+        if x._v_name.startswith("Raw")
+    }
+    return dict(sorted(out.items()))
+
+
+def _get_distances(acq):
+    """Get the distance ranges and spacing."""
+    user_settings = acq.Custom.UserSettings._v_attrs
+    start = user_settings.StartDistance
+    # Note: subtracting StopDistance from StartDistance doesn't equal the
+    # length specified in MeasuredLength. If MeasuredLength is multiplied
+    # by Custom/SystemSettings.FiberLengthMultiplier, however, it does. So,
+    # to be consistent with the TDMS reader, we assume this is correct, which
+    # means the SpatialResolution is multiplied by the modifier.
+    stop = user_settings.StopDistance
+    multiplier = acq.Custom.SystemSettings._v_attrs.FibreLengthMultiplier
+    step = user_settings.SpatialResolution * multiplier
+    out = dict(distance_min=start, distance_max=stop, d_distance=step)
+    return out
+
+
+def _get_time_info(node):
+    """Get the time information from a Raw node."""
+    time_attrs = node.RawDataTime._v_attrs
+    start = np.datetime64(time_attrs.PartStartTime.decode().split("+")[0])
+    end = np.datetime64(time_attrs.PartEndTime.decode().split("+")[0])
+    step = (end - start) / (len(node.RawDataTime) - 1)
+    out = dict(time_min=start, time_max=end, d_time=step)
+    return out
+
+
+def _get_data_unit_and_type(node):
+    """Get the data type and units."""
+    attrs = node._v_attrs
+    out = dict(
+        data_type=attrs.RawDescription.decode().lower().replace(" ", "_"),
+        data_units=attrs.RawDataUnit.decode(),
+    )
+    return out
+
+
+def _get_prodml_attrs(fi, extras=None, cls=PatchAttrs):
+    """Scan a prodML file, return metadata."""
+    base_info = dict(
+        gauge_length=fi.root.Acquisition._v_attrs.GaugeLength,
+    )
+    acq = fi.root.Acquisition
+    base_info.update(_get_distances(acq))
+    raw_nodes = _get_raw_node_dict(acq)
+    # Iterate each raw data node. I have only ever seen 1 in a file but since
+    # it is indexed like Raw[0] there might be more.
+    out = []
+    for node in raw_nodes.values():
+        info = dict(base_info)
+        info.update(_get_data_unit_and_type(node))
+        info.update(_get_time_info(node))
+        info["dims"] = ["time", "distance"]
+        if extras is not None:
+            info.update(extras)
+        out.append(cls(**info))
+    return out
+
+
+def _get_data_attr(attrs, node, time, distance):
+    """Get a new attributes with adjusted time/distance and data array."""
+    shape = node.RawData.shape
+    time_inds, distance_inds = slice(None), slice(None)
+    if time is not None:
+        time_inds, attrs = trim_attrs_get_inds(attrs, shape[0], time=time)
+    if distance is not None:
+        distance_inds, attrs = trim_attrs_get_inds(attrs, shape[1], distance=distance)
+    data = node.RawData[time_inds, distance_inds]
+    return data, attrs
+
+
+def _read_prodml(fi, distance=None, time=None):
+    """Read the prodml values into a patch."""
+    attr_list = _get_prodml_attrs(fi)
+    nodes = list(_get_raw_node_dict(fi.root.Acquisition).values())
+    out = []
+    for attrs, node in zip(attr_list, nodes):
+        data, new_attrs = _get_data_attr(attrs, node, time, distance)
+        dims = ("time", "distance")  # dims are fixed for this file format
+        if data.size:
+            out.append(dc.Patch(data=data, attrs=new_attrs, dims=dims))
+    return out

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -371,3 +371,11 @@ def list_ser_to_str(ser: pd.Series) -> pd.Series:
     """
     values = [",".join(x) if not isinstance(x, str) else x for x in ser.values]
     return pd.Series(values, index=ser.index, dtype=object)
+
+
+def _model_list_to_df(mod_list: Sequence[BaseModel]) -> pd.DataFrame:
+    """Get a dataframe from a sequence of pydantic models."""
+    df = pd.DataFrame([dict(x) for x in mod_list])
+    if "dims" in df.columns:
+        df["dims"] = list_ser_to_str(df["dims"])
+    return df

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,30 @@ def terra15_v6_path():
     return fetch("terra15_v6_test_file.hdf5")
 
 
+@pytest.fixture(scope="session")
+def prodml_v2_0_example_path():
+    """Return the path to the prodml v2.0 file."""
+    out = fetch("prodml_2.0.h5")
+    assert out.exists()
+    return out
+
+
+@pytest.fixture(scope="session")
+def prodml_v2_1_example_path():
+    """Return the path to the prodml v2.1 file."""
+    out = fetch("prodml_2.1.h5")
+    assert out.exists()
+    return out
+
+
+@pytest.fixture(scope="session")
+def idas_h5_example_path():
+    """Return the path to the example terra15 file."""
+    out = fetch("iDAS005_hdf5_example.626.h5")
+    assert out.exists()
+    return out
+
+
 @pytest.fixture()
 @register_func(SPOOL_FIXTURES)
 def terra15_das_spool(terra15_das_example_path) -> SpoolType:
@@ -127,6 +151,22 @@ def terra15_das_patch(terra15_das_example_path) -> Patch:
     attr_time = out.attrs["time_max"]
     coord_time = out.coords["time"].max()
     assert attr_time == coord_time
+    return out
+
+
+@pytest.fixture(scope="session")
+@register_func(PATCH_FIXTURES)
+def prodml_v2_0_patch(prodml_v2_0_example_path) -> Patch:
+    """Read the prodML v2.0 patch"""
+    out = read(prodml_v2_0_example_path, "prodml")[0]
+    return out
+
+
+@pytest.fixture(scope="session")
+@register_func(PATCH_FIXTURES)
+def prodml_v2_1_patch(prodml_v2_1_example_path) -> Patch:
+    """Read the prodML v2.1 patch"""
+    out = read(prodml_v2_1_example_path, "prodml")[0]
     return out
 
 

--- a/tests/test_io/test_prodml/test_prod_ml.py
+++ b/tests/test_io/test_prodml/test_prod_ml.py
@@ -1,0 +1,25 @@
+"""
+Generic tests for prodml support.
+"""
+import pytest
+
+import dascore as dc
+
+
+class TestSilixaFile:
+    """
+    Ensure we can read the file provided by Silixa.
+
+    We do this since the other tests read the prodML files, even though
+    the Silixa file is technical just ProdML v2.1.
+    """
+
+    @pytest.fixture(scope="class")
+    def silixa_h5_patch(self, idas_h5_example_path):
+        """Get the silixa file, return Patch."""
+        return dc.spool(idas_h5_example_path)[0]
+
+    def test_read_silixa(self, silixa_h5_patch):
+        """Ensure we can read  Silixa file."""
+        assert isinstance(silixa_h5_patch, dc.Patch)
+        assert silixa_h5_patch.shape

--- a/tests/test_io/test_prodml/test_prodml_v2_0.py
+++ b/tests/test_io/test_prodml/test_prodml_v2_0.py
@@ -1,0 +1,123 @@
+"""
+Tests for ProdML Version 2.0
+"""
+
+import numpy as np
+
+import dascore as dc
+from dascore.constants import REQUIRED_DAS_ATTRS
+from dascore.core.schema import PatchFileSummary
+from dascore.io.prodml import ProdMLV2_0
+
+
+class TestReadProdML2_0Patch:
+    """Tests for reading the prodML format."""
+
+    def test_type(self, prodml_v2_0_patch):
+        """Ensure the expected type is returned."""
+        assert isinstance(prodml_v2_0_patch, dc.Patch)
+
+    def test_attributes(self, prodml_v2_0_patch):
+        """Ensure a few of the expected attrs exist in array."""
+        attrs = dict(prodml_v2_0_patch.attrs)
+        expected_attrs = {"time_min", "time_max", "distance_min", "data_units"}
+        assert set(expected_attrs).issubset(set(attrs))
+
+    def test_has_required_attrs(self, prodml_v2_0_patch):
+        """ "Ensure the required das attrs are found"""
+        assert set(REQUIRED_DAS_ATTRS).issubset(set(dict(prodml_v2_0_patch.attrs)))
+
+    def test_coord_attr_time_equal(self, prodml_v2_0_patch):
+        """The time reported in the attrs and coords should match"""
+        attr_time = prodml_v2_0_patch.attrs["time_max"]
+        coord_time = prodml_v2_0_patch.coords["time"].max()
+        assert attr_time == coord_time
+
+    def test_read_with_limits(self, prodml_v2_0_patch, prodml_v2_0_example_path):
+        """If start/end time sare select the same patch ought to be returned."""
+        attrs = prodml_v2_0_patch.attrs
+        time = (attrs["time_min"], attrs["time_max"])
+        dist = (attrs["distance_min"], attrs["distance_max"])
+        patch = ProdMLV2_0().read(
+            prodml_v2_0_example_path,
+            time=time,
+            distance=dist,
+        )[0]
+        assert attrs["time_max"] == patch.attrs["time_max"]
+
+    def test_time_dist_slice(self, prodml_v2_0_patch, prodml_v2_0_example_path):
+        """Ensure slicing distance and time works from read func."""
+        time_array = prodml_v2_0_patch.coords["time"]
+        dist_array = prodml_v2_0_patch.coords["distance"]
+        t1, t2 = time_array[10], time_array[40]
+        d1, d2 = dist_array[10], dist_array[40]
+        patch = ProdMLV2_0().read(
+            prodml_v2_0_example_path, time=(t1, t2), distance=(d1, d2)
+        )[0]
+        attrs, coords = patch.attrs, patch.coords
+        assert attrs["time_min"] == coords["time"].min() == t1
+        assert attrs["time_max"] == coords["time"].max()
+        # since we use floats sometimes this are a little off.
+        assert (attrs["time_max"] - t2) < (attrs["d_time"] / 4)
+        assert attrs["distance_min"] == coords["distance"].min() == d1
+        assert attrs["distance_max"] == coords["distance"].max() == d2
+
+    def test_one_sided_slice(self, prodml_v2_0_patch, prodml_v2_0_example_path):
+        """Ensure slice can specify only one side."""
+        time_array = prodml_v2_0_patch.coords["time"]
+        dist_array = prodml_v2_0_patch.coords["distance"]
+        t1 = time_array[10]
+        d2 = dist_array[40]
+        patch = ProdMLV2_0().read(
+            prodml_v2_0_example_path, time=(t1, None), distance=(None, d2)
+        )[0]
+        attrs, coords = patch.attrs, patch.coords
+        assert attrs["time_min"] == coords["time"].min() == t1
+        assert attrs["time_max"] == coords["time"].max()
+        assert attrs["time_min"] >= t1
+        assert attrs["distance_max"] <= d2
+        assert attrs["distance_max"] == coords["distance"].max() == d2
+
+    def test_no_arrays_in_attrs(self, prodml_v2_0_patch):
+        """
+        Ensure that the attributes are not arrays.
+        Originally, attrs like time_min can be arrays with empty shapes.
+        """
+        for key, val in prodml_v2_0_patch.attrs.items():
+            assert not isinstance(val, np.ndarray)
+
+
+class TestIsProdMLv2_0:
+    """Tests for function to determine if a file is a ProdML v2.0 file."""
+
+    def test_format_and_version(self, prodml_v2_0_example_path):
+        """Ensure version returns correct information."""
+        name, version = ProdMLV2_0().get_format(prodml_v2_0_example_path)
+        assert (name, version) == (ProdMLV2_0.name, ProdMLV2_0.version)
+
+    def test_not_prodML_not_h5(self, dummy_text_file):
+        """Test for not even a hdf5 file."""
+        parser = ProdMLV2_0()
+        assert not parser.get_format(dummy_text_file)
+        assert not parser.get_format(dummy_text_file.parent)
+
+    def test_hdf5file_not_prodml(self, terra15_v5_path):
+        """Assert that the terra15 hdf5 file is not a prodml."""
+        parser = ProdMLV2_0()
+        assert not parser.get_format(terra15_v5_path)
+
+
+class TestScanProdMLV2_0:
+    """Tests for scanning prodML file."""
+
+    def test_basic_scan(self, prodml_v2_0_example_path):
+        """Tests for getting summary info from ProdML data."""
+        parser = ProdMLV2_0()
+        out = parser.scan(prodml_v2_0_example_path)
+        assert isinstance(out, list)
+        assert len(out) == 1
+        assert isinstance(out[0], PatchFileSummary)
+
+        data = out[0]
+        assert data.file_format == parser.name
+        assert data.file_version == parser.version

--- a/tests/test_io/test_prodml/test_prodml_v2_1.py
+++ b/tests/test_io/test_prodml/test_prodml_v2_1.py
@@ -1,0 +1,123 @@
+"""
+Tests for ProdML Version 2.0
+"""
+
+import numpy as np
+
+import dascore as dc
+from dascore.constants import REQUIRED_DAS_ATTRS
+from dascore.core.schema import PatchFileSummary
+from dascore.io.prodml import ProdMLV2_1
+
+
+class TestReadProdML2_0Patch:
+    """Tests for reading the prodML format."""
+
+    def test_type(self, prodml_v2_1_patch):
+        """Ensure the expected type is returned."""
+        assert isinstance(prodml_v2_1_patch, dc.Patch)
+
+    def test_attributes(self, prodml_v2_1_patch):
+        """Ensure a few of the expected attrs exist in array."""
+        attrs = dict(prodml_v2_1_patch.attrs)
+        expected_attrs = {"time_min", "time_max", "distance_min", "data_units"}
+        assert set(expected_attrs).issubset(set(attrs))
+
+    def test_has_required_attrs(self, prodml_v2_1_patch):
+        """ "Ensure the required das attrs are found"""
+        assert set(REQUIRED_DAS_ATTRS).issubset(set(dict(prodml_v2_1_patch.attrs)))
+
+    def test_coord_attr_time_equal(self, prodml_v2_1_patch):
+        """The time reported in the attrs and coords should match"""
+        attr_time = prodml_v2_1_patch.attrs["time_max"]
+        coord_time = prodml_v2_1_patch.coords["time"].max()
+        assert attr_time == coord_time
+
+    def test_read_with_limits(self, prodml_v2_1_patch, prodml_v2_1_example_path):
+        """If start/end time sare select the same patch ought to be returned."""
+        attrs = prodml_v2_1_patch.attrs
+        time = (attrs["time_min"], attrs["time_max"])
+        dist = (attrs["distance_min"], attrs["distance_max"])
+        patch = ProdMLV2_1().read(
+            prodml_v2_1_example_path,
+            time=time,
+            distance=dist,
+        )[0]
+        assert attrs["time_max"] == patch.attrs["time_max"]
+
+    def test_time_dist_slice(self, prodml_v2_1_patch, prodml_v2_1_example_path):
+        """Ensure slicing distance and time works from read func."""
+        time_array = prodml_v2_1_patch.coords["time"]
+        dist_array = prodml_v2_1_patch.coords["distance"]
+        t1, t2 = time_array[10], time_array[40]
+        d1, d2 = dist_array[10], dist_array[40]
+        patch = ProdMLV2_1().read(
+            prodml_v2_1_example_path, time=(t1, t2), distance=(d1, d2)
+        )[0]
+        attrs, coords = patch.attrs, patch.coords
+        assert attrs["time_min"] == coords["time"].min() == t1
+        assert attrs["time_max"] == coords["time"].max()
+        # since we use floats sometimes this are a little off.
+        assert (attrs["time_max"] - t2) < (attrs["d_time"] / 4)
+        assert attrs["distance_min"] == coords["distance"].min() == d1
+        assert attrs["distance_max"] == coords["distance"].max() == d2
+
+    def test_one_sided_slice(self, prodml_v2_1_patch, prodml_v2_1_example_path):
+        """Ensure slice can specify only one side."""
+        time_array = prodml_v2_1_patch.coords["time"]
+        dist_array = prodml_v2_1_patch.coords["distance"]
+        t1 = time_array[10]
+        d2 = dist_array[40]
+        patch = ProdMLV2_1().read(
+            prodml_v2_1_example_path, time=(t1, None), distance=(None, d2)
+        )[0]
+        attrs, coords = patch.attrs, patch.coords
+        assert attrs["time_min"] == coords["time"].min() == t1
+        assert attrs["time_max"] == coords["time"].max()
+        assert attrs["time_min"] >= t1
+        assert attrs["distance_max"] <= d2
+        assert attrs["distance_max"] == coords["distance"].max() == d2
+
+    def test_no_arrays_in_attrs(self, prodml_v2_1_patch):
+        """
+        Ensure that the attributes are not arrays.
+        Originally, attrs like time_min can be arrays with empty shapes.
+        """
+        for key, val in prodml_v2_1_patch.attrs.items():
+            assert not isinstance(val, np.ndarray)
+
+
+class TestIsProdMLV2_1:
+    """Tests for function to determine if a file is a ProdML v2.0 file."""
+
+    def test_format_and_version(self, prodml_v2_1_example_path):
+        """Ensure version returns correct information."""
+        name, version = ProdMLV2_1().get_format(prodml_v2_1_example_path)
+        assert (name, version) == (ProdMLV2_1.name, ProdMLV2_1.version)
+
+    def test_not_prodML_not_h5(self, dummy_text_file):
+        """Test for not even a hdf5 file."""
+        parser = ProdMLV2_1()
+        assert not parser.get_format(dummy_text_file)
+        assert not parser.get_format(dummy_text_file.parent)
+
+    def test_hdf5file_not_prodml(self, terra15_v5_path):
+        """Assert that the terra15 hdf5 file is not a prodml."""
+        parser = ProdMLV2_1()
+        assert not parser.get_format(terra15_v5_path)
+
+
+class TestScanProdMLV2_1:
+    """Tests for scanning prodML file."""
+
+    def test_basic_scan(self, prodml_v2_1_example_path):
+        """Tests for getting summary info from ProdML data."""
+        parser = ProdMLV2_1()
+        out = parser.scan(prodml_v2_1_example_path)
+        assert isinstance(out, list)
+        assert len(out) == 1
+        assert isinstance(out[0], PatchFileSummary)
+
+        data = out[0]
+        assert data.file_format == parser.name
+        assert data.file_version == parser.version

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -239,6 +239,12 @@ class TestIterFiles:
         has_hidden_by_parent = ["hidden_by_parent" in x for x in out2]
         assert sum(has_hidden_by_parent) == 1
 
+    def test_pass_file(self, dummy_text_file):
+        """Just pass a single file and ensure it gets returned."""
+        out = list(iter_files(dummy_text_file))
+        assert len(out) == 1
+        assert out[0] == dummy_text_file
+
 
 class TestIterate:
     """Test case for iterate."""


### PR DESCRIPTION
## Description

This adds read support for ProdML (version 2.0 and 2.1), the file format used by Silixa's iDAS series and probably others. More info about the format can be found [here](https://www.energistics.org/prodml-developers-users).

@ahmadtourei - Could you please test this branch on your Silixa data to see what issues you run into? I imagine there are some edge cases I haven't account for yet.

@rwporritt - It would be great if you could also test this branch on some of your datasets.

Related issues: #121, #152 

Side note: of all the HDF5 formats we currently support, this one would probably be easiest to implement write support, but that will have to be a different PR.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
