### PR TITLE
fix #611

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -514,6 +514,9 @@ class CoordManager(DascoreBaseModel):
 
         These coordinates will no longer be associated with a dimension in
         the coord manager but can still be retrieved.
+        If one of the provided names is a dimension, coordinates associated
+        with that dimension are dropped unless they are also explicitly listed
+        in ``coord``.
 
         Parameters
         ----------

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -354,8 +354,9 @@ def _get_stft_coords(patch, dim, axis, coord, stft, window):
         time = dc.to_timedelta64(time)
     # Get new dimensions
     new_dims = list(_get_stft_dims(dim, patch.dims, axis))
-    # Make dict of coordinates and return coord manager.
-    coord_map = dict(patch.coords.coord_map)
+    # Match dft behavior by removing coords associated with transformed dim,
+    # while keeping the transformed dim itself as a non-dimensional coord.
+    coord_map = patch.coords.disassociate_coord(dim).get_coord_tuple_map()
     new_units = invert_quantity(coord.units)
     coord_map.update(
         {
@@ -431,6 +432,8 @@ def stft(
     - If an array is passed for taper_window that has a different length
       than specified in kwargs, artificial enriching of frequency resolution
       (equivalent to zero padding in time domain) can occur.
+    - Non-dimensional coordinates associated with transformed coordinates
+      are dropped in the output.
 
     See Also
     --------

--- a/docs/tutorial/transformations.qmd
+++ b/docs/tutorial/transformations.qmd
@@ -70,3 +70,8 @@ inverse =  transformed.istft()
 
 transformed.abs().select(distance=0, samples=True).squeeze().viz.waterfall();
 ```
+
+:::{.callout-note}
+`stft` drops non-dimensional coordinates associated with the transformed
+dimension, matching `dft` behavior.
+:::

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -341,6 +341,19 @@ class TestSTFT:
         out = random_patch.stft(time=1, overlap=None)
         assert isinstance(out, dc.Patch)
 
+    def test_non_dim_coord_associated_with_transform(self):
+        """See #611."""
+        patch = dc.get_example_patch("random_das", shape=(10, 200))
+        aux_time = np.arange(len(patch.get_coord("time")), dtype=float)
+        aux_dist = np.arange(len(patch.get_coord("distance")), dtype=float)
+        patch = patch.update_coords(
+            aux_time=("time", aux_time),
+            aux_dist=("distance", aux_dist),
+        )
+        out = patch.stft(time=0.1)
+        assert "aux_time" not in out.coords.coord_map
+        assert "aux_dist" in out.coords.coord_map
+
 
 class TestInverseSTFT:
     """Tests for the inverse short-time Fourier transform."""


### PR DESCRIPTION
## Description

This PR fixes #611 by dropping coordinates associated with the transform dimension on the stft call. This behavior is consistent with  `Patch.dft`. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced coordinate handling in STFT to drop non-dimensional coordinates associated with transformed dimensions, aligning with DFT behavior.

* **Documentation**
  * Clarified coordinate handling behavior in STFT documentation and tutorials.

* **Tests**
  * Added test coverage for non-dimensional coordinate handling in STFT operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->