### PR TITLE
add get_name patch/spool method

### DIFF
--- a/.github/doc_environment.yml
+++ b/.github/doc_environment.yml
@@ -2,6 +2,7 @@ name: dascore
 channels:
   - conda-forge
 dependencies:
+  - python=3.12
   - pytest
   - pydantic>2.0
   - pip

--- a/.github/workflows/build_deploy_master_docs.yaml
+++ b/.github/workflows/build_deploy_master_docs.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           micromamba-version: '1.5.8-0' # versions: https://github.com/mamba-org/micromamba-releases
-          environment-file: environment.yml
+          environment-file: ./.github/doc_environment.yml
           init-shell: >-
             bash
             powershell

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -41,16 +41,23 @@ jobs:
       - name: Get tags
         run: git fetch --tags origin
 
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v3
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          python-version: "3.11"
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
-          activate-environment: dascore
-          environment-file: environment.yml
-          condarc-file: .github/test_condarc.yml
+          micromamba-version: '1.5.8-0' # versions: https://github.com/mamba-org/micromamba-releases
+          environment-file: ./.github/doc_environment.yml
+          init-shell: >-
+            bash
+            powershell
+          cache-environment: true
+          post-cleanup: 'all'
+
+      # Not sure why this is needed but it appears to be the case
+      - name: fix env
+        shell: bash -l {0}
+        run: | 
+          micromamba shell init --shell bash --root-prefix=~/micromamba
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate dascore
 
       - name: install dascore with docbuild reqs
         shell: bash -l {0}

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -260,7 +260,15 @@ class Patch:
     coords_from_df = dascore.proc.coords_from_df
     make_broadcastable_to = dascore.proc.make_broadcastable_to
     apply_ufunc = dascore.proc.apply_ufunc
-    get_patch_names = get_patch_names
+
+    def get_patch_name(self, *args, **kwargs) -> str:
+        """
+        Return the name of the patch.
+
+        See [`get_patch_names`](`dascore.utils.patch.get_patch_names`)
+        for argument details.
+        """
+        return get_patch_names(self, *args, **kwargs).iloc[0]
 
     def assign_coords(self, *args, **kwargs):
         """Deprecated method for update_coords."""

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -19,7 +19,7 @@ from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.coords import BaseCoord
 from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
 from dascore.utils.models import ArrayLike
-from dascore.utils.patch import check_patch_attrs, check_patch_coords
+from dascore.utils.patch import check_patch_attrs, check_patch_coords, get_patch_name
 from dascore.utils.time import to_float
 from dascore.viz import VizPatchNameSpace
 
@@ -260,6 +260,7 @@ class Patch:
     coords_from_df = dascore.proc.coords_from_df
     make_broadcastable_to = dascore.proc.make_broadcastable_to
     apply_ufunc = dascore.proc.apply_ufunc
+    get_name = get_patch_name
 
     def assign_coords(self, *args, **kwargs):
         """Deprecated method for update_coords."""

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -19,7 +19,7 @@ from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.coords import BaseCoord
 from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
 from dascore.utils.models import ArrayLike
-from dascore.utils.patch import check_patch_attrs, check_patch_coords, get_patch_name
+from dascore.utils.patch import check_patch_attrs, check_patch_coords, get_patch_names
 from dascore.utils.time import to_float
 from dascore.viz import VizPatchNameSpace
 
@@ -260,7 +260,7 @@ class Patch:
     coords_from_df = dascore.proc.coords_from_df
     make_broadcastable_to = dascore.proc.make_broadcastable_to
     apply_ufunc = dascore.proc.apply_ufunc
-    get_name = get_patch_name
+    get_patch_names = get_patch_names
 
     def assign_coords(self, *args, **kwargs):
         """Deprecated method for update_coords."""

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -33,6 +33,7 @@ from dascore.utils.patch import (
     _force_patch_merge,
     _spool_up,
     concatenate_patches,
+    get_patch_name,
     patches_to_df,
     stack_patches,
 )
