### PR TITLE
get_coords to accept quantity

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1587,6 +1587,10 @@ def get_coord(
     _check_data_compatibility(data, start, stop, step)
     # data array was passed; see if it is monotonic/evenly sampled
     if data is not None:
+        # Handle attached units.
+        if isinstance(data, dc.units.Quantity):
+            data, maybe_units = data.magnitude, data.units
+            units = units if units is not None else maybe_units
         if isinstance(data, (int | np.integer)):
             shape = _get_shape(data)
             attrs = dict(

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -91,18 +91,43 @@ def get_coord(
     require_evenly_sampled: bool = False,
 ) -> BaseCoord:
     """
-    Get a managed coordinate, raising if it doesn't meet requirements.
+    Get a managed coordinate from the patch.
 
     Parameters
     ----------
     name
-        Name of the coordinate to fetch.
+        The name of the coordinate to fetch from the patch.
     require_sorted
         If True, require the coordinate to be sorted or raise Error.
     require_evenly_sampled
         If True, require the coordinate to be evenly sampled or raise Error.
+
+    Raises
+    ------
+    [`CoordError`](`dascore.exceptions.CoordError`) if the coordinate does
+    not exist or does not meet the imposed requirements.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch("patch_with_lat_lon")
+    >>>
+    >>> # Get the the distance coordinate from the patch.
+    >>> distance = patch.get_coord("distance")
+    >>>
+    >>> # Get the time coordinate from the patch, raise CoordError if it
+    >>> # is not evenly sampled.
+    >>> time = patch.get_coord("time", require_evenly_sampled=True)
+
+    See Also
+    --------
+    [get_array](`dascore.Patch.get_array`).
+
     """
-    coord = self.coords.coord_map[name]
+    if (coord := self.coords.coord_map.get(name)) is None:
+        coords = sorted(self.coords.coord_map)
+        msg = f"Coordinate '{name}' not found in Patch coordinates: {coords}"
+        raise CoordError(msg)
     if require_evenly_sampled and coord.step is None:
         extra = f"as required by {get_parent_code_name()}"  # adds caller name
         msg = f"Coordinate {name} is not evenly sampled {extra}"
@@ -131,6 +156,29 @@ def get_array(
         If True, require the coordinate to be sorted or raise Error.
     require_evenly_sampled
         If True, require the coordinate to be evenly sampled or raise Error.
+
+    Raises
+    ------
+    [`CoordError`](`dascore.exceptions.CoordError`) if the coordinate does
+    not exist or does not meet the imposed requirements.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch("patch_with_lat_lon")
+    >>>
+    >>> # Get the patch data array.
+    >>> data = patch.get_array()  # same as patch.data
+    >>>
+    >>> # Get an array of distance values
+    >>> distance_array = patch.get_array("distance")
+    >>>
+    >>> # Get an array of time values. Raise an error if they arent sorted.
+    >>> time_array = patch.get_array("time", require_sorted=True)
+
+    See Also
+    --------
+    [Patch.get_coord](`dascore.Patch.get_coord`)
     """
     if name is None:
         return self.data
@@ -185,6 +233,7 @@ def update_coords(self: PatchType, **kwargs) -> PatchType:
     >>> import numpy as np
     >>> import dascore as dc
     >>> pa = dc.get_example_patch()
+    >>>
     >>> # Add 1 to all distance coords
     >>> new_dist = pa.coords.get_array('distance') + 1
     >>> pa2 = pa.update_coords(distance=new_dist)

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -110,7 +110,7 @@ def get_coord(
     Examples
     --------
     >>> import dascore as dc
-    >>> patch = dc.get_example_patch("patch_with_lat_lon")
+    >>> patch = dc.get_example_patch()
     >>>
     >>> # Get the the distance coordinate from the patch.
     >>> distance = patch.get_coord("distance")
@@ -165,7 +165,7 @@ def get_array(
     Examples
     --------
     >>> import dascore as dc
-    >>> patch = dc.get_example_patch("patch_with_lat_lon")
+    >>> patch = dc.get_example_patch()
     >>>
     >>> # Get the patch data array.
     >>> data = patch.get_array()  # same as patch.data

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -946,6 +946,14 @@ class TestUpdate:
             assert cm.ndim == (coord_manager.ndim + 1)
             assert cm.dims[-1] == "bob"
 
+    def test_update_with_units(self, coord_manager):
+        """Ensure units stick around when updated."""
+        ft = dc.get_quantity("ft")
+        dist = coord_manager.get_array("distance")
+        new = coord_manager.update(distance=(dist * 2) * ft)
+        new_coord = new.coord_map["distance"]
+        assert dc.get_quantity(new_coord.units) == ft
+
 
 class TestSqueeze:
     """Tests for squeezing degenerate dimensions."""

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1892,3 +1892,10 @@ class TestIssues:
             units="m",
         )
         assert np.issubdtype(coord.dtype, np.floating)
+
+    def test_array_units_preserved(self):
+        """Ensure the units attached to an array are preserved."""
+        ft = dc.get_quantity("ft")
+        array = np.array([1, 2, 3])
+        out = get_coord(data=array * ft)
+        assert dc.get_quantity(out.units) == ft

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -700,3 +700,14 @@ class TestHistory:
         old_len = len(random_patch.attrs.history)
         new_len = len(patch.attrs.history)
         assert old_len == new_len - 1
+
+    def test_history_not_too_long(self, random_patch):
+        """Ensure a single history entry doesnt get too long."""
+        patch = random_patch
+        dist = patch.get_array("distance")
+        patch_new_dist = patch.update_coords(distance=(dist + 12))
+        # this should use the contracted array rep
+        hist = patch_new_dist.attrs.history
+        entry = hist[-1]
+        array_part = entry.split("'[")[-1].split("]'")[0]
+        assert len(array_part) < 100

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -450,6 +450,12 @@ class TestGetCoord:
         coord = wacky_dim_patch.get_coord("time", require_sorted=True)
         assert isinstance(coord, BaseCoord)
 
+    def test_non_existent_coord_raises(self, random_patch):
+        """Ensure requesting non-existent coordinates raises CoordError."""
+        msg = "not found in Patch"
+        with pytest.raises(CoordError, match=msg):
+            random_patch.get_coord("fire_house")
+
     def test_require_evenly_sampled(self, wacky_dim_patch):
         """Test required evenly sampled raises if coord isn't."""
         msg = "is not evenly sampled"


### PR DESCRIPTION

## Description

This PR does 2 things.

- Adds some examples to the docstrings of `Patch.get_array` and `Patch.get_coord`
- Allows quantities to be passed to `get_coord` with the values argument. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
