### PR TITLE
allow chunking to drop non-dimensional coords

### DIFF
--- a/dascore/utils/coordmanager.py
+++ b/dascore/utils/coordmanager.py
@@ -18,10 +18,10 @@ def merge_coord_managers(
     coord_managers: Sequence[dc.CoordManager],
     dim: str,
     snap_tolerance: float | None = None,
-    drop_conflicting=False,
+    drop_conflicting: bool = False,
 ) -> dc.CoordManager:
     """
-    Merger coordinate managers along a specified dimension.
+    Merge coordinate managers along a specified dimension.
 
     Parameters
     ----------
@@ -80,7 +80,7 @@ def merge_coord_managers(
             msg = (
                 f"Non merging coordinates {coord_name} are not equal. "
                 "Coordinate managers cannot be merged. Try using "
-                "spool.chunk with conflicts='drop'."
+                "spool.chunk with conflict='drop'."
             )
             raise CoordMergeError(msg)
         return out

--- a/dascore/utils/coordmanager.py
+++ b/dascore/utils/coordmanager.py
@@ -18,6 +18,7 @@ def merge_coord_managers(
     coord_managers: Sequence[dc.CoordManager],
     dim: str,
     snap_tolerance: float | None = None,
+    drop_conflicting=False,
 ) -> dc.CoordManager:
     """
     Merger coordinate managers along a specified dimension.
@@ -34,6 +35,9 @@ def merge_coord_managers(
         start/end to be joined together. If they don't meet this requirement
         an [CoordMergeError](`dascore.exceptions.CoordMergeError`) is raised.
         If None, no checks are performed.
+    drop_conflicting
+        If True, drop conflicting (non-dimensional) coordinates, otherwise
+        raise an exception if they occur.
     """
 
     def _get_dims(managers):
@@ -68,9 +72,15 @@ def merge_coord_managers(
                 dims = managers[0].dim_map[coord_name]
                 out[coord_name] = (dims, first)
                 continue
+            # Simply skip conflicting
+            elif drop_conflicting:
+                # These are non dimensional coords
+                if not any(coord_name in x.dims for x in managers):
+                    continue
             msg = (
                 f"Non merging coordinates {coord_name} are not equal. "
-                "Coordinate managers cannot be merged."
+                "Coordinate managers cannot be merged. Try using "
+                "spool.chunk with conflicts='drop'."
             )
             raise CoordMergeError(msg)
         return out

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -486,7 +486,7 @@ class TestChunkMerge:
         Private coords that conflict should be dropped and not block merge
         when conflict="drop".
 
-        Otherwise they should be dropped.
+        Otherwise they should raise.
         """
         p1, p2 = patches_conflicting_private_coord
         merged_spool = dc.spool([p1, p2]).chunk(time=None, conflict="drop")

--- a/tests/test_utils/test_coordmanager_utils.py
+++ b/tests/test_utils/test_coordmanager_utils.py
@@ -33,7 +33,7 @@ class TestMergeCoordManagers:
         c2 = rand.random(c1.shape)
 
         time = cm_basic.get_coord("time")
-        cm1 = cm_basic.update(_bad_coord=("distance", c1))
+        cm1 = cm_basic.update_coords(_bad_coord=("distance", c1))
         cm2 = cm1.update_coords(
             _bad_coord=("distance", c2), time=time + time.coord_range()
         )

--- a/tests/test_utils/test_coordmanager_utils.py
+++ b/tests/test_utils/test_coordmanager_utils.py
@@ -4,6 +4,7 @@ Tests for coordinate manager utils.
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from dascore.core.coords import CoordArray, CoordMonotonicArray, CoordRange
@@ -22,6 +23,21 @@ class TestMergeCoordManagers:
         attr_name = f"{name}_min"
         new, _ = cm.update_from_attrs({attr_name: start + value})
         return new
+
+    @pytest.fixture(scope="class")
+    def conflicting_non_dim_coords(self, cm_basic):
+        """Get two coord managers with conflicting non-dimensional coordinates."""
+        dist_ax = cm_basic.dims.index("distance")
+        rand = np.random.RandomState(42)
+        c1 = rand.random(cm_basic.shape[dist_ax])
+        c2 = rand.random(c1.shape)
+
+        time = cm_basic.get_coord("time")
+        cm1 = cm_basic.update(_bad_coord=("distance", c1))
+        cm2 = cm1.update_coords(
+            _bad_coord=("distance", c2), time=time + time.coord_range()
+        )
+        return cm1, cm2
 
     def test_merge_simple(self, cm_basic):
         """Ensure we can merge simple, contiguous, coordinates together."""
@@ -136,3 +152,16 @@ class TestMergeCoordManagers:
         cm = cm_dt_small_diff
         coord = cm.coord_map["time"]
         assert coord.sorted
+
+    def test_conflicting_non_dimensional_coords(self, conflicting_non_dim_coords):
+        """
+        Ensure conflicting non-dimensional coords can be merged if drop_conflict=True,
+        Otherwise raise.
+        """
+        c1, c2 = conflicting_non_dim_coords
+
+        out = merge_coord_managers([c1, c2], dim="time", drop_conflicting=True)
+        assert not any([x.startswith("_") for x in out.coord_map])
+
+        with pytest.raises(CoordMergeError, match="cannot be merged"):
+            merge_coord_managers([c1, c2], dim="time", drop_conflicting=False)


### PR DESCRIPTION

## Description
This PR allows `patch.chunk` to drop conflicting, non dimensional coordinates when `conflict = 'drop'`


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to drop conflicting non-dimensional coordinates during merges.
  * Patch merging now respects conflict settings: "drop" or "keep_first" can discard conflicting private coordinates instead of failing.
  * Merge operations raise clearer errors when conflicts remain, with guidance on conflict-handling options.

* **Documentation**
  * Parameter docs updated to describe the new conflict-dropping behavior.

* **Tests**
  * Added tests covering merge behavior for conflicting private/non-dimensional coordinates (drop and error paths).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->