### PR TITLE
Patch flip

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -68,6 +68,7 @@ from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import (
     _apply_union_indexers,
     _matches_prefix_suffix,
+    broadcast_for_index,
     cached_method,
     iterate,
 )
@@ -1079,6 +1080,39 @@ class CoordManager(DascoreBaseModel):
     def coord_range(self, coord_name: str):
         """Return a scaler value for the coordinate (e.g., number of seconds)."""
         return self.get_coord(coord_name).coord_range()
+
+    def flip(self, **coord_names):
+        """
+        Flip one or more coordinates.
+
+        Parameters
+        ----------
+        coord_names
+            A tuple of coordinates to flip.
+        """
+
+        def _flip_coord(coord, axis):
+            inds = broadcast_for_index(coord.ndim, axis, slice(None, None, -1))
+            return coord[inds]
+
+        out = dict(self.coord_map)
+        dim_map = self.dim_map
+        dim_to_coord_map = self.dim_to_coord_map
+
+        for name in coord_names:
+            coord = self.get_coord(name)
+            if coord.ndim != 1:
+                msg = (
+                    "CoordManager can only flip 1D coords directly. "
+                    "Flipping associated dimensions will flip multidimensional "
+                    "coords."
+                )
+                raise CoordError(msg)
+            out[name] = _flip_coord(coord, 0)
+            for associated in dim_to_coord_map.get(name, ()):
+                axis = dim_map[associated].index(name)
+                out[associated] = _flip_coord(out[associated], axis)
+        return dc.get_coord_manager(coords=out, dims=self.dims)
 
 
 def get_coord_manager(

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -422,6 +422,7 @@ class Patch:
     pad = dascore.proc.pad
     roll = dascore.proc.roll
     where = dascore.proc.where
+    flip = dascore.proc.flip
 
     @deprecate(
         "patch.iresample is deprecated. Please use patch.resample " "with samples=True",

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -753,3 +753,38 @@ def where(
     # Use numpy.where to apply condition
     new_data = np.where(cond_array, patch.data, other_array)
     return patch.new(data=new_data)
+
+
+@patch_function()
+def flip(patch, *dims, flip_coords=True):
+    """
+    Flip patch data and (optionally coords) along specified dimensions.
+
+    Parameters
+    ----------
+    patch
+        The patch to flip.
+    *dims
+        The dimensions over which to flip (mirror).
+    flip_coords
+        If True, also flip coords associated with dimensions, otherwise
+        leave them unchanged.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Flip patch over time axis
+    >>> out = patch.flip("time")
+    >>> assert np.all(patch.get_array("time") == out.get_array("time")[::-1])
+    >>>
+    >>> # Flip patch over all dimensions.
+    >>> out = patch.flip(*patch.dims)
+    """
+    axes = tuple(patch.get_axis(name) for name in dims)
+    data = np.flip(patch.data, axis=axes)
+    coords = patch.coords
+    if flip_coords:
+        coords = coords.flip(*dims)
+    return patch.new(data=data, coords=coords)

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -782,9 +782,9 @@ def flip(patch, *dims, flip_coords=True):
     >>> # Flip patch over all dimensions.
     >>> out = patch.flip(*patch.dims)
     """
+    if not dims:
+        return patch  # no-op
     axes = tuple(patch.get_axis(name) for name in dims)
-    data = np.flip(patch.data, axis=axes)
-    coords = patch.coords
-    if flip_coords:
-        coords = coords.flip(*dims)
+    data = np.flip(patch.data, axis=axes) if dims else patch.data
+    coords = patch.coords.flip(*dims) if flip_coords else patch.coords
     return patch.new(data=data, coords=coords)

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -78,9 +78,7 @@ def dispersion_phase_shift(
     patch = (
         dc.get_example_patch('dispersion_event')
     )
-    axis = patch.get_axis("distance")
-    flipped_data = np.flip(patch.data, axis=axis)
-    mirrored_patch = patch.update(data=flipped_data)
+    mirrored_patch = patch.flip("distance")
 
     disp_patch = mirrored_patch.dispersion_phase_shift(np.arange(100,1500,1),
             approx_resolution=0.1,approx_freq=[5,70])

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -1342,3 +1342,7 @@ class TestSetDims:
         match = "does not match the shape of"
         with pytest.raises(CoordError, match=match):
             cm.set_dims(distance="quality")
+
+
+class TestFlip:
+    """Tests for flipping a coord manager."""

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -1345,4 +1345,133 @@ class TestSetDims:
 
 
 class TestFlip:
-    """Tests for flipping a coord manager."""
+    """
+    Tests for flipping a coord manager.
+
+    The flip method takes positional arguments: flip(*dims) and correctly
+    flips both dimensional coordinates and their associated coordinates.
+    """
+
+    def test_flip_single_dim_coord(self, cm_basic):
+        """Ensure we can flip a single dimensional coordinate."""
+        cm = cm_basic
+        original_time = cm.get_array("time")
+        flipped_cm = cm.flip("time")
+
+        # The flipped coordinate should be reversed
+        flipped_time = flipped_cm.get_array("time")
+        assert np.array_equal(flipped_time, original_time[::-1])
+
+        # Other coordinates should remain unchanged
+        assert np.array_equal(
+            flipped_cm.get_array("distance"), cm.get_array("distance")
+        )
+
+        # Shape and dimensions should remain the same
+        assert flipped_cm.shape == cm.shape
+        assert flipped_cm.dims == cm.dims
+
+    def test_flip_multiple_dim_coords(self, cm_basic):
+        """Ensure we can flip multiple dimensional coordinates."""
+        cm = cm_basic
+        original_time = cm.get_array("time")
+        original_distance = cm.get_array("distance")
+
+        flipped_cm = cm.flip("time", "distance")
+
+        # Both coordinates should be reversed
+        flipped_time = flipped_cm.get_array("time")
+        flipped_distance = flipped_cm.get_array("distance")
+
+        assert np.array_equal(flipped_time, original_time[::-1])
+        assert np.array_equal(flipped_distance, original_distance[::-1])
+
+        # Shape and dimensions should remain the same
+        assert flipped_cm.shape == cm.shape
+        assert flipped_cm.dims == cm.dims
+
+    def test_flip_with_associated_coords(self, cm_multidim):
+        """Ensure flipping a dim coord also flips associated coordinates."""
+        cm = cm_multidim
+        original_distance = cm.get_array("distance")
+        original_latitude = cm.get_array("latitude")
+
+        # Flip the distance coordinate
+        flipped_cm = cm.flip("distance")
+
+        # Distance should be flipped
+        flipped_distance = flipped_cm.get_array("distance")
+        assert np.array_equal(flipped_distance, original_distance[::-1])
+
+        # Associated coordinates (like latitude) should also be flipped
+        flipped_latitude = flipped_cm.get_array("latitude")
+        assert np.array_equal(flipped_latitude, original_latitude[::-1])
+
+        # Time should remain unchanged
+        assert np.array_equal(flipped_cm.get_array("time"), cm.get_array("time"))
+
+    def test_flip_2d_coord_raises(self, cm_multidim):
+        """Ensure flipping a 2D coordinate directly raises an error."""
+        cm = cm_multidim
+        msg = "CoordManager can only flip 1D coords directly"
+        with pytest.raises(CoordError, match=msg):
+            cm.flip("quality")
+
+    def test_flip_nonexistent_coord(self, cm_basic):
+        """Ensure flipping a nonexistent coordinate raises an appropriate error."""
+        cm = cm_basic
+        # This should raise when trying to get the coordinate
+        with pytest.raises(CoordError):
+            cm.flip("nonexistent_coord")
+
+    def test_flip_preserves_other_properties(self, cm_basic):
+        """Ensure flip preserves coordinate properties like units, etc."""
+        cm = cm_basic
+        original_time_coord = cm.coord_map["time"]
+
+        flipped_cm = cm.flip("time")
+        flipped_time_coord = flipped_cm.coord_map["time"]
+
+        # Properties other than values should be preserved
+        assert original_time_coord.units == flipped_time_coord.units
+        assert original_time_coord.dtype == flipped_time_coord.dtype
+        assert len(original_time_coord) == len(flipped_time_coord)
+
+    def test_flip_empty_coord(self, cm_basic):
+        """Ensure we can flip an empty coordinate."""
+        cm = cm_basic
+        # Create a coordinate manager with an empty time coordinate
+        empty_time = cm.coord_map["time"].empty()
+        empty_cm = cm.update(time=empty_time)
+
+        # Flipping should work even with empty coordinates
+        flipped_cm = empty_cm.flip("time")
+        assert len(flipped_cm.get_array("time")) == 0
+        assert flipped_cm.shape[empty_cm.get_axis("time")] == 0
+
+    def test_flip_preserves_coord_manager_equality(self, cm_basic):
+        """Ensure flipping twice returns to original state."""
+        cm = cm_basic
+        double_flipped = cm.flip("time").flip("time")
+
+        # Double flip should return to original state
+        assert cm == double_flipped
+        assert np.array_equal(cm.get_array("time"), double_flipped.get_array("time"))
+        assert np.array_equal(
+            cm.get_array("distance"), double_flipped.get_array("distance")
+        )
+
+    def test_flip_all_dimensions(self, cm_basic):
+        """Ensure we can flip all dimensions at once."""
+        cm = cm_basic
+        all_flipped = cm.flip(*cm.dims)
+
+        # All coordinates should be flipped
+        for dim in cm.dims:
+            original = cm.get_array(dim)
+            flipped = all_flipped.get_array(dim)
+            assert np.array_equal(flipped, original[::-1])
+
+        # Shape and dimension order should remain the same
+        assert all_flipped.shape == cm.shape
+        assert all_flipped.dims == cm.dims

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -810,3 +810,27 @@ class TestFlip:
         """Ensure coord doesn't change with flip_coords=False"""
         flipped_patch = random_patch.flip("time", flip_coords=False)
         assert flipped_patch.get_coord("time") == random_patch.get_coord("time")
+
+    def test_flip_reverses_data_time(self, random_patch):
+        """Test that data is actually reversed along time axis."""
+        axis = random_patch.get_axis("time")
+        out = random_patch.flip("time")
+        expected = np.flip(random_patch.data, axis=axis)
+        assert np.array_equal(out.data, expected)
+
+    def test_double_flip_restores(self, random_patch):
+        """Test that double flipping restores original patch."""
+        out = random_patch.flip("time").flip("time")
+        assert random_patch.equals(out)
+
+    def test_flip_coords_false_reverses_data_only(self, random_patch):
+        """Test that flip_coords=False only reverses data, not coordinates."""
+        axis = random_patch.get_axis("time")
+        out = random_patch.flip("time", flip_coords=False)
+        assert np.array_equal(out.data, np.flip(random_patch.data, axis=axis))
+        assert out.get_coord("time") == random_patch.get_coord("time")
+
+    def test_no_op(self, random_patch):
+        """Ensure passing no dims does nothing."""
+        out = random_patch.flip()
+        assert out is random_patch

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -772,3 +772,41 @@ class TestWhere:
         # Verify the actual time values match the expected overlap
         expected_time_values = time_coord[8:15]
         assert np.array_equal(result_time, expected_time_values)
+
+
+class TestFlip:
+    """Test for flipping patch."""
+
+    def test_flipped_time(self, random_patch):
+        """Test basic properties of flipped patch."""
+        flipped_patch = random_patch.flip("time")
+
+        # Dimensions and shape should be the same.
+        assert flipped_patch.data.shape == random_patch.shape
+        assert flipped_patch.dims == random_patch.dims
+
+        # Time coord should have reversed.
+        flipped_time = flipped_patch.coords.get_array("time")
+        time = random_patch.get_array("time")
+        assert np.all(flipped_time == time[::-1])
+
+    def test_flipped_time_and_distance(self, random_patch):
+        """Test basic properties of flipped patch."""
+        flipped_patch = random_patch.flip("time", "distance")
+
+        # Dimensions and shape should be the same.
+        assert flipped_patch.data.shape == random_patch.shape
+        assert flipped_patch.dims == random_patch.dims
+
+        # Time and distance should have reversed.
+        flipped_time = flipped_patch.coords.get_array("time")
+        time = random_patch.get_array("time")
+        assert np.all(flipped_time == time[::-1])
+        flipped_distance = flipped_patch.coords.get_array("distance")
+        distance = random_patch.get_array("distance")
+        assert np.all(flipped_distance == distance[::-1])
+
+    def test_no_coords(self, random_patch):
+        """Ensure coord doesn't change with flip_coords=False"""
+        flipped_patch = random_patch.flip("time", flip_coords=False)
+        assert flipped_patch.get_coord("time") == random_patch.get_coord("time")


### PR DESCRIPTION
## Description

This PR implements the `Patch.flip` method which just flips the underlying data, and optionally, the coordinates.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] your name has been added to the contributors page (docs/contributors.md).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Flip data and associated coordinates along one or more dimensions; patch.flip added with option to flip data only or also update coordinates.
- Refactor
  - Replaced manual mirroring in dispersion processing with the unified flip capability for cleaner, consistent behavior.
- Tests
  - Added comprehensive tests for single/multi-dimension flips, associated-coordinate propagation, error cases, idempotency, empty coordinates, and optional coordinate preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->