### PR TITLE
patch method iselect

### DIFF
--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -18,7 +18,7 @@ env:
 
 # Cancel previous runs when this one starts.
 concurrency:
-  group: TestCode-${{ github.event.pull_request.number || github.run_id }}
+  group: TestCodeMinDeps-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -331,11 +331,28 @@ class CoordManager(DascoreBaseModel):
         no_dim_coords = [x for x in cmap if dim_map[x] == ()]
         return self.drop_coord(no_dim_coords)
 
+    def iselect(
+        self, array: MaybeArray = None, relative=False, **kwargs
+    ) -> Tuple[Self, MaybeArray]:
+        """
+        Perform index-based selection on coordinates.
+
+        Parameters
+        ----------
+        array
+            An array to which the selection will be applied.
+        **kwargs
+            Used to specify select arguments. Can be of the form
+            {coord_name: (lower_index, upper_index) or coord_name: index}.
+            As is standard in python, negative indices refer to the end of
+            sequence.
+        """
+
     def select(
         self, array: MaybeArray = None, relative=False, **kwargs
     ) -> Tuple[Self, MaybeArray]:
         """
-        Perform selection on coordinates.
+        Perform value-based selection on coordinates.
 
         Parameters
         ----------

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -42,7 +42,17 @@ from collections import defaultdict
 from contextlib import suppress
 from functools import reduce
 from operator import and_, or_
-from typing import Annotated, Dict, Mapping, Optional, Sequence, Tuple, TypeVar, Union
+from typing import (
+    Annotated,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Sized,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
 from pydantic import field_validator, model_validator
@@ -67,6 +77,76 @@ from dascore.utils.models import ArrayLike, DascoreBaseModel, PlainValidator
 MaybeArray = TypeVar("MaybeArray", ArrayLike, np.ndarray, None)
 
 frozendict_validator = PlainValidator(lambda x: FrozenDict(x))
+
+
+def _validate_select_coords(coord, coord_name):
+    """Ensure multi-dims are not used."""
+    if not len(coord.shape) == 1:
+        msg = (
+            "Only 1 dimensional coordinates can be used for selection "
+            f"{coord_name} has {len(coord.shape)} dimensions."
+        )
+        raise CoordError(msg)
+
+
+def _indirect_coord_updates(cm, dim_name, coord_name, reduction, new_coords):
+    """
+    Applies trim to coordinates when other associated coordinates
+    Are trimmed.
+    """
+    other_coords = set(cm.dim_to_coord_map[dim_name]) - {coord_name}
+    # perform indirect updates.
+    for icoord in other_coords:
+        dims, coord = new_coords[icoord]
+        axis = cm.dim_map[icoord].index(dim_name)
+        new = coord.index(reduction, axis=axis)
+        new_coords[icoord] = (dims, new)
+
+
+def _to_slice(limits):
+    """Convert slice or two len tuple to slice."""
+    if isinstance(limits, slice):
+        return limits
+    # ints should be interpreted as Slice(int, int+1) to not collapse dim.
+    if isinstance(limits, int):
+        if limits == -1:  # -1 case needs open interval to work
+            return slice(-1, None)
+        return slice(limits, limits + 1)
+    if limits is ... or limits is None:
+        return slice(None, None)
+    assert isinstance(limits, Sized) and len(limits) == 2
+    val1, val2 = limits
+    start = None if val1 is ... or val1 is None else val1
+    stop = None if val2 is ... or val2 is None else val2
+    return slice(start, stop)
+
+
+def _get_indexers_and_new_coords_dict(cm, kwargs, index=False, relative=False):
+    """Function to get reductions for each dimension."""
+    dim_reductions = {x: slice(None, None) for x in cm.dims}
+    dimap = cm.dim_map
+    new_coords = dict(cm._get_dim_array_dict(keep_coord=True))
+    for coord_name, limits in kwargs.items():
+        # this is not a selectable coord, just skip.
+        if coord_name not in cm.coord_map:
+            continue
+        coord = cm.coord_map[coord_name]
+        _validate_select_coords(coord, coord_name)
+        dim_name = dimap[coord_name][0]
+        # different logic if we are using indices or values
+        if not index:
+            new_coord, reductions = coord.select(limits, relative=relative)
+        else:
+            reductions = _to_slice(limits)
+            new_coord = coord[reductions]
+        # this handles the case of out-of-bound selections.
+        # These should be converted to degenerate coords.
+        dim_reductions[dim_name] = reductions
+        new_coords[coord_name] = (dimap[coord_name], new_coord)
+        # update other coords affected by change.
+        _indirect_coord_updates(cm, dim_name, coord_name, reductions, new_coords)
+    indexers = tuple(dim_reductions[x] for x in cm.dims)
+    return new_coords, indexers
 
 
 class CoordManager(DascoreBaseModel):
@@ -331,9 +411,7 @@ class CoordManager(DascoreBaseModel):
         no_dim_coords = [x for x in cmap if dim_map[x] == ()]
         return self.drop_coord(no_dim_coords)
 
-    def iselect(
-        self, array: MaybeArray = None, relative=False, **kwargs
-    ) -> Tuple[Self, MaybeArray]:
+    def iselect(self, array: MaybeArray = None, **kwargs) -> Tuple[Self, MaybeArray]:
         """
         Perform index-based selection on coordinates.
 
