### PR TITLE
fix_534

### DIFF
--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -65,7 +65,15 @@ def _get_extents(dims_r, coords):
     lims = {x: [] for x in dims_r}
     for dim in dims_r:
         array = coords[dim]
-        lims[dim] += [array.min(), array.max()]
+        # Use nanmin/nanmax to handle NaN/NaT values in coordinates
+        with suppress_warnings(RuntimeWarning):
+            array_min = np.nanmin(array)
+            array_max = np.nanmax(array)
+        # If all values are NaN/NaT, fall back to index-based extents
+        if np.isnan(array_min) or np.isnan(array_max):
+            array_min = 0
+            array_max = len(array) - 1
+        lims[dim] += [array_min, array_max]
     # find datetime coords and convert to numpy mtimes
     _convert_datetimes(coords, lims)
     _convert_timedeltas(coords, lims)

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -179,3 +179,14 @@ class TestWaterfall:
         assert (
             cb_label == expected_label
         ), f"Expected '{expected_label}', but got '{cb_label}'"
+
+    def test_incomplete_time_coord(self):
+        """Test waterfall plot with incomplete time coordinates (issue #534)."""
+        # Create a patch with aggregated time dimension (all NaN coordinates)
+        spool = dc.get_example_spool()
+        sub = spool.chunk(time=2, overlap=1)
+        aggs = dc.spool([x.max("time") for x in sub]).concatenate(time=None)[0]
+        # This should not raise an error
+        ax = aggs.viz.waterfall()
+        assert ax is not None
+        assert isinstance(ax, plt.Axes)


### PR DESCRIPTION
## Description

Implements a fix for #534. 


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plotting robustness when time coordinates contain NaN/NaT values by using sensible fallbacks for axis extents, preventing blank plots or errors.
  * Waterfall plots now render reliably even with incomplete or irregular time data.

* **Tests**
  * Added a test to verify correct rendering of waterfall plots with incomplete time coordinates (issue #534), enhancing confidence in plotting behavior under real-world data irregularities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->