### PR TITLE
fix #416: switch history attribute to tuple

### DIFF
--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import Annotated, Any, Literal
 
 import numpy as np
@@ -118,8 +118,9 @@ class PatchAttrs(DascoreBaseModel):
     network: str = Field(
         default="", max_length=max_lens["network"], description="A network code."
     )
-    history: str | Sequence[str] = Field(
-        default_factory=list, description="A list of processing performed on the patch."
+    history: str | tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="A list of processing performed on the patch.",
     )
 
     dims: CommaSeparatedStr = Field(

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -175,8 +175,7 @@ def all_close(ar1, ar2):
 def _all_null(maybe_ar):
     """Return True if values is nullish, or all sub-values nullish if sequence."""
     out = pd.isnull(maybe_ar)
-    if hasattr(out, "all"):
-        out = out.all()
+    out = out.all() if hasattr(out, "all") else out
     return out
 
 

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -683,3 +683,20 @@ class TestSetDims:
             time="my_coord"
         )  # set mycoord as dim (rather than time)
         assert "my_coord" in out.dims
+
+
+class TestHistory:
+    """Specific tests for tracking history of Patches."""
+
+    def test_history_is_tuple(self, random_patch):
+        """The history attribute should be immutable. See #417."""
+        assert isinstance(random_patch.attrs.history, tuple)
+
+    def test_history_tuple_after_operation(self, random_patch):
+        """Ensure the history tuple remains after a patch operation."""
+        patch = random_patch.pass_filter(time=(..., 20))
+        assert isinstance(patch.attrs.history, tuple)
+
+        old_len = len(random_patch.attrs.history)
+        new_len = len(patch.attrs.history)
+        assert old_len == new_len - 1


### PR DESCRIPTION
## Description

This PR fixes #416 by changing the type annotation of `history` to `str | tuple[str, ...]` so that values of history should be immutable. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
