### PR TITLE
Implement rolling functions

### DIFF
--- a/benchmarks/notebooks/rolling.ipynb
+++ b/benchmarks/notebooks/rolling.ipynb
@@ -287,7 +287,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dascore",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -301,9 +301,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/benchmarks/notebooks/rolling.ipynb
+++ b/benchmarks/notebooks/rolling.ipynb
@@ -1,0 +1,309 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rolling method\n",
+    "\n",
+    "A few simple profiling tests to clock rolling method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dascore as dc\n",
+    "import numba\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rolling_mean(data, window_size,step_size, axis = 0):\n",
+    "    total_samples = data.shape[axis]\n",
+    "    mean_values = np.empty((int(total_samples/step_size),data.shape[1]))\n",
+    "\n",
+    "    for j, k in enumerate(range(0, total_samples, step_size)):\n",
+    "\n",
+    "        if k+window_size>total_samples:\n",
+    "            mean_values[j, :] = np.full((data.shape[1]), np.nan)\n",
+    "        else:\n",
+    "            mean_values[j, :] = np.mean(\n",
+    "                data[k : k + window_size, :], axis=axis\n",
+    "            )\n",
+    "\n",
+    "\n",
+    "    return mean_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "patch = dc.get_example_patch()\n",
+    "\n",
+    "mean_values = rolling_mean(patch.data, 1000, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%timeit mean_values = rolling_mean(patch.data, 1000, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@numba.jit\n",
+    "def rolling_mean_numba(data, window_size,step_size, axis = 0):\n",
+    "    total_samples = data.shape[axis]\n",
+    "    mean_values = np.empty((int(total_samples/step_size),data.shape[1]))\n",
+    "\n",
+    "    for j, k in enumerate(range(0, total_samples, step_size)):\n",
+    "        mean_values[j, :] = np.mean(\n",
+    "            data[k : k + window_size, :],\n",
+    "        )\n",
+    "    return mean_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%timeit rolling_mean = rolling_mean_numba(patch.data, 1000, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_data = np.array([[0,1,-2,9.2,8.12,-7,0,0,10.5,0,0],\n",
+    "                    [5,4.41,6,-3,-0.01,0,9.8,-5,8.13,10,0],\n",
+    "                    [0,0,0,0,12.4,-3,-9,1,2.45,0.001,-2.5]])\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.DataFrame(my_data)\n",
+    "rolling_mean = df.rolling(3, step=2, axis=0).mean()\n",
+    "print(np.array(rolling_mean))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_data = np.array([[0,1,-2,9.2,8.12,-7,0,0,10.5,0,0],\n",
+    "                    [5,4.41,6,-3,-0.01,0,9.8,-5,8.13,10,0],\n",
+    "                    [0,0,0,0,12.4,-3,-9,1,2.45,0.001,-2.5]])\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.DataFrame(my_data)\n",
+    "rolling_mean = df.rolling(3, step=2, axis=1).mean()\n",
+    "print(np.array(rolling_mean))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = dc.get_example_patch()\n",
+    "num_rows = np.random.randint(1, 5)\n",
+    "num_cols = np.random.randint(1, 11)\n",
+    "my_data = np.random.random((num_rows,num_cols))\n",
+    "print(p)\n",
+    "print(p.data.shape)\n",
+    "p_dec = p.resample(time=np.timedelta64(10, 'ms'))\n",
+    "# p.resample(distance=num_rows)\n",
+    "# p.new(data=my_data)\n",
+    "\n",
+    "print(p_dec.data.shape)\n",
+    "\n",
+    "\n",
+    "# print(p.coords)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(p_dec.coords['time']))\n",
+    "print(p_dec.attrs['time_step']/np.timedelta64(1, 's'))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(p.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(p.data.shape)\n",
+    "window_size = 3\n",
+    "mean_values = rolling_mean(p.data, window_size =window_size, step_size = 1, axis =0)\n",
+    "# mean_values = np.roll(mean_values, int(window_size/2), axis=0)\n",
+    "print(mean_values)\n",
+    "print(mean_values.shape)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd \n",
+    "df = pd.DataFrame(p.data)\n",
+    "rolling_mean_panas = df.rolling(3, step=1, axis=0, center=False).mean()\n",
+    "print(np.array(rolling_mean_panas))\n",
+    "print(np.array(rolling_mean_panas).shape)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dascore as dc\n",
+    "\n",
+    "p = dc.get_example_patch(\"iDAS\")\n",
+    "print(p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dc.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dascore.utils.time import to_timedelta64\n",
+    "\n",
+    "\n",
+    "array = np.random.random(size=(2_000, 300))\n",
+    "t1 = np.datetime64(\"2017-09-18\")\n",
+    "attrs = dict(\n",
+    "    d_distance=1,\n",
+    "    d_time=to_timedelta64(1 / 250),\n",
+    "    category=\"DAS\",\n",
+    "    id=\"test_data1\",\n",
+    "    time_min=t1,\n",
+    ")\n",
+    "\n",
+    "print(to_timedelta64(1 / 250))\n",
+    "coords = dict(\n",
+    "    time=np.arange(array.shape[0]) * attrs[\"d_time\"],\n",
+    "    distance=np.arange(array.shape[1]) * attrs[\"d_distance\"] ,)\n",
+    "dims = ('time', 'distance')\n",
+    "\n",
+    "pa = dc.Patch(data=array, coords=coords, attrs=attrs, dims=dims)\n",
+    "\n",
+    "print(pa)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = dc.get_example_patch()\n",
+    "\n",
+    "new_attrs = dict(p.attrs)\n",
+    "samples = np.array(p.coords[\"time\"])\n",
+    "\n",
+    "print(patch.coords)\n",
+    "new_coords = {x: patch.coords[x] for x in patch.dims}\n",
+    "print(new_coords)\n",
+    "\n",
+    "reversed_coords = {coord: values[::-1] for coord, values in new_coords.items()}\n",
+    "print(reversed_coords)\n",
+    "\n",
+    "# new_coords[\"time\"] = samples\n",
+    "# new_attrs[f\"d_time\"] = dt\n",
+    "# new_attrs[f\"min_time\"] = np.min(samples)\n",
+    "# new_attrs[f\"max_time\"] = np.max(samples)\n",
+    "# new_patch = patch.new(data=p.data.T, attrs=new_attrs, dims=patch.dims, coords=new_coords)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dascore as dc\n",
+    "pa = dc.get_example_patch()\n",
+    "\n",
+    "# update start time should also shift endtime\n",
+    "pa1 = pa.update_attrs(time_min='2000-01-01')\n",
+    "\n",
+    "print(pa.attrs['time_min'])\n",
+    "print(pa1.attrs['time_min'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dascore",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/benchmarks/notebooks/rolling.ipynb
+++ b/benchmarks/notebooks/rolling.ipynb
@@ -96,112 +96,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_data = np.array([[0,1,-2,9.2,8.12,-7,0,0,10.5,0,0],\n",
-    "                    [5,4.41,6,-3,-0.01,0,9.8,-5,8.13,10,0],\n",
-    "                    [0,0,0,0,12.4,-3,-9,1,2.45,0.001,-2.5]])\n",
-    "\n",
-    "import pandas as pd\n",
-    "\n",
-    "df = pd.DataFrame(my_data)\n",
-    "rolling_mean = df.rolling(3, step=2, axis=0).mean()\n",
-    "print(np.array(rolling_mean))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "my_data = np.array([[0,1,-2,9.2,8.12,-7,0,0,10.5,0,0],\n",
-    "                    [5,4.41,6,-3,-0.01,0,9.8,-5,8.13,10,0],\n",
-    "                    [0,0,0,0,12.4,-3,-9,1,2.45,0.001,-2.5]])\n",
-    "\n",
-    "import pandas as pd\n",
-    "\n",
-    "df = pd.DataFrame(my_data)\n",
-    "rolling_mean = df.rolling(3, step=2, axis=1).mean()\n",
-    "print(np.array(rolling_mean))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "p = dc.get_example_patch()\n",
-    "num_rows = np.random.randint(1, 5)\n",
-    "num_cols = np.random.randint(1, 11)\n",
-    "my_data = np.random.random((num_rows,num_cols))\n",
-    "print(p)\n",
-    "print(p.data.shape)\n",
-    "p_dec = p.resample(time=np.timedelta64(10, 'ms'))\n",
-    "# p.resample(distance=num_rows)\n",
-    "# p.new(data=my_data)\n",
-    "\n",
-    "print(p_dec.data.shape)\n",
-    "\n",
-    "\n",
-    "# print(p.coords)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(len(p_dec.coords['time']))\n",
-    "print(p_dec.attrs['time_step']/np.timedelta64(1, 's'))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(p.data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(p.data.shape)\n",
-    "window_size = 3\n",
-    "mean_values = rolling_mean(p.data, window_size =window_size, step_size = 1, axis =0)\n",
-    "# mean_values = np.roll(mean_values, int(window_size/2), axis=0)\n",
-    "print(mean_values)\n",
-    "print(mean_values.shape)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd \n",
-    "df = pd.DataFrame(p.data)\n",
-    "rolling_mean_panas = df.rolling(3, step=1, axis=0, center=False).mean()\n",
-    "print(np.array(rolling_mean_panas))\n",
-    "print(np.array(rolling_mean_panas).shape)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import numpy as np\n",
     "import dascore as dc\n",
-    "\n",
-    "p = dc.get_example_patch(\"iDAS\")\n",
-    "print(p)"
+    "from dascore.units import s\n"
    ]
   },
   {
@@ -210,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dc.__version__"
+    "patch = dc.get_example_patch()"
    ]
   },
   {
@@ -219,28 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dascore.utils.time import to_timedelta64\n",
-    "\n",
-    "\n",
-    "array = np.random.random(size=(2_000, 300))\n",
-    "t1 = np.datetime64(\"2017-09-18\")\n",
-    "attrs = dict(\n",
-    "    d_distance=1,\n",
-    "    d_time=to_timedelta64(1 / 250),\n",
-    "    category=\"DAS\",\n",
-    "    id=\"test_data1\",\n",
-    "    time_min=t1,\n",
-    ")\n",
-    "\n",
-    "print(to_timedelta64(1 / 250))\n",
-    "coords = dict(\n",
-    "    time=np.arange(array.shape[0]) * attrs[\"d_time\"],\n",
-    "    distance=np.arange(array.shape[1]) * attrs[\"d_distance\"] ,)\n",
-    "dims = ('time', 'distance')\n",
-    "\n",
-    "pa = dc.Patch(data=array, coords=coords, attrs=attrs, dims=dims)\n",
-    "\n",
-    "print(pa)"
+    "%timeit patch_mean = patch.rolling(time=1*s, step=0.5*s).mean()"
    ]
   },
   {
@@ -249,23 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = dc.get_example_patch()\n",
-    "\n",
-    "new_attrs = dict(p.attrs)\n",
-    "samples = np.array(p.coords[\"time\"])\n",
-    "\n",
-    "print(patch.coords)\n",
-    "new_coords = {x: patch.coords[x] for x in patch.dims}\n",
-    "print(new_coords)\n",
-    "\n",
-    "reversed_coords = {coord: values[::-1] for coord, values in new_coords.items()}\n",
-    "print(reversed_coords)\n",
-    "\n",
-    "# new_coords[\"time\"] = samples\n",
-    "# new_attrs[f\"d_time\"] = dt\n",
-    "# new_attrs[f\"min_time\"] = np.min(samples)\n",
-    "# new_attrs[f\"max_time\"] = np.max(samples)\n",
-    "# new_patch = patch.new(data=p.data.T, attrs=new_attrs, dims=patch.dims, coords=new_coords)"
+    "patch = dc.spool(\"/mnt/c/test_spool\")[0]"
    ]
   },
   {
@@ -274,20 +134,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import dascore as dc\n",
-    "pa = dc.get_example_patch()\n",
-    "\n",
-    "# update start time should also shift endtime\n",
-    "pa1 = pa.update_attrs(time_min='2000-01-01')\n",
-    "\n",
-    "print(pa.attrs['time_min'])\n",
-    "print(pa1.attrs['time_min'])"
+    "%timeit patch_mean = patch.rolling(time=1*s, step=0.5*s).mean()\n"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "dascore",
    "language": "python",
    "name": "python3"
   },
