### PR TITLE
Fix dasdae format reads with datetime-like coords

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -885,6 +885,12 @@ class CoordArray(BaseCoord):
             out = out & (values <= val2)
         if not np.any(out):
             return self.empty(), out
+        if np.all(out):
+            return self, slice(None, None)
+        # Convert boolean to int indexes because these are supported for
+        # indexing pytables arrays but booleans are not.
+        if len(self.shape) == 1:
+            out = np.arange(len(out))[out]
         return self.new(values=values[out]), out
 
     def sort(self, reverse=False) -> tuple[BaseCoord, slice | ArrayLike]:

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1027,10 +1027,9 @@ class TestNonOrderedArrayCoords:
         min_v, max_v = np.min(random_coord.values), np.max(random_coord.values)
         dist = max_v - min_v
         val1, val2 = min_v + 0.2 * dist, max_v - 0.2 * dist
-        new, bool_array = random_coord.select((val1, val2))
+        new, ind_array = random_coord.select((val1, val2))
         assert np.all(new.values >= val1)
         assert np.all(new.values <= val2)
-        assert bool_array.sum() == len(new)
 
     def test_sort(self, random_coord):
         """Ensure the coord can be ordered."""


### PR DESCRIPTION

## Description

This PR fixes an issue which caused DASCore to fail to read DASDAE formatted patches if an attached coordinate was associated with a dimension and a datetime-type. 

It also fixed an issue that would cause selecting with multiple coordinates that reference to the same dimension to not perform the selection properly (only the second selection was performed previously).

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
