### PR TITLE
Fix FiberIO plugin discovery when entry-point registry is empty

### DIFF
--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -129,7 +129,7 @@ class _FiberIOManager:
     @cached_property
     def known_formats(self):
         """Return names of known formats."""
-        formats = self._eps.index.str.split("__").str[0]
+        formats = [name.split("__", maxsplit=1)[0] for name in self._eps.index]
         return set(formats) | set(self._format_version)
 
     @property
@@ -179,7 +179,8 @@ class _FiberIOManager:
         formats = {format} if format is not None else unloaded
         # Load one, or all, formats
         for form in formats:
-            for eps in self._eps.loc[self._eps.index.str.startswith(form)]:
+            entries = [name for name in self._eps.index if name.startswith(form)]
+            for eps in self._eps.loc[entries]:
                 self.register_fiberio(eps()())
         # The selected format(s) should now be loaded
         assert set(formats).isdisjoint(self.unloaded_formats)

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -208,6 +208,20 @@ class TestFormatManager:
         name_ver = [(x.name, x.version) for x in out]
         assert len(name_ver) == len(set(name_ver))
 
+    def test_known_formats_empty_entry_points(self, format_manager):
+        """Known formats should tolerate an empty/non-string entry-point index."""
+        format_manager.__dict__.pop("_eps", None)
+        format_manager.__dict__.pop("known_formats", None)
+        format_manager._eps = pd.Series(dtype=object)
+        assert isinstance(format_manager.known_formats, set)
+
+    def test_load_plugins_empty_entry_points(self, format_manager):
+        """Loading plugins should no-op when no entry points are present."""
+        format_manager.__dict__.pop("_eps", None)
+        format_manager.__dict__.pop("known_formats", None)
+        format_manager._eps = pd.Series(dtype=object)
+        format_manager.load_plugins()
+
 
 class TestFormatter:
     """Tests for adding file supports through Formatter."""


### PR DESCRIPTION
### Motivation
- The FiberIO manager used pandas `.str` accessors on the entry-point index, which raises when the entry-point `Series` is empty and uses a non-string `RangeIndex`.
- Ensure plugin discovery and loading are robust when no entry points are registered (e.g. in test environments or minimal installs).

### Description
- Replace use of `self._eps.index.str.split("__").str[0]` with a pure-Python list comprehension: ` [name.split("__", maxsplit=1)[0] for name in self._eps.index]` to derive `known_formats` in `_FiberIOManager`.
- Change plugin-loading filtering to compute `entries = [name for name in self._eps.index if name.startswith(form)]` and iterate `self._eps.loc[entries]` to avoid pandas string accessors on empty/non-string indexes.
- Add two regression tests in `tests/test_io/test_io_core.py`: `test_known_formats_empty_entry_points` and `test_load_plugins_empty_entry_points` that simulate an empty entry-point registry and assert `known_formats` is a `set` and `load_plugins()` is a no-op.
- Files modified: `dascore/io/core.py` and `tests/test_io/test_io_core.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985b409f6108332b51610fd730842ae)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized plugin and format discovery logic for improved performance.

* **Tests**
  * Added test coverage for edge cases in plugin loading to ensure robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->