### PR TITLE
remove twitter from website

### DIFF
--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -29,7 +29,6 @@ website:
 
   image: "_static/logo.png"
   favicon: "_static/logo.png"
-  twitter-card: true
   repo-subdir: docs
   repo-branch: master
   repo-actions: [edit]
@@ -60,10 +59,6 @@ website:
         file: api/dascore.qmd
 
     right:
-
-      - icon: twitter
-        href: https://twitter.com/dasdae_org
-        aria-label: DASDAE Twitter
 
       - icon: github
         href: https://github.com/dasdae/dascore


### PR DESCRIPTION

## Description
 
X, formally known as twitter, doesn't seem to have the same engagement and academic vibrancy it once did. This PR removes the twitter icon from the top right corner of the DASCore website.

![image](https://github.com/DASDAE/dascore/assets/11671536/88ca1b0c-d7d7-42cb-895e-b463841e778c)

Please let me know if anyone disagrees and we can keep the icon. 

