### PR TITLE
Multi source correlate

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1591,7 +1591,7 @@ def get_coord(
         if isinstance(data, BaseCoord):  # just return coordinate
             return data
         if not isinstance(data, np.ndarray):
-            data = array(data)
+            data = np.atleast_1d(data)
         if np.size(data) == 0:
             dtype = dtype or data.dtype
             return CoordPartial(shape=data.shape, units=units, step=step, dtype=dtype)

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1371,9 +1371,8 @@ class CoordMonotonicArray(CoordArray):
         stop = self._get_index(v2, forward=True)
         new_stop = stop if stop is not None and stop < len(self) else None
         # We need to add 1 to end so 1 sample get selected if start == stop
-        if new_start is not None and new_stop is not None:
-            eq_values = self.values[new_start] == self.values[new_stop]
-            if eq_values and self.values[new_start] == v1:
+        if new_stop is not None:
+            if self.values[new_stop] == v2:
                 new_stop = new_stop + 1
         out = slice(new_start, new_stop)
         if self._slice_degenerate(out):
@@ -1403,7 +1402,7 @@ class CoordMonotonicArray(CoordArray):
         # right_ok = (right < len(self)) & (right < 0)
         left = np.searchsorted(values, new_value, side="left")
         left_ok = (left < len(self)) & (left > 0)
-        eq = left_ok & (values.take(left, mode='clip') == new_value)
+        eq = left_ok & (values.take(left, mode="clip") == new_value)
         out = right if forward else left
         # where equal it should also be left values. This makes the function
         # behavior consistent with BaseCoord._get_index.

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1130,9 +1130,6 @@ class CoordRange(BaseCoord):
         bad_values = lt_forward | gt_back
         if not input_is_array and np.any(bad_values):
             return None
-        # Bad array values should be mined out so min finds them later.
-        elif np.any(bad_values):
-            out[bad_values] = -9999
         return out if input_is_array else int(out[0])
 
     @compose_docstring(doc=BaseCoord.update_limits.__doc__)

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -278,6 +278,7 @@ class Patch:
         return self.select(*args, samples=True, **kwargs)
 
     correlate = dascore.proc.correlate
+    correlate_shift = dascore.proc.correlate_shift
     decimate = dascore.proc.decimate
     detrend = dascore.proc.detrend
     dropna = dascore.proc.dropna
@@ -288,6 +289,7 @@ class Patch:
     savgol_filter = dascore.proc.savgol_filter
     gaussian_filter = dascore.proc.gaussian_filter
     abs = dascore.proc.abs
+    conj = dascore.proc.conj
     real = dascore.proc.real
     imag = dascore.proc.imag
     angle = dascore.proc.angle

--- a/dascore/io/silixah5/core.py
+++ b/dascore/io/silixah5/core.py
@@ -1,6 +1,7 @@
 """
 Core modules for Silixa H5 support.
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -16,9 +17,9 @@ from .utils import _get_attr, _get_patch, _get_version_string
 class SilixaPatchAttrs(dc.PatchAttrs):
     """Patch Attributes for Silixa hdf5 format."""
 
-    gauge_length: float = np.NaN
+    gauge_length: float = np.nan
     gauge_length_units: str = "m"
-    pulse_width: float = np.NaN
+    pulse_width: float = np.nan
     pulse_width_units: str = "ns"
 
 

--- a/dascore/io/silixah5/utils.py
+++ b/dascore/io/silixah5/utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions for AP sensing module.
 """
+
 import pandas as pd
 
 import dascore as dc

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import dascore.proc.aggregate as agg
 from .basic import *  # noqa
 from .coords import *  # noqa
-from .correlate import correlate
+from .correlate import correlate, correlate_shift
 from .detrend import detrend
 from .filter import median_filter, pass_filter, sobel_filter, savgol_filter, gaussian_filter
 from .resample import decimate, interpolate, resample

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -216,7 +216,7 @@ def conj(patch: PatchType) -> PatchType:
     >>> pa = dascore.get_example_patch()
     >>>
     >>> # Example 1
-    >>> dft = pa.dft()  # multi-dim dft
+    >>> dft = pa.dft(None)  # multi-dim dft
     >>> conj = dft.conj()
     """
     return patch.new(data=np.conj(patch.data))

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -6,13 +6,14 @@ from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
+from scipy.fft import next_fast_len
 
 import dascore as dc
 from dascore.constants import DEFAULT_ATTRS_TO_IGNORE, PatchType
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.coords import get_coord
-from dascore.exceptions import PatchBroadcastError, UnitError
+from dascore.exceptions import ParameterError, PatchBroadcastError, UnitError
 from dascore.units import DimensionalityError, Quantity, Unit, get_quantity
 from dascore.utils.models import ArrayLike
 from dascore.utils.patch import (
@@ -202,6 +203,23 @@ def abs(patch: PatchType) -> PatchType:
     >>> out = pa.abs() # take absolute value of generated example patch data
     """
     return patch.new(data=np.abs(patch.data))
+
+
+@patch_function()
+def conj(patch: PatchType) -> PatchType:
+    """
+    Apply the complex conjugate of the patch data.
+
+    Examples
+    --------
+    >>> import dascore
+    >>> pa = dascore.get_example_patch()
+    >>>
+    >>> # Example 1
+    >>> dft = pa.dft()  # multi-dim dft
+    >>> conj = dft.conj()
+    """
+    return patch.new(data=np.conj(patch.data))
 
 
 @patch_function()
@@ -550,7 +568,7 @@ def pad(
     patch: PatchType,
     mode: Literal["constant"] = "constant",
     constant_values: Any = 0,
-    expand_coords=False,
+    expand_coords=True,
     samples=False,
     **kwargs,
 ) -> PatchType:
@@ -569,25 +587,68 @@ def pad(
         If set to True, the coordinates will be expanded to maintain their
         order and even sampling (if originally evenly sampled), by extrapolating
         based on the coordinate's step size.
-        If set to False, the new coordinates introduced by padding will be
-        filled with NaN values, preserving the original coordinate values but
-        not the order or sampling rate.
+        If set to False, or coordinate is not evenly sampled, the new
+        coordinates introduced by padding will be padded with NaN values.
     **kwargs:
         Used to specify dimension and number of elements,
         either an integer or a tuple (before, after).
+        In addition, the following strings are supported:
+
+        "fft" - pad to the next fast fft length along the given dimension by
+        adding values to the end of the axis.
+
+        "correlate" - prepare the coordinate for correlation/convolution in
+        the frequency domain by pading to the next fast fft length after
+        2*n - 1 where n is the current dimension length by adding values
+        to the end of the axis.
 
     Examples
     --------
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
-    >>> # zero pad `time` dimension with 2 patch's time unit (e.g., sec)
+    >>> # Zero pad `time` dimension with 2 patch's time unit (e.g., sec)
     >>> # zeros before and 3 zeros after
-    >>> padded_patch_1 = patch.pad(time = (2, 3))
-    >>> # zero pad `distance` dimension with 4 unit values before and after
-    >>> padded_patch_3 = patch.pad(distance = 4, constant_values = 1, samples=True)
+    >>> padded_patch_1 = patch.pad(time=(2, 3))
+    >>> # Pad `distance` dimension with 1s 4 samples before and 4 after.
+    >>> padded_patch_3 = patch.pad(distance=4, constant_values=1, samples=True)
+    >>> # Get patch ready for fast fft along time dimension.
+    >>> padded_fft = patch.pad(time="fft")
     """
-    if isinstance(constant_values, list | tuple):
-        raise TypeError("constant_values must be a scalar, not a sequence.")
+
+    def _get_pad_tuple(value, samples, coord):
+        """
+        Get a tuple, in samples, of (pad_to_start, pad_to_end).
+        """
+        if value in {"fft", "correlate"}:
+            target_length = len(coord) if value == "fft" else 2 * len(coord) - 1
+            # Determine value so that the output dim will be a fast length.
+            value = (0, next_fast_len(target_length) - len(coord))
+            samples = True  # ensure padding isn't interpreted as coord units.
+        elif not isinstance(value, Sequence):
+            value = (value, value)
+        if not samples:  # Ensure values are in samples.
+            value = tuple(coord.get_sample_count(x) for x in value)
+        return value
+
+    def _get_new_coord(coord, pad_tuple, expand_coords):
+        """Get the new coordinate along the expanded axis."""
+        if expand_coords and coord.evenly_sampled:
+            new_start = coord.min() - pad_tuple[0] * coord.step
+            new_end = coord.max() + (pad_tuple[1] + 1) * coord.step
+            assert coord.evenly_sampled, "expand_coords requires evenly sampled."
+            new_coord = get_coord(
+                start=new_start, stop=new_end, step=coord.step, units=coord.units
+            )
+        else:
+            old_values = coord.values.astype(np.float64)
+            added_nan_values = np.pad(
+                old_values, pad_width=pad_tuple, constant_values=np.nan
+            )
+            new_coord = coord.update(data=added_nan_values)
+        return new_coord
+
+    if isinstance(constant_values, Sequence):
+        raise ParameterError("constant_values must be a scalar, not a sequence.")
 
     pad_width = [(0, 0)] * len(patch.shape)
     dimfo = get_multiple_dim_value_from_kwargs(patch, kwargs)
@@ -595,44 +656,14 @@ def pad(
 
     for _, info in dimfo.items():
         axis, dim, value = info["axis"], info["dim"], info["value"]
+        coord = patch.get_coord(dim, require_evenly_sampled=not samples)
+        pad_tuple = _get_pad_tuple(value, samples, coord)
+        pad_width[axis] = pad_tuple
+        new_coords[dim] = _get_new_coord(coord, pad_tuple, expand_coords)
 
-        # Ensure pad_width is a tuple, even if a single integer is provided
-        if isinstance(value, int):
-            value = (value, value)
-
-        # Ensure kwargs are in samples
-        if not samples:
-            coord = patch.get_coord(dim, require_evenly_sampled=True)
-            value = (
-                coord.get_sample_count(value[0], samples=samples),
-                coord.get_sample_count(value[1], samples=samples),
-            )
-        pad_width[axis] = value
-
-        # Get new coordinate
-        if expand_coords:
-            new_start = coord.min() - value[0] * coord.step
-            new_end = coord.max() + (value[1] + 1) * coord.step
-            coord = patch.get_coord(dim, require_evenly_sampled=True)
-            old_values = coord.values
-            new_coord = get_coord(
-                start=new_start, stop=new_end, step=coord.step, units=coord.units
-            )
-        else:
-            coord = patch.get_coord(dim)
-            old_values = coord.values.astype(np.float64)
-            added_nan_values = np.pad(
-                old_values, pad_width=value, constant_values=np.nan
-            )
-            new_coord = coord.update(data=added_nan_values)
-        new_coords[dim] = new_coord
-
-    # Pad patch's data
+    # Pad data, update coord manager, and return.
     new_data = np.pad(patch.data, pad_width, mode=mode, constant_values=constant_values)
-
-    # Update coord manager
     new_coords = patch.coords.update(**new_coords)
-
     return patch.new(data=new_data, coords=new_coords)
 
 

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -142,9 +142,9 @@ def correlate(
     >>> # and the 10 m channel as the master channel. The new patch has dimensions
     >>> # (lag_time, distance, source_distance)
     >>> cc_patch = (
-    >>>     patch.correlate(distance = 10 * m)
-    >>>     .select(lag_time=(-2, 2))
-    >>> )
+    ...     patch.correlate(distance = 10 * m)
+    ...     .select(lag_time=(-2, 2))
+    ... )
     >>>
     >>> # Example 3
     >>> # Use 2nd channel (python is 0 indexed) along distance as master channel
@@ -159,11 +159,11 @@ def correlate(
     >>> padded_patch = patch.pad(time="correlate")  # pad to at least 2n + 1
     >>> dft_patch = patch.dft("time", real=True)
     >>> # Any other pre-processing steps go here...
-    >>> ...
+    >>> # ...
     >>> # Perform the correlation with 3 source channels
     >>> cc_patch = dft_patch.correlate(distance=[1, 3, 7], samples=True)
     >>> # Perform any post-processing here
-    >>> ...
+    >>> # ...
     >>> # Convert back to time domain, apply `correlate shift` to undo
     >>> # fft related shifting and scaling.
     >>> cc_out = cc_patch.idft().correlate_shift("time")

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 
 import dascore as dc
@@ -85,6 +87,7 @@ def correlate_shift(patch, dim, undo_weighting=True):
 def correlate(
     patch: PatchType,
     samples=False,
+    lag=None,
     **kwargs,
 ) -> PatchType:
     """
@@ -110,6 +113,8 @@ def correlate(
     samples : bool, optional (default = False)
         If True, the argument specified in kwargs refers to the *sample* not
         value along that axis. See examples for details.
+    lag
+        Deprecated, just use select on the output patch instead.
     **kwargs
         Specifies correlation dimension and the master source(s), to which
         we want to cross-correlate all other channels/time samples.If the
@@ -180,6 +185,9 @@ def correlate(
     2 - The output dimension is opposite of the one specified in kwargs, has
     the units of float, and the string "lag_" prepended. For example, "lag_time".
     """
+    if lag is not None:
+        msg = "Correlate lag is deprecated. Simply use on the output patch."
+        warnings.warn(msg, DeprecationWarning)
     assert len(patch.dims) == 2, "must be a 2D patch."
     dim, source_axis, source = get_dim_value_from_kwargs(patch, kwargs)
     # Get the axis and coord over which fft should be calculated.

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -49,7 +49,7 @@ def correlate_shift(patch, dim, undo_weighting=True):
     undo_weighting
         If True, also undo the weighting artifact caused by DASCore's dft
         weighting. This is done by simply dividing by the coordinate step.
-        See [dft note](`notes/dft_notes.qmd`) for more details.
+        See [dft note](`docs/notes/dft_notes.qmd`) for more details.
 
     Examples
     --------
@@ -92,9 +92,9 @@ def correlate(
 
     Correlations are done in the frequency domain. This function can accept a
     patch whose target dimension has already been transformed with the
-    [`Patch.dft`](`dascore.proc.fourier.dft`) method, otherwise the dft
+    [`Patch.dft`](`dascore.transform.fourier.dft`) method, otherwise the dft
     will be performed. If the input has already been transformed,
-    [`Patch.correlation_shift`](`dascore.proc.correlation.correlation_shift`)
+    [`Patch.correlation_shift`](`dascore.proc.correlate.correlate_shift`)
     is useful to undo dft artefacts after the idft is applied.
 
     While a 2D patch is required for input, a 3D patch is returned where the
@@ -129,14 +129,14 @@ def correlate(
     ...     frequency=range(10, 20),
     ...     duration=5,
     ...     channel_count=10,
-    ... ).taper(time=0.5)
-
+    ... ).taper(time=0.5).set_units(distance='m')
+    >>>
     >>> # Example 1
     >>> # Calculate cc for all channels as receivers and
     >>> # the 10 m channel as the master channel. Squeeze the output
     >>> # so the returned patch is 2D.
     >>> cc_patch = patch.correlate(distance = 10 * m).squeeze()
-
+    >>>
     >>> # Example 2
     >>> # Get cc within (-2,2) sec of lag for all channels as receivers
     >>> # and the 10 m channel as the master channel. The new patch has dimensions
@@ -146,15 +146,14 @@ def correlate(
     >>>     .select(lag_time=(-2, 2))
     >>> )
     >>>
-
     >>> # Example 3
     >>> # Use 2nd channel (python is 0 indexed) along distance as master channel
     >>> cc_patch = patch.correlate(distance=1, samples=True)
-
+    >>>
     >>> # Example 4
     >>> # Correlate along time dimension
     >>> cc_patch = patch.correlate(time=100, samples=True)
-
+    >>>
     >>> # Example 5
     >>> # An example pipeline of frequency domain correlation.
     >>> padded_patch = patch.pad(time="correlate")  # pad to at least 2n + 1

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -8,7 +8,6 @@ import dascore as dc
 from dascore.constants import PatchType
 from dascore.core.coordmanager import get_coord_manager
 from dascore.transform.fourier import _get_dft_attrs
-from dascore.units import Quantity
 from dascore.utils.misc import broadcast_for_index
 from dascore.utils.patch import (
     _get_dx_or_spacing_and_axes,
@@ -47,11 +46,50 @@ def _shift(data, cx_len, axis):
     return data
 
 
+def _correlate_fft(patch, fft_axis, fft_dim):
+    """Perform a padded FFT for correlations."""
+    is_real = not np.issubdtype(patch.data.dtype, np.complexfloating)
+    # perform FFT (since the input is not already in the frequency domain)
+    fft_func = np.fft.rfft if is_real else np.fft.fft
+    # get the closest fast length. Some padding is applied in the fft to avoid
+    # inefficient lengths. Note: This is not always a power of 2.
+    cx_len = patch.shape[fft_axis] * 2 - 1
+    fast_len = next_fast_len(cx_len)
+    # perform ffts and get source array (a sub-slice of larger fft)
+    fft = fft_func(patch.data, axis=fft_axis, n=fast_len)
+    # ensure coordinate is evenly spaced
+    fft_coord = patch.get_coord(fft_dim)
+    return fft, fft_coord, fast_len, is_real
+
+
+def _get_fft_array(patch, fft_axis, fft_dim):
+    """Get the array info from pre-transformed patch."""
+    fft = patch.data
+    fft_coord = patch.get_coord(fft_dim)
+    cx_len = patch.shape[fft_axis]
+    fast_len = cx_len
+    # If fft axis is strictly positive a real dft was used.
+    is_real = fft_coord.min() >= 0
+    return fft, fft_coord, fast_len, is_real
+
+
+def _get_sources(patch, fft, dim, source, source_axis, samples):
+    """Get an array of coordinate sources."""
+    # get the coordinate which contains the source
+    ndim = patch.ndim
+    coord_source = patch.get_coord(dim)
+    index_source = coord_source.get_next_index(source, samples=samples)
+    slicer = slice(index_source, index_source + 1)
+    inds = broadcast_for_index(ndim, axis=source_axis, value=slicer)
+    source_fft = fft[inds]
+    print(source_fft)
+    assert 0
+    pass
+
+
 @patch_function()
 def correlate(
     patch: PatchType,
-    lag: int | float | Quantity | None = None,
-    step_size: int = 1,
     samples=False,
     idft=True,
     **kwargs,
@@ -65,14 +103,6 @@ def correlate(
     patch : PatchType
         The input data patch to be cross-correlated. Must be 2-dimensional.
         The patch can be in time or frequency domains.
-    lag :
-        An optional argument to save only certain lags instead of full
-        output. It can't be used if idft = False.
-    step_size : int, optional (default = None)
-        An optional argument to skip rows/columns for the virtual receiver.
-        A step_size = 2 means performing cross correlation (cc)
-        with every other channels instead of the full array.
-        This will reduce computation and storage cost if needed.
     samples : bool, optional (default = False)
         If True, the argument specified in kwargs refers to the *sample* not
         value along that axis. See examples for details.
@@ -82,8 +112,8 @@ def correlate(
         Additional arguments to specify cc dimension and the
         master source(s), to which we want to cross-correlate all other
         channels/time samples (with or without a step_size).
-        If the master source is an array, the function will compute cc for all the
-        half of all possible pairs (i.e., only a-b and not b-a).
+        If the master source is an array, the function will compute cc for all
+        the half of all possible pairs (i.e., only a-b and not b-a).
         This will result in a 3D patch.
 
     Examples
@@ -126,8 +156,7 @@ def correlate(
 
     Notes
     -----
-    1- The cross-correlation is performed in the frequency domain for efficiency
-    reasons.
+    1- The cross-correlation is performed in the frequency domain.
 
     2- The output dimension is opposite of the one specified in kwargs, has
     the units of float, and the string "lag_" prepended. For example, "lag_time".
@@ -138,106 +167,58 @@ def correlate(
     use the correlate function, which automatically handles the zero padding.
     """
     assert len(patch.dims) == 2, "must be a 2D patch."
-    if not idft and lag is not None:
-        msg = "lag argument can't be used when idft is set to False."
-        raise ValueError(msg)
     dim, source_axis, source = get_dim_value_from_kwargs(patch, kwargs)
-    # get the axis and coord over which fft should be calculated.
+    # Get the axis and coord over which fft should be calculated.
     fft_axis = next(iter(set(range(len(patch.dims))) - {source_axis}))
     fft_dim = patch.dims[fft_axis]
-    # get the coordinate which contains the source
-    coord_source = patch.get_coord(dim)
-    index_source = coord_source.get_next_index(source, samples=samples)
-
-    if step_size is not None and step_size > 1:
-        step = patch.get_coord(dim).step * step_size
-        new_coord_step = dc.core.get_coord(
-            start=patch.get_coord(dim)[0],
-            stop=patch.get_coord(dim)[-1],
-            step=step,
-        )
-        coords = patch.coords.update(**{dim: new_coord_step})
-        attrs = patch.attrs
-        patch_new_data = patch.data.take(
-            range(0, patch.data.shape[source_axis], step_size), axis=source_axis
-        )
-        patch = patch.update(data=patch_new_data, coords=coords, attrs=attrs)
-
-    # determine whether fft is needed
-    # determine proper fft, idft functions based on data being real or complex
-    if (dim == "distance" and fft_dim != "ft_time") or (
-        dim == "time" and fft_dim != "ft_distance"
-    ):
-        needed_fft = True
-        is_real = not np.issubdtype(patch.data.dtype, np.complexfloating)
-        # perform FFT (since the input is not already in the frequency domain)
-        fft_func = np.fft.rfft if is_real else np.fft.fft
-        # get the closest fast length. Some padding is applied in the fft to avoid
-        # inefficient lengths. Note: This is not always a power of 2.
-        cx_len = patch.shape[fft_axis] * 2 - 1
-        fast_len = next_fast_len(cx_len)
-        # perform ffts and get source array (a sub-slice of larger fft)
-        fft = fft_func(patch.data, axis=fft_axis, n=fast_len)
-        # ensure coordinate is evenly spaced
-        fft_coord = patch.get_coord(fft_dim)
-
-    else:
-        needed_fft = False
-        is_real = not np.min(patch.coords.get_array(fft_dim)) < 0
-        # assume input is already in the frequency domain, skip FFT
-        fft = patch.data
-        fft_coord = patch.get_coord(fft_dim)  # edit: needs adjustment?
-
-        cx_len = patch.shape[fft_axis]
-        fast_len = cx_len
-
-    ndims = len(patch.shape)
-    slicer = slice(index_source, index_source + 1)
-    inds = broadcast_for_index(ndims, axis=source_axis, value=slicer)
-    source_fft = fft[inds]
-    # perform correlation in freq domain and transform back to time domain
+    # Determine if the DFT needs to be performed or just extract dft array.
+    dft_func = _get_fft_array if fft_dim.startswith("ft_") else _correlate_fft
+    fft, fft_coord, fast_len, is_real = dft_func(patch, fft_axis, fft_dim)
+    # Get the sources.
+    source_fft = _get_sources(patch, fft, dim, source, source_axis, samples)
+    # Perform correlation in freq domain
     fft_prod = fft * np.conj(source_fft)
     # the n parameter needs to be odd so we have a 0 lag time. This only
     # applies to real fft
     n_out = fast_len if (not is_real or fast_len % 2 != 0) else fast_len - 1
-
-    if idft:
-        ifft_func = np.fft.irfft if is_real else np.fft.ifft
-        if needed_fft:
-            corr_array = ifft_func(fft_prod, axis=fft_axis, n=n_out)
-            corr_data = _shift(corr_array, cx_len, axis=fft_axis)
-            # get new coordinate along correlation dimension
-            new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
-            coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
-                **{fft_dim: f"lag_{fft_dim}"}
-            )
-            out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
-            if lag is not None:
-                out = out.select(**{f"lag_{fft_dim}": (-lag, +lag)})
-            return out
-        else:
-            corr_array = np.real(ifft_func(fft_prod, axis=fft_axis, n=n_out))
-            corr_data = _shift(corr_array, cx_len, axis=fft_axis)
-            # get new coordinate along correlation dimension
-            new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
-            coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
-                **{fft_dim: f"{fft_dim}"}
-            )
-            out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
-            return out
-    else:
-        dims = fft_dim
-        _, axes = _get_dx_or_spacing_and_axes(patch, dims, require_evenly_spaced=True)
-        # get new coordinates
-        old_cm = patch.coords.disassociate_coord(dims)
-        new_cm = old_cm.get_coord_tuple_map()
-        ft = FourierTransformatter()
-        name = ft.rename_dims(fft_dim)[0]
-        coord = _get_correlated_coord(fft_coord, fft_prod.shape[fft_axis])
-        new_cm[name] = (name, coord)
-        new_dims = ft.rename_dims(patch.dims, index=axes)
-        new_coords = get_coord_manager(new_cm, dims=new_dims)
-        # get attributes
-        attrs = _get_dft_attrs(patch, dims, new_coords)
-        # return the frequency domain data directly without taking the inverse FFT
-        return patch.new(fft_prod, coords=new_coords, attrs=attrs)
+    #
+    # if idft:
+    #     ifft_func = np.fft.irfft if is_real else np.fft.ifft
+    #     if needed_fft:
+    #         corr_array = ifft_func(fft_prod, axis=fft_axis, n=n_out)
+    #         corr_data = _shift(corr_array, cx_len, axis=fft_axis)
+    #         # get new coordinate along correlation dimension
+    #         new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
+    #         coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
+    #             **{fft_dim: f"lag_{fft_dim}"}
+    #         )
+    #         out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
+    #         if lag is not None:
+    #             out = out.select(**{f"lag_{fft_dim}": (-lag, +lag)})
+    #         return out
+    #     else:
+    #         corr_array = np.real(ifft_func(fft_prod, axis=fft_axis, n=n_out))
+    #         corr_data = _shift(corr_array, cx_len, axis=fft_axis)
+    #         # get new coordinate along correlation dimension
+    #         new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
+    #         coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
+    #             **{fft_dim: f"{fft_dim}"}
+    #         )
+    #         out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
+    #         return out
+    # else:
+    #     dims = fft_dim
+    #     _, axes = _get_dx_or_spacing_and_axes(patch, dims, require_evenly_spaced=True)
+    #     # get new coordinates
+    #     old_cm = patch.coords.disassociate_coord(dims)
+    #     new_cm = old_cm.get_coord_tuple_map()
+    #     ft = FourierTransformatter()
+    #     name = ft.rename_dims(fft_dim)[0]
+    #     coord = _get_correlated_coord(fft_coord, fft_prod.shape[fft_axis])
+    #     new_cm[name] = (name, coord)
+    #     new_dims = ft.rename_dims(patch.dims, index=axes)
+    #     new_coords = get_coord_manager(new_cm, dims=new_dims)
+    #     # get attributes
+    #     attrs = _get_dft_attrs(patch, dims, new_coords)
+    #     # return the frequency domain data directly without taking the inverse FFT
+    #     return patch.new(fft_prod, coords=new_coords, attrs=attrs)

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -6,6 +6,8 @@ from scipy.fftpack import next_fast_len
 
 import dascore as dc
 from dascore.constants import PatchType
+from dascore.core.coordmanager import get_coord_manager
+from dascore.transform.fourier import _get_dft_attrs
 from dascore.units import Quantity
 from dascore.utils.misc import broadcast_for_index
 from dascore.utils.patch import (
@@ -13,9 +15,10 @@ from dascore.utils.patch import (
     get_dim_value_from_kwargs,
     patch_function,
 )
+from dascore.utils.transformatter import FourierTransformatter
 
 
-def _get_correlated_coord(old_coord, data_shape, real=True):
+def _get_correlated_coord(old_coord, data_shape):
     """Get the new coordinate which corresponds to correlated values."""
     step = old_coord.step
     one_sided_len = data_shape // 2
@@ -24,8 +27,7 @@ def _get_correlated_coord(old_coord, data_shape, real=True):
         stop=(one_sided_len + 1) * step,
         step=step,
     )
-    assert len(new) == data_shape, "failed to create correlated coord"
-    return new
+    return new.change_length(data_shape)
 
 
 def _shift(data, cx_len, axis):
@@ -47,25 +49,42 @@ def _shift(data, cx_len, axis):
 
 @patch_function()
 def correlate(
-    patch: PatchType, lag: int | float | Quantity | None = None, samples=False, **kwargs
+    patch: PatchType,
+    lag: int | float | Quantity | None = None,
+    step_size: int = 1,
+    samples=False,
+    ifft=True,
+    **kwargs,
 ) -> PatchType:
     """
-    Correlate a single row/column in a 2D patch with every other row/column.
+    Correlate row/column (virtual sources) in a 2D patch with other
+    rows/columns (virtual receivers).
 
     Parameters
     ----------
     patch : PatchType
         The input data patch to be cross-correlated. Must be 2-dimensional.
+        The patch can be in time or frequency domains.
     lag :
-        An optional argument to save only certain lag times instead of full
-        output.
+        An optional argument to save only certain lags instead of full
+        output. It can't be used if ifft = False.
+    step_size : int, optional (default = None)
+        An optional argument to skip rows/columns for the virtual receiver.
+        A step_size = 2 means performing cross correlation (cc)
+        with every other channels instead of the full array.
+        This will reduce computation and storage cost if needed.
     samples : bool, optional (default = False)
         If True, the argument specified in kwargs refers to the *sample* not
         value along that axis. See examples for details.
+    ifft : bool, optional (default = Ture)
+        If True, it applies ifft and return results in time domain.
     **kwargs
-        Additional arguments to specify cross correlation dimension and the
-        master source, to which
-        we cross-correlate all other channels/time samples.
+        Additional arguments to specify cc dimension and the
+        master source(s), to which we want to cross-correlate all other
+        channels/time samples (with or without a step_size).
+        If the master source is an array, the function will compute cc for all the
+        half of all possible pairs (i.e., only a-b and not b-a).
+        This will result in a 3D patch.
 
     Examples
     --------
@@ -93,35 +112,86 @@ def correlate(
     >>> # Correlate along time dimension
     >>> cc_patch = patch.correlate(time=100, samples=True)
 
+    >>> # Example 5
+    >>> # Calculate cc of a patch for all channels as receivers and
+    >>> # the 10 m channel as the master channel and result data in frequency domain.
+    >>> # The new patch has dimensions (ft_time, distance).
+    >>> cc_patch = patch.correlate(distance = 10 * m, ifft = False)
+
+    >>> # Example 6
+    >>> # Calculate cc of channel numbers [1,3,7,8,20] as master channels
+    >>> # and every fourth channel as receivers.
+    >>> # The new patch has dimensions (lag_time, distance, source_distance).
+    >>> cc_patch = patch.correlate(distance = [1,3,7,8,20], step_size = 4)
+
     Notes
     -----
-    The cross-correlation is performed in the frequency domain for efficiency
+    1- The cross-correlation is performed in the frequency domain for efficiency
     reasons.
 
-    The output dimension is opposite of the one specified in kwargs, has
+    2- The output dimension is opposite of the one specified in kwargs, has
     the units of float, and the string "lag_" prepended. For example, "lag_time".
+
+    3- If the patch is in the frequency domain, it needs to be zero-padded in
+    the time domain first. If not, first apply the
+    [idft](`dascore.transform.fourier.idft`) function to the patch, and then
+    use the correlate function, which automatically handles the zero padding.
     """
-    assert len(patch.dims) == 2, "must be a 2D patch"
+    assert len(patch.dims) == 2, "must be a 2D patch."
+    if not ifft and lag is not None:
+        msg = "lag argument can't be used when ifft is set to False."
+        raise ValueError(msg)
     dim, source_axis, source = get_dim_value_from_kwargs(patch, kwargs)
     # get the axis and coord over which fft should be calculated.
     fft_axis = next(iter(set(range(len(patch.dims))) - {source_axis}))
     fft_dim = patch.dims[fft_axis]
-    # ensure coordinate is evenly spaced
-    _get_dx_or_spacing_and_axes(patch, fft_dim, require_evenly_spaced=True)
-    fft_coord = patch.get_coord(fft_dim)
     # get the coordinate which contains the source
     coord_source = patch.get_coord(dim)
     index_source = coord_source.get_next_index(source, samples=samples)
-    # get the closest fast length. Some padding is applied in the fft to avoid
-    # inefficient lengths. Note: This is not always a power of 2.
-    cx_len = patch.shape[fft_axis] * 2 - 1
-    fast_len = next_fast_len(cx_len)
+
+    if step_size is not None and step_size > 1:
+        step = patch.get_coord(dim).step * step_size
+        new_coord_step = dc.core.get_coord(
+            start=patch.get_coord(dim)[0],
+            stop=patch.get_coord(dim)[-1],
+            step=step,
+        )
+        coords = patch.coords.update(**{dim: new_coord_step})
+        attrs = patch.attrs
+        patch_new_data = patch.data.take(
+            range(0, patch.data.shape[source_axis], step_size), axis=source_axis
+        )
+        patch = patch.update(data=patch_new_data, coords=coords, attrs=attrs)
+
     # determine proper fft, ifft functions based on data being real or complex
-    is_real = not np.issubdtype(patch.data.dtype, np.complexfloating)
-    fft_func = np.fft.rfft if is_real else np.fft.fft
-    ifft_func = np.fft.irfft if is_real else np.fft.ifft
-    # perform ffts and get source array (a sub-slice of larger fft)
-    fft = fft_func(patch.data, axis=fft_axis, n=fast_len)
+    if (dim == "distance" and fft_dim != "ft_time") or (
+        dim == "time" and fft_dim != "ft_distance"
+    ):
+        needed_fft = True
+        is_real = not np.issubdtype(patch.data.dtype, np.complexfloating)
+        # perform FFT (since the input is not already in the frequency domain)
+        fft_func = np.fft.rfft if is_real else np.fft.fft
+        # perform ffts and get source array (a sub-slice of larger fft)
+        fft = fft_func(
+            patch.data, axis=fft_axis, n=next_fast_len(patch.shape[fft_axis] * 2 - 1)
+        )
+        # ensure coordinate is evenly spaced
+        fft_coord = patch.get_coord(fft_dim)
+
+        # get the closest fast length. Some padding is applied in the fft to avoid
+        # inefficient lengths. Note: This is not always a power of 2.
+        cx_len = patch.shape[fft_axis] * 2 - 1
+        fast_len = next_fast_len(cx_len)
+    else:
+        needed_fft = False
+        is_real = not np.min(patch.coords.get_array(fft_dim)) < 0
+        # assume input is already in the frequency domain, skip FFT
+        fft = patch.data
+        fft_coord = patch.get_coord(fft_dim)  # edit: needs adjustment?
+
+        cx_len = patch.shape[fft_axis]
+        fast_len = cx_len
+
     ndims = len(patch.shape)
     slicer = slice(index_source, index_source + 1)
     inds = broadcast_for_index(ndims, axis=source_axis, value=slicer)
@@ -131,14 +201,44 @@ def correlate(
     # the n parameter needs to be odd so we have a 0 lag time. This only
     # applies to real fft
     n_out = fast_len if (not is_real or fast_len % 2 != 0) else fast_len - 1
-    corr_array = ifft_func(fft_prod, axis=fft_axis, n=n_out)
-    corr_data = _shift(corr_array, cx_len, axis=fft_axis)
-    # get new coordinate along correlation dimension
-    new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
-    coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
-        **{fft_dim: f"lag_{fft_dim}"}
-    )
-    out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
-    if lag is not None:
-        out = out.select(**{f"lag_{fft_dim}": (-lag, +lag)})
-    return out
+
+    if ifft:
+        ifft_func = np.fft.irfft if is_real else np.fft.ifft
+        if needed_fft:
+            corr_array = ifft_func(fft_prod, axis=fft_axis, n=n_out)
+            corr_data = _shift(corr_array, cx_len, axis=fft_axis)
+            # get new coordinate along correlation dimension
+            new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
+            coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
+                **{fft_dim: f"lag_{fft_dim}"}
+            )
+            out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
+            if lag is not None:
+                out = out.select(**{f"lag_{fft_dim}": (-lag, +lag)})
+            return out
+        else:
+            corr_array = np.real(ifft_func(fft_prod, axis=fft_axis, n=n_out))
+            corr_data = _shift(corr_array, cx_len, axis=fft_axis)
+            # get new coordinate along correlation dimension
+            new_coord = _get_correlated_coord(fft_coord, corr_data.shape[fft_axis])
+            coords = patch.coords.update(**{fft_dim: new_coord}).rename_coord(
+                **{fft_dim: f"{fft_dim}"}
+            )
+            out = dc.Patch(coords=coords, data=corr_data, attrs=patch.attrs)
+            return out
+    else:
+        dims = fft_dim
+        _, axes = _get_dx_or_spacing_and_axes(patch, dims, require_evenly_spaced=True)
+        # get new coordinates
+        old_cm = patch.coords.disassociate_coord(dims)
+        new_cm = old_cm.get_coord_tuple_map()
+        ft = FourierTransformatter()
+        name = ft.rename_dims(fft_dim)[0]
+        coord = _get_correlated_coord(fft_coord, fft_prod.shape[fft_axis])
+        new_cm[name] = (name, coord)
+        new_dims = ft.rename_dims(patch.dims, index=axes)
+        new_coords = get_coord_manager(new_cm, dims=new_dims)
+        # get attributes
+        attrs = _get_dft_attrs(patch, dims, new_coords)
+        # return the frequency domain data directly without taking the inverse FFT
+        return patch.new(fft_prod, coords=new_coords, attrs=attrs)

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -6,15 +6,11 @@ from scipy.fftpack import next_fast_len
 
 import dascore as dc
 from dascore.constants import PatchType
-from dascore.core.coordmanager import get_coord_manager
-from dascore.transform.fourier import _get_dft_attrs
 from dascore.utils.misc import broadcast_for_index
 from dascore.utils.patch import (
-    _get_dx_or_spacing_and_axes,
     get_dim_value_from_kwargs,
     patch_function,
 )
-from dascore.utils.transformatter import FourierTransformatter
 
 
 def _get_correlated_coord(old_coord, data_shape):
@@ -82,8 +78,8 @@ def _get_sources(patch, fft, dim, source, source_axis, samples):
     slicer = slice(index_source, index_source + 1)
     inds = broadcast_for_index(ndim, axis=source_axis, value=slicer)
     source_fft = fft[inds]
-    print(source_fft)
-    assert 0
+    # print(source_fft)
+    assert source_fft
     pass
 
 
@@ -181,6 +177,9 @@ def correlate(
     # the n parameter needs to be odd so we have a 0 lag time. This only
     # applies to real fft
     n_out = fast_len if (not is_real or fast_len % 2 != 0) else fast_len - 1
+
+    assert fft_prod
+    assert n_out
     #
     # if idft:
     #     ifft_func = np.fft.irfft if is_real else np.fft.ifft

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -113,8 +113,8 @@ def correlate(
     **kwargs
         Specifies correlation dimension and the master source(s), to which
         we want to cross-correlate all other channels/time samples.If the
-        master source is an array, the function will compute cc for all
-        the posible pairs.
+        master source is an array, the function will compute correlations for
+        all the posible pairs.
 
     Examples
     --------
@@ -147,15 +147,20 @@ def correlate(
     ... )
     >>>
     >>> # Example 3
-    >>> # Use 2nd channel (python is 0 indexed) along distance as master channel
-    >>> cc_patch = patch.correlate(distance=1, samples=True)
+    >>> # Correlate along distance having the 2nd channel (python is 0 indexed)
+    >>> # as a master channel and skip every other channel to reduce memory
+    >>> cc_patch = (
+    ...     patch.decimate(distance=2, filter_type=None)
+    ...     .correlate(distance=1, samples=True)
+    ... )
     >>>
     >>> # Example 4
-    >>> # Correlate along time dimension
+    >>> # Correlate along time dimension (perhaps for template matching
+    >>> # applications)
     >>> cc_patch = patch.correlate(time=100, samples=True)
     >>>
     >>> # Example 5
-    >>> # An example pipeline of frequency domain correlation.
+    >>> # A pipeline of frequency domain correlation and an array of sources
     >>> padded_patch = patch.pad(time="correlate")  # pad to at least 2n + 1
     >>> dft_patch = patch.dft("time", real=True)
     >>> # Any other pre-processing steps go here...
@@ -165,7 +170,7 @@ def correlate(
     >>> # Perform any post-processing here
     >>> # ...
     >>> # Convert back to time domain, apply `correlate shift` to undo
-    >>> # fft related shifting and scaling.
+    >>> # fft related shifting and scaling as well as create lag coordinate.
     >>> cc_out = cc_patch.idft().correlate_shift("time")
 
     Notes

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -147,8 +147,8 @@ def correlate(
     ... )
     >>>
     >>> # Example 3
-    >>> # Correlate along distance having the 2nd channel (python is 0 indexed)
-    >>> # as a master channel and skip every other channel to reduce memory
+    >>> # First remove every other distance channel (less memory usage)
+    >>> # the use the new 2nd channel as the source.
     >>> cc_patch = (
     ...     patch.decimate(distance=2, filter_type=None)
     ...     .correlate(distance=1, samples=True)

--- a/dascore/proc/whiten.py
+++ b/dascore/proc/whiten.py
@@ -20,7 +20,7 @@ def whiten(
     patch: PatchType,
     smooth_size: float | None = None,
     tukey_alpha: float = 0.1,
-    ifft: bool = True,
+    idft: bool = True,
     **kwargs,
 ) -> PatchType:
     """
@@ -41,7 +41,7 @@ def whiten(
         its value is 0.1.
         See more details at https://docs.scipy.org/doc/scipy/reference
         /generated/scipy.signal.windows.tukey.html
-    ifft
+    idft
         If False, returns the whitened result in the frequency domain without
         converting it back to the time domain. Defaults to True.
     **kwargs
@@ -61,7 +61,7 @@ def whiten(
 
     3) Amplitude is NOT preserved
 
-    4) If ifft = False, since for the purely real input data the negative
+    4) If idft = False, since for the purely real input data the negative
        frequency terms are just the complex conjugates of the corresponding
        positive-frequency terms, the output does not include the negative
        frequency terms, and therefore the length of the transformed axis
@@ -226,7 +226,7 @@ def whiten(
 
     norm_amp *= tiled_win
 
-    if ifft:
+    if idft:
         # revert back to time-domain, using the phase of the original signal
         whitened_data = np.real(
             nft.irfft(norm_amp * np.exp(1j * phase), n=comp_nsamp, axis=dim_ind)

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -127,8 +127,7 @@ def dft(
     - Non-dimensional coordiantes associated with transformed coordinates
       will be dropped in the output.
 
-    - See the [FFT note](`notes/dft_notes.qmd`) in the Notes section
-      of DASCore's documentation for more details.
+    - See the [FFT notes](`docs/notes/dft_notes.qmd`) for more details.
 
     See Also
     --------

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -132,6 +132,9 @@ def convert_units(
     to_units, from_units = get_quantity(to_units), get_quantity(from_units)
     if from_units is None:
         return data
+    elif to_units is None:
+        msg = "Cannot convert units to_units are not specified"
+        raise UnitError(msg)
     try:
         mult1, add, mult2 = _get_conversion_factors(from_units, to_units)
     except DimensionalityError as e:

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -683,20 +683,21 @@ def check_coords(
 
 def _merge_aligned_coords(cm1, cm2):
     """Merge aligned coordinates removing non coords."""
-    assert cm1.dims == cm2.dims, "coordinates are not aligned"
+    assert cm1.dims == cm2.dims, "dimensions are not aligned"
     out = {}
     for name in set(cm1.coord_map) & set(cm2.coord_map):
         coord1 = cm1.coord_map[name]
         coord2 = cm2.coord_map[name]
+        dim1, dim2 = cm1.dim_map.get(name), cm2.dim_map.get(name)
         # Coords already equal, just use first.
-        if coord1.approx_equal(coord2):
-            out[name] = coord1
+        if coord1.approx_equal(coord2) and dim1 == dim2:
+            out[name] = (dim1, coord1)
         # Deal with Non coords
         non_count = sum([coord1._partial, coord2._partial])
         if non_count == 1:
-            out[name] = coord1 if coord2._partial else coord2
+            out[name] = (dim1, coord1 if coord2._partial else coord2)
         elif non_count == 2:
-            out[name] = coord1 if coord1.size > coord2.size else coord2
+            out[name] = (dim1, coord1 if coord1.size > coord2.size else coord2)
         assert name in out
     return cm1.update(**out)
 

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1703,6 +1703,14 @@ class TestGetNextIndex:
         out2 = coord.get_next_index(values)
         assert np.all(out1 == inds) and np.all(out2 == out1)
 
+    def test_out_of_bounds_array_range_coord(self, evenly_sampled_coord):
+        """Ensure get index works with array that has out of bounds values."""
+        coord = evenly_sampled_coord
+        values = coord.values
+        inputs = np.arange(3) + np.max(values)
+        out = coord.get_next_index(inputs, allow_out_of_bounds=True)
+        assert np.allclose(out, 99)
+
     def test_non_sorted_coord_raises(self, random_coord):
         """Ensure a non-sorted coord raises."""
         msg = "Coords must be sorted"

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1674,6 +1674,16 @@ class TestGetNextIndex:
     def test_units(self, evenly_sampled_float_coord_with_units):
         """Ensure values with units work."""
         coord = evenly_sampled_float_coord_with_units
+        val1 = np.array([10, 20]) * get_quantity("m")
+        val2 = val1.to(get_quantity("ft"))
+        ind1 = coord.get_next_index(val1)
+        ind2 = coord.get_next_index(val2)
+        assert len(val1) == len(ind1)
+        assert np.all(ind1 == ind2)
+
+    def test_unit_array(self, evenly_sampled_float_coord_with_units):
+        """Ensure an array of units returns inds of equal shape."""
+        coord = evenly_sampled_float_coord_with_units.set_units("m")
         val1 = 10 * get_quantity("m")
         val2 = val1.to(get_quantity("ft"))
         ind1 = coord.get_next_index(val1)

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1879,3 +1879,16 @@ class TestIssues:
         """Ensure off by one error don't occur with snap."""
         out = awkward_off_by_one.snap()
         assert out.shape == awkward_off_by_one.shape
+
+    def test_dtype_start_int_others_float(self):
+        """
+        Ensure the correct dtype is given when the start value is an int
+        but the other values are not.
+        """
+        coord = get_coord(
+            start=0,
+            step=1.1,
+            stop=11.2,
+            units="m",
+        )
+        assert np.issubdtype(coord.dtype, np.floating)

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -467,9 +467,6 @@ class TestSelect:
     def test_select_end_end_time(self, coord):
         """Ensure when time range is == (end, end) that dim has len 1."""
         out = coord.select((coord.max(), coord.max()))[0]
-        if not len(out) == 1:
-            breakpoint()
-            coord.select((coord.max(), coord.max()))[0]
         assert len(out) == 1
 
     def test_intra_sample_select(self, coord):
@@ -482,22 +479,12 @@ class TestSelect:
         arg = values[0] + (values[1] - values[0]) / 2
         assert arg not in np.unique(values)
         out, indexer = coord.select((arg, arg))
-
-        if not out.degenerate:
-            breakpoint()
-            coord.select((arg, arg))
-
         assert out.degenerate
         assert np.size(coord.data[indexer]) == 0
 
     def test_select_start_start_time(self, coord):
         """Ensure when time range is == (start, start) that dim has len 1."""
         out = coord.select((coord.min(), coord.min()))[0]
-
-        if not len(out) == 1:
-            breakpoint()
-            coord.select((coord.min(), coord.min()))[0]
-
         assert len(out) == 1
 
     def test_select_inclusive(self, long_coord):
@@ -543,11 +530,6 @@ class TestSelect:
         assert np.size(coord.data[indexer]) == 0
         # Same thing if end time is too early
         new, indexer = coord.select((None, v2))
-
-        if not new.degenerate:
-            breakpoint()
-            coord.select((None, v2))
-
         assert new.degenerate
         assert np.size(coord.data[indexer]) == 0
         # but this should be fine
@@ -585,15 +567,7 @@ class TestSelect:
         v1 = coord.min() - 10 * diff
         v2 = coord.max() + 10 * diff
         out, slice_thing = coord.select((v1, v2))
-
-        try:
-            _is_equal(coord, out, slice_thing)
-        except:
-            breakpoint()
-            out, slice_thing = coord.select((v1, v2))
-
-
-
+        _is_equal(coord, out, slice_thing)
         out, slice_thing = coord.select((None, v2))
         _is_equal(coord, out, slice_thing)
         out, slice_thing = coord.select((v1, None))
@@ -619,16 +593,7 @@ class TestSelect:
         assert slice_value == 20
         # test end index
         new, sliced = coord.select((..., value1))
-
-
-        try:
-            assert sliced.stop == 11 if new.sorted else sliced.start == 10
-        except AssertionError:
-            breakpoint()
-            coord.select((..., value1))
-
-
-
+        assert sliced.stop == 11 if new.sorted else sliced.start == 10
         new, sliced = coord.select((..., value2))
         assert sliced.stop == 21 if new.sorted else sliced.start == 20
         # test range
@@ -1724,13 +1689,7 @@ class TestGetNextIndex:
             pytest.skip(f"{coord} doesn't support get_next_index.")
         values = coord.values[inds]
         out2 = coord.get_next_index(values)
-
-        try:
-            assert np.all(out1 == inds) and np.all(out2 == out1)
-        except:
-            breakpoint()
-            coord.get_next_index(values)
-
+        assert np.all(out1 == inds) and np.all(out2 == out1)
 
     def test_non_sorted_coord_raises(self, random_coord):
         """Ensure a non-sorted coord raises."""

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -544,14 +544,14 @@ class TestPad:
         distance_axis = random_patch.dims.index("distance")
         ch_spacing = random_patch.attrs["distance_step"]
         assert (
-                new_shape[distance_axis] == original_shape[distance_axis] + 14 * ch_spacing
+            new_shape[distance_axis] == original_shape[distance_axis] + 14 * ch_spacing
         )
         # Ensure that padded values are zeros
         assert np.all(padded_patch.select(distance=(None, 7), samples=True).data == 0)
         assert np.all(padded_patch.select(distance=(-7, None), samples=True).data == 0)
 
     def test_pad_distance_dimension_expand_coords(
-            self, random_patch, expand_coords=True
+        self, random_patch, expand_coords=True
     ):
         """Test padding the distance with same number of zeros on both sides."""
         padded_patch = random_patch.pad(distance=4, expand_coords=expand_coords)
@@ -561,7 +561,7 @@ class TestPad:
         ch_spacing = random_patch.attrs["distance_step"]
         dist_max = random_patch.attrs["distance_max"]
         assert (
-                new_shape[distance_axis] == original_shape[distance_axis] + 8 * ch_spacing
+            new_shape[distance_axis] == original_shape[distance_axis] + 8 * ch_spacing
         )
         # Ensure that padded values are zeros
         assert np.all(padded_patch.select(distance=(None, -1)).data == 0)
@@ -577,7 +577,7 @@ class TestPad:
         distance_axis = random_patch.dims.index("distance")
         assert padded_patch.shape[time_axis] == random_patch.shape[time_axis] + 13
         assert (
-                padded_patch.shape[distance_axis] == random_patch.shape[distance_axis] + 5
+            padded_patch.shape[distance_axis] == random_patch.shape[distance_axis] + 5
         )
         # Check padding values
         assert np.allclose(
@@ -624,7 +624,7 @@ class TestPad:
 
 
 class TestConj:
-    """Tests for complex conjugate. """
+    """Tests for complex conjugate."""
 
     def test_imaginary_part_reversed(self, random_dft_patch):
         """Ensure the imaginary part of the array is reversed."""
@@ -657,8 +657,8 @@ class TestRoll:
         patcht = random_patch.transpose("time", ...)
         rolled_patch = patcht.roll(time=5, samples=True, update_coord=True)
         assert (
-                patcht.coords.get_array("time")[0]
-                == rolled_patch.coords.get_array("time")[5]
+            patcht.coords.get_array("time")[0]
+            == rolled_patch.coords.get_array("time")[5]
         )
 
     def test_dist_coord_roll(self, random_patch):
@@ -667,6 +667,6 @@ class TestRoll:
         coord = random_patch.get_coord("distance")
         value = coord.get_sample_count(30)
         assert (
-                random_patch.coords.get_array("distance")[0]
-                == rolled_patch.coords.get_array("distance")[value]
+            random_patch.coords.get_array("distance")[0]
+            == rolled_patch.coords.get_array("distance")[value]
         )

--- a/tests/test_proc/test_correlate.py
+++ b/tests/test_proc/test_correlate.py
@@ -153,3 +153,8 @@ class TestCorrelateInternal:
         assert isinstance(out1, dc.Patch)
         out2 = patch.correlate(distance=np.array([1, 2]) * m)
         assert isinstance(out2, dc.Patch)
+
+    def test_lag_deprecated(self, corr_patch):
+        """Ensure the lag parameter is deprecated."""
+        with pytest.warns(DeprecationWarning):
+            corr_patch.correlate(time=1, lag=10, samples=True)

--- a/tests/test_proc/test_correlate.py
+++ b/tests/test_proc/test_correlate.py
@@ -133,6 +133,13 @@ class TestCorrelateInternal:
         # plus a dimension 1 for the source.
         assert out.shape == tuple([*corr_patch.shape, 1])
 
+    def test_correlate_decimated_patch(self, corr_patch):
+        """Ensure a decimated patch can be correlated."""
+        out = corr_patch.decimate(distance=2, filter_type=None).correlate(
+            distance=1, samples=True
+        )
+        assert isinstance(out, dc.Patch)
+
     def test_correlate_units_raises(self, corr_patch):
         """When the patch doesn't have units an error should raise."""
         patch = corr_patch.set_units(distance=None)

--- a/tests/test_proc/test_correlate.py
+++ b/tests/test_proc/test_correlate.py
@@ -119,14 +119,14 @@ class TestCorrelateInternal:
             out.channel_count == corr_patch.channel_count
         ), "Expected size of the output distance coordinate to match the original patch"
 
-    def test_correlation_ifft_false(self, corr_patch):
+    def test_correlation_idft_false(self, corr_patch):
         """
         Ensure correlate function can return the result in the frequency domain
-        when the ifft flag is set to Flase.
+        when the idft flag is set to Flase.
         """
         # return correlation in frequency domain
         correlated_patch_freq_domain = corr_patch.correlate(
-            distance=2, samples=True, ifft=False
+            distance=2, samples=True, idft=False
         )
 
         # check if the returned data is in the frequency domain

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -194,13 +194,13 @@ class TestWhiten:
             whitened_patch.coords.get_array("distance"),
         )
 
-    def test_whiten_ifft_false(self, test_patch):
+    def test_whiten_idft_false(self, test_patch):
         """
         Ensure whiten function can return the result in the frequency domain
-        when the ifft flag is set to Flase.
+        when the idft flag is set to Flase.
         """
         # whiten the patch and return in frequency domain
-        whitened_patch_freq_domain = test_patch.whiten(smooth_size=5, ifft=False)
+        whitened_patch_freq_domain = test_patch.whiten(smooth_size=5, idft=False)
 
         # check if the returned data is in the frequency domain
         assert np.iscomplexobj(

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -197,7 +197,7 @@ class TestWhiten:
     def test_whiten_ifft_false(self, test_patch):
         """
         Ensure whiten function can return the result in the frequency domain
-        when the ifft flag is set to True.
+        when the ifft flag is set to Flase.
         """
         # whiten the patch and return in frequency domain
         whitened_patch_freq_domain = test_patch.whiten(smooth_size=5, ifft=False)
@@ -205,4 +205,4 @@ class TestWhiten:
         # check if the returned data is in the frequency domain
         assert np.iscomplexobj(
             whitened_patch_freq_domain.data
-        ), "Expected the data to be complex, indicating freq. domain representation."
+        ), "Expected the output to be complex, indicating freq. domain representation."

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -254,3 +254,9 @@ class TestConvertUnits:
         f_array = (array * (9 * 2.5 / 5) + 32.0) / 6
         out = convert_units(array, from_units="2.5*degC", to_units="6*degF")
         assert np.allclose(f_array, out)
+
+    def test_not_output_units_raises(self):
+        """Ensure an error is raised if output units are None."""
+        msg = "are not specified"
+        with pytest.raises(UnitError, match=msg):
+            convert_units(1, from_units="m", to_units=None)


### PR DESCRIPTION

## Description

This PR changes the correlate function in a few ways:

1. Multiple sources can now be selected in a single go
2. Removed the `lag` parameter as it was redundant (eg the user should do a `select` on the return value)
3. Greatly simplified the internals to simply use `patch.dft`
4. Adds the `Patch.conj` method for getting the complex conjugate of a patch
5. Adds the `Patch.correlate_shift` for undoing the fft-related shift and scaling
6. Fixes a few small bugs with coords/units. 

supersedes #364 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
