### PR TITLE
private coords to not affect equality

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -779,10 +779,15 @@ class CoordManager(DascoreBaseModel):
         """Return True if other coordinates are approx equal."""
         if not isinstance(other, self.__class__):
             return False
-        if not (coord_set := set(self.coord_map)) == set(other.coord_map):
+        if not set(self.dims) == set(other.dims):
+            return False
+        # Account for private coords (which don't have to be equal).
+        s1 = {x for x in self.coord_map if x in self.dims or not x.startswith("_")}
+        s2 = {x for x in other.coord_map if x in other.dims or not x.startswith("_")}
+        if not s1 == s2:
             return False
         cdict_1, cdict_2 = self.coord_map, other.coord_map
-        for name in coord_set:
+        for name in s1:
             if not cdict_1[name].approx_equal(cdict_2[name]):
                 return False
         return True

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -822,6 +822,24 @@ class TestEquals:
         assert non_2 != cm_basic
         assert cm_basic != non_2
 
+    def test_private_non_dimension_coord(self, cm_basic):
+        """Private, non-dimensional coords shouldn't affect comparisons."""
+        time = cm_basic.get_array("time")
+        new = cm_basic.update(_some_time=("time", time))
+        assert new == cm_basic
+
+    def test_private_dims_effect_equals(self, cm_basic):
+        """Private dimensions should affect the comparisons."""
+        time = cm_basic.get_array("time")
+        new_time = time + dc.to_timedelta64(10)
+        new = cm_basic.update(time=new_time)
+        assert new != cm_basic
+
+        new_priv = new.rename_coord(time="_time")
+        cm_priv = cm_basic.rename_coord(time="_time")
+        assert "_time" in new_priv.dims
+        assert new_priv != cm_priv
+
 
 class TestTranspose:
     """Test suite for transposing dimensions."""

--- a/tests/test_utils/test_models.py
+++ b/tests/test_utils/test_models.py
@@ -32,6 +32,12 @@ class TestModelEquals:
         mod2 = _TestModel(_private=2)
         assert sensible_model_equals(mod1, mod2)
 
+    def test_private_disjoint(self):
+        """Private attrs not shared should not affect equality."""
+        mod1 = _TestModel(_private_1=1)
+        mod2 = _TestModel(_private_2=2)
+        assert sensible_model_equals(mod1, mod2)
+
     def test_new(self):
         """Ensure a new model can b e created."""
         mod = _TestModel(some_str="test")


### PR DESCRIPTION
## Description
Private coordinates should not affect equality checks in coord managers. This PR tests and enforces this. Now coords behave the same as attributes. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved equality comparison logic for coordinate objects to properly handle private coordinates and enforce dimension alignment checks.

* **Tests**
  * Added test coverage for private coordinate handling in equality comparisons and model equality with disjoint private attributes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->