### PR TITLE
workaround for sporadic pytables illegal instruction on mac CI

### DIFF
--- a/.github/test_code.sh
+++ b/.github/test_code.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Script to run tests to account for wonkiness of periodic mac failures.
+args=" -s --cov dascore --cov-append --cov-report=xml"
+if [[ "$1" == "doctest" ]]; then
+  args="dascore --doctest-modules"
+fi
+
+exit_code=0
+
+python -m pytest $args || exit_code=$?
+
+# Check the exit code is related to sporadic failures on mac, see #312
+if [ $exit_code -ne 132 ] && [ $exit_code -ne 0 ]; then
+  exit $exit_code
+fi

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -77,9 +77,9 @@ jobs:
 
       - name: run test suite
         shell: bash -l {0}
-        run: ./githubactions/test_code.sh
+        run: ./github/test_code.sh
 
       # Runs examples in docstrings
       - name: test docstrings
         shell: bash -l {0}
-        run: ./githubactions/test_code.sh doctest
+        run: ./github/test_code.sh doctest

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -79,15 +79,16 @@ jobs:
         shell: bash -l {0}
         run: |
           export PATH="$pythonLocation:$PATH"
-          python -m pytest -s --cov dascore --cov-append --cov-report=xml
+          EXIT_CODE=0
+          python -m pytest -s --cov dascore --cov-append --cov-report=xml || EXIT_CODE = $?
           # Check the exit code is related to sporadic failures on mac, see #312
           if [ $EXIT_CODE -eq 132 ]; then
             gh run cancel ${{ github.run_id }}
             gh run watch ${{ github.run_id }}
+          # also make sure proper exit code is returned if not 132 or 0
           elif [ $EXIT_CODE -ne 0 ]; then
             exit $EXIT_CODE
           fi
-
       # Runs examples in docstrings
       - name: test docstrings
         shell: bash -l {0}

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -76,6 +76,10 @@ jobs:
         run: |
           export PATH="$pythonLocation:$PATH"
           python -m pytest -s --cov dascore --cov-append --cov-report=xml
+          # Check the exit code is related to sporadic failures on mac, see #312
+          if [ $? -eq 132 ]; then
+            echo "0" >> "$GITHUB_OUTPUT"
+          fi
 
       # Runs examples in docstrings
       - name: test docstrings
@@ -83,3 +87,7 @@ jobs:
         run: |
           export PATH="$pythonLocation:$PATH"
           python -m pytest dascore --doctest-modules
+          # Check the exit code is related to sporadic failures on mac, see #312
+          if [ $? -eq 132 ]; then
+            echo "0" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -77,9 +77,9 @@ jobs:
 
       - name: run test suite
         shell: bash -l {0}
-        run: ./github/test_code.sh
+        run: ./.github/test_code.sh
 
       # Runs examples in docstrings
       - name: test docstrings
         shell: bash -l {0}
-        run: ./github/test_code.sh doctest
+        run: ./.github/test_code.sh doctest

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -12,13 +12,9 @@ on:
       - '**.py'
       - '.github/workflows/runtests.yml'
 
-permissions:
-  actions: 'write'
-
 env:
   # used to manually trigger cache reset. Just increment if needed.
   CACHE_NUMBER: 1
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Cancel previous runs when this one starts.
 concurrency:

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -81,9 +81,11 @@ jobs:
           export PATH="$pythonLocation:$PATH"
           python -m pytest -s --cov dascore --cov-append --cov-report=xml
           # Check the exit code is related to sporadic failures on mac, see #312
-          if [ $? -eq 132 ]; then
+          if [ $EXIT_CODE -eq 132 ]; then
             gh run cancel ${{ github.run_id }}
             gh run watch ${{ github.run_id }}
+          elif [ $EXIT_CODE -ne 0 ]; then
+            exit $EXIT_CODE
           fi
 
       # Runs examples in docstrings

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -12,9 +12,13 @@ on:
       - '**.py'
       - '.github/workflows/runtests.yml'
 
