### PR TITLE
update correlate

### DIFF
--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -6,6 +6,8 @@ from scipy.fftpack import next_fast_len
 
 import dascore as dc
 from dascore.constants import PatchType
+from dascore.core.coordmanager import get_coord_manager
+from dascore.transform.fourier import _get_dft_attrs
 from dascore.units import Quantity
 from dascore.utils.misc import broadcast_for_index
 from dascore.utils.patch import (
@@ -13,9 +15,10 @@ from dascore.utils.patch import (
     get_dim_value_from_kwargs,
     patch_function,
 )
+from dascore.utils.transformatter import FourierTransformatter
 
 
-def _get_correlated_coord(old_coord, data_shape, real=True):
+def _get_correlated_coord(old_coord, data_shape):
     """Get the new coordinate which corresponds to correlated values."""
     step = old_coord.step
     one_sided_len = data_shape // 2
@@ -24,8 +27,7 @@ def _get_correlated_coord(old_coord, data_shape, real=True):
         stop=(one_sided_len + 1) * step,
         step=step,
     )
-    assert len(new) == data_shape, "failed to create correlated coord"
-    return new
+    return new.change_length(data_shape)
 
 
 def _shift(data, cx_len, axis):
@@ -47,25 +49,42 @@ def _shift(data, cx_len, axis):
 
 @patch_function()
 def correlate(
-    patch: PatchType, lag: int | float | Quantity | None = None, samples=False, **kwargs
+    patch: PatchType,
+    lag: int | float | Quantity | None = None,
+    step_size: int = 1,
+    samples=False,
+    ifft=True,
+    **kwargs,
 ) -> PatchType:
     """
-    Correlate a single row/column in a 2D patch with every other row/column.
+    Correlate row/column (virtual sources) in a 2D patch with other
+    rows/columns (virtual receivers).
 
     Parameters
     ----------
     patch : PatchType
         The input data patch to be cross-correlated. Must be 2-dimensional.
+        The patch can be in time or frequency domains.
     lag :
-        An optional argument to save only certain lag times instead of full
-        output.
+        An optional argument to save only certain lags instead of full
+        output. It can't be used if ifft = False.
+    step_size : int, optional (default = None)
+        An optional argument to skip rows/columns for the virtual receiver.
+        A step_size = 2 means performing cross correlation (cc)
+        with every other channels instead of the full array.
+        This will reduce computation and storage cost if needed.
     samples : bool, optional (default = False)
         If True, the argument specified in kwargs refers to the *sample* not
         value along that axis. See examples for details.
+    ifft : bool, optional (default = Ture)
+        If True, it applies ifft and return results in time domain.
     **kwargs
-        Additional arguments to specify cross correlation dimension and the
-        master source, to which
-        we cross-correlate all other channels/time samples.
+        Additional arguments to specify cc dimension and the
+        master source(s), to which we want to cross-correlate all other
+        channels/time samples (with or without a step_size).
+        If the master source is an array, the function will compute cc for all the
+        half of all possible pairs (i.e., only a-b and not b-a).
+        This will result in a 3D patch.
 
     Examples
     --------
@@ -93,35 +112,86 @@ def correlate(
     >>> # Correlate along time dimension
     >>> cc_patch = patch.correlate(time=100, samples=True)
 
+    >>> # Example 5
+    >>> # Calculate cc of a patch for all channels as receivers and
+    >>> # the 10 m channel as the master channel and result data in frequency domain.
+    >>> # The new patch has dimensions (ft_time, distance).
+    >>> cc_patch = patch.correlate(distance = 10 * m, ifft = False)
+
+    >>> # Example 6
+    >>> # Calculate cc of channel numbers [1,3,7,8,20] as master channels
+    >>> # and every fourth channel as receivers.
+    >>> # The new patch has dimensions (lag_time, distance, source_distance).
+    >>> cc_patch = patch.correlate(distance = [1,3,7,8,20], step_size = 4)
+
     Notes
     -----
-    The cross-correlation is performed in the frequency domain for efficiency
+    1- The cross-correlation is performed in the frequency domain for efficiency
     reasons.
 
-    The output dimension is opposite of the one specified in kwargs, has
+    2- The output dimension is opposite of the one specified in kwargs, has
     the units of float, and the string "lag_" prepended. For example, "lag_time".
+
+    3- If the patch is in the frequency domain, it needs to be zero-padded in
+    the time domain first. If not, first apply the
+    [idft](`dascore.transform.fourier.idft`) function to the patch, and then
+    use the correlate function, which automatically handles the zero padding.
     """
-    assert len(patch.dims) == 2, "must be a 2D patch"
+    assert len(patch.dims) == 2, "must be a 2D patch."
+    if not ifft and lag is not None:
+        msg = "lag argument can't be used when ifft is set to False."
+        raise ValueError(msg)
     dim, source_axis, source = get_dim_value_from_kwargs(patch, kwargs)
     # get the axis and coord over which fft should be calculated.
     fft_axis = next(iter(set(range(len(patch.dims))) - {source_axis}))
     fft_dim = patch.dims[fft_axis]
