### PR TITLE
numpy 2.0 prep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     # Ruff is a replacement for flake8 and many other linters (much faster too)
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.8
+    rev: v0.4.8
     hooks:
     -   id: ruff
         args: ["--fix"]

--- a/benchmarks/generic_io_benchmarks.py
+++ b/benchmarks/generic_io_benchmarks.py
@@ -1,4 +1,5 @@
 """Benchmark for generic memory spool operations."""
+
 from __future__ import annotations
 
 from functools import cache

--- a/benchmarks/memory_spool_benchmarks.py
+++ b/benchmarks/memory_spool_benchmarks.py
@@ -1,4 +1,5 @@
 """Benchmark for generic memory spool operations."""
+
 from __future__ import annotations
 
 import dascore as dc

--- a/benchmarks/patch_benchmarks.py
+++ b/benchmarks/patch_benchmarks.py
@@ -1,4 +1,5 @@
 """Benchmarks for patch functions."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -3,6 +3,7 @@ A spool for working with file systems.
 
 The spool uses a simple hdf5 index for keeping track of files.
 """
+
 from __future__ import annotations
 
 import copy

--- a/dascore/clients/filespool.py
+++ b/dascore/clients/filespool.py
@@ -1,4 +1,5 @@
 """A spool for working with a single file."""
+
 from __future__ import annotations
 
 import copy

--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -4,15 +4,19 @@ Compatibility module for DASCore.
 All components/functions that may be exchanged for other numpy/scipy
 compatible libraries should go in this model.
 """
+
 from __future__ import annotations
 
 from contextlib import suppress
 
 import numpy as np
 from numpy import floor, interp  # NOQA
+from numpy.random import RandomState
 from scipy.interpolate import interp1d  # NOQA
 from scipy.ndimage import zoom  # NOQA
 from scipy.signal import decimate, resample, resample_poly  # NOQA
+
+random_state = RandomState(42)
 
 
 class DataArray:

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -1,4 +1,5 @@
 """Constants used throughout obsplus."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -1,4 +1,5 @@
 """Pydantic schemas used by DASCore."""
+
 from __future__ import annotations
 
 import warnings
@@ -281,5 +282,5 @@ class PatchAttrs(DascoreBaseModel):
                 if is_time:
                     out[step_name] = np.timedelta64("NaT")
                 elif isinstance(start, float | np.floating):