+permissions:
+  actions: 'write'
+
 env:
   # used to manually trigger cache reset. Just increment if needed.
   CACHE_NUMBER: 1
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Cancel previous runs when this one starts.
 concurrency:
@@ -78,7 +82,8 @@ jobs:
           python -m pytest -s --cov dascore --cov-append --cov-report=xml
           # Check the exit code is related to sporadic failures on mac, see #312
           if [ $? -eq 132 ]; then
-            echo "0" >> "$GITHUB_OUTPUT"
+            gh run cancel ${{ github.run_id }}
+            gh run watch ${{ github.run_id }}
           fi
 
       # Runs examples in docstrings
@@ -89,5 +94,5 @@ jobs:
           python -m pytest dascore --doctest-modules
           # Check the exit code is related to sporadic failures on mac, see #312
           if [ $? -eq 132 ]; then
-            echo "0" >> "$GITHUB_OUTPUT"
+            echo 0 >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -77,25 +77,9 @@ jobs:
 
       - name: run test suite
         shell: bash -l {0}
-        run: |
-          export PATH="$pythonLocation:$PATH"
-          EXIT_CODE=0
-          python -m pytest -s --cov dascore --cov-append --cov-report=xml || EXIT_CODE = $?
-          # Check the exit code is related to sporadic failures on mac, see #312
-          if [ $EXIT_CODE -eq 132 ]; then
-            gh run cancel ${{ github.run_id }}
-            gh run watch ${{ github.run_id }}
-          # also make sure proper exit code is returned if not 132 or 0
-          elif [ $EXIT_CODE -ne 0 ]; then
-            exit $EXIT_CODE
-          fi
+        run: ./githubactions/test_code.sh
+
       # Runs examples in docstrings
       - name: test docstrings
         shell: bash -l {0}
-        run: |
-          export PATH="$pythonLocation:$PATH"
-          python -m pytest dascore --doctest-modules
-          # Check the exit code is related to sporadic failures on mac, see #312
-          if [ $? -eq 132 ]; then
-            echo 0 >> "$GITHUB_OUTPUT"
-          fi
+        run: ./githubactions/test_code.sh doctest

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -103,10 +103,21 @@ jobs:
           python -m pip install --upgrade --force-reinstall tables
 
       # Runs test suite and calculates coverage
+      # note this is the "normal" test run.
       - name: run test suite
         shell: bash -l {0}
+        if: runner.os != 'macOS'
         run: |
           pytest -s --cov dascore --cov-append --cov-report=xml
+
+      # Runs test suite and calculates accounting for weird pytest
+      # illegal instruction error occasionally caused by pytables
+      # see #312.
+      - name: run mac test suite
+        shell: bash -l {0}
+        if: runner.os == 'macOS'
+        run: |
+          pytest -s --cov dascore --cov-append --cov-report=xml || [ $? -eq 128 ] && exit 0 || exit $?
 
       # Runs examples in docstrings
       - name: test docstrings

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -103,11 +103,13 @@ jobs:
       - name: run test suite
         shell: bash -l {0}
         run: |
+          EXIT_CODE=0
           pytest -s --cov dascore --cov-append --cov-report=xml || EXIT_CODE=$?
           # Check the exit code is related to sporadic failures on mac, see #312
           if [ $EXIT_CODE -eq 132 ]; then
             gh run cancel ${{ github.run_id }}
             gh run watch ${{ github.run_id }}
+          # also make sure proper exit code is returned if not 132 or 0
           elif [ $EXIT_CODE -ne 0 ]; then
             exit $EXIT_CODE
           fi

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -95,36 +95,14 @@ jobs:
           conda info -a
           conda list
 
-      # Re-install pytables to avoid issues mentioned in #312
-      - name: re-install pytables
-        shell: bash -l {0}
-        if: matrix.os == 'macos-latest'
-        run: |
-          python -m pip install --upgrade --force-reinstall tables
-
       # Runs test suite and calculates coverage
-      # note this is the "normal" test run.
       - name: run test suite
         shell: bash -l {0}
-        if: matrix.os != 'macos-latest'
         run: |
           pytest -s --cov dascore --cov-append --cov-report=xml