@@ -301,9 +154,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/benchmarks/notebooks/rolling.ipynb
+++ b/benchmarks/notebooks/rolling.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "patch = dc.spool(\"/mnt/c/test_spool\")[0]"
+    "patch = dc.spool(\"/mnt/c/test_spool_1\")[0]"
    ]
   },
   {
@@ -135,6 +135,24 @@
    "outputs": [],
    "source": [
     "%timeit patch_mean = patch.rolling(time=1*s, step=0.5*s).mean()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "patch = dc.spool(\"/mnt/c/test_spool_2\")[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%timeit patch_mean = patch.rolling(time=3*s, step=1*s).mean()\n"
    ]
   }
  ],

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -747,12 +747,15 @@ class CoordManager(DascoreBaseModel):
         ----------
         dim
             The dimension name, or sequence of dimension names, to drop.
+            If None, drop all length 1 dims
 
         Raises
         ------
         CoordError if the selected dimension has a length gt 1.
         """
         to_drop = []
+        if dim is None:
+            dim = [x for x in self.dims if len(self.coord_map[x]) <= 1]
         bad_dim = set(iterate(dim)) - set(self.dims)
         if bad_dim:
             msg = (

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -217,7 +217,7 @@ class Patch:
     normalize = dascore.proc.normalize
     standardize = dascore.proc.standardize
     taper = dascore.proc.taper
-    rolling = dascore.proc.rolling
+    rolling = dascore.proc.rolling.rolling
 
     # --- Method Namespaces
     # Note: these can't be cached_property (from functools) or references

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -217,6 +217,7 @@ class Patch:
     normalize = dascore.proc.normalize
     standardize = dascore.proc.standardize
     taper = dascore.proc.taper
+    rolling = dascore.proc.rolling
 
     # --- Method Namespaces
     # Note: these can't be cached_property (from functools) or references

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -218,7 +218,7 @@ class Patch:
     normalize = dascore.proc.normalize
     standardize = dascore.proc.standardize
     taper = dascore.proc.taper
-    rolling = dascore.proc.rolling.rolling
+    rolling = dascore.proc.rolling
 
     # --- Method Namespaces
     # Note: these can't be cached_property (from functools) or references

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -203,6 +203,7 @@ class Patch:
     iselect = dascore.proc.iselect
     decimate = dascore.proc.decimate
     detrend = dascore.proc.detrend
+    dropna = dascore.proc.dropna
     pass_filter = dascore.proc.pass_filter
     sobel_filter = dascore.proc.sobel_filter
     median_filter = dascore.proc.median_filter

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -80,65 +80,6 @@ def _random_patch(
     return patch
 
 
-@register_func(EXAMPLE_PATCHES, key="random_das_time_dist")
-def _random_patch_time_dist(
-    *,
-    starttime="2017-09-18",
-    start_distance=0,
-    network="",
-    station="",
-    tag="random",
-    shape=(2_000, 300),
-    time_step=to_timedelta64(1 / 250),
-    distance_step=1,
-    time_array=None,
-    dist_array=None,
-):
-    """Generate a random DAS Patch."""
-    # get input data
-    rand = np.random.RandomState(13)
-    array = rand.random(shape)
-    # create attrs
-    t1 = np.atleast_1d(np.datetime64(starttime))[0]
-    d1 = np.atleast_1d(start_distance)
-    attrs = dict(
-        time_step=to_timedelta64(time_step),
-        distance_step=distance_step,
-        category="DAS",
-        time_min=t1,
-        network=network,
-        station=station,
-        tag=tag,
-        time_units="s",
-        distance_units="m",
-    )
-    # need to pop out dim attrs if coordinates provided.
-    if time_array is not None:
-        attrs.pop("time_min")
-        # need to keep time_step if time_array is len 1 to get coord range
-        if len(time_array) > 1:
-            attrs.pop("time_step")
-    else:
-        time_array = dascore.core.get_coord(
-            values=t1 + np.arange(array.shape[1]) * attrs["time_step"],
-            step=attrs["time_step"],
-            units=attrs["time_units"],
-        )
-    if dist_array is not None:
-        attrs.pop("distance_step")
-    else:
-        dist_array = dascore.core.get_coord(
-            values=d1 + np.arange(array.shape[0]) * attrs["distance_step"],
-            step=attrs["distance_step"],
-            units=attrs["distance_units"],
-        )
-    coords = dict(time=time_array, distance=dist_array)
-    # assemble and output.
-    out = dict(data=array, coords=coords, attrs=attrs, dims=("distance", "time"))
-    patch = dc.Patch(**out)
-    return patch
-
-
 @register_func(EXAMPLE_PATCHES, key="patch_with_null")
 def _patch_with_null():
     """Create a patch which has nullish values."""

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -139,6 +139,18 @@ def _random_patch_time_dist(
     return patch
 
 
+@register_func(EXAMPLE_PATCHES, key="patch_with_null")
+def _patch_with_null():
+    """Create a patch which has nullish values."""
+    patch = _random_patch()
+    data = np.array(patch.data)
+    data[data > 0.9] = np.NaN
+    # also set the first row and column to NaN
+    data[:, 0] = np.NaN
+    data[0, :] = np.NaN
+    return patch.new(data=data)
+
+
 @register_func(EXAMPLE_PATCHES, key="wacky_dim_coords_patch")
 def _wacky_dim_coord_patch():
     """Creates a patch with one Monotonic and one Array coord."""

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -8,7 +8,7 @@ from .coords import *  # noqa
 from .detrend import detrend
 from .filter import median_filter, pass_filter, sobel_filter
 from .resample import decimate, interpolate, iresample, resample
-from .rolling import _NumpyPatchRoller
+from .rolling import rolling
 from .select import iselect, select
 from .taper import taper
 from .units import convert_units, set_units, simplify_units

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -8,6 +8,7 @@ from .coords import *  # noqa
 from .detrend import detrend
 from .filter import median_filter, pass_filter, sobel_filter
 from .resample import decimate, interpolate, iresample, resample
+from .rolling import mean
 from .select import iselect, select
 from .taper import taper
 from .units import convert_units, set_units, simplify_units

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -8,7 +8,7 @@ from .coords import *  # noqa
 from .detrend import detrend
 from .filter import median_filter, pass_filter, sobel_filter
 from .resample import decimate, interpolate, iresample, resample
-from .rolling import mean
+from .rolling import PatchRoller
 from .select import iselect, select
 from .taper import taper
 from .units import convert_units, set_units, simplify_units

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -8,7 +8,7 @@ from .coords import *  # noqa
 from .detrend import detrend
 from .filter import median_filter, pass_filter, sobel_filter
 from .resample import decimate, interpolate, iresample, resample
-from .rolling import PatchRoller
+from .rolling import _NumpyPatchRoller
 from .select import iselect, select
 from .taper import taper
 from .units import convert_units, set_units, simplify_units

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -20,15 +20,15 @@ from dascore.utils.patch import patch_function
 
 def set_dims(self: PatchType, **kwargs: str) -> PatchType:
     """
-        Set dimension to non-dimensional coordinate.
+    Set dimension to non-dimensional coordinate.
 
     Parameters
     ----------
-        **kwargs
-            A mapping indicating old_dim: new_dim where new_dim refers to
-            the name of a non-dimensional coordinate which will become a
-            dimensional coordinate. The old dimensional coordinate will
-            become a non-dimensional coordinate.
+    **kwargs
+        A mapping indicating old_dim: new_dim where new_dim refers to
+        the name of a non-dimensional coordinate which will become a
+        dimensional coordinate. The old dimensional coordinate will
+        become a non-dimensional coordinate.
 
     Examples
     --------
@@ -403,7 +403,7 @@ def apply_operator(patch: PatchType, other, operator) -> PatchType:
     >>> new = apply_operator(patch, noise, np.add)
     >>> assert np.allclose(new.data, patch.data + noise)
     >>> # subtract one patch from another. Coords and attrs must be compatible
-    >>> new = patch - patch
+    >>> new = apply_operator(patch, patch, np.subtract)
     >>> assert np.allclose(new.data, 0)
     """
     if isinstance(other, dc.Patch):
@@ -456,11 +456,11 @@ def dropna(patch: PatchType, dim, how: Literal["any", "all"] = "any") -> PatchTy
     --------
     >>> import dascore as dc
     >>> # load an example patch which has some NaN values.
-    >>> patch = dc.get_example_spool("patch_with_null")
+    >>> patch = dc.get_example_patch("patch_with_null")
     >>> # drop all time labels that have a single null value
     >>> out = patch.dropna("time", how="any")
     >>> # drop all distance labels that have all null values
-    >>> out = patch.drop("distance", how="all")
+    >>> out = patch.dropna("distance", how="all")
     """
     axis = patch.dims.index(dim)
     func = np.any if how == "any" else np.all

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -169,8 +169,13 @@ def sobel_filter(patch: PatchType, dim: str, mode="reflect", cval=0.0) -> PatchT
 
     Parameters
     ----------
