### PR TITLE
Fix rolling center

### DIFF
--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -300,7 +300,7 @@ def rolling(
         engines = {"numpy": _NumpyPatchRoller, "pandas": _PandasPatchRoller}
         if cls := engines.get(engine):
             return cls
-        if step < 10 and len(patch.dims) < 2:
+        if step < 10 and len(patch.squeeze().dims) < 2:
             return _PandasPatchRoller
         return _NumpyPatchRoller
 

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -81,7 +81,7 @@ class _NumpyPatchRoller(_PatchRollerInfo):
             assert padded.shape == self.patch.data.shape
         if self.center:
             # roll array along axis to center
-            padded = np.roll(padded, -self.window // 2, axis=self.axis)
+            padded = np.roll(padded, -(self.window // 2), axis=self.axis)
         return padded
 
     def apply(self, function):
@@ -231,10 +231,10 @@ def rolling(
     step
         The window is evaluated at every step result, equivalent to slicing
         at every step. If the step argument is not None, the result will
-        have a different shape than the input.
+        have a different shape than the input. Default None.
     center
         If False, set the window labels as the right edge of the window index.
-        If True, set the window labels as the center of the window index.
+        If True, set the window labels as the center of the window index. Default False.
     engine
         Determines how the rolling operations are applied. If None, try to
         determine which will be fastest for a given step. Options are:

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -81,7 +81,7 @@ class _NumpyPatchRoller(_PatchRollerInfo):
             assert padded.shape == self.patch.data.shape
         if self.center:
             # roll array along axis to center
-            padded = np.roll(padded, -(self.window // 2), axis=self.axis)
+            padded = np.roll(padded, -(num_nans // 2), axis=self.axis)
         return padded
 
     def apply(self, function):
@@ -105,9 +105,8 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         step_slice.append(slice(None, None))
         # this accounts for NaNs that pad the start of the array.
         start = self.get_start_index()
-        # start = (self.window - 1) % self.step
         step_slice[self.axis] = slice(start, None, self.step)
-        # apply function, then pad with zeros and roll
+        # apply function, then pad with NaNs and roll
         kwargs = self.func_kwargs
         trimmed_slide_view = slide_view[tuple(step_slice)]
         raw = function(trimmed_slide_view, axis=-1, **kwargs).astype(np.float64)

--- a/dasdasdasd
+++ b/dasdasdasd
@@ -1,0 +1,2 @@
+* [32mfix_rolling_center[m
+  master[m

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -248,6 +248,21 @@ class TestNumpyVsPandasRolling:
             np.equal(numpy_isnan, pandas_isnan)
         ), "The NaN indices do not match"
 
+    def test_center_same_stepped(self, range_patch):
+        """Ensure center values are handled the same."""
+        dt = range_patch.get_coord("time").step
+        numpy_out = range_patch.rolling(
+            time=13 * dt, step=3 * dt, center=True, engine="numpy"
+        ).sum()
+        pandas_out = range_patch.rolling(
+            time=13 * dt, step=3 * dt, center=True, engine="pandas"
+        ).sum()
+        numpy_isnan = np.isnan(numpy_out.data)
+        pandas_isnan = np.isnan(pandas_out.data)
+        assert np.all(
+            np.equal(numpy_isnan, pandas_isnan)
+        ), "The NaN indices do not match"
+
     def test_dimension_order(self, range_patch):
         """Ensure the dimension order doesn't matter."""
         for patch in [range_patch, range_patch.transpose()]:

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -270,7 +270,16 @@ class TestNumpyVsPandasRolling:
                 coord = patch.get_coord(dim)
                 step = coord.step
                 total_len = len(coord) - 2
-                kwargs = {dim: step * total_len, "step": total_len * step}
-                pandas_out = patch.rolling(**kwargs).mean().dropna(dim)
-                numpy_out = patch.rolling(**kwargs).mean().dropna(dim)
+                kwargs_pandas = {
+                    dim: step * total_len,
+                    "step": total_len * step,
+                    "engine": "pandas",
+                }
+                kwargs_numpy = {
+                    dim: step * total_len,
+                    "step": total_len * step,
+                    "engine": "numpy",
+                }
+                pandas_out = patch.rolling(**kwargs_pandas).mean().dropna(dim)
+                numpy_out = patch.rolling(**kwargs_numpy).mean().dropna(dim)
                 assert pandas_out == numpy_out

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -238,11 +238,15 @@ class TestNumpyVsPandasRolling:
     def test_center_same(self, range_patch):
         """Ensure center values are handled the same."""
         dt = range_patch.get_coord("time").step
-        numpy_out = range_patch.rolling(time=13 * dt, center=True).sum()
-        pandas_out = range_patch.rolling(time=13 * dt, center=True).sum()
+        numpy_out = range_patch.rolling(time=13 * dt, center=True, engine="numpy").sum()
+        pandas_out = range_patch.rolling(
+            time=13 * dt, center=True, engine="pandas"
+        ).sum()
         numpy_isnan = np.isnan(numpy_out.data)
         pandas_isnan = np.isnan(pandas_out.data)
-        assert np.all(np.equal(numpy_isnan, pandas_isnan))
+        assert np.all(
+            np.equal(numpy_isnan, pandas_isnan)
+        ), "The NaN indices do not match"
 
     def test_dimension_order(self, range_patch):
         """Ensure the dimension order doesn't matter."""


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description
This PR fixes two issues regarding the `center=True` in the `Patch.rolling` function when `engine="numpy"`:
1. The first issue was related to using a wrong `-window//2` roll size instead of `-(window//2)` in `np.roll` function to roll NaN values. This could cause unequal NaNs at the beginning and end of the rolled patch.
2. The second issue was related to using `-(window//2)` instead of `-(num_nans//2)` inside the `np.roll` that led to the wrong number of indices to roll when the `step` size is not equal to `None` (and therefore the size of the padded array is different than the original patch's data).

<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
