### PR TITLE
fix timedelta to datetime conversion

### DIFF
--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -95,7 +95,7 @@ def _array_to_datetime64(array: np.ndarray) -> np.datetime64 | np.ndarray:
     # dealing with numerical data
     elif not np.issubdtype(array.dtype, np.datetime64) and np.isreal(array[0]):
         with np.errstate(divide="ignore", invalid="ignore"):
-            array = np.array(array)  # need to make copy to write
+            array = to_float(np.array(array))  # need to make copy to write
             array[nans] = 0  # temporary replace NaNs
             abs_array = np.abs(array)
             sign = np.sign(array)

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -176,15 +176,20 @@ class TestToDateTime64:
     def test_immutable_inputs(self):
         """Ensure immutable array inputs work."""
         # See #575.
-        rand = np.random.RandomState(42)
-        array_no_nan = rand.random(100)
-        array_nan = rand.random(100)
+        array_no_nan = random_state.random(100)
+        array_nan = random_state.random(100)
         array_nan[10] = np.nan
 
         for array in [array_no_nan, array_nan]:
             array.setflags(write=False)
             time = to_datetime64(array_no_nan)
             assert np.issubdtype(time.dtype, "M8")
+
+    def test_timedelta_array(self):
+        """Ensure timedelta arrays can be converted to datetime64."""
+        td = to_timedelta64(random_state.random(100))
+        out = to_datetime64(td)
+        assert np.issubdtype(out.dtype, "M8")
 
 
 class TestToTimeDelta64:
@@ -317,9 +322,8 @@ class TestToTimeDelta64:
     def test_immutable_inputs(self):
         """Ensure immutable array inputs work."""
         # See #575.
-        rand = np.random.RandomState(42)
-        array_no_nan = rand.random(100)
-        array_nan = rand.random(100)
+        array_no_nan = random_state.random(100)
+        array_nan = random_state.random(100)
         array_nan[10] = np.nan
 
         for array in [array_no_nan, array_nan]:


### PR DESCRIPTION
## Description

This PR allows the conversion of timedelta64 to datetime64 arrays. Currently it raises a TypeError.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced numeric data handling in datetime conversions for improved type safety and edge-case processing.

* **Tests**
  * Added test coverage for timedelta64 to datetime64 conversion verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->