### PR TITLE
patch_name method for dir spools

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -602,7 +602,7 @@ class DataFrameSpool(BaseSpool):
         """{doc}."""
         return self._df[filter_df(self._df, **self._select_kwargs)]
 
-    def patch_name(self, patch_number):
+    def patch_name(self, patch_number, file_format=False):
         """
         Return the name of the patch at the specified index.
 
@@ -627,7 +627,10 @@ class DataFrameSpool(BaseSpool):
             path = df["path"].iloc[patch_number]
         except IndexError:
             raise IndexError(f"Patch number {patch_number} is out of bounds.")
-        name = os.path.splitext(Path(path).name)[0]
+        if file_format:
+            name = Path(path).name
+        else:
+            name = os.path.splitext(Path(path).name)[0]
         return name
 
 

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import os
 from collections.abc import Callable, Generator, Mapping, Sequence
 from functools import singledispatch
 from pathlib import Path
@@ -600,6 +601,34 @@ class DataFrameSpool(BaseSpool):
     def get_contents(self) -> pd.DataFrame:
         """{doc}."""
         return self._df[filter_df(self._df, **self._select_kwargs)]
+
+    def patch_name(self, patch_number):
+        """
+        Return the name of the patch at the specified index.
+
+        Parameters
+        ----------
+        patch_number : int
+            The index of the patch.
+
+        Returns
+        -------
+        name : str
+            The original name of the patch.
+        """
+        df = self.get_contents()
+        if len(self) == 0:
+            raise IndexError("Cannot get patch name from an empty spool.")
+        if "path" not in df.columns:
+            raise ValueError(
+                "The 'path' column is not available in the spool contents."
+            )
+        try:
+            path = df["path"].iloc[patch_number]
+        except IndexError:
+            raise IndexError(f"Patch number {patch_number} is out of bounds.")
+        name = os.path.splitext(Path(path).name)[0]
+        return name
 
 
 class MemorySpool(DataFrameSpool):

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -555,6 +555,19 @@ class TestPatchName:
         ):
             empty_spool.patch_name(patch_number=0)
 
+    def test_patch_name_with_file_format_true(
+        self, random_directory_spool, file_format=True
+    ):
+        """Test patch_name returns name with extension when file_format is True."""
+        patch_number = 0
+        name = random_directory_spool.patch_name(patch_number, file_format=file_format)
+
+        df = random_directory_spool.get_contents()
+        expected_path = df["path"].iloc[patch_number]
+        expected_name = Path(expected_path).name  # Includes the extension
+
+        assert name == expected_name
+
 
 class TestMisc:
     """Tests for misc. spool cases."""


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->

This PR adds a method named `patch_name()` that returns the name of a patch in a directory spool.
It is related to discussion #460.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
