### PR TITLE
fix 529

### DIFF
--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -67,6 +67,9 @@ def _format_values(val):
             precision=FLOAT_PRECISION,
             threshold=dascore_styles["patch_history_array_threshold"],
         )
+    elif isinstance(val, dc.Patch):
+        # Truncate patch representations in history (issue #529)
+        out = "Patch..."
     else:
         out = str(val)
     return out

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -186,6 +186,29 @@ class TestHistory:
         # No new patch should have been created.
         assert out is random_patch
 
+    def test_patch_argument_truncated(self, random_patch):
+        """
+        Ensure patch arguments are truncated in history (issue #529).
+        """
+        from dascore.utils.patch import patch_function
+
+        @patch_function()
+        def func_with_patch_arg(patch, other_patch):
+            """Test function with patch argument."""
+            return patch.new(data=patch.data + 1)
+
+        other = random_patch.mean("time")
+        result = func_with_patch_arg(random_patch, other_patch=other)
+        history_str = result.attrs.history[0]
+
+        # History should contain truncated representation, not full patch string
+        assert "Patch..." in history_str
+        # Should not contain the full multi-line patch representation
+        assert "\n➤ Coordinates" not in history_str
+        assert "\n➤ Data" not in history_str
+        # Check it's reasonably short (less than 100 chars)
+        assert len(history_str) < 100
+
 
 class TestMergePatches:
     """Tests for merging patches together."""


### PR DESCRIPTION
This PR fixes #529 by truncating the patch representation in history strings. 


## Description

<!--
Please describe your PR here. What problem are you trying to solve, or what feature are you adding?

Also link any relevant issues/discussions (this can be done using the issue/discussion number preceded by a
pound sign, e.g. `#12` without the backticks)
-->

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * History displays now truncate Patch objects to a concise “Patch...” placeholder, improving readability and preventing overly long, noisy entries.
* **Tests**
  * Added tests to confirm Patch arguments are shortened in history output, exclude detailed patch contents, and keep entries within a compact length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->