-    **kwargs
-        Used to specify the dimension, mode, and for the 'constant' mode, cval.
+    dim
+        The dimension along which to apply
+    mode
+        Determines how the input array is extended when the filter
+        overlaps with a border.
+    cval
+        Fill value when mode="constant".
 
     Examples
     --------
@@ -184,7 +189,7 @@ def sobel_filter(patch: PatchType, dim: str, mode="reflect", cval=0.0) -> PatchT
     >>> sobel_arbitrary = pa.sobel_filter(dim='time', mode='constant', cval=1)
 
     >>> # 3. Apply Sobel filter along both axes
-    >>> sobel_time_space = pa.sobel_filter('time',).sobel_filter('distance')
+    >>> sobel_time_space = pa.sobel_filter('time').sobel_filter('distance')
     """
     dim, mode, cval = _check_sobel_args(dim, mode, cval)
     axis = patch.dims.index(dim)
@@ -240,7 +245,6 @@ def median_filter(patch: PatchType, kernel_size=3) -> PatchType:
     Written by Ge Jin (gjin@mines.edu)
 
     """
-    # get nyquist and low/high in terms of nyquist
     out = medfilt2d(patch.data, kernel_size=kernel_size)
     return dascore.Patch(
         data=out, coords=patch.coords, attrs=patch.attrs, dims=patch.dims

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -306,6 +306,10 @@ def rolling(
     coord = patch.get_coord(dim)
     window = coord.get_sample_count(value)
     step = 1 if step is None else coord.get_sample_count(step)
+    if window == 0 or step == 0:
+        msg = "Window or step size can't be zero. Use any positive values."
+        raise ParameterError(msg)
+
     if window > len(coord) or step > len(coord):
         msg = (
             "Window or step size is larger than total number of samples in "

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -244,20 +244,21 @@ def rolling(
         determine which will be fastest for a given step. Options are:
             "numpy" - which uses np.lib.stride_tricks.sliding_window_view.
             "pandas" - which uses pandas.rolling.
-        If step < 10 samples, pandas is probably faster, otherwise numpy is
-        faster.
+        If step < 10 samples, pandas is faster for all operations other than apply.
+        If step > 10 samples, or `apply` is the desired rolling operation, numpy
+        is probably better.
     **kwargs
         Used to pass dimension and window size.
         For example `time=10` represents window size of
         10*(default unit) along the time axis.
-
 
     Examples
     --------
     >>> # Simple example for rolling mean function
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
-    >>> mean_patch = patch.rolling(time=10, step=5).mean()
+    >>> # apply rolling over 1 second with 0.5 step
+    >>> mean_patch = patch.rolling(time=1, step=0.5).mean()
     >>> # drop nan at the start of the time axis.
     >>> out = mean_patch.dropna("time")
 
@@ -272,18 +273,21 @@ def rolling(
     will appear at the start of the dimension. You can use
     [`patch.dropna`](`dascore.Patch.dropna`) to remove the NaN values.
 
-    Second, the step parameter is equivalent applying striding along the
-    specified dimension.
+    Second, the step parameter is equivalent applying to the output along the
+    specified dimension. For example, if step=2 the output of the chosen
+    dimension will be 1/2 of the input length.
 
-    To understand how this works, consider a patch with a simple 1D array:
-        a = [0, 1, 2, 3, 4, 5]
-    If window = 2 the output is
+    Here are a few examples to help illustrate how rolling works.
+
+    Consider a patch with a simple 1D array in the dimension "time":
+        [0, 1, 2, 3, 4, 5]
+    If time = 2 * dt the output is
         [NaN, 0.5, 1.5, 2.5, 3.5, 4.5]
-    If window = 3 the output is
+    If time = 3 * dt the output is
         [NaN, NaN, 1.0, 2.0, 3.0, 4.0]
-    if window = 3 and step = 2
+    if time = 3 * dt and step = 2 * dt
         [NaN, 1.0, 3.0]
-    if window = 3 and step = 3
+    if time = 3 * dt and step = 3 * dt
         [NaN, 2.0]
     """
 

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -98,9 +98,7 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         Parameters
         ----------
         function
-            The function which is applied. This must accept a numpy array
-            with the same number of dimensions as input patch, then return an
-            array with the same shape except axis is removed.
+            The function which is applied. Must accept an axis argument.
         """
         # TODO look at replacing this with a call to `as_strided` that
         # accounts for strides.

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -1,0 +1,49 @@
+"""Processing for applying roller operations."""
+
+import numpy as np
+from dascore.utils.patch import get_dim_value_from_kwargs
+
+
+class PatchRoller:
+    """A class to apply roller operations to patches"""
+
+    def __init__(self, patch, *, window=None, step=None, center=False, **kwargs):
+        self.patch = patch
+        self.window = window
+        self.step = step
+        self.center = center
+        self.kwargs = kwargs
+
+    def mean(self):
+        patch = self.patch
+        window_size = self.window
+        step_size = self.step
+        center = self.center
+        axis = self.kwargs
+
+        total_samples = patch.data.shape[0]
+        mean_values = np.empty((int(total_samples / step_size), patch.data.shape[1]))
+
+        if center:
+            for j, k in enumerate(range(0, total_samples, step_size)):
+                mean_values[j, :] = np.mean(
+                    patch.data[k - int(window_size / 2) : k + int(window_size / 2), :],
+                    axis=axis,
+                )
+                # need to take care of edges?
+        else:
+            for j, k in enumerate(range(0, total_samples, step_size)):
+                mean_values[j, :] = np.mean(
+                    patch.data[k : k + window_size, :], axis=axis
+                )
+
+        return mean_values
+
+
+def rolling(patch, *, window=None, step=None, center=False, **kwargs):
+    """
+    nice docs
+    """
+    dim, axis, value = get_dim_value_from_kwargs(patch, kwargs)
+    # probably other things I am missing.
+    return PatchRoller(patch, window=window, step=step, center=center, axis=axis)

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -54,14 +54,10 @@ class PatchRoller:
         Accounts for centered or non-centered coordinates. If the window
         length is even, the first half value is used.
         """
-        if self.center:
-            half = self.window // 2
-            start = int(np.floor(half))
-            stop = int(np.ceil(half))
-            new = self.coord[start : -stop : self.step]
-        else:
-            new = self.coord[self.window - 1 :: self.step]
-        return self.patch.coords.update_coords(**{self.dim: new})
+        coord = self.coord
+        if self.step > 1:
+            coord = self.coord[:: self.step]
+        return self.patch.coords.update_coords(**{self.dim: coord})
 
     def _get_attrs_with_apply_history(self, func):
         """Get new attrs that has history from apply attached."""
@@ -70,6 +66,19 @@ class PatchRoller:
         new_history.append(f"{self._roll_hist}.apply({func_name})")
         attrs = self.patch.attrs.update(history=new_history, coords={})
         return attrs
+
+    def _pad_roll_array(self, data):
+        """Pad"""
+        num_nans = 1 + (self.window - 2) // self.step
+        pad_width = [(0, 0)] * len(data.shape)
+        pad_width[self.axis] = (num_nans, 0)
+        padded = np.pad(data, pad_width, constant_values=np.NaN)
+        if self.step == 1:
+            assert padded.shape == self.patch.data.shape
+        if self.center:
+            # roll array along axis to center
+            padded = np.roll(padded, self.window // 2, axis=self.axis)
+        return padded
 
     def apply(self, function):
         """
@@ -92,8 +101,13 @@ class PatchRoller:
         # get slice to account for step (stride)
         step_slice = [slice(None, None)] * len(self.patch.data.shape)
         step_slice.append(slice(None, None))
-        step_slice[self.axis] = slice(None, None, self.step)
-        out = function(array[tuple(step_slice)], axis=-1)
+        # this accounts for NaNs that pad the start of the array.
+        start = (self.step - ((self.window - 2) % self.step)) % self.step
+        # start = (self.window - 1) % self.step
+        step_slice[self.axis] = slice(start, None, self.step)
+        # apply function, then pad with zeros and roll
+        raw = function(array[tuple(step_slice)], axis=-1).astype(np.float_)
+        out = self._pad_roll_array(raw)
         new_coords = self.get_coords()
         attrs = self._get_attrs_with_apply_history(function)
         return self.patch.new(data=out, coords=new_coords, attrs=attrs)
@@ -148,5 +162,32 @@ def rolling(patch: dc.Patch, step=None, center=False, **kwargs) -> PatchRoller:
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
     >>> mean_patch = patch.rolling(time=10, step=5).mean()
+    >>> # note this will contain
+
+
+    Notes
+    -----
+    This class behaves like pandas.rolling
+    (https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.rolling.html)
+    which has some important implications.
+
+    First, when step is not defined or set to 1, the output patch will have the
+    same shape as the input patch. The consequence of this is that NaN values
+    will appear at the start of the dimension. You can use
+    [`patch.dropna`](`dascore.Patch.dropna`) to remove the NaN values.
+
+    Second, the step parameter is equivalent applying striding along the
+    specified dimension.
+
+    To understand how this works, consider a patch with a simple 1D array:
+        a = [0, 1, 2, 3, 4, 5]
+    If window = 2 the output is
+        [NaN, 0.5, 1.5, 2.5, 3.5, 4.5]
+    If window = 3 the output is
+        [NaN, NaN, 1.0, 2.0, 3.0, 4.0]
+    if window = 3 and step = 2
+        [NaN, 1.0, 3.0]
+    if window = 3 and step = 3
+        [NaN, 2.0]
     """
     return PatchRoller(patch, step=step, center=center, **kwargs)

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -5,45 +5,130 @@ from dascore.utils.patch import get_dim_value_from_kwargs
 
 
 class PatchRoller:
-    """A class to apply roller operations to patches"""
+    """A class to apply roller operations to patches."""
 
     def __init__(self, patch, *, window=None, step=None, center=False, **kwargs):
         self.patch = patch
-        self.window = window
-        self.step = step
+
         self.center = center
         self.kwargs = kwargs
+        dim, axis, value = get_dim_value_from_kwargs(patch, self.kwargs)
+        self.axis = axis
+        coord = patch.get_coord(dim)
+        if dim == "time":
+            window = coord.get_sample_count(value)
+            step = 1 if step is None else coord.get_sample_count(step)
+        else:
+            window = value
+            step = 1 if step is None else step
+        self.window = window
+        self.step = step
 
-    def mean(self):
+        assert (
+            window < patch.data.shape[axis] or step < patch.data.shape[axis]
+        ), "Window or step size is larger than total number \
+        of samples in the specified coordinate."
+
+    def apply(self, function):
         patch = self.patch
         window_size = self.window
         step_size = self.step
         center = self.center
-        axis = self.kwargs
+        axis = self.axis
 
-        total_samples = patch.data.shape[0]
-        mean_values = np.empty((int(total_samples / step_size), patch.data.shape[1]))
+        time_samples = len(patch.coords["time"])
+        distance_samples = len(patch.coords["distance"])
+
+        if axis == 0:
+            if patch.dims[0] == "time":
+                iter_range = range(0, time_samples, step_size)
+                shape = (int(time_samples / step_size), int(distance_samples))
+                out = np.empty(shape)
+                for j, k in enumerate(iter_range):
+                    if k + window_size > time_samples:
+                        out[j, :] = np.full((1, distance_samples), np.nan)
+                    else:
+                        out[j, :] = function(
+                            patch.data[k : k + window_size, :], axis=axis
+                        )
+            elif patch.dims[0] == "distance":
+                iter_range = range(0, distance_samples, step_size)
+                shape = (int(distance_samples / step_size), int(time_samples))
+                out = np.empty(shape)
+                for j, k in enumerate(iter_range):
+                    if k + window_size > distance_samples:
+                        out[j, :] = np.full((1, time_samples), np.nan)
+                    else:
+                        out[j, :] = function(
+                            patch.data[k : k + window_size, :], axis=axis
+                        )
+        elif axis == 1:
+            if patch.dims[0] == "time":
+                iter_range = range(0, distance_samples, step_size)
+                shape = (time_samples, int(distance_samples / step_size))
+                out = np.empty(shape)
+                for j, k in enumerate(iter_range):
+                    if k + window_size > distance_samples:
+                        out[:, j] = np.full((time_samples, 1), np.nan)
+                    else:
+                        out[:, j] = function(
+                            patch.data[:, k : k + window_size], axis=axis
+                        )
+            elif patch.dims[0] == "distance":
+                iter_range = range(0, time_samples, step_size)
+                shape = (int(distance_samples), int(time_samples / step_size))
+                out = np.empty(shape)
+                for j, k in enumerate(iter_range):
+                    if k + window_size > time_samples:
+                        out[:, j] = np.full((distance_samples), np.nan)
+                    else:
+                        out[:, j] = function(
+                            patch.data[:, k : k + window_size], axis=axis
+                        )
 
         if center:
-            for j, k in enumerate(range(0, total_samples, step_size)):
-                mean_values[j, :] = np.mean(
-                    patch.data[k - int(window_size / 2) : k + int(window_size / 2), :],
-                    axis=axis,
-                )
-                # need to take care of edges?
-        else:
-            for j, k in enumerate(range(0, total_samples, step_size)):
-                mean_values[j, :] = np.mean(
-                    patch.data[k : k + window_size, :], axis=axis
-                )
+            out = np.roll(out, int(window_size / 2), axis=axis)
 
-        return mean_values
+        return out
+
+    def mean(self):
+        return self.apply(np.mean)
+
+    def median(self):
+        return self.apply(np.median)
+
+    def min(self):
+        return self.apply(np.min)
+
+    def max(self):
+        return self.apply(np.max)
 
 
-def rolling(patch, *, window=None, step=None, center=False, **kwargs):
+def rolling(patch, step=None, center=False, **kwargs):
     """
-    nice docs
+    Apply a rolling function along a specified dimension
+    with a specified factor as the window size.
+
+    Parameters
+    ----------
+    step
+        The window is evaluated at every step result,
+        equivalent to slicing at every step.
+        If the step argument is not None or 1,
+        the result will have a different shape than the input.
+    center
+        If False, set the window labels as the right edge of the window index.
+        If True, set the window labels as the center of the window index.
+    **kwargs
+        Used to pass dimension and factor.
+        For example `time=10` represents window size of
+        10*(default unit) along the time axis.
+
+    Examples
+    --------
+    # Simple example for rolling mean function
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>> mean_values = patch.rolling(time=10, step=10)
     """
-    dim, axis, value = get_dim_value_from_kwargs(patch, kwargs)
-    # probably other things I am missing.
-    return PatchRoller(patch, window=window, step=step, center=center, axis=axis)
+    return PatchRoller(patch, step=step, center=center, **kwargs)

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -28,10 +28,10 @@ def _set_scale(im, scale, scale_type, patch):
     data = patch.data
     modifier = 1
     if scale_type == "relative":
-        modifier = 0.5 * (data.max() - data.min())
+        modifier = 0.5 * (np.nanmax(data) - np.nanmin(data))
         # only one scale parameter provided, center around mean
     if isinstance(scale, float):
-        mean = patch.data.mean()
+        mean = np.nanmean(patch.data)
         scale = np.array([mean - scale * modifier, mean + scale * modifier])
     im.set_clim(scale)
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -57,7 +57,7 @@ from dascore.utils.time import to_timedelta64
 array = np.random.random(size=(300, 2_000))
 
 # Create attributes, or metadata
-t1 = np.datetime64("2017-09-18")
+t1 = np.to_datetime64("2017-09-18")
 attrs = dict(
     d_distance=1,
     d_time=to_timedelta64(1 / 250),

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -231,7 +231,7 @@ out = (
     .pass_filter(time=(..., 10))  # apply a low-pass 10 Hz butterworth filter
 )
 ```
-The processing methods are located in the [dascore.proc](`dascore.proc`) module.
+The processing methods are located in the [dascore.proc](`dascore.proc`) module. The [patch processing tutorial](processing.qmd) provides more information about various processing routines.
 
 # Visualization
 

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -1,10 +1,68 @@
 ---
-title: Processing
+title: Patch Processing
 execute:
   warning: false
 ---
 The following shows some simple examples of patch processing. See the
 [proc module documentation](`dascore.proc`) for a list of processing functions.
+
+
+# Basic
+
+There are several "basic" processing functions which manipulate the patch metadata, shape, etc. Many of these are covered in the [patch tutorial](patch.qmd), but here are a few that aren't:
+
+## Transpose
+The [`transpose` patch function](`dascore.Patch.transpose`) patch function simply transposes the dimensions of the patch, either by rotating the dimensions or to a new specified dimension.
+
+```{python}
+import dascore as dc
+
+patch = dc.get_example_patch()
+print(f"dims before transpose: {patch.dims}")
+transposed = patch.transpose()
+print(f"dims after transpose: {transposed.dims}")
+# dims can be manually specified as well
+transposed = patch.transpose("time", "distance")
+```
+
+## Squeeze
+The [`squeeze` patch function](`dascore.Patch.squeeze`) removes dimensions which have a single value (just like numpy.squeeze).
+
+```{python}
+import dascore as dc
+
+patch = dc.get_example_patch()
+# select first distance value to make distance dim flat.
+flat_patch = patch.iselect(distance=0)
+print(f"Pre-squeeze dims: {flat_patch.shape}")
+
+squeezed = flat_patch.squeeze()
+print(f"Post-squeeze dims: {squeezed.shape}")
+```
+
+## Dropna
+
+The [`dropna` patch function](`dascore.Patch.dropna`) patch function drops "nullish" values from a given label.
+
+```{python}
+import numpy as np
+
+import dascore as dc
+
+patch = dc.get_example_patch()
+
+# create a patch with nan values
+data = np.array(patch.data)
+data[:, 0] = np.NaN
+patch_with_nan = patch.new(data=data)
+
+# drop Nan along axis 1
+dim = patch_with_nan.dims[1]
+no_na_patch = patch_with_nan.dropna(dim)
+
+assert not np.any(np.isnan(no_na_patch.data))
+```
+
 
 # Decimate
 
@@ -128,3 +186,22 @@ patch = (
 
 patch.viz.waterfall(show=True, scale=0.15);
 ```
+
+
+# Rolling
+The [rolling patch function](`dascore.Patch.rolling`) implements moving window operators similar to [pandas rolling](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.rolling.html). It is useful for smoothing, calculating aggregated statistics, etc.
+
+Here is an example of using a rolling mean to smooth along the time axis for an example event:
+
+```{python}
+import dascore as dc
+
+patch = dc.get_example_patch("example_event_1")
+# apply moving mean window over every 10 samples
+dt = patch.get_coord('time').step
+
+smoothed = patch.rolling(time=50*dt).mean()
+smoothed.viz.waterfall(scale=.1);
+```
+
+Notice the NaN values at the start of the time axis. These can be trimmed with [`Patch`.dropna](`dascore.Patch.dropna`).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,6 +207,20 @@ def event_patch_1():
     return dc.get_example_patch("example_event_1")
 
 
+@pytest.fixture(scope="class")
+@register_func(PATCH_FIXTURES)
+def range_patch_3d():
+    """Return a 3D patch for testing."""
+    data = np.broadcast_to(np.arange(10)[:, None, None], (10, 10, 10))
+    coords = {
+        "time": np.arange(10),
+        "distance": np.arange(10),
+        "smell": np.arange(10),
+    }
+    patch = dc.Patch(data=data, coords=coords, dims=tuple(coords))
+    return patch
+
+
 @pytest.fixture(scope="session")
 @register_func(PATCH_FIXTURES)
 def wacky_dim_patch():

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -751,6 +751,12 @@ class TestSqueeze:
         out = cm.squeeze("time")
         assert "time" not in out.dims
 
+    def test_squeeze_no_dim(self, coord_manager_degenerate_time):
+        """Ensure all degenerate dims are squeezed when no dim specified."""
+        cm = coord_manager_degenerate_time
+        out = cm.squeeze()
+        assert "time" not in out.dims
+
 
 class TestNonDimCoords:
     """Tests for adding non-dimensional coordinates."""

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -453,16 +453,6 @@ class TestUpdateAttrs:
         assert patch1 == patch2
 
 
-class TestSqueeze:
-    """Tests for squeeze."""
-
-    def test_remove_dimension(self, random_patch):
-        """Tests for removing random dimensions."""
-        out = random_patch.aggregate("time").squeeze("time")
-        assert "time" not in out.dims
-        assert len(out.data.shape) == 1, "data should be 1d"
-
-
 class TestReleaseMemory:
     """Ensure memory is released when the patch is deleted."""
 

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -278,6 +278,22 @@ class TestApplyOperator:
             apply_operator(pa1, other, np.add)
 
 
+class TestSqueeze:
+    """Tests for squeeze."""
+
+    def test_remove_dimension(self, random_patch):
+        """Tests for removing random dimensions."""
+        out = random_patch.aggregate("time").squeeze("time")
+        assert "time" not in out.dims
+        assert len(out.data.shape) == 1, "data should be 1d"
+
+    def test_tutorial_example(self, random_patch):
+        """Ensure the tutorial snippet works."""
+        flat_patch = random_patch.iselect(distance=0)
+        squeezed = flat_patch.squeeze()
+        assert len(squeezed.dims) < len(flat_patch.dims)
+
+
 class TestDropNa:
     """Tests for dropping nullish values in a patch."""
 

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -1,0 +1,185 @@
+"""Tests for applying rolling functions on patch's data."""
+
+import pandas as pd
+import numpy as np
+
+import dascore as dc
+from dascore.proc.rolling import PatchRoller
+from dascore.units import s
+
+
+class TestRolling:
+    """Tests for applying rolling functions on patch's data."""
+
+    # @pytest.fixture(scope="class")
+    # def my_patch_dis_time(self, random_patch):
+    #     """Create a Patch containing known data with (distance, time)."""
+    #     num_rows, num_cols = random_patch.data.shape
+    #     my_data = np.random.random((num_rows,num_cols))
+    #     new_patch = random_patch.new(data=my_data)
+    #     return new_patch
+
+    # @pytest.fixture(scope="class")
+    # def my_patch_time_dis(self):
+    #     """Create a Patch containing known data with (time, distance)."""
+
+    #     array = np.random.random(size=(2_000, 300))
+    #     t1 = np.datetime64("2017-09-18")
+    #     attrs = dict(
+    #         d_distance=1,
+    #         d_time=to_timedelta64(1 / 250),
+    #         category="DAS",
+    #         id="test_data1",
+    #         time_min=t1,
+    #     )
+    #     coords = dict(
+    #         time=np.arange(array.shape[0]) * attrs["d_time"],
+    #         distance=np.arange(array.shape[1]) * attrs["d_distance"] ,)
+    #     dims = ('time', 'distance')
+
+    # pa = dc.Patch(data=array, coords=coords, attrs=attrs, dims=dims)
+
+    #     return pa
+
+    def test_apply_axis_0_dist_time(self):
+        """Test the apply method of PatchRoller when time coordinate is entered
+        and the fist axis is distance.
+        """
+        random_das_dist_time = dc.get_example_patch("random_das")
+        axis = 0
+        if random_das_dist_time.dims[1] == "time":
+            axis = 1
+        sampling_interval = random_das_dist_time.attrs["time_step"] / np.timedelta64(
+            1, "s"
+        )
+        window = 6
+        step = 2
+        roller = PatchRoller(
+            random_das_dist_time,
+            time=(window * sampling_interval) * s,
+            step=(step * sampling_interval) * s,
+        )
+        applied_result = roller.apply(np.mean)
+
+        valid_data = ~np.isnan(applied_result).any(axis=axis)
+        filtered_data_rolling = applied_result[valid_data]
+
+        df = pd.DataFrame(random_das_dist_time.data)
+        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+
+        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=axis)
+        filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
+
+        assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+
+    def test_apply_axis_1_dis_time(self):
+        """Test the apply method of PatchRoller when distance coordinate is entered
+        and the fist axis is distance.
+        """
+        random_das_dist_time = dc.get_example_patch("random_das")
+        axis = 1
+        if random_das_dist_time.dims[0] == "distance":
+            axis = 0
+        # channel_spacing = my_patch_dis_time.attrs['distance_step']
+        window = 6
+        step = 2
+        roller = PatchRoller(random_das_dist_time, distance=window, step=step)
+        applied_result = roller.apply(np.mean)
+
+        valid_data = ~np.isnan(applied_result).any(axis=axis)
+        filtered_data_rolling = applied_result[:, valid_data]
+
+        df = pd.DataFrame(random_das_dist_time.data)
+        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+
+        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=axis)
+        filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
+
+        assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+
+    def test_apply_axis_0_time_dist(self):
+        """Test the apply method of PatchRoller when time coordinate is entered
+        and the fist axis is time.
+        """
+        random_das_time_dist = dc.get_example_patch("random_das_time_dist")
+        axis = 0
+        if random_das_time_dist.dims[1] == "time":
+            axis = 1
+        sampling_interval = random_das_time_dist.attrs["time_step"] / np.timedelta64(
+            1, "s"
+        )
+        window = 6
+        step = 2
+        roller = PatchRoller(
+            random_das_time_dist,
+            time=(window * sampling_interval) * s,
+            step=(step * sampling_interval) * s,
+        )
+        applied_result = roller.apply(np.mean)
+
+        valid_data = ~np.isnan(applied_result).any(axis=axis)
+        filtered_data_rolling = applied_result[valid_data]
+
+        df = pd.DataFrame(random_das_time_dist.data)
+        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+
+        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=axis)
+        filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
+
+        assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+
+    def test_apply_axis_1_time_dis(self):
+        """Test the apply method of PatchRoller when distance coordinate is entered
+        and the fist axis is time."""
+        random_das_time_dist = dc.get_example_patch("random_das_time_dist")
+        axis = 1
+        if random_das_time_dist.dims[0] == "distance":
+            axis = 0
+        # channel_spacing = my_patch.attrs['distance_step']
+        window = 6
+        step = 2
+        roller = PatchRoller(random_das_time_dist, distance=window, step=step)
+        applied_result = roller.apply(np.mean)
+
+        valid_data = ~np.isnan(applied_result).any(axis=axis)
+        filtered_data_rolling = applied_result[:, valid_data]
+
+        df = pd.DataFrame(random_das_time_dist.data)
+        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+
+        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=axis)
+        filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
+
+        assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+
+    # def test_center(self, my_patch):
+    #     """Test the center option in PatchRoller."""
+    #     sampling_interval = my_patch.attrs['time_step']/np.timedelta64(1, 's')
+    #     window = 6
+    #     step = 2
+    #     roll = my_patch.rolling(time=(window*sampling_interval)*s,
+    # step=(step*sampling_interval)*s, center=True)
+    #     centered_result = roll.mean()
+
+    #     df = pd.DataFrame(my_patch.data)
+    #     rolling_mean_pandas = df.rolling(3, step=2, axis=0, center=True).mean()
+
+    #     assert centered_result.shape == np.array(rolling_mean_pandas).shape
+    #     assert np.allclose(centered_result, rolling_mean_pandas)
+
+    def test_misc(self, random_patch):
+        """Test miscellaneous functionality."""
+        sampling_interval = random_patch.attrs["time_step"] / np.timedelta64(1, "s")
+        window = 6
+        step = 2
+        rolling = random_patch.rolling(
+            time=(window * sampling_interval) * s, step=(step * sampling_interval) * s
+        )
+        assert isinstance(rolling.mean())
+        assert isinstance(rolling.median())
+        assert isinstance(rolling.min())
+        assert isinstance(rolling.max())

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -7,7 +7,7 @@ import pandas as pd
 import dascore as dc
 from dascore.exceptions import ParameterError
 from dascore.proc.rolling import PatchRoller
-from dascore.units import s, m
+from dascore.units import m
 
 
 class TestRolling:
@@ -122,13 +122,14 @@ class TestRolling:
         assert isinstance(rolling.max(), dc.Patch)
         assert isinstance(rolling.std(), dc.Patch)
 
-    @pytest.mark.parametrize("_", list(range(10)))
+    @pytest.mark.parametrize("_", list(range(1)))
     def test_apply_axis_0_dist_time(self, _):
         """Test the apply method of PatchRoller when distance coordinate is entered
         and the first axis is distance.
         """
         random_das_dist_time = dc.get_example_patch("random_das")
-        axis = 0
+        # axis = 0
+        axis = random_das_dist_time.dims.index("distance")
         channel_spacing = random_das_dist_time.attrs["distance_step"]
         window = np.random.randint(1, 100)
         step = np.random.randint(1, 100)
@@ -139,8 +140,8 @@ class TestRolling:
         )
         applied_result = roller.apply(np.mean).data
 
