### PR TITLE
config stable and dev docs

### DIFF
--- a/.github/workflows/build_deploy_master_docs.yaml
+++ b/.github/workflows/build_deploy_master_docs.yaml
@@ -1,5 +1,7 @@
-# Create documentation and deploy
-name: BuildDeployDocs
+# This action renders and publishes the development docs whenever
+# new commits are added to the master bracnh.
+
+name: BuildDeployDevDocs
 
 on:
   # Runs on pushes targeting the default branch
@@ -61,16 +63,10 @@ jobs:
         shell: bash -l {0}
         run: |
           python scripts/build_api_docs.py
-          quarto render docs
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+      - name: Render and Publish
+        uses: quarto-dev/quarto-actions/publish@v2
         with:
-          path: 'docs/_site'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+          target: quarto-pub
+          path: docs
+          QUARTO_PUB_AUTH_TOKEN: ${{ secrets.QUARTO_PUB_AUTH_TOKEN }}

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -1,0 +1,76 @@
+# Create documentation for stable (latest version) and deploy
+name: BuildDeployStableDocs
+
+on:
+  # Runs when creating a new release
+  release:
+    types: [created]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  deployments: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: 'latest'
+          python-version: "3.10"
+          activate-environment: dascore
+          environment-file: environment.yml
+          condarc-file: .github/test_condarc.yml
+
+      - name: install dascore with docbuild reqs
+        shell: bash -l {0}
+        run: |
+          conda install -c conda-forge pandoc
+          python -m pip install -e .[docs]
+
+      - name: Install quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: 1.2.335
+          tinytex: true
+
+      - name: print quarto version
+        run: |
+          quarto --version
+
+      - name: Render Quarto Project
+        shell: bash -l {0}
+        run: |
+          python scripts/build_api_docs.py
+          quarto render docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'docs/_site'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/_publish.yml
+++ b/docs/_publish.yml
@@ -1,0 +1,4 @@
+- source: project
+  quarto-pub:
+    - id: 8eac2ae5-137b-4292-8938-d747e3babd25
+      url: 'https://quartopub.com/sites/dascore/dascore'

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -14,9 +14,12 @@ A python library for distributed fiber optic sensing.
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dascore.svg?label=conda)](https://github.com/conda-forge/dascore-feedstock)
 [![Licence](https://www.gnu.org/graphics/lgplv3-88x31.png)](https://www.gnu.org/licenses/lgpl.html)
 
+[Code](https://github.com/DASDAE/dascore)
+
 [Documentation](https://dascore.org)
 
-[Code](https://github.com/DASDAE/dascore)
+[Documentation (Dev version)](https://dascore.quarto.pub/dascore/)
+
 
 # Highlights
 

--- a/readme.md
+++ b/readme.md
@@ -9,8 +9,10 @@ A python library for distributed fiber optic sensing.
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7373559.svg)](https://doi.org/10.5281/zenodo.7373559)
 [![Licence](https://www.gnu.org/graphics/lgplv3-88x31.png)](https://www.gnu.org/licenses/lgpl.html)
 
+[Code](https://github.com/DASDAE/dascore)
+
 [Documentation](https://dascore.org)
 
-[Code](https://github.com/DASDAE/dascore)
+[Documentation (Dev version)](https://dascore.quarto.pub/dascore/)
 
 **WARNING**: dascore is still very new. There will be bugs and API changes.


### PR DESCRIPTION
## Description

This PR implements two documentation build/deployments and updates the corresponding links in the readme and top page of the docs. 

The two builds are: 

stable: deployed at dascore.org  and built whenever a new release is made from github (which triggers PyPI/conda releases). 

development: deployed at dascore.quarto.pub/dascore and built whenever commits are merged into master.

The problem this solves:

New users install dascore with pip/conda. Then they look at dascore.org, but the code there might not work since currently it is for the master branch (which might be quite different from the previous release). Essentially,  this PR should make for a better (less confusing) onboarding experience for new users while still giving us a chance to see up-to-date development (from master branch) docs.

The hosting site for the development docs is (quarto-pub)[https://quartopub.com/], a free site for hosting quarto projects up to 100mb. Dascore's docs are currently ~40mb. 

closes #160

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
