### PR TITLE
fix doc-build

### DIFF
--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -20,7 +20,8 @@ decimation frequency and one below.
 ```{python}
 import dascore as dc
 
-patch = dc.examples.sin_wave_patch(
+patch = dc.examples.get_example_patch(
+    "sin_wav",
     sample_rate=1000,
     frequency=[200, 10],
     channel_count=2,

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -156,7 +156,7 @@ website:
       contents:
         - notes/notes.qmd
 
-        - text: Fourier transform notes
+        - text: Fourier transforms
           href: notes/dft_notes.qmd
 
     - title: 'API'


### PR DESCRIPTION

## Description

In a refactoring of an example function name in #192, I missed a doc reference to the old function name. This fixes the issue. 

Side note: we should add a tag for building the docs as part of the test suite.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
