### PR TITLE
minor fix for LF proc

### DIFF
--- a/docs/recipes/low_freq_proc.qmd
+++ b/docs/recipes/low_freq_proc.qmd
@@ -39,7 +39,7 @@ cutoff_freq = 1 / (2*dt)
 filter_safety_factor = 0.9
 
 # Enter memory size to be dedicated for processing (in MB)
-memory_limit_MB = 75
+memory_limit_MB = 1_000
 
 # Define a tolerance for determining edge effects (used in next step)
 tolerance = 1e-3
@@ -69,13 +69,16 @@ memory_size_per_second_MB = memory_size_per_second / 1e6
 chunk_size = memory_limit_MB / memory_size_per_second_MB
 
 # Ensure `chunk_size` does not exceed the spool length
-merged_sp = sp.chunk(time=None)[0]
-if chunk_size > merged_sp.seconds:
+time_step = sp[0].get_coord('time').step
+time_min = sp[0].get_coord('time').min()
+time_max = sp[-1].get_coord('time').max()
+spool_length = dc.to_float((time_max - time_min + time_step))
+if chunk_size > spool_length:
    print(
    f"Warning: Specified `chunk_size` ({chunk_size:.2f} seconds) exceeds the spool length "
-   f"({merged_sp.seconds:.2f} seconds). Adjusting `chunk_size` to match spool length."
+   f"({spool_length:.2f} seconds). Adjusting `chunk_size` to match spool length."
    )
-   chunk_size = merged_sp.seconds 
+   chunk_size = spool_length
 ```
 
 Next, we need to determine the extent of artifacts introduced by low-pass filtering at the edges of each patch. To achieve this, we apply LF processing to a delta function patch, which contains a unit value at the center and zeros elsewhere. The distorted edges are then identified based on a defined threshold.
@@ -100,12 +103,11 @@ ind_1 = np.where(ind)[1][0]
 ind_2 = np.where(ind)[1][-1]
 
 # Get the total duration of the processed delta function patch in seconds
-time_coord = delta_pa_lfp.get_coord('time')
-delta_pa_lfp_seconds = dc.to_float((time_coord.max() - time_coord.min()))
+delta_pa_lfp_length = delta_pa_lfp.seconds 
 # Convert the new time axis to absolute seconds, relative to the first timestamp
 time_ax_abs = (new_time_ax - new_time_ax[0]) / np.timedelta64(1, "s")
 # Center the time axis 
-time_ax_centered = time_ax_abs - delta_pa_lfp_seconds // 2 
+time_ax_centered = time_ax_abs - delta_pa_lfp_length // 2 
 
 # Calculate the maximum of edges in both sides (in seconds) where artifacts are present
 edge = max(np.abs(time_ax_centered[ind_1]), np.abs(time_ax_centered[ind_2]))


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

Minor changes to PR #470 for the low-frequency processing recipe to make the code clearer and avoid filling memory with `spool.chunk(time=None)[0].seconds` (to get spool's length). 

<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased memory limit from 75 MB to 1,000 MB for improved data processing capabilities
	- Enhanced chunk size calculation to use actual spool length
	- Improved error handling for chunk size validation

- **Documentation**
	- Updated variable names for improved clarity in low-frequency processing workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->