### PR TITLE
fix dasdae to read multi-dim coordinates

### DIFF
--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -265,6 +265,25 @@ class TestRoundTrips:
         patch = dc.spool(path, file_format="DASDAE")[0]
         assert isinstance(patch, dc.Patch)
 
+    def test_roundtrip_coord_multiple_dims(
+        self, tmp_path_factory, multi_dim_coords_patch
+    ):
+        """
+        Ensure a patch with a non-dimensional coordinate that is associated
+        with two dims can round-trip.
+        """
+        patch = multi_dim_coords_patch
+        folder = tmp_path_factory.mktemp("dasdae_multi_dim_coord")
+        path = folder / "multidimcoord.hdf"
+        patch.io.write(path, "dasdae")
+
+        # Ensure we can read it from a directory
+        patch2 = dc.spool(folder).update()[0]
+        # And from a single file
+        patch3 = dc.spool(path)[0]
+        # All of the patches should be equal.
+        assert patch == patch2 == patch3
+
     # Frustratingly, it doesn't seem pytables can store NaN values using
     # create_array, even when specifying an Atom with dflt=np.nan. See
     # https://github.com/PyTables/PyTables/issues/423


### PR DESCRIPTION
## Description

Currently, patches with multi-dimensional coordinates cannot round-trip in the  DASDAE format. This PR fixes that. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing and handling of coordinate dimensions in DAS DAE file I/O. Multi-dimensional coordinates are now correctly preserved during read operations.

* **Tests**
  * Added test coverage to verify correct round-trip handling of patches with multi-dimensional coordinates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->