### PR TITLE
Patch operators

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -655,6 +655,12 @@ class CoordManager(DascoreBaseModel):
 
     @property
     @cache
+    def coord_shapes(self) -> Dict[str, Tuple[int, ...]]:
+        """Get a dict of {coord_name: shape}"""
+        return {i: v.shape for i, v in self.coord_map.items()}
+
+    @property
+    @cache
     def dim_to_coord_map(self) -> FrozenDict[str, Tuple[str, ...]]:
         """Get a dimension to coordinate map."""
         out = defaultdict(list)

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -509,6 +509,10 @@ class CoordManager(DascoreBaseModel):
         for name, coord in self.coord_map.items():
             start, stop = attrs.get(f"{name}_min"), attrs.get(f"{name}_max")
             step = attrs.get(f"d_{name}")
+            # update units, use type so None can be set.
+            if (data_units := attrs.get(f"{name}_units", type)) is not type:
+                coord = coord.convert_units(data_units)
+                out[name] = coord
             # quick path for not updating.
             all_none = all([x is None for x in (start, stop, step)])
             limits_equal = coord.max() == stop and coord.min() == start

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -14,7 +14,7 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.compat import array
-from dascore.constants import PatchType, dascore_styles
+from dascore.constants import dascore_styles
 from dascore.exceptions import CoordError, ParameterError
 from dascore.units import Quantity, Unit, get_conversion_factor, get_factor_and_unit
 from dascore.utils.display import get_nice_text
@@ -62,45 +62,6 @@ def _get_nullish_for_type(dtype):
     # a bit of a problem for ints, which have no null rep., but upcasting
     # to float will probably cause less damage then using None
     return np.NaN
-
-
-def assign_coords(patch: PatchType, **kwargs) -> PatchType:
-    """
-    Add non-dimensional coordinates to a patch.
-
-    Parameters
-    ----------
-    patch
-        The patch to which coordinates will be added.
-    **kwargs
-        Used to specify the name, dimension, and values of the new
-        coordinates.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> import dascore as dc
-    >>> patch_1 = dc.get_example_patch()
-    >>> coords = patch_1.coords
-    >>> dist = coords['distance']
-    >>> time = coords['time']
-    >>> # Add a single coordinate associated with distance dimension
-    >>> lat = np.arange(0, len(dist)) * .001 -109.857952
-    >>> out_1 = patch_1.assign_coords(latitude=('distance', lat))
-    >>> # Add multiple coordinates associated with distance dimension
-    >>> lon = np.arange(0, len(dist)) *.001 + 41.544654
-    >>> out_2 = patch_1.assign_coords(
-    ...     latitude=('distance', lat),
-    ...     longitude=('distance', lon),
-    ... )
-    >>> # Add multi-dimensional coordinates
-    >>> quality = np.ones_like(patch_1.data)
-    >>> out_3 = patch_1.assign_coords(
-    ...     quality=(patch_1.dims, quality)
-    ... )
-    """
-    coords = patch.coords.update_coords(**kwargs)
-    return patch.new(coords=coords, dims=patch.dims)
 
 
 class BaseCoord(DascoreBaseModel, abc.ABC):

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -156,7 +156,7 @@ class Patch:
     def new(
         self: PatchType,
         data: None | ArrayLike = None,
-        coords: None | dict[str | Sequence[str], ArrayLike] = None,
+        coords: None | dict[str | Sequence[str], ArrayLike] | CoordManager = None,
         dims: None | Sequence[str] = None,
         attrs: None | Mapping = None,
     ) -> PatchType:
@@ -259,13 +259,17 @@ class Patch:
         return xr.DataArray(self.data, attrs=attrs, dims=dims, coords=coords)
 
     squeeze = dascore.proc.squeeze
-    rename = dascore.proc.rename
     transpose = dascore.proc.transpose
     snap_coords = dascore.proc.snap_coords
     sort_coords = dascore.proc.sort_cords
+    rename_coords = dascore.proc.rename_coords
+
     set_units = dascore.proc.set_units
     convert_units = dascore.proc.convert_units
     simplify_units = dascore.proc.simplify_units
+
+    def __pow__(self, power, modulo=None):
+        return dascore.proc.pow(self, power)
 
     # --- processing funcs
 

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -3,7 +3,7 @@ A 2D trace object.
 """
 from __future__ import annotations
 
-from typing import Callable, Mapping, Optional, Sequence, Union
+from typing import Callable, Dict, Mapping, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -13,7 +13,6 @@ import dascore.proc
 from dascore.compat import DataArray, array
 from dascore.constants import PatchType
 from dascore.core.coordmanager import CoordManager, get_coord_manager
-from dascore.core.coords import assign_coords
 from dascore.core.schema import PatchAttrs
 from dascore.io import PatchIO
 from dascore.transform import TransformPatchNameSpace
@@ -86,17 +85,27 @@ class Patch:
 
     def __eq__(self, other):
         """
-        Compare one Trace2D to another.
-
-        Parameters
-        ----------
-        other
-
-        Returns
-        -------
-
+        Compare one Patch.
         """
         return self.equals(other)
+
+    def __add__(self, other):
+        return dascore.proc.apply_operator(self, other, np.add)
+
+    def __sub__(self, other):
+        return dascore.proc.apply_operator(self, other, np.subtract)
+
+    def __floordiv__(self, other):
+        return dascore.proc.apply_operator(self, other, np.floor_divide)
+
+    def __truediv__(self, other):
+        return dascore.proc.apply_operator(self, other, np.divide)
+
+    def __mul__(self, other):
+        return dascore.proc.apply_operator(self, other, np.multiply)
+
+    def __pow__(self, other):
+        return dascore.proc.apply_operator(self, other, np.power)
 
     def __rich__(self):
         dascore_text = get_dascore_text()
@@ -158,7 +167,7 @@ class Patch:
         data: None | ArrayLike = None,
         coords: None | dict[str | Sequence[str], ArrayLike] | CoordManager = None,
         dims: None | Sequence[str] = None,
-        attrs: None | Mapping = None,
+        attrs: None | Mapping | PatchAttrs = None,
     ) -> PatchType:
         """
         Return a copy of the Patch with updated data, coords, dims, or attrs.
