### PR TITLE
simplify coord snap

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -962,15 +962,9 @@ class CoordArray(BaseCoord):
             start, stop = max_v, min_v + step
         else:
             start, stop = min_v, max_v + step
-        # get potential output, ensure it is the same length as original
+        # Get potential output, ensure it is the same length as original.
         out = CoordRange(start=start, stop=stop, step=step, units=self.units)
-        # A hack to deal with those pesky off-by-one errors.
-        if out.shape != self.shape:
-            diff = len(self) - len(out)
-            new_stop = stop + diff * step  # increase or decrease coord length
-            out = out.update(stop=new_stop)
-        assert len(out) == len(self)
-        return out
+        return out.change_length(len(self))
 
     @compose_docstring(doc=BaseCoord.update_limits.__doc__)
     def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:


### PR DESCRIPTION
## Description

This PR simplifies `Coord.snap`'s dealing with off by one errors. Previously, custom logic was implemented in the `snap` method, but we have since added `coord.change_length` with essentially does the same thing. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