@@ -601,6 +602,8 @@ class DataFrameSpool(BaseSpool):
         """{doc}."""
         return self._df[filter_df(self._df, **self._select_kwargs)]
 
+    get_name = get_patch_name
+
 
 class MemorySpool(DataFrameSpool):
     """A Spool for storing patches in memory."""
@@ -617,10 +620,14 @@ class MemorySpool(DataFrameSpool):
         base = super().__rich__()
         df = self._df
         if len(df):
-            t1, t2 = df["time_min"].min(), df["time_max"].max()
+            t1 = df["time_min"].min() if "time_min" in df.columns else ""
+            t2 = df["time_min"].max() if "time_min" in df.columns else ""
             tmin = get_nice_text(t1)
             tmax = get_nice_text(t2)
-            duration = get_nice_text(t2 - t1)
+            if t1 != "" and t2 != "":
+                duration = get_nice_text(t2 - t1)
+            else:
+                duration = ""
             base += Text(f"\n    Time Span: <{duration}> {tmin} to {tmax}")
         return base
 

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -33,7 +33,7 @@ from dascore.utils.patch import (
     _force_patch_merge,
     _spool_up,
     concatenate_patches,
-    get_patch_name,
+    get_patch_names,
     patches_to_df,
     stack_patches,
 )
@@ -602,7 +602,7 @@ class DataFrameSpool(BaseSpool):
         """{doc}."""
         return self._df[filter_df(self._df, **self._select_kwargs)]
 
-    get_name = get_patch_name
+    get_patch_names = get_patch_names
 
 
 class MemorySpool(DataFrameSpool):

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -193,6 +193,9 @@ class BaseSpool(abc.ABC):
         >>> df = spool.get_contents()
         """
 
+    # Bind get_patch names as a spool method.
+    get_patch_names = get_patch_names
+
     # --- optional methods
 
     def sort(self, attribute) -> Self:
@@ -601,8 +604,6 @@ class DataFrameSpool(BaseSpool):
     def get_contents(self) -> pd.DataFrame:
         """{doc}."""
         return self._df[filter_df(self._df, **self._select_kwargs)]
-
-    get_patch_names = get_patch_names
 
 
 class MemorySpool(DataFrameSpool):

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -451,6 +451,24 @@ def random_spool(time_gap=0, length=3, time_min=np.datetime64("2020-01-03"), **k
     return dc.spool(out)
 
 
+@register_func(EXAMPLE_SPOOLS, key="radom_directory_das")
+def random_directory_spool(path=None, **kwargs):
+    """
+    Create a random spool, then save to specified path.
+
+    Parameters
+    ----------
+    path
+        If provided, the path to save the directory spool. If None, use
+        a temporary path.
+
+    kwargs are passed to [`random_spool`](`dascore.examples.random_spool`)
+    """
+    spool = random_spool(**kwargs)
+    path = spool_to_directory(spool, path)
+    return dc.spool(path)
+
+
 @register_func(EXAMPLE_SPOOLS, key="diverse_das")
 def diverse_spool():
     """

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -18,7 +18,7 @@ from dascore.exceptions import UnknownExampleError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import register_func
-from dascore.utils.patch import get_patch_name
+from dascore.utils.patch import get_patch_names
 from dascore.utils.time import to_timedelta64
 
 EXAMPLE_PATCHES = {}
@@ -506,7 +506,7 @@ def spool_to_directory(spool, path=None, file_format="DASDAE", extention="hdf5")
         path = Path(tempfile.mkdtemp())
         assert path.exists()
     for patch in spool:
