### PR TITLE
add dim_reduce to aggregates, refactor patch utils

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: '1.5.8-0' # versions: https://github.com/mamba-org/micromamba-releases
+          micromamba-version: '2.0.2-1' # versions: https://github.com/mamba-org/micromamba-releases
           environment-file: environment.yml
           init-shell: >-
             bash

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -54,6 +54,7 @@ jobs:
             bash
             powershell
           cache-environment: true
+          cache-environment-key: environment-${{ steps.date.outputs.date }}
           post-cleanup: 'all'
 
       # Not sure why this is needed but it appears to be the case

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -8,11 +8,11 @@ from typing import Literal, Protocol, TypeVar, runtime_checkable
 import numpy as np
 import pandas as pd
 
-import dascore
+import dascore as dc
 
-PatchType = TypeVar("PatchType", bound="dascore.Patch")
+PatchType = TypeVar("PatchType", bound="dc.Patch")
 
-SpoolType = TypeVar("SpoolType", bound="dascore.BaseSpool")
+SpoolType = TypeVar("SpoolType", bound="dc.BaseSpool")
 
 
 @runtime_checkable

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from functools import partial
-from typing import Literal
 
 import numpy as np
 
@@ -43,8 +42,11 @@ dim
 dim_reduce
     How to reduce the dimensional coordinate associated with the 
     aggregated axis. Can be the name of any valid aggregator, a callable,
-    or "empty" - which returns and empty coord, or "squeeze" which drops
-    the coordinate.
+    "empty" - which returns and empty coord, or "squeeze" which drops
+    the coordinate. For dimensions with datetime or timedelta datatypes, 
+    if the operation fails it will automatically be applied to the
+    coordinates converted to floats then the output converted back 
+    to the appropriate time type.
 """
 
 AGG_NOTES = """
@@ -53,27 +55,6 @@ Notes
 See [`Patch.aggregate`](`dascore.Patch.aggregate`) for examples
 and more details.
 """
-
-COORD_MODE_DOC_STR = """
-coord_mode
-    Controls the behavior of the aggregated coordinate.
-    Options are: 
-        empty - empty the coordinate values but keep it in output.
-        squeeze - remove the aggregated dimension.
-        min - keep the min value of the aggregated dimension. 
-        mean - keep the mean value of the aggregated dimension.
-    If the operation fails and the coords are a time-type it will be tried
-    again converting to, then back, from floats. This can cause a small 
-    loss of precision.
-"""
-
-_COORD_MODE_TYPE_HINT = Literal[
-    "empty",
-    "squeeze",
-    "min",
-    "mean",
-    "max",
-]
 
 
 def _get_new_coord(coord, dim_reduce):

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -14,7 +14,12 @@ from dascore.exceptions import ParameterError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import iterate
 from dascore.utils.patch import get_dim_axis_value, patch_function
-from dascore.utils.time import dtype_time_like, is_datetime64, is_timedelta64
+from dascore.utils.time import (
+    dtype_time_like,
+    is_datetime64,
+    to_datetime64,
+    to_timedelta64,
+)
 
 _AGG_FUNCS = {
     "mean": np.nanmean,
@@ -80,11 +85,8 @@ def _get_new_coord(coord, dim_reduce):
             out = func(data)
         except Exception:  # Fall back to floats and re-packing.
             float_data = dc.to_float(data)
-            out = func(float_data)
-            if is_datetime64(data):
-                out = dc.to_datetime64(out)
-            if is_timedelta64(data):
-                out = dc.to_timedelta64(out)
+            dfunc = to_datetime64 if is_datetime64(data) else to_timedelta64
+            out = dfunc(func(float_data))
         return np.atleast_1d(out)
 
     if dim_reduce == "empty":

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -42,11 +42,11 @@ dim
 dim_reduce
     How to reduce the dimensional coordinate associated with the 
     aggregated axis. Can be the name of any valid aggregator, a callable,
-    "empty" - which returns and empty coord, or "squeeze" which drops
-    the coordinate. For dimensions with datetime or timedelta datatypes, 
-    if the operation fails it will automatically be applied to the
-    coordinates converted to floats then the output converted back 
-    to the appropriate time type.
+    "empty" (the default) - which returns and empty coord, or "squeeze" 
+    which drops the coordinate. For dimensions with datetime or timedelta 
+    datatypes, if the operation fails it will automatically be applied 
+    to the coordinates converted to floats then the output converted back 
+    to the appropriate time type. 
 """
 
 AGG_NOTES = """
@@ -106,13 +106,8 @@ def aggregate(
         The aggregation to apply along dimension. Options are:
             {options}
 
-    Notes
-    -----
-    - The old dimension is kept but its coordiante values are removed.
-      use [`Patch.squeeze`](`dascore.Patch.squeeze`) to remove them or
-      [`Patch.update_coords`](`dascore.Patch.update_coords`) to set a
-      coordinate value.
-
+    See Also
+    --------
     - See also the aggregation shortcut methods in the
       [aggregate module](`dascore.proc.aggregate`).
 

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -110,8 +110,8 @@ def _get_new_coord(coord, dim_reduce):
 def aggregate(
     patch: PatchType,
     dim: str | Sequence[str] | None = None,
-    dim_reduce: str | Callable = "empty",
     method: str | Callable = "mean",
+    dim_reduce: str | Callable = "empty",
 ) -> PatchType:
     """
     Aggregate values along a specified dimension.

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -85,7 +85,7 @@ def _get_new_coord(coord, dim_reduce):
                 out = dc.to_datetime64(out)
             if is_timedelta64(data):
                 out = dc.to_timedelta64(out)
