### PR TITLE
Added bit (sample-by-sample) normalization

### DIFF
--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -159,6 +159,10 @@ class TestNormalize:
             norm = zeroed_patch.normalize("time", norm=norm_type)
             assert np.all(norm.data[0, :] == 0.0)
             assert np.all(norm.data[:, 0] == 0.0)
+        for norm_type in ["l1", "l2", "max", "bit"]:
+            norm = zeroed_patch.normalize("distance", norm=norm_type)
+            assert np.all(norm.data[0, :] == 0.0)
+            assert np.all(norm.data[:, 0] == 0.0)
 
 
 class TestStandarize:


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

Solves https://github.com/DASDAE/dascore/issues/281 and adds sample-by-sample normalization
Cherry-picked commits from dispersion, supersedes #283  

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
