### PR TITLE
array spool indexing

### DIFF
--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -101,6 +101,37 @@ for patch in spool:
 new_spool = spool[1:]
 ```
 
+An array can also be used (just like numpy) to select/re-arrange spool contents. For example, a boolean array can be used to de-select patches:
+
+```{python}
+import dascore as dc
+import numpy as np
+
+spool = dc.get_example_spool()
+
+# Get bool array, true values indicate patch is kept, false is discarded.
+bool_array = np.ones(len(spool), dtype=np.bool_)
+bool_array[1] = False
+
+# Remove patch at position 1 from spool.
+new = spool[bool_array]
+```
+
+and an integer array can be used to deselect/rearrange patches
+
+```{python}
+import dascore as dc
+import numpy as np
+
+spool = dc.get_example_spool()
+
+# Get an array of integers which indicate the new order or patches  
+bool_array = np.array([2, 0])
+
+# create a new spool with patch 2 and patch 0 in that order.
+new = spool[bool_array]
+```
+
 # get_contents
 
 The [`get_contents`](`dascore.core.spool.BaseSpool.get_contents`) method returns a dataframe listing the spool contents. This method may not be supported on all spools, especially those interfacing with large remote resources.

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -125,10 +125,10 @@ import numpy as np
 
 spool = dc.get_example_spool()
 
-# Get an array of integers which indicate the new order or patches  
+# Get an array of integers which indicate the index of included patches
 bool_array = np.array([2, 0])
 
-# create a new spool with patch 2 and patch 0 in that order.
+# create a new spool with patch 2 and patch 0.
 new = spool[bool_array]
 ```
 

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -179,6 +179,62 @@ class TestSlicing:
         assert new_spool[1].equals(random_spool[2])
 
 
+class TestSpoolBoolArraySelect:
+    """Tests for selecting patches using a boolean array."""
+
+    def test_bool_all_true(self, random_spool):
+        """All True should return an equal spool."""
+        bool_array = np.ones(len(random_spool), dtype=np.bool_)
+        out = random_spool[bool_array]
+        assert out == random_spool
+
+    def test_bool_all_false(self, random_spool):
+        """All False should return an empty spool."""
+        bool_array = np.zeros(len(random_spool), dtype=np.bool_)
+        out = random_spool[bool_array]
+        assert len(out) == 0
+
+    def test_bool_some_true(self, random_spool):
+        """Some true values should return a spool with some values."""
+        bool_array = np.ones(len(random_spool), dtype=np.bool_)
+        bool_array[1] = False
+        out = random_spool[bool_array]
+        assert len(out) == sum(bool_array)
+        df1 = out.get_contents()
+        df2 = random_spool.get_contents()[bool_array]
+        assert df1.equals(df2)
+
+
+class TestSpoolIntArraySelect:
+    """Tests for selecting patches using an integer array."""
+
+    def test_uniform(self, random_spool):
+        """A uniform monotonic increasing array should return same spool."""
+        array = np.arange(len(random_spool))
+        spool = random_spool[array]
+        assert spool == random_spool
+
+    def test_out_of_bounds_raises(self, random_spool):
+        """Ensure int values gt the spool len raises."""
+        array = np.arange(len(random_spool))
+        array[0] = len(random_spool) + 10
+        with pytest.raises(IndexError):
+            random_spool[array]
+
+    def test_bad_array_type(self, random_spool):
+        """Ensure a non-index or int array raises."""
+        array = np.arange(len(random_spool)) + 0.01
+        with pytest.raises(ValueError, match="Only bool or int dtypes"):
+            random_spool[array]
+
+    def test_rearrange(self, random_spool):
+        """Ensure patch order can be changed."""
+        array = np.array([len(random_spool) - 1, 0])
+        out = random_spool[array]
+        assert out[0] == random_spool[-1]
+        assert out[-1] == random_spool[0]
+
+
 class TestSpoolIterable:
     """Tests for iterating Spools."""
 


### PR DESCRIPTION


## Description

This PR enables indexing a spool with a numpy array, which is the same behavior as numpy arrays. For example, boolean arrays can be used to "deselect" patches like so:

```python
import dascore as dc
import numpy as np

spool = dc.get_example_spool()

# Get bool array, true values indicate patch is kept, false is discarded.
bool_array = np.ones(len(spool), dtype=np.bool_)
bool_array[1] = False

# Remove patch at position 1 from spool.
new = spool[bool_array]
```

and integer arrays can be used to re-arrange patches:

```python
import dascore as dc
import numpy as np

spool = dc.get_example_spool()

# Get an array of integers which indicate the new order or patches  
bool_array = np.array([2, 0])

# create a new spool with patch 2 and patch 0 in that order.
new = spool[bool_array]
```


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced data selection now supports flexible indexing using slices, boolean, and integer arrays, allowing for more versatile retrieval and rearrangement of data.
- **Documentation**
  - Updated tutorials now include clear examples demonstrating how to select and reorder data using these new indexing methods.
- **Tests**
  - Introduced new test classes to validate the functionality of selecting patches using boolean and integer arrays, improving test coverage for these features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->