### PR TITLE
support for geothermal data repo h5 format

### DIFF
--- a/dascore/data_registry.txt
+++ b/dascore/data_registry.txt
@@ -29,3 +29,4 @@ decimated_optodas.hdf5 48ce9c2ab4916d5536faeef0bd789f326ec4afc232729d32014d4d835
 neubrex_das_1.h5 48a97e27c56e66cc2954ba4eaaadd2169919bb8f897d78e95ef6ab50abb5027b https://github.com/dasdae/test_data/raw/master/das/neubrex_das_1.h5
 UoU_lf_urban.hdf5 d3f8fa6ff3d8ae993484b3fbf9b39505e2cf15cb3b39925a3519b27d5fbe7b5b https://github.com/dasdae/test_data/raw/master/das/UoU_lf_urban.hdf5
 small_channel_patch.sgy 31e551aadb361189c1c9325d504c883114ba9a7bb75fe4791e5089fabccef704 https://github.com/dasdae/test_data/raw/master/das/small_channel_patch.sgy
+gdr_1.h5 aaf11a7333b720436d194e3c7f4fa66f38907bb0c9abfa1804c150e634642aa2 https://github.com/dasdae/test_data/raw/master/das/gdr_1.h5

--- a/dascore/io/gdr/__init__.py
+++ b/dascore/io/gdr/__init__.py
@@ -1,0 +1,11 @@
+"""
+Support for the Geothermal Data Repository (gdr) h5 format.
+
+The gdr format is a combination of prodml and the Earthscope DMC's meta
+data spec. It houses many data sets, not just DFOS.
+
+Find more information here: https://gdr.openei.org/. Information regarding
+the DAS format can be found here: https://gdr.openei.org/das_data_standard
+"""
+
+from .core import GDR_V1

--- a/dascore/io/gdr/core.py
+++ b/dascore/io/gdr/core.py
@@ -1,0 +1,70 @@
+"""
+Core modules for reading GDR data.
+
+GDR files do not specify the GDR version directly. Instead, they use versions
+from other standards for the metadata and raw data. These can be found in the
+overview attributes MetadataStandard and RawDataStandard.
+"""
+
+from __future__ import annotations
+
+import dascore as dc
+from dascore.constants import SpoolType
+from dascore.io import FiberIO
+from dascore.io.gdr.utils_das import (
+    _get_attrs_coords_and_data,
+    _get_version,
+    _maybe_trim_data,
+)
+from dascore.utils.hdf5 import H5Reader
+
+
+class GDRPatchAttrs(dc.PatchAttrs):
+    """Patch attrs for GDR files."""
+
+    gauge_length: float
+    gauge_length_units: str
+    project_number: str = ""
+
+
+class GDR_V1(FiberIO):  # noqa
+    """
+    Support for GDR version 1.
+    """
+
+    name = "GDR_DAS"
+    preferred_extensions = ("hdf5", "h5")
+    version = "1"
+
+    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+        """Determine if the resource belongs to this format."""
+        return _get_version(resource)
+
+    def read(self, resource: H5Reader, snap=True, **kwargs) -> SpoolType:
+        """
+        Read a resource belonging to this format.
+
+        Parameters
+        ----------
+        resource
+            The open h5 object.
+        snap
+            If True, snap each coordinate to be evenly sampled.
+        **kwargs
+            Passed to filtering coordinates.
+        """
+        attr_dict, cm, data = _get_attrs_coords_and_data(resource, snap=snap)
+        if kwargs:
+            cm, data = _maybe_trim_data(cm, data, **kwargs)
+        attrs = GDRPatchAttrs(**attr_dict)
+        patch = dc.Patch(coords=cm, data=data[:], attrs=attrs)
+        return dc.spool([patch])
+
+    def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[dc.PatchAttrs]:
+        """Get the attributes of a resource belong to this type."""
+        attrs, cm, data = _get_attrs_coords_and_data(resource, snap)
+        attrs["coords"] = cm.to_summary_dict()
+        attrs["path"] = resource.filename
+        attrs["file_format"] = self.name
+        attrs["file_version"] = self.version
+        return [dc.PatchAttrs(**attrs)]

