### PR TITLE
added ability to read SEGY file version 0.0

### DIFF
--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -87,6 +87,11 @@ class SegyV1_0(FiberIO):  # noqa
         _write_segy(spool, resource, self.version, segyio)
 
 
+class SegyV0_0(SegyV1_0):  # noqa
+    """An IO class supporting version 0.0 of the SEGY format. Or if the version is not set. """
+
+    version = "0.0"
+
 class SegyV2_0(SegyV1_0):  # noqa
     """An IO class supporting version 2.0 of the SEGY format."""
 

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -89,12 +89,13 @@ class SegyV1_0(FiberIO):  # noqa
 
 class SegyV0_0(SegyV1_0):  # noqa
     """
-    An IO class supporting version 0.0 of the SEGY format. 
-    
-    Or if the version is not set. 
+    An IO class supporting version 0.0 of the SEGY format.
+
+    Or if the version is not set.
     """
 
     version = "0.0"
+
 
 class SegyV2_0(SegyV1_0):  # noqa
     """An IO class supporting version 2.0 of the SEGY format."""

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -88,7 +88,11 @@ class SegyV1_0(FiberIO):  # noqa
 
 
 class SegyV0_0(SegyV1_0):  # noqa
-    """An IO class supporting version 0.0 of the SEGY format. Or if the version is not set. """
+    """
+    An IO class supporting version 0.0 of the SEGY format. 
+    
+    Or if the version is not set. 
+    """
 
     version = "0.0"
 


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

Added ability to read a segy file if version is set to 0.0
Tested on file from:
https://ddfe.curtin.edu.au/7h0e-d392/2020_GeoLab_WVSP_Geophone_wgm.sgy

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for SEGY version 0.0 format in the data processing library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->