### PR TITLE
ifft=False for whiten

### DIFF
--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -76,13 +76,13 @@ def correlate(
 
     >>> # Example 1
     >>> # Calculate cc for all channels as receivers and
-    >>> # the 10 m channel as the master channel. The new patch has dimensions
-    >>> # (lag_time, distance)
+    >>> # the 10 m channel as the master channel.
     >>> cc_patch = patch.correlate(distance = 10 * m)
 
     >>> # Example 2
     >>> # Calculate cc within (-2,2) sec of lag for all channels as receivers and
-    >>> # the 10 m channel as the master channel.
+    >>> # the 10 m channel as the master channel. The new patch has dimensions
+    >>> # (lag_time, distance)
     >>> cc_patch = patch.correlate(distance = 10 * m, lag = 2 * s)
 
     >>> # Example 3

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -110,7 +110,7 @@ The data arrays should be read-only. This means you can't modify them, but must 
 ```python
 import numpy as np
 
-patch.data[:10] = 12  # wont work
+patch.data[:10] = 12  # won't work
 
 array = np.array(patch.data)  # this makes a copy
 array[:10] = 12  # then this works

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -193,3 +193,16 @@ class TestWhiten:
             test_patch.coords.get_array("distance"),
             whitened_patch.coords.get_array("distance"),
         )
+
+    def test_whiten_ifft_true(self, test_patch):
+        """
+        Ensure whiten function can return the result in the frequency domain
+        when the ifft flag is set to True.
+        """
+        # whiten the patch and return in frequency domain
+        whitened_patch_freq_domain = test_patch.whiten(smooth_size=5, ifft=False)
+
+        # check if the returned data is in the frequency domain
+        assert np.iscomplexobj(
+            whitened_patch_freq_domain.data
+        ), "Expected the data to be complex, indicating freq. domain representation."

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -194,7 +194,7 @@ class TestWhiten:
             whitened_patch.coords.get_array("distance"),
         )
 
-    def test_whiten_ifft_true(self, test_patch):
+    def test_whiten_ifft_false(self, test_patch):
         """
         Ensure whiten function can return the result in the frequency domain
         when the ifft flag is set to True.


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->

This PR makes [whiten](https://dascore.org/api/dascore/proc/whiten/whiten.html) function capable of outputting in the frequency domain. This enhancement is particularly useful when whitening is performed as a preprocessing step for subsequent processes, such as computing cross-correlation.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
