### PR TITLE
update waterfall plot

### DIFF
--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -61,8 +61,6 @@ def _format_time_axis(ax, dims_r):
     axis_name = "x" if dims_r[0] == "time" else "y"
     # set date time formatting so MPL knows this axis is a date
     getattr(ax, f"{axis_name}axis_date")()
-    # Set number of date ticks, even when zooming in
-    getattr(ax, f"{axis_name}axis").set_major_locator(plt.MaxNLocator(4))
     # Set intelligent, zoom-in-able date formatter
     locator = getattr(ax, f"{axis_name}axis").get_major_locator()
     off_formats = ["", "%Y", "%Y-%m", "%Y-%m-%d", "%Y-%m-%d", "%Y-%m-%dT%H:%M"]

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -44,6 +44,8 @@ def waterfall(
     show=False,
 ) -> plt.Axes:
     """
+    Create a waterfall plot of the Patch data.
+
     Parameters
     ----------
     patch
@@ -51,7 +53,8 @@ def waterfall(
     ax
         A matplotlib object, if None create one.
     cmap
-        A matplotlib colormap string or instance.
+        A matplotlib colormap string or instance. Set to None to not plot the
+        colorbar.
     scale
         If not None, controls the saturation level of the colorbar.
         Values can either be a float, to set upper and lower limit to the same
@@ -90,7 +93,8 @@ def waterfall(
     if "time" in dims_r:
         _format_time_axis(ax, dims_r)
     # add color bar
-    ax.get_figure().colorbar(im)
+    if cmap is not None:
+        ax.get_figure().colorbar(im)
     ax.invert_yaxis()  # invert y axis so origin is at top
     if show:
         plt.show()

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -71,6 +71,8 @@ class TestWaterfall:
         min_time = random_patch.coords["time"].min()
         assert str(min_time).startswith(offset_str)
 
-
-class TestTimeFormatting:
-    """Tests for formatting time axis."""
+    def test_no_colorbar(self, random_patch):
+        """Ensure the colorbar can be disabled."""
+        ax = random_patch.viz.waterfall(cmap=None)
+        # ensure no colorbar was created.
+        assert ax.images[-1].colorbar is None


### PR DESCRIPTION

## Description

This PR address #174. Also fixes the first line in the `waterfall` method docstring, and removes the line forcing exactly 4 ticks in the time axis. I verified that zooming in still dynamically re-configures the ticks, but allowing matplotlib to decide the number has yielded slightly better results in my experience.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
