### PR TITLE
Reduce progress refresh rate.

### DIFF
--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -16,14 +16,18 @@ def track(sequence, description):
         return
     # Normal progress bar behavior
     progress = prog.Progress(
-        prog.SpinnerColumn(),
+        # prog.SpinnerColumn(),
         prog.TextColumn("[progress.description]{task.description}"),
         prog.BarColumn(bar_width=30),
         prog.TaskProgressColumn(),
         prog.TimeRemainingColumn(),
         prog.TimeElapsedColumn(),
         prog.MofNCompleteColumn(),
+        refresh_per_second=1,
     )
+    # Note: we rest the refresh-rate low because of latency issues with
+    # remote servers. It also helped to remove the spinner so the bar didnt
+    # look so jumpy. See #305.
     total = len(sequence)
     with progress:
         yield from progress.track(

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -9,7 +9,8 @@ class TestProgressBar:
     """Tests for the rich progress bar."""
 
     def test_progressbar_shows(self, monkeypatch):
-        """Undo debug patch to progress bar shows."""
+        """A test for when the progress bar shows to run progress logic."""
+        # Undo debug patch so progress bar shows.
         monkeypatch.setattr(dc, "_debug", False)
         for _ in track([1, 2, 3], "testing_tracker"):
             pass


### PR DESCRIPTION


## Description

This PR reduces the default progress bar's refresh rate from 10Hz to 1Hz. It also removes the spinner at the start of the progress bar as it looks a little too jumpy with the lower rate.

This appears to be needed to avoid the progress bar updates from "pilling up" on remote servers. See #305.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
