### PR TITLE
fix suffix in IO

### DIFF
--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -649,7 +649,9 @@ def get_format(
         path = man.source
         if not os.path.exists(path):
             raise FileNotFoundError(f"{path} does not exist.")
-        ext = Path(path).suffix or None
+        # get extension (minus .)
+        suffix = Path(path).suffix
+        ext = suffix[1:] if suffix else None
         iterator = FiberIO.manager.yield_fiberio(
             file_format, file_version, extension=ext
         )


### PR DESCRIPTION

## Description

It turns out the file extension optimization for finding the correct `FiberIO` wasn't working because DASCore expects the extension without the dot (eg "h5") but [this line](https://github.com/DASDAE/dascore/blob/e2cc41609162801f9eae8c3788d624d3c6ad01ae/dascore/io/core.py#L652) returns the suffix with the starting dot (eg ".h5"). This should speed up automatic file determinations a bit.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
