### PR TITLE
Add proper error message for missing dims in Patch.transpose

### DIFF
--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -608,6 +608,14 @@ def transpose(self: PatchType, *dims: str) -> PatchType:
     """
     dims = tuple(dims)
     old_dims = self.coords.dims
+    # Filter out ellipsis from dims to validate
+    dims_to_check = [d for d in dims if d is not ...]
+    # Check for invalid dimensions
+    if invalid_dims := set(dims_to_check) - set(old_dims):
+        invalid_list = sorted(invalid_dims)
+        valid_list = sorted(old_dims)
+        msg = f"Dimension(s) {invalid_list} not found in Patch dimensions: {valid_list}"
+        raise ParameterError(msg)
     new_coord = self.coords.transpose(*dims)
     new_dims = new_coord.dims
     axes = tuple(old_dims.index(x) for x in new_dims)

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -115,16 +115,6 @@ class TestsAngle:
         assert np.allclose(out.data, np.angle(random_complex_patch.data))
 
 
-class TestTranspose:
-    """Tests for transposing patch."""
-
-    def test_transpose_no_args(self, random_patch):
-        """Ensure transposing rotates dimensions."""
-        pa = random_patch.transpose()
-        assert pa.dims != random_patch.dims
-        assert pa.dims == random_patch.dims[::-1]
-
-
 class TestNormalize:
     """Tests for normalization."""
 


### PR DESCRIPTION
## Description

This PR adds an error message to `Patch.transpose` raised when one of the dimensions is not found in the patch. It also improves the testing of the transpose function. 

closes #570.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved transpose validation: ignores ellipsis in provided dimensions and raises a clear error when unknown dimensions are supplied, including a list of valid options. Standard transpose behavior is unchanged.

- Tests
  - Expanded test coverage for transpose across multiple dimensions, permutations, and ellipsis handling, ensuring shapes and data integrity are correct.
  - Removed an outdated transpose test to streamline the suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->