### PR TITLE
fix coordmanager non associated coord

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -1102,7 +1102,7 @@ def get_coord_manager(
     # from dict keys.
     if dims is None:
         if isinstance(coords, Mapping) and all(isinstance(x, str) for x in coords):
-            dims = tuple(coords.keys())
+            dims = tuple(i for i, v in coords.items() if not isinstance(v, tuple))
         elif attrs is not None and "dims" in attrs or hasattr(attrs, "dims"):
             dims = tuple(attrs["dims"].split(","))
         else:
@@ -1160,7 +1160,7 @@ def _get_coord_dim_map(coords, dims):
                 " (dimension, coord) or ((dimensions,...), coord)"
             )
             raise CoordError(msg)
-        dim_names = iterate(coord[0])
+        dim_names = tuple(i for i in iterate(coord[0]) if i)
         # # all dims must be in the input dims or a new coord.
         d1, d2 = set(dim_names), set(dims)
         if (not d1.issubset(d2)) and d1 != {name}:

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -961,6 +961,7 @@ def stack_patches(
     dim_vary
         The name of the dimension which can be different in values
         (but not shape) and patches still added together.
+        If None, all dimension values must be equal.
     {check_desc}
 
     Examples

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -62,6 +62,16 @@ class TestGetCoordManager:
         assert out.shape == (10, 2)
         assert out.dims == ("time", "money")
 
+    def test_not_associated_coord_1(self):
+        """Ensure a not associated coord works as only input."""
+        coords = {"time": (None, np.arange(10))}
+        assert isinstance(get_coord_manager(coords), CoordManager)
+
+    def test_not_associated_coord_2(self):
+        """Ensure an empty string not associated coord works as only input."""
+        coords = {"time": ("", np.arange(10))}
+        assert isinstance(get_coord_manager(coords), CoordManager)
+
 
 class TestBasicCoordManager:
     """Ensure basic things work with coord managers."""

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -48,6 +48,18 @@ def written_dascore_v1_empty(tmp_path_factory):
     return path
 
 
+@pytest.fixture(scope="class")
+@register_func(WRITTEN_FILES)
+def written_dascore_correlate(tmp_path_factory, random_patch):
+    """Write a correlate patch to the dascore format."""
+    path = tmp_path_factory.mktemp("correlate_patcc") / "correlate.hdf5"
+    padded_pa = random_patch.pad(time="correlate")
+    dft_pa = padded_pa.dft("time", real=True)
+    cc_pa = dft_pa.correlate(distance=[0, 1, 2], samples=True)
+    dc.write(cc_pa, path, "DASDAE", file_version="1")
+    return path
+
+
 @pytest.fixture(params=WRITTEN_FILES, scope="class")
 def dasdae_v1_file_path(request):
     """Gatherer fixture to iterate through each written dasedae format."""
@@ -100,6 +112,11 @@ class TestWriteDASDAE:
         random_patch.io.write(written_dascore_v1_random, "dasdae")
         read_patch = dc.spool(written_dascore_v1_random)[0]
         assert random_patch == read_patch
+
+    def test_write_cc_patch(self, written_dascore_correlate):
+        """Ensure cross correlated patches can be writen and read."""
+        sp_cc = dc.spool(written_dascore_correlate)
+        assert isinstance(sp_cc[0], dc.Patch)
 
 
 class TestReadDASDAE:


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->


## Description

<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->
This PR resolves issue #434 by ensuring that a patch with a non-associated coordinate can be accessed without any issues.

Thanks to @d-chambers for his help on this PR.
## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
