### PR TITLE
fix dasvader time offset

### DIFF
--- a/dascore/io/dasvader/utils.py
+++ b/dascore/io/dasvader/utils.py
@@ -10,7 +10,12 @@ from dascore.compat import array
 from dascore.core.coords import get_coord
 from dascore.utils.misc import maybe_get_items, unbyte
 
-_JULIA_EPOCH_MS = 62135596800000
+# Julia DateTime "instant" values (Dates.value) are milliseconds since
+# 0000-12-31T00:00:00 (Rata Die epoch). Note that Dates.epochms2datetime(0)
+# is 0000-01-01, which is *not* the epoch used by Dates.value/JLD2 storage.
+# Therefore the Unix epoch offset for JLD2 DateTime integers is 62135683200000 ms.
+_JULIA_EPOCH_MS = 62135683200000
+
 
 attrs_map = {
     "GaugeLength": "gauge_length",
@@ -43,7 +48,7 @@ def _step_range_len_to_params(sr):
 
 
 def _julia_ms_to_datetime64(ms_values):
-    """Convert Julia DateTime milliseconds to numpy datetime64[ms]."""
+    """Convert Julia DateTime milliseconds to numpy datetime64[ns]."""
     # Here we just prevent infinite loops.
     count = 0
     while isinstance(ms_values, np.void) and count < 10:

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -16,7 +16,7 @@ class TestDASVader:
         """Get the dasvader patch."""
         return dc.get_example_patch("das_vader_1.jld2")
 
-    def test_all_attrs_resoved(self, das_vader_patch):
-        """Ensure all attributes are resolted (no hf references)"""
+    def test_all_attrs_resolved(self, das_vader_patch):
+        """Ensure all attributes are resolved (no hdf5 references)"""
         for attr, value in das_vader_patch.attrs.items():
             assert not isinstance(value, Reference)


### PR DESCRIPTION
## Description

This PR fixes an issue with re-creating the time vectors from DASVader files. The offset time was wrong, but this PR ensures the DASCore times match those reported by DASVader.jl when reading the same file. Replaces #602 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
