### PR TITLE
add_distance_to

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -250,6 +250,7 @@ class Patch:
     squeeze = dascore.proc.coords.squeeze
     append_dims = dascore.proc.coords.append_dims
     transpose = dascore.proc.coords.transpose
+    add_distance_to = dascore.proc.coords.add_distance_to
     snap_coords = dascore.proc.snap_coords
     sort_coords = dascore.proc.sort_coords
     rename_coords = dascore.proc.rename_coords

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -132,7 +132,7 @@ def patch_with_null(**kwargs):
 @register_func(EXAMPLE_PATCHES, key="random_patch_with_lat_lon")
 def random_patch_lat_lon(**kwargs):
     """
-    Create a patch with latitude/longitude coords on distance dim.
+    Create a patch with latitude/longitude coords on distance dimension.
 
     Parameters
     ----------
@@ -145,6 +145,26 @@ def random_patch_lat_lon(**kwargs):
     lon = np.arange(0, len(dist)) * 0.001 + 41.544654
     # add a single coord
     out = patch.update_coords(latitude=("distance", lat), longitude=("distance", lon))
+    return out
+
+
+@register_func(EXAMPLE_PATCHES, key="random_patch_with_xyz")
+def random_patch_xyz(**kwargs):
+    """
+    Create a patch with x, y, and z coords on distance dimension.
+
+    Parameters
+    ----------
+    **kwargs
+        Parameters passed to [`random_patch`](`dascore.examples.random_patch`).
+    """
+    patch = random_patch(**kwargs)
+    dist = patch.coords.get_array("distance")
+    x = np.arange(0, len(dist)) * 5
+    y = np.arange(0, len(dist)) * 5
+    z = np.zeros_like(dist)
+    # add a single coord
+    out = patch.update_coords(x=("distance", x), y=("distance", y), z=("distance", z))
     return out
 
 

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -646,7 +646,6 @@ def add_distance_to(
     >>>
     >>> # Of course, the new coordinate can be used for sorting.
     >>> sorted_patch = patch_with_distance.sort_coords("origin_distance")
-
     """
     # Ensure all index values are represented in coord map.
     if missing_coords := (set(origin.index) - set(patch.coords.coord_map)):

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -10,7 +10,7 @@ from scipy.interpolate import interp1d
 
 from dascore.constants import PatchType, select_values_description
 from dascore.core.coords import BaseCoord
-from dascore.exceptions import CoordError, ParameterError
+from dascore.exceptions import CoordError, ParameterError, PatchError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import get_parent_code_name
 from dascore.utils.patch import patch_function
@@ -606,3 +606,69 @@ def squeeze(self: PatchType, dim=None) -> PatchType:
     axis = None if dim is None else self.coords.dims.index(dim)
     data = np.squeeze(self.data, axis=axis)
     return self.new(data=data, coords=coords)
