### PR TITLE
More flexible DASDAE io

### DIFF
--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -14,6 +14,11 @@ from dascore.utils.time import to_int
 # --- Functions for writing DASDAE format
 
 
+def _create_or_get_group(h5, group, name):
+    """Create a new group or get existing."""
+    h5.create_group(group, name)
+
+
 def _write_meta(hfile, file_version):
     """Write metadata to hdf5 file."""
     attrs = hfile.root._v_attrs

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import numpy as np
+from tables import NodeError
 
 import dascore as dc
 from dascore.core.attrs import PatchAttrs
@@ -16,7 +17,22 @@ from dascore.utils.time import to_int
 
 def _create_or_get_group(h5, group, name):
     """Create a new group or get existing."""
-    h5.create_group(group, name)
+    try:
+        group = h5.create_group(group, name)
+    except NodeError:
+        group = getattr(group, name)
+    return group
+
+
+def _create_or_squash_array(h5, group, name, data):
+    """Create a new array, if it exists delete and re-create."""
+    try:
+        array = h5.create_array(group, name, data)
+    except NodeError:
+        old_node = getattr(group, name)
+        h5.remove_node(old_node)
+        array = h5.create_array(group, name, data)
+    return array
 
 
 def _write_meta(hfile, file_version):
@@ -31,7 +47,8 @@ def _save_attrs_and_dims(patch, patch_group):
     """Save the attributes."""
     # copy attrs to group attrs
     # TODO will need to test if objects are serializable
-    for i, v in patch.attrs.items():
+    attr_dict = patch.attrs.model_dump(exclude_unset=True)
+    for i, v in attr_dict.items():
         patch_group._v_attrs[f"_attrs_{i}"] = v
     patch_group._v_attrs["_dims"] = ",".join(patch.dims)
 
@@ -43,13 +60,9 @@ def _save_array(data, name, group, h5):
     is_td = np.issubdtype(data.dtype, np.timedelta64)
     if is_dt or is_td:
         data = to_int(data)
-    out = h5.create_array(
-        group,
-        name,
-        data,
-    )
-    out._v_attrs["is_datetime64"] = is_dt
-    out._v_attrs["is_timedelta64"] = is_td
+    array_node = _create_or_squash_array(h5, group, name, data)
+    array_node._v_attrs["is_datetime64"] = is_dt
+    array_node._v_attrs["is_timedelta64"] = is_td
 
 
 def _save_coords(patch, patch_group, h5):
@@ -69,12 +82,12 @@ def _save_coords(patch, patch_group, h5):
 def _save_patch(patch, wave_group, h5):
     """Save the patch to disk."""
     name = get_default_patch_name(patch)
-    patch_group = h5.create_group(wave_group, name)
+    patch_group = _create_or_get_group(h5, wave_group, name)
     _save_attrs_and_dims(patch, patch_group)
     _save_coords(patch, patch_group, h5)
     # add data
     if patch.data.shape:
-        h5.create_array(patch_group, "data", patch.data)
+        _create_or_squash_array(h5, patch_group, "data", patch.data)
 
 
 # --- Functions for reading

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import dascore as dc
+from dascore.constants import VALID_DATA_TYPES
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
 from dascore.utils.misc import iterate, maybe_get_attrs, unbyte
@@ -76,10 +77,14 @@ def _get_time_coord(node):
 def _get_data_unit_and_type(node):
     """Get the data type and units."""
     attrs = node._v_attrs
-    out = dict(
-        data_type=unbyte(attrs.RawDescription).lower().replace(" ", "_"),
-        data_units=unbyte(attrs.RawDataUnit),
-    )
+    attr_map = {
+        "RawDescription": "data_type",
+        "RawDataUnit": "data_units",
+    }
+    out = maybe_get_attrs(attrs, attr_map)
+    if (data_type := attr_map.get("data_type")) is not None:
+        clean = data_type.lower().replace(" ", "_")
+        out["data_type"] = clean if clean in VALID_DATA_TYPES else ""
     return out
 
 

--- a/tests/test_core/test_attrs.py
+++ b/tests/test_core/test_attrs.py
@@ -190,6 +190,12 @@ class TestPatchAttrs:
         for name, coord in attr.coords.items():
             assert isinstance(coord, CoordSummary)
 
+    def test_items(self, random_patch):
+        """Ensure items works like a dict."""
+        attrs = random_patch.attrs
+        out = dict(attrs.items())
+        assert out == attrs.model_dump()
+
 
 class TestSummaryAttrs:
     """Tests for summarizing a schema."""

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -97,7 +97,7 @@ class TestWriteDASDAE:
     def test_write_again(self, written_dascore_v1_random, random_patch):
         """Ensure a patch can be written again to file (should overwrite old)."""
         random_patch.io.write(written_dascore_v1_random, "dasdae")
-        read_patch = dc.spool(written_dascore_v1_random)
+        read_patch = dc.spool(written_dascore_v1_random)[0]
         assert random_patch == read_patch
 
 
@@ -192,9 +192,9 @@ class TestRoundTrips:
         new_patch = spool[0]
         assert patch.equals(new_patch)
 
-    def test_roundtrip_1_dim_patch(self, tmp_path_factory, random_patch):
-        """A spool with a dimension of length 1 should roundtrip."""
-        path = tmp_path_factory.mktemp("round_trip_dim_1") / "out.h5"
+    def test_roundtrip_empty_time_patch(self, tmp_path_factory, random_patch):
+        """A patch with a dimension of length 0 should roundtrip."""
+        path = tmp_path_factory.mktemp("round_trip_time_degenerate") / "out.h5"
         patch = random_patch
         # get degenerate patch
         time = patch.get_coord("time")
@@ -205,3 +205,18 @@ class TestRoundTrips:
         spool = formatter.read(path)
         new_patch = spool[0]
         assert empty_patch.equals(new_patch)
+
+    def test_roundtrip_dim_1_patch(self, tmp_path_factory, random_patch):
+        """A patch with length 1 time axis should roundtrip."""
+        path = tmp_path_factory.mktemp("round_trip_dim_1") / "out.h5"
+        patch = dc.get_example_patch(
+            "random_das",
+            time_step=0.999767552,
+            shape=(100, 1),
+            starttime="2023-06-13T15:38:00.49953408",
+        )
+        patch.io.write(path, "dasdae")
+        formatter = DASDAEV1()
+        spool = formatter.read(path)
+        new_patch = spool[0]
+        assert patch.equals(new_patch)


### PR DESCRIPTION

## Description

This PR makes the DASDAE format more flexible; mainly it is now possible to write a patch to a file twice (old patch is squashed). Before `NodeError`s would get raised if this was attempted (which happens a lot by accident).

Also tests roundtrip for degenerate patch but this didn't require any changes to make it work.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
