### PR TITLE
fix_321

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -564,6 +564,16 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
         Parameters
         ----------
+        ----------from dascore.core import get_coord
+
+        # no problems here
+        coord = get_coord(start=1, stop=5, step=-1)
+
+        # len still works
+        len(coord)
+
+        # but accessing any of the values fails
+        coord[0]  # raises IndexError
         value
             The value which could be contained by the coordinate.
         samples
@@ -629,6 +639,11 @@ class CoordRange(BaseCoord):
         """If any info is neglected the coord is invalid."""
         for name in ["start", "stop", "step"]:
             assert values[name] is not None
+        # step should have the same sign as stop-start, see #321.
+        diff = values["stop"] - values["start"]
+        if not np.sign(values["step"]) == np.sign(diff):
+            msg = "Sign of step must match sign of stop - start"
+            raise CoordError(msg)
         return values
 
     @model_validator(mode="before")

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import rich.text
+from pydantic import ValidationError
 
 import dascore as dc
 from dascore.core.coords import (
@@ -311,6 +312,14 @@ class TestBasics:
         ar = np.array(coord)
         assert isinstance(ar, np.ndarray)
         assert len(ar) == len(coord)
+
+    def test_bad_range_step(self):
+        """Ensure start, stop, step are consistent. See #321."""
+        msg = "Sign of step must match"
+        with pytest.raises(ValidationError, match=msg):
+            get_coord(start=1, stop=5, step=-1)
+        with pytest.raises(ValidationError, match=msg):
+            get_coord(start=1, stop=-5, step=1)
 
 
 class TestCoordSummary:


### PR DESCRIPTION

## Description

Fixes #321 by adding logic to the `Coord` validation to raise an exception if `stop`-`start` doesn't have the same sign as `step` for evenly sampled monotonic coords (`CoordRange`).  

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