-    # ensure coordinate is evenly spaced
-    _get_dx_or_spacing_and_axes(patch, fft_dim, require_evenly_spaced=True)
-    fft_coord = patch.get_coord(fft_dim)
     # get the coordinate which contains the source
     coord_source = patch.get_coord(dim)
     index_source = coord_source.get_next_index(source, samples=samples)
-    # get the closest fast length. Some padding is applied in the fft to avoid
-    # inefficient lengths. Note: This is not always a power of 2.
-    cx_len = patch.shape[fft_axis] * 2 - 1
-    fast_len = next_fast_len(cx_len)
+
+    if step_size is not None and step_size > 1:
+        step = patch.get_coord(dim).step * step_size
+        new_coord_step = dc.core.get_coord(
+            start=patch.get_coord(dim)[0],
+            stop=patch.get_coord(dim)[-1],
+            step=step,
+        )
+        coords = patch.coords.update(**{dim: new_coord_step})
+        attrs = patch.attrs
+        patch_new_data = patch.data.take(
+            range(0, patch.data.shape[source_axis], step_size), axis=source_axis
+        )
+        patch = patch.update(data=patch_new_data, coords=coords, attrs=attrs)
+
     # determine proper fft, ifft functions based on data being real or complex
-    is_real = not np.issubdtype(patch.data.dtype, np.complexfloating)
-    fft_func = np.fft.rfft if is_real else np.fft.fft
-    ifft_func = np.fft.irfft if is_real else np.fft.ifft
-    # perform ffts and get source array (a sub-slice of larger fft)
-    fft = fft_func(patch.data, axis=fft_axis, n=fast_len)
+    if (dim == "distance" and fft_dim != "ft_time") or (
+        dim == "time" and fft_dim != "ft_distance"
+    ):
+        needed_fft = True
+        is_real = not np.issubdtype(patch.data.dtype, np.complexfloating)
+        # perform FFT (since the input is not already in the frequency domain)
+        fft_func = np.fft.rfft if is_real else np.fft.fft
+        # perform ffts and get source array (a sub-slice of larger fft)
+        fft = fft_func(
+            patch.data, axis=fft_axis, n=next_fast_len(patch.shape[fft_axis] * 2 - 1)
+        )
+        # ensure coordinate is evenly spaced
+        fft_coord = patch.get_coord(fft_dim)
+
+        # get the closest fast length. Some padding is applied in the fft to avoid
+        # inefficient lengths. Note: This is not always a power of 2.
+        cx_len = patch.shape[fft_axis] * 2 - 1
+        fast_len = next_fast_len(cx_len)
+    else:
+        needed_fft = False
+        is_real = not np.min(patch.coords.get_array(fft_dim)) < 0
+        # assume input is already in the frequency domain, skip FFT
+        fft = patch.data
+        fft_coord = patch.get_coord(fft_dim)  # edit: needs adjustment?
+
+        cx_len = patch.shape[fft_axis]
+        fast_len = cx_len
+
     ndims = len(patch.shape)
     slicer = slice(index_source, index_source + 1)
     inds = broadcast_for_index(ndims, axis=source_axis, value=slicer)
@@ -131,14 +201,44 @@ def correlate(
     # the n parameter needs to be odd so we have a 0 lag time. This only
     # applies to real fft
     n_out = fast_len if (not is_real or fast_len % 2 != 0) else fast_len - 1
-    corr_array = ifft_func(fft_prod, axis=fft_axis, n=n_out)
-    corr_data = _shift(corr_array, cx_len, axis=fft_axis)
-    # get new coordinate along correlation dimension
-    new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
-    coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
-        **{fft_dim: f"lag_{fft_dim}"}
-    )
-    out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
-    if lag is not None:
-        out = out.select(**{f"lag_{fft_dim}": (-lag, +lag)})
-    return out
+
+    if ifft:
+        ifft_func = np.fft.irfft if is_real else np.fft.ifft
+        if needed_fft:
+            corr_array = ifft_func(fft_prod, axis=fft_axis, n=n_out)
+            corr_data = _shift(corr_array, cx_len, axis=fft_axis)
+            # get new coordinate along correlation dimension
+            new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
+            coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
+                **{fft_dim: f"lag_{fft_dim}"}
+            )
+            out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
+            if lag is not None:
+                out = out.select(**{f"lag_{fft_dim}": (-lag, +lag)})
+            return out
+        else:
+            corr_array = np.real(ifft_func(fft_prod, axis=fft_axis, n=n_out))
+            corr_data = _shift(corr_array, cx_len, axis=fft_axis)
+            # get new coordinate along correlation dimension
+            new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
+            coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
+                **{fft_dim: f"{fft_dim}"}
+            )
+            out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
+            return out
+    else:
+        dims = fft_dim
+        _, axes = _get_dx_or_spacing_and_axes(patch, dims, require_evenly_spaced=True)
+        # get new coordinates
+        old_cm = patch.coords.disassociate_coord(dims)
+        new_cm = old_cm.get_coord_tuple_map()
+        ft = FourierTransformatter()
+        name = ft.rename_dims(fft_dim)[0]
+        coord = _get_correlated_coord(fft_coord, fft_prod.shape[fft_axis])
+        new_cm[name] = (name, coord)
+        new_dims = ft.rename_dims(patch.dims, index=axes)
+        new_coords = get_coord_manager(new_cm, dims=new_dims)
+        # get attributes
+        attrs = _get_dft_attrs(patch, dims, new_coords)
+        # return the frequency domain data directly without taking the inverse FFT
+        return patch.new(fft_prod, coords=new_coords, attrs=attrs)

