### PR TITLE
allow prodml files without gauge length

### DIFF
--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -13,7 +13,6 @@ from dascore.utils.misc import iterate, maybe_get_items, unbyte
 # --- Getting format/version
 
 EXPECTED_ATTRS = (
-    "GaugeLength",
     "PulseRate",
     "PulseWidth",
     "NumberOfLoci",


### PR DESCRIPTION


## Description

Turns out the request in #501 was super easy to implement. We just need to loosen the ProdML attrs we are looking for to allow files without `GaugeLength`. After doing that, DASCore can read the prodml files included in the mentioned data. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved ProdML file compatibility by relaxing the required attributes for detection. Files missing GaugeLength are now correctly recognized as ProdML.
  - Reduces false negatives when opening or identifying ProdML datasets, improving import reliability without affecting version reporting.
  - No user action needed; previously rejected files should now open as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->