### PR TITLE
fix_272

### DIFF
--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -124,9 +124,11 @@ def interpolate(patch: PatchType, kind: str | int = "linear", **kwargs) -> Patch
         coord_num, patch.data, axis=axis, kind=kind, fill_value="extrapolate"
     )
     out = func(samples_num)
-    new_coords = dict(patch.coords.coord_map)
-    new_coords[dim] = samples
-    return patch.new(data=out, coords=new_coords)
+    cm = patch.coords
+    associated_dims = cm.dim_map[dim]
+    coord_new = dc.core.get_coord(values=samples)
+    cm_new = cm.update_coords(**{dim: (associated_dims, coord_new)})
+    return patch.new(data=out, coords=cm_new)
 
 
 @patch_function()

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -367,12 +367,13 @@ def scan_patches(patches: PatchType | Sequence[PatchType]) -> list[dc.PatchAttrs
 
 
 def get_start_stop_step(patch: PatchType, dim):
-    """Convenience method for getting start, stop, step for a given dimension."""
+    """Convenience method for getting start, stop, step for a given coord."""
     assert dim in patch.dims, f"{dim} is not in Patch dimensions of {patch.dims}"
-    start = patch.attrs[f"{dim}_min"]
-    end = patch.attrs[f"{dim}_max"]
-    step = patch.attrs[f"{dim}_step"]
-    return start, end, step
+    coord = patch.get_coord(dim)
+    start = coord.min()
+    stop = coord.max()
+    step = coord.step
+    return start, stop, step
 
 
 def get_default_patch_name(patch):

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -267,3 +267,8 @@ class TestResample:
         """Ensure iresample issues deprecation warning."""
         with pytest.warns(DeprecationWarning):
             random_patch.iresample(distance=42)
+
+    def test_resample_fft(self, random_patch):
+        """Tests for resample rft axis. See #272."""
+        out = random_patch.dft("time", real="time").resample(ft_time=1)
+        assert isinstance(out, dc.Patch)


### PR DESCRIPTION

## Description

This PR fixes #272, which was related to the `interpolate` and `resample` methods using older ways of interacting with coordinates. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
