### PR TITLE
Fix docbuild action

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -19,3 +19,8 @@ runs:
       shell: bash -l {0}
       run: |
         python scripts/build_api_docs.py
+
+    - name: build quarto project
+      shell: bash -l {0}
+      run: |
+        quarto render docs

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -42,16 +42,16 @@ jobs:
       - uses: ./.github/actions/build-docs
 
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'docs/_site'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v3
 
       - name: Zip doc build
         run: zip docs.zip docs/_site -r

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -57,7 +57,7 @@ jobs:
         run: zip docs.zip docs/_site -r
 
       - name: Upload release docs
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: docs.zip


### PR DESCRIPTION
## Description

Part 2 to #494. Trying to add explicit quarto project render to custom build doc action. Apparently the build master docs action triggered on the quarto publish command, but since build stable docs doesn't have this the project is not getting rendered. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the documentation build process with an additional step for rendering improved content.
- **Chores**
  - Updated and upgraded key steps in the documentation deployment workflow to boost performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->