### PR TITLE
conda cache string to include architecture 

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -41,7 +41,7 @@ jobs:
                || startsWith(matrix.os, 'macos') && '/Users/runner/miniconda3/envs/dascore'
                || startsWith(matrix.os, 'windows') && 'C:\Miniconda3\envs\dascore' }}
       # set individual cache key (only the start of it)
-      cache_key: ${{ matrix.os }}-py${{ matrix.python-version }}
+      cache_key: ${{ matrix.os }}-${{ github.arch }}-py${{ matrix.python-version }}
       # set conda environment file with dependencies
       env_file: "environment.yml"
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -95,6 +95,13 @@ jobs:
           conda info -a
           conda list
 
+      # Re-install pytables to avoid issues mentioned in #312
+      - name: re-install pytables
+        shell: bash -l {0}
+        if: matrix.os == 'macos-latest'
+        run: |
+          python -m pip install --upgrade --no-deps --force-reinstall tables
+
       # Runs test suite and calculates coverage
       - name: run test suite
         shell: bash -l {0}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -41,7 +41,7 @@ jobs:
                || startsWith(matrix.os, 'macos') && '/Users/runner/miniconda3/envs/dascore'
                || startsWith(matrix.os, 'windows') && 'C:\Miniconda3\envs\dascore' }}
       # set individual cache key (only the start of it)
-      cache_key: ${{ matrix.os }}-${{ github.arch }}-py${{ matrix.python-version }}
+      cache_key: ${{ matrix.os }}-${{ runner.arch }}-py${{ matrix.python-version }}
       # set conda environment file with dependencies
       env_file: "environment.yml"
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -41,7 +41,7 @@ jobs:
                || startsWith(matrix.os, 'macos') && '/Users/runner/miniconda3/envs/dascore'
                || startsWith(matrix.os, 'windows') && 'C:\Miniconda3\envs\dascore' }}
       # set individual cache key (only the start of it)
-      cache_key: ${{ matrix.os }}-${{ runner.arch }}-py${{ matrix.python-version }}
+      cache_key: ${{ matrix.os }}-py${{ matrix.python-version }}
       # set conda environment file with dependencies
       env_file: "environment.yml"
 
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.prefix }}
-          key: ${{ env.cache_key }}-hash${{ hashFiles(env.env_file) }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+          key: ${{ env.cache_key }}-${{ runner.arch }}-hash${{ hashFiles(env.env_file) }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
         id: cache
 
       - name: Update environment


### PR DESCRIPTION

## Description

This PR adds the system architecture to the cache string in the CI systems. Occasionally the OSX CI will fail and issue an "illegal operation error". From some precursory googling this can be due to the system using the wrong binaries. I suspect Github CI may be introducing some Mx chips into the OSX pool, so if the cache is created with a x86 machine then a M2 machine tries to use the complied bits we could get this error.

Of course, this is just speculation but having this extra part in the cache string wont hurt anything so its worth a shot.  

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
