### PR TITLE
Implement Short time Fourier transform and its inverse

### DIFF
--- a/.github/actions/mamba-install-dascore/action.yml
+++ b/.github/actions/mamba-install-dascore/action.yml
@@ -42,7 +42,7 @@ runs:
           powershell
         cache-environment: true
         cache-environment-key: environment-${{ env.CURRENT_DATE }}-${{ inputs.environment-file }}
-        post-cleanup: 'all'
+        post-cleanup: "shell-init"
         create-args: >-
           python=${{ inputs.python-version }}
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', "3.12"]
+        python-version: ['3.10', '3.11', "3.12", "3.13"]
 
     # only run if CI isn't turned off
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -247,6 +247,13 @@ class PatchAttrs(DascoreBaseModel):
             out["coords"] = {}
         return self.__class__(**out)
 
+    def drop(self, *args):
+        """Drop specific keys if they exist."""
+        contents = dict(self)
+        ok_to_keep = set(contents) - set(args)
+        out = {i: v for i, v in contents.items() if i in ok_to_keep}
+        return self.__class__(**out)
+
     def drop_private(self) -> Self:
         """Drop all private attributes."""
         contents = dict(self)

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -782,8 +782,8 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             samples = int(np.ceil(duration / self.step))
         if enforce_lt_coord and samples > len(self):
             msg = (
-                f"value of {value} results in a window larger than coordinate "
-                f"length of {len(self)}"
+                f"value of {value} with samples={samples }results in a window "
+                f"larger than coordinate length of {len(self)}."
             )
             raise ParameterError(msg)
         return samples

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -763,6 +763,9 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             The value (supports units).
         samples
             If True, value is already in units of samples.
+        enforce_lt_coord
+            If True, raise an error if the number of samples obtained exceeds
+            the length of the coordinate.
         """
         assert self.ndim == 1, "get sample count only works for 1D coords."
         if not self.evenly_sampled:

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -350,6 +350,8 @@ class Patch:
     rfft = transform.rfft
     dft = transform.dft
     idft = transform.idft
+    stft = transform.stft
+    istft = transform.istft
     integrate = transform.integrate
     spectrogram = transform.spectrogram
     velocity_to_strain_rate = transform.velocity_to_strain_rate

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -558,13 +558,22 @@ def transpose(self: PatchType, *dims: str) -> PatchType:
     ----------
     *dims
         Dimension names which define the new data axis order.
+        Can also include ... to indicate diemsnions that should be left
+        alone.
 
     Examples
     --------
     >>> import dascore # import dascore library
     >>> pa = dascore.get_example_patch() # generate example patch
-    >>> # transpose the time and data array dimensions in the example patch
-    >>> out = dascore.proc.transpose(pa,"time", "distance")
+    >>>
+    >>> # Transpose the time and data array dimensions in the example patch
+    >>> out = pa.transpose("time", "distance")
+    >>>
+    >>> # Set "distance" as the last dimension
+    >>> out = pa.transpose(..., "distance")
+    >>>
+    >>> # Set distance as the first dimension.
+    >>> out = pa.transpose("distance", ...)
     """
     dims = tuple(dims)
     old_dims = self.coords.dims

--- a/dascore/transform/__init__.py
+++ b/dascore/transform/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from .differentiate import differentiate
 from .fft import rfft
-from .fourier import dft, idft
+from .fourier import dft, idft, stft, istft
 from .integrate import integrate
 from .spectro import spectrogram
 from .strain import velocity_to_strain_rate, velocity_to_strain_rate_edgeless, radians_to_strain

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -356,10 +356,7 @@ def _get_stft_coords(patch, dim, axis, coord, stft, window):
     new_dims = list(_get_stft_dims(dim, patch.dims, axis))
     # Make dict of coordinates nd return coord manager.
     coord_map = dict(patch.coords.coord_map)
