### PR TITLE
pint numpy compat

### DIFF
--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -44,11 +44,13 @@ def _get_definite_integral(patch, dxs_or_vals, dims, axes):
     array = patch.data
     ndims = len(patch.shape)
     for dxs_or_val, ax in zip(dxs_or_vals, axes):
+        # Numpy 2/3 compat code
+        trap = getattr(np, "trapezoid", getattr(np, "trapz"))
         indexer = broadcast_for_index(ndims, ax, None, fill=slice(None))
         if is_array(dxs_or_val):
-            array = np.trapezoid(array, x=dxs_or_val, axis=ax)[indexer]
+            array = trap(array, x=dxs_or_val, axis=ax)[indexer]
         else:
-            array = np.trapezoid(array, dx=dxs_or_val, axis=ax)[indexer]
+            array = trap(array, dx=dxs_or_val, axis=ax)[indexer]
     array, coords = _get_new_coords_and_array(patch, array, dims)
     return array, coords
 

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -34,7 +34,9 @@ def get_registry():
     # allow multiplication with offset units.
     ureg.autoconvert_offset_to_baseunit = True
     # set the shortest display for units.
-    ureg.formatter.default_format = "~"
+    # .formatter was added in new versions of pint; this makes it work with both
+    formatter = getattr(ureg, "formatter", ureg)
+    formatter.default_format = "~"
     pint.set_application_registry(ureg)
     return ureg
 

--- a/scripts/build_api_docs.py
+++ b/scripts/build_api_docs.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import sys
+
 from _index_api import get_alias_mapping, parse_project
 from _qmd_builder import create_quarto_qmd
 from _render_api import render_project
 from _validate_links import validate_all_links
 
 import dascore as dc
+
+sys.stdout.encoding = "utf-8"
+
 
 if __name__ == "__main__":
     print("Building documentation")  # noqa

--- a/tests/test_transform/test_integrate.py
+++ b/tests/test_transform/test_integrate.py
@@ -90,7 +90,8 @@ class TestDefiniteIntegration:
             out = patch.integrate(dim=dim, definite=True)
             assert out.shape[ax] == 1
             step = to_float(patch.get_coord(dim).step)
-            expected_data = np.trapezoid(patch.data, dx=step, axis=ax)
+            trap = getattr(np, "trapezoid", getattr(np, "trapz"))
+            expected_data = trap(patch.data, dx=step, axis=ax)
             ndims = len(patch.dims)
             indexer = broadcast_for_index(ndims, ax, None)
             assert np.allclose(out.data, expected_data[indexer])


### PR DESCRIPTION
## Description

This PR adds some compatibility code between numpy < 2 and numpy > 2 plus newer/older versions of pint. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
