### PR TITLE
Allow spool negative indexing

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -152,6 +152,8 @@ class DataFrameSpool(BaseSpool):
         if isinstance(df_ind, slice):  # handle slicing
             df1 = instruction.loc[instruction["current_index"].values[df_ind]]
         else:  # Filter instruction df to only include current index.
+            # handle negative index.
+            df_ind = df_ind if df_ind >= 0 else len(self._df) + df_ind
             df1 = instruction[instruction["current_index"] == df_ind]
         if df1.empty:
             msg = f"index of [{df_ind}] is out of bounds for spool."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,8 +201,7 @@ def multi_dim_coords_patch(random_patch):
 @register_func(PATCH_FIXTURES)
 def event_patch_1():
     """Fetch event patch 1."""
-    path = fetch("example_dasdae_event_1.h5")
-    return dc.spool(path)[0]
+    return dc.get_example_patch("example_event_1")
 
 
 @pytest.fixture(scope="class", params=PATCH_FIXTURES)
@@ -322,6 +321,23 @@ def basic_file_spool(two_patch_directory):
 def terra15_file_spool(terra15_v5_path):
     """A file spool for terra15."""
     return dc.spool(terra15_v5_path)
+
+
+@pytest.fixture(scope="class")
+@register_func(SPOOL_FIXTURES)
+def memory_spool_dim_1_patches():
+    """
+    Memory spool with patches that have length 1 in one dimension.
+    Related to #171.
+    """
+    spool = dc.get_example_spool(
+        "random_das",
+        d_time=0.999767552,
+        shape=(100, 1),
+        length=10,
+        starttime="2023-06-13T15:38:00.49953408",
+    )
+    return spool
 
 
 @pytest.fixture(scope="class", params=SPOOL_FIXTURES)


### PR DESCRIPTION
## Description

This PR allows negative indexing on spools. It also adds tests for slicing with negative indexing, and some tests related to #171 which failed to reproduce the reported bug but which are, nevertheless, probably useful to include in the test suite.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
