### PR TITLE
handle incorrectly sized sintela binary + keyboard interrupt in scan

### DIFF
--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -12,6 +12,7 @@ from contextlib import suppress
 import numpy as np
 from numpy import floor, interp  # NOQA
 from numpy.random import RandomState
+from rich.progress import Progress  # NOQA
 from scipy.interpolate import interp1d  # NOQA
 from scipy.ndimage import zoom  # NOQA
 from scipy.signal import decimate, resample, resample_poly  # NOQA

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -838,9 +838,11 @@ def scan(
     )
     length = _count_generator(_generator)
     generator = _iterate_scan_inputs(path, ext=ext, mtime=timestamp)
+    # We want to avoid printing long object str reprs, so only print paths.
+    resource_str = path if isinstance(path, (str, Path)) else ""
     tracker = track(
         generator,
-        f"scan {path}",
+        f"scan {resource_str}",
         progress=progress,
         length=length,
         min_length=20,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -839,7 +839,7 @@ def scan(
     length = _count_generator(_generator)
     generator = _iterate_scan_inputs(path, ext=ext, mtime=timestamp)
     # We want to avoid printing long object str reprs, so only print paths.
-    resource_str = path if isinstance(path, (str, Path)) else ""
+    resource_str = path if isinstance(path, str | Path) else ""
     tracker = track(
         generator,
         f"scan {resource_str}",

--- a/tests/test_io/test_sintela_binary/test_sintela_binary.py
+++ b/tests/test_io/test_sintela_binary/test_sintela_binary.py
@@ -1,0 +1,35 @@
+"""
+Tests for sintela binary format.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from dascore.exceptions import InvalidFiberFileError
+from dascore.io.sintela_binary import SintelaBinaryV3
+from dascore.utils.downloader import fetch
+
+
+class TestScanSintelaBinary:
+    """Tests for scanning a binary file."""
+
+    @pytest.fixture(scope="class")
+    def extra_bytes_file(self, tmp_path_factory):
+        """Create a sintela binary file with extra bytes."""
+        tmp = tmp_path_factory.mktemp("sintela_binary")
+        binary_path = Path(fetch("sintela_binary_v3_test_1.raw"))
+        new = tmp / "extra_bytes.raw"
+        shutil.copy(binary_path, new)
+
+        with open(new, "ab") as fi:
+            fi.write(b"some_bytes_des_is")
+
+        return new
+
+    def test_extra_bytes_raises(self, extra_bytes_file):
+        """Ensure a file with extra bytes raises an exception."""
+        fiber_io = SintelaBinaryV3()
+        with pytest.raises(InvalidFiberFileError):
+            fiber_io.scan(extra_bytes_file)


### PR DESCRIPTION
## Description

In one of our Sintela DAS datasets there are a small number of files which are not an integer size of packets. These files would cause the indexing of the entire directory to crash. This PR fixes that issues by checking and raising the correct error when such a situation is found, then expanding the types of exceptions caught when scanning. 

It also fixes a minor annoying "feature" that ctl + c didn't work correctly to kill the progress bar while indexing. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Accept a custom rich Progress instance/class for progress utilities and scanning.

- **Bug Fixes**
  - Scanning is more robust: corrupt files and missing optional dependencies are skipped with clearer errors.
  - Sintela binary files with extra/misaligned bytes now raise a specific error.
  - KeyboardInterrupt during scanning stops progress cleanly.
  - Reduced repeated-work via internal caching for faster repeated scans.

- **Documentation**
  - Updated progress-related docstrings.

- **Tests**
  - Added tests for keyboard interrupt handling and Sintela binary validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->