-        valid_data = ~np.isnan(applied_result).any(axis=1)
-        filtered_data_rolling = applied_result[valid_data]
+        # valid_data = ~np.isnan(applied_result).any(axis=1)
+        # filtered_data_rolling = applied_result[valid_data]
 
         df = pd.DataFrame(random_das_dist_time.data)
         rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
@@ -148,121 +149,121 @@ class TestRolling:
         valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
         filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
 
-        assert applied_result.shape == np.array(rolling_mean_pandas).shape
-        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+        # assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(applied_result, filtered_data_pandas)
 
-    @pytest.mark.parametrize("_", list(range(10)))
-    def test_apply_axis_1_dist_time(self, _):
-        """Test the apply method of PatchRoller when time coordinate is entered
-        and the first axis is distance.
-        """
-        random_das_dist_time = dc.get_example_patch("random_das")
-        axis = 1
-        sampling_interval = random_das_dist_time.attrs["time_step"] / np.timedelta64(
-            1, "s"
-        )
-        window = np.random.randint(1, 100)
-        step = np.random.randint(1, 100)
-        roller = PatchRoller(
-            random_das_dist_time,
-            time=(window * sampling_interval) * s,
-            step=(step * sampling_interval) * s,
-        )
-        applied_result = roller.apply(np.mean).data
+    # @pytest.mark.parametrize("_", list(range(10)))
+    # def test_apply_axis_1_dist_time(self, _):
+    #     """Test the apply method of PatchRoller when time coordinate is entered
+    #     and the first axis is distance.
+    #     """
+    #     random_das_dist_time = dc.get_example_patch("random_das")
+    #     axis = 1
+    #     sampling_interval = random_das_dist_time.attrs["time_step"] / np.timedelta64(
+    #         1, "s"
+    #     )
+    #     window = np.random.randint(1, 100)
+    #     step = np.random.randint(1, 100)
+    #     roller = PatchRoller(
+    #         random_das_dist_time,
+    #         time=(window * sampling_interval) * s,
+    #         step=(step * sampling_interval) * s,
+    #     )
+    #     applied_result = roller.apply(np.mean).data
 
