### PR TITLE
add `change_length` coord method

### DIFF
--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -878,6 +878,25 @@ class TestCoordRange:
         time_coord = get_coord(data=time)
         assert len(time) == len(time_coord)
 
+    def test_change_length_no_change(self, evenly_sampled_coord):
+        """Ensure change_length works when no length change is needed."""
+        new = evenly_sampled_coord.change_length(len(evenly_sampled_coord))
+        assert new == evenly_sampled_coord
+
+    def test_change_length_lengthen(self, evenly_sampled_float_coord_with_units):
+        """Ensure the length can increase."""
+        coord = evenly_sampled_float_coord_with_units
+        current = len(coord)
+        new = coord.change_length(current + 1)
+        assert len(new) == current + 1
+
+    def test_change_length_shorten(self, evenly_sampled_float_coord_with_units):
+        """Ensure the length can increase."""
+        coord = evenly_sampled_float_coord_with_units
+        current = len(coord)
+        new = coord.change_length(current - 1)
+        assert len(new) == current - 1
+
 
 class TestMonotonicCoord:
     """Tests for monotonic array coords."""


### PR DESCRIPTION
## Description

This PR adds a method to `CoordRange` called `change_length` to allow easy modifications to the length of evenly sampled coordinates. It was primarily added to mitigate off by one errors related to float coordinates, but may be useful for other things to.

It looks like this:

```python
new_coord = coord.change_length(length=10)  # change length to 10 by adjusting end values.
```

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
