### PR TITLE
fix_353

### DIFF
--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -18,6 +18,7 @@ from dascore.utils.misc import (
     cached_method,
     optional_import,
 )
+from dascore.utils.time import to_float
 
 HANDLE_FUNCTIONS = {
     str: lambda x: str(x),
@@ -182,10 +183,14 @@ def patch_to_obspy(patch: PatchType):
     def _get_time_stats(patch):
         """Get stats dict with time values."""
         coord = patch.get_coord("time")
+        tmin = dc.to_datetime64(coord.min())
+        tmax = dc.to_datetime64(coord.max())
+        dt = np.timedelta64(1, "s") / coord.step
+
         time_stats = {
-            "starttime": obspy.UTCDateTime(str(coord.min())),
-            "endtime": obspy.UTCDateTime(str(coord.max())),
-            "sampling_rate": np.timedelta64(1, "s") / coord.step,
+            "starttime": obspy.UTCDateTime(str(tmin)),
+            "endtime": obspy.UTCDateTime(str(tmax)),
+            "sampling_rate": to_float(dt),
         }
         return time_stats
 

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -215,3 +215,12 @@ class TestObsPy:
         st = obspy.Stream([])
         patch = dc.io.obspy_to_patch(st)
         assert not patch.dims
+
+    def test_example_event(self, event_patch_2):
+        """Ensure example event can be converted to stream."""
+        obspy = pytest.importorskip("obspy")
+        # make patch smaller to make test faster
+        patch = event_patch_2.select(distance=(500, 550))
+        st = patch.io.to_obspy()
+        assert isinstance(st, obspy.Stream)
+        assert len(st) == len(patch.get_coord("distance"))


### PR DESCRIPTION


## Description

Fixes #353.

The problem was the example event 2 has a time coordinate that has a dtype of float rather than `datetime64` so the obspy converter needed to be made robust to this.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