+
+
+@patch_function()
+def add_distance_to(
+    patch: PatchType, origin: pd.Series, ord=None, prefix: str = "origin"
+) -> PatchType:
+    """
+    Calculate the distance to "origin" and create new coordinate.
+
+    A new coordinate called `origin_distance` is added to the output patch
+    to specify the exact distance, and the original location is added to
+    the patch attrs (e.g, patch.attrs.origin_x, patch.attrs.origin_y, ...)
+
+    Parameters
+    ----------
+    patch
+        The patch object which contains some overlap in coordiantes as
+        index names in origin.
+    origin
+        A series which contains index names that overlap with patch coordinates.
+        All of the referenced coordinates must be associated with the
+        same dimension.
+    ord
+        Controls the norm type. Default is Frobenius norm, see the norm
+        function of numpy.linalg for supported options.
+    prefix
+        The prefix name for the added coordinates and attributes.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>>
+    >>> import dascore as dc
+    >>>
+    >>> shot = pd.Series({"x": 10, "y": 10, "z": 0})
+    >>> patch = dc.get_example_patch("random_patch_with_xyz")
+    >>> patch_with_distance = patch.add_distance_to(shot)
+    >>>
+    >>> # Of course, the new coordinate can be used for sorting.
+    >>> sorted_patch = patch_with_distance.sort_coords("origin_distance")
+
+    """
+    # Ensure all index values are represented in coord map.
+    if missing_coords := (set(origin.index) - set(patch.coords.coord_map)):
+        msg = f"Indices {missing_coords} are not patch coordinates."
+        raise PatchError(msg)
+    # Ensure all coordinates have the same associated dimension.
+    associated_dims = {patch.coords.dim_map[x] for x in origin.index}
+    if len(associated_dims) > 1:
+        dims = {i: v for i, v in patch.coords.dim_map.items() if i in origin.index}
+        msg = (
+            "All coordinate must be associated with the same dimension to "
+            f"calculate distance. Relevant dimension mappings are {dims}"
+        )
+        raise PatchError(msg)
+    # Create 2d arrays from coords and origin.
+    coord_array = np.stack([patch.get_array(x) for x in origin.index], axis=1)
+    origin_array = np.atleast_2d(origin.values)
+    # Translate coords to origin and take norm.
+    distance = np.linalg.norm(origin_array - coord_array, axis=1, ord=ord)
+    # Add attrs and coords to new patch
+    dims = next(iter(associated_dims))
+    new_attrs = {f"{prefix}_{i}": v for i, v in origin.items()}
+    new_coord = {f"{prefix}_distance": (dims, distance)}
+    out = patch.update_coords.func(patch, **new_coord).update_attrs(**new_attrs)
+    return out

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -645,13 +645,13 @@ def add_distance_to(
     >>> # Add a coordinate specifying the distance to a theoretical shot.
     >>> shot = pd.Series({"x": 10, "y": 10, "z": 0})
     >>> patch = dc.get_example_patch("random_patch_with_xyz")
-    >>> patch_with_distance = patch.add_distance_to(shot)
+    >>> patch_with_origin_dist = patch.add_distance_to(shot)
     >>> # Now the new coordinates of distance and shot origin exist.
-    >>> dist = patch_with_distance.get_array("origin_distance")
-    >>> origin_x = patch_with_distance.get_array("origin_x")
+    >>> dist = patch_with_origin_dist.get_array("origin_distance")
+    >>> origin_x = patch_with_origin_dist.get_array("origin_x")
     >>>
     >>> # Of course, the new coordinate can be used for sorting.
-    >>> sorted_patch = patch_with_distance.sort_coords("origin_distance")
+    >>> sorted_patch = patch_with_origin_dist.sort_coords("origin_distance")
     """
     # Ensure all index values are represented in coord map.
     if missing_coords := (set(origin.index) - set(patch.coords.coord_map)):

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -34,7 +34,7 @@ def get_registry():
     # allow multiplication with offset units.
     ureg.autoconvert_offset_to_baseunit = True
     # set the shortest display for units.
-    ureg.default_format = "~"
+    ureg.formatter.default_format = "~"
     pint.set_application_registry(ureg)
     return ureg
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,6 +301,14 @@ def random_patch_with_lat_lon(random_patch):
 
 @pytest.fixture(scope="class")
 @register_func(PATCH_FIXTURES)
+def random_patch_with_xyz(random_patch):
+    """Get a random patch with added x, y, and z coordinates."""
+    out = dc.get_example_patch("random_patch_with_xyz")
+    return out
+
+
+@pytest.fixture(scope="class")
+@register_func(PATCH_FIXTURES)
 def multi_dim_coords_patch(random_patch):
     """A patch with a multiple dimensional coord."""
     quality = np.ones(random_patch.shape)

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -509,8 +509,8 @@ class TestGetArray:
             assert is_array(array)
 
 
-class TestDistanceTo:
-    """Tests for getting distance to coords."""
+class TestAddDistanceTo:
+    """Tests for adding distance from a point to coords."""
 
     @pytest.fixture(scope="class")
     def shot_series(self):
@@ -518,13 +518,12 @@ class TestDistanceTo:
         shot = pd.Series({"x": 1000, "y": 42, "z": 15})
         return shot
 
-    def test_coord_and_attrs(self, random_patch_with_xyz, shot_series):
-        """Ensure coord and attrs have been added."""
+    def test_coord(self, random_patch_with_xyz, shot_series):
+        """Ensure coords have been added."""
         out = random_patch_with_xyz.add_distance_to(shot_series)
         assert "origin_distance" in out.coords.coord_map
-        attr_set = set(out.attrs.model_dump())
         for name in shot_series.index:
-            assert f"origin_{name}" in attr_set
+            assert f"origin_{name}" in out.coords.coord_map
 
     def test_bad_name_raises(self, random_patch_with_xyz):
         """Ensure a PatchError is raised when index are not coords."""


### PR DESCRIPTION
## Description

This PR adds a `add_distance_to` patch method for calculating the distance to a point specified by a series. It can then be used to sort the channels of the patch. See #429. 

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
