### PR TITLE
Prodml fbe

### DIFF
--- a/dascore/data_registry.txt
+++ b/dascore/data_registry.txt
@@ -31,3 +31,4 @@ UoU_lf_urban.hdf5 d3f8fa6ff3d8ae993484b3fbf9b39505e2cf15cb3b39925a3519b27d5fbe7b
 small_channel_patch.sgy 31e551aadb361189c1c9325d504c883114ba9a7bb75fe4791e5089fabccef704 https://github.com/dasdae/test_data/raw/master/das/small_channel_patch.sgy
 gdr_1.h5 aaf11a7333b720436d194e3c7f4fa66f38907bb0c9abfa1804c150e634642aa2 https://github.com/dasdae/test_data/raw/master/das/gdr_1.h5
 sintela_binary_v3_test_1.raw 4c0afae1ab60b73ddcb3c4f7ac55b976d4d18d1ffc9ea6cd2dfa6a881b697101 https://github.com/dasdae/test_data/raw/master/das/sintela_binary_v3_test_1.raw
+prodml_fbe_1.h5 1e7fa0e63bd701ae5f65e5c1adfb02957594b4e334a6933a38cae2481ecdeabb https://github.com/dasdae/test_data/raw/master/das/prodml_fbe_1.h5

--- a/dascore/io/ap_sensing/core.py
+++ b/dascore/io/ap_sensing/core.py
@@ -11,7 +11,7 @@ from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 
-from .utils import _get_attrs_dict, _get_patch, _get_version_string
+from .utils import _get_attrs_dict, _get_patches, _get_version_string
 
 
 class APSensingPatchAttrs(dc.PatchAttrs):
@@ -61,7 +61,7 @@ class APSensingV10(FiberIO):
         **kwargs,
     ) -> dc.BaseSpool:
         """Read a single file with APSensing data inside."""
