### PR TITLE
get_coord to allow non-array

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -834,7 +834,7 @@ class CoordArray(BaseCoord):
             msg = "At most one parameter can be specified in update_limits."
             raise ValueError(msg)
         out = self
-        if not pd.isnull(step):
+        if not pd.isnull(step) and len(self):
             out = self.snap().update_limits(step=step)
         elif min is not None:
             diff = min - self.min()

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1024,8 +1024,7 @@ def get_coord(
                 raise CoordError(msg)
 
     def _get_new_max(data, min, step):
-        """Get the new length to use"""
-
+        """Get the new length to use."""
         # for int based data types we need to modify the end time
         # otherwise this will just go nuts
         dtype = getattr(min, "dtype", None)
@@ -1062,6 +1061,9 @@ def get_coord(
     _check_inputs(values, start, stop, step)
     # data array was passed; see if it is monotonic/evenly sampled
     if values is not None:
+        if not isinstance(values, np.ndarray | BaseCoord):
+            values = np.array(values)
+        # values = np.array(values)  # ensure we have a numpy array
         if isinstance(values, BaseCoord):  # just return coordinate
             return values
         if np.size(values) == 0:

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -292,6 +292,11 @@ class DirectoryIndexer(AbstractIndexer):
         data_list = [y.flat_dump() for x in smooth_iterator for y in dc.scan(x)]
         df = pd.DataFrame(data_list)
         if not df.empty:
+            # Some users were surprised the spool wasn't sorted. We still cant
+            # guarantee all spools will be sorted but we can make sure most are
+            # by sorting the contents before dumping to index.
+            if "time_min" in df.columns:
+                df = df.sort_values("time_min").reset_index(drop=True)
             # ensure the base path is not in the path column
             assert "path" in set(df.columns), f"{df} has no path column"
             self._index_table.write_update(df, update_time, base_path=self.path)

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -2,16 +2,16 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Literal, Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
 from pydantic import Field
 
 import dascore as dc
-from dascore.utils.patch import get_dim_value_from_kwargs
 from dascore.exceptions import ParameterError
 from dascore.utils.models import DascoreBaseModel
+from dascore.utils.patch import get_dim_value_from_kwargs
 
 
 class _PatchRollerInfo(DascoreBaseModel):
@@ -60,12 +60,7 @@ class _PatchRollerInfo(DascoreBaseModel):
 
 
 class _NumpyPatchRoller(_PatchRollerInfo):
-    """
-    A class to apply roller operations to patches.
-
-    Parameters
-    ----------
-    """
+    """A class to apply roller operations to patches."""
 
     @cache
     def get_start_index(self):
@@ -79,7 +74,7 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         return int(out)
 
     def _pad_roll_array(self, data):
-        """Pad"""
+        """Pad."""
         num_nans = 1 + (self.window - 2) // self.step
         pad_width = [(0, 0)] * len(data.shape)
         pad_width[self.axis] = (num_nans, 0)
@@ -149,9 +144,7 @@ class _NumpyPatchRoller(_PatchRollerInfo):
 
 
 class _PandasPatchRoller(_PatchRollerInfo):
-    """
-    A class to apply pandas rolling operations.
-    """
+    """A class to apply pandas rolling operations."""
 
     @cache
     def _get_df(self) -> pd.DataFrame:
@@ -196,7 +189,7 @@ class _PandasPatchRoller(_PatchRollerInfo):
         return self._repack_patch(df, attrs=attrs)
 
     def mean(self):
-        """Apply mean"""
+        """Apply mean."""
         return self._call_rolling_func(name="mean")
 
     def median(self):
@@ -292,7 +285,7 @@ def rolling(
     """
 
     def _get_engine(step, engine, patch):
-        """Get the engine"""
+        """Get the engine."""
         engines = {"numpy": _NumpyPatchRoller, "pandas": _PandasPatchRoller}
         if cls := engines.get(engine):
             return cls

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -1,7 +1,6 @@
 """Processing for applying roller operations."""
 from __future__ import annotations
 
-from functools import cache
 from typing import Any, Literal
 
 import numpy as np
@@ -56,14 +55,10 @@ class _PatchRollerInfo(DascoreBaseModel):
         attrs = self.patch.attrs.update(history=new_history, coords={})
         return attrs
 
-    def __hash__(self):
-        return id(self)
-
 
 class _NumpyPatchRoller(_PatchRollerInfo):
     """A class to apply roller operations to patches."""
 
-    @cache
     def get_start_index(self):
         """
         Get the start index to account for non-zero step size.

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -1,7 +1,6 @@
 """Processing for applying roller operations."""
 from __future__ import annotations
 
-from functools import cache
 from typing import Any, Literal
 
 import numpy as np
@@ -30,7 +29,6 @@ class _PatchRollerInfo(DascoreBaseModel):
     roll_hist: str = ""
     func_kwargs: dict = Field(default_factory=dict)
 
-    @cache
     def get_coords(self):
         """
         Get the new coordinates for "rolled" patch.
@@ -62,7 +60,6 @@ class _PatchRollerInfo(DascoreBaseModel):
 class _NumpyPatchRoller(_PatchRollerInfo):
     """A class to apply roller operations to patches."""
 
-    @cache
     def get_start_index(self):
         """
         Get the start index to account for non-zero step size.
@@ -146,7 +143,6 @@ class _NumpyPatchRoller(_PatchRollerInfo):
 class _PandasPatchRoller(_PatchRollerInfo):
     """A class to apply pandas rolling operations."""
 
-    @cache
     def _get_df(self) -> pd.DataFrame:
         """Get the dataframe from patch data."""
         if len(self.patch.dims) > 2:
@@ -155,7 +151,6 @@ class _PandasPatchRoller(_PatchRollerInfo):
         df = pd.DataFrame(self.patch.data)
         return df
 
-    @cache
     def _get_rolling(self):
         """Get rolling."""
         df = self._get_df()

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -345,12 +345,7 @@ class HDFPatchIndexManager:
 
     @cached_method
     def validate_version(self):
-        """
-        Handles issues with version mismatches.
-
-        If this is the case, there is no guarantee it will work, but no knowing
-        if it won't...
-        """
+        """Handles issues with version mismatches."""
         # get the version from file, if the file doesnt exist then None
         version = self._version_or_none
         if version is not None:

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -242,7 +242,7 @@ def _array_to_int(array: np.ndarray) -> np.ndarray:
     """Convert an array of floating point timestamps to an array of np.datatime64."""
     array = np.array(array)
     if not len(array):
-        return array
+        return array.astype(np.int64)
     # dealing with an array of datetime64 or empty array
     is_dt = np.issubdtype(array.dtype, np.datetime64)
     is_td = np.issubdtype(array.dtype, np.timedelta64)

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1128,3 +1128,9 @@ class TestIssues:
         time_vals = event_patch_1.coords["time"]
         coord = get_coord(values=time_vals)
         assert coord.evenly_sampled
+
+    def test_len_1_list(self):
+        """A len 1 list should work as input to get_coords."""
+        coord = get_coord(values=[0])
+        assert isinstance(coord, BaseCoord)
+        assert len(coord) == 1

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -121,6 +121,13 @@ def coord(request) -> BaseCoord:
     return request.getfixturevalue(request.param)
 
 
+@pytest.fixture()
+def degenerate_time_coord():
+    """Return a simply degenerate coord."""
+    ar = np.empty((0, 10), dtype="datetime64[ns]")
+    return get_coord(values=ar)
+
+
 @pytest.fixture(scope="session")
 def two_d_coord():
     """Return a 2D coordinate."""
@@ -1021,12 +1028,6 @@ class TestNonOrderedArrayCoords:
 class TestDegenerateCoords:
     """Tests for degenerate coordinates."""
 
-    @pytest.fixture()
-    def basic_degenerate(self):
-        """Return a simply degenerate coord."""
-        ar = np.empty((0, 10), dtype="datetime64[ns]")
-        return get_coord(values=ar)
-
     def test_init_degen(self):
         """Ensure degen is inited by any sort of empty array."""
         arrays = [
@@ -1040,22 +1041,22 @@ class TestDegenerateCoords:
             assert out.dtype == ar.dtype
             assert len(out) == 0
 
-    def test_select(self, basic_degenerate):
+    def test_select(self, degenerate_time_coord):
         """Selecting should simply return the same degenerate."""
-        coord = basic_degenerate
+        coord = degenerate_time_coord
         assert coord.select((10, 100))[0] == coord
         assert coord.select((None, 100))[0] == coord
         assert coord.select((10, None))[0] == coord
         assert coord.select((None, None))[0] == coord
 
-    def test_empty(self, basic_degenerate):
+    def test_empty(self, degenerate_time_coord):
         """Ensure empty just returns self."""
-        assert basic_degenerate.empty() == basic_degenerate
+        assert degenerate_time_coord.empty() == degenerate_time_coord
 
-    def test_min_max(self, basic_degenerate):
+    def test_min_max(self, degenerate_time_coord):
         """Ensure min/max are nullish."""
-        assert pd.isnull(basic_degenerate.min())
-        assert pd.isnull(basic_degenerate.max())
+        assert pd.isnull(degenerate_time_coord.min())
+        assert pd.isnull(degenerate_time_coord.max())
 
     def test_degenerate_with_step_from_array(self):
         """CoordRange should be possible empty."""
@@ -1134,3 +1135,10 @@ class TestIssues:
         coord = get_coord(values=[0])
         assert isinstance(coord, BaseCoord)
         assert len(coord) == 1
+
+    def test_update_degenerate_from_attrs(self, degenerate_time_coord):
+        """Ensure updating dt on degenerate time coord doesn't fail."""
+        # before this would cause infinite recursion.
+        out = degenerate_time_coord.update(step=10)
+        assert isinstance(out, BaseCoord)
+        assert len(out) == 0

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 import pandas as pd
+import pytest
 
 import dascore as dc
 from dascore.exceptions import ParameterError
@@ -176,7 +176,7 @@ class TestRolling:
             assert isinstance(roller.sum(), dc.Patch)
 
     def test_pandas_apply(self, random_patch):
-        """test pandas apply works."""
+        """Test pandas apply works."""
         # This can be very slow so we use a large window and step size.
         dt = random_patch.get_coord("time").step
         time_len = random_patch.shape[random_patch.dims.index("time")]

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -337,6 +337,12 @@ class TestToInt:
         with pytest.raises(NotImplementedError):
             to_int(Dummy())
 
+    def test_empy_dt_array(self):
+        """Ensure an empty datatime array gets converted to int."""
+        array = np.empty(0, dtype="datetime64[ns]")
+        out = to_int(array)
+        assert np.issubdtype(out.dtype, np.integer)
+
 
 class TestIsDateTime:
     """Ensure is_datetime64 detects datetimes."""


### PR DESCRIPTION
## Description

This PR fixes an issue in which `get_coord` would fail if a list was passed as the `values` argument (rather than an array).

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
