### PR TITLE
Optional segyio and segy write

### DIFF
--- a/dascore/data_registry.txt
+++ b/dascore/data_registry.txt
@@ -28,3 +28,4 @@ neubrex_dts_forge.h5 940f7bea6dd4c8a1340b4936b8eb7f9edc577cbcaf77c1f5ac295890f88
 decimated_optodas.hdf5 48ce9c2ab4916d5536faeef0bd789f326ec4afc232729d32014d4d835a9fb74e https://github.com/dasdae/test_data/raw/master/das/decimated_optodas.hdf5
 neubrex_das_1.h5 48a97e27c56e66cc2954ba4eaaadd2169919bb8f897d78e95ef6ab50abb5027b https://github.com/dasdae/test_data/raw/master/das/neubrex_das_1.h5
 UoU_lf_urban.hdf5 d3f8fa6ff3d8ae993484b3fbf9b39505e2cf15cb3b39925a3519b27d5fbe7b5b https://github.com/dasdae/test_data/raw/master/das/UoU_lf_urban.hdf5
+small_channel_patch.sgy 31e551aadb361189c1c9325d504c883114ba9a7bb75fe4791e5089fabccef704 https://github.com/dasdae/test_data/raw/master/das/small_channel_patch.sgy

--- a/dascore/io/segy/__init__.py
+++ b/dascore/io/segy/__init__.py
@@ -5,6 +5,13 @@ Notes
 -----
 - Distance information is not found in most SEGY DAS files so returned
   dimensions are "channel" and "time" rather than "distance" and "time".
+- Segy standards found at: https://library.seg.org/pb-assets/technical-standards
+
+segy v1 spec: seg_y_rev1-1686080991247.pdf
+
+segy v2 spec: seg_y_rev2_0-mar2017-1686080998003.pdf
+
+segy v2.1 spec: seg_y_rev2_1-oct2023-1701361639333.pdf
 
 Examples
 --------

--- a/dascore/io/segy/__init__.py
+++ b/dascore/io/segy/__init__.py
@@ -24,4 +24,4 @@ path = fetch("conoco_segy_1.sgy")
 segy_patch = dc.spool(path)[0]
 """
 
-from .core import SegyV2
+from .core import SegyV1_0, SegyV2_0, SegyV2_1

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -7,7 +7,7 @@ import segyio
 import dascore as dc
 from dascore.io.core import FiberIO
 
-from .utils import _get_attrs, _get_coords, _get_filtered_data_and_coords
+from .utils import _get_attrs, _get_coords, _get_filtered_data_and_coords, _is_segy
 
 
 class SegyV2(FiberIO):
@@ -21,11 +21,13 @@ class SegyV2(FiberIO):
 
     def get_format(self, path, **kwargs) -> tuple[str, str] | bool:
         """Make sure input is segy."""
-        try:
-            with segyio.open(path, ignore_geometry=True):
-                return self.name, self.version
-        except Exception:
-            return False
+        with open(path, "rb") as fp:
+            return _is_segy(fp)
+        # try:
+        #     with segyio.open(path, ignore_geometry=True):
+        #         return self.name, self.version
+        # except Exception:
+        #     return False
 
     def read(self, path, time=None, channel=None, **kwargs):
         """

--- a/dascore/io/segy/utils.py
+++ b/dascore/io/segy/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import warnings
 
 import numpy as np
 
@@ -14,7 +15,6 @@ from dascore import to_float
 from dascore.core import get_coord_manager
 from dascore.exceptions import InvalidSpoolError, PatchError
 from dascore.utils.misc import optional_import
-from dascore.utils.patch import check_patch_coords
 
 # Valid data format codes as specified in the SEGY rev1 manual.
 VALID_FORMATS = [1, 2, 3, 4, 5, 8]
