### PR TITLE
Progress bar options

### DIFF
--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -13,6 +13,7 @@ from rich.text import Text
 from typing_extensions import Self
 
 import dascore as dc
+from dascore.constants import PROGRESS_LEVELS
 from dascore.core.spool import BaseSpool, DataFrameSpool
 from dascore.io.indexer import AbstractIndexer, DirectoryIndexer
 from dascore.utils.docs import compose_docstring
@@ -100,10 +101,10 @@ class DirectorySpool(DataFrameSpool):
         return self._df
 
     @compose_docstring(doc=BaseSpool.update.__doc__)
-    def update(self) -> Self:
+    def update(self, progress: PROGRESS_LEVELS = "standard") -> Self:
         """{doc}."""
         out = self.__class__(
-            base_path=self.indexer.update(),
+            base_path=self.indexer.update(progress=progress),
             preferred_format=self._preferred_format,
             select_kwargs=self._select_kwargs,
         )

--- a/dascore/clients/filespool.py
+++ b/dascore/clients/filespool.py
@@ -8,7 +8,7 @@ from rich.text import Text
 from typing_extensions import Self
 
 import dascore as dc
-from dascore.constants import SpoolType
+from dascore.constants import PROGRESS_LEVELS, SpoolType
 from dascore.core.spool import BaseSpool, DataFrameSpool
 from dascore.io.core import FiberIO
 from dascore.utils.docs import compose_docstring
@@ -67,7 +67,7 @@ class FileSpool(DataFrameSpool):
         return dc.read(**kwargs)[0]
 
     @compose_docstring(doc=BaseSpool.update.__doc__)
-    def update(self: SpoolType) -> Self:
+    def update(self: SpoolType, progress: PROGRESS_LEVELS = "standard") -> Self:
         """
         {doc}.
 

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Literal, Protocol, TypeVar, runtime_checkable
 
 import numpy as np
 import pandas as pd
@@ -93,6 +93,9 @@ LARGEDT64 = np.datetime64(MAXINT64 - 5_000_000_000, "ns")
 
 # Required shared attributes to merge patches together
 PATCH_MERGE_ATTRS = ("network", "station", "dims", "data_type", "data_category")
+
+# Level of progress bar
+PROGRESS_LEVELS = Literal["standard", "basic", None]
 
 # A map from the unit name to the code used in numpy.timedelta64
 NUMPY_TIME_UNIT_MAPPING = {

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -14,6 +14,7 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.constants import (
+    PROGRESS_LEVELS,
     ExecutorType,
     PatchType,
     attr_conflict_description,
@@ -231,8 +232,18 @@ class BaseSpool(abc.ABC):
         msg = f"spool of type {self.__class__} has no split implementation"
         raise NotImplementedError(msg)
 
-    def update(self) -> Self:
-        """Updates the contents of the spool and returns a spool."""
+    def update(self, progress: PROGRESS_LEVELS = "standard") -> Self:
+        """
+        Updates the contents of the spool, return the updated spool.
+
+        Parameters
+        ----------
+        progress
+            Controls the progress bar. "standard" produces the standard
+            progress bar. "basic" is a simplified version with lower refresh
+            rates, best for high-latency environments, and None disables
+            the progress bar.
+        """
         return self
 
     def map(

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -314,7 +314,9 @@ class DirectoryIndexer(AbstractIndexer):
         self._enforce_min_version()  # delete index if schema has changed
         update_time = time.time()
         new_files = list(self._get_file_iterator(paths=paths, only_new=True))
-        smooth_iterator = track(new_files, f"Indexing {self.path.name}")
+        smooth_iterator = track(
+            new_files, f"Indexing {self.path.name}", progress=progress
+        )
         data_list = [y.flat_dump() for x in smooth_iterator for y in dc.scan(x)]
         df = pd.DataFrame(data_list)
         if not df.empty:

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -15,7 +15,7 @@ import pooch
 from typing_extensions import Self
 
 import dascore as dc
-from dascore.constants import ONE_SECOND_IN_NS, path_types
+from dascore.constants import ONE_SECOND_IN_NS, PROGRESS_LEVELS, path_types
 from dascore.exceptions import InvalidIndexVersionError
 from dascore.utils.hdf5 import HDFPatchIndexManager
 from dascore.utils.misc import iter_files, iterate
@@ -296,11 +296,20 @@ class DirectoryIndexer(AbstractIndexer):
         }
         return out
 
-    def update(self, paths=None) -> Self:
+    def update(self, paths=None, progress: PROGRESS_LEVELS = "standard") -> Self:
         """
         Updates the contents of the Indexer.
 
