### PR TITLE
ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,6 @@ repos:
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: debug-statements
     -   id: check-merge-conflict
     -   id: mixed-line-ending
         args: ['--fix=lf']
@@ -14,10 +12,12 @@ repos:
     # Ruff is a replacement for flake8 and many other linters (much faster too)
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.280
+    rev: v0.1.8
     hooks:
     -   id: ruff
         args: ["--fix"]
+        # Run the formatter.
+    -   id: ruff-format
 
     # ensures __future__ import annotations at top of files which require it
     # for the typing features they are using.
@@ -25,12 +25,6 @@ repos:
     rev: 0.5.0
     hooks:
     -   id: fix-future-annotations
-
--   repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-    -   id: black
-        #language_version: python3.10
 
     # strips out all outputs from notebooks.
 -   repo: https://github.com/kynan/nbstripout

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -224,7 +224,7 @@ def _ricker_moveout(
         f = frequency
         # get amplitude and exp term of ricker
         const = 1 - 2 * np.pi**2 * f**2 * new_time**2
-        exp = np.exp(-np.pi**2 * f**2 * new_time**2)
+        exp = np.exp(-(np.pi**2) * f**2 * new_time**2)
         return const * exp
 
     time = np.arange(0, duration + time_step, time_step)

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -91,9 +91,9 @@ def parse_time_stamp(fractions, seconds):
     @rtype : datetime.datetime.
     """
     if fractions is not None and seconds is not None and fractions + seconds > 0:
-        return datetime.timedelta(
-            0, fractions * 2**-64 + seconds
-        ) + datetime.datetime(1904, 1, 1)
+        return datetime.timedelta(0, fractions * 2**-64 + seconds) + datetime.datetime(
+            1904, 1, 1
+        )
     else:
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,10 @@ WAV = "dascore.io.wav.core:WavIO"
 
 [tool.ruff]
 
+line-length = 88
+
 # enable certain types of linting
-select = ["E", "F", "UP", "RUF", "I001", "D", "FA"]
+select = ["E", "F", "UP", "RUF", "I001", "D", "FA", "T"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -165,3 +167,7 @@ filterwarnings = [
     # Ignore hdf5 warnings from pytables, See pytables #1035
     'ignore::Warning:tables:'
 ]
+
+[tool.ruff.format]
+# Use `\n` line endings for all files
+line-ending = "lf"

--- a/scripts/_validate_links.py
+++ b/scripts/_validate_links.py
@@ -51,7 +51,7 @@ def validate_all_links():
                 bad_links += 1
             else:
                 good_links += 1
-    print(
+    print(  # noqa
         f"Validated links in documentation. Scanned {file_count} files, "
         f"found {good_links} good links and {bad_links} bad links"
     )

--- a/scripts/build_api_docs.py
+++ b/scripts/build_api_docs.py
@@ -9,15 +9,15 @@ from _validate_links import validate_all_links
 import dascore as dc
 
 if __name__ == "__main__":
-    print("Building documentation")
-    print(f"Parsing project {dc.__name__}")
+    print("Building documentation")  # noqa
+    print(f"Parsing project {dc.__name__}")  # noqa
     data_dict = parse_project(dc)
     obj_dict = get_alias_mapping(dc)
-    print("Generating qmd files")
+    print("Generating qmd files")  # noqa
     render_project(data_dict, obj_dict, debug=False)
     # create the quarto info file (needs templating)
-    print("creating quarto config")
+    print("creating quarto config")  # noqa
     create_quarto_qmd()
     # validate links
-    print("Validating links")
+    print("Validating links")  # noqa
     validate_all_links()

--- a/scripts/find_futures.py
+++ b/scripts/find_futures.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
         if not has_search_str(path, search_str):
             rewrite_file(path, search_str)
     for path in missing:
-        print(path)
+        print(path)  # noqa

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -316,7 +316,7 @@ class TestBasics:
 class TestCoordSummary:
     """tests for converting to and from summary coords."""
 
-    cast_data_list: ClassVar = [  # noqa
+    cast_data_list: ClassVar = [
         {"min": 400.0, "step": 1.0, "units": "", "max": 1000.0},
         {"min": 0, "max": 10},
         {"min": dc.to_datetime64(10), "max": dc.to_datetime64(100)},


### PR DESCRIPTION
## Description

This PR re-configures the pre-commit hook to use ruff format rather than black. The two formatters produce nearly the same result, ruff is just faster.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
