### PR TITLE
add better decimate error message

### DIFF
--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -10,6 +10,7 @@ from scipy.signal import decimate as scipy_decimate
 import dascore as dc
 import dascore.compat as compat
 from dascore.constants import PatchType
+from dascore.exceptions import FilterValueError
 from dascore.units import get_filter_units
 from dascore.utils.patch import (
     get_dim_value_from_kwargs,
@@ -17,6 +18,24 @@ from dascore.utils.patch import (
     patch_function,
 )
 from dascore.utils.time import to_int, to_timedelta64
+
+
+
+def _apply_scipy_decimation(patch, factor, ftype, axis):
+    """
+    Apply decimation along axis.
+    """
+    try:
+        data = scipy_decimate(patch.data, factor, ftype=ftype, axis=axis)
+    except ValueError as e:
+        msg = (
+            "Scipy decimation failed. This can happen for dimensions with"
+            "few elements. Consider setting filter_type to False. The raised "
+            f"exception was {e}"
+        )
+        raise FilterValueError(msg)
+    return data
+
 
 
 @patch_function()
@@ -46,8 +65,12 @@ def decimate(
 
     Notes
     -----
-    Simply uses scipy.signal.decimate if filter_type is specified. Otherwise,
-    just slice data long specified dimension only including every n samples.
+    - Simply uses scipy.signal.decimate if filter_type is specified.
+      Otherwise,just slice data long specified dimension only including
+      every n samples.
+
+    - If the decimation dimension is small, this can fail due to lack of
+      padding values.
 
     Examples
     --------
@@ -62,7 +85,9 @@ def decimate(
     coords, slices = patch.coords.decimate(**{dim: int(factor)})
     # Apply scipy.signal.decimate and get new coords
     if filter_type:
-        data = scipy_decimate(patch.data, factor, ftype=filter_type, axis=axis)
+        data = _apply_scipy_decimation(
+            patch.data, factor, ftype=filter_type, axis=axis
+        )
     else:  # No filter, simply slice along specified dimension.
         data = patch.data[slices]
         # Need to copy so array isn't a slice and holds onto reference of parent

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -8,6 +8,7 @@ import pytest
 
 import dascore as dc
 from dascore.compat import random_state
+from dascore.exceptions import FilterValueError
 from dascore.units import Hz, m, s
 from dascore.utils.patch import get_start_stop_step
 
@@ -123,6 +124,13 @@ class TestDecimate:
 
         decimated_none = patch.decimate(time=10, filter_type=None)
         assert not np.any(pd.isnull(decimated_none.data))
+
+    def test_decimate_small_dimension(self, random_patch):
+        """Ensure decimation raises helpful error on small dimensions."""
+        small_patch = random_patch.select(distance=(0, 10), samples=True)
+        match = "Scipy decimation failed."
+        with pytest.raises(FilterValueError, match=match):
+            small_patch.decimate(distance=2)
 
 
 class TestResample:


### PR DESCRIPTION

## Description
This PR adds a nicer error message for when scipy's decimation fails. This occurs when decimating an axis few values (small length).

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
