### PR TITLE
Polish additional QMD documentation wording for clarity

### DIFF
--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -203,7 +203,7 @@ Next we need to write tests for the format (you weren't thinking of skipping thi
 
 Once the test file is added to the data registry, you can register the new format so a suite of tests run automatically. This is done by adding the format to the appropriate data structures in `tests/test_io/test_common_io.py`. The comments at the top of the file will guide you through this process.
 
-For some formats, the generic tests will be sufficient. For others, additional test cases may be required. These are placed in test_io folder. In our example, we would create the folder `dascore/tests/test_io/test_jingle`. Assuming you added a file called "jingle_test_file.jgl" to DASCore's data registry, then we could create the test file `dascore/tests/test_io/test_jingle/test_jingle.py` and its contents might look something like this:
+For some formats, the generic tests will be sufficient. For others, additional test cases may be required. Place these in the `tests/test_io` folder. In our example, we would create the folder `dascore/tests/test_io/test_jingle`. Assuming you added a file called "jingle_test_file.jgl" to DASCore's data registry, then we could create the test file `dascore/tests/test_io/test_jingle/test_jingle.py` and its contents might look something like this:
 
 
 ```{python filename="tests/test_io/test_jingle/test_jingle.py"}
@@ -238,7 +238,7 @@ class TestJingleIO:
 
 ## Register Plugin
 
-Now that the Jingle format support is implemented and tested, the final step is to register the jingle `FiberIO` subclasses in DASCore's entry points. This is done under the [project.entry-points."dascore.fiber_io"] section in DASCore's `pyproject.`toml file. For example, after adding jingle, the `pyproject.toml` section might look like this:
+Now that the Jingle format support is implemented and tested, the final step is to register the jingle `FiberIO` subclasses in DASCore's entry points. This is done under the `[project.entry-points."dascore.fiber_io"]` section in DASCore's `pyproject.toml` file. For example, after adding jingle, the `pyproject.toml` section might look like this:
 
 ```default
 [project.entry-points."dascore.fiber_io"]

--- a/docs/recipes/correlate.qmd
+++ b/docs/recipes/correlate.qmd
@@ -5,7 +5,7 @@ execute:
 ---
 
 
-Here, we demonstrate how to utilize the `Correlate` module to perform cross-correlation between a specific channel/time sample and other channels/time samples within a given patch. By doing so, we create a new "correlate patch", which is essentially a data construct that encapsulates the results of these cross-correlation operations.
+This recipe demonstrates how to use the `Correlate` module to cross-correlate a specific channel/time sample with other channel/time samples in a patch. The result is a new "correlate patch" that stores the cross-correlation output.
 We use the Ricker wavelet as an example signal and compute its cross-correlation using DASCore.
 
 
@@ -25,7 +25,7 @@ patch.viz.waterfall();
 
 ## Compute Ricker wavelet's cross-correlation
 
-As an example, here we cross-correlate our Ricker patch's all channels with channel number 4 as a master channel or virtual source. In the correlate patch, the first three traces have negative time lag, but the fourth trace appears at 0.0 sec time lag (auto-correlation) along with other traces with positive time lags. As expected, both Ricker patch and the correlate patch have the same 100 m/s moveout.
+In this example, we cross-correlate all channels in the Ricker patch against channel 4 as the master channel (virtual source). In the correlate patch, the first three traces have negative time lag, and the fourth trace appears at 0.0 s lag (auto-correlation), followed by traces with positive lags. As expected, both the Ricker patch and the correlate patch show the same 100 m/s moveout.
 
 ```{python}
 import dascore as dc

--- a/docs/recipes/external_conversion.qmd
+++ b/docs/recipes/external_conversion.qmd
@@ -4,7 +4,7 @@ execute:
   warning: false
 ---
 
-Although DASCore provides a lot of the functionality needed for DFOS processing, is not intended to do absolutely everything, and some other libraries might be better suited for a particular task. In addition to making it simple to access the underlying data as shown in the [patch tutorial](../tutorial/patch.qmd), DASCore provides convenience functions to convert data to formats used by other libraries. Here are a few examples:
+Although DASCore provides much of the functionality needed for DFOS processing, it is not intended to do everything, and other libraries may be better suited for specific tasks. In addition to making it simple to access the underlying data as shown in the [patch tutorial](../tutorial/patch.qmd), DASCore provides convenience functions to convert data to formats used by other libraries. Here are a few examples:
 
 
 ## [Pandas](https://pandas.pydata.org/)
@@ -50,5 +50,5 @@ patch_from_dar = dc.io.obspy_to_patch(stream)
 ```
 
 :::{.callout-note}
-As explained in the [`obspy_to_patch` docs](`dascore.utils.io.obspy_to_patch`), there must be a value in the stats dict which indicates values for a non-time dimension. For example, each trace might have a 'distance' key in its stats dict which DASCore uses to construct the distance dimensional coordinate.
+As explained in the [`obspy_to_patch` docs](`dascore.utils.io.obspy_to_patch`), the stats dictionary must include a value for at least one non-time dimension. For example, each trace might include a `distance` key in `stats`, which DASCore uses to construct the distance coordinate.
 :::

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -35,9 +35,9 @@ A single file can be loaded like this:
 
 ```{python}
 #| code-fold: true
-# This codeblock is just to get a usable path for the next cell.
+# This code block is only here to create a usable path for the next cell.
 import dascore as dc
-# Import fetch to read DASCore example files 
+# Import fetch to read DASCore example files.
 from dascore.utils.downloader import fetch
 
 
@@ -50,7 +50,7 @@ path = fetch("terra15_das_1_trimmed.hdf5")
 ```{python}
 import dascore as dc
 
-# path should be a path to your file. EG,
+# path should point to your file, e.g.
 # path = mydata.hdf5
 
 pa = dc.spool(path)[0]
@@ -221,13 +221,13 @@ DASCore Patches offer a few shortcuts for quickly accessing commonly used inform
 import dascore as dc
 
 patch = dc.get_example_patch()
-print(patch.seconds) # to get the number of seconds in the patch.
-print(patch.channel_count) # to get the number of channels in the patch.
+print(patch.seconds)  # number of seconds in the patch
+print(patch.channel_count)  # number of channels in the patch
 ```
 
-These only work for patches with dimensions "time" and "distance" but can help new users who may be unfamiliar with datetimes and coordinates. 
+These shortcuts only work for patches with dimensions "time" and "distance", but they can help new users who may be unfamiliar with datetimes and coordinates.
 
-The "name" of the patch, which is the filename that would be used if the patch were saved to disk by DASCore, can be generated via the [`Spool.get_patch_names`](`dascore.BaseSpool.get_patch_names`) to get a series of the names of the managed patches, or [`Patch.get_patch_name`](`dascore.Patch.get_patch_name`) to get a string of the patch name.
+The "name" of a patch (the filename DASCore would use if the patch were saved to disk) can be generated with [`Patch.get_patch_name`](`dascore.Patch.get_patch_name`). For a spool, use [`Spool.get_patch_names`](`dascore.BaseSpool.get_patch_names`) to get the names of its managed patches.
 
 ```python 
 import dascore as dc
@@ -536,7 +536,7 @@ import dascore as dc
 # This patch has latitude and longitude coordinates
 patch = dc.get_example_patch("random_patch_with_lat_lon")
 
-# Drop latitude, this wont affect the data or other coordinates
+# Drop latitude, this won't affect the data or other coordinates
 patch_dropped_lat = patch.drop_coords("latitude")
 print(patch_dropped_lat.coords)
 ```


### PR DESCRIPTION
### Motivation
- Continue the documentation cleanup pass by reviewing `.qmd` files for remaining wording and typographical issues after the prior patch tutorial pass. 
- Improve readability and consistency in recipe and contributor-guide examples so new contributors and users encounter clearer instructions.

### Description
- Reworded the `Correlate` recipe (`docs/recipes/correlate.qmd`) to use clearer, more concise language in the introduction and the Ricker example explanation.  
- Tightened phrasing in the patch conversions recipe (`docs/recipes/external_conversion.qmd`) and clarified the ObsPy callout to state the `stats` dictionary requirement for non-time coordinates.  
- Clarified guidance in the new-format contributor guide (`docs/contributing/new_format.qmd`) by specifying the `tests/test_io` folder for extra tests and fixing the `pyproject.toml` entry-point formatting.  
- Performed minor punctuation and phrasing cleanups to improve consistency across the edited `.qmd` files.

### Testing
- Ran `codespell $(rg --files docs -g '*.qmd')` against the documentation files and it completed with no flagged misspellings.  
- Verified the modified `.qmd` files contain the intended replacements via localized `rg`/`sed` inspection and observed the updated text in each target file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985bacc6f548332bb1114b61e58b6b9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity and precision in contributing guidelines for test placement.
  * Enhanced explanations in recipe documentation for correlate and external conversion modules.
  * Refined tutorial documentation with consistent formatting, punctuation, and wording improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->