### PR TITLE
adjust step requirements for merging

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -818,8 +818,8 @@ def _get_coord_dim_map(coords, dims, attrs=None):
         # pull out any relevant info from attrs.
         maybe_attrs = attrs or {}
         units = maybe_attrs.get(f"{name}_units", None)
-        d_time = maybe_attrs.get(f"d_{name}", None)
-        coord_out = get_coord(values=coord[1], units=units, step=d_time)
+        step = maybe_attrs.get(f"d_{name}", None)
+        coord_out = get_coord(values=coord[1], units=units, step=step)
         assert coord_out.shape == np.shape(coord[1])
         return coord_out, dim_names
 

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -18,7 +18,7 @@ from dascore.constants import PatchType, dascore_styles
 from dascore.exceptions import CoordError, ParameterError
 from dascore.units import Quantity, Unit, get_conversion_factor, get_factor_and_unit
 from dascore.utils.display import get_nice_text
-from dascore.utils.misc import all_diffs_close_enough, get_middle_value, iterate
+from dascore.utils.misc import all_diffs_close_enough, iterate
 from dascore.utils.models import ArrayLike, DascoreBaseModel, DTypeLike, UnitQuantity
 from dascore.utils.time import is_datetime64, is_timedelta64
 
@@ -900,14 +900,16 @@ def get_coord(
         is_monotonic = np.all(view1 > view2) or np.all(view2 > view1)
         # the array cannot be evenly sampled if it isn't monotonic
         if is_monotonic:
-            unique_diff = np.unique(view2 - view1)
+            diffs = view2 - view1
+            unique_diff = np.unique(diffs)
             # here we are dealing with a length 0 or 1 array.
-            if not len(unique_diff):
+            if len(view2) < 2:
                 return None, None, None, False
             if len(unique_diff) == 1 or all_diffs_close_enough(unique_diff):
                 _min = data[0]
                 _max = data[-1]
-                _step = get_middle_value(unique_diff)
+                # this is a poor man's median that preserves dtype
+                _step = np.sort(diffs)[len(diffs) // 2]
                 return _min, _max + _step, _step, is_monotonic
         return None, None, None, is_monotonic
 

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -108,9 +108,6 @@ def interpolate(
     This function just uses scipy's interp1d function under the hood.
     See scipy.interpolate.interp1d for information.
 
-    Be aware than non-evenly sampled extrapolation values may make it
-    so some patch processing methods no longer work.
-
     See also [snap](`dascore.core.Patch.snap`).
 
     Examples

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -327,7 +327,9 @@ def all_diffs_close_enough(diffs):
     if is_td or is_dt:
         diffs = diffs.astype(np.int64).astype(np.float64)
     med = np.median(diffs)
-    return np.allclose(diffs, med)
+    # Note: The rtol parameter here is a bit arbitrary; it was set
+    # based on experience but there is probably a better way to do this.
+    return np.allclose(diffs, med, rtol=0.001)
 
 
 def unbyte(byte_or_str: Union[bytes, str]) -> str:

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -428,7 +428,8 @@ def _force_patch_merge(patch_dict_list):
     attrs = [x.attrs for x in patches]
     new_data = np.concatenate(datas, axis=axis)
     new_coord = _get_new_coord(df, merge_dim, coords)
-    new_attrs = merge_models(attrs, merge_dim)
+    coord = new_coord.coord_map[merge_dim] if merge_dim in dims else None
+    new_attrs = merge_models(attrs, merge_dim, coord=coord)
     patch = dc.Patch(data=new_data, coords=new_coord, attrs=new_attrs, dims=dims)
     new_dict = {"patch": patch}
     return [new_dict]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,21 +21,17 @@ extend_ignore =
     D414
     W605
     BLK100
+    C901
 ; exclude certain files
 exclude =
     .git
     __pycache__
     docs
-    old/*
     build
     dist
-    wip
     __init__.py
     .eggs
-    .tox
-    wip/*
     docs/*
-    versioneer.py
 
 docstring-convention = numpy
 

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -20,7 +20,7 @@ class TestInterpolate:
         new_coord = np.arange(start, stop, new_sampling)
         out = random_patch.interpolate(distance=new_coord)
         assert out.data.shape[axis] == len(new_coord)
-        assert np.all(out.coords["distance"] == new_coord)
+        assert np.allclose(out.coords["distance"], new_coord)
 
     def test_interp_down_sample_distance(self, random_patch):
         """Ensure interp can be used to downsample data."""
@@ -30,7 +30,7 @@ class TestInterpolate:
         new_coord = np.arange(start, stop, new_sampling)
         out = random_patch.interpolate(distance=new_coord)
         assert out.data.shape[axis] == len(new_coord)
-        assert np.all(out.coords["distance"] == new_coord)
+        assert np.allclose(out.coords["distance"], new_coord)
 
     def test_uneven_sampling_rates(self, random_patch):
         """Uneven sampling should now work fine."""
@@ -107,7 +107,7 @@ class TestDecimate:
         dt = dc.to_timedelta64(0.001)
         t1 = dc.to_datetime64("2020-01-01")
         coords = {
-            "distance": [1, 2],
+            "distance": np.array([1, 2]),
             "time": np.arange(0, ar.shape[0]) * dt + t1,
         }
         dims = ("time", "distance")
@@ -218,7 +218,8 @@ class TestResample:
         """Tests resampling to odd time interval."""
         dt = np.timedelta64(1234567, "ns")
         out = random_patch.resample(time=dt)
-        assert out.attrs["d_time"] == dt
+        new_dt = out.attrs["d_time"]
+        assert np.isclose(float(new_dt), float(dt))
         assert out.attrs
 
     def test_huge_resample(self, random_patch):


### PR DESCRIPTION

## Description

This PR adjusts the coordinate step requirements for merging. I found a real dataset where the d_time values were slightly outside of the acceptable range, so I changed the is_close check to pass if d_time values are within .1% of the median d_time value.

There were also a few other (minor) fixes that were needed after the change (see file diff tab).

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
