### PR TITLE
fix correlate doc build

### DIFF
--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -70,9 +70,7 @@ def correlate_shift(patch, dim, undo_weighting=True):
     data = np.fft.fftshift(patch.data, axes=axis)
     if undo_weighting:
         data = data / to_float(coord.step)
-    # so it appears (from testing) there is one lest sample on the positive
-    # side.
-    step = to_float(coord.step)
+    step = coord.step
     new_start = -np.ceil((len(coord) - 1) / 2) * step
     new_end = np.ceil((len(coord) - 1) / 2) * step
     new_coord = dc.get_coord(start=new_start, stop=new_end, step=step)
@@ -182,8 +180,9 @@ def correlate(
     -----
     1 - The cross-correlation is performed in the frequency domain.
 
-    2 - The output dimension is opposite of the one specified in kwargs, has
-    the units of float, and the string "lag_" prepended. For example, "lag_time".
+    2 - The output dimension is opposite of the one specified in kwargs and
+      shares a name with the original coord except the string "lag_" is
+      prepended. For example, "lag_time".
     """
     if lag is not None:
         msg = "Correlate lag is deprecated. Simply use on the output patch."

--- a/docs/recipes/correlate.qmd
+++ b/docs/recipes/correlate.qmd
@@ -38,5 +38,7 @@ patch = dc.get_example_patch(
 
 corr = patch.correlate(distance=3, samples=True)
 
-corr.viz.waterfall();
+# Note we squeeze the last dimension to get 2D patch
+
+corr.squeeze().viz.waterfall();
 ```

--- a/tests/test_proc/test_correlate.py
+++ b/tests/test_proc/test_correlate.py
@@ -24,7 +24,7 @@ class TestCorrelateShift:
         # ensure the max value happens at zero lag time.
         time_ax = auto_patch.dims.index("lag_time")
         argmax = np.argmax(random_dft_patch.data, axis=time_ax)
-        assert np.allclose(coord_array[argmax], 0)
+        assert np.all(coord_array[argmax] == dc.to_timedelta64(0))
 
 
 class TestCorrelateInternal:


### PR DESCRIPTION

## Description

This PR fixes the issues with the documentation build from the recent correlate changes.

It also keeps the new correlate coordinate in compatible units rather than forcing a conversion to float. For example, if the time coord was a `datetime64` the "lag_time" coordinate will now be a `timedelta64` coordinate. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
