### PR TITLE
fix #462

### DIFF
--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -93,6 +93,22 @@ def wiggle(
     >>> _ = patch.viz.wiggle()
     """
     ax = _get_ax(ax)
+
+    # Handle 1D patches (issue #462)
+    if len(patch.dims) == 1:
+        plot_dim = patch.dims[0]
+        x_values = patch.coords.get_array(plot_dim)
+        y_values = patch.data
+        ax.plot(x_values, y_values, color=color, alpha=alpha)
+        ax.set_xlabel(_get_dim_label(patch, plot_dim))
+        ax.set_ylabel("amplitude")
+        # Format time axis if applicable
+        if np.issubdtype(patch.get_coord(plot_dim).dtype, np.datetime64):
+            _format_time_axis(ax, plot_dim, "x")
+        if show:
+            plt.show()
+        return ax
+
     assert len(patch.dims) == 2, "Can only make wiggle plot of 2D Patch"
     # After transpose selected dim must be axis 0 and other axis 1
     patch = patch.transpose(dim, ...)

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -54,3 +54,19 @@ class TestWiggle:
         """Ensure show path is callable."""
         monkeypatch.setattr(plt, "show", lambda: None)
         random_patch.viz.wiggle(show=True)
+
+    def test_1d_patch(self, random_patch):
+        """Test that wiggle works with 1D patches (issue #462)."""
+        # Create a 1D patch by reducing one dimension
+        patch_1d = random_patch.mean("distance", dim_reduce="squeeze")
+        # This should work without raising an assertion error
+        ax = patch_1d.viz.wiggle()
+        assert isinstance(ax, plt.Axes)
+        # The remaining dimension should be on the x-axis
+        assert patch_1d.dims[0].lower() in ax.get_xlabel().lower()
+
+    def test_1d_patch_show(self, random_patch, monkeypatch):
+        """Test that show works with 1D patches (issue #462)."""
+        monkeypatch.setattr(plt, "show", lambda: None)
+        patch_1d = random_patch.mean("distance", dim_reduce="squeeze")
+        patch_1d.viz.wiggle(show=True)


### PR DESCRIPTION
## Description
This PR fixes #462. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Wiggle plot now supports 1D data: directly plots using the remaining coordinate on the x-axis.
  * Automatically labels axes (x: dimension label, y: amplitude) and formats time axes when coordinates are datetime.
  * Optional display via show is supported; returns the plotting axis.

* Tests
  * Added tests validating 1D wiggle plotting and show behavior to ensure correct axis labeling and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->