@@ -347,6 +425,14 @@ class CoordManager(DascoreBaseModel):
             As is standard in python, negative indices refer to the end of
             sequence.
         """
+        new_coords, indexers = _get_indexers_and_new_coords_dict(
+            self,
+            kwargs,
+            relative=False,
+            index=True,
+        )
+        new_cm = self.update_coords(**new_coords)
+        return new_cm, self._get_new_data(indexers, array)
 
     def select(
         self, array: MaybeArray = None, relative=False, **kwargs
@@ -364,52 +450,9 @@ class CoordManager(DascoreBaseModel):
             Used to specify select arguments. Can be of the form
             {coord_name: (lower_limit, upper_limit)}.
         """
-
-        def _validate_coords(coord, coord_name):
-            """Ensure multi-dims are not used."""
-            if not len(coord.shape) == 1:
-                msg = (
-                    "Only 1 dimensional coordinates can be used for selection "
-                    f"{coord_name} has {len(coord.shape)} dimensions."
-                )
-                raise CoordError(msg)
-
-        def _indirect_coord_updates(dim_name, coord_name, reduction, new_coords):
-            """
-            Applies trim to coordinates when other associated coordinates
-            Are trimmed.
-            """
-            other_coords = set(self.dim_to_coord_map[dim_name]) - {coord_name}
-            # perform indirect updates.
-            for icoord in other_coords:
-                dims, coord = new_coords[icoord]
-                axis = self.dim_map[icoord].index(dim_name)
-                new = coord.index(reduction, axis=axis)
-                new_coords[icoord] = (dims, new)
-
-        def _get_indexers_and_new_coords_dict():
-            """Function to get reductions for each dimension."""
-            dim_reductions = {x: slice(None, None) for x in self.dims}
-            dimap = self.dim_map
-            new_coords = dict(self._get_dim_array_dict(keep_coord=True))
-            for coord_name, limits in kwargs.items():
-                # this is not a selectable coord, just skip.
-                if coord_name not in self.coord_map:
-                    continue
-                coord = self.coord_map[coord_name]
-                _validate_coords(coord, coord_name)
-                dim_name = dimap[coord_name][0]
-                # this handles the case of out-of-bound selections.
-                # These should be converted to degenerate coords.
-                new_coord, reductions = coord.select(limits, relative=relative)
-                dim_reductions[dim_name] = reductions
-                new_coords[coord_name] = (dimap[coord_name], new_coord)
-                # update other coords affected by change.
-                _indirect_coord_updates(dim_name, coord_name, reductions, new_coords)
-            indexers = tuple(dim_reductions[x] for x in self.dims)
-            return new_coords, indexers
-
-        new_coords, indexers = _get_indexers_and_new_coords_dict()
+        new_coords, indexers = _get_indexers_and_new_coords_dict(
+            self, kwargs, index=False, relative=relative
+        )
         new_cm = self.update_coords(**new_coords)
         return new_cm, self._get_new_data(indexers, array)
 

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -410,7 +410,12 @@ class CoordRange(BaseCoord):
             if item >= len(self):
                 raise IndexError(f"{item} exceeds coord length of {self}")
             return self.values[item]
-        # Todo we can probably add more intelligent logic for slices.
+        # handle ... as None
+        if isinstance(item, slice):
+            start = None if item.start is ... else item.start
+            end = None if item.stop is ... else item.stop
+            # Todo we can probably add more intelligent logic for slices.
+            item = slice(start, end, item.step)
         out = self.values[item]
         return get_coord(values=out, units=self.units)
 

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -335,6 +335,7 @@ class Patch:
     # --- processing funcs
 
     select = dascore.proc.select
+    iselect = dascore.proc.iselect
     decimate = dascore.proc.decimate
     detrend = dascore.proc.detrend
     pass_filter = dascore.proc.pass_filter

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -1,5 +1,5 @@
 """
-Module to Patch Processing.
+Module containing patch processing routines.
 """
 from .aggregate import aggregate
 from .basic import *  # noqa
