### PR TITLE
remove trapz from doc example

### DIFF
--- a/docs/notes/dft_notes.qmd
+++ b/docs/notes/dft_notes.qmd
@@ -165,7 +165,7 @@ def integrate_amp_squared(x, signal):
     """Integrate the square of the abs of signal with x coordinates."""
     dx = x[1] - x[0]  # x must be evenly sampled.
     amp_sq = np.abs(signal) ** 2
-    return np.trapz(amp_sq, dx=dx)
+    return np.trapezoid(amp_sq, dx=dx)
 
 # Check for first sine wave
 fft1_energy = integrate_amp_squared(freqs1, n_scaled_fft1)


### PR DESCRIPTION
## Description

This PR removes the np.trapz usage from docs. Since this function was renamed in numpy, it broke the doc build. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal numerical integration implementation with equivalent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->