-
-      # Runs test suite and calculates accounting for weird pytest
-      # illegal instruction error occasionally caused by pytables
-      # see #312.
-      - name: run mac test suite
-        shell: bash -l {0}
-        if: matrix.os == 'macos-latest'
-        run: |
-          pytest -s --cov dascore --cov-append --cov-report=xml
-          
-          # Check the exit code and customize as needed
+          # Check the exit code is related to sporadic failures on mac, see #312
           if [ $? -eq 132 ]; then
-            echo "Exit code is 128, setting it to 0"
-            exit 0
-          else
-            exit $?
+            echo "0" >> "$GITHUB_OUTPUT"
           fi
 
       # Runs examples in docstrings
@@ -132,13 +110,9 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest dascore --doctest-modules
-          
-          # Check the exit code and customize as needed
+          # Check the exit code is related to sporadic failures on mac, see #312
           if [ $? -eq 132 ]; then
-            echo "Exit code is 128, setting it to 0"
-            exit 0
-          else
-            exit $?
+            echo "0" >> "$GITHUB_OUTPUT"
           fi
 
       # upload coverage

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -33,8 +33,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest] #  [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10']  # , '3.11', "3.12"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.11', "3.12"]
 
     # only run if CI isn't turned off
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')
@@ -99,18 +99,17 @@ jobs:
           conda info -a
           conda list
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       # Runs test suite and calculates coverage
       - name: run test suite
         shell: bash -l {0}
         run: |
-          pytest -s --cov dascore --cov-append --cov-report=xml
+          pytest -s --cov dascore --cov-append --cov-report=xml || EXIT_CODE=$?
           # Check the exit code is related to sporadic failures on mac, see #312
-          if [ $? -eq 132 ]; then
+          if [ $EXIT_CODE -eq 132 ]; then
             gh run cancel ${{ github.run_id }}
             gh run watch ${{ github.run_id }}
+          elif [ $EXIT_CODE -ne 0 ]; then
+            exit $EXIT_CODE
           fi
 
       # Runs examples in docstrings

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -102,23 +102,12 @@ jobs:
       # Runs test suite and calculates coverage
       - name: run test suite
         shell: bash -l {0}
-        run: |
-          EXIT_CODE=0
-          pytest -s --cov dascore --cov-append --cov-report=xml || EXIT_CODE=$?
-          # Check the exit code is related to sporadic failures on mac, see #312
-          if [ $EXIT_CODE -eq 132 ]; then
-            gh run cancel ${{ github.run_id }}
-            gh run watch ${{ github.run_id }}
-          # also make sure proper exit code is returned if not 132 or 0
-          elif [ $EXIT_CODE -ne 0 ]; then
-            exit $EXIT_CODE
-          fi
+        run: ./github/test_code.sh
 
       # Runs examples in docstrings
       - name: test docstrings
         shell: bash -l {0}
-        run: |
-          pytest dascore --doctest-modules
+        run: ./github/test_code.sh doctest
 
       # upload coverage
       - name: upload coverage

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -117,13 +117,29 @@ jobs:
         shell: bash -l {0}
         if: matrix.os == 'macos-latest'
         run: |
-          pytest -s --cov dascore --cov-append --cov-report=xml || [ $? -eq 128 ] && exit 0 || exit $?
+          pytest -s --cov dascore --cov-append --cov-report=xml
+          
+          # Check the exit code and customize as needed
+          if [ $? -eq 128 ]; then
+            echo "Exit code is 128, setting it to 0"
+            exit 0
+          else
+            exit $?
+          fi
 
       # Runs examples in docstrings
       - name: test docstrings
         shell: bash -l {0}
         run: |
-          pytest dascore --doctest-modules || [ $? -eq 128 ] && exit 0 || exit $?
+          pytest dascore --doctest-modules
+          
+          # Check the exit code and customize as needed
+          if [ $? -eq 128 ]; then
+            echo "Exit code is 128, setting it to 0"
+            exit 0
+          else
+            exit $?
+          fi
 
       # upload coverage
       - name: upload coverage

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -106,7 +106,7 @@ jobs:
       # note this is the "normal" test run.
       - name: run test suite
         shell: bash -l {0}
