### PR TITLE
add support for percent in taper and coord select

### DIFF
--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from contextlib import suppress
 
 import numpy as np
-from numpy import floor, interp  # NOQA
+from numpy import floor, interp, ndarray  # NOQA
 from numpy.random import RandomState
 from rich.progress import Progress  # NOQA
 from scipy.interpolate import interp1d  # NOQA

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -108,7 +108,7 @@ def update_attrs(self: PatchType, **attrs) -> PatchType:
     return self.__class__(self.data, **out)
 
 
-def equals(self: PatchType, other: Any, only_required_attrs=True) -> bool:
+def equals(self: PatchType, other: Any, only_required_attrs=True, close=False) -> bool:
     """
     Determine if the current patch equals another.
 
@@ -119,6 +119,9 @@ def equals(self: PatchType, other: Any, only_required_attrs=True) -> bool:
     only_required_attrs
         If True, only compare required attributes. This helps avoid issues
         with comparing histories or custom attrs of patches, for example.
+    close
+        If True, the data can be "close" using np.allclose, otherwise
+        all data must be equal.
     """
     # different types are not equal
     if not isinstance(other, type(self)):
@@ -145,8 +148,12 @@ def equals(self: PatchType, other: Any, only_required_attrs=True) -> bool:
         }
         if not_equal:
             return False
-
-    return np.equal(self.data, other.data).all()
+    # Test data equality or proximity.
+    if close and not np.allclose(self.data, other.data):
+        return False
+    elif not close and not np.equal(self.data, other.data).all():
+        return False
+    return True
 
 
 def update(

--- a/dascore/utils/signal.py
+++ b/dascore/utils/signal.py
@@ -1,0 +1,35 @@
+"""
+Utilities for signal processing.
+"""
+
+from scipy.signal import windows
+
+from dascore.exceptions import ParameterError
+
+WINDOW_FUNCTIONS = dict(
+    barthann=windows.barthann,
+    bartlett=windows.bartlett,
+    blackman=windows.blackman,
+    blackmanharris=windows.blackmanharris,
+    bohman=windows.bohman,
+    hamming=windows.hamming,
+    hann=windows.hann,
+    cos=windows.hann,
+    nuttall=windows.nuttall,
+    parzen=windows.parzen,
+    triang=windows.triang,
+    ramp=windows.triang,
+)
+
+
+def _get_window_function(window_type):
+    """Get the window function to use for taper."""
+    # get taper function or raise if it isn't known.
+    if window_type not in WINDOW_FUNCTIONS:
+        msg = (
+            f"'{window_type}' is not a known window type. "
+            f"Options are: {sorted(WINDOW_FUNCTIONS)}"
+        )
+        raise ParameterError(msg)
+    func = WINDOW_FUNCTIONS[window_type]
+    return func

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -401,6 +401,12 @@ class TestEquals:
         assert -random_patch == -random_patch
         assert (-random_patch).abs() == random_patch
 
+    def test_close(self, random_patch):
+        """Test the `close` parameter"""
+        new = random_patch * 0.999999999999999
+        assert not new.equals(random_patch, close=False)
+        assert new.equals(random_patch, close=True)
+
 
 class TestTranspose:
     """Tests for switching dimensions."""

--- a/tests/test_proc/test_taper.py
+++ b/tests/test_proc/test_taper.py
@@ -7,9 +7,10 @@ import pytest
 
 import dascore as dc
 from dascore.exceptions import ParameterError
-from dascore.proc.taper import TAPER_FUNCTIONS, taper
-from dascore.units import m
+from dascore.proc.taper import taper
+from dascore.units import m, percent
 from dascore.utils.misc import broadcast_for_index
+from dascore.utils.signal import WINDOW_FUNCTIONS
 
 gen = np.random.default_rng(32)
 
@@ -21,7 +22,7 @@ def patch_ones(random_patch):
     return patch
 
 
-@pytest.fixture(scope="session", params=sorted(TAPER_FUNCTIONS))
+@pytest.fixture(scope="session", params=sorted(WINDOW_FUNCTIONS))
 def time_tapered_patch(request, patch_ones):
     """Return a tapered trace."""
     # first get a patch with all ones for easy testing
@@ -37,6 +38,14 @@ def _get_start_end_indices(patch, dim):
     inds_start = broadcast_for_index(n_dims, axis, 0)
     inds_end = broadcast_for_index(n_dims, axis, -1)
     return inds_start, inds_end
+
+
+@pytest.fixture(scope="class")
+def patch_sorted_time(random_patch):
+    """Return a patch with sorted but not evenly spaced time dim."""
+    times = gen.random(len(random_patch.get_coord("time")))
+    new_times = dc.to_datetime64(np.sort(times))
+    return random_patch.update_coords(time=new_times)
 
 
 class TestTaperBasics:
@@ -125,16 +134,20 @@ class TestTaperBasics:
         patch2 = random_patch.taper(time=time2)
         assert patch1 == patch2
 
+    def test_percentage_taper(self, patch_ones):
+        """Ensure a percentage unit can be used in addition to fraction."""
+        out1 = patch_ones.taper(time=(0.1, 0.2))
+        out2 = patch_ones.taper(time=(10 * percent, 20 * percent))
+        assert out1.equals(out2, close=True)
+
+    def test_uneven_time_coord(self, patch_sorted_time):
+        """Ensure taper works on patches without even sampling."""
+        out = patch_sorted_time.taper(time=(0.1, 0.2))
+        assert isinstance(out, dc.Patch)
+
 
 class TestTaperRange:
     """Test for tapering a range of values."""
-
-    @pytest.fixture(scope="class")
-    def patch_sorted_time(self, random_patch):
-        """Return a patch with sorted but not evenly spaced time dim."""
-        times = gen.random(len(random_patch.get_coord("time")))
-        new_times = dc.to_datetime64(np.sort(times))
-        return random_patch.update_coords(time=new_times)
 
     def test_dims(self, patch_ones):
         """Ensure both dimensions work."""


### PR DESCRIPTION

## Description

This PR adds support for using percent (as in from dascore.units) in coord select and taper. It is interpreted as % of the coord range in these contexts. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