-        Resets any previous selection.
+        Also resets any previous selection.
+
+        Parameters
+        ----------
+        paths
+            A sequence of paths to limit the updates, if None, index all
+            the contents of directory.
+        progress
+            The type of progress bar to use. None disables progress bar and
+            "basic" is best for low latency scenarios.
         """
         self._enforce_min_version()  # delete index if schema has changed
         update_time = time.time()

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -4,18 +4,15 @@ from __future__ import annotations
 import rich.progress as prog
 
 import dascore as dc
+from dascore.constants import PROGRESS_LEVELS
 
 
-def track(sequence, description):
-    """A simple iterator for tracking updates."""
-    # This is a dirty hack to allow debugging while running tests.
-    # Otherwise, pdb doesn't work in any tracking scope.
-    # See: https://github.com/Textualize/rich/issues/1053
-    if dc._debug or not len(sequence):
-        yield from sequence
-        return
-    # Normal progress bar behavior
-    progress = prog.Progress(
+def get_progress_instance(progress: PROGRESS_LEVELS = "standard"):
+    """
+    Get the Rich progress bar instance based on complexity level.
+    """
+    kwargs = {}
+    progress_list = [
         prog.SpinnerColumn(),
         prog.TextColumn("[progress.description]{task.description}"),
         prog.BarColumn(bar_width=30),
@@ -23,9 +20,28 @@ def track(sequence, description):
         prog.TimeRemainingColumn(),
         prog.TimeElapsedColumn(),
         prog.MofNCompleteColumn(),
-    )
-    total = len(sequence)
+    ]
+    if progress == "basic":
+        # set the refresh rate very low and eliminate the spinner
+        kwargs["refresh_per_second"] = 0.25
+        progress_list = progress_list[1:]
+    return prog.Progress(*progress_list, **kwargs)
+
+
+def track(sequence, description, progress: PROGRESS_LEVELS = "standard"):
+    """A simple iterator for tracking updates."""
+    # This is a dirty hack to allow debugging while running tests.
+    # Otherwise, pdb doesn't work in any tracking scope.
+    # See: https://github.com/Textualize/rich/issues/1053
+    if dc._debug or not len(sequence) or progress is None:
+        yield from sequence
+        return
+    update = 1.0 if progress == "standard" else 5.0
+    progress = get_progress_instance(progress)
     with progress:
         yield from progress.track(
-            sequence, total=total, description=description, update_period=1.0
+            sequence,
+            total=len(sequence),
+            description=description,
+            update_period=update,
         )

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -1,8 +1,10 @@
 """Test the progress bar."""
 from __future__ import annotations
 
+from rich.progress import Progress
+
 import dascore as dc
-from dascore.utils.progress import track
+from dascore.utils.progress import get_progress_instance, track
 
 
 class TestProgressBar:
@@ -13,3 +15,8 @@ class TestProgressBar:
         monkeypatch.setattr(dc, "_debug", False)
         for _ in track([1, 2, 3], "testing_tracker"):
             pass
+
+    def test_get_basic_progress(self):
+        """Ensure we can return a basic progress bar."""
+        pbar = get_progress_instance("basic")
+        assert isinstance(pbar, Progress)


### PR DESCRIPTION

## Description

This PR adds a `progress` argument to `spool.update` for controlling how the progress bar works, and adjusts other functions used by it accordingly. The default remains the same, but "basic" produces a simpler progress bar with lower refresh rates to address #305. 

closes #305 and closes #308. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
