### PR TITLE
shorter patch history with numpy arrays

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -162,6 +162,7 @@ history
 # Rich styles for various object displays.
 dascore_styles = dict(
     np_array_threshold=100,  # max number of elements to show in array
+    patch_history_array_threshold=10,  # max elements of array in hist str.
     dc_blue="#002868",
     dc_red="#cf0029",
     dc_yellow="#ffc934",

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -35,7 +35,7 @@ def _format_values(val):
         out = np.array2string(
             val,
             precision=FLOAT_PRECISION,
-            threshold=dascore_styles['patch_history_array_threshold']
+            threshold=dascore_styles["patch_history_array_threshold"],
         )
     else:
         out = val

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -23,8 +23,23 @@ from dascore.exceptions import (
 from dascore.units import get_quantity
 from dascore.utils.misc import all_diffs_close_enough, get_middle_value, iterate
 from dascore.utils.time import to_float
+from dascore.constants import FLOAT_PRECISION, dascore_styles
 
 attr_type = dict[str, Any] | str | Sequence[str] | None
+
+
+def _format_values(val):
+    """string formatting for values for history string."""
+    if isinstance(val, np.ndarray):
+        # make sure numpy strings arent too long!
+        out = np.array2string(
+            val,
+            precision=FLOAT_PRECISION,
+            threshold=dascore_styles['patch_history_array_threshold']
+        )
+    else:
+        out = val
+    return out
 
 
 def _func_and_kwargs_str(func: Callable, patch, *args, **kwargs) -> str:
@@ -34,8 +49,12 @@ def _func_and_kwargs_str(func: Callable, patch, *args, **kwargs) -> str:
     callargs.pop("self", None)
     kwargs_ = callargs.pop("kwargs", {})
     arguments = []
-    arguments += [f"{k}={v!r}" for k, v in callargs.items() if v is not None]
-    arguments += [f"{k}={v!r}" for k, v in kwargs_.items() if v is not None]
+    arguments += [
+        f"{k}={_format_values(v)!r}" for k, v in callargs.items() if v is not None
+    ]
+    arguments += [
+        f"{k}={_format_values(v)!r}" for k, v in kwargs_.items() if v is not None
+    ]
     arguments.sort()
     out = f"{func.__name__}("
     if arguments:


### PR DESCRIPTION

## Description 

This PR just shortens the history strings of patch functions which have large numpy arrays in them. 

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