@@ -7,6 +7,6 @@ from .coords import snap_coords, sort_coords
 from .detrend import detrend
 from .filter import median_filter, pass_filter, sobel_filter
 from .resample import decimate, interpolate, iresample, resample
-from .select import select
+from .select import iselect, select
 from .taper import taper
 from .units import convert_units, set_units, simplify_units

--- a/dascore/proc/select.py
+++ b/dascore/proc/select.py
@@ -73,7 +73,7 @@ def iselect(patch: PatchType, *, copy=False, **kwargs) -> PatchType:
 
     Any dimension of the data can be passed as key, and the values
     should either be a Slice, a tuple of (min_ind, max_ind) or a single
-    int. If a single int is used, the patch will be flattened.
+    int.
 
     Parameters
     ----------
@@ -89,7 +89,12 @@ def iselect(patch: PatchType, *, copy=False, **kwargs) -> PatchType:
 
     Examples
     --------
-
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>> # Select first 10 distance indices
+    >>> out1 = patch.iselect(distance=(..., 10))
+    >>> # Select last time row/column
+    >>> out2 = patch.iselect(time=-1)
     """
     new_coords, data = patch.coords.iselect(**kwargs, array=patch.data)
     # no slicing was performed, just return original.

--- a/dascore/proc/select.py
+++ b/dascore/proc/select.py
@@ -8,7 +8,7 @@ from dascore.utils.patch import patch_function
 @patch_function(history=None)
 def select(patch: PatchType, *, copy=False, relative=False, **kwargs) -> PatchType:
     """
-    Return a subset of the patch based on query parameters.
+    Return a subset of the patch using value-based query parameters.
 
     Any dimension of the data can be passed as key, and the values
     should either be a Slice or a tuple of (min, max) for that
@@ -30,6 +30,8 @@ def select(patch: PatchType, *, copy=False, relative=False, **kwargs) -> PatchTy
         possitive, or the end of the coordinate, if negative.
     **kwargs
         Used to specify the dimension and slices to select on.
+
+    See also [iselect](`dascore.proc.select.iselect`).
 
     Examples
     --------
@@ -55,6 +57,41 @@ def select(patch: PatchType, *, copy=False, relative=False, **kwargs) -> PatchTy
     new_coords, data = patch.coords.select(
         **kwargs, array=patch.data, relative=relative
     )
+    # no slicing was performed, just return original.
+    if data.shape == patch.data.shape:
+        return patch
+    if copy:
+        data = data.copy()
+    attrs, dims = patch.attrs, patch.dims
+    return patch.__class__(data, attrs=attrs, coords=new_coords, dims=dims)
+
+
+@patch_function(history=None)
+def iselect(patch: PatchType, *, copy=False, **kwargs) -> PatchType:
+    """
+    Return a subset of the patch using index-based query parameters.
+
+    Any dimension of the data can be passed as key, and the values
+    should either be a Slice, a tuple of (min_ind, max_ind) or a single
+    int. If a single int is used, the patch will be flattened.
+
+    Parameters
+    ----------
+    patch
+        The patch object.
+    copy
+        If True, copy the resulting data. This is needed so the old
+        array can get gc'ed and memory freed.
+    **kwargs
+        Used to specify the dimension and slices to select on.
+
+    See also [select](`dascore.proc.select.select`).
+
+    Examples
+    --------
+
+    """
+    new_coords, data = patch.coords.iselect(**kwargs, array=patch.data)
     # no slicing was performed, just return original.
     if data.shape == patch.data.shape:
         return patch

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -3,7 +3,6 @@ execute:
   warning: false
 ---
 