-        valid_data = ~np.isnan(applied_result).any(axis=0)
-        filtered_data_rolling = applied_result[:, valid_data]
+    #     valid_data = ~np.isnan(applied_result).any(axis=0)
+    #     filtered_data_rolling = applied_result[:, valid_data]
 
-        df = pd.DataFrame(random_das_dist_time.data)
-        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+    #     df = pd.DataFrame(random_das_dist_time.data)
+    #     rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
 
-        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=0)
-        filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
+    #     valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=0)
+    #     filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
 
-        assert applied_result.shape == np.array(rolling_mean_pandas).shape
-        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+    #     assert applied_result.shape == np.array(rolling_mean_pandas).shape
+    #     assert np.allclose(filtered_data_rolling, filtered_data_pandas)
 
-    @pytest.mark.parametrize("_", list(range(10)))
-    def test_apply_axis_0_time_dist(self, _):
-        """Test the apply method of PatchRoller when time coordinate is entered
-        and the first axis is time.
-        """
-        random_das_time_dist = dc.get_example_patch("random_das_time_dist")
-        axis = 0
-        sampling_interval = random_das_time_dist.attrs["time_step"] / np.timedelta64(
-            1, "s"
-        )
-        window = np.random.randint(1, 100)
-        step = np.random.randint(1, 100)
-        roller = PatchRoller(
-            random_das_time_dist,
-            time=(window * sampling_interval) * s,
-            step=(step * sampling_interval) * s,
-        )
-        applied_result = roller.apply(np.mean).data
+    # @pytest.mark.parametrize("_", list(range(10)))
+    # def test_apply_axis_0_time_dist(self, _):
+    #     """Test the apply method of PatchRoller when time coordinate is entered
+    #     and the first axis is time.
+    #     """
+    #     random_das_time_dist = dc.get_example_patch("random_das_time_dist")
+    #     axis = 0
+    #     sampling_interval = random_das_time_dist.attrs["time_step"] / np.timedelta64(
+    #         1, "s"
+    #     )
+    #     window = np.random.randint(1, 100)
+    #     step = np.random.randint(1, 100)
+    #     roller = PatchRoller(
+    #         random_das_time_dist,
+    #         time=(window * sampling_interval) * s,
+    #         step=(step * sampling_interval) * s,
+    #     )
+    #     applied_result = roller.apply(np.mean).data
 
