### PR TITLE
Allow scalar data for zero-dim CoordManager and propagate CoordManager dims in PatchAttrs.update

### DIFF
--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -241,9 +241,10 @@ class PatchAttrs(DascoreBaseModel):
             new_coords = passed_in_coords.model_dump(exclude_unset=True)
             out["dims"] = passed_in_coords.dims
 
-        coord_info, attr_info = separate_coord_info(
-            kwargs, dims=tuple(out.get("dims", self.dim_tuple))
-        )
+        dims = out.get("dims", self.dim_tuple)
+        if isinstance(dims, str):
+            dims = tuple(dims.split(",")) if dims else tuple()
+        coord_info, attr_info = separate_coord_info(kwargs, dims=tuple(dims))
         out.update(attr_info)
         # Iterate the coordinate information and update.
         for name, coord_dict in coord_info.items():

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -239,8 +239,11 @@ class PatchAttrs(DascoreBaseModel):
         new_coords = dict(out.get("coords", {}))
         if isinstance(passed_in_coords, dc.CoordManager):
             new_coords = passed_in_coords.model_dump(exclude_unset=True)
+            out["dims"] = passed_in_coords.dims
 
-        coord_info, attr_info = separate_coord_info(kwargs, dims=self.dim_tuple)
+        coord_info, attr_info = separate_coord_info(
+            kwargs, dims=tuple(out.get("dims", self.dim_tuple))
+        )
         out.update(attr_info)
         # Iterate the coordinate information and update.
         for name, coord_dict in coord_info.items():

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -819,6 +819,8 @@ class CoordManager(DascoreBaseModel):
     def validate_data(self, data):
         """Ensure data conforms to coordinates."""
         data = np.asarray([]) if data is None else data
+        if not self.dims and data.shape == ():
+            return data
         if self.shape != data.shape:
             msg = (
                 f"Data array has a shape of {data.shape} which doesnt match "

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -818,7 +818,7 @@ class CoordManager(DascoreBaseModel):
 
     def validate_data(self, data):
         """Ensure data conforms to coordinates."""
-        data = np.asarray([]) if data is None else data
+        data = np.asarray([]) if data is None else np.asarray(data)
         if not self.dims and data.shape == ():
             return data
         if self.shape != data.shape:

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -169,6 +169,12 @@ class TestBasicCoordManager:
         out = get_coord_manager(input_dict, dims=list(input_dict))
         assert set(out.dims) == set(input_dict)
 
+    def test_scalar_data_ok_for_no_dims(self):
+        """Ensure scalar data validates for coordinate managers with no dims."""
+        cm = get_coord_manager()
+        out = cm.validate_data(np.array(1.0))
+        assert out.shape == ()
+
     def test_bad_datashape_raises(self, cm_basic):
         """Ensure a bad datashape raises."""
         match = "match the coordinate manager shape"

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -175,6 +175,13 @@ class TestBasicCoordManager:
         out = cm.validate_data(np.array(1.0))
         assert out.shape == ()
 
+    def test_python_scalar_data_ok_for_no_dims(self):
+        """Ensure python scalars are converted and validate with no dims."""
+        cm = get_coord_manager()
+        out = cm.validate_data(1.0)
+        assert isinstance(out, np.ndarray)
+        assert out.shape == ()
+
     def test_bad_datashape_raises(self, cm_basic):
         """Ensure a bad datashape raises."""
         match = "match the coordinate manager shape"

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -673,6 +673,14 @@ class TestSqueeze:
         if coords:
             assert set(coords) == set(patch.coords.coord_map)
 
+    def test_squeeze_all_dims_len_one(self, random_patch):
+        """Squeezing a (1, 1) patch should produce scalar patch with no dims."""
+        patch = random_patch.aggregate(dim=None, method="mean", dim_reduce="empty")
+        out = patch.squeeze()
+        assert out.data.shape == ()
+        assert out.dims == ()
+        assert out.attrs.dim_tuple == ()
+
 
 class TestGetCoord:
     """Tests for the get_coord convenience function."""


### PR DESCRIPTION
### Motivation
- Ensure a `CoordManager` with no dimensions accepts scalar data arrays so zero-dim patches can be represented as scalars.
- Ensure that when a `PatchAttrs` is updated with a `CoordManager`, the patch dimensions are updated and subsequent coordinate parsing uses the new dims.

### Description
- In `PatchAttrs.update`, if `coords` is a `CoordManager` then set `out["dims"] = passed_in_coords.dims` so the model reflects the incoming dims. 
- Update the `separate_coord_info` call to use `tuple(out.get("dims", self.dim_tuple))` so coordinate extraction honors the updated dims.
- In `CoordManager.validate_data`, allow scalar data for managers with no dims by returning the scalar when `not self.dims` and `data.shape == ()`.
- Add tests `test_scalar_data_ok_for_no_dims` in `tests/test_core/test_coordmanager.py` and `test_squeeze_all_dims_len_one` in `tests/test_proc/test_proc_coords.py` to cover the new behaviors.

### Testing
- Added unit test `test_scalar_data_ok_for_no_dims` which asserts a zero-dim `CoordManager` accepts scalar `np.array(1.0)` and the test passed.
- Added unit test `test_squeeze_all_dims_len_one` which asserts squeezing an aggregated (1,1) patch produces a scalar patch with no dims and the test passed.
- Ran the related coord manager and patch coordinate tests (coordmanager and proc coord suites) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40e09b8848332b4ddf54ea6c433b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of scalar/0‑dim data so empty/no-dimension arrays validate and propagate without errors.
  * Ensured externally supplied dimension metadata is respected and applied during coordinate updates and parsing.

* **Tests**
  * Added tests validating scalar data acceptance, squeezing to scalar, and correct empty-dimension metadata after reductions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->