### PR TITLE
raise error when select on bad patch coord

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -115,22 +115,41 @@ def _get_indexers_and_new_coords_dict(
 ):
     """Get reductions for each dimension."""
     dim_reductions = {x: slice(None, None) for x in cm.dims}
-    dimap = cm.dim_map
     new_coords = dict(cm._get_dim_array_dict(keep_coord=True))
     for coord_name, vals in kwargs.items():
-        # this is not a selectable coord, just skip.
-        if coord_name not in cm.coord_map or not len(cm.dim_map[coord_name]):
+        # Skip coordinates not in coord_map
+        if coord_name not in cm.coord_map:
             continue
         coord = cm.coord_map[coord_name]
+        coord_dims = cm.dim_map[coord_name]
+        # Handle non-dimensional coordinates (not tied to any dimension)
+        if not len(coord_dims):
+            _ensure_1d_coord(coord, coord_name)
+            # Apply operation directly to the non-dimensional coordinate
+            method = getattr(coord, operation)
+            new_coord, _ = method(vals, relative=relative, samples=samples)
+            # Update only this coordinate in new_coords, don't affect array indexing
+            new_coords[coord_name] = (coord_dims, new_coord)
+            continue
+
+        # Handle coordinates with more than one dimension
+        if len(coord_dims) > 1:
+            msg = (
+                "Only 1 dimensional coordinates can be used for selection "
+                f"{coord_name} has {len(coord_dims)} dimensions."
+            )
+            raise CoordError(msg)
+
+        # Handle dimensional coordinates (tied to exactly one dimension)
         _ensure_1d_coord(coord, coord_name)
-        dim_name = dimap[coord_name][0]
+        dim_name = coord_dims[0]
         # different logic if we are using indices or values
         method = getattr(coord, operation)
         new_coord, reductions = method(vals, relative=relative, samples=samples)
         # this handles the case of out-of-bound selections.
         # These should be converted to degenerate coords.
         dim_reductions[dim_name] = reductions
