### PR TITLE
fixed time origin on o1 for RSF writer and made dummy starttime variable

### DIFF
--- a/dascore/io/rsf/core.py
+++ b/dascore/io/rsf/core.py
@@ -82,7 +82,7 @@ class RSFV1(FiberIO):
         hdr_info = [hdr_str, file_formt, f"esize={file_esize}"]
         for i in range(length):
             hdr_info.append(f"n{i+1}={axis_lengs[i]}")
-            if i == 0:
+            if axis_names[i] == "time":
                 hdr_info.append(f"o{i+1}=0.0")
                 hdr_info.append(f"starttime={axis_origs[i]}")
             else:

--- a/dascore/io/rsf/core.py
+++ b/dascore/io/rsf/core.py
@@ -36,6 +36,9 @@ class RSFV1(FiberIO):
 
         spool needs to have a single patch in it
 
+        time origin is forced to 0.0 in the new RSF file, but a dummy
+        variable named 'starttime' still holds the real start time
+
         Parameters
         ----------
         spool
@@ -79,7 +82,11 @@ class RSFV1(FiberIO):
         hdr_info = [hdr_str, file_formt, f"esize={file_esize}"]
         for i in range(length):
             hdr_info.append(f"n{i+1}={axis_lengs[i]}")
-            hdr_info.append(f"o{i+1}={axis_origs[i]}")
+            if i == 0:
+                hdr_info.append(f"o{i+1}=0.0")
+                hdr_info.append(f"starttime={axis_origs[i]}")
+            else:
+                hdr_info.append(f"o{i+1}={axis_origs[i]}")
             hdr_info.append(f"d{i+1}={axis_steps[i]}")
             hdr_info.append(f'label{i+1}="{axis_names[i]}"')
             hdr_info.append(f'unit{i+1}="{axis_units[i]}"')


### PR DESCRIPTION


## Description

For ease of readability by Madagascar, the RSF writer has now been modified to output o1=0.0 
A dummy variable with the real start time called 'starttime' is placed in the RSF header. At a later date when an RSF reader is created, that dummy variable can be used.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
