### PR TITLE
get_filter error message

### DIFF
--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -155,7 +155,7 @@ def pass_filter(patch: PatchType, corners=4, zerophase=True, **kwargs) -> PatchT
     dim, (arg1, arg2) = _check_filter_kwargs(kwargs)
     axis = patch.dims.index(dim)
     coord_units = patch.coords.coord_map[dim].units
-    filt_min, filt_max = get_filter_units(arg1, arg2, to_unit=coord_units)
+    filt_min, filt_max = get_filter_units(arg1, arg2, to_unit=coord_units, dim=dim)
     sr = get_dim_sampling_rate(patch, dim)
     # get nyquist and low/high in terms of nyquist
     sos = _get_sos(sr, filt_min, filt_max, corners)

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -153,7 +153,7 @@ class TestPassFilter:
         assert p.pass_filter(time=(10, None)) == p.pass_filter(time=(10, ...))
 
     def test_non_zero_phase(self, random_patch):
-        """Enssure non-zero-phase filter logic runs."""
+        """Ensure non-zero-phase filter logic runs."""
         out = random_patch.pass_filter(time=(..., 20), zerophase=False)
         assert isinstance(out, dc.Patch)
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -173,6 +173,13 @@ class TestGetFilterUnits:
         with pytest.raises(UnitError, match=match):
             get_filter_units(1.0 * m, 10.0 * m, s)
 
+    def test_specifying_units_unitless_dimension_raises(self):
+        """Check an error is raised when units are used on a unitless dimension."""
+        msg = "Cannot use units on dimension"
+        m = dc.get_unit("m")
+        with pytest.raises(UnitError, match=msg):
+            get_filter_units(1 * m, 2 * m, None)
+
 
 class TestDTypeCompatible:
     """Ensure dtype compatibility check works."""


### PR DESCRIPTION


## Description

This PR adds an error message for `get_filter_units`  when filter units are specified but coordinate units are not.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
