### PR TITLE
coord.get_sample_count

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -528,6 +528,26 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             out = out.convert_units(units)
         return out
 
+    def get_sample_count(self, value) -> int:
+        """
+        Return the number of samples represented by a value.
+
+        This is calculated by dividing the value by dt and rounding up.
+        Therefore, the output will always be greater or equal to 1.
+
+        Parameters
+        ----------
+        value
+            The value (supports units).
+        """
+        if not self.evenly_sampled:
+            msg = "Coordinate is not evenly sampled, cant get sample count."
+            raise CoordError(msg)
+        compat_val = self._get_compatible_value(value, relative=True)
+        duration = compat_val - self.min()
+        samples = int(np.ceil(duration / self.step))
+        return samples
+
 
 class CoordRange(BaseCoord):
     """

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1081,6 +1081,34 @@ class TestCoercion:
         assert out.dtype == coord.dtype
 
 
+class TestGetSampleCount:
+    """Tests for getting the number of samples from a coordinate."""
+
+    def test_uneven_raises(self, monotonic_float_coord):
+        """Unevenly sampled counts should raise."""
+        msg = "Coordinate is not evenly sampled"
+        with pytest.raises(CoordError, match=msg):
+            monotonic_float_coord.get_sample_count(10)
+
+    def test_dt_lt_step(self, evenly_sampled_coord):
+        """Ensure sample count is 1 when value < dt"""
+        dt = evenly_sampled_coord.step * 0.1
+        out = evenly_sampled_coord.get_sample_count(dt)
+        assert out == 1
+
+    def test_datetime(self, evenly_sampled_date_coord):
+        """Ensure evenly sampled date coords work."""
+        dt = evenly_sampled_date_coord.step
+        out = evenly_sampled_date_coord.get_sample_count(12 * dt)
+        assert out == 12
+
+    def test_timedelta(self, evenly_sampled_time_delta_coord):
+        """Ensure timedelta works."""
+        dt = evenly_sampled_time_delta_coord.step
+        out = evenly_sampled_time_delta_coord.get_sample_count(12 * dt)
+        assert out == 12
+
+
 class TestIssues:
     """Tests for special issues related to coords."""
 


### PR DESCRIPTION

## Description
Adds a coordinate method `get_sample_count`.  This returns the number of samples in an evenly sampled coordinate represented by a value. Also handles units. This will be used in the windowing functionality.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
