### PR TITLE
DFT padding and slope filter simplification

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -702,6 +702,9 @@ class CoordManager(DascoreBaseModel):
         non_dim_coords = sorted(set(self.coord_map) - set(self.dims))
         names = list(self.dims) + non_dim_coords
         for name in names:
+            # skip private coords for display
+            if name.startswith("_"):
+                continue
             coord = self.coord_map[name]
             coord_dims = self.dim_map[name]
             if name in self.dims:

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -508,6 +508,12 @@ class CoordManager(DascoreBaseModel):
         no_dim_coords = [x for x in cmap if dim_map[x] == ()]
         return self.drop_coords(*no_dim_coords)
 
+    def drop_private_coords(self, array=None) -> Self:
+        """Drop all coordinates whose name begin with an underscore."""
+        cmap = self.coord_map
+        private = tuple(x for x in cmap.keys() if x.startswith("_"))
+        return self.drop_coords(*private, array=array)
+
     def set_dims(self, **kwargs: str) -> Self:
         """
         Set dimension to non-dimensional coordinate.

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -19,6 +19,7 @@ from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.coords import BaseCoord
 from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
 from dascore.utils.models import ArrayLike
+from dascore.utils.patch import check_patch_attrs, check_patch_coords
 from dascore.utils.time import to_float
 from dascore.viz import VizPatchNameSpace
 
@@ -240,7 +241,8 @@ class Patch:
     new = dascore.proc.update
     equals = dascore.proc.equals
     update_attrs = dascore.proc.update_attrs
-    assert_has_coords = dascore.proc.assert_has_coords
+    check_coords = check_patch_coords
+    check_attrs = check_patch_attrs
     get_coord = dascore.proc.get_coord
     get_array = dascore.proc.get_array
     pipe = dascore.proc.pipe

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -255,6 +255,7 @@ class Patch:
     rename_coords = dascore.proc.rename_coords
     update_coords = dascore.proc.update_coords
     drop_coords = dascore.proc.drop_coords
+    drop_private_coords = dascore.proc.drop_private_coords
     coords_from_df = dascore.proc.coords_from_df
     make_broadcastable_to = dascore.proc.make_broadcastable_to
     apply_ufunc = dascore.proc.apply_ufunc

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -55,8 +55,8 @@ class ChunkError(DASCoreError):
     """Raised when chunking goes awry."""
 
 
-class PatchDimError(ValueError, PatchError):
-    """Raised when something is wrong with a Patch's dimension."""
+class PatchCoordinateError(ValueError, PatchError):
+    """Raised when something is wrong with a Patch's coordinates."""
 
 
 class PatchBroadcastError(ValueError, PatchError):

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -71,7 +71,7 @@ class WavIO(FiberIO):
     @staticmethod
     def _get_wav_data(patch, resample):
         """Pre-condition patch data for writing. Return array and sample rate."""
-        check_patch_coords(patch, ("time", "distance"), dims=True)
+        check_patch_coords(patch, ("time", "distance"))
         assert len(patch.dims) == 2, "only 2D patches supported for this function."
         # handle resampling and normalization
         pat = patch.transpose("time", "distance")

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -9,7 +9,7 @@ from scipy.io.wavfile import write
 
 from dascore.constants import ONE_SECOND, SpoolType
 from dascore.io.core import FiberIO
-from dascore.utils.patch import check_patch_dims
+from dascore.utils.patch import check_patch_coords
 
 
 class WavIO(FiberIO):
@@ -71,7 +71,7 @@ class WavIO(FiberIO):
     @staticmethod
     def _get_wav_data(patch, resample):
         """Pre-condition patch data for writing. Return array and sample rate."""
-        check_patch_dims(patch, ("time", "distance"))
+        check_patch_coords(patch, ("time", "distance"), dims=True)
         assert len(patch.dims) == 2, "only 2D patches supported for this function."
         # handle resampling and normalization
         pat = patch.transpose("time", "distance")

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -236,11 +236,11 @@ def drop_private_coords(self: PatchType) -> PatchType:
     >>> import numpy as np
     >>> import dascore as dc
     >>> pa = (
-    ...     dc.get_example_patch("random_patch")
-    ...     .update_coords(_private=np.array([1,2,3]))
+    ...     dc.get_example_patch("random_das")
+    ...     .update_coords(_private=(None, np.array([1,2,3])))
     ... )
