### PR TITLE
fix #221

### DIFF
--- a/tests/test_io/test_prodml/test_prod_ml.py
+++ b/tests/test_io/test_prodml/test_prod_ml.py
@@ -1,7 +1,10 @@
 """Generic tests for prodml support."""
 from __future__ import annotations
 
+import shutil
+
 import pytest
+import tables
 
 import dascore as dc
 from dascore.io.core import read
@@ -35,6 +38,20 @@ class TestProdMLFile:
     """
 
     @pytest.fixture(scope="class")
+    def issue_221_patch_path(self, tmp_path_factory):
+        """Ensure dims are correctly ascertained."""
+        tmp_path = tmp_path_factory.mktemp("issue_221")
+        path = dc.utils.downloader.fetch("prodml_2.0.h5")
+        new_path = shutil.copy2(path, tmp_path / "prod_2_monkey_patched.h5")
+        with tables.open_file(new_path, "a") as fi:
+            # monkey patch dimensions to simulate issue.
+            new_dims = "time, locus"
+            parent_node = fi.root.Acquisition["Raw[0]"]
+            node = parent_node["RawData"]
+            node._v_attrs.Dimensions = new_dims
+        return new_path
+
+    @pytest.fixture(scope="class")
     def silixa_h5_patch(self, idas_h5_example_path):
         """Get the silixa file, return Patch."""
         return dc.spool(idas_h5_example_path)[0]
@@ -48,6 +65,11 @@ class TestProdMLFile:
         """Ensure gauge-length is found in patch attrs."""
         patch = silixa_h5_patch
         assert hasattr(patch.attrs, "gauge_length")
+
+    def test_issue_221(self, issue_221_patch_path):
+        """Ensure dims are correctly ascertained."""
+        patch = dc.read(issue_221_patch_path)[0]
+        assert isinstance(patch, dc.Patch)
 
 
 class TestReadQuantXV2:


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

This PR fixes https://github.com/DASDAE/dascore/issues/221 by adding logic to get the prodml dimension name and order from the file meta data.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