-        return out
+        return np.atleast_1d(out)
 
     if dim_reduce == "empty":
         new_coord = coord.update(shape=(1,), start=None, stop=None, data=None)

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -22,8 +22,7 @@ from dascore.utils.patch import (
     _merge_aligned_coords,
     _merge_models,
     align_patch_coords,
-    get_dim_value_from_kwargs,
-    get_multiple_dim_value_from_kwargs,
+    get_dim_axis_value,
     patch_function,
 )
 
@@ -657,11 +656,10 @@ def pad(
         raise ParameterError("constant_values must be a scalar, not a sequence.")
 
     pad_width = [(0, 0)] * len(patch.shape)
-    dimfo = get_multiple_dim_value_from_kwargs(patch, kwargs)
+    dimfo = get_dim_axis_value(patch, kwargs=kwargs, allow_multiple=True)
     new_coords = {}
 
-    for _, info in dimfo.items():
-        axis, dim, value = info["axis"], info["dim"], info["value"]
+    for dim, axis, value in dimfo:
         coord = patch.get_coord(dim, require_evenly_sampled=not samples)
         pad_tuple = _get_pad_tuple(value, samples, coord)
         pad_width[axis] = pad_tuple
@@ -700,7 +698,7 @@ def roll(patch, samples=False, update_coord=False, **kwargs):
     >>> # roll time dimension 5 elements and update coordinates
     >>> rolled_patch3 = patch.roll(time=5, samples=True, update_coord=True)
     """
-    dim, axis, input_value = get_dim_value_from_kwargs(patch, kwargs)
+    dim, axis, input_value = get_dim_axis_value(patch, kwargs=kwargs)[0]
     arr = patch.data
     coord = patch.get_coord(dim)
     value = coord.get_sample_count(input_value, samples=samples)

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -9,7 +9,7 @@ import numpy as np
 import dascore as dc
 from dascore.constants import PatchType
 from dascore.utils.patch import (
-    get_dim_value_from_kwargs,
+    get_dim_axis_value,
     patch_function,
 )
 from dascore.utils.time import to_float
@@ -188,7 +188,7 @@ def correlate(
         msg = "Correlate lag is deprecated. Simply use on the output patch."
         warnings.warn(msg, DeprecationWarning)
     assert len(patch.dims) == 2, "must be a 2D patch."
-    dim, source_axis, source = get_dim_value_from_kwargs(patch, kwargs)
+    dim, source_axis, source = get_dim_axis_value(patch, kwargs=kwargs)[0]
     # Get the axis and coord over which fft should be calculated.
     fft_axis = next(iter(set(range(len(patch.dims))) - {source_axis}))
     fft_dim = patch.dims[fft_axis]

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -13,7 +13,7 @@ from dascore.constants import PatchType
 from dascore.exceptions import FilterValueError
 from dascore.units import get_filter_units
 from dascore.utils.patch import (
-    get_dim_value_from_kwargs,
+    get_dim_axis_value,
     get_start_stop_step,
     patch_function,
 )
@@ -79,7 +79,7 @@ def decimate(
     >>> # Example using fir along distance dimension
     >>> decimated_fir = patch.decimate(distance=10, filter_type='fir')
     """
-    dim, axis, factor = get_dim_value_from_kwargs(patch, kwargs)
+    dim, axis, factor = get_dim_axis_value(patch, kwargs=kwargs)[0]
     coords, slices = patch.coords.decimate(**{dim: int(factor)})
     # Apply scipy.signal.decimate and get new coords
     if filter_type:
@@ -133,7 +133,7 @@ def interpolate(patch: PatchType, kind: str | int = "linear", **kwargs) -> Patch
     >>> patch = dc.get_example_patch("wacky_dim_coords_patch")
     >>> patch_time_even = patch.interpolate(time=None)
     """
-    dim, axis, samples = get_dim_value_from_kwargs(patch, kwargs)
+    dim, axis, samples = get_dim_axis_value(patch, kwargs=kwargs)[0]
     # if samples is None, get evenly sampled coords along dimension.
     if samples is None:
         coord = patch.coords.coord_map[dim]
@@ -212,7 +212,7 @@ def resample(
     [decimate](`dascore.proc.resample.decimate`)
     [interpolate](`dascore.proc.resample.interpolate`)
     """
-    dim, axis, value = get_dim_value_from_kwargs(patch, kwargs)
+    dim, axis, value = get_dim_axis_value(patch, kwargs=kwargs)[0]
     coord = patch.get_coord(dim, require_sorted=True, require_evenly_sampled=True)
     new_step = None
     if not samples:

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -13,7 +13,7 @@ from dascore.constants import samples_arg_description
 from dascore.exceptions import ParameterError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.models import DascoreBaseModel
-from dascore.utils.patch import get_dim_value_from_kwargs
+from dascore.utils.patch import get_dim_axis_value
 from dascore.utils.pd import rolling_df
 
 
@@ -338,7 +338,7 @@ def rolling(
         return _NumpyPatchRoller
 
     # get window sizes in samples
-    dim, axis, value = get_dim_value_from_kwargs(patch, kwargs)
+    dim, axis, value = get_dim_axis_value(patch, kwargs=kwargs)[0]
     roll_hist = f"rolling({dim}={value}, step={step}, center={center}, engine={engine})"
     coord = patch.get_coord(dim)
     window = coord.get_sample_count(value, samples=samples, enforce_lt_coord=True)

--- a/dascore/proc/taper.py
+++ b/dascore/proc/taper.py
@@ -14,7 +14,7 @@ from dascore.exceptions import ParameterError
 from dascore.units import Quantity
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import broadcast_for_index
-from dascore.utils.patch import get_dim_value_from_kwargs, patch_function
+from dascore.utils.patch import get_dim_axis_value, patch_function
 from dascore.utils.time import to_float
 
 TAPER_FUNCTIONS = dict(
@@ -35,7 +35,7 @@ TAPER_FUNCTIONS = dict(
 
 def _get_taper_slices(patch, kwargs):
     """Get slice for start/end of patch."""
-    dim, axis, value = get_dim_value_from_kwargs(patch, kwargs)
+    dim, axis, value = get_dim_axis_value(patch, kwargs=kwargs)[0]
     coord = patch.coords.coord_map[dim]
     if isinstance(value, Sequence | np.ndarray):
         assert len(value) == 2, "Length 2 sequence required."
@@ -302,7 +302,7 @@ def taper_range(
     >>> patch_tapered_5 = patch.taper_range(distance=taper_range)
 
     """
-    dim, ax, values = get_dim_value_from_kwargs(patch, kwargs)
+    dim, ax, values = get_dim_axis_value(patch, kwargs=kwargs)[0]
     coord = patch.get_coord(dim, require_sorted=True)
     inds = _get_taper_coord_inds(coord, values, relative, samples)
     env = _get_range_envelope(coord, inds, window_type, invert)

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -201,8 +201,8 @@ def patch_function(
             None - Function call is not recorded in history attribute.
     validate_call
         If True, use pydantic to validate the function call. This can save
-        quite a lot of code in validation checks, does have some overhead.
-        See: https://docs.pydantic.dev/latest/api/validate_call/.
+        quite a lot of code in validation checks, but does have some overhead.
+        See [validate_call](https://docs.pydantic.dev/latest/api/validate_call/).
 
     Examples
     --------
@@ -221,7 +221,7 @@ def patch_function(
     ...     # called "data_type" or its values is not equal to "DAS".
     >>>
     >>> # 3. A patch method which does type checking on inputs.
-    >>> # The `Field` allows enforces various properties (like ranges)
+    >>> # The `Field` instance can require various data properties (like ranges)
     >>> from typing_extensions import Annotated, Literal
     >>> from pydantic import Field
     >>> @dc.patch_function(validate_call=True)
@@ -230,7 +230,7 @@ def patch_function(
     ...     int_le_10_ge_1: int = Field(ge=1, le=10, default=1),
     ...     option: Literal["min", "max", None] = None,
     ... ):
-    ...     pass
+    ...     ...
 
     Notes
     -----
@@ -264,9 +264,10 @@ def patch_function(
                     out = out.update_attrs(history=hist)
             return out
 
-        # attach original function
+        # attach original function. Although we want to encourage raw_function
+        # for consistency with pydantic, we leave this to not break old code.
         _func.func = getattr(func, "raw_function", func)
-        # matches pydantic behavior.
+        # matches pydantic naming.
         _func.raw_function = getattr(func, "raw_function", func)
         _func.__wrapped__ = func
 
@@ -486,7 +487,14 @@ def get_dim_axis_value(
     allow_multiple
         If True, allow multiple dimensions to be selected.
     allow_extra
-        If True, do not raise if extra kwargs found.
+        If True, do not raise an error if extra args or kwargs are found.
+
+    Returns
+    -------
+    Returns a tuple of:
+        ((dim, axis, value), (dim, axis, value), ...)
+    To support retreiving multiple values from the same inputs. If dim name
+    is found in args, its corresponding values is `None`.
 
     Examples
     --------

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -196,6 +196,11 @@ def _array_to_timedelta64(array: np.ndarray) -> np.datetime64:
             return np.timedelta64(array)
         else:
             return array.astype("timedelta64[ns]")
+    # Need to just get the ns form datetime64
+    elif np.issubdtype(array.dtype, np.datetime64):
+        int_array = array.view(np.int64)
+        return np.array(int_array).astype("timedelta64[ns]")
+
     assert np.isreal(array[0])
     nans = pd.isnull(array)
     array[nans] = 0

--- a/tests/test_proc/test_aggregate.py
+++ b/tests/test_proc/test_aggregate.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.exceptions import ParameterError
 from dascore.proc.aggregate import _AGG_FUNCS
 from dascore.utils.misc import broadcast_for_index
 
@@ -56,6 +57,21 @@ class TestBasicAggregations:
         out = random_patch.aggregate(dim="time", method="mean", dim_reduce="mean")
         new_time = out.get_coord("time")
         assert len(new_time) == 1
+
+    def test_dim_reduce_mean_time_delta(self, random_patch):
+        """Ensure the mean value can be left on the coord."""
+        time = random_patch.get_coord("time")
+        dt = dc.to_timedelta64(time.values)
+        patch = random_patch.update_coords(time=dt)
+        out = patch.aggregate(dim="time", method="mean", dim_reduce="mean")
+        new_time = out.get_coord("time")
+        assert len(new_time) == 1
+
+    def test_invalid_dim_reduce(self, random_patch):
+        """Ensure an invalid dim_reduce argument raises."""
+        msg = "dim_reduce must be"
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.aggregate(dim="time", dim_reduce="invalid")
 
     def test_dim_reduce_first(self, random_patch):
         """Ensure first takes the first value"""

--- a/tests/test_proc/test_aggregate.py
+++ b/tests/test_proc/test_aggregate.py
@@ -64,13 +64,6 @@ class TestBasicAggregations:
         assert len(new_time) == 1
         assert new_time[0] == out.get_array("time")[0]
 
-    def test_dim_reduce_median(self, random_patch):
-        """Ensure the median values also work on dim reduction."""
-        new_time = dc.to_timedelta64(random_patch.get_array("time"))
-        patch = random_patch.update_coords(time=new_time)
-        out = patch.aggregate(dim="time", method="mean", dim_reduce="median")
-        assert "time" in out.dims
-
     def test_dim_reduce_distance(self, random_patch):
         """Ensure non-time dims also work."""
         out = random_patch.aggregate(dim="distance", method="mean", dim_reduce=np.var)

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -205,7 +205,7 @@ class TestMedianFilter:
 
     def test_median_no_kwargs_raises(self, random_patch):
         """Apply default values."""
-        msg = "You must specify one or more dimension in keyword args."
+        msg = "You must use exactly one"
         with pytest.raises(PatchCoordinateError, match=msg):
             random_patch.median_filter()
 
@@ -232,7 +232,7 @@ class TestNotchFilter:
 
     def test_notch_no_kwargs_raises(self, random_patch):
         """Test that no dimension raises an appropriate error."""
-        msg = "You must specify one or more"
+        msg = "You must use exactly one"
         with pytest.raises(PatchCoordinateError, match=msg):
             random_patch.notch_filter(q=30)
 
@@ -281,7 +281,7 @@ class TestSavgolFilter:
 
     def test_savgol_no_kwargs_raises(self, random_patch):
         """Apply default values."""
-        msg = "You must specify one or more"
+        msg = "You must use exactly one"
         with pytest.raises(PatchCoordinateError, match=msg):
             random_patch.savgol_filter(polyorder=2)
 
@@ -321,7 +321,7 @@ class TestGaussianFilter:
     """Test the Guassian Filter."""
 
     def test_filter_time(self, event_patch_2):
-        """Test for simple filter along time axis."""
+        """Test for simple filter along the time axis."""
         out = event_patch_2.gaussian_filter(time=0.001)
         assert isinstance(out, dc.Patch)
         assert out.shape == event_patch_2.shape

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -295,6 +295,12 @@ class TestToTimeDelta64:
         out = to_timedelta64(ar)
         assert np.all(pd.isnull(out))
 
+    def test_array_of_datetimes(self, random_patch):
+        """Ensure datetime64 array can be converted to timedelta array."""
+        dt_array = random_patch.get_coord("time").values
+        out = to_timedelta64(dt_array)
+        assert np.all(out.astype(np.int64) == dt_array.astype(np.int64))
+
 
 class TestToInt:
     """Tests for converting time-like types to ints, or passing through reals."""


### PR DESCRIPTION

## Description

This PR does 3 sorta related things:

1. Adds a `dim_reduce` keyword to `Patch.aggregate` and friends (eg mean, min, max) which controls what happens to the aggregated dimension. Options now are to apply another numpy-like reducer, squeeze out the dimension, or empty it. The default behavior is unchanged, but the additional options are useful when calculating stats over patches in a spool.

2. Unified getting dimension name, axis, and values from args and kwargs into one new function `dascore.utils.patch.get_dim_axis_value` and replaced usages of two overlapping functions that did  this before. 

3. Added a `validate_call` option to `patch_function` which uses pydantic's [validate_call decorator](https://docs.pydantic.dev/latest/concepts/validation_decorator/#using-field-to-describe-function-arguments) to do type checking on patch functions when enabled. This makes it much easier to enforce certain types and ranges on patch function parameters. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
