### PR TITLE
Add module for dispersion image calculation

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -245,6 +245,7 @@ class Patch:
     integrate = transform.integrate
     spectrogram = transform.spectrogram
     velocity_to_strain_rate = transform.velocity_to_strain_rate
+    phase_shift = transform.phase_shift
 
     # --- Method Namespaces
     # Note: these can't be cached_property (from functools) or references

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -245,7 +245,7 @@ class Patch:
     integrate = transform.integrate
     spectrogram = transform.spectrogram
     velocity_to_strain_rate = transform.velocity_to_strain_rate
-    phase_shift = transform.phase_shift
+    dispersion_phase_shift = transform.dispersion_phase_shift
 
     # --- Method Namespaces
     # Note: these can't be cached_property (from functools) or references

--- a/dascore/data_registry.txt
+++ b/dascore/data_registry.txt
@@ -13,3 +13,4 @@ prodml_2.1.h5 47875ae1fa17d99849cdb595e9fa6853d162605c1556be90225f37aaa123dded h
 h5_simple_1.h5 52803b26a5738da541cc9b32b867434cad0a845686c47dd93551b8eb431f8bc0 https://github.com/DASDAE/test_data/raw/master/das/h5_simple_1.h5
 h5_simple_2.h5 8a70b873c5c2c172871ecd63760d24fa2c305c015e2ca1c84018c6864d2fb304 https://github.com/dasdae/test_data/raw/master/das/h5_simple_2.h5
 conoco_segy_1.sgy 3944297d7c27dd265b40d56d4797f1a14caa5c2bed9f0af020b0f6ea193d4dfd https://github.com/dasdae/test_data/raw/master/das/conoco_segy_1.sgy
+dispersion_event.h5 598c8baa2a5610c930e1c003f2ba02da13f8d8686e3ccf2a034e94bfc5e1990c https://github.com/dasdae/test_data/raw/master/das/dispersion_event.h5

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -247,6 +247,13 @@ def _diverse_spool():
     return dc.spool([y for x in all_spools for y in x])
 
 
