### PR TITLE
pin pydantic < 2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - pytest
-  - pydantic>1.9.0
+  - pydantic>1.9.0,<2.0.0
   - pip
   - pandas
   - pooch>=1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
      "packaging",
      "pandas",
      "pooch>=1.2",
-     "pydantic>=1.9.0",
+     "pydantic>=1.9.0,<2.0.0",
      "rich",
      "scipy>=1.10.0",
      "tables",


### PR DESCRIPTION

## Description
Pydantic V2 was released yesterday. It has several breaking changes (which break DASCore) so I am pinning the requirement to less than 2 until we update DASCore's pydantic models.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
