### PR TITLE
add an automatic table of io supports

### DIFF
--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -366,7 +366,7 @@ class FiberIO:
         """
         A function for making a table of all the supported formats and the methods.
         """
-        # loads all the plugin so we know about all the FiberIO classes
+        # load all the plugins, so we know about all the FiberIO classes
         FiberIO.manager.load_plugins()
         out = []
         # iterate the dict _format_version_items,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -357,8 +357,31 @@ class FiberIO:
 
     @property
     def implements_get_format(self) -> bool:
-        """Return True if the subclass implements its own get_format method."""
+        """
+        Return True if the subclass implements its own get_format method.
+        """
         return not _is_wrapped_func(self.get_format, FiberIO.get_format)
+
+    def get_supported_io_table():
+        """
+        A function for making a table of all the supported formats and the methods.
+        """
+        # loads all the plugin so we know about all the FiberIO classes
+        FiberIO.manager.load_plugins()
+        out = []
+        # iterate the dict _format_version_items,
+        # which has the form {format_name: {version_str: FiberIO}}
+        for format_name, version_dict in FiberIO.manager._format_version.items():
+            for version_name, fiberio in version_dict.items():
+                format_info = {}
+                format_info["name"] = format_name
+                format_info["version"] = version_name
+                format_info["scan"] = fiberio.implements_scan
+                format_info["get_format"] = fiberio.implements_get_format
+                format_info["read"] = fiberio.implements_read
+                format_info["write"] = fiberio.implements_write
+                out.append(format_info)
+        return pd.DataFrame(out)
 
     def __hash__(self):
         """FiberIO instances should be uniquely defined by (format, version)"""

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -22,7 +22,7 @@ format:
 
 
 website:
-  title: DASCore (0.0.13.dev13)
+  title: DASCore (0.0.13.dev17)
   repo-url: https://github.com/dasdae/dascore
   site-path: /docs
   site-url: https://www.dascore.org

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -35,6 +35,13 @@ DASCore is a foundational package of the [DAS Data Analysis Ecosystem (DASDAE)](
 facilitates rapid development of other DASDAE packages that do more specialized analysis/visualization.
 :::
 
+# Supporting input/output formats
+```{python}
+#| echo: false
+from dascore.io.core import FiberIO
+FiberIO.get_supported_io_table()
+```
+
 # Introductory usage
 
 ## Read a file

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -38,8 +38,9 @@ facilitates rapid development of other DASDAE packages that do more specialized 
 # Supporting input/output formats
 ```{python}
 #| echo: false
+import pandas as pd
 from dascore.io.core import FiberIO
-FiberIO.get_supported_io_table()
+FiberIO.get_supported_io_table().replace(True, value='✅').replace(False, value='❌')
 ```
 
 # Introductory usage

--- a/docs/recipes/contributing_to_documentation.qmd
+++ b/docs/recipes/contributing_to_documentation.qmd
@@ -40,5 +40,5 @@ quarto preview docs
 This will take a few minutes the first time you run it. After that, the results are cached on only the changed files are re-rendered.
 :::
 
-Now, you can make new documentation or make changes in the /dascore/index.qmd file, /dascore/docs/ directory and so on.
+Now, you can make new documentation or make changes to the "index.qmd" file on the /dascore/docs/ directory and so on.
 However, if you make changes to any of DASCore's docstring, you need to re-run the build_api_docs.py script for the changes to appear.

--- a/docs/recipes/how_to_contribute.qmd
+++ b/docs/recipes/how_to_contribute.qmd
@@ -49,7 +49,7 @@ pytest --pdb
 
 Finally, to make a commit and push your branch to GitHub, follow below steps:
 
-1- Run the following command twice(the first time will automatically fix some issues):
+1- Run the following command twice (the first time will automatically fix some issues):
 
 ```bash
 pre-commit run –all

--- a/docs/recipes/how_to_contribute.qmd
+++ b/docs/recipes/how_to_contribute.qmd
@@ -52,7 +52,7 @@ Finally, to make a commit and push your branch to GitHub, follow below steps:
 1- Run the following command twice (the first time will automatically fix some issues):
 
 ```bash
-pre-commit run –all
+pre-commit run --all
 ```
 
 2- Run all the following commands:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TypeVar, Union
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import dascore as dc
@@ -88,7 +89,7 @@ class _FiberUnsupportedTypeHints(FiberIO):
 
 
 class TestFormatManager:
-    """tests for the format manager."""
+    """Tests for the format manager."""
 
     @pytest.fixture(scope="class")
     def format_manager(self):
@@ -283,7 +284,7 @@ class TestCastType:
     """Test suite to ensure types are intelligently cast to type hints."""
 
     def test_read(self, dummy_text_file):
-        """ensure write casts type."""
+        """Ensure write casts type."""
         io = _FiberCaster()
         # this passes if it doesnt raise.
         io.read(dummy_text_file)
@@ -312,3 +313,18 @@ class TestCastType:
         version = _FiberUnsupportedTypeHints.version
         out = dc.read(dummy_text_file, name, version)
         assert out == Path(dummy_text_file).read_text()
+
+
+class TestGetSupportedIOTable:
+    """A test for creating the supported io table."""
+
+    def test_get_supported_io_table(self):
+        """Test the get_supported_io_table function."""
+        # call the function to get the result
+        result_df = FiberIO.get_supported_io_table()
+
+        # assert that the result is a DataFrame
+        assert isinstance(result_df, pd.DataFrame)
+
+        # assert that the length of the DataFrame is not 0
+        assert len(result_df) > 0


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description
Adding an automatically generated table of supported formats to the DASCore's homepage documentation.
Related to #159
<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
