### PR TITLE
Fix redundant doc build

### DIFF
--- a/.github/workflows/build_deploy_master_docs.yaml
+++ b/.github/workflows/build_deploy_master_docs.yaml
@@ -43,8 +43,6 @@ jobs:
           python-version: "3.12"
           environment-file: './.github/doc_environment.yml'
 
-      - uses: ./.github/actions/build-docs
-
       - name: publish docs to netlify
         shell: bash -l {0}
         env:

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -323,6 +323,7 @@ class Patch:
     dropna = dascore.proc.dropna
     fillna = dascore.proc.fillna
     pass_filter = dascore.proc.pass_filter
+    hample_filter = dascore.proc.hampel_filter
     sobel_filter = dascore.proc.sobel_filter
     median_filter = dascore.proc.median_filter
     notch_filter = dascore.proc.notch_filter

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -323,7 +323,7 @@ class Patch:
     dropna = dascore.proc.dropna
     fillna = dascore.proc.fillna
     pass_filter = dascore.proc.pass_filter
-    hample_filter = dascore.proc.hampel_filter
+    hampel_filter = dascore.proc.hampel_filter
     sobel_filter = dascore.proc.sobel_filter
     median_filter = dascore.proc.median_filter
     notch_filter = dascore.proc.notch_filter

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -14,3 +14,4 @@ from .rolling import rolling
 from .taper import taper, taper_range
 from .units import convert_units, set_units, simplify_units
 from .whiten import whiten
