### PR TITLE
try to fix github cache

### DIFF
--- a/.github/actions/cache-test-data/action.yml
+++ b/.github/actions/cache-test-data/action.yml
@@ -5,6 +5,18 @@ inputs:
     description: "Cache number. Use != 1 to reset data cache"
     required: false
     default: "1"
+  mode:
+    description: "One of restore, save, or restore-save"
+    required: false
+    default: "restore"
+
+outputs:
+  cache-hit:
+    description: "True if an exact cache key was restored"
+    value: ${{ steps.restore-test-data.outputs.cache-hit }}
+  cache-key:
+    description: "The cache key derived from OS and registry hash"
+    value: ${{ env.DATA_CACHE_KEY }}
 
 runs:
   using: "composite"
@@ -34,12 +46,27 @@ runs:
       run: |
         echo "DATA_CACHE_PATH=$(python -c "import pooch; print(pooch.os_cache('dascore'))")" >> $GITHUB_ENV
 
-    - name: cache test data
-      uses: actions/cache@v4
+    - name: get data cache key
+      shell: bash -el {0}
+      run: |
+        echo "DATA_CACHE_KEY=data-${{ runner.os }}-${{ env.DATA_REGISTRY_HASH }}-${{ inputs.cache-number }}" >> $GITHUB_ENV
+
+    - name: restore test data cache
+      if: ${{ inputs.mode == 'restore' || inputs.mode == 'restore-save' }}
+      uses: actions/cache/restore@v4
+      id: restore-test-data
+      with:
+        enableCrossOsArchive: true
+        path: ${{ env.DATA_CACHE_PATH }}
+        key: ${{ env.DATA_CACHE_KEY }}
+        restore-keys: |
+          data-${{ runner.os }}-${{ env.DATA_REGISTRY_HASH }}-
+
+    - name: save test data cache
+      if: ${{ inputs.mode == 'save' || inputs.mode == 'restore-save' }}
+      uses: actions/cache/save@v4
       id: cache-test-data
       with:
         enableCrossOsArchive: true
         path: ${{ env.DATA_CACHE_PATH }}
-        key: data-${{ env.DATA_REGISTRY_HASH }}-${{ inputs.cache-number }}
-        restore-keys: |
-          data-${{ env.DATA_REGISTRY_HASH }}-
+        key: ${{ env.DATA_CACHE_KEY }}