-    >>> pa_no_priv = pa.drop_private_coords()
-    >>> assert "_private" not in pa.coords.coord_map
+    >>> pa_no_private = pa.drop_private_coords()
+    >>> assert "_private" not in pa_no_private.coords.coord_map
     """
     new_coord, data = self.coords.drop_private_coords(array=self.data)
     return self.new(coords=new_coord, dims=new_coord.dims, data=data)

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -222,6 +222,31 @@ def drop_coords(self: PatchType, *coords: str | Collection[str]) -> PatchType:
 
 
 @patch_function()
+def drop_private_coords(self: PatchType) -> PatchType:
+    """
+    Drop any provate coords in the patch.
+
+    Parameters
+    ----------
+    self
+        Patch
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import dascore as dc
+    >>> pa = (
+    ...     dc.get_example_patch("random_patch")
+    ...     .update_coords(_private=np.array([1,2,3]))
+    ... )
+    >>> pa_no_priv = pa.drop_private_coords()
+    >>> assert "_private" not in pa.coords.coord_map
+    """
+    new_coord, data = self.coords.drop_private_coords(array=self.data)
+    return self.new(coords=new_coord, dims=new_coord.dims, data=data)
+
+
+@patch_function()
 def make_broadcastable_to(
     self: PatchType,
     shape: tuple[int, ...],

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Sequence
+from collections.abc import Collection
 
 import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
-from typing_extensions import Self
 
 from dascore.constants import PatchType, select_values_description
 from dascore.core.coords import BaseCoord
 from dascore.exceptions import CoordError, ParameterError
 from dascore.utils.docs import compose_docstring
-from dascore.utils.misc import get_parent_code_name, iterate
+from dascore.utils.misc import get_parent_code_name
 from dascore.utils.patch import patch_function
 
 
@@ -142,16 +141,6 @@ def get_array(
         require_evenly_sampled=require_evenly_sampled,
     )
     return coord.data
-
-
-def assert_has_coords(self: PatchType, coord_names: Sequence[str] | str) -> Self:
-    """Raise an error if patch doesn't have required coordinates."""
-    required_coords = set(iterate(coord_names))
-    current_coords = set(self.coords.coord_map)
-    if missing := required_coords - current_coords:
-        msg = f"Patch does not have required coordinate(s): {missing}"
-        raise CoordError(msg)
-    return self
 
 
 @patch_function()

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -224,7 +224,7 @@ def drop_coords(self: PatchType, *coords: str | Collection[str]) -> PatchType:
 @patch_function()
 def drop_private_coords(self: PatchType) -> PatchType:
     """
-    Drop any provate coords in the patch.
+    Drop all private coords in the patch.
 
     Parameters
     ----------

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -18,10 +18,10 @@ from scipy.ndimage import median_filter as nd_median_filter
 from scipy.signal import iirfilter, sosfilt, sosfiltfilt, zpk2sos
 from scipy.signal import savgol_filter as np_savgol_filter
 
-import dascore
+import dascore as dc
 from dascore.constants import PatchType, samples_arg_description
-from dascore.exceptions import FilterValueError, ParameterError
-from dascore.units import get_filter_units
+from dascore.exceptions import FilterValueError, ParameterError, UnitError
+from dascore.units import convert_units, get_filter_units, invert_quantity
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import (
     broadcast_for_index,
@@ -134,9 +134,7 @@ def pass_filter(patch: PatchType, corners=4, zerophase=True, **kwargs) -> PatchT
         out = sosfiltfilt(sos, patch.data, axis=axis)
     else:
         out = sosfilt(sos, patch.data, axis=axis)
-    return dascore.Patch(
-        data=out, coords=patch.coords, attrs=patch.attrs, dims=patch.dims
-    )
+    return dc.Patch(data=out, coords=patch.coords, attrs=patch.attrs, dims=patch.dims)
 
 
 @patch_function()
@@ -171,9 +169,7 @@ def sobel_filter(patch: PatchType, dim: str, mode="reflect", cval=0.0) -> PatchT
     dim, mode, cval = _check_sobel_args(dim, mode, cval)
     axis = patch.dims.index(dim)
     out = ndimage.sobel(patch.data, axis=axis, mode=mode, cval=cval)
-    return dascore.Patch(
-        data=out, coords=patch.coords, attrs=patch.attrs, dims=patch.dims
-    )
+    return dc.Patch(data=out, coords=patch.coords, attrs=patch.attrs, dims=patch.dims)
 
 
 #
@@ -431,34 +427,47 @@ def slope_filter(
 
     Examples
     --------
+    >>> # Example 1: Compare slope filtered patch to Non-filtered.
     >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
     >>> import dascore as dc
     >>> from dascore.units import Hz
-    >>> import sys
     >>> # Apply taper function and bandpass filter along time axis from 1 to 500 Hz
-    >>> patch_raw = (
+    >>> patch = (
     ...     dc.get_example_patch('example_event_1')
+    ...     .set_units(distance='m', time='s')
     ... 	.taper(time=0.05)
     ... 	.pass_filter(time=(1*Hz, 500*Hz))
     ... )
+    >>> filt = np.array([2e3,2.2e3,8e3,2e4])
     >>> # Apply fk filter
-    >>> patch_filtered = patch_raw.slope_filter(
-    ...     filt=[2e3,2.2e3,8e3,2e4],
+    >>> patch_filtered = patch.slope_filter(
+    ...     filt=filt,
     ... 	directional=False,
     ...     notch=False
     ... )
     >>> # Plot results
     >>> fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 8))
-    >>> ax1 = patch_raw.viz.waterfall(ax=ax1, scale=0.5)
+    >>> ax1 = patch.viz.waterfall(ax=ax1, scale=0.5)
     >>> _ = ax1.set_title('Raw')
     >>> ax2 = patch_filtered.viz.waterfall(ax=ax2, scale=0.5)
     >>> _ = ax2.set_title('Filtered')
+    >>>
+    >>> # Example 2: Notch filter
+    >>> patch_filtered = patch.slope_filter(filt=filt, notch=True)
+    >>>
+    >>> # Example 3: specify units
+    >>> filt = np.array([2e3,2.2e3,8e3,2e4]) * dc.get_unit("m/s")
+    >>> patch_filtered = patch.slope_filter(filt=filt)
+
+    The [fk recipe](`docs/recipes/fk.qmd`) provides addtional examples.
     """
 
     def _check_inputs(patch, filt, dims):
         """Ensure inputs are valid."""