-    # Get units on new coordinates.
-    new_units = None
-    if coord.units is not None:
-        new_units = 1 / dc.get_quantity(coord.units)
+    new_units = invert_quantity(coord.units)
     coord_map.update(
         {
             dim: get_coord(values=time + coord.min(), units=coord.units),
@@ -431,7 +428,7 @@ def stft(
       series signal before the transformation.
     - If an array is passed for taper_window that has a different length
       than specified in kwargs, artificial enriching of frequency resolution
-      (equivalent to zero pading in time domain) can occur.
+      (equivalent to zero padding in time domain) can occur.
 
     See Also
     --------
@@ -442,7 +439,7 @@ def stft(
     coord = patch.get_coord(dim, require_evenly_sampled=True)
     window_samples = coord.get_sample_count(val, samples=samples, enforce_lt_coord=True)
     step = dc.to_float(coord.step)
-    sampling_rate = 1 / dc.to_float(step)
+    sampling_rate = 1 / step
     # Create window and calculate hop.
     if isinstance(taper_window, ndarray):
         window = taper_window
@@ -537,7 +534,7 @@ def istft(
     patch,
 ):
     """
-    Inverse a short-time fourier transform.
+    Invert a short-time fourier transform.
 
     Parameters
     ----------

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -370,7 +370,7 @@ def _get_stft_coords(patch, dim, axis, coord, stft, window):
     return out
 
 
-@patch_function
+@patch_function()
 def stft(
     patch: PatchType,
     taper_window: str | ndarray | tuple[str, Any, ...] = "hann",

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -427,9 +427,10 @@ def stft(
 
     Notes
     -----
-    - The output is scalled the same as [Patch.dft](`dascore.Patch.dft`).
-    - For a given sliding window, Parseval's thereom doesn't hold exactly
-      unless a boxcare window is used.
+    - The output is scaled the same as [Patch.dft](`dascore.Patch.dft`).
+      For a given sliding window, Parseval's theorem doesn't hold exactly
+      (unless a boxcar window is used) because the taper window changes the time
+      series signal before the transformation.
     - If an array is passed for taper_window that has a different length
       than specified in kwargs, artificial enriching of frequency resolution
       (equivalent to zero pading in time domain) can occur.
@@ -533,7 +534,7 @@ def _get_short_time_fft(patch) -> ShortTimeFFT:
     return stft
 
 
-@patch_function
+@patch_function()
 def istft(
     patch,
 ):

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -403,8 +403,6 @@ def stft(
         If True, detrend each time window before performing fourier transform.
         This can lead to nicer looking spectrograms, but means the istft is
         no longer possible.
-    psd
-        If True, return the power spectral density (PSD).
     **kwargs
         Used to specify window length in data units, percent, or samples.
 
@@ -517,7 +515,7 @@ def _get_istft_coord(coords, frequency_axis, time_axis):
     new_dims = list(dims)
     new_dims[frequency_axis] = dims[time_axis]
     new_dims.pop(time_axis)
-    return get_coord_manager(coords=coord_map, dims=new_dims), time
+    return get_coord_manager(coords=coord_map, dims=tuple(new_dims)), time
 
 
 def _get_short_time_fft(patch) -> ShortTimeFFT:
@@ -571,6 +569,7 @@ def istft(
         patch.data / dc.to_float(coord.step), t_axis=time_axis, f_axis=frequency_axis
     )
     # Trim data array to remove effect of padding.
+    # Note: after ISTFT, `frequency_axis` now indexes the restored time axis.
     index = broadcast_for_index(
         data_untrimmed.ndim, frequency_axis, slice(0, len(coord))
     )

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -439,7 +439,7 @@ def stft(
     coord = patch.get_coord(dim, require_evenly_sampled=True)
     window_samples = coord.get_sample_count(val, samples=samples, enforce_lt_coord=True)
     step = dc.to_float(coord.step)
-    sampling_rate = 1 / step
+    sampling_rate = 1 / abs(step)
     # Create window and calculate hop.
     if isinstance(taper_window, ndarray):
         window = taper_window
@@ -530,9 +530,7 @@ def _get_short_time_fft(patch) -> ShortTimeFFT:
 
 
 @patch_function()
-def istft(
-    patch,
-):
+def istft(patch) -> PatchType:
     """
     Invert a short-time fourier transform.
 

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -403,6 +403,8 @@ def stft(
         If True, detrend each time window before performing fourier transform.
         This can lead to nicer looking spectrograms, but means the istft is
         no longer possible.
+    psd
+        If True, return the power spectral density (PSD).
     **kwargs
         Used to specify window length in data units, percent, or samples.
 

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -430,6 +430,9 @@ def stft(
     - The output is scalled the same as [Patch.dft](`dascore.Patch.dft`).
     - For a given sliding window, Parseval's thereom doesn't hold exactly
       unless a boxcare window is used.
+    - If an array is passed for taper_window that has a different length
+      than specified in kwargs, artificial enriching of frequency resolution
+      (equivalent to zero pading in time domain) can occur.
 
     See Also
     --------
@@ -530,6 +533,7 @@ def _get_short_time_fft(patch) -> ShortTimeFFT:
     return stft
 
 
+@patch_function
 def istft(
     patch,
 ):
@@ -573,6 +577,7 @@ def istft(
     assert new_data.shape == cm.shape
     # Re-assemble and return new patch.
     new_attrs = {i: v for i, v in patch.attrs.items() if not i.startswith("_stft")}
-    new_attrs["data_units"] = _get_data_units_from_dims(patch, "time", truediv)
+    dim = patch.dims[time_axis]
+    new_attrs["data_units"] = _get_data_units_from_dims(patch, dim, truediv)
     attrs = dc.PatchAttrs(**new_attrs).drop("coords")
     return patch.new(data=new_data, coords=cm, attrs=attrs)

--- a/dascore/transform/spectro.py
+++ b/dascore/transform/spectro.py
@@ -11,6 +11,7 @@ from dascore.constants import PatchType
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_compatible_values, get_coord
+from dascore.utils.deprecate import deprecate
 from dascore.utils.misc import iterate
 from dascore.utils.patch import (
     _get_data_units_from_dims,
@@ -58,6 +59,11 @@ def _get_new_dims(patch, dim, new_coord_name):
 
 
 @patch_function()
+@deprecate(
+    info="Use Patch.stft() instead.",
+    since="0.1.11",
+    removed_in="0.2.0",
+)
 def spectrogram(patch: PatchType, dim: str = "time", **kwargs) -> PatchType:
     """
     Calculate a spectrogram from the patch data.

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -172,7 +172,7 @@ def assert_dtype_compatible_with_units(dtype, quantity) -> Quantity:
     return quant
 
 
-def invert_quantity(unit: pint.Unit | str) -> pint.Unit:
+def invert_quantity(unit: pint.Unit | str) -> pint.Unit | None:
     """Invert a unit."""
     # just get magnitude for isnull test to avoid warning of casting
     # quantity to array.

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -380,28 +380,36 @@ def _time_delta_to_float(time_delta: np.timedelta64):
     return to_timedelta64(time_delta) / ONE_SECOND
 
 
-def is_datetime64(obj) -> bool:
-    """Return True if object is a datetime64 (or equivalent) or an array of such."""
-    if isinstance(obj, np.datetime64):
+def _is_dtype(obj, numpy_dtype, pandas_dtype) -> bool:
+    """
+    Test if a variety of object types are of numpy or pandas dtype.
+
+    Returns True if the object is a numpy type, pandas type,
+    numpy dtype, pandas dtype, or an array-like of dtype values.
+    """
+    # Handle scalars: np.datetime64, pandas.Timestamp
+    if isinstance(obj, numpy_dtype | pandas_dtype):
         return True
-    if isinstance(obj, np.ndarray | list | tuple | pd.Series):
-        if np.issubdtype(np.asarray(obj).dtype, np.datetime64):
-            return True
-    if isinstance(obj, pd.Timestamp):
-        return True
+    # Handle numpy/pandas datetime64 dtypes directly
+    if isinstance(obj, (np.dtype | pd.api.extensions.ExtensionDtype)):
+        return np.issubdtype(obj, numpy_dtype)
+    # Handle pandas Series
+    if isinstance(obj, pd.Series):
+        return np.issubdtype(obj.dtype, numpy_dtype)
+    # Handle array-like objects (numpy arrays, lists, tuples)
+    if isinstance(obj, np.ndarray | list | tuple):
+        return np.issubdtype(np.asarray(obj).dtype, numpy_dtype)
     return False
 
 
-def is_timedelta64(obj) -> bool:
-    """Return True if object is a timedelta64 (or equivalent) or an array of such."""
-    if isinstance(obj, np.timedelta64):
-        return True
-    if isinstance(obj, np.ndarray | list | tuple | pd.Series):
-        if np.issubdtype(np.asarray(obj).dtype, np.timedelta64):
-            return True
-    if isinstance(obj, pd.Timedelta):
-        return True
-    return False
+def is_datetime64(obj):
+    """Determine if an object represents a timedelta64 dtype or value(s)."""
+    return _is_dtype(obj, np.datetime64, pd.Timestamp)
+
+
+def is_timedelta64(obj):
+    """Determine if an object represents a timedelta64 dtype or value(s)."""
+    return _is_dtype(obj, np.timedelta64, pd.Timedelta)
 
 
 def dtype_time_like(dtype_or_array) -> bool:

--- a/docs/tutorial/transformations.qmd
+++ b/docs/tutorial/transformations.qmd
@@ -42,12 +42,6 @@ print(real_transform.get_coord("ft_distance"))
 
 The Inverse Discrete Fourier Transform [idft](`dascore.transform.fourier.idft`) undoes the transformation.
 
-```{python}
-# Transform distance axis to Fourier domain using real fourier transform
-real_transform = patch.dft(dim='distance', real=True)
-print(real_transform.get_coord("ft_distance"))
-```
-
 # Short Time Fourier Transform
 
 Related to the Discrete Fourier Transform, the [Short Term Fourier Transform](https://en.wikipedia.org/wiki/Short-time_Fourier_transform) is useful for analyzing the time-dependent frequency content. DASCore implements this as [stft](`dascore.transform.fourier.stft`) and the corresponding [istft](`dascore.transform.fourier.istft`).

--- a/docs/tutorial/transformations.qmd
+++ b/docs/tutorial/transformations.qmd
@@ -57,7 +57,7 @@ patch = (
     .set_units("m/s")
 )
 
-patch.viz.waterfall(scale=0.1)
+patch.viz.waterfall();
 ```
 
 ```{python}
@@ -68,5 +68,5 @@ transformed = (
 )
 inverse =  transformed.istft()
 
-transformed.abs().select(distance=0, samples=True).squeeze().viz.waterfall()
+transformed.abs().select(distance=0, samples=True).squeeze().viz.waterfall();
 ```

--- a/docs/tutorial/transformations.qmd
+++ b/docs/tutorial/transformations.qmd
@@ -43,7 +43,36 @@ print(real_transform.get_coord("ft_distance"))
 The Inverse Discrete Fourier Transform [idft](`dascore.transform.fourier.idft`) undoes the transformation.
 
 ```{python}
-# Transform back to time domain, take only real component.
-patch_2 = transformed.idft().real()
-assert np.allclose(patch_2.data, patch.data)
+# Transform distance axis to Fourier domain using real fourier transform
+real_transform = patch.dft(dim='distance', real=True)
+print(real_transform.get_coord("ft_distance"))
+```
+
+# Short Time Fourier Transform
+
+Related to the Discrete Fourier Transform, the [Short Term Fourier Transform](https://en.wikipedia.org/wiki/Short-time_Fourier_transform) is useful for analyzing the time-dependent frequency content. DASCore implements this as [stft](`dascore.transform.fourier.stft`) and the corresponding [istft](`dascore.transform.fourier.istft`).
+
+```{python}
+import numpy as np
+import dascore as dc
+from dascore.units import second, percent
+
+# Get example patch, set unit to velocity (for demonstration)
+patch = (
+    dc.get_example_patch("chirp", channel_count=3)
+    .set_units("m/s")
+)
+
+patch.viz.waterfall(scale=0.1)
+```
+
+```{python}
+# Perform the transform, visualize the amplitude spectra, for the first
+# channel then invert.
+transformed = (
+    patch.stft(time=1*second, overlap=50*percent)
+)
+inverse =  transformed.istft()
+
+transformed.abs().select(distance=0, samples=True).squeeze().viz.waterfall()
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -3,16 +3,19 @@ channels:
   - conda-forge
 dependencies:
   - pytest
-  - pydantic>2.0
+  - numpy>=1.24
+  - pydantic>2.1
   - pip
-  - pandas
+  - pandas>=2.0
   - pooch>=1.2
   - xarray
   - pre-commit
   - pytables
   - h5py
-  - matplotlib
-  - scipy>=1.10.0
+  - matplotlib>=3.5
+  - scipy>=1.15.0
   - findiff
   - jupyter
   - nbformat
+  - pint
+  - typing_extensions>=4.12

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - pytest
   - numpy>=1.24
-  - pydantic>2.1
+  - pydantic>=2.1
   - pip
   - pandas>=2.0
   - pooch>=1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
      "pooch>=1.2",
      "pydantic>2.1",
      "rich",
-     "scipy>=1.14.1",
      "tables>=3.7",
      "typing_extensions>=4.12",
      "pint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
      "tables>=3.7",
      "typing_extensions>=4.12",
      "pint",
+     "scipy>=1.15",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_core/test_attrs.py
+++ b/tests/test_core/test_attrs.py
@@ -250,12 +250,23 @@ class TestRenameDimension:
 class TestDropPrivate:
     """Tests for dropping private attrs."""
 
-    def test_simple_drop(self):
+    def test_simple_drop_private(self):
         """Ensure private attrs are removed after operation."""
         attrs = PatchAttrs(_private1=1, extra_attr=2).drop_private()
         attr_dict = dict(attrs)
         assert "_private1" not in attr_dict
         assert "extra_attr" in attr_dict
+
+
+class TestDrop:
+    """Tests for dropping attrs."""
+
+    def test_simple_drop(self):
+        """Ensure a single attr can be dropped."""
+        attrs = PatchAttrs(bob=1, bill=2, sue="Z")
+        new = dict(attrs.drop("bob", "bill"))
+        assert "bob" not in new and "bill" not in new
+        assert "sue" in new
 
 
 class TestMisc:

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -288,6 +288,12 @@ class TestSTFT:
         assert isinstance(patch, dc.Patch)
         assert len(patch.dims) == (len(chirp_patch.dims) + 1)
 
+    def test_array_window(self, random_patch):
+        """Ensure an array can be used as a window function."""
+        win = np.ones(100)
+        out = random_patch.stft(time=100, taper_window=win, overlap=10, samples=True)
+        assert len(out.dims) == (len(random_patch.dims) + 1)
+
 
 class TestInverseSTFT:
     """Tests for the inverse short-time Fourier transform."""

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -399,6 +399,13 @@ class TestIsDateTime:
         ser = pd.Series(array)
         assert is_datetime64(ser)
 
+    def test_dtype(self):
+        """Giving the function a numpy datatype should also work."""
+        d1 = np.array([1.0, 2.0]).dtype
+        d2 = np.array([1, 2]).astype("datetime64[ms]").dtype
+        assert not is_datetime64(d1)
+        assert is_datetime64(d2)
+
 
 class TestToFloat:
     """Tests for converting datetime(ish) things to floats."""
@@ -482,6 +489,13 @@ class TestIsTimeDelta:
         """Datetimes are not timedeltas :)."""
         dt = to_datetime64("2020-01-02")
         assert not is_timedelta64(dt)
+
+    def test_dtype(self):
+        """Giving the function a numpy datatype should also work."""
+        d1 = np.array([1.0, 2.0]).dtype
+        d2 = np.array([1, 2]).astype("timedelta64[ms]").dtype
+        assert not is_timedelta64(d1)
+        assert is_timedelta64(d2)
 
 
 class TestGetmaxMinTimes:


### PR DESCRIPTION
## Description

This PR implements the stft by simply wrapping the scipy function. 

Todos
- [ ] properly handle units and scaling
- [ ] deprecate `Patch.spectrogram`
- [ ] Add more examples
- [ ] Test a wider range of window functions and overlaps.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - STFT and inverse‑STFT transforms; ability to create attribute‑dropped copies of patches.

- Documentation
  - Tutorials updated with STFT/ISTFT examples and clarified messaging.

- Refactor
  - Centralized datetime/timedelta detection for broader dtype coverage.

- Tests
  - Added STFT/ISTFT round‑trip and error tests; expanded time‑dtype and attr‑drop tests.

- Chores
  - Bumped dependency constraints, added Python 3.13 to CI, adjusted CI cleanup behavior.

- Deprecated
  - Spectrogram function marked deprecated (use STFT).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->