### PR TITLE
Io typehint support

### DIFF
--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -3,6 +3,7 @@ Utilities for basic IO tasks.
 """
 import abc
 import typing
+from contextlib import suppress
 from functools import cache, singledispatch
 from inspect import isfunction, ismethod
 from pathlib import Path
@@ -101,8 +102,9 @@ def get_handle_from_resource(uri, required_type):
 
     return uri if required type is not specified.
     """
-    if isinstance(uri, required_type):
-        return uri
+    with suppress(TypeError):
+        if isinstance(uri, required_type):
+            return uri
     if (func := HANDLE_FUNCTIONS.get(required_type)) is None:
         return uri
     return func(uri)

--- a/docs/contributing/adding_test_data.qmd
+++ b/docs/contributing/adding_test_data.qmd
@@ -2,17 +2,11 @@
 title: Adding Test Data
 ---
 
-There are a few different way to add test data to dascore. The key, however,
-is to ensure test files and generated patches are small (a few mb at most) so
-the documentation and test suite still run quickly.
+There are a few different way to add test data to dascore. The key, however, is to ensure test files and generated patches are small (a few mb at most) so the documentation and test suite still run quickly.
 
 # Adding functions which create example data
 
-The [examples module](`dascore.examples`) contains several functions for creating
-example `Patch` and `Spool` instances. You can add a new function in that module
-which creates a new patch or spool, then just register the function so it can be
-called from `dc.get_example_patch` or `dc.get_example_spool`. These should be simple
-objects which can be generated within python. If you need to download a file see
+The [examples module](`dascore.examples`) contains several functions for creating example `Patch` and `Spool` instances. You can add a new function in that module which creates a new patch or spool, then just register the function so it can be called from `dc.get_example_patch` or `dc.get_example_spool`. These should be simple objects which can be generated within python. If you need to download a file see
 [adding a data file](#adding_a_data_file).
 
 :::{.callout-note}
@@ -45,24 +39,16 @@ patch_example = dc.get_example_patch("new_das_patch", argument_1="bob")
 spool_example = dc.get_example_spool("new_das_spool")
 ```
 
-If, in the test code, the example patch or spool is used only once, just call
-the get_example function in the test. If it is needed multiple times, consider
-putting it in a fixture. See [testing](./testing.qmd) for more on fixtures.
+If, in the test code, the example patch or spool is used only once, just call the get_example function in the test. If it is needed multiple times, consider putting it in a fixture. See [testing](./testing.qmd) for more on fixtures.
 
 # Adding a data file
 
-Of course, not all data can easily be generated in python. For example, testing
-[support for new file formats](./new_format.qmd) typically requires a test file.
+Of course, not all data can easily be generated in python. For example, testing [support for new file formats](./new_format.qmd) typically requires a test file.
 
-If you have a small file that isn't already hosted on a permanent site, you can put
- it into [dasdae's data repo](https://github.com/DASDAE/test_data).
-Simply clone the repo, add you file format, and push back to master or open a
-PR on a separate branch and someone will merge it in.
+If you have a small file that isn't already hosted on a permanent site, you can put it into [dasdae's data repo](https://github.com/DASDAE/test_data). Simply clone the repo, add you file format, and push back to master or open a PR on a separate branch and someone will merge it in.
 
 Next, add your file to dascore's data registry (dascore/data_registry.txt).
-You will have to get the sha256 hash of your test file, for that you can simply
-use [Pooch's hash_file function](https://www.fatiando.org/pooch/latest/api/generated/pooch.file_hash.html),
-and you can create the proper download url using the other entries as examples.
+You will have to get the sha256 hash of your test file, for that you can simply use [Pooch's hash_file function](https://www.fatiando.org/pooch/latest/api/generated/pooch.file_hash.html), and you can create the proper download url using the other entries as examples.
 
 The name, hash, and url might look something like this:
 ```

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -150,7 +150,7 @@ class JingleV1(FiberIO):
         # raise an error if we get the wrong type
         assert isinstance(resource, BinaryReader)
         # read first 50 bytes (maybe they have header info)
-        first_50_bytes = resourec.read(50)
+        first_50_bytes = resource.read(50)
         # seek back to byte 20
         resource.seek(20)
         # etc.

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -103,12 +103,12 @@ It is very important that the `scan` method returns *exactly* the same patch inf
 
 ## Support for Streams/Buffers
 
-Rather than using paths for the IO methods as shown above, it is better practice to write a `FiberIO` which supports the [python stream interface](https://docs.python.org/3/library/io.html#io.BufferedIOBase), sometimes referred to as buffers, or accept an opened HDF5 file in the form of a `pytables.File` object. There are a few reasons for this:
+Rather than using paths for the IO methods as shown above, it is better practice to write a `FiberIO` which supports the [python stream interface](https://docs.python.org/3/library/io.html#io.BufferedIOBase) or an opened HDF5 file in the form of a `pytables.File` object. There are a few reasons for this:
 
 * More types of inputs can be supported, including steaming file contents from the web or in-memory streams like [`BytesIO`](https://docs.python.org/3/library/io.html#io.BytesIO).
 * It is usually more efficient since open-file handles can be automatically reused by DASCore.
 
-To make this easy, DASCore will automatically manager and serve the right input to `FiberIO` methods based on type hints. Here are the ones currently supported, all of which are imported from [dascore.io](`dascore.io`) :
+To make this easy, DASCore will automatically manage and serve the right input to `FiberIO` methods based on type hints. Here are the ones currently supported, all of which are imported from [dascore.io](`dascore.io`) :
 
 1. [BinaryReader](`dascore.io.BinaryReader`) - A stream-like object which must have a `read` and `seek` method.
 
@@ -118,7 +118,13 @@ To make this easy, DASCore will automatically manager and serve the right input 
 
 4. [HDF5Writer](`dascore.io.HDF5Writer`) - An instance of pytables.File which is open in write or append (append is default) mode.
 
-Deciding which to use depends on whether the file is an HDF5 or binary format. Assuming Jingle is a binary file format, here is an implementation which supports binary streams (only showing the `read` method for brevity):
+Deciding which to use depends on whether the file is an HDF5-based or binary format.
+
+:::{.callout-note}
+If a type hint other than the ones listed above is given to the relevant parameter (path, or resource in these examples) it will have no effect.
+:::
+
+Assuming Jingle is a binary file format, here is an implementation which supports binary streams (only showing the `read` method for brevity):
 
 
 ```{python filename="dascore/io/jingle/core.py"}
@@ -137,16 +143,16 @@ class JingleV1(FiberIO):
     preferred_extensions = ('jgl',)
     version = '1'
 
-    def read(self, stream: BinaryReader, jingle_param=1, **kwargs):
+    def read(self, resource: BinaryReader, jingle_param=1, **kwargs):
         """
         get_format now accepts a stream, which DASCore will ensure is provided.
         """
         # raise an error if we get the wrong type
-        assert isinstance(stream, BinaryReader)
+        assert isinstance(resource, BinaryReader)
         # read first 50 bytes (maybe they have header info)
-        first_50_bytes = stream.read(50)
+        first_50_bytes = resourec.read(50)
         # seek back to byte 20
-        stream.seek(20)
+        resource.seek(20)
         # etc.
 
 ```


### PR DESCRIPTION

## Description

This PR ensures FiberIO methods with non-supported hints for auto-casting (see #195) still work. Also fixes a small issue with the doc build from that same PR.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