-        if not isinstance(filt, Sequence) or not len(filt) == 4:
-            msg = "filt param must be a length 4 sequence."
+        sorted_filt = np.all(filt[:-1] <= filt[1:])
+        if not (sorted_filt and len(filt) == 4):
+            msg = f"filt must be a sorted length 4 sequence. You passed {filt}"
             raise ParameterError(msg)
         if missing := set(dims) - set(patch.coords.coord_map):
             msg = f"Cant apply slope filter. {missing} are missing from patch."
@@ -497,11 +506,34 @@ def slope_filter(
             slope = np.abs(slope)
         return slope
 
+    def _maybe_transform_units(filt, dft_patch, freq_dims):
+        """Handle units on filter."""
+        if not isinstance(filt, dc.units.Quantity):
+            return filt
+        array, units = filt.magnitude, filt.units
+        coord_unit_1 = dft_patch.get_coord(freq_dims[-1]).units
+        coord_unit_2 = dft_patch.get_coord(freq_dims[-2]).units
+        if not (coord_unit_1 and coord_unit_2):
+            msg = (
+                f"Units of {units} specified in Patch.slope_filter, but units "
+                f"are not defined for both specified dimensions: {dims}."
+            )
+            raise UnitError(msg)
+        new_units = coord_unit_1 / coord_unit_2
+        # Determine if we need to flip units.
+        if new_units.dimensionality == (1 / units).dimensionality:
+            array, units = np.sort(1 / array), invert_quantity(units)
+        out = convert_units(array, new_units, units)
+        return out
+
     _check_inputs(patch, filt, dims)
     freq_dims = tuple(f"ft_{x}" for x in dims)
     dft_patch = patch.dft.func(patch, dims)
     transformed = patch is not dft_patch
+
     slope = _get_slope_array(dft_patch, directional, freq_dims)
+    filt = _maybe_transform_units(filt, dft_patch, freq_dims)
+
     mask = _get_taper_mask(filt, slope, notch)
     new_data = dft_patch.data * mask
     out = dft_patch.update(data=new_data)

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -28,8 +28,14 @@ from dascore.utils.time import to_float
 from dascore.utils.transformatter import FourierTransformatter
 
 
-def _get_dft_new_coords(patch, dxs, dims, axes, real):
-    """Create coordinates based on dxs and patch shape."""
+def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
+    """
+    Create coordinates based on dxs and patch shape.
+
+    if original_cm is not none, it means the patch was padded.
+    """
+    # Note: We need original_cm and patch because patch may have undergone
+    # padding.
 
     def _get_fft_coord(x_len, dx, units):
         """Get coord for normal fft coord."""
@@ -57,18 +63,21 @@ def _get_dft_new_coords(patch, dxs, dims, axes, real):
         units = old_coord.units
         size = old_coord.shape[0]
         dx = dxs[i]
-        name = ft.rename_dims(dim)[0]
+        new_name = ft.rename_dims(dim)[0]
         if dim == real:
             coord = _get_rfft_coord(size, dx, units)
         else:
             coord = _get_fft_coord(size, dx, units)
-        new_coords[name] = (name, coord)
+        new_coords[new_name] = (new_name, coord)
+        # Add padded coordinates
+        if original_cm is not None:
+            new_coords[f"_{dim}_unpadded"] = (None, original_cm.get_coord(dim))
     new_dims = ft.rename_dims(patch.dims, index=axes)
     cm = get_coord_manager(new_coords, dims=new_dims)
     return cm
 
 
-def _get_dft_attrs(patch, dims, new_coords):
+def _get_dft_attrs(patch, dims, new_coords, pad=False):
     """Get new attributes for transformed patch."""
     new = dict(patch.attrs)
     new["dims"] = new_coords.dims
@@ -76,6 +85,7 @@ def _get_dft_attrs(patch, dims, new_coords):
     # As per #390, we also want to remove data_type (eg the patch is no
     # longer in strain rate after the dft)
     new["_pre_dft_data_type"] = new.pop("data_type", None)
+    new["_dft_padded"] = pad
     return PatchAttrs(**new)
 
 
@@ -93,7 +103,11 @@ def _get_untransformed_dims(patch, dims):
 
 @patch_function()
 def dft(
-    patch: PatchType, dim: str | None | Sequence[str], *, real: str | bool | None = None
+    patch: PatchType,
+    dim: str | None | Sequence[str],
+    *,
+    real: str | bool | None = None,
+    pad: bool = True,
 ) -> PatchType:
     """
     Perform the discrete Fourier transform (dft) on specified dimension(s).
@@ -109,6 +123,10 @@ def dft(
         Either 1) The name of the axis over which to perform a rfft, 2)
         True, which means the last (possibly only) dimenson should have an
         rfft performed, or 3) None, meaning no rfft.
+    pad
+        If True, pad patch before peforming dft along desired dimensions to
+        the next fast length. This can avoid major slow-downs when dimension
+        lengths are prime numbers.
 
     Notes
     -----
@@ -145,7 +163,7 @@ def dft(
     >>> dft_some_real = patch.dft(dim=("time", "distance"), real="time")
     """
     dims = list(iterate(dim if dim is not None else patch.dims))
-    patch.assert_has_coords(dims)
+    patch.check_coords(coords=dims)
     real = dims[-1] if real is True else real  # if true grab last dim
     dims = _get_untransformed_dims(patch, dims)
     real = real if real in dims else None  # may need to reset real
@@ -155,25 +173,31 @@ def dft(
     if isinstance(real, str):
         assert real in dims, "real must be in provided dimensions."
         dims.append(dims.pop(dims.index(real)))
+    original_cm = patch.coords if pad else None
+    if pad:  # apply padding to avoid slow dft lengths.
+        pad_kwargs = {x: "fft" for x in dims}
+        patch = patch.pad.func(patch, **pad_kwargs)
     # get axes and spacing along desired dimensions.
     dxs, axes = _get_dx_or_spacing_and_axes(patch, dims, require_evenly_spaced=True)
+    # get new coordinates (need before pad)
+    new_coords = _get_dft_new_coords(
+        patch, dxs, dims, axes, real, original_cm=original_cm
+    )
     func = nft.rfftn if real is not None else nft.fftn
-    # scale by dx's as explained above and in notes, then shift
+    # scale as explained above and in notes, then shift
     scale_factor = np.prod(dxs)
     fft_data = func(patch.data, axes=axes) * scale_factor
     shift_slice = slice(None) if real is None else slice(None, -1)
     data = nft.fftshift(fft_data, axes=axes[shift_slice])
-    # get new coordinates
-    new_coords = _get_dft_new_coords(patch, dxs, dims, axes, real)
     # get attributes
-    attrs = _get_dft_attrs(patch, dims, new_coords)
+    attrs = _get_dft_attrs(patch, dims, new_coords, pad=pad)
     return patch.new(data=data, coords=new_coords, attrs=attrs)
 
 
 def _get_idft_dims_steps_axis(patch, dim):
     """
     Get the dimensions, step sizes as a float, axis numbers and if an
-    rff should be performed.
+    irft should be performed.
     """
     ft = FourierTransformatter()
     if dim is None:
@@ -182,7 +206,7 @@ def _get_idft_dims_steps_axis(patch, dim):
     # ft_time for brevity.
     current_dims = set(patch.dims)
     dims = [x if x in current_dims else ft.rename_dims(x)[0] for x in iterate(dim)]
-    patch.assert_has_coords(dims)
+    patch.check_coords(dims=dims)
     coords = [patch.get_coord(x, require_evenly_sampled=True) for x in dims]
     is_real = [1 if to_float(x.min()) == 0 else 0 for x in coords]
     real_sum = sum(is_real)
@@ -212,8 +236,8 @@ def _get_idft_coords_and_sizes(patch, dims, new_dims, axes, real):
             )
             raise NotImplementedError(msg)
         if (len(potential_coord) == ax_len) or (real and old_dim == dims[-1]):
-            coord_map[new_dim] = (new_dim, potential_coord)
             sizes.append(len(potential_coord))
+        coord_map[new_dim] = (new_dim, potential_coord)
     ft = FourierTransformatter()
     new_dims = ft.rename_dims(patch.dims, index=axes, forward=False)
     cm = get_coord_manager(coord_map, dims=new_dims).drop_coords(*dims)[0]
@@ -230,7 +254,19 @@ def _get_idft_attrs(patch, dims, new_coords):
     # Restore the pre-dft datatype.
     if "_pre_dft_data_type" in new:
         new["data_type"] = new.pop("_pre_dft_data_type", None)
+    new.pop("_dft_padded", None)
     return PatchAttrs(**new)
+
+
+def _undo_dft_padding(out, patch, dims):
+    """Undo the padding from dft by trimming values from end of dims"""
+    cmap = patch.coords.coord_map
+    trims = {}
+    for dim in dims:
+        diff = len(cmap[f"_{dim}_unpadded"]) - len(cmap[dim])
+        if diff < 0:
+            trims[dim] = (0, diff)
+    return out.select.func(out, **trims, samples=True)
 
 
 @patch_function()
@@ -285,4 +321,7 @@ def idft(patch: PatchType, dim: str | None | Sequence[str] = None) -> PatchType:
     _preped = nft.ifftshift(patch.data / scale_factor, axes=axes[ax_slice])
     data = func(_preped, s=sizes, axes=axes)
     attrs = _get_idft_attrs(patch, dims, coords)
-    return patch.new(data=data, attrs=attrs, coords=coords)
+    out = patch.new(data=data, attrs=attrs, coords=coords)
+    if patch.attrs.get("_dft_padded"):  # need to undo padding.
+        out = _undo_dft_padding(out, patch, new_dims)
+    return out

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -138,6 +138,9 @@ def attrs_to_text(attrs) -> Text:
     txt = Text("➤ ") + Text("Attributes", style=dascore_styles["dc_yellow"])
     txt += Text("\n")
     for name, attr in dict(attrs).items():
+        # skip private coords for display
+        if name.startswith("_"):
+            continue
         # determine styles here based on keys
         style = dascore_styles.get(name, None)
         if name.endswith("units"):

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -894,7 +894,8 @@ def concatenate_patches(
 
     def get_compatible_patches(patches, dim, check_behavior):
         """Get the patches which can be concatenated, dim names, and new dim."""
-        patches = list(patches)
+        # We need to drop private coords for dft concats to work.
+        patches = list(x.drop_private_coords() for x in patches)
         first_patch = patches[0]
         compat_patches = []
         # Ensure patch dimensions are compatible.

--- a/docs/recipes/fk.qmd
+++ b/docs/recipes/fk.qmd
@@ -1,29 +1,46 @@
 ---
-title: F-K Transform
+title: F-K Transform and Filtering
 execute:
     warning: False
 ---
 
-[F-k transforms](https://wiki.seg.org/wiki/F-k_filtering) are common in geophysical applications for various types of filtering.
+## FK transforms
+
+[F-k transforms](https://wiki.seg.org/wiki/F-k_filtering) are common in geophysical applications for various types of filtering. For the following examples we will use the example_event included in DASCore's example files.
 
 ```{python}
+import numpy as np
+import matplotlib.pyplot as plt
+
 import dascore as dc
 
 patch = (
     dc.get_example_patch('example_event_1')
-    .set_units("mm/(m*s)", distance='m', time='s')
-    .taper(time=0.05)
+    .set_units("mstrain/s", distance='m', time='s')
+)
+
+patch.viz.waterfall(scale=0.2);
+
+```
+
+With some simple processing, as shown in other parts of the tutorial, we can clean up the patch:
+
+```{python}
+import dascore as dc
+
+patch_filtered = (
+    patch.taper(time=0.075)
     .pass_filter(time=(None, 300))
 )
 
-patch.viz.waterfall(show=True, scale=0.2);
+patch_filtered.viz.waterfall(show=True, scale=0.2);
 ```
 
 We can transform and visualize the patch in the F-K domain using the dft.
 
 ```{python}
 # Apply transform on all dimensions
-fk_patch = patch.dft(patch.dims)
+fk_patch = patch_filtered.dft(patch.dims)
 
 # We can't plot complex arrays so only plot amplitude
 ax = fk_patch.abs().viz.waterfall()
@@ -31,4 +48,48 @@ ax = fk_patch.abs().viz.waterfall()
 # Zoom in around interesting frequencies
 ax.set_xlim(-500, 500);
 ax.set_ylim(-.2, .2);
+```
+
+## Slope Filtering
+
+One advantage of the FK transform is the ability to manipulate signals based on their apparent velocities. [`Patch.slope_filter`](`dascore.Patch.slope_filter`) can be used for this purpose.
+
+For example, given the first example event, we can apply a slope filter whose range covers reasonable seismic velocities. The `filt` parameter specifies the slope (apparent velocities). It is a 4 length sequence of the form [va, vb, vc, vd] where velocities between `vb` and `vc` are unchanged (or set to zero if the `notch` parameter is `True`) and values between `va` and `vb`, as well as  those between `vc` and `vd`, are tapered. 
+
+
+```{python}  
+filt = np.array([2_000, 2_200, 8_000, 9_000])
+patch_filtered_2 = patch_filtered.slope_filter(filt=filt)
+patch_filtered_2.viz.waterfall(scale=1);
+```
+
+:::{.callout-note}
+It's important to remember that *apparent* velocities (>= velocity) are filtered. For the case of local seismicity occurring near the cable the apparent velocity will approximate the medium velocity for part of the recording. Additional considerations are needed for more distant events.   
+:::
+
+### Phase Separation
+
+Another application of [`slope_filter`](`dascore.Patch.slope_filter`) is to separate P/S waves. In this case, the P velocity is about 4500 amd the S velocity is about 2700. The following code highlights S waves, but also introduces some artifacts: 
+
+```{python}  
+filt_p = np.array([1_000, 2_300, 3_000, 4_000])
+patch_filtered_p = patch_filtered.slope_filter(filt=filt_p)
+patch_filtered_p.viz.waterfall(scale=1);
+```
+
+### Up/Down separation
+
+Up/down (or left/right) separation is also possible using the `directional` keyword. Up-going (waves moving towards the interrogator according a decreasing distance value) have positive velocities and down-going (waves moving away from the interrogator) have negative velocities. 
+
+
+```{python}  
+patch_upgoing = patch_filtered.slope_filter(filt=filt, directional=True)
+patch_downgoing = patch_filtered.slope_filter(filt=-filt[::-1], directional=True)
+
+fig, (ax_up, ax_down) = plt.subplots(2, 1, figsize=(6,10), sharex=True)
+
+patch_upgoing.viz.waterfall(scale=1, ax=ax_up);
+ax_up.set_title("Upgoing");
+patch_downgoing.viz.waterfall(scale=1, ax=ax_down);
+ax_down.set_title("Downgoing");
 ```

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -356,6 +356,21 @@ class TestDrop:
             assert coord not in set(cm_new.coord_map)
 
 
+class TestDropPrivateCoords:
+    """Tests for dropping private coordinates."""
+
+    def test_drop_private(self, cm_basic):
+        """Ensure private coords are removed."""
+        cm = cm_basic.update_coords(_bad=(None, np.array([1, 2, 3])))
+        out = cm.drop_private_coords()[0]
+        assert "_bad" not in out.coord_map
+
+    def test_no_private_coords(self, cm_basic):
+        """Ensure this does nothing when no private attrs are found."""
+        out = cm_basic.drop_private_coords()[0]
+        assert out is cm_basic
+
+
 class TestSelect:
     """Tests for filtering coordinates."""
 

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -652,28 +652,6 @@ class TestGetCoord:
             patch.get_coord("distance", require_sorted=True)
 
 
-class TestAssertHasCoords:
-    """Test suite for has coords."""
-
-    def test_raises_single(self, random_patch):
-        """Ensure an error is raised if as single required coord isnt found."""
-        match = "does not have required coordinate"
-        with pytest.raises(CoordError, match=match):
-            random_patch.assert_has_coords("foo")
-
-    def test_raises_multiple(self, random_patch):
-        """Ensure an error is raised if required coords aren't found."""
-        match = "does not have required coordinate"
-        with pytest.raises(CoordError, match=match):
-            random_patch.assert_has_coords(("bar", "depth"))
-
-    def test_has_coords_ok(self, random_patch):
-        """No Error should be raised if the patch has the coordinates."""
-        dims = random_patch.dims
-        random_patch.assert_has_coords(dims[0])
-        random_patch.assert_has_coords(dims)
-
-
 class TestDeprecations:
     """Ensure deprecations are issued."""
 

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -11,7 +11,7 @@ from dascore.exceptions import (
     CoordDataError,
     FilterValueError,
     ParameterError,
-    PatchDimError,
+    PatchCoordinateError,
     UnitError,
 )
 
@@ -201,7 +201,7 @@ class TestMedianFilter:
     def test_median_no_kwargs_raises(self, random_patch):
         """Apply default values."""
         msg = "You must specify one or more dimension in keyword args."
-        with pytest.raises(PatchDimError, match=msg):
+        with pytest.raises(PatchCoordinateError, match=msg):
             random_patch.median_filter()
 
     def test_median_filter_time(self, random_patch):
@@ -228,7 +228,7 @@ class TestSavgolFilter:
     def test_savgol_no_kwargs_raises(self, random_patch):
         """Apply default values."""
         msg = "You must specify one or more"
-        with pytest.raises(PatchDimError, match=msg):
+        with pytest.raises(PatchCoordinateError, match=msg):
             random_patch.savgol_filter(polyorder=2)
 
     def test_savgol_filter_time(self, random_patch):

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -243,3 +243,15 @@ class TestInverseDiscreteFourierTransform:
         idft = dft_patch.idft()
         assert idft.shape == sin_patch_trimmed.shape
         assert np.allclose(np.real(idft.data), sin_patch_trimmed.data)
+
+    def test_no_extra_attrs_or_coords(self, sin_patch):
+        """Ensure no extra attrs or coords remain after round trip."""
+        dft = sin_patch.dft(dim=None)
+        idft = dft.idft()
+        old_attrs = set(dict(sin_patch.attrs).keys())
+        new_attrs = set(dict(idft.attrs).keys())
+        # Before, there were a lot of ft_* keys added from extra coords.
+        diff = new_attrs - old_attrs
+        assert not diff, "attr keys shouldn't change"
+        # Test no extra coords
+        assert set(sin_patch.coords.coord_map) == set(idft.coords.coord_map)

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from scipy.fft import next_fast_len
 
 import dascore as dc
 from dascore.transform.fourier import dft, idft
@@ -21,6 +22,12 @@ def sin_patch():
         .update_attrs(data_type="strain_rate")
     )
     return patch
+
+
+@pytest.fixture(scope="session")
+def sin_patch_trimmed(sin_patch):
+    """Get the sine wave patch trimmed to a non-fast len along time dim."""
+    return sin_patch.select(time=(0, -2), samples=True)
 
 
 @pytest.fixture(scope="session")
@@ -157,6 +164,22 @@ class TestDiscreteFourierTransform:
         assert sin_patch.attrs.data_type == "strain_rate"
         assert fft_sin_patch_time.attrs.data_type == ""
 
+    def test_pad(self, sin_patch_trimmed):
+        """Ensure patch is padded when requested and not otherwise."""
+        trimmed = sin_patch_trimmed
+        old_time_len = trimmed.coord_shapes["time"][0]
+        dft_pad = trimmed.dft("time")
+        dft_no_pad = trimmed.dft("time", pad=False)
+        assert dft_pad.shape != dft_no_pad.shape
+        assert dft_pad.coord_shapes["ft_time"][0] == next_fast_len(old_time_len)
+        assert dft_no_pad.coord_shapes["ft_time"] == trimmed.coord_shapes["time"]
+
+    def test_display(self, fft_sin_patch_time):
+        """Ensure a transformed patch returns a str rep."""
+        out = str(fft_sin_patch_time)
+        assert isinstance(out, str)
+        assert out
+
 
 class TestInverseDiscreteFourierTransform:
     """Inverse DFT suite."""
@@ -206,3 +229,17 @@ class TestInverseDiscreteFourierTransform:
         """Ensure data_type attr is restored."""
         out = fft_sin_patch_time.idft("time")
         assert out.attrs.data_type == sin_patch.attrs.data_type
+
+    def test_undo_padding(self, sin_patch_trimmed):
+        """Ensure the padding is undone in idft."""
+        dft_patch = sin_patch_trimmed.dft("time")
+        idft = dft_patch.idft()
+        assert idft.shape == sin_patch_trimmed.shape
+        assert np.allclose(np.real(idft.data), sin_patch_trimmed.data)
+
+    def test_undo_padding_rft(self, sin_patch_trimmed):
+        """Ensure padded rft still works."""
+        dft_patch = sin_patch_trimmed.dft("time", real=True)
+        idft = dft_patch.idft()
+        assert idft.shape == sin_patch_trimmed.shape
+        assert np.allclose(np.real(idft.data), sin_patch_trimmed.data)

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -449,6 +449,15 @@ class TestConcatenate:
             nearly_eq = old_array == new_array
         assert np.all(both_nan | nearly_eq)
 
+    def test_private_coords_dropped(self, random_patch):
+        """Ensure private coords don't interfere with concat along new dim."""
+        pa1 = random_patch.update_coords(_private_1=(None, np.array([1, 2, 3])))
+        pa2 = random_patch.update_coords(_private_1=(None, np.array([2, 2, 2])))
+        spool = dc.spool([pa1, pa2])
+        out = spool.concatenate(time_new=None)
+        assert len(out) == 1
+        assert out[0].shape[-1] == 2
+
     def test_concat_dropped_coord(self, random_spool):
         """Ensure patches after dropping a coordinate can be concatenated together
         and the concatenated patch can have a new dimension.


### PR DESCRIPTION
## Description

This PR adds a `pad` argument to `Patch.dft` so that transformed dimensions can be padded to avoid slow lengths. It also simplifies some of the `Patch.slope_filter` implementation, as well as a few other improvements. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
