### PR TITLE
Use UV for linting action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: "get tags"
+        run: |
+          git fetch --tags --force # Retrieve annotated tags.
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: install linting packages
-        run: pip install pre-commit --break-system-packages
+        run: uv tool install pre-commit
 
       - name: run all precommits
-        run: pre-commit run --files dascore/**/*
+        run: uv run pre-commit run --all


### PR DESCRIPTION

## Description

After @aissah's excellent plug for UV I decided to try it out. Turns out they have a good Github Action that will hopefully run the linter without the issues with pip installing packages into the system directories. This PR just updates the linting action.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
