### PR TITLE
Fix spool equality, patch reverse operation

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -208,7 +208,7 @@ class CoordManager(DascoreBaseModel):
             "future dascore version it will return a BaseCoord instance. "
             "Use patch.coords.get_array(coord_name) instead."
         )
-        warnings.warn(msg, UserWarning, stacklevel=2)
+        warnings.warn(msg, UserWarning, stacklevel=6)
         return self.get_coord(item).values
 
     def __getattr__(self, item) -> BaseCoord:

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -146,12 +146,28 @@ class Patch:
     # Also add reverse operators
 
     __radd__ = __add__
-    __rsub__ = __sub__
+
+    def __rsub__(self, other):
+        """Reverse subtraction: other - self."""
+        return dascore.utils.array.apply_ufunc(np.subtract, other, self)
+
     __rmul__ = __mul__
-    __rpow__ = __pow__
-    __rtruediv__ = __truediv__
-    __rfloordiv__ = __floordiv__
-    __rmod__ = __mod__
+
+    def __rpow__(self, other):
+        """Reverse power: other ** self."""
+        return dascore.utils.array.apply_ufunc(np.power, other, self)
+
+    def __rtruediv__(self, other):
+        """Reverse true division: other / self."""
+        return dascore.utils.array.apply_ufunc(np.divide, other, self)
+
+    def __rfloordiv__(self, other):
+        """Reverse floor division: other // self."""
+        return dascore.utils.array.apply_ufunc(np.floor_divide, other, self)
+
+    def __rmod__(self, other):
+        """Reverse modulo: other % self."""
+        return dascore.utils.array.apply_ufunc(np.mod, other, self)
 
     def __neg__(self):
         return self.update(data=-self.data)

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -29,7 +29,7 @@ from dascore.utils.chunk import ChunkManager
 from dascore.utils.display import get_dascore_text, get_nice_text
 from dascore.utils.docs import compose_docstring
 from dascore.utils.mapping import FrozenDict
