### PR TITLE
fix 533

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -518,7 +518,8 @@ class DataFrameSpool(BaseSpool):
         **kwargs,
     ) -> Self:
         """{doc}"""
-        df = self._df.drop(columns=list(self._drop_columns), errors="ignore")
+        df = self._source_df.drop(columns=list(self._drop_columns), errors="ignore")
+        # df = self._df
         chunker = ChunkManager(
             overlap=overlap,
             keep_partial=keep_partial,
@@ -535,7 +536,7 @@ class DataFrameSpool(BaseSpool):
             instructions = chunker.get_instruction_df(in_df, out_df)
         return self.new_from_df(
             out_df,
-            source_df=self._df,
+            source_df=self._source_df,
             instruction_df=instructions,
             merge_kwargs={"conflicts": conflict},
         )
@@ -570,10 +571,14 @@ class DataFrameSpool(BaseSpool):
             ignore_bad_kwargs=True,
             **kwargs,
         ).loc[lambda x: x["current_index"].isin(filtered_df.index)]
+        source = adjust_segments(
+            self._source_df.loc[inst.index], ignore_bad_kwargs=True, **kwargs
+        )
         # Determine if the instructions are the same as the source dataframe.
         out = self.new_from_df(
             filtered_df,
-            source_df=self._source_df,
+            # Drop rows that are no longer needed.
+            source_df=source,
             instruction_df=inst,
             select_kwargs=extra_kwargs,
         )

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -450,7 +450,7 @@ def _remove_overlaps(df, name):
 
 
 def _column_or_value(df, col, value):
-    """Return the values from a column, if they exist, else bool array of False."""
+    """Return the values from a column, if they exist, else bool array of value."""
     if col in df.columns:
         return df[col].values
     out = np.broadcast_to(np.array(value), len(df))

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -498,3 +498,82 @@ class TestChunkMerge:
         # Without conflict drop this should raise.
         with pytest.raises(CoordMergeError, match="conflict"):
             dc.spool([p1, p2]).chunk(time=None)[0]
+
+    def test_chunk_merge_then_chunk_split(self, random_spool):
+        """
+        Test chaining chunk(time=...) followed by chunk(time=duration).
+        See #533.
+        """
+        spool = random_spool
+
+        # First merge all patches along time, then chunk into 2s segments
+        chunk_1_spool = spool.chunk(time=...)
+        result_spool = chunk_1_spool.chunk(time=2)
+
+        # Should be able to access patches
+        first_patch = result_spool[0]
+        assert isinstance(first_patch, dc.Patch)
+
+        # Should have more patches (chunking into smaller pieces)
+        assert len(result_spool) > len(spool)
+
+        # Verify NO patches have NaN values and dataframe consistency
+        result_contents = result_spool.get_contents()
+        for i, patch in enumerate(result_spool):
+            # Assert no NaN values in patch attributes
+            assert not pd.isna(patch.attrs["time_min"]), f"Patch {i} has NaN time_min"
+            assert not pd.isna(patch.attrs["time_max"]), f"Patch {i} has NaN time_max"
+
+            # Verify dataframe contains reasonable time values
+            df_row = result_contents.iloc[i]
+            df_time_min = dc.to_datetime64(df_row["time_min"])
+            df_time_max = dc.to_datetime64(df_row["time_max"])
+
+            # Dataframe times should not be NaN or invalid
+            assert not pd.isna(df_time_min), f"DF row {i} has NaN time_min"
+            assert not pd.isna(df_time_max), f"DF row {i} has NaN time_max"
+            assert df_time_min <= df_time_max, f"DF row {i} has invalid time range"
+
+    def test_multiple_chained_chunks(self):
+        """Test multiple chained chunk operations. See #533."""
+        spool = dc.get_example_spool()
+
+        # Chain multiple chunk operations
+        result_spool = spool.chunk(time=...).chunk(time=5).chunk(time=2)
+
+        # Should be able to access all patches
+        for i in range(len(result_spool)):
+            patch = result_spool[i]
+            assert isinstance(patch, dc.Patch)
+
+    def test_chunk_split_then_merge(self):
+        """Test chaining chunk split followed by merge. See #533."""
+        spool = dc.get_example_spool()
+
+        # First chunk into smaller pieces, then merge back
+        result_spool = spool.chunk(time=1).chunk(time=...)
+
+        # Should be able to access patches (this test the fix works)
+        first_patch = result_spool[0]
+        assert isinstance(first_patch, dc.Patch)
+
+        # The merge operation should result in fewer patches than the chunked operation
+        chunked_spool = spool.chunk(time=1)
+        assert len(result_spool) <= len(chunked_spool)
+
+        # Verify NO patches have NaN values and dataframe consistency
+        result_contents = result_spool.get_contents()
+        for i, patch in enumerate(result_spool):
+            # Assert no NaN values in patch attributes
+            assert not pd.isna(patch.attrs["time_min"]), f"Patch {i} has NaN time_min"
+            assert not pd.isna(patch.attrs["time_max"]), f"Patch {i} has NaN time_max"
+
+            # Verify dataframe contains reasonable time values
+            df_row = result_contents.iloc[i]
+            df_time_min = dc.to_datetime64(df_row["time_min"])
+            df_time_max = dc.to_datetime64(df_row["time_max"])
+
+            # Dataframe times should not be NaN or invalid
+            assert not pd.isna(df_time_min), f"DF row {i} has NaN time_min"
+            assert not pd.isna(df_time_max), f"DF row {i} has NaN time_max"
+            assert df_time_min <= df_time_max, f"DF row {i} has invalid time range"


### PR DESCRIPTION

## Description

This PR fixes the double chunk issue mentioned in #533. 
This is done by resetting the spool's dataframe to the source dataframe upon using `Spool.chunk`, and also ensuring the source dataframe is also filtered and time adjusted in `Spool.select`

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