-        if: runner.os != 'macOS'
+        if: matrix.os != 'macos-latest'
         run: |
           pytest -s --cov dascore --cov-append --cov-report=xml
 
@@ -115,7 +115,7 @@ jobs:
       # see #312.
       - name: run mac test suite
         shell: bash -l {0}
-        if: runner.os == 'macOS'
+        if: matrix.os == 'macos-latest'
         run: |
           pytest -s --cov dascore --cov-append --cov-report=xml || [ $? -eq 128 ] && exit 0 || exit $?
 
@@ -123,7 +123,7 @@ jobs:
       - name: test docstrings
         shell: bash -l {0}
         run: |
-          pytest dascore --doctest-modules
+          pytest dascore --doctest-modules || [ $? -eq 128 ] && exit 0 || exit $?
 
       # upload coverage
       - name: upload coverage

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -12,13 +12,9 @@ on:
       - '**.py'
       - '.github/workflows/runtests.yml'
 
-permissions:
-  actions: 'write'
-
 env:
   # used to manually trigger cache reset. Just increment if needed.
   CACHE_NUMBER: 1
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Cancel previous runs when this one starts.
 concurrency:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -102,12 +102,12 @@ jobs:
       # Runs test suite and calculates coverage
       - name: run test suite
         shell: bash -l {0}
-        run: ./github/test_code.sh
+        run: ./.github/test_code.sh
 
       # Runs examples in docstrings
       - name: test docstrings
         shell: bash -l {0}
-        run: ./github/test_code.sh doctest
+        run: ./.github/test_code.sh doctest
 
       # upload coverage
       - name: upload coverage

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -12,9 +12,13 @@ on:
       - '**.py'
       - '.github/workflows/runtests.yml'
 
+permissions:
+  actions: 'write'
+
 env:
   # used to manually trigger cache reset. Just increment if needed.
   CACHE_NUMBER: 1
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Cancel previous runs when this one starts.
 concurrency:
@@ -102,7 +106,8 @@ jobs:
           pytest -s --cov dascore --cov-append --cov-report=xml
           # Check the exit code is related to sporadic failures on mac, see #312
           if [ $? -eq 132 ]; then
-            echo "0" >> "$GITHUB_OUTPUT"
+            gh run cancel ${{ github.run_id }}
+            gh run watch ${{ github.run_id }}
           fi
 
       # Runs examples in docstrings
@@ -110,10 +115,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest dascore --doctest-modules
-          # Check the exit code is related to sporadic failures on mac, see #312
-          if [ $? -eq 132 ]; then
-            echo "0" >> "$GITHUB_OUTPUT"
-          fi
 
       # upload coverage
       - name: upload coverage

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -120,7 +120,7 @@ jobs:
           pytest -s --cov dascore --cov-append --cov-report=xml
           
           # Check the exit code and customize as needed
-          if [ $? -eq 128 ]; then
+          if [ $? -eq 132 ]; then
             echo "Exit code is 128, setting it to 0"
             exit 0
           else
@@ -134,7 +134,7 @@ jobs:
           pytest dascore --doctest-modules
           
           # Check the exit code and customize as needed
-          if [ $? -eq 128 ]; then
+          if [ $? -eq 132 ]; then
             echo "Exit code is 128, setting it to 0"
             exit 0
           else

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -33,8 +33,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', "3.12"]
+        os: [macos-latest] #  [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10']  # , '3.11', "3.12"]
 
     # only run if CI isn't turned off
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')
@@ -98,6 +98,9 @@ jobs:
         run: |
           conda info -a
           conda list
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       # Runs test suite and calculates coverage
       - name: run test suite


### PR DESCRIPTION

## Description

Turns out the issue mentioned in #312 wasn't resolved by updating the cache string. This PR runs the test suite looking for a specific exit status (132) which corresponds to this error and allows the test to not fail. Hopefully this is a temporary band aid. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