-        patches = _get_patch(
+        patches = _get_patches(
             resource, time=time, distance=distance, attr_cls=APSensingPatchAttrs
         )
         return dc.spool(patches)

--- a/dascore/io/ap_sensing/utils.py
+++ b/dascore/io/ap_sensing/utils.py
@@ -87,7 +87,7 @@ def _get_attrs_dict(resource):
     return out
 
 
-def _get_patch(resource, time=None, distance=None, attr_cls=dc.PatchAttrs):
+def _get_patches(resource, time=None, distance=None, attr_cls=dc.PatchAttrs):
     """Get a patch from ap_sensing file."""
     attrs = _get_attrs_dict(resource)
     coords = attrs["coords"]
@@ -95,5 +95,7 @@ def _get_patch(resource, time=None, distance=None, attr_cls=dc.PatchAttrs):
     if time is not None or distance is not None:
         coords, data = coords.select(array=data, time=time, distance=distance)
         attrs["coords"] = coords
+        if not data.size:
+            return []
     attrs = attr_cls.model_validate(attrs)
-    return dc.Patch(data=data[:], coords=coords, attrs=attrs)
+    return [dc.Patch(data=data[:], coords=coords, attrs=attrs)]

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -117,7 +117,10 @@ class DASDAEV1(FiberIO):
         except (KeyError, IndexError):
             return dc.spool([])
         for patch_group in waveform_group:
-            patches.append(_read_patch(patch_group, **kwargs))
+            patch = _read_patch(patch_group, **kwargs)
+            if not patch.data.size and kwargs:
+                continue
+            patches.append(patch)
         return dc.spool(patches)
 
     def scan(self, resource: PyTablesReader, **kwargs):

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -21,6 +21,7 @@ from dascore.utils.patch import get_patch_names
 
 from .utils import (
     _get_contents_from_patch_groups,
+    _kwargs_empty,
     _read_patch,
     _save_patch,
     _write_meta,
@@ -118,7 +119,7 @@ class DASDAEV1(FiberIO):
             return dc.spool([])
         for patch_group in waveform_group:
             patch = _read_patch(patch_group, **kwargs)
-            if not patch.data.size and kwargs:
+            if not patch.data.size and not _kwargs_empty(kwargs):
                 continue
             patches.append(patch)
         return dc.spool(patches)

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -12,6 +12,10 @@ from dascore.core.coords import get_coord
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.time import to_int
 
+# Keys not counted as true kwargs for determining if patch is filtered/selected.
+_KWARG_NON_KEYS = {"file_version", "file_format", "path"}
+
+
 # --- Functions for writing DASDAE format
 
 
@@ -183,12 +187,13 @@ def _get_contents_from_patch_groups(h5, file_version, file_format="DASDAE"):
     return out
 
 
-def _kwargs_empty(kwargs):
-    """Determine if the keyword arguments are effectively empty."""
+def _kwargs_empty(kwargs) -> bool:
+    """Determine if the keyword arguments are *effectively* empty."""
     # These keys get passed in from some spools, so don't count them.
-    pop_keys = {"file_version", "file_format", "path"}
     # We also only count keys whose values are not None.
-    out = {i: v for i, v in kwargs.items() if v is not None and i not in pop_keys}
+    out = {
+        i: v for i, v in kwargs.items() if v is not None and i not in _KWARG_NON_KEYS
+    }
     return not bool(out)
 
 

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -183,6 +183,15 @@ def _get_contents_from_patch_groups(h5, file_version, file_format="DASDAE"):
     return out
 
 
+def _kwargs_empty(kwargs):
+    """Determine if the keyword arguments are effectively empty."""
+    # These keys get passed in from some spools, so don't count them.
+    pop_keys = {"file_version", "file_format", "path"}
+    # We also only count keys whose values are not None.
+    out = {i: v for i, v in kwargs.items() if v is not None and i not in pop_keys}
+    return not bool(out)
+
+
 def _get_patch_content_from_group(group):
     """Get patch content from a single node."""
     attrs = group._v_attrs

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -68,6 +68,8 @@ class DASHDF5(FiberIO):
             time=time,
             channel=channel,
         )
+        if not data.size:
+            return dc.spool([])
         attrs = _get_cf_attrs(resource, coords_new)
         patch = dc.Patch(
             data=data, attrs=attrs, coords=coords_new, dims=coords_new.dims

--- a/dascore/io/gdr/core.py
+++ b/dascore/io/gdr/core.py
@@ -56,6 +56,8 @@ class GDR_V1(FiberIO):  # noqa
         attr_dict, cm, data = _get_attrs_coords_and_data(resource, snap=snap)
         if kwargs:
             cm, data = _maybe_trim_data(cm, data, **kwargs)
+        if not data.size:  # skip empty patches.
+            return dc.spool([])
         attrs = GDRPatchAttrs(**attr_dict)
         patch = dc.Patch(coords=cm, data=data[:], attrs=attrs)
         return dc.spool([patch])

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -38,6 +38,8 @@ class H5Simple(FiberIO):
         """
         attrs, cm, data = _get_attrs_coords_and_data(resource, snap, self)
         new_cm, new_data = _maybe_trim_data(cm, data, kwargs)
+        if not new_cm.size:
+            return dc.spool([])
         patch = dc.Patch(coords=new_cm, data=new_data[:], attrs=attrs)
         return dc.spool([patch])
 

--- a/dascore/io/neubrex/core.py
+++ b/dascore/io/neubrex/core.py
@@ -71,6 +71,8 @@ class NeubrexRFSV1(FiberIO):
         attr_dict, cm, data = rfs_utils._get_attrs_coords_and_data(resource, snap)
         if kwargs:
             cm, data = rfs_utils._maybe_trim_data(cm, data, **kwargs)
+        if not data.size:
+            return dc.spool([])
         attrs = NeubrexRFSPatchAttrs(**attr_dict)
         patch = dc.Patch(coords=cm, data=data[:], attrs=attrs)
         return dc.spool([patch])
@@ -116,6 +118,8 @@ class NeubrexDASV1(FiberIO):
         attr_dict, cm, data = das_utils._get_attrs_coords_and_data(resource)
         if kwargs:
             cm, data = das_utils._maybe_trim_data(cm, data, **kwargs)
+        if not data.size:
+            return dc.spool([])
         attrs = NeubrexRFSPatchAttrs(**attr_dict)
         patch = dc.Patch(coords=cm, data=data[:], attrs=attrs)
         return dc.spool([patch])

--- a/dascore/io/optodas/utils.py
+++ b/dascore/io/optodas/utils.py
@@ -84,6 +84,8 @@ def _read_opto_das(fi, distance=None, time=None, attr_cls=dc.PatchAttrs):
     data_node = fi["data"]
     coords = attrs.pop("coords")
     cm, data = coords.select(array=data_node, distance=distance, time=time)
+    if not data.size:
+        return []
     attrs["coords"] = cm.to_summary_dict()
     attrs["dims"] = cm.dims
     return [dc.Patch(data=data, coords=cm, attrs=attr_cls(**attrs))]

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -10,7 +10,7 @@ from dascore.io import FiberIO
 from dascore.utils.models import UnitQuantity, UTF8Str
 
 from ...utils.hdf5 import H5Reader
-from .utils import _get_prodml_attrs, _get_prodml_version_str, _read_prodml
+from .utils import _get_prodml_version_str, _read_prodml, _yield_prodml_attrs_coords
 
 
 class ProdMLPatchAttrs(dc.PatchAttrs):
@@ -51,8 +51,10 @@ class ProdMLV2_0(FiberIO):  # noqa
             "file_format": self.name,
             "file_version": str(file_version),
         }
-        attrs = _get_prodml_attrs(resource, extras=extras)
-        return [ProdMLPatchAttrs(**x) for x in attrs]
+        out = []
+        for attr, coords in _yield_prodml_attrs_coords(resource, extras=extras):
+            out.append(attr.update(coords=coords))
+        return out
 
     def read(
         self,
@@ -62,9 +64,7 @@ class ProdMLV2_0(FiberIO):  # noqa
         **kwargs,
     ) -> dc.BaseSpool:
         """Read a ProdML file."""
-        patches = _read_prodml(
-            resource, time=time, distance=distance, attr_cls=ProdMLPatchAttrs
-        )
+        patches = _read_prodml(resource, time=time, distance=distance)
         return dc.spool(patches)
 
 

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -239,9 +239,9 @@ def _get_processed_node_attr_coords(node_info, d_coord, base_info):
     # For some reason, the distance coords in raw and fbe data are not the
     # same. For now, we just assume the FBE distance is a subset of the raw
     # distance referenced by StartLocusIndex. It may be that the test file used
-    # develop this code was wrong and we need to revise this.
-    start_ind = unbyte(node_info.parent_node.attrs["NumberOfLoci"])
-    total_inds = unbyte(node_info.parent_node.attrs["NumberOfLoci"])
+    # develop this code was malformed and we need to revise this.
+    start_ind = node_info.parent_node.attrs.get("StartLocusIndex", 0)
+    total_inds = node_info.parent_node.attrs["NumberOfLoci"]
     # Put the coords back together.
     distance = d_coord[start_ind : start_ind + total_inds]
     coords = dc.get_coord_manager(
@@ -299,7 +299,7 @@ def _get_dims_from_attrs(attrs):
 def _read_prodml(fi, distance=None, time=None):
     """Read the prodml values into a patch."""
     out = []
-    iterator = zip(_yield_prodml_attrs_coords(fi), _yield_data_nodes(fi))
+    iterator = zip(_yield_prodml_attrs_coords(fi), _yield_data_nodes(fi), strict=True)
     for (attrs, cm), info in iterator:
         data_func = _NODE_DATA_PROCESSORS[info.patch_type]
         data = data_func(info)

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -242,8 +242,18 @@ def _get_processed_node_attr_coords(node_info, d_coord, base_info):
     # same. For now, we just assume the FBE distance is a subset of the raw
     # distance referenced by StartLocusIndex. It may be that the test file used
     # develop this code was malformed and we need to revise this.
-    start_ind = node_info.parent_node.attrs.get("StartLocusIndex", 0)
-    total_inds = node_info.parent_node.attrs["NumberOfLoci"]
+    start_raw = node_info.parent_node.attrs.get("StartLocusIndex", 0)
+    total_raw = node_info.parent_node.attrs["NumberOfLoci"]
+    start_ind = int(
+        np.asarray(unbyte(start_raw))
+        if isinstance(start_raw, bytes | np.bytes_)
+        else np.asarray(start_raw).item()
+    )
+    total_inds = int(
+        np.asarray(unbyte(total_raw))
+        if isinstance(total_raw, bytes | np.bytes_)
+        else np.asarray(total_raw).item()
+    )
     # Put the coords back together.
     distance = d_coord[start_ind : start_ind + total_inds]
     coords = dc.get_coord_manager(

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -303,8 +303,8 @@ def _read_prodml(fi, distance=None, time=None):
     for (attrs, cm), info in iterator:
         data_func = _NODE_DATA_PROCESSORS[info.patch_type]
         data = data_func(info)
+        if time is not None or distance is not None:
+            cm, data = cm.select(array=data, time=time, distance=distance)
         if data.size:
-            if time is not None or distance is not None:
-                cm, data = cm.select(array=data, time=time, distance=distance)
             out.append(dc.Patch(data=data, attrs=attrs, coords=cm))
     return out

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -264,8 +264,7 @@ def _get_raw_data(node_info):
 @register_func(_NODE_DATA_PROCESSORS, key="fbe")
 def _get_fbe_data(node_info):
     """Get the data from a fbe node."""
-    node = node_info.node
-    return node[:]
+    return node_info.node
 
 
 def _yield_prodml_attrs_coords(fi, extras=None):

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -242,20 +242,12 @@ def _get_processed_node_attr_coords(node_info, d_coord, base_info):
     # same. For now, we just assume the FBE distance is a subset of the raw
     # distance referenced by StartLocusIndex. It may be that the test file used
     # develop this code was malformed and we need to revise this.
-    start_raw = node_info.parent_node.attrs.get("StartLocusIndex", 0)
-    total_raw = node_info.parent_node.attrs["NumberOfLoci"]
-    start_ind = int(
-        np.asarray(unbyte(start_raw))
-        if isinstance(start_raw, bytes | np.bytes_)
-        else np.asarray(start_raw).item()
-    )
-    total_inds = int(
-        np.asarray(unbyte(total_raw))
-        if isinstance(total_raw, bytes | np.bytes_)
-        else np.asarray(total_raw).item()
-    )
+    start = node_info.parent_node.attrs.get("StartLocusIndex", 0)
+    total = node_info.parent_node.attrs["NumberOfLoci"]
+    ind_1 = int(unbyte(start) if isinstance(start, bytes | np.bytes_) else start)
+    count = int(unbyte(total) if isinstance(total, bytes | np.bytes_) else total)
     # Put the coords back together.
-    distance = d_coord[start_ind : start_ind + total_inds]
+    distance = d_coord[ind_1 : ind_1 + count]
     coords = dc.get_coord_manager(
         coords={"time": t_coord, "distance": distance},
         dims=_get_dims_from_attrs(node_info.parent_node.attrs),

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -47,10 +47,11 @@ class SegyV1_0(FiberIO):  # noqa
             data, coords = _get_filtered_data_and_coords(
                 fi, coords, time=time, channel=channel
             )
+        if not data.size:
+            return dc.spool([])
 
         patch = dc.Patch(coords=coords, data=data, attrs=attrs)
-        patch_trimmed = patch.select(time=time, channel=channel)
-        return dc.spool([patch_trimmed])
+        return dc.spool([patch])
 
     def scan(self, path, **kwargs) -> list[dc.PatchAttrs]:
         """

--- a/dascore/io/silixah5/core.py
+++ b/dascore/io/silixah5/core.py
@@ -11,7 +11,7 @@ from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 
-from .utils import _get_attr, _get_patch, _get_version_string
+from .utils import _get_attr, _get_patches, _get_version_string
 
 
 class SilixaPatchAttrs(dc.PatchAttrs):
@@ -62,7 +62,7 @@ class SilixaH5V1(FiberIO):
         **kwargs,
     ) -> dc.BaseSpool:
         """Read a single file with Silixa H5 data inside."""
-        patches = _get_patch(
+        patches = _get_patches(
             resource, time=time, distance=distance, attr_cls=SilixaPatchAttrs
         )
         return dc.spool(patches)

--- a/dascore/io/silixah5/utils.py
+++ b/dascore/io/silixah5/utils.py
@@ -101,7 +101,7 @@ def _get_attr(resource, attr_cls, extras=None):
     return attrs
 
 
-def _get_patch(resource, time=None, distance=None, attr_cls=dc.PatchAttrs):
+def _get_patches(resource, time=None, distance=None, attr_cls=dc.PatchAttrs):
     """Get a patch from ap_sensing file."""
     attrs = _get_attr_dict(resource)
     coords = attrs["coords"]
@@ -109,7 +109,9 @@ def _get_patch(resource, time=None, distance=None, attr_cls=dc.PatchAttrs):
     if time is not None or distance is not None:
         coords, data = coords.select(array=data, time=time, distance=distance)
         attrs["coords"] = coords
+    if not data.size:
+        return []
     expected_fields = set(attr_cls.model_fields)
     attrs_sub = {i: v for i, v in attrs.items() if i in expected_fields}
     attrs = attr_cls.model_validate(attrs_sub)
-    return dc.Patch(data=data[:], coords=coords, attrs=attrs)
+    return [dc.Patch(data=data[:], coords=coords, attrs=attrs)]

--- a/dascore/io/sintela_binary/core.py
+++ b/dascore/io/sintela_binary/core.py
@@ -15,7 +15,7 @@ from .utils import (
     _HEADER_SIZES,
     SYNC_WORD,
     _get_attrs_coords_header,
-    _get_patch,
+    _get_patches,
     _read_base_header,
 )
 
@@ -74,7 +74,8 @@ class SintelaBinaryV3(FiberIO):
         **kwargs,
     ) -> dc.BaseSpool:
         """Read a single Sintela binary file."""
-        patch = _get_patch(
+        patch = _get_patches(
             resource, time=time, distance=distance, attr_class=SintelaPatchAttrs
         )
+
         return dc.spool(patch)

--- a/dascore/io/sintela_binary/utils.py
+++ b/dascore/io/sintela_binary/utils.py
@@ -223,7 +223,7 @@ def _get_patches(
     # can be sliced before loading all data into memory.
     if time is not None or distance is not None:
         cm, data = cm.select(data, time=time, distance=distance)
-    patch = dc.Patch(data=array(data), coords=cm, attrs=patch_attrs)
     if not data.size:  # no data in this slice.
         return []
+    patch = dc.Patch(data=array(data), coords=cm, attrs=patch_attrs)
     return [patch]

--- a/dascore/io/sintela_binary/utils.py
+++ b/dascore/io/sintela_binary/utils.py
@@ -213,7 +213,7 @@ def _get_attrs_coords_header(rid, attr_class=PatchAttrs, extras=None):
     return attr_class(**attrs), cm, header
 
 
-def _get_patch(
+def _get_patches(
     resource, attr_class=PatchAttrs, extras=None, time=None, distance=None, **kwargs
 ):
     """Get the patch from the sintela file."""
@@ -224,4 +224,6 @@ def _get_patch(
     if time is not None or distance is not None:
         cm, data = cm.select(data, time=time, distance=distance)
     patch = dc.Patch(data=array(data), coords=cm, attrs=patch_attrs)
-    return patch
+    if not data.size:  # no data in this slice.
+        return []
+    return [patch]

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -59,5 +59,7 @@ class TDMSFormatterV4713(FiberIO):
         # trim data if required
         if time is not None or distance is not None:
             coords, data = coords.select(data, time=time, distance=distance)
+        if not data.size:
+            return dc.spool([])
         patch = Patch(data=data, coords=coords, attrs=attrs)
         return dc.spool(patch)

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -70,6 +70,8 @@ class Terra15FormatterV4(FiberIO):
             negligible.
         """
         patch = _read_terra15(resource, time, distance, snap_dims=snap_dims)
+        if not patch.data.size:
+            return dc.spool([])
         return dc.spool(patch)
 
 

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -130,8 +130,13 @@ class TestReadDASDAE:
         assert len(out) == 1
         assert out[0].equals(random_patch)
 
+    @pytest.mark.xfail()
     def test_round_trip_empty_patch(self, written_dascore_v1_empty):
-        """Ensure an emtpy patch can be deserialize."""
+        """Ensure an emtpy patch can be deserialized."""
+        # Note: since we added support for FBE prodml and tested that slicing
+        # doesn't return empty patches, we can no longer round trip empty
+        # patches. This is an obscure edge case and will probably not affect
+        # any codes in the wild.
         spool = dc.read(written_dascore_v1_empty)
         assert len(spool) == 1
         spool[0].equals(dc.Patch())

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -130,13 +130,8 @@ class TestReadDASDAE:
         assert len(out) == 1
         assert out[0].equals(random_patch)
 
-    @pytest.mark.xfail()
     def test_round_trip_empty_patch(self, written_dascore_v1_empty):
-        """Ensure an emtpy patch can be deserialized."""
-        # Note: since we added support for FBE prodml and tested that slicing
-        # doesn't return empty patches, we can no longer round trip empty
-        # patches. This is an obscure edge case and will probably not affect
-        # any codes in the wild.
+        """Ensure an empty patch can be deserialized."""
         spool = dc.read(written_dascore_v1_empty)
         assert len(spool) == 1
         spool[0].equals(dc.Patch())


### PR DESCRIPTION
 <!--
Thanks for contributing to DASCore, community contributions are most welcomed!

Before contributing, please read through the [contributors doc](https://dascore.org/contributing/contributing.html)

Before making big changes to the code or adding large complex features, it is a good idea to [open a discussion](https://github.com/DASDAE/dascore/discussions). Don't hesitate to ask a question or ask for
help if something isn't clear.
-->

## Description
This PR adds support for FBE (frequency band extracted) patches in prodml files. It also tests that slicing out of bands returns empty spools for all commonly tested fiberIO instances. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded ProdML support and added ProdML patch attribute types.

* **Bug Fixes**
  * Readers across formats now return empty results when time/distance selections yield no data (prevent empty patches).

* **Behavior Changes**
  * SEGY reads no longer perform channel/time trimming; full patch returned unless selection excludes all samples.

* **Tests**
  * Added tests verifying empty-read behavior when slices exclude all patches; minor docstring fix.

* **Chores**
  * Added a new sample dataset entry to the data registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->