### PR TITLE
add prodml pulse width units

### DIFF
--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -105,9 +105,11 @@ def _get_prodml_attrs(fi, extras=None) -> list[dict]:
     _root_attrs = {
         "PulseWidth": "pulse_width",
         "PulseWidthUnits": "pulse_width_units",
+        "PulseWidthUnit": "pulse_width_units",
         "PulseWidth.uom": "pulse_width_units",
         "PulseRate": "pulse_rate",
         "PulseRateUnit": "pulse_rate_units",
+        "PulseRateUnits": "pulse_rate_units",
         "PulseRate.uom": "pulse_rate_units",
         "GaugeLength": "gauge_length",
         "GaugeLengthUnit": "gauge_length_units",


### PR DESCRIPTION
## Description

Some prodml files define pulse width units as `pulseWidthUnit` and others as `pulseWidthUnits`. This simple PR just makes sure both cases are handled.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