@@ -224,6 +233,11 @@ class Patch:
         return self.coords.dims
 
     @property
+    def coord_shapes(self) -> Dict[str, tuple[int, ...]]:
+        """Return a dict of coordinate: (shape, ...)"""
+        return self.coords.coord_shapes
+
+    @property
     def attrs(self) -> PatchAttrs:
         """Return the dimensions contained in patch."""
         return self._attrs
@@ -263,13 +277,12 @@ class Patch:
     snap_coords = dascore.proc.snap_coords
     sort_coords = dascore.proc.sort_cords
     rename_coords = dascore.proc.rename_coords
+    update_coords = dascore.proc.update_coords
+    assign_coords = dascore.proc.update_coords
 
     set_units = dascore.proc.set_units
     convert_units = dascore.proc.convert_units
     simplify_units = dascore.proc.simplify_units
-
-    def __pow__(self, power, modulo=None):
-        return dascore.proc.pow(self, power)
 
     # --- processing funcs
 
@@ -326,6 +339,3 @@ class Patch:
             Keyword arguments passed to func.
         """
         return func(self, *args, **kwargs)
-
-    # Bind assign_coords as method
-    assign_coords = assign_coords

--- a/dascore/core/schema.py
+++ b/dascore/core/schema.py
@@ -162,6 +162,12 @@ class PatchAttrs(BaseModel):
         new["dims"] = tuple(new_dims)
         return self.__class__(**new)
 
+    def update(self, **kwargs) -> Self:
+        """Update an attribute in the model, return new model."""
+        out = dict(self)
+        out.update(kwargs)
+        return self.__class__(**out)
+
 
 class PatchFileSummary(PatchAttrs):
     """

--- a/dascore/core/schema.py
+++ b/dascore/core/schema.py
@@ -149,6 +149,19 @@ class PatchAttrs(BaseModel):
         """Return a tuple of dimensions. The dims attr is a string."""
         return tuple(self.dims.split(","))
 
+    def rename_dimension(self, **kwargs):
+        """
+        Rename one or more dimensions if in kwargs. Return new PatchAttrs.
+        """
+        if not (dims := set(kwargs) & set(self.dim_tuple)):
+            return self
+        new = dict(self)
+        new_dims = list(self.dim_tuple)
+        for old_name, new_name in {x: kwargs[x] for x in dims}.items():
+            new_dims[new_dims.index(old_name)] = new_name
+        new["dims"] = tuple(new_dims)
+        return self.__class__(**new)
+
 
 class PatchFileSummary(PatchAttrs):
     """

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -29,6 +29,10 @@ class PatchError(DASCoreError):
     """Parent class for more specific Patch Errors."""
 
 
+class IncompatiblePatchError(PatchError):
+    """Raised when an operator cannot be performed on a patch."""
+
+
 class CoordError(ValueError, PatchError):
     """Raised when something is wrong with a Coordinate."""
 

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -2,7 +2,7 @@
 Module to Patch Processing.
 """
 from .aggregate import aggregate
