### PR TITLE
Waterfall refactor

### DIFF
--- a/dascore/proc/taper.py
+++ b/dascore/proc/taper.py
@@ -277,7 +277,6 @@ def taper_range(
     >>> # Apply two non-overlapping tapers
     >>> taper_range = ((25,50,100,125), (150,175,200,225))
     >>> patch_tapered_5 = patch.taper_range(distance=taper_range)
-
     """
     dim, ax, values = get_dim_axis_value(patch, kwargs=kwargs)[0]
     coord = patch.get_coord(dim, require_sorted=True)

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -401,7 +401,7 @@ def maybe_convert_percent_to_fraction(obj):
     """
     percent = get_unit("percent")
     out = []
-    obj = [obj] if isinstance(obj, Quantity | Unit) and obj.ndim == 0 else obj
+    obj = [obj] if isinstance(obj, Quantity) and obj.ndim == 0 else obj
     for val in iterate(obj):
         if hasattr(val, "units"):
             mag, unit = val.magnitude, val.units

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -80,7 +80,7 @@ def _get_scale(scale, scale_type, data):
         case (scale, "relative"):
             scale = np.array(scale)
             # Validate scale parameters
-            if np.any(scale < 0) or scale[0] > scale[1] or len(scale) != 2:
+            if len(scale) != 2 or np.any(scale < 0) or scale[0] > scale[1]:
                 msg = (
                     "Relative scale values cannot be negative and the first "
                     f"value must be less than the second. You passed {scale}"
@@ -182,7 +182,7 @@ def waterfall(
     >>> _ = patch.viz.waterfall(scale=10*percent, scale_type="absolute")
     >>>
     >>> # Use relative scaling with a tuple to show the middle 80% of data range
-    >>> # Scale values of (0.1, 0.9) map to 10th and 90th percentile of data
+    >>> # Scale values of (0.1, 0.9) map to 10% and 90% of [data_min, data_max]
     >>> _ = patch.viz.waterfall(scale=(0.1, 0.9), scale_type="relative")
     >>>
     >>> # Use absolute scaling to set specific colorbar limits

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -34,13 +34,17 @@ def _validate_scale_type(scale_type):
 
 def _validate_patch_dims(patch):
     """Validate that patch is 2D for waterfall plotting."""
-    dims = patch.dims
-    if len(dims) != 2:
-        msg = (
-            f"Can only make waterfall plot of 2D Patch, "
-            f"but got {len(dims)}D patch with dims {dims}"
-        )
-        raise ParameterError(msg)
+    if patch.ndim != 2:
+        # Try squeezing out degenerate dims to visualize.
+        patch = patch.squeeze()
+        if patch.ndim != 2:
+            dims = patch.dims
+            msg = (
+                f"Can only make waterfall plot of 2D Patch, "
+                f"but got {patch.ndim}D patch with dims {dims}"
+            )
+            raise ParameterError(msg)
+    return patch
 
 
 def _get_scale(scale, scale_type, patch):
@@ -187,7 +191,7 @@ def waterfall(
       problem. To get the old behavior, simply set scale=1.0.
     """
     # Validate inputs
-    _validate_patch_dims(patch)
+    patch = _validate_patch_dims(patch)
 
     # Setup axes and data
     ax = _get_ax(ax)

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -59,7 +59,15 @@ def _get_scale(scale, scale_type, data):
         # Scale is symmetric around the mean, using fraction of dynamic range
         case (scale, "relative") if len(scale) == 1:
             scale = scale[0]
+            if scale == 0:
+                msg = (
+                    "Relative scale value of 0 would produce degenerate colorbar limits"
+                )
+                raise ParameterError(msg)
             mod = 0.5 * (np.nanmax(data) - np.nanmin(data))
+            if mod == 0:
+                # Constant data, use small epsilon to avoid degenerate limits
+                mod = 1e-10
             mean = np.nanmean(data)
             scale = np.asarray([mean - scale * mod, mean + scale * mod])
         # Case 2: No scale specified with relative scaling
@@ -176,7 +184,7 @@ def waterfall(
     >>>
     >>> # Use relative scaling with a tuple to show a specific fraction
     >>> # of data range. Scale values of (0.1, 0.9) map to 10% and 90%
-    >>> # of the [data_min, data_max] range data's dynamic range
+    >>> # of the data's [min, max] range
     >>> _ = patch.viz.waterfall(scale=0.1, scale_type="relative")
     >>> # Likewise, percent units can be used for additional clarity
     >>> _ = patch.viz.waterfall(scale=10*percent, scale_type="absolute")
@@ -241,7 +249,7 @@ def waterfall(
         origin="lower",
         # Note: these parameters are so that matplotlib versions > 3.10 behave
         # like matplotlib < 3.9, which tends to work better for visualizing large
-        # DAS data. See # 512. We might consider making these parameters of the
+        # DAS data. See #512. We might consider making these parameters of the
         # waterfall function in the future.
         interpolation="antialiased",
         interpolation_stage="data",

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -230,7 +230,19 @@ def waterfall(
     # Plot using imshow and set colorbar limits
     extents = _get_extents(dims_r, coords)
     scale = _get_scale(scale, scale_type, patch)
-    im = ax.imshow(data, extent=extents, aspect="auto", cmap=cmap, origin="lower")
+    im = ax.imshow(
+        data,
+        extent=extents,
+        aspect="auto",
+        cmap=cmap,
+        origin="lower",
+        # Note: these parameters are so that matplotlib versions > 3.10 behave
+        # like matplotlib < 3.9, which tends to work better for visualizing large
+        # DAS data. See # 512. We might consider making these parameters of the
+        # waterfall function in the future.
+        interpolation="antialiased",
+        interpolation_stage="data",
+    )
     im.set_clim(scale)
 
     # Format axis labels and handle time-like dimensions

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -20,28 +20,58 @@ from dascore.utils.plotting import (
     _get_extents,
 )
 
+# Constants
+IQR_FENCE_MULTIPLIER = 1.5  # Tukey's fence for outlier detection
+
+
+def _validate_scale_type(scale_type):
+    """Validate that scale_type is either 'relative' or 'absolute'."""
+    valid_types = {"absolute", "relative"}
+    if scale_type not in valid_types:
+        msg = f"scale_type must be one of {valid_types}, " f"but got '{scale_type}'"
+        raise ParameterError(msg)
+
+
+def _validate_patch_dims(patch):
+    """Validate that patch is 2D for waterfall plotting."""
+    dims = patch.dims
+    if len(dims) != 2:
+        msg = (
+            f"Can only make waterfall plot of 2D Patch, "
+            f"but got {len(dims)}D patch with dims {dims}"
+        )
+        raise ParameterError(msg)
+
 
 def _get_scale(scale, scale_type, patch):
-    """Set the scale of the color bar based on scale and scale_type."""
-    # check scale parameters
-    assert scale_type in {"absolute", "relative"}
+    """
+    Calculate the color bar scale limits based on scale and scale_type.
+    """
+    _validate_scale_type(scale_type)
     data = patch.data
 
     match (scale, scale_type):
-        # Floating point value, relative type and zero mean
+        # Case 1: Single value with relative scaling
+        # Scale is symmetric around the mean, using fraction of dynamic range
         case (scale, "relative") if isinstance(scale, float | int):
             mod = 0.5 * (np.nanmax(data) - np.nanmin(data))
-            mean = np.nanmean(patch.data)
+            mean = np.nanmean(data)
             scale = np.asarray([mean - scale * mod, mean + scale * mod])
-        # No scale specified and relative, use fence.
+        # Case 2: No scale specified with relative scaling
+        # Use Tukey's fence (1.5*IQR) to exclude outliers. This prevents
+        # a few extreme values from obscuring the majority of the data.
         case (None, "relative"):
             q2, q3 = np.nanpercentile(data, [25, 75])
-            diff = q3 - q2
-            scale = np.asarray([q2 - diff * 1.5, q3 + diff * 1.5])
-        # Here scale must be a list, tuple, or array.
+            diff = q3 - q2  # Interquartile range (IQR)
+            scale = np.asarray(
+                [q2 - diff * IQR_FENCE_MULTIPLIER, q3 + diff * IQR_FENCE_MULTIPLIER]
+            )
+        # Case 3: Sequence with relative scaling
+        # Scale values represent fractions of the data range [0, 1]
+        # and are mapped to [data_min, data_max]
         case (scale, "relative"):
-            # Raise if invalid scale params.
             scale = np.array(scale)
+            # Validate scale parameters
             if np.any(scale < 0) or scale[0] > scale[1] or len(scale) != 2:
                 msg = (
                     "Relative scale values cannot be negative and the first "
@@ -50,8 +80,40 @@ def _get_scale(scale, scale_type, patch):
                 raise ParameterError(msg)
             dmin, dmax = np.nanmin(data), np.nanmax(data)
             data_range = dmax - dmin
+            # Map [0, 1] to [data_min, data_max]
             scale = dmin + scale * data_range
+    # Case 4: Absolute scaling (default, no match needed)
+    # Scale values are used directly as colorbar limits
     return scale
+
+
+def _format_axis_labels(ax, patch, dims_r):
+    """
+    Format axis labels and handle time-like axes.
+    """
+    for dim, x in zip(dims_r, ["x", "y"]):
+        getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
+        coord = patch.get_coord(dim)
+        if np.issubdtype(coord.dtype, np.datetime64):
+            _format_time_axis(ax, dim, x)
+            # Invert the y axis so origin is at the top. This follows the
+            # convention for seismic shot gathers where time increases downward.
+            if x == "y":
+                ax.invert_yaxis()
+
+
+def _add_colorbar(ax, im, patch, log):
+    """
+    Add a colorbar with appropriate labels to the plot.
+    """
+    cb = ax.get_figure().colorbar(im, ax=ax, fraction=0.05, pad=0.025)
+    data_type = str(patch.attrs["data_type"])
+    data_units = get_quantity_str(patch.attrs.data_units) or ""
+    dunits = f" ({data_units})" if (data_type and data_units) else f"{data_units}"
+    if log:
+        dunits = f"{dunits} - log_10"
+    label = f"{data_type}{dunits}"
+    cb.set_label(label)
 
 
 @patch_function()
@@ -61,86 +123,88 @@ def waterfall(
     cmap="bwr",
     scale: float | Sequence[float] | None = None,
     scale_type: Literal["relative", "absolute"] = "relative",
-    log=False,
-    show=False,
+    log: bool = False,
+    show: bool = False,
 ) -> plt.Axes:
     """
     Create a waterfall plot of the Patch data.
 
-    Parameters
-    ----------
-    patch
-        The Patch object.
-    ax
-        A matplotlib object, if None create one.
-    cmap
-        A matplotlib colormap string or instance. Set to None to not plot the
-        colorbar.
-    scale
-        Controls the saturation level of the colorbar. Values can be:
-        - A float to set upper and lower limit to the same value.
-          This will be cenetered around 0 by default.
-        - A length 2 tuple to independantly set the lower and uper limit
-        - None means use the 1.5*IQR fence to set the upper and lower limits.
-    scale_type
-        Controls the type of scaling specified by `scale` parameter. Options
-        are:
-        - relative - scale based on half the dynamic range in patch
-        - absolute - scale based on absolute values provided to `scale`
-    log
-        If True, visualize the common logarithm of the absolute values of patch data.
-    show
-        If True, show the plot, else just return axis.
-
     Examples
     --------
-    >>> # Plot the default patch
+    >>> # Plot with default scaling (uses 1.5*IQR fence to exclude outliers)
     >>> import dascore as dc
-    >>> patch = dc.get_example_patch()
+    >>> patch = dc.get_example_patch("example_event_1").normalize("time")
     >>> _ = patch.viz.waterfall()
+    >>>
+    >>> # Use relative scaling with a float to saturate at 10% of dynamic range
+    >>> # This centers the colorbar around the mean and extends ±10% of the
+    >>> # data's dynamic range in each direction
+    >>> _ = patch.viz.waterfall(scale=0.1, scale_type="relative")
+    >>>
+    >>> # Use relative scaling with a tuple to show the middle 80% of data range
+    >>> # Scale values of (0.1, 0.9) map to 10th and 90th percentile of data
+    >>> _ = patch.viz.waterfall(scale=(0.1, 0.9), scale_type="relative")
+    >>>
+    >>> # Use absolute scaling to set specific colorbar limits
+    >>> # This directly sets the colorbar limits to [-0.5, 0.5]
+    >>> _ = patch.viz.waterfall(scale=(-0.5, 0.5), scale_type="absolute")
+    >>>
+    >>> # Visualize data on a logarithmic scale
+    >>> # Useful for data spanning multiple orders of magnitude
+    >>> _ = patch.viz.waterfall(log=True)
+    >>>
+    >>> # Compare scale types: relative vs absolute
+    >>> import matplotlib.pyplot as plt
+    >>> fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
+    >>> # Relative: 0.5 means ±50% of dynamic range around mean
+    >>> _ = patch.viz.waterfall(scale=0.5, scale_type="relative", ax=ax1)
+    >>> _ = ax1.set_title("Relative scaling (scale=0.5)")
+    >>> # Absolute: 0.5 means colorbar limits are [-0.5, 0.5]
+    >>> _ = patch.viz.waterfall(scale=0.5, scale_type="absolute", ax=ax2)
+    >>> _ = ax2.set_title("Absolute scaling (scale=0.5)")
+    >>>
+    >>> # Undo Y axis inversion which occurs when time is on the Y
+    >>> ax = patch.viz.waterfall()
+    >>> ax.invert_yaxis()
 
     Notes
     -----
-    Until DASCore version 0.1.13, the default behavior when scale=None was to
-    scale along the entire range of the data. However, very often in real data
-    a few anonomously large or small would obscur most of the patch details.
-    In version 0.1.13 the default behavior is to now use a stiatical fence to
-    avoid the problem. To get the old behavior, simply set scale=1.0.
+    - The Y axis is automatically inverted if it is "time-like". This is to
+      be consistent with standard seismic plotting convention. If you don't
+      want this, simply invert the y axis of the returned axis object as
+      shown in the example section.
+
+    - Changes to default scale behavior: Until DASCore version 0.1.13, the
+      default behavior when scale=None was to scale along the entire range of
+      the data. However, very often in real data a few anomalously large or
+      small values would obscure most of the patch details. In version 0.1.13
+      the default behavior is to now use a statistical fence to avoid the
+      problem. To get the old behavior, simply set scale=1.0.
     """
+    # Validate inputs
+    _validate_patch_dims(patch)
+
+    # Setup axes and data
     ax = _get_ax(ax)
     cmap = _get_cmap(cmap)
     data = np.log10(np.absolute(patch.data)) if log else patch.data
     dims = patch.dims
-    assert len(dims) == 2, "Can only make waterfall plot of 2D Patch"
     dims_r = tuple(reversed(dims))
     coords = {dim: patch.coords.get_array(dim) for dim in dims}
-    # Plot using imshow, set colorbar limits.
+
+    # Plot using imshow and set colorbar limits
     extents = _get_extents(dims_r, coords)
     scale = _get_scale(scale, scale_type, patch)
     im = ax.imshow(data, extent=extents, aspect="auto", cmap=cmap, origin="lower")
     im.set_clim(scale)
 
-    # format all dims which have time types.
-    for dim, x in zip(dims_r, ["x", "y"]):
-        getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
-        coord = patch.get_coord(dim)
-        if np.issubdtype(coord.dtype, np.datetime64):
-            _format_time_axis(ax, dim, x)
-            # Invert the y axis so origin is at the top. This is convention
-            # for seismic shot gathers, but if axis is not time-like is just
-            # annoying.
-            if x == "y":
-                ax.invert_yaxis()
-    # add color bar with title
+    # Format axis labels and handle time-like dimensions
+    _format_axis_labels(ax, patch, dims_r)
+
+    # Add colorbar if requested
     if cmap is not None:
-        cb = ax.get_figure().colorbar(im, ax=ax, fraction=0.05, pad=0.025)
-        data_type = str(patch.attrs["data_type"])
-        data_units = get_quantity_str(patch.attrs.data_units) or ""
-        dunits = f" ({data_units})" if (data_type and data_units) else f"{data_units}"
-        if log:
-            dunits = f"{dunits} - log_10"
-        label = f"{data_type}{dunits}"
-        cb.set_label(label)
+        _add_colorbar(ax, im, patch, log)
+
     if show:
         plt.show()
     return ax

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -20,7 +20,7 @@ from dascore.utils.plotting import (
     _get_extents,
 )
 
-IQR_FENCE_MULTIPLIER = 3.0  # 3.0 looked better for some common cases than 1.5
+IQR_FENCE_MULTIPLIER = 1.5
 
 
 def _validate_scale_type(scale_type):
@@ -61,8 +61,9 @@ def _get_scale(scale, scale_type, patch):
             mean = np.nanmean(data)
             scale = np.asarray([mean - scale * mod, mean + scale * mod])
         # Case 2: No scale specified with relative scaling
-        # Use Tukey's fence (1.5*IQR) to exclude outliers. This prevents
-        # a few extreme values from obscuring the majority of the data.
+        # Use Tukey's fence (C*IQR, C is normally 1.5) to exclude outliers.
+        # This prevents a few extreme values from obscuring the majority of the
+        # data at the cost of a slight performance penalty.
         case (None, "relative"):
             q2, q3 = np.nanpercentile(data, [25, 75])
             dmin, dmax = np.nanmin(data), np.nanmax(data)

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -66,6 +66,7 @@ def _get_scale(scale, scale_type, patch):
             scale = np.asarray(
                 [q2 - diff * IQR_FENCE_MULTIPLIER, q3 + diff * IQR_FENCE_MULTIPLIER]
             )
+            return scale
         # Case 3: Sequence with relative scaling
         # Scale values represent fractions of the data range [0, 1]
         # and are mapped to [data_min, data_max]
@@ -82,7 +83,11 @@ def _get_scale(scale, scale_type, patch):
             data_range = dmax - dmin
             # Map [0, 1] to [data_min, data_max]
             scale = dmin + scale * data_range
-    # Case 4: Absolute scaling (default, no match needed)
+        # Case 4: Absolute scaling
+        case (scale, "absolute") if isinstance(scale, int | float):
+            scale = np.array([-abs(scale), abs(scale)])
+        # Case 5: Absolute scaling with sequence: no match needed.
+
     # Scale values are used directly as colorbar limits
     return scale
 
@@ -91,7 +96,7 @@ def _format_axis_labels(ax, patch, dims_r):
     """
     Format axis labels and handle time-like axes.
     """
-    for dim, x in zip(dims_r, ["x", "y"]):
+    for dim, x in zip(dims_r, ["x", "y"], strict=True):
         getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
         coord = patch.get_coord(dim)
         if np.issubdtype(coord.dtype, np.datetime64):

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -46,12 +46,11 @@ def _validate_patch_dims(patch):
     return patch
 
 
-def _get_scale(scale, scale_type, patch):
+def _get_scale(scale, scale_type, data):
     """
     Calculate the color bar scale limits based on scale and scale_type.
     """
     _validate_scale_type(scale_type)
-    data = patch.data
 
     match (scale, scale_type):
         # Case 1: Single value with relative scaling
@@ -153,8 +152,8 @@ def waterfall(
         Values can either be a float, to set upper and lower limit to the same
         value centered around the mean of the data, a length 2 tuple
         specifying upper and lower limits, or None, which will automatically
-        determine limits based on a quartile fence. (uses q1 - 3.0 * (q3 - q1)
-        and q3 + 3.0 * (q3 - q1)).
+        determine limits based on a quartile fence. (uses q1 - 1.5 * (q3 - q1)
+        and q3 + 1.5 * (q3 - q1)).
     scale_type
         Controls the type of scaling specified by `scale` parameter. Options
         are:
@@ -230,7 +229,7 @@ def waterfall(
 
     # Plot using imshow and set colorbar limits
     extents = _get_extents(dims_r, coords)
-    scale = _get_scale(scale, scale_type, patch)
+    scale = _get_scale(scale, scale_type, data)
     im = ax.imshow(
         data,
         extent=extents,

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from dascore.constants import PatchType
+from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str
 from dascore.utils.patch import patch_function
 from dascore.utils.plotting import (
@@ -20,21 +21,37 @@ from dascore.utils.plotting import (
 )
 
 
-def _set_scale(im, scale, scale_type, patch):
+def _get_scale(scale, scale_type, patch):
     """Set the scale of the color bar based on scale and scale_type."""
     # check scale parameters
     assert scale_type in {"absolute", "relative"}
-    assert isinstance(scale, float | int) or len(scale) == 2
-    # make sure we have a len two array
     data = patch.data
-    modifier = 1
-    if scale_type == "relative":
-        modifier = 0.5 * (np.nanmax(data) - np.nanmin(data))
-        # only one scale parameter provided, center around mean
-    if isinstance(scale, float | int):
-        mean = np.nanmean(patch.data)
-        scale = np.asarray([mean - scale * modifier, mean + scale * modifier])
-    im.set_clim(scale)
+
+    match (scale, scale_type):
+        # Floating point value, relative type and zero mean
+        case (scale, "relative") if isinstance(scale, float | int):
+            mod = 0.5 * (np.nanmax(data) - np.nanmin(data))
+            mean = np.nanmean(patch.data)
+            scale = np.asarray([mean - scale * mod, mean + scale * mod])
+        # No scale specified and relative, use fence.
+        case (None, "relative"):
+            q2, q3 = np.nanpercentile(data, [25, 75])
+            diff = q3 - q2
+            scale = np.asarray([q2 - diff * 1.5, q3 + diff * 1.5])
+        # Here scale must be a list, tuple, or array.
+        case (scale, "relative"):
+            # Raise if invalid scale params.
+            scale = np.array(scale)
+            if np.any(scale < 0) or scale[0] > scale[1] or len(scale) != 2:
+                msg = (
+                    "Relative scale values cannot be negative and the first "
+                    f"value must be less than the second. You passed {scale}"
+                )
+                raise ParameterError(msg)
+            dmin, dmax = np.nanmin(data), np.nanmax(data)
+            data_range = dmax - dmin
+            scale = dmin + scale * data_range
+    return scale
 
 
 @patch_function()
@@ -60,16 +77,16 @@ def waterfall(
         A matplotlib colormap string or instance. Set to None to not plot the
         colorbar.
     scale
-        If not None, controls the saturation level of the colorbar.
-        Values can either be a float, to set upper and lower limit to the same
-        value centered around the mean of the data, or a length 2 tuple
-        specifying upper and lower limits. See `scale_type` for controlling how
-        values are scaled.
+        Controls the saturation level of the colorbar. Values can be:
+        - A float to set upper and lower limit to the same value.
+          This will be cenetered around 0 by default.
+        - A length 2 tuple to independantly set the lower and uper limit
+        - None means use the 1.5*IQR fence to set the upper and lower limits.
     scale_type
         Controls the type of scaling specified by `scale` parameter. Options
         are:
-            relative - scale based on half the dynamic range in patch
-            absolute - scale based on absolute values provided to `scale`
+        - relative - scale based on half the dynamic range in patch
+        - absolute - scale based on absolute values provided to `scale`
     log
         If True, visualize the common logarithm of the absolute values of patch data.
     show
@@ -80,7 +97,15 @@ def waterfall(
     >>> # Plot the default patch
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
-    >>> _ = patch.viz.waterfall(scale=0.1)
+    >>> _ = patch.viz.waterfall()
+
+    Notes
+    -----
+    Until DASCore version 0.1.13, the default behavior when scale=None was to
+    scale along the entire range of the data. However, very often in real data
+    a few anonomously large or small would obscur most of the patch details.
+    In version 0.1.13 the default behavior is to now use a stiatical fence to
+    avoid the problem. To get the old behavior, simply set scale=1.0.
     """
     ax = _get_ax(ax)
     cmap = _get_cmap(cmap)
@@ -89,17 +114,23 @@ def waterfall(
     assert len(dims) == 2, "Can only make waterfall plot of 2D Patch"
     dims_r = tuple(reversed(dims))
     coords = {dim: patch.coords.get_array(dim) for dim in dims}
+    # Plot using imshow, set colorbar limits.
     extents = _get_extents(dims_r, coords)
+    scale = _get_scale(scale, scale_type, patch)
     im = ax.imshow(data, extent=extents, aspect="auto", cmap=cmap, origin="lower")
-    # scale colorbar
-    if scale is not None:
-        _set_scale(im, scale, scale_type, patch)
+    im.set_clim(scale)
+
+    # format all dims which have time types.
     for dim, x in zip(dims_r, ["x", "y"]):
         getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
-        # format all dims which have time types.
         coord = patch.get_coord(dim)
         if np.issubdtype(coord.dtype, np.datetime64):
             _format_time_axis(ax, dim, x)
+            # Invert the y axis so origin is at the top. This is convention
+            # for seismic shot gathers, but if axis is not time-like is just
+            # annoying.
+            if x == "y":
+                ax.invert_yaxis()
     # add color bar with title
     if cmap is not None:
         cb = ax.get_figure().colorbar(im, ax=ax, fraction=0.05, pad=0.025)
@@ -110,7 +141,6 @@ def waterfall(
             dunits = f"{dunits} - log_10"
         label = f"{data_type}{dunits}"
         cb.set_label(label)
-    ax.invert_yaxis()  # invert y axis so origin is at top
     if show:
         plt.show()
     return ax

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -104,7 +104,7 @@ import dascore as dc
 
 patch = dc.get_example_patch('example_event_2')
 
-patch.viz.waterfall(show=True, scale=0.2);
+patch.viz.waterfall(show=True);
 ```
 
 # Installation

--- a/docs/recipes/edge_effects.qmd
+++ b/docs/recipes/edge_effects.qmd
@@ -16,7 +16,7 @@ patch = (
     .pass_filter(time=(None, 300))
 )
 
-patch.viz.waterfall(show=True, scale=0.04);
+patch.viz.waterfall(show=True);
 ```
 
 ### Bandpass filtering with tapering
@@ -30,5 +30,5 @@ patch = (
     .pass_filter(time=(None, 300))
 )
 
-patch.viz.waterfall(show=True, scale=0.15);
+patch.viz.waterfall(show=True);
 ```

--- a/docs/recipes/fk.qmd
+++ b/docs/recipes/fk.qmd
@@ -19,7 +19,7 @@ patch = (
     .set_units("mstrain/s", distance='m', time='s')
 )
 
-patch.viz.waterfall(scale=0.2);
+patch.viz.waterfall();
 
 ```
 
@@ -33,7 +33,7 @@ patch_filtered = (
     .pass_filter(time=(None, 300))
 )
 
-patch_filtered.viz.waterfall(show=True, scale=0.2);
+patch_filtered.viz.waterfall(show=True);
 ```
 
 We can transform and visualize the patch in the F-K domain using the discrete Fourier transform (DFT).

--- a/docs/recipes/low_freq_proc.qmd
+++ b/docs/recipes/low_freq_proc.qmd
@@ -161,8 +161,8 @@ sp_lf = dc.spool(output_data_dir)
 sp_lf_merged = sp_lf.chunk(time=None, conflict="keep_first")
 pa_lf_merged = sp_lf_merged[0]
 
-# Visualize the results. Try different scale values for better visualization.
-pa_lf_merged.viz.waterfall(scale=0.5)
+# Visualize the results.
+pa_lf_merged.viz.waterfall()
 ```
 
 #### For any questions, please contact [Ahmad Tourei](https://github.com/ahmadtourei).

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -398,7 +398,7 @@ patch = (
     .pass_filter(time=(None, 300))
 )
 
-patch.viz.waterfall(show=True, scale=0.2);
+patch.viz.waterfall(show=True);
 ```
 
 # Modifying patches

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -165,7 +165,7 @@ patch = dc.get_example_patch("example_event_1")
 dt = patch.get_coord('time').step
 
 smoothed = patch.rolling(time=50*dt).mean()
-smoothed.viz.waterfall(scale=.1);
+smoothed.viz.waterfall();
 ```
 
 Notice the nan values at the start of the time axis. These can be trimmed with [`Patch.dropna`](`dascore.Patch.dropna`).

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -16,7 +16,32 @@ import dascore as dc
 
 patch = dc.get_example_patch('example_event_2')
 
-patch.viz.waterfall(show=True, scale=(-50,50))
+# Default scaling uses IQR-based fence to handle outliers
+patch.viz.waterfall(show=True)
+```
+
+### Controlling color scaling
+
+The `scale` parameter controls the colorbar saturation. By default, waterfall uses a statistical fence (1.5×IQR) to exclude outliers and show the majority of the data clearly.
+
+```{python}
+import matplotlib.pyplot as plt
+import dascore as dc
+
+patch = dc.get_example_patch('example_event_2')
+
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
+
+# Relative scaling: 0.2 means ±20% of dynamic range around mean
+patch.viz.waterfall(scale=0.2, scale_type="relative", ax=ax1)
+ax1.set_title("Relative scaling (scale=0.2)")
+
+# Absolute scaling: directly set colorbar limits
+patch.viz.waterfall(scale=(-50, 50), scale_type="absolute", ax=ax2)
+ax2.set_title("Absolute scaling (scale=(-50, 50))")
+
+plt.tight_layout()
+plt.show()
 ```
 
 ## Wiggle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = ["geophysics", "distributed-acoustic-sensing"]
 
 dependencies = [
      "h5py",
-     "matplotlib>=3.10",
+     "matplotlib>=3.8",
      "numpy>=1.24",
      "packaging",
      "pandas>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = ["geophysics", "distributed-acoustic-sensing"]
 
 dependencies = [
      "h5py",
-     "matplotlib>=3.5",
+     "matplotlib>=3.10",
      "numpy>=1.24",
      "packaging",
      "pandas>=2.0",

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -226,3 +226,10 @@ class TestWaterfall:
         assert len(patch_1d.dims) == 1
         with pytest.raises(ParameterError, match=msg):
             patch_1d.viz.waterfall()
+
+    def test_constant_patch(self, random_patch):
+        """Ensure the plotting works on constant value patches."""
+        data = np.ones(random_patch.shape)
+        patch = random_patch.update(data=data)
+        ax = patch.viz.waterfall()
+        assert isinstance(ax, plt.Axes)

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str
 from dascore.utils.time import is_datetime64, to_timedelta64
 
@@ -190,3 +191,16 @@ class TestWaterfall:
         ax = aggs.viz.waterfall()
         assert ax is not None
         assert isinstance(ax, plt.Axes)
+
+    def test_bad_relative_scale_raises(self, random_patch):
+        """Ensure malformed relative scales raise ParameterError."""
+        msg = "Relative scale"
+        # Negative value in scale.
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.viz.waterfall(scale=(-0.1, 0.9), scale_type="relative")
+        # Reversed order.
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.viz.waterfall(scale=(0.9, 0.1), scale_type="relative")
+        # More than two values
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.viz.waterfall(scale=(0.1, 0.2, 0.9), scale_type="relative")

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -234,5 +234,27 @@ class TestWaterfall:
         ax = patch.viz.waterfall()
         assert isinstance(ax, plt.Axes)
 
+    def test_constant_data_with_relative_scale(self, random_patch):
+        """Ensure constant data works with non-zero relative scale."""
+        data = np.ones(random_patch.shape) * 42.0
+        patch = random_patch.update(data=data)
+        # Should not raise, epsilon handling should prevent degenerate limits
+        ax = patch.viz.waterfall(scale=0.5, scale_type="relative")
+        assert isinstance(ax, plt.Axes)
+        # Verify colorbar limits are not identical
+        clim = ax.images[0].get_clim()
+        assert clim[0] != clim[1], "Colorbar limits should not be identical"
+
+    def test_scale_zero_raises(self, random_patch):
+        """Ensure scale=0 with relative scaling raises ParameterError."""
+        msg = "Relative scale value of 0"
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.viz.waterfall(scale=0, scale_type="relative")
+        # Also test with constant data to ensure same behavior
+        data = np.ones(random_patch.shape)
+        patch = random_patch.update(data=data)
+        with pytest.raises(ParameterError, match=msg):
+            patch.viz.waterfall(scale=0, scale_type="relative")
+
     def test_precent_scale(self, random_patch):
         """Ensure the percent unit works with scale."""

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -16,7 +16,7 @@ def check_label_units(patch, ax):
     """Ensure patch label units match axis."""
     axis_dict = {0: "yaxis", 1: "xaxis"}
     dims = patch.dims
-    # Check coord-inate names
+    # Check coordinate names
     for coord_name in dims:
         coord = patch.coords.coord_map[coord_name]
         if is_datetime64(coord[0]):
@@ -204,3 +204,25 @@ class TestWaterfall:
         # More than two values
         with pytest.raises(ParameterError, match=msg):
             random_patch.viz.waterfall(scale=(0.1, 0.2, 0.9), scale_type="relative")
+
+    def test_invalid_scale_type_raises(self, random_patch):
+        """Ensure invalid scale_type values raise ParameterError."""
+        msg = "scale_type must be one of"
+        # Invalid string
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.viz.waterfall(scale_type="invalid")
+        # Typo
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.viz.waterfall(scale_type="relatve")
+        # Case sensitivity
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.viz.waterfall(scale_type="Relative")
+
+    def test_non_2d_patch_raises(self, random_patch):
+        """Ensure non-2D patches raise ParameterError."""
+        msg = "Can only make waterfall plot of 2D Patch"
+        # Test with 1D patch - select single value and squeeze
+        patch_1d = random_patch.select(distance=0, samples=True).squeeze()
+        assert len(patch_1d.dims) == 1
+        with pytest.raises(ParameterError, match=msg):
+            patch_1d.viz.waterfall()

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -233,3 +233,6 @@ class TestWaterfall:
         patch = random_patch.update(data=data)
         ax = patch.viz.waterfall()
         assert isinstance(ax, plt.Axes)
+
+    def test_precent_scale(self, random_patch):
+        """Ensure the percent unit works with scale."""


### PR DESCRIPTION
## Description

This PR refactors `viz.waterfall` function. It does a few things:

1. Fixes typos, clarifies the docs, and some minor refactoring of internal functions.

2. Changes default behavior when scale=None to perform the standard statistical fence to select ranges rather than using the whole data range. This will eliminate, or at least alleviate, the need for constant fiddling with the scale parameter when there are a few outliers in the data (very common). The old behavior can re-created using scale=1.0. 

3. Replaces the assertions with proper exception raises for malformed parameters.

4. Makes the automatic Y axis flip only occur when the Y axis of the patch is time-like. This will still match seismic convention but stop flipping with other types of coordinates. This can always be manipulated directly with the returned matplotlib axis. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waterfall visualization now defaults to an IQR-based (1.5×IQR) outlier-resistant color scale and supports relative/absolute scaling options.
  * Utility to convert percentage values to fractional form added.

* **Improvements**
  * Stronger input validation with clearer errors for invalid scales/scale types and non-2D data; improved axis/time labeling, colorbar handling, and explicit show/return behavior.

* **Documentation**
  * Examples updated to showcase default IQR scaling and explicit scaling modes.

* **Tests**
  * New tests for scale validation, non-2D inputs, constant-data handling, and percent conversion.

* **Chores**
  * Raised minimum matplotlib requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->