### PR TITLE
test 467

### DIFF
--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -369,7 +369,7 @@ class TestBasics:
         coord = get_coord(start=d1, stop=d2, step=step)
         assert isinstance(coord, BaseCoord)
         assert str(d1) == str(coord.min())
-        assert str(d2) == str(coord.max())
+        assert str(d2) == str(coord.max() + coord.step)
 
 
 class TestCoordSummary:

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -367,7 +367,9 @@ class TestBasics:
         d2 = datetime.datetime.fromisoformat("2017-09-18T02")
         step = datetime.timedelta(minutes=1)
         coord = get_coord(start=d1, stop=d2, step=step)
+        assert isinstance(coord, BaseCoord)
         assert str(d1) == str(coord.min())
+        assert str(d2) == str(coord.max())
 
 
 class TestCoordSummary:

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import pickle
 from functools import partial
 from io import BytesIO
@@ -359,6 +360,14 @@ class TestBasics:
         msg = "has to be called on an evenly sampled"
         with pytest.raises(CoordError, match=msg):
             monotonic_float_coord.coord_range()
+
+    def test_get_coord_datetime(self):
+        """Ensure get_coord accepts a datetime object. See #467."""
+        d1 = datetime.datetime.fromisoformat("2017-09-18T01")
+        d2 = datetime.datetime.fromisoformat("2017-09-18T02")
+        step = datetime.timedelta(minutes=1)
+        coord = get_coord(start=d1, stop=d2, step=step)
+        assert str(d1) == str(coord.min())
 
 
 class TestCoordSummary:


### PR DESCRIPTION


## Description
This PR adds a test for issue #467. It turns out it wasn't really an issue; the example just needs to use a timedelta rather than float in the step argument. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a new test method to verify datetime object handling in coordinate retrieval functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->