### PR TITLE
fix febus overlap issue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: "get tags"
+        run: |
+          git fetch --tags --force # Retrieve annotated tags.
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: install linting packages
-        run: pip install pre-commit --break-system-packages
+        run: uv tool install pre-commit
 
       - name: run all precommits
-        run: pre-commit run --files dascore/**/*
+        run: uv run pre-commit run --all

--- a/tests/test_io/test_febus/test_febus.py
+++ b/tests/test_io/test_febus/test_febus.py
@@ -32,7 +32,12 @@ class TestFebus:
 
         with h5py.File(febus_path, "r") as f:
             feb = _flatten_febus_info(f)[0]
+            # First check total time extent
             n_blocks = feb.zone[feb.data_name].shape[0]
             block_time = 1 / (feb.zone.attrs["BlockRate"] / 1_000)
             expected_time_span = block_time * n_blocks
             assert np.isclose(expected_time_span, time_span)
+            # Then check absolute time
+            time_offset = feb.zone.attrs["Origin"][1] / 1_000
+            time_start = feb.source["time"][0] + time_offset
+            assert np.isclose(to_float(time.min()), time_start)

--- a/tests/test_io/test_febus/test_febus.py
+++ b/tests/test_io/test_febus/test_febus.py
@@ -1,0 +1,38 @@
+"""
+Febus specific tests.
+"""
+
+import h5py
+import numpy as np
+import pytest
+
+from dascore.io.febus import Febus2
+from dascore.io.febus.utils import _flatten_febus_info
+from dascore.utils.downloader import fetch
+from dascore.utils.time import to_float
+
+
+class TestFebus:
+    """Special test cases for febus."""
+
+    @pytest.fixture(scope="class")
+    def febus_path(self):
+        """Return the path to a test febus file."""
+        return fetch("febus_1.h5")
+
+    def test_time_coords_consistent_with_metadata(self, febus_path):
+        """
+        Ensure the time coords returned have the same length as
+        metadata indicates.
+        """
+        patch = Febus2().read(febus_path)[0]
+        coords = patch.coords
+        time = coords.get_coord("time")
+        time_span = to_float((time.max() - time.min()) + time.step)
+
+        with h5py.File(febus_path, "r") as f:
+            feb = _flatten_febus_info(f)[0]
+            n_blocks = feb.zone[feb.data_name].shape[0]
+            block_time = 1 / (feb.zone.attrs["BlockRate"] / 1_000)
+            expected_time_span = block_time * n_blocks
+            assert np.isclose(expected_time_span, time_span)


### PR DESCRIPTION

## Description

The way the overlapping time samples were calculated in the febus file format were off. Moreover, sometimes the percentage overlap in the header was set, but the block rate, temporal sampling, and data shape would indicate there is no overlap. This PR fixes both issues by calculating the number of overlapping samples based on the temporal sampling, block rate, and data shape and ignoring the block overlap attribute which can be wrong. 

I also ran into a precision issue with the datetime64 object. One file @jinwar gave me has a temporal sampling rate of 3.33333333e-5. When converted to a timedelta64 this is 33333ns. It then causes some issues in determining the exact end of a file. In this case, the endtime is off by 0.003 seconds for a 5 minute file. Hopefully we can just work around this for now, but we may need to think of a better solution for cases like this in the future.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