-                    out[step_name] = np.NaN
+                    out[step_name] = np.nan
         return out

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -38,6 +38,7 @@ print(f"New data shape: {new_data.shape}")
 print(new_cm)
 ```
 """
+
 from __future__ import annotations
 
 import warnings

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1,4 +1,5 @@
 """Machinery for coordinates."""
+
 from __future__ import annotations
 
 import abc
@@ -72,7 +73,7 @@ def ensure_consistent_dtype(value, name, dtype):
         value = dc.to_timedelta64(value)
     # convert numpy numerics back to python
     elif np.issubdtype(dtype, np.floating):
-        value = float(value) if value is not None else np.NaN
+        value = float(value) if value is not None else np.nan
     elif np.issubdtype(dtype, np.integer):
         value = int(value)
     return value

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -1,4 +1,5 @@
 """A 2D trace object."""
+
 from __future__ import annotations
 
 import warnings

--- a/dascore/core/schema.py
+++ b/dascore/core/schema.py
@@ -1,4 +1,5 @@
 """A deprecated module."""
+
 from __future__ import annotations
 
 import warnings

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -1,4 +1,5 @@
 """Module for spools, containers of patches."""
+
 from __future__ import annotations
 
 import abc

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -1,4 +1,5 @@
 """A module for loading examples."""
+
 from __future__ import annotations
 
 import tempfile
@@ -11,6 +12,7 @@ import pandas as pd
 
 import dascore as dc
 import dascore.core
+from dascore.compat import random_state
 from dascore.exceptions import UnknownExampleError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.downloader import fetch
@@ -120,10 +122,10 @@ def patch_with_null(**kwargs):
     """
     patch = random_patch(**kwargs)
     data = np.array(patch.data)
-    data[data > 0.9] = np.NaN
+    data[data > 0.9] = np.nan
     # also set the first row and column to NaN
-    data[:, 0] = np.NaN
-    data[0, :] = np.NaN
+    data[:, 0] = np.nan
+    data[0, :] = np.nan
     return patch.new(data=data)
 
 
@@ -153,9 +155,9 @@ def wacky_dim_coord_patch():
     """
     shape = (100, 1_000)
     # distance is neither monotonic nor evenly sampled.
-    dist_ar = np.random.random(100) + np.arange(100) * 0.3
+    dist_ar = random_state.random(100) + np.arange(100) * 0.3
     # time is monotonic, not evenly sampled.
-    time_ar = dc.to_datetime64(np.cumsum(np.random.random(1_000)))
+    time_ar = dc.to_datetime64(np.cumsum(random_state.random(1_000)))
     patch = random_patch(shape=shape, dist_array=dist_ar, time_array=time_ar)
     # check attrs
     attrs = patch.attrs

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -1,4 +1,5 @@
 """Custom dascore exceptions."""
+
 from __future__ import annotations
 
 

--- a/dascore/io/ap_sensing/core.py
+++ b/dascore/io/ap_sensing/core.py
@@ -1,6 +1,7 @@
 """
 Core modules for AP sensing support.
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -16,8 +17,8 @@ from .utils import _get_attrs_dict, _get_patch, _get_version_string
 class APSensingPatchAttrs(dc.PatchAttrs):
     """Patch Attributes for AP sensing."""
 
-    gauge_length: float = np.NaN
-    radians_to_nano_strain: float = np.NaN
+    gauge_length: float = np.nan
+    radians_to_nano_strain: float = np.nan
 
 
 class APSensingV10(FiberIO):

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -2,6 +2,7 @@
 Base functionality for reading, writing, determining file formats, and scanning
 Das Data.
 """
+
 from __future__ import annotations
 
 import inspect

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -1,4 +1,5 @@
 """Core module for reading and writing DASDAE format."""
+
 from __future__ import annotations
 
 import contextlib

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -1,4 +1,5 @@
 """DASDAE format utilities."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -1,4 +1,5 @@
 """IO module for reading prodML data."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -17,7 +18,7 @@ class ProdMLPatchAttrs(dc.PatchAttrs):
 
     pulse_width: float = np.NAN
     pulse_width_units: UnitQuantity | None = None
-    gauge_length: float = np.NaN
+    gauge_length: float = np.nan
     gauge_length_units: UnitQuantity | None = None
     schema_version: UTF8Str = ""
 

--- a/dascore/io/dashdf5/utils.py
+++ b/dascore/io/dashdf5/utils.py
@@ -1,4 +1,5 @@
 """Utilities for terra15."""
+
 from __future__ import annotations
 
 import dascore as dc

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -1,6 +1,7 @@
 """
 IO module for reading Febus data.
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -30,9 +31,9 @@ class FebusPatchAttrs(dc.PatchAttrs):
         The zone designations
     """
 
-    gauge_length: float = np.NaN
+    gauge_length: float = np.nan
     gauge_length_units: str = "m"
-    pulse_width: float = np.NaN
+    pulse_width: float = np.nan
     pulse_width_units: str = "m"
 
     group: str = ""

--- a/dascore/io/febus/utils.py
+++ b/dascore/io/febus/utils.py
@@ -1,4 +1,5 @@
 """Utilities for Febus."""
+
 from __future__ import annotations
 
 from collections import namedtuple

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -1,4 +1,5 @@
 """IO module for reading simple h5 data."""
+
 from __future__ import annotations
 
 import dascore as dc

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -1,4 +1,5 @@
 """Utilities for terra15."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -1,4 +1,5 @@
 """An HDF5-based indexer for local file systems."""
+
 from __future__ import annotations
 
 import abc

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -1,4 +1,5 @@
 """IO module for reading OptoDAS data."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -15,7 +16,7 @@ from .utils import _get_opto_das_attrs, _get_opto_das_version_str, _read_opto_da
 class OptoDASPatchAttrs(dc.PatchAttrs):
     """Patch attrs for OptoDAS."""
 
-    gauge_length: float = np.NaN
+    gauge_length: float = np.nan
     gauge_length_units: UnitQuantity | None = None
     schema_version: UTF8Str = ""
 

--- a/dascore/io/optodas/utils.py
+++ b/dascore/io/optodas/utils.py
@@ -1,4 +1,5 @@
 """Utilities for OptoDAS."""
+
 from __future__ import annotations
 
 import dascore as dc

--- a/dascore/io/pickle/core.py
+++ b/dascore/io/pickle/core.py
@@ -1,4 +1,5 @@
 """Core module for reading and writing pickle format."""
+
 from __future__ import annotations
 
 import pickle

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -1,4 +1,5 @@
 """IO module for reading prodML data."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -17,7 +18,7 @@ class ProdMLPatchAttrs(dc.PatchAttrs):
 
     pulse_width: float = np.NAN
     pulse_width_units: UnitQuantity | None = None
-    gauge_length: float = np.NaN
+    gauge_length: float = np.nan
     gauge_length_units: UnitQuantity | None = None
     schema_version: UTF8Str = ""
 

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -1,4 +1,5 @@
 """Utilities for prodML."""
+
 from __future__ import annotations
 
 import dascore as dc

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -1,4 +1,5 @@
 """IO module for reading SEGY file format support."""
+
 from __future__ import annotations
 
 import segyio

--- a/dascore/io/sentek/core.py
+++ b/dascore/io/sentek/core.py
@@ -1,4 +1,5 @@
 """IO module for reading Sentek's DAS data format."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -1,4 +1,5 @@
 """IO module for reading Silixa's TDMS DAS data format."""
+
 from __future__ import annotations
 
 import dascore as dc

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -1,4 +1,5 @@
 """Utilities for TDMS format."""
+
 from __future__ import annotations
 
 import datetime

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -1,4 +1,5 @@
 """IO module for reading Terra15 DAS data."""
+
 from __future__ import annotations
 
 import dascore as dc

--- a/dascore/io/terra15/utils.py
+++ b/dascore/io/terra15/utils.py
@@ -1,4 +1,5 @@
 """Utilities for terra15."""
+
 from __future__ import annotations
 
 import dascore as dc

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -1,4 +1,5 @@
 """Core module for wave format."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -1,4 +1,5 @@
 """IO module for reading binary raw format DAS data."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -18,7 +19,7 @@ class BinaryPatchAttrs(dc.PatchAttrs):
     """Patch attrs for Binary."""
 
     pulse_width_ns: float = np.NAN
-    gauge_length: float = np.NaN
+    gauge_length: float = np.nan
     instrument_id: UTF8Str = ""
     distance_units: UTF8Str = ""
     zone_name: UTF8Str = ""

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -1,4 +1,5 @@
 """Utilities for Binary."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -1,4 +1,5 @@
 """Module for applying aggregations along a specified axis."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -1,4 +1,5 @@
 """Basic operations for patches."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -1,4 +1,5 @@
 """Processing operations that have much to do with coordinates."""
+
 from __future__ import annotations
 
 from collections.abc import Collection, Sequence

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -1,4 +1,5 @@
 """Module for calculating cross-correlation over time or distance."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/dascore/proc/detrend.py
+++ b/dascore/proc/detrend.py
@@ -1,4 +1,5 @@
 """Module for detrending."""
+
 from __future__ import annotations
 
 from scipy.signal import detrend as scipy_detrend

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -4,6 +4,7 @@ dascore Filtering module.
 Much of this code was inspired by ObsPy's filtering module created by:
 Tobias Megies, Moritz Beyreuther, Yannik Behr
 """
+
 from __future__ import annotations
 
 import pandas as pd

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -1,4 +1,5 @@
 """Module for re-sampling patches."""
+
 from __future__ import annotations
 
 from typing import Literal

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -1,4 +1,5 @@
 """Processing for applying roller operations."""
+
 from __future__ import annotations
 
 from typing import Any, Literal
@@ -75,7 +76,7 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         num_nans = 1 + (self.window - 2) // self.step
         pad_width = [(0, 0)] * len(data.shape)
         pad_width[self.axis] = (num_nans, 0)
-        padded = np.pad(data, pad_width, constant_values=np.NaN)
+        padded = np.pad(data, pad_width, constant_values=np.nan)
         if self.step == 1:
             assert padded.shape == self.patch.data.shape
         if self.center:
@@ -109,7 +110,7 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         # apply function, then pad with zeros and roll
         kwargs = self.func_kwargs
         trimmed_slide_view = slide_view[tuple(step_slice)]
-        raw = function(trimmed_slide_view, axis=-1, **kwargs).astype(np.float_)
+        raw = function(trimmed_slide_view, axis=-1, **kwargs).astype(np.float64)
         out = self._pad_roll_array(raw)
         new_coords = self.get_coords()
         attrs = self._get_attrs_with_apply_history(function)

--- a/dascore/proc/taper.py
+++ b/dascore/proc/taper.py
@@ -1,4 +1,5 @@
 """Processing for applying a taper."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/dascore/proc/units.py
+++ b/dascore/proc/units.py
@@ -1,4 +1,5 @@
 """Processing functions dealing with units and unit conversions."""
+
 from __future__ import annotations
 
 import dascore as dc

--- a/dascore/proc/whiten.py
+++ b/dascore/proc/whiten.py
@@ -1,4 +1,5 @@
 """Spectral whitening."""
+
 from __future__ import annotations
 
 import math

--- a/dascore/transform/differentiate.py
+++ b/dascore/transform/differentiate.py
@@ -1,4 +1,5 @@
 """Module for performing differentiation on patches."""
+
 from __future__ import annotations
 
 from operator import truediv

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -1,4 +1,5 @@
 """Dispersion computation using the phase-shift (Park et al., 1999) method."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/dascore/transform/fft.py
+++ b/dascore/transform/fft.py
@@ -2,6 +2,7 @@
 Deprecated module for Fourier transforms. Use
 [fourier](`dascore.transform.fourier`) instead.
 """
+
 from __future__ import annotations
 
 import warnings

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -4,6 +4,7 @@ Module for Fourier transforms.
 See the [FFT note](/notes/dft_notes.qmd) for discussion on the
 implementation.
 """
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -1,4 +1,5 @@
 """Module for performing integration on patches."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/dascore/transform/spectro.py
+++ b/dascore/transform/spectro.py
@@ -1,4 +1,5 @@
 """Module to transform a Patch into spectrograms."""
+
 from __future__ import annotations
 
 from operator import mul

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -1,4 +1,5 @@
 """Transformations to strain rates."""
+
 from __future__ import annotations
 
 from dascore.constants import PatchType

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -1,4 +1,5 @@
 """Module for handling units."""
+
 from __future__ import annotations
 
 from functools import cache

--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -1,6 +1,7 @@
 """
 Utils for working with attributes.
 """
+
 from __future__ import annotations
 
 import warnings

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -1,4 +1,5 @@
 """Utilities for chunking dataframes."""
+
 from __future__ import annotations
 
 from collections.abc import Collection

--- a/dascore/utils/coordmanager.py
+++ b/dascore/utils/coordmanager.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from _operator import and_, or_
 from collections.abc import Sequence
 from functools import reduce
 
 import numpy as np
-from _operator import and_, or_
 
 import dascore as dc
 from dascore.exceptions import CoordMergeError

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -1,4 +1,5 @@
 """Utils for displaying dascore objects."""
+
 from __future__ import annotations
 
 import textwrap
@@ -35,7 +36,7 @@ def get_nice_text(value, style=None) -> Text:
 
 
 @get_nice_text.register(float)
-@get_nice_text.register(np.float_)
+@get_nice_text.register(np.float64)
 def _nice_float_string(value, style=None):
     """Nice print value for floats."""
     fmt_str = f".{FLOAT_PRECISION}"

--- a/dascore/utils/docs.py
+++ b/dascore/utils/docs.py
@@ -1,4 +1,5 @@
 """Utilities for documentation."""
+
 from __future__ import annotations
 
 import inspect
@@ -79,7 +80,7 @@ def compose_docstring(**kwargs: str | Sequence[str]):
             value = value if isinstance(value, str) else "\n".join(value)
             # strip out first line if needed
             value = textwrap.dedent(value).lstrip()
-            search_value = "{%s}" % key
+            search_value = f"{{{key}}}"
             # find all lines that match values
             lines = [x for x in docstring.split("\n") if search_value in x]
             for line in lines:

--- a/dascore/utils/downloader.py
+++ b/dascore/utils/downloader.py
@@ -1,4 +1,5 @@
 """Simple script for downloading external files."""
+
 from __future__ import annotations
 
 from functools import cache

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -4,6 +4,7 @@ Utilities for working with HDF5 files.
 Pytables should only be imported in this module in case we need to switch
 out the hdf5 backend in the future.
 """
+
 from __future__ import annotations
 
 import time

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -1,4 +1,5 @@
 """Utilities for basic IO tasks."""
+
 from __future__ import annotations
 
 import io

--- a/dascore/utils/mapping.py
+++ b/dascore/utils/mapping.py
@@ -3,6 +3,7 @@ A few mappings that might be useful.
 
 We can't simply use types.MappingProxyType because it can't be pickled.
 """
+
 from __future__ import annotations
 
 from collections.abc import Mapping as ABCMap

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -1,4 +1,5 @@
 """Misc Utilities."""
+
 from __future__ import annotations
 
 import contextlib

--- a/dascore/utils/models.py
+++ b/dascore/utils/models.py
@@ -1,4 +1,5 @@
 """Utilities for models."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -1,4 +1,5 @@
 """Utilities for working with the Patch class."""
+
 from __future__ import annotations
 
 import functools

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -1,4 +1,5 @@
 """Pandas utilities."""
+
 from __future__ import annotations
 
 import fnmatch

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -1,4 +1,5 @@
 """Utilities for plotting with matplotlib."""
+
 from __future__ import annotations
 
 import matplotlib.dates as mdates

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -1,4 +1,5 @@
 """Simple interface for progress markers."""
+
 from __future__ import annotations
 
 from collections.abc import Generator, Sized

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -1,4 +1,5 @@
 """Utility for working with time."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -304,7 +305,7 @@ def _time_to_int(datetime):
 @to_int.register(type(pd.NA))
 def _return_number_null(null):
     """Convert non to NaT."""
-    return np.NaN
+    return np.nan
 
 
 @to_int.register(np.timedelta64)
@@ -364,7 +365,7 @@ def _time_to_float(datetime):
 @to_float.register(type(pd.NA))
 def _return_null(null):
     """Convert non to NaT."""
-    return np.NaN
+    return np.nan
 
 
 @to_float.register(np.timedelta64)

--- a/dascore/utils/transformatter.py
+++ b/dascore/utils/transformatter.py
@@ -1,4 +1,5 @@
 """Implements logic to apply formatting changes to patches from transformations."""
+
 from __future__ import annotations
 
 import abc

--- a/dascore/utils/xml.py
+++ b/dascore/utils/xml.py
@@ -1,6 +1,7 @@
 """
 Utilities for working with xml files.
 """
+
 from xml.etree import ElementTree
 
 

--- a/dascore/version.py
+++ b/dascore/version.py
@@ -1,4 +1,5 @@
 """Module for reporting the version of dascore."""
+
 from __future__ import annotations
 
 from contextlib import suppress

--- a/dascore/viz/map_fiber.py
+++ b/dascore/viz/map_fiber.py
@@ -1,4 +1,5 @@
 """Module for waterfall plotting."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -1,4 +1,5 @@
 """A spectrogram visualization."""
+
 from __future__ import annotations
 
 import matplotlib.colors as colors

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -1,4 +1,5 @@
 """Module for waterfall plotting."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -1,4 +1,5 @@
 """Module for wiggle plotting."""
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/docs/filters/fill_links.py
+++ b/docs/filters/fill_links.py
@@ -4,6 +4,7 @@ Custom filter that makes dynamic (sphinx-esc) cross links work.
 Replaces markdown such as [Patch](`dascore.Patch`) with the path to the markdown
 file created from dascore/scripts/build_api_docs.py.
 """
+
 from __future__ import annotations
 
 import io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = ["geophysics", "distributed-acoustic-sensing"]
 dependencies = [
      "h5py",
      "matplotlib>=3.5",
-     "numpy>=1.24",
+     "numpy>=1.24, <2",
      "packaging",
      "pandas>=2.0",
      "pooch>=1.2",
@@ -128,7 +128,19 @@ XMLBINARY__V1 = "dascore.io.xml_binary.core:XMLBinaryV1"
 line-length = 88
 
 # enable certain types of linting
-select = ["E", "F", "UP", "RUF", "I001", "D", "FA", "T", "N"]
+lint.select = [
+    "E",
+    "F",
+    "UP",
+    "RUF",
+    "I001",
+    "D",
+    "FA",
+    "T",
+    "N",
+    "NPY",
+    "NPY201",
+]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -159,17 +171,17 @@ exclude = [
 # lowest python version supported
 target-version = "py310"
 
-fixable = ["ALL"]
+lint.fixable = ["ALL"]
 
 # List of codes to ignore
-ignore = ["D105", "D107", "D401", "D205", "D200", "D400"]
+lint.ignore = ["D105", "D107", "D401", "D205", "D200", "D400"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 
 # config for docstring parsing
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.pytest.ini_options]

--- a/scripts/_benchmark_uilts.py
+++ b/scripts/_benchmark_uilts.py
@@ -1,4 +1,5 @@
 """Utils for running benchmarks."""
+
 from __future__ import annotations
 
 import os

--- a/scripts/_index_api.py
+++ b/scripts/_index_api.py
@@ -1,4 +1,5 @@
 """A script to create an index of the structure of the DASCore package."""
+
 from __future__ import annotations
 
 import inspect

--- a/scripts/_qmd_builder.py
+++ b/scripts/_qmd_builder.py
@@ -1,4 +1,5 @@
 """A script to build quartos main config file."""
+
 from __future__ import annotations
 
 import os

--- a/scripts/_render_api.py
+++ b/scripts/_render_api.py
@@ -1,4 +1,5 @@
 """Create the html tables for parameters and such from dataframes."""
+
 from __future__ import annotations
 
 import hashlib

--- a/scripts/_validate_links.py
+++ b/scripts/_validate_links.py
@@ -1,4 +1,5 @@
 """Script to validate links in qmd files."""
+
 from __future__ import annotations
 
 import json

--- a/scripts/build_api_docs.py
+++ b/scripts/build_api_docs.py
@@ -1,4 +1,5 @@
 """Script to build the API docs for dascore."""
+
 from __future__ import annotations
 
 from _index_api import get_alias_mapping, parse_project

--- a/scripts/find_futures.py
+++ b/scripts/find_futures.py
@@ -1,4 +1,5 @@
 """Find all python files which dont have "from __future__ import annotation"."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/scripts/paper/make_viz_figure.py
+++ b/scripts/paper/make_viz_figure.py
@@ -1,4 +1,5 @@
 """A script to make the vizualization figure of the DASCore paper."""
+
 import matplotlib.pyplot as plt
 
 import dascore as dc

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -12,6 +12,7 @@ A few notes:
     support projects without setup.py files, so this is a bit of a hack
     until that gets fixed.
 """
+
 from __future__ import annotations
 
 from _benchmark_uilts import (

--- a/scripts/test_render_api.py
+++ b/scripts/test_render_api.py
@@ -1,4 +1,5 @@
 """Tests for rendering api stuff."""
+
 from __future__ import annotations
 
 import pytest

--- a/scripts/visualize_benchmarks.py
+++ b/scripts/visualize_benchmarks.py
@@ -1,4 +1,5 @@
 """Load the benchmark files and create simple table."""
+
 from __future__ import annotations
 
 from _benchmark_uilts import REFERENCE_BRANCH, compare_asv, console, git_hash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """pytest configuration for dascore."""
+
 from __future__ import annotations
 
 import os
@@ -16,6 +17,7 @@ import tables.parameters
 import dascore as dc
 import dascore.examples as ex
 from dascore.clients.dirspool import DirectorySpool
+from dascore.compat import random_state
 from dascore.constants import SpoolType
 from dascore.core import Patch
 from dascore.examples import get_example_patch
@@ -130,7 +132,7 @@ def cm_multidim() -> dc.CoordManager:
         "time": dc.to_datetime64(np.arange(10, 110, 10)),
         "distance": dc.get_coord(data=np.arange(0, 1000, 10)),
         "quality": (("time", "distance"), np.ones((10, 100))),
-        "latitude": ("distance", np.random.rand(100)),
+        "latitude": ("distance", random_state.rand(100)),
     }
     dims = ("time", "distance")
 
@@ -312,9 +314,9 @@ def random_patch_many_coords(random_patch):
     """Get a random patch with many different coordinates."""
     shapes = random_patch.coord_shapes
     patch = random_patch.update_coords(
-        lat=("distance", np.random.random(shapes["distance"])),
-        time2=("time", np.random.random(shapes["time"])),
-        quality=(random_patch.dims, np.random.random(random_patch.shape)),
+        lat=("distance", random_state.random(shapes["distance"])),
+        time2=("time", random_state.random(shapes["time"])),
+        quality=(random_patch.dims, random_state.random(random_patch.shape)),
     )
     return patch
 
@@ -581,7 +583,7 @@ def generic_hdf5(tmp_path_factory):
 
     with tb.open_file(str(path), "w") as fi:
         group = fi.create_group("/", "bob")
-        fi.create_carray(group, "data", obj=np.random.rand(10))
+        fi.create_carray(group, "data", obj=random_state.rand(10))
     return path
 
 

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -1,4 +1,5 @@
 """Tests for FileSpool."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/test_clients/test_filespool.py
+++ b/tests/test_clients/test_filespool.py
@@ -1,4 +1,5 @@
 """Tests for the file spool."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_core/test_attrs.py
+++ b/tests/test_core/test_attrs.py
@@ -1,4 +1,5 @@
 """Tests for Patch attrs modules."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -1,4 +1,5 @@
 """Tests for coordinate manager."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -8,6 +9,7 @@ from rich.text import Text
 
 import dascore as dc
 from dascore import to_datetime64
+from dascore.compat import random_state
 from dascore.core.coordmanager import (
     CoordManager,
     get_coord_manager,
@@ -240,7 +242,7 @@ class TestCoordManagerInputs:
     def test_additional_coords(self):
         """Ensure a additional (non-dimensional) coords work."""
         coords = dict(COORDS)
-        lats = np.random.rand(len(COORDS["distance"]))
+        lats = random_state.rand(len(COORDS["distance"]))
         coords["latitude"] = ("distance", lats)
         out = get_coord_manager(coords, DIMS)
         assert isinstance(out.coord_map["latitude"], BaseCoord)

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1,4 +1,5 @@
 """Tests for coordinate object."""
+
 from __future__ import annotations
 
 import pickle
@@ -13,6 +14,7 @@ import rich.text
 from pydantic import ValidationError
 
 import dascore as dc
+from dascore.compat import random_state
 from dascore.core.coords import (
     BaseCoord,
     CoordMonotonicArray,
@@ -81,7 +83,7 @@ def evenly_sampled_time_delta_coord():
 @register_func(COORDS)
 def monotonic_float_coord():
     """Create coordinates which are not evenly sampled."""
-    ar = np.cumsum(np.abs(np.random.rand(100)))
+    ar = np.cumsum(np.abs(random_state.rand(100)))
     return get_coord(data=ar)
 
 
@@ -89,7 +91,7 @@ def monotonic_float_coord():
 @register_func(COORDS)
 def reverse_monotonic_float_coord():
     """Create coordinates which are evenly sampled."""
-    ar = np.cumsum(np.abs(np.random.rand(100)))[::-1]
+    ar = np.cumsum(np.abs(random_state.rand(100)))[::-1]
     return get_coord(data=ar)
 
 
@@ -97,7 +99,7 @@ def reverse_monotonic_float_coord():
 @register_func(COORDS)
 def monotonic_datetime_coord():
     """Create coordinates which are evenly sampled."""
-    ar = np.cumsum(np.abs(np.random.rand(100) * 1_000))
+    ar = np.cumsum(np.abs(random_state.rand(100) * 1_000))
     return get_coord(data=dc.to_datetime64(ar))
 
 
@@ -105,7 +107,7 @@ def monotonic_datetime_coord():
 @register_func(COORDS)
 def reverse_monotonic_datetime_coord():
     """Create coordinates which are evenly sampled."""
-    ar = -np.cumsum(np.abs(np.random.rand(100) * 1_000))
+    ar = -np.cumsum(np.abs(random_state.rand(100) * 1_000))
     return get_coord(data=dc.to_datetime64(ar))
 
 
@@ -113,7 +115,7 @@ def reverse_monotonic_datetime_coord():
 @register_func(COORDS)
 def random_coord():
     """Create coordinates which are evenly sampled."""
-    ar = np.random.rand(100) * 1_000
+    ar = random_state.rand(100) * 1_000
     return get_coord(data=ar)
 
 
@@ -121,7 +123,7 @@ def random_coord():
 @register_func(COORDS)
 def random_date_coord():
     """Create coordinates which are evenly sampled."""
-    ar = np.random.rand(100) * 1_000
+    ar = random_state.rand(100) * 1_000
     return get_coord(data=dc.to_datetime64(ar))
 
 
@@ -502,7 +504,7 @@ class TestSelect:
         assert (new_max <= args[1]) or np.isclose(new_max, args[1])
         # There can often be a bit of "slop" in float indices. We may
         # need to rethink this but this is good enough for now.
-        if not np.issubdtype(new.dtype, np.float_):
+        if not np.issubdtype(new.dtype, np.float64):
             assert {values[3], values[-3]}.issubset(value_set)
 
     def test_select_bounds(self, long_coord):
@@ -516,7 +518,7 @@ class TestSelect:
         new_min, new_max = np.min(new_values), np.max(new_values)
         assert (new_min >= val1) or np.isclose(new_min, val1)
         assert (new_max <= val2) or np.isclose(new_max, val2)
-        if not np.issubdtype(new.dtype, np.float_):
+        if not np.issubdtype(new.dtype, np.float64):
             assert set(values).issuperset(set(new.values))
 
     def test_select_out_of_bounds_too_early(self, coord):
@@ -670,7 +672,7 @@ class TestSelect:
     def test_values_not_in_coord(self, long_coord):
         """Ensure using values not in coord results in an empty coordinate."""
         values1 = long_coord.values[: len(long_coord) // 2]
-        rand = np.random.rand(len(values1))
+        rand = random_state.rand(len(values1))
         # try to make values that won't be in the coordinate.
         values2 = long_coord._get_compatible_value(-to_float(values1) + rand)
         # if by some chance there are any overlaps just bail out.
@@ -786,7 +788,7 @@ class TestOrder:
     def test_values_no_in_coord(self, long_coord):
         """Ensure using values not in coord results in an empty coordinate."""
         values1 = long_coord.values[: len(long_coord) // 2]
-        rand = np.random.rand(len(values1))
+        rand = random_state.rand(len(values1))
         # try to make values that won't be in the coordinate.
         values2 = long_coord._get_compatible_value(-to_float(values1) + rand)
         # if by some chance there are any overlaps just bail out.
@@ -1166,7 +1168,7 @@ class TestMonotonicCoord:
 
     def test_reverse_monotonic(self):
         """Ensure reverse monotonic values can be handled."""
-        ar = np.cumsum(np.abs(np.random.rand(100)))[::-1]
+        ar = np.cumsum(np.abs(random_state.rand(100)))[::-1]
         coord = get_coord(data=ar)
         assert np.allclose(coord.values, ar)
         new, sliced = coord.select((ar[10], ar[20]))
@@ -1465,7 +1467,7 @@ class TestPartialCoord:
     def test_uptype_with_data(self):
         """Ensure adding a data array converts to Coord Array."""
         coord = get_coord(shape=10)
-        data = np.random.rand(10)
+        data = random_state.rand(10)
         out = coord.update(data=data)
         assert np.all(out.data == data)
 

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -1,4 +1,5 @@
 """Tests for Trace2D object."""
+
 from __future__ import annotations
 
 import operator
@@ -10,6 +11,7 @@ import pytest
 from rich.text import Text
 
 import dascore as dc
+from dascore.compat import random_state
 from dascore.core import Patch
 from dascore.core.coords import BaseCoord, CoordRange
 from dascore.exceptions import CoordError
@@ -26,7 +28,7 @@ def get_simple_patch() -> Patch:
     """
     attrs = {"time_step": 1}
     pa = Patch(
-        data=np.random.random((100, 100)),
+        data=random_state.random((100, 100)),
         coords={"time": np.arange(100) * 0.01, "distance": np.arange(100) * 0.2},
         attrs=attrs,
         dims=("time", "distance"),
@@ -75,7 +77,7 @@ class TestInit:
     @pytest.fixture(scope="class")
     def test_conflicting_attrs_coords_raises(self):
         """Patch for testing conflicting coordinates/attributes."""
-        array = np.random.random((10, 10))
+        array = random_state.random((10, 10))
         # create attrs, these should all get overwritten by coords.
         attrs = dict(
             distance_step=10,
@@ -87,8 +89,8 @@ class TestInit:
         )
         # create coords
         coords = dict(
-            time=dc.to_datetime64(np.cumsum(np.random.random(10))),
-            distance=np.random.random(10),
+            time=dc.to_datetime64(np.cumsum(random_state.random(10))),
+            distance=random_state.random(10),
         )
         # assemble and output.
         dims = ("distance", "time")
@@ -136,8 +138,11 @@ class TestInit:
     def test_no_attrs(self):
         """Ensure a patch with no attrs can be created."""
         pa = Patch(
-            data=np.random.random((100, 100)),
-            coords={"time": np.random.random(100), "distance": np.random.random(100)},
+            data=random_state.random((100, 100)),
+            coords={
+                "time": random_state.random(100),
+                "distance": random_state.random(100),
+            },
             dims=("time", "distance"),
         )
         assert isinstance(pa, Patch)
@@ -209,14 +214,14 @@ class TestInit:
 
     def test_new_patch_non_standard_dims(self):
         """Ensure a non-standard dimension has matching dims in attrs and coords."""
-        data = np.random.rand(10, 5)
+        data = random_state.rand(10, 5)
         coords = {"time": np.arange(10), "can": np.arange(5)}
         patch = dc.Patch(data=data, coords=coords, dims=("time", "can"))
         assert patch.dims == patch.attrs.dim_tuple
 
     def test_non_coord_dims(self):
         """Ensure non-coordinate dimensions can work and create non-coord."""
-        data = np.random.rand(10, 5)
+        data = random_state.rand(10, 5)
         coords = {"time": np.arange(10)}
         patch = dc.Patch(data=data, coords=coords, dims=("time", "money"))
         assert patch.dims == ("time", "money")
@@ -358,7 +363,7 @@ class TestEquals:
     def test_both_attrs_nan(self, random_patch):
         """If Both Attrs are some type of NaN the patches should be equal."""
         attrs1 = dict(random_patch.attrs)
-        attrs1["label"] = np.NaN
+        attrs1["label"] = np.nan
         patch1 = random_patch.new(attrs=attrs1)
         attrs2 = dict(attrs1)
         attrs2["label"] = None
@@ -695,7 +700,7 @@ class TestSetDims:
     def test_doctest_example(self, random_patch):
         """Ensure the doctest example works."""
         patch = random_patch
-        my_coord = np.random.random(patch.coord_shapes["time"])
+        my_coord = random_state.random(patch.coord_shapes["time"])
         out = patch.update_coords(my_coord=("time", my_coord)).set_dims(  # add my_coord
             time="my_coord"
         )  # set mycoord as dim (rather than time)

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -4,6 +4,7 @@ Test file for chunk/merge.
 This is separated from spool tests because these need to be quite
 extensive.
 """
+
 from __future__ import annotations
 
 import random

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -1,4 +1,5 @@
 """Test for spool functions."""
+
 from __future__ import annotations
 
 import copy
@@ -392,7 +393,7 @@ class TestMap:
         """Ensure outputs don't have to be patches."""
         out = list(random_spool.map(lambda x: np.max(x.data)))
         for val in out:
-            assert isinstance(val, np.float_)
+            assert isinstance(val, np.float64)
 
     def test_dummy_client(self, random_spool):
         """Ensure a client arguments works."""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,5 @@
 """Tests for example fetching."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_integrations/test_doc_examples.py
+++ b/tests/test_integrations/test_doc_examples.py
@@ -1,4 +1,5 @@
 """Tests for some doc examples which had problems at one point."""
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -7,6 +7,7 @@ tests should go in their respective test modules. Tests for *how* specific
 IO functions (i.e., not that they work on various files) should go in
 test_io_core.py
 """
+
 from __future__ import annotations
 
 from contextlib import suppress

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -1,4 +1,5 @@
 """Tests for DASDAE format."""
+
 from __future__ import annotations
 
 import shutil
@@ -8,6 +9,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.compat import random_state
 from dascore.io.dasdae.core import DASDAEV1
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
@@ -184,7 +186,7 @@ class TestRoundTrips:
         dims = random_patch_with_lat_lon.dims
         # add time deltas to ensure they are also serialized/deserialized.
         dist_shape = shape[dims.index("distance")]
-        time_deltas = dc.to_timedelta64(np.random.random(dist_shape))
+        time_deltas = dc.to_timedelta64(random_state.random(dist_shape))
         patch = random_patch_with_lat_lon.update_coords(
             delta_times=("distance", time_deltas),
         )

--- a/tests/test_io/test_h5simple/test_h5simple.py
+++ b/tests/test_io/test_h5simple/test_h5simple.py
@@ -1,4 +1,5 @@
 """Tests for simple h5 format."""
+
 from __future__ import annotations
 
 import shutil

--- a/tests/test_io/test_indexer.py
+++ b/tests/test_io/test_indexer.py
@@ -1,4 +1,5 @@
 """Tests for indexing local file systems."""
+
 from __future__ import annotations
 
 import os

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -1,4 +1,5 @@
 """Test for basic IO and related functions."""
+
 from __future__ import annotations
 
 import copy

--- a/tests/test_io/test_pickle/test_pickle.py
+++ b/tests/test_io/test_pickle/test_pickle.py
@@ -1,4 +1,5 @@
 """Tests for reading/writing pickles."""
+
 from __future__ import annotations
 
 import pickle

--- a/tests/test_io/test_prodml/test_prod_ml.py
+++ b/tests/test_io/test_prodml/test_prod_ml.py
@@ -1,4 +1,5 @@
 """Generic tests for prodml support."""
+
 from __future__ import annotations
 
 import shutil

--- a/tests/test_io/test_sentek/test_sentek.py
+++ b/tests/test_io/test_sentek/test_sentek.py
@@ -1,8 +1,10 @@
 """
 Tests specific to the Sentek format.
 """
+
 import numpy as np
 
+from dascore.compat import random_state
 from dascore.io.sentek import SentekV5
 
 
@@ -12,7 +14,7 @@ class TestSentekV5:
     def test_das_extension_not_sentek(self, tmp_path_factory):
         """Ensure a non-sentek file with a das extension isn't id as sentek."""
         path = tmp_path_factory.mktemp("sentek_test") / "not_sentek.das"
-        ar = np.random.random(10)
+        ar = random_state.random(10)
         with path.open("wb") as fi:
             np.save(fi, ar)
         sentek = SentekV5()

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -1,4 +1,5 @@
 """Misc. tests for Terra15."""
+
 from __future__ import annotations
 
 import shutil

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -1,4 +1,5 @@
 """Tests module for wave format."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/test_io/test_xml_binary/test_xml_binary.py
+++ b/tests/test_io/test_xml_binary/test_xml_binary.py
@@ -1,4 +1,5 @@
 """Misc. tests for xml binary."""
+
 from __future__ import annotations
 
 import shutil

--- a/tests/test_proc/test_aggregate.py
+++ b/tests/test_proc/test_aggregate.py
@@ -1,4 +1,5 @@
 """Tests for performing aggregations."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -1,4 +1,5 @@
 """Tests for basic patch functions."""
+
 from __future__ import annotations
 
 import operator
@@ -43,7 +44,7 @@ class TestAbs:
     def test_all_real(self, random_complex_patch):
         """Ensure all values are real after abs on complex data."""
         out = random_complex_patch.abs()
-        assert np.issubdtype(out.data.dtype, np.float_)
+        assert np.issubdtype(out.data.dtype, np.float64)
         assert np.allclose(np.imag(out.data), 0)
 
 
@@ -424,10 +425,10 @@ class TestDropNa:
     @pytest.fixture(scope="class")
     def patch_3d_with_null(self, range_patch_3d):
         """Return a patch which has nullish values."""
-        data = np.array(range_patch_3d.data).astype(np.float_)
+        data = np.array(range_patch_3d.data).astype(np.float64)
         nans = [(1, 1, 1), (0, 9, 9)]
         for nan_ind in nans:
-            data[nan_ind] = np.NaN
+            data[nan_ind] = np.nan
         patch = range_patch_3d.update(data=data)
         return patch
 
@@ -487,10 +488,10 @@ class TestFillNa:
     @pytest.fixture(scope="class")
     def patch_3d_with_null(self, range_patch_3d):
         """Return a patch which has nullish values."""
-        data = np.array(range_patch_3d.data).astype(np.float_)
+        data = np.array(range_patch_3d.data).astype(np.float64)
         nans = [(1, 1, 1), (0, 9, 9)]
         for nan_ind in nans:
-            data[nan_ind] = np.NaN
+            data[nan_ind] = np.nan
         patch = range_patch_3d.update(data=data)
         return patch
 

--- a/tests/test_proc/test_detrend.py
+++ b/tests/test_proc/test_detrend.py
@@ -1,4 +1,5 @@
 """Tests for detrending functions."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -1,4 +1,5 @@
 """Tests for filters."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -1,4 +1,5 @@
 """Tests for coordinate processing methods."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_proc/test_proc_units.py
+++ b/tests/test_proc/test_proc_units.py
@@ -1,4 +1,5 @@
 """Tests for unit dealings on patches."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -1,4 +1,5 @@
 """Tests for decimation."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -6,6 +7,7 @@ import pandas as pd
 import pytest
 
 import dascore as dc
+from dascore.compat import random_state
 from dascore.units import Hz, m, s
 from dascore.utils.patch import get_start_stop_step
 
@@ -102,7 +104,7 @@ class TestDecimate:
 
         See scipy#15072.
         """
-        ar = np.random.random((10_000, 2)).astype("float32")
+        ar = random_state.random((10_000, 2)).astype("float32")
         dt = dc.to_timedelta64(0.001)
         t1 = dc.to_datetime64("2020-01-01")
         coords = {

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -1,4 +1,5 @@
 """Tests for applying rolling functions on patch's data."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_proc/test_taper.py
+++ b/tests/test_proc/test_taper.py
@@ -1,4 +1,5 @@
 """Tests for taper processing function."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -1,4 +1,5 @@
 """Tests for signal whiten."""
+
 import numpy as np
 import pytest
 

--- a/tests/test_transform/test_differentiate.py
+++ b/tests/test_transform/test_differentiate.py
@@ -1,4 +1,5 @@
 """Module for testing differentiation of patches."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_transform/test_dispersion.py
+++ b/tests/test_transform/test_dispersion.py
@@ -1,4 +1,5 @@
 """Tests for Dispersion transforms."""
+
 import numpy as np
 import pytest
 

--- a/tests/test_transform/test_fft.py
+++ b/tests/test_transform/test_fft.py
@@ -1,4 +1,5 @@
 """Tests for Fourier transforms."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -1,4 +1,5 @@
 """Tests for Fourier transforms."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_transform/test_integrate.py
+++ b/tests/test_transform/test_integrate.py
@@ -1,4 +1,5 @@
 """Module for performing integrations."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_transform/test_spectro_transform.py
+++ b/tests/test_transform/test_spectro_transform.py
@@ -1,4 +1,5 @@
 """Tests for the spectrogram transformation."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_transform/test_transformations.py
+++ b/tests/test_transform/test_transformations.py
@@ -1,4 +1,5 @@
 """General tests for transformations."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_transform/test_velocity_to_strainrate.py
+++ b/tests/test_transform/test_velocity_to_strainrate.py
@@ -1,4 +1,5 @@
 """Tests for converting velocity to strain-rate."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,4 +1,5 @@
 """Module for testing units."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -186,7 +187,7 @@ class TestDTypeCompatible:
     """Ensure dtype compatibility check works."""
 
     quants = ("degC", "m/s", get_quantity("kg"))
-    non_dt_dtypes = (np.float_, np.int_, np.float32)
+    non_dt_dtypes = (np.float64, np.int_, np.float32)
 
     def test_non_datetime(self):
         """Any non-datetime should be compatible."""

--- a/tests/test_utils/test_accessor.py
+++ b/tests/test_utils/test_accessor.py
@@ -1,4 +1,5 @@
 """Tests for creating/registering accessors."""
+
 from __future__ import annotations
 
 

--- a/tests/test_utils/test_attrs_utils.py
+++ b/tests/test_utils/test_attrs_utils.py
@@ -1,6 +1,7 @@
 """
 Tests for attr utilities.
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -1,4 +1,5 @@
 """Tests for chunking dataframes."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_utils/test_coordmanager_utils.py
+++ b/tests/test_utils/test_coordmanager_utils.py
@@ -1,6 +1,7 @@
 """
 Tests for coordinate manager utils.
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -1,4 +1,5 @@
 """Tests for displaying dascore objects."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -1,4 +1,5 @@
 """Tests for docstring utils."""
+
 from __future__ import annotations
 
 import textwrap

--- a/tests/test_utils/test_downloader.py
+++ b/tests/test_utils/test_downloader.py
@@ -1,4 +1,5 @@
 """Tests for dascore's downloader."""
+
 from __future__ import annotations
 
 import pandas as pd

--- a/tests/test_utils/test_hdf_utils.py
+++ b/tests/test_utils/test_hdf_utils.py
@@ -1,4 +1,5 @@
 """Tests for hdf5 utils."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -1,4 +1,5 @@
 """Tests for IO utilities."""
+
 from __future__ import annotations
 
 from io import BufferedReader, BufferedWriter

--- a/tests/test_utils/test_mapping_utils.py
+++ b/tests/test_utils/test_mapping_utils.py
@@ -1,4 +1,5 @@
 """Simple tests for FrozenDict."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -1,4 +1,5 @@
 """Misc. tests for misfit utilities."""
+
 from __future__ import annotations
 
 import os

--- a/tests/test_utils/test_models.py
+++ b/tests/test_utils/test_models.py
@@ -1,4 +1,5 @@
 """Tests for DASCore models and related functionality."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -1,4 +1,5 @@
 """Test patch utilities."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -1,4 +1,5 @@
 """Tests for pandas utility functions."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -1,4 +1,5 @@
 """Test the progress bar."""
+
 from __future__ import annotations
 
 from rich.progress import Progress

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -1,4 +1,5 @@
 """Tests for time variables."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -7,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from dascore.compat import random_state
 from dascore.exceptions import TimeError
 from dascore.utils.time import (
     get_max_min_times,
@@ -321,8 +323,8 @@ class TestToInt:
 
     def test_nullish_returns_nan(self):
         """Ensure a timedelta array works."""
-        assert to_int(None) is np.NaN
-        assert to_int(pd.NaT) is np.NaN
+        assert to_int(None) is np.nan
+        assert to_int(pd.NaT) is np.nan
 
     def test_converted_to_int(self):
         """Ensure a number is converted to int."""
@@ -402,12 +404,12 @@ class TestToFloat:
 
     def test_numerical_array(self):
         """Tests for numerical arrays."""
-        ar = np.random.random(10)
+        ar = random_state.random(10)
         assert np.allclose(to_float(ar), ar)
-        assert np.issubdtype(ar.dtype, np.float_)
+        assert np.issubdtype(ar.dtype, np.float64)
         ar = np.ones(10)
         assert np.allclose(ar, 1.0)
-        assert np.issubdtype(ar.dtype, np.float_)
+        assert np.issubdtype(ar.dtype, np.float64)
 
     def test_timedelta(self):
         """Ensure time delta is floated."""
@@ -418,7 +420,7 @@ class TestToFloat:
         """Tests for arrays of time deltas."""
         td = to_timedelta64(np.ones(10))
         out = to_float(td)
-        assert np.issubdtype(out.dtype, np.float_)
+        assert np.issubdtype(out.dtype, np.float64)
         assert np.allclose(out, 1.0)
 
     def test_datetime(self):
@@ -432,20 +434,20 @@ class TestToFloat:
         """Tests for arrays of date times."""
         dt = to_datetime64(np.ones(10))
         out = to_float(dt)
-        assert np.issubdtype(out.dtype, np.float_)
+        assert np.issubdtype(out.dtype, np.float64)
         assert np.allclose(out, 1.0)
 
     def test_none(self):
         """Ensure None returns NaN."""
         out = to_float(None)
-        assert out is np.NaN
+        assert out is np.nan
 
     def test_empty_array(self):
         """Empty arrays should work too."""
         ar = np.array([])
         out = to_float(ar)
         assert len(out) == 0
-        assert np.issubdtype(out.dtype, np.float_)
+        assert np.issubdtype(out.dtype, np.float64)
 
     def test_series(self):
         """Ensure a series works."""

--- a/tests/test_utils/test_transformatter.py
+++ b/tests/test_utils/test_transformatter.py
@@ -1,4 +1,5 @@
 """Tests for transformatter."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_viz/conftest.py
+++ b/tests/test_viz/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for all vizualization tests."""
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/tests/test_viz/test_map_fiber.py
+++ b/tests/test_viz/test_map_fiber.py
@@ -1,4 +1,5 @@
 """Tests for waterfall plots."""
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/tests/test_viz/test_spectrogram.py
+++ b/tests/test_viz/test_spectrogram.py
@@ -1,4 +1,5 @@
 """Tests for plotting a spectrogram."""
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -1,4 +1,5 @@
 """Tests for waterfall plots."""
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -1,4 +1,5 @@
 """Tests for wiggle plots."""
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Description

This PR updates the version of ruff used in pre-commit and includes numpy linting rules (which also check for compatibility issues). There are a few dependencies that don't yet support numpy 2, so we can't fully test for this yet so we are forced to pin numpy < 2.0 until all the dependencies support it. At least this way, new installations of DASCore wont break once numpy v2 is released.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