@@ -56,8 +56,11 @@ def _get_segy_version(fp):
     fixed_len_flag = twos_comp(header[302:304])
 
     checks = (
-        # First check that some samples and a sampling rate is defined.
-        samples_per_trace > 0 and sample_interval > 0,
+        # First check that some samples are defined.
+        samples_per_trace > 0,
+        # Then ensure the sample intervals is defined. This can be defined in trace
+        # header so 0 is ok, but not negative numbers.
+        sample_interval >= 0,
         # Ensure the data sample format code is valid using range in 2,1 standard
         1 <= data_format_code <= 16,
         # Check version code
@@ -120,7 +123,7 @@ def _get_coords(fi):
 
     # get time array from SEGY headers
     starttime = _get_time_from_header(header_0)
-    dt = dc.to_timedelta64(header_0[trace_field.TRACE_SAMPLE_INTERVAL] / 1000)
+    dt = dc.to_timedelta64(header_0[trace_field.TRACE_SAMPLE_INTERVAL] / 1_000_000)
     ns = header_0[trace_field.TRACE_SAMPLE_COUNT]
     time_array = starttime + dt * np.arange(ns)
 
@@ -161,10 +164,25 @@ def _get_time_from_header(header):
     return dc.to_datetime64(time)
 
 
+def _get_patch_with_channel_coord(patch):
+    """Ensure the patch has a channel coordinate."""
+    dims = set(patch.dims)
+    non_time = next(iter(dims - {"time"}))
+    msg = (
+        "Currently to segy only handles channels as non-time dimension "
+        f"this results in a loss of the {non_time} dimension."
+    )
+    warnings.warn(msg)
+    coord = patch.get_coord(non_time)
+    array = np.arange(len(coord))
+    patch = patch.rename_coords(time=non_time).update_coords(**{non_time: array})
+    return patch
+
+
 def _get_segy_compatible_patch(spool):
     """
     Get a patch that will be writable as a segy file.
-    Ensure coords are distance time.
+    Ensure coords are ("channel", "time").
     """
     # Ensure we have a single patch with coordinates time and distance.
     spool = [spool] if isinstance(spool, dc.Patch) else spool
@@ -172,7 +190,13 @@ def _get_segy_compatible_patch(spool):
         msg = "Can only write a spool with as single patch as segy."
         raise InvalidSpoolError(msg)
     patch = spool[0]
-    check_patch_coords(patch, dims=("time", "distance"))
+    dims = set(patch.dims)
+    if len(dims) != 2 or "time" not in dims:
+        msg = "Can only save 2D patches to SEGY with a time dimension."
+        raise PatchError(msg)
+    # Currently we only support channels not distance dimension.
+    if "channel" not in dims:
+        patch = _get_patch_with_channel_coord(patch)
     # Ensure there will be no loss in the time sampling.
     # segy supports us precision
     time_step = dc.to_float(patch.get_coord("time").step)
@@ -185,14 +209,14 @@ def _get_segy_compatible_patch(spool):
             "patch.update_coords or resample the time axis with patch.resample"
         )
         raise PatchError(msg)
-    return patch.transpose("distance", "time")
+    return patch.transpose("channel", "time")
 
 
 def _make_time_header_dict(time_coord):
     """Make the time header dict from a time coordinate."""
     header = {}
     timestamp = pd.Timestamp(dc.to_datetime64(time_coord.min()))
-    time_step_us = to_float(time_coord.step) * 1_000_000
+    time_step_ms = np.round(to_float(time_coord.step) * 1_000_000)
 
     segyio = optional_import("segyio")
     trace_field = segyio.TraceField
@@ -202,6 +226,7 @@ def _make_time_header_dict(time_coord):
     header[trace_field.HourOfDay] = timestamp.hour
     header[trace_field.MinuteOfHour] = timestamp.minute
     header[trace_field.SecondOfMinute] = timestamp.second
-    header[trace_field.TRACE_SAMPLE_INTERVAL] = time_step_us
+    header[trace_field.TRACE_SAMPLE_INTERVAL] = int(time_step_ms)
+    header[trace_field.TRACE_SAMPLE_COUNT] = len(time_coord)
 
     return header

