### PR TITLE
add examples to public methods

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -233,6 +233,18 @@ class CoordManager(DascoreBaseModel):
 
         Input values can be of the same form as initialization.
         To drop coordinates, simply pass {coord_name: None}
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> import numpy as np
+        >>> patch = dc.get_example_patch()
+        >>> coords = patch.coords
+        >>>
+        >>> # Update time coordinate
+        >>> new_time = np.arange(len(coords.get_array('time')))
+        >>> new_coords = coords.update(time=new_time)
+        >>> assert 'time' in new_coords
         """
 
         def _get_dim_change_drop(coord_map, dim_map):
@@ -588,6 +600,16 @@ class CoordManager(DascoreBaseModel):
             If True, the query meaning is in samples.
         **kwargs
             Used to specify dimension and select arguments.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> patch = dc.get_example_patch()
+        >>> coords = patch.coords
+        >>>
+        >>> # Select subset of coordinates
+        >>> new_coords, _ = coords.select(time=(0, 10))
+        >>> assert 'time' in new_coords
 
         See also [`CoordManager.order`](`dascore.core.CoordManager.order`).
         """
@@ -1120,7 +1142,7 @@ def get_coord_manager(
     if dims is None:
         if isinstance(coords, Mapping) and all(isinstance(x, str) for x in coords):
             dims = tuple(i for i, v in coords.items() if not isinstance(v, tuple))
-        elif attrs is not None and "dims" in attrs or hasattr(attrs, "dims"):
+        elif (attrs is not None and "dims" in attrs) or hasattr(attrs, "dims"):
             dims = tuple(attrs["dims"].split(","))
         else:
             dims = ()

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -210,7 +210,19 @@ class Patch:
 
     @property
     def dims(self) -> tuple[str, ...]:
-        """Return the dimensions contained in patch."""
+        """
+        Return the dimensions contained in patch.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> patch = dc.get_example_patch()
+        >>>
+        >>> # Get dims from patch.
+        >>> dims = patch.dims
+        >>> assert 'time' in dims
+        >>> assert 'distance' in dims
+        """
         return self.coords.dims
 
     @property
@@ -225,27 +237,81 @@ class Patch:
 
     @property
     def attrs(self) -> PatchAttrs:
-        """Return the dimensions contained in patch."""
+        """
+        Return the patch attributes.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> patch = dc.get_example_patch()
+        >>>
+        >>> # Get attrs from patch.
+        >>> attrs = patch.attrs
+        >>> assert hasattr(attrs, 'data_type')
+        """
         return self._attrs
 
     @property
     def coords(self) -> CoordManager:
-        """Return the dimensions contained in patch."""
+        """
+        Return the patch coordinates.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> patch = dc.get_example_patch()
+        >>> coords = patch.coords
+        >>>
+        >>> # Get coords from patch.
+        >>> assert 'time' in coords
+        >>> assert 'distance' in coords
+        """
         return self._coords
 
     @property
     def data(self) -> ArrayLike:
-        """Return the data contained in patch."""
+        """
+        Return the data contained in patch.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> patch = dc.get_example_patch()
+        >>> data = patch.data
+        >>> assert data.shape == patch.shape
+        """
         return self._data
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """Return the shape of the data array."""
+        """
+        Return the shape of the data array.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> patch = dc.get_example_patch()
+        >>>
+        >>> # Get shape from patch.
+        >>> shape = patch.shape
+        >>> assert len(shape) == len(patch.dims)
+        """
         return self.coords.shape
 
     @property
     def size(self) -> int:
-        """Return the size of the data array."""
+        """
+        Return the size of the data array.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> patch = dc.get_example_patch()
+        >>>
+        >>> # Get size from patch.
+        >>> size = patch.size
+        >>> assert size == patch.data.size
+        """
         return self.coords.size
 
     @property

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -93,6 +93,15 @@ def min(
     ----------
     {params}
 
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Get minimum along time dimension
+    >>> min_patch = patch.min(dim='time')
+    >>> assert min_patch.size < patch.size
+
     {notes}
     """
     return aggregate.func(patch, dim=dim, method=np.nanmin, dim_reduce=dim_reduce)
@@ -112,6 +121,15 @@ def max(
     ----------
     {params}
 
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Get maximum along distance dimension
+    >>> max_patch = patch.max(dim='distance')
+    >>> assert max_patch.size < patch.size
+
     {notes}
     """
     return aggregate.func(patch, dim=dim, method=np.nanmax, dim_reduce=dim_reduce)
@@ -130,6 +148,15 @@ def mean(
     Parameters
     ----------
     {params}
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Get mean along time dimension
+    >>> time_mean = patch.mean(dim='time')
+    >>> assert time_mean.size < patch.size
 
     {notes}
     """

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -72,6 +72,21 @@ def pipe(
         Positional arguments that get passed to func.
     **kwargs
         Keyword arguments passed to func.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Define a custom function that squares the data
+    >>> def square_data(patch):
+    ...     return patch.new(data=patch.data ** 2)
+    >>>
+    >>> # Use pipe to apply the function
+    >>> squared = patch.pipe(square_data)
+    >>>
+    >>> # Can also chain with other methods
+    >>> result = patch.pipe(square_data).mean(dim="time")
     """
     return func(self, *args, **kwargs)
 
@@ -84,6 +99,17 @@ def update_attrs(self: PatchType, **attrs) -> PatchType:
     ----------
     **attrs
         attrs to add/update.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Update existing attributes
+    >>> updated = patch.update_attrs(instrument_type="DAS")
+    >>>
+    >>> # Add new custom attributes
+    >>> with_custom = patch.update_attrs(processing_date="2024-01-01")
     """
 
     def _fast_attr_update(self, attrs):
@@ -119,6 +145,23 @@ def equals(self: PatchType, other: Any, only_required_attrs=True, close=False) -
     close
         If True, the data can be "close" using np.allclose, otherwise
         all data must be equal.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch1 = dc.get_example_patch()
+    >>> patch2 = dc.get_example_patch()
+    >>>
+    >>> # Test equality
+    >>> are_equal = patch1.equals(patch2)
+    >>>
+    >>> # Test with modified patch
+    >>> modified = patch1.update_attrs(custom_attr="test")
+    >>> equal_ignoring_custom = patch1.equals(modified, only_required_attrs=True)
+    >>>
+    >>> # Test with close comparison for numerical data
+    >>> noisy = patch1.new(data=patch1.data + 1e-10)
+    >>> close_equal = patch1.equals(noisy, close=True)
     """
     # different types are not equal
     if not isinstance(other, type(self)):
@@ -300,6 +343,20 @@ def normalize(
             l2 - divide each sample by the l2 of the axis.
             max - divide each sample by the maximum of the absolute value of the axis.
             bit - sample-by-sample normalization (-1/+1)
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # L2 normalization along time dimension
+    >>> l2_norm = patch.normalize(dim="time", norm="l2")
+    >>>
+    >>> # Max normalization along distance dimension
+    >>> max_norm = patch.normalize(dim="distance", norm="max")
+    >>>
+    >>> # Bit normalization (sign only)
+    >>> bit_norm = patch.normalize(dim="time", norm="bit")
     """
     axis = self.get_axis(dim)
     data = self.data
@@ -460,8 +517,10 @@ def fillna(patch: PatchType, value, include_inf=True) -> PatchType:
     >>> import dascore as dc
     >>> # load an example patch which has some NaN values.
     >>> patch = dc.get_example_patch("patch_with_null")
+    >>>
     >>> # Replace all occurrences of NaN with 0
     >>> out = patch.fillna(0)
+    >>>
     >>> # Replace all occurrences of NaN with 5
     >>> out = patch.fillna(5)
     """
@@ -518,11 +577,14 @@ def pad(
     --------
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
+    >>>
     >>> # Zero pad `time` dimension with 2 patch's time unit (e.g., sec)
     >>> # zeros before and 3 zeros after
     >>> padded_patch_1 = patch.pad(time=(2, 3))
+    >>>
     >>> # Pad `distance` dimension with 1s 4 samples before and 4 after.
     >>> padded_patch_3 = patch.pad(distance=4, constant_values=1, samples=True)
+    >>>
     >>> # Get patch ready for fast fft along time dimension.
     >>> padded_fft = patch.pad(time="fft")
     """
@@ -602,10 +664,13 @@ def roll(patch, samples=False, update_coord=False, **kwargs):
     --------
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
+    >>>
     >>> # roll time dimension 5 elements
     >>> rolled_patch = patch.roll(time=5, samples=True)
+    >>>
     >>> # roll distance dimension 30 meters(or units of distance in patch)
     >>> rolled_patch2 = patch.roll(distance=30, samples=False)
+    >>>
     >>> # roll time dimension 5 elements and update coordinates
     >>> rolled_patch3 = patch.roll(time=5, samples=True, update_coord=True)
     """

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -42,8 +42,10 @@ def snap_coords(patch: PatchType, *coords, reverse=False):
     >>> import dascore as dc
     >>> # get an example patch which has unevenly sampled coords time, distance
     >>> patch = dc.get_example_patch("wacky_dim_coords_patch")
+    >>>
     >>> # snap time dimension
     >>> time_snap = patch.snap_coords("time")
+    >>>
     >>> # snap the distance dimension
     >>> dist_snap = patch.snap_coords("distance")
     """
@@ -73,9 +75,11 @@ def sort_coords(patch: PatchType, *coords, reverse=False):
     >>> import dascore as dc
     >>> # get an example patch which has unevenly sampled coords time, distance
     >>> patch = dc.get_example_patch("wacky_dim_coords_patch")
+    >>>
     >>> # sort time coordinate (dimension) in ascending order
     >>> time_snap = patch.sort_coords("time")
     >>> assert time_snap.coords.coord_map['time'].sorted
+    >>>
     >>> # sort distance coordinate (dimension) in descending order
     >>> dist_snap = patch.sort_coords("distance", reverse=True)
     >>> assert dist_snap.coords.coord_map['distance'].reverse_sorted
@@ -205,6 +209,7 @@ def rename_coords(self: PatchType, **kwargs) -> PatchType:
     --------
     >>> import dascore as dc
     >>> pa = dc.get_example_patch()
+    >>>
     >>> # rename dim "distance" to "fragrance"
     >>> pa2 = pa.rename_coords(distance='fragrance')
     >>> assert 'fragrance' in pa2.dims
@@ -449,27 +454,37 @@ def select(
     >>> import dascore as dc
     >>> from dascore.examples import get_example_patch
     >>> patch = get_example_patch()
+    >>>
     >>> # select meters 50 to 300
     >>> new_distance = patch.select(distance=(50, 300))
+    >>>
     >>> # select channels less than 300
     >>> lt_dist = patch.select(distance=(..., 300))
+    >>>
     >>> # select time (1 second from start to -1 second from end)
     >>> t1 = patch.attrs.time_min + dc.to_timedelta64(1)
     >>> t2 = patch.attrs.time_max - dc.to_timedelta64(1)
     >>> new_time1 = patch.select(time=(t1, t2))
+    >>>
     >>> # this can be accomplished more simply using the relative keyword
     >>> new_time2 = patch.select(time=(1, -1), relative=True)
+    >>>
     >>> # filter 1 second from start time to 3 seconds from start time
     >>> new_time3 = patch.select(time=(1, 3), relative=True)
+    >>>
     >>> # filter 6 second from end time to 1 second from end time
     >>> new_time4 = patch.select(time=(-6, -1), relative=True)
+    >>>
     >>> # Select first 10 distance indices
     >>> new_distance1 = patch.select(distance=(..., 10), samples=True)
+    >>>
     >>> # Select last time row/column
     >>> new_distance2 = patch.select(time=-1, samples=True)
+    >>>
     >>> # only include certain rows/columns based on a boolean array.
     >>> time = patch.get_array("time")
     >>> new_time_5 = patch.select(time=time>time[2])
+    >>>
     >>> # Select only specific values along a dimension
     >>> distance = patch.get_array("distance")
     >>> new_distance_3 = patch.select(distace=distance[1::2])
@@ -524,10 +539,12 @@ def order(
     >>> import dascore as dc
     >>> from dascore.examples import get_example_patch
     >>> patch = get_example_patch()
+    >>>
     >>> # Sub-select only a section of the distance and ensure order.
     >>> dist = patch.get_array("distance")
     >>> new_dist = dist[1:5][::-1]
     >>> patch_1 = patch.order(distance=new_dist)
+    >>>
     >>> # Get duplicate the first time row or column
     >>> patch_2 = patch.order(time=[0, 0, 0], samples=True)
 
@@ -603,18 +620,18 @@ def append_dims(patch: PatchType, *empty_dims, **dim_kwargs) -> PatchType:
     --------
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
-
+    >>>
     >>> # Add two dummy dimensions to patch named "end" and "stop"
     >>> new = patch.append_dims("end", "stop")
-
+    >>>
     >>> # Add a dummy dimension called "face" to end of patch
     >>> # which has a coordinate value of [1].
     >>> new = patch.append_dims(face=[1])
-
+    >>>
     >>> # Same thing as above, but with a larger coords which broadcasts
     >>> # the data to shape appropriate to mach coordinates.
     >>> new = patch.append_dims(face=[1, 2])
-
+    >>>
     >>> # Add a dummy dimension of length 3 to end of patch.
     >>> # the data to shape appropriate to mach coordinates.
     >>> new = patch.append_dims(face=3)
@@ -659,6 +676,19 @@ def squeeze(self: PatchType, dim=None) -> PatchType:
         Selects a subset of the length one dimensions. If a dimension
         is selected with length greater than one, an error is raised.
         If None, all length one dimensions are squeezed.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> import numpy as np
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Create a patch with a length-1 dimension by selecting time slice
+    >>> time_array = patch.coords.get_array("time")
+    >>> single_time = patch.select(time=(time_array[0], time_array[0]))
+    >>>
+    >>> # Squeeze the length-1 time dimension
+    >>> squeezed = single_time.squeeze(dim="time")
     """
     coords = self.coords.squeeze(dim)
     if dim is None:
@@ -755,6 +785,7 @@ def get_axis(self: PatchType, dim: str) -> int:
     --------
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
+    >>>
     >>> axis = patch.get_axis("time")
     >>> assert axis == patch.get_axis("time")
     """

--- a/dascore/proc/units.py
+++ b/dascore/proc/units.py
@@ -45,10 +45,13 @@ def set_units(
     --------
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
+    >>>
     >>> # set the data units
     >>> patch_with_units = patch.set_units("km/ms")
+    >>>
     >>> # set the units of the distance coordinate
     >>> patch_feet = patch.set_units(distance='feet')
+    >>>
     >>> # remove data units
     >>> patch_removed_units = patch_with_units.set_units(None)
     """
@@ -83,6 +86,20 @@ def convert_units(
     ------
     [UnitError](`dascore.exceptions.UnitError`) if any of the new units
     are not compatible with the old units.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Set initial units
+    >>> patch_with_units = patch.set_units("m/s", distance="m", time="s")
+    >>>
+    >>> # Convert data units from m/s to km/s
+    >>> converted_data = patch_with_units.convert_units(data_units="km/s")
+    >>>
+    >>> # Convert coordinate units
+    >>> converted_coords = patch_with_units.convert_units(distance="km")
     """
     # convert data
     if data_units is not None:
@@ -106,6 +123,17 @@ def simplify_units(
 
     All data and coordinate units will be converted to their
     base units and corresponding data/labels multiplied by a conversion factor.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Set complex units
+    >>> complex_units = patch.set_units("km/h", distance="km", time="h")
+    >>>
+    >>> # Simplify to base units (m/s, m, s)
+    >>> simplified = complex_units.simplify_units()
     """
     # get data and data units
     attrs = patch.attrs

--- a/dascore/transform/fft.py
+++ b/dascore/transform/fft.py
@@ -27,6 +27,15 @@ def rfft(patch: PatchType, dim="time") -> PatchType:
     """
     Perform a real fourier transform along the specified dimension.
 
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Transform along time dimension
+    >>> ft_patch = patch.rfft(dim='time')
+    >>> assert 'ft_time' in ft_patch.dims
+
     Notes
     -----
     - Use [dft](`dascore.transform.fourier.dft`) instead.

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -51,6 +51,19 @@ def get_unit(value) -> Unit:
     Usually quantities, generated with
     [`get_quantity`](`dascore.units.get_quantity`), are easy to work
     with.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>>
+    >>> # Create unit from string
+    >>> unit = dc.get_unit('m/s')
+    >>> assert str(unit) == 'm / s'
+    >>>
+    >>> # Create unit from existing quantity
+    >>> quantity = dc.get_quantity('10 Hz')
+    >>> unit = dc.get_unit(quantity.units)
+    >>> assert str(unit) == 'Hz'
     """
     if isinstance(value, Quantity):
         assert value.magnitude == 1.0
@@ -81,6 +94,7 @@ def get_quantity(value: str_or_none) -> Quantity | None:
     >>> import dascore as dc
     >>> meters = dc.get_quantity("m")
     >>> accel = dc.get_quantity("m/s^2")
+    >>>
     >>> # This can also convert date times.
     >>> many_seconds = dc.get_quantity(dc.to_timedelta64(200))
     """
@@ -258,10 +272,12 @@ def get_filter_units(
     Examples
     --------
     >>> from dascore.units import get_filter_units, Hz, s
+    >>>
     >>> # Passing a tuple in Hz leaves the output in Hz
     >>> assert get_filter_units(1 * Hz, 10 * Hz, s) == (1., 10.)
     >>> assert get_filter_units(None, 10 * Hz, s) == (None, 10.)
     >>> assert get_filter_units(1 * Hz, 10 * Hz, s) == (1., 10.)
+    >>>
     >>> # Passing a tuple in seconds will convert to Hz and switch order, if needed.
     >>> assert get_filter_units(1 * s, 10 * s, s) == (0.1, 1.)
     >>> assert get_filter_units(None, 10 * s, s) == (None, 0.1)

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -815,14 +815,12 @@ def deep_equality_check(obj1, obj2, visited=None):
     >>> from dascore.utils.misc import deep_equality_check
     >>>
     >>> # Basic usage
-    >>> deep_equality_check({"a": 1}, {"a": 1})
-    True
+    >>> assert deep_equality_check({"a": 1}, {"a": 1})
     >>>
     >>> # With numpy arrays
     >>> dict1 = {"arr": np.array([1, 2, 3])}
     >>> dict2 = {"arr": np.array([1, 2, 3])}
-    >>> deep_equality_check(dict1, dict2)
-    True
+    >>> assert deep_equality_check(dict1, dict2)
     """
 
     def _robust_equality_check(obj1, obj2):

--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -70,6 +70,14 @@ def spectrogram(
     **kwargs : dict, optional
         Passed to `scipy.signal.spectrogram` to control spectrogram options.
         See its documentation for options.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Create a spectrogram plot
+    >>> ax = patch.viz.spectrogram(show=False)
     """
     dims = patch.dims
     if len(dims) > 2 or len(dims) < 1:


### PR DESCRIPTION
## Description
This PR adds more examples to DASCore's public API, specifically for methods/functions that didn't have any. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified docstrings with practical Examples across coordinates, patch properties, aggregation, processing helpers, unit handling, FFT, spectrogram, and utilities to improve learnability and consistency.

* **Bug Fixes**
  * Fixed boolean-precedence issue when detecting dims from attributes to ensure more robust, predictable coordinate-manager initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->