-        new_coords[coord_name] = (dimap[coord_name], new_coord)
+        new_coords[coord_name] = (coord_dims, new_coord)
         # update other coords affected by change.
         _indirect_coord_updates(cm, dim_name, coord_name, reductions, new_coords)
     indexers = tuple(dim_reductions[x] for x in cm.dims)

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -132,7 +132,6 @@ def _get_indexers_and_new_coords_dict(
             new_coords[coord_name] = (coord_dims, new_coord)
             continue
         # Handle dimensional coordinates (tied to exactly one dimension)
-        _ensure_1d_coord(coord, coord_name)
         dim_name = coord_dims[0]
         # different logic if we are using indices or values
         method = getattr(coord, operation)

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -492,7 +492,7 @@ def select(
     >>>
     >>> # Select only specific values along a dimension
     >>> distance = patch.get_array("distance")
-    >>> new_distance_3 = patch.select(distace=distance[1::2])
+    >>> new_distance_3 = patch.select(distance=distance[1::2])
 
     Notes
     -----

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -10,7 +10,12 @@ from scipy.interpolate import interp1d
 
 from dascore.constants import PatchType, select_values_description
 from dascore.core.coords import BaseCoord
-from dascore.exceptions import CoordError, ParameterError, PatchError
+from dascore.exceptions import (
+    CoordError,
+    ParameterError,
+    PatchCoordinateError,
+    PatchError,
+)
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import get_parent_code_name, iterate
 from dascore.utils.patch import patch_function
@@ -497,6 +502,15 @@ def select(
       See [`Patch.order`](`dascore.Patch.order`).
 
     """
+    # Check for and raise on invalid kwargs.
+    if invalid_coords := set(kwargs) - set(patch.coords.coord_map):
+        invalid_list = sorted(invalid_coords)
+        valid_list = sorted(patch.coords.coord_map)
+        msg = (
+            f"Coordinate(s) {invalid_list} not found in patch coordinates: {valid_list}"
+        )
+        raise PatchCoordinateError(msg)
+
     new_coords, data = patch.coords.select(
         **kwargs,
         array=patch.data,

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -517,8 +517,8 @@ def select(
         relative=relative,
         samples=samples,
     )
-    # no slicing was performed, just return original.
-    if data.shape == patch.data.shape:
+    # no slicing was performed, just return original if coordinates also unchanged.
+    if data.shape == patch.data.shape and new_coords == patch.coords:
         return patch
     if copy:
         data = data.copy()

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -41,7 +41,7 @@ def hampel_filter(
     *,
     threshold: float,
     samples=False,
-    separable=True,
+    separable=False,
     **kwargs,
 ):
     """

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -96,7 +96,7 @@ def hampel_filter(
     >>> data[10, 5] = 10  # Add a large spike
     >>> patch = patch.update(data=data)
     >>>
-    >>> # Apply hampel filter along time dimension with 1.0 unit window
+    >>> # Apply hampel filter along time dimension with 0.2 unit window
     >>> filtered = patch.hampel_filter(time=0.2, threshold=3.5)
     >>> assert filtered.data.shape == patch.data.shape
     >>> # The spike should be reduced

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -41,7 +41,7 @@ def hampel_filter(
     *,
     threshold: float,
     samples=False,
-    separable=False,
+    separable=True,
     **kwargs,
 ):
     """
@@ -97,14 +97,10 @@ def hampel_filter(
     >>> patch = patch.update(data=data)
     >>>
     >>> # Apply hampel filter along time dimension with 1.0 unit window
-    >>> filtered = patch.hampel_filter(time=1.0, threshold=3.5)
+    >>> filtered = patch.hampel_filter(time=0.2, threshold=3.5)
     >>> assert filtered.data.shape == patch.data.shape
     >>> # The spike should be reduced
     >>> assert abs(filtered.data[10, 5]) < abs(patch.data[10, 5])
-    >>>
-    >>> # Apply filter with a lower threshold for more aggressive filtering
-    >>> filtered_aggressive = patch.hampel_filter(time=1.0, threshold=2.0)
-    >>> assert isinstance(filtered_aggressive, dc.Patch)
     >>>
     >>> # Apply filter along multiple dimensions:
     >>> filtered_2d = patch.hampel_filter(time=1.0, distance=5.0, threshold=3.5)
@@ -115,10 +111,6 @@ def hampel_filter(
     ...     time=3, distance=3, samples=True, threshold=3.5
     ... )
     >>>
-    >>> # Use separable filtering for faster processing (approximation)
-    >>> filtered_fast = patch.hampel_filter(
-    ...     time=1.0, distance=5.0, threshold=3.5, separable=True
-    ... )
     """
     if threshold <= 0 or not np.isfinite(threshold):
         msg = "hampel_filter threshold must be finite and greater than zero"

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -621,6 +621,74 @@ class TestSelect:
         out, _ = new_cm.select(new_dim=(1, 20))
         assert new_cm == out
 
+    def test_select_non_dim_coord_shortens_coordinate(self, cm_basic):
+        """Test that selecting non-dimensional coords shortens only that coordinate."""
+        # Add a non-dimensional coordinate with numeric values
+        quality_scores = np.array([0.1, 0.5, 0.9, 0.2, 0.8, 0.3, 0.7])
+        new_cm = cm_basic.update(quality=(None, quality_scores))
+        # Select subset of quality scores using array indexing
+        selected_indices = np.array([1, 3, 5])  # Select indices 1, 3, 5
+        out, _ = new_cm.select(quality=selected_indices, samples=True)
+        # Quality coordinate should be shortened
+        expected_quality = quality_scores[selected_indices]
+        assert np.array_equal(out.get_array("quality"), expected_quality)
+        # Dimensional coordinates should be unchanged
+        assert cm_basic.shape == out.shape
+        assert np.array_equal(out.get_array("time"), new_cm.get_array("time"))
+        assert np.array_equal(out.get_array("distance"), new_cm.get_array("distance"))
+
+    def test_select_non_dim_coord_with_boolean_mask(self, cm_basic):
+        """Test selecting non-dimensional coordinates using boolean arrays."""
+        # Add a non-dimensional coordinate
+        values = np.array([10, 20, 30, 40, 50, 60, 70])
+        new_cm = cm_basic.update(sensor_values=(None, values))
+        # Create boolean mask
+        mask = values > 35  # Should select [40, 50, 60, 70]
+        out, _ = new_cm.select(sensor_values=mask)
+        # Only the non-dimensional coordinate should be affected
+        expected_values = values[mask]
+        assert np.array_equal(out.get_array("sensor_values"), expected_values)
+        # Dimensional coordinates should remain unchanged
+        for coord in set(cm_basic.coord_map) - {"sensor_values"}:
+            assert cm_basic.get_coord(coord) == new_cm.get_coord(coord)
+
+    def test_select_multi_dim_coord_raises(self, cm_multidim):
+        """
+        Coords that are associated with more than one dim cannot be selected
+        because it could ruin the squareness of the patch.
+        """
+        # Non-dim coord associated with one dimension should work.
+        lat = cm_multidim.get_array("latitude")
+        lat_mean = np.mean(lat)
+        out, _ = cm_multidim.select(latitude=slice(lat, lat_mean))
+        assert isinstance(out, dc.CoordManager)
+        # Multi-dim coord should raise PatchCoordError
+        msg = "Cannot select on a coordinate with more than one dim. "
+        with pytest.raises(CoordError, match=msg):
+            cm_multidim.select(quality=slice(1, 20))
+
+    def test_select_coord_tied_to_dimension_affects_others(self, cm_multidim):
+        """
+        Test that selecting a coord tied to a dimension affects other coords
+        on that dim.
+        """
+        # cm_multidim should have coordinates that share dimensions
+        # Get a coordinate that's tied to a dimension and has other coords sharing
+        # that dim
+        lat = cm_multidim.get_array("latitude")
+        lat_mean = np.mean(lat)
+        out, _ = cm_multidim.select(latitude=slice(lat, lat_mean))
+        # Check that the new lat is what we expect.
+        new_lat = out.get_coord("latitude")
+        expected = lat.values[lat.values <= lat_mean]
+        assert np.all(new_lat == expected)
+        # And the other coord associated with that dimension have the same len.
+        for coord, name in out.coord_map.items():
+            if name not in (dims := out.dim_map[name]):
+                continue
+            axis = dims.index(coord)
+            assert coord.shape[axis] == len(new_lat)
+
 
 class TestOrder:
     """Tests for ordering coordinate managers."""

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -354,7 +354,7 @@ class TestSelect:
         PatchCoordinateError.
         """
         # Try to select on multiple coordinates that don't exist
-        with pytest.raises(PatchCoordinateError, match="coord1.*coord2"):
+        with pytest.raises(PatchCoordinateError, match=r"coord1.*coord2"):
             random_patch.select(bad_coord1=(0, 10), bad_coord2=(5, 15))
 
     def test_select_mix_valid_invalid_coordinates_raises_error(self, random_patch):

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -14,6 +14,7 @@ from dascore.exceptions import (
     CoordError,
     ParameterError,
     PatchBroadcastError,
+    PatchCoordinateError,
     PatchError,
 )
 from dascore.units import get_quantity
@@ -320,6 +321,33 @@ class TestSelect:
         face_angle = patch.get_coord("face_angle")
         new = patch.select(face_angle=(face_angle.min(), face_angle.max()))
         assert new == patch
+
+    def test_select_nonexistent_coordinate_raises_error(self, random_patch):
+        """
+        Test that selecting on a non-existing coordinate
+        raises PatchCoordinateError.
+        """
+        # Try to select on a coordinate that doesn't exist
+        with pytest.raises(PatchCoordinateError, match="nonexistent_coord"):
+            random_patch.select(nonexistent_coord=(0, 10))
+
+    def test_select_multiple_nonexistent_coordinates_raises_error(self, random_patch):
+        """
+        Test that selecting on multiple non-existing coordinates raises
+        PatchCoordinateError.
+        """
+        # Try to select on multiple coordinates that don't exist
+        with pytest.raises(PatchCoordinateError, match="coord1.*coord2"):
+            random_patch.select(bad_coord1=(0, 10), bad_coord2=(5, 15))
+
+    def test_select_mix_valid_invalid_coordinates_raises_error(self, random_patch):
+        """
+        Test that mixing valid and invalid coordinates raises
+        PatchCoordinateError.
+        """
+        # Try to select on a mix of valid and invalid coordinates
+        with pytest.raises(PatchCoordinateError, match="invalid_coord"):
+            random_patch.select(time=(0, 1), invalid_coord=(0, 10))
 
 
 class TestOrder:

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -193,6 +193,23 @@ class TestCoordsFromDf:
 class TestSelect:
     """Tests for selecting data from patch."""
 
+    def _add_non_dim_coords(self, patch, coord_dict):
+        """Helper to add non-dimensional coordinates to a patch."""
+        new_coords = patch.coords.update(**coord_dict)
+        return patch.new(coords=new_coords)
+
+    def _assert_coord_unchanged(self, original_patch, selected_patch, coord_name):
+        """Helper to assert a coordinate remains unchanged."""
+        assert np.array_equal(
+            original_patch.coords.get_array(coord_name),
+            selected_patch.coords.get_array(coord_name),
+        )
+
+    def _assert_data_shape_unchanged(self, original_patch, selected_patch):
+        """Helper to assert data shape remains unchanged."""
+        assert selected_patch.data.shape == original_patch.data.shape
+        assert np.array_equal(selected_patch.data, original_patch.data)
+
     def test_select_by_distance(self, random_patch):
         """Ensure distance can be used to filter patch."""
         dmin, dmax = 100, 200
@@ -348,6 +365,188 @@ class TestSelect:
         # Try to select on a mix of valid and invalid coordinates
         with pytest.raises(PatchCoordinateError, match="invalid_coord"):
             random_patch.select(time=(0, 1), invalid_coord=(0, 10))
+
+    def test_select_non_dim_coord_with_boolean_mask(self, random_patch):
+        """Test selecting non-dimensional coordinates using boolean masks on Patch."""
+        # Add a non-dimensional coordinate to the patch
+        quality_values = np.random.RandomState(42).rand(10)
+        patch_with_coord = self._add_non_dim_coords(
+            random_patch, {"quality": (None, quality_values)}
+        )
+
+        # Create boolean mask and select
+        mask = quality_values > 0.5
+        selected_patch = patch_with_coord.select(quality=mask)
+
+        # Only the non-dimensional coordinate should be affected
+        expected_quality = quality_values[mask]
+        assert np.array_equal(
+            selected_patch.coords.get_array("quality"), expected_quality
+        )
+
+        # Patch data and dimensional coordinates should remain unchanged
+        self._assert_data_shape_unchanged(patch_with_coord, selected_patch)
+        self._assert_coord_unchanged(patch_with_coord, selected_patch, "time")
+        self._assert_coord_unchanged(patch_with_coord, selected_patch, "distance")
+
+    def test_select_non_dim_coord_with_array_indices(self, random_patch):
+        """Test selecting non-dimensional coordinates using array indices on Patch."""
+        # Add non-dimensional coordinates to the patch
+        sensor_ids = np.arange(100, 115)  # 15 values
+        temperature_data = np.random.RandomState(42).rand(15) * 100
+        patch_with_coords = self._add_non_dim_coords(
+            random_patch,
+            {"sensor_ids": (None, sensor_ids), "temperature": (None, temperature_data)},
+        )
+
+        # Select subset using array indices
+        selected_indices = np.array([2, 5, 8, 12])
+        selected_patch = patch_with_coords.select(
+            sensor_ids=selected_indices, samples=True
+        )
+
+        # Check that only the selected coordinate was affected
+        expected_ids = sensor_ids[selected_indices]
+        assert np.array_equal(
+            selected_patch.coords.get_array("sensor_ids"), expected_ids
+        )
+        # Temperature should remain unchanged since we only selected sensor_ids
+        self._assert_coord_unchanged(patch_with_coords, selected_patch, "temperature")
+
+        # Patch data and dimensional coordinates should be unchanged
+        self._assert_data_shape_unchanged(patch_with_coords, selected_patch)
+        for dim in patch_with_coords.dims:
+            self._assert_coord_unchanged(patch_with_coords, selected_patch, dim)
+
+    def test_select_mixed_dim_and_non_dim_coords(self, random_patch):
+        """
+        Test selecting both dimensional and non-dimensional coordinates
+        simultaneously.
+        """
+        # Add non-dimensional coordinate with numeric values
+        station_ids = np.array([101, 102, 103, 104, 105])
+        patch_with_coord = self._add_non_dim_coords(
+            random_patch, {"station_ids": (None, station_ids)}
+        )
+
+        # Select on both dimensional and non-dimensional coordinates
+        time_coord = patch_with_coord.coords.get_array("time")
+        time_subset = time_coord[: len(time_coord) // 2]  # First half of time
+        station_mask = np.array(
+            [True, False, True, False, True]
+        )  # Select 101, 103, 105
+
+        selected_patch = patch_with_coord.select(
+            time=time_subset, station_ids=station_mask
+        )
+
+        # Check both selections worked
+        expected_stations = station_ids[station_mask]  # [101, 103, 105]
+        assert np.array_equal(
+            selected_patch.coords.get_array("station_ids"), expected_stations
+        )
+        assert np.array_equal(selected_patch.coords.get_array("time"), time_subset)
+
+        # Check dimensional selection affected patch shape
+        assert selected_patch.data.shape != patch_with_coord.data.shape
+        assert len(selected_patch.coords.get_array("time")) == len(time_subset)
+
+    def test_select_non_dim_coord_associated_with_dimension(self, random_patch):
+        """
+        Test selecting non-dimensional coordinates that are associated with a
+        dimension.
+        """
+        # Add a non-dimensional coordinate associated with distance dimension
+        distance_coord = random_patch.coords.get_array("distance")
+        elevation_values = np.random.RandomState(42).rand(len(distance_coord)) * 1000
+        patch_with_coord = self._add_non_dim_coords(
+            random_patch, {"elevation": ("distance", elevation_values)}
+        )
+
+        # Select using boolean mask on the elevation coordinate
+        elevation_subset = elevation_values > 500  # Select high elevations
+        selected_patch = patch_with_coord.select(elevation=elevation_subset)
+
+        # Both elevation and distance coordinates should be affected
+        expected_elevation = elevation_values[elevation_subset]
+        expected_distance = distance_coord[elevation_subset]
+        assert np.array_equal(
+            selected_patch.coords.get_array("elevation"), expected_elevation
+        )
+        assert np.array_equal(
+            selected_patch.coords.get_array("distance"), expected_distance
+        )
+
+        # Patch data shape should change because distance dimension changed
+        assert selected_patch.data.shape != patch_with_coord.data.shape
+        distance_axis = patch_with_coord.get_axis("distance")
+        assert selected_patch.data.shape[distance_axis] == np.sum(elevation_subset)
+
+        # Time coordinate should remain unchanged
+        self._assert_coord_unchanged(patch_with_coord, selected_patch, "time")
+
+    def test_select_non_dim_coord_with_array_values(self, random_patch):
+        """Test selecting non-dimensional coordinates using specific array values."""
+        # Add coordinates with same length as distance dimension
+        distance_coord = random_patch.coords.get_array("distance")
+        sensor_ids = np.arange(1000, 1000 + len(distance_coord))
+        fiber_quality = np.random.RandomState(42).rand(len(distance_coord))
+        patch_with_coord = self._add_non_dim_coords(
+            random_patch,
+            {
+                "sensor_ids": ("distance", sensor_ids),
+                "fiber_quality": ("distance", fiber_quality),
+            },
+        )
+
+        # Select specific sensor IDs by array values (select a subset)
+        selected_ids = sensor_ids[10:15]  # Select 5 sensors
+        selected_patch = patch_with_coord.select(sensor_ids=selected_ids)
+
+        # All coordinates tied to distance should be affected
+        expected_quality = fiber_quality[10:15]
+        expected_distance = distance_coord[10:15]
+        assert np.array_equal(
+            selected_patch.coords.get_array("sensor_ids"), selected_ids
+        )
+        assert np.array_equal(
+            selected_patch.coords.get_array("fiber_quality"), expected_quality
+        )
+        assert np.array_equal(
+            selected_patch.coords.get_array("distance"), expected_distance
+        )
+
+        # Data shape should change along distance axis
+        distance_axis = patch_with_coord.get_axis("distance")
+        assert selected_patch.data.shape[distance_axis] == 5
+
+    def test_select_coord_tied_to_time_dimension(self, random_patch):
+        """Test selecting coordinates associated with time dimension."""
+        # Add a coordinate tied to time (e.g., measurement quality over time)
+        time_coord = random_patch.coords.get_array("time")
+        quality_over_time = np.random.RandomState(42).rand(len(time_coord))
+        patch_with_coord = self._add_non_dim_coords(
+            random_patch, {"measurement_quality": ("time", quality_over_time)}
+        )
+
+        # Select time periods with high quality measurements
+        high_quality_mask = quality_over_time > 0.7
+        selected_patch = patch_with_coord.select(measurement_quality=high_quality_mask)
+
+        # Both quality and time coordinates should be affected
+        expected_quality = quality_over_time[high_quality_mask]
+        expected_time = time_coord[high_quality_mask]
+        assert np.array_equal(
+            selected_patch.coords.get_array("measurement_quality"), expected_quality
+        )
+        assert np.array_equal(selected_patch.coords.get_array("time"), expected_time)
+
+        # Data shape should change along time axis
+        time_axis = patch_with_coord.get_axis("time")
+        assert selected_patch.data.shape[time_axis] == np.sum(high_quality_mask)
+
+        # Distance coordinate should remain unchanged
+        self._assert_coord_unchanged(patch_with_coord, selected_patch, "distance")
 
 
 class TestOrder:


### PR DESCRIPTION
## Description

This PR partially addresses #435 by making the `Patch.select` raise an error when a keyword that is not a dimension is passed in. Fixing the spool will require much more work because the indexer may not know about all the dimensions in its managed patches. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selection now validates coordinate names up-front and raises a clear error listing invalid and valid coordinates; selection behavior for non‑dimensional coordinates is handled more consistently.

* **Tests**
  * Added extensive tests covering invalid/mixed coordinate selections and non‑dimensional coordinate selection behaviors.

* **Documentation**
  * Fixed a typo in select examples and updated Hampel filter docstring examples (time window value adjusted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->