--- a/dascore/io/segy/utils.py
+++ b/dascore/io/segy/utils.py
@@ -38,7 +38,9 @@ def twos_comp(bytes_):
 
 def _get_segy_version(fp):
     """
-    Return True if file pointer contains segy formatted data.
+    Determine if file handle contains segy data.
+
+    Returns (segy, version) if so else False.
 
     Based on ObsPy's implementation writen by Lion Krischer.
     https://github.com/obspy/obspy/blob/master/obspy/io/segy/core.py

--- a/dascore/io/segy/utils.py
+++ b/dascore/io/segy/utils.py
@@ -4,13 +4,69 @@ from __future__ import annotations
 
 import datetime
 
+# --- Getting format/version
 import numpy as np
 from segyio import TraceField
 
 import dascore as dc
 from dascore.core import get_coord_manager
 
-# --- Getting format/version
+# Valid data format codes as specified in the SEGY rev1 manual.
+VALID_FORMATS = [1, 2, 3, 4, 5, 8]
+
+# This is the maximum possible interval between two samples due to the nature
+# of the SEG Y format.
+MAX_INTERVAL_IN_SECONDS = 0.065535
+
+# largest number possible with int16
+MAX_NUMBER_OF_SAMPLES = 32767
+
+
+def twos_comp(bytes_):
+    """Get twos complement of bytestring."""
+    bits = len(bytes_) * 8
+    val = int.from_bytes(bytes_, "big")
+    if (val & (1 << (bits - 1))) != 0:  # if sign bit is set e.g., 8bit: 128-255
+        val = val - (1 << bits)  # compute negative value
+    return val  # return positive value as is
+
+
+def _is_segy(fp):
+    """
+    Return True if file pointer contains segy formatted data.
+
+    Based on ObsPy's implementation writen by Lion Krischer.
+    https://github.com/obspy/obspy/blob/master/obspy/io/segy/core.py
+    """
+    # # Read 400byte header into byte string.
+    # fp.seek(3200)
+    # header = fp.read(400)
+    # data_trace_count = twos_comp(header[12:14])
+    # auxiliary_trace_count = twos_comp(header[14:16])
+    # sample_interval = twos_comp(header[16:18])
+    # samples_per_trace = twos_comp(header[20:22])
+    # data_format_code = twos_comp(header[24:26])
+    # format_number_major = int.from_bytes(header[300:301])
+    # format_number_minor = int.from_bytes(header[301:302])
+    # fixed_len_flag = twos_comp(header[302:304])
+    #
+    #
+    # if _format_number not in (0x0000, 0x0100, 0x0010, 0x0001):
+    #     return False
+    #
+    # _fixed_length = unpack(fmt, _fixed_length)[0]
+    # _extended_number = unpack(fmt, _extended_number)[0]
+    # # Make some sanity checks and return False if they fail.
+    # if (
+    #     _sample_interval <= 0
+    #     or _samples_per_trace <= 0
+    #     or _number_of_data_traces < 0
+    #     or _number_of_auxiliary_traces < 0
+    #     or _fixed_length < 0
+    #     or _extended_number < 0
+    # ):
+    #     return False
+    return True
 
 
 def _get_filtered_data_and_coords(segy_fi, coords, time=None, channel=None):

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -325,7 +325,7 @@ def optional_import(package_name: str) -> ModuleType:
     except ImportError:
         msg = (
             f"{package_name} is not installed but is required for the "
-            f"requested functionality"
+            f"requested functionality."
         )
         raise MissingOptionalDependencyError(msg)
     return mod

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -269,7 +269,7 @@ def patch_function(
                     out = out.update_attrs(history=hist)
             return out
 
-        # attach original function. Although we want to encourage raw_function
+        # Attach original function. Although we want to encourage raw_function
         # for consistency with pydantic, we leave this to not break old code.
         _func.func = getattr(func, "raw_function", func)
         # matches pydantic naming.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
      "tables>=3.7",
      "typing_extensions",
      "pint",
-     "segyio",
 ]
 
 [project.optional-dependencies]
@@ -64,6 +63,7 @@ extras = [
     "findiff",
     "obspy",
     "numba",
+     "segyio",
 ]
 
 docs = [
@@ -119,7 +119,9 @@ TERRA15__V4 = "dascore.io.terra15.core:Terra15FormatterV4"
 TERRA15__V5 = "dascore.io.terra15.core:Terra15FormatterV5"
 TERRA15__V6 = "dascore.io.terra15.core:Terra15FormatterV6"
 SILIXA_H5__V1 = "dascore.io.silixah5:SilixaH5V1"
-SEGY__V2 = "dascore.io.segy.core:SegyV2"
+SEGY__V1_0 = "dascore.io.segy.core:SegyV1_0"
+SEGY__V2_0 = "dascore.io.segy.core:SegyV2_0"
+SEGY__V2_1 = "dascore.io.segy.core:SegyV2_1"
 RSF__V1 = "dascore.io.rsf.core:RSFV1"
 WAV = "dascore.io.wav.core:WavIO"
 XMLBINARY__V1 = "dascore.io.xml_binary.core:XMLBinaryV1"

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -31,7 +31,7 @@ from dascore.io.neubrex import NeubrexDASV1, NeubrexRFSV1
 from dascore.io.optodas import OptoDASV8
 from dascore.io.pickle import PickleIO
 from dascore.io.prodml import ProdMLV2_0, ProdMLV2_1
-from dascore.io.segy import SegyV2
+from dascore.io.segy import SegyV1_0
 from dascore.io.sentek import SentekV5
 from dascore.io.silixah5 import SilixaH5V1
 from dascore.io.tdms import TDMSFormatterV4713
@@ -75,7 +75,7 @@ COMMON_IO_READ_TESTS = {
     Terra15FormatterV5(): ("terra15_v5_test_file.hdf5",),
     Terra15FormatterV6(): ("terra15_v6_test_file.hdf5",),
     Terra15FormatterV6(): ("terra15_v6_test_file.hdf5",),
-    SegyV2(): ("conoco_segy_1.sgy",),
+    SegyV1_0(): ("conoco_segy_1.sgy",),
     DASHDF5(): ("PoroTomo_iDAS_1.h5",),
     SentekV5(): ("DASDMSShot00_20230328155653619.das",),
 }
@@ -83,7 +83,7 @@ COMMON_IO_READ_TESTS = {
 # This tuple is for fiber io which support a write method and can write
 # generic patches. If the patch has to be in some special form, for example
 # only flat patches can be written to WAV, don't put it here.
-COMMON_IO_WRITE_TESTS = (PickleIO(), DASDAEV1())
+COMMON_IO_WRITE_TESTS = (PickleIO(), DASDAEV1(), SegyV1_0())
 
 # Specifies data registry entries which should not be tested.
 SKIP_DATA_FILES = {"whale_1.hdf5", "brady_hs_DAS_DTS_coords.csv"}

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -83,7 +83,10 @@ COMMON_IO_READ_TESTS = {
 # This tuple is for fiber io which support a write method and can write
 # generic patches. If the patch has to be in some special form, for example
 # only flat patches can be written to WAV, don't put it here.
-COMMON_IO_WRITE_TESTS = (PickleIO(), DASDAEV1(), SegyV1_0())
+COMMON_IO_WRITE_TESTS = (
+    PickleIO(),
+    DASDAEV1(),
+)
 
 # Specifies data registry entries which should not be tested.
 SKIP_DATA_FILES = {"whale_1.hdf5", "brady_hs_DAS_DTS_coords.csv"}

--- a/tests/test_io/test_segy/test_segy.py
+++ b/tests/test_io/test_segy/test_segy.py
@@ -64,6 +64,8 @@ class TestSegyWrite:
     def test_channel_patch_round_trip(self, channel_patch_path, channel_patch):
         """The channel patch should round trip."""
         patch1 = channel_patch
-        patch2 = dc.spool(channel_patch_path)[0]
-
+        patch2 = dc.spool(channel_patch_path)[0].transpose(*patch1.dims)
+        # We really don't have a way to transport attributes yet, so we
+        # just check that data and coords are equal.
         assert np.allclose(patch1.data, patch2.data)
+        assert patch1.coords == patch2.coords

--- a/tests/test_io/test_segy/test_segy.py
+++ b/tests/test_io/test_segy/test_segy.py
@@ -1,12 +1,14 @@
 """Tests for SEGY format."""
 
+import numpy as np
 import pytest
 
+import dascore as dc
 from dascore.io.segy.core import SegyV1_0
 
 
-class TestSegy:
-    """Tests for SEGY format."""
+class TestSegyGetFormat:
+    """Tests for getting format codes of SEGY files."""
 
     @pytest.fixture(scope="class")
     def small_file(self, tmp_path_factory):
@@ -17,7 +19,7 @@ class TestSegy:
             f.write(b"abd")
         return path
 
-    def test_small_file(self, small_file):
+    def test_get_formate_small_file(self, small_file):
         """
         Ensure a file that is too small to contain segy header doesn't throw
         an error.
