### PR TITLE
fix_514

### DIFF
--- a/dascore/io/prodml/__init__.py
+++ b/dascore/io/prodml/__init__.py
@@ -1,8 +1,6 @@
 """
 Support for prodML format.
 
-This is used by Silixa's iDAS as an HDF5 format and perhaps other interrogators.
-
 More info about ProdML can be found here:
 https://www.energistics.org/prodml-developers-users
 """

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -63,7 +63,7 @@ def _get_distance_coord(acq):
 def _get_time_coord(node):
     """Get the time information from a Raw node."""
     time_array = node["RawDataTime"]
-    time_attrs = node["RawDataTime"].attrs
+    time_attrs = time_array.attrs
     start_str = unbyte(time_attrs["PartStartTime"]).split("+")[0]
     start = dc.to_datetime64(start_str.rstrip("Z"))
     end_str = unbyte(time_attrs["PartEndTime"]).split("+")[0]
@@ -123,7 +123,6 @@ def _get_prodml_attrs(fi, extras=None) -> list[dict]:
     for node in raw_nodes.values():
         info = dict(base_info)
         t_coord = _get_time_coord(node)
-        # info.update(t_coord.get_attrs_dict("time"))
         info.update(_get_data_unit_and_type(node))
         dims = _get_dims(node)
         info["dims"] = dims

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import VALID_DATA_TYPES
 from dascore.core.coordmanager import get_coord_manager
@@ -60,13 +62,26 @@ def _get_distance_coord(acq):
 
 def _get_time_coord(node):
     """Get the time information from a Raw node."""
+    time_array = node["RawDataTime"]
     time_attrs = node["RawDataTime"].attrs
     start_str = unbyte(time_attrs["PartStartTime"]).split("+")[0]
     start = dc.to_datetime64(start_str.rstrip("Z"))
     end_str = unbyte(time_attrs["PartEndTime"]).split("+")[0]
     end = dc.to_datetime64(end_str.rstrip("Z"))
-    step = (end - start) / (len(node["RawDataTime"]) - 1)
-    return get_coord(start=start, stop=end + step, step=step, units="s")
+    step = (end - start) / (len(time_array) - 1)
+    time_coord = get_coord(start=start, stop=end + step, step=step, units="s")
+    # Sometimes the "PartEndTime" can be wrong. Check for this and try to
+    # compensate. See #414.
+    last = time_array[-1:].astype("datetime64[us]")
+    diff = np.abs(time_coord.max() - last) / step
+    # Note: just in case the time array is not in microseconds as it should
+    # be, we prefer to use the iso 8601 strings in the 'PartStartTime' attrs
+    # because they are less likely to get messed up. Therefore, we only
+    # correct time coordinate from time array if the values are "close" but off.
+    if 0 < diff < 10:
+        time_array = time_array[:].astype("datetime64[us]")
+        time_coord = get_coord(data=time_array)
+    return time_coord
 
 
 def _get_data_unit_and_type(node):
@@ -108,9 +123,10 @@ def _get_prodml_attrs(fi, extras=None) -> list[dict]:
     for node in raw_nodes.values():
         info = dict(base_info)
         t_coord = _get_time_coord(node)
-        info.update(t_coord.get_attrs_dict("time"))
+        # info.update(t_coord.get_attrs_dict("time"))
         info.update(_get_data_unit_and_type(node))
-        info["dims"] = _get_dims(node)
+        dims = _get_dims(node)
+        info["dims"] = dims
         if extras is not None:
             info.update(extras)
         info["coords"] = {"time": t_coord, "distance": d_coord}


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

This PR fixes issue #514. The Prodml parser now checks the last element of the time array, while also trying to take into account the possibility that the time array may not be in microseconds (to make the parser more robust). 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved robustness when reading ProdML files with inconsistent or drifting end-time metadata so time coordinates are accurate and files load reliably.

- Tests
  - Added tests that simulate incorrect PartEndTime metadata to verify files still read correctly.
  - Introduced a fixture to patch sample data for end-time validation.

- Documentation
  - Cleaned a module docstring by removing a vendor-specific statement.

- Refactor
  - Streamlined internal time handling without changing the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->