### PR TITLE
FiberIO Directory Support and XML Binary support

### DIFF
--- a/dascore/clients/filespool.py
+++ b/dascore/clients/filespool.py
@@ -74,6 +74,8 @@ class FileSpool(DataFrameSpool):
         Note: If the file format supports indexing (e.g. DASDAE) this will
         trigger an indexing of the file.
         """
-        formater = FiberIO.manager.get_fiberio(self._file_format, self._file_version)
+        formater = FiberIO.manager.get_fiberio(
+            format=self._file_format, version=self._file_version
+        )
         getattr(formater, "index", lambda x: None)(self._path)
         return self

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -689,7 +689,7 @@ def _spool_from_str(path, **kwargs):
     # Return a FileSpool (lazy file reader), else return DirectorySpool.
     elif path.exists():  # a single file path was passed.
         _format, _version = dc.get_format(path, **kwargs)
-        formatter = dc.io.FiberIO.manager.get_fiberio(_format, _version)
+        formatter = dc.io.FiberIO.manager.get_fiberio(format=_format, version=_version)
         if formatter.implements_scan:
             from dascore.clients.filespool import FileSpool
 

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -681,12 +681,10 @@ def _iterate_scan_inputs(patch_source, ext, mtime, **kwargs):
     """Yield scan candidates."""
     for el in iterate(patch_source):
         if isinstance(el, str | Path) and (path := Path(el)).exists():
-            generator = iter_fs_contents(path, ext=ext, mtime=mtime)
-            for sub_el in generator:
-                # This allows consumers to send signal back to generator.
-                sig = yield sub_el
-                if sig is not None:
-                    generator.send(sig)
+            generator = iter_fs_contents(
+                path, ext=ext, mtime=mtime, include_directories=True
+            )
+            yield from generator
         else:
             yield el
 

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -31,7 +31,7 @@ from dascore.core.attrs import str_validator
 from dascore.exceptions import InvalidFiberIOError, UnknownFiberFormatError
 from dascore.utils.io import IOResourceManager, get_handle_from_resource
 from dascore.utils.mapping import FrozenDict
-from dascore.utils.misc import cached_method, iter_fs_contents, iterate
+from dascore.utils.misc import cached_method, iter_filesystem, iterate
 from dascore.utils.models import (
     CommaSeparatedStr,
     DascoreBaseModel,
@@ -361,10 +361,10 @@ class _FiberIOManager:
         """Get the name of the IO type."""
         # This effectively acts as a dispatch to determine which type of
         # FiberIO could possibly read the obj.
+        out = "file"
         if isinstance(obj, str | Path) and (path := Path(obj)).exists():
             out = "directory" if path.is_dir() else "file"
-            return out
-        return "file"
+        return out
 
 
 # ------------- Protocol for File Format support
@@ -681,7 +681,7 @@ def _iterate_scan_inputs(patch_source, ext, mtime, **kwargs):
     """Yield scan candidates."""
     for el in iterate(patch_source):
         if isinstance(el, str | Path) and (path := Path(el)).exists():
-            generator = iter_fs_contents(
+            generator = iter_filesystem(
                 path, ext=ext, mtime=mtime, include_directories=True
             )
             yield from generator

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -95,7 +95,7 @@ class DASDAEV1(FiberIO):
         )
         return df
 
-    def get_format(self, resource: PyTablesReader) -> tuple[str, str] | bool:
+    def get_format(self, resource: PyTablesReader, **kwargs) -> tuple[str, str] | bool:
         """Return the format from a dasdae file."""
         is_dasdae, version = False, ""  # NOQA
         with contextlib.suppress(KeyError):
@@ -116,7 +116,7 @@ class DASDAEV1(FiberIO):
             patches.append(_read_patch(patch_group, **kwargs))
         return dc.spool(patches)
 
-    def scan(self, resource: PyTablesReader):
+    def scan(self, resource: PyTablesReader, **kwargs):
         """
         Get the patch info from the file.
 

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -29,7 +29,7 @@ class DASHDF5(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "1.0"
 
-    def get_format(self, resource: H5Reader) -> tuple[str, str] | bool:
+    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
         """
         Return True if file contains terra15 version 2 data else False.
 
@@ -42,7 +42,7 @@ class DASHDF5(FiberIO):
         if version_str:
             return self.name, version_str
 
-    def scan(self, resource: H5Reader) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
         """Get metadata from file."""
         coords = _get_cf_coords(resource)
         extras = {

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -52,7 +52,7 @@ class Febus2(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "2"
 
-    def get_format(self, resource: H5Reader) -> tuple[str, str] | bool:
+    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
         """
         Return True if file contains febus version 8 data else False.
 
@@ -65,7 +65,7 @@ class Febus2(FiberIO):
         if version_str:
             return self.name, version_str
 
-    def scan(self, resource: H5Reader) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
         """Scan a febus file, return summary information about the file's contents."""
         out = []
         file_version = _get_febus_version_str(resource)

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -16,7 +16,7 @@ class H5Simple(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "1"
 
-    def get_format(self, resource: PyTablesReader) -> tuple[str, str] | bool:
+    def get_format(self, resource: PyTablesReader, **kwargs) -> tuple[str, str] | bool:
         """Determine if is simple h5 format."""
         if _is_h5simple(resource):
             return self.name, self.version
@@ -40,7 +40,9 @@ class H5Simple(FiberIO):
         patch = dc.Patch(coords=new_cm, data=new_data[:], attrs=attrs)
         return dc.spool([patch])
 
-    def scan(self, resource: PyTablesReader, snap=True) -> list[dc.PatchAttrs]:
+    def scan(
+        self, resource: PyTablesReader, snap=True, **kwargs
+    ) -> list[dc.PatchAttrs]:
         """Get the attributes of a h5simple file."""
         attrs, cm, data = _get_attrs_coords_and_data(resource, snap, self)
         attrs["coords"] = cm.to_summary_dict()

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -298,17 +298,6 @@ class DirectoryIndexer(AbstractIndexer):
         }
         return out
 
-    def _estimate_number_of_updates(self, paths, mtime):
-        """Estimate the number of updates needed."""
-        # TODO: This is a but sloppy, need to think of a better way to do
-        # this to avoid double iteration.
-        # First get total number of possible update-able files
-        entity_count = 0
-        generator = iter_fs_contents(paths, mtime=mtime)
-        for _ in generator:
-            entity_count += 1
-        return entity_count
-
     def update(self, paths=None, progress: PROGRESS_LEVELS = "standard") -> Self:
         """
         Updates the contents of the Indexer.
@@ -328,17 +317,10 @@ class DirectoryIndexer(AbstractIndexer):
         update_time = time.time()
         mtime = self._get_mtime(only_new=True)
         paths = self._get_paths(paths)
-        entity_count = self._estimate_number_of_updates(paths, mtime)
-        new_progress = partial(
-            track,
-            progress=progress,
-            length=entity_count,
-            description="Updating index",
-        )
         df = dc.scan_to_df(
             path=paths,
             mtime=mtime,
-            progress=new_progress,
+            progress=progress,
             ext=self.ext,
         )
         # Put contents found into database.

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -18,7 +18,7 @@ import dascore as dc
 from dascore.constants import ONE_SECOND_IN_NS, PROGRESS_LEVELS, path_types
 from dascore.exceptions import InvalidIndexVersionError
 from dascore.utils.hdf5 import HDFPatchIndexManager
-from dascore.utils.misc import iter_files, iterate
+from dascore.utils.misc import iter_contents, iterate
 from dascore.utils.pd import filter_df
 from dascore.utils.progress import track
 from dascore.utils.time import get_max_min_times, to_timedelta64
@@ -270,7 +270,7 @@ class DirectoryIndexer(AbstractIndexer):
                 for x in iterate(paths)
             ]
         # return file iterator
-        return iter_files(paths, ext=self.ext, mtime=mtime)
+        return iter_contents(paths, ext=self.ext, mtime=mtime)
 
     def _enforce_min_version(self):
         """Ensure the minimum version is met, else delete index file."""

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -314,11 +314,11 @@ class DirectoryIndexer(AbstractIndexer):
         """
         self._enforce_min_version()  # delete index if schema has changed
         update_time = time.time()
-        mtime = self._get_mtime(only_new=True)
+        timestamp = self._get_mtime(only_new=True)
         paths = self._get_paths(paths)
         df = dc.scan_to_df(
             path=paths,
-            mtime=mtime,
+            timestamp=timestamp,
             progress=progress,
             ext=self.ext,
         )

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -7,7 +7,7 @@ import os
 import time
 import warnings
 from contextlib import suppress
-from functools import cache, partial
+from functools import cache
 from pathlib import Path
 
 import pandas as pd
@@ -18,9 +18,8 @@ import dascore as dc
 from dascore.constants import ONE_SECOND_IN_NS, PROGRESS_LEVELS
 from dascore.exceptions import InvalidIndexVersionError
 from dascore.utils.hdf5 import HDFPatchIndexManager
-from dascore.utils.misc import iter_fs_contents, iterate
+from dascore.utils.misc import iterate
 from dascore.utils.pd import filter_df
-from dascore.utils.progress import track
 from dascore.utils.time import get_max_min_times, to_timedelta64
 
 # supported read_hdf5 kwargs

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -27,7 +27,7 @@ class OptoDASV8(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "8"
 
-    def get_format(self, resource: H5Reader) -> tuple[str, str] | bool:
+    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
         """
         Return True if file contains OptoDAS version 8 data else False.
 
@@ -40,7 +40,7 @@ class OptoDASV8(FiberIO):
         if version_str:
             return self.name, version_str
 
-    def scan(self, resource: H5Reader) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
         """Scan a OptoDAS file, return summary information about the file's contents."""
         file_version = _get_opto_das_version_str(resource)
         extras = {

--- a/dascore/io/pickle/core.py
+++ b/dascore/io/pickle/core.py
@@ -26,7 +26,7 @@ class PickleIO(FiberIO):
         spool_or_patch = b"Spool" in byte_stream or b"Patch" in byte_stream
         return has_dascore and spool_or_patch
 
-    def get_format(self, resource: BinaryReader) -> tuple[str, str] | bool:
+    def get_format(self, resource: BinaryReader, **kwargs) -> tuple[str, str] | bool:
         """
         Return True if file contains a pickled Patch or Spool.
 

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -29,7 +29,7 @@ class ProdMLV2_0(FiberIO):  # noqa
     preferred_extensions = ("hdf5", "h5")
     version = "2.0"
 
-    def get_format(self, resource: PyTablesReader) -> tuple[str, str] | bool:
+    def get_format(self, resource: PyTablesReader, **kwargs) -> tuple[str, str] | bool:
         """
         Return True if file contains prodML version 2 data else False.
 
@@ -42,7 +42,7 @@ class ProdMLV2_0(FiberIO):  # noqa
         if version_str:
             return (self.name, version_str)
 
-    def scan(self, resource: PyTablesReader) -> list[dc.PatchAttrs]:
+    def scan(self, resource: PyTablesReader, **kwargs) -> list[dc.PatchAttrs]:
         """Scan a prodml file, return summary information about the file's contents."""
         file_version = _get_prodml_version_str(resource)
         extras = {

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -18,7 +18,7 @@ class SegyV2(FiberIO):
     # just make another class in the same module named JingleV2.
     version = "2"
 
-    def get_format(self, path) -> tuple[str, str] | bool:
+    def get_format(self, path, **kwargs) -> tuple[str, str] | bool:
         """Make sure input is segy."""
         try:
             with segyio.open(path, ignore_geometry=True):
@@ -45,7 +45,7 @@ class SegyV2(FiberIO):
         patch_trimmed = patch.select(time=time, channel=channel)
         return dc.spool([patch_trimmed])
 
-    def scan(self, path) -> list[dc.PatchAttrs]:
+    def scan(self, path, **kwargs) -> list[dc.PatchAttrs]:
         """
         Used to get metadata about a file without reading the whole file.
 

--- a/dascore/io/sentek/core.py
+++ b/dascore/io/sentek/core.py
@@ -35,11 +35,11 @@ class SentekV5(FiberIO):
         # is probably ok though since Sentek files tend to be quite small.
         return dc.spool(patch).select(time=time, distance=distance)
 
-    def get_format(self, resource: BinaryReader) -> tuple[str, str] | bool:
+    def get_format(self, resource: BinaryReader, **kwargs) -> tuple[str, str] | bool:
         """Auto detect sentek format."""
         return _get_version(resource)
 
-    def scan(self, resource: BinaryReader):
+    def scan(self, resource: BinaryReader, **kwargs):
         """Extract metadata from sentek file."""
         extras = {
             "file_format": self.name,

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -17,7 +17,7 @@ class TDMSFormatterV4713(FiberIO):
     preferred_extensions = ("tdms",)
     lead_in_length = 28
 
-    def get_format(self, stream: BinaryReader) -> tuple[str, str] | bool:
+    def get_format(self, stream: BinaryReader, **kwargs) -> tuple[str, str] | bool:
         """
         Return a tuple of (TDMS, version) if TDMS else False.
 
@@ -35,7 +35,7 @@ class TDMSFormatterV4713(FiberIO):
         except Exception:
             return False
 
-    def scan(self, resource: BinaryReader) -> list[dc.PatchAttrs]:
+    def scan(self, resource: BinaryReader, **kwargs) -> list[dc.PatchAttrs]:
         """Scan a tdms file, return summary information about the file's contents."""
         out = _get_default_attrs(resource)
         out["path"] = getattr(resource, "name", "")

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -21,7 +21,7 @@ class Terra15FormatterV4(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "4"
 
-    def get_format(self, resource: H5Reader) -> tuple[str, str] | bool:
+    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
         """
         Return True if file contains terra15 version 2 data else False.
 
@@ -34,7 +34,7 @@ class Terra15FormatterV4(FiberIO):
         if version_str:
             return (self.name, version_str)
 
-    def scan(self, resource: H5Reader) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
         """Scan a terra15 v2 file, return summary information."""
         version, data_node = _get_version_data_node(resource)
         extras = {

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -16,7 +16,9 @@ class WavIO(FiberIO):
 
     name = "WAV"
 
-    def write(self, spool: SpoolType, resource: str | Path, resample_frequency=None):
+    def write(
+        self, spool: SpoolType, resource: str | Path, resample_frequency=None, **kwargs
+    ):
         """
         Write the contents of the patch to one or more wav files.
 

--- a/dascore/io/xml_binary/__init__.py
+++ b/dascore/io/xml_binary/__init__.py
@@ -1,9 +1,15 @@
 """
-Module for reading data stored in binary raw format.
+Module for reading data stored in xml_binary format.
 
-Notes
------
-The metadata is stored in each data directory in an XML file.
+This format is a directory which contains metadata as a single xml file
+as well as any number of binary files (raw numeric buffers) which contain
+information about their start time in the file name. An example directory
+might look like this:
+
+data_folder
+   metadata.xml
+   DAS_20240530T011500_000000Z.raw
+   DAS_20240530T011501_000000Z.raw
 """
 from __future__ import annotations
 from .core import XMLBinaryV1

--- a/dascore/io/xml_binary/__init__.py
+++ b/dascore/io/xml_binary/__init__.py
@@ -6,4 +6,4 @@ Notes
 The metadata is stored in each data directory in an XML file.
 """
 from __future__ import annotations
-from .core import XMLBinary
+from .core import XMLBinaryV1

--- a/dascore/io/xml_binary/__init__.py
+++ b/dascore/io/xml_binary/__init__.py
@@ -1,0 +1,9 @@
+"""
+Module for reading data stored in binary raw format.
+
+Notes
+-----
+The metadata is stored in each data directory in an XML file.
+"""
+from __future__ import annotations
+from .core import XMLBinary

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -1,0 +1,63 @@
+"""IO module for reading binary raw format DAS data."""
+from __future__ import annotations
+
+import dascore as dc
+from dascore.constants import timeable_types
+from dascore.io import FiberIO
+
+# from .utils import read_xml_binary
+
+
+# class BinaryPatchAttrs(dc.PatchAttrs):
+#     """Patch attrs for Binary."""
+
+#     pulse_width_ns: float = np.NAN
+#     units: UnitQuantity | None = None
+#     data_type: UTF8Str = ""
+#     gauge_length: float = np.NaN
+#     iu_id: UTF8Str = ""
+#     n_lasers: int = np.NaN
+#     itu_channels_laser_1: UTF8Str = ""
+#     itu_channels_laser_2: UTF8Str = ""
+#     file_format: UTF8Str = ""
+#     transposed_data: bool = False
+#     use_relative_strain: bool = False
+#     original_time_step: float = np.NaN
+
+
+class XMLBinary(FiberIO):
+    """Support for binary data format with xml metadata."""
+
+    name = "XMLBinary"
+    preferred_extensions = "raw"
+
+    def read(
+        self,
+        path,
+        time: tuple[timeable_types, timeable_types] | None = None,
+        distance: tuple[float, float] | None = None,
+        snap_dims: bool = True,
+        **kwargs,
+    ) -> dc.BaseSpool:
+        """
+        Read a binary file.
+
+        Parameters
+        ----------
+        path
+            The path to the file.
+        time
+            A tuple for filtering time.
+        distance
+            A tuple for filtering distance.
+        snap_dims
+            If True, ensure the coordinates are evenly sampled monotonic.
+            This will cause some loss in precision but it is usually
+            negligible.
+        """
+        # patch = read_xml_binary(
+        #     path,
+        #     time=time,
+        #     distance=distance,
+        # )
+        # return dc.spool(patch)

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -67,7 +67,7 @@ class XMLBinaryV1(FiberIO):
             Extra keyword arguments are ignored.
         """
         path = Path(resource)
-        base_path = path if resource.is_dir() else path.parent
+        base_path = path if path.is_dir() else path.parent
         meta_data = _read_xml_metadata(base_path / self._metadata_name)
         if path.is_dir():
             path = list(path.glob(f"*{self._data_extension}"))

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -21,7 +21,7 @@ class BinaryPatchAttrs(dc.PatchAttrs):
     pulse_width_ns: float = np.NAN
     gauge_length: float = np.NaN
     instrument_id: UTF8Str = ""
-    data_units: UTF8Str = ""
+    distance_units: UTF8Str = ""
     zone_name: UTF8Str = ""
 
 

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -32,7 +32,7 @@ class XMLBinaryV1(FiberIO):
     input_type = "directory"
 
     _metadata_name = "metadata.xml"
-    # File exetension for data files.
+    # File extension for data files.
     _data_extension = ".raw"
 
     def scan(self, resource) -> list[dc.PatchAttrs]:

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -1,63 +1,94 @@
 """IO module for reading binary raw format DAS data."""
 from __future__ import annotations
 
+from pathlib import Path
+from xml.etree.ElementTree import ParseError
+
+import numpy as np
+from pydantic import ValidationError
+
 import dascore as dc
-from dascore.constants import timeable_types
 from dascore.io import FiberIO
+from dascore.utils.models import UTF8Str
 
-# from .utils import read_xml_binary
-
-
-# class BinaryPatchAttrs(dc.PatchAttrs):
-#     """Patch attrs for Binary."""
-
-#     pulse_width_ns: float = np.NAN
-#     units: UnitQuantity | None = None
-#     data_type: UTF8Str = ""
-#     gauge_length: float = np.NaN
-#     iu_id: UTF8Str = ""
-#     n_lasers: int = np.NaN
-#     itu_channels_laser_1: UTF8Str = ""
-#     itu_channels_laser_2: UTF8Str = ""
-#     file_format: UTF8Str = ""
-#     transposed_data: bool = False
-#     use_relative_strain: bool = False
-#     original_time_step: float = np.NaN
+from .utils import _load_patches, _paths_to_attrs, _read_xml_metadata
 
 
-class XMLBinary(FiberIO):
+class BinaryPatchAttrs(dc.PatchAttrs):
+    """Patch attrs for Binary."""
+
+    pulse_width_ns: float = np.NAN
+    gauge_length: float = np.NaN
+    instrument_id: UTF8Str = ""
+    data_units: UTF8Str = ""
+    zone_name: UTF8Str = ""
+
+
+class XMLBinaryV1(FiberIO):
     """Support for binary data format with xml metadata."""
 
     name = "XMLBinary"
-    preferred_extensions = "raw"
+    version = "1"
+    input_type = "directory"
 
-    def read(
-        self,
-        path,
-        time: tuple[timeable_types, timeable_types] | None = None,
-        distance: tuple[float, float] | None = None,
-        snap_dims: bool = True,
-        **kwargs,
-    ) -> dc.BaseSpool:
+    _metadata_name = "metadata.xml"
+    # File exetension for data files.
+    _data_extension = ".raw"
+
+    def scan(self, resource) -> list[dc.PatchAttrs]:
+        """Scan the contents of the directory."""
+        path = Path(resource)
+        metadata = _read_xml_metadata(path / self._metadata_name)
+        data_files = list(path.glob(f"*{self._data_extension}"))
+        extra_attrs = {
+            "file_version": self.version,
+            "file_format": self.name,
+        }
+        return _paths_to_attrs(
+            data_files,
+            metadata,
+            attr_cls=BinaryPatchAttrs,
+            extra_attrs=extra_attrs,
+        )
+
+    def read(self, resource, time=None, distance=None, **kwargs) -> dc.BaseSpool:
         """
-        Read a binary file.
+        Load data from the directory structure.
 
         Parameters
         ----------
-        path
-            The path to the file.
+        resource
+            A directory, path to the index file, or path to a data file.
         time
-            A tuple for filtering time.
+            Parameters for filtering by time.
         distance
-            A tuple for filtering distance.
-        snap_dims
-            If True, ensure the coordinates are evenly sampled monotonic.
-            This will cause some loss in precision but it is usually
-            negligible.
+            Parameters for filtering by distance.
+        **kwargs
+            Extra keyword arguments are ignored.
         """
-        # patch = read_xml_binary(
-        #     path,
-        #     time=time,
-        #     distance=distance,
-        # )
-        # return dc.spool(patch)
+        path = Path(resource)
+        base_path = path if resource.is_dir() else path.parent
+        meta_data = _read_xml_metadata(base_path / self._metadata_name)
+        if path.is_dir():
+            path = list(path.glob(f"*{self._data_extension}"))
+        # Determine if this is a single file or all of them.
+        patches = _load_patches(
+            path,
+            meta_data,
+            time=time,
+            distance=distance,
+            attr_cls=BinaryPatchAttrs,
+        )
+        return dc.spool(patches)
+
+    def get_format(self, resource) -> tuple[str, str] | bool:
+        """Determine if directory is an XML Binary type."""
+        path = Path(resource)
+        index_path = path / self._metadata_name
+        if not index_path.exists():
+            return False
+        try:
+            _ = _read_xml_metadata(index_path)
+        except (ParseError, TypeError, IndexError, ValidationError):
+            return False
+        return self.name, self.version

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -1,0 +1,95 @@
+"""Utilities for Binary."""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ElementTree
+from functools import lru_cache
+
+
+@lru_cache
+def read_xml_metadata(path):
+    """A function to read metadata from the xml file."""
+    tree = ElementTree.parse(path)
+    root = tree.getroot()
+    # Key metadata
+    total_n_chans = int(root.find("NumberOfChannels").text)
+    gauge_length = float(root.find("GaugeLengthM").text)
+    distance_step = float(root.find("OriginalSpatialSamplingInterval").text)
+    n_time = int(root.find("NumberOfFrames").text)
+    time_step = 1 / float(root.find("OutputTemporalSamplingRate").text)
+    data_type = root.find("DataType").text
+    file_format = root.find("FileFormat").text
+    # Secondary metadata
+    iu_id = root.find("DasInterrogatorSerial/Interrogator_1").text
+    time_start = root.find("DateTime").text
+    itu_channels_laser_1 = root.find("ITUChannels/Laser_1").text
+    itu_channels_laser_2 = root.find("ITUChannels/Laser_2").text
+    n_lasers = root.find("NumberOfLasers").text
+    original_time_step = 1 / float(root.find("OriginalTemporalSamplingRate").text)
+    pulse_width_ns = float(root.find("PulseWidthNs").text)
+    transposed_data = root.find("TransposedData").text
+    units = root.find("Units").text
+    use_relative_strain = root.find("UseRelativeStrain").text
+    start_channel = int(root.find("Zones/Zone/StartChannel").text)
+    end_channel = int(root.find("Zones/Zone/EndChannel").text)
+    channel_stride = int(root.find("Zones/Zone/Stride").text)
+    zone_n_chans = int(root.find("Zones/Zone/NumberOfChannels").text)
+
+    metadata = dict(
+        total_n_chans=total_n_chans,
+        n_time=n_time,
+        time_start=time_start,
+        time_step=time_step,
+        distance_step=distance_step,
+        pulse_width_ns=pulse_width_ns,
+        units=units,
+        data_type=data_type,
+        gauge_length=gauge_length,
+        iu_id=iu_id,
+        n_lasers=n_lasers,
+        itu_channels_laser_1=itu_channels_laser_1,
+        itu_channels_laser_2=itu_channels_laser_2,
+        file_format=file_format,
+        transposed_data=transposed_data,
+        use_relative_strain=use_relative_strain,
+        original_time_step=original_time_step,
+        start_channel=start_channel,
+        end_channel=end_channel,
+        channel_stride=channel_stride,
+        zone_n_chans=zone_n_chans,
+    )
+    return metadata
+
+
+# def read_xml_binary(path, distance=None, time=None):
+#     """Read the binary values into a patch."""
+
+#     # Define metadata
+#     metadata_name = 'metadata.xml'
+#     data_dir = "/same/as/spool/"
+
+#     metadata = read_xml_metadata(path_to_xml)
+
+#     if transposed_data:
+#         data = np.float64(np.fromfile(data_path, dtype=np.dtype(data_type)
+#                          .reshape((n_chans, n_time)))
+#         dims = ('distance', 'time')
+#         axes = [1,0]
+#     else:
+#        data = np.float64(np.fromfile(data_path, dtype=np.dtype(data_type)
+#                         .reshape((n_time, n_chans)))
+#        dims = ('time', 'distance')
+#        axes = [0,1]
+#     # Create coordinates, labels for each axis in the array
+#     time_start = dc.to_datetime64(time_start)
+#     patch_index = to_timedelta64(patch_index) # need to figure out
+#     time_step = to_timedelta64(time_step)
+#     time = time_start + np.arange(data.shape[axes[0]]) * time_step
+
+#     distance_start = 0
+#     distance = distance_start + np.arange(data.shape[axes[1]]) * distance_step
+
+#     # Define coordinates
+#     coords = dict(time=time, distance=distance)
+
+#     patch = dc.Patch(data=data, attrs=attrs, coords=coords)
+#     return patch

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -1,15 +1,26 @@
 """Utilities for Binary."""
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import lru_cache
+from pathlib import Path
 
+import numpy as np
+import pandas as pd
 from pydantic import ConfigDict
 from pydantic.alias_generators import to_pascal
 
+import dascore as dc
+from dascore.core import get_coord, get_coord_manager
+from dascore.utils.misc import iterate
 from dascore.utils.models import BaseModel, DateTime64
+from dascore.utils.pd import _model_list_to_df, adjust_segments, filter_df
 from dascore.utils.xml import xml_to_dict
 
 # -- Create a pydantic model for the metadata info to help keep thins organized.
+
+DATE_TIME_PATTERN = r"\b\d{8}T\d{6}_d{6}Z\b"
+STANDARD_DIMS = ("time", "distance")
 
 
 class _XMLModel(BaseModel):
@@ -52,7 +63,156 @@ class XMLBinaryInfo(_XMLModel):
 
 
 @lru_cache
-def read_xml_metadata(path):
+def _read_xml_metadata(path):
     """A function to read metadata from the xml file."""
     contents = xml_to_dict(path.read_bytes())
     return XMLBinaryInfo.model_validate(contents)
+
+
+def _make_distance_coord(metadata: XMLLaserZones):
+    """
+    Make the base coordinates from the metadata.
+    """
+    zones = metadata.zones
+    zone = next(iter(zones.values()))
+    dx = metadata.original_spatial_sampling_interval
+
+    distance = get_coord(
+        start=(zone.start_channel - 1) * dx,
+        stop=zone.end_channel * dx,
+        step=dx,
+        units="m",
+    )
+    return distance
+
+
+def _make_time_coord(file_start_times, metadata: XMLLaserZones):
+    """Create time coord for each file."""
+    dt = dc.to_timedelta64(metadata.output_temporal_sampling_rate)
+    nt = metadata.number_of_frames
+    for start in file_start_times:
+        yield get_coord(start=start, stop=start + dt * nt, step=dt, units="s")
+
+
+def _make_base_attrs_dict(metadata: XMLLaserZones):
+    """
+    Make the base attributes and coordinates from metadata.
+    """
+    zones = metadata.zones
+    assert len(zones) == 1, "expecting single zone per metadata file."
+    zone_name = next(iter(zones))
+
+    ius = metadata.das_interrogator_serial
+    assert len(ius) == 1, "expecting one interrogator."
+    iu_name = next(iter(ius.values()))
+    attrs = dict(
+        pulse_width_ns=metadata.pulse_width_ns,
+        gauge_length=metadata.gauge_length_m,
+        instrument_id=iu_name,
+        data_units=metadata.units,
+        zone_name=zone_name,
+    )
+    return attrs
+
+
+def _get_path_datetime_64(paths):
+    """Get a series of datetime64 and path as index."""
+    ser = pd.Series(x.name for x in paths)
+    split = ser.str.split("_", expand=True)
+    year = split[1].str[:4]
+    month = split[1].str[4:6]
+    day = split[1].str[6:8]
+    hour = split[1].str[9:11]
+    minute = split[1].str[11:13]
+    second = split[1].str[13:15]
+    frac_sec = split[2].str.split("Z", expand=True)[0]
+    iso8601 = (
+        year
+        + "-"
+        + month
+        + "-"
+        + day
+        + "T"
+        + hour
+        + ":"
+        + minute
+        + ":"
+        + second
+        + "."
+        + frac_sec
+    )
+    dt = dc.to_datetime64(iso8601.values)
+    return pd.Series(dt, index=ser.values)
+
+
+def paths_to_df(paths, metadata, attr_cls):
+    """Convert paths to dataframe of info."""
+    attrs = _paths_to_attrs(paths=paths, metadata=metadata, attr_cls=attr_cls)
+    return _model_list_to_df(attrs)
+
+
+def _read_single_file(path, metadata, time, distance):
+    """Read a single file into a patch."""
+    attr = _paths_to_attrs(path, metadata, summarize=False)[0]
+    time_coord = attr.coords["time"].to_coord()
+    distance_coord = attr.coords["distance"].to_coord()
+    cm = get_coord_manager(
+        {"time": time_coord, "distance": distance_coord},
+        dims=attr.dim_tuple,
+    )
+    data = np.fromfile(path, dtype=metadata.data_type).reshape(cm.shape)
+    patch = dc.Patch(
+        data=data,
+        dims=attr.dim_tuple,
+        coords=cm,
+        attrs=attr.update(coord=None),
+    )
+    return patch.select(time=time, distance=distance)
+
+
+def _patch_from_series(ser):
+    """Get a patch from a series with relevant info."""
+
+
+def _load_patches(paths, metadata, time, distance, attr_cls):
+    """Load the data file or file into a patch."""
+    # Fast case for single file.
+    if isinstance(paths, Path) and paths.is_file():
+        return _read_single_file(paths, metadata, time, distance)
+    # Since there could be **MANY** files, we have to create a mini-index
+    # here to determine which files to read. Under normal circumstances
+    # this isn't required as a spool can manage it.
+    df = paths_to_df(paths=paths, metadata=metadata, attr_cls=attr_cls)
+    df["path"] = paths
+    filtered_df = df[filter_df(df, time=time, distance=distance)].pipe(
+        adjust_segments, time=time, distance=distance
+    )
+    out = []
+
+
+def _paths_to_attrs(
+    paths: Path | Sequence[Path],
+    metadata,
+    summarize=True,
+    attr_cls=dc.PatchAttrs,
+    extra_attrs=None,
+):
+    """Convert a path to a Patch attribute."""
+    extra_attrs = {} if not extra_attrs else extra_attrs
+    paths = iterate(paths)
+    base_attrs = _make_base_attrs_dict(metadata)
+    distance_coord = _make_distance_coord(metadata)
+    dt_ser = _get_path_datetime_64(paths)
+    dims = STANDARD_DIMS[::-1] if metadata.transposed_data else STANDARD_DIMS
+    out = []
+    for path, time_coord in zip(paths, _make_time_coord(dt_ser.values, metadata)):
+        cm = get_coord_manager(
+            {"time": time_coord, "distance": distance_coord},
+            dims=dims,
+        )
+        if summarize:
+            cm = cm.to_summary_dict()
+        attr_dict = {**base_attrs, **extra_attrs}
+        attrs = attr_cls(coords=cm, path=path, **attr_dict)
+        out.append(attrs)
+    return out

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -160,7 +160,10 @@ def _read_single_file(path, metadata, time, distance):
         {"time": time_coord, "distance": distance_coord},
         dims=attr.dim_tuple,
     )
-    data = np.memmap(path, dtype=metadata.data_type, shape=cm.shape)
+    memmap = np.memmap(path, dtype=metadata.data_type)
+    size = np.prod(cm.shape)
+    assert memmap.size == size, f"wrong data shape for {path}"
+    data = memmap.reshape(cm.shape)
     patch = dc.Patch(
         data=data,
         dims=attr.dim_tuple,

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -110,7 +110,7 @@ def _make_base_attrs_dict(metadata: XMLLaserZones):
         pulse_width_ns=metadata.pulse_width_ns,
         gauge_length=metadata.gauge_length_m,
         instrument_id=iu_name,
-        data_units=metadata.units,
+        distance_units=metadata.units,
         zone_name=zone_name,
     )
     return attrs

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -9,11 +9,12 @@ from pydantic.alias_generators import to_pascal
 from dascore.utils.models import BaseModel, DateTime64
 from dascore.utils.xml import xml_to_dict
 
-
 # -- Create a pydantic model for the metadata info to help keep thins organized.
+
 
 class _XMLModel(BaseModel):
     """Base model which converts camel case to snake."""
+
     model_config = ConfigDict(
         alias_generator=to_pascal,
     )
@@ -21,6 +22,7 @@ class _XMLModel(BaseModel):
 
 class XMLLaserZones(_XMLModel):
     """Zones in the xml header."""
+
     start_channel: int
     end_channel: int
     stride: int
@@ -29,6 +31,7 @@ class XMLLaserZones(_XMLModel):
 
 class XMLBinaryInfo(_XMLModel):
     """Base level of information about XML index file."""
+
     file_format: str
     date_time: DateTime64
     das_interrogator_serial: dict[str, str]
@@ -48,7 +51,7 @@ class XMLBinaryInfo(_XMLModel):
     transposed_data: bool
 
 
-@lru_cache()
+@lru_cache
 def read_xml_metadata(path):
     """A function to read metadata from the xml file."""
     contents = xml_to_dict(path.read_bytes())

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -80,8 +80,8 @@ def read_xml_metadata(path):
 #        dims = ('time', 'distance')
 #        axes = [0,1]
 #     # Create coordinates, labels for each axis in the array
+#     # need to figure out time_start based on file name, not the start time from xml
 #     time_start = dc.to_datetime64(time_start)
-#     patch_index = to_timedelta64(patch_index) # need to figure out
 #     time_step = to_timedelta64(time_step)
 #     time = time_start + np.arange(data.shape[axes[0]]) * time_step
 

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -1,95 +1,55 @@
 """Utilities for Binary."""
 from __future__ import annotations
 
-import xml.etree.ElementTree as ElementTree
 from functools import lru_cache
 
+from pydantic import ConfigDict
+from pydantic.alias_generators import to_pascal
 
-@lru_cache
+from dascore.utils.models import BaseModel, DateTime64
+from dascore.utils.xml import xml_to_dict
+
+
+# -- Create a pydantic model for the metadata info to help keep thins organized.
+
+class _XMLModel(BaseModel):
+    """Base model which converts camel case to snake."""
+    model_config = ConfigDict(
+        alias_generator=to_pascal,
+    )
+
+
+class XMLLaserZones(_XMLModel):
+    """Zones in the xml header."""
+    start_channel: int
+    end_channel: int
+    stride: int
+    number_of_channels: int
+
+
+class XMLBinaryInfo(_XMLModel):
+    """Base level of information about XML index file."""
+    file_format: str
+    date_time: DateTime64
+    das_interrogator_serial: dict[str, str]
+    gauge_length_m: float
+    pulse_width_ns: float
+    data_type: str
+    number_of_lasers: int
+    i_t_u_channels: dict[str, int]
+    original_temporal_sampling_rate: float
+    output_temporal_sampling_rate: float
+    original_spatial_sampling_interval: float
+    units: str
+    zones: dict[str, XMLLaserZones]
+    number_of_channels: int
+    number_of_frames: int
+    use_relative_strain: bool
+    transposed_data: bool
+
+
+@lru_cache()
 def read_xml_metadata(path):
     """A function to read metadata from the xml file."""
-    tree = ElementTree.parse(path)
-    root = tree.getroot()
-    # Key metadata
-    total_n_chans = int(root.find("NumberOfChannels").text)
-    gauge_length = float(root.find("GaugeLengthM").text)
-    distance_step = float(root.find("OriginalSpatialSamplingInterval").text)
-    n_time = int(root.find("NumberOfFrames").text)
-    time_step = 1 / float(root.find("OutputTemporalSamplingRate").text)
-    data_type = root.find("DataType").text
-    file_format = root.find("FileFormat").text
-    # Secondary metadata
-    iu_id = root.find("DasInterrogatorSerial/Interrogator_1").text
-    time_start = root.find("DateTime").text
-    itu_channels_laser_1 = root.find("ITUChannels/Laser_1").text
-    itu_channels_laser_2 = root.find("ITUChannels/Laser_2").text
-    n_lasers = root.find("NumberOfLasers").text
-    original_time_step = 1 / float(root.find("OriginalTemporalSamplingRate").text)
-    pulse_width_ns = float(root.find("PulseWidthNs").text)
-    transposed_data = root.find("TransposedData").text
-    units = root.find("Units").text
-    use_relative_strain = root.find("UseRelativeStrain").text
-    start_channel = int(root.find("Zones/Zone/StartChannel").text)
-    end_channel = int(root.find("Zones/Zone/EndChannel").text)
-    channel_stride = int(root.find("Zones/Zone/Stride").text)
-    zone_n_chans = int(root.find("Zones/Zone/NumberOfChannels").text)
-
-    metadata = dict(
-        total_n_chans=total_n_chans,
-        n_time=n_time,
-        time_start=time_start,
-        time_step=time_step,
-        distance_step=distance_step,
-        pulse_width_ns=pulse_width_ns,
-        units=units,
-        data_type=data_type,
-        gauge_length=gauge_length,
-        iu_id=iu_id,
-        n_lasers=n_lasers,
-        itu_channels_laser_1=itu_channels_laser_1,
-        itu_channels_laser_2=itu_channels_laser_2,
-        file_format=file_format,
-        transposed_data=transposed_data,
-        use_relative_strain=use_relative_strain,
-        original_time_step=original_time_step,
-        start_channel=start_channel,
-        end_channel=end_channel,
-        channel_stride=channel_stride,
-        zone_n_chans=zone_n_chans,
-    )
-    return metadata
-
-
-# def read_xml_binary(path, distance=None, time=None):
-#     """Read the binary values into a patch."""
-
-#     # Define metadata
-#     metadata_name = 'metadata.xml'
-#     data_dir = "/same/as/spool/"
-
-#     metadata = read_xml_metadata(path_to_xml)
-
-#     if transposed_data:
-#         data = np.float64(np.fromfile(data_path, dtype=np.dtype(data_type)
-#                          .reshape((n_chans, n_time)))
-#         dims = ('distance', 'time')
-#         axes = [1,0]
-#     else:
-#        data = np.float64(np.fromfile(data_path, dtype=np.dtype(data_type)
-#                         .reshape((n_time, n_chans)))
-#        dims = ('time', 'distance')
-#        axes = [0,1]
-#     # Create coordinates, labels for each axis in the array
-#     # need to figure out time_start based on file name, not the start time from xml
-#     time_start = dc.to_datetime64(time_start)
-#     time_step = to_timedelta64(time_step)
-#     time = time_start + np.arange(data.shape[axes[0]]) * time_step
-
-#     distance_start = 0
-#     distance = distance_start + np.arange(data.shape[axes[1]]) * distance_step
-
-#     # Define coordinates
-#     coords = dict(time=time, distance=distance)
-
-#     patch = dc.Patch(data=data, attrs=attrs, coords=coords)
-#     return patch
+    contents = xml_to_dict(path.read_bytes())
+    return XMLBinaryInfo.model_validate(contents)

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -104,7 +104,7 @@ class IOResourceManager:
         return source
 
     def get_resource(self, required_type: RequiredType) -> RequiredType:
-        """Get the requested resource from."""
+        """Get the requested resource."""
         # no required type, just return source of manager.
         if required_type is None:
             return self.source

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -169,7 +169,7 @@ def all_close(ar1, ar2):
         return np.all(ar1 == ar2)
 
 
-def iter_contents(
+def iter_fs_contents(
     paths: str | Path | Iterable[str | Path],
     ext: str | None = None,
     mtime: float | None = None,
@@ -177,7 +177,9 @@ def iter_contents(
     include_directories: bool = False,
 ) -> Generator[str, str, None]:
     """
-    Iterate contents of paths, optionally filtering and terminating early.
+    Iterate contents of a filesystem like thing.
+
+    Options allow for filtering and terminating early.
 
     Parameters
     ----------
@@ -185,9 +187,9 @@ def iter_contents(
         The path to the base directory to traverse. Can also use a collection
         of paths.
     ext : str or None
-        The extensions to map.
+        The extensions of files to return.
     mtime : int or float
-        Time stamp indicating the minimum mtime.
+        Time stamp indicating the minimum mtime to scan.
     skip_hidden : bool
         If True skip files or folders (they begin with a '.')
     include_directories
@@ -212,7 +214,7 @@ def iter_contents(
                     if entry.name[0] != "." or not skip_hidden:
                         yield entry.path
             elif entry.is_dir() and not (skip_hidden and entry.name[0] == "."):
-                yield from iter_contents(
+                yield from iter_fs_contents(
                     entry.path,
                     ext=ext,
                     mtime=mtime,
@@ -221,7 +223,7 @@ def iter_contents(
                 )
     except (TypeError, AttributeError):  # multiple paths were passed
         for path in paths:
-            yield from iter_contents(path, ext, mtime, skip_hidden)
+            yield from iter_fs_contents(path, ext, mtime, skip_hidden)
     except NotADirectoryError:  # a file path was passed, just return it
         yield paths
 

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -169,7 +169,7 @@ def all_close(ar1, ar2):
         return np.all(ar1 == ar2)
 
 
-def iter_fs_contents(
+def iter_filesystem(
     paths: str | Path | Iterable[str | Path],
     ext: str | None = None,
     mtime: float | None = None,
@@ -213,14 +213,9 @@ def iter_fs_contents(
             if entry.is_file() and (ext is None or entry.name.endswith(ext)):
                 if mtime is None or entry.stat().st_mtime >= mtime:
                     if entry.name[0] != "." or not skip_hidden:
-                        sig = yield entry.path
-                        # Handle skip sig. One extra yield so StopIteration wont
-                        # Raise on send call.
-                        if sig is not None and sig == "skip":
-                            yield
-                            return
+                        yield entry.path
             elif entry.is_dir() and not (skip_hidden and entry.name[0] == "."):
-                yield from iter_fs_contents(
+                yield from iter_filesystem(
                     entry.path,
                     ext=ext,
                     mtime=mtime,
@@ -229,7 +224,7 @@ def iter_fs_contents(
                 )
     except (TypeError, AttributeError):  # multiple paths were passed
         for path in paths:
-            yield from iter_fs_contents(path, ext, mtime, skip_hidden)
+            yield from iter_filesystem(path, ext, mtime, skip_hidden)
     except NotADirectoryError:  # a file path was passed, just return it
         yield paths
 

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -9,10 +9,9 @@ import os
 import re
 import warnings
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from functools import cache
 from pathlib import Path
-from typing import Generator
 from types import ModuleType
 
 import numpy as np

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -169,10 +169,10 @@ def all_close(ar1, ar2):
         return np.all(ar1 == ar2)
 
 
-def iter_filesystem(
+def _iter_filesystem(
     paths: str | Path | Iterable[str | Path],
     ext: str | None = None,
-    mtime: float | None = None,
+    timestamp: float | None = None,
     skip_hidden: bool = True,
     include_directories: bool = False,
 ) -> Generator[str, str, None]:
@@ -188,7 +188,7 @@ def iter_filesystem(
         of paths.
     ext : str or None
         The extensions of files to return.
-    mtime : int or float
+    timestamp : int or float
         Time stamp indicating the minimum mtime to scan.
     skip_hidden : bool
         If True skip files or folders (they begin with a '.')
@@ -211,20 +211,20 @@ def iter_filesystem(
     try:  # a single path was passed
         for entry in os.scandir(paths):
             if entry.is_file() and (ext is None or entry.name.endswith(ext)):
-                if mtime is None or entry.stat().st_mtime >= mtime:
+                if timestamp is None or entry.stat().st_mtime >= timestamp:
                     if entry.name[0] != "." or not skip_hidden:
                         yield entry.path
             elif entry.is_dir() and not (skip_hidden and entry.name[0] == "."):
-                yield from iter_filesystem(
+                yield from _iter_filesystem(
                     entry.path,
                     ext=ext,
-                    mtime=mtime,
+                    timestamp=timestamp,
                     skip_hidden=skip_hidden,
                     include_directories=include_directories,
                 )
     except (TypeError, AttributeError):  # multiple paths were passed
         for path in paths:
-            yield from iter_filesystem(path, ext, mtime, skip_hidden)
+            yield from _iter_filesystem(path, ext, timestamp, skip_hidden)
     except NotADirectoryError:  # a file path was passed, just return it
         yield paths
 

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -88,6 +88,9 @@ def split_df_query(kwargs, df, ignore_bad_kwargs=False):
             new_val = [None if x is ... else x for x in val]
             range_query[key] = tuple(new_val)
             out.pop(key, None)
+        # If this is an empty range query just pop out key.
+        elif val is None:
+            out.pop(key, None)
         else:
             unsupported[key] = val
     # raise if bad keys are found and not ignored.

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -1,10 +1,10 @@
 """Simple interface for progress markers."""
 from __future__ import annotations
 
-from typing import Sized, Generator
+from collections.abc import Generator, Sized
+from contextlib import suppress
 
 import rich.progress as prog
-from contextlib import suppress
 
 import dascore as dc
 from dascore.constants import PROGRESS_LEVELS
@@ -32,11 +32,11 @@ def get_progress_instance(progress: PROGRESS_LEVELS = "standard"):
 
 
 def track(
-        sequence: Sized | Generator,
-        description: str,
-        progress: PROGRESS_LEVELS = "standard",
-        length: int=None,
-        min_length: int=1,
+    sequence: Sized | Generator,
+    description: str,
+    progress: PROGRESS_LEVELS = "standard",
+    length: int | None = None,
+    min_length: int = 1,
 ):
     """
     A simple iterator for tracking updates.

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -1,7 +1,10 @@
 """Simple interface for progress markers."""
 from __future__ import annotations
 
+from typing import Sized, Generator
+
 import rich.progress as prog
+from contextlib import suppress
 
 import dascore as dc
 from dascore.constants import PROGRESS_LEVELS
@@ -28,12 +31,40 @@ def get_progress_instance(progress: PROGRESS_LEVELS = "standard"):
     return prog.Progress(*progress_list, **kwargs)
 
 
-def track(sequence, description, progress: PROGRESS_LEVELS = "standard", length=None):
-    """A simple iterator for tracking updates."""
+def track(
+        sequence: Sized | Generator,
+        description: str,
+        progress: PROGRESS_LEVELS = "standard",
+        length: int=None,
+        min_length: int=1,
+):
+    """
+    A simple iterator for tracking updates.
+
+    Parameters
+    ----------
+    sequence
+        A sequence or generator to trace the iteration over.
+    description
+        A string describing the operation
+    progress
+        options are
+        None- disable progress bar,
+        "basic" reduced refresh rate,
+        "standard" - the normal progress bar
+    min_length
+        The minimum length to emmit a progress bar.
+    """
+    # In the case of a generator we need to make sure this just exists
+    guess_len = length if length is not None else 0
+    with suppress(TypeError, ValueError):
+        length = len(sequence) if not guess_len else guess_len
+    if length < min_length:
+        length = 0
     # This is a dirty hack to allow debugging while running tests.
     # Otherwise, pdb doesn't work in any tracking scope.
     # See: https://github.com/Textualize/rich/issues/1053
-    if dc._debug or not len(sequence) or progress is None:
+    if dc._debug or not length or progress is None:
         yield from sequence
         return
     update = 1.0 if progress == "standard" else 5.0

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -28,7 +28,7 @@ def get_progress_instance(progress: PROGRESS_LEVELS = "standard"):
     return prog.Progress(*progress_list, **kwargs)
 
 
-def track(sequence, description, progress: PROGRESS_LEVELS = "standard"):
+def track(sequence, description, progress: PROGRESS_LEVELS = "standard", length=None):
     """A simple iterator for tracking updates."""
     # This is a dirty hack to allow debugging while running tests.
     # Otherwise, pdb doesn't work in any tracking scope.
@@ -41,7 +41,7 @@ def track(sequence, description, progress: PROGRESS_LEVELS = "standard"):
     with progress:
         yield from progress.track(
             sequence,
-            total=len(sequence),
+            total=length or len(sequence),
             description=description,
             update_period=update,
         )

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -56,6 +56,9 @@ def to_datetime64(obj: timeable_types | np.ndarray):
 @to_datetime64.register(str)
 def _str_to_datetime64(obj: str) -> np.datetime64:
     """Convert a string to a datetime64 object."""
+    # strip off timezone info so numpy doesn't complain.
+    if obj.endswith("Z"):
+        obj = obj[:-1]
     return np.datetime64(obj, "ns")
 
 

--- a/dascore/utils/xml.py
+++ b/dascore/utils/xml.py
@@ -11,7 +11,12 @@ def xml_to_dict(xml_string):
 
 
 def _element_to_dict(element):
-    """Recursively convert an element tree into a dict."""
+    """
+    Recursively convert an element tree into a dict.
+
+    Note: This function is probably not general enough to handle complicated
+    xml, use with caution.
+    """
     # Base case: If the element has no children, return its text content
     if len(element) == 0:
         return element.text
@@ -19,12 +24,12 @@ def _element_to_dict(element):
     # Recursive case: Convert children to dictionary
     result = {}
     for child in element:
-        child_dict = _element_to_dict(child)
+        child_value = _element_to_dict(child)
         if child.tag in result:
             if isinstance(result[child.tag], list):
-                result[child.tag].append(child_dict)
+                result[child.tag].append(child_value)
             else:
-                result[child.tag] = [result[child.tag], child_dict]
+                result[child.tag] = [result[child.tag], child_value]
         else:
-            result[child.tag] = child_dict
+            result[child.tag] = child_value
     return result

--- a/dascore/utils/xml.py
+++ b/dascore/utils/xml.py
@@ -1,0 +1,30 @@
+"""
+Utilities for working with xml files.
+"""
+from xml.etree import ElementTree
+
+
+def xml_to_dict(xml_string):
+    """Convert a simple xml string to a dict."""
+    root = ElementTree.fromstring(xml_string)
+    return _element_to_dict(root)
+
+
+def _element_to_dict(element):
+    """Recursively convert an element tree into a dict."""
+    # Base case: If the element has no children, return its text content
+    if len(element) == 0:
+        return element.text
+
+    # Recursive case: Convert children to dictionary
+    result = {}
+    for child in element:
+        child_dict = _element_to_dict(child)
+        if child.tag in result:
+            if isinstance(result[child.tag], list):
+                result[child.tag].append(child_dict)
+            else:
+                result[child.tag] = [result[child.tag], child_dict]
+        else:
+            result[child.tag] = child_dict
+    return result

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -30,7 +30,7 @@ def _set_scale(im, scale, scale_type, patch):
     if scale_type == "relative":
         modifier = 0.5 * (np.nanmax(data) - np.nanmin(data))
         # only one scale parameter provided, center around mean
-    if isinstance(scale, float):
+    if isinstance(scale, float | int):
         mean = np.nanmean(patch.data)
         scale = np.array([mean - scale * modifier, mean + scale * modifier])
     im.set_clim(scale)

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -39,8 +39,11 @@ def _shade(offsets, ax, data_scaled, color, wiggle_labels):
 
 def _format_y_axis_ticks(ax, offsets, other_axis_ticks, max_ticks=10):
     """Format the Y axis tick labels."""
+    # make sure not printing too many digits on the figure
+    if other_axis_ticks.dtype != np.dtype("<M8[ns]"):
+        other_axis_ticks = np.around(other_axis_ticks, decimals=2)
     # set the offset
-    ax.set_yticks(offsets, np.around(other_axis_ticks, 2))
+    ax.set_yticks(offsets, other_axis_ticks)
     min_bins = min(len(other_axis_ticks), max_ticks)
     plt.locator_params(axis="y", nbins=min_bins)
 

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -40,7 +40,7 @@ def _shade(offsets, ax, data_scaled, color, wiggle_labels):
 def _format_y_axis_ticks(ax, offsets, other_axis_ticks, max_ticks=10):
     """Format the Y axis tick labels."""
     # set the offset
-    ax.set_yticks(offsets, other_axis_ticks)
+    ax.set_yticks(offsets, np.around(other_axis_ticks, 2))
     min_bins = min(len(other_axis_ticks), max_ticks)
     plt.locator_params(axis="y", nbins=min_bins)
 

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -11,6 +11,7 @@ from dascore.utils.plotting import (
     _get_ax,
     _get_dim_label,
 )
+from dascore.utils.time import dtype_time_like
 
 
 def _get_offsets_factor(patch, dim, scale, other_labels):
@@ -40,7 +41,7 @@ def _shade(offsets, ax, data_scaled, color, wiggle_labels):
 def _format_y_axis_ticks(ax, offsets, other_axis_ticks, max_ticks=10):
     """Format the Y axis tick labels."""
     # make sure not printing too many digits on the figure
-    if other_axis_ticks.dtype != np.dtype("<M8[ns]"):
+    if not dtype_time_like(other_axis_ticks):
         other_axis_ticks = np.around(other_axis_ticks, decimals=2)
     # set the offset
     ax.set_yticks(offsets, other_axis_ticks)

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -242,3 +242,7 @@ JINGLE__V1 = "dascore.io.jingle.core:JingleV1"
 :::{.callout-note}
 The name and version of the format are separated by a double underscore.
 :::
+
+## Directories as Inputs
+
+Some `FiberIO` formats may not be self-contained files, but rather must be understood in the context of an entire directory. In these cases, the `input_type` parameter on the `FiberIO` subclass should be set to "directory". See the [xml_binary](`dascore.core.io.xml_binary`) module for an example of a directory based `FiberIO` implementation. 

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -245,7 +245,7 @@ The name and version of the format are separated by a double underscore.
 
 ## Directories as Inputs
 
-Some `FiberIO` formats may not be self-contained files, but rather must be understood in the context of an entire directory. In these cases, the `input_type` parameter on the `FiberIO` subclass should be set to "directory". See the [xml_binary](`dascore.core.io.xml_binary`) module for an example of a directory based `FiberIO` implementation. 
+Some `FiberIO` formats may not be self-contained files, but rather must be understood in the context of an entire directory. In these cases, the `input_type` parameter on the `FiberIO` subclass should be set to "directory". See the [xml_binary](`dascore.io.xml_binary`) module for an example of a directory based `FiberIO` implementation. 
 
 :::{.callout-warning}
 DASCore assumes a directory-based `FiberIO` does not have any sub patch files of a different format. Once a valid `FiberIO` directory is found, contents of the directory are no longer searched for Patch files.  

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -71,7 +71,7 @@ class JingleV1(FiberIO):
         be implemented as well.
         """
 
-    def get_format(self, path):
+    def get_format(self, path, **kwargs):
         """
         Used to determine if path is a supported jingle file.
 
@@ -80,7 +80,7 @@ class JingleV1(FiberIO):
         dascore.exceptions.UnknownFiberFormat exception.
         """
 
-    def scan(self, path):
+    def scan(self, path, **kwargs):
         """
         Used to get metadata about a file without reading the whole file.
 
@@ -97,6 +97,11 @@ class JingleV1(FiberIO):
 ```
 
 All 4 methods are optional; some formats will only support reading, others only writing. If `is_format` is not implemented the format will not be auto-detectable, meaning you will have to manually pass the format to [`read`](`dascore.read`) and [`spool`](`dascore.spool`).
+
+
+:::{.callout-note}
+Note that each of these methods should have `**kwargs` at the end. This allows certain formats to have special keywords while others are not required.
+:::
 
 :::{.callout-warning}
 It is very important that the `scan` method returns *exactly* the same patch information as reading the patch would, otherwise the lazy merge planning done by spool can be wrong!

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -246,3 +246,7 @@ The name and version of the format are separated by a double underscore.
 ## Directories as Inputs
 
 Some `FiberIO` formats may not be self-contained files, but rather must be understood in the context of an entire directory. In these cases, the `input_type` parameter on the `FiberIO` subclass should be set to "directory". See the [xml_binary](`dascore.core.io.xml_binary`) module for an example of a directory based `FiberIO` implementation. 
+
+:::{.callout-warning}
+DASCore assumes a directory-based `FiberIO` does not have any sub patch files of a different format. Once a valid `FiberIO` directory is found, contents of the directory are no longer searched for Patch files.  
+:::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ TERRA15__V6 = "dascore.io.terra15.core:Terra15FormatterV6"
 SEGY__V2 = "dascore.io.segy.core:SegyV2"
 RSF__V1 = "dascore.io.rsf.core:RSFV1"
 WAV = "dascore.io.wav.core:WavIO"
-Binary = "dascore.io.binary.core:BinaryRaw"
+XML_BINARY_V1 = "dascore.io.xml_binary.core:XMLBinaryV1"
 
 
 # --- External tool configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ TERRA15__V6 = "dascore.io.terra15.core:Terra15FormatterV6"
 SEGY__V2 = "dascore.io.segy.core:SegyV2"
 RSF__V1 = "dascore.io.rsf.core:RSFV1"
 WAV = "dascore.io.wav.core:WavIO"
+Binary = "dascore.io.binary.core:BinaryRaw"
 
 
 # --- External tool configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ TERRA15__V6 = "dascore.io.terra15.core:Terra15FormatterV6"
 SEGY__V2 = "dascore.io.segy.core:SegyV2"
 RSF__V1 = "dascore.io.rsf.core:RSFV1"
 WAV = "dascore.io.wav.core:WavIO"
-XML_BINARY_V1 = "dascore.io.xml_binary.core:XMLBinaryV1"
+XMLBINARY__V1 = "dascore.io.xml_binary.core:XMLBinaryV1"
 
 
 # --- External tool configuration

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -194,7 +194,7 @@ website:
         - text: Documentation Strategy
           href: notes/doc_strategy.qmd
 
-        - text: Fourier transforms
+        - text: Fourier Transforms
           href: notes/dft_notes.qmd
 
     - id: API

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -146,7 +146,7 @@ class TestDirectoryIndex:
         # ensure the index was created in the expected place
         assert spool1.indexer.index_path == index_path
         # ensure the default index file was not written
-        default_index_path = bank_path / spool1.indexer._index_name
+        default_index_path = bank_path / spool1.indexer._metadata_name
         assert not default_index_path.exists()
         # future banks should remember this path.
         spool2 = dc.spool(bank_path)

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -146,7 +146,7 @@ class TestDirectoryIndex:
         # ensure the index was created in the expected place
         assert spool1.indexer.index_path == index_path
         # ensure the default index file was not written
-        default_index_path = bank_path / spool1.indexer._metadata_name
+        default_index_path = bank_path / spool1.indexer._index_name
         assert not default_index_path.exists()
         # future banks should remember this path.
         spool2 = dc.spool(bank_path)

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -315,6 +315,11 @@ class TestScan:
         out = dc.scan(nested_directory_with_patches)
         assert len(out) == 3
 
+    def test_scan_single_file(self, terra15_v6_path):
+        """Ensure scan works on a single file."""
+        out = dc.scan(terra15_v6_path)
+        assert len(out) == 1
+
     def test_can_raise(self):
         """
         Scan, when called from a FiberIO, should be able to raise if

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -79,7 +79,7 @@ class _FiberCaster(FiberIO):
 
 
 class _FiberUnsupportedTypeHints(FiberIO):
-    """A fiber io which implements typehints which have not casting meaning."""
+    """A fiber io which implements typehints which have no casting meaning."""
 
     name = "_TypeHinterNotRight"
     version = "2"
@@ -88,6 +88,11 @@ class _FiberUnsupportedTypeHints(FiberIO):
         """Dummy read."""
         with open(resource) as fi:
             return fi.read()
+
+
+class _FiberDirectory(FiberIO):
+    """A FiberIO which accepts a directory."""
+
 
 
 class TestPatchFileSummary:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -94,7 +94,6 @@ class _FiberDirectory(FiberIO):
     """A FiberIO which accepts a directory."""
 
 
-
 class TestPatchFileSummary:
     """Tests for getting patch file information."""
 

--- a/tests/test_io/test_xml_binary/test_xml_binary.py
+++ b/tests/test_io/test_xml_binary/test_xml_binary.py
@@ -1,0 +1,70 @@
+"""Misc. tests for xml binary."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dascore.io.xml_binary.utils import read_xml_metadata
+
+metadata = """<?xml version='1.0' encoding='utf-8'?>
+<Metadata>
+  <FileFormat>RAW</FileFormat>
+  <DateTime>2024-05-30T01:15:00Z</DateTime>
+  <DasInterrogatorSerial>
+    <Interrogator_1>CRI-4400_A001</Interrogator_1>
+  </DasInterrogatorSerial>
+  <GaugeLengthM>1</GaugeLengthM>
+  <PulseWidthNs>100</PulseWidthNs>
+  <DataType>uint16</DataType>
+  <NumberOfLasers>2</NumberOfLasers>
+  <ITUChannels>
+    <Laser_1>15</Laser_1>
+    <Laser_2>10</Laser_2>
+  </ITUChannels>
+  <OriginalTemporalSamplingRate>1000</OriginalTemporalSamplingRate>
+  <OutputTemporalSamplingRate>1000</OutputTemporalSamplingRate>
+  <OriginalSpatialSamplingInterval>1</OriginalSpatialSamplingInterval>
+  <Units>m</Units>
+  <Zones>
+    <Zone>
+      <StartChannel>1</StartChannel>
+      <EndChannel>10</EndChannel>
+      <Stride>1</Stride>
+      <NumberOfChannels>10</NumberOfChannels>
+    </Zone>
+  </Zones>
+  <NumberOfChannels>10</NumberOfChannels>
+  <NumberOfFrames>1000</NumberOfFrames>
+  <UseRelativeStrain>False</UseRelativeStrain>
+  <TransposedData>False</TransposedData>
+</Metadata>
+"""
+
+
+@pytest.fixture(scope="session")
+def binary_xml_directory(tmp_path_factory):
+    """Creates a directory of binary files and an xml metadata."""
+    new = tmp_path_factory.mktemp("xml_binary_test_data")
+    metadata_path = new / "metadata.xml"
+    data_1_path = new / "DAS_20240530T011500_000000Z.raw"
+    data_2_path = new / "DAS_20240530T011501.raw"
+    with open(metadata_path, "w") as fi:
+        fi.write(metadata)
+    with open(data_1_path, "wb") as fi:
+        ar = np.arange(1000 * 10, dtype=np.dtype("uint16"))
+        ar.tofile(fi)
+    with open(data_2_path, "wb") as fi:
+        ar = np.arange(1000 * 10, dtype=np.dtype("uint16"))
+        ar.tofile(fi)
+    return new
+
+
+class TestReadXMLMetadata:
+    """Misc tests reading xml metadata."""
+
+    def test_read_metadata_contents(self, binary_xml_directory):
+        """Test reading xml metadata contents and metadata types."""
+        metadata_path_1 = binary_xml_directory / "metadata.xml"
+        metadata = read_xml_metadata(metadata_path_1)
+        assert metadata
+        assert isinstance(metadata, dict)

--- a/tests/test_io/test_xml_binary/test_xml_binary.py
+++ b/tests/test_io/test_xml_binary/test_xml_binary.py
@@ -71,4 +71,3 @@ class TestReadXMLMetadata:
         expected_attrs = ["file_format", "date_time", "units"]
         for attr in expected_attrs:
             assert hasattr(metadata, attr)
-

--- a/tests/test_io/test_xml_binary/test_xml_binary.py
+++ b/tests/test_io/test_xml_binary/test_xml_binary.py
@@ -139,4 +139,5 @@ class TestRead:
     def test_simple_spool(self, binary_xml_directory):
         """Ensure the simple path can be read into a spool."""
         spool = dc.spool(binary_xml_directory).update()
+        assert isinstance(spool, dc.BaseSpool)
         assert len(spool) == 2

--- a/tests/test_io/test_xml_binary/test_xml_binary.py
+++ b/tests/test_io/test_xml_binary/test_xml_binary.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from dascore.io.xml_binary.utils import read_xml_metadata
+import dascore as dc
+from dascore.exceptions import UnknownFiberFormatError
+from dascore.io.xml_binary import XMLBinaryV1
+from dascore.io.xml_binary.utils import _read_xml_metadata
 
 metadata = """<?xml version='1.0' encoding='utf-8'?>
 <Metadata>
@@ -47,7 +50,7 @@ def binary_xml_directory(tmp_path_factory):
     new = tmp_path_factory.mktemp("xml_binary_test_data")
     metadata_path = new / "metadata.xml"
     data_1_path = new / "DAS_20240530T011500_000000Z.raw"
-    data_2_path = new / "DAS_20240530T011501.raw"
+    data_2_path = new / "DAS_20240530T011501_000000Z.raw"
     with open(metadata_path, "w") as fi:
         fi.write(metadata)
     with open(data_1_path, "wb") as fi:
@@ -59,15 +62,78 @@ def binary_xml_directory(tmp_path_factory):
     return new
 
 
+@pytest.fixture(scope="session")
+def directory_bad_xml(tmp_path_factory):
+    """Create a directory with bad xml metadata."""
+    new = tmp_path_factory.mktemp("xml_binary_bad_xml")
+    metadata_path = new / "metadata.xml"
+    with open(metadata_path, "w") as fi:
+        fi.write("The bathhouse makes him crazy.")
+    return new
+
+
 class TestReadXMLMetadata:
     """Misc tests reading xml metadata."""
 
     def test_read_metadata_contents(self, binary_xml_directory):
         """Test reading xml metadata contents and metadata types."""
         metadata_path_1 = binary_xml_directory / "metadata.xml"
-        metadata = read_xml_metadata(metadata_path_1)
+        metadata = _read_xml_metadata(metadata_path_1)
         assert metadata is not None
         # Just test a couple of attrs, pydantic should handle the rest.
         expected_attrs = ["file_format", "date_time", "units"]
         for attr in expected_attrs:
             assert hasattr(metadata, attr)
+
+
+class TestGetFormat:
+    """Test suite for xml binary get format."""
+
+    def test_returns_name_format(self, binary_xml_directory):
+        """Ensure the proper name/format are returned from working folder."""
+        name, version = dc.get_format(binary_xml_directory)
+        fiber_io = XMLBinaryV1()
+        assert name == fiber_io.name
+        assert version == fiber_io.version
+
+    def test_bad_xml_metadata(self, directory_bad_xml):
+        """Ensure get format raises with bad xml metadata."""
+        # dc.get_format should raise, as per its docs
+        with pytest.raises(UnknownFiberFormatError):
+            dc.get_format(directory_bad_xml)
+        # but the specific class get_format should return false.
+        fiber_io = XMLBinaryV1()
+        out = fiber_io.get_format(directory_bad_xml)
+        assert not out
+
+
+class TestScanContents:
+    """Test scanning contents of xml binary directory."""
+
+    def test_two_patches(self, binary_xml_directory):
+        """Ensure the default test case has two patches."""
+        fiber = XMLBinaryV1()
+        out = fiber.scan(binary_xml_directory)
+        assert len(out) == 2
+
+
+class TestRead:
+    """Tests for reading contents into Patches."""
+
+    def test_read_single_file(self, binary_xml_directory):
+        """Ensure we can read a single binary file in the directory."""
+        fiber_io = XMLBinaryV1()
+        path = next(binary_xml_directory.glob("*.raw"))
+        out = fiber_io.read(path)
+        assert isinstance(out, dc.BaseSpool)
+        assert len(out) == 1
+
+    def test_read_whole_directory(self, binary_xml_directory):
+        """Ensure the simple path can be read by fiber io instance."""
+        fiber_io = XMLBinaryV1()
+        spool = fiber_io.read(binary_xml_directory)
+
+    def test_simple_spool(self, binary_xml_directory):
+        """Ensure the simple path can be read into a spool."""
+        spool = dc.spool(binary_xml_directory)
+        assert len(spool) == 2

--- a/tests/test_io/test_xml_binary/test_xml_binary.py
+++ b/tests/test_io/test_xml_binary/test_xml_binary.py
@@ -66,5 +66,9 @@ class TestReadXMLMetadata:
         """Test reading xml metadata contents and metadata types."""
         metadata_path_1 = binary_xml_directory / "metadata.xml"
         metadata = read_xml_metadata(metadata_path_1)
-        assert metadata
-        assert isinstance(metadata, dict)
+        assert metadata is not None
+        # Just test a couple of attrs, pydantic should handle the rest.
+        expected_attrs = ["file_format", "date_time", "units"]
+        for attr in expected_attrs:
+            assert hasattr(metadata, attr)
+

--- a/tests/test_io/test_xml_binary/test_xml_binary.py
+++ b/tests/test_io/test_xml_binary/test_xml_binary.py
@@ -132,8 +132,11 @@ class TestRead:
         """Ensure the simple path can be read by fiber io instance."""
         fiber_io = XMLBinaryV1()
         spool = fiber_io.read(binary_xml_directory)
+        assert len(spool) == 2
+        for patch in spool:
+            assert isinstance(patch, dc.Patch)
 
     def test_simple_spool(self, binary_xml_directory):
         """Ensure the simple path can be read into a spool."""
-        spool = dc.spool(binary_xml_directory)
+        spool = dc.spool(binary_xml_directory).update()
         assert len(spool) == 2

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -159,7 +159,7 @@ class TestIterContents:
         assert out[0] == dummy_text_file
 
     def test_no_directories(self, simple_dir):
-        """Ensure no directories are included when include_directories=False"""
+        """Ensure no directories are included when include_directories=False."""
         out = list(iter_contents(simple_dir, include_directories=False))
         has_dirs = [Path(x).is_dir() for x in out]
         assert not any(has_dirs)
@@ -330,6 +330,7 @@ class TestWarnOrRaise:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             warn_or_raise(msg, behavior=None)
+
 
 #
 # class TestIterContents:

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -330,31 +330,3 @@ class TestWarnOrRaise:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             warn_or_raise(msg, behavior=None)
-
-
-#
-# class TestIterContents:
-#     """Tests for iterating contents of a directory."""
-#
-#     @pytest.fixture(scope='class')
-#     def basic_dir(self, tmp_path_factory):
-#         """
-#         Basic directory setup with contents like:
-#         top
-#           file.txt
-#           folder
-#              file.txt
-#              another.bin
-#              sub_folder
-#                file.txt
-#         """
-#         path = Path(tmp_path_factory.mktemp('basic_dir'))
-#         (path / 'file.txt').write_text("content of txt")
-#         folder_path = (path / "folder")
-#         folder_path.mkdir(exist_ok=True)
-#         (folder_path / "file.txt").write_text("content of sub text")
-#         (folder_path / "another.bin").write_bytes(b"bytey bytes")
-#         sub_folder_path = folder_path / "sub_folder"
-#         sub_folder_path.mkdir(exist_ok=True)
-#         (sub_folder_path / "file.txt").write_text("content of sub sub text")
-#         return path

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -14,7 +14,7 @@ from dascore.utils.misc import (
     MethodNameSpace,
     cached_method,
     get_stencil_coefs,
-    iter_files,
+    iter_contents,
     iterate,
     maybe_get_items,
     optional_import,
@@ -59,7 +59,7 @@ class TestNamespaceClass:
         assert pc.namespace.new_method(ParentClass)
 
 
-class TestIterFiles:
+class TestIterContents:
     """Tests for iterating directories of files."""
 
     sub = {"D": {"C": ".mseed"}, "F": ".json", "G": {"H": ".txt"}}  # noqa
@@ -102,20 +102,20 @@ class TestIterFiles:
     def test_basic(self, simple_dir):
         """Test basic usage of iterfiles."""
         files = set(self.get_file_paths(self.file_paths, simple_dir))
-        out = {Path(x) for x in iter_files(simple_dir)}
+        out = {Path(x) for x in iter_contents(simple_dir)}
         assert files == out
 
     def test_one_subdir(self, simple_dir):
         """Test with one sub directory."""
         subdirs = simple_dir / "B" / "D"
-        out = set(iter_files(subdirs))
+        out = set(iter_contents(subdirs))
         assert len(out) == 1
 
     def test_multiple_subdirs(self, simple_dir):
         """Test with multiple sub directories."""
         path1 = simple_dir / "B" / "D"
         path2 = simple_dir / "B" / "G"
-        out = {Path(x) for x in iter_files([path1, path2])}
+        out = {Path(x) for x in iter_contents([path1, path2])}
         files = self.get_file_paths(self.file_paths, simple_dir)
         expected = {
             x
@@ -124,9 +124,9 @@ class TestIterFiles:
         }
         assert out == expected
 
-    def test_extention(self, simple_dir):
+    def test_extension(self, simple_dir):
         """Test filtering based on extention."""
-        out = set(iter_files(simple_dir, ext=".txt"))
+        out = set(iter_contents(simple_dir, ext=".txt"))
         for val in out:
             assert val.endswith(".txt")
 
@@ -138,25 +138,55 @@ class TestIterFiles:
         first_file = files[0]
         os.utime(first_file, (now + 10, now + 10))
         # get output make sure it only returned first file
-        out = list(iter_files(simple_dir, mtime=now + 5))
+        out = list(iter_contents(simple_dir, mtime=now + 5))
         assert len(out) == 1
         assert Path(out[0]) == first_file
 
     def test_skips_files_in_hidden_directory(self, dir_with_hidden_dir):
         """Hidden directory files should be skipped."""
-        out1 = list(iter_files(dir_with_hidden_dir))
+        out1 = list(iter_contents(dir_with_hidden_dir))
         has_hidden_by_parent = ["hidden_by_parent" in x for x in out1]
         assert not any(has_hidden_by_parent)
         # But if skip_hidden is False it should be there
-        out2 = list(iter_files(dir_with_hidden_dir, skip_hidden=False))
+        out2 = list(iter_contents(dir_with_hidden_dir, skip_hidden=False))
         has_hidden_by_parent = ["hidden_by_parent" in x for x in out2]
         assert sum(has_hidden_by_parent) == 1
 
     def test_pass_file(self, dummy_text_file):
         """Just pass a single file and ensure it gets returned."""
-        out = list(iter_files(dummy_text_file))
+        out = list(iter_contents(dummy_text_file))
         assert len(out) == 1
         assert out[0] == dummy_text_file
+
+    def test_no_directories(self, simple_dir):
+        """Ensure no directories are included when include_directories=False"""
+        out = list(iter_contents(simple_dir, include_directories=False))
+        has_dirs = [Path(x).is_dir() for x in out]
+        assert not any(has_dirs)
+
+    def test_include_directories(self, simple_dir):
+        """Ensure we can get directories back."""
+        out = list(iter_contents(simple_dir, include_directories=True))
+        returned_dirs = [Path(x) for x in out if Path(x).is_dir()]
+        assert len(returned_dirs)
+        # The top level directory should have been included
+        assert simple_dir in returned_dirs
+        # Directory names
+        dir_names = {x.name for x in returned_dirs}
+        expected_names = {"B", "G", "D"}
+        assert expected_names.issubset(dir_names)
+
+    def test_skip_signal_directory(self, simple_dir):
+        """Ensure a skip signal can be sent to stop parsing on directory."""
+        out = []
+        iterator = iter_contents(simple_dir, include_directories=True)
+        for path in iterator:
+            if Path(path).name == "B":
+                iterator.send("skip")
+            out.append(path)
+        names = {Path(x).name.split(".")[0] for x in out}
+        # Anything after B should have been skipped
+        assert {"C", "D", "E", "F"}.isdisjoint(names)
 
 
 class TestIterate:
@@ -300,3 +330,30 @@ class TestWarnOrRaise:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             warn_or_raise(msg, behavior=None)
+
+#
+# class TestIterContents:
+#     """Tests for iterating contents of a directory."""
+#
+#     @pytest.fixture(scope='class')
+#     def basic_dir(self, tmp_path_factory):
+#         """
+#         Basic directory setup with contents like:
+#         top
+#           file.txt
+#           folder
+#              file.txt
+#              another.bin
+#              sub_folder
+#                file.txt
+#         """
+#         path = Path(tmp_path_factory.mktemp('basic_dir'))
+#         (path / 'file.txt').write_text("content of txt")
+#         folder_path = (path / "folder")
+#         folder_path.mkdir(exist_ok=True)
+#         (folder_path / "file.txt").write_text("content of sub text")
+#         (folder_path / "another.bin").write_bytes(b"bytey bytes")
+#         sub_folder_path = folder_path / "sub_folder"
+#         sub_folder_path.mkdir(exist_ok=True)
+#         (sub_folder_path / "file.txt").write_text("content of sub sub text")
+#         return path

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -14,7 +14,7 @@ from dascore.utils.misc import (
     MethodNameSpace,
     cached_method,
     get_stencil_coefs,
-    iter_fs_contents,
+    iter_filesystem,
     iterate,
     maybe_get_items,
     optional_import,
@@ -59,7 +59,7 @@ class TestNamespaceClass:
         assert pc.namespace.new_method(ParentClass)
 
 
-class TestIterFSContents:
+class TestIterFS:
     """Tests for iterating directories of files."""
 
     sub = {"D": {"C": ".mseed"}, "F": ".json", "G": {"H": ".txt"}}  # noqa
@@ -102,20 +102,20 @@ class TestIterFSContents:
     def test_basic(self, simple_dir):
         """Test basic usage of iterfiles."""
         files = set(self.get_file_paths(self.file_paths, simple_dir))
-        out = {Path(x) for x in iter_fs_contents(simple_dir)}
+        out = {Path(x) for x in iter_filesystem(simple_dir)}
         assert files == out
 
     def test_one_subdir(self, simple_dir):
         """Test with one sub directory."""
         subdirs = simple_dir / "B" / "D"
-        out = set(iter_fs_contents(subdirs))
+        out = set(iter_filesystem(subdirs))
         assert len(out) == 1
 
     def test_multiple_subdirs(self, simple_dir):
         """Test with multiple sub directories."""
         path1 = simple_dir / "B" / "D"
         path2 = simple_dir / "B" / "G"
-        out = {Path(x) for x in iter_fs_contents([path1, path2])}
+        out = {Path(x) for x in iter_filesystem([path1, path2])}
         files = self.get_file_paths(self.file_paths, simple_dir)
         expected = {
             x
@@ -126,7 +126,7 @@ class TestIterFSContents:
 
     def test_extension(self, simple_dir):
         """Test filtering based on extention."""
-        out = set(iter_fs_contents(simple_dir, ext=".txt"))
+        out = set(iter_filesystem(simple_dir, ext=".txt"))
         for val in out:
             assert val.endswith(".txt")
 
@@ -138,35 +138,35 @@ class TestIterFSContents:
         first_file = files[0]
         os.utime(first_file, (now + 10, now + 10))
         # get output make sure it only returned first file
-        out = list(iter_fs_contents(simple_dir, mtime=now + 5))
+        out = list(iter_filesystem(simple_dir, mtime=now + 5))
         assert len(out) == 1
         assert Path(out[0]) == first_file
 
     def test_skips_files_in_hidden_directory(self, dir_with_hidden_dir):
         """Hidden directory files should be skipped."""
-        out1 = list(iter_fs_contents(dir_with_hidden_dir))
+        out1 = list(iter_filesystem(dir_with_hidden_dir))
         has_hidden_by_parent = ["hidden_by_parent" in x for x in out1]
         assert not any(has_hidden_by_parent)
         # But if skip_hidden is False it should be there
-        out2 = list(iter_fs_contents(dir_with_hidden_dir, skip_hidden=False))
+        out2 = list(iter_filesystem(dir_with_hidden_dir, skip_hidden=False))
         has_hidden_by_parent = ["hidden_by_parent" in x for x in out2]
         assert sum(has_hidden_by_parent) == 1
 
     def test_pass_file(self, dummy_text_file):
         """Just pass a single file and ensure it gets returned."""
-        out = list(iter_fs_contents(dummy_text_file))
+        out = list(iter_filesystem(dummy_text_file))
         assert len(out) == 1
         assert out[0] == dummy_text_file
 
     def test_no_directories(self, simple_dir):
         """Ensure no directories are included when include_directories=False."""
-        out = list(iter_fs_contents(simple_dir, include_directories=False))
+        out = list(iter_filesystem(simple_dir, include_directories=False))
         has_dirs = [Path(x).is_dir() for x in out]
         assert not any(has_dirs)
 
     def test_include_directories(self, simple_dir):
         """Ensure we can get directories back."""
-        out = list(iter_fs_contents(simple_dir, include_directories=True))
+        out = list(iter_filesystem(simple_dir, include_directories=True))
         returned_dirs = [Path(x) for x in out if Path(x).is_dir()]
         assert len(returned_dirs)
         # The top level directory should have been included
@@ -179,7 +179,7 @@ class TestIterFSContents:
     def test_skip_signal_directory(self, simple_dir):
         """Ensure a skip signal can be sent to stop parsing on directory."""
         out = []
-        iterator = iter_fs_contents(simple_dir, include_directories=True)
+        iterator = iter_filesystem(simple_dir, include_directories=True)
         for path in iterator:
             if Path(path).name == "B":
                 iterator.send("skip")

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -12,9 +12,9 @@ import pytest
 from dascore.exceptions import MissingOptionalDependencyError
 from dascore.utils.misc import (
     MethodNameSpace,
+    _iter_filesystem,
     cached_method,
     get_stencil_coefs,
-    iter_filesystem,
     iterate,
     maybe_get_items,
     optional_import,
@@ -102,20 +102,20 @@ class TestIterFS:
     def test_basic(self, simple_dir):
         """Test basic usage of iterfiles."""
         files = set(self.get_file_paths(self.file_paths, simple_dir))
-        out = {Path(x) for x in iter_filesystem(simple_dir)}
+        out = {Path(x) for x in _iter_filesystem(simple_dir)}
         assert files == out
 
     def test_one_subdir(self, simple_dir):
         """Test with one sub directory."""
         subdirs = simple_dir / "B" / "D"
-        out = set(iter_filesystem(subdirs))
+        out = set(_iter_filesystem(subdirs))
         assert len(out) == 1
 
     def test_multiple_subdirs(self, simple_dir):
         """Test with multiple sub directories."""
         path1 = simple_dir / "B" / "D"
         path2 = simple_dir / "B" / "G"
-        out = {Path(x) for x in iter_filesystem([path1, path2])}
+        out = {Path(x) for x in _iter_filesystem([path1, path2])}
         files = self.get_file_paths(self.file_paths, simple_dir)
         expected = {
             x
@@ -126,7 +126,7 @@ class TestIterFS:
 
     def test_extension(self, simple_dir):
         """Test filtering based on extention."""
-        out = set(iter_filesystem(simple_dir, ext=".txt"))
+        out = set(_iter_filesystem(simple_dir, ext=".txt"))
         for val in out:
             assert val.endswith(".txt")
 
@@ -138,35 +138,35 @@ class TestIterFS:
         first_file = files[0]
         os.utime(first_file, (now + 10, now + 10))
         # get output make sure it only returned first file
-        out = list(iter_filesystem(simple_dir, mtime=now + 5))
+        out = list(_iter_filesystem(simple_dir, timestamp=now + 5))
         assert len(out) == 1
         assert Path(out[0]) == first_file
 
     def test_skips_files_in_hidden_directory(self, dir_with_hidden_dir):
         """Hidden directory files should be skipped."""
-        out1 = list(iter_filesystem(dir_with_hidden_dir))
+        out1 = list(_iter_filesystem(dir_with_hidden_dir))
         has_hidden_by_parent = ["hidden_by_parent" in x for x in out1]
         assert not any(has_hidden_by_parent)
         # But if skip_hidden is False it should be there
-        out2 = list(iter_filesystem(dir_with_hidden_dir, skip_hidden=False))
+        out2 = list(_iter_filesystem(dir_with_hidden_dir, skip_hidden=False))
         has_hidden_by_parent = ["hidden_by_parent" in x for x in out2]
         assert sum(has_hidden_by_parent) == 1
 
     def test_pass_file(self, dummy_text_file):
         """Just pass a single file and ensure it gets returned."""
-        out = list(iter_filesystem(dummy_text_file))
+        out = list(_iter_filesystem(dummy_text_file))
         assert len(out) == 1
         assert out[0] == dummy_text_file
 
     def test_no_directories(self, simple_dir):
         """Ensure no directories are included when include_directories=False."""
-        out = list(iter_filesystem(simple_dir, include_directories=False))
+        out = list(_iter_filesystem(simple_dir, include_directories=False))
         has_dirs = [Path(x).is_dir() for x in out]
         assert not any(has_dirs)
 
     def test_include_directories(self, simple_dir):
         """Ensure we can get directories back."""
-        out = list(iter_filesystem(simple_dir, include_directories=True))
+        out = list(_iter_filesystem(simple_dir, include_directories=True))
         returned_dirs = [Path(x) for x in out if Path(x).is_dir()]
         assert len(returned_dirs)
         # The top level directory should have been included
@@ -179,7 +179,7 @@ class TestIterFS:
     def test_skip_signal_directory(self, simple_dir):
         """Ensure a skip signal can be sent to stop parsing on directory."""
         out = []
-        iterator = iter_filesystem(simple_dir, include_directories=True)
+        iterator = _iter_filesystem(simple_dir, include_directories=True)
         for path in iterator:
             if Path(path).name == "B":
                 iterator.send("skip")

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -165,6 +165,11 @@ class TestFilterDfAdvanced:
         out2 = filter_df(example_df_2, time=(None, str(tmax)))
         assert len(out2) == len(example_df_2)
 
+    def test_empty_filter(self, example_df_2):
+        """Empty filter kwargs, for convenience, should be ok."""
+        out = filter_df(example_df_2, time=None)
+        assert np.all(out)
+
 
 class TestAdjustSegments:
     """Tests for adjusting segments of dataframes."""

--- a/tests/test_utils/test_xml_utils.py
+++ b/tests/test_utils/test_xml_utils.py
@@ -2,12 +2,11 @@
 Tests for xml utilities.
 """
 
-import pytest
 from dascore.utils.xml import xml_to_dict
 
 
-
 class TestXMLtoDict:
+    """Tests for converting XML to dictionaries."""
 
     def test_single_element(self):
         """Test conversion of XML with a single element."""
@@ -17,23 +16,23 @@ class TestXMLtoDict:
     def test_multiple_elements(self):
         """Test conversion of XML with multiple elements."""
         xml_string = "<root><a>1</a><b>2</b></root>"
-        expected_dict = {'a': '1', 'b': '2'}
+        expected_dict = {"a": "1", "b": "2"}
         assert xml_to_dict(xml_string) == expected_dict
 
     def test_nested_elements(self):
         """Test conversion of XML with nested elements."""
         xml_string = "<root><a><b>1</b></a></root>"
-        expected_dict = {'a': {'b': '1'}}
+        expected_dict = {"a": {"b": "1"}}
         assert xml_to_dict(xml_string) == expected_dict
 
     def test_multiple_nested_elements(self):
         """Test conversion of XML with multiple nested elements."""
         xml_string = "<root><a><b>1</b></a><c><d>2</d></c></root>"
-        expected_dict = {'a': {'b': '1'}, 'c': {'d': '2'}}
+        expected_dict = {"a": {"b": "1"}, "c": {"d": "2"}}
         assert xml_to_dict(xml_string) == expected_dict
 
     def test_repeated_elements(self):
         """Test conversion of XML with repeated elements."""
         xml_string = "<root><a>1</a><a>2</a></root>"
-        expected_dict = {'a': ['1', '2']}
+        expected_dict = {"a": ["1", "2"]}
         assert xml_to_dict(xml_string) == expected_dict

--- a/tests/test_utils/test_xml_utils.py
+++ b/tests/test_utils/test_xml_utils.py
@@ -31,8 +31,14 @@ class TestXMLtoDict:
         expected_dict = {"a": {"b": "1"}, "c": {"d": "2"}}
         assert xml_to_dict(xml_string) == expected_dict
 
-    def test_repeated_elements(self):
+    def test_elements_repeated_twice(self):
         """Test conversion of XML with repeated elements."""
         xml_string = "<root><a>1</a><a>2</a></root>"
         expected_dict = {"a": ["1", "2"]}
+        assert xml_to_dict(xml_string) == expected_dict
+
+    def test_repeated_elements(self):
+        """Test conversion of XML with repeated elements."""
+        xml_string = "<root><a>1</a><a>2</a><a>3</a></root>"
+        expected_dict = {"a": ["1", "2", "3"]}
         assert xml_to_dict(xml_string) == expected_dict

--- a/tests/test_utils/test_xml_utils.py
+++ b/tests/test_utils/test_xml_utils.py
@@ -1,0 +1,39 @@
+"""
+Tests for xml utilities.
+"""
+
+import pytest
+from dascore.utils.xml import xml_to_dict
+
+
+
+class TestXMLtoDict:
+
+    def test_single_element(self):
+        """Test conversion of XML with a single element."""
+        xml_string = "<root>Hello</root>"
+        assert xml_to_dict(xml_string) == "Hello"
+
+    def test_multiple_elements(self):
+        """Test conversion of XML with multiple elements."""
+        xml_string = "<root><a>1</a><b>2</b></root>"
+        expected_dict = {'a': '1', 'b': '2'}
+        assert xml_to_dict(xml_string) == expected_dict
+
+    def test_nested_elements(self):
+        """Test conversion of XML with nested elements."""
+        xml_string = "<root><a><b>1</b></a></root>"
+        expected_dict = {'a': {'b': '1'}}
+        assert xml_to_dict(xml_string) == expected_dict
+
+    def test_multiple_nested_elements(self):
+        """Test conversion of XML with multiple nested elements."""
+        xml_string = "<root><a><b>1</b></a><c><d>2</d></c></root>"
+        expected_dict = {'a': {'b': '1'}, 'c': {'d': '2'}}
+        assert xml_to_dict(xml_string) == expected_dict
+
+    def test_repeated_elements(self):
+        """Test conversion of XML with repeated elements."""
+        xml_string = "<root><a>1</a><a>2</a></root>"
+        expected_dict = {'a': ['1', '2']}
+        assert xml_to_dict(xml_string) == expected_dict


### PR DESCRIPTION
## Description

This PR reworks some of the DASCore discovery internals so that `FiberIO` can now work on directories and implements a directory spool format called `XML_Binary`. `XML_Binary` stores a single xml file at the top of a directory with metadata and the rest of the files are simple binary files. 

TODO:

- [ ] Run profile tests to determine how much this slows down normal indexing and patch retrieval
- [x] @ahmadtourei to test on his datasets which use this format
- [ ] Update contributing docs to mention directory `FiberIO`. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.



