### PR TITLE
fix compute start, stop distance bug

### DIFF
--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -162,9 +162,9 @@ def _get_distance_coord(attr):
     # is the correct way to do this, but this seems safe for now.
     multiplier = attr["Fibre Length Multiplier"]
     total_length = attr["MeasureLength[m]"] * multiplier
-    start = attr["StartPosition[m]"] + total_length
+    start = attr["StartPosition[m]"]
     step = attr["SpatialResolution[m]"] * multiplier
-    stop = start + (attr["n_channels"]) * step
+    stop = start + total_length
     d_coord = get_coord(start=start, stop=stop, step=step, units="m")
     return d_coord
 


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

<!--
Changed the computation of the start and stop distances for the tdms parser. This fixes #498:
"""
I saw you project DASCore and was interested to use it in a project where we measure with a Silixa iDAS. However, when I load tdms files, the distance coordinates appear to be shifted. I saw in the code that the starting point is "the starting point read from the file" + "total measured length" (dascore/io/tdms/utils.py, line 165: start = attr["StartPosition[m]"] + total_length). I would have removed the addition of the total length.

Is this a feature or a bug? I thought I could notify you about it!
"""
-->

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings or appropriate doc page.
- [x] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] your name has been added to the contributors page (docs/contributors.md).
- [] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the calculation of the distance axis range, ensuring the start and stop coordinates are accurately derived from the provided attributes. This results in improved accuracy for distance-based data representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->