### PR TITLE
remove redundant doc build

### DIFF
--- a/.github/workflows/build_deploy_master_docs.yaml
+++ b/.github/workflows/build_deploy_master_docs.yaml
@@ -43,8 +43,6 @@ jobs:
           python-version: "3.12"
           environment-file: './.github/doc_environment.yml'
 
-      - uses: ./.github/actions/build-docs
-
       - name: publish docs to netlify
         shell: bash -l {0}
         env:


### PR DESCRIPTION

## Description

Retry of #545

Apparently, the docs were getting built twice in the publish master docs action. Once for build docs, then again when they are published to netlify. This PR just removes the first doc_build to improve speed and reduce redundancy.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
