### PR TITLE
changed the RSF writer to byteorder Fortran due to RSF requirement

### DIFF
--- a/dascore/io/rsf/core.py
+++ b/dascore/io/rsf/core.py
@@ -71,7 +71,7 @@ class RSFV1(FiberIO):
         file_esize = dtype.itemsize
         file_formt = 'data_format="native_float"'
 
-        data_bytes = data.astype(np.float32).tobytes()
+        data_bytes = data.astype(np.float32).tobytes("F")
 
         hdr_str = f"DASCORE {dc.__version__}   {dt.datetime.now()} \n"
 


### PR DESCRIPTION


## Description

The RSF writer was default output to C byteorder, but RSF requires Fortran byte order. This fixes that so Madagascar can read the outputs by default.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
