### PR TITLE
fix align_coords bug

### DIFF
--- a/dascore/proc/align.py
+++ b/dascore/proc/align.py
@@ -41,15 +41,15 @@ def _get_source_indices(shifts, start_shift, end_shift, n_samples):
 def _get_dest_indices(shifts, start_shift, end_shift, n_samples, output_size):
     """Get indices in the output array."""
     start = np.maximum(0, shifts - start_shift)
-    # Calculate actual source data length for each trace
+    # Clamp source indices to valid range [0, n_samples]
     min_start = -shifts + start_shift
-    source_start = np.where(min_start < 0, 0, min_start)
+    source_start = np.clip(min_start, 0, n_samples)
     max_end = n_samples - shifts + end_shift
-    source_end = np.where(max_end > n_samples, n_samples, max_end)
-    source_length = source_end - source_start
-    # Destination end is start + actual source length
-    max_ends = start + source_length
-    end = np.where(max_ends > output_size, output_size, max_ends)
+    source_end = np.clip(max_end, 0, n_samples)
+    # Compute source length, ensuring non-negative
+    source_length = np.maximum(source_end - source_start, 0)
+    # Destination end bounded to [0, output_size]
+    end = np.clip(start + source_length, 0, output_size)
     return (start, end)
 
 

--- a/tests/test_proc/test_align.py
+++ b/tests/test_proc/test_align.py
@@ -463,7 +463,7 @@ class TestAlignToCoord:
         # Reverse - this should work without broadcasting error
         reversed_patch = aligned.align_to_coord(
             relative=False,
-            reverse=False,
+            reverse=True,
             samples=True,
             mode="same",
             time="shifts",


### PR DESCRIPTION
## Description

This PR fixes a bug in `Patch.align_to_coord` where the source and destination lengths can be misaligned. Since this isn't in a release yet its probably not a big deal. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Alignment reversal now correctly handles per-trace available data lengths when shifts vary, preventing destination/source size mismatches and improving reverse alignment accuracy.

* **Tests**
  * Added tests covering alignment reversal with varying shift magnitudes and modes to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->