### PR TITLE
Fix 419

### DIFF
--- a/dascore/data_registry.txt
+++ b/dascore/data_registry.txt
@@ -25,3 +25,4 @@ silixa_h5_1.hdf5 d3f1b92b17ae2d00f900426e80d48964fb5a33b9480ef9805721ac756acd4a2
 deformation_rate_event_1.hdf5 be8574ae523de9b17d2a0f9e847f30301e1607e2076366e005cdb3a46b79f172 https://github.com/dasdae/test_data/raw/master/das/deformation_rate_event_1.hdf5
 neubrex_dss_forge.h5 49e501e16d880b22c5d9d8997223f0c1aceb942386efb09aae938b9d97eb51ed https://github.com/dasdae/test_data/raw/master/dss/neubrex_dss_forge.h5
 neubrex_dts_forge.h5 940f7bea6dd4c8a1340b4936b8eb7f9edc577cbcaf77c1f5ac295890f88c9ba5 https://github.com/dasdae/test_data/raw/master/dts/neubrex_dts_forge.h5
+decimated_optodas.hdf5 48ce9c2ab4916d5536faeef0bd789f326ec4afc232729d32014d4d835a9fb74e https://github.com/dasdae/test_data/raw/master/das/decimated_optodas.hdf5

--- a/tests/test_io/test_optodas/test_optodas.py
+++ b/tests/test_io/test_optodas/test_optodas.py
@@ -1,0 +1,27 @@
+"""
+Tests for optoDAS files.
+"""
+
+import dascore as dc
+from dascore.io.optodas import OptoDASV8
+from dascore.utils.downloader import fetch
+
+
+class TestOptoDASIssues:
+    """Test case related to issues in OptoDAS parser."""
+
+    def test_read_decimated_patch(self):
+        """Tests for reading spatially decimated patch (#419)"""
+        path = fetch("decimated_optodas.hdf5")
+        fiber_io = OptoDASV8()
+
+        fmt_str, version_str = fiber_io.get_format(path)
+        assert (fmt_str, version_str) == (fiber_io.name, fiber_io.version)
+
+        spool = fiber_io.read(path)
+        patch = spool[0]
+        assert isinstance(patch, dc.Patch)
+        assert patch.data.shape
+
+        patch2 = dc.read(path)[0]
+        assert patch == patch2

--- a/tests/test_io/test_optodas/test_optodas.py
+++ b/tests/test_io/test_optodas/test_optodas.py
@@ -22,6 +22,3 @@ class TestOptoDASIssues:
         patch = spool[0]
         assert isinstance(patch, dc.Patch)
         assert patch.data.shape
-
-        patch2 = dc.read(path)[0]
-        assert patch == patch2


### PR DESCRIPTION
## Description

This PR closes #419. Before the OptoDAS parser didn't account for spatial decimation, now it does.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