-from .basic import abs, normalize, rename, squeeze, standardize, transpose
+from .basic import abs, normalize, pow, rename_coords, squeeze, standardize, transpose
 from .coords import snap_coords, sort_cords
 from .detrend import detrend
 from .filter import median_filter, pass_filter, sobel_filter

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -2,7 +2,16 @@
 Module to Patch Processing.
 """
 from .aggregate import aggregate
-from .basic import abs, normalize, pow, rename_coords, squeeze, standardize, transpose
+from .basic import (
+    abs,
+    apply_operator,
+    normalize,
+    rename_coords,
+    squeeze,
+    standardize,
+    transpose,
+    update_coords,
+)
 from .coords import snap_coords, sort_cords
 from .detrend import detrend
 from .filter import median_filter, pass_filter, sobel_filter

--- a/dascore/proc/select.py
+++ b/dascore/proc/select.py
@@ -46,11 +46,11 @@ def select(patch: PatchType, *, copy=False, relative=False, **kwargs) -> PatchTy
     >>> t2 = patch.attrs.time_max - dc.to_timedelta64(1)
     >>> new_time1 = patch.select(time=(t1, t2))
     >>> # this can be accomplished more simply using the relative keyword
-    >>> new_time2 = patch.select(time=(1, -1))
+    >>> new_time2 = patch.select(time=(1, -1), relative=True)
     >>> # filter 1 second from start time to 3 seconds from start time
-    >>> new_time3 = patch.select(time=(1, 3))
+    >>> new_time3 = patch.select(time=(1, 3), relative=True)
     >>> # filter 6 second from end time to 1 second from end time
-    >>> new_time4 = patch.select(time=(-6, -1))
+    >>> new_time4 = patch.select(time=(-6, -1), relative=True)
     """
     new_coords, data = patch.coords.select(
         **kwargs, array=patch.data, relative=relative

--- a/dascore/transform/__init__.py
+++ b/dascore/transform/__init__.py
@@ -6,7 +6,7 @@ Transforms are defined as
 
 from dascore.utils.misc import MethodNameSpace
 
-from .fft import irfft, rfft
+from .fft import rfft
 from .spectro import spectrogram
 from .strain import velocity_to_strain_rate
 
@@ -17,4 +17,4 @@ class TransformPatchNameSpace(MethodNameSpace):
     velocity_to_strain_rate = velocity_to_strain_rate
     spectrogram = spectrogram
     rfft = rfft
-    irfft = irfft
+    # irfft = irfft

--- a/dascore/transform/__init__.py
+++ b/dascore/transform/__init__.py
@@ -6,7 +6,7 @@ Transforms are defined as
 
 from dascore.utils.misc import MethodNameSpace
 
-from .fft import rfft
+from .fft import irfft, rfft
 from .spectro import spectrogram
 from .strain import velocity_to_strain_rate
 
@@ -17,3 +17,4 @@ class TransformPatchNameSpace(MethodNameSpace):
     velocity_to_strain_rate = velocity_to_strain_rate
     spectrogram = spectrogram
     rfft = rfft
+    irfft = irfft

--- a/dascore/transform/fft.py
+++ b/dascore/transform/fft.py
@@ -4,6 +4,8 @@ Modules for Fourier transforms.
 import numpy as np
 
 from dascore.constants import PatchType
+from dascore.core.coords import get_coord
+from dascore.units import get_quantity
 from dascore.utils.misc import _get_sampling_rate
 from dascore.utils.patch import patch_function
 from dascore.utils.transformatter import FourierTransformatter
@@ -24,15 +26,59 @@ def rfft(patch: PatchType, dim="time") -> PatchType:
     Notes
     -----
     The real Fourier Transform is only appropriate for real-valued data arrays.
+
+    This implementation uses a unitary transform (norm='ortho') such that
+    Parseval's theorem holds.
     """
     ft = FourierTransformatter()
     data = patch.data
     axis = patch.dims.index(dim)
     sr = 1 / _get_sampling_rate(patch.attrs[f"d_{dim}"])
     freqs = np.fft.rfftfreq(data.shape[axis], sr)
-    new_data = np.fft.rfft(data, axis=axis)
+    new_data = np.fft.rfft(data, axis=axis, norm="ortho")
+    # get new dims/attrs
     new_dim_name = ft._forward_rename(patch.dims[axis])
     dims, attrs = ft.transform_dims_and_attrs(patch.dims, patch.attrs, index=axis)
-    new_coords = {new_dim_name: freqs}
+    # get new coord
+    units = get_quantity(patch.coords.coord_map[dim].units)
+    coord = get_coord(values=freqs, units=None if units is None else 1 / units)
+    new_coords = {new_dim_name: coord}
+    new_coords.update({x: patch.coords[x] for x in patch.dims if x != dim})
+    return patch.__class__(data=new_data, coords=new_coords, dims=dims, attrs=attrs)
+
+
+@patch_function()
+def irfft(patch: PatchType, dim="time") -> PatchType:
+    """
+    Perform an inverse real fourier transform along the specified dimension.
+
+    Parameters
+    ----------
+    patch
+        The Patch object to transform.
+    dim
+        The dimension along which the transform is applied.
+
+    Notes
+    -----
+    The inverse real Fourier Transform is only appropriate for real-valued
+    data arrays.
+
+    This implementation uses a unitary transform (norm='ortho') such that
+    Parseval's theorem holds.
+    """
+    ft = FourierTransformatter()
+    data = patch.data
+    axis = patch.dims.index(dim)
+    sr = 1 / _get_sampling_rate(patch.attrs[f"d_{dim}"])
+    freqs = np.fft.rfftfreq(data.shape[axis], sr)
+    new_data = np.fft.rfft(data, axis=axis, norm="ortho")
+    # get new dims/attrs
+    new_dim_name = ft._forward_rename(patch.dims[axis])
+    dims, attrs = ft.transform_dims_and_attrs(patch.dims, patch.attrs, index=axis)
+    # get new coord
+    units = get_quantity(patch.coords.coord_map[dim].units)
+    coord = get_coord(values=freqs, units=None if units is None else 1 / units)
+    new_coords = {new_dim_name: coord}
     new_coords.update({x: patch.coords[x] for x in patch.dims if x != dim})
     return patch.__class__(data=new_data, coords=new_coords, dims=dims, attrs=attrs)

--- a/dascore/transform/fft.py
+++ b/dascore/transform/fft.py
@@ -47,38 +47,38 @@ def rfft(patch: PatchType, dim="time") -> PatchType:
     return patch.__class__(data=new_data, coords=new_coords, dims=dims, attrs=attrs)
 
 
-@patch_function()
-def irfft(patch: PatchType, dim="time") -> PatchType:
-    """
-    Perform an inverse real fourier transform along the specified dimension.
-
-    Parameters
-    ----------
-    patch
-        The Patch object to transform.
-    dim
-        The dimension along which the transform is applied.
-
-    Notes
-    -----
-    The inverse real Fourier Transform is only appropriate for real-valued
-    data arrays.
-
-    This implementation uses a unitary transform (norm='ortho') such that
-    Parseval's theorem holds.
-    """
-    ft = FourierTransformatter()
-    data = patch.data
-    axis = patch.dims.index(dim)
-    sr = 1 / _get_sampling_rate(patch.attrs[f"d_{dim}"])
-    freqs = np.fft.rfftfreq(data.shape[axis], sr)
-    new_data = np.fft.rfft(data, axis=axis, norm="ortho")
-    # get new dims/attrs
-    new_dim_name = ft._forward_rename(patch.dims[axis])
-    dims, attrs = ft.transform_dims_and_attrs(patch.dims, patch.attrs, index=axis)
-    # get new coord
-    units = get_quantity(patch.coords.coord_map[dim].units)
-    coord = get_coord(values=freqs, units=None if units is None else 1 / units)
-    new_coords = {new_dim_name: coord}
-    new_coords.update({x: patch.coords[x] for x in patch.dims if x != dim})
-    return patch.__class__(data=new_data, coords=new_coords, dims=dims, attrs=attrs)
+# @patch_function()
+# def irfft(patch: PatchType, dim="time") -> PatchType:
+#     """
+#     Perform an inverse real fourier transform along the specified dimension.
+#
+#     Parameters
+#     ----------
+#     patch
+#         The Patch object to transform.
+#     dim
+#         The dimension along which the transform is applied.
+#
+#     Notes
+#     -----
+#     The inverse real Fourier Transform is only appropriate for real-valued
+#     data arrays.
+#
+#     This implementation uses a unitary transform (norm='ortho') such that
+#     Parseval's theorem holds.
+#     """
+#     ft = FourierTransformatter()
+#     data = patch.data
+#     axis = patch.dims.index(dim)
+#     sr = 1 / _get_sampling_rate(patch.attrs[f"d_{dim}"])
+#     freqs = np.fft.rfftfreq(data.shape[axis], sr)
+#     new_data = np.fft.rfft(data, axis=axis, norm="ortho")
+#     # get new dims/attrs
+#     new_dim_name = ft._forward_rename(patch.dims[axis])
+#     dims, attrs = ft.transform_dims_and_attrs(patch.dims, patch.attrs, index=axis)
+#     # get new coord
+#     units = get_quantity(patch.coords.coord_map[dim].units)
+#     coord = get_coord(values=freqs, units=None if units is None else 1 / units)
+#     new_coords = {new_dim_name: coord}
+#     new_coords.update({x: patch.coords[x] for x in patch.dims if x != dim})
+#     return patch.__class__(data=new_data, coords=new_coords, dims=dims, attrs=attrs)

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -39,18 +39,3 @@ def velocity_to_strain_rate(
     attrs["data_type"] = "strain_rate"
     attrs["gauge_length"] = d_distance * gauge_multiple
     return patch.new(data=new, attrs=attrs)
-
-
-#
-# def convert_velocity_to_strain_rate(
-#         patch: PatchType, gauge_length, dx_dec, start_index2=None, end_index2=None
-# ) -> PatchType:
-#     """The nasty func copied from terra15 note."""
-#     sliced_inp = get_slices_by_range(inp, start_index2, end_index2)
-#     n_t, n_d = sliced_inp[0, :, :].shape  # Convert gauge length to spatial
-#     samplesg = np.int32(round(gauge_length / dx_dec))
-#     inv_gauge_length = np.float32(1.0 / gauge_length)
-#     strain_rates = (
-#         sliced_inp[:, :, g:n_d] - sliced_inp[:, :, 0 : n_d - g]
-#     ) * inv_gauge_length
-#     return strain_rates

--- a/dascore/utils/models.py
+++ b/dascore/utils/models.py
@@ -1,6 +1,7 @@
 """
 Utilities for models.
 """
+from collections import ChainMap
 from functools import _lru_cache_wrapper, cached_property, reduce
 from typing import Optional, Sequence
 
@@ -104,7 +105,7 @@ class UnitQuantity(str, SimpleValidator):
 def merge_models(
     model_list: Sequence[BaseModel],
     dim: Optional[str] = None,
-    conflicts: Literal["drop", "raise"] = "raise",
+    conflicts: Literal["drop", "raise", "keep_first"] = "raise",
     drop_attrs: Optional[Sequence[str]] = None,
 ):
     """
@@ -122,7 +123,8 @@ def merge_models(
         indicated by dim. If "drop" simply drop conflicting attributes,
         or attributes not shared by all models. If "raise" raise an
         [AttributeMergeError](`dascore.exceptions.AttributeMergeError`] when
-        issues are encountered.
+        issues are encountered. If "keep_first", just keep the first value
+        for each attribute.
     drop_attrs
         If provided, attributes which should be dropped.
     """
@@ -186,6 +188,8 @@ def merge_models(
 
     def _handle_other_attrs(mod_dict_list):
         """Check the other attributes and handle based on conflicts param."""
+        if conflicts == "keep_first":
+            return [dict(ChainMap(*mod_dict_list))]
         no_null_ = _replace_null_with_None(mod_dict_list)
         all_eq = all(no_null_[0] == x for x in no_null_)
         if all_eq:

--- a/dascore/utils/transformatter.py
+++ b/dascore/utils/transformatter.py
@@ -49,10 +49,18 @@ class BaseTransformatter(abc.ABC):
         func = self._forward_unit_label if forward else self._inverse_unit_label
         index_list = [index] if index is not None else range(len(dims))
         out = dict(attrs)  # this ensures we have a dict and a copy
+        new_units = []
         for ind in index_list:
             dim_unit_attr_name = f"{dims[ind]}_units"
             if dim_unit_attr_name in out:
-                out[dim_unit_attr_name] = func(out[dim_unit_attr_name])
+                quant = func(out[dim_unit_attr_name])
+                out[dim_unit_attr_name] = quant
+                new_units.append(get_quantity(quant))
+        if "data_units" in out and (dunits := out["data_units"]) is not None:
+            data_units = get_quantity(dunits)
+            for new_unit in new_units:
+                data_units /= new_unit
+            out["data_units"] = str(data_units)
         return out
 
     def transform_dims_and_attrs(self, dims, attrs, index=None, forward=True):

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -22,7 +22,7 @@ format:
 
 
 website:
-  title: DASCore (0.0.12.dev8)
+  title: DASCore (0.0.11.dev9)
   repo-url: https://github.com/dasdae/dascore
   site-path: /docs
   site-url: https://www.dascore.org

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -158,9 +158,51 @@ patch = dc.get_example_patch()
 print(patch)
 ```
 
-# Processing
+:::{callout-note}
+For various reasons, Patches should be treated as *immutable*, meaning they should not be modified in place, but rather new patches are created when something needs to be modified.
+:::
 
-For various reasons, Patches should be treated as *immutable*, meaning they should not be modified in place, but rather new patches created when something needs to be modified.
+# Selecting (trimming)
+
+Patches are trimmed using the [`select`](`dascore.Patch.select`) method.  `select` takes the coordinate name and a tuple of (lower_limit, upper_limit) as the values. Either limit can be `None` or `...` indicating an open interval.
+
+```{python}
+import numpy as np
+
+import dascore as dc
+
+patch = dc.get_example_patch()
+attrs = patch.attrs
+
+# select 1 sec after current start time to 1 sec before end time.
+one_sec = dc.to_timedelta64(1)
+select_tuple = (attrs.time_min + one_sec, attrs.time_max - one_sec)
+new = patch.select(time=select_tuple)
+
+# select only the first half of the distance channels.
+distance_max = np.mean(patch.coords['distance'])
+new = patch.select(distance=(..., distance_max))
+```
+
+The "relative" keyword is used to trim coordinates based on start (positive) to end (negative)
+
+```{python}
+import dascore as dc
+from dascore.units import ft
+
+patch = dc.get_example_patch()
+
+# We can make the example above simpler with relative selection
+new = patch.select(time=(1, -1), relative=True)
+
+# select 2 seconds from end to 1 second from end
+new = patch.select(time=(-2, -1), relative=True)
+
+# select last 100 ft of distance channels
+new = patch.select(distance=(..., -100 * ft), relative=True)
+```
+
+# Processing
 
 The patch has several methods which are intended to be chained together via a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface), meaning each method returns a new `Patch` instance.
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -276,14 +276,11 @@ pa = (
 
 # Adding Coordinates
 
-It is common to have additional coordinates, such as latitude/longitude,
-attached to a particular dimension (e.g., distance). There are two ways
-to add coordinates to a patch:
+It is common to have additional coordinates, such as latitude/longitude,  attached to a particular dimension (e.g., distance). There are two ways to add coordinates to a patch:
 
-## Assign Coordinates
+## Update Coordinates
 
-The [assign_coordinates](`dascore.utils.coords.assign_coords`) method will
-add the requested coordinates and return a new patch instance.
+The [update_coords](`dascore.Patch.update_coords`) method will return a new patch with the coordinate added, if it didn't exist in the original, or replaced, if it did.
 
 ```{python}
 import numpy as np
@@ -295,18 +292,18 @@ time = coords['time']
 
 # Add a single coordinate associated with distance dimension
 lat = np.arange(0, len(dist)) * .001 -109.857952
-out_1 = pa.assign_coords(latitude=('distance', lat))
+out_1 = pa.update_coords(latitude=('distance', lat))
 
 # Add multiple coordinates associated with distance dimension
 lon = np.arange(0, len(dist)) *.001 + 41.544654
-out_2 = pa.assign_coords(
+out_2 = pa.update_coords(
     latitude=('distance', lat),
     longitude=('distance', lon),
 )
 
 # Add multi-dimensional coordinates
 quality = np.ones_like(pa.data)
-out_3 = pa.assign_coords(
+out_3 = pa.update_coords(
     quality=(pa.dims, quality)
 )
 ```
@@ -346,3 +343,91 @@ coords = dict(
 dims = ("distance", "time")
 out = dc.Patch(data=array, coords=coords, attrs=attrs, dims=dims)
 ```
+
+# Patch Operations
+
+Patches implement common operators which means that many [ufunc](https://numpy.org/doc/stable/reference/ufuncs.html) type operations can be applied directly on a patch with built-in python operators.
+
+In the case of scalars and numpy arrays, the operations are broadcast over the patch data. In the case of two patches, compatibility between patches are first checked, the intersection of the coords and attrs are calculated, then the operator is applied to both patchs' data. Here are a few examples:
+
+## Patch operations with scalars
+
+```{python}
+import dascore as dc
+import numpy as np
+
+patch = dc.get_example_patch()
+
+out1 = patch / 10
+assert np.allclose(patch.data / 10, out1.data)
+
+out2 = patch ** 2.3
+assert np.allclose(patch.data ** 2.3, out2.data)
+
+out3 = patch - 3
+assert np.allclose(patch.data - 3, out3.data)
+```
+
+Units are also fully supported.
+
+```{python}
+import dascore as dc
+from dascore.units import m, s
+
+patch = dc.get_example_patch().set_units("m/s")
+
+# multiplying patches by a quantity with units updates the data_units attribute.
+new = patch * 10 * m/s
+
+print(f"units before operation {patch.attrs.data_units}")
+print(f"units after operation {new.attrs.data_units}")
+```
+
+## Patch operations with numpy arrays
+
+```{python}
+import numpy as np
+
+import dascore as dc
+
+patch = dc.get_example_patch()
+ones = np.ones(patch.shape)
+
+out1 = patch + ones
+assert np.allclose(patch.data + ones, out1.data)
+```
+
+Units also work with numpy arrays.
+
+```{python}
+import numpy as np
+
+import dascore as dc
+from dascore.units import furlongs
+
+patch = dc.get_example_patch()
+ones = np.ones(patch.shape) * furlongs
+
+out1 = patch * ones
+print(f"units before operation {patch.attrs.data_units}")
+print(f"units after operation {out1.attrs.data_units}")
+```
+
+## Patch operations with other patches
+
+```{python}
+import numpy as np
+
+import dascore as dc
+from dascore.units import furlongs
+
+patch = dc.get_example_patch()
+
+# adding two patches together simply adds their data and checks/merges their
+# coords and attrs.
+out = patch + patch
+
+assert np.allclose(patch.data * 2, out.data)
+```
+
+See [`merge_compatible_coords_attrs`](`dascore.utils.patch.merge_compatible_coords_attrs`) for more details on how attributes and coordinates are handled when performing operations on two patches.

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -353,8 +353,9 @@ In the case of scalars and numpy arrays, the operations are broadcast over the p
 ## Patch operations with scalars
 
 ```{python}
-import dascore as dc
 import numpy as np
+
+import dascore as dc
 
 patch = dc.get_example_patch()
 

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -12,7 +12,6 @@ from rich.text import Text
 import dascore as dc
 from dascore.core import Patch
 from dascore.core.coords import CoordRange
-from dascore.exceptions import IncompatiblePatchError
 from dascore.proc.basic import apply_operator
 
 
@@ -599,23 +598,11 @@ class TestApplyOperator:
     def test_scalar1(self, random_patch, operation):
         """Tests for scalar operators."""
         new = operation(random_patch, 2)
-        expected = operator(random_patch.data, 2)
+        expected = operation(random_patch.data, 2)
         assert np.allclose(new.data, expected)
-
-    def test_scalar2(self, random_patch):
-        """Test for a single scalar."""
-        new = apply_operator(random_patch, 10, np.multiply)
-        assert np.allclose(new.data, random_patch.data * 10)
 
     def test_array_like(self, random_patch):
         """Ensure array-like operations work."""
-        ones = np.ones_like(random_patch.shape)
+        ones = np.ones(random_patch.shape)
         new = apply_operator(random_patch, ones, np.add)
         assert np.allclose(new.data, ones + random_patch.data)
-
-    def test_incompatible_coords(self, random_patch):
-        """Ensure incompatible dimensions raises."""
-        # new = random_patch.update_attrs(time_min=random_patch.attrs.time_max)
-        assert False
-        # with pytest.raises(IncompatiblePatchError):
-        #     apply_operator(new, random_patch)

--- a/tests/test_core/test_schema.py
+++ b/tests/test_core/test_schema.py
@@ -95,3 +95,17 @@ class TestSchemaIsDictLike:
             random_attrs.bob = 1
         with pytest.raises(TypeError, match="is immutable"):
             random_attrs["bob"] = 1
+
+
+class TestRenameDimension:
+    """Ensure rename dimension works."""
+
+    def test_simple_rename(self, random_attrs):
+        """Ensure renaming a dimension works."""
+        attrs = random_attrs
+        new_name = "money"
+        time_ind = attrs.dim_tuple.index("time")
+        out = attrs.rename_dimension(time=new_name)
+        assert new_name in out.dims
+        assert out.dim_tuple[time_ind] == new_name
+        assert len(out.dim_tuple) == len(attrs.dim_tuple)

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -4,6 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from dascore.exceptions import IncompatiblePatchError
+from dascore.proc.basic import apply_operator
+
 
 class TestAbs:
     """Test absolute values."""
@@ -122,3 +125,26 @@ class TestStandarize:
         assert np.allclose(
             np.round(np.mean(out.data, axis=axis, keepdims=True), decimals=1), 0.0
         )
+
+
+class TestApplyOperator:
+    """Tests for applying various ufunc-type operators."""
+
+    def test_scalar(self, random_patch):
+        """Test for a single scalar."""
+        new = apply_operator(random_patch, 10, np.multiply)
+        assert np.allclose(new.data, random_patch.data * 10)
+
+    def test_array_like(self, random_patch):
+        """Ensure array-like operations work."""
+        ones = np.ones_like(random_patch.shape)
+        new = apply_operator(random_patch, ones, np.add)
+        assert np.allclose(new.data, ones + random_patch.data)
+
+    def test_incompatible_coords(self, random_patch):
+        """Ensure incompatible dimensions raises."""
+        assert False
+        # new = random_patch.update_attrs(time_min=random_patch.attrs.time_max)
+        # breakpoint()
+        # with pytest.raises(IncompatiblePatchError):
+        #     apply_operator(new, random_patch)

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -4,8 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from dascore.exceptions import IncompatiblePatchError
+from dascore.exceptions import IncompatiblePatchError, UnitError
 from dascore.proc.basic import apply_operator
+from dascore.units import furlongs, get_quantity, m, s
 
 
 class TestAbs:
@@ -137,14 +138,81 @@ class TestApplyOperator:
 
     def test_array_like(self, random_patch):
         """Ensure array-like operations work."""
-        ones = np.ones_like(random_patch.shape)
+        ones = np.ones(random_patch.shape)
         new = apply_operator(random_patch, ones, np.add)
         assert np.allclose(new.data, ones + random_patch.data)
 
     def test_incompatible_coords(self, random_patch):
         """Ensure incompatible dimensions raises."""
-        assert False
-        # new = random_patch.update_attrs(time_min=random_patch.attrs.time_max)
-        # breakpoint()
-        # with pytest.raises(IncompatiblePatchError):
-        #     apply_operator(new, random_patch)
+        new = random_patch.update_attrs(time_min=random_patch.attrs.time_max)
+        with pytest.raises(IncompatiblePatchError):
+            apply_operator(new, random_patch, np.multiply)
+
+    def test_quantity_scalar(self, random_patch):
+        """Ensure operators work with quantities."""
+        patch = random_patch.set_units("m/s")
+        other = 10 * m / s
+        # first try multiply
+        new = apply_operator(patch, other, np.multiply)
+        new_units = get_quantity("m/s") * get_quantity("m/s")
+        assert get_quantity(new.attrs.data_units) == new_units
+        assert isinstance(new.data, np.ndarray)
+        # try add
+        new = apply_operator(patch, other, np.add)
+        new_units = get_quantity("m/s")
+        assert get_quantity(new.attrs.data_units) == new_units
+        assert isinstance(new.data, np.ndarray)
+        # and divide
+        new = apply_operator(patch, other, np.divide)
+        new_units = get_quantity("m/s") / get_quantity("m/s")
+        assert get_quantity(new.attrs.data_units) == new_units
+        assert isinstance(new.data, np.ndarray)
+
+    def test_unit(self, random_patch):
+        """Units should only affect the unit attr"""
+        patch = random_patch.set_units("m/s")
+        other = m / s
+        # first try multiply
+        new = apply_operator(patch, other, np.multiply)
+        new_units = get_quantity("m/s") * get_quantity("m/s")
+        assert get_quantity(new.attrs.data_units) == new_units
+        assert np.allclose(new.data, random_patch.data)
+        # try add
+        new = apply_operator(patch, other, np.add)
+        new_units = get_quantity("m/s")
+        assert get_quantity(new.attrs.data_units) == new_units
+        assert np.allclose(new.data, random_patch.data + 1)
+        # and divide
+        new = apply_operator(patch, other, np.divide)
+        new_units = get_quantity("m/s") / get_quantity("m/s")
+        assert get_quantity(new.attrs.data_units) == new_units
+        assert np.allclose(new.data, random_patch.data)
+
+    def test_patch_with_units(self, random_patch):
+        """Ensure when patch units are set they are applied as well."""
+        # test add
+        pa1 = random_patch.set_units("m/s")
+        out1 = apply_operator(pa1, pa1, np.add)
+        assert get_quantity(out1.attrs.data_units) == get_quantity("m/s")
+        # test multiply
+        out2 = apply_operator(pa1, pa1, np.multiply)
+        assert get_quantity(out2.attrs.data_units) == get_quantity("m**2/s**2")
+
+    def test_array_with_units(self, random_patch):
+        """Ensure an array with units works for multiplication."""
+        patch1 = random_patch
+        ones = np.ones(patch1.shape) * furlongs
+        out1 = patch1 * ones
+        assert get_quantity(out1.attrs.data_units) == get_quantity(furlongs)
+        # test division with units
+        patch2 = random_patch.set_units("m")
+        out2 = patch2 / ones
+        expected = get_quantity("m/furlongs")
+        assert get_quantity(out2.attrs.data_units) == expected
+
+    def test_incompatible_units(self, random_patch):
+        """Ensure incompatible units raise."""
+        pa1 = random_patch.set_units("m/s")
+        other = 10 * get_quantity("m")
+        with pytest.raises(UnitError):
+            apply_operator(pa1, other, np.add)

--- a/tests/test_transform/test_fft_transforms.py
+++ b/tests/test_transform/test_fft_transforms.py
@@ -50,7 +50,8 @@ class TestRfft:
 
     def test_parsevals_theorem(self, random_patch, rfft_patch):
         """Ensure parsevals theorem holds for transform."""
-        assert False
+        # TODO work on this after integrate and diff are implemented.
+        pytest.skip("not yet implemented.")
         # pa1 = (random_patch**2).integrate("time")
         # pa2 = (rfft_patch**2).integrate("frequency")
         # breakpoint()

--- a/tests/test_transform/test_fft_transforms.py
+++ b/tests/test_transform/test_fft_transforms.py
@@ -33,3 +33,24 @@ class TestRfft:
         """Ensure abs works with rfft to get amplitude spectra."""
         out = rfft_patch.abs()
         assert np.allclose(out.data, np.abs(rfft_patch.data))
+
+    def test_time_coord_units(self, random_patch, rfft_patch):
+        """Ensure time label units have been correctly set."""
+        units1 = random_patch.coords.coord_map["time"].units
+        units2 = rfft_patch.coords.coord_map["ft_time"].units
+        assert get_quantity(units1) == 1 / get_quantity(units2)
+
+    def test_data_units(self, random_patch):
+        """Ensure data units have been updated."""
+        patch = random_patch.update_attrs(data_units="m/s")
+        fft_patch = patch.tran.rfft("time")
+        dunits1 = get_quantity(patch.attrs.data_units)
+        dunits2 = get_quantity(fft_patch.attrs.data_units)
+        assert dunits2 == dunits1 * get_quantity("second")
+
+    def test_parsevals_theorem(self, random_patch, rfft_patch):
+        """Ensure parsevals theorem holds for transform."""
+        assert False
+        # pa1 = (random_patch**2).integrate("time")
+        # pa2 = (rfft_patch**2).integrate("frequency")
+        # breakpoint()

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -12,6 +12,7 @@ from dascore.exceptions import MissingOptionalDependency
 from dascore.utils.misc import (
     MethodNameSpace,
     get_slice_from_monotonic,
+    get_stencil_coefs,
     iter_files,
     iterate,
     optional_import,
@@ -248,3 +249,25 @@ class TestOptionalImport:
         """Ensure a module which is missing raises the appropriate Error."""
         with pytest.raises(MissingOptionalDependency, match="boblib4"):
             optional_import("boblib4")
+
+
+class TestGetStencilCoefficients:
+    """Tests for stencil coefficients."""
+
+    def test_3_point_1st_derivative(self):
+        """3 point 1st derivative"""
+        out = get_stencil_coefs(1, 1)
+        expected = np.array([-1 / 2, 0, 1 / 2])
+        assert np.allclose(out, expected)
+
+    def test_5_point_1st_derivative(self):
+        """5 point 1st derivative"""
+        out = get_stencil_coefs(2, 1)
+        expected = np.array([1, -8, 0, 8, -1]) / 12.0
+        assert np.allclose(out, expected)
+
+    def test_3_point_2nd_derivative(self):
+        """3 point 2nd derivative"""
+        out = get_stencil_coefs(1, 2)
+        expected = np.array([1, -2, 1])
+        assert np.allclose(out, expected)

--- a/tests/test_utils/test_models.py
+++ b/tests/test_utils/test_models.py
@@ -78,3 +78,12 @@ class TestMergeModels:
         assert isinstance(out, PatchAttrs)
         assert out.tag == defaults.tag
         assert out.station == defaults.station
+
+    def test_keep_disjoint_values(self, random_patch):
+        """Ensure when disjoint values should be kept they are."""
+        random_attrs = random_patch.attrs
+        new = dict(random_attrs)
+        new["jazz_hands"] = 1984
+        attrs1 = PatchAttrs(**new)
+        out = merge_models([attrs1, random_attrs], conflicts="keep_first")
+        assert out.jazz_hands == 1984

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -4,8 +4,16 @@ Test patch utilities.
 import pytest
 
 import dascore as dc
-from dascore.exceptions import PatchAttributeError, PatchDimError
-from dascore.utils.patch import _merge_patches, get_dim_value_from_kwargs
+from dascore.exceptions import (
+    IncompatiblePatchError,
+    PatchAttributeError,
+    PatchDimError,
+)
+from dascore.utils.patch import (
+    _merge_patches,
+    get_dim_value_from_kwargs,
+    merge_compatible_coords_attrs,
+)
 
 
 @dc.patch_function(required_dims=("time", "distance"))
@@ -53,7 +61,7 @@ class TestPatchFunction:
 
     def test_doesnt_have_required_dims(self, random_patch):
         """Raises if patch doesn't have required dimensions."""
-        pa = random_patch.rename(time="for_a_hug")
+        pa = random_patch.rename_coords(time="for_a_hug")
 
         with pytest.raises(PatchDimError):
             time_dist_func(pa)
@@ -131,3 +139,36 @@ class TestGetDimValueFromKwargs:
         kwargs = {}
         with pytest.raises(PatchDimError):
             get_dim_value_from_kwargs(random_patch, kwargs)
+
+
+class TestMergeCompatibleCoordsAttrs:
+    """Tests for merging compatible attrs, coords."""
+
+    def test_simple(self, random_patch):
+        """Simple merge test."""
+        coords, attrs = merge_compatible_coords_attrs(random_patch, random_patch)
+        assert coords == random_patch.coords
+        assert attrs == random_patch.attrs
+
+    def test_incompatible_dims(self, random_patch):
+        """Ensure incompatible dims raises."""
+        new = random_patch.rename_coords(time="money")
+        match = "their dimensions are not equal"
+        with pytest.raises(IncompatiblePatchError, match=match):
+            merge_compatible_coords_attrs(random_patch, new)
+
+    def test_incompatible_coords(self, random_patch):
+        """Ensure an incompatible error is raised for coords that dont match"""
+        new_time = random_patch.attrs.time_max
+        new = random_patch.update_attrs(time_min=new_time)
+        match = "coordinates are not equal"
+        with pytest.raises(IncompatiblePatchError, match=match):
+            merge_compatible_coords_attrs(new, random_patch)
+
+    def test_extra_coord(self, random_patch, random_patch_with_lat_lon):
+        """Extra coords on both patch should end up in the merged."""
+        pa1, pa2 = random_patch, random_patch_with_lat_lon
+        # add new coordinate to patch 1
+        expected = set(pa1.coords.coord_map) & set(pa2.coords.coord_map)
+        coords, attrs = merge_compatible_coords_attrs(pa1, pa2)
+        assert set(coords.coord_map) == expected

--- a/tests/test_utils/test_transformatter.py
+++ b/tests/test_utils/test_transformatter.py
@@ -60,6 +60,7 @@ class TestFTUnitRename:
     attrs = {
         "distance_units": str(get_quantity("1.0 m")),
         "time_units": str(get_quantity("1.0 s")),
+        "data_units": str(get_quantity("1.0 V")),
     }
 
     def test_forward_unit_transform(self, ft_reformatter):
@@ -79,3 +80,32 @@ class TestFTUnitRename:
         assert 1 / get_quantity(value) == get_quantity(out[key])
         out_2 = ft_reformatter.rename_attrs(self.dims, out, index=0, forward=False)
         assert out_2 == self.attrs
+
+    def test_data_units_single_index(self, ft_reformatter):
+        """Ensure data units are renamed when a single index is specified."""
+        for index, dim in enumerate(self.dims):
+            out = ft_reformatter.rename_attrs(
+                self.dims, self.attrs, index=index, forward=False
+            )
+            new_units = get_quantity(out["data_units"])
+            old_units = get_quantity(self.attrs["data_units"])
+            old_coord_units = get_quantity(self.attrs[f"{dim}_units"])
+            assert new_units == old_units * old_coord_units
+            # now check round tripping
+            rt = ft_reformatter.rename_attrs(
+                self.dims,
+                out,
+                index=index,
+                forward=True,
+            )
+            assert get_quantity(rt["data_units"]) == old_units
+
+    def test_data_units_no_index(self, ft_reformatter):
+        """Ensure data units are renamed when all units are specified."""
+        out = ft_reformatter.rename_attrs(self.dims, self.attrs)
+        dunit = get_quantity(self.attrs["data_units"])
+        time_unit = get_quantity(self.attrs["time_units"])
+        dist_units = get_quantity(self.attrs["distance_units"])
+        assert get_quantity(out["data_units"]) == dunit * time_unit * dist_units
+        reverse = ft_reformatter.rename_attrs(self.dims, out)
+        assert get_quantity(reverse["data_units"]) == dunit


### PR DESCRIPTION
## Description

This PR adds support for various patch operators (add, subtract, pow, etc.). I have updated to patch tutorial page to reflect these new features, but here is a sample:

```python
import numpy as np

import dascore as dc
from dascore.units import m, s

patch = dc.get_example_patch()

# add a scalar to a patch
out1 = patch + 10

# add random noise
noise = np.random.random(patch.shape)
out2 = patch + noise

# divide a patch by another patch
out3 = patch / patch

# multiply patch by a few meters
out4 = patch * 2 * m
```

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
