### PR TITLE
support for numpy 2

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -429,7 +429,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
     __repr__ = __str__
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=False):
         """Numpy method for getting array data with `np.array(coord)`."""
         return self.data
 

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -16,7 +16,7 @@ from .utils import _get_cf_attrs, _get_cf_coords, _get_cf_version_str
 class ProdMLPatchAttrs(dc.PatchAttrs):
     """Patch attrs for ProdML."""
 
-    pulse_width: float = np.NAN
+    pulse_width: float = np.nan
     pulse_width_units: UnitQuantity | None = None
     gauge_length: float = np.nan
     gauge_length_units: UnitQuantity | None = None

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -16,7 +16,7 @@ from .utils import _get_prodml_attrs, _get_prodml_version_str, _read_prodml
 class ProdMLPatchAttrs(dc.PatchAttrs):
     """Patch attrs for ProdML."""
 
-    pulse_width: float = np.NAN
+    pulse_width: float = np.nan
     pulse_width_units: UnitQuantity | None = None
     gauge_length: float = np.nan
     gauge_length_units: UnitQuantity | None = None

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -18,7 +18,7 @@ from .utils import _load_patches, _paths_to_attrs, _read_xml_metadata
 class BinaryPatchAttrs(dc.PatchAttrs):
     """Patch attrs for Binary."""
 
-    pulse_width_ns: float = np.NAN
+    pulse_width_ns: float = np.nan
     gauge_length: float = np.nan
     instrument_id: UTF8Str = ""
     distance_units: UTF8Str = ""

--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -46,9 +46,9 @@ def _get_definite_integral(patch, dxs_or_vals, dims, axes):
     for dxs_or_val, ax in zip(dxs_or_vals, axes):
         indexer = broadcast_for_index(ndims, ax, None, fill=slice(None))
         if is_array(dxs_or_val):
-            array = np.trapz(array, x=dxs_or_val, axis=ax)[indexer]
+            array = np.trapezoid(array, x=dxs_or_val, axis=ax)[indexer]
         else:
-            array = np.trapz(array, dx=dxs_or_val, axis=ax)[indexer]
+            array = np.trapezoid(array, dx=dxs_or_val, axis=ax)[indexer]
     array, coords = _get_new_coords_and_array(patch, array, dims)
     return array, coords
 

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -34,7 +34,7 @@ def get_registry():
     # allow multiplication with offset units.
     ureg.autoconvert_offset_to_baseunit = True
     # set the shortest display for units.
-    ureg.default_format = "~"
+    ureg.formatter.default_format = "~"
     pint.set_application_registry(ureg)
     return ureg
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = ["geophysics", "distributed-acoustic-sensing"]
 dependencies = [
      "h5py",
      "matplotlib>=3.5",
-     "numpy>=1.24, <2",
+     "numpy>=1.24",
      "packaging",
      "pandas>=2.0",
      "pooch>=1.2",

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -38,7 +38,7 @@ class TestPassFilterChecks:
     def test_all_null_kwarg_raises(self, random_patch):
         """There must be one Non-null kwarg."""
         with pytest.raises(FilterValueError, match="at least one filter"):
-            _ = random_patch.pass_filter(time=[None, np.NAN])
+            _ = random_patch.pass_filter(time=[None, np.nan])
 
     def test_unordered_params(self, random_patch):
         """Ensure a low parameter greater than a high parameter raises."""

--- a/tests/test_transform/test_integrate.py
+++ b/tests/test_transform/test_integrate.py
@@ -90,7 +90,7 @@ class TestDefiniteIntegration:
             out = patch.integrate(dim=dim, definite=True)
             assert out.shape[ax] == 1
             step = to_float(patch.get_coord(dim).step)
-            expected_data = np.trapz(patch.data, dx=step, axis=ax)
+            expected_data = np.trapezoid(patch.data, dx=step, axis=ax)
             ndims = len(patch.dims)
             indexer = broadcast_for_index(ndims, ax, None)
             assert np.allclose(out.data, expected_data[indexer])


### PR DESCRIPTION
## Description

This PR supports numpy > 2. Previously we had to pin numpy < 2 otherwise pytables wouldn't work , but with the release of [pytables 3.10.1](https://github.com/PyTables/PyTables/releases/tag/v3.10.1) everything works fine now. 

It also fixes some deprecation warnings related to numpy v2.  

Fixes #432. Thanks to @coutanto for pointing out the issue. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
