### PR TITLE
minor tweaks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,4 +27,4 @@ jobs:
         run: uv tool install pre-commit
 
       - name: run all precommits
-        run: uv run pre-commit run --all
+        run: uv tool run pre-commit run --all

--- a/dascore/__init__.py
+++ b/dascore/__init__.py
@@ -11,7 +11,7 @@ from dascore.examples import get_example_patch, get_example_spool
 from dascore.io.core import get_format, read, scan, scan_to_df, write
 from dascore.units import get_quantity, get_unit
 from dascore.utils.patch import patch_function
-from dascore.utils.time import to_datetime64, to_timedelta64
+from dascore.utils.time import to_datetime64, to_timedelta64, to_float
 from dascore.version import __last_version__, __version__
 
 # flag for disabling progress bar when debugging

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -314,7 +314,7 @@ def example_event_2():
     delta_time = patch.coords.get_array("time") - patch.coords.min("time")
     out = (
         patch.update_coords(time=delta_time / np.timedelta64(1, "s"))
-        .set_units("1/s", distance="m", time="s")
+        .set_units("strain/s", distance="m", time="s")
         .taper(time=0.05)
         .pass_filter(time=(..., 300))
     )

--- a/dascore/utils/downloader.py
+++ b/dascore/utils/downloader.py
@@ -24,6 +24,7 @@ fetcher = pooch.create(
 fetcher.load_registry(REGISTRY_PATH)
 
 
+@cache
 def get_registry_df() -> pd.DataFrame:
     """Returns a dataframe of all files in the data registry."""
     names = (


### PR DESCRIPTION

## Description

This PR makes a few small changes to DASCore:

- Adds the `to_float` to the main dascore namespace
- Sets the lint action will run pre-commit as a uv tool
- Adds a `cache` decorator the `get_registry_df` in utils.downloader. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
