### PR TITLE
Hampel speed

### DIFF
--- a/benchmarks/test_io_benchmarks.py
+++ b/benchmarks/test_io_benchmarks.py
@@ -30,35 +30,35 @@ class TestIOBenchmarks:
     """Benchmarks for IO operations."""
 
     @pytest.mark.benchmark
-    def test_scan_performance(self, test_file_paths):
+    def test_scan(self, test_file_paths):
         """Time for basic scanning of all datafiles."""
         for path in test_file_paths.values():
             with suppress(MissingOptionalDependencyError):
                 dc.scan(path)
 
     @pytest.mark.benchmark
-    def test_scan_df_performance(self, test_file_paths):
+    def test_scan_df(self, test_file_paths):
         """Time for basic scanning of all datafiles to DataFrame."""
         for path in test_file_paths.values():
             with suppress(MissingOptionalDependencyError):
                 dc.scan_to_df(path)
 
     @pytest.mark.benchmark
-    def test_get_format_performance(self, test_file_paths):
+    def test_get_format(self, test_file_paths):
         """Time for format detection of all datafiles."""
         for path in test_file_paths.values():
             with suppress(MissingOptionalDependencyError):
                 dc.get_format(path)
 
     @pytest.mark.benchmark
-    def test_read_performance(self, test_file_paths):
+    def test_read(self, test_file_paths):
         """Time for basic reading of all datafiles."""
         for path in test_file_paths.values():
             with suppress(MissingOptionalDependencyError):
                 dc.read(path)[0]
 
     @pytest.mark.benchmark
-    def test_spool_performance(self, test_file_paths):
+    def test_spool(self, test_file_paths):
         """Time for creating spools from all datafiles."""
         for path in test_file_paths.values():
             with suppress(MissingOptionalDependencyError):

--- a/benchmarks/test_patch_benchmarks.py
+++ b/benchmarks/test_patch_benchmarks.py
@@ -47,7 +47,7 @@ class TestProcessingBenchmarks:
         return np.arange(start, stop, step)
 
     @pytest.mark.benchmark
-    def test_pass_filter_performance(self, example_patch):
+    def test_pass_filter(self, example_patch):
         """Time the pass filter."""
         patch = example_patch
         patch.pass_filter(distance=(0.1, 0.2))
@@ -56,20 +56,20 @@ class TestProcessingBenchmarks:
         patch.pass_filter(time=(10, 100))
 
     @pytest.mark.benchmark
-    def test_median_filter_performance(self, example_patch):
+    def test_median_filter(self, example_patch):
         """Time the median filter."""
         patch = example_patch
         patch.median_filter(distance=5, time=5, samples=True)
         patch.median_filter(time=5, samples=True)
 
     @pytest.mark.benchmark
-    def test_interpolate_performance(self, example_patch, interp_time):
+    def test_interpolate(self, example_patch, interp_time):
         """Time interpolate operations."""
         patch = example_patch
         patch.interpolate(time=interp_time)
 
     @pytest.mark.benchmark
-    def test_decimate_performance(self, example_patch):
+    def test_decimate(self, example_patch):
         """Time decimation."""
         patch = example_patch
         patch.decimate(time=2)
@@ -78,7 +78,7 @@ class TestProcessingBenchmarks:
         patch.decimate(time=10, filter_type=None)
 
     @pytest.mark.benchmark
-    def test_select_performance(self, example_patch):
+    def test_select(self, example_patch):
         """Selecting on time/distance dimension"""
         patch = example_patch
         patch.select(distance=(100, 200))
@@ -89,53 +89,58 @@ class TestProcessingBenchmarks:
         patch.select(time=(t1, t2))
 
     @pytest.mark.benchmark
-    def test_sobel_filter_performance(self, example_patch):
+    def test_sobel_filter(self, example_patch):
         """Time the Sobel filter."""
         patch = example_patch
         patch.sobel_filter(dim="time")
 
     @pytest.mark.benchmark
-    def test_standardize_performance(self, example_patch):
+    def test_standardize(self, example_patch):
         """Time standardization operation."""
         patch = example_patch
         patch.standardize(dim="time")
 
     @pytest.mark.benchmark
-    def test_taper_performance(self, example_patch):
+    def test_taper(self, example_patch):
         """Time tapering operations."""
         patch = example_patch
         patch.taper(time=0.1)
 
     @pytest.mark.benchmark