+from .hampel import hampel_filter

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -121,6 +121,10 @@ def hampel_filter(
     dimension they will be adjusted to be an odd length. This ensures
     a clean median calculation is possible.
 
+    See Also
+    --------
+    - The (Despikine recipe)[`docs/recipes/despiking.qmd`].
+
     Examples
     --------
     >>> import numpy as np

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -14,8 +14,10 @@ from dascore.utils.patch import get_dim_axis_value, patch_function
 
 def _get_hampel_window_size(patch, kwargs, samples):
     """Get the size of the hampel operator."""
+    import warnings
+
     aggs = get_dim_axis_value(patch, kwargs=kwargs, allow_multiple=True)
-    size = [1] * len(aggs)
+    size = [1] * patch.data.ndim
     for name, axis, val in aggs:
         coord = patch.get_coord(name, require_evenly_sampled=True)
         samps = coord.get_sample_count(val, samples=samples)
@@ -27,23 +29,58 @@ def _get_hampel_window_size(patch, kwargs, samples):
             raise ParameterError(msg)
         # Just to make sure the median is a nice value, we need an odd number
         # of samples. Just bump if samples wasn't specified, else raise.
-        if (samps % 2 == 1) and not samples:
+        if (samps % 2 != 1) and not samples:
             samps += 1
-        if (samps % 2 == 1) and samples:
+        if (samps % 2 != 1) and samples:
             msg = (
                 "For clean median calculation in hampel function, dimension "
                 f"windows must be odd but {name} has a value of {samps} samples."
             )
             raise ParameterError(msg)
+
+        # Warn if window size is large
+        if samps > 10:
+            msg = (
+                f"Large window size ({samps} samples) in dimension '{name}' "
+                f"may result in slow performance. Consider using separable=True "
+                f"for faster processing or reducing the window size."
+            )
+            warnings.warn(msg, UserWarning)
+
+        size[axis] = samps
     return tuple(size)
+
+
+def _separable_median(data, size, mode):
+    """Calculate the median along each dimension sequentially."""
+    med = data
+
+    # Apply 1D median filters along each dimension with size > 1
+    for axis, window_size in enumerate(size):
+        if window_size > 1:
+            # Create size tuple for this dimension
+            axis_size = [1] * len(size)
+            axis_size[axis] = window_size
+            med = median_filter(med, size=tuple(axis_size), mode=mode)
+
+    return med
+
+
+def _calculate_standard_median_and_mad(data, size, mode):
+    """Calculate median and MAD using standard 2D median filters."""
+    med = median_filter(data, size=size, mode=mode)
+    abs_med_diff = np.abs(data - med)
+    mad = median_filter(abs_med_diff, size=size, mode=mode)
+    return med, abs_med_diff, mad
 
 
 @patch_function()
 def hampel_filter(
     patch: PatchType,
     *,
-    mad_threshold: float = 3.5,
+    threshold: float,
     samples=False,
+    separable=False,
     **kwargs,
 ):
     """
@@ -53,17 +90,71 @@ def hampel_filter(
     ----------
     patch
         Input patch.
-    mad_threshold
+    threshold
         Outlier threshold in MAD units.
     samples
         If True, values specified by kwargs are in samples not coordinate units.
+    separable
+        If True, apply 1D median filters sequentially along each dimension
+        instead of a true 2D median filter. This is much faster (3-4x speedup)
+        but provides an approximation of the true 2D median. The approximation
+        is usually good enough for spike removal purposes.
     **kwargs
         Used to specify the lengths of the filter in each dimension. Each
-        selected dim must be evenly sampled.
+        selected dim must be evenly sampled and should represent a window
+        with an odd number of samples.
+
+    Warning
+    -------
+    Selecting windows with many samples can be *very* slow. It is recommended
+    window size in each dimension be <10 samples. For larger windows, consider
+    using `separable=True` for significantly faster processing (3-4x speedup)
+    at the cost of a slight approximation.
 
     Returns
     -------
     Patch with outliers replaced by local median.
+
+    Notes
+    -----
+    If the selected window lengths don't represent odd numbers in each
+    dimension they will be adjusted to be an odd length. This ensures
+    a clean median calculation is possible.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import dascore as dc
+    >>> # Get an example patch and add artificial spikes
+    >>> patch = dc.get_example_patch()
+    >>> data = patch.data.copy()
+    >>> data[10, 5] = 10  # Add a large spike
+    >>> patch = patch.update(data=data)
+    >>>
+    >>> # Apply hampel filter along time dimension with 1.0 unit window
+    >>> filtered = patch.hampel_filter(time=1.0, threshold=3.5)
+    >>> assert filtered.data.shape == patch.data.shape
+    >>> # The spike should be reduced
+    >>> assert abs(filtered.data[10, 5]) < abs(patch.data[10, 5])
+    >>>
+    >>> # Apply filter with a lower threshold for more aggressive filtering
+    >>> filtered_aggressive = patch.hampel_filter(time=1.0, threshold=2.0)
+    >>> assert isinstance(filtered_aggressive, dc.Patch)
+    >>>
+    >>> # Apply filter along multiple dimensions:
+    >>> filtered_2d = patch.hampel_filter(time=1.0, distance=5.0, threshold=3.5)
+    >>> assert filtered_2d.data.shape == patch.data.shape
+    >>>
+    >>> # Specify hampel window in samples not coord units.
+    >>> filtered_samps = patch.hampel_filter(
+    ...     time=3, distance=3, samples=True, threshold=3.5
+    ... )
+    >>>
+    >>> # Use separable filtering for faster processing (approximation)
+    >>> filtered_fast = patch.hampel_filter(
+    ...     time=1.0, distance=5.0, threshold=3.5, separable=True
+    ... )
+
     """
     # First build axis windows
     data = patch.data
@@ -71,13 +162,21 @@ def hampel_filter(
     # makes sense in a DAS data context.
     mode = "reflect"
     size = _get_hampel_window_size(patch, kwargs, samples)
+
     # Local median and MAD via median filters.
-    med = median_filter(data, size=size, mode=mode)
-    abs_med_diff = np.abs(data - med)
-    mad = median_filter(abs_med_diff, size=size, mode=mode)
+    if separable and len(size) > 1 and all(s > 1 for s in size):
+        # Use separable filtering for multi-dimensional windows
+        # This is faster but provides an approximation
+        med = _separable_median(data, size, mode)
+        abs_med_diff = np.abs(data - med)
+        mad = _separable_median(abs_med_diff, size, mode)
+    else:
+        # Use standard 2D median filter (more accurate but slower)
+        med, abs_med_diff, mad = _calculate_standard_median_and_mad(data, size, mode)
+
     # Handle mad values of 0 so denominator doesn't blow up.
-    mad = np.where(mad == 0.0, np.finfo(float).eps, mad)
+    mad_safe = np.where(mad == 0.0, np.finfo(float).eps, mad)
     # Hampel test and replacement.
-    thresholded = abs_med_diff / mad
-    out = np.where(thresholded > mad_threshold, med, data)
+    thresholded = abs_med_diff / mad_safe
+    out = np.where(thresholded > threshold, med, data)
     return patch.update(data=out)

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -158,8 +158,11 @@ def hampel_filter(
     >>> filtered_fast = patch.hampel_filter(
     ...     time=1.0, distance=5.0, threshold=3.5, separable=True
     ... )
-
     """
+    if threshold <= 0:
+        msg = "hampel_filter threshold must be greater than zero"
+        raise ParameterError(msg)
+
     # First build axis windows
     data = patch.data
     # For now we just hardcode mode as it is probably the only one that

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -1,0 +1,83 @@
+"""
+Functionality for Hampel despiking.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import median_filter
+
+from dascore.constants import PatchType
+from dascore.exceptions import ParameterError
+from dascore.utils.patch import get_dim_axis_value, patch_function
+
+
+def _get_hampel_window_size(patch, kwargs, samples):
+    """Get the size of the hampel operator."""
+    aggs = get_dim_axis_value(patch, kwargs=kwargs, allow_multiple=True)
+    size = [1] * len(aggs)
+    for name, axis, val in aggs:
+        coord = patch.get_coord(name, require_evenly_sampled=True)
+        samps = coord.get_sample_count(val, samples=samples)
+        if samps < 3:
+            msg = (
+                f"hampel must have at least 3 samples along each dimension. "
+                f"{name} has {samps} samples. Try increasing its value."
+            )
+            raise ParameterError(msg)
+        # Just to make sure the median is a nice value, we need an odd number
+        # of samples. Just bump if samples wasn't specified, else raise.
+        if (samps % 2 == 1) and not samples:
+            samps += 1
+        if (samps % 2 == 1) and samples:
+            msg = (
+                "For clean median calculation in hampel function, dimension "
+                f"windows must be odd but {name} has a value of {samps} samples."
+            )
+            raise ParameterError(msg)
+    return tuple(size)
+
+
+@patch_function()
+def hampel_filter(
+    patch: PatchType,
+    *,
+    mad_threshold: float = 3.5,
+    samples=False,
+    **kwargs,
+):
+    """
+    A Hampel filter implementation useful for removing spikes in data.
+
+    Parameters
+    ----------
+    patch
+        Input patch.
+    mad_threshold
+        Outlier threshold in MAD units.
+    samples
+        If True, values specified by kwargs are in samples not coordinate units.
+    **kwargs
+        Used to specify the lengths of the filter in each dimension. Each
+        selected dim must be evenly sampled.
+
+    Returns
+    -------
+    Patch with outliers replaced by local median.
+    """
+    # First build axis windows
+    data = patch.data
+    # For now we just hardcode mode as it is probably the only one that
+    # makes sense in a DAS data context.
+    mode = "reflect"
+    size = _get_hampel_window_size(patch, kwargs, samples)
+    # Local median and MAD via median filters.
+    med = median_filter(data, size=size, mode=mode)
+    abs_med_diff = np.abs(data - med)
+    mad = median_filter(abs_med_diff, size=size, mode=mode)
+    # Handle mad values of 0 so denominator doesn't blow up.
+    mad = np.where(mad == 0.0, np.finfo(float).eps, mad)
+    # Hampel test and replacement.
+    thresholded = abs_med_diff / mad
+    out = np.where(thresholded > mad_threshold, med, data)
+    return patch.update(data=out)

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -123,7 +123,7 @@ def hampel_filter(
 
     See Also
     --------
-    - The (Despikine recipe)[`docs/recipes/despiking.qmd`].
+    - The (Despiking recipe)[`docs/recipes/despiking.qmd`].
 
     Examples
     --------

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -45,7 +45,7 @@ def _get_hampel_window_size(patch, kwargs, samples):
                 f"may result in slow performance. Consider using separable=True "
                 f"for faster processing or reducing the window size."
             )
-            warnings.warn(msg, UserWarning)
+            warnings.warn(msg, UserWarning, stacklevel=2)
 
         size[axis] = samps
     return tuple(size)
@@ -123,7 +123,7 @@ def hampel_filter(
 
     See Also
     --------
-    - The (Despiking recipe)[`docs/recipes/despiking.qmd`].
+    - Despiking recipe: docs/recipes/despiking.qmd
 
     Examples
     --------
@@ -167,20 +167,25 @@ def hampel_filter(
     mode = "reflect"
     size = _get_hampel_window_size(patch, kwargs, samples)
 
+    # Convert to float64 to avoid integer overflow/precision loss
+    dataf = np.asarray(data, dtype=np.float64)
+
     # Local median and MAD via median filters.
     if separable and len(size) > 1 and all(s > 1 for s in size):
         # Use separable filtering for multi-dimensional windows
         # This is faster but provides an approximation
-        med = _separable_median(data, size, mode)
-        abs_med_diff = np.abs(data - med)
+        med = _separable_median(dataf, size, mode)
+        abs_med_diff = np.abs(dataf - med)
         mad = _separable_median(abs_med_diff, size, mode)
     else:
         # Use standard 2D median filter (more accurate but slower)
-        med, abs_med_diff, mad = _calculate_standard_median_and_mad(data, size, mode)
+        med, abs_med_diff, mad = _calculate_standard_median_and_mad(dataf, size, mode)
 
     # Handle mad values of 0 so denominator doesn't blow up.
     mad_safe = np.where(mad == 0.0, np.finfo(float).eps, mad)
     # Hampel test and replacement.
     thresholded = abs_med_diff / mad_safe
-    out = np.where(thresholded > threshold, med, data)
+    out = np.where(thresholded > threshold, med, dataf)
+    # Cast back to original dtype
+    out = out.astype(data.dtype, copy=False)
     return patch.update(data=out)

--- a/docs/recipes/despiking.qmd
+++ b/docs/recipes/despiking.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Despiking"
 execute:
-  warn: false
+  warning: false
 ---
 
 This recipe demonstrates how to remove spikes from DAS data.
@@ -23,7 +23,6 @@ We'll start by creating synthetic data with artificial spikes to demonstrate the
 
 ```{python}
 import numpy as np
-import matplotlib.pyplot as plt
 
 import dascore as dc
 
@@ -42,7 +41,7 @@ data[150, 200] = 1200.0  # Another positive spike
 data[:, 75] = 1500.0
 
 # Add time spike
-data [75, :] = -1400
+data[75, :] = -1400
 
 # Create patch with spikes
 spike_patch = patch.update(data=data)
@@ -63,12 +62,12 @@ filtered_time = spike_patch.hampel_filter(time=0.02, threshold=3.5)
 ax = filtered_time.viz.waterfall(**plot_kwargs)
 ax.set_title("Filtered along Time (threshold=3.5)");
 ```
-The resulting signal had some of the spikes removed with minimal distorting to the original signal. To remove the time spike, we need to apply the filter along the distance axis. We could apply two filters separately, but often a multidimensional filter is easier.  
+The resulting signal had some of the spikes removed with minimal distortion to the original signal. To remove the time spike, we need to apply the filter along the distance axis. We could apply two filters separately, but often a multidimensional filter is easier.  
 
 
-```{warning}
+::: {.callout-warning}
 The Hampel filter can be quite slow if large windows are used. We recommend using window sizes that correspond to <10 samples for most cases.
-```
+:::
 
 ### Multi-dimensional Filtering
 

--- a/docs/recipes/despiking.qmd
+++ b/docs/recipes/despiking.qmd
@@ -95,4 +95,3 @@ ax.set_title("Filtered along Time and Distance");
 5. **Edge effects**: The filter uses reflection mode at boundaries to minimize edge effects.
 
 6. **Validation**: Always visually inspect results and consider domain-specific requirements when choosing parameters.
-

--- a/docs/recipes/despiking.qmd
+++ b/docs/recipes/despiking.qmd
@@ -1,0 +1,98 @@
+---
+title: "Despiking"
+execute:
+  warn: false
+---
+
+This recipe demonstrates how to remove spikes from DAS data.
+
+
+## The Hampel Filter Method
+
+The Hampel filter is effective for removing outliers (spikes) in data by identifying values that deviate significantly from the local median in terms of median absolute deviation [(MAD)](https://en.wikipedia.org/wiki/Median_absolute_deviation). This makes it particularly useful for cleaning DAS data that may contain various types of noise spikes.
+
+DASCore provides the [`Patch.hampel_filter`](`dascore.Patch.hampel_filter`). The filter works by:
+
+1. Computing the local median within a sliding window (optionally along multiple dimensions)
+2. Calculating the median absolute deviation (MAD) within the same window
+3. Replacing values that exceed a threshold (in MAD units) with the local median
+
+### Example Data
+
+We'll start by creating synthetic data with artificial spikes to demonstrate the filter's effectiveness:
+
+```{python}
+import numpy as np
+import matplotlib.pyplot as plt
+
+import dascore as dc
+
+plot_kwargs = dict(scale=(-200, 200), scale_type="absolute")
+
+# Get example patch and add artificial spikes
+patch = dc.get_example_patch("example_event_2")
+data = patch.data.copy()
+
+# Add some large spikes at various locations
+data[50, 100] = 600   # Large positive spike
+data[100, 150] = -1000  # Large negative spike
+data[150, 200] = 1200.0  # Another positive spike
+
+# Add a channel-wide spike (entire distance channel)
+data[:, 75] = 1500.0
+
+# Add time spike
+data [75, :] = -1400
+
+# Create patch with spikes
+spike_patch = patch.update(data=data)
+
+# Visualize the data with spikes
+ax = spike_patch.viz.waterfall(**plot_kwargs)
+ax.set_title("Data with Artificial Spikes");
+```
+
+### Basic Hampel Filtering
+
+The simplest usage applies the filter along a single dimension. The `threshold` parameter controls the sensitivity - lower values result in more aggressive filtering:
+
+```{python}
+# Apply Hampel filter along time dimension
+filtered_time = spike_patch.hampel_filter(time=0.02, threshold=3.5)
+
+ax = filtered_time.viz.waterfall(**plot_kwargs)
+ax.set_title("Filtered along Time (threshold=3.5)");
+```
+The resulting signal had some of the spikes removed with minimal distorting to the original signal. To remove the time spike, we need to apply the filter along the distance axis. We could apply two filters separately, but often a multidimensional filter is easier.  
+
+
+```{warning}
+The Hampel filter can be quite slow if large windows are used. We recommend using window sizes that correspond to <10 samples for most cases.
+```
+
+### Multi-dimensional Filtering
+
+For more effective spike removal, especially for channel-wide spikes, apply the filter along multiple dimensions:
+
+```{python}
+# Apply filter along both time and distance dimensions
+filtered_2d = spike_patch.hampel_filter(time=0.02, distance=5.0, threshold=3.5)
+
+ax = filtered_2d.viz.waterfall(**plot_kwargs)
+ax.set_title("Filtered along Time and Distance");
+```
+
+### Best Practices for Hampel Filter
+
+1. **Multi-dimensional filtering**: For most DAS applications, applying the filter along both time and distance dimensions is more effective than single-dimension filtering.
+
+2. **Threshold selection**: Start with a conservative threshold (3.5-5.0) and adjust based on your data characteristics and noise level.
+
+3. **Window size**: Choose window sizes that are large enough to provide stable statistics but small enough to preserve local features. Start with ~5-9 samples per dimension.
+
+4. **Performance optimization**: For large windows (>10 samples), use `separable=True` to achieve a speedup with minimal quality loss.
+
+5. **Edge effects**: The filter uses reflection mode at boundaries to minimize edge effects.
+
+6. **Validation**: Always visually inspect results and consider domain-specific requirements when choosing parameters.
+

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -133,11 +133,12 @@ website:
         - section: "Processing"
           contents:
 
+            - recipes/despike.qmd
+            - recipes/smoothing.qmd
             - recipes/correlate.qmd
             - recipes/edge_effects.qmd
             - recipes/fk.qmd
             - recipes/real_time_proc.qmd
-            - recipes/smoothing.qmd
             - recipes/parallelization.qmd
             - recipes/low_freq_proc.qmd
 

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -133,7 +133,7 @@ website:
         - section: "Processing"
           contents:
 
-            - recipes/despike.qmd
+            - recipes/despiking.qmd
             - recipes/smoothing.qmd
             - recipes/correlate.qmd
             - recipes/edge_effects.qmd

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -275,7 +275,7 @@ class TestHampelFilter:
 
     def test_bad_threshold_raises(self, patch_with_spikes):
         """Ensure a bad threshold raises ParameterError."""
-        with pytest.raises(ParameterError, match="must be greater than zero"):
+        with pytest.raises(ParameterError, match="greater than zero"):
             patch_with_spikes.hampel_filter(time=0.6, threshold=0)
         with pytest.raises(ParameterError, match="must be finite"):
             patch_with_spikes.hampel_filter(time=0.6, threshold=np.inf)

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -275,6 +275,11 @@ class TestHampelFilter:
         assert result_high.data.shape == patch_with_spikes.data.shape
         assert result_default.data.shape == patch_with_spikes.data.shape
 
+    def test_bad_threshold_raises(self, patch_with_spikes):
+        """Ensure a bad threshold raises ParameterError."""
+        with pytest.raises(ParameterError, match="must be greater than zero"):
+            patch_with_spikes.hampel_filter(time=0.6, threshold=0)
+
     def test_entire_distance_channel_spike_removal(self, patch_with_spikes):
         """
         Test that spikes encompassing an entire distance channel are removed with

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -1,0 +1,3 @@
+"""
+Tests fir the hampel filter implementation.
+"""

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -1,3 +1,435 @@
 """
-Tests fir the hampel filter implementation.
+Tests for the hampel filter implementation.
 """
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import numpy as np
+import pytest
+
+import dascore as dc
+from dascore.exceptions import ParameterError
+
+
+class TestHampelFilter:
+    """Tests for the hampel_filter function."""
+
+    # Class variables for spike locations to avoid hard-coding
+    SPIKE_LOCATIONS: ClassVar[list[tuple[int, int, float]]] = [
+        (10, 15, 10.0),  # (time_idx, distance_idx, spike_value)
+        (20, 25, -10.0),  # Large negative spike
+        (30, 35, 8.0),  # Another spike
+    ]
+
+    # Channel-wide spike indices
+    DISTANCE_CHANNEL_SPIKE_IDX = 20
+    TIME_CHANNEL_SPIKE_IDX = 30
+
+    # Values for channel-wide spikes
+    DISTANCE_CHANNEL_SPIKE_VALUE = 15.0
+    TIME_CHANNEL_SPIKE_VALUE = -12.0
+
+    @pytest.fixture()
+    def patch_with_spikes(self):
+        """Create a patch with artificial spikes for testing."""
+        # Get example patch and add spikes
+        patch = dc.get_example_patch()
+        data = patch.data.copy()
+
+        # Add individual spikes using class variables
+        for time_idx, dist_idx, spike_val in self.SPIKE_LOCATIONS:
+            if time_idx < data.shape[0] and dist_idx < data.shape[1]:
+                data[time_idx, dist_idx] = spike_val
+
+        new_patch = patch.update(data=data)
+        # Change sampling rate as to avoid long windows.
+        return new_patch.update_coords(time_step=0.2)
+
+    @pytest.fixture()
+    def patch_uniform_data(self):
+        """Create a patch with uniform data for testing edge cases."""
+        # Get example patch and make data uniform (zeros)
+        patch = dc.get_example_patch()
+        data = np.zeros_like(patch.data)
+        new_patch = patch.update(data=data)
+        return new_patch.update_coords(time_step=0.2)
+
+    def test_basic_hampel_filter(self, patch_with_spikes):
+        """Test basic hampel filtering functionality."""
+        # Test with time dimension filtering
+        result = patch_with_spikes.hampel_filter(time=0.6, threshold=3.5)
+
+        # Check that data shape is preserved
+        assert result.data.shape == patch_with_spikes.data.shape
+
+        # Check that spikes are reduced (using first spike location)
+        time_idx, dist_idx, _ = self.SPIKE_LOCATIONS[0]
+        original_spike = patch_with_spikes.data[time_idx, dist_idx]
+        filtered_spike = result.data[time_idx, dist_idx]
+        assert abs(filtered_spike) < abs(original_spike)
+
+    def test_multiple_dimensions(self, patch_with_spikes):
+        """Test hampel filter with multiple dimensions."""
+        result = patch_with_spikes.hampel_filter(time=0.6, distance=3.0, threshold=3.5)
+
+        # Check that data shape is preserved
+        assert result.data.shape == patch_with_spikes.data.shape
+
+        # Should remove spikes more effectively (using first spike location)
+        time_idx, dist_idx, _ = self.SPIKE_LOCATIONS[0]
+        original_spike = patch_with_spikes.data[time_idx, dist_idx]
+        filtered_spike = result.data[time_idx, dist_idx]
+        assert abs(filtered_spike) < abs(original_spike)
+
+    def test_threshold_parameter(self, patch_with_spikes):
+        """Test different threshold values."""
+        # Low threshold - more aggressive filtering
+        result_low = patch_with_spikes.hampel_filter(time=0.6, threshold=1.0)
+
+        # High threshold - less aggressive filtering
+        result_high = patch_with_spikes.hampel_filter(time=0.6, threshold=10.0)
+
+        # Low threshold should change more values
+        diff_low = np.sum(result_low.data != patch_with_spikes.data)
+        diff_high = np.sum(result_high.data != patch_with_spikes.data)
+
+        assert diff_low >= diff_high
+
+    def test_samples_parameter_true(self, patch_with_spikes):
+        """Test with samples=True parameter."""
+        # Use samples instead of coordinate units (must be odd number)
+        result = patch_with_spikes.hampel_filter(time=9, samples=True, threshold=3.5)
+
+        # Check that data shape is preserved
+        assert result.data.shape == patch_with_spikes.data.shape
+
+    def test_samples_parameter_false(self, patch_with_spikes):
+        """Test with samples=False parameter (default)."""
+        # Use coordinate units
+        result = patch_with_spikes.hampel_filter(time=0.6, samples=False, threshold=3.5)
+
+        # Check that data shape is preserved
+        assert result.data.shape == patch_with_spikes.data.shape
+
+    def test_separable_parameter(self, patch_with_spikes):
+        """Test the separable parameter for faster processing."""
+        # Standard 2D filtering
+        result_standard = patch_with_spikes.hampel_filter(
+            time=0.6, distance=3.0, threshold=3.5, separable=False
+        )
+
+        # Separable filtering (approximation)
+        result_separable = patch_with_spikes.hampel_filter(
+            time=0.6, distance=3.0, threshold=3.5, separable=True
+        )
+
+        # Both should have same shape
+        assert result_standard.data.shape == patch_with_spikes.data.shape
+        assert result_separable.data.shape == patch_with_spikes.data.shape
+
+        # Results should be similar but not identical (approximation)
+        # Check that spikes are still reduced in both cases
+        time_idx, dist_idx, _ = self.SPIKE_LOCATIONS[0]
+        original_spike = abs(patch_with_spikes.data[time_idx, dist_idx])
+
+        standard_spike = abs(result_standard.data[time_idx, dist_idx])
+        separable_spike = abs(result_separable.data[time_idx, dist_idx])
+
+        # Both should reduce the spike
+        assert standard_spike < original_spike
+        assert separable_spike < original_spike
+
+    def test_separable_single_dimension(self, patch_with_spikes):
+        """Test separable parameter with single dimension (should behave the same)."""
+        # Single dimension cases should behave the same regardless of separable
+        result_standard = patch_with_spikes.hampel_filter(
+            time=0.6, threshold=3.5, separable=False
+        )
+        result_separable = patch_with_spikes.hampel_filter(
+            time=0.6, threshold=3.5, separable=True
+        )
+
+        # Should be identical for single dimension
+        np.testing.assert_array_equal(result_standard.data, result_separable.data)
+
+    def test_performance_warning(self, patch_with_spikes):
+        """Test that performance warning is issued for large windows."""
+        # This should issue a warning for large window size
+        with pytest.warns(
+            UserWarning, match="Large window size.*may result in slow performance"
+        ):
+            # Use a large window that will trigger the warning
+            patch_with_spikes.hampel_filter(time=3.0, threshold=3.5)
+
+    def test_insufficient_samples_error(self, patch_with_spikes):
+        """Test error when window size results in less than 3 samples."""
+        # This should raise an error because window is too small
+        with pytest.raises(ParameterError, match="must have at least 3 samples"):
+            patch_with_spikes.hampel_filter(
+                time=0.00001, threshold=3.5
+            )  # Very small window
+
+    def test_odd_samples_with_samples_true_error(self, patch_with_spikes):
+        """Test error when samples=True and sample count is even."""
+        # This should raise an error because even samples with samples=True
+        with pytest.raises(ParameterError, match="windows must be odd"):
+            patch_with_spikes.hampel_filter(
+                time=4, samples=True, threshold=3.5
+            )  # 4 is even
+
+    def test_odd_samples_with_samples_false_adjustment(self, patch_with_spikes):
+        """Test that odd samples are adjusted when samples=False."""
+        # This should work because samples=False allows adjustment
+        # We need to find a value that gives odd samples when converted
+        # Let's use a value that will result in an odd number of samples
+
+        # Get coordinate info to calculate a value that gives odd samples
+        coord = patch_with_spikes.get_coord("time")
+        step = coord.step
+        # Use a value that when divided by step gives an odd number
+        odd_value = step * 5.5  # This should give 5-6 samples, we can adjust
+
+        result = patch_with_spikes.hampel_filter(
+            time=odd_value, samples=False, threshold=3.5
+        )
+        assert result.data.shape == patch_with_spikes.data.shape
+
+    def test_zero_mad_handling(self, patch_uniform_data):
+        """Test handling of zero MAD values."""
+        # Uniform data should have MAD = 0, test that eps is used
+        result = patch_uniform_data.hampel_filter(time=0.6, threshold=3.5)
+
+        assert result.data.shape == patch_uniform_data.data.shape
+        # With uniform data, output should be same as input
+        np.testing.assert_array_equal(result.data, patch_uniform_data.data)
+
+    def test_get_hampel_window_size_function(self, patch_with_spikes):
+        """Test the _get_hampel_window_size helper function."""
+        from dascore.proc.hampel import _get_hampel_window_size
+
+        # Test with valid parameters
+        kwargs = {"time": 1.0}
+        size = _get_hampel_window_size(patch_with_spikes, kwargs, samples=False)
+
+        assert isinstance(size, tuple)
+        assert len(size) > 0
+
+    def test_non_separable_conditions(self, patch_with_spikes):
+        """Test conditions where separable mode is not used."""
+        # Test case 1: separable=False
+        result1 = patch_with_spikes.hampel_filter(
+            time=0.6, distance=3.0, threshold=3.5, separable=False
+        )
+        assert result1.data.shape == patch_with_spikes.data.shape
+
+        # Test case 2: len(size) <= 1 (single dimension)
+        result2 = patch_with_spikes.hampel_filter(
+            time=0.6, threshold=3.5, separable=True
+        )
+        assert result2.data.shape == patch_with_spikes.data.shape
+
+        # Test case 3: not all(s > 1 for s in size) (some dimensions have size 1)
+        # This will use the separable path since it has 2 dimensions with size > 1
+        result3 = patch_with_spikes.hampel_filter(
+            time=0.6, distance=3.0, threshold=3.5, separable=True
+        )
+        assert result3.data.shape == patch_with_spikes.data.shape
+
+    def test_thresholding_logic(self, patch_with_spikes):
+        """Test the core thresholding and replacement logic."""
+        # Test with a very low threshold to ensure replacement happens
+        result = patch_with_spikes.hampel_filter(time=0.6, threshold=0.1)
+
+        # Should have replaced many values
+        differences = np.sum(result.data != patch_with_spikes.data)
+        assert differences > 0
+
+    def test_single_dimension_filter(self, patch_with_spikes):
+        """Test filtering along a single dimension."""
+        # Test time dimension only
+        result_time = patch_with_spikes.hampel_filter(time=0.6, threshold=3.5)
+
+        # Test distance dimension only
+        result_distance = patch_with_spikes.hampel_filter(distance=3.0, threshold=3.5)
+
+        # Check that data shapes are preserved
+        assert result_time.data.shape == patch_with_spikes.data.shape
+        assert result_distance.data.shape == patch_with_spikes.data.shape
+        assert result_time.data.shape == patch_with_spikes.data.shape
+        assert result_distance.data.shape == patch_with_spikes.data.shape
+
+    def test_different_threshold_values(self, patch_with_spikes):
+        """Test various threshold values for edge cases."""
+        # Test very low threshold
+        result_low = patch_with_spikes.hampel_filter(time=0.6, threshold=0.5)
+
+        # Test high threshold
+        result_high = patch_with_spikes.hampel_filter(time=0.6, threshold=100.0)
+
+        # Test default threshold
+        result_default = patch_with_spikes.hampel_filter(time=0.6, threshold=3.5)
+
+        # Check that data shapes are preserved
+        assert result_low.data.shape == patch_with_spikes.data.shape
+        assert result_high.data.shape == patch_with_spikes.data.shape
+        assert result_default.data.shape == patch_with_spikes.data.shape
+
+    def test_entire_distance_channel_spike_removal(self, patch_with_spikes):
+        """
+        Test that spikes encompassing an entire distance channel are removed with
+        multi-dimensional filtering.
+        """
+        # Add spikes across an entire distance channel using class variable
+        spike_data = patch_with_spikes.data.copy()
+        spike_data[:, self.DISTANCE_CHANNEL_SPIKE_IDX] = (
+            self.DISTANCE_CHANNEL_SPIKE_VALUE
+        )
+
+        # Create patch with channel-wide spike
+        spike_patch = patch_with_spikes.update(data=spike_data)
+
+        # Single-dimension filtering along time should NOT remove the channel spike
+        # (since all time samples in that channel have the same spike value)
+        # Use a minimal window (3 samples) to ensure the spike remains
+        result_time_only = spike_patch.hampel_filter(time=0.6, threshold=3.5)
+        time_only_max = np.max(
+            np.abs(result_time_only.data[:, self.DISTANCE_CHANNEL_SPIKE_IDX])
+        )
+        original_max = np.max(
+            np.abs(spike_patch.data[:, self.DISTANCE_CHANNEL_SPIKE_IDX])
+        )
+
+        # With the new time step, even minimal filtering can affect channel spikes
+        # The key test is that multi-dimensional filtering is more effective
+        # We'll check this in the comparison below
+
+        # Multi-dimensional filtering should detect and remove the channel spike
+        result_multi = spike_patch.hampel_filter(time=0.6, distance=3.0, threshold=3.5)
+        multi_filtered_max = np.max(
+            np.abs(result_multi.data[:, self.DISTANCE_CHANNEL_SPIKE_IDX])
+        )
+
+        # Multi-dimensional filter should significantly reduce the spike
+        assert multi_filtered_max < original_max / 2
+
+        # Multi-dimensional filtering should be more effective than single-dimensional
+        assert multi_filtered_max < time_only_max
+
+        # Other channels should be less affected (use a different channel index)
+        # Use channel 10 indices away
+        other_channel_idx = self.DISTANCE_CHANNEL_SPIKE_IDX - 10
+        other_channel_diff = np.mean(
+            np.abs(
+                result_multi.data[:, other_channel_idx]
+                - spike_patch.data[:, other_channel_idx]
+            )
+        )
+        spike_channel_diff = np.mean(
+            np.abs(
+                result_multi.data[:, self.DISTANCE_CHANNEL_SPIKE_IDX]
+                - spike_patch.data[:, self.DISTANCE_CHANNEL_SPIKE_IDX]
+            )
+        )
+        assert spike_channel_diff > other_channel_diff
+
+    def test_entire_time_channel_spike_removal(self, patch_with_spikes):
+        """Test that spikes encompassing an entire time channel are removed with
+        multi-dimensional filtering.
+        """
+        # Add spikes across an entire time channel using class variable
+        spike_data = patch_with_spikes.data.copy()
+        spike_data[self.TIME_CHANNEL_SPIKE_IDX, :] = self.TIME_CHANNEL_SPIKE_VALUE
+
+        # Create patch with channel-wide spike
+        spike_patch = patch_with_spikes.update(data=spike_data)
+
+        # Single-dimension filtering along distance should NOT remove the time
+        # channel spike (since all distance samples at that time have the same
+        # spike value)
+        result_distance_only = spike_patch.hampel_filter(distance=3.0, threshold=3.5)
+        distance_only_max = np.max(
+            np.abs(result_distance_only.data[self.TIME_CHANNEL_SPIKE_IDX, :])
+        )
+        original_max = np.max(np.abs(spike_patch.data[self.TIME_CHANNEL_SPIKE_IDX, :]))
+
+        # With the new time step, even single-dimensional filtering can be effective
+        # The key test is that multi-dimensional filtering is more effective
+
+        # Multi-dimensional filtering should detect and remove the time channel spike
+        result_multi = spike_patch.hampel_filter(time=0.6, distance=3.0, threshold=3.5)
+        multi_filtered_max = np.max(
+            np.abs(result_multi.data[self.TIME_CHANNEL_SPIKE_IDX, :])
+        )
+
+        # Multi-dimensional filter should significantly reduce the spike
+        assert multi_filtered_max < original_max / 2
+
+        # Multi-dimensional filtering should be more effective than single-dimensional
+        assert multi_filtered_max < distance_only_max
+
+        # Other time channels should be less affected (use a different time index)
+        other_time_idx = self.TIME_CHANNEL_SPIKE_IDX - 10  # Use time 10 indices away
+        other_channel_diff = np.mean(
+            np.abs(
+                result_multi.data[other_time_idx, :]
+                - spike_patch.data[other_time_idx, :]
+            )
+        )
+        spike_channel_diff = np.mean(
+            np.abs(
+                result_multi.data[self.TIME_CHANNEL_SPIKE_IDX, :]
+                - spike_patch.data[self.TIME_CHANNEL_SPIKE_IDX, :]
+            )
+        )
+        assert spike_channel_diff > other_channel_diff
+
+    def test_multiple_channel_spikes_removal(self, patch_with_spikes):
+        """Test removal of spikes in multiple channels simultaneously."""
+        # Add spikes to multiple channels using class variables
+        spike_data = patch_with_spikes.data.copy()
+        multi_distance_idx = self.DISTANCE_CHANNEL_SPIKE_IDX - 5  # Distance channel 15
+        multi_time_idx = self.TIME_CHANNEL_SPIKE_IDX - 5  # Time channel 25
+        individual_spike_time, individual_spike_dist, _ = self.SPIKE_LOCATIONS[2]
+
+        spike_data[:, multi_distance_idx] = 20.0  # Spike in distance channel
+        spike_data[multi_time_idx, :] = -18.0  # Spike in time channel
+        if (
+            individual_spike_time < spike_data.shape[0]
+            and individual_spike_dist < spike_data.shape[1]
+        ):
+            # Individual point spike
+            spike_data[individual_spike_time, individual_spike_dist] = 25.0
+
+        # Create patch with multiple channel spikes
+        spike_patch = patch_with_spikes.update(data=spike_data)
+
+        # Filter along both dimensions
+        result = spike_patch.hampel_filter(time=1.0, distance=3.0, threshold=3.5)
+
+        # Check all spikes are reduced
+        # Distance channel spike
+        assert (
+            np.max(np.abs(result.data[:, multi_distance_idx]))
+            < np.max(np.abs(spike_patch.data[:, multi_distance_idx])) / 2
+        )
+
+        # Time channel spike
+        assert (
+            np.max(np.abs(result.data[multi_time_idx, :]))
+            < np.max(np.abs(spike_patch.data[multi_time_idx, :])) / 2
+        )
+
+        # Individual point spike
+        if (
+            individual_spike_time < result.data.shape[0]
+            and individual_spike_dist < result.data.shape[1]
+        ):
+            original_spike = abs(
+                spike_patch.data[individual_spike_time, individual_spike_dist]
+            )
+            filtered_spike = abs(
+                result.data[individual_spike_time, individual_spike_dist]
+            )
+            assert filtered_spike < original_spike / 2

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -256,8 +256,6 @@ class TestHampelFilter:
         # Check that data shapes are preserved
         assert result_time.data.shape == patch_with_spikes.data.shape
         assert result_distance.data.shape == patch_with_spikes.data.shape
-        assert result_time.data.shape == patch_with_spikes.data.shape
-        assert result_distance.data.shape == patch_with_spikes.data.shape
 
     def test_different_threshold_values(self, patch_with_spikes):
         """Test various threshold values for edge cases."""
@@ -279,6 +277,10 @@ class TestHampelFilter:
         """Ensure a bad threshold raises ParameterError."""
         with pytest.raises(ParameterError, match="must be greater than zero"):
             patch_with_spikes.hampel_filter(time=0.6, threshold=0)
+        with pytest.raises(ParameterError, match="must be finite"):
+            patch_with_spikes.hampel_filter(time=0.6, threshold=np.inf)
+        with pytest.raises(ParameterError, match="must be finite"):
+            patch_with_spikes.hampel_filter(time=0.6, threshold=np.nan)
 
     def test_entire_distance_channel_spike_removal(self, patch_with_spikes):
         """


### PR DESCRIPTION
## Description

Apparently, the docs were getting built twice in the publish master docs action. Once for build docs, then again when they are published to netlify. This PR just removes the first doc_build to improve speed and reduce redundancy. 
 
## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
