### PR TITLE
fixes 575

### DIFF
--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -203,7 +203,11 @@ def _array_to_timedelta64(array: np.ndarray) -> np.datetime64:
 
     assert np.isreal(array[0])
     nans = pd.isnull(array)
-    array[nans] = 0
+    # Need to make copy to 1) not change original array and 2) handle
+    # immutable arrays. See #575.
+    if np.any(nans):
+        array = np.array(array)
+        array[nans] = 0
     # inf/NaN complain, salience these types of warnings for this block.
     with np.errstate(divide="ignore", invalid="ignore"):
         # separate seconds and factions, convert fractions to ns precision,

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -173,6 +173,19 @@ class TestToDateTime64:
         with pytest.raises(NotImplementedError):
             to_datetime64(Dummy())
 
+    def test_immutable_inputs(self):
+        """Ensure immutable array inputs work."""
+        # See #575.
+        rand = np.random.RandomState(42)
+        array_no_nan = rand.random(100)
+        array_nan = rand.random(100)
+        array_nan[10] = np.nan
+
+        for array in [array_no_nan, array_nan]:
+            array.setflags(write=False)
+            time = to_datetime64(array_no_nan)
+            assert np.issubdtype(time.dtype, "M8")
+
 
 class TestToTimeDelta64:
     """Tests for creating timedeltas."""
@@ -300,6 +313,19 @@ class TestToTimeDelta64:
         dt_array = random_patch.get_coord("time").values
         out = to_timedelta64(dt_array)
         assert np.all(out.astype(np.int64) == dt_array.astype(np.int64))
+
+    def test_immutable_inputs(self):
+        """Ensure immutable array inputs work."""
+        # See #575.
+        rand = np.random.RandomState(42)
+        array_no_nan = rand.random(100)
+        array_nan = rand.random(100)
+        array_nan[10] = np.nan
+
+        for array in [array_no_nan, array_nan]:
+            array.setflags(write=False)
+            time = to_timedelta64(array_no_nan)
+            assert np.issubdtype(time.dtype, "m8")
 
 
 class TestToInt:


### PR DESCRIPTION
## Description

This PR fixes #575 by simply creating a copy of an array which has NaNs that need to be masked when creating datetime64 array from a generic array input.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
