### PR TITLE
warning for chunking gappy spools

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -132,8 +132,8 @@ class BaseSpool(abc.ABC):
             If True, snap the coords on joined patches such that the spacing
             remains constant.
         tolerance
-            The number of samples a block of data can be spaced and still be
-            considered contiguous.
+            The maximum number of samples a block of data can be spaced (gap) and
+            still be considered contiguous.
         conflict
             {conflict_desc}
         kwargs

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -201,14 +201,14 @@ class ChunkManager:
         stop_cum_max = stop_sorted.cummax()
         end_markers = stop_cum_max.shift() + step_sorted * self._tolerance
         has_gap = start_sorted > end_markers
-        if bool(np.asarray(has_gap).any()):
+        if has_gap.any():
             msg = (
                 "There is a gap in the patch. As a result, some patches in the "
                 "chunked spool may be unevenly sampled. However, they are "
                 "still considered contiguous as a tolerance of {self._tolerance} "
                 "was used in the chunk function."
             )
-            warnings.warn(msg, UserWarning, stacklevel=2)
+            warnings.warn(msg, UserWarning, stacklevel=3)
         group_num = has_gap.astype(np.int64).cumsum()
         return group_num[start.index]
 

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Collection
 from functools import reduce
 
@@ -200,6 +201,14 @@ class ChunkManager:
         stop_cum_max = stop_sorted.cummax()
         end_markers = stop_cum_max.shift() + step_sorted * self._tolerance
         has_gap = start_sorted > end_markers
+        if bool(np.asarray(has_gap).any()):
+            msg = (
+                "There is a gap in the patch. As a result, some patches in the "
+                "chunked spool may be unevenly sampled. However, they are "
+                "still considered contiguous as a tolerance of {self._tolerance} "
+                "was used in the chunk function."
+            )
+            warnings.warn(msg, UserWarning, stacklevel=2)
         group_num = has_gap.astype(np.int64).cumsum()
         return group_num[start.index]
 

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -258,6 +258,9 @@ class TestChunkToMerge:
         expected_durations = gapy_df["time_max"] - gapy_df["time_min"]
         durations = out["time_max"] - out["time_min"]
         assert expected_durations.equals(durations)
+        # Assert a UserWarning about gaps is raised
+        with pytest.warns(UserWarning, match=r"There is a gap in the patch"):
+            _, out = cm.chunk(gapy_df)
 
     def test_doesnt_merge_unordered_gappy_df(self, gapy_df_unordered):
         """Ensure the gappy dataframe doesn't get merged."""


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to
[open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or for
help if something isn't clear.
-->

## Description

<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->

This PR addresses #509 by adding a warning when a gap is detected in the spool during chunking.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Emits a UserWarning when gaps are detected but data is still treated as contiguous due to configured tolerance.
- Documentation
  - Clarified the tolerance parameter to specify the maximum allowable gap and explicitly define "gap."
- Tests
  - Updated tests to expect the new warning when processing gappy data while preserving existing behavior checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->