-from dascore.utils.misc import CacheDescriptor, _spool_map
+from dascore.utils.misc import CacheDescriptor, _spool_map, deep_equality_check
 from dascore.utils.patch import (
     _force_patch_merge,
     _spool_up,
@@ -85,26 +85,9 @@ class BaseSpool(abc.ABC):
 
     def __eq__(self, other) -> bool:
         """Simple equality checks on spools."""
-
-        def _vals_equal(dict1, dict2):
-            if (set1 := set(dict1)) != set(dict2):
-                return False
-            for key in set1:
-                val1, val2 = dict1[key], dict2[key]
-                if isinstance(val1, dict):
-                    if not _vals_equal(val1, val2):
-                        return False
-                # this is primarily for dataframes which have equals method.
-                elif hasattr(val1, "equals"):
-                    if not val1.equals(val2):
-                        return False
-                elif val1 != val2:
-                    return False
-            return True
-
         my_dict = self.__dict__
         other_dict = getattr(other, "__dict__", {})
-        return _vals_equal(my_dict, other_dict)
+        return deep_equality_check(my_dict, other_dict)
 
     @abc.abstractmethod
     @compose_docstring(conflict_desc=attr_conflict_description)

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -99,6 +99,10 @@ def velocity_to_strain_rate(
         warnings.warn(msg, DeprecationWarning)
         step_multiple = gauge_multiple * 2
 
+    if step_multiple <= 0:
+        msg = "step_multiple must be positive."
+        raise ParameterError(msg)
+
     if step_multiple % 2 != 0:
         msg = (
             "Step_multiple must be even. Use velocity_to_strain_rate_edgeless "
@@ -173,6 +177,10 @@ def velocity_to_strain_rate_edgeless(
     [`velocity_to_strain_rate` note](docs/notes/velocity_to_strain_rate.qmd)
     for more details on step_multiple and order effects.
     """
+    if step_multiple <= 0:
+        msg = "step_multiple must be positive."
+        raise ParameterError(msg)
+
     coord = patch.get_coord("distance", require_evenly_sampled=True)
     distance_step = coord.step
     gauge_length = step_multiple * distance_step

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -650,6 +650,26 @@ class TestApplyOperator:
         assert np.issubdtype(out.dtype, np.bool_)
         assert not out.all()
 
+    def test_reverse_subtraction(self):
+        """Test that reverse subtraction works correctly."""
+        patch = dc.get_example_patch("random_das")
+        scalar = 10.0
+        # Test reverse subtraction: scalar - patch
+        result = scalar - patch
+        # The result should be scalar - patch.data, not patch.data - scalar
+        expected = scalar - patch.data
+        assert np.allclose(result.data, expected)
+
+    def test_reverse_subtraction_with_array(self):
+        """Test reverse subtraction with array."""
+        patch = dc.get_example_patch("random_das")
+        array = np.ones_like(patch.data) * 5.0
+        # Test array - patch
+        result = array - patch
+        # Should be array - patch.data
+        expected = array - patch.data
+        assert np.allclose(result.data, expected)
+
 
 class TestBool:
     """Tests for boolean operators on Patches."""

--- a/tests/test_transform/test_strain.py
+++ b/tests/test_transform/test_strain.py
@@ -99,6 +99,35 @@ class TestStrainRateConversion:
             )
             assert np.allclose(out1.data, expected)
 
+    def test_negative_step_multiple_raises(self, linear_velocity_patch):
+        """Test that negative step_multiple raises an error."""
+        patch = linear_velocity_patch
+        # Negative step_multiple should raise an error
+        with pytest.raises(ParameterError, match="must be positive"):
+            patch.velocity_to_strain_rate(step_multiple=-2)
+
+    def test_zero_step_multiple_raises(self, linear_velocity_patch):
+        """Test that zero step_multiple raises an error."""
+        patch = linear_velocity_patch
+        # Zero step_multiple should raise an error
+        with pytest.raises(ParameterError, match="must be positive"):
+            patch.velocity_to_strain_rate(step_multiple=0)
+
+    def test_positive_odd_step_multiple_raises(self, linear_velocity_patch):
+        """Test that odd step_multiple still raises appropriate error."""
+        patch = linear_velocity_patch
+        # Odd step_multiple should raise the existing error about being even
+        with pytest.raises(ParameterError, match="must be even"):
+            patch.velocity_to_strain_rate(step_multiple=3)
+
+    def test_positive_even_step_multiple_works(self, linear_velocity_patch):
+        """Test that positive even step_multiple works correctly."""
+        patch = linear_velocity_patch
+        # This should work fine
+        result = patch.velocity_to_strain_rate(step_multiple=2)
+        assert result is not None
+        assert result.attrs.data_type == "strain_rate"
+
 
 class TestStaggeredStrainRateConversion:
     """Tests for converting velocity to strain-rate with staggered function."""
@@ -165,11 +194,23 @@ class TestStaggeredStrainRateConversion:
             strain1 = patch.velocity_to_strain_rate(step_multiple=mult).select(
                 distance=(mult // 2, -mult // 2), samples=True
             )
-
             # Function 2's output should match function 1.
             strain2 = patch.velocity_to_strain_rate_edgeless(step_multiple=mult)
-
             assert np.allclose(strain1.data, strain2.data)
+
+    def test_negative_step_multiple_raises(self, linear_velocity_patch):
+        """Test that velocity_to_strain_rate_edgeless also validates step_multiple."""
+        patch = linear_velocity_patch
+        # Negative step_multiple should raise an error
+        with pytest.raises(ParameterError, match="must be positive"):
+            patch.velocity_to_strain_rate_edgeless(step_multiple=-1)
+
+    def test_zero_step_multiple_raises(self, linear_velocity_patch):
+        """Test that velocity_to_strain_rate_edgeless validates zero step_multiple."""
+        patch = linear_velocity_patch
+        # Zero step_multiple should raise an error
+        with pytest.raises(ParameterError, match="must be positive"):
+            patch.velocity_to_strain_rate_edgeless(step_multiple=0)
 
 
 class TestRadianToStrain:

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -9,6 +9,7 @@ from io import BytesIO
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from dascore.exceptions import MissingOptionalDependencyError
@@ -16,6 +17,7 @@ from dascore.utils.misc import (
     MethodNameSpace,
     _iter_filesystem,
     cached_method,
+    deep_equality_check,
     get_buffer_size,
     get_stencil_coefs,
     iterate,
@@ -380,3 +382,215 @@ class TestMaybeMemMap:
         bio.seek(0)
         arr_full = maybe_mem_map(bio)
         assert arr_end_pos.size == arr_full.size == 6
+
+
+class TestDeepEqualityCheck:
+    """Comprehensive tests for the deep_equality_check function."""
+
+    def test_none_visited_initialization(self):
+        """Test that visited is initialized to empty set when None."""
+        result = deep_equality_check({"a": 1}, {"a": 1})
+        assert result is True
+
+    def test_circular_reference_detection(self):
+        """Test circular reference detection and handling."""
+        dict1 = {"a": 1}
+        dict2 = {"a": 1}
+        # Create circular references
+        dict1["self"] = dict1
+        dict2["self"] = dict2
+        assert deep_equality_check(dict1, dict2)
+
+    def test_non_dict_comparison_equal(self):
+        """Test non-dict objects that are equal."""
+        assert deep_equality_check("hello", "hello")
+        assert deep_equality_check(42, 42)
+        assert deep_equality_check([1, 2, 3], [1, 2, 3])
+
+    def test_non_dict_comparison_unequal(self):
+        """Test non-dict objects that are not equal."""
+        assert not deep_equality_check("hello", "world")
+        assert not deep_equality_check(42, 43)
+        assert not deep_equality_check([1, 2, 3], [1, 2, 4])
+
+    def test_dict_different_keys(self):
+        """Test dictionaries with different keys."""
+        dict1 = {"a": 1, "b": 2}
+        dict2 = {"a": 1, "c": 2}
+        assert not deep_equality_check(dict1, dict2)
+
+    def test_object_identity_skip(self):
+        """Test that identical objects are skipped."""
+        shared_obj = {"nested": "value"}
+        dict1 = {"shared": shared_obj, "other": 1}
+        dict2 = {"shared": shared_obj, "other": 1}
+        assert deep_equality_check(dict1, dict2)
+
+    def test_nested_dict_equality(self):
+        """Test nested dictionary comparison."""
+        dict1 = {"a": {"nested": 1}}
+        dict2 = {"a": {"nested": 1}}
+        assert deep_equality_check(dict1, dict2)
+
+    def test_nested_dict_inequality(self):
+        """Test nested dictionary comparison that fails."""
+        dict1 = {"a": {"nested": 1}}
+        dict2 = {"a": {"nested": 2}}
+        assert not deep_equality_check(dict1, dict2)
+
+    def test_dataframe_equality(self):
+        """Test pandas DataFrame comparison using equals method."""
+        df1 = pd.DataFrame({"a": [1, 2, 3]})
+        df2 = pd.DataFrame({"a": [1, 2, 3]})
+        dict1 = {"df": df1}
+        dict2 = {"df": df2}
+        assert deep_equality_check(dict1, dict2)
+
+    def test_dataframe_inequality(self):
+        """Test pandas DataFrame comparison that fails."""
+        df1 = pd.DataFrame({"a": [1, 2, 3]})
+        df2 = pd.DataFrame({"a": [1, 2, 4]})
+        dict1 = {"df": df1}
+        dict2 = {"df": df2}
+        assert not deep_equality_check(dict1, dict2)
+
+    def test_object_with_dict_equal(self):
+        """Test objects with __dict__ that are equal."""
+
+        class TestObj:
+            def __init__(self, value):
+                self.value = value
+
+        obj1 = TestObj(42)
+        obj2 = TestObj(42)
+        dict1 = {"obj": obj1}
+        dict2 = {"obj": obj2}
+        assert deep_equality_check(dict1, dict2)
+
+    def test_object_with_dict_unequal(self):
+        """Test objects with __dict__ that are not equal."""
+
+        class TestObj:
+            def __init__(self, value):
+                self.value = value
+
+        obj1 = TestObj(42)
+        obj2 = TestObj(43)
+        dict1 = {"obj": obj1}
+        dict2 = {"obj": obj2}
+        assert not deep_equality_check(dict1, dict2)
+
+    def test_numpy_array_equal(self):
+        """Test numpy array comparison (equal)."""
+        arr1 = np.array([1, 2, 3])
+        arr2 = np.array([1, 2, 3])
+        dict1 = {"arr": arr1}
+        dict2 = {"arr": arr2}
+        assert deep_equality_check(dict1, dict2)
+
+    def test_numpy_array_unequal(self):
+        """Test numpy array comparison (not equal)."""
+        arr1 = np.array([1, 2, 3])
+        arr2 = np.array([1, 2, 4])
+        dict1 = {"arr": arr1}
+        dict2 = {"arr": arr2}
+        assert not deep_equality_check(dict1, dict2)
+
+    def test_regular_value_equal(self):
+        """Test regular values that are equal."""
+        dict1 = {"val": 42}
+        dict2 = {"val": 42}
+        assert deep_equality_check(dict1, dict2)
+
+    def test_regular_value_unequal(self):
+        """Test regular values that are not equal."""
+        dict1 = {"val": 42}
+        dict2 = {"val": 43}
+        assert not deep_equality_check(dict1, dict2)
+
+    def test_value_error_exception_handling(self):
+        """Test ValueError exception handling."""
+
+        class BadComparisonObj:
+            """Object without __dict__ that raises ValueError on comparison."""
+
+            __slots__ = ["value"]
+
+            def __init__(self, value):
+                self.value = value
+
+            def __eq__(self, other):
+                raise ValueError("Cannot compare")
+
+        obj1 = BadComparisonObj(1)
+        obj2 = BadComparisonObj(2)
+        dict1 = {"bad": obj1}
+        dict2 = {"bad": obj2}
+        assert not deep_equality_check(dict1, dict2)
+
+    def test_successful_comparison_return_true(self):
+        """Test successful comparison returns True."""
+        dict1 = {"a": 1, "b": 2, "c": 3}
+        dict2 = {"a": 1, "b": 2, "c": 3}
+        assert deep_equality_check(dict1, dict2)
+
+    def test_finally_block_cleanup(self):
+        """Test that visited set is cleaned up in finally block."""
+        # This is harder to test directly, but we can verify the function
+        # works correctly with nested calls, which requires proper cleanup
+        dict1 = {"a": {"b": {"c": 1}}}
+        dict2 = {"a": {"b": {"c": 1}}}
+        assert deep_equality_check(dict1, dict2)
+
+    def test_mixed_comparison_types(self):
+        """Test comparison with mixed types to ensure full coverage."""
+        import pandas as pd
+
+        class CustomObj:
+            def __init__(self, val):
+                self.val = val
+
+        # Complex nested structure to test multiple code paths
+        dict1 = {
+            "string": "hello",
+            "int": 42,
+            "array": np.array([1, 2, 3]),
+            "dataframe": pd.DataFrame({"x": [1, 2]}),
+            "custom_obj": CustomObj(10),
+            "nested": {"inner_array": np.array([4, 5, 6]), "inner_obj": CustomObj(20)},
+        }
+
+        dict2 = {
+            "string": "hello",
+            "int": 42,
+            "array": np.array([1, 2, 3]),
+            "dataframe": pd.DataFrame({"x": [1, 2]}),
+            "custom_obj": CustomObj(10),
+            "nested": {"inner_array": np.array([4, 5, 6]), "inner_obj": CustomObj(20)},
+        }
+
+        assert deep_equality_check(dict1, dict2)
+
+    def test_one_has_equals_method_other_doesnt(self):
+        """Test when only one object has equals method."""
+        import pandas as pd
+
+        class NoEqualsMethod:
+            def __init__(self, val):
+                self.val = val
+
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        obj = NoEqualsMethod(42)
+        dict1 = {"item": df}
+        dict2 = {"item": obj}
+        # This should fall through to the general comparison path
+        assert not deep_equality_check(dict1, dict2)
+
+    def test_both_have_equals_method_but_one_fails(self):
+        """Test when both have equals method but comparison fails."""
+        df1 = pd.DataFrame({"a": [1, 2, 3]})
+        df2 = pd.DataFrame({"a": [4, 5, 6]})
+        dict1 = {"df": df1}
+        dict2 = {"df": df2}
+        # This should use equals() method and return False
+        assert not deep_equality_check(dict1, dict2)


### PR DESCRIPTION
## Description

This PR fixes a bug in patch reverse operations (currently are not correct), and makes the spool equality comparisons more robust to circular references (just in case). 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
