### PR TITLE
fixing doc building error on mac

### DIFF
--- a/scripts/_render_api.py
+++ b/scripts/_render_api.py
@@ -362,6 +362,9 @@ def to_quarto_code(code_lines):
         for line in code_lines:
             if line.startswith(option_chars):
                 options.append(line)
+            # Strip out the python code specifier.
+            elif line.startswith("```{"):
+                continue
             else:
                 code_segments.append(line)
         return code_segments, options
@@ -535,6 +538,7 @@ def write_api_markdown(data_dict, api_path, address_dict, debug=False):
         # get path and ensure parents exist
         sub_dir = api_path / "/".join(data["key"].split(".")[:-1])
         path = api_path / sub_dir / f"{data['name']}.qmd"
+
         path.parent.mkdir(exist_ok=True, parents=True)
         # remove path from files to delete
         if path in files_to_delete:


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

Fixing an error when running quarto preview docs on mac.

<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