-        valid_data = ~np.isnan(applied_result).any(axis=1)
-        filtered_data_rolling = applied_result[valid_data]
+    #     valid_data = ~np.isnan(applied_result).any(axis=1)
+    #     filtered_data_rolling = applied_result[valid_data]
 
-        df = pd.DataFrame(random_das_time_dist.data)
-        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+    #     df = pd.DataFrame(random_das_time_dist.data)
+    #     rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
 
-        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
-        filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
+    #     valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
+    #     filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
 
-        assert applied_result.shape == np.array(rolling_mean_pandas).shape
-        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+    #     assert applied_result.shape == np.array(rolling_mean_pandas).shape
+    #     assert np.allclose(filtered_data_rolling, filtered_data_pandas)
 
-    @pytest.mark.parametrize("_", list(range(10)))
-    def test_apply_axis_1_time_dist(self, _):
-        """Test the apply method of PatchRoller when distance coordinate is entered
-        and the first axis is time."""
-        random_das_time_dist = dc.get_example_patch("random_das_time_dist")
-        axis = 1
-        channel_spacing = random_das_time_dist.attrs["distance_step"]
-        window = np.random.randint(1, 100)
-        step = np.random.randint(1, 100)
-        roller = PatchRoller(
-            random_das_time_dist,
-            distance=(window * channel_spacing) * m,
-            step=(step * channel_spacing) * m,
-        )
-        applied_result = roller.apply(np.mean).data
+    # @pytest.mark.parametrize("_", list(range(10)))
+    # def test_apply_axis_1_time_dist(self, _):
+    #     """Test the apply method of PatchRoller when distance coordinate is entered
+    #     and the first axis is time."""
+    #     random_das_time_dist = dc.get_example_patch("random_das_time_dist")
+    #     axis = 1
+    #     channel_spacing = random_das_time_dist.attrs["distance_step"]
+    #     window = np.random.randint(1, 100)
+    #     step = np.random.randint(1, 100)
+    #     roller = PatchRoller(
+    #         random_das_time_dist,
+    #         distance=(window * channel_spacing) * m,
+    #         step=(step * channel_spacing) * m,
+    #     )
+    #     applied_result = roller.apply(np.mean).data
 
-        valid_data = ~np.isnan(applied_result).any(axis=0)
-        filtered_data_rolling = applied_result[:, valid_data]
+    #     valid_data = ~np.isnan(applied_result).any(axis=0)
+    #     filtered_data_rolling = applied_result[:, valid_data]
 
-        df = pd.DataFrame(random_das_time_dist.data)
-        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+    #     df = pd.DataFrame(random_das_time_dist.data)
+    #     rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
 
-        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=0)
-        filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
+    #     valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=0)
+    #     filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
 
-        assert applied_result.shape == np.array(rolling_mean_pandas).shape
-        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+    #     assert applied_result.shape == np.array(rolling_mean_pandas).shape
+    #     assert np.allclose(filtered_data_rolling, filtered_data_pandas)
 
-    def test_center(self):
-        """Test the center option in PatchRoller."""
-        random_das_dist_time = dc.get_example_patch("random_das")
-        axis = 0
-        channel_spacing = random_das_dist_time.attrs["distance_step"]
-        window = np.random.randint(1, 100)
-        step = np.random.randint(1, 100)
-        roller = PatchRoller(
-            random_das_dist_time,
-            distance=(window * channel_spacing) * m,
-            step=(step * channel_spacing) * m,
-        )
-        applied_result = roller.apply(np.mean).data
+    # def test_center(self):
+    #     """Test the center option in PatchRoller."""
+    #     random_das_dist_time = dc.get_example_patch("random_das")
+    #     axis = 0
+    #     channel_spacing = random_das_dist_time.attrs["distance_step"]
+    #     window = np.random.randint(1, 100)
+    #     step = np.random.randint(1, 100)
+    #     roller = PatchRoller(
+    #         random_das_dist_time,
+    #         distance=(window * channel_spacing) * m,
+    #         step=(step * channel_spacing) * m,
+    #     )
+    #     applied_result = roller.apply(np.mean).data
 
-        valid_data = ~np.isnan(applied_result).any(axis=1)
-        filtered_data_rolling = applied_result[valid_data]
+    #     valid_data = ~np.isnan(applied_result).any(axis=1)
+    #     filtered_data_rolling = applied_result[valid_data]
 
-        df = pd.DataFrame(random_das_dist_time.data)
-        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+    #     df = pd.DataFrame(random_das_dist_time.data)
+    #     rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
 
-        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
-        filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
+    #     valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
+    #     filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
 
-        assert applied_result.shape == np.array(rolling_mean_pandas).shape
-        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+    #     assert applied_result.shape == np.array(rolling_mean_pandas).shape
+    #     assert np.allclose(filtered_data_rolling, filtered_data_pandas)

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -2,9 +2,12 @@
 
 import numpy as np
 import pytest
+import pandas as pd
 
 import dascore as dc
 from dascore.exceptions import ParameterError
+from dascore.proc.rolling import PatchRoller
+from dascore.units import s, m
 
 
 class TestRolling:
@@ -118,3 +121,148 @@ class TestRolling:
         assert isinstance(rolling.min(), dc.Patch)
         assert isinstance(rolling.max(), dc.Patch)
         assert isinstance(rolling.std(), dc.Patch)
+
+    @pytest.mark.parametrize("_", list(range(10)))
+    def test_apply_axis_0_dist_time(self, _):
+        """Test the apply method of PatchRoller when distance coordinate is entered
+        and the first axis is distance.
+        """
+        random_das_dist_time = dc.get_example_patch("random_das")
+        axis = 0
+        channel_spacing = random_das_dist_time.attrs["distance_step"]
+        window = np.random.randint(1, 100)
+        step = np.random.randint(1, 100)
+        roller = PatchRoller(
+            random_das_dist_time,
+            distance=(window * channel_spacing) * m,
+            step=(step * channel_spacing) * m,
+        )
+        applied_result = roller.apply(np.mean).data
+
+        valid_data = ~np.isnan(applied_result).any(axis=1)
+        filtered_data_rolling = applied_result[valid_data]
+
+        df = pd.DataFrame(random_das_dist_time.data)
+        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+
+        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
+        filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
+
+        assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+
+    @pytest.mark.parametrize("_", list(range(10)))
+    def test_apply_axis_1_dist_time(self, _):
+        """Test the apply method of PatchRoller when time coordinate is entered
+        and the first axis is distance.
+        """
+        random_das_dist_time = dc.get_example_patch("random_das")
+        axis = 1
+        sampling_interval = random_das_dist_time.attrs["time_step"] / np.timedelta64(
+            1, "s"
+        )
+        window = np.random.randint(1, 100)
+        step = np.random.randint(1, 100)
+        roller = PatchRoller(
+            random_das_dist_time,
+            time=(window * sampling_interval) * s,
+            step=(step * sampling_interval) * s,
+        )
+        applied_result = roller.apply(np.mean).data
+
+        valid_data = ~np.isnan(applied_result).any(axis=0)
+        filtered_data_rolling = applied_result[:, valid_data]
+
+        df = pd.DataFrame(random_das_dist_time.data)
+        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+
+        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=0)
+        filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
+
+        assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+
+    @pytest.mark.parametrize("_", list(range(10)))
+    def test_apply_axis_0_time_dist(self, _):
+        """Test the apply method of PatchRoller when time coordinate is entered
+        and the first axis is time.
+        """
+        random_das_time_dist = dc.get_example_patch("random_das_time_dist")
+        axis = 0
+        sampling_interval = random_das_time_dist.attrs["time_step"] / np.timedelta64(
+            1, "s"
+        )
+        window = np.random.randint(1, 100)
+        step = np.random.randint(1, 100)
+        roller = PatchRoller(
+            random_das_time_dist,
+            time=(window * sampling_interval) * s,
+            step=(step * sampling_interval) * s,
+        )
+        applied_result = roller.apply(np.mean).data
+
+        valid_data = ~np.isnan(applied_result).any(axis=1)
+        filtered_data_rolling = applied_result[valid_data]
+
+        df = pd.DataFrame(random_das_time_dist.data)
+        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+
+        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
+        filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
+
+        assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+
+    @pytest.mark.parametrize("_", list(range(10)))
+    def test_apply_axis_1_time_dist(self, _):
+        """Test the apply method of PatchRoller when distance coordinate is entered
+        and the first axis is time."""
+        random_das_time_dist = dc.get_example_patch("random_das_time_dist")
+        axis = 1
+        channel_spacing = random_das_time_dist.attrs["distance_step"]
+        window = np.random.randint(1, 100)
+        step = np.random.randint(1, 100)
+        roller = PatchRoller(
+            random_das_time_dist,
+            distance=(window * channel_spacing) * m,
+            step=(step * channel_spacing) * m,
+        )
+        applied_result = roller.apply(np.mean).data
+
+        valid_data = ~np.isnan(applied_result).any(axis=0)
+        filtered_data_rolling = applied_result[:, valid_data]
+
+        df = pd.DataFrame(random_das_time_dist.data)
+        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+
+        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=0)
+        filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
+
+        assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
+
+    def test_center(self):
+        """Test the center option in PatchRoller."""
+        random_das_dist_time = dc.get_example_patch("random_das")
+        axis = 0
+        channel_spacing = random_das_dist_time.attrs["distance_step"]
+        window = np.random.randint(1, 100)
+        step = np.random.randint(1, 100)
+        roller = PatchRoller(
+            random_das_dist_time,
+            distance=(window * channel_spacing) * m,
+            step=(step * channel_spacing) * m,
+        )
+        applied_result = roller.apply(np.mean).data
+
+        valid_data = ~np.isnan(applied_result).any(axis=1)
+        filtered_data_rolling = applied_result[valid_data]
+
+        df = pd.DataFrame(random_das_dist_time.data)
+        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+
+        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
+        filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
+
+        assert applied_result.shape == np.array(rolling_mean_pandas).shape
+        assert np.allclose(filtered_data_rolling, filtered_data_pandas)

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -103,8 +103,15 @@ class TestRolling:
         expected = np.arange(range_patch_3d.shape[0])
         assert np.allclose(out.data, expected[:, None, None])
 
