### PR TITLE
add wav write support for patches with non-distance dimensions

### DIFF
--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -26,9 +26,9 @@ class WavIO(FiberIO):
         Parameters
         ----------
         resource
-            If a path that ends with .wav, write all the distance channels
-            to a single file. If not, assume the path is a directory and write
-            each distance channel to its own wav file.
+            If a path that ends with .wav, write all non-time channels
+            to a single file. If not, assume the path is a directory and
+            write each non-time channel to its own wav file.
         resample_frequency
             A resample frequency in Hz. If None, do not perform resampling.
             Often DAS has non-int sampling rates, so the default resampling
@@ -45,7 +45,7 @@ class WavIO(FiberIO):
             and normalized before writing.
 
             - If a single wavefile is specified with the path argument, and
-            the output the patch has more than one len along the distance
+            the output the patch has more than one len along the non-time
             dimension, a multi-channel wavefile is created. There may be some
             players that do not support multi-channel wavefiles.
 
@@ -62,14 +62,8 @@ class WavIO(FiberIO):
             write(filename=str(resource), rate=int(sr), data=data)
         else:  # write data to directory, one file for each non-time
             resource.mkdir(exist_ok=True, parents=True)
-            non_time_name = next(
-                iter(
-                    set(patch.dims)
-                    - {
-                        "time",
-                    }
-                )
-            )
+            non_time_set = set(patch.dims) - {"time"}
+            non_time_name = next(iter(non_time_set))
             non_time = patch.coords.get_array(non_time_name)
             for ind, val in enumerate(non_time):
                 sub_data = np.take(data, ind, axis=1)

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -9,7 +9,7 @@ from scipy.io.wavfile import read as read_wav
 
 import dascore as dc
 
-ONE_SECOND = dc.to_timedelta64(1)
+from dascore.constants import ONE_SECOND
 
 
 class TestWriteWav:

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -8,7 +8,6 @@ import pytest
 from scipy.io.wavfile import read as read_wav
 
 import dascore as dc
-
 from dascore.constants import ONE_SECOND
 
 

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -9,6 +9,8 @@ from scipy.io.wavfile import read as read_wav
 
 import dascore as dc
 
+ONE_SECOND = dc.to_timedelta64(1)
+
 
 class TestWriteWav:
     """Tests for writing wav format to disk."""
@@ -58,3 +60,12 @@ class TestWriteWav:
         patch = audio_patch_non_distance_dim
         patch.io.write(path, "wav")
         assert path.exists()
+        # Verify number of WAV files
+        wavs = list(path.rglob("*.wav"))
+        assert len(wavs) == len(patch.coords.get_array("microphone"))
+        # Verify file naming
+        for mic_val in patch.coords.get_array("microphone"):
+            assert path / f"microphone_{mic_val}.wav" in wavs
+            # Verify content of first file
+            sr, data = read_wav(str(wavs[0]))
+        assert sr == int(ONE_SECOND / patch.get_coord("time").step)

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -25,6 +25,12 @@ class TestWriteWav:
         dc.write(audio_patch, new, "wav")
         return new
 
+    @pytest.fixture(scope="class")
+    def audio_patch_non_distance_dim(self, audio_patch):
+        """Create a patch that has a non-distance dimension in addition to time."""
+        patch = audio_patch.rename_coords(distance="microphone")
+        return patch
+
     def test_directory(self, wave_dir, audio_patch):
         """Sanity checks on wav directory."""
         assert wave_dir.exists()
@@ -43,3 +49,12 @@ class TestWriteWav:
         dc.write(audio_patch, path, "wav", resample_frequency=1000)
         (sr, ar) = read_wav(str(path))
         assert sr == 1000
+
+    def test_write_non_distance_dims(
+        self, audio_patch_non_distance_dim, tmp_path_factory
+    ):
+        """Ensure any non-time dimension still works."""
+        path = tmp_path_factory.mktemp("wav_resample")
+        patch = audio_patch_non_distance_dim
+        patch.io.write(path, "wav")
+        assert path.exists()


### PR DESCRIPTION
This PR simply allows patches that have a time dimension and a non-distance dimension to be written as a single wav file or a directory of wav files.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced audio file writing to dynamically support patches with additional dimensions beyond time, improving overall flexibility.
- **Tests**
	- Introduced new tests to ensure correct processing of audio patches with non-standard dimension configurations, including non-distance dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->