### PR TITLE
fix #265

### DIFF
--- a/tests/test_io/test_indexer.py
+++ b/tests/test_io/test_indexer.py
@@ -63,7 +63,7 @@ def empty_index(tmp_path_factory):
 class TestFindIndex:
     """Tests for finding the index."""
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     def unwritable_directory(self, tmp_path_factory):
         """Return an un-writable directory."""
         # currently this doesn't work on windows so we need to skip any test


### PR DESCRIPTION


## Description

Fixes #265 with a bit of a hack in `dascore.misc._spool_map`. Basically, when the spool is split, several flags are added to to the newly created spools to ensure only one will display a progress bar when the processing is run on separate threads or processes.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
