### PR TITLE
add radian to strain transform

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -253,6 +253,7 @@ class Patch:
     add_distance_to = dascore.proc.coords.add_distance_to
     snap_coords = dascore.proc.snap_coords
     sort_coords = dascore.proc.sort_coords
+    radians_to_strain = dascore.transform.radians_to_strain
     rename_coords = dascore.proc.rename_coords
     update_coords = dascore.proc.update_coords
     drop_coords = dascore.proc.drop_coords

--- a/dascore/transform/__init__.py
+++ b/dascore/transform/__init__.py
@@ -10,6 +10,6 @@ from .fft import rfft
 from .fourier import dft, idft
 from .integrate import integrate
 from .spectro import spectrogram
-from .strain import velocity_to_strain_rate, velocity_to_strain_rate_edgeless
+from .strain import velocity_to_strain_rate, velocity_to_strain_rate_edgeless, radians_to_strain
 from .dispersion import dispersion_phase_shift
 from .taup import tau_p

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import warnings
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
 from dascore.transform.differentiate import differentiate
+from dascore.units import get_factor_and_unit, get_unit
 from dascore.utils.patch import patch_function
 
 
@@ -197,3 +200,69 @@ def velocity_to_strain_rate_edgeless(
     )
 
     return dc.Patch(data=strain_rate, coords=new_coords, attrs=new_attrs)
+
+
+@patch_function()
+def radians_to_strain(
+    patch: PatchType,
+    gauge_length=None,
+    wave_length: float = 1550.0 * 10 ** (-9),
+    stress_constant: float = 0.79,
+    refractive_index: float = 1.445,
+):
+    r"""
+    Convert data in radians to strain (rate).
+
+    This applies the simple formula found in @lindsey2020broadband to convert
+    data whose units have a radians component to strain.
+
+    Parameters
+    ----------
+    gauge_length
+        The gauge length in meters.
+    wave_length
+        The laser wavelength in m.
+    stress_constant
+        The stress constant.
+    refractive_index
+        The refractive index of the cable.
+
+    Notes
+    -----
+    Equation 3 of @lindsey2020broadband:
+    $$
+    \epsilon_{xx}(t, x_j) = \frac{\lambda}{4 \pi n L_{g} \zeta} \Delta \Phi
+    $$
+    Where
+    \lambda : Laser wavelength (usually 1550 nm)
+    n : refractive index of cable (usually 1.445)
+    L_g : Gauge length
+    \zeta : stress multiplicative factor (0.79 for pure silica at 1550nm)
+    """
+    # First get gauge length, using gl passed into function or attached to attrs.
+    gl = getattr(patch.attrs, "gauge_length", None)
+    gauge = gauge_length if gauge_length is not None else gl
+    if gauge is None or gauge <= 0:
+        msg = (
+            "Gauge length must be non-zero positive and provided "
+            "or defined in patch attrs."
+        )
+        raise ParameterError(msg)
+    # If units doesn't contain radians just return so function is idempotent
+    if str(dc.get_unit("radians")) not in str(patch.attrs.data_units):
+        msg = (
+            f"Patch {patch} has no radians in its data_units, "
+            f"skipping strain conversion."
+        )
+        warnings.warn(msg)
+        return patch
+    # Get constant to multiply with data array.
+    const = wave_length / (4 * np.pi * refractive_index * gauge * stress_constant)
+    # Handle unit conversions.
+    data_units = patch.attrs.get("data_units", None)
+    d_factor, d_units = get_factor_and_unit(data_units, simplify=True)
+    new_units = d_units * get_unit("strain/radians")
+    # Build output patch
+    new_attrs = patch.attrs.update(data_units=new_units)
+    new_data = patch.data * const * d_factor
+    return patch.update(data=new_data, attrs=new_attrs)

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -224,7 +224,7 @@ def radians_to_strain(
         The laser wavelength in m.
     stress_constant ($\zeta$)
         The stress constant.
-    refractive_index ($\Delta \Phi$)
+    refractive_index ($n$)
         The refractive index of the cable.
 
     Notes

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -46,3 +46,14 @@
   year={2022},
   publisher={MDPI}
 }
+
+@article{lindsey2020broadband,
+  title={On the broadband instrument response of fiber-optic DAS arrays},
+  author={Lindsey, Nathaniel J and Rademacher, Horst and Ajo-Franklin, Jonathan B},
+  journal={Journal of Geophysical Research: Solid Earth},
+  volume={125},
+  number={2},
+  pages={e2019JB018145},
+  year={2020},
+  publisher={Wiley Online Library}
+}

--- a/tests/test_transform/test_strain.py
+++ b/tests/test_transform/test_strain.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
-from dascore.exceptions import ParameterError, PatchAttributeError
+from dascore.exceptions import ParameterError, PatchAttributeError, UnitError
 from dascore.units import get_quantity
 
 
@@ -214,3 +214,9 @@ class TestRadianToStrain:
             out = patch.radians_to_strain()
 
         assert out is patch
+
+    def test_bad_units(self, rad_patch):
+        """Ensure when units are too complicated an error is raised."""
+        patch = rad_patch.update_attrs(data_units=dc.get_unit("radians * radians"))
+        with pytest.raises(UnitError, match="failed to convert"):
+            patch.radians_to_strain()


### PR DESCRIPTION

## Description

Adds a helper function for converting from radians to strain using Equation 3 of @lindsey2020broadband. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a radians→strain conversion to the public transform API and as an operation available on data patches, with optional gauge length, wavelength, stress constant, and refractive index parameters.
  - Conversion validates gauge length, warns and returns unchanged when input units aren’t radians, and errors on incompatible units.
- Tests
  - New tests cover successful conversion, missing/invalid gauge length, non-radian inputs, and unit failures.
- Documentation
  - Added a bibliography entry on broadband instrument response for fiber‑optic DAS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->