+    def test_window_zero_raises(self, random_patch):
+        """When the window or step is entered 0 it should raise."""
+        random_patch.get_coord("time")
+        msg = "Window or step size can't be zero"
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.rolling(time=0)
+
     def test_window_too_big_raises(self, random_patch):
-        """When the window is too large it should raise."""
+        """When the window or step is too large it should raise."""
         coord = random_patch.get_coord("time")
         duration = coord.max() - coord.min()
         msg = "Window or step size is larger than"

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -125,11 +125,12 @@ class TestRolling:
         """Test the apply method of PatchRoller when distance coordinate is entered
         and the first axis is distance.
         """
+        random = np.random.RandomState(42)
         patch = range_patch
         axis = patch.dims.index("distance")
         # random window and step sizes for each trial run.
-        window = np.random.randint(1, patch.shape[axis])
-        step = np.random.randint(1, patch.shape[axis])
+        window = random.randint(1, patch.shape[axis])
+        step = random.randint(1, patch.shape[axis])
         # setup patch and apply mean.
         channel_spacing = patch.attrs["distance_step"]
         roller = patch.rolling(
@@ -179,122 +180,6 @@ class TestRolling:
         patch_1 = roll1.apply(np.sum)
         patch_2 = roll2.apply(np.sum)
         assert patch_2.shape == patch_1.shape
-
-    # @pytest.mark.parametrize("_", list(range(10)))
-    # def test_apply_axis_1_dist_time(self, _):
-    #     """Test the apply method of PatchRoller when time coordinate is entered
-    #     and the first axis is distance.
-    #     """
-    #     random_das_dist_time = dc.get_example_patch("random_das")
-    #     axis = 1
-    #     sampling_interval = random_das_dist_time.attrs["time_step"] / np.timedelta64(
-    #         1, "s"
-    #     )
-    #     window = np.random.randint(1, 100)
-    #     step = np.random.randint(1, 100)
-    #     roller = PatchRoller(
-    #         random_das_dist_time,
-    #         time=(window * sampling_interval) * s,
-    #         step=(step * sampling_interval) * s,
-    #     )
-    #     applied_result = roller.apply(np.mean).data
-
-    #     valid_data = ~np.isnan(applied_result).any(axis=0)
-    #     filtered_data_rolling = applied_result[:, valid_data]
-
-    #     df = pd.DataFrame(random_das_dist_time.data)
-    #     rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
-
-    #     valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=0)
-    #     filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
-
-    #     assert applied_result.shape == np.array(rolling_mean_pandas).shape
-    #     assert np.allclose(filtered_data_rolling, filtered_data_pandas)
-
-    # @pytest.mark.parametrize("_", list(range(10)))
-    # def test_apply_axis_0_time_dist(self, _):
-    #     """Test the apply method of PatchRoller when time coordinate is entered
-    #     and the first axis is time.
-    #     """
-    #     random_das_time_dist = dc.get_example_patch("random_das_time_dist")
-    #     axis = 0
-    #     sampling_interval = random_das_time_dist.attrs["time_step"] / np.timedelta64(
-    #         1, "s"
-    #     )
-    #     window = np.random.randint(1, 100)
-    #     step = np.random.randint(1, 100)
-    #     roller = PatchRoller(
-    #         random_das_time_dist,
-    #         time=(window * sampling_interval) * s,
-    #         step=(step * sampling_interval) * s,
-    #     )
-    #     applied_result = roller.apply(np.mean).data
-
-    #     valid_data = ~np.isnan(applied_result).any(axis=1)
-    #     filtered_data_rolling = applied_result[valid_data]
-
-    #     df = pd.DataFrame(random_das_time_dist.data)
-    #     rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
-
-    #     valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
-    #     filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
-
-    #     assert applied_result.shape == np.array(rolling_mean_pandas).shape
-    #     assert np.allclose(filtered_data_rolling, filtered_data_pandas)
-
-    # @pytest.mark.parametrize("_", list(range(10)))
-    # def test_apply_axis_1_time_dist(self, _):
-    #     """Test the apply method of PatchRoller when distance coordinate is entered
-    #     and the first axis is time."""
-    #     random_das_time_dist = dc.get_example_patch("random_das_time_dist")
-    #     axis = 1
-    #     channel_spacing = random_das_time_dist.attrs["distance_step"]
-    #     window = np.random.randint(1, 100)
-    #     step = np.random.randint(1, 100)
-    #     roller = PatchRoller(
-    #         random_das_time_dist,
-    #         distance=(window * channel_spacing) * m,
-    #         step=(step * channel_spacing) * m,
-    #     )
-    #     applied_result = roller.apply(np.mean).data
-
-    #     valid_data = ~np.isnan(applied_result).any(axis=0)
-    #     filtered_data_rolling = applied_result[:, valid_data]
-
-    #     df = pd.DataFrame(random_das_time_dist.data)
-    #     rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
-
-    #     valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=0)
-    #     filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
-
-    #     assert applied_result.shape == np.array(rolling_mean_pandas).shape
-    #     assert np.allclose(filtered_data_rolling, filtered_data_pandas)
-
-    # def test_center(self):
-    #     """Test the center option in PatchRoller."""
-    #     random_das_dist_time = dc.get_example_patch("random_das")
-    #     axis = 0
-    #     channel_spacing = random_das_dist_time.attrs["distance_step"]
-    #     window = np.random.randint(1, 100)
-    #     step = np.random.randint(1, 100)
-    #     roller = PatchRoller(
-    #         random_das_dist_time,
-    #         distance=(window * channel_spacing) * m,
-    #         step=(step * channel_spacing) * m,
-    #     )
-    #     applied_result = roller.apply(np.mean).data
-
-    #     valid_data = ~np.isnan(applied_result).any(axis=1)
-    #     filtered_data_rolling = applied_result[valid_data]
-
-    #     df = pd.DataFrame(random_das_dist_time.data)
-    #     rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
-
-    #     valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=1)
-    #     filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
-
-    #     assert applied_result.shape == np.array(rolling_mean_pandas).shape
-    #     assert np.allclose(filtered_data_rolling, filtered_data_pandas)
 
 
 class TestNumpyVsPandasRolling:
@@ -349,3 +234,15 @@ class TestNumpyVsPandasRolling:
         numpy_isnan = np.isnan(numpy_out.data)
         pandas_isnan = np.isnan(pandas_out.data)
         assert np.all(np.equal(numpy_isnan, pandas_isnan))
+
+    def test_dimension_order(self, range_patch):
+        """Ensure the dimension order doesn't matter."""
+        for patch in [range_patch, range_patch.transpose()]:
+            for dim in patch.dims:
+                coord = patch.get_coord(dim)
+                step = coord.step
+                total_len = len(coord) - 2
+                kwargs = {dim: step * total_len, "step": total_len * step}
+                pandas_out = patch.rolling(**kwargs).mean().dropna(dim)
+                numpy_out = patch.rolling(**kwargs).mean().dropna(dim)
+                assert pandas_out == numpy_out

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -88,11 +88,18 @@ class TestRolling:
     def test_3D_patch(self, range_patch_3d):
         """Ensure rolling works with 3D patch."""
         patch = range_patch_3d
+        # first try along time axis.
         out = patch.rolling(time=3).min()
-
-        expected = patch.data[:-2]
-        out = patch.rolling(time=3).min()
-        assert np.allclose(expected, out.data)
+        expected = np.arange(range_patch_3d.shape[0] - 2)
+        assert np.allclose(out.data, expected[:, None, None])
+        # then distance
+        out = patch.rolling(distance=3).min()
+        expected = np.arange(range_patch_3d.shape[0])
+        assert np.allclose(out.data, expected[:, None, None])
+        # then smell
+        out = patch.rolling(smell=3).min()
+        expected = np.arange(range_patch_3d.shape[0])
+        assert np.allclose(out.data, expected[:, None, None])
 
     def test_window_too_big_raises(self, random_patch):
         """When the window is too large it should raise."""

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -1,185 +1,113 @@
 """Tests for applying rolling functions on patch's data."""
 
-import pandas as pd
 import numpy as np
+import pytest
 
 import dascore as dc
-from dascore.proc.rolling import PatchRoller
-from dascore.units import s
+from dascore.exceptions import ParameterError
 
 
 class TestRolling:
     """Tests for applying rolling functions on patch's data."""
 
-    # @pytest.fixture(scope="class")
-    # def my_patch_dis_time(self, random_patch):
-    #     """Create a Patch containing known data with (distance, time)."""
-    #     num_rows, num_cols = random_patch.data.shape
-    #     my_data = np.random.random((num_rows,num_cols))
-    #     new_patch = random_patch.new(data=my_data)
-    #     return new_patch
+    window = 16
+    step = 8
 
-    # @pytest.fixture(scope="class")
-    # def my_patch_time_dis(self):
-    #     """Create a Patch containing known data with (time, distance)."""
+    @pytest.fixture(scope="class")
+    def range_patch(self, random_patch):
+        """Return a patch with sequential values for its 0th dim."""
+        new_data = np.ones_like(random_patch.data)
+        range_array = np.arange(0, new_data.shape[0])[:, None]
+        return random_patch.new(data=new_data * range_array)
 
-    #     array = np.random.random(size=(2_000, 300))
-    #     t1 = np.datetime64("2017-09-18")
-    #     attrs = dict(
-    #         d_distance=1,
-    #         d_time=to_timedelta64(1 / 250),
-    #         category="DAS",
-    #         id="test_data1",
-    #         time_min=t1,
-    #     )
-    #     coords = dict(
-    #         time=np.arange(array.shape[0]) * attrs["d_time"],
-    #         distance=np.arange(array.shape[1]) * attrs["d_distance"] ,)
-    #     dims = ('time', 'distance')
+    @pytest.fixture(scope="class")
+    def dist_roll_range_patch(self, range_patch):
+        """Return a patch with sequential values for its 0th dim."""
+        dist_step = range_patch.get_coord("distance").step
+        out = range_patch.rolling(distance=dist_step * self.window).max()
+        return out
 
-    # pa = dc.Patch(data=array, coords=coords, attrs=attrs, dims=dims)
+    @pytest.fixture(scope="class")
+    def range_patch_3d(self):
+        """Return a 3D patch for testing."""
+        data = np.broadcast_to(np.arange(10)[:, None, None], (10, 10, 10))
+        coords = {
+            "time": np.arange(10),
+            "distance": np.arange(10),
+            "smell": np.arange(10),
+        }
+        patch = dc.Patch(data=data, coords=coords, dims=tuple(coords))
+        return patch
 
-    #     return pa
+    def test_apply_correct_no_step(self, dist_roll_range_patch):
+        """Ensure the apply is correct without using a step size."""
+        # determine what the values should be:
+        ax_0_len = dist_roll_range_patch.shape[0]
+        samps = self.window - 1
+        expected_values = np.arange(samps, ax_0_len + samps)[:, None]
+        # and assert they are indeed that.
+        assert np.allclose(dist_roll_range_patch.data, expected_values)
 
-    def test_apply_axis_0_dist_time(self):
-        """Test the apply method of PatchRoller when time coordinate is entered
-        and the fist axis is distance.
-        """
-        random_das_dist_time = dc.get_example_patch("random_das")
-        axis = 0
-        if random_das_dist_time.dims[1] == "time":
-            axis = 1
-        sampling_interval = random_das_dist_time.attrs["time_step"] / np.timedelta64(
-            1, "s"
+    def test_along_time(self, range_patch):
+        """Ensure time axis also works."""
+        time_step = range_patch.get_coord("time").step
+        out = range_patch.rolling(time=time_step * self.window).sum()
+        shape = range_patch.shape
+        # Note: we start at 0 here because range is along 0th axis and
+        # time is first axis so all windows are the same values.
+        expected = (np.arange(0, shape[0]) * self.window)[:, None]
+        assert np.allclose(out.data, expected)
+        # this should also work if patch is transposed.
+        trans = range_patch.transpose()
+        out = trans.rolling(time=time_step * self.window).sum()
+        assert np.allclose(out.data, expected.transpose())
+
+    def test_apply_with_step(self, range_patch):
+        """Ensure apply works with various step sizes."""
+        # first calculate rolling max on time axis.
+        step = range_patch.get_coord("distance").step
+        out = range_patch.rolling(
+            distance=self.window * step, step=self.step * step
+        ).max()
+        # Determine what output should be.
+        vals = np.arange(self.window - 1, range_patch.shape[0])
+        expected = vals[:: self.step, None]
+        assert np.allclose(out.data, expected)
+
+    def test_1D_patch(self):
+        """Ensure rolling works with 1D patch."""
+        patch = dc.Patch(
+            data=np.arange(10),
+            coords={"time": dc.to_datetime64(np.arange(10))},
+            dims=("time",),
         )
-        window = 6
-        step = 2
-        roller = PatchRoller(
-            random_das_dist_time,
-            time=(window * sampling_interval) * s,
-            step=(step * sampling_interval) * s,
-        )
-        applied_result = roller.apply(np.mean)
+        expected = patch.data[:-2]
+        out = patch.rolling(time=3).min()
+        assert np.allclose(expected, out.data)
 
-        valid_data = ~np.isnan(applied_result).any(axis=axis)
-        filtered_data_rolling = applied_result[valid_data]
+    def test_3D_patch(self, range_patch_3d):
+        """Ensure rolling works with 3D patch."""
+        patch = range_patch_3d
+        out = patch.rolling(time=3).min()
 
-        df = pd.DataFrame(random_das_dist_time.data)
-        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
+        expected = patch.data[:-2]
+        out = patch.rolling(time=3).min()
+        assert np.allclose(expected, out.data)
 
-        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=axis)
-        filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
-
-        assert applied_result.shape == np.array(rolling_mean_pandas).shape
-        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
-
-    def test_apply_axis_1_dis_time(self):
-        """Test the apply method of PatchRoller when distance coordinate is entered
-        and the fist axis is distance.
-        """
-        random_das_dist_time = dc.get_example_patch("random_das")
-        axis = 1
-        if random_das_dist_time.dims[0] == "distance":
-            axis = 0
-        # channel_spacing = my_patch_dis_time.attrs['distance_step']
-        window = 6
-        step = 2
-        roller = PatchRoller(random_das_dist_time, distance=window, step=step)
-        applied_result = roller.apply(np.mean)
-
-        valid_data = ~np.isnan(applied_result).any(axis=axis)
-        filtered_data_rolling = applied_result[:, valid_data]
-
-        df = pd.DataFrame(random_das_dist_time.data)
-        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
-
-        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=axis)
-        filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
-
-        assert applied_result.shape == np.array(rolling_mean_pandas).shape
-        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
-
-    def test_apply_axis_0_time_dist(self):
-        """Test the apply method of PatchRoller when time coordinate is entered
-        and the fist axis is time.
-        """
-        random_das_time_dist = dc.get_example_patch("random_das_time_dist")
-        axis = 0
-        if random_das_time_dist.dims[1] == "time":
-            axis = 1
-        sampling_interval = random_das_time_dist.attrs["time_step"] / np.timedelta64(
-            1, "s"
-        )
-        window = 6
-        step = 2
-        roller = PatchRoller(
-            random_das_time_dist,
-            time=(window * sampling_interval) * s,
-            step=(step * sampling_interval) * s,
-        )
-        applied_result = roller.apply(np.mean)
-
-        valid_data = ~np.isnan(applied_result).any(axis=axis)
-        filtered_data_rolling = applied_result[valid_data]
-
-        df = pd.DataFrame(random_das_time_dist.data)
-        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
-
-        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=axis)
-        filtered_data_pandas = np.array(rolling_mean_pandas)[valid_data]
-
-        assert applied_result.shape == np.array(rolling_mean_pandas).shape
-        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
-
-    def test_apply_axis_1_time_dis(self):
-        """Test the apply method of PatchRoller when distance coordinate is entered
-        and the fist axis is time."""
-        random_das_time_dist = dc.get_example_patch("random_das_time_dist")
-        axis = 1
-        if random_das_time_dist.dims[0] == "distance":
-            axis = 0
-        # channel_spacing = my_patch.attrs['distance_step']
-        window = 6
-        step = 2
-        roller = PatchRoller(random_das_time_dist, distance=window, step=step)
-        applied_result = roller.apply(np.mean)
-
-        valid_data = ~np.isnan(applied_result).any(axis=axis)
-        filtered_data_rolling = applied_result[:, valid_data]
-
-        df = pd.DataFrame(random_das_time_dist.data)
-        rolling_mean_pandas = df.rolling(window, step=step, axis=axis).mean()
-
-        valid_data = ~np.isnan(np.array(rolling_mean_pandas)).any(axis=axis)
-        filtered_data_pandas = np.array(rolling_mean_pandas)[:, valid_data]
-
-        assert applied_result.shape == np.array(rolling_mean_pandas).shape
-        assert np.allclose(filtered_data_rolling, filtered_data_pandas)
-
-    # def test_center(self, my_patch):
-    #     """Test the center option in PatchRoller."""
-    #     sampling_interval = my_patch.attrs['time_step']/np.timedelta64(1, 's')
-    #     window = 6
-    #     step = 2
-    #     roll = my_patch.rolling(time=(window*sampling_interval)*s,
-    # step=(step*sampling_interval)*s, center=True)
-    #     centered_result = roll.mean()
-
-    #     df = pd.DataFrame(my_patch.data)
-    #     rolling_mean_pandas = df.rolling(3, step=2, axis=0, center=True).mean()
-
-    #     assert centered_result.shape == np.array(rolling_mean_pandas).shape
-    #     assert np.allclose(centered_result, rolling_mean_pandas)
+    def test_window_too_big_raises(self, random_patch):
+        """When the window is too large it should raise."""
+        coord = random_patch.get_coord("time")
+        duration = coord.max() - coord.min()
+        msg = "Window or step size is larger than"
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.rolling(time=duration * 2)
 
     def test_misc(self, random_patch):
         """Test miscellaneous functionality."""
-        sampling_interval = random_patch.attrs["time_step"] / np.timedelta64(1, "s")
-        window = 6
-        step = 2
-        rolling = random_patch.rolling(
-            time=(window * sampling_interval) * s, step=(step * sampling_interval) * s
-        )
-        assert isinstance(rolling.mean())
-        assert isinstance(rolling.median())
-        assert isinstance(rolling.min())
-        assert isinstance(rolling.max())
+        time_step = random_patch.get_coord("time").step
+        rolling = random_patch.rolling(time=6 * time_step, step=2 * time_step)
+        assert isinstance(rolling.mean(), dc.Patch)
+        assert isinstance(rolling.median(), dc.Patch)
+        assert isinstance(rolling.min(), dc.Patch)
+        assert isinstance(rolling.max(), dc.Patch)
+        assert isinstance(rolling.std(), dc.Patch)


### PR DESCRIPTION

## Description

This PR implements rolling methods discussed in #214. It has both a "numpy" and "pandas" engine and some discussion on when to use them. We also needed to do a few other things to make this happen:

- Implemented `Patch.dropna` (closes #143) 
- Test `CoordManager.squeeze` with default arguments
- Make `Waterfall`'s scale parameter robust to `NaNs`


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
