### PR TITLE
Loosen instrument naming requirement for febus files

### DIFF
--- a/dascore/io/febus/utils.py
+++ b/dascore/io/febus/utils.py
@@ -52,6 +52,7 @@ def _get_febus_version_str(hdf_fi) -> str:
     """Return the version string for febus file."""
     # Define a few root attrs that act as a "fingerprint"
     # all Febus DAS files have folders that start with fa (I hope).
+    # Edit: They do not. I have simply removed this requirement (#525).
     inst_keys = sorted(hdf_fi.keys())
     expected_source_attrs = {
         "AmpliPower",
@@ -59,8 +60,7 @@ def _get_febus_version_str(hdf_fi) -> str:
         "WholeExtent",
         "SamplingRate",
     }
-    # iterate instrument keys
-    is_febus = all([x.startswith("fa") for x in inst_keys])
+    is_febus = True
     # Version 1, or what I think is version one (eg Valencia PubDAS data)
     # did not include a Version attr in Source dataset, so we use that as
     # the default.


### PR DESCRIPTION

## Description
Previously, part of the format check for Febus files looked at the instrument name. All the examples I had seen started with "fa" but it turns out this isn't always true. Since there are other strong checks, like the presence of "Source_X" datasets and specific attributes on each of these, I have simply removed this part of the febus format check.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FEBUS dataset recognition by using attribute-based checks instead of requiring instrument names to follow a specific prefix. This reduces false negatives and increases compatibility with varied naming conventions, while preserving existing version detection behavior. Expect fewer misclassifications and smoother imports across diverse projects.
  * No user-facing API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->