### PR TITLE
neubrex decimation check

### DIFF
--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -51,15 +51,18 @@ jobs:
           git fetch --tags --force # Retrieve annotated tags.
 
       # Have to use conda to install hdf5 so mac (I guess m1/2) runners work.
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.8-0' # versions: https://github.com/mamba-org/micromamba-releases
+          micromamba-version: '2.0.2-1' # versions: https://github.com/mamba-org/micromamba-releases
           environment-file: environment.yml
           init-shell: >-
             bash
             powershell
           cache-environment: true
+          cache-environment-key: environment-${{ steps.date.outputs.date }}
           post-cleanup: 'all'
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       # Not sure why this is needed but it appears to be the case
       - name: fix env
@@ -68,6 +71,11 @@ jobs:
           micromamba shell init --shell bash --root-prefix=~/micromamba
           eval "$(micromamba shell hook --shell bash)"
           micromamba activate dascore
+
+      - name: print python version
+        shell: bash -el {0}
+        run: |
+          python --version
 
       - name: install hdf5
         if: matrix.os=='macos-latest'

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -57,8 +57,7 @@ jobs:
           cache-environment-key: environment-${{ steps.date.outputs.date }}
           post-cleanup: 'all'
           create-args: >-
-            python=${{ matrix.python_version }}
-            numpy
+            python=${{ matrix.python-version }}
 
       # Not sure why this is needed but it appears to be the case
       - name: fix env
@@ -67,6 +66,11 @@ jobs:
           micromamba shell init --shell bash --root-prefix=~/micromamba
           eval "$(micromamba shell hook --shell bash)"
           micromamba activate dascore
+
+      - name: print python version
+        shell: bash -el {0}
+        run: |
+          python --version
 
       - name: install dascore
         shell: bash -el {0}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git fetch --tags --force # Retrieve annotated tags.
 
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '2.0.2-1' # versions: https://github.com/mamba-org/micromamba-releases
           environment-file: environment.yml
@@ -56,6 +56,9 @@ jobs:
           cache-environment: true
           cache-environment-key: environment-${{ steps.date.outputs.date }}
           post-cleanup: 'all'
+          create-args: >-
+            python=${{ matrix.python_version }}
+            numpy
 
       # Not sure why this is needed but it appears to be the case
       - name: fix env

--- a/dascore/io/neubrex/core.py
+++ b/dascore/io/neubrex/core.py
@@ -33,6 +33,8 @@ class NeubrexDASPatchAttrs(dc.PatchAttrs):
     triggered_time: np.datetime64 | None = None
     phase_to_strain: float | None = None
     instrument_model: str = ""
+    distance_decimation_filter: int = 0
+    time_decimation_filter: int = 0
 
 
 class NeubrexRFSV1(FiberIO):

--- a/dascore/io/neubrex/utils_das.py
+++ b/dascore/io/neubrex/utils_das.py
@@ -27,7 +27,8 @@ def _get_coord_manager(acoustic):
         """Get the time coordinate."""
         attrs = acoustic.attrs
 
-        assert attrs["TimeDecimationFilter"] == 0, "not yet implemented"
+        # We havent encountered a time decimated file yet; raise over guess
+        assert attrs["TimeDecimationFilter"] in {0, 1}, "not implemented"
 
         gps = unbyte(attrs["GPSTimeStamp(UTC)"])
         cpu = unbyte(attrs["CPUTimeStamp(UTC)"])
@@ -42,7 +43,8 @@ def _get_coord_manager(acoustic):
         dist_len = acoustic.shape[1]
         attrs = acoustic.attrs
 
-        assert attrs["DistanceDecimationFilter"] == 0, "not yet implemented"
+        # We havent encountered a distance decimated file yet; raise over guess
+        assert attrs["DistanceDecimationFilter"] in {0, 1}, "not yet implemented"
 
         step = attrs["SpatialSamplingInterval"]
         units = dc.get_quantity(attrs["StartStopPositionUnit"])

--- a/dascore/io/neubrex/utils_das.py
+++ b/dascore/io/neubrex/utils_das.py
@@ -75,6 +75,8 @@ def _get_attr_dict(acoustic):
         "PhaseToStrainConversion(MicroStrainPerRadian)": "phase_to_strain",
         "NEUBRESCOPE.DAS.SerialNum": "instrument_id",
         "NEUBRESCOPE.DAS.Model": "instrument_model",
+        "DistanceDecimationFilter": "distance_decimation_filter",
+        "TimeDecimationFilter": "time_decimation_filter",
     }
     attrs = dict(acoustic.attrs)
     out = maybe_get_items(attrs, mapping)


### PR DESCRIPTION

## Description

This PR modifies the time/distance decimation check for reading neubrex DAS files. Previously, we simply raise an exception if the `DistanceDecimationFilter` or the `TimeDecimationFilter` attributes are non-zero. This is because I was not sure if this is a binary flag indicating a low-pass anti-aliasing filter was applied (to either the time or space dimension) or if it is an integer value indicating the time/distance coordinate was decimated. For example, a `DistanceDecimationFilter`=2 could mean every other channel was discarded. 

 It appears that some files (eg the [forge neubrex das files](https://data.openei.org/s3_viewer?bucket=gdr-data-lake&prefix=FORGE%2FDAS%2FNeubrex)) have a value of 1, so it is probably a binary flag. In this case, I don't think there is anything else for DASCore to do except add this info to the attrs. 

This PR just allows `DistanceDecimationFilter` and `TimeDecimationFilter` to be either 1 or 0 and adds `distance_decimation_filter` and `time_decimation_filter` to the patch attrs. 

@arturguzik, if you can confirm my intrepretation of the `TimeDecimationFilter` and `DistanceDecimationFilter` parameters that would be useful. Thanks! 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
