### PR TITLE
scan optimization

### DIFF
--- a/dascore/io/plugin.py
+++ b/dascore/io/plugin.py
@@ -1,2 +1,0 @@
-"""A module for handling dascore' plugins."""
-from __future__ import annotations


### PR DESCRIPTION

## Description

This PR implements an optimization for `scan`. Since in large DAS file archives a single file type is usually used, rather than iterate through each compatible `FiberIO` to figure out the format, for each file, once the format for a single file is discovered it is most likely all other files will be the same format. This PR prioritizes the last discovered format, then falls back to the normal behavior. 

In the added benchmark, I observe speed ups of up to 100% in scanning a directory of files.    

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
