### PR TITLE
Fix #604: make coordinates behave like arrays for arithmetic

### DIFF
--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -259,6 +259,18 @@ class TestBasics:
         out = str(coord)
         assert isinstance(out, str)
 
+    def test_scalar_arithmetic_behaves_like_array(self):
+        """Coordinates should support simple arithmetic like ndarrays."""
+        coord = get_coord(data=[1, 2, 3])
+        assert np.array_equal(coord + 1, np.array([2, 3, 4]))
+        assert np.array_equal(1 + coord, np.array([2, 3, 4]))
+        assert np.array_equal(coord - 1, np.array([0, 1, 2]))
+
+    def test_numpy_ufunc_arithmetic(self):
+        """Numpy ufuncs should operate directly on coordinates."""
+        coord = get_coord(data=[1, 2, 3])
+        assert np.array_equal(np.add(coord, 2), np.array([3, 4, 5]))
+
     def test_rich(self, coord):
         """Each coord should have nice rich printing."""
         out = coord.__rich__()


### PR DESCRIPTION
### Motivation
- Coordinates should behave like NumPy arrays for arithmetic so expressions like `coord + 1` and `1 + coord` work without raising `TypeError`.
- Previous unrelated DASVader changes were removed to keep this fix focused on coordinate arithmetic behavior.

### Description
- Make `BaseCoord` inherit `numpy.lib.mixins.NDArrayOperatorsMixin` so NumPy operator dispatch applies to coordinate objects.
- Implement `BaseCoord.__array_ufunc__` to route NumPy ufunc calls to the underlying `.data` arrays and to handle the `out=` argument when present.
- Add regression tests `test_scalar_arithmetic_behaves_like_array` and `test_numpy_ufunc_arithmetic` to `tests/test_core/test_coords.py` that verify `coord + 1`, `1 + coord`, `coord - 1`, and `np.add(coord, 2)` produce expected array results.
- Apply minor linting adjustments to satisfy line-length/style checks introduced by the new code.

### Testing
- Ran the targeted tests with `pytest -q tests/test_core/test_coords.py -k "scalar_arithmetic_behaves_like_array or numpy_ufunc_arithmetic"`, which passed (`2 passed`).
- Verified interactive behavior with a small script using `dc.get_coord(data=[1,2,3])` that demonstrated `coord + 1` and `1 + coord` produce `[2 3 4]` as expected.
- Ran `ruff` style checks and adjusted formatting to resolve reported issues; lint check now passes for the modified lines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985b4b1a84c8332b918f49bddd5b621)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coordinate objects now support scalar arithmetic operations and NumPy universal functions. Mathematical operations on coordinates behave consistently with standard NumPy arrays, enabling seamless integration with NumPy-based workflows and calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->