@@ -25,3 +27,43 @@ class TestSegy:
         segy = SegyV1_0()
         out = segy.get_format(small_file)
         assert out is False  # we actually want to make sure its False.
+
+
+class TestSegyWrite:
+    """Tests for writing segy files."""
+
+    @pytest.fixture(scope="class")
+    def test_segy_directory(self, tmp_path_factory):
+        """Make a tmp directory for saving files."""
+        path = tmp_path_factory.mktemp("test_segy_write_directory")
+        return path
+
+    @pytest.fixture(scope="class")
+    def channel_patch(self, random_patch):
+        """Get a patch with channels rather than distance."""
+        distance = random_patch.get_coord("distance")
+        new = random_patch.rename_coords(distance="channel").update_coords(
+            **{"channel": np.arange(len(distance))}
+        )
+        return new
+
+    @pytest.fixture(scope="class")
+    def channel_patch_path(self, channel_patch, test_segy_directory):
+        """Write the channel patch to disk."""
+        path = test_segy_directory / "patch_with_channel_coord.segy"
+        channel_patch.io.write(path, "segy")
+        return path
+
+    def test_can_get_format(self, channel_patch_path):
+        """Ensure we can get the correct format/version."""
+        segy = SegyV1_0()
+        out = segy.get_format(channel_patch_path)
+        assert out, "Failed to detect written segy file."
+        assert out[0] == segy.name
+
+    def test_channel_patch_round_trip(self, channel_patch_path, channel_patch):
+        """The channel patch should round trip."""
+        patch1 = channel_patch
+        patch2 = dc.spool(channel_patch_path)[0]
+
+        assert np.allclose(patch1.data, patch2.data)