-
 # DASCore
 
 A python library for distributed fiber optic sensing.

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -202,6 +202,21 @@ new = patch.select(time=(-2, -1), relative=True)
 new = patch.select(distance=(..., -100 * ft), relative=True)
 ```
 
+[`iselect`](`dascore.Patch.iselect`) provides the same functionality, but for index-based trimming.
+
+```{python}
+import dascore as dc
+
+patch = dc.get_example_patch()
+
+# Trim patch to only include first 10 time rows (or columns)
+new = patch.iselect(time=(..., 10))
+
+# get the last dimension column/row
+new = patch.iselect(distance=-1)
+```
+
+
 # Processing
 
 The patch has several methods which are intended to be chained together via a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface), meaning each method returns a new `Patch` instance.

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -408,6 +408,13 @@ class TestSelect:
         assert out == basic_coord_manager
 
 
+class TestISelect:
+    """Tests for index-based selections."""
+
+    def test_compare_to_select(self, basic_coord_manager):
+        """Ensure"""
+
+
 class TestEquals:
     """Tests for coord manager equality"""
 

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -32,7 +32,7 @@ from dascore.exceptions import (
     ParameterError,
 )
 from dascore.units import get_conversion_factor
-from dascore.utils.misc import get_middle_value, register_func
+from dascore.utils.misc import all_close, get_middle_value, register_func
 
 COORD_MANAGERS = []
 
@@ -411,8 +411,76 @@ class TestSelect:
 class TestISelect:
     """Tests for index-based selections."""
 
-    def test_compare_to_select(self, basic_coord_manager):
-        """Ensure"""
+    # index ranges to compare with normal select.
+    slice_inds = (
+        (None, 5),
+        (..., 5),
+        (1, 5),
+        (1, None),
+        (1, ...),
+        (..., ...),
+        (None, None),
+        (3, 4),
+        (-4, -1),
+        (1, -1),
+    )
+    # single index values to test
+    inds = (
+        0,
+        1,
+        -1,
+        -2,
+    )
+
+    @pytest.mark.parametrize("slice_range", slice_inds)
+    def test_compare_to_select(self, basic_coord_manager, slice_range):
+        """Ensure select and iselect behave the same with equiv. data."""
+        cm = basic_coord_manager
+        for name, coord in cm.coord_map.items():
+            ind_tuple = slice_range
+            ind_1, ind_2 = slice_range
+            val1 = coord[ind_1] if isinstance(ind_1, int) else ind_1
+            val2 = coord[ind_2 - 1] if isinstance(ind_2, int) else ind_2
+            value_tuple = (val1, val2)
+            # first, just check coords are equal
+            out1 = coord.select(value_tuple)[0]
+            out2 = coord[slice(*ind_tuple)]
+            if not out1 == out2:
+                assert all_close(out1.values, out2.values)
+            # then check that the whole coord_manager are equal
+            cm1 = cm.select(**{name: value_tuple})
+            cm2 = cm.iselect(**{name: ind_tuple})
+            assert cm1 == cm2
+
+    @pytest.mark.parametrize("index", inds)
+    def test_single_values(self, basic_coord_manager, index):
+        """
+        Single values should be treated like slice(val, val+1)
+        as not to collapse the dimensions.
+        """
+        cm = basic_coord_manager
+        data = np.empty(cm.shape)
+        for dim in basic_coord_manager.dims:
+            kwargs = {dim: index}
+            out1, new_data = cm.iselect(array=data, **kwargs)
+            dim_ind = cm.dims.index(dim)
+            # now the array should have a len(1) in the selected dimension.
+            assert out1.shape[dim_ind] == new_data.shape[dim_ind] == 1
+            new_value = out1.coord_map[dim].values[0]
+            expected_value = cm[dim][index]
+            all_close(new_value, expected_value)
+
+    def test_trim_related_coords(self, coord_manager_multidim):
+        """Ensure trim also trims related dimensions."""
+        cm = coord_manager_multidim
+        data = np.empty(cm.shape)
+        out, new_data = cm.iselect(array=data, time=slice(2, 4))
+        for name, coord in out.coord_map.items():
+            dims = cm.dim_map[name]
+            if "time" not in dims:
+                continue
+            time_id = dims.index("time")
+            assert coord.shape[time_id] == 2
 
 
 class TestEquals:

--- a/tests/test_proc/test_select.py
+++ b/tests/test_proc/test_select.py
@@ -106,6 +106,35 @@ class TestSelect:
         assert patch1 == patch2
 
 
+class TestISelect:
+    """Tests for Index-based selection."""
+
+    # Note: since this uses nearly all the same logic as select, it
+    # is not necessary to test it as extensively.
+    def test_time_slice(self, random_patch):
+        """Ensure a simple time slice works."""
+        pa1 = random_patch.iselect(time=(1, 5))
+        pa2 = random_patch.iselect(time=slice(1, 5))
+        assert pa1 == pa2
+
+    def test_non_slice(self, random_patch):
+        """Ensure a non-slice doesnt change patch."""
+        pa1 = random_patch.iselect(distance=(..., ...))
+        pa2 = random_patch.iselect(distance=(None, ...))
+        pa3 = random_patch.iselect(distance=slice(None, None))
+        pa4 = random_patch.iselect(distance=...)
+        assert pa1 == pa2 == pa3 == pa4
+
+    def test_copy(self, random_patch):
+        """Ensure the copy keyword works."""
+        out1 = random_patch.iselect(time=slice(1, 10), copy=True)
+        # base is None means this isnt a view
+        assert out1.data.base is None
+        out2 = random_patch.iselect(time=slice(1, 10), copy=False)
+        # base is not None means it is a view
+        assert out2.data.base is not None
+
+
 class TestSelectHistory:
     """Test behavior of history added by select."""
 


### PR DESCRIPTION

## Description

This PR adds a patch method called `iselect` which is similar to `select` except it uses indices rather than values for the selection.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