--- a/dascore/io/gdr/utils_das.py
+++ b/dascore/io/gdr/utils_das.py
@@ -1,0 +1,119 @@
+"""
+Utilities functions for GDR DAS format.
+
+See: https://gdr.openei.org/das_data_standard for more info.
+"""
+
+import numpy as np
+
+import dascore as dc
+from dascore.core import get_coord
+from dascore.utils.hdf5 import extract_h5_attrs, h5_matches_structure
+from dascore.utils.misc import unbyte
+
+# This defines the metadata/rawdata version combinations that define GDR versions.
+_COMPOSITE_VERSIONS = {
+    ("DAS-RCN v1.10", "PRODML v2.2"): "1",
+}
+
+_BASE_STRUCTURE = (
+    "DasMetadata/Interrogator/Acquisition",
+    "DasRawData/DasTimeArray",
+    "DasRawData/RawData",
+    "DasMetadata.MetadataStandard",
+    "DasMetadata.RawDataStandard",
+)
+
+# Attribute map for version 1. {current_name: new_name}
+ACQ = "DasMetadata/Interrogator/Acquisition"
+_V1_ATTR_MAP = {
+    f"{ACQ}.GaugeLength": "gauge_length",
+    f"{ACQ}.GaugeLengthUnit": "gauge_length_units",
+    f"{ACQ}.UnitOfMeasure": "data_units",
+    "DasMetadata/Interrogator.SerialNumber": "instrument_id",
+}
+
+
+def _get_version(h5fi):
+    """Get the version code of the GDR file."""
+    if not h5_matches_structure(h5fi, _BASE_STRUCTURE):
+        return False
+    meta = h5fi["DasMetadata"].attrs
+    data_fmt = meta["RawDataStandard"]
+    meta_fmt = meta["MetadataStandard"]
+    return "GDR_DAS", _COMPOSITE_VERSIONS[(meta_fmt, data_fmt)]
+
+
+def _get_attrs_coords_and_data(resource, snap):
+    """
+    Get attributes, coordinates, and data from the file.
+    """
+    fill = {"NaN": "", "nan": ""}
+    attrs = extract_h5_attrs(resource, _V1_ATTR_MAP, fill_values=fill)
+    coords = _get_coord_manager(resource, snap)
+    data = resource["DasRawData/RawData"]
+    return attrs, coords, data
+
+
+def _get_coord_manager(resource, snap=True):
+    """Get a coordinate manager from the file."""
+
+    def get_time_coord(resource, snap):
+        """Get the time coordinate."""
+        # TODO: I am not sure if time will always be in ns, check on it.
+        time = resource["DasRawData/DasTimeArray"]
+        if not snap:
+            return get_coord(data=np.array(time).astype("datetime64[ns]"))
+        t1 = np.int64(time[0]).astype("datetime64[ns]")
+        t2 = np.int64(time[-1]).astype("datetime64[ns]")
+        step = (t2 - t1) / (len(time) - 1)
+        return get_coord(start=t1, stop=t2, step=step).change_length(len(time))
+
+    def get_dist_coord(resource, length):
+        """Get distance coordinates."""
+        # Note: There is not enough info to correctly infer the start of
+        # distance coordinate since Channels are often not included. In this
+        # case we just assume the distance starts at 0 since the location of
+        # each channel must be attached alter anyway. This at least includes
+        # correct dx information.
+        group = resource["DasMetadata/Interrogator/Acquisition"]
+        dx = float(unbyte(group.attrs["SpatialSamplingInterval"]))
+        units = unbyte(group.attrs["SpatialSamplingIntervalUnit"])
+        start = 0
+        stop = length * dx
+        coord = get_coord(start=start, stop=stop, step=dx, units=units)
+        return coord.change_length(length)
+
+    def get_dims(dataset):
+        """Get the dimension names."""
+        das_dims = dataset.attrs["DasDimensions"]
+        out = [""] * 2
+        for num, dim in enumerate(das_dims):
+            if dim.startswith("time"):
+                out[num] = "time"
+            elif dim == "locus":
+                out[num] = "distance"
+        assert all(out)
+        return tuple(out)
+
+    time_coord = get_time_coord(resource, snap)
+    dataset = resource["DasRawData/RawData"]
+    dims = get_dims(dataset)
+    # Get distance coord.
+    dist_axis = dims.index("distance")
+    dist_length = dataset.shape[dist_axis]
+    dist_coord = get_dist_coord(resource, dist_length)
+
+    coords = {
+        "time": time_coord,
+        "distance": dist_coord,
+    }
+
+    return dc.get_coord_manager(coords=coords, dims=dims)
+
+
+def _maybe_trim_data(cm, data, time=None, distance=None, **kwargs):
+    """Maybe trim the data."""
+    if time is not None or distance is not None:
+        cm, data = cm.select(time=time, distance=distance, array=data)
+    return cm, data