--- a/.github/scripts/cache_test_data.py
+++ b/.github/scripts/cache_test_data.py
@@ -1,0 +1,22 @@
+"""Populate the pooch cache with every file in dascore's data registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dascore.utils.downloader import fetch, get_registry_df
+
+
+def main() -> None:
+    """Fetch every registered test-data file into the local pooch cache."""
+    registry = get_registry_df()
+    total = len(registry)
+    print(f"Priming DASCore test-data cache with {total} files")
+    for index, name in enumerate(registry["name"], start=1):
+        path = Path(fetch(name))
+        print(f"[{index}/{total}] {name} -> {path}")
+    print("Finished priming DASCore test-data cache")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/get_coverage.yml
+++ b/.github/workflows/get_coverage.yml
@@ -6,7 +6,44 @@ on:
       - master
 
 jobs:
+  prime_test_data_cache:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/load-shared-vars
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT }}
+
+      - name: Install dascore for cache priming
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - uses: ./.github/actions/cache-test-data
+        id: cache-test-data
+        with:
+          mode: restore
+          cache-number: 1
+
+      - name: Download all registered test data
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        shell: bash
+        run: python .github/scripts/cache_test_data.py
+
+      - name: Save primed test data cache
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-test-data
+        with:
+          mode: save
+          cache-number: 1
+
   calc_coverage:
+    needs: prime_test_data_cache
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/prime_test_data_cache.yml
+++ b/.github/workflows/prime_test_data_cache.yml
@@ -1,0 +1,63 @@
+name: PrimeTestDataCache
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1"
+  push:
+    branches:
+      - master
+    paths:
+      - "dascore/data_registry.txt"
+      - ".github/actions/cache-test-data/action.yml"
+      - ".github/scripts/cache_test_data.py"
+      - ".github/workflows/prime_test_data_cache.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "dascore/data_registry.txt"
+      - ".github/actions/cache-test-data/action.yml"
+      - ".github/scripts/cache_test_data.py"
+      - ".github/workflows/prime_test_data_cache.yml"
+
+jobs:
+  prime_test_data_cache:
+    name: Prime test data cache (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/load-shared-vars
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT }}
+
+      - name: Install dascore
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      # The cache key is tied to runner.os and the registry hash, so a hit means
+      # every file for this OS is already available in the pooch cache.
+      - uses: ./.github/actions/cache-test-data
+        id: cache-test-data
+        with:
+          mode: restore
+
+      - name: Download all registered test data
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        shell: bash
+        run: python .github/scripts/cache_test_data.py
+
+      - name: Save primed test data cache
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-test-data
+        with:
+          mode: save

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -13,8 +13,46 @@ permissions:
   id-token: write # required for OIDC authentication with CodSpeed
 
 jobs:
+  prime_test_data_cache:
+    name: Prime test data cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: "true"
+          fetch-depth: '0'
+
+      - uses: ./.github/actions/load-shared-vars
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT }}
+
+      - name: Install dascore for cache priming
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - uses: ./.github/actions/cache-test-data
+        id: cache-test-data
+        with:
+          mode: restore
+          cache-number: 1
+
+      - name: Download all registered test data
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        run: python .github/scripts/cache_test_data.py
+
+      - name: Save primed test data cache
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-test-data
+        with:
+          mode: save
+          cache-number: 1
+
   benchmarks:
     name: Run benchmarks
+    needs: prime_test_data_cache
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +72,7 @@ jobs:
 
       - uses: ./.github/actions/cache-test-data
         with:
+          mode: restore
           cache-number: 1
 
       - name: Run benchmarks

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -11,6 +11,7 @@ on:
       - 'pyproject.toml'
       - '**.py'
       - '.github/workflows/run_min_dep_tests.yml'
+      - '.github/actions/**/*.yml'
 
 env:
   # Ensure matplotlib doesn't try to show figures in CI
@@ -35,8 +36,49 @@ jobs:
         id: load-vars
 
   # Runs the tests on combinations of the supported python/os matrix.
-  test_code_min_deps:
+  prime_test_data_cache:
     needs: setup
+    timeout-minutes: 20
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/load-shared-vars
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT }}
+
+      - name: Install dascore for cache priming
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - uses: ./.github/actions/cache-test-data
+        id: cache-test-data
+        with:
+          mode: restore
+          cache-number: 1
+
+      - name: Download all registered test data
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        shell: bash
+        run: python .github/scripts/cache_test_data.py
+
+      - name: Save primed test data cache
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-test-data
+        with:
+          mode: save
+          cache-number: 1
+
+  test_code_min_deps:
+    needs: [setup, prime_test_data_cache]
     timeout-minutes: 25
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -11,6 +11,7 @@ on:
       - 'pyproject.toml'
       - '**.py'
       - '.github/workflows/*.yml'
+      - '.github/actions/**/*.yml'
 
 env:
   # used to manually trigger cache reset. Just increment if needed.
@@ -37,8 +38,51 @@ jobs:
         id: load-vars
 
   # Runs the tests on combinations of the supported python/os matrix.
-  test_code:
+  prime_test_data_cache:
     needs: setup
+    timeout-minutes: 20
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/load-shared-vars
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT }}
+
+      - name: Install dascore for cache priming
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      # Prime the full pooch cache once per OS before the test matrix starts so
+      # matrix jobs only consume the shared cache instead of racing to create it.
+      - uses: ./.github/actions/cache-test-data
+        id: cache-test-data
+        with:
+          mode: restore
+          cache-number: ${{ env.CACHE_NUMBER }}
+
+      - name: Download all registered test data
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        shell: bash
+        run: python .github/scripts/cache_test_data.py
+
+      - name: Save primed test data cache
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-test-data
+        with:
+          mode: save
+          cache-number: ${{ env.CACHE_NUMBER }}
+
+  test_code:
+    needs: [setup, prime_test_data_cache]
     timeout-minutes: 25
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -5,10 +5,52 @@ on:
     types: [labeled, synchronize]
 
 jobs:
+  prime_test_data_cache:
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'documentation')
+      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'documentation'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: "true"
+          fetch-depth: '0'
+
+      - uses: ./.github/actions/load-shared-vars
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT }}
+
+      - name: Install dascore for cache priming
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - uses: ./.github/actions/cache-test-data
+        id: cache-test-data
+        with:
+          mode: restore
+          cache-number: 1
+
+      - name: Download all registered test data
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        shell: bash
+        run: python .github/scripts/cache_test_data.py
+
+      - name: Save primed test data cache
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-test-data
+        with:
+          mode: save
+          cache-number: 1
+
   test_build_docs:
     if: |
       (github.event.action == 'labeled' && github.event.label.name == 'documentation')
       || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'documentation'))
+    needs: prime_test_data_cache
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

  This PR makes test-data caching deterministic in GitHub Actions.

  Previously, DASCore’s test data cache was populated lazily during test execution. Because multiple CI jobs shared the same cache key, whichever job saved first could publish a partial cache. Later jobs would restore
  that incomplete cache and still need to download missing files, which made the cache look unreliable.

  This change introduces an explicit cache-priming step that downloads the full contents of dascore/data_registry.txt before test jobs run.
