### PR TITLE
fix #286

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -170,8 +170,20 @@ def _get_nullish_for_type(dtype):
     return np.NaN
 
 
-def _get_compatible_values(val, dtype):
-    """Get values compatible with dtype."""
+def get_compatible_values(val, dtype):
+    """
+    Get values compatible with dtype.
+
+    This will essentially perform any type conversions needed to go from
+    one dtype to another. It is useful for handling datetime conversions.
+
+    Parameters
+    ----------
+    val
+        The values to convert.
+    dtype
+        A numpy compatible datatype or string.
+    """
     validators = _get_coord_filter_validators(dtype)
     for func in validators:
         if val is not None:
@@ -396,7 +408,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
                 value = dc.to_timedelta64(value)
             value = self._get_relative_values(value)
         # apply validators. These can, eg, coerce to correct dtype.
-        out = _get_compatible_values(value, self.dtype)
+        out = get_compatible_values(value, self.dtype)
         return out
 
     def _slice_degenerate(self, sliz):
@@ -690,16 +702,16 @@ class CoordRange(BaseCoord):
         # after ensuring that the types are compatible.
         out = self
         if step is not None:
-            step = _get_compatible_values(step, type(self.step))
+            step = get_compatible_values(step, type(self.step))
             new_stop = out.start + step * len(out)
             out = out.new(stop=new_stop, step=step)
         if min is not None:
-            min = _get_compatible_values(min, self.dtype)
+            min = get_compatible_values(min, self.dtype)
             diff = min - out.start
             new_stop = out.stop + diff
             out = out.new(start=min, stop=new_stop)
         if max is not None:
-            max = _get_compatible_values(max, self.dtype)
+            max = get_compatible_values(max, self.dtype)
             translation = (max + out.step) - out.stop
             new_start = self.start + translation
             # we add step so the new range is inclusive of stop.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,6 +207,13 @@ def event_patch_1():
     return dc.get_example_patch("example_event_1")
 
 
+@pytest.fixture(scope="session")
+@register_func(PATCH_FIXTURES)
+def dispersion_patch():
+    """Fetch dispersion event."""
+    return dc.get_example_patch("dispersion_event")
+
+
 @pytest.fixture(scope="class")
 @register_func(PATCH_FIXTURES)
 def range_patch_3d():

--- a/tests/test_transform/test_spectro_transform.py
+++ b/tests/test_transform/test_spectro_transform.py
@@ -63,3 +63,12 @@ class TestSpectroTransform:
         """Ensure distance dimension works."""
         out = random_patch.transpose().spectrogram("distance")
         assert set(out.dims) == (set(random_patch.dims) | {"ft_distance"})
+
+    def test_time_range_unchanged(self, dispersion_patch):
+        """Ensure time axis isn't outside original bounds, see #286."""
+        spectro = dispersion_patch.spectrogram(dim="time")
+        # the new time on the spectrogram should be contained in the original
+        original_time = dispersion_patch.get_coord("time")
+        new_time = spectro.get_coord("time")
+        assert new_time.min() >= original_time.min()
+        assert new_time.max() <= original_time.max()


### PR DESCRIPTION
## Description

Fixes #286. The main issue is that the `fs` parameter of `scipy.signal.spectrogram` requires sampling *frequency*, sampling spacing was passed in prior to this PR. I also simplified `_get_new_original_coord` private function.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