--- a/tests/test_io/test_segy/test_segy.py
+++ b/tests/test_io/test_segy/test_segy.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.exceptions import MissingOptionalDependencyError
 from dascore.io.segy.core import SegyV1_0
 
 
@@ -51,7 +52,10 @@ class TestSegyWrite:
     def channel_patch_path(self, channel_patch, test_segy_directory):
         """Write the channel patch to disk."""
         path = test_segy_directory / "patch_with_channel_coord.segy"
-        channel_patch.io.write(path, "segy")
+        try:
+            channel_patch.io.write(path, "segy")
+        except MissingOptionalDependencyError:
+            pytest.skip("Test requires segyio to be installed.")
         return path
 
     def test_can_get_format(self, channel_patch_path):

--- a/tests/test_io/test_segy/test_segy.py
+++ b/tests/test_io/test_segy/test_segy.py
@@ -1,1 +1,27 @@
 """Tests for SEGY format."""
+
+import pytest
+
+from dascore.io.segy.core import SegyV1_0
+
+
+class TestSegy:
+    """Tests for SEGY format."""
+
+    @pytest.fixture(scope="class")
+    def small_file(self, tmp_path_factory):
+        """Creates a small file with only a few bytes."""
+        parent = tmp_path_factory.mktemp("small_file")
+        path = parent / "test_file.segy"
+        with path.open("wb") as f:
+            f.write(b"abd")
+        return path
+
+    def test_small_file(self, small_file):
+        """
+        Ensure a file that is too small to contain segy header doesn't throw
+        an error.
+        """
+        segy = SegyV1_0()
+        out = segy.get_format(small_file)
+        assert out is False  # we actually want to make sure its False.


### PR DESCRIPTION

## Description

This PR removes segyio as a hard dependency. Segyio is great, but usually very slow to upgrade to newer python versions which, in tern, keeps DASCore from upgrading.  This PR fixes this. 

It also implements very simple support for writing segy files as requested in #428. This will probably require more work in the future to get right, but at least we have a start here.

@aaronjgirard, do you mind reviewing this PR? 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