--- a/dascore/proc/whiten.py
+++ b/dascore/proc/whiten.py
@@ -20,7 +20,7 @@ def whiten(
     patch: PatchType,
     smooth_size: float | None = None,
     tukey_alpha: float = 0.1,
-    ifft: bool = True,
+    idft: bool = True,
     **kwargs,
 ) -> PatchType:
     """
@@ -41,7 +41,7 @@ def whiten(
         its value is 0.1.
         See more details at https://docs.scipy.org/doc/scipy/reference
         /generated/scipy.signal.windows.tukey.html
-    ifft
+    idft
         If False, returns the whitened result in the frequency domain without
         converting it back to the time domain. Defaults to True.
     **kwargs
@@ -61,7 +61,7 @@ def whiten(
 
     3) Amplitude is NOT preserved
 
-    4) If ifft = False, since for the purely real input data the negative
+    4) If idft = False, since for the purely real input data the negative
        frequency terms are just the complex conjugates of the corresponding
        positive-frequency terms, the output does not include the negative
        frequency terms, and therefore the length of the transformed axis
@@ -226,7 +226,7 @@ def whiten(
 
     norm_amp *= tiled_win
 
-    if ifft:
+    if idft:
         # revert back to time-domain, using the phase of the original signal
         whitened_data = np.real(
             nft.irfft(norm_amp * np.exp(1j * phase), n=comp_nsamp, axis=dim_ind)

--- a/tests/test_proc/test_correlate.py
+++ b/tests/test_proc/test_correlate.py
@@ -119,14 +119,14 @@ class TestCorrelateInternal:
             out.channel_count == corr_patch.channel_count
         ), "Expected size of the output distance coordinate to match the original patch"
 
-    def test_correlation_ifft_false(self, corr_patch):
+    def test_correlation_idft_false(self, corr_patch):
         """
         Ensure correlate function can return the result in the frequency domain
-        when the ifft flag is set to Flase.
+        when the idft flag is set to Flase.
         """
         # return correlation in frequency domain
         correlated_patch_freq_domain = corr_patch.correlate(
-            distance=2, samples=True, ifft=False
+            distance=2, samples=True, idft=False
         )
 
         # check if the returned data is in the frequency domain

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -194,13 +194,13 @@ class TestWhiten:
             whitened_patch.coords.get_array("distance"),
         )
 
-    def test_whiten_ifft_false(self, test_patch):
+    def test_whiten_idft_false(self, test_patch):
         """
         Ensure whiten function can return the result in the frequency domain
-        when the ifft flag is set to Flase.
+        when the idft flag is set to Flase.
         """
         # whiten the patch and return in frequency domain
-        whitened_patch_freq_domain = test_patch.whiten(smooth_size=5, ifft=False)
+        whitened_patch_freq_domain = test_patch.whiten(smooth_size=5, idft=False)
 
         # check if the returned data is in the frequency domain
         assert np.iscomplexobj(

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -197,7 +197,7 @@ class TestWhiten:
     def test_whiten_ifft_false(self, test_patch):
         """
         Ensure whiten function can return the result in the frequency domain
-        when the ifft flag is set to True.
+        when the ifft flag is set to Flase.
         """
         # whiten the patch and return in frequency domain
         whitened_patch_freq_domain = test_patch.whiten(smooth_size=5, ifft=False)
@@ -205,4 +205,4 @@ class TestWhiten:
         # check if the returned data is in the frequency domain
         assert np.iscomplexobj(
             whitened_patch_freq_domain.data
-        ), "Expected the data to be complex, indicating freq. domain representation."
+        ), "Expected the output to be complex, indicating freq. domain representation."


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->

This PR adds four new capabilities to the [correlate](https://dascore.org/api/dascore/proc/correlate/correlate.html) function:

- [x] patch can be in the frequency domain, thereby eliminating the need for the Fourier transform step.
- [x] keeps the patch in the frequency domain after computing the correlation if the idft argument is set to False.
- [x] an step_size argument to skip receivers.
- [ ] compute correlation over an array of master sources (passed as kwargs) instead of one master source, which results in a 3D patch.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