--- a/docs/contributing/adding_test_data.qmd
+++ b/docs/contributing/adding_test_data.qmd
@@ -45,7 +45,7 @@ If, in the test code, the example patch or spool is used only once, just call th
 
 Of course, not all data can easily be generated in python. For example, testing [support for new file formats](./new_format.qmd) typically requires a test file.
 
-If you have a small file that isn't already hosted on a permanent site, you can put it into [dasdae's data repo](https://github.com/DASDAE/test_data). Simply clone the repo, add you file format, and push back to master or open a PR on a separate branch and someone will merge it in.
+If you have a small file that isn't already hosted on a permanent site, you can put it into [dasdae's data repo](https://github.com/DASDAE/test_data). Simply clone the repo, add you file format, and push back to master or open a PR on a separate branch and someone will merge it.
 
 Next, add your file to dascore's data registry (dascore/data_registry.txt).
 You will have to get the sha256 hash of your test file, for that you can simply use [Pooch's hash_file function](https://www.fatiando.org/pooch/latest/api/generated/pooch.file_hash.html), and you can create the proper download url using the other entries as examples.
@@ -62,3 +62,5 @@ https://github.com/dasdae/test_data/raw/master/das/jingle_test_file.jgl
 from dascore.utils.downloader import fetch
 path = fetch("jingle_test_file.jgl")
 ```
+
+If you need to create a smaller version of an existing hdf5 file you can use the `modify_h5_file.py` in DASCore's scripts directory. It will require some modifications, but shows how to copy and modify datasets and attributes. 

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -199,7 +199,7 @@ path.unlink()  # cleanup test file
 
 ## Writing Tests
 
-Next we need to write tests for the format (you weren't thinking of skipping this step were you!?). The hardest part of testing new file formats is finding a *small* (typically no more than 10 ish mb) file to include in the test suite. Once you have such a file, [Adding test data](adding_test_data.qmd) details how to add it to the registry.
+Next we need to write tests for the format (you weren't thinking of skipping this step were you!?). The hardest part of testing new file formats is finding a *small* (typically no more than 10 ish mb) file to include in the test suite. The `modify_h5_file.py` script in DASCore's scripts folder can help downsize an existing hdf5 file. Once you have a small test file, [Adding test data](adding_test_data.qmd) details how to add it to DASCore's registry.
 
 Once the test file is added to the data registry, you can register the new format so a suite of tests run automatically. This is done by adding the format to the appropriate data structures in `tests/test_io/test_common_io.py`. The comments at the top of the file will guide you through this process.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ SEGY__V2_1 = "dascore.io.segy.core:SegyV2_1"
 RSF__V1 = "dascore.io.rsf.core:RSFV1"
 WAV = "dascore.io.wav.core:WavIO"
 XMLBINARY__V1 = "dascore.io.xml_binary.core:XMLBinaryV1"
+GDR_DAS__V1 = "dascore.io.gdr.core:GDR_V1"
 
 
 # --- External tool configuration

--- a/scripts/modify_h5_file.py
+++ b/scripts/modify_h5_file.py
@@ -1,0 +1,98 @@
+"""
+A simple script to create and downsize a hdf5 files.
+
+This script can be used as a template for creating small test files.
+"""
+
+from __future__ import annotations
+
+import h5py
+from h5py import Dataset, Group
+
+
+def _copy_attrs(
+    old_obj: Group | Dataset,
+    new_obj: Group | Dataset,
+    address: str,
+    replace=None,
+):
+    """Copy attrs from obj1 to obj2"""
+    replace = {} if not replace else replace
+    # Iterate each of the attributes
+    for key, value in old_obj.attrs.items():
+        addr = f"{address}.{key}"
+        new_obj.attrs[key] = replace.get(addr, value)
+    return new_obj
+
+
+def _recurse_n_replace(f_in, f_out, address, replaces, funcs):
+    """Recurse the object applying replacements when needed."""
+    iterator = f_in[address].items() if address else f_in.items()
+
+    for name, value in iterator:
+        new_address = f"{address}/{name}" if address else name
+        if func := funcs.get(new_address):
+            func(f_in, f_out, new_address, replaces)
+        elif isinstance(value, Dataset):
+            group = f_out[address]
+            old_dataset = f_in[new_address]
+            new_dataset = group.create_dataset_like(name, other=value)
+            # copy the actual data.
+            new_dataset[:] = value[:]
+            _copy_attrs(old_dataset, new_dataset, new_address, replaces)
+        if isinstance(value, Group):
+            new_group = f_out.create_group(new_address)
+            _copy_attrs(value, new_group, new_address, replaces)
+            _recurse_n_replace(f_in, f_out, new_address, replaces, funcs)
+
+
+def copy_h5(path_old, path_new, attrs_to_replace=None, funcs=None):
+    """
+    Copy an old h5 to a new one while apply specific modifications.
+
+    Parameters
+    ----------
+    path_old
+        The old path
+    path_new
+        The new path
+    attrs_to_replace
+        A dict of attributes which will be replaced with new values.
+    funcs
+        A dict of functions whose keys are addresses and values are
+        custome functions to apply.
+    """
+    replace = attrs_to_replace if attrs_to_replace else {}
+    funcs = funcs if funcs else {}
+    with h5py.File(path_old, "r") as fi_in:
+        with h5py.File(path_new, "w") as fi_out:
+            _recurse_n_replace(fi_in, fi_out, "", replace, funcs)
+
+
+def downsize_raw_data(f_in, f_out, address, replaces):
+    """A custom function to replace the raw data."""
+    group_name = "/".join(address.split("/")[:-1])
+    dataset_name = address.split("/")[-1]
+
+    group = f_out[group_name]
+    old_dataset = f_in[address]
+    new_data = old_dataset[:, 0:10]
+
+    new_dataset = group.create_dataset(name=dataset_name, data=new_data)
+    _copy_attrs(old_dataset, new_dataset, address, replaces)
+
+
+if __name__ == "__main__":
+    path_old = "Fibre_Pos_DD00_160308174030.h5"
+    path_new = "gdr_example_1.h5"
+
+    new_overview = "This is a modified file from GDR created for DASCore's test suite"
+    acq_path = "DasMetadata/Interrogator/Acquisition"
+    attrs_to_replace = {
+        f"{acq_path}.NumberOfChannels": 10,
+        f"{acq_path}.Acquisition/ChannelGroup.LastUsableChannelID": 10,
+        "DasMetadata.Overview": new_overview,
+    }
+    replace_funcs = {"DasRawData/RawData": downsize_raw_data}
+
+    copy_h5(path_old, path_new, funcs=replace_funcs, attrs_to_replace=attrs_to_replace)

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -27,6 +27,7 @@ from dascore.io.ap_sensing import APSensingV10
 from dascore.io.dasdae import DASDAEV1
 from dascore.io.dashdf5 import DASHDF5
 from dascore.io.febus import Febus2
+from dascore.io.gdr import GDR_V1
 from dascore.io.h5simple import H5Simple
 from dascore.io.neubrex import NeubrexDASV1, NeubrexRFSV1
 from dascore.io.optodas import OptoDASV8
@@ -54,6 +55,7 @@ from dascore.utils.misc import all_close, iterate
 # See the docs on adding a new IO format, in the contributing section,
 # for more details.
 COMMON_IO_READ_TESTS = {
+    GDR_V1(): ("gdr_1.h5",),
     NeubrexDASV1(): ("neubrex_das_1.h5",),
     NeubrexRFSV1(): ("neubrex_dss_forge.h5", "neubrex_dts_forge.h5"),
     SilixaH5V1(): ("silixa_h5_1.hdf5",),

--- a/tests/test_io/test_gdr/test_gdr.py
+++ b/tests/test_io/test_gdr/test_gdr.py
@@ -1,0 +1,27 @@
+"""Tests for the GDR file format."""
+
+import numpy as np
+import pytest
+
+from dascore.io.gdr import GDR_V1
+from dascore.utils.downloader import fetch
+
+
+@pytest.fixture(scope="module")
+def gpr_path():
+    """Return the file path to a GDR file."""
+    return fetch("gdr_1.h5")
+
+
+class TestGDR:
+    """Misc. tests not covered by common tests."""
+
+    def test_no_snap(self, gpr_path):
+        """Ensure snap or no snap produces the same coord for this file."""
+        fiber_io = GDR_V1()
+        patch1 = fiber_io.read(gpr_path, snap=False)[0]
+        patch2 = fiber_io.read(gpr_path, snap=True)[0]
+        time_1 = patch1.get_coord("time")
+        time_2 = patch2.get_coord("time")
+        assert len(time_1) == len(time_2)
+        assert np.all(time_1.values == time_2.values)

--- a/tests/test_utils/test_hdf_utils.py
+++ b/tests/test_utils/test_hdf_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import h5py
 import pandas as pd
 import pytest
 import tables
@@ -11,11 +12,23 @@ from tables.exceptions import ClosedNodeError
 
 import dascore as dc
 from dascore.exceptions import InvalidFileHandlerError
+from dascore.utils.downloader import fetch
 from dascore.utils.hdf5 import (
     HDFPatchIndexManager,
     PyTablesWriter,
+    extract_h5_attrs,
+    h5_matches_structure,
     open_hdf5_file,
 )
+
+
+@pytest.fixture(scope="class")
+def h5_example_file():
+    """Get an example file."""
+    path = fetch("gdr_1.h5")
+    with h5py.File(path, "r") as fi:
+        yield fi
+    fi.close()
 
 
 class TestGetHDF5Handlder:
@@ -161,3 +174,48 @@ class TestHDFReaders:
         assert isinstance(handle, tables.File)
         handle_2 = PyTablesWriter.get_handle(handle)
         assert isinstance(handle_2, tables.File)
+
+
+class TestH5MatchesStructure:
+    """Tests for the h5 matches structure function."""
+
+    def test_has_structure(self, h5_example_file):
+        """Ensure the simple structure match works."""
+        struct = (
+            "DasMetadata",
+            "DasMetadata/Cable/Fiber",
+            "DasMetadata/Cable/Fiber.FiberComment",
+        )
+        assert h5_matches_structure(h5_example_file, struct)
+
+    def test_missing_group(self, h5_example_file):
+        """Ensure false is returned when a group is missing."""
+        struct = ("DasBonkersData",)
+        assert not h5_matches_structure(h5_example_file, struct)
+
+    def test_missing_attribute(self, h5_example_file):
+        """Ensure false is returned when an attribute is missing."""
+        struct = ("DasMetadata/Cable.HasPolkaDots",)
+        assert not h5_matches_structure(h5_example_file, struct)
+
+
+class TestExtractH5Attrs:
+    """Extract H5 attributes."""
+
+    def test_extract_existing_attrs(self, h5_example_file):
+        """Test extracting existing attributes."""
+        acq = "DasMetadata/Interrogator/Acquisition"
+        map_names = {
+            "DasMetadata.Country": "country",
+            f"{acq}.AcquisitionSampleRate": "sample_rate",
+        }
+        out = extract_h5_attrs(h5_example_file, map_names)
+        assert "sample_rate" in out and "country" in out
+
+    def test_bad_attr_raises(self, h5_example_file):
+        """A bad attibute should raise a KeyError."""
+        map_name = {
+            "DasMetadata.CountryBumpkins": "country",
+        }
+        with pytest.raises(KeyError):
+            extract_h5_attrs(h5_example_file, map_name)


### PR DESCRIPTION
## Description

This PR:

1. Adds support for the [geothermal data repository](https://gdr.openei.org/)'s [DAS hdf5  format](https://gdr.openei.org/das_data_standard).
2. Adds a few utilities to make extracting attributes and checking hdf5 structures easier. 
3. Adds an example script for slimming down test hdf5 files. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