+@register_func(EXAMPLE_PATCHES, key="dispersion_event")
+def _dispersion_event():
+    """Returns an example of a synthetic shot record that exhibits dispersion."""
+    path = fetch("dispersion_event.h5")
+    return dc.spool(path)[0]
+
+
 def spool_to_directory(spool, path=None, file_format="DASDAE", extention="hdf5"):
     """
     Write out each patch in a spool to a directory.

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -100,3 +100,7 @@ class UnitError(ValueError, DASCoreError):
 
 class AttributeMergeError(ValueError, DASCoreError):
     """Raised when something is wrong with combining attributes."""
+
+
+class DispersionParameterError(ValueError, DASCoreError):
+    """Raised when something is wrong with dispersion computation paramters."""

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -100,7 +100,3 @@ class UnitError(ValueError, DASCoreError):
 
 class AttributeMergeError(ValueError, DASCoreError):
     """Raised when something is wrong with combining attributes."""
-
-
-class DispersionParameterError(ValueError, DASCoreError):
-    """Raised when something is wrong with dispersion computation paramters."""

--- a/dascore/transform/__init__.py
+++ b/dascore/transform/__init__.py
@@ -11,4 +11,4 @@ from .fourier import dft, idft
 from .integrate import integrate
 from .spectro import spectrogram
 from .strain import velocity_to_strain_rate
-from .dispersion import phase_shift
+from .dispersion import dispersion_phase_shift

--- a/dascore/transform/__init__.py
+++ b/dascore/transform/__init__.py
@@ -11,3 +11,4 @@ from .fourier import dft, idft
 from .integrate import integrate
 from .spectro import spectrogram
 from .strain import velocity_to_strain_rate
+from .dispersion import phase_shift

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -1,0 +1,139 @@
+"""Dispersion computation using the phase-shift (Park et al., 1999) method."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import numpy.fft as nft
+
+from dascore.constants import PatchType
+from dascore.exceptions import DispersionParameterError
+from dascore.utils.patch import patch_function
+
+
+@patch_function
+def phase_shift(
+    patch: PatchType, vels: Sequence[float], direction: str, approxdf: float = 0.0
+) -> PatchType:
+    """
+    Compute dispersion images using the phase-shift method (Park et al., 1999)
+    Inspired by https://geophydog.cool/post/masw_phase_shift/.
+
+    Parameters
+    ----------
+    patch
+        Patch to transform. Has to have dimensions of time and distance
+    vels
+        NumPY array of positive velocities, monotonically increasing, for
+        which the dispersion will be computed
+    direction
+        Indicating whether the event is down-dip ('ltr') or up-dip ('rtl')
+    approxdf
+        Approximated frequency (Hz) resolution for the output. If left empty,
+        the frequency resolution is dictated by the number of samples.
+
+    Notes
+    -----
+    - Dims/Units of the output are forced to be 'frequency' ('Hz')
+      and 'velocity' ('m/s')
+
+    Example
+    --------
+    import dascore as dc
+    import numpy as np
+
+    patch = (
+        dc.get_example_patch('example_event_1')
+        .set_units("mm/(m*s)", distance='m', time='s')
+        .taper(time=0.05)
+        .pass_filter(time=(None, 300))
+    )
+
+    disp_patch = patch.phase_shift(np.arange(1500,6001,10),direction='rtl',approxdf=5.0)
+    ax = disp_patch.viz.waterfall(show=False, scale=0.5,cmap=None)
+    ax.set_xlim(10, 300)
+    ax.set_ylim(6000, 1500)
+    disp_patch.viz.waterfall(show=True, scale=0.5, ax=ax)
+
+    """
+    patch_cop = patch.new()
+
+    if not np.all(np.diff(np.abs(vels)) > 0):
+        raise DispersionParameterError(
+            "Velocities for dispersion computation\
+         must be monotonically increasing"
+        )
+
+    if set(patch_cop.dims) != set(["distance", "time"]):
+        raise DispersionParameterError(
+            "Dispersion can only be computed\
+         for distance-time patches"
+        )
+
+    if np.amin(np.abs(vels)) <= 0:
+        raise DispersionParameterError(
+            "Velocity has to be positive.\
+         Control the direction parameter if needed."
+        )
+
+    if direction == "ltr":
+        dirflag = 1
+    elif direction == "rtl":
+        dirflag = -1
+    else:
+        raise DispersionParameterError("Direction can only be ltr or rtl")
+
+    if patch.dims[0] == "time":
+        patch_cop.transpose("distance", "time")
+
+    patch_cop.convert_units(distance="m")
+    dist = patch_cop.coords.get_array("distance")
+    time = patch_cop.coords.get_array("time")
+
+    dt = (time[1] - time[0]) / np.timedelta64(1, "s")  # There has to be an easier way.
+    nchan = dist.size
+    nt = time.size
+    m, n = patch_cop.data.shape
+    assert m == nchan
+    assert n == nt
+
+    fs = 1 / dt
+    if approxdf > 0.0:
+        approxnf = int(nt * (fs / (nt)) / approxdf)
+        f = np.arange(approxnf) * fs / (approxnf - 1)
+    else:
+        f = np.arange(nt) * fs / (nt - 1)
+    f[1] - f[0]
+
+    nf = np.size(f)
+
+    nv = np.size(vels)
+    w = 2 * np.pi * f
+    fft_d = np.zeros((nchan, nf), dtype=complex)
+    for i in range(nchan):
+        fft_d[i] = nft.fft(patch_cop.data[i, :], n=nf)
+
+    fft_d = np.divide(
+        fft_d, abs(fft_d), out=np.zeros_like(fft_d), where=abs(fft_d) != 0
+    )
+
+    fft_d[np.isnan(fft_d)] = 0
+
+    hnf = int(nf / 2)
+    fc = np.zeros(shape=(nv, hnf))
+    preamb = 1j * dirflag
+    for ci in range(nv):
+        for fi in range(hnf):
+            fc[ci, fi] = abs(
+                sum(np.exp(preamb * w[fi] / vels[ci] * dist) * fft_d[:, fi])
+            )
+
+    attrs = dict(category="Dispersion")
+    coords = dict(velocity=vels, frequency=f[0:hnf])
+
+    disp_patch = patch.new(
+        data=fc, coords=coords, attrs=attrs, dims=["velocity", "frequency"]
+    )
+    disp_patch.set_units(velocity="m/s", frequency="Hz")
+
+    return disp_patch

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -57,7 +57,7 @@ def dispersion_phase_shift(
 
     patch = (
         dc.get_example_patch('dispersion_event')
-        .set_units("mm/(m*s)", distance='m', time='s')
+        .set_units(distance='m', time='s')
         .taper(time=0.05)
         .pass_filter(time=(None, 300))
     )

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -33,7 +33,7 @@ def dispersion_phase_shift(
         the frequency resolution is dictated by the number of samples.
     approx_min_freq
         Minimum frequency to compute dispersion for. If left empty, 0 Hz
-     approx_max_freq
+    approx_max_freq
         Maximum frequency to compute dispersion for. If left empty,
         Nyquist frequency will be used.
 

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -57,9 +57,6 @@ def dispersion_phase_shift(
 
     patch = (
         dc.get_example_patch('dispersion_event')
-        .set_units(distance='m', time='s')
-        .taper(time=0.05)
-        .pass_filter(time=(None, 300))
     )
 
     disp_patch = patch.dispersion_phase_shift(np.arange(100,1500,1),

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -7,13 +7,13 @@ import numpy as np
 import numpy.fft as nft
 
 from dascore.constants import PatchType
-from dascore.exceptions import DispersionParameterError
+from dascore.exceptions import ParameterError
 from dascore.utils.patch import patch_function
 
 
-@patch_function
+@patch_function(required_dims=("time", "distance"))
 def phase_shift(
-    patch: PatchType, vels: Sequence[float], direction: str, approxdf: float = 0.0
+    patch: PatchType, vels: Sequence[float], direction: str, approxdf: float = -1.0
 ) -> PatchType:
     """
     Compute dispersion images using the phase-shift method (Park et al., 1999)
@@ -63,19 +63,13 @@ def phase_shift(
     patch_cop = patch.new()
 
     if not np.all(np.diff(np.abs(vels)) > 0):
-        raise DispersionParameterError(
+        raise ParameterError(
             "Velocities for dispersion computation\
          must be monotonically increasing"
         )
 
-    if set(patch_cop.dims) != set(["distance", "time"]):
-        raise DispersionParameterError(
-            "Dispersion can only be computed\
-         for distance-time patches"
-        )
-
     if np.amin(np.abs(vels)) <= 0:
-        raise DispersionParameterError(
+        raise ParameterError(
             "Velocity has to be positive.\
          Control the direction parameter if needed."
         )
@@ -85,7 +79,7 @@ def phase_shift(
     elif direction == "rtl":
         dirflag = -1
     else:
-        raise DispersionParameterError("Direction can only be ltr or rtl")
+        raise ParameterError("Direction can only be ltr or rtl")
 
     if patch.dims[0] == "time":
         patch_cop.transpose("distance", "time")

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -37,6 +37,10 @@ def phase_shift(
     - Dims/Units of the output are forced to be 'frequency' ('Hz')
       and 'velocity' ('m/s')
 
+    - The patch's distance coordinates are assumed to be ordered by
+    distance from the source, and not "fiber distance". In other
+    words, data are effectively mapped along a 2-D line.
+
     Example
     --------
     import dascore as dc

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -19,5 +19,7 @@ A Huge thanks to all of our contributors:
 
 [Aaron Girard](https://github.com/aaronjgirard)
 
+[Ariel Lellouch](https://github.com/ariellellouch)
+
 You can find more contributor information
 [here](https://github.com/DASDAE/dascore/graphs/contributors)

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -42,3 +42,12 @@
   volume={10},
   year={2022}
 }
+
+@incollection{park1998imaging,
+  title={Imaging dispersion curves of surface waves on multi-channel record},
+  author={Park, Choon Byong and Miller, Richard D and Xia, Jianghai},
+  booktitle={SEG technical program expanded abstracts 1998},
+  pages={1377--1380},
+  year={1998},
+  publisher={Society of Exploration Geophysicists}
+}

--- a/tests/test_transform/test_dispersion.py
+++ b/tests/test_transform/test_dispersion.py
@@ -33,7 +33,7 @@ class TestDispersion:
         # check that the approximate frequency resolution is obtained
 
     def test_dispersion_no_resolution(self, random_patch):
-        """Ensure dispersion calc works when no resolution is provided."""
+        """Ensure dispersion calc works when no resolution nor limits are provided."""
         test_vels = np.linspace(1500, 5000, 50)
         # create a smaller patch so this runs quicker.
         patch = random_patch.select(
@@ -66,4 +66,52 @@ class TestDispersion:
             random_patch.dispersion_phase_shift(
                 phase_velocities=test_vels,
                 approx_resolution=-1,
+            )
+
+    def test_freq_range_gt_0(self, random_patch):
+        """Ensure negative Parameter Error."""
+        msg = "Minimal and maximal frequencies have to be positive"
+        velocities = np.linspace(1500, 5000, 50)
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.dispersion_phase_shift(
+                phase_velocities=velocities,
+                approx_resolution=1.0,
+                approx_freq=[-10, 50],
+            )
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.dispersion_phase_shift(
+                phase_velocities=velocities,
+                approx_resolution=1.0,
+                approx_freq=[10, -50],
+            )
+
+    def test_freq_range_raises(self, random_patch):
+        """Ensure negative Parameter Error."""
+        msg = "Maximal frequency needs to be larger than minimal frequency"
+        velocities = np.linspace(1500, 5000, 50)
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.dispersion_phase_shift(
+                phase_velocities=velocities, approx_resolution=1.0, approx_freq=[23, 22]
+            )
+
+    def test_freq_range_nyquist(self, random_patch):
+        """Ensure negative Parameter Error."""
+        msg = "Frequency range cannot exceed Nyquist"
+        velocities = np.linspace(1500, 5000, 50)
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.dispersion_phase_shift(
+                phase_velocities=velocities,
+                approx_resolution=1.0,
+                approx_freq=[5000, 8000],
+            )
+
+    def test_freq_range_yields_empty(self, random_patch):
+        """Ensure negative Parameter Error."""
+        msg = "Combination of frequency resolution and range is not an array"
+        velocities = np.linspace(1500, 5000, 50)
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.dispersion_phase_shift(
+                phase_velocities=velocities,
+                approx_resolution=2.0,
+                approx_freq=[22.0, 22.1],
             )

--- a/tests/test_transform/test_dispersion.py
+++ b/tests/test_transform/test_dispersion.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 
-from dascore.transform import phase_shift
+from dascore.transform import dispersion_phase_shift
 from dascore.utils.misc import suppress_warnings
 
 
@@ -14,22 +14,19 @@ class TestDispersion:
         """Return the random patched transformed along time w/ rrft."""
         test_vels = np.linspace(1500, 5000, 351)
         with suppress_warnings(DeprecationWarning):
-            out = phase_shift(random_patch, test_vels, direction="rtl", approxdf=2.0)
+            out = dispersion_phase_shift(random_patch, test_vels, approx_resolution=2.0)
         return out
 
     def test_dispersion(self, dispersion_patch):
         """Check consistency of test_dispersion module."""
-        dims = dispersion_patch.dims
-        dimvel = [x.startswith("vel") for x in dims]
-        dimfreq = [x.startswith("freq") for x in dims]
-
-        assert any(dimvel)
-        assert any(dimfreq)
+        # assert velocity dimension
+        assert "velocity" in dispersion_patch.dims
+        # assert frequency dimension
+        assert "frequency" in dispersion_patch.dims
 
         vels = dispersion_patch.coords.get_array("velocity")
-        # assert velocity dimension
+
         freqs = dispersion_patch.coords.get_array("frequency")
-        # assert frequency dimension
 
         assert np.array_equal(vels, np.linspace(1500, 5000, 351))
         # Check that the velocity output is correct

--- a/tests/test_transform/test_dispersion.py
+++ b/tests/test_transform/test_dispersion.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore import get_example_patch
 from dascore.exceptions import ParameterError
 from dascore.transform import dispersion_phase_shift
 from dascore.utils.misc import suppress_warnings
@@ -13,7 +14,7 @@ class TestDispersion:
 
     @pytest.fixture(scope="class")
     def dispersion_patch(self, random_patch):
-        """Return the random patched transformed along time w/ rrft."""
+        """Return the random patched transformed to frequency-velocity."""
         test_vels = np.linspace(1500, 5000, 351)
         with suppress_warnings(DeprecationWarning):
             out = dispersion_phase_shift(random_patch, test_vels, approx_resolution=2.0)
@@ -68,18 +69,19 @@ class TestDispersion:
                 approx_resolution=-1,
             )
 
-    def test_freq_range_gt_0(self, random_patch):
+    def test_freq_range_gt_0(self):
         """Ensure negative Parameter Error."""
         msg = "Minimal and maximal frequencies have to be positive"
         velocities = np.linspace(1500, 5000, 50)
+        patch = get_example_patch("dispersion_event")
         with pytest.raises(ParameterError, match=msg):
-            random_patch.dispersion_phase_shift(
+            patch.dispersion_phase_shift(
                 phase_velocities=velocities,
                 approx_resolution=1.0,
                 approx_freq=[-10, 50],
             )
         with pytest.raises(ParameterError, match=msg):
-            random_patch.dispersion_phase_shift(
+            patch.dispersion_phase_shift(
                 phase_velocities=velocities,
                 approx_resolution=1.0,
                 approx_freq=[10, -50],

--- a/tests/test_transform/test_dispersion.py
+++ b/tests/test_transform/test_dispersion.py
@@ -1,0 +1,38 @@
+"""Tests for Dispersion transforms."""
+import numpy as np
+import pytest
+
+from dascore.transform import phase_shift
+from dascore.utils.misc import suppress_warnings
+
+
+class TestDispersion:
+    """Tests for the dispersion module."""
+
+    @pytest.fixture(scope="class")
+    def dispersion_patch(self, random_patch):
+        """Return the random patched transformed along time w/ rrft."""
+        test_vels = np.linspace(1500, 5000, 351)
+        with suppress_warnings(DeprecationWarning):
+            out = phase_shift(random_patch, test_vels, direction="rtl", approxdf=2.0)
+        return out
+
+    def test_dispersion(self, dispersion_patch):
+        """Check consistency of test_dispersion module."""
+        dims = dispersion_patch.dims
+        dimvel = [x.startswith("vel") for x in dims]
+        dimfreq = [x.startswith("freq") for x in dims]
+
+        assert any(dimvel)
+        assert any(dimfreq)
+
+        vels = dispersion_patch.coords.get_array("velocity")
+        # assert velocity dimension
+        freqs = dispersion_patch.coords.get_array("frequency")
+        # assert frequency dimension
+
+        assert np.array_equal(vels, np.linspace(1500, 5000, 351))
+        # Check that the velocity output is correct
+
+        assert freqs[1] - freqs[0] > 1.9 and freqs[1] - freqs[0] < 2.1
+        # check that the approximate frequency resolution is obtained


### PR DESCRIPTION
This module was created to generate dispersion images directly from patches. It uses the distance coordinates to compute a dispersion image using the phase-shift method. 

## Checklist

I have (if applicable):

- [X] referenced the GitHub issue this PR closes.
- [X] documented the new feature with docstrings or appropriate doc page.
- [X] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] your name has been added to the contributors page (docs/contributors.md).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.