-    def test_transpose_performance(self, example_patch):
+    def test_transpose(self, example_patch):
         """Time transpose operations."""
         patch = example_patch
         dims = patch.dims[::-1]
         patch.transpose(*dims)
 
     @pytest.mark.benchmark
-    def test_roll_performance(self, example_patch):
+    def test_roll(self, example_patch):
         """Time roll/shift operations."""
         patch = example_patch
         patch.roll(time=10, samples=True)
 
     @pytest.mark.benchmark
-    def test_snap_coords_performance(self, patch_uneven_time):
+    def test_snap_coords(self, patch_uneven_time):
         """Time coordinate snapping."""
         patch = patch_uneven_time
         patch.snap_coords("time")
 
     @pytest.mark.benchmark
-    def test_hampel_filter_performance(self, example_patch):
+    def test_hampel_filter_non_separable(self, example_patch):
         """Time the Hampel filter."""
-        patch = example_patch
-        patch.hampel_filter(threshold=3.0, time=5, samples=True)
-        patch.hampel_filter(
-            threshold=2.5, distance=3, time=5, samples=True, separable=True
+        example_patch.hampel_filter(
+            threshold=3.0, distance=3, time=5, samples=True, separable=False
         )
 
     @pytest.mark.benchmark
-    def test_wiener_filter_performance(self, example_patch):
+    def test_hampel_filter(self, example_patch):
+        """Time the Hampel filter."""
+        example_patch.hampel_filter(
+            threshold=3.0, distance=3, time=5, samples=True, separable=True
+        )
+
+    @pytest.mark.benchmark
+    def test_wiener_filter(self, example_patch):
         """Time the Wiener filter."""
         patch = example_patch
         patch.wiener_filter(time=3, samples=True)
@@ -150,27 +155,27 @@ class TestTransformBenchmarks:
         return example_patch.dft("time")
 
     @pytest.mark.benchmark
-    def test_indefinite_integrate_performance(self, example_patch):
+    def test_indefinite_integrate(self, example_patch):
         """Integrate along time axis."""
         example_patch.integrate(dim="time", definite=False)
 
     @pytest.mark.benchmark
-    def test_definite_integrate_performance(self, example_patch):
+    def test_definite_integrate(self, example_patch):
         """Integrate along time axis."""
         example_patch.integrate(dim="time", definite=True)
 
     @pytest.mark.benchmark
-    def test_differentiate_performance(self, example_patch):
+    def test_differentiate(self, example_patch):
         """Differentiate along time axis."""
         example_patch.differentiate(dim="time")
 
     @pytest.mark.benchmark
-    def test_dft_performance(self, example_patch):
+    def test_dft(self, example_patch):
         """The discrete fourier transform."""
         example_patch.dft(dim="time")
 
     @pytest.mark.benchmark
-    def test_idft_performance(self, dft_patch):
+    def test_idft(self, dft_patch):
         """The inverse of the fourier transform."""
         dft_patch.idft()
 
@@ -181,13 +186,13 @@ class TestTransformBenchmarks:
         patch.stft(time=1, overlap=0.25)
 
     @pytest.mark.benchmark
-    def test_hilbert_performance(self, example_patch):
+    def test_hilbert(self, example_patch):
         """Time Hilbert transform."""
         patch = example_patch
         patch.hilbert(dim="time")
 
     @pytest.mark.benchmark
-    def test_envelope_performance(self, example_patch):
+    def test_envelope(self, example_patch):
         """Time envelope calculation."""
         patch = example_patch
         patch.envelope(dim="time")
@@ -197,22 +202,22 @@ class TestVisualizationBenchmarks:
     """Benchmarks for patch visualization operations (or str repr)."""
 
     @pytest.mark.benchmark
-    def test_waterfall_performance(self, example_patch, cleanup_mpl):
+    def test_waterfall(self, example_patch, cleanup_mpl):
         """Timing for waterfall patch."""
         example_patch.viz.waterfall()
 
     @pytest.mark.benchmark
-    def test_str_performance(self, example_patch):
+    def test_str(self, example_patch):
         """Timing for getting str rep."""
         str(example_patch)
 
     @pytest.mark.benchmark
-    def test_repr_performance(self, example_patch):
+    def test_repr(self, example_patch):
         """Time representation generation."""
         repr(example_patch)
 
     @pytest.mark.benchmark
-    def test_wiggle_performance(self, example_patch, cleanup_mpl):
+    def test_wiggle(self, example_patch, cleanup_mpl):
         """Time wiggle plot visualization."""
         patch = example_patch.select(distance=(0, 100))  # Subset for performance
         patch.viz.wiggle()
@@ -222,55 +227,55 @@ class TestAggregationBenchmarks:
     """Benchmarks for patch aggregation operations."""
 
     @pytest.mark.benchmark
-    def test_mean_performance(self, example_patch):
+    def test_mean(self, example_patch):
         """Time mean aggregation."""
         patch = example_patch
         patch.mean(dim="time")
         patch.mean(dim="distance")
 
     @pytest.mark.benchmark
-    def test_max_performance(self, example_patch):
+    def test_max(self, example_patch):
         """Time max aggregation."""
         patch = example_patch
         patch.max(dim="time")
         patch.max(dim="distance")
 
     @pytest.mark.benchmark
-    def test_min_performance(self, example_patch):
+    def test_min(self, example_patch):
         """Time min aggregation."""
         patch = example_patch
         patch.min(dim="time")
         patch.min(dim="distance")
 
     @pytest.mark.benchmark
-    def test_std_performance(self, example_patch):
+    def test_std(self, example_patch):
         """Time standard deviation aggregation."""
         patch = example_patch
         patch.std(dim="time")
         patch.std(dim="distance")
 
     @pytest.mark.benchmark
-    def test_sum_performance(self, example_patch):
+    def test_sum(self, example_patch):
         """Time sum aggregation."""
         patch = example_patch
         patch.sum(dim="time")
         patch.sum(dim="distance")
 
     @pytest.mark.benchmark
-    def test_median_performance(self, example_patch):
+    def test_median(self, example_patch):
         """Time median aggregation."""
         patch = example_patch
         patch.median(dim="time")
         patch.median(dim="distance")
 
     @pytest.mark.benchmark
-    def test_first_performance(self, example_patch):
+    def test_first(self, example_patch):
         """Time first aggregation."""
         patch = example_patch
         patch.first(dim="time")
 
     @pytest.mark.benchmark
-    def test_last_performance(self, example_patch):
+    def test_last(self, example_patch):
         """Time last aggregation."""
         patch = example_patch
         patch.last(dim="distance")
@@ -293,11 +298,11 @@ class TestRollingBenchmarks:
         return example_patch.rolling(time=roll_time)
 
     @pytest.mark.benchmark
-    def test_rolling_small_roller_mean_performance(self, small_roller):
+    def test_rolling_small_roller_mean(self, small_roller):
         """Time rolling mean calculation for small roller."""
         small_roller.mean()
 
     @pytest.mark.benchmark
-    def test_rolling_large_roller_mean_performance(self, big_roller):
+    def test_rolling_large_roller_mean(self, big_roller):
         """Time rolling mean calculation."""
         big_roller.mean()

--- a/benchmarks/test_spool_benchmarks.py
+++ b/benchmarks/test_spool_benchmarks.py
@@ -39,29 +39,29 @@ class TestChunkBenchmarks:
     """Benchmarks for spool chunking operations."""
 
     @pytest.mark.benchmark
-    def test_contiguous_merge_performance(self, spool_no_gap):
+    def test_contiguous_merge(self, spool_no_gap):
         """Time merging contiguous patches from in-memory spool."""
         _chunk_and_check(spool_no_gap)
 
     @pytest.mark.benchmark
-    def test_no_overlap_merge_performance(self, gapped_spool_no_overlap):
+    def test_no_overlap_merge(self, gapped_spool_no_overlap):
         """Timing for trying to chunk patches that have no overlap."""
         chunked = gapped_spool_no_overlap.chunk(time=None)
         # In this case the spool should not be merged.
         assert len(chunked) == len(gapped_spool_no_overlap)
 
     @pytest.mark.benchmark
-    def test_diverse_merge_performance(self, diverse_spool):
+    def test_diverse_merge(self, diverse_spool):
         """Time trying to merge the diverse spool."""
         _chunk_and_check(diverse_spool, length=None)
 
     @pytest.mark.benchmark
-    def test_1second_chunk_performance(self, spool_no_gap):
+    def test_1second_chunk(self, spool_no_gap):
         """Time chunking for one second along no gap spool."""
         _chunk_and_check(spool_no_gap, time=1, length=None)
 
     @pytest.mark.benchmark
-    def test_half_second_chunk_performance(self, spool_no_gap):
+    def test_half_second_chunk(self, spool_no_gap):
         """Time chunking for 0.5 along no gap spool."""
         _chunk_and_check(spool_no_gap, time=0.5, length=None)
 
@@ -75,7 +75,7 @@ class TestSelectionBenchmarks:
         return spool_no_gap.get_contents()
 
     @pytest.mark.benchmark
-    def test_select_full_range_performance(self, spool_no_gap, spool_no_gap_df):
+    def test_select_full_range(self, spool_no_gap, spool_no_gap_df):
         """Timing selecting the full time range."""
         df, spool = spool_no_gap_df, spool_no_gap
         t1, t2 = df["time_min"].min(), df["time_max"].max()
@@ -84,7 +84,7 @@ class TestSelectionBenchmarks:
         spool.select(time=(t1, None))
 
     @pytest.mark.benchmark
-    def test_select_half_range_performance(self, spool_no_gap, spool_no_gap_df):
+    def test_select_half_range(self, spool_no_gap, spool_no_gap_df):
         """Time selecting and trimming."""
         df, spool = spool_no_gap_df, spool_no_gap
         t1, t2 = df["time_min"].min(), df["time_max"].max()
@@ -93,14 +93,14 @@ class TestSelectionBenchmarks:
         spool.select(time=(t1 + duration, t2))
 
     @pytest.mark.benchmark
-    def test_select_strings_performance(self, diverse_spool):
+    def test_select_strings(self, diverse_spool):
         """Time select non-dimensional selects."""
         spool = diverse_spool
         spool.select(tag="some_tag")
         spool.select(station="wayout")
 
     @pytest.mark.benchmark
-    def test_select_string_match_performance(self, diverse_spool):
+    def test_select_string_match(self, diverse_spool):
         """Time select non-dimensional selects with wildcards."""
         spool = diverse_spool
         spool.select(tag="some_*")

--- a/dascore/utils/__init__.py
+++ b/dascore/utils/__init__.py
@@ -1,3 +1,12 @@
 """Utilities for dascore."""
 from __future__ import annotations
 from .time import to_datetime64, to_timedelta64
+from .moving import (
+    move_max,
+    move_mean,
+    move_median,
+    move_min,
+    move_std,
+    move_sum,
+    moving_window,
+)

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -14,6 +14,7 @@ from functools import cache
 from io import IOBase
 from pathlib import Path
 from types import ModuleType
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -113,7 +114,7 @@ def warn_or_raise(
     behavior
         If None, do nothing. If
     """
-    if not behavior:
+    if not behavior or behavior == "ignore":
         return
     if behavior == "raise":
         raise exception(msg)
@@ -296,15 +297,22 @@ class CacheDescriptor:
         cache[self._name] = value
 
 
-def optional_import(package_name: str) -> ModuleType:
+def optional_import(
+    package_name: str, on_missing: Literal["raise", "warn", "ignore"] = "raise"
+) -> ModuleType | None:
     """
-    Import a module and return the module object if installed, else raise error.
+    Import a module and return the module object if installed.
+
+    If not installed, raise an Error or return None.
 
     Parameters
     ----------
     package_name
         The name of the package which may or may not be installed. Can
         also be sub-packages/modules (eg dascore.core).
+    on_missing
+        If "raise" raise an Error if missing, if "warn" or "ignore",
+        return None.
 
     Raises
     ------
@@ -320,6 +328,9 @@ def optional_import(package_name: str) -> ModuleType:
     ...     optional_import('boblib5')  # doesn't exist so this raises
     ... except MissingOptionalDependencyError:
     ...     pass
+    >>>
+    >>> bob = optional_import('boblib5', return_none=True)
+    >>> assert bob is not None
     """
     try:
         mod = importlib.import_module(package_name)
@@ -328,7 +339,8 @@ def optional_import(package_name: str) -> ModuleType:
             f"{package_name} is not installed but is required for the "
             f"requested functionality."
         )
-        raise MissingOptionalDependencyError(msg)
+        warn_or_raise(msg, MissingOptionalDependencyError, behavior=on_missing)
+        mod = None
     return mod
 
 

--- a/dascore/utils/moving.py
+++ b/dascore/utils/moving.py
@@ -1,0 +1,217 @@
+"""
+Unified interface for moving window operations with automatic engine selection.
+
+This module provides a generic interface for 1D moving window operations
+that can use either scipy or bottleneck backends, with automatic fallback
+when optional dependencies are missing.
+"""
+
+from __future__ import annotations
+
+import warnings
+from functools import cache
+import importlib
+from typing import Callable, Literal
+
+import numpy as np
+from sympy.physics.units import boltzmann
+
+from dascore.exceptions import ParameterError
+from dascore.utils.misc import optional_import
+
+bn = optional_import("bottleneck", on_missing="ignore")
+
+# Operation registry mapping operations to engine implementations
+OPERATION_REGISTRY = {
+    "median": {
+        "scipy": ("scipy.ndimage", "median_filter"),
+        "bottleneck": ("bottleneck", "move_median"),
+    },
+    "mean": {
+        "scipy": ("scipy.ndimage", "uniform_filter1d"),
+        "bottleneck": ("bottleneck", "move_mean"),
+    },
+    "std": {
+        "scipy": None,
+        "bottleneck": ("bottleneck", "move_std"),
+    },
+    "sum": {
+        "scipy": ("scipy.ndimage", "uniform_filter1d"),  # Needs scaling
+        "bottleneck": ("bottleneck", "move_sum"),
+    },
+    "min": {
+        "scipy": ("scipy.ndimage", "minimum_filter1d"),
+        "bottleneck": ("bottleneck", "move_min"),
+    },
+    "max": {
+        "scipy": ("scipy.ndimage", "maximum_filter1d"),
+        "bottleneck": ("bottleneck", "move_max"),
+    },
+}
+
+
+def _apply_scipy_operation(data: np.ndarray, window: int, operation: str, axis: int, **kwargs) -> np.ndarray:
+    """Apply scipy operation with proper handling."""
+    module_name, func_name = OPERATION_REGISTRY[operation]["scipy"]
+    func = _get_engine_function("scipy",operation)
+
+    # Apply function with appropriate parameters
+    if func_name == "uniform_filter1d":
+        uniform = func(data.astype(float), size=window, axis=axis, **kwargs)
+        if operation.lower() == "sum":
+            # For sum, uniform_filter1d computes mean, so we scale by window size
+            uniform *= window
+        return uniform
+    elif func_name == "median_filter":
+        # Need full size tuple for median_filter
+        size = [1] * data.ndim
+        size[axis] = window
+        return func(data, size=tuple(size), **kwargs)
+    else:
+        # 1D filters (minimum_filter1d, maximum_filter1d)
+        return func(data, size=window, axis=axis, **kwargs)
+
+
+def _apply_bottleneck_operation(data: np.ndarray, window: int, operation: str, axis: int, **kwargs) -> np.ndarray:
+    """Apply bottleneck operation with error handling."""
+    func = _get_engine_function("bottleneck", operation)
+
+    # Filter out scipy-specific kwargs that bottleneck doesn't accept
+    bottleneck_kwargs = {k: v for k, v in kwargs.items() if k not in ['mode']}
+    result = func(data, window=window, axis=axis, min_count=1, **bottleneck_kwargs)
+    return result
+
+
+# Engine function wrappers (defined after functions)
+ENGINE_WRAPPERS = {
+    "scipy": _apply_scipy_operation,
+    "bottleneck": _apply_bottleneck_operation,
+}
+
+
+
+@cache
+def _get_module(module_name):
+    """Import a module based on its name."""
+    return importlib.import_module(module_name)
+
+
+@cache
+def _get_available_engines() -> list[str]:
+    """Get list of available engines (cached)."""
+    bottle_list = [] if bn is None else ["bottleneck"]
+    return tuple(['scipy'] + bottle_list)
+
+
+def _get_engine_function(engine: str, func_name: str) -> Callable | None:
+    """Get and cache engine function."""
+    module_name, func_name = OPERATION_REGISTRY[func_name][engine]
+    mod = _get_module(module_name)
+    return getattr(mod, func_name)
+
+
+def _select_engine(preferred: str, operation: str) -> str:
+    """Select best available engine with fallback."""
+    available = _get_available_engines()
+    preferred = "bottleneck" if preferred == "auto" else preferred
+
+    if preferred not in available:
+        engine = available[0]
+        msg = (
+            f"Cant use engine: {engine} for function: {operation} "
+            f"because preferred engine {preferred} is not available. It may "
+            "require an additional installation."
+        )
+        warnings.warn(msg, UserWarning, stacklevel=4)
+        preferred = engine
+
+    # Check if operation is available in preferred engine
+    registry_entry = OPERATION_REGISTRY.get(operation, {}).get(preferred)
+    if registry_entry is None:
+        # Try fallback
+        msg = f"Operation '{operation}' is not available for engine: {preferred}"
+        raise ParameterError(msg)
+
+    return preferred
+
+
+def moving_window(
+        data: np.ndarray,
+        window: int,
+        operation: str,
+        axis: int = 0,
+        engine: Literal["auto", "scipy", "bottleneck"] = "auto",
+        **kwargs
+) -> np.ndarray:
+    """
+    Generic moving window operation with automatic engine selection.
+
+    Parameters
+    ----------
+    data : array-like
+        Input data
+    window : int
+        Window size
+    operation : str
+        Operation name ("median", "mean", "std", "sum", "min", "max")
+    axis : int, default 0
+        Axis along which to operate
+    engine : {"auto", "scipy", "bottleneck"}, default "auto"
+        Engine to use
+    **kwargs
+        Additional arguments passed to the engine function
+
+    Returns
+    -------
+    np.ndarray
+        Result of moving window operation
+    """
+    data = np.asarray(data)
+    # Validate inputs
+    if window <= 0:
+        raise ParameterError("Window size must be positive")
+    if operation not in OPERATION_REGISTRY:
+        raise ParameterError(f"Unknown operation: {operation}")
+    if window > data.shape[axis]:
+        msg = (
+            f"Window size ({window}) larger than data size ({data.shape[axis]}) "
+            f"along axis {axis}",
+        )
+        raise ParameterError(msg)
+
+    # Select engine and apply operation
+    selected_engine = _select_engine(engine, operation)
+    wrapper_func = ENGINE_WRAPPERS[selected_engine]
+
+    return wrapper_func(data, window, operation, axis, **kwargs)
+
+
+# Convenience functions - much simpler now!
+def move_median(data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs) -> np.ndarray:
+    """Moving median filter."""
+    return moving_window(data, window, "median", axis, engine, **kwargs)
+
+
+def move_mean(data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs) -> np.ndarray:
+    """Moving mean filter."""
+    return moving_window(data, window, "mean", axis, engine, **kwargs)
+
+
+def move_std(data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs) -> np.ndarray:
+    """Moving standard deviation filter."""
+    return moving_window(data, window, "std", axis, engine, **kwargs)
+
+
+def move_sum(data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs) -> np.ndarray:
+    """Moving sum filter."""
+    return moving_window(data, window, "sum", axis, engine, **kwargs)
+
+
+def move_min(data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs) -> np.ndarray:
+    """Moving minimum filter."""
+    return moving_window(data, window, "min", axis, engine, **kwargs)
+
+
+def move_max(data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs) -> np.ndarray:
+    """Moving maximum filter."""
+    return moving_window(data, window, "max", axis, engine, **kwargs)

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -394,3 +394,17 @@ class TestHampelFilter:
         patch = random_patch.update(data=data)
         out = patch.hampel_filter(time=5, samples=True, threshold=5)
         assert np.issubdtype(out.dtype, np.integer)
+
+    def test_unchanged_patch_data(self, patch_with_spikes):
+        """Ensure original patch data isn't modified wit separable."""
+        # Since we are doing some fancy inplace tricks just make sure original
+        # data array is left unchanged.
+        original = patch_with_spikes.data.copy()
+        out = patch_with_spikes.hampel_filter(
+            time=5, distance=5, samples=True, threshold=5, separable=True,
+        )
+        now = patch_with_spikes.data
+        assert np.all(original == now)
+        # Just in case, make sure the filter actually did something, otherwise
+        # the check above is pointless.
+        assert not np.all(original == out.data)

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -401,7 +401,11 @@ class TestHampelFilter:
         # data array is left unchanged.
         original = patch_with_spikes.data.copy()
         out = patch_with_spikes.hampel_filter(
-            time=5, distance=5, samples=True, threshold=5, separable=True,
+            time=5,
+            distance=5,
+            samples=True,
+            threshold=5,
+            separable=True,
         )
         now = patch_with_spikes.data
         assert np.all(original == now)

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -228,6 +228,11 @@ class TestOptionalImport:
         with pytest.raises(MissingOptionalDependencyError, match="boblib4"):
             optional_import("boblib4")
 
+    def test_ignore(self):
+        """If on_missing == "ignore" none is returned."""
+        out = optional_import("boblib4", on_missing="ignore")
+        assert out is None
+
 
 class TestGetStencilCoefficients:
     """Tests for stencil coefficients."""

--- a/tests/test_utils/test_moving.py
+++ b/tests/test_utils/test_moving.py
@@ -1,0 +1,261 @@
+"""Tests for moving window operations."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from dascore.exceptions import ParameterError
+from dascore.utils.moving import (
+    _get_available_engines,
+    OPERATION_REGISTRY,
+    move_max,
+    move_mean,
+    move_median,
+    move_min,
+    move_std,
+    move_sum,
+    moving_window,
+)
+
+# Test configuration
+TEST_OPERATIONS = list(OPERATION_REGISTRY.keys())
+TEST_ENGINES = ["scipy", "bottleneck", "auto"]
+TEST_CONVENIENCE_FUNCS = {
+    "median": move_median,
+    "mean": move_mean,
+    "std": move_std,
+    "sum": move_sum,
+    "min": move_min,
+    "max": move_max,
+}
+
+
+class TestMovingWindow:
+    """Test moving window operations with different engines."""
+
+    # Helper methods
+    def _validate_basic_result(self, result, original_data):
+        """Validate basic properties of results."""
+        assert isinstance(result, np.ndarray)
+        assert result.shape == original_data.shape
+        assert result.dtype.kind in ['f', 'i', 'c']  # float, int, or complex
+
+    def _test_finite_properties(self, results, data):
+        """Test mathematical properties of operations."""
+        # Find where all results are finite
+        all_finite = np.ones(len(data), dtype=bool)
+        for result in results.values():
+            all_finite &= np.isfinite(result)
+
+        if not np.any(all_finite):
+            return  # Skip if no finite values
+
+        finite_indices = np.where(all_finite)[0]
+
+        # Test properties only where values are finite
+        mean_vals = results["mean"][finite_indices]
+        sum_vals = results["sum"][finite_indices]
+        min_vals = results["min"][finite_indices]
+        max_vals = results["max"][finite_indices]
+
+        # Sum should be >= mean (for positive window size)
+        assert np.all(sum_vals >= mean_vals)
+        # Min should be <= max
+        assert np.all(min_vals <= max_vals)
+
+    def _compare_engine_results(self, result1, result2, window, operation):
+        """Compare results from different engines."""
+        # Compare interior values (avoiding edge effects)
+        interior_slice = slice(window // 2, -window // 2 if window > 2 else None)
+
+        interior1 = result1[interior_slice]
+        interior2 = result2[interior_slice]
+
+        # Both should be finite in interior
+        finite1 = np.isfinite(interior1)
+        finite2 = np.isfinite(interior2)
+
+        if np.any(finite1 & finite2):
+            common_finite = finite1 & finite2
+            vals1 = interior1[common_finite]
+            vals2 = interior2[common_finite]
+
+            # Check that both give reasonable results (within data range)
+            data_min, data_max = -10, 10  # Reasonable range
+            assert np.all((vals1 >= data_min) & (vals1 <= data_max))
+            assert np.all((vals2 >= data_min) & (vals2 <= data_max))
+
+            # For most operations, results should be similar
+            # (allowing for different edge handling)
+            if len(vals1) > 0:
+                mean1, mean2 = np.mean(vals1), np.mean(vals2)
+                if abs(mean1) > 1e-10 and abs(mean2) > 1e-10:
+                    rel_diff = abs(mean1 - mean2) / max(abs(mean1), abs(mean2))
+                    assert rel_diff < 0.5  # Allow 50% difference for edge handling differences
+
+    # Fixtures
+
+    @pytest.fixture(scope="class")
+    def test_data(self):
+        """Test data fixtures."""
+        return {
+            "1d": np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]),
+            "2d": np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15]]),
+            "large": np.random.rand(1000),
+            "single": np.array([5.0]),
+            "constant": np.array([5.0, 5.0, 5.0, 5.0, 5.0]),
+        }
+
+    @pytest.fixture(scope="class")
+    def available_engines(self):
+        """Get available engines."""
+        return _get_available_engines()
+
+    # Core functionality tests
+    @pytest.mark.parametrize("operation", TEST_OPERATIONS)
+    @pytest.mark.parametrize("engine", TEST_ENGINES)
+    def test_operation_engine_combinations(self, test_data, operation, engine, available_engines):
+        """Test all operation/engine combinations."""
+        if engine == "bottleneck" and "bottleneck" not in available_engines:
+            pytest.skip("Bottleneck not available")
+
+        data = test_data["1d"]
+        window = 3
+
+        try:
+            result = moving_window(data, window, operation, engine=engine)
+            self._validate_basic_result(result, data)
+        except ParameterError as e:
+            if "not available" in str(e):
+                pytest.skip(f"Operation {operation} not available in {engine}")
+            else:
+                raise
+
+    def test_convenience_functions(self, test_data):
+        """Test that convenience functions work correctly."""
+        data = test_data["1d"]
+        window = 3
+
+        for operation, func in TEST_CONVENIENCE_FUNCS.items():
+            result = func(data, window)
+            self._validate_basic_result(result, data)
+
+            # Check equivalence with generic function
+            expected = moving_window(data, window, operation)
+            np.testing.assert_array_equal(result, expected)
+
+    def test_multi_axis_operations(self, test_data):
+        """Test operations on different axes."""
+        data = test_data["2d"]
+        window = 2
+
+        for axis in [0, 1]:
+            result = move_median(data, window, axis=axis)
+            assert result.shape == data.shape
+
+    # Input validation tests
+    @pytest.mark.parametrize("invalid_window", [0, -1])
+    def test_invalid_window_size(self, test_data, invalid_window):
+        """Test invalid window sizes."""
+        with pytest.raises(ParameterError, match="Window size must be positive"):
+            moving_window(test_data["1d"], invalid_window, "median")
+
+    def test_invalid_operation(self, test_data):
+        """Test invalid operation name."""
+        with pytest.raises(ParameterError, match="Unknown operation"):
+            moving_window(test_data["1d"], 3, "invalid_operation")
+
+    def test_unavailable_engine_warns(self, test_data):
+        """Test unavailable engine warns."""
+        with pytest.warns(UserWarning, match="not available"):
+            moving_window(test_data["1d"], 3, "median", engine="invalid_engine")
+
+    def test_large_window_warning(self, test_data):
+        """Test warning for window larger than data."""
+        data = test_data["1d"]
+        large_window = len(data) + 1
+        with pytest.raises(ParameterError, match="larger than data size"):
+            result = moving_window(data, large_window, "median")
+            assert isinstance(result, np.ndarray)
+
+    # Edge cases
+    def test_edge_cases(self, test_data):
+        """Test various edge cases."""
+        edge_cases = [
+            ("single", 1, "Single element array"),
+            ("constant", 3, "Constant values"),
+        ]
+
+        for data_key, window, description in edge_cases:
+            data = test_data[data_key]
+
+            result = move_median(data, window)
+            self._validate_basic_result(result, data)
+
+            # For window size 1, result should equal input
+            if window == 1:
+                np.testing.assert_array_equal(result, data)
+
+    def test_different_dtypes(self, test_data):
+        """Test with different data types."""
+        base_data = test_data["1d"][:5]  # Smaller for faster testing
+
+        dtypes = [np.int32, np.float32, np.float64]
+        for dtype in dtypes:
+            data = base_data.astype(dtype)
+            result = move_mean(data, 3)
+            assert isinstance(result, np.ndarray)
+
+    # Numerical properties tests
+    def test_operation_properties(self, test_data):
+        """Test mathematical properties of operations."""
+        data = test_data["1d"]
+        window = 3
+
+        results = {}
+        for operation in ["median", "mean", "sum", "min", "max"]:
+            results[operation] = moving_window(data, window, operation)
+
+        # Test properties where both results are finite
+        self._test_finite_properties(results, data)
+
+    def test_numerical_accuracy(self):
+        """Test numerical accuracy with known results."""
+        data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        window = 3
+
+        # Test median accuracy
+        result_median = move_median(data, window, engine="scipy")
+        # Interior elements should be exact
+        assert result_median[2] == 3.0  # median of [2,3,4]
+
+        # Test mean accuracy
+        result_mean = move_mean(data, window, engine="scipy")
+        expected_mean = np.array([2.0, 3.0, 4.0])  # means of [1,2,3], [2,3,4], [3,4,5]
+        # Check interior values
+        np.testing.assert_allclose(result_mean[1:4], expected_mean, rtol=1e-12)
+
+    def test_engine_consistency(self, test_data, available_engines):
+        """Test consistency between engines where applicable."""
+        if "bottleneck" not in available_engines:
+            pytest.skip("Bottleneck not available for comparison")
+
+        data = test_data["large"][:100]  # Manageable size
+        window = 10
+
+        operations_to_test = ["median", "mean", "sum", "min", "max"]
+
+        for operation in operations_to_test:
+            try:
+                result_scipy = moving_window(data, window, operation, engine="scipy")
+                result_bn = moving_window(data, window, operation, engine="bottleneck")
+
+                # Compare interior values (avoiding edge effects)
+                self._compare_engine_results(result_scipy, result_bn, window, operation)
+
+            except ParameterError:
+                # Skip if operation not available in one engine
+                continue


### PR DESCRIPTION

## Description

This PR speeds up the hampel_filter by allocating fewer arrays and introducing bottleneck as an optional dependency. It also adds a moving module for simplifying window operations. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
