### PR TITLE
fix attr update from coords

### DIFF
--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -235,8 +235,8 @@ class PatchAttrs(DascoreBaseModel):
         """Update an attribute in the model, return new model."""
         passed_in_coords = kwargs.get("coords", True)
         out = self.model_dump(exclude_unset=True)
-        # If coords passed in, base new coordiantes on that.
-        new_coords = out.get("coords", {})
+        # If coord manager passed in, base new coordinates on that.
+        new_coords = dict(out.get("coords", {}))
         if isinstance(passed_in_coords, dc.CoordManager):
             new_coords = passed_in_coords.model_dump(exclude_unset=True)
 
@@ -249,7 +249,7 @@ class PatchAttrs(DascoreBaseModel):
             else:
                 new_coords[name].update(coord_dict)
         out["coords"] = new_coords
-        # If falsy coords passed in clear the coordinates.
+        # If falsy coords passed in, clear the coordinates.
         if not passed_in_coords:
             out["coords"] = {}
         return self.__class__(**out)

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -191,12 +191,12 @@ def update(
     if dims is None:
         dims = coords.dims if isinstance(coords, CoordManager) else self.dims
     coords = get_coord_manager(coords, dims)
-    if attrs:
+    if attrs is not None:
         coords, attrs = coords.update_from_attrs(attrs)
     else:
         _attrs = dc.PatchAttrs.from_dict(attrs or self.attrs)
-        attrs = _attrs.update(coords=coords, dims=coords.dims)
-    return self.__class__(data=data, coords=coords, attrs=attrs, dims=coords.dims)
+        attrs = _attrs.update(coords=coords)
+    return self.__class__(data=data, coords=coords, attrs=attrs)
 
 
 @patch_function()

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -449,7 +449,7 @@ def slope_filter(
     """
     Filter the patch over certain slopes in the 2D Fourier domain.
 
-    Most commonly this used as an F-K (frequency wavenumber)
+    Most commonly this is used as an F-K (frequency wavenumber)
     filter to attenuate energy with specified apparent velocities.
 
     Parameters
@@ -458,7 +458,7 @@ def slope_filter(
         The patch to filter.
     filt
         A length 4 array of the form [va, vb, vc, vd]. If notch is False,
-        the filter selects the apparent velocites between 'vb' and 'vc'
+        the filter selects the apparent velocities between 'vb' and 'vc'
         with tapering boundaries from 'va' to 'vb' and from 'vc' to 'vd'.
     dims
         The dimensions used to determine slope. The first dim is in the
@@ -469,11 +469,11 @@ def slope_filter(
         If True, the filter should be considered direction. That is to say,
         the sign of the values in `filt` indicate the direction (towards or
         away) with increasing coordinate values.
-        This can be used for up-down/left-right separation, assuming a
+        This can be used for up/down or left/right separation, assuming a
         near-linear fiber layout.
     notch
         If True, the filter represents a notch, meaning the slopes
-        specified by the inner `filt` parameterse are attenuated rather
+        specified by the inner `filt` parameters are attenuated rather
         than those outside of them.
 
     Examples
@@ -514,7 +514,7 @@ def slope_filter(
     >>> filt = np.array([2e3,2.2e3,8e3,2e4]) * dc.get_unit("m/s")
     >>> patch_filtered = patch.slope_filter(filt=filt)
 
-    The [fk recipe](`docs/recipes/fk.qmd`) provides addtional examples.
+    The [FK recipe](`docs/recipes/fk.qmd`) provides addtional examples.
     """
 
     def _check_inputs(patch, filt, dims):

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -470,7 +470,7 @@ def slope_filter(
         the sign of the values in `filt` indicate the direction (towards or
         away) with increasing coordinate values.
         This can be used for up-down/left-right separation, assuming a
-        near-linear fiber layoyt.
+        near-linear fiber layout.
     notch
         If True, the filter represents a notch, meaning the slopes
         specified by the inner `filt` parameterse are attenuated rather

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -374,7 +374,7 @@ def _get_stft_coords(patch, dim, axis, coord, stft, window):
 def stft(
     patch: PatchType,
     taper_window: str | ndarray | tuple[str, Any, ...] = "hann",
-    overlap: Quantity | int = 50 * percent,
+    overlap: Quantity | int | None = 50 * percent,
     samples: bool = False,
     detrend: bool = False,
     **kwargs,
@@ -392,7 +392,9 @@ def stft(
         or an array, or a tuple of name and parameters passed to scipy.signal's
         get_window function.
     overlap
-        The overlap between windows
+        The overlap between windows. Can be a number (assumed to be in units of
+        the transformed dimension if `samples`==False), a percent, or None for
+        0 overlap.
     samples
         If True, the window length (provided in kwargs) and overlap parameters
         are in samples (or explicit units).

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -446,11 +446,14 @@ def stft(
     else:
         window = get_window(taper_window, window_samples, fftbins=False)
     # By using a coord and enforce_lt_coord, we guarantee the overlap is lt window.
-    overlap = coord[:window_samples].get_sample_count(
-        overlap,
-        samples=samples,
-        enforce_lt_coord=True,
-    )
+    if overlap is not None:
+        overlap = coord[:window_samples].get_sample_count(
+            overlap,
+            samples=samples,
+            enforce_lt_coord=True,
+        )
+    else:
+        overlap = 0
     hop = window_samples - overlap
     # Perform stft
     fft_mode = "onesided" if np.isrealobj(patch.data) else "centered"

--- a/tests/test_core/test_attrs.py
+++ b/tests/test_core/test_attrs.py
@@ -299,6 +299,14 @@ class TestUpdateAttrs:
         new = attrs.update(coords=new_patch.coords)
         assert new.dim_tuple == new_patch.dims
 
+    def test_update_coord_summary(self, random_patch):
+        """Ensure updating attrs updates the summary."""
+        coords, _ = random_patch.coords.drop_coords("distance")
+        attr = random_patch.attrs.update(coords=coords)
+        coord_summary = attr.coords
+        # Distance should have been dropped from the coord summary.
+        assert set(coord_summary) == set(coords.coord_map)
+
 
 class TestGetAttrSummary:
     """Test getting dataframe of summary info."""

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -122,9 +122,10 @@ class TestInit:
     def test_min_max_populated(self, random_patch):
         """The min/max values of the distance attrs should have been populated."""
         attrs = random_patch.attrs
+        attr_class = type(attrs)
         expected_filled_in = [
             x
-            for x in list(attrs.model_fields)
+            for x in list(attr_class.model_fields)
             if x.startswith("distance") and "units" not in x
         ]
         for attr in expected_filled_in:

--- a/tests/test_integrations/test_misc_integrations.py
+++ b/tests/test_integrations/test_misc_integrations.py
@@ -8,32 +8,39 @@ import dascore as dc
 from dascore.utils.downloader import fetch
 
 
+@pytest.fixture(scope="module")
+def train_patch():
+    """Get an example patch with trains in it."""
+    out = dc.spool(fetch("UoU_lf_urban.hdf5"))[0]
+    return out
+
+
 class TestFilterInteractions:
     """Tests for various filters working together."""
-
-    @pytest.fixture
-    def train_patch(self):
-        """Get an example patch with trains in it."""
-        out = dc.spool(fetch("UoU_lf_urban.hdf5"))[0]
-        return out
 
     def test_filter_stft(self, random_patch):
         """Ensure a stft transformed patch can be filtered."""
         patch = random_patch
-        stft = patch.stft(time=0.1, overlap=None)
-        out = stft.pass_filter(time=(0.01, ...))
+        stft_patch = patch.stft(time=0.1, overlap=None)
+        out = stft_patch.pass_filter(time=(0.01, ...))
         assert isinstance(out, dc.Patch)
+        assert out.dims == stft_patch.dims
 
     def test_slope_filter_stft(self, train_patch):
         """Tests for filtering velocity anomalies in different bands."""
         # First apply stft.
-        stft = train_patch.stft(
+        stft_patch = train_patch.stft(
             time=3, overlap=0.5, taper_window=("tukey", 0.1), detrend=True
         )
         # Then sum power over 1 to 2 Hz
-        banded_patch = (stft.abs() ** 2).select(ft_time=(1, 2)).sum("ft_time").squeeze()
+        banded_patch = (
+            (stft_patch.abs() ** 2).select(ft_time=(1, 2)).sum("ft_time").squeeze()
+        )
         # Then try to slope filter.
         mph = dc.get_quantity("miles/hour")
         filt = [10 * mph, 30 * mph, 100 * mph, 130 * mph]
         sf = banded_patch.slope_filter(filt)
+        assert "slope_filter" in str(sf.attrs.history)
+        assert sf.data.shape == banded_patch.data.shape
+        assert sf.dims == banded_patch.dims
         assert "slope_filter" in str(sf.attrs.history)

--- a/tests/test_integrations/test_misc_integrations.py
+++ b/tests/test_integrations/test_misc_integrations.py
@@ -1,0 +1,39 @@
+"""
+A collection of integration-type tests that don't seem to fit anywhere else.
+"""
+
+import pytest
+
+import dascore as dc
+from dascore.utils.downloader import fetch
+
+
+class TestFilterInteractions:
+    """Tests for various filters working together."""
+
+    @pytest.fixture
+    def train_patch(self):
+        """Get an example patch with trains in it."""
+        out = dc.spool(fetch("UoU_lf_urban.hdf5"))[0]
+        return out
+
+    def test_filter_stft(self, random_patch):
+        """Ensure a stft transformed patch can be filtered."""
+        patch = random_patch
+        stft = patch.stft(time=0.1, overlap=None)
+        out = stft.pass_filter(time=(0.01, ...))
+        assert isinstance(out, dc.Patch)
+
+    def test_slope_filter_stft(self, train_patch):
+        """Tests for filtering velocity anomalies in different bands."""
+        # First apply stft.
+        stft = train_patch.stft(
+            time=3, overlap=0.5, taper_window=("tukey", 0.1), detrend=True
+        )
+        # Then sum power over 1 to 2 Hz
+        banded_patch = (stft.abs() ** 2).select(ft_time=(1, 2)).sum("ft_time").squeeze()
+        # Then try to slope filter.
+        mph = dc.get_quantity("miles/hour")
+        filt = [10 * mph, 30 * mph, 100 * mph, 130 * mph]
+        sf = banded_patch.slope_filter(filt)
+        assert "slope_filter" in str(sf.attrs.history)

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -431,6 +431,14 @@ class TestSqueeze:
         with pytest.raises(CoordError, match=msg):
             flat_patch.squeeze(dim="time")
 
+    def test_coord_summary(self, flat_patch):
+        """Ensure the coordinate summary doesn't contain squeezed dim."""
+        patch = flat_patch.squeeze()
+        attrs = patch.attrs
+        coords = attrs.get("coords", None)
+        if coords:
+            assert set(coords) == set(patch.coords.coord_map)
+
 
 class TestGetCoord:
     """Tests for the get_coord convenience function."""

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -335,6 +335,11 @@ class TestSTFT:
         ipa2 = pa2.istft()
         assert ipa1.attrs.data_units == ipa2.attrs.data_units
 
+    def test_none_for_overlap(self, random_patch):
+        """Using None for overlap should be supported."""
+        out = random_patch.stft(time=1, overlap=None)
+        assert isinstance(out, dc.Patch)
+
 
 class TestInverseSTFT:
     """Tests for the inverse short-time Fourier transform."""

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -535,11 +535,8 @@ class TestConcatenate:
             pa_dft_dropped_time = pa_dft.update(coords=cm.update(time=None))
             pa_list.append(pa_dft_dropped_time)
         sp_dft = dc.spool(pa_list)
-        time_min_coord = sp_dft.get_contents()["time_min"]
         sp_concat = sp_dft.concatenate(time_min=None)
         pa_concat = sp_concat[0]
-        updated_coords = pa_concat.coords.update(time_min=time_min_coord)
-        pa_concat = pa_concat.update(coords=updated_coords)
         assert pa_concat.shape[-1] == len(sp)
         assert "time_min" in pa_concat.dims
 


### PR DESCRIPTION
## Description

This PR fixes a few small bugs:

- fixes `PatchAttr` update when explicitly passed a `CoordManager` as coords to just use that `CoordManager`
- Allows `overlap` to be None in `Patch.stft`
- Added some integration tests.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * STFT now accepts overlap=None (explicit 0-overlap option).
  * Dimension inference improved when updating coordinates/attributes.

* **Bug Fixes**
  * Coordinate summaries now stay in sync after updates, removals, and squeeze operations.
  * Update paths handle empty attribute mappings more consistently.

* **Documentation**
  * Typos and wording clarified in slope_filter docs.

* **Tests**
  * Unit and integration tests added for STFT overlap, coord-summary consistency, and filter interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->