-        name = get_patch_name(patch).iloc[0]
+        name = get_patch_names(patch).iloc[0]
         out_path = path / (f"{name}.{extention}")
         patch.io.write(out_path, file_format=file_format)
     return path

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -451,7 +451,7 @@ def random_spool(time_gap=0, length=3, time_min=np.datetime64("2020-01-03"), **k
     return dc.spool(out)
 
 
-@register_func(EXAMPLE_SPOOLS, key="radom_directory_das")
+@register_func(EXAMPLE_SPOOLS, key="random_directory_das")
 def random_directory_spool(path=None, **kwargs):
     """
     Create a random spool, then save to specified path.

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -18,7 +18,7 @@ from dascore.exceptions import UnknownExampleError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import register_func
-from dascore.utils.patch import get_default_patch_name
+from dascore.utils.patch import get_patch_name
 from dascore.utils.time import to_timedelta64
 
 EXAMPLE_PATCHES = {}
@@ -506,7 +506,8 @@ def spool_to_directory(spool, path=None, file_format="DASDAE", extention="hdf5")
         path = Path(tempfile.mkdtemp())
         assert path.exists()
     for patch in spool:
-        out_path = path / (f"{get_default_patch_name(patch)}.{extention}")
+        name = get_patch_name(patch).iloc[0]
+        out_path = path / (f"{name}.{extention}")
         patch.io.write(out_path, file_format=file_format)
     return path
 

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -648,7 +648,7 @@ def read(
 
 
 def scan_to_df(
-    path: Path | str | PatchType | SpoolType | IOResourceManager,
+    path: Path | str | PatchType | SpoolType | IOResourceManager | pd.DataFrame,
     file_format: str | None = None,
     file_version: str | None = None,
     ext: str | None = None,
@@ -665,7 +665,7 @@ def scan_to_df(
     Parameters
     ----------
     path
-        The path the to file to scan
+        The path to the to file to scan
     file_format
         Format of the file. If not provided DASCore will try to determine it.
     file_version
@@ -682,6 +682,8 @@ def scan_to_df(
     >>>
     >>> df = dc.scan_to_df(file_path)
     """
+    if isinstance(path, pd.DataFrame):
+        return path
     info = scan(
         path=path,
         file_format=file_format,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -30,13 +30,12 @@ from dascore.constants import (
     timeable_types,
 )
 from dascore.core.attrs import str_validator
+from dascore.core.spool import DataFrameSpool
 from dascore.exceptions import (
     InvalidFiberIOError,
     MissingOptionalDependencyError,
     UnknownFiberFormatError,
 )
-from dascore.core.spool import DataFrameSpool
-from dascore.exceptions import InvalidFiberIOError, UnknownFiberFormatError
 from dascore.utils.io import IOResourceManager, get_handle_from_resource
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import _iter_filesystem, cached_method, iterate, warn_or_raise

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -35,6 +35,8 @@ from dascore.exceptions import (
     MissingOptionalDependencyError,
     UnknownFiberFormatError,
 )
+from dascore.core.spool import DataFrameSpool
+from dascore.exceptions import InvalidFiberIOError, UnknownFiberFormatError
 from dascore.utils.io import IOResourceManager, get_handle_from_resource
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import _iter_filesystem, cached_method, iterate, warn_or_raise
@@ -684,6 +686,8 @@ def scan_to_df(
     """
     if isinstance(path, pd.DataFrame):
         return path
+    if isinstance(path, DataFrameSpool):
+        return path.get_contents()
     info = scan(
         path=path,
         file_format=file_format,

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -17,7 +17,7 @@ from dascore.utils.hdf5 import (
     PyTablesWriter,
 )
 from dascore.utils.misc import unbyte
-from dascore.utils.patch import get_default_patch_name
+from dascore.utils.patch import get_patch_name
 
 from .utils import (
     _get_contents_from_patch_groups,
@@ -78,8 +78,9 @@ class DASDAEV1(FiberIO):
             resource.create_group(resource.root, "waveforms")
         waveforms = resource.get_node("/waveforms")
         # write new patches to file
-        for patch in patches:
-            _save_patch(patch, waveforms, resource)
+        patch_names = get_patch_name(patches).values
+        for patch, name in zip(patches, patch_names):
+            _save_patch(patch, waveforms, resource, name)
         indexer = HDFPatchIndexManager(resource)
         if index or indexer.has_index:
             df = self._get_patch_summary(patches)
@@ -90,7 +91,7 @@ class DASDAEV1(FiberIO):
         df = (
             dc.scan_to_df(patches)
             .assign(
-                path=[f"waveforms/{get_default_patch_name(x)}" for x in patches],
+                path=lambda x: get_patch_name(x),
                 file_format=self.name,
                 file_version=self.version,
             )

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -17,7 +17,7 @@ from dascore.utils.hdf5 import (
     PyTablesWriter,
 )
 from dascore.utils.misc import unbyte
-from dascore.utils.patch import get_patch_name
+from dascore.utils.patch import get_patch_names
 
 from .utils import (
     _get_contents_from_patch_groups,
@@ -78,7 +78,7 @@ class DASDAEV1(FiberIO):
             resource.create_group(resource.root, "waveforms")
         waveforms = resource.get_node("/waveforms")
         # write new patches to file
-        patch_names = get_patch_name(patches).values
+        patch_names = get_patch_names(patches).values
         for patch, name in zip(patches, patch_names):
             _save_patch(patch, waveforms, resource, name)
         indexer = HDFPatchIndexManager(resource)
@@ -91,7 +91,7 @@ class DASDAEV1(FiberIO):
         df = (
             dc.scan_to_df(patches)
             .assign(
-                path=lambda x: get_patch_name(x),
+                path=lambda x: get_patch_names(x),
                 file_format=self.name,
                 file_version=self.version,
             )

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -10,7 +10,6 @@ from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
 from dascore.utils.misc import suppress_warnings
-from dascore.utils.patch import get_default_patch_name
 from dascore.utils.time import to_int
 
 # --- Functions for writing DASDAE format
@@ -80,9 +79,8 @@ def _save_coords(patch, patch_group, h5):
         patch_group._v_attrs[save_name] = ",".join(dims)
 
 
-def _save_patch(patch, wave_group, h5):
+def _save_patch(patch, wave_group, h5, name):
     """Save the patch to disk."""
-    name = get_default_patch_name(patch)
     patch_group = _create_or_get_group(h5, wave_group, name)
     _save_attrs_and_dims(patch, patch_group)
     _save_coords(patch, patch_group, h5)

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -431,7 +431,7 @@ def get_start_stop_step(patch: PatchType, dim):
     return start, stop, step
 
 
-def get_patch_name(
+def get_patch_names(
     patch_data: pd.DataFrame | dc.Patch | dc.BaseSpool,
     prefix="DAS",
     attrs=("network", "station", "tag"),
@@ -465,9 +465,9 @@ def get_patch_name(
     Examples
     --------
     >>> import dascore as dc
-    >>> from dascore.utils.patch import get_patch_name
+    >>> from dascore.utils.patch import get_patch_names
     >>> patch = dc.get_example_patch()
-    >>> name = get_patch_name(patch)
+    >>> name = get_patch_names(patch)
     """
 
     def _format_time_column(ser):

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -227,6 +227,18 @@ print(patch.channel_count) # to get the number of channels in the patch.
 
 These only work for patches with dimensions "time" and "distance" but can help new users who may be unfamiliar datetimes and coordinates. 
 
+The "name" of the patch, which is the filename that would be used if the patch were saved to disk by DASCore, can be generated via the [`Spool.get_patch_names`](`dascore.BaseSpool.get_patch_names`) to get a series of the names of the managed patches, or [`Patch.get_patch_name`](`dascore.Patch.get_patch_name`) to get a string of the patch name.
+
+```python 
+import dascore as dc
+
+patch = dc.get_example_patch()
+spool = dc.get_example_spool()
+
+patch_name = patch.get_patch_name()
+patch_names = spool.get_patch_names()
+```
+
 # Trim and Reshape
 
 The following methods help trim, reshape, and manipulate coordinates.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,12 +386,10 @@ def one_file_dir(tmp_path_factory, random_patch):
 
 
 @pytest.fixture(scope="session")
-def random_spool_directory(tmp_path_factory):
+def random_directory_spool(tmp_path_factory):
     """A directory with a few patch files."""
-    out = Path(tmp_path_factory.mktemp("one_file_file_spool"))
-    spool = ex.get_example_spool("random_das")
-    out_path = ex.spool_to_directory(spool, path=out)
-    return dc.spool(out_path).update()
+    path = Path(tmp_path_factory.mktemp("one_file_file_spool"))
+    return dc.examples.random_directory_spool(path)
 
 
 @pytest.fixture(scope="class")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,6 +385,15 @@ def one_file_dir(tmp_path_factory, random_patch):
     return ex.spool_to_directory(spool, path=out)
 
 
+@pytest.fixture(scope="session")
+def random_spool_directory(tmp_path_factory):
+    """A directory with a few patch files."""
+    out = Path(tmp_path_factory.mktemp("one_file_file_spool"))
+    spool = ex.get_example_spool("random_das")
+    out_path = ex.spool_to_directory(spool, path=out)
+    return dc.spool(out_path).update()
+
+
 @pytest.fixture(scope="class")
 def two_patch_directory(tmp_path_factory, terra15_das_example_path, random_patch):
     """Create a directory of DAS files for testing."""

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -711,3 +711,12 @@ class TestHistory:
         entry = hist[-1]
         array_part = entry.split("'[")[-1].split("]'")[0]
         assert len(array_part) < 100
+
+
+class TestGetPatchName:
+    """Tests for getting the name of a patch."""
+
+    def test_simple_get_name(self, random_patch):
+        """Happy path test."""
+        name = random_patch.get_patch_name()
+        assert isinstance(name, str)

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -56,12 +56,18 @@ class TestSpoolBasics:
         assert len(out) == 0
 
     def test_updated_spool_eq(self, random_spool):
-        """Ensure updating the spool doesnt change equality."""
+        """Ensure updating the spool doesn't change equality."""
         assert random_spool == random_spool.update()
 
     def test_empty_spool_str(self):
         """Ensure and empty spool has a string rep. See #295."""
         spool = dc.spool([])
+        spool_str = str(spool)
+        assert "Spool" in spool_str
+
+    def test_spool_with_empty_patch_str(self):
+        """A spool with an empty patch should have a str."""
+        spool = dc.spool(dc.Patch())
         spool_str = str(spool)
         assert "Spool" in spool_str
 

--- a/tests/test_io/test_indexer.py
+++ b/tests/test_io/test_indexer.py
@@ -15,7 +15,7 @@ from packaging.version import parse as get_version
 import dascore as dc
 from dascore.examples import spool_to_directory
 from dascore.io.indexer import DirectoryIndexer
-from dascore.utils.patch import get_patch_name
+from dascore.utils.patch import get_patch_names
 
 
 @pytest.fixture(scope="class")
@@ -224,7 +224,7 @@ class TestUpdate:
 
     def test_add_one_patch(self, empty_index, random_patch):
         """Ensure a new patch added to the directory shows up."""
-        path = empty_index.path / get_patch_name(random_patch).iloc[0]
+        path = empty_index.path / get_patch_names(random_patch).iloc[0]
         random_patch.io.write(path, file_format="dasdae")
         new_index = empty_index.update()
         contents = new_index()

--- a/tests/test_io/test_indexer.py
+++ b/tests/test_io/test_indexer.py
@@ -15,7 +15,7 @@ from packaging.version import parse as get_version
 import dascore as dc
 from dascore.examples import spool_to_directory
 from dascore.io.indexer import DirectoryIndexer
-from dascore.utils.patch import get_default_patch_name
+from dascore.utils.patch import get_patch_name
 
 
 @pytest.fixture(scope="class")
@@ -224,7 +224,7 @@ class TestUpdate:
 
     def test_add_one_patch(self, empty_index, random_patch):
         """Ensure a new patch added to the directory shows up."""
-        path = empty_index.path / get_default_patch_name(random_patch)
+        path = empty_index.path / get_patch_name(random_patch).iloc[0]
         random_patch.io.write(path, file_format="dasdae")
         new_index = empty_index.update()
         contents = new_index()

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -370,10 +370,10 @@ class TestScanToDF:
         out = dc.scan_to_df(df)
         assert out is df
 
-    def test_spool_dataframe(self, random_spool_directory):
+    def test_spool_dataframe(self, random_directory_spool):
         """Ensure scan_to_df just gets the dataframe from the spool."""
-        expected = random_spool_directory.get_contents()
-        out = dc.scan_to_df(random_spool_directory)
+        expected = random_directory_spool.get_contents()
+        out = dc.scan_to_df(random_directory_spool)
         assert out.equals(expected)
 
 

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -370,6 +370,12 @@ class TestScanToDF:
         out = dc.scan_to_df(df)
         assert out is df
 
+    def test_spool_dataframe(self, random_spool_directory):
+        """Ensure scan_to_df just gets the dataframe from the spool."""
+        expected = random_spool_directory.get_contents()
+        out = dc.scan_to_df(random_spool_directory)
+        assert out.equals(expected)
+
 
 class TestCastType:
     """Test suite to ensure types are intelligently cast to type hints."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -361,6 +361,16 @@ class TestScan:
         assert not len(scan)
 
 
+class TestScanToDF:
+    """Tests for scanning to dataframes."""
+
+    def test_input_dataframe(self, random_spool):
+        """Ensure a dataframe returns a dataframe."""
+        df = random_spool.get_contents()
+        out = dc.scan_to_df(df)
+        assert out is df
+
+
 class TestCastType:
     """Test suite to ensure types are intelligently cast to type hints."""
 

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -611,8 +611,8 @@ class TestStackPatches:
         assert dist_coords.units == orig_dist_coords.units
 
 
-class TestGetDefaultName:
-    """Tests for getting the default name of patches/spools."""
+class TestGetPatchName:
+    """Tests for getting the default name from patch sources."""
 
     def test_single_patch(self, random_patch):
         """Ensure the random patch can have a name."""
@@ -629,3 +629,17 @@ class TestGetDefaultName:
         """Ensure an empty thing returns a series of the right type."""
         out = get_patch_name([])
         assert isinstance(out, pd.Series)
+
+    def test_name_column_exists(self, random_spool):
+        """If the name or path field already exist this should be used."""
+        df = random_spool.get_contents().assign(name=lambda x: np.arange(len(x)))
+        # This should convert to string type and return.
+        names = get_patch_name(df)
+        assert np.all(names.values == np.arange(len(df)).astype(str))
+
+    def test_path_column(self, random_spool_directory):
+        """Ensure the path column works."""
+        names = get_patch_name(random_spool_directory)
+        df = random_spool_directory.get_contents()
+        expected = pd.Series([x[-1].split(".")[0] for x in df["path"].str.split("/")])
+        assert np.all(names == expected)

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -637,9 +637,9 @@ class TestGetPatchName:
         names = get_patch_names(df)
         assert np.all(names.values == np.arange(len(df)).astype(str))
 
-    def test_path_column(self, random_spool_directory):
+    def test_path_column(self, random_directory_spool):
         """Ensure the path column works."""
-        names = get_patch_names(random_spool_directory)
-        df = random_spool_directory.get_contents()
+        names = get_patch_names(random_directory_spool)
+        df = random_directory_spool.get_contents()
         expected = pd.Series([x[-1].split(".")[0] for x in df["path"].str.split("/")])
         assert np.all(names == expected)

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -644,7 +644,7 @@ class TestGetPatchName:
         expected = pd.Series([x[-1].split(".")[0] for x in df["path"].str.split("/")])
         assert np.all(names == expected)
 
-    def tet_path_column_leave_extension(self, random_directory_spool):
+    def test_path_column_leave_extension(self, random_directory_spool):
         """If extension is false the file extension should remain."""
         names = get_patch_names(random_directory_spool, strip_extension=False)
         assert "." in names.iloc[0]

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -24,9 +24,9 @@ from dascore.utils.patch import (
     align_patch_coords,
     concatenate_patches,
     get_dim_axis_value,
+    get_patch_name,
     merge_compatible_coords_attrs,
     patches_to_df,
-    scan_patches,
     stack_patches,
 )
 
@@ -261,16 +261,6 @@ class TestPatchesToDF:
         df = random_spool.get_contents().drop(columns="history", errors="ignore")
         out = patches_to_df(df)
         assert "history" in out.columns
-
-
-class TestScanPaches:
-    """Tests for scanning patches to get metadata."""
-
-    def test_single_patch(self, random_patch):
-        """Ensure a single patch works."""
-        out = scan_patches(random_patch)
-        assert len(out) == 1
-        assert isinstance(out[0], dc.PatchAttrs)
 
 
 class TestAlignPatches:
@@ -619,3 +609,23 @@ class TestStackPatches:
         assert dist_coords.stop == orig_dist_coords.stop
         assert dist_coords.step == orig_dist_coords.step
         assert dist_coords.units == orig_dist_coords.units
+
+
+class TestGetDefaultName:
+    """Tests for getting the default name of patches/spools."""
+
+    def test_single_patch(self, random_patch):
+        """Ensure the random patch can have a name."""
+        out = get_patch_name(random_patch)
+        assert isinstance(out, pd.Series)
+        assert len(out) == 1
+
+    def test_spool(self, random_spool):
+        """Ensure names can be generated from a spool as well."""
+        out = get_patch_name(random_spool)
+        assert len(out) == len(random_spool)
+
+    def test_empty(self):
+        """Ensure an empty thing returns a series of the right type."""
+        out = get_patch_name([])
+        assert isinstance(out, pd.Series)

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -643,3 +643,8 @@ class TestGetPatchName:
         df = random_directory_spool.get_contents()
         expected = pd.Series([x[-1].split(".")[0] for x in df["path"].str.split("/")])
         assert np.all(names == expected)
+
+    def tet_path_column_leave_extension(self, random_directory_spool):
+        """If extension is false the file extension should remain."""
+        names = get_patch_names(random_directory_spool, strip_extension=False)
+        assert "." in names.iloc[0]

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -24,7 +24,7 @@ from dascore.utils.patch import (
     align_patch_coords,
     concatenate_patches,
     get_dim_axis_value,
-    get_patch_name,
+    get_patch_names,
     merge_compatible_coords_attrs,
     patches_to_df,
     stack_patches,
@@ -616,30 +616,30 @@ class TestGetPatchName:
 
     def test_single_patch(self, random_patch):
         """Ensure the random patch can have a name."""
-        out = get_patch_name(random_patch)
+        out = get_patch_names(random_patch)
         assert isinstance(out, pd.Series)
         assert len(out) == 1
 
     def test_spool(self, random_spool):
         """Ensure names can be generated from a spool as well."""
-        out = get_patch_name(random_spool)
+        out = get_patch_names(random_spool)
         assert len(out) == len(random_spool)
 
     def test_empty(self):
         """Ensure an empty thing returns a series of the right type."""
-        out = get_patch_name([])
+        out = get_patch_names([])
         assert isinstance(out, pd.Series)
 
     def test_name_column_exists(self, random_spool):
         """If the name or path field already exist this should be used."""
         df = random_spool.get_contents().assign(name=lambda x: np.arange(len(x)))
         # This should convert to string type and return.
-        names = get_patch_name(df)
+        names = get_patch_names(df)
         assert np.all(names.values == np.arange(len(df)).astype(str))
 
     def test_path_column(self, random_spool_directory):
         """Ensure the path column works."""
-        names = get_patch_name(random_spool_directory)
+        names = get_patch_names(random_spool_directory)
         df = random_spool_directory.get_contents()
         expected = pd.Series([x[-1].split(".")[0] for x in df["path"].str.split("/")])
         assert np.all(names == expected)


### PR DESCRIPTION

## Description

This PR implements a `get_name` method for the patch and the spool to return a series of names. The names are either generated by columns provided to the function (which has sensible defaults to maintain the old behavior) or by existing columns such as `name` or `path`. 

This PR supersede  #461.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
