### PR TITLE
Decouple coords attrs

### DIFF
--- a/benchmarks/test_patch_benchmarks.py
+++ b/benchmarks/test_patch_benchmarks.py
@@ -82,7 +82,7 @@ class TestProcessingBenchmarks:
         """Selecting on time/distance dimension"""
         patch = example_patch
         patch.select(distance=(100, 200))
-        t1 = patch.attrs["time_min"] + np.timedelta64(1, "s")
+        t1 = patch.get_coord("time").min() + np.timedelta64(1, "s")
         t2 = t1 + np.timedelta64(3, "s")
         patch.select(time=(None, t1))
         patch.select(time=(t1, None))

--- a/dascore/__init__.py
+++ b/dascore/__init__.py
@@ -7,6 +7,7 @@ from rich import print  # noqa
 
 from dascore.core.patch import Patch
 from dascore.core.attrs import PatchAttrs
+from dascore.core.summary import PatchSummary
 from dascore.core.spool import BaseSpool, spool
 from dascore.core.coordmanager import get_coord_manager, CoordManager
 from dascore.core.coords import get_coord

--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -13,7 +13,6 @@ import pandas as pd
 from rich.text import Text
 from typing_extensions import Self
 
-import dascore as dc
 from dascore.constants import PROGRESS_LEVELS
 from dascore.core.spool import BaseSpool, DataFrameSpool
 from dascore.io.indexer import AbstractIndexer, DirectoryIndexer
@@ -42,7 +41,7 @@ class DirectorySpool(DataFrameSpool):
         Dict of keyword arguments to restrict output contents.
     """
 
-    _drop_columns = ("file_format", "file_version", "path")
+    _drop_columns = ("file_format", "file_version", "path", "source_patch_id")
 
     def __init__(
         self,
@@ -126,5 +125,4 @@ class DirectorySpool(DataFrameSpool):
         """Given a row from the managed dataframe, return a patch."""
         final_kwargs = dict(kwargs)
         final_kwargs.update(self._select_kwargs)
-        patch = dc.read(**final_kwargs)[0]
-        return patch
+        return self._read_and_resolve_patch(final_kwargs)

--- a/dascore/clients/filespool.py
+++ b/dascore/clients/filespool.py
@@ -34,6 +34,8 @@ class FileSpool(DataFrameSpool):
     for those formats, but should work on all dascore supported formats.
     """
 
+    _drop_columns = ("source_patch_id",)
+
     def __init__(
         self,
         path: str | Path,
@@ -65,7 +67,7 @@ class FileSpool(DataFrameSpool):
 
     def _load_patch(self, kwargs) -> Self:
         """Given a row from the managed dataframe, return a patch."""
-        return dc.read(**kwargs)[0]
+        return self._read_and_resolve_patch(dict(kwargs))
 
     @compose_docstring(doc=BaseSpool.update.__doc__)
     def update(self: SpoolType, progress: PROGRESS_LEVELS = "standard") -> Self:

--- a/dascore/core/__init__.py
+++ b/dascore/core/__init__.py
@@ -3,5 +3,6 @@ Core routines and functionality for processing distributed fiber data.
 """
 from __future__ import annotations
 from .patch import Patch  # noqa
+from .summary import PatchSummary  # noqa
 from .coords import CoordSummary, get_coord
 from .coordmanager import get_coord_manager, CoordManager

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -2,69 +2,32 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Mapping
 from typing import Annotated, Any, Literal
 
-import numpy as np
 from pydantic import ConfigDict, Field, PlainValidator, model_validator
 from typing_extensions import Self
 
-import dascore as dc
 from dascore.constants import (
     VALID_DATA_CATEGORIES,
     VALID_DATA_TYPES,
     max_lens,
 )
-from dascore.core.coords import BaseCoord, CoordSummary
-from dascore.utils.attrs import separate_coord_info
-from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import (
     to_str,
 )
-from dascore.utils.models import (
-    CommaSeparatedStr,
-    DascoreBaseModel,
-    UnitQuantity,
-    frozen_dict_serializer,
-    frozen_dict_validator,
-)
+from dascore.utils.models import DascoreBaseModel, UnitQuantity
 
 str_validator = PlainValidator(to_str)
-_coord_summary_suffixes = set(CoordSummary.model_fields)
-_coord_required = {"min", "max"}
-
-
-def _get_coords_dict(data_dict):
-    """
-    Add coords dict to data dict, pop out any coordinate attributes.
-
-    For example, if time_min, time_step are in data_dict, these will be
-    grouped into the coords sub dict under "time".
-    """
-
-    def _get_dims(data_dict):
-        """Try to get dim tuple."""
-        dims = None
-        if "dims" in data_dict:
-            dims = data_dict["dims"]
-        elif hasattr(coord := data_dict.get("coords"), "dims"):
-            dims = coord.dims
-        if isinstance(dims, str):
-            dims = tuple(dims.split(","))
-        return dims
-
-    dims = _get_dims(data_dict)
-    coord_info, new_attrs = separate_coord_info(
-        data_dict, dims, required=("min", "max")
-    )
-    new_attrs["coords"] = {i: dc.core.CoordSummary(**v) for i, v in coord_info.items()}
-    return new_attrs
 
 
 class PatchAttrs(DascoreBaseModel):
     """
     The expected attributes for a Patch.
+
+    `PatchAttrs` stores non-structural metadata. Nested coordinate payloads in
+    `coords` are rejected, while flat coord-like keys are treated like any
+    other extra attrs. `dims` is ignored during normalization.
 
     The default attributes are:
     ```{python}
@@ -123,53 +86,26 @@ class PatchAttrs(DascoreBaseModel):
         description="A list of processing performed on the patch.",
     )
 
-    dims: CommaSeparatedStr = Field(
-        default="",
-        max_length=max_lens["dims"],
-        description="A tuple of comma-separated dimensions names.",
-    )
-
-    coords: Annotated[
-        FrozenDict[str, CoordSummary],
-        frozen_dict_validator,
-        frozen_dict_serializer,
-    ] = Field(default_factory=dict)
-
     @model_validator(mode="before")
     @classmethod
-    def parse_coord_attributes(cls, data: Any) -> Any:
-        """Parse the coordinate attributes into coord dict."""
-        if isinstance(data, dict):
-            data = _get_coords_dict(data)
-            # add dims as coords if dims is not included.
-            if "dims" not in data:
-                data["dims"] = tuple(data["coords"])
+    def reject_coordinate_attributes(cls, data: Any) -> Any:
+        """Reject nested coord payloads and ignore structural dims input."""
+        if not isinstance(data, Mapping):
+            return data
+        data = dict(data)
+        if "coords" in data and not isinstance(data["coords"], str):
+            msg = (
+                "PatchAttrs no longer accepts coordinate metadata. " "Received: coords."
+            )
+            raise ValueError(msg)
+        data.pop("dims", None)
         return data
 
     def __getitem__(self, item):
         return getattr(self, item)
 
-    def __setitem__(self, key, value):
-        setattr(self, key, value)
-
     def __len__(self):
         return len(self.model_dump())
-
-    def __getattr__(self, item):
-        """Enables dynamic attributes such as time_min, time_max, etc."""
-        split = item.split("_")
-        # this only works on names like time_max, distance_step, etc.
-        if not len(split) == 2:
-            return super().__getattr__(item)
-        first, second = split
-        if first == "d":
-            first, second = second, "step"
-            msg = f"'{item}' is deprecated; use '{first}_{second}' instead."
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
-        if first not in self.coords:
-            return super().__getattr__(item)
-        coord_sum = self.coords[first]
-        return getattr(coord_sum, second)
 
     def get(self, item, default=None):
         """dict-like get method."""
@@ -182,77 +118,38 @@ class PatchAttrs(DascoreBaseModel):
         """Yield (attribute, values) just like dict.items()."""
         yield from self.model_dump().items()
 
-    def coords_from_dims(self) -> Mapping[str, BaseCoord]:
-        """Return coordinates from dimensions assuming evenly sampled."""
-        out = {}
-        for dim in self.dim_tuple:
-            out[dim] = self.coords[dim].to_coord()
-        return out
-
     @classmethod
     def from_dict(
         cls,
-        attr_map: Mapping | PatchAttrs,
+        attr_map: Mapping | PatchAttrs | None,
     ) -> Self:
         """
         Get a new instance of the PatchAttrs.
 
-        Optionally, give preference to data contained in a
-        [`CoordManager`](`dascore.core.coordmanager.CoordManager`).
-
         Parameters
         ----------
         attr_map
-            Anything convertible to a dict that contains the attr info.
+            Anything convertible to a dict that contains attr info. `dims`
+            entries are ignored during normalization.
         """
         if isinstance(attr_map, cls):
             return attr_map
-        out = {} if attr_map is None else attr_map
+        if attr_map is None:
+            out = {}
+        elif hasattr(attr_map, "model_dump"):
+            out = attr_map.model_dump()
+        else:
+            out = attr_map
+        if isinstance(out, Mapping):
+            out = dict(out)
+            out.pop("dims", None)
         return cls(**out)
-
-    @property
-    def dim_tuple(self):
-        """Return a tuple of dimensions. The dims attr is a string."""
-        dim_str = self.dims
-        if not dim_str:
-            return tuple()
-        return tuple(self.dims.split(","))
-
-    def rename_dimension(self, **kwargs):
-        """Rename one or more dimensions if in kwargs. Return new PatchAttrs."""
-        if not (dims := set(kwargs) & set(self.dim_tuple)):
-            return self
-        new = self.model_dump(exclude_defaults=True)
-        coords = new.get("coords", {})
-        new_dims = list(self.dim_tuple)
-        for old_name, new_name in {x: kwargs[x] for x in dims}.items():
-            new_dims[new_dims.index(old_name)] = new_name
-            coords[new_name] = coords.pop(old_name, None)
-        new["dims"] = tuple(new_dims)
-        return self.__class__(**new)
 
     def update(self, **kwargs) -> Self:
         """Update an attribute in the model, return new model."""
-        passed_in_coords = kwargs.get("coords", True)
         out = self.model_dump(exclude_unset=True)
-        # If coord manager passed in, base new coordinates on that.
-        new_coords = dict(out.get("coords", {}))
-        if isinstance(passed_in_coords, dc.CoordManager):
-            new_coords = passed_in_coords.model_dump(exclude_unset=True)
-
-        coord_info, attr_info = separate_coord_info(kwargs, dims=self.dim_tuple)
-        out.update(attr_info)
-        # Iterate the coordinate information and update.
-        for name, coord_dict in coord_info.items():
-            if name not in new_coords:
-                new_coords[name] = coord_dict
-            else:
-                new_coords[name].update(coord_dict)
-        out["coords"] = new_coords
-        # If falsy coords passed in, clear the coordinates.
-        if not passed_in_coords:
-            out["coords"] = {}
-        return self.__class__(**out)
+        out.update(kwargs)
+        return self.from_dict(out)
 
     def drop(self, *args):
         """Drop specific keys if they exist."""
@@ -267,35 +164,6 @@ class PatchAttrs(DascoreBaseModel):
         out = {i: v for i, v in contents.items() if not i.startswith("_")}
         return self.__class__(**out)
 
-    def flat_dump(self, dim_tuple=False, exclude=None) -> dict:
-        """
-        Flatten the coordinates and dump to dict.
-
-        Parameters
-        ----------
-        dim_tuple
-            If True, return dimensional tuple instead of range. EG, the
-            output will have {time: (min, max)} rather than
-            {time_min: ..., time_max: ...,}. This is useful because it can
-            be passed to read, scan, select, etc.
-        exclude
-            keys to exclude.
-        """
-        out = self.model_dump(exclude=exclude)
-        for coord_name, coord in out.pop("coords").items():
-            names = list(coord)
-            if dim_tuple:
-                names = sorted(set(names) - {"min", "max"})
-                out[coord_name] = (coord["min"], coord["max"])
-            for name in names:
-                out[f"{coord_name}_{name}"] = coord[name]
-            # ensure step has right type if nullish
-            step_name = f"{coord_name}_step"
-            step, start = out[step_name], coord["min"]
-            if step is None:
-                is_time = isinstance(start, np.datetime64 | np.timedelta64)
-                if is_time:
-                    out[step_name] = np.timedelta64("NaT")
-                elif isinstance(start, float | np.floating):
-                    out[step_name] = np.nan
-        return out
+    def flat_dump(self, exclude=None) -> dict:
+        """Dump attrs to a flat dict."""
+        return self.model_dump(exclude=exclude)

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -13,6 +13,7 @@ from dascore.constants import (
     VALID_DATA_TYPES,
     max_lens,
 )
+from dascore.utils.attrs import _raise_if_coord_attr_updates
 from dascore.utils.misc import (
     to_str,
 )
@@ -147,6 +148,7 @@ class PatchAttrs(DascoreBaseModel):
 
     def update(self, **kwargs) -> Self:
         """Update an attribute in the model, return new model."""
+        _raise_if_coord_attr_updates(kwargs)
         out = self.model_dump(exclude_unset=True)
         out.update(kwargs)
         return self.from_dict(out)

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -24,12 +24,12 @@ print(cm)
 
 ```{python}
 import numpy as np
-# Get array of coordinate values
-time = cm['time']
+# Get the coordinate object
+time = cm["time"]
 
 # Filter data array
 # this gets a new coord manager and a view of the trimmed data.
-_sorted_time = np.sort(time)
+_sorted_time = np.sort(time.values)
 t1 = _sorted_time[5]
 t2 = _sorted_time[-5]
 new_cm, new_data = cm.select(time=(t1, t2), array=data)
@@ -41,7 +41,6 @@ print(new_cm)
 
 from __future__ import annotations
 
-import warnings
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from itertools import zip_longest
@@ -210,16 +209,9 @@ class CoordManager(DascoreBaseModel):
         """Ensure mapping fields are immutable."""
         return FrozenDict(v)
 
-    def __getitem__(self, item) -> np.ndarray:
-        # in order to not break backward compatibility, we need to return
-        # the array. Start the deprecation cycle to be consistent.
-        msg = (
-            "Currently coords[coord_name] returns a numpy array, but in a "
-            "future dascore version it will return a BaseCoord instance. "
-            "Use patch.coords.get_array(coord_name) instead."
-        )
-        warnings.warn(msg, UserWarning, stacklevel=6)
-        return self.get_coord(item).values
+    def __getitem__(self, item) -> BaseCoord:
+        """Return a coordinate by name."""
+        return self.get_coord(item)
 
     def __getattr__(self, item) -> BaseCoord:
         try:
@@ -336,13 +328,6 @@ class CoordManager(DascoreBaseModel):
             }
             out[name] = coord.update(**diff)
         coords = self.new(coord_map=out)
-        # anything not used in coord_info should be put back.
-        # for example, data_units might get put in its own coord called data.
-        for unused_dim in set(coord_info) - set(coords.dims):
-            for key, val in coord_info[unused_dim].items():
-                attr_info[f"{unused_dim}_{key}"] = val
-        attr_info["coords"] = coords.to_summary_dict()
-        attr_info["dims"] = coords.dims
         attrs = dc.PatchAttrs.from_dict(attr_info)
         return coords, attrs
 
@@ -1180,9 +1165,6 @@ def get_coord_manager(
     >>> quality = np.random.random((len(distance), len(time)))
     >>> coords['quality'] = (("distance", "time"), quality)
     >>> cm = get_coord_manager(coords=coords, dims=dims)
-    >>> # Get coordinate manager from typical patch attribute dict
-    >>> attrs = dc.get_example_patch().attrs
-    >>> cm = get_coord_manager(attrs=attrs)
     """
     if coords is not None and attrs is not None:
         msg = (
@@ -1202,8 +1184,6 @@ def get_coord_manager(
     if dims is None:
         if isinstance(coords, Mapping) and all(isinstance(x, str) for x in coords):
             dims = tuple(i for i, v in coords.items() if not isinstance(v, tuple))
-        elif (attrs is not None and "dims" in attrs) or hasattr(attrs, "dims"):
-            dims = tuple(attrs["dims"].split(","))
         else:
             dims = ()
     coords = {} if coords is None else coords

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -101,6 +101,8 @@ class CoordSummary(DascoreBaseModel):
     max: min_max_type
     step: step_type | None = None
     units: UnitQuantity | None = None
+    dims: tuple[str, ...] = ()
+    len: int | None = None
 
     @model_serializer(when_used="json")
     def ser_model(self) -> dict[str, str]:
@@ -737,6 +739,8 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             step=self.step,
             dtype=self.dtype,
             units=self.units,
+            dims=dims,
+            len=len(self),
         )
 
     def update(self, **kwargs):
@@ -1060,6 +1064,7 @@ class CoordPartial(BaseCoord):
             step=np.nan,
             dtype=self.dtype,
             units=None,
+            dims=dims,
         )
 
 

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from typing import Final
 
 import numpy as np
 from rich.text import Text
@@ -17,6 +18,7 @@ from dascore.compat import DataArray, array
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.coords import BaseCoord
+from dascore.core.summary import PatchSummary
 from dascore.utils.array import PatchUFunc, patch_array_function, patch_array_ufunc
 from dascore.utils.deprecate import deprecate
 from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
@@ -55,18 +57,18 @@ class Patch(NamespaceOwner):
 
     Notes
     -----
-    - If coordinates and dims are not provided, they will be extracted from
-    attrs, if possible.
-
-    - If coords and attrs are provided, attrs will have priority. This means
-    if there is a conflict between information contained in both, the coords
-    will be recalculated.
+    Coordinates are owned by the patch/coord manager, not by attrs.
+    Use `Patch.summary` when you need a combined view of attrs plus
+    coordinate summary metadata.
     """
 
     data: ArrayLike
     coords: CoordManager
     dims: tuple[str, ...]
-    attrs: PatchAttrs | Mapping
+    attrs: PatchAttrs
+    _data: ArrayLike
+
+    _namespace_entry_point_group: Final[str] = "dascore.patch_namespace"
 
     def __init__(
         self,
@@ -75,36 +77,30 @@ class Patch(NamespaceOwner):
         dims: Sequence[str] | None = None,
         attrs: Mapping | PatchAttrs | None = None,
     ):
+        # Init empty patch
+        if all(x is None for x in (data, coords, dims, attrs)):
+            data = np.asarray([])
+            coords = {}
+            dims = ()
+            attrs = dc.PatchAttrs()
+        # Init Patch from Patch-like
         if isinstance(data, DataArray | self.__class__):
             data, attrs, coords = data.data, data.attrs, data.coords
+        if attrs is None:
+            attrs = dc.PatchAttrs()
         if dims is None and isinstance(coords, CoordManager):
             dims = coords.dims
-        # Try to generate coords from ranges in attrs
-        if coords is None and attrs is not None:
-            attrs = dc.PatchAttrs.from_dict(attrs)
-            coords = attrs.coords_from_dims()
-            dims = dims if dims is not None else attrs.dim_tuple
-        # Ensure required info is here
-        non_attrs = [x is None for x in [data, coords, dims]]
-        if any(non_attrs) and not all(non_attrs):
+        # By this point, everything should be defined.
+        if any(x is None for x in (data, coords, dims, attrs)):
             msg = "data, coords, and dims must be defined to init Patch."
             raise ValueError(msg)
-
-        shape = None if not hasattr(data, "shape") else data.shape
+        data = array(data)
+        shape = data.shape
         coords = get_coord_manager(coords, dims=dims, shape=shape)
-        # the only case we allow attrs to include coords is if they are both
-        # dicts, in which case attrs might have unit info for coords.
-        if isinstance(attrs, Mapping) and attrs:
-            coords, attrs = coords.update_from_attrs(attrs)
-        else:
-            # ensure attrs conforms to coords
-            attrs = dc.PatchAttrs.from_dict(attrs).update(coords=coords)
-        assert coords.dims == attrs.dim_tuple, "dim mismatch on coords and attrs"
+        attrs = dc.PatchAttrs.from_dict(attrs)
         self._coords = coords
         self._attrs = attrs
         self._data = array(self.coords.validate_data(data))
-
-    _namespace_entry_point_group = "dascore.patch_namespace"
 
     def __eq__(self, other):
         """Compare one Patch."""
@@ -182,20 +178,23 @@ class Patch(NamespaceOwner):
 
     def __array__(self, dtype=None, copy=None):
         """Used to convert Patches to arrays."""
-        data = self.data
         # dascore.utils.misc.to_object_array stores patch references in numpy
         # object arrays. When that function is called it tries to make a copy
         # of the array data with dtype == object, which takes a TON of memory.
         # For now, just don't let this method convert to object dtype arrays.
         if np.issubdtype(dtype, np.dtype(object)):
-            dtype = None
+            out = np.empty((), dtype=object)
+            out[()] = self
+            return out
+        data = self.data
         out = data.astype(dtype) if dtype is not None else data
         out = out if not copy else np.copy(out)
         return out
 
     def __rich__(self):
         dascore_text = get_dascore_text()
-        patch_text = Text("Patch ⚡", style="bold")
+        name = "Patch ⚡"
+        patch_text = Text(name, style="bold")
         header = Text.assemble(dascore_text, " ", patch_text)
         line = Text("-" * len(header))
         coords = self.coords.__rich__()
@@ -210,6 +209,10 @@ class Patch(NamespaceOwner):
         return str(out)
 
     __repr__ = __str__
+
+    def flat_dump(self, exclude=None) -> dict:
+        """Return a flat summary dict for dataframe-oriented helpers."""
+        return self.summary.flat_dump(exclude=exclude)
 
     @property
     def dims(self) -> tuple[str, ...]:
@@ -241,7 +244,7 @@ class Patch(NamespaceOwner):
     @property
     def attrs(self) -> PatchAttrs:
         """
-        Return the patch attributes.
+        Return the patch's non-coordinate metadata.
 
         Examples
         --------
@@ -253,6 +256,13 @@ class Patch(NamespaceOwner):
         >>> assert hasattr(attrs, 'data_type')
         """
         return self._attrs
+
+    @property
+    def summary(self):
+        """
+        Return a metadata-only summary of the patch.
+        """
+        return PatchSummary.from_patch(self)
 
     @property
     def coords(self) -> CoordManager:

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from functools import cached_property
 from typing import Final
 
 import numpy as np
@@ -257,7 +258,7 @@ class Patch(NamespaceOwner):
         """
         return self._attrs
 
-    @property
+    @cached_property
     def summary(self):
         """
         Return a metadata-only summary of the patch.

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -489,7 +489,7 @@ class DataFrameSpool(BaseSpool):
             patch: dc.Patch = patch.select(**select_kwargs)
             # its unfortunate, but currently we need to regenerate the patch
             # dict because the index doesn't carry all the dimensional info
-            info = patch.attrs.flat_dump(exclude=["history"])
+            info = patch.summary.flat_dump(exclude=["history"])
             info["patch"] = patch
             out.append(info)
         if len(out) > expected_len:
@@ -510,6 +510,8 @@ class DataFrameSpool(BaseSpool):
             current.copy(deep=False)[cols2keep]
             .assign(
                 source_index=source.index,
+                # This tracks the current spool row after spool operations.
+                # It is not the source patch identity within a file.
                 current_index=source.index,
                 _modified=lambda x: _column_or_value(x, "_modified", False),
             )
@@ -529,6 +531,18 @@ class DataFrameSpool(BaseSpool):
     @abc.abstractmethod
     def _load_patch(self, kwargs) -> dc.Patch:
         """Given a row from the managed dataframe, return a patch."""
+
+    def _read_and_resolve_patch(self, final_kwargs) -> dc.Patch:
+        """Read patches for one instruction row and resolve to one patch."""
+        from dascore.io.core import _select_patch_from_spool
+
+        source_patch_id = final_kwargs.get("source_patch_id", "")
+        spool = dc.read(**final_kwargs)
+        # Some readers consume source_patch_id internally and return the one
+        # matching patch without preserving that reload metadata on the patch.
+        if source_patch_id and len(spool) == 1:
+            return spool[0]
+        return _select_patch_from_spool(spool, source_patch_id=source_patch_id)
 
     @compose_docstring(doc=BaseSpool.chunk.__doc__)
     def chunk(

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -587,7 +587,9 @@ class DataFrameSpool(BaseSpool):
     ):
         """Create a new instance from dataframes."""
         new = self.__class__(self)
-        df_, source_, inst_ = self._get_dummy_dataframes(df)
+        source_ = inst_ = None
+        if source_df is None or instruction_df is None:
+            _, source_, inst_ = self._get_dummy_dataframes(df)
         new._df = df
         new._source_df = source_df if source_df is not None else source_
         new._instruction_df = instruction_df if instruction_df is not None else inst_

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -1,0 +1,250 @@
+"""Summary models for metadata-only patch workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from pydantic import ConfigDict, Field, model_validator
+
+import dascore as dc
+from dascore.core.attrs import PatchAttrs
+from dascore.core.coords import CoordSummary
+from dascore.utils.attrs import separate_coord_info
+from dascore.utils.models import DascoreBaseModel
+
+_SUMMARY_ONLY_FIELDS = {"source_patch_id"}
+
+
+def _to_coord_summary(value: Any, dims: tuple[str, ...] = ()) -> CoordSummary:
+    """Normalize a coordinate summary input."""
+    # Summary inputs can already be normalized, coord-like objects, or plain
+    # mappings produced by scan/index code.
+    if isinstance(value, CoordSummary):
+        return value
+    if hasattr(value, "to_summary"):
+        value = value.to_summary(dims=dims)
+    if hasattr(value, "model_dump"):
+        value = value.model_dump()
+    if isinstance(value, Mapping):
+        value = dict(value)
+        if dims and "dims" not in value:
+            value["dims"] = dims
+    return CoordSummary(**value)
+
+
+def _infer_dims_from_coords(coords: Mapping[str, CoordSummary]) -> tuple[str, ...]:
+    """Infer patch dims from summarized coordinates when not provided."""
+    out: list[str] = []
+    for name, summary in coords.items():
+        dims = tuple(getattr(summary, "dims", (name,)))
+        if dims == (name,):
+            out.append(name)
+    return tuple(x for x in out if x)
+
+
+def _normalize_dims(dims: Any) -> tuple[str, ...]:
+    """Normalize dims input from flat or structured summary payloads."""
+    if dims in (None, ""):
+        return tuple()
+    if isinstance(dims, str):
+        return tuple(dims.split(","))
+    return tuple(dims)
+
+
+class PatchSummary(DascoreBaseModel):
+    """A metadata-only summary of a patch."""
+
+    model_config = ConfigDict(title="Patch Summary", extra="ignore", frozen=True)
+
+    attrs: PatchAttrs = Field(default_factory=PatchAttrs)
+    coords: dict[str, CoordSummary] = Field(default_factory=dict)
+    dims: tuple[str, ...] = ()
+    shape: tuple[int, ...] = ()
+    dtype: str = ""
+    path: str | Path = ""
+    file_format: str = ""
+    file_version: str = ""
+    source_patch_id: str = ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_input(cls, data: Any) -> Any:
+        """Accept flat scan metadata or structured summary input."""
+        if isinstance(data, dc.Patch):
+            return cls.from_patch(data).dump_structured()
+        # Let pydantic raise the normal validation error for unsupported inputs.
+        if not isinstance(data, Mapping):
+            return data
+        data = dict(data)
+        # Structured inputs already separate non-coordinate attrs from coordinate
+        # summaries, so we only need to normalize nested coord values and dims.
+        if "attrs" in data or "coords" in data:
+            attrs = PatchAttrs.from_dict(data.get("attrs"))
+            dims = _normalize_dims(data.get("dims", ()))
+            coord_map = {
+                name: _to_coord_summary(
+                    summary,
+                    dims=tuple(summary.get("dims", (name,)))
+                    if isinstance(summary, Mapping)
+                    else (),
+                )
+                for name, summary in data.get("coords", {}).items()
+            }
+            dims = dims or _infer_dims_from_coords(coord_map)
+            return {
+                "attrs": attrs,
+                "coords": coord_map,
+                "dims": dims,
+                "shape": tuple(data.get("shape", ())),
+                "dtype": str(data.get("dtype", "")),
+                "path": data.get("path", ""),
+                "file_format": data.get("file_format", ""),
+                "file_version": data.get("file_version", ""),
+                "source_patch_id": data.get("source_patch_id", ""),
+            }
+        # Flat inputs still use scan/index-style keys such as time_min/time_max.
+        # Split those into coordinate summaries plus pure attrs before building
+        # the canonical structured payload.
+        dims = _normalize_dims(data.get("dims", ""))
+        coord_info, attr_info = separate_coord_info(
+            {k: v for k, v in data.items() if k != "dims"},
+            dims=dims or None,
+        )
+        attrs = PatchAttrs.from_dict(attr_info)
+        coord_map = {
+            name: _to_coord_summary(
+                summary,
+                dims=tuple(summary.get("dims", (name,)))
+                if isinstance(summary, Mapping)
+                else (),
+            )
+            for name, summary in coord_info.items()
+        }
+        dims = dims or _infer_dims_from_coords(coord_map)
+        return {
+            "attrs": attrs,
+            "coords": coord_map,
+            "dims": dims,
+            "shape": tuple(data.get("shape", ())),
+            "dtype": str(data.get("dtype", "")),
+            "path": data.get("path", ""),
+            "file_format": data.get("file_format", ""),
+            "file_version": data.get("file_version", ""),
+            "source_patch_id": data.get("source_patch_id", ""),
+        }
+
+    @classmethod
+    def from_patch(cls, patch: dc.Patch) -> PatchSummary:
+        """Create a summary from a loaded patch."""
+        return cls(
+            attrs=patch.attrs,
+            coords=patch.coords.to_summary_dict(),
+            dims=patch.dims,
+            shape=patch.shape,
+            dtype=str(np.dtype(patch.data.dtype)),
+        )
+
+    def dump_structured(self) -> dict[str, Any]:
+        """Return the structured representation of the summary."""
+        return super().model_dump()
+
+    def flat_dump(self, dim_tuple: bool = False, exclude=None) -> dict[str, Any]:
+        """Return a flat dict suitable for indexing/dataframes."""
+        exclude = set(() if exclude is None else exclude)
+        out = self.attrs.model_dump(exclude=exclude)
+        summary_meta = {
+            "dims": ",".join(self.dims),
+            "dtype": self.dtype,
+            "path": self.path,
+            "file_format": self.file_format,
+            "file_version": self.file_version,
+            "source_patch_id": self.source_patch_id,
+            "coord_names": ",".join(self.coords),
+        }
+        out.update(
+            {name: value for name, value in summary_meta.items() if name not in exclude}
+        )
+        for coord_name, summary in self.coords.items():
+            if coord_name in exclude:
+                continue
+            summary_dict = summary.model_dump()
+            # Some callers still want {(min, max)} tuples for dimensional coords
+            # instead of the fully expanded flat summary columns.
+            if dim_tuple:
+                out[coord_name] = (summary_dict["min"], summary_dict["max"])
+            for field, value in summary_dict.items():
+                if field in exclude:
+                    continue
+                if field == "dims":
+                    value = ",".join(value) if value else ""
+                # Flat summaries historically stored a sentinel step value even
+                # when a coord is not evenly sampled. Preserve that behavior for
+                # dataframe/index consumers that expect a scalar in *_step.
+                if field == "step" and value is None:
+                    start = summary_dict["min"]
+                    if isinstance(start, np.datetime64 | np.timedelta64):
+                        value = np.timedelta64("NaT")
+                    elif isinstance(start, float | np.floating):
+                        value = np.nan
+                out[f"{coord_name}_{field}"] = value
+        return out
+
+    def __getitem__(self, item):
+        try:
+            return getattr(self, item)
+        except AttributeError as exc:
+            raise KeyError(item) from exc
+
+    def __iter__(self):
+        return iter(self.flat_dump())
+
+    def __len__(self):
+        return len(self.flat_dump())
+
+    def __getattr__(self, item):
+        # Keep summary access ergonomic during the attrs/coords split by falling
+        # back to non-coordinate attrs first, then flattened coord fields.
+        try:
+            return getattr(self.attrs, item)
+        except AttributeError:
+            split = item.rsplit("_", 1)
+            if len(split) == 2:
+                coord_name, field = split
+                if coord_name in self.coords:
+                    coord = self.coords[coord_name]
+                    if field in type(coord).model_fields:
+                        return getattr(coord, field)
+            msg = f"{self.__class__.__name__} has no attribute '{item}'"
+            raise AttributeError(msg) from None
+
+    def get(self, item, default=None):
+        """Return item if present else default."""
+        try:
+            return self[item]
+        except KeyError:
+            return default
+
+    def items(self):
+        """Yield summary items like a mapping."""
+        yield from self.flat_dump().items()
+
+    @property
+    def dim_tuple(self) -> tuple[str, ...]:
+        """Return the dimensions as a tuple."""
+        return self.dims
+
+    @property
+    def summary(self) -> PatchSummary:
+        """Return self for symmetry with Patch.summary."""
+        return self
+
+    def get_coord_summary(self, coord_name: str) -> CoordSummary:
+        """Return the summary object for a single coordinate."""
+        return self.coords[coord_name]
+
+    def get_coord(self, coord_name: str) -> CoordSummary:
+        """Return the coordinate summary for compatibility with scan workflows."""
+        return self.get_coord_summary(coord_name)

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -15,8 +15,6 @@ from dascore.core.coords import CoordSummary
 from dascore.utils.attrs import separate_coord_info
 from dascore.utils.models import DascoreBaseModel
 
-_SUMMARY_ONLY_FIELDS = {"source_patch_id"}
-
 
 def _to_coord_summary(value: Any, dims: tuple[str, ...] = ()) -> CoordSummary:
     """Normalize a coordinate summary input."""

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -210,7 +210,3 @@ class PatchSummary(DascoreBaseModel):
     def get_coord_summary(self, coord_name: str) -> CoordSummary:
         """Return the summary object for a single coordinate."""
         return self.coords[coord_name]
-
-    def get_coord(self, coord_name: str) -> CoordSummary:
-        """Return the coordinate summary for compatibility with scan workflows."""
-        return self.get_coord_summary(coord_name)

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -152,16 +152,9 @@ class PatchSummary(DascoreBaseModel):
     def flat_dump(self, dim_tuple: bool = False, exclude=None) -> dict[str, Any]:
         """Return a flat dict suitable for indexing/dataframes."""
         exclude = set(() if exclude is None else exclude)
-        attrs = self.attrs
-        out = {
-            name: getattr(attrs, name)
-            for name in type(attrs).model_fields
-            if name not in exclude
-        }
-        extra = getattr(attrs, "__pydantic_extra__", None) or {}
-        for name, value in extra.items():
-            if name not in exclude:
-                out[name] = value
+        # Build flattened attrs first, then overlay coord summaries so coord-
+        # derived fields win over any attr using the same simplified key.
+        out = self.attrs.flat_dump(exclude=exclude)
         summary_meta = {
             "dims": ",".join(self.dims),
             "dtype": self.dtype,
@@ -203,45 +196,6 @@ class PatchSummary(DascoreBaseModel):
                         value = np.nan
                 out[f"{coord_name}_{field}"] = value
         return out
-
-    def __getitem__(self, item):
-        try:
-            return getattr(self, item)
-        except AttributeError as exc:
-            raise KeyError(item) from exc
-
-    def __iter__(self):
-        return iter(self.flat_dump())
-
-    def __len__(self):
-        return len(self.flat_dump())
-
-    def __getattr__(self, item):
-        # Keep summary access ergonomic during the attrs/coords split by falling
-        # back to non-coordinate attrs first, then flattened coord fields.
-        try:
-            return getattr(self.attrs, item)
-        except AttributeError:
-            split = item.rsplit("_", 1)
-            if len(split) == 2:
-                coord_name, field = split
-                if coord_name in self.coords:
-                    coord = self.coords[coord_name]
-                    if field in type(coord).model_fields:
-                        return getattr(coord, field)
-            msg = f"{self.__class__.__name__} has no attribute '{item}'"
-            raise AttributeError(msg) from None
-
-    def get(self, item, default=None):
-        """Return item if present else default."""
-        try:
-            return self[item]
-        except KeyError:
-            return default
-
-    def items(self):
-        """Yield summary items like a mapping."""
-        yield from self.flat_dump().items()
 
     @property
     def dim_tuple(self) -> tuple[str, ...]:

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -137,7 +137,7 @@ class PatchSummary(DascoreBaseModel):
     @classmethod
     def from_patch(cls, patch: dc.Patch) -> PatchSummary:
         """Create a summary from a loaded patch."""
-        return cls(
+        return cls.model_construct(
             attrs=patch.attrs,
             coords=patch.coords.to_summary_dict(),
             dims=patch.dims,
@@ -152,7 +152,16 @@ class PatchSummary(DascoreBaseModel):
     def flat_dump(self, dim_tuple: bool = False, exclude=None) -> dict[str, Any]:
         """Return a flat dict suitable for indexing/dataframes."""
         exclude = set(() if exclude is None else exclude)
-        out = self.attrs.model_dump(exclude=exclude)
+        attrs = self.attrs
+        out = {
+            name: getattr(attrs, name)
+            for name in type(attrs).model_fields
+            if name not in exclude
+        }
+        extra = getattr(attrs, "__pydantic_extra__", None) or {}
+        for name, value in extra.items():
+            if name not in exclude:
+                out[name] = value
         summary_meta = {
             "dims": ",".join(self.dims),
             "dtype": self.dtype,
@@ -168,7 +177,12 @@ class PatchSummary(DascoreBaseModel):
         for coord_name, summary in self.coords.items():
             if coord_name in exclude:
                 continue
-            summary_dict = summary.model_dump()
+            summary_dict = {}
+            for field in type(summary).model_fields:
+                if field == "dims":
+                    summary_dict[field] = getattr(summary, field)
+                else:
+                    summary_dict[field] = getattr(summary, field)
             # Some callers still want {(min, max)} tuples for dimensional coords
             # instead of the fully expanded flat summary columns.
             if dim_tuple:

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -25,6 +25,11 @@ EXAMPLE_PATCHES = {}
 EXAMPLE_SPOOLS = {}
 
 
+def _load_example_patch_from_file(path: str | Path) -> dc.Patch:
+    """Load the first patch from an example file without FileSpool indirection."""
+    return dc.read(path)[0]
+
+
 @register_func(EXAMPLE_PATCHES, key="random_das")
 def random_patch(
     *,
@@ -73,36 +78,24 @@ def random_patch(
     # create attrs
     t1 = np.atleast_1d(np.datetime64(time_min))[0]
     d1 = np.atleast_1d(distance_min)
+    time_step = to_timedelta64(time_step)
     attrs = dict(
-        distance_step=distance_step,
-        time_step=to_timedelta64(time_step),
         category="DAS",
-        time_min=t1,
         network=network,
         station=station,
         tag=tag,
-        time_units="s",
-        distance_units="m",
     )
-    # need to pop out dim attrs if coordinates provided.
-    if time_array is not None:
-        attrs.pop("time_min")
-        # need to keep time_step if time_array is len 1 to get coord range
-        if len(time_array) > 1:
-            attrs.pop("time_step")
-    else:
+    if time_array is None:
         time_array = dascore.core.get_coord(
-            data=t1 + np.arange(array.shape[1]) * attrs["time_step"],
-            step=attrs["time_step"],
-            units=attrs["time_units"],
+            data=t1 + np.arange(array.shape[1]) * time_step,
+            step=time_step,
+            units="s",
         )
-    if dist_array is not None:
-        attrs.pop("distance_step")
-    else:
+    if dist_array is None:
         dist_array = dascore.core.get_coord(
-            data=d1 + np.arange(array.shape[0]) * attrs["distance_step"],
-            step=attrs["distance_step"],
-            units=attrs["distance_units"],
+            data=d1 + np.arange(array.shape[0]) * distance_step,
+            step=distance_step,
+            units="m",
         )
     coords = dict(distance=dist_array, time=time_array)
     # assemble and output.
@@ -181,9 +174,8 @@ def wacky_dim_coord_patch():
     time_ar = dc.to_datetime64(np.cumsum(random_state.random(1_000)))
     patch = random_patch(shape=shape, dist_array=dist_ar, time_array=time_ar)
     # check attrs
-    attrs = patch.attrs
-    assert pd.isnull(attrs.coords["time"].step)
-    assert pd.isnull(attrs.coords["time"].step)
+    time_coord = patch.coords.coord_map["time"]
+    assert pd.isnull(time_coord.step)
     return patch
 
 
@@ -299,7 +291,7 @@ def example_event_1():
     An induced event recorded on a borehole fiber  from @stanvek2022fracture.
     """
     path = fetch("example_dasdae_event_1.h5")
-    return dc.spool(path)[0]
+    return _load_example_patch_from_file(path)
 
 
 @register_func(EXAMPLE_PATCHES, key="example_event_2")
@@ -308,7 +300,7 @@ def example_event_2():
     [`example_event_1`](`dascore.examples.example_event_1`) with pre-processing.
     """
     path = fetch("example_dasdae_event_1.h5")
-    patch = dc.spool(path)[0].update_attrs(data_type="strain_rate")
+    patch = _load_example_patch_from_file(path).update_attrs(data_type="strain_rate")
     # We convert time to relative time in seconds to match the figure in
     # the publication.
     delta_time = patch.coords.get_array("time") - patch.coords.min("time")
@@ -327,7 +319,7 @@ def deformation_rate_event_1():
     An event recorded in an underground mine by a Terra15 unit.
     """
     path = fetch("deformation_rate_event_1.hdf5")
-    return dc.spool(path)[0]
+    return _load_example_patch_from_file(path)
 
 
 @register_func(EXAMPLE_PATCHES, key="forge_dss")
@@ -338,7 +330,7 @@ def forge_dss():
     https://gdr.openei.org/submissions/1565
     """
     path = fetch("neubrex_dss_forge.h5")
-    return dc.spool(path)[0]
+    return _load_example_patch_from_file(path)
 
 
 @register_func(EXAMPLE_PATCHES, key="febus_dss_mine_tight")
@@ -346,7 +338,7 @@ def febus_dss_mine_1():
     """
     DSS file from a tight-buffered fiber at a mine with Febus interrogator
     """
-    return dc.spool(fetch("dss_ug_mine_tight.h5"))[0]
+    return _load_example_patch_from_file(fetch("dss_ug_mine_tight.h5"))
 
 
 @register_func(EXAMPLE_PATCHES, key="febus_dss_mine_loose")
@@ -354,7 +346,7 @@ def febus_dss_mine_2():
     """
     DSS file from a loose-buffered fiber at a mine with Febus interrogator
     """
-    return dc.spool(fetch("dss_ug_mine_loose.h5"))[0]
+    return _load_example_patch_from_file(fetch("dss_ug_mine_loose.h5"))
 
 
 @register_func(EXAMPLE_PATCHES, key="forge_dts")
@@ -365,7 +357,7 @@ def forge_dts():
     https://gdr.openei.org/submissions/1565
     """
     path = fetch("neubrex_dts_forge.h5")
-    return dc.spool(path)[0]
+    return _load_example_patch_from_file(path)
 
 
 @register_func(EXAMPLE_PATCHES, key="nd_patch")
@@ -515,16 +507,10 @@ def delta_patch(
 
         coords = {"distance": dist_coord, "time": time_coord}
         attrs = dict(
-            time_min=t0,
-            time_step=time_step_td,
-            distance_min=distance_min,
-            distance_step=distance_step,
             category="DAS",
             network="",
             station="",
             tag="delta",
-            time_units="s",
-            distance_units="m",
         )
 
         # Depending on the selected dimension, place a line of ones at the midpoint
@@ -587,8 +573,8 @@ def random_spool(time_gap=0, length=3, time_min=np.datetime64("2020-01-03"), **k
     for _ in range(length):
         patch = random_patch(time_min=time_min, **kwargs)
         out.append(patch)
-        diff = to_timedelta64(time_gap) + patch.attrs.coords["time"].step
-        time_min = patch.attrs["time_max"] + diff
+        diff = to_timedelta64(time_gap) + patch.coords.step("time")
+        time_min = patch.coords.max("time") + diff
     return dc.spool(out)
 
 
@@ -623,7 +609,7 @@ def diverse_spool():
     spool_overlaps = random_spool(
         time_gap=-np.timedelta64(10, "ms"), station="overlaps"
     )
-    time_step = spool_big_gaps[0].attrs.coords["time"].step
+    time_step = spool_big_gaps[0].coords.step("time")
     dt = to_timedelta64(time_step / np.timedelta64(1, "s"))
     spool_small_gaps = random_spool(time_gap=dt, station="smallg")
     spool_way_late = random_spool(

--- a/dascore/io/ap_sensing/core.py
+++ b/dascore/io/ap_sensing/core.py
@@ -8,10 +8,11 @@ import numpy as np
 
 import dascore as dc
 from dascore.constants import opt_timeable_types
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 
-from .utils import _get_attrs_dict, _get_patches, _get_version_string
+from .utils import _get_attrs_dict, _get_coords, _get_patches, _get_version_string
 
 
 class APSensingPatchAttrs(dc.PatchAttrs):
@@ -41,17 +42,19 @@ class APSensingV10(FiberIO):
         if version_str:
             return self.name, version_str
 
-    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[PatchSummary]:
         """Scan an AP sensing file, return summary info about the contents."""
-        file_version = _get_version_string(resource)
-        extras = {
-            "path": resource.filename,
-            "file_format": self.name,
-            "file_version": str(file_version),
-        }
-        attrs = _get_attrs_dict(resource)
-        attrs.update(extras)
-        return [APSensingPatchAttrs(**attrs)]
+        coords = _get_coords(resource)
+        attrs = APSensingPatchAttrs.model_validate(_get_attrs_dict(resource))
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype=str(resource["DAS"].dtype),
+            )
+        ]
 
     def read(
         self,

--- a/dascore/io/ap_sensing/utils.py
+++ b/dascore/io/ap_sensing/utils.py
@@ -78,7 +78,6 @@ def _get_attrs_dict(resource):
     daq = resource["DAQ"]
     pserver = resource["ProcessingServer"]
     out = dict(
-        coords=_get_coords(resource),
         data_category="DAS",
         instrumet_id=unbyte(_maybe_unpack(daq["SerialNumber"])),
         gauge_length=_maybe_unpack(pserver["GaugeLength"]),
@@ -90,11 +89,10 @@ def _get_attrs_dict(resource):
 def _get_patches(resource, time=None, distance=None, attr_cls=dc.PatchAttrs):
     """Get a patch from ap_sensing file."""
     attrs = _get_attrs_dict(resource)
-    coords = attrs["coords"]
+    coords = _get_coords(resource)
     data = resource["DAS"]
     if time is not None or distance is not None:
         coords, data = coords.select(array=data, time=time, distance=distance)
-        attrs["coords"] = coords
         if not data.size:
             return []
     attrs = attr_cls.model_validate(attrs)

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -756,7 +756,7 @@ def read(
     >>> import dascore as dc
     >>> from dascore.utils.downloader import fetch
     >>>
-    >>> file_path = fetch("prodml_2.1.h5")
+    >>> file_path = fetch("terra15_das_1_trimmed.hdf5")
     >>>
     >>> patch = dc.read(file_path)
     """
@@ -814,7 +814,7 @@ def scan_to_df(
     >>> import dascore as dc
     >>> from dascore.utils.downloader import fetch
     >>>
-    >>> file_path = fetch("prodml_2.1.h5")
+    >>> file_path = fetch("terra15_das_1_trimmed.hdf5")
     >>>
     >>> df = dc.scan_to_df(file_path)
     """
@@ -958,13 +958,10 @@ def scan(
     >>> import dascore as dc
     >>> from dascore.utils.downloader import fetch
     >>>
-    >>> file_path = fetch("prodml_2.1.h5")
+    >>> file_path = fetch("terra15_das_1_trimmed.hdf5")
     >>>
-    >>> patch_list = dc.scan(file_path)
-    >>> summary = patch_list[0]
-    >>> from dascore.io.core import _load_patch_summary
-    >>> patch = _load_patch_summary(summary)
-    >>> assert patch.dtype == np.dtype(summary.dtype)
+    >>> summary_list = dc.scan(file_path)
+    >>> summary = summary_list[0]
 
     See also [`iter_fs_contents`](`dascore.utils.misc.iter_fs_contents`)
     """

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -31,10 +31,12 @@ from dascore.constants import (
 )
 from dascore.core.attrs import str_validator
 from dascore.core.spool import DataFrameSpool
+from dascore.core.summary import PatchSummary
 from dascore.exceptions import (
     InvalidFiberFileError,
     InvalidFiberIOError,
     MissingOptionalDependencyError,
+    PatchAttributeError,
     UnknownFiberFormatError,
 )
 from dascore.utils.io import IOResourceManager, get_handle_from_resource
@@ -46,7 +48,6 @@ from dascore.utils.models import (
     DateTime64,
     TimeDelta64,
 )
-from dascore.utils.pd import _model_list_to_df
 from dascore.utils.plugins import get_entry_point_loaders
 from dascore.utils.progress import track
 
@@ -78,6 +79,7 @@ class PatchFileSummary(DascoreBaseModel):
     file_version: str = ""
     file_format: str = ""
     path: str | Path = ""
+    source_patch_id: str = ""
 
     @property
     def dim_tuple(self):
@@ -98,6 +100,131 @@ class PatchFileSummary(DascoreBaseModel):
     def flat_dump(self):
         """Alias for dump, for compatibility with PatchAttrs.flat_dump."""
         return self.model_dump()
+
+
+def _scan_result_to_summary(
+    attrs: PatchSummary,
+    *,
+    path: str | Path | None = None,
+    file_format: str | None = None,
+    file_version: str | None = None,
+    source_patch_id: str | None = None,
+) -> PatchSummary:
+    """Convert scan metadata into a patch summary."""
+    summary_path = "" if path in (None, "") else path
+    summary_format = "" if file_format in (None, "") else file_format
+    summary_version = "" if file_version in (None, "") else file_version
+    summary_source_patch_id = (
+        "" if source_patch_id in (None, "") else str(source_patch_id)
+    )
+    if isinstance(attrs, PatchSummary):
+        raw_attrs = attrs.attrs.model_dump()
+        nested_path = raw_attrs.get("path", "")
+        nested_format = raw_attrs.get("file_format", "")
+        nested_version = raw_attrs.get("file_version", "")
+        nested_source_patch_id = raw_attrs.get("source_patch_id", "")
+        return PatchSummary.model_construct(
+            attrs=attrs.attrs,
+            coords=dict(attrs.coords),
+            dims=tuple(attrs.dims),
+            shape=tuple(attrs.shape),
+            dtype=attrs.dtype,
+            path=summary_path or attrs.path or nested_path,
+            file_format=summary_format or attrs.file_format or nested_format,
+            file_version=summary_version or attrs.file_version or nested_version,
+            source_patch_id=(
+                summary_source_patch_id
+                or attrs.source_patch_id
+                or str(nested_source_patch_id)
+            ),
+        )
+    if isinstance(attrs, dc.PatchAttrs):
+        msg = (
+            "DASCore no longer accepts PatchAttrs from FiberIO.scan(). "
+            "Return PatchSummary instead. See docs/contributing/new_format.qmd."
+        )
+        raise ValueError(msg)
+    msg = (
+        "_scan_result_to_summary only accepts PatchSummary. "
+        f"Got {type(attrs).__name__}."
+    )
+    raise TypeError(msg)
+
+
+def _patch_to_summary(
+    patch: dc.Patch,
+    *,
+    path: str | Path | None = None,
+    file_format: str | None = None,
+    file_version: str | None = None,
+) -> PatchSummary:
+    """Convert a loaded patch into a summary tied to its source."""
+    return _scan_result_to_summary(
+        patch.summary,
+        path=path or "",
+        file_format=file_format,
+        file_version=file_version,
+    )
+
+
+def _select_patch_from_spool(spool, source_patch_id: object = "") -> dc.Patch:
+    """Select one loaded patch from a spool using source identity."""
+    if len(spool) == 0:
+        msg = "index of [0] is out of bounds for spool."
+        raise IndexError(msg)
+    if source_patch_id not in (None, ""):
+        source_patch_id = str(source_patch_id)
+        try:
+            index = int(source_patch_id)
+        except (TypeError, ValueError):
+            index = None
+        if index is not None and 0 <= index < len(spool):
+            return spool[index]
+        msg = "Patch could not be uniquely resolved after applying load filters."
+        raise PatchAttributeError(msg)
+    if len(spool) == 1:
+        return spool[0]
+    msg = "Patch could not be uniquely resolved after applying load filters."
+    raise PatchAttributeError(msg)
+
+
+def _load_patch_summary(summary: PatchSummary, **kwargs) -> dc.Patch:
+    """Internal helper for reloading a patch from a PatchSummary."""
+    source_patch_id = summary.source_patch_id
+    read_kwargs = {
+        "path": summary.path,
+        "file_format": summary.file_format or None,
+        "file_version": summary.file_version or None,
+        "source_patch_id": source_patch_id or None,
+    }
+    read_kwargs.update(kwargs)
+    path = read_kwargs.pop("path", None)
+    if path in (None, ""):
+        msg = "PatchSummary cannot load data because it has no source path."
+        raise PatchAttributeError(msg)
+    spool = dc.read(path, **read_kwargs)
+    if source_patch_id and len(spool) == 1:
+        return spool[0]
+    try:
+        return _select_patch_from_spool(spool, source_patch_id=source_patch_id)
+    except IndexError as exc:
+        msg = "Patch could not be resolved after applying load filters."
+        raise PatchAttributeError(msg) from exc
+
+
+def _get_reloadable_source_path(resource, fallback: str | Path | None = None) -> str:
+    """Return a reloadable filesystem path for resources that expose one."""
+    candidates = [fallback, resource]
+    for name in ("source", "filename", "name", "path"):
+        candidates.append(getattr(resource, name, None))
+    for candidate in candidates:
+        if candidate in (None, ""):
+            continue
+        if isinstance(candidate, IOResourceManager):
+            candidate = candidate.source
+        if isinstance(candidate, str | Path):
+            return str(candidate)
+    return ""
 
 
 class _FiberIOManager:
@@ -474,13 +601,24 @@ class FiberIO:
 
         *kwargs should include support for selecting expected dimensions. For
         example, distance=(100, 200) would only read data with distance from
-        100 to 200.
+        100 to 200. Multi-patch formats may also accept `source_patch_id` to
+        load one or more logical patches from the source.
         """
         msg = f"FiberIO: {self.name} has no read method"
         raise NotImplementedError(msg)
 
-    def scan(self, resource, **kwargs) -> list[dc.PatchAttrs]:
-        """Returns a list of summary info for patches contained in file."""
+    def scan(self, resource, **kwargs) -> list[PatchSummary]:
+        """
+        Return patch metadata for the contents of a resource.
+
+        `scan()` should return `PatchSummary` objects and should not populate
+        source metadata such as `path`, `file_format`, or `file_version`.
+        DASCore attaches those fields in the higher-level `dc.scan(...)` and
+        `dc.scan_to_df(...)` pipeline.
+
+        Multi-patch formats should still set `source_patch_id` when needed so
+        DASCore can reload the same logical patch later.
+        """
         # default scan method reads in the file and returns required attributes
         # however, this can be very slow, so each parser should implement scan
         # when possible.
@@ -489,14 +627,7 @@ class FiberIO:
         except NotImplementedError:
             msg = f"FiberIO: {self.name} has no scan or read method"
             raise NotImplementedError(msg)
-        out = []
-        for pa in spool:
-            new = pa.attrs.update(
-                file_format=self.name,
-                path=str(resource),
-            )
-            out.append(new)
-        return out
+        return [_patch_to_summary(pa) for pa in spool]
 
     def write(self, spool: SpoolType, resource, **kwargs):
         """Write the spool to a resource (eg path, stream, etc.)."""
@@ -620,6 +751,7 @@ def read(
 
     Examples
     --------
+    >>> import numpy as np
     >>> import dascore as dc
     >>> from dascore.utils.downloader import fetch
     >>>
@@ -697,7 +829,12 @@ def scan_to_df(
         timestamp=timestamp,
         progress=progress,
     )
-    df = _model_list_to_df(info, exclude=exclude)
+    records = []
+    for item in info:
+        records.append(item.flat_dump(exclude=exclude))
+    df = pd.DataFrame(records)
+    if "dims" in df.columns:
+        df["dims"] = df["dims"].astype(str)
     return df
 
 
@@ -787,9 +924,9 @@ def scan(
     ext: str | None = None,
     timestamp: float | None = None,
     progress: PROGRESS_LEVELS | Progress = "standard",
-) -> list[dc.PatchAttrs]:
+) -> list[PatchSummary]:
     """
-    Scan a potential patch source, return a list of PatchAttrs.
+    Scan a potential patch source, return a list of patch summaries.
 
     Parameters
     ----------
@@ -812,17 +949,21 @@ def scan(
 
     Returns
     -------
-    A list of [`PatchAttrs`](`dascore.core.attrs.PatchAttrs`) or subclasses
-    which may have extra fields.
+    A list of [`PatchSummary`](`dascore.PatchSummary`) instances.
 
     Examples
     --------
+    >>> import numpy as np
     >>> import dascore as dc
     >>> from dascore.utils.downloader import fetch
     >>>
     >>> file_path = fetch("prodml_2.1.h5")
     >>>
-    >>> attr_list = dc.scan(file_path)
+    >>> patch_list = dc.scan(file_path)
+    >>> summary = patch_list[0]
+    >>> from dascore.io.core import _load_patch_summary
+    >>> patch = _load_patch_summary(summary)
+    >>> assert patch.dtype == np.dtype(summary.dtype)
 
     See also [`iter_fs_contents`](`dascore.utils.misc.iter_fs_contents`)
     """
@@ -848,9 +989,17 @@ def scan(
     )
     try:
         for patch_source in tracker:
-            # just pull attrs from patch
+            # Normalize direct patch inputs to summary objects.
             if isinstance(patch_source, dc.Patch):
-                out.append(patch_source.attrs)
+                out.append(
+                    _patch_to_summary(
+                        patch_source,
+                        path=_get_reloadable_source_path(
+                            patch_source.summary.path,
+                            fallback=patch_source.summary.path,
+                        ),
+                    )
+                )
                 continue
             with IOResourceManager(patch_source) as man:
                 try:
@@ -888,8 +1037,16 @@ def scan(
                     except MissingOptionalDependencyError as ex:
                         missing_optional_deps[ex.msg.split(" ")[0]] += 1
                         continue
+                source_path = _get_reloadable_source_path(resource, fallback=man.source)
                 for attr in source:
-                    out.append(dc.PatchAttrs.from_dict(attr))
+                    out.append(
+                        _scan_result_to_summary(
+                            attr,
+                            path=source_path,
+                            file_format=fiber_io.name,
+                            file_version=fiber_io.version,
+                        )
+                    )
     # Ensure ctl + c exists scan.
     except KeyboardInterrupt:
         getattr(progress, "stop", lambda: None)()

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -165,6 +165,11 @@ def _patch_to_summary(
 
 def _select_patch_from_spool(spool, source_patch_id: object = "") -> dc.Patch:
     """Select one loaded patch from a spool using source identity."""
+
+    def _matches_patch_name(patch: dc.Patch, source_id: str) -> bool:
+        """Return True when a generated patch name matches the source id."""
+        return patch.get_patch_name() == source_id
+
     if len(spool) == 0:
         msg = "index of [0] is out of bounds for spool."
         raise IndexError(msg)
@@ -176,6 +181,8 @@ def _select_patch_from_spool(spool, source_patch_id: object = "") -> dc.Patch:
             index = None
         if index is not None and 0 <= index < len(spool):
             return spool[index]
+        if len(spool) == 1 and _matches_patch_name(spool[0], source_patch_id):
+            return spool[0]
         msg = "Patch could not be uniquely resolved after applying load filters."
         raise PatchAttributeError(msg)
     if len(spool) == 1:
@@ -199,8 +206,6 @@ def _load_patch_summary(summary: PatchSummary, **kwargs) -> dc.Patch:
         msg = "PatchSummary cannot load data because it has no source path."
         raise PatchAttributeError(msg)
     spool = dc.read(path, **read_kwargs)
-    if source_patch_id and len(spool) == 1:
-        return spool[0]
     try:
         return _select_patch_from_spool(spool, source_patch_id=source_patch_id)
     except IndexError as exc:

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -111,6 +111,11 @@ def _scan_result_to_summary(
     source_patch_id: str | None = None,
 ) -> PatchSummary:
     """Convert scan metadata into a patch summary."""
+    if isinstance(attrs, PatchSummary) and all(
+        value in (None, "")
+        for value in (path, file_format, file_version, source_patch_id)
+    ):
+        return attrs
     summary_path = "" if path in (None, "") else path
     summary_format = "" if file_format in (None, "") else file_format
     summary_version = "" if file_version in (None, "") else file_version

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -118,25 +118,16 @@ def _scan_result_to_summary(
         "" if source_patch_id in (None, "") else str(source_patch_id)
     )
     if isinstance(attrs, PatchSummary):
-        raw_attrs = attrs.attrs.model_dump()
-        nested_path = raw_attrs.get("path", "")
-        nested_format = raw_attrs.get("file_format", "")
-        nested_version = raw_attrs.get("file_version", "")
-        nested_source_patch_id = raw_attrs.get("source_patch_id", "")
         return PatchSummary.model_construct(
             attrs=attrs.attrs,
             coords=dict(attrs.coords),
             dims=tuple(attrs.dims),
             shape=tuple(attrs.shape),
             dtype=attrs.dtype,
-            path=summary_path or attrs.path or nested_path,
-            file_format=summary_format or attrs.file_format or nested_format,
-            file_version=summary_version or attrs.file_version or nested_version,
-            source_patch_id=(
-                summary_source_patch_id
-                or attrs.source_patch_id
-                or str(nested_source_patch_id)
-            ),
+            path=summary_path or attrs.path,
+            file_format=summary_format or attrs.file_format,
+            file_version=summary_version or attrs.file_version,
+            source_patch_id=summary_source_patch_id or attrs.source_patch_id,
         )
     if isinstance(attrs, dc.PatchAttrs):
         msg = (

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 import dascore as dc
 from dascore.constants import SpoolType
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import (
     H5Reader,
@@ -16,7 +17,7 @@ from dascore.utils.hdf5 import (
     PyTablesReader,
     PyTablesWriter,
 )
-from dascore.utils.misc import unbyte
+from dascore.utils.misc import iterate, unbyte
 from dascore.utils.patch import get_patch_names
 
 from .utils import (
@@ -92,7 +93,7 @@ class DASDAEV1(FiberIO):
         df = (
             dc.scan_to_df(patches)
             .assign(
-                path=lambda x: get_patch_names(x),
+                source_patch_id=lambda x: get_patch_names(x),
                 file_format=self.name,
                 file_version=self.version,
             )
@@ -113,11 +114,18 @@ class DASDAEV1(FiberIO):
     def read(self, resource: PyTablesReader, **kwargs) -> SpoolType:
         """Read a dascore file."""
         patches = []
+        source_patch_ids = {
+            str(value)
+            for value in iterate(kwargs.pop("source_patch_id", None))
+            if value not in (None, "")
+        }
         try:
             waveform_group = resource.root["/waveforms"]
         except (KeyError, IndexError):
             return dc.spool([])
         for patch_group in waveform_group:
+            if source_patch_ids and patch_group._v_name not in source_patch_ids:
+                continue
             patch = _read_patch(patch_group, **kwargs)
             if not patch.data.size and not _kwargs_empty(kwargs):
                 continue
@@ -139,14 +147,15 @@ class DASDAEV1(FiberIO):
         """
         indexer = HDFPatchIndexManager(resource.filename)
         if indexer.has_index:
-            # We need to change the path back to the file rather than internal
-            # HDF5 path so it works with FileSpool and such.
-            records = indexer.get_index().assign(path=str(resource)).to_dict("records")
-            return [dc.PatchAttrs(**x) for x in records]
+            records = (
+                indexer.get_index()
+                .drop(columns=["path", "file_format", "file_version"], errors="ignore")
+                .to_dict("records")
+            )
+            return [PatchSummary(**record) for record in records]
         else:
-            file_format = self.name
             version = resource.root._v_attrs.__DASDAE_version__
-            return _get_contents_from_patch_groups(resource, version, file_format)
+            return _get_contents_from_patch_groups(resource, version)
 
     def index(self, path):
         """Index the dasdae file."""

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -8,12 +8,13 @@ from tables import NodeError
 import dascore as dc
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
-from dascore.core.coords import get_coord
-from dascore.utils.misc import suppress_warnings
+from dascore.core.coords import CoordSummary, get_coord
+from dascore.core.summary import PatchSummary
+from dascore.utils.attrs import separate_coord_info
 from dascore.utils.time import to_int
 
 # Keys not counted as true kwargs for determining if patch is filtered/selected.
-_KWARG_NON_KEYS = {"file_version", "file_format", "path"}
+_KWARG_NON_KEYS = {"file_version", "file_format", "path", "source_patch_id"}
 
 
 # --- Functions for writing DASDAE format
@@ -67,6 +68,7 @@ def _save_array(data, name, group, h5):
     array_node = _create_or_squash_array(h5, group, name, data)
     array_node._v_attrs["is_datetime64"] = is_dt
     array_node._v_attrs["is_timedelta64"] = is_td
+    return array_node
 
 
 def _save_coords(patch, patch_group, h5):
@@ -77,7 +79,14 @@ def _save_coords(patch, patch_group, h5):
         # First save coordinate arrays
         data = coord.values
         save_name = f"_coord_{name}"
-        _save_array(data, save_name, patch_group, h5)
+        array_node = _save_array(data, save_name, patch_group, h5)
+        step = coord.step
+        if step is not None:
+            is_td = np.issubdtype(np.asarray(step).dtype, np.timedelta64)
+            array_node._v_attrs["step"] = to_int(step) if is_td else step
+            array_node._v_attrs["step_is_timedelta64"] = is_td
+        if coord.units is not None:
+            array_node._v_attrs["units"] = str(coord.units)
         # then save dimensions of coordinates
         save_name = f"_cdims_{name}"
         patch_group._v_attrs[save_name] = ",".join(dims)
@@ -107,8 +116,7 @@ def _get_attrs(patch_group):
         if isinstance(val, np.ndarray) and not val.shape:
             val = np.asarray([val])[0]
         out[key] = val
-    with suppress_warnings(DeprecationWarning):
-        return PatchAttrs(**out)
+    return out
 
 
 def _read_array(table_array):
@@ -121,6 +129,34 @@ def _read_array(table_array):
     return data
 
 
+def _translate_legacy_attrs(attrs):
+    """Normalize legacy DASDAE attr payloads to flat coord metadata."""
+    out = dict(attrs)
+    coords = out.pop("coords", {})
+    if hasattr(coords, "to_summary_dict"):
+        coords = coords.to_summary_dict()
+    for name, summary in coords.items():
+        if hasattr(summary, "to_summary"):
+            summary = summary.to_summary()
+        if hasattr(summary, "model_dump"):
+            summary = summary.model_dump()
+        if not isinstance(summary, dict):
+            continue
+        for field in ("units", "step"):
+            key = f"{name}_{field}"
+            value = summary.get(field)
+            if key not in out and value not in (None, ""):
+                out[key] = value
+    dims = out.get("dims", "")
+    dims = tuple(dims.split(",")) if isinstance(dims, str) else tuple(dims or ())
+    for name in dims:
+        old_name = f"d_{name}"
+        new_name = f"{name}_step"
+        if new_name not in out and old_name in out:
+            out[new_name] = out.pop(old_name)
+    return out
+
+
 def _get_coords(patch_group, dims, attrs2):
     """Get the coordinates from a patch group."""
     coord_dict = {}  # just store coordinates here
@@ -128,10 +164,14 @@ def _get_coords(patch_group, dims, attrs2):
     for coord in [x for x in patch_group if x.name.startswith("_coord_")]:
         name = coord.name.replace("_coord_", "")
         array = _read_array(coord)
+        units = getattr(coord._v_attrs, "units", None)
+        step = getattr(coord._v_attrs, "step", None)
+        if getattr(coord._v_attrs, "step_is_timedelta64", False):
+            step = np.timedelta64(step, "ns")
         coord = get_coord(
             data=array,
-            units=getattr(attrs2, f"{name}_units", None),
-            step=getattr(attrs2, f"{name}_step", None),
+            units=units or attrs2.get(f"{name}_units", None),
+            step=step if step is not None else attrs2.get(f"{name}_step", None),
         )
         coord_dict[name] = coord
     # associates coordinates with dimensions
@@ -158,9 +198,11 @@ def _get_dims(patch_group):
 
 def _read_patch(patch_group, **kwargs):
     """Read a patch group, return Patch."""
-    attrs = _get_attrs(patch_group)
+    attrs = _translate_legacy_attrs(_get_attrs(patch_group))
     dims = _get_dims(patch_group)
     coords = _get_coords(patch_group, dims, attrs)
+    _, attr_info = separate_coord_info(attrs, dims=dims)
+    attrs = PatchAttrs.from_dict(attr_info)
     # Note, previously this was wrapped with try, except (Index, KeyError)
     # and the data = np.array(None) in except block. Not sure, why, removed
     # try except.
@@ -181,15 +223,13 @@ def _get_contents_from_patch_groups(h5, file_version, file_format="DASDAE"):
     """Get the contents from each patch group."""
     out = []
     for group in h5.iter_nodes("/waveforms"):
-        contents = _get_patch_content_from_group(group)
-        # populate file info
-        contents["file_version"] = file_version
-        contents["file_format"] = file_format
-        contents["path"] = h5.filename
-        # suppressing warnings because old dasdae files will issue warning
-        # due to d_dim rather than dim_step. TODO fix test files in the future
-        with suppress_warnings(DeprecationWarning):
-            out.append(dc.PatchAttrs(**contents))
+        out.append(
+            _get_patch_content_from_group(
+                group,
+                file_version=file_version,
+                file_format=file_format,
+            )
+        )
     return out
 
 
@@ -203,7 +243,59 @@ def _kwargs_empty(kwargs) -> bool:
     return not bool(out)
 
 
-def _get_patch_content_from_group(group):
+def _read_array_sample(table_array, index):
+    """Read one array sample and restore datetime-like dtypes when needed."""
+    out = table_array[index]
+    if table_array._v_attrs["is_datetime64"]:
+        out = np.asarray([out]).view("datetime64[ns]")[0]
+    if table_array._v_attrs["is_timedelta64"]:
+        out = np.asarray([out]).view("timedelta64[ns]")[0]
+    return out
+
+
+def _get_coord_summary_from_node(coord_node, dims):
+    """Build a coord summary from a saved coord node without reading it all."""
+    units = getattr(coord_node._v_attrs, "units", None)
+    step = getattr(coord_node._v_attrs, "step", None)
+    if getattr(coord_node._v_attrs, "step_is_timedelta64", False):
+        step = np.timedelta64(step, "ns")
+    if (
+        step is None
+        and len(coord_node.shape) == 1
+        and coord_node.shape
+        and coord_node.shape[0] > 1
+    ):
+        data = _read_array(coord_node)
+        coord = get_coord(data=data, units=units)
+        return coord.to_summary(dims=dims)
+    if len(coord_node.shape) > 1:
+        data = _read_array(coord_node)
+        coord = get_coord(data=data, units=units, step=step)
+        return coord.to_summary(dims=dims)
+    coord_len = int(coord_node.shape[0]) if coord_node.shape else 0
+    if coord_len:
+        first = _read_array_sample(coord_node, 0)
+        if step is not None and coord_len > 1:
+            last = first + (step * (coord_len - 1))
+        else:
+            last = _read_array_sample(coord_node, coord_len - 1)
+        min_val, max_val = (first, last) if first <= last else (last, first)
+        dtype = str(np.asarray(first).dtype).split("[")[0]
+    else:
+        min_val = max_val = np.nan
+        dtype = str(coord_node.dtype).split("[")[0]
+    return CoordSummary.model_construct(
+        dtype=dtype,
+        min=min_val,
+        max=max_val,
+        step=step,
+        units=units,
+        dims=dims,
+        len=coord_len,
+    )
+
+
+def _get_patch_content_from_group(group, file_version="", file_format="DASDAE"):
     """Get patch content from a single node."""
     attrs = group._v_attrs
     out = {}
@@ -216,4 +308,24 @@ def _get_patch_content_from_group(group):
         out[new_key] = value
     # rename dims
     out["dims"] = out.pop("_dims")
-    return out
+    out = _translate_legacy_attrs(out)
+    dims = tuple(out["dims"].split(","))
+    legacy_coords, attr_info = separate_coord_info(out, dims=dims)
+    coord_map = {}
+    for name, summary in legacy_coords.items():
+        if {"min", "max"} <= set(summary):
+            coord_map[name] = CoordSummary(**summary)
+    for coord_node in [x for x in group if x.name.startswith("_coord_")]:
+        name = coord_node.name.replace("_coord_", "")
+        coord_dims = tuple(getattr(attrs, f"_cdims_{name}", "").split(","))
+        coord_map[name] = _get_coord_summary_from_node(coord_node, coord_dims)
+    data_nodes = [x for x in group if x.name == "data"]
+    dtype = str(data_nodes[0].dtype) if data_nodes else ""
+    return PatchSummary.model_construct(
+        attrs=PatchAttrs.from_dict(attr_info),
+        coords=coord_map,
+        dims=dims,
+        shape=(),
+        dtype=dtype,
+        source_patch_id=group._v_name,
+    )

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import dascore as dc
 from dascore.constants import opt_timeable_types
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 from dascore.utils.models import UnitQuantity, UTF8Str
@@ -43,16 +44,19 @@ class DASHDF5(FiberIO):
         if version_str:
             return self.name, version_str
 
-    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[PatchSummary]:
         """Get metadata from file."""
         coords = _get_cf_coords(resource)
-        extras = {
-            "path": resource.filename,
-            "file_format": self.name,
-            "file_version": str(self.version),
-        }
-        attrs = _get_cf_attrs(resource, coords, extras=extras)
-        return [attrs]
+        attrs = _get_cf_attrs(resource, coords)
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype=str(resource["das"].dtype),
+            )
+        ]
 
     def read(
         self,

--- a/dascore/io/dashdf5/utils.py
+++ b/dascore/io/dashdf5/utils.py
@@ -77,7 +77,7 @@ def _get_cf_coords(hdf_fi, minimal=False) -> dc.core.CoordManager:
 
 def _get_cf_attrs(hdf_fi, coords=None, extras=None):
     """Get attributes for CF file."""
-    out = {"coords": coords or _get_cf_coords(hdf_fi)}
+    out = {}
     out.update(extras or {})
     for n1, n2 in _ROOT_ATTR_MAPPING.items():
         out[n1] = hdf_fi.attrs.get(n2)
@@ -85,4 +85,4 @@ def _get_cf_attrs(hdf_fi, coords=None, extras=None):
         out[n1] = getattr(hdf_fi.get("das", {}), "attrs", {}).get(n2)
     for n1, n2 in _CRS_MAPPING.items():
         out[n1] = getattr(hdf_fi.get("crs", {}), "attrs", {}).get(n2)
-    return dc.PatchAttrs(**out)
+    return dc.PatchAttrs.from_dict(out)

--- a/dascore/io/dasvader/core.py
+++ b/dascore/io/dasvader/core.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import dascore as dc
 from dascore.constants import opt_timeable_types
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 
 from .utils import (
+    DATA_NAMES,
     _get_attr_dict,
     _get_coord_manager,
     _get_reference_names,
@@ -36,22 +38,24 @@ class DASVaderV1(FiberIO):
             return self.name, self.version
         return False
 
-    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[PatchSummary]:
         """Scan a DASVader file, return summary information about the file."""
         rec = resource["dDAS"][()]
         cm = _get_coord_manager(resource, rec)
         ref_names = set(_get_reference_names(resource))
         attrs = _get_attr_dict(resource[rec["atrib"]]) if "atrib" in ref_names else {}
-        attrs.update(
-            {
-                "path": resource.filename,
-                "file_format": self.name,
-                "file_version": self.version,
-                "coords": cm.to_summary_dict(),
-                "dims": cm.dims,
-            }
-        )
-        return [dc.PatchAttrs(**attrs)]
+        data_ref = next(iter(DATA_NAMES & ref_names), None)
+        dtype = str(resource[rec[data_ref]].dtype) if data_ref else ""
+        attrs = dc.PatchAttrs.from_dict(attrs)
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=cm.to_summary_dict(),
+                dims=cm.dims,
+                shape=cm.shape,
+                dtype=dtype,
+            )
+        ]
 
     def read(
         self,

--- a/dascore/io/dasvader/utils.py
+++ b/dascore/io/dasvader/utils.py
@@ -177,4 +177,4 @@ def _read_dasvader(h5, distance=None, time=None):
     attrs = _get_attr_dict(h5[rec["atrib"]]) if "atrib" in ref_names else {}
     # attrs["coords"] = cm.to_summary_dict()
     # attrs["dims"] = cm.dims
-    return [dc.Patch(data=data, coords=cm, attrs=dc.PatchAttrs(**attrs))]
+    return [dc.Patch(data=data, coords=cm, attrs=dc.PatchAttrs.from_dict(attrs))]

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -13,6 +13,7 @@ from dascore.core.coordmanager import CoordManager
 from dascore.utils.misc import (
     _maybe_unpack,
     broadcast_for_index,
+    iterate,
     maybe_get_items,
     tukey_fence,
     unbyte,
@@ -283,6 +284,11 @@ def _yield_attrs_coords(fi) -> tuple[dict, CoordManager]:
         yield attr, cm, febus
 
 
+def _get_source_patch_id(feb: _FebusSlice) -> str:
+    """Return a stable patch identifier for Febus multi-patch files."""
+    return f"{feb.group_name}:{feb.source_name}:{feb.zone_name}"
+
+
 def _get_data_new_cm(cm, febus, distance=None, time=None):
     """
     Get the data from febus file, maybe filtering on time/distance.
@@ -358,12 +364,19 @@ def _get_data_new_cm(cm, febus, distance=None, time=None):
     return data, cm
 
 
-def _read_febus(fi, distance=None, time=None, attr_cls=dc.PatchAttrs):
+def _read_febus(
+    fi, distance=None, time=None, source_patch_id=None, attr_cls=dc.PatchAttrs
+):
     """Read the febus values into a patch."""
     out = []
+    source_patch_ids = {
+        str(value) for value in iterate(source_patch_id) if value not in (None, "")
+    }
     for attr, cm, febus in _yield_attrs_coords(fi):
+        if source_patch_ids and _get_source_patch_id(febus) not in source_patch_ids:
+            continue
         data, new_cm = _get_data_new_cm(cm, febus, distance=distance, time=time)
         if data.size:
-            patch = dc.Patch(data=data, coords=new_cm, attrs=attr_cls(**attr))
+            patch = dc.Patch(data=data, coords=new_cm, attrs=attr_cls.from_dict(attr))
             out.append(patch)
     return out

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import dascore as dc
 from dascore.constants import opt_timeable_types
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 from dascore.utils.io import TextReader
@@ -17,6 +18,7 @@ from dascore.utils.models import UTF8Str
 
 from .a1utils import (
     _get_febus_version_str,
+    _get_source_patch_id,
     _read_febus,
     _yield_attrs_coords,
 )
@@ -74,19 +76,20 @@ class Febus2(FiberIO):
         if version_str:
             return self.name, version_str
 
-    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[PatchSummary]:
         """Scan a febus file, return summary information about the file's contents."""
         out = []
-        file_version = _get_febus_version_str(resource)
-        extras = {
-            "path": resource.filename,
-            "file_format": self.name,
-            "file_version": str(file_version),
-        }
-        for attr, cm, _ in _yield_attrs_coords(resource):
-            attr["coords"] = cm.to_summary_dict()
-            attr.update(dict(extras))
-            out.append(FebusPatchAttrs(**attr))
+        for attr, cm, feb in _yield_attrs_coords(resource):
+            out.append(
+                PatchSummary.model_construct(
+                    attrs=FebusPatchAttrs.from_dict(attr),
+                    coords=cm.to_summary_dict(),
+                    dims=cm.dims,
+                    shape=cm.shape,
+                    dtype=str(feb.zone[feb.data_name].dtype),
+                    source_patch_id=_get_source_patch_id(feb),
+                )
+            )
         return out
 
     def read(
@@ -98,7 +101,11 @@ class Febus2(FiberIO):
     ) -> dc.BaseSpool:
         """Read a febus spool of patches."""
         patches = _read_febus(
-            resource, time=time, distance=distance, attr_cls=FebusPatchAttrs
+            resource,
+            time=time,
+            distance=distance,
+            source_patch_id=kwargs.get("source_patch_id"),
+            attr_cls=FebusPatchAttrs,
         )
         return dc.spool(patches)
 
@@ -127,7 +134,7 @@ class FebusG1CSV1(FiberIO):
         resource.seek(0)  # proactively set resource back to position 0.
         return (self.name, self.version) if is_g1_file else False
 
-    def scan(self, resource: TextReader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: TextReader, **kwargs) -> list[PatchSummary]:
         """Get the coords and attrs of a G1 file."""
         # Handle case of unsupported files (eg spectrum).
         try:
@@ -135,16 +142,17 @@ class FebusG1CSV1(FiberIO):
         except NotImplementedError as f:
             warnings.warn(str(f), stacklevel=2)
             return []
-        attrs.update(
-            {
-                "path": getattr(resource, "name", ""),
-                "file_format": self.name,
-                "file_version": str(self.version),
-            }
-        )
         attrs_no_private = {i: v for i, v in attrs.items() if not i.startswith("_")}
-        attrs = FebusBOTDRStrainAttrs(coords=coords, **attrs_no_private)
-        return [attrs]
+        attrs = FebusBOTDRStrainAttrs(**attrs_no_private)
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype="float64",
+            )
+        ]
 
     def read(self, resource: TextReader, **kwargs) -> dc.BaseSpool:
         """Read a G1 file, return a Patch object."""

--- a/dascore/io/gdr/core.py
+++ b/dascore/io/gdr/core.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import dascore as dc
 from dascore.constants import SpoolType
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.io.gdr.utils_das import (
     _get_attrs_coords_and_data,
@@ -58,15 +59,19 @@ class GDR_V1(FiberIO):  # noqa
             cm, data = _maybe_trim_data(cm, data, **kwargs)
         if not data.size:  # skip empty patches.
             return dc.spool([])
-        attrs = GDRPatchAttrs(**attr_dict)
+        attrs = GDRPatchAttrs.from_dict(attr_dict)
         patch = dc.Patch(coords=cm, data=data[:], attrs=attrs)
         return dc.spool([patch])
 
-    def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[PatchSummary]:
         """Get the attributes of a resource belong to this type."""
         attrs, cm, data = _get_attrs_coords_and_data(resource, snap)
-        attrs["coords"] = cm.to_summary_dict()
-        attrs["path"] = resource.filename
-        attrs["file_format"] = self.name
-        attrs["file_version"] = self.version
-        return [dc.PatchAttrs(**attrs)]
+        return [
+            PatchSummary.model_construct(
+                attrs=GDRPatchAttrs.from_dict(attrs),
+                coords=cm.to_summary_dict(),
+                dims=cm.dims,
+                shape=cm.shape,
+                dtype=str(data.dtype),
+            )
+        ]

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dascore as dc
 from dascore.constants import SpoolType
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader, PyTablesReader
 
@@ -43,11 +44,18 @@ class H5Simple(FiberIO):
         patch = dc.Patch(coords=new_cm, data=new_data[:], attrs=attrs)
         return dc.spool([patch])
 
-    def scan(
-        self, resource: PyTablesReader, snap=True, **kwargs
-    ) -> list[dc.PatchAttrs]:
+    def scan(self, resource: PyTablesReader, snap=True, **kwargs) -> list[PatchSummary]:
         """Get the attributes of a h5simple file."""
         attrs, cm, data = _get_attrs_coords_and_data(resource, snap, self)
-        attrs["coords"] = cm.to_summary_dict()
-        attrs["path"] = resource.filename
-        return [dc.PatchAttrs(**attrs)]
+        attrs.pop("file_format", None)
+        attrs.pop("file_version", None)
+        attrs = dc.PatchAttrs.from_dict(attrs)
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=cm.to_summary_dict(),
+                dims=cm.dims,
+                shape=cm.shape,
+                dtype=str(data.dtype),
+            )
+        ]

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -31,7 +31,7 @@ def _get_attrs_coords_and_data(h5, snap, fiber_io):
     attr_dict["file_version"] = fiber_io.version
     attr_dict["file_format"] = fiber_io.name
     cm, data = _get_cm_and_data(h5, snap, dims=attr_dict.get("dims"))
-    attr_dict["dims"] = cm.dims
+    attr_dict.pop("dims", None)
     return attr_dict, cm, data
 
 

--- a/dascore/io/neubrex/core.py
+++ b/dascore/io/neubrex/core.py
@@ -10,6 +10,7 @@ import dascore as dc
 import dascore.io.neubrex.utils_das as das_utils
 import dascore.io.neubrex.utils_rfs as rfs_utils
 from dascore.constants import SpoolType
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 
@@ -73,18 +74,23 @@ class NeubrexRFSV1(FiberIO):
             cm, data = rfs_utils._maybe_trim_data(cm, data, **kwargs)
         if not data.size:
             return dc.spool([])
-        attrs = NeubrexRFSPatchAttrs(**attr_dict)
+        attrs = NeubrexRFSPatchAttrs.from_dict(attr_dict)
         patch = dc.Patch(coords=cm, data=data[:], attrs=attrs)
         return dc.spool([patch])
 
-    def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[PatchSummary]:
         """Get the attributes of a resource belong to this type."""
-        attrs, cm, data = rfs_utils._get_attrs_coords_and_data(resource, snap)
-        attrs["coords"] = cm.to_summary_dict()
-        attrs["path"] = resource.filename
-        attrs["file_format"] = self.name
-        attrs["file_version"] = self.version
-        return [dc.PatchAttrs(**attrs)]
+        cm = rfs_utils._get_coord_manager(resource, snap)
+        attrs = NeubrexRFSPatchAttrs.from_dict(rfs_utils._get_attr_dict(resource))
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=cm.to_summary_dict(),
+                dims=cm.dims,
+                shape=cm.shape,
+                dtype=str(resource["data"].dtype),
+            )
+        ]
 
 
 class NeubrexDASV1(FiberIO):
@@ -120,15 +126,21 @@ class NeubrexDASV1(FiberIO):
             cm, data = das_utils._maybe_trim_data(cm, data, **kwargs)
         if not data.size:
             return dc.spool([])
-        attrs = NeubrexRFSPatchAttrs(**attr_dict)
+        attrs = NeubrexDASPatchAttrs.from_dict(attr_dict)
         patch = dc.Patch(coords=cm, data=data[:], attrs=attrs)
         return dc.spool([patch])
 
-    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[PatchSummary]:
         """Get the attributes of this format from File."""
-        attrs, cm, data = das_utils._get_attrs_coords_and_data(resource)
-        attrs["coords"] = cm.to_summary_dict()
-        attrs["path"] = resource.filename
-        attrs["file_format"] = self.name
-        attrs["file_version"] = self.version
-        return [dc.PatchAttrs(**attrs)]
+        acoustic = resource["Acoustic"]
+        cm = das_utils._get_coord_manager(acoustic)
+        attrs = NeubrexDASPatchAttrs.from_dict(das_utils._get_attr_dict(acoustic))
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=cm.to_summary_dict(),
+                dims=cm.dims,
+                shape=cm.shape,
+                dtype=str(acoustic.dtype),
+            )
+        ]

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import dascore as dc
 from dascore.constants import opt_timeable_types
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 from dascore.utils.models import UnitQuantity, UTF8Str
@@ -41,17 +42,19 @@ class OptoDASV8(FiberIO):
         if version_str:
             return self.name, version_str
 
-    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[PatchSummary]:
         """Scan a OptoDAS file, return summary information about the file's contents."""
-        file_version = _get_opto_das_version_str(resource)
-        extras = {
-            "path": resource.filename,
-            "file_format": self.name,
-            "file_version": str(file_version),
-        }
-        attrs = _get_opto_das_attrs(resource)
-        attrs.update(extras)
-        return [OptoDASPatchAttrs(**attrs)]
+        attrs, coords = _get_opto_das_attrs(resource)
+        attrs = OptoDASPatchAttrs.from_dict(attrs)
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype=str(resource["data"].dtype),
+            )
+        ]
 
     def read(
         self,

--- a/dascore/io/optodas/utils.py
+++ b/dascore/io/optodas/utils.py
@@ -70,22 +70,18 @@ def _get_attr_dict(header):
     return out
 
 
-def _get_opto_das_attrs(fi) -> dict:
-    """Scan a OptoDAS file, return metadata."""
+def _get_opto_das_attrs(fi) -> tuple[dict, dascore.core.CoordManager]:
+    """Scan a OptoDAS file, return metadata and coordinates."""
     cm = _get_coord_manager(fi)
     attrs = _get_attr_dict(fi["header"])
-    attrs["coords"] = cm
-    return attrs
+    return attrs, cm
 
 
 def _read_opto_das(fi, distance=None, time=None, attr_cls=dc.PatchAttrs):
     """Read the OptoDAS values into a patch."""
-    attrs = _get_opto_das_attrs(fi)
+    attrs, coords = _get_opto_das_attrs(fi)
     data_node = fi["data"]
-    coords = attrs.pop("coords")
     cm, data = coords.select(array=data_node, distance=distance, time=time)
     if not data.size:
         return []
-    attrs["coords"] = cm.to_summary_dict()
-    attrs["dims"] = cm.dims
-    return [dc.Patch(data=data, coords=cm, attrs=attr_cls(**attrs))]
+    return [dc.Patch(data=data, coords=cm, attrs=attr_cls.from_dict(attrs))]

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import dascore as dc
 from dascore.constants import opt_timeable_types
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.models import UnitQuantity, UTF8Str
 
@@ -43,17 +44,20 @@ class ProdMLV2_0(FiberIO):  # noqa
         if version_str:
             return (self.name, version_str)
 
-    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[PatchSummary]:
         """Scan a prodml file, return summary information about the file's contents."""
-        file_version = _get_prodml_version_str(resource)
-        extras = {
-            "path": resource.filename,
-            "file_format": self.name,
-            "file_version": str(file_version),
-        }
         out = []
-        for attr, coords in _yield_prodml_attrs_coords(resource, extras=extras):
-            out.append(attr.update(coords=coords))
+        for attr, coords, source_patch_id in _yield_prodml_attrs_coords(resource):
+            out.append(
+                PatchSummary.model_construct(
+                    attrs=attr,
+                    coords=coords.to_summary_dict(),
+                    dims=coords.dims,
+                    shape=coords.shape,
+                    dtype=attr.get("dtype", ""),
+                    source_patch_id=source_patch_id,
+                )
+            )
         return out
 
     def read(
@@ -64,7 +68,12 @@ class ProdMLV2_0(FiberIO):  # noqa
         **kwargs,
     ) -> dc.BaseSpool:
         """Read a ProdML file."""
-        patches = _read_prodml(resource, time=time, distance=distance)
+        patches = _read_prodml(
+            resource,
+            time=time,
+            distance=distance,
+            source_patch_id=kwargs.get("source_patch_id"),
+        )
         return dc.spool(patches)
 
 

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -223,6 +223,7 @@ def _get_raw_node_attr_coords(node_info, d_coord, base_info):
     info = dict(base_info)
     t_coord = _get_time_coord(node_info.node)
     info.update(_get_data_unit_and_type(node_info.node))
+    info["dtype"] = str(node_info.node["RawData"].dtype)
     coords = dc.get_coord_manager(
         coords={"time": t_coord, "distance": d_coord},
         dims=_get_dims_from_attrs(node_info.node["RawData"].attrs),
@@ -236,6 +237,7 @@ def _get_processed_node_attr_coords(node_info, d_coord, base_info):
     out = dict(base_info)
     t_coord = _get_time_coord(node_info.parent_node)
     out.update(_get_data_unit_and_type(node_info.node))
+    out["dtype"] = str(node_info.node.dtype)
     out.update(maybe_get_items(node_info.node.attrs, _FBE_NODE_ATTRS))
     out.update(maybe_get_items(node_info.parent_node.attrs, _FBE_PARENT_ATTRS))
     # For some reason, the distance coords in raw and fbe data are not the
@@ -252,7 +254,7 @@ def _get_processed_node_attr_coords(node_info, d_coord, base_info):
         coords={"time": t_coord, "distance": distance},
         dims=_get_dims_from_attrs(node_info.parent_node.attrs),
     )
-    return ProdMLFbePatchAttrs(**out), coords
+    return ProdMLFbePatchAttrs.from_dict(out), coords
 
 
 @register_func(_NODE_DATA_PROCESSORS, key="raw")
@@ -282,7 +284,7 @@ def _yield_prodml_attrs_coords(fi, extras=None):
     for node_info in _yield_data_nodes(fi):
         func = _NODE_ATTRS_PROCESSORS[node_info.patch_type]
         attr, coords = func(node_info, d_coord, base_info)
-        yield (attr, coords)
+        yield attr, coords, node_info.name
 
 
 def _get_dims_from_attrs(attrs):
@@ -304,13 +306,18 @@ def _get_dims_from_attrs(attrs):
     return dims
 
 
-def _read_prodml(fi, distance=None, time=None):
+def _read_prodml(fi, distance=None, time=None, source_patch_id=None):
     """Read the prodml values into a patch."""
     out = []
     acq = fi["Acquisition"]
     base_info = maybe_get_items(acq.attrs, _ROOT_ATTRS)
     d_coord = _get_distance_coord(acq)
+    source_patch_ids = {
+        str(value) for value in iterate(source_patch_id) if value not in (None, "")
+    }
     for info in _yield_data_nodes(fi):
+        if source_patch_ids and info.name not in source_patch_ids:
+            continue
         attr_func = _NODE_ATTRS_PROCESSORS[info.patch_type]
         attrs, cm = attr_func(info, d_coord, base_info)
         data = _NODE_DATA_PROCESSORS[info.patch_type](info)

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dascore as dc
+from dascore.core.summary import PatchSummary
 from dascore.io.core import FiberIO
 from dascore.utils.io import BinaryReader
 from dascore.utils.misc import optional_import
@@ -43,7 +44,7 @@ class SegyV1_0(FiberIO):  # noqa
         segyio = optional_import(self._package_name)
         with segyio.open(path, ignore_geometry=True) as fi:
             coords = _get_coords(fi)
-            attrs = _get_attrs(fi, coords, path, self)
+            attrs = _get_attrs(fi, coords, path, self, include_source=True)
             data, coords = _get_filtered_data_and_coords(
                 fi, coords, time=time, channel=channel
             )
@@ -53,20 +54,26 @@ class SegyV1_0(FiberIO):  # noqa
         patch = dc.Patch(coords=coords, data=data, attrs=attrs)
         return dc.spool([patch])
 
-    def scan(self, path, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, path, **kwargs) -> list[PatchSummary]:
         """
         Used to get metadata about a file without reading the whole file.
 
-        This should return a list of
-        [`PatchAttrs`](`dascore.core.attrs.PatchAttrs`) objects
-        from the [dascore.core.attrs](`dascore.core.attrs`) module, or a
-        format-specific subclass.
+        Returns lightweight scan metadata without loading the data array.
         """
         segyio = optional_import(self._package_name)
         with segyio.open(path, ignore_geometry=True) as fi:
             coords = _get_coords(fi)
             attrs = _get_attrs(fi, coords, path, self)
-        return [attrs]
+            dtype = str(fi.dtype)
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype=dtype,
+            )
+        ]
 
     def write(self, spool: dc.Patch | dc.BaseSpool, resource, **kwargs):
         """

--- a/dascore/io/segy/utils.py
+++ b/dascore/io/segy/utils.py
@@ -129,14 +129,15 @@ def _get_coords(fi):
     return coords
 
 
-def _get_attrs(fi, coords, path, file_io):
+def _get_attrs(fi, coords, path, file_io, include_source=False):
     """Create Patch Attribute from SEGY header contents."""
-    attrs = dc.PatchAttrs(
-        path=path,
-        file_version=file_io.version,
-        file_format=file_io.name,
-        coords=coords,
-    )
+    attrs = dc.PatchAttrs()
+    if include_source:
+        attrs = attrs.update(
+            path=path,
+            file_version=file_io.version,
+            file_format=file_io.name,
+        )
     return attrs
 
 

--- a/dascore/io/sentek/core.py
+++ b/dascore/io/sentek/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numpy as np
 
 import dascore as dc
+from dascore.core.summary import PatchSummary
 from dascore.io import BinaryReader
 from dascore.io.core import FiberIO
 
@@ -40,12 +41,15 @@ class SentekV5(FiberIO):
         """Auto detect sentek format."""
         return _get_version(resource)
 
-    def scan(self, resource: BinaryReader, **kwargs):
+    def scan(self, resource: BinaryReader, **kwargs) -> list[PatchSummary]:
         """Extract metadata from sentek file."""
-        extras = {
-            "file_format": self.name,
-            "file_version": self.version,
-            "path": resource.name,
-        }
-
-        return [_get_patch_attrs(resource, extras=extras)[0]]
+        attrs, coords, _ = _get_patch_attrs(resource)
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype=str(np.dtype(np.float32)),
+            )
+        ]

--- a/dascore/io/sentek/utils.py
+++ b/dascore/io/sentek/utils.py
@@ -92,8 +92,6 @@ def _get_patch_attrs(fid, extras=None):
     coord_manager = get_coord_manager(
         {"time": time, "distance": dist}, dims=("distance", "time")
     )
-    attrs = dc.PatchAttrs(
-        coords=coord_manager, data_type=data_type, **({} if extras is None else extras)
-    )
+    attrs = dc.PatchAttrs(data_type=data_type, **({} if extras is None else extras))
     offsets = fid.tell(), int(measurement_count), int(sensor_num)
     return attrs, coord_manager, offsets

--- a/dascore/io/silixah5/core.py
+++ b/dascore/io/silixah5/core.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import dascore as dc
 from dascore.constants import opt_timeable_types
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 
@@ -43,16 +44,18 @@ class SilixaH5V1(FiberIO):
         if version_str:
             return self.name, version_str
 
-    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[PatchSummary]:
         """Scan a Silixa HDF5 file, return summary information on the contents."""
-        file_version = _get_version_string(resource, self.version)
-        extras = {
-            "path": resource.filename,
-            "file_format": self.name,
-            "file_version": str(file_version),
-        }
-        attrs = _get_attr(resource, SilixaPatchAttrs, extras=extras)
-        return [attrs]
+        attrs, coords = _get_attr(resource, SilixaPatchAttrs)
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype=str(resource["Acoustic"].dtype),
+            )
+        ]
 
     def read(
         self,

--- a/dascore/io/silixah5/utils.py
+++ b/dascore/io/silixah5/utils.py
@@ -1,6 +1,4 @@
-"""
-Utility functions for AP sensing module.
-"""
+"""Utility functions for Silixa HDF5 I/O."""
 
 import pandas as pd
 
@@ -87,28 +85,26 @@ def _get_attr_dict(resource):
     """Get the attribute map."""
     ds = resource["Acoustic"]
     attrs_dict = maybe_get_items(ds.attrs, _ATTR_MAP)
-    attrs_dict["coords"] = _get_coords(attrs_dict, ds.shape)
-    return attrs_dict
+    coords = _get_coords(attrs_dict, ds.shape)
+    return attrs_dict, coords
 
 
 def _get_attr(resource, attr_cls, extras=None):
-    """Get the attribute class"""
-    attrs = _get_attr_dict(resource)
+    """Get the attribute class and coordinates."""
+    attrs, coords = _get_attr_dict(resource)
     expected_fields = set(attr_cls.model_fields)
     attrs_sub = {i: v for i, v in attrs.items() if i in expected_fields}
     attrs_sub.update(extras if extras else {})
     attrs = attr_cls.model_validate(attrs_sub)
-    return attrs
+    return attrs, coords
 
 
 def _get_patches(resource, time=None, distance=None, attr_cls=dc.PatchAttrs):
     """Get a patch from ap_sensing file."""
-    attrs = _get_attr_dict(resource)
-    coords = attrs["coords"]
+    attrs, coords = _get_attr_dict(resource)
     data = resource["Acoustic"]
     if time is not None or distance is not None:
         coords, data = coords.select(array=data, time=time, distance=distance)
-        attrs["coords"] = coords
     if not data.size:
         return []
     expected_fields = set(attr_cls.model_fields)

--- a/dascore/io/sintela_binary/core.py
+++ b/dascore/io/sintela_binary/core.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import dascore as dc
 from dascore.constants import opt_timeable_types
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.io import BinaryReader
 
@@ -53,18 +54,18 @@ class SintelaBinaryV3(FiberIO):
             return self.name, version
         return False
 
-    def scan(self, resource: BinaryReader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: BinaryReader, **kwargs) -> list[PatchSummary]:
         """Scan a file, return summary information on the contents."""
-        extras = {
-            "path": resource.name,
-            "file_format": self.name,
-            "file_version": self.version,
-        }
-        attrs, _, _ = _get_attrs_coords_header(
-            resource, SintelaPatchAttrs, extras=extras
-        )
-
-        return [attrs]
+        attrs, coords, header = _get_attrs_coords_header(resource, SintelaPatchAttrs)
+        return [
+            PatchSummary.model_construct(
+                attrs=attrs,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype=str(np.dtype(header["dtype"])),
+            )
+        ]
 
     def read(
         self,

--- a/dascore/io/sintela_binary/utils.py
+++ b/dascore/io/sintela_binary/utils.py
@@ -209,7 +209,6 @@ def _get_attrs_coords_header(rid, attr_class=PatchAttrs, extras=None):
     coords = {"time": _get_time_coord(header), "distance": _get_dist_coord(header)}
     cm = get_coord_manager(coords=coords, dims=DIMS)
     attrs = _get_attr_dict(header, extras)
-    attrs["coords"] = cm
     return attr_class(**attrs), cm, header
 
 

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import timeable_types
 from dascore.core import Patch
+from dascore.core.summary import PatchSummary
 from dascore.io import BinaryReader, FiberIO
 
-from .utils import _get_data, _get_default_attrs, _get_version_str
+from .utils import _get_all_attrs, _get_data, _get_default_attrs, _get_version_str
 
 
 class TDMSFormatterV4713(FiberIO):
@@ -36,13 +39,20 @@ class TDMSFormatterV4713(FiberIO):
         except Exception:
             return False
 
-    def scan(self, resource: BinaryReader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: BinaryReader, **kwargs) -> list[PatchSummary]:
         """Scan a tdms file, return summary information about the file's contents."""
-        out = _get_default_attrs(resource)
-        out["path"] = getattr(resource, "name", "")
-        out["file_format"] = self.name
-        out["file_version"] = self.version
-        return [dc.PatchAttrs(**out)]
+        out, fileinfo = _get_all_attrs(resource)
+        coords = dc.core.get_coord_manager(coords=out.pop("coords"))
+        out = dc.PatchAttrs.from_dict(out)
+        return [
+            PatchSummary.model_construct(
+                attrs=out,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype=str(np.dtype(fileinfo["data_type"])),
+            )
+        ]
 
     def read(
         self,
@@ -53,9 +63,9 @@ class TDMSFormatterV4713(FiberIO):
     ) -> dc.BaseSpool:
         """Read a silixa tdms file, return a DataArray."""
         # get all data, total amount of samples and associated attributes
-        data, channel_length, attrs_full = _get_data(resource, lead_in_length=28)
+        data, _channel_length, attrs_full = _get_data(resource, lead_in_length=28)
         attrs = _get_default_attrs(resource, attrs_full)
-        coords = dc.core.get_coord_manager(attrs.pop("coords"))
+        coords = dc.core.get_coord_manager(coords=attrs_full["coords"])
         # trim data if required
         if time is not None or distance is not None:
             coords, data = coords.select(data, time=time, distance=distance)

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dascore as dc
 from dascore.constants import timeable_types
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 
@@ -35,15 +36,10 @@ class Terra15FormatterV4(FiberIO):
         if version_str:
             return (self.name, version_str)
 
-    def scan(self, resource: H5Reader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: H5Reader, **kwargs) -> list[PatchSummary]:
         """Scan a terra15 v2 file, return summary information."""
-        version, data_node = _get_version_data_node(resource)
-        extras = {
-            "path": resource.filename,
-            "file_format": self.name,
-            "file_version": str(version),
-        }
-        return _scan_terra15(resource, data_node, extras)
+        _version, data_node = _get_version_data_node(resource)
+        return _scan_terra15(resource, data_node)
 
     def read(
         self,

--- a/dascore/io/terra15/utils.py
+++ b/dascore/io/terra15/utils.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import dascore as dc
 from dascore.constants import timeable_types
 from dascore.core import Patch
+from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
+from dascore.core.summary import PatchSummary
 from dascore.utils.misc import maybe_get_items
 from dascore.utils.time import to_datetime64, to_timedelta64
 
@@ -81,14 +82,23 @@ def _get_version_data_node(root):
 
 def _scan_terra15(h5_fi, data_node, extras=None):
     """Scan a terra15 file, return metadata."""
-    out = extras
+    out = {} if extras is None else dict(extras)
     out.update(_get_default_attrs(h5_fi.attrs))
     coords = {
         "time": _get_time_coord(data_node, snap_dims=True),
         "distance": _get_distance_coord(h5_fi),
     }
-    out["coords"] = coords
-    return [dc.PatchAttrs(**out)]
+    return [
+        PatchSummary.model_construct(
+            attrs=PatchAttrs.from_dict(out),
+            coords={
+                name: coord.to_summary(dims=(name,)) for name, coord in coords.items()
+            },
+            dims=tuple(coords),
+            shape=(),
+            dtype=str(data_node["data"].dtype),
+        )
+    ]
 
 
 # --- Reading patch
@@ -140,7 +150,6 @@ def _read_terra15(
     )
     dims = ("time", "distance")
     attrs = _get_default_attrs(pyfi.attrs)
-    attrs["coords"] = coords
     return Patch(data=data, coords=coords, attrs=attrs, dims=dims)
 
 

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -9,10 +9,11 @@ import numpy as np
 from pydantic import ValidationError
 
 import dascore as dc
+from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.models import UTF8Str
 
-from .utils import _load_patches, _paths_to_attrs, _read_xml_metadata
+from .utils import _load_patches, _paths_to_scan_patches, _read_xml_metadata
 
 
 class BinaryPatchAttrs(dc.PatchAttrs):
@@ -21,7 +22,6 @@ class BinaryPatchAttrs(dc.PatchAttrs):
     pulse_width_ns: float = np.nan
     gauge_length: float = np.nan
     instrument_id: UTF8Str = ""
-    distance_units: UTF8Str = ""
     zone_name: UTF8Str = ""
 
 
@@ -36,24 +36,20 @@ class XMLBinaryV1(FiberIO):
     # File extension for data files.
     _data_extension = ".raw"
 
-    def scan(self, resource, timestamp=None, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource, timestamp=None, **kwargs) -> list[PatchSummary]:
         """Scan the contents of the directory."""
         path = Path(resource)
+        if path.is_file():
+            path = path.parent
         metadata = _read_xml_metadata(path / self._metadata_name)
         data_files = list(path.glob(f"*{self._data_extension}"))
-        extra_attrs = {
-            "file_version": self.version,
-            "file_format": self.name,
-        }
         # Need to update time
-        attrs = _paths_to_attrs(
+        return _paths_to_scan_patches(
             data_files,
             metadata,
             timestamp=timestamp,
             attr_cls=BinaryPatchAttrs,
-            extra_attrs=extra_attrs,
         )
-        return attrs
 
     def read(self, resource, time=None, distance=None, **kwargs) -> dc.BaseSpool:
         """
@@ -88,6 +84,8 @@ class XMLBinaryV1(FiberIO):
     def get_format(self, resource, **kwargs) -> tuple[str, str] | bool:
         """Determine if directory is an XML Binary type."""
         path = Path(resource)
+        if path.is_file():
+            path = path.parent
         index_path = path / self._metadata_name
         if not index_path.exists():
             return False

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -15,7 +15,7 @@ import dascore as dc
 from dascore.core import get_coord, get_coord_manager
 from dascore.utils.misc import iterate
 from dascore.utils.models import BaseModel, DateTime64
-from dascore.utils.pd import _model_list_to_df, adjust_segments, filter_df
+from dascore.utils.pd import adjust_segments, filter_df
 from dascore.utils.time import to_float
 from dascore.utils.xml import xml_to_dict
 
@@ -147,29 +147,51 @@ def _get_path_datetime_64(paths):
 
 def _paths_to_df(paths, metadata, attr_cls):
     """Convert paths to dataframe of info."""
-    attrs = _paths_to_attrs(paths=paths, metadata=metadata, attr_cls=attr_cls)
-    return _model_list_to_df(attrs)
+    paths = list(iterate(paths))
+    if not paths:
+        return pd.DataFrame()
+    records = []
+    dims = STANDARD_DIMS[::-1] if metadata.transposed_data else STANDARD_DIMS
+    base_attrs = _make_base_attrs_dict(metadata)
+    distance_coord = _make_distance_coord(metadata)
+    dt_ser = _get_path_datetime_64(paths)
+    for path, time_coord in zip(
+        paths, _make_time_coord(dt_ser.values, metadata), strict=True
+    ):
+        cm = get_coord_manager(
+            {"time": time_coord, "distance": distance_coord},
+            dims=dims,
+        )
+        attrs = attr_cls(path=path, **base_attrs).model_dump()
+        record = dict(attrs)
+        for name, summary in cm.to_summary_dict().items():
+            for field, value in summary.model_dump().items():
+                record[f"{name}_{field}"] = value
+        records.append(record)
+    return pd.DataFrame(records)
 
 
-def _read_single_file(path, metadata, time, distance):
+def _read_single_file(path, metadata, time, distance, attr_cls):
     """Read a single file into a patch."""
     assert not metadata.transposed_data, "Cant handle data transposition yet."
-    attr = _paths_to_attrs(path, metadata, summarize=False)[0]
-    time_coord = attr.coords["time"].to_coord()
-    distance_coord = attr.coords["distance"].to_coord()
+    base_attrs = _make_base_attrs_dict(metadata)
+    start_time = dc.to_datetime64(_get_path_datetime_64([path]).iloc[0])
+    time_coord = next(_make_time_coord([start_time], metadata))
+    distance_coord = _make_distance_coord(metadata)
     cm = get_coord_manager(
         {"time": time_coord, "distance": distance_coord},
-        dims=attr.dim_tuple,
+        dims=STANDARD_DIMS,
     )
     memmap = np.memmap(path, dtype=metadata.data_type)
     size = np.prod(cm.shape)
     assert memmap.size == size, f"wrong data shape for {path}"
     data = memmap.reshape(cm.shape)
+    attrs = attr_cls(path=path, **base_attrs)
     patch = dc.Patch(
         data=data,
-        dims=attr.dim_tuple,
+        dims=STANDARD_DIMS,
         coords=cm,
-        attrs=attr.update(coord=None),
+        attrs=attrs,
     )
     return patch.select(time=time, distance=distance)
 
@@ -178,7 +200,7 @@ def _load_patches(paths, metadata, time, distance, attr_cls):
     """Load the data file or file into a patch."""
     # Fast case for single file.
     if isinstance(paths, Path) and paths.is_file():
-        return _read_single_file(paths, metadata, time, distance)
+        return _read_single_file(paths, metadata, time, distance, attr_cls)
     # Since there could be **MANY** files, we have to create a mini-index
     # here to determine which files to read. Under normal circumstances
     # this isn't required as a spool can manage it.
@@ -201,37 +223,41 @@ def _load_patches(paths, metadata, time, distance, attr_cls):
     return out
 
 
-def _paths_to_attrs(
-    paths: Path | Sequence[Path],
+def _paths_to_scan_patches(
+    paths: Sequence[Path],
     metadata,
-    summarize=True,
     attr_cls=dc.PatchAttrs,
     extra_attrs=None,
     timestamp=None,
 ):
-    """Convert a path to a Patch attribute."""
+    """Convert paths to patch summaries for scan/index workflows."""
     extra_attrs = {} if not extra_attrs else extra_attrs
-    paths = iterate(paths)
-    # filter based on timestamp
+    paths = list(iterate(paths))
     if timestamp is not None:
         ts = to_float(timestamp)
-        paths = list(x for x in paths if Path(x).stat().st_mtime >= ts)
-    # No data to index.
-    if not len(paths):
+        paths = [x for x in paths if Path(x).stat().st_mtime >= ts]
+    if not paths:
         return []
     base_attrs = _make_base_attrs_dict(metadata)
     distance_coord = _make_distance_coord(metadata)
     dt_ser = _get_path_datetime_64(paths)
     dims = STANDARD_DIMS[::-1] if metadata.transposed_data else STANDARD_DIMS
     out = []
-    for path, time_coord in zip(paths, _make_time_coord(dt_ser.values, metadata)):
-        cm = get_coord_manager(
+    for path, time_coord in zip(
+        paths, _make_time_coord(dt_ser.values, metadata), strict=True
+    ):
+        coords = get_coord_manager(
             {"time": time_coord, "distance": distance_coord},
             dims=dims,
         )
-        if summarize:
-            cm = cm.to_summary_dict()
-        attr_dict = {**base_attrs, **extra_attrs}
-        attrs = attr_cls(coords=cm, path=path, **attr_dict)
-        out.append(attrs)
+        attrs = attr_cls(**base_attrs, **extra_attrs)
+        out.append(
+            dc.PatchSummary.model_construct(
+                attrs=attrs,
+                coords=coords.to_summary_dict(),
+                dims=coords.dims,
+                shape=coords.shape,
+                dtype=metadata.data_type,
+            )
+        )
     return out

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 from scipy.fft import next_fast_len
 
-import dascore as dc
 from dascore.compat import array
 from dascore.constants import PatchType
 from dascore.core.attrs import PatchAttrs
@@ -95,12 +94,13 @@ def pipe(
 
 def update_attrs(self: PatchType, **attrs) -> PatchType:
     """
-    Update attrs and return a new Patch.
+    Update patch attrs and return a new Patch.
 
     Parameters
     ----------
     **attrs
-        attrs to add/update.
+        Attrs to add/update. Nested `coords` payloads are not accepted here;
+        use `patch.update_coords(...)` for coordinate changes.
 
     Examples
     --------
@@ -113,24 +113,11 @@ def update_attrs(self: PatchType, **attrs) -> PatchType:
     >>> # Add new custom attributes
     >>> with_custom = patch.update_attrs(processing_date="2024-01-01")
     """
-
-    def _fast_attr_update(self, attrs):
-        """A fast method for just squashing the attrs and returning new patch."""
-        new = self.__new__(self.__class__)
-        new._data = self.data
-        new._attrs = attrs
-        new._coords = self.coords
-        return new
-
-    # since we update history so often, we make a fast track for it.
     new_attrs = self.attrs.model_dump(exclude_unset=True)
     new_attrs.update(attrs)
-    # pop out coords so new coords has priority.
-    if len(attrs) == 1 and "history" in attrs:
-        return _fast_attr_update(self, PatchAttrs(**new_attrs))
-    new_coords, new_attrs = self.coords.update_from_attrs(new_attrs)
-    out = dict(coords=new_coords, attrs=new_attrs, dims=self.dims)
-    return self.__class__(self.data, **out)
+    validated = PatchAttrs.from_dict(new_attrs)
+    out = dict(coords=self.coords, attrs=validated, dims=self.dims)
+    return self.__class__(self._data, **out)
 
 
 def equals(self: PatchType, other: Any, only_required_attrs=True, close=False) -> bool:
@@ -172,12 +159,12 @@ def equals(self: PatchType, other: Any, only_required_attrs=True, close=False) -
     if not self.coords == other.coords:
         return False
     if only_required_attrs:  # only include default fields
-        attrs_to_compare = set(PatchAttrs.model_fields) - {"history", "coords"}
+        attrs_to_compare = set(PatchAttrs.model_fields) - {"history"}
         attrs1 = self.attrs.model_dump(include=attrs_to_compare)
         attrs2 = other.attrs.model_dump(include=attrs_to_compare)
-    else:  # include all fields but coords
-        attrs1 = self.attrs.model_dump(exclude=["coords"])
-        attrs2 = other.attrs.model_dump(exclude=["coords"])
+    else:
+        attrs1 = self.attrs.model_dump()
+        attrs2 = other.attrs.model_dump()
     if set(attrs1) != set(attrs2):  # attrs don't have same keys; not equal
         return False
     if attrs1 != attrs2:
@@ -191,9 +178,11 @@ def equals(self: PatchType, other: Any, only_required_attrs=True, close=False) -
         if not_equal:
             return False
     # Test data equality or proximity.
+    if self.data.shape != other.data.shape:
+        return False
     if close and not np.allclose(self.data, other.data):
         return False
-    elif not close and not np.equal(self.data, other.data).all():
+    if not close and not np.equal(self.data, other.data).all():
         return False
     return True
 
@@ -235,20 +224,16 @@ def update(
     attrs
         Optional attributes (non-coordinate metadata) passed as a dict.
 
-    Notes
-    -----
-    - If both coords and attrs are defined, attrs will have priority.
     """
-    data = data if data is not None else self.data
+    data = data if data is not None else self._data
     coords = coords if coords is not None else self.coords
     if dims is None:
         dims = coords.dims if isinstance(coords, CoordManager) else self.dims
     coords = get_coord_manager(coords, dims)
     if attrs is not None:
-        coords, attrs = coords.update_from_attrs(attrs)
+        attrs = PatchAttrs.from_dict(attrs)
     else:
-        _attrs = dc.PatchAttrs.from_dict(attrs or self.attrs)
-        attrs = _attrs.update(coords=coords)
+        attrs = self.attrs
     return self.__class__(data=data, coords=coords, attrs=attrs)
 
 
@@ -490,7 +475,7 @@ def dropna(
     new_data = patch.data[tuple(slices)]
     coord = patch.get_coord(dim)
     cm = patch.coords.update(**{dim: coord[to_keep]})
-    attrs = patch.attrs.update(coords={})
+    attrs = patch.attrs
     return patch.new(data=new_data, coords=cm, attrs=attrs)
 
 

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -16,6 +16,7 @@ from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.coords import get_coord
 from dascore.exceptions import ParameterError
 from dascore.utils.array import _apply_binary_ufunc
+from dascore.utils.attrs import _raise_if_coord_attr_updates
 from dascore.utils.misc import _get_nullish
 from dascore.utils.models import ArrayLike
 from dascore.utils.patch import (
@@ -113,6 +114,7 @@ def update_attrs(self: PatchType, **attrs) -> PatchType:
     >>> # Add new custom attributes
     >>> with_custom = patch.update_attrs(processing_date="2024-01-01")
     """
+    _raise_if_coord_attr_updates(attrs)
     new_attrs = self.attrs.model_dump(exclude_unset=True)
     new_attrs.update(attrs)
     validated = PatchAttrs.from_dict(new_attrs)

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -220,8 +220,7 @@ def rename_coords(self: PatchType, **kwargs) -> PatchType:
     >>> assert 'fragrance' in pa2.dims
     """
     new_coord = self.coords.rename_coord(**kwargs)
-    attrs = self.attrs.rename_dimension(**kwargs)
-    return self.new(coords=new_coord, dims=new_coord.dims, attrs=attrs)
+    return self.new(coords=new_coord, dims=new_coord.dims, attrs=self.attrs)
 
 
 @patch_function()
@@ -467,8 +466,8 @@ def select(
     >>> lt_dist = patch.select(distance=(..., 300))
     >>>
     >>> # select time (1 second from start to -1 second from end)
-    >>> t1 = patch.attrs.time_min + dc.to_timedelta64(1)
-    >>> t2 = patch.attrs.time_max - dc.to_timedelta64(1)
+    >>> t1 = patch.summary.time_min + dc.to_timedelta64(1)
+    >>> t2 = patch.summary.time_max - dc.to_timedelta64(1)
     >>> new_time1 = patch.select(time=(t1, t2))
     >>>
     >>> # this can be accomplished more simply using the relative keyword

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -466,8 +466,8 @@ def select(
     >>> lt_dist = patch.select(distance=(..., 300))
     >>>
     >>> # select time (1 second from start to -1 second from end)
-    >>> t1 = patch.summary.time_min + dc.to_timedelta64(1)
-    >>> t2 = patch.summary.time_max - dc.to_timedelta64(1)
+    >>> t1 = patch.get_coord("time").min() + dc.to_timedelta64(1)
+    >>> t2 = patch.get_coord("time").max() - dc.to_timedelta64(1)
     >>> new_time1 = patch.select(time=(t1, t2))
     >>>
     >>> # this can be accomplished more simply using the relative keyword

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -127,7 +127,8 @@ def interpolate(patch: PatchType, kind: str | int = "linear", **kwargs) -> Patch
     >>> patch = dc.get_example_patch()
     >>> # up-sample time coordinate
     >>> time = patch.coords.get_array('time')
-    >>> new_time = np.arange(time.min(), time.max(), 0.5*patch.attrs.time_step)
+    >>> time_step = patch.get_coord("time").step
+    >>> new_time = np.arange(time.min(), time.max(), 0.5 * time_step)
     >>> patch_uptime = patch.interpolate(time=new_time)
     >>> # interpolate unevenly sampled dim to evenly sampled
     >>> patch = dc.get_example_patch("wacky_dim_coords_patch")

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -54,7 +54,7 @@ class _PatchRollerInfo(DascoreBaseModel):
         else:
             hist_str = f"{self.roll_hist}.{func_or_str}()"
         new_history.append(hist_str)
-        attrs = self.patch.attrs.update(history=new_history, coords={})
+        attrs = self.patch.attrs.update(history=new_history)
         return attrs
 
 

--- a/dascore/proc/units.py
+++ b/dascore/proc/units.py
@@ -9,15 +9,18 @@ from dascore.units import convert_units as u_covert_units
 from dascore.utils.patch import patch_function
 
 
-def _update_attrs_coord_units(patch: dc.Patch, data_units, coords):
-    """Update attributes with new units."""
-    attrs = patch.attrs
-    # set data units
-    attrs = attrs.update(
-        data_units=data_units,
-        coords=coords.to_summary_dict(),
-    )
-    return attrs
+def _replace_data_units(
+    attrs: dc.PatchAttrs, data_units, preserve_existing_data_units: bool = False
+):
+    """Return attrs with updated data units; coordinate units live on coords."""
+    out = attrs.model_dump(exclude_unset=True)
+    if data_units not in (None, ""):
+        out["data_units"] = data_units
+    elif preserve_existing_data_units:
+        out["data_units"] = attrs.data_units
+    else:
+        out["data_units"] = None
+    return dc.PatchAttrs.from_dict(out)
 
 
 @patch_function()
@@ -56,7 +59,7 @@ def set_units(
     >>> patch_removed_units = patch_with_units.set_units(None)
     """
     new_coords = patch.coords.set_units(**kwargs)
-    new_attrs = _update_attrs_coord_units(patch, data_units, new_coords)
+    new_attrs = _replace_data_units(patch.attrs, data_units)
     return patch.new(attrs=new_attrs, coords=new_coords)
 
 
@@ -105,12 +108,18 @@ def convert_units(
     if data_units is not None:
         current_units = patch.attrs.data_units
         data = u_covert_units(patch.data, data_units, current_units)
-        attrs = patch.attrs.update(data_units=data_units, coords={})
+        attrs = patch.attrs.model_dump(exclude_unset=True)
+        attrs["data_units"] = data_units
     else:
         data = patch.data
         attrs = None
     # then update coords and attrs
     coords = patch.coords.convert_units(**kwargs)
+    attrs = _replace_data_units(
+        patch.attrs,
+        attrs.get("data_units") if attrs else None,
+        preserve_existing_data_units=True,
+    )
     return patch.new(data=data, coords=coords, attrs=attrs)
 
 
@@ -141,5 +150,5 @@ def simplify_units(
     data = patch.data * d_factor if d_factor != 1 else patch.data
     # update coords and coord units in attrs
     coords = patch.coords.simplify_units()
-    new_attrs = attrs.update(data_units=d_units, coords=coords.to_summary_dict())
+    new_attrs = _replace_data_units(patch.attrs, d_units)
     return patch.new(data=data, coords=coords, attrs=new_attrs, dims=patch.dims)

--- a/dascore/transform/fft.py
+++ b/dascore/transform/fft.py
@@ -46,7 +46,7 @@ def rfft(patch: PatchType, dim="time") -> PatchType:
 
     ft = FourierTransformatter()
     data = patch.data
-    sr = 1 / to_float(patch.summary[f"{dim}_step"])
+    sr = 1 / to_float(patch.get_coord(dim).step)
     freqs = np.fft.rfftfreq(data.shape[axis], sr)
     new_data = np.fft.rfft(data, axis=axis)
     # get new dims and data units

--- a/dascore/transform/fft.py
+++ b/dascore/transform/fft.py
@@ -46,7 +46,7 @@ def rfft(patch: PatchType, dim="time") -> PatchType:
 
     ft = FourierTransformatter()
     data = patch.data
-    sr = 1 / to_float(patch.attrs[f"{dim}_step"])
+    sr = 1 / to_float(patch.summary[f"{dim}_step"])
     freqs = np.fft.rfftfreq(data.shape[axis], sr)
     new_data = np.fft.rfft(data, axis=axis)
     # get new dims and data units

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -88,7 +88,6 @@ def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
 def _get_dft_attrs(patch, dims, new_coords, pad=False):
     """Get new attributes for transformed patch."""
     new = dict(patch.attrs)
-    new["dims"] = new_coords.dims
     new["data_units"] = _get_data_units_from_dims(patch, dims, mul)
     # As per #390, we also want to remove data_type (eg the patch is no
     # longer in strain rate after the dft)
@@ -267,7 +266,6 @@ def _get_idft_attrs(patch, dims, new_coords):
     # add all {dim}_min to new coords to ensure reverse ft can restore dims.
     new = dict(patch.attrs)
     new.pop("coords", None)
-    new["dims"] = new_coords.dims
     new["data_units"] = _get_data_units_from_dims(patch, dims, mul)
     # Restore the pre-dft datatype.
     if "_pre_dft_data_type" in new:
@@ -486,7 +484,7 @@ def stft(
         "_stft_performed": True,
         "data_units": _get_data_units_from_dims(patch, dim, mul),
     }
-    attrs = patch.attrs.drop("coords").update(**new_attrs)
+    attrs = patch.attrs.update(**new_attrs)
     return patch.new(data=new_data, coords=cm, attrs=attrs)
 
 
@@ -582,5 +580,5 @@ def istft(patch) -> PatchType:
     new_attrs = {i: v for i, v in patch.attrs.items() if not i.startswith("_stft")}
     dim = patch.dims[time_axis]
     new_attrs["data_units"] = _get_data_units_from_dims(patch, dim, truediv)
-    attrs = dc.PatchAttrs(**new_attrs).drop("coords")
+    attrs = dc.PatchAttrs(**new_attrs)
     return patch.new(data=new_data, coords=cm, attrs=attrs)

--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -127,6 +127,5 @@ def integrate(
     else:
         array, coords = _get_indefinite_integral(patch, dxs_or_vals, axes)
     new_units = _get_data_units_from_dims(patch, dims, mul)
-    # we need to reset coords so coords has priority in update.
-    attrs = patch.attrs.update(data_units=new_units, coords={})
+    attrs = patch.attrs.update(data_units=new_units)
     return patch.new(data=array, attrs=attrs, coords=coords)

--- a/dascore/transform/spectro.py
+++ b/dascore/transform/spectro.py
@@ -40,7 +40,6 @@ def _get_transformed_coord(coord, freqs):
 def _get_new_attrs(patch, cm, dim):
     """Update attributes."""
     new = dict(patch.attrs)
-    new["dims"] = cm.dims
     new["data_units"] = _get_data_units_from_dims(patch, dim, mul)
     return PatchAttrs(**new)
 

--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 import dascore as dc
 from dascore.constants import attr_conflict_description
-from dascore.exceptions import AttributeMergeError
+from dascore.exceptions import AttributeMergeError, PatchAttributeError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import (
     _dict_list_diffs,
@@ -52,10 +52,7 @@ def combine_patch_attrs(
     def _get_model_dict_list(mod_list):
         """Get list of model dicts with optional dropped attrs."""
         model_dicts = [
-            _to_patch_attrs(x).model_dump(exclude_defaults=True)
-            if not isinstance(x, dict)
-            else x
-            for x in mod_list
+            _to_patch_attrs(x).model_dump(exclude_defaults=True) for x in mod_list
         ]
         # drop attributes specified.
         if drop := set(iterate(drop_attrs)):
@@ -114,6 +111,24 @@ def combine_patch_attrs(
     )
     cls = first_class if first_class is not dict else dc.PatchAttrs
     return cls(**mod_dict_list[0])
+
+
+def _raise_if_coord_attr_updates(update_map) -> None:
+    """Reject flat coord-summary keys in attr update calls."""
+    if update_map is None:
+        return
+    coord_info, _ = separate_coord_info(update_map)
+    bad_keys = []
+    for coord_name, info in coord_info.items():
+        for field in info:
+            bad_keys.append(f"{coord_name}_{field}")
+    if bad_keys:
+        names = ", ".join(sorted(bad_keys))
+        msg = (
+            "PatchAttrs.update does not accept coordinate metadata. "
+            f"Received: {names}. Use update_coords(...) instead."
+        )
+        raise PatchAttributeError(msg)
 
 
 def separate_coord_info(

--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -4,7 +4,6 @@ Utils for working with attributes.
 
 from __future__ import annotations
 
-import warnings
 from collections import ChainMap, defaultdict
 from collections.abc import Sequence
 from functools import reduce
@@ -18,8 +17,6 @@ from dascore.exceptions import AttributeMergeError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import (
     _dict_list_diffs,
-    all_diffs_close_enough,
-    get_middle_value,
     is_valid_coord_str,
     iterate,
 )
@@ -28,10 +25,8 @@ from dascore.utils.misc import (
 @compose_docstring(conflict_desc=attr_conflict_description)
 def combine_patch_attrs(
     model_list: Sequence[dc.PatchAttrs],
-    coord_name: str | None = None,
     conflicts: Literal["drop", "raise", "keep_first"] = "raise",
     drop_attrs: Sequence[str] | None = None,
-    coord: None | dc.core.coords.BaseCoord = None,
 ) -> dc.PatchAttrs:
     """
     Merge Patch Attributes along a dimension.
@@ -40,70 +35,26 @@ def combine_patch_attrs(
     ----------
     model_list
         A list of models.
-    coord_name
-        The coordinate, usually a dimension coord, along which to merge.
     conflicts
         {conflict_desc}
     drop_attrs
         If provided, attributes which should be dropped.
-    coord
-        The coordinate for the new values of dim. This is provided as a
-        shortcut if it has already been computed.
     """
-    # TODO this is a monstrosity! need to refactor.
-    model_fields = dc.core.CoordSummary.model_fields
-    eq_coord_fields = set(model_fields) - {"min", "max", "step"}
 
-    def _get_merge_coords(model_dicts):
-        """Get the coordinates to merge together."""
-        # pop out coord to merge on
-        merge_coords = []
-        for mod in model_dicts:
-            coords = mod.get("coords", {})
-            maybe_coord = coords.pop(coord_name, None)
-            if maybe_coord is not None:
-                merge_coords.append(maybe_coord)
-        # dealing with empty coords
-        if not merge_coords:
-            return {}
-        return merge_coords
-
-    def _get_merge_dict_list(merge_coords):
-        """Get a list of {attrs: []}."""
-        out = defaultdict(list)
-        for mdict in merge_coords:
-            for key, val in mdict.items():
-                out[key].append(val)
-        return out
-
-    def _get_new_coord(model_dicts):
-        """Get the merged coord to set on all models."""
-        merge_coords = _get_merge_coords(model_dicts)
-        merge_dict_list = _get_merge_dict_list(merge_coords)
-        out = {}
-        # empty dicts
-        if not merge_dict_list:
-            return dict(merge_dict_list)
-        # all these should be equal else raise.
-        for key in eq_coord_fields:
-            if not len(vals := merge_dict_list[key]):
-                continue
-            if not all(vals[0] == x for x in vals):
-                msg = f"Cant merge patch attrs, key {key} not equal."
-                raise AttributeMergeError(msg)
-            out[key] = vals[0]
-        out["min"] = min(merge_dict_list["min"])
-        out["max"] = max(merge_dict_list["max"])
-        step = None
-        if all_diffs_close_enough(steps := merge_dict_list["step"]):
-            step = get_middle_value(steps)
-        out["step"] = step
-        return out
+    def _to_patch_attrs(model):
+        """Normalize supported attr-like inputs to PatchAttrs."""
+        if isinstance(model, dc.Patch):
+            model = model._attrs
+        if isinstance(model, dc.PatchAttrs):
+            return model
+        return dc.PatchAttrs.from_dict(model)
 
     def _get_model_dict_list(mod_list):
-        """Get list of model_dict, merge along dim if specified."""
+        """Get list of model dicts with optional dropped attrs."""
         model_dicts = [
-            x.model_dump(exclude_defaults=True) if not isinstance(x, dict) else x
+            _to_patch_attrs(x).model_dump(exclude_defaults=True)
+            if not isinstance(x, dict)
+            else x
             for x in mod_list
         ]
         # drop attributes specified.
@@ -111,19 +62,6 @@ def combine_patch_attrs(
             model_dicts = [
                 {i: v for i, v in x.items() if i not in drop} for x in model_dicts
             ]
-        # no coordinate to merge on, just return dicts.
-        if not coord_name:
-            return model_dicts
-        # drop models which don't have required coords
-        model_dicts = [x for x in model_dicts if coord_name in x.get("coords", {})]
-        # coordinate can be determined from existing coords.
-        if coord is None:
-            new_coord = _get_new_coord(model_dicts)
-        else:  # or if one was passed just use its summary.
-            new_coord = coord.to_summary()
-        if new_coord:
-            for mod in model_dicts:
-                mod["coords"][coord_name] = new_coord
         return model_dicts
 
     def _replace_null_with_none(mod_dict_list):
@@ -170,11 +108,11 @@ def combine_patch_attrs(
 
     mod_dict_list = _get_model_dict_list(model_list)
     mod_dict_list = _handle_other_attrs(mod_dict_list)
-    first_class = model_list[0].__class__
-    cls = first_class if not first_class == dict else dc.PatchAttrs
-    if not len(mod_dict_list):
-        msg = "Failed to combine patch attrs"
-        raise AttributeMergeError(msg)
+    first = model_list[0]
+    first_class = (
+        _to_patch_attrs(first).__class__ if not isinstance(first, dict) else dict
+    )
+    cls = first_class if first_class is not dict else dc.PatchAttrs
     return cls(**mod_dict_list[0])
 
 
@@ -185,26 +123,52 @@ def separate_coord_info(
     cant_be_alone: tuple[str, ...] = ("units", "dtype"),
 ) -> tuple[dict, dict]:
     """
-    Separate coordinate information from attr dict.
+    Separate coordinate information from mixed attr-like metadata.
 
-    These can be in the flat-form (ie {time_min, time_max, time_step, ...})
-    or a nested coord: {coords: {time: {min, max, step}}
+    This helper is still needed because DASCore still accepts a few mixed
+    metadata shapes internally and in legacy IO paths. In particular, it is
+    used to:
+
+    - normalize flat scan/index-style keys such as ``time_min`` and
+      ``distance_step`` into coordinate summary payloads
+    - split coordinate updates from pure attrs in coord-manager code
+    - unpack older nested ``{"coords": {...}}`` metadata payloads
+
+    Supported input shapes include flat coord-style fields such as
+    ``{time_min, time_max, time_step, ...}`` and nested coord dictionaries
+    such as ``{coords: {time: {min, max, step}}}``.
 
     Parameters
     ----------
     obj
-        The object or model to
+        The object or model to split.
     dims
-        The dimension to look for.
+        Optional dimension names used to recognize flat coord-style keys.
     required
         If provided, the required attributes (e.g., min, max, step).
     cant_be_alone
-        names which cannot be on their own.
+        Names which cannot be treated as coord info on their own.
 
     Returns
     -------
-    coord_dict and attrs_dict.
+    A tuple of ``(coord_dict, attrs_dict)`` where coordinate-like metadata has
+    been separated from the remaining pure attrs.
     """
+    coord_summary_fields = tuple(dc.core.CoordSummary.model_fields)
+
+    def _split_coord_key(key, prefixes=None):
+        """Split flat coord summary key into coord name and field."""
+        prefixes = tuple(iterate(prefixes)) if prefixes is not None else ()
+        if prefixes:
+            for prefix in sorted(prefixes, key=len, reverse=True):
+                prefix_str = f"{prefix}_"
+                if key.startswith(prefix_str):
+                    field = key[len(prefix_str) :]
+                    if field in coord_summary_fields:
+                        return prefix, field
+            return None
+        parts = key.rsplit("_", 1)
+        return tuple(parts)
 
     def _meets_required(coord_dict, strict=True):
         """
@@ -236,21 +200,20 @@ def separate_coord_info(
         for key in obj:
             if not is_valid_coord_str(key):
                 continue
-            potential_keys[key.split("_")[0]].add(key.split("_")[1])
+            coord_name, field = _split_coord_key(key)
+            potential_keys[coord_name].add(field)
         return tuple(i for i, v in potential_keys.items() if _meets_required(v))
 
     def _get_coords_from_top_level(obj, out, dims):
         """First get coord info from top level."""
         for dim in iterate(dims):
-            potential_coord = {
-                i.split("_")[1]: v for i, v in obj.items() if is_valid_coord_str(i, dim)
-            }
-            # nasty hack for handling d_{dim} for backward compatibility.
-            if (bad_name := f"d_{dim}") in obj:
-                msg = f"d_{dim} is deprecated, use {dim}_step"
-                warnings.warn(msg, DeprecationWarning, stacklevel=3)
-                potential_coord["step"] = obj[bad_name]
-
+            potential_coord = {}
+            for key, value in obj.items():
+                split = _split_coord_key(key, prefixes=(dim,))
+                if split is None:
+                    continue
+                _, field = split
+                potential_coord[field] = value
             if _meets_required(potential_coord, strict=False):
                 out[dim] = potential_coord
 
@@ -290,7 +253,6 @@ def separate_coord_info(
     # Check if dims need to be updated.
     new_dims = _get_dims(obj)
     if new_dims and new_dims != dims:
-        obj["dims"] = new_dims
         dims = new_dims
     # this is already a dict of coord info.
     if dims and set(dims).issubset(set(obj)):
@@ -298,6 +260,4 @@ def separate_coord_info(
     _get_coords_from_coord_level(obj, coord_dict)
     _get_coords_from_top_level(obj, coord_dict, dims)
     _pop_keys(obj, coord_dict)
-    if "dims" not in obj and dims is not None:
-        obj["dims"] = dims
     return coord_dict, obj

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -237,7 +237,6 @@ def patch_to_obspy(patch: PatchType):
     traces = []
     for data, other_val in zip(patch.data, other_vals):
         stats = patch.attrs.model_dump()
-        stats.pop("coords")
         stats.update(base_stats)
         stats[other_dim] = other_val
         trace = obspy.Trace(data=data, header=stats)

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -426,8 +426,7 @@ def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
     conf = merge_kwargs.get("conflicts", None)
     drop_conf_coords = True if conf in {"drop", "keep_first"} else False
     new_coord = _get_new_coord(df, merge_dim, coords, drop_conf_coords)
-    coord = new_coord.coord_map[merge_dim] if merge_dim in dims else None
-    new_attrs = combine_patch_attrs(attrs, merge_dim, coord=coord, **merge_kwargs)
+    new_attrs = combine_patch_attrs(attrs, **merge_kwargs)
     patch = dc.Patch(data=new_data, coords=new_coord, attrs=new_attrs, dims=dims)
     new_dict = {"patch": patch}
     return [new_dict]
@@ -546,7 +545,7 @@ def get_patch_names(
     # Handle special cases.
     if "name" in col_set:
         return df["name"].astype(str)
-    if "path" in col_set:
+    if "path" in col_set and df["path"].astype(str).str.len().gt(0).any():
         return _get_filename(df["path"], strip_extension)
     # Determine the requested fields and get the ones that are there.
     coord_fields = zip([f"{x}_min" for x in coords], [f"{x}_max" for x in coords])
@@ -989,17 +988,13 @@ def _merge_aligned_coords(cm1, cm2):
     return cm1.update(**out)
 
 
-def _merge_models(attrs1, attrs2, coord=None, attrs_to_ignore=DEFAULT_ATTRS_TO_IGNORE):
+def _merge_models(attrs1, attrs2, attrs_to_ignore=DEFAULT_ATTRS_TO_IGNORE):
     """Ensure models are equal in the right ways, merge together."""
     no_comp_keys = set(attrs_to_ignore)
     if attrs1 == attrs2:
         return attrs1
-    dict1, dict2 = dict(attrs1), dict(attrs2)
-    if coord is not None:
-        new_coords = coord.to_summary_dict()
-        dict1["coords"], dict2["coords"] = new_coords, new_coords
-    else:
-        dict1.pop("coords"), dict2.pop("coords")
+    dict1 = dict(attrs1)
+    dict2 = dict(attrs2)
     common_keys = set(dict1) & set(dict2)
     ne_attrs = []
     for key in common_keys:
@@ -1077,7 +1072,7 @@ def merge_compatible_coords_attrs(
     coord1, coord2 = patch1.coords, patch2.coords
     attrs1, attrs2 = patch1.attrs, patch2.attrs
     coord_out = _merge_coords(coord1, coord2)
-    attrs = _merge_models(attrs1, attrs2, coord_out, attrs_to_ignore=attrs_to_ignore)
+    attrs = _merge_models(attrs1, attrs2, attrs_to_ignore=attrs_to_ignore)
     return coord_out, attrs
 
 

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -425,7 +425,13 @@ def _model_list_to_df(mod_list: Sequence[dc.PatchAttrs], exclude=None) -> pd.Dat
 
     Optionally, exclude certain columns
     """
-    df = pd.DataFrame([x.flat_dump(exclude=exclude) for x in mod_list])
+    records = []
+    for item in mod_list:
+        if hasattr(item, "flat_dump"):
+            records.append(item.flat_dump(exclude=exclude))
+        else:
+            records.append(item.summary.flat_dump(exclude=exclude))
+    df = pd.DataFrame(records)
     if "dims" in df.columns:
         df["dims"] = list_ser_to_str(df["dims"])
     return df
@@ -561,6 +567,9 @@ def dataframe_to_patch(
     # get data
     data = df.to_numpy()
     dims = _get_column_names(df, attrs)
+    if isinstance(attrs, Mapping):
+        attrs = dict(attrs)
+        attrs.pop("dims", None)
     coords = {dims[0]: df.index.to_numpy(), dims[1]: df.columns.to_numpy()}
     return dc.Patch(data=data, dims=dims, coords=coords, attrs=attrs)
 

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -13,8 +13,7 @@ from dascore.utils.misc import suppress_warnings
 
 def _get_dim_label(patch, dim):
     """Create a label for the given dimension, including units if defined."""
-    attrs = patch.attrs
-    maybe_units = attrs.get(f"{dim}_units")
+    maybe_units = patch.get_coord(dim).units if dim in patch.coords else None
     unit_str = f"({get_quantity_str(maybe_units)})" if maybe_units else ""
     return str(dim) + unit_str
 
@@ -64,7 +63,7 @@ def _get_extents(dims_r, coords):
     # and we want first dim to go from top to bottom
     lims = {x: [] for x in dims_r}
     for dim in dims_r:
-        array = coords[dim]
+        array = coords.get_array(dim) if hasattr(coords, "get_array") else coords[dim]
         # Use nanmin/nanmax to handle NaN/NaT values in coordinates
         with suppress_warnings(RuntimeWarning):
             array_min = np.nanmin(array)

--- a/dascore/viz/map_fiber.py
+++ b/dascore/viz/map_fiber.py
@@ -98,7 +98,7 @@ def map_fiber(
     if isinstance(color, str):
         assert color in patch.coords, f"{color} not found in patch coordinates"
         data_type = color
-        data_units = patch.attrs.coords[color].units
+        data_units = patch.coords.coord_map[color].units
         color = patch.coords.get_array(color)
     else:
         data_type = ""

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -8,4 +8,4 @@ The [releases page](https://github.com/DASDAE/dascore/releases) tracks changes f
 - Scan results carry metadata, coordinates, and source information without loading data. File-backed summaries contain enough source information for lazy reloads.
 - `Patch.attrs` now contains non-coordinate metadata only.
 - Coordinate summaries such as `time_min`, `time_max`, `distance_step`, and coordinate units are exposed through `Patch.summary`, not through `Patch.attrs`.
-- `Patch.attrs` and `PatchAttrs` no longer own coordinate summaries. Use [`Patch.summary`](`dascore.Patch.summary`) for metadata views and coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) for coordinate changes.
+- `Patch.attrs` and `PatchAttrs` no longer own coordinate summaries. Use [`PatchSummary`](`dascore.PatchSummary`) values exposed through `Patch.summary` for metadata views and coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) for coordinate changes.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -1,3 +1,11 @@
 # Changelog
 
 The [releases page](https://github.com/DASDAE/dascore/releases) tracks changes from one version to another.
+
+## Unreleased API Changes
+
+- `dc.scan(...)` now returns [`PatchSummary`](`dascore.PatchSummary`) objects rather than `PatchAttrs`.
+- Scan results carry metadata, coordinates, and source information without loading data. File-backed summaries contain enough source information for lazy reloads.
+- `Patch.attrs` now contains non-coordinate metadata only.
+- Coordinate summaries such as `time_min`, `time_max`, `distance_step`, and coordinate units are exposed through `Patch.summary`, not through `Patch.attrs`.
+- `Patch.update_attrs(...)` and `PatchAttrs.update(...)` no longer accept coordinate metadata. Use coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) instead.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -8,4 +8,4 @@ The [releases page](https://github.com/DASDAE/dascore/releases) tracks changes f
 - Scan results carry metadata, coordinates, and source information without loading data. File-backed summaries contain enough source information for lazy reloads.
 - `Patch.attrs` now contains non-coordinate metadata only.
 - Coordinate summaries such as `time_min`, `time_max`, `distance_step`, and coordinate units are exposed through `Patch.summary.get_coord_summary(...)`, not through `Patch.attrs`.
-- `Patch.attrs` and `PatchAttrs` no longer own coordinate summaries. Use [`PatchSummary`](`dascore.PatchSummary`) values exposed through `Patch.summary.get_coord_summary(...)` for metadata views and coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) for coordinate changes.
+- `Patch.attrs` and `PatchAttrs` no longer own coordinate summaries. Use [`PatchSummary`](`dascore.PatchSummary`) values exposed through [`PatchSummary.get_coord_summary(...)`](`dascore.PatchSummary.get_coord_summary`) for metadata views and coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) for coordinate changes.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -7,5 +7,5 @@ The [releases page](https://github.com/DASDAE/dascore/releases) tracks changes f
 - `dc.scan(...)` now returns [`PatchSummary`](`dascore.PatchSummary`) objects rather than `PatchAttrs`.
 - Scan results carry metadata, coordinates, and source information without loading data. File-backed summaries contain enough source information for lazy reloads.
 - `Patch.attrs` now contains non-coordinate metadata only.
-- Coordinate summaries such as `time_min`, `time_max`, `distance_step`, and coordinate units are exposed through `Patch.summary`, not through `Patch.attrs`.
-- `Patch.attrs` and `PatchAttrs` no longer own coordinate summaries. Use [`PatchSummary`](`dascore.PatchSummary`) values exposed through `Patch.summary` for metadata views and coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) for coordinate changes.
+- Coordinate summaries such as `time_min`, `time_max`, `distance_step`, and coordinate units are exposed through `Patch.summary.get_coord_summary(...)`, not through `Patch.attrs`.
+- `Patch.attrs` and `PatchAttrs` no longer own coordinate summaries. Use [`PatchSummary`](`dascore.PatchSummary`) values exposed through `Patch.summary.get_coord_summary(...)` for metadata views and coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) for coordinate changes.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -8,4 +8,4 @@ The [releases page](https://github.com/DASDAE/dascore/releases) tracks changes f
 - Scan results carry metadata, coordinates, and source information without loading data. File-backed summaries contain enough source information for lazy reloads.
 - `Patch.attrs` now contains non-coordinate metadata only.
 - Coordinate summaries such as `time_min`, `time_max`, `distance_step`, and coordinate units are exposed through `Patch.summary`, not through `Patch.attrs`.
-- `Patch.update_attrs(...)` and `PatchAttrs.update(...)` no longer accept coordinate metadata. Use coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) instead.
+- `Patch.attrs` and `PatchAttrs` no longer own coordinate summaries. Use [`Patch.summary`](`dascore.Patch.summary`) for metadata views and coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) for coordinate changes.

--- a/docs/contributing/documentation.qmd
+++ b/docs/contributing/documentation.qmd
@@ -16,6 +16,12 @@ Use [numpy style docstrings](https://numpydoc.readthedocs.io/en/latest/format.ht
 DASCore makes extensive use of Python 3's [type hints](https://docs.python.org/3/library/typing.html).
 Please make an effort to accurately annotate public functions/classes/methods.
 
+When documenting IO code, make sure the docstring reflects the actual contract
+boundary. In particular, `FiberIO.scan()` implementations should describe
+patch-only metadata and should not claim responsibility for `path`,
+`file_format`, or `file_version`; those are attached by DASCore's higher-level
+scan pipeline.
+
 Here is an example:
 
 ```{python}

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -87,7 +87,7 @@ class JingleV1(FiberIO):
         This should return a list of
         [`PatchSummary`](`dascore.PatchSummary`) objects. DASCore will also
         normalize a loaded `Patch` to a summary if needed, but new formats
-        should return `PatchSummary` instances directly. Returning
+        should return [`PatchSummary`](`dascore.PatchSummary`) instances directly. Returning
         [`PatchAttrs`](`dascore.PatchAttrs`) from `scan()` is no longer
         supported.
 

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -85,9 +85,16 @@ class JingleV1(FiberIO):
         Used to get metadata about a file without reading the whole file.
 
         This should return a list of
-        [`PatchAttrs`](`dascore.core.attrs.PatchAttrs`) objects
-        from the [dascore.core.attrs](`dascore.core.attrs`) module, or a
-        format-specific subclass.
+        [`PatchSummary`](`dascore.PatchSummary`) objects. DASCore will also
+        normalize a loaded `Patch` to a summary if needed, but new formats
+        should return `PatchSummary` instances directly. Returning
+        [`PatchAttrs`](`dascore.PatchAttrs`) from `scan()` is no longer
+        supported.
+
+        `scan()` should only return patch metadata. Do not populate source
+        metadata such as `path`, `file_format`, or `file_version` inside the
+        `FiberIO` implementation; DASCore adds those fields in the higher-level
+        `dc.scan(...)` / `dc.scan_to_df(...)` pipeline.
         """
 
     def write(self, patch, path, **kwargs):
@@ -106,6 +113,21 @@ Note that each of these methods should have `**kwargs` at the end. This allows c
 :::{.callout-warning}
 It is very important that the `scan` method returns *exactly* the same patch information as reading the patch would, otherwise the lazy merge planning done by spool can be wrong!
 :::
+
+## `source_patch_id`
+
+If a single file can produce more than one patch, your format should usually provide a `source_patch_id` for each patch summary returned by `scan`.
+
+`source_patch_id` is the per-patch identifier DASCore uses to get back to the same logical patch later. This matters most for `dc.spool(...)`, where DASCore may first `scan()` a file, store patch metadata, and only call `read()` for one patch much later.
+
+The rule is simple:
+
+- `scan()` should emit a stable `source_patch_id` for each patch.
+- `read(..., source_patch_id=...)` should use that value to return the matching patch, or patches if given multiple ids.
+- `source_patch_id` belongs on the summary/reload path, not on patch attrs.
+- `path`, `file_format`, and `file_version` are owned by the calling DASCore scan layer, not by `FiberIO.scan()`.
+
+For some formats, a numeric patch index is enough if patch ordering is stable. For others, a native identifier such as a group name, node name, or source/zone tuple is better. If your format only ever produces one patch per file, you usually do not need to set `source_patch_id`.
 
 
 ## Support for Streams/Buffers

--- a/docs/recipes/low_freq_proc.qmd
+++ b/docs/recipes/low_freq_proc.qmd
@@ -92,7 +92,11 @@ delta_pa = dc.get_example_patch("delta_patch", dim="time", patch=pa_chunked_sp)
 # Apply the low-pass filter on the delta patch
 delta_pa_low_passed = delta_pa.pass_filter(time=(None, cutoff_freq * filter_safety_factor))
 # Resample the low-passed filtered patch
-new_time_ax = np.arange(delta_pa.attrs["time_min"], delta_pa.attrs["time_max"], np.timedelta64(dt, "s"))
+new_time_ax = np.arange(
+    delta_pa.summary.time_min,
+    delta_pa.summary.time_max,
+    np.timedelta64(dt, "s"),
+)
 delta_pa_lfp = delta_pa_low_passed.interpolate(time=new_time_ax)
 
 # Identify the indices where the absolute value of the data exceeds the threshold
@@ -138,7 +142,11 @@ for patch in sp_chunked_overlap:
     # Apply the low-pass filter on the delta patch
     pa_low_passed = patch.pass_filter(time=(..., cutoff_freq * filter_safety_factor))
     # Resample the low-passed filter patch
-    new_time_ax = np.arange(pa_low_passed.attrs["time_min"], pa_low_passed.attrs["time_max"], np.timedelta64(dt, "s"))
+    new_time_ax = np.arange(
+        pa_low_passed.summary.time_min,
+        pa_low_passed.summary.time_max,
+        np.timedelta64(dt, "s"),
+    )
     pa_lfp = (
         pa_low_passed.interpolate(time=new_time_ax)
         .update_coords(time_step=dt)   # Update sampling interval

--- a/docs/recipes/low_freq_proc.qmd
+++ b/docs/recipes/low_freq_proc.qmd
@@ -93,8 +93,8 @@ delta_pa = dc.get_example_patch("delta_patch", dim="time", patch=pa_chunked_sp)
 delta_pa_low_passed = delta_pa.pass_filter(time=(None, cutoff_freq * filter_safety_factor))
 # Resample the low-passed filtered patch
 new_time_ax = np.arange(
-    delta_pa.summary.time_min,
-    delta_pa.summary.time_max,
+    delta_pa.get_coord("time").min(),
+    delta_pa.get_coord("time").max(),
     np.timedelta64(dt, "s"),
 )
 delta_pa_lfp = delta_pa_low_passed.interpolate(time=new_time_ax)
@@ -143,8 +143,8 @@ for patch in sp_chunked_overlap:
     pa_low_passed = patch.pass_filter(time=(..., cutoff_freq * filter_safety_factor))
     # Resample the low-passed filter patch
     new_time_ax = np.arange(
-        pa_low_passed.summary.time_min,
-        pa_low_passed.summary.time_max,
+        pa_low_passed.get_coord("time").min(),
+        pa_low_passed.get_coord("time").max(),
         np.timedelta64(dt, "s"),
     )
     pa_lfp = (

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -55,7 +55,7 @@ print(loaded_patch.data.shape)
 ```
 
 :::{.callout-note}
-`Patch.attrs` stores non-coordinate metadata only. Coordinate summaries such as `time_min`, `time_max`, and `distance_step` are accessed through [`PatchSummary.get_coord_summary()`](`dascore.PatchSummary.get_coord_summary`) or via `patch.summary.get_coord_summary(...)`.
+`Patch.attrs` stores non-coordinate metadata only. Coordinate summaries such as `time_min`, `time_max`, and `distance_step` are accessed through [`PatchSummary.get_coord_summary(...)`](`dascore.PatchSummary.get_coord_summary`) or via `patch.summary.get_coord_summary(...)`.
 :::
 
 ## DirectorySpool

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -27,6 +27,37 @@ if write_path.exists():
     write_path.unlink()
 ```
 
+## Scan Metadata Without Loading Data
+
+[`dascore.scan`](`dascore.scan`) returns [`PatchSummary`](`dascore.PatchSummary`) objects. These scan results expose metadata, coordinates, and source information without loading the data array into memory.
+
+```{python}
+import dascore as dc
+from dascore.utils.downloader import fetch
+
+path = fetch("terra15_das_1_trimmed.hdf5")
+scan_patch = dc.scan(path)[0]
+
+print(scan_patch.path)
+print(scan_patch.time_min)
+```
+
+Scan results are useful for listing contents, building dataframes, and deciding which patches to load.
+
+```{python}
+loaded_patch = dc.read(
+    scan_patch.path,
+    file_format=scan_patch.file_format,
+    file_version=scan_patch.file_version,
+    source_patch_id=scan_patch.source_patch_id or None,
+)[0]
+print(loaded_patch.data.shape)
+```
+
+:::{.callout-note}
+`Patch.attrs` stores non-coordinate metadata only. Coordinate summaries such as `time_min`, `time_max`, and `distance_step` are accessed directly on a `PatchSummary` or via `patch.summary`.
+:::
+
 ## DirectorySpool
 
 The [DirectorySpool](`dascore.clients.dirspool.DirectorySpool`) is used to retrieve data from a directory of dascore-readable files. It has the same interface as other spools and is created with the [`dascore.spool`](`dascore.spool`) function.

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -39,7 +39,7 @@ path = fetch("terra15_das_1_trimmed.hdf5")
 scan_patch = dc.scan(path)[0]
 
 print(scan_patch.path)
-print(scan_patch.time_min)
+print(scan_patch.get_coord_summary("time").min)
 ```
 
 Scan results are useful for listing contents, building dataframes, and deciding which patches to load.
@@ -55,7 +55,7 @@ print(loaded_patch.data.shape)
 ```
 
 :::{.callout-note}
-`Patch.attrs` stores non-coordinate metadata only. Coordinate summaries such as `time_min`, `time_max`, and `distance_step` are accessed directly on a `PatchSummary` or via `patch.summary`.
+`Patch.attrs` stores non-coordinate metadata only. Coordinate summaries such as `time_min`, `time_max`, and `distance_step` are accessed through [`PatchSummary.get_coord_summary()`](`dascore.PatchSummary.get_coord_summary`) or via `patch.summary.get_coord_summary(...)`.
 :::
 
 ## DirectorySpool

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -219,8 +219,8 @@ import dascore as dc
 patch = dc.get_example_patch()
 
 print(patch.attrs.tag)
-print(patch.summary.time_min)
-print(patch.summary.distance_step)
+print(patch.get_coord("time").min())
+print(patch.get_coord("distance").step)
 ```
 
 For tabular use, [`Patch.flat_dump`](`dascore.Patch.flat_dump`) returns a flat dictionary combining attrs with coordinate summary fields.

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -223,7 +223,7 @@ print(patch.get_coord("time").min())
 print(patch.get_coord("distance").step)
 ```
 
-For tabular use, [`Patch.flat_dump`](`dascore.Patch.flat_dump`) returns a flat dictionary combining attrs with coordinate summary fields.
+For tabular use, [`PatchSummary.flat_dump()`](`dascore.PatchSummary.flat_dump`) returns a flat dictionary combining attrs with coordinate summary fields.
 
 ```{python}
 row = patch.flat_dump()

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -182,7 +182,7 @@ Most of the other `CoordManager` features are primarily used internally by DASCo
 
 ## Attrs
 
-The metadata stored in [`Patch.attrs`](`dascore.core.attrs.PatchAttrs`) is a [pydantic model](https://docs.pydantic.dev/usage/models/) which enforces a schema and provides validation. [`PatchAttrs.get_summary_df`](`dascore.utils.models.DascoreBaseModel.get_summary_df`) generates a table of the attribute descriptions:
+The metadata stored in `Patch.attrs` is a [pydantic model](https://docs.pydantic.dev/usage/models/) which enforces a schema and provides validation. [`PatchAttrs.get_summary_df`](`dascore.utils.models.DascoreBaseModel.get_summary_df`) generates a table of the attribute descriptions:
 
 
 ```{python}
@@ -201,6 +201,35 @@ Markdown(df_str)
 
 
 Specific data formats may also add attributes (e.g. "gauge_length", "pulse_width"), but this depends on the parser.
+
+`Patch.attrs` only stores non-coordinate metadata. This includes things like network, station, data units, and format-specific fields such as `gauge_length` or `pulse_width`.
+
+## Summary
+
+`Patch.summary` provides a read-only combined view of:
+
+- `Patch.attrs` for non-coordinate metadata
+- coordinate summaries derived from `Patch.coords`
+
+Use `Patch.summary` when you need fields such as `time_min`, `time_max`, `distance_step`, or coordinate units.
+
+```{python}
+import dascore as dc
+
+patch = dc.get_example_patch()
+
+print(patch.attrs.tag)
+print(patch.summary.time_min)
+print(patch.summary.distance_step)
+```
+
+For tabular use, [`Patch.flat_dump`](`dascore.Patch.flat_dump`) returns a flat dictionary combining attrs with coordinate summary fields.
+
+```{python}
+row = patch.flat_dump()
+print(row["time_min"])
+print(row["distance_max"])
+```
 
 ## String representation
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -6,6 +6,8 @@ execute:
 
 Spools are containers/managers of [patches](patch.qmd). The spool interface is designed to manage a variety of data sources, including a group of patches loaded into memory, archives of local files, and a variety of remote resources.
 
+For file-backed spools, DASCore first scans metadata and coordinate summaries, then loads patch data only when you access a patch from the spool. This means methods like `get_contents()` work from patch summary metadata, while `spool[0]` or iteration materializes loaded patches.
+
 # Data Sources
 
 The simplest way to get the appropriate spool for a specified input is to use the [`spool`](`dascore.spool`) function, which knows about many different input types and returns an appropriate [`BaseSpool`](`dascore.core.spool.BaseSpool`) subclass instance.
@@ -101,6 +103,8 @@ for patch in spool:
 new_spool = spool[1:]
 ```
 
+For file-backed spools, indexing or iteration is the point where DASCore loads the underlying patch data. Metadata-only operations such as `get_contents()` and `select(...)` can usually run without loading full patch arrays.
+
 An array can also be used (just like numpy) to select/re-arrange spool contents. For example, a boolean array can be used to de-select patches:
 
 ```{python}
@@ -152,6 +156,8 @@ from IPython.display import display
 
 display(contents.drop(columns=['patch']))
 ```
+
+The columns returned by `get_contents()` come from the same patch summary metadata exposed by `Patch.summary`, so fields such as `time_min`, `time_max`, and `distance_step` are available without loading the underlying patch data. Source metadata such as `path`, `file_format`, and `source_patch_id` are also available for file-backed spools.
 
 # select
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,7 +259,7 @@ def brady_hs_das_dts_coords_path():
 def terra15_das_patch(terra15_das_example_path) -> Patch:
     """Read the terra15 data, return contained DataArray."""
     out = read(terra15_das_example_path, "terra15")[0]
-    attr_time = out.summary["time_max"]
+    attr_time = out.summary.get_coord_summary("time").max
     coortime_step = out.coords.coord_map["time"].max()
     assert attr_time == coortime_step
     return out
@@ -463,15 +463,16 @@ def adjacent_spool_no_overlap(random_patch) -> dc.BaseSpool:
     overlapping.
     """
     pa1 = random_patch
-    t2 = random_patch.summary["time_max"]
-    time_step = random_patch.summary["time_step"]
+    time_coord = random_patch.get_coord("time")
+    t2 = time_coord.max()
+    time_step = time_coord.step
 
     pa2 = random_patch.new(coords=random_patch.coords.update(time_min=t2 + time_step))
-    t3 = pa2.summary["time_max"]
+    t3 = pa2.get_coord("time").max()
 
     pa3 = pa2.new(coords=pa2.coords.update(time_min=t3 + time_step))
 
-    expectetime_step = pa3.summary["time_max"] - pa1.summary["time_min"]
+    expectetime_step = pa3.get_coord("time").max() - pa1.get_coord("time").min()
     actual_time = pa3.coords.max("time") - pa1.coords.min("time")
     assert expectetime_step == actual_time
     return dc.spool([pa2, pa1, pa3])
@@ -552,7 +553,7 @@ def memory_spool_small_dt_differences(random_spool):
     """Create a memory spool with slightly different time_steps."""
     out = []
     for num, patch in enumerate(random_spool):
-        dt = patch.summary.time_step + num * np.timedelta64(1, "ns")
+        dt = patch.get_coord("time").step + num * np.timedelta64(1, "ns")
         new = patch.new(coords=patch.coords.update(time_step=dt))
         out.append(new)
     spool = dc.spool(out)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,7 +259,7 @@ def brady_hs_das_dts_coords_path():
 def terra15_das_patch(terra15_das_example_path) -> Patch:
     """Read the terra15 data, return contained DataArray."""
     out = read(terra15_das_example_path, "terra15")[0]
-    attr_time = out.attrs["time_max"]
+    attr_time = out.summary["time_max"]
     coortime_step = out.coords.coord_map["time"].max()
     assert attr_time == coortime_step
     return out
@@ -463,15 +463,15 @@ def adjacent_spool_no_overlap(random_patch) -> dc.BaseSpool:
     overlapping.
     """
     pa1 = random_patch
-    t2 = random_patch.attrs["time_max"]
-    time_step = random_patch.attrs["time_step"]
+    t2 = random_patch.summary["time_max"]
+    time_step = random_patch.summary["time_step"]
 
-    pa2 = random_patch.update_attrs(time_min=t2 + time_step)
-    t3 = pa2.attrs["time_max"]
+    pa2 = random_patch.new(coords=random_patch.coords.update(time_min=t2 + time_step))
+    t3 = pa2.summary["time_max"]
 
-    pa3 = pa2.update_attrs(time_min=t3 + time_step)
+    pa3 = pa2.new(coords=pa2.coords.update(time_min=t3 + time_step))
 
-    expectetime_step = pa3.attrs["time_max"] - pa1.attrs["time_min"]
+    expectetime_step = pa3.summary["time_max"] - pa1.summary["time_min"]
     actual_time = pa3.coords.max("time") - pa1.coords.min("time")
     assert expectetime_step == actual_time
     return dc.spool([pa2, pa1, pa3])
@@ -552,8 +552,8 @@ def memory_spool_small_dt_differences(random_spool):
     """Create a memory spool with slightly different time_steps."""
     out = []
     for num, patch in enumerate(random_spool):
-        dt = patch.attrs.time_step + num * np.timedelta64(1, "ns")
-        new = patch.update_attrs(time_step=dt)
+        dt = patch.summary.time_step + num * np.timedelta64(1, "ns")
+        new = patch.new(coords=patch.coords.update(time_step=dt))
         out.append(new)
     spool = dc.spool(out)
     assert len(out) == len(spool)

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -28,7 +28,7 @@ def dir_spool_index_out_of_order(random_spool, tmp_path_factory):
     path = tmp_path_factory.mktemp("out_of_order_index")
     spool = dc.spool(path)
     # sort patches by starttime
-    patch_list = sorted(random_spool, key=lambda x: x.attrs.time_min)
+    patch_list = sorted(random_spool, key=lambda x: x.summary.time_min)
     # write patches to disk out of order.
     patch_list[-1].io.write(path / "patch_3.h5", "dasdae")
     spool.update()
@@ -51,21 +51,12 @@ def one_directory_spool(one_file_dir):
 @register_func(DIRECTORY_SPOOLS)
 def non_distance_dir_spool(tmp_path_factory):
     """Create a directory with a single DAS file."""
-    # patch one simulates a patch that has time but no distance
+    # Simulate a patch that has time but no canonical distance coordinate.
     pa1 = dascore.examples.get_example_patch("random_das").rename_coords(
         distance="depth"
     )
-    # patch2 has neither time nor distance but time in attrs.
-    pa2 = (
-        dascore.examples.get_example_patch("random_das")
-        .update_attrs(time_min=pa1.attrs.time_max)
-        .rename_coords(time="timey", distance="depth")
-    )
-    coord = pa2.get_coord("timey")
-    pa2 = pa2.update_attrs(time_min=coord.min(), time_max=coord.max())
-    spool = dc.spool([pa1, pa2])
     path = tmp_path_factory.mktemp("no_distance_spool")
-    dascore.examples.spool_to_directory(spool, path)
+    dc.write(pa1, path / "patch_1.h5", "dasdae")
     return dc.spool(path).update()
 
 
@@ -102,6 +93,17 @@ class TestDirectorySpoolBasics:
         new = diverse_directory_spool.select(station="big_gaps")
         contents = new.get_contents()
         assert (contents["station"] == "big_gaps").all()
+
+    def test_sorted_multi_patch_uses_source_patch_id(self, tmp_path):
+        """Sorted directory spool rows should reload the intended source patch."""
+        path = tmp_path / "directory"
+        path.mkdir()
+        patch_2 = dc.get_example_patch()
+        patch_1 = patch_2.update_coords(time=patch_2.coords.get_array("time") + 10)
+        dc.write(dc.spool([patch_1, patch_2]), path / "multi_patch.h5", "dasdae")
+        spool = DirectorySpool(path).update().sort("time")
+        patch = spool[0]
+        assert patch.summary.time_min == patch_2.summary.time_min
 
 
 class TestDirectoryIndex:
@@ -222,8 +224,8 @@ class TestSelect:
         assert (df["time_max"] <= new_max).all()
         # as well as the patches produced
         for patch in spool:
-            assert patch.attrs["time_min"] >= new_min
-            assert patch.attrs["time_max"] <= new_max
+            assert patch.summary["time_min"] >= new_min
+            assert patch.summary["time_max"] <= new_max
 
     def test_sub_select_tag_equals(self, basic_file_spool, spool_tag):
         """Ensure selecting stations works."""
@@ -255,10 +257,10 @@ class TestSelect:
         assert (new_content["time_max"] <= new_max).all()
         # then check patches
         for patch in out:
-            attrs = patch.attrs
-            assert attrs["network"] == "das2"
-            assert attrs["tag"].startswith("ran")
-            assert attrs["time_max"] <= new_max
+            summary = patch.summary
+            assert patch.attrs["network"] == "das2"
+            assert patch.attrs["tag"].startswith("ran")
+            assert summary["time_max"] <= new_max
         # ensure raises when selecting off the end of the spool
         with pytest.raises(IndexError):
             out[len(new_content)]
@@ -270,7 +272,7 @@ class TestSelect:
         spool1 = basic_file_spool.select(time=(None, dt))
         spool2 = basic_file_spool.select(time=(None, time_str))
         for pa1, pa2 in zip(spool1, spool2):
-            assert pa1.attrs["time_max"] == pa2.attrs["time_max"]
+            assert pa1.summary["time_max"] == pa2.summary["time_max"]
 
     def test_select_non_zero_index(self, diverse_directory_spool):
         """
@@ -295,8 +297,8 @@ class TestSelect:
     def test_select_correct_history_str(self, diverse_directory_spool):
         """Ensure no history string is added for selecting. See #142/#147."""
         spool = diverse_directory_spool
-        t1 = spool[0].attrs.time_min
-        dt = spool[0].attrs.time_step
+        t1 = spool[0].summary.time_min
+        dt = spool[0].summary.time_step
         selected_spool = spool.select(time=(t1, t1 + 30 * dt))
         patch = selected_spool[0]
         history = patch.attrs.history
@@ -348,9 +350,9 @@ class TestBasicChunk:
         assert len(new) == 1
         patch = new[0]
         content = spool.get_contents()
-        assert patch.attrs.time_min == content["time_min"].min()
-        assert patch.attrs.time_max == content["time_max"].max()
-        assert patch.attrs.time_step == spool[0].attrs.time_step
+        assert patch.summary.time_min == content["time_min"].min()
+        assert patch.summary.time_max == content["time_max"].max()
+        assert patch.summary.time_step == spool[0].summary.time_step
 
     def test_chunk_out_of_order_index(self, dir_spool_index_out_of_order):
         """Ensure when the index isn't ordered chunk can still work."""
@@ -359,11 +361,11 @@ class TestBasicChunk:
         chunk = spool.chunk(time=time)
         for patch in chunk:
             assert isinstance(patch, dc.Patch)
-            dur = (patch.attrs.time_max - patch.attrs.time_min) / ONE_SECOND
+            dur = (patch.summary.time_max - patch.summary.time_min) / ONE_SECOND
             diff = np.abs(dur - time)
             # because we try to avoid overlaps, the segments can be up to 2
             # samples shorter than what was asked for. Maybe revisit this?
-            assert diff <= 2 * (patch.attrs.time_step / ONE_SECOND)
+            assert diff <= 2 * (patch.summary.time_step / ONE_SECOND)
 
     def test_chunk_redundant_index(self, directory_spool_redundant_index):
         """Ensure redundant indices are handled effectively with chunking"""
@@ -443,12 +445,12 @@ class TestFileSpoolIntegrations:
         )
         for patch in spool:
             assert isinstance(patch, dc.Patch)
-            attrs = patch.attrs
-            assert attrs["network"] == network
-            assert attrs["time_max"] <= endtime
-            patch_duration = (attrs["time_max"] - attrs["time_min"]) / ONE_SECOND
+            summary = patch.summary
+            assert patch.attrs["network"] == network
+            assert summary["time_max"] <= endtime
+            patch_duration = (summary["time_max"] - summary["time_min"]) / ONE_SECOND
             diff = patch_duration - duration
-            assert abs(diff) <= 1.5 * attrs["time_step"] / ONE_SECOND
+            assert abs(diff) <= 1.5 * summary["time_step"] / ONE_SECOND
 
     def test_chunk_select(self, dir_spool_index_out_of_order):
         """Ensure chunking can be performed first, then selecting."""
@@ -473,7 +475,7 @@ class TestFileSpoolIntegrations:
         # str should work
         assert str(non_distance_dir_spool)
         contents = non_distance_dir_spool.get_contents()
-        assert len(contents) == 2
+        assert len(contents) == 1
         for patch in non_distance_dir_spool:
             assert isinstance(patch, dc.Patch)
 

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -28,7 +28,7 @@ def dir_spool_index_out_of_order(random_spool, tmp_path_factory):
     path = tmp_path_factory.mktemp("out_of_order_index")
     spool = dc.spool(path)
     # sort patches by starttime
-    patch_list = sorted(random_spool, key=lambda x: x.summary.time_min)
+    patch_list = sorted(random_spool, key=lambda x: x.get_coord("time").min())
     # write patches to disk out of order.
     patch_list[-1].io.write(path / "patch_3.h5", "dasdae")
     spool.update()
@@ -103,7 +103,7 @@ class TestDirectorySpoolBasics:
         dc.write(dc.spool([patch_1, patch_2]), path / "multi_patch.h5", "dasdae")
         spool = DirectorySpool(path).update().sort("time")
         patch = spool[0]
-        assert patch.summary.time_min == patch_2.summary.time_min
+        assert patch.get_coord("time").min() == patch_2.get_coord("time").min()
 
 
 class TestDirectoryIndex:
@@ -224,8 +224,8 @@ class TestSelect:
         assert (df["time_max"] <= new_max).all()
         # as well as the patches produced
         for patch in spool:
-            assert patch.summary["time_min"] >= new_min
-            assert patch.summary["time_max"] <= new_max
+            assert patch.get_coord("time").min() >= new_min
+            assert patch.get_coord("time").max() <= new_max
 
     def test_sub_select_tag_equals(self, basic_file_spool, spool_tag):
         """Ensure selecting stations works."""
@@ -257,10 +257,9 @@ class TestSelect:
         assert (new_content["time_max"] <= new_max).all()
         # then check patches
         for patch in out:
-            summary = patch.summary
             assert patch.attrs["network"] == "das2"
             assert patch.attrs["tag"].startswith("ran")
-            assert summary["time_max"] <= new_max
+            assert patch.get_coord("time").max() <= new_max
         # ensure raises when selecting off the end of the spool
         with pytest.raises(IndexError):
             out[len(new_content)]
@@ -272,7 +271,7 @@ class TestSelect:
         spool1 = basic_file_spool.select(time=(None, dt))
         spool2 = basic_file_spool.select(time=(None, time_str))
         for pa1, pa2 in zip(spool1, spool2):
-            assert pa1.summary["time_max"] == pa2.summary["time_max"]
+            assert pa1.get_coord("time").max() == pa2.get_coord("time").max()
 
     def test_select_non_zero_index(self, diverse_directory_spool):
         """
@@ -297,8 +296,9 @@ class TestSelect:
     def test_select_correct_history_str(self, diverse_directory_spool):
         """Ensure no history string is added for selecting. See #142/#147."""
         spool = diverse_directory_spool
-        t1 = spool[0].summary.time_min
-        dt = spool[0].summary.time_step
+        time_coord = spool[0].get_coord("time")
+        t1 = time_coord.min()
+        dt = time_coord.step
         selected_spool = spool.select(time=(t1, t1 + 30 * dt))
         patch = selected_spool[0]
         history = patch.attrs.history
@@ -350,9 +350,10 @@ class TestBasicChunk:
         assert len(new) == 1
         patch = new[0]
         content = spool.get_contents()
-        assert patch.summary.time_min == content["time_min"].min()
-        assert patch.summary.time_max == content["time_max"].max()
-        assert patch.summary.time_step == spool[0].summary.time_step
+        time_coord = patch.get_coord("time")
+        assert time_coord.min() == content["time_min"].min()
+        assert time_coord.max() == content["time_max"].max()
+        assert time_coord.step == spool[0].get_coord("time").step
 
     def test_chunk_out_of_order_index(self, dir_spool_index_out_of_order):
         """Ensure when the index isn't ordered chunk can still work."""
@@ -361,11 +362,12 @@ class TestBasicChunk:
         chunk = spool.chunk(time=time)
         for patch in chunk:
             assert isinstance(patch, dc.Patch)
-            dur = (patch.summary.time_max - patch.summary.time_min) / ONE_SECOND
+            time_coord = patch.get_coord("time")
+            dur = (time_coord.max() - time_coord.min()) / ONE_SECOND
             diff = np.abs(dur - time)
             # because we try to avoid overlaps, the segments can be up to 2
             # samples shorter than what was asked for. Maybe revisit this?
-            assert diff <= 2 * (patch.summary.time_step / ONE_SECOND)
+            assert diff <= 2 * (time_coord.step / ONE_SECOND)
 
     def test_chunk_redundant_index(self, directory_spool_redundant_index):
         """Ensure redundant indices are handled effectively with chunking"""
@@ -445,12 +447,12 @@ class TestFileSpoolIntegrations:
         )
         for patch in spool:
             assert isinstance(patch, dc.Patch)
-            summary = patch.summary
             assert patch.attrs["network"] == network
-            assert summary["time_max"] <= endtime
-            patch_duration = (summary["time_max"] - summary["time_min"]) / ONE_SECOND
+            time_coord = patch.get_coord("time")
+            assert time_coord.max() <= endtime
+            patch_duration = (time_coord.max() - time_coord.min()) / ONE_SECOND
             diff = patch_duration - duration
-            assert abs(diff) <= 1.5 * summary["time_step"] / ONE_SECOND
+            assert abs(diff) <= 1.5 * time_coord.step / ONE_SECOND
 
     def test_chunk_select(self, dir_spool_index_out_of_order):
         """Ensure chunking can be performed first, then selecting."""

--- a/tests/test_clients/test_filespool.py
+++ b/tests/test_clients/test_filespool.py
@@ -54,8 +54,8 @@ class TestBasic:
     def test_chunk(self, terra15_file_spool):
         """Ensure chunking along time axis works with FileSpool."""
         spool = terra15_file_spool
-        summary = spool[0].summary
-        duration = summary.time_max - summary.time_min
+        time_coord = spool[0].get_coord("time")
+        duration = time_coord.max() - time_coord.min()
         dt = duration / 3
         spool = terra15_file_spool.chunk(time=dt, keep_partial=True)
         assert len(spool) == 3
@@ -70,7 +70,7 @@ class TestBasic:
         dc.write(dc.spool([patch_1, patch_2]), path, "dasdae", file_version="1")
         spool = FileSpool(path).sort("time")
         patch = spool[0]
-        assert patch.summary.time_min == patch_2.summary.time_min
+        assert patch.get_coord("time").min() == patch_2.get_coord("time").min()
 
     def test_multi_patch_without_source_patch_id_raises(self, tmp_path):
         """Multi-patch reload should fail instead of guessing from row index."""

--- a/tests/test_clients/test_filespool.py
+++ b/tests/test_clients/test_filespool.py
@@ -6,6 +6,7 @@ import pytest
 
 import dascore as dc
 from dascore.clients.filespool import FileSpool
+from dascore.exceptions import PatchAttributeError
 from dascore.utils.hdf5 import HDFPatchIndexManager
 
 
@@ -53,10 +54,30 @@ class TestBasic:
     def test_chunk(self, terra15_file_spool):
         """Ensure chunking along time axis works with FileSpool."""
         spool = terra15_file_spool
-        attrs = spool[0].attrs
-        duration = attrs.time_max - attrs.time_min
+        summary = spool[0].summary
+        duration = summary.time_max - summary.time_min
         dt = duration / 3
         spool = terra15_file_spool.chunk(time=dt, keep_partial=True)
         assert len(spool) == 3
         for patch in spool:
             assert isinstance(patch, dc.Patch)
+
+    def test_sorted_multi_patch_uses_source_patch_id(self, tmp_path):
+        """Sorting should not change which source patch gets reloaded."""
+        path = tmp_path / "multi_patch.h5"
+        patch_2 = dc.get_example_patch()
+        patch_1 = patch_2.update_coords(time=patch_2.coords.get_array("time") + 10)
+        dc.write(dc.spool([patch_1, patch_2]), path, "dasdae", file_version="1")
+        spool = FileSpool(path).sort("time")
+        patch = spool[0]
+        assert patch.summary.time_min == patch_2.summary.time_min
+
+    def test_multi_patch_without_source_patch_id_raises(self, tmp_path):
+        """Multi-patch reload should fail instead of guessing from row index."""
+        path = tmp_path / "multi_patch.h5"
+        spool = dc.examples.get_example_spool("random_das", length=2)
+        dc.write(spool, path, "dasdae", file_version="1")
+        file_spool = FileSpool(path)
+        kwargs = {"path": str(path), "file_format": "DASDAE", "file_version": "1"}
+        with pytest.raises(PatchAttributeError, match="uniquely resolved"):
+            file_spool._load_patch(kwargs)

--- a/tests/test_core/test_attrs.py
+++ b/tests/test_core/test_attrs.py
@@ -1,4 +1,4 @@
-"""Tests for Patch attrs modules."""
+"""Tests for PatchAttrs."""
 
 from __future__ import annotations
 
@@ -8,192 +8,103 @@ import pytest
 from pydantic import ValidationError
 
 import dascore as dc
-from dascore.core.attrs import (
-    PatchAttrs,
-)
-from dascore.core.coords import CoordSummary, get_coord
-from dascore.utils.misc import register_func
-
-MORE_COORDS_ATTRS = []
+from dascore.core.attrs import PatchAttrs
+from dascore.core.coords import get_coord
 
 
 @pytest.fixture(scope="class")
 def random_summary(random_patch) -> PatchAttrs:
-    """Return the summary of the random patch."""
+    """Return attrs reconstructed from pure patch attrs."""
     return PatchAttrs.model_validate(random_patch.attrs.model_dump())
 
 
 @pytest.fixture(scope="class")
 def random_attrs(random_patch) -> PatchAttrs:
-    """Return the summary of the random patch."""
+    """Return patch attrs view."""
     return random_patch.attrs
-
-
-@pytest.fixture(scope="session")
-@register_func(MORE_COORDS_ATTRS)
-def attrs_coords_1() -> PatchAttrs:
-    """Add non-standard coords to attrs."""
-    attrs = {"depth_min": 10.0, "depth_max": 12.0, "another_name": "FooBar"}
-    out = PatchAttrs(**attrs)
-    assert "depth" in out.coords
-    return out
-
-
-@pytest.fixture(scope="session")
-@register_func(MORE_COORDS_ATTRS)
-def attrs_coords_2() -> PatchAttrs:
-    """Add non-standard coords to attrs."""
-    coords = {"depth": {"min": 10.0, "max": 12.0}}
-    attrs = {"coords": coords, "another_name": "FooBar"}
-    return PatchAttrs(**attrs)
-
-
-@pytest.fixture(scope="session", params=MORE_COORDS_ATTRS)
-def more_coords_attrs(request) -> PatchAttrs:
-    """
-    Meta fixture for attributes with extra coords.
-    These are initiated in different ways but should be identical.
-    """
-    return request.getfixturevalue(request.param)
 
 
 class TestPatchAttrs:
     """Basic tests on patch attributes."""
 
-    def test_get(self, random_attrs):
-        """Ensure get returns existing values."""
-        out = random_attrs.get("time_min")
-        assert out == random_attrs.time_min
-
     def test_get_existing_key(self, random_attrs):
         """Ensure get returns existing values."""
-        out = random_attrs.get("time_min")
-        assert out == random_attrs.time_min
+        assert random_attrs.get("tag") == random_attrs.tag
 
     def test_get_no_key(self, random_attrs):
         """Ensure missing keys return default value."""
-        out = random_attrs.get("not_a_key", 1)
-        assert out == 1
+        assert random_attrs.get("not_a_key", 1) == 1
 
-    def test_immutable(self, random_attrs):
-        """Ensure random_attrs is faux-immutable."""
+    def test_immutable(self):
+        """PatchAttrs instances remain frozen."""
+        attrs = PatchAttrs(tag="bob")
         with pytest.raises(ValidationError, match="Instance is frozen"):
-            random_attrs.bob = 1
-        with pytest.raises(ValidationError, match="Instance is frozen"):
-            random_attrs["bob"] = 1
+            attrs.tag = "bill"
 
-    def test_coords_with_coord_keys(self):
-        """Ensure coords with base keys work."""
-        coords = {"distance": get_coord(data=np.arange(100))}
-        out = PatchAttrs(**{"coords": coords})
-        assert out.coords
-        assert "distance" in out.coords
-        for _name, val in out.coords.items():
-            assert isinstance(val, CoordSummary)
+    def test_model_validate_existing_instance(self):
+        """Model validation should accept existing PatchAttrs instances."""
+        attrs = PatchAttrs(tag="bob")
+        assert PatchAttrs.model_validate(attrs) == attrs
 
-    def test_coords_with_coord_manager(self, random_patch):
-        """Ensure coords with a coord manager works."""
-        cm = random_patch.coords
-        out = PatchAttrs(**{"coords": cm})
-        assert out.coords
-        assert set(cm.coord_map) == set(out.coords)
-        assert out.dims == ",".join(cm.dims)
+    def test_model_validate_non_mapping(self):
+        """Non-mapping inputs should pass through to normal model validation."""
+        with pytest.raises(ValidationError):
+            PatchAttrs.model_validate(1)
 
-    def test_coords_are_coord_summary(self, more_coords_attrs):
-        """All the coordinates should be Coordinate Summarys not dict."""
-        for _, coord_sum in more_coords_attrs.coords.items():
-            assert isinstance(coord_sum, CoordSummary)
+    def test_rejects_coord_keys(self):
+        """Unknown flat keys remain allowed at raw PatchAttrs construction."""
+        out = PatchAttrs(time_min=1, time_max=10)
+        assert out.time_min == 1
+        assert out.time_max == 10
 
-    def test_access_min_max_step_etc(self, more_coords_attrs):
-        """Ensure min, max, step etc can be accessed for new coordinate."""
-        expected_attrs = ["_min", "_max", "_step", "_units", "_dtype"]
-        for eat in expected_attrs:
-            attr_name = "depth" + eat
-            assert hasattr(more_coords_attrs, attr_name)
-            val = getattr(more_coords_attrs, attr_name)
-            if eat == "min":
-                assert val == 10.0
-            if eat == "max":
-                assert val == 12.0
+    def test_rejects_coords_mapping(self):
+        """Nested coords are rejected as well."""
+        with pytest.raises(ValueError, match="no longer accepts coordinate metadata"):
+            PatchAttrs(coords={"time": {"min": 0, "max": 1}})
 
-    def test_deprecated_d_set(self):
-        """Ensure setting attributes d_whatever is deprecated."""
-        with pytest.warns(DeprecationWarning):
-            PatchAttrs(time_min=1, time_max=10, d_time=10)
+    def test_rejects_coords_key(self):
+        """String coords values are allowed as plain extra attrs."""
+        out = PatchAttrs(coords="not-valid")
+        assert out.coords == "not-valid"
 
-    def test_deprecated_d_get(self, random_attrs):
-        """Access attr.d_{whatever} is deprecated."""
-        with pytest.warns(DeprecationWarning):
-            _ = random_attrs.d_time
+    def test_rejects_coord_manager(self, random_patch):
+        """CoordManager input should be rejected."""
+        with pytest.raises(ValueError, match="no longer accepts coordinate metadata"):
+            PatchAttrs(coords=random_patch.coords)
 
-    def test_access_coords(self, more_coords_attrs):
-        """Ensure coordinates can be accessed as well."""
-        assert "depth" in more_coords_attrs.coords
-        assert more_coords_attrs.coords["depth"].min == more_coords_attrs.depth_min
+    def test_ignores_dims(self):
+        """Dimensions are ignored during raw construction normalization."""
+        out = PatchAttrs(dims="time,distance")
+        assert "dims" not in out.model_dump()
 
-    def test_extra_attrs_not_in_dump(self, more_coords_attrs):
-        """When using the extra attrs, they shouldn't show up in the dump."""
-        dump = more_coords_attrs.model_dump()
-        not_expected = {"depth_min", "depth_max", "depth_step"}
-        assert not_expected.isdisjoint(set(dump))
+    def test_extra_attrs_supported(self):
+        """Non-coordinate extras should still be supported."""
+        out = PatchAttrs(bob="doesnt", bill_min=12)
+        assert out.bob == "doesnt"
+        assert out.bill_min == 12
 
     def test_extra_attrs_not_in_dump_random_attrs(self, random_attrs):
-        """When using the extra attrs, they shouldn't show up in the dump."""
+        """Coord summaries should not be present in attrs dumps."""
         dump = random_attrs.model_dump()
         not_expected = {"time_min", "time_max", "time_step"}
         assert not_expected.isdisjoint(set(dump))
 
-    def test_supports_extra_attrs(self):
-        """The attr dict should allow extra attributes."""
-        out = PatchAttrs(bob="doesnt", bill_min=12, bob_max="2012-01-12")
-        assert out.bob == "doesnt"
-        assert out.bill_min == 12
-
-    def test_flat_dump(self, more_coords_attrs):
-        """Ensure flat dump flattens out the coords."""
-        out = more_coords_attrs.flat_dump()
-        expected = {
-            "depth_min",
-            "depth_max",
-            "depth_step",
-            "depth_units",
-            "depth_dtype",
-        }
-        assert set(out).issuperset(expected)
-
-    def test_flat_dump_coords(self, more_coords_attrs):
-        """Ensure flat dim with dim_tuple works."""
-        attrs = more_coords_attrs
-        out = attrs.flat_dump(dim_tuple=True)
-        assert "depth" in out
-        depth = attrs.coords["depth"]
-        dep_min, dep_max = depth.min, depth.max
-        assert out["depth"] == (dep_min, dep_max)
-
-    def test_coords_to_coord_summary(self):
-        """Coordinates included in coords should be converted to coord summary."""
-        out = {
-            "station": "01",
-            "coords": {
-                "time": get_coord(start=0, stop=10, step=1),
-                "distance": get_coord(start=10, stop=100, step=1, units="m"),
-            },
-        }
-        attr = dc.PatchAttrs(**out)
-        assert attr.dims == ",".join(("time", "distance"))
-        for name, coord in attr.coords.items():
-            assert isinstance(coord, CoordSummary)
+    def test_flat_dump_matches_model_dump(self, random_patch):
+        """Patch summaries flatten attrs and coordinate summaries."""
+        out = random_patch.summary.flat_dump()
+        assert out["time_min"] == random_patch.coords.min("time")
+        assert out["distance_max"] == random_patch.coords.max("distance")
 
     def test_items(self, random_patch):
         """Ensure items works like a dict."""
         attrs = random_patch.attrs
-        out = dict(attrs.items())
-        assert out == attrs.model_dump()
+        assert dict(attrs.items()) == attrs.model_dump()
 
-    def test_dims_match_attrs(self, random_patch):
-        """Ensure the dims from patch attrs matches patch dims."""
+    def test_dims_live_on_patch(self, random_patch):
+        """Dimensions remain available on patch after renaming coords."""
         pat = random_patch.rename_coords(distance="channel")
-        assert pat.dims == pat.attrs.dim_tuple
+        assert pat.dims == ("channel", "time")
+        assert "dims" not in pat.attrs.model_dump()
 
 
 class TestSummaryAttrs:
@@ -203,48 +114,50 @@ class TestSummaryAttrs:
         """Ensure all the expected attrs are extracted."""
         summary1 = dict(random_summary)
         attrs = dict(random_patch.attrs)
-        common_keys = set(summary1) & set(attrs)
-        for key in common_keys:
+        for key in set(summary1) & set(attrs):
             assert summary1[key] == attrs[key]
 
     def test_can_jsonize(self, random_summary):
         """Ensure the summary can be converted to json."""
-        json = random_summary.model_dump_json()
-        assert isinstance(json, str)
+        assert isinstance(random_summary.model_dump_json(), str)
 
     def test_can_roundtrip(self, random_summary):
         """Ensure json can be round-tripped."""
         json = random_summary.model_dump_json()
-        random_summary2 = PatchAttrs.model_validate_json(json)
-        assert random_summary2 == random_summary
+        assert PatchAttrs.model_validate_json(json) == random_summary
 
     def test_from_dict(self, random_attrs):
-        """Test new method for more intuitive init."""
+        """from_dict should accept attrs views and mappings."""
         out = PatchAttrs.from_dict(random_attrs)
-        assert out == random_attrs
+        assert isinstance(out, PatchAttrs)
         new_dict = dict(random_attrs)
         new_dict["data_units"] = "m/s"
         out = PatchAttrs.from_dict(new_dict)
         assert isinstance(out, PatchAttrs)
 
+    def test_from_dict_none(self):
+        """from_dict should normalize None to an empty attrs instance."""
+        out = PatchAttrs.from_dict(None)
+        assert isinstance(out, PatchAttrs)
+        assert out.model_dump() == PatchAttrs().model_dump()
 
-class TestRenameDimension:
-    """Ensure rename dimension works."""
+    def test_from_dict_drops_dims(self):
+        """from_dict should continue dropping dims during normalization."""
+        out = PatchAttrs.from_dict({"tag": "bob", "dims": "time,distance"})
+        assert out.tag == "bob"
+        assert "dims" not in out.model_dump()
 
-    def test_simple_rename(self, random_attrs):
-        """Ensure renaming a dimension works."""
-        attrs = random_attrs
-        new_name = "money"
-        time_ind = attrs.dim_tuple.index("time")
-        out = attrs.rename_dimension(time=new_name)
-        assert new_name in out.dims
-        assert out.dim_tuple[time_ind] == new_name
-        assert len(out.dim_tuple) == len(attrs.dim_tuple)
+    def test_from_dict_model_dump_provider(self, random_patch):
+        """from_dict should accept non-PatchAttrs objects with model_dump."""
 
-    def test_empty_rename(self, random_attrs):
-        """Passing no kwargs should return same attrs."""
-        attrs = random_attrs.rename_dimension()
-        assert attrs == random_attrs
+        class ModelDumpProvider:
+            """Simple object that only exposes model_dump."""
+
+            def model_dump(self):
+                return {"tag": random_patch.attrs.tag}
+
+        out = PatchAttrs.from_dict(ModelDumpProvider())
+        assert isinstance(out, PatchAttrs)
 
 
 class TestDropPrivate:
@@ -253,9 +166,12 @@ class TestDropPrivate:
     def test_simple_drop_private(self):
         """Ensure private attrs are removed after operation."""
         attrs = PatchAttrs(_private1=1, extra_attr=2).drop_private()
-        attr_dict = dict(attrs)
-        assert "_private1" not in attr_dict
-        assert "extra_attr" in attr_dict
+        assert "_private1" not in dict(attrs)
+        assert "extra_attr" in dict(attrs)
+
+    def test_flat_dump_alias(self, random_attrs):
+        """flat_dump should stay an alias for model_dump."""
+        assert random_attrs.flat_dump() == random_attrs.model_dump()
 
 
 class TestDrop:
@@ -272,40 +188,38 @@ class TestDrop:
 class TestMisc:
     """Misc small tests."""
 
-    def test_get_attrs_non_dim_coordinates(self, random_patch_with_lat_lon):
-        """
-        Ensure only dims show up in dims even when coord manager has many
-        coordinates.
-        """
-        patch = random_patch_with_lat_lon
-        cm = patch.coords
-        attrs = dc.PatchAttrs(coords=cm)
-        assert attrs.dim_tuple == cm.dims
+    def test_patch_summary_exposes_coord_summaries(self, random_patch_with_lat_lon):
+        """Patch summary should expose coordinate summary accessors."""
+        summary = random_patch_with_lat_lon.summary
+        assert summary.time_min == random_patch_with_lat_lon.coords.min("time")
+        assert (
+            random_patch_with_lat_lon.summary.get_coord_summary("time")
+            == random_patch_with_lat_lon.coords.to_summary_dict()["time"]
+        )
 
 
 class TestUpdateAttrs:
     """Tests for updating attributes."""
 
-    def test_attrs_can_update(self, random_attrs):
-        """Ensure attributes can update coordinates."""
-        attrs = random_attrs.update(distance_units="miles")
-        expected = dc.get_quantity("miles")
-        assert dc.get_quantity(attrs.coords["distance"].units) == expected
+    def test_attrs_can_update_non_coord_fields(self, random_attrs):
+        """Non-coordinate updates still work."""
+        attrs = PatchAttrs.from_dict(random_attrs).update(tag="miles")
+        assert attrs.tag == "miles"
 
-    def test_update_from_coords(self, random_patch):
-        """Ensure attrs.update updates dims from coords."""
-        attrs = random_patch.attrs
-        new_patch = random_patch.rename_coords(distance="channel")
-        new = attrs.update(coords=new_patch.coords)
-        assert new.dim_tuple == new_patch.dims
+    def test_update_allows_coord_like_fields(self, random_attrs):
+        """Flat coordinate-like fields are now treated as plain attrs."""
+        out = PatchAttrs.from_dict(random_attrs).update(distance_units="miles")
+        assert out.distance_units == "miles"
 
-    def test_update_coord_summary(self, random_patch):
-        """Ensure updating attrs updates the summary."""
-        coords, _ = random_patch.coords.drop_coords("distance")
-        attr = random_patch.attrs.update(coords=coords)
-        coord_summary = attr.coords
-        # Distance should have been dropped from the coord summary.
-        assert set(coord_summary) == set(coords.coord_map)
+    def test_update_rejects_nested_coords(self, random_patch):
+        """Passing coords directly should fail."""
+        with pytest.raises(ValueError, match="no longer accepts coordinate metadata"):
+            PatchAttrs.from_dict(random_patch.attrs).update(coords=random_patch.coords)
+
+    def test_update_ignores_dims(self, random_attrs):
+        """Passing dimensions directly should be ignored by normalization."""
+        out = PatchAttrs.from_dict(random_attrs).update(dims=("time", "distance"))
+        assert "dims" not in out.model_dump()
 
 
 class TestGetAttrSummary:
@@ -315,3 +229,17 @@ class TestGetAttrSummary:
         """Ensure a dataframe is returned."""
         out = random_attrs.get_summary_df()
         assert isinstance(out, pd.DataFrame)
+
+
+class TestSeparateConstruction:
+    """Tests for constructing coords separately from attrs."""
+
+    def test_patch_accepts_coords_and_attrs(self):
+        """Patch construction should keep attrs pure while coords carry summaries."""
+        coord = get_coord(start=0, stop=10, step=1)
+        patch = dc.Patch(
+            data=np.asarray([[1] * 10]),
+            coords={"time": coord, "distance": [0]},
+            dims=("distance", "time"),
+        )
+        assert patch.summary.time_min == coord.min()

--- a/tests/test_core/test_attrs.py
+++ b/tests/test_core/test_attrs.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 import dascore as dc
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coords import get_coord
+from dascore.exceptions import PatchAttributeError
 
 
 @pytest.fixture(scope="class")
@@ -191,7 +192,9 @@ class TestMisc:
     def test_patch_summary_exposes_coord_summaries(self, random_patch_with_lat_lon):
         """Patch summary should expose coordinate summary accessors."""
         summary = random_patch_with_lat_lon.summary
-        assert summary.time_min == random_patch_with_lat_lon.coords.min("time")
+        assert summary.get_coord_summary(
+            "time"
+        ).min == random_patch_with_lat_lon.coords.min("time")
         assert (
             random_patch_with_lat_lon.summary.get_coord_summary("time")
             == random_patch_with_lat_lon.coords.to_summary_dict()["time"]
@@ -206,14 +209,14 @@ class TestUpdateAttrs:
         attrs = PatchAttrs.from_dict(random_attrs).update(tag="miles")
         assert attrs.tag == "miles"
 
-    def test_update_allows_coord_like_fields(self, random_attrs):
-        """Flat coordinate-like fields are now treated as plain attrs."""
-        out = PatchAttrs.from_dict(random_attrs).update(distance_units="miles")
-        assert out.distance_units == "miles"
+    def test_update_rejects_coord_like_fields(self, random_attrs):
+        """Flat coordinate-like fields should go through update_coords instead."""
+        with pytest.raises(PatchAttributeError, match="update_coords"):
+            PatchAttrs.from_dict(random_attrs).update(time_min=1)
 
     def test_update_rejects_nested_coords(self, random_patch):
         """Passing coords directly should fail."""
-        with pytest.raises(ValueError, match="no longer accepts coordinate metadata"):
+        with pytest.raises(PatchAttributeError, match="coordinate metadata"):
             PatchAttrs.from_dict(random_patch.attrs).update(coords=random_patch.coords)
 
     def test_update_ignores_dims(self, random_attrs):
@@ -242,4 +245,4 @@ class TestSeparateConstruction:
             coords={"time": coord, "distance": [0]},
             dims=("distance", "time"),
         )
-        assert patch.summary.time_min == coord.min()
+        assert patch.summary.get_coord_summary("time").min == coord.min()

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -50,10 +50,11 @@ class TestGetCoordManager:
             get_coord_manager(coords=coords, attrs=attrs)
 
     def test_coords_from_attrs(self, random_patch):
-        """Ensure we can get coordinates from patch attrs."""
+        """Patch attrs no longer reconstruct coordinates."""
         attrs = random_patch.attrs
-        cm = get_coord_manager(attrs=attrs)
-        assert "time" in cm.coord_map
+        out = get_coord_manager(attrs=attrs)
+        assert out.dims == ()
+        assert not out.coord_map
 
     def test_non_coord_dims(self):
         """Ensure non coordinate dimensions can be created using shape."""
@@ -209,11 +210,9 @@ class TestBasicCoordManager:
             coord = getattr(cm_basic, dim)
             assert coord == cm_basic.coord_map[dim]
 
-    def test_get_item_warning(self, cm_basic):
-        """Ensure get item emits a warning."""
-        msg = "returns a numpy array"
-        with pytest.warns(UserWarning, match=msg):
-            _ = cm_basic["time"]
+    def test_get_item_returns_coord(self, cm_basic):
+        """Ensure get item returns the coordinate."""
+        assert cm_basic["time"] == cm_basic.get_coord("time")
 
     def test_has_attr(self, cm_basic):
         """Ensure hasattr returns correct result."""
@@ -237,7 +236,9 @@ class TestBasicCoordManager:
         """Ensure we can get a scaler value for the coordinate."""
         coord_array = random_patch.get_coord("time").data
         expected = (
-            np.max(coord_array) - np.min(coord_array) + random_patch.attrs["time_step"]
+            np.max(coord_array)
+            - np.min(coord_array)
+            + random_patch.summary["time_step"]
         )
         assert random_patch.coords.coord_range("time") == expected
 
@@ -963,19 +964,19 @@ class TestUpdateFromAttrs:
             assert new_coord.min() == coord.min()
 
     def test_attrs_as_dict(self, cm_basic):
-        """Ensure the attrs returned has coords attached."""
+        """Returned attrs should stay pure metadata."""
         coord = cm_basic.coord_map["time"]
         attrs = {"time_max": coord.min()}
         cm, attrs = cm_basic.update_from_attrs(attrs)
-        assert attrs.coords == cm.to_summary_dict()
-        assert attrs.dim_tuple == cm.dims
+        assert "dims" not in attrs.model_dump()
+        assert cm.dims == cm_basic.dims
 
     def test_attrs_as_patch_attr(self, cm_basic):
-        """Ensure this also works when attrs is a patch attr."""
-        attrs = dc.PatchAttrs(time_min=to_datetime64("2022-01-01"))
+        """Ensure pure PatchAttrs inputs are still accepted."""
+        attrs = dc.PatchAttrs(tag="example")
         cm, new_attrs = cm_basic.update_from_attrs(attrs)
-        assert new_attrs.coords == cm.to_summary_dict()
-        assert new_attrs.dim_tuple == cm.dims
+        assert new_attrs == attrs
+        assert cm.dims == cm_basic.dims
 
     def test_consistent_attrs_leaves_coords_unchanged(self, random_patch):
         """Attrs which are already consistent should leave coord unchanged."""
@@ -1274,7 +1275,7 @@ class TestSnap:
     ):
         """Ensure snapping creates expected dt from merged df."""
         spool = memory_spool_small_dt_differences
-        expected_dt = get_middle_value([x.attrs.time_step for x in spool])
+        expected_dt = get_middle_value([x.summary.time_step for x in spool])
         snapped = cm_dt_small_diff.snap()[0]
         assert snapped.coord_map["time"].step == expected_dt
 

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -238,7 +238,7 @@ class TestBasicCoordManager:
         expected = (
             np.max(coord_array)
             - np.min(coord_array)
-            + random_patch.summary["time_step"]
+            + random_patch.get_coord("time").step
         )
         assert random_patch.coords.coord_range("time") == expected
 
@@ -1275,7 +1275,7 @@ class TestSnap:
     ):
         """Ensure snapping creates expected dt from merged df."""
         spool = memory_spool_small_dt_differences
-        expected_dt = get_middle_value([x.summary.time_step for x in spool])
+        expected_dt = get_middle_value([x.get_coord("time").step for x in spool])
         snapped = cm_dt_small_diff.snap()[0]
         assert snapped.coord_map["time"].step == expected_dt
 

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -431,6 +431,13 @@ class TestCoordSummary:
         out = CoordSummary(**data)
         assert np.dtype(out.dtype) == np.dtype(type(data["min"]))
 
+    def test_json_serializer(self):
+        """JSON serialization should stringify values."""
+        summary = CoordSummary(min=1.0, max=2.0, step=0.5, units="m")
+        dumped = summary.model_dump(mode="json")
+        assert dumped["units"] == "m"
+        assert dumped["min"] == "1.0"
+
 
 class TestGetSliceTuple:
     """Tests for getting slice tuples."""
@@ -1015,6 +1022,12 @@ class TestCoordRange:
             assert np.all(np.equal(values1, values2))
         else:
             np.allclose(values1, values2 / factor)
+
+    def test_update_convert_units_branch(self):
+        """Updating units should route through convert_units."""
+        coord = get_coord(data=np.arange(5.0), units="m")
+        out = coord.update(units="ft")
+        assert out.units == get_quantity("ft")
 
     def test_select_date_string(self, evenly_sampled_date_coord):
         """Ensure string selection works with datetime objects."""

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -442,6 +442,12 @@ class TestPatchSummary:
         with pytest.raises(TypeError):
             _ = summary["time_min"]
 
+    def test_summary_get_coord_is_removed(self, random_patch):
+        """PatchSummary should only expose get_coord_summary."""
+        summary = random_patch.summary
+        with pytest.raises(AttributeError, match="get_coord"):
+            summary.get_coord("time")
+
     def test_flat_dump_prefers_coord_values_over_attrs(self, random_patch):
         """flat_dump should overlay coord summaries on top of attrs."""
         attrs = dc.PatchAttrs(**(random_patch.attrs.model_dump() | {"time_step": 10}))

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 
 import operator
 import weakref
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 from rich.text import Text
 
 import dascore as dc
 from dascore.compat import random_state
 from dascore.core import Patch
 from dascore.core.coords import BaseCoord, CoordRange
-from dascore.exceptions import CoordError, ParameterError
+from dascore.core.summary import PatchSummary
+from dascore.exceptions import CoordError, ParameterError, PatchAttributeError
+from dascore.io.core import _load_patch_summary, _select_patch_from_spool
 from dascore.proc.basic import apply_operator
 from dascore.utils.misc import suppress_warnings
 
@@ -26,11 +30,9 @@ def get_simple_patch() -> Patch:
     Note: This cant be a fixture as pytest seems to hold a reference,
     even for function scoped outputs.
     """
-    attrs = {"time_step": 1}
     pa = Patch(
         data=random_state.random((100, 100)),
         coords={"time": np.arange(100) * 0.01, "distance": np.arange(100) * 0.2},
-        attrs=attrs,
         dims=("time", "distance"),
     )
     return pa
@@ -46,10 +48,12 @@ class TestInit:
         """Create a random patch with a datetime coord."""
         rand = np.random.RandomState(13)
         array = rand.random(size=(20, 200))
-        attrs = dict(dx=1, time_step=1 / 250.0, category="DAS", id="test_data1")
-        time_deltas = dc.to_timedelta64(np.arange(array.shape[1]) * attrs["time_step"])
+        dx = 1
+        dt = 1 / 250.0
+        attrs = dict(category="DAS", id="test_data1")
+        time_deltas = dc.to_timedelta64(np.arange(array.shape[1]) * dt)
         coords = dict(
-            distance=np.arange(array.shape[0]) * attrs["dx"],
+            distance=np.arange(array.shape[0]) * dx,
             time=self.time1 + time_deltas,
         )
         dims = tuple(coords)
@@ -62,10 +66,10 @@ class TestInit:
         rand = np.random.RandomState(13)
         array = rand.random(size=(20, 100))
         dt = 1 / 250.0
-        attrs = dict(distance_step=1, time_step=dt, category="DAS", id="test_data1")
-        time_deltas = dc.to_timedelta64(np.arange(array.shape[1]) * attrs["time_step"])
+        attrs = dict(category="DAS", id="test_data1")
+        time_deltas = dc.to_timedelta64(np.arange(array.shape[1]) * dt)
         coords = dict(
-            distance=np.arange(array.shape[0]) * attrs["distance_step"],
+            distance=np.arange(array.shape[0]),
             time=self.time1 + time_deltas,
             latitude=("distance", array[:, 0]),
             quality=(("distance", "time"), array),
@@ -78,7 +82,7 @@ class TestInit:
     def test_conflicting_attrs_coords_raises(self):
         """Patch for testing conflicting coordinates/attributes."""
         array = random_state.random((10, 10))
-        # create attrs, these should all get overwritten by coords.
+        # create attrs with coordinate metadata; these should now be rejected.
         attrs = dict(
             distance_step=10,
             time_step=dc.to_timedelta64(1),
@@ -95,28 +99,39 @@ class TestInit:
         # assemble and output.
         dims = ("distance", "time")
         out = dict(data=array, coords=coords, attrs=attrs, dims=dims)
-        msg = "Coords and attrs are incompatible."
+        msg = "coordinate metadata"
         with pytest.raises(ValueError, match=msg):
             dc.Patch(**out)
 
     def test_start_time_inferred_from_dt64_coords(self, random_dt_coord):
         """Ensure the time_min and time_max attrs can be inferred from coord time."""
         patch = random_dt_coord
-        assert patch.attrs["time_min"] == self.time1
+        assert patch.summary["time_min"] == self.time1
 
     def test_end_time_inferred_from_dt64_coords(self, random_dt_coord):
         """Ensure the time_min and time_max attrs can be inferred from coord time."""
         patch = random_dt_coord
         time = patch.coords.coord_map["time"].max()
-        assert patch.attrs["time_max"] == time
+        assert patch.summary["time_max"] == time
 
     def test_init_from_array(self, random_patch):
         """Ensure a trace can be created from raw components; array, coords, attrs."""
         assert isinstance(random_patch, Patch)
 
+    def test_init_from_nested_lists(self):
+        """Plain Python lists should still be valid array-like patch inputs."""
+        patch = dc.Patch(
+            data=[[1, 2], [3, 4]],
+            coords={"x": [0, 1], "y": [0, 1]},
+            dims=("x", "y"),
+        )
+        assert patch.shape == (2, 2)
+        assert patch.dims == ("x", "y")
+        np.testing.assert_array_equal(patch.data, np.array([[1, 2], [3, 4]]))
+
     def test_max_time_populated(self, random_patch):
         """Ensure the time_max is populated when not explicitly given."""
-        end_time = random_patch.attrs["time_max"]
+        end_time = random_patch.summary["time_max"]
         assert not pd.isnull(end_time)
 
     def test_min_max_populated(self, random_patch):
@@ -171,6 +186,12 @@ class TestInit:
         with pytest.raises(ValueError, match="data, coords, and dims"):
             Patch(data=data)
 
+    def test_missing_data_raises(self):
+        """Patch requires data for non-empty construction."""
+        coords = {"time": np.arange(10), "distance": np.arange(10)}
+        with pytest.raises(ValueError, match="data, coords, and dims"):
+            Patch(coords=coords, dims=("time", "distance"))
+
     def test_coords_from_1_element_array(self):
         """Ensure CoordRange is still returned despite 1D array in time."""
         patch = dc.get_example_patch("random_das", shape=(100, 1))
@@ -191,15 +212,79 @@ class TestInit:
         assert time_shape == len(patch.coords.get_array("time"))
 
     def test_init_no_coords(self, random_patch):
-        """Ensure a new patch can be inited from only attrs."""
+        """Attrs alone no longer provide enough information to build coords."""
         attrs = random_patch.attrs
-        new = random_patch.__class__(attrs=attrs, data=random_patch.data)
-        assert isinstance(new, dc.Patch)
+        with pytest.raises(ValueError, match="data, coords, and dims"):
+            random_patch.__class__(attrs=attrs, data=random_patch.data)
 
     def test_init_with_patch(self, random_patch):
         """Ensure a patch inited on a patch just returns a patch."""
         new = dc.Patch(random_patch)
         assert new == random_patch
+
+    def test_load_patch_summary_with_filters_on_multi_patch_file(self, tmp_path):
+        """Filtered internal summary load should still resolve the correct patch."""
+        path = tmp_path / "multi_patch.h5"
+        spool = dc.examples.get_example_spool("random_das", length=2)
+        dc.write(spool, path, "DASDAE", file_version="1")
+        scanned = dc.scan(path)
+        target = scanned[1]
+        assert target.source_patch_id
+        loaded = _load_patch_summary(target, time=(target.time_min, target.time_max))
+        assert loaded.summary.time_min == target.summary.time_min
+        assert loaded.summary.time_max == target.summary.time_max
+
+    def test_load_patch_summary_requires_path_for_in_memory_summary(self, random_patch):
+        """In-memory summaries cannot be reloaded without a source path."""
+        scanned = dc.scan(random_patch)[0]
+        with pytest.raises(PatchAttributeError, match="no source path"):
+            _load_patch_summary(scanned)
+
+    def test_load_patch_summary_requires_path(self, random_patch):
+        """Summaries without a source path should raise cleanly."""
+        scanned = dc.scan(random_patch)[0]
+        with pytest.raises(PatchAttributeError, match="no source path"):
+            _load_patch_summary(scanned)
+
+    def test_load_patch_summary_passes_source_patch_id_to_read(self, monkeypatch):
+        """Reload should forward source_patch_id and accept a single filtered patch."""
+        patch = dc.get_example_patch()
+        summary = PatchSummary(
+            attrs=patch.attrs,
+            coords=patch.coords.to_summary_dict(),
+            dims=patch.dims,
+            shape=patch.shape,
+            dtype=str(np.dtype(patch.data.dtype)),
+            path=Path("/tmp/example.h5"),
+            file_format="PRODML",
+            file_version="2.1",
+            source_patch_id="node-1",
+        )
+        called = {}
+
+        def fake_read(path, **kwargs):
+            called["path"] = path
+            called["kwargs"] = kwargs
+            return dc.spool([patch])
+
+        monkeypatch.setattr(dc, "read", fake_read)
+        out = _load_patch_summary(summary)
+        assert out == patch
+        assert called["path"] == summary.path
+        assert called["kwargs"]["source_patch_id"] == "node-1"
+
+    def test_load_patch_summary_empty_filtered_read_raises(self, tmp_path):
+        """
+        Internal summary load should translate empty filtered reads to patch errors.
+        """
+        path = tmp_path / "single_patch.h5"
+        patch = dc.get_example_patch()
+        dc.write(patch, path, "DASDAE", file_version="1")
+        scanned = dc.scan(path)[0]
+        with pytest.raises(PatchAttributeError, match="could not be resolved"):
+            _load_patch_summary(
+                scanned, time=(np.datetime64("1900-01-01"), np.datetime64("1900-01-02"))
+            )
 
     def test_non_time_distance_dims(self):
         """Ensure dimensions other than time/distance work."""
@@ -214,11 +299,12 @@ class TestInit:
         assert random_patch.size == random_patch.data.size
 
     def test_new_patch_non_standard_dims(self):
-        """Ensure a non-standard dimension has matching dims in attrs and coords."""
+        """Ensure a non-standard dimension is owned by the patch/coords layer."""
         data = random_state.rand(10, 5)
         coords = {"time": np.arange(10), "can": np.arange(5)}
         patch = dc.Patch(data=data, coords=coords, dims=("time", "can"))
-        assert patch.dims == patch.attrs.dim_tuple
+        assert patch.dims == ("time", "can")
+        assert "dims" not in patch.attrs.model_dump()
 
     def test_non_coord_dims(self):
         """Ensure non-coordinate dimensions can work and create non-coord."""
@@ -266,6 +352,188 @@ class TestNew:
         dims = ("tom", "jerry")
         out = random_patch.new(dims=dims)
         assert out.dims == dims
+
+
+class TestPatchSummary:
+    """Tests for patch summary helpers and selection fallbacks."""
+
+    def test_summary_mapping_methods(self, random_patch):
+        """Summary should behave like a small mapping."""
+        summary = random_patch.summary
+        assert summary["time_min"] == random_patch.coords.min("time")
+        assert summary.get("missing", 1) == 1
+        assert "time_min" in dict(summary.items())
+        with pytest.raises(KeyError):
+            _ = summary["missing"]
+
+    def test_scan_returns_summary(self, random_patch):
+        """Scanning a patch should return a PatchSummary."""
+        scanned = dc.scan(random_patch)[0]
+        assert isinstance(scanned, dc.PatchSummary)
+
+    def test_flat_dump_dim_tuple_and_exclude(self):
+        """flat_dump should support dim tuples and exclusions."""
+        coords = {"time": np.array([0.0, 1.5, 3.5]), "distance": np.array([1.0, 2.0])}
+        data = np.arange(6).reshape(2, 3)
+        patch = dc.Patch(data=data, coords=coords, dims=("distance", "time"))
+        out = patch.summary.flat_dump(dim_tuple=True, exclude={"distance"})
+        assert out["time"] == (patch.coords.min("time"), patch.coords.max("time"))
+        assert "distance_min" not in out
+        assert np.isnan(out["time_step"])
+
+    def test_select_from_spool_by_integer_source_patch_id(self, random_patch):
+        """Integer-like source ids should fall back to positional selection."""
+        spool = dc.spool(
+            [
+                random_patch.update_attrs(tag="first"),
+                random_patch.update_attrs(tag="second"),
+            ]
+        )
+        out = _select_patch_from_spool(spool, source_patch_id="1")
+        assert out.attrs.tag == "second"
+
+    def test_select_from_spool_by_generated_name_raises(self, random_patch):
+        """Generated patch names should not be used as spool identity."""
+        spool = dc.spool(
+            [
+                random_patch.update_attrs(tag="first"),
+                random_patch.update_attrs(tag="second"),
+            ]
+        )
+        patch_name = spool[1].get_patch_name()
+        with pytest.raises(PatchAttributeError, match="uniquely resolved"):
+            _select_patch_from_spool(spool, source_patch_id=patch_name)
+
+    def test_select_from_single_patch_spool_requires_matching_source_patch_id(
+        self, random_patch
+    ):
+        """A requested source id must not be ignored on a single-patch spool."""
+        spool = dc.spool([random_patch])
+        with pytest.raises(PatchAttributeError, match="uniquely resolved"):
+            _select_patch_from_spool(spool, source_patch_id="999")
+
+    def test_select_from_spool_ambiguous_raises(self):
+        """Ambiguous spool selection should raise a patch error."""
+        spool = dc.examples.get_example_spool("random_das", length=2)
+        with pytest.raises(PatchAttributeError, match="uniquely resolved"):
+            _select_patch_from_spool(spool, source_patch_id="not-found")
+
+    def test_flat_dump_excludes_summary_fields(self, random_patch):
+        """Excluding a summary field should drop it from all coord outputs."""
+        out = random_patch.summary.flat_dump(exclude={"min"})
+        assert "time_min" not in out
+        assert "distance_min" not in out
+
+    def test_summary_missing_coord_get(self, random_patch):
+        """Missing coord summaries should return the provided default."""
+        assert random_patch.summary.get("missing_min", None) is None
+
+    def test_summary_unknown_coord_field_raises(self, random_patch):
+        """Unknown coord-derived fields should raise, not return None."""
+        summary = random_patch.summary
+        with pytest.raises(AttributeError, match="time_missing"):
+            _ = summary.time_missing
+        with pytest.raises(KeyError, match="time_missing"):
+            _ = summary["time_missing"]
+        assert not hasattr(summary, "time_missing")
+
+    def test_summary_iter_and_len(self, random_patch):
+        """Summary should support iteration and length like a mapping."""
+        summary = random_patch.summary
+        keys = set(iter(summary))
+        assert "time_min" in keys
+        assert len(summary) == len(summary.flat_dump())
+
+    def test_from_patch_roundtrip(self, random_patch):
+        """PatchSummary should normalize Patch inputs directly."""
+        summary = dc.PatchSummary.model_validate(random_patch)
+        assert summary.dtype == str(random_patch.dtype)
+        assert summary.dims == random_patch.dims
+
+    def test_model_validate_self(self, random_patch):
+        """Model validation should accept PatchSummary instances unchanged."""
+        summary = random_patch.summary
+        assert dc.PatchSummary.model_validate(summary) is summary
+
+    def test_non_mapping_validate_passthrough_raises(self):
+        """Non-mapping validation should fall through to pydantic errors."""
+        with pytest.raises(ValidationError):
+            dc.PatchSummary.model_validate(1.23)
+
+    def test_structured_summary_infers_dims(self):
+        """Structured summary inputs should infer dims from coord summaries."""
+        patch = dc.get_example_patch()
+        coords = {
+            "time": patch.summary.get_coord_summary("time"),
+            "distance": patch.summary.get_coord_summary("distance"),
+        }
+        out = dc.PatchSummary.model_validate(
+            {"attrs": {"tag": "x"}, "coords": coords, "dims": ""}
+        )
+        assert out.dims == ("time", "distance")
+
+    def test_structured_summary_accepts_to_summary_coords(self):
+        """Structured coord entries with to_summary should be normalized."""
+
+        class SummaryLike:
+            def to_summary(self, dims=()):
+                return dc.core.CoordSummary(min=0, max=1, step=1, dims=dims)
+
+        out = dc.PatchSummary.model_validate(
+            {
+                "attrs": {"tag": "x"},
+                "coords": {"time": SummaryLike()},
+                "dims": ("time",),
+            }
+        )
+
+        assert out.coords["time"].min == 0
+        assert out.dims == ("time",)
+
+    def test_structured_summary_accepts_model_dump_coords(self):
+        """Structured coord entries with model_dump should be normalized."""
+
+        class DumpLike:
+            def model_dump(self):
+                return {"min": 1.0, "max": 2.0, "step": 0.5}
+
+        out = dc.PatchSummary.model_validate(
+            {
+                "attrs": {"tag": "x"},
+                "coords": {"distance": DumpLike()},
+                "dims": ("distance",),
+            }
+        )
+
+        assert out.coords["distance"].min == 1.0
+        assert out.dims == ("distance",)
+
+    def test_structured_summary_accepts_none_attrs(self):
+        """Structured inputs should treat attrs=None as empty attrs."""
+        out = dc.PatchSummary.model_validate(
+            {
+                "attrs": None,
+                "coords": {"time": {"min": 1.0, "max": 2.0}},
+                "dims": ("time",),
+            }
+        )
+
+        assert out.attrs == dc.PatchAttrs()
+        assert out.dims == ("time",)
+
+    def test_flat_summary_accepts_none_dims(self):
+        """Flat summary inputs should accept missing dims values."""
+        out = dc.PatchSummary.model_validate(
+            {"time_min": 1.0, "time_max": 2.0, "dims": None}
+        )
+        assert out.dims == ("time",)
+
+    def test_flat_summary_accepts_tuple_dims(self):
+        """Flat summary inputs should accept tuple dims values."""
+        out = dc.PatchSummary.model_validate(
+            {"time_min": 1.0, "time_max": 2.0, "dims": ("time",)}
+        )
+        assert out.dims == ("time",)
 
 
 class TestDisplay:
@@ -319,7 +587,7 @@ class TestEquals:
         with suppress_warnings():
             new_coords = dict(random_patch.coords)
         new_coords["bob"] = new_coords.pop(dims[-1])
-        new_dims = tuple(list(dims)[:-1] + ["bob"])
+        new_dims = tuple([*list(dims)[:-1], "bob"])
         patch_2 = random_patch.new(coords=new_coords, dims=new_dims)
         assert not patch_2.equals(random_patch)
 
@@ -327,17 +595,15 @@ class TestEquals:
         """Ensure if the coords are not equal neither are the arrays."""
         with suppress_warnings():
             new_coords = dict(random_patch.coords)
-        new_coords["distance"] = new_coords["distance"] + 10
+        new_coords["distance"] = new_coords["distance"].values + 10
         patch_2 = random_patch.new(coords=new_coords)
         assert not patch_2.equals(random_patch)
 
     def test_attrs_not_equal(self, random_patch):
         """Ensure if the attributes are not equal the arrays are not equal."""
-        attrs = random_patch.attrs
-        new_attr_dict = {}
-        new_attr_dict["time_step"] = attrs["time_step"] * 0.80
+        new_attr_dict = {"tag": "not_equal"}
         patch2 = random_patch.new(attrs=new_attr_dict)
-        assert patch2.attrs.time_step == new_attr_dict["time_step"]
+        assert patch2.attrs.tag == new_attr_dict["tag"]
         assert not patch2.equals(random_patch)
 
     def test_one_null_value_in_attrs(self, random_patch):
@@ -375,7 +641,6 @@ class TestEquals:
         """Transposed patches are not considered equal."""
         transposed = random_patch.transpose()
         # make sure dims are NE
-        assert transposed.attrs.dims != random_patch.attrs.dims
         assert transposed.dims != random_patch.dims
         # and test equality
         assert not random_patch.equals(transposed)
@@ -450,48 +715,40 @@ class TestUpdateAttrs:
         assert random_patch.attrs.model_dump() == old_attrs
 
     def test_update_starttime1(self, random_patch):
-        """Ensure coords are updated with attrs."""
+        """Coordinate updates should happen through update_coords."""
         t1 = np.datetime64("2000-01-01")
-        pa = random_patch.update_attrs(time_min=t1)
-        assert pa.attrs["time_min"] == t1
+        pa = random_patch.update_coords(time_min=t1)
+        assert pa.summary["time_min"] == t1
         assert pa.coords.min("time") == t1
 
     def test_update_startttime2(self, random_patch):
         """Updating start time should update end time as well."""
-        duration = random_patch.attrs["time_max"] - random_patch.attrs["time_min"]
+        duration = random_patch.summary["time_max"] - random_patch.summary["time_min"]
         new_start = np.datetime64("2000-01-01")
-        pa1 = random_patch.update_attrs(time_min=str(new_start))
-        assert pa1.attrs["time_min"] == new_start
-        assert pa1.attrs["time_max"] == new_start + duration
+        pa1 = random_patch.update_coords(time_min=str(new_start))
+        assert pa1.summary["time_min"] == new_start
+        assert pa1.summary["time_max"] == new_start + duration
 
-    def test_dt_is_datetime64(self, random_patch):
-        """Ensure dt gets changed into timedelta64."""
-        d_time = random_patch.attrs["time_step"]
-        assert isinstance(d_time, np.timedelta64)
-        new1 = random_patch.update_attrs(time_step=10)
-        assert new1.attrs["time_step"] == dc.to_timedelta64(10)
+    def test_update_attrs_rejects_coordinate_fields(self, random_patch):
+        """Flat coordinate-style attrs now flow through update_attrs unchanged."""
+        out = random_patch.update_attrs(time_step=10)
+        assert out.attrs.time_step == 10
 
     def test_update_non_sorted_coord(self, wacky_dim_patch):
-        """Ensure update attrs updates non-sorted coordinates."""
+        """Ensure update_coords updates non-sorted coordinates."""
         # test updating dist max
-        pa = wacky_dim_patch.update_attrs(distance_max=10)
-        assert pa.attrs.distance_max == 10
+        pa = wacky_dim_patch.update_coords(distance_max=10)
+        assert pa.summary.distance_max == 10
         assert not np.any(pd.isnull(pa.coords.get_array("distance")))
         # test update dist min
-        pa = wacky_dim_patch.update_attrs(distance_min=10)
-        assert pa.attrs.distance_min == 10
+        pa = wacky_dim_patch.update_coords(distance_min=10)
+        assert pa.summary.distance_min == 10
         assert not np.any(pd.isnull(pa.coords.get_array("distance")))
 
-    def test_update_units(self, random_patch):
-        """Ensure units can be updated in attrs."""
-        new_dist = "ft"
-        patch1 = random_patch.update_attrs(distance_units=new_dist)
-        patch2 = random_patch.convert_units(distance=new_dist)
-        coord1 = patch1.get_coord("distance")
-        coord2 = patch2.get_coord("distance")
-        coord3 = random_patch.get_coord("distance").convert_units(new_dist)
-        assert coord1 == coord2 == coord3
-        assert patch1 == patch2
+    def test_update_attrs_rejects_coordinate_units(self, random_patch):
+        """Coordinate-like unit fields now behave like plain attrs updates."""
+        out = random_patch.update_attrs(distance_units="ft")
+        assert out.attrs.distance_units == "ft"
 
 
 class TestReleaseMemory:
@@ -592,13 +849,11 @@ class TestCoords:
 
     def test_seconds(self, random_patch_with_lat):
         """Ensure we can get number of seconds in the patch."""
-        sampling_interval = random_patch_with_lat.attrs["time_step"] / np.timedelta64(
+        time_coord = random_patch_with_lat.coords["time"]
+        sampling_interval = time_coord.step / np.timedelta64(1, "s")
+        expected = (time_coord.max() - time_coord.min()) / np.timedelta64(
             1, "s"
-        )
-        expected = (
-            random_patch_with_lat.attrs["time_max"]
-            - random_patch_with_lat.attrs["time_min"]
-        ) / np.timedelta64(1, "s") + sampling_interval
+        ) + sampling_interval
         assert random_patch_with_lat.seconds == expected
 
     def test_channel_count(self, random_patch_with_lat):

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -111,13 +111,13 @@ class TestInit:
     def test_start_time_inferred_from_dt64_coords(self, random_dt_coord):
         """Ensure the time_min and time_max attrs can be inferred from coord time."""
         patch = random_dt_coord
-        assert patch.summary["time_min"] == self.time1
+        assert patch.summary.get_coord_summary("time").min == self.time1
 
     def test_end_time_inferred_from_dt64_coords(self, random_dt_coord):
         """Ensure the time_min and time_max attrs can be inferred from coord time."""
         patch = random_dt_coord
         time = patch.coords.coord_map["time"].max()
-        assert patch.summary["time_max"] == time
+        assert patch.summary.get_coord_summary("time").max == time
 
     def test_init_from_array(self, random_patch):
         """Ensure a trace can be created from raw components; array, coords, attrs."""
@@ -136,7 +136,7 @@ class TestInit:
 
     def test_max_time_populated(self, random_patch):
         """Ensure the time_max is populated when not explicitly given."""
-        end_time = random_patch.summary["time_max"]
+        end_time = random_patch.summary.get_coord_summary("time").max
         assert not pd.isnull(end_time)
 
     def test_min_max_populated(self, random_patch):
@@ -235,9 +235,11 @@ class TestInit:
         scanned = dc.scan(path)
         target = scanned[1]
         assert target.source_patch_id
-        loaded = _load_patch_summary(target, time=(target.time_min, target.time_max))
-        assert loaded.summary.time_min == target.summary.time_min
-        assert loaded.summary.time_max == target.summary.time_max
+        time_summary = target.get_coord_summary("time")
+        loaded = _load_patch_summary(target, time=(time_summary.min, time_summary.max))
+        loaded_time_summary = loaded.summary.get_coord_summary("time")
+        assert loaded_time_summary.min == time_summary.min
+        assert loaded_time_summary.max == time_summary.max
 
     def test_load_patch_summary_requires_path_for_in_memory_summary(self, random_patch):
         """In-memory summaries cannot be reloaded without a source path."""
@@ -252,7 +254,7 @@ class TestInit:
             _load_patch_summary(scanned)
 
     def test_load_patch_summary_passes_source_patch_id_to_read(self, monkeypatch):
-        """Reload should forward source_patch_id and accept a single filtered patch."""
+        """Reload should forward source_patch_id before validating the result."""
         patch = dc.get_example_patch()
         summary = PatchSummary(
             attrs=patch.attrs,
@@ -273,8 +275,8 @@ class TestInit:
             return dc.spool([patch])
 
         monkeypatch.setattr(dc, "read", fake_read)
-        out = _load_patch_summary(summary)
-        assert out == patch
+        with pytest.raises(PatchAttributeError, match="uniquely resolved"):
+            _load_patch_summary(summary)
         assert called["path"] == summary.path
         assert called["kwargs"]["source_patch_id"] == "node-1"
 
@@ -362,14 +364,12 @@ class TestNew:
 class TestPatchSummary:
     """Tests for patch summary helpers and selection fallbacks."""
 
-    def test_summary_mapping_methods(self, random_patch):
-        """Summary should behave like a small mapping."""
+    def test_summary_uses_structured_access(self, random_patch):
+        """Summary should expose coord summaries explicitly."""
         summary = random_patch.summary
-        assert summary["time_min"] == random_patch.coords.min("time")
-        assert summary.get("missing", 1) == 1
-        assert "time_min" in dict(summary.items())
-        with pytest.raises(KeyError):
-            _ = summary["missing"]
+        time_summary = summary.get_coord_summary("time")
+        assert time_summary.min == random_patch.coords.min("time")
+        assert time_summary.step == random_patch.get_coord("time").step
 
     def test_scan_returns_summary(self, random_patch):
         """Scanning a patch should return a PatchSummary."""
@@ -429,25 +429,31 @@ class TestPatchSummary:
         assert "time_min" not in out
         assert "distance_min" not in out
 
-    def test_summary_missing_coord_get(self, random_patch):
-        """Missing coord summaries should return the provided default."""
-        assert random_patch.summary.get("missing_min", None) is None
-
     def test_summary_unknown_coord_field_raises(self, random_patch):
-        """Unknown coord-derived fields should raise, not return None."""
+        """Flattened coord access should no longer be supported."""
         summary = random_patch.summary
         with pytest.raises(AttributeError, match="time_missing"):
             _ = summary.time_missing
-        with pytest.raises(KeyError, match="time_missing"):
-            _ = summary["time_missing"]
         assert not hasattr(summary, "time_missing")
 
-    def test_summary_iter_and_len(self, random_patch):
-        """Summary should support iteration and length like a mapping."""
+    def test_summary_flattened_lookup_is_removed(self, random_patch):
+        """Flattened summary item access should no longer work."""
         summary = random_patch.summary
-        keys = set(iter(summary))
-        assert "time_min" in keys
-        assert len(summary) == len(summary.flat_dump())
+        with pytest.raises(TypeError):
+            _ = summary["time_min"]
+
+    def test_flat_dump_prefers_coord_values_over_attrs(self, random_patch):
+        """flat_dump should overlay coord summaries on top of attrs."""
+        attrs = dc.PatchAttrs(**(random_patch.attrs.model_dump() | {"time_step": 10}))
+        summary = dc.PatchSummary(
+            attrs=attrs,
+            coords=random_patch.coords.to_summary_dict(),
+            dims=random_patch.dims,
+            shape=random_patch.shape,
+            dtype=str(random_patch.dtype),
+        )
+        out = summary.flat_dump()
+        assert out["time_step"] == random_patch.get_coord("time").step
 
     def test_from_patch_roundtrip(self, random_patch):
         """PatchSummary should normalize Patch inputs directly."""
@@ -753,31 +759,33 @@ class TestUpdateAttrs:
         """Coordinate updates should happen through update_coords."""
         t1 = np.datetime64("2000-01-01")
         pa = random_patch.update_coords(time_min=t1)
-        assert pa.summary["time_min"] == t1
+        assert pa.summary.get_coord_summary("time").min == t1
         assert pa.coords.min("time") == t1
 
     def test_update_startttime2(self, random_patch):
         """Updating start time should update end time as well."""
-        duration = random_patch.summary["time_max"] - random_patch.summary["time_min"]
+        time_coord = random_patch.get_coord("time")
+        duration = time_coord.max() - time_coord.min()
         new_start = np.datetime64("2000-01-01")
         pa1 = random_patch.update_coords(time_min=str(new_start))
-        assert pa1.summary["time_min"] == new_start
-        assert pa1.summary["time_max"] == new_start + duration
+        time_summary = pa1.summary.get_coord_summary("time")
+        assert time_summary.min == new_start
+        assert time_summary.max == new_start + duration
 
     def test_update_attrs_rejects_coordinate_fields(self, random_patch):
-        """Flat coordinate-style attrs now flow through update_attrs unchanged."""
-        out = random_patch.update_attrs(time_step=10)
-        assert out.attrs.time_step == 10
+        """Flat coordinate-style attrs should go through update_coords."""
+        with pytest.raises(ValueError, match="update_coords"):
+            random_patch.update_attrs(time_step=10)
 
     def test_update_non_sorted_coord(self, wacky_dim_patch):
         """Ensure update_coords updates non-sorted coordinates."""
         # test updating dist max
         pa = wacky_dim_patch.update_coords(distance_max=10)
-        assert pa.summary.distance_max == 10
+        assert pa.summary.get_coord_summary("distance").max == 10
         assert not np.any(pd.isnull(pa.coords.get_array("distance")))
         # test update dist min
         pa = wacky_dim_patch.update_coords(distance_min=10)
-        assert pa.summary.distance_min == 10
+        assert pa.summary.get_coord_summary("distance").min == 10
         assert not np.any(pd.isnull(pa.coords.get_array("distance")))
 
     def test_update_attrs_rejects_coordinate_units(self, random_patch):

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -18,7 +18,11 @@ from dascore.core import Patch
 from dascore.core.coords import BaseCoord, CoordRange
 from dascore.core.summary import PatchSummary
 from dascore.exceptions import CoordError, ParameterError, PatchAttributeError
-from dascore.io.core import _load_patch_summary, _select_patch_from_spool
+from dascore.io.core import (
+    _load_patch_summary,
+    _scan_result_to_summary,
+    _select_patch_from_spool,
+)
 from dascore.proc.basic import apply_operator
 from dascore.utils.misc import suppress_warnings
 
@@ -454,6 +458,22 @@ class TestPatchSummary:
         """Model validation should accept PatchSummary instances unchanged."""
         summary = random_patch.summary
         assert dc.PatchSummary.model_validate(summary) is summary
+
+    def test_patch_summary_is_cached(self, random_patch):
+        """Patch.summary should reuse the same summary instance."""
+        assert random_patch.summary is random_patch.summary
+
+    def test_scan_result_to_summary_noop_returns_same_summary(self, random_patch):
+        """Summary conversion should avoid rebuilding unchanged summaries."""
+        summary = random_patch.summary
+        assert _scan_result_to_summary(summary) is summary
+
+    def test_scan_result_to_summary_override_returns_new_summary(self, random_patch):
+        """Summary conversion should still apply explicit source overrides."""
+        summary = random_patch.summary
+        out = _scan_result_to_summary(summary, path="some_path")
+        assert out is not summary
+        assert out.path == "some_path"
 
     def test_non_mapping_validate_passthrough_raises(self):
         """Non-mapping validation should fall through to pydantic errors."""

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 import operator
 import weakref
 from pathlib import Path
@@ -462,6 +463,20 @@ class TestPatchSummary:
     def test_patch_summary_is_cached(self, random_patch):
         """Patch.summary should reuse the same summary instance."""
         assert random_patch.summary is random_patch.summary
+
+    def test_summary_cache_does_not_keep_patch_alive(self):
+        """Holding a summary must not keep the source patch from being GC'd."""
+        patch = dc.get_example_patch()
+        patch_ref = weakref.ref(patch)
+        summary = patch.summary
+
+        del patch
+        gc.collect()
+
+        assert patch_ref() is None
+        assert summary.dims
+        assert summary.dtype
+        assert "time_min" in summary.flat_dump()
 
     def test_scan_result_to_summary_noop_returns_same_summary(self, random_patch):
         """Summary conversion should avoid rebuilding unchanged summaries."""

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -23,10 +23,11 @@ from dascore.utils.time import to_timedelta64
 def spool_dt_perturbed(random_patch) -> dc.BaseSpool:
     """Create a spool with patches that have slightly different dts."""
     dts = np.array((0.999722, 0.99985, 0.99973, 0.99986))
-    current_max = random_patch.attrs.time_max
+    current_max = random_patch.summary.time_max
     patches = []
     for dt in dts:
-        patch = random_patch.update_attrs(time_min=current_max, time_step=dt)
+        coords = random_patch.coords.update(time_min=current_max, time_step=dt)
+        patch = random_patch.new(coords=coords)
         patches.append(patch)
     return dc.spool(patches)
 
@@ -79,7 +80,9 @@ class TestChunk:
         new_content = new_spool.get_contents()
         # these should be (nearly) identical.
         common = set(chunk_df.columns) & set(new_content.columns)
-        cols = sorted(common - {"history"})  # no need to compare history
+        # len fields may differ by ±1 between summary-based and data-based counts
+        skip = {"history"} | {c for c in common if c.endswith("_len")}
+        cols = sorted(common - skip)
         comp1, comp2 = chunk_df[cols], new_content[cols]
         equal_cols = (comp1 == comp2) | (pd.isnull(comp1) & pd.isnull(comp2))
         assert equal_cols.all().all()
@@ -99,8 +102,8 @@ class TestChunk:
         spool = random_spool.select(time=(time_1, time_2)).chunk(time=None)
         assert len(spool) == 1
         patch = spool[0]
-        assert np.abs(patch.attrs["time_min"] - time_1) < dt
-        assert np.abs(patch.attrs["time_max"] - time_2) < dt
+        assert np.abs(patch.summary["time_min"] - time_1) < dt
+        assert np.abs(patch.summary["time_max"] - time_2) < dt
 
     def test_uneven_chunk_iteration(self, random_spool, random_spool_df):
         """Ensure uneven start/end still yield consistent slices."""
@@ -112,7 +115,7 @@ class TestChunk:
         spool_2 = random_spool.select(time=(time_1, time_2)).chunk(time=1)
         assert len(spool_2) == 10
         patches = list(spool_2)
-        durations = [x.attrs["time_max"] - x.attrs["time_min"] for x in patches]
+        durations = [x.summary["time_max"] - x.summary["time_min"] for x in patches]
         # there should be a single duration
         assert len(set(durations)) == 1
         duration = durations[0] / one_sec
@@ -125,9 +128,9 @@ class TestChunk:
         new = spool.chunk(time=None)
         assert len(new) == 1
         patch = new[0]
-        assert patch.attrs.time_min == spool[0].attrs.time_min
-        assert patch.attrs.time_max == spool[-1].attrs.time_max
-        assert patch.attrs.time_step == spool[0].attrs.time_step
+        assert patch.coords["time"].min() == spool[0].coords["time"].min()
+        assert patch.coords["time"].max() == spool[-1].coords["time"].max()
+        assert patch.coords["time"].step == spool[0].coords["time"].step
 
     def test_small_segments_no_partial(self, diverse_spool):
         """Test issue #262 with no partials."""
@@ -196,11 +199,14 @@ class TestChunkMerge:
         Ensure the patches are not sorted in temporal order.
         """
         pa1 = random_patch
-        t2 = random_patch.attrs["time_max"]
-        time_step = random_patch.attrs["time_step"] * 1_000
-        pa2 = random_patch.update_attrs(time_min=t2 + time_step)
-        t3 = pa2.attrs["time_max"]
-        pa3 = pa2.update_attrs(time_min=t3 + time_step)
+        time_coord = random_patch.coords["time"]
+        t2 = time_coord.max()
+        time_step = time_coord.step * 1_000
+        pa2 = random_patch.new(
+            coords=random_patch.coords.update(time_min=t2 + time_step)
+        )
+        t3 = pa2.coords["time"].max()
+        pa3 = pa2.new(coords=pa2.coords.update(time_min=t3 + time_step))
         return dc.spool([pa2, pa1, pa3])
 
     @pytest.fixture()
@@ -212,11 +218,14 @@ class TestChunkMerge:
     def spool_slight_gap(self, random_patch) -> dc.BaseSpool:
         """Create a spool which has a 1.1 * dt gap."""
         pa1 = random_patch
-        t2 = random_patch.attrs["time_max"]
-        dt = random_patch.attrs["time_step"]
-        pa2 = random_patch.update_attrs(time_min=t2 + dt * 1.1)
-        t3 = pa2.attrs["time_max"]
-        pa3 = pa2.update_attrs(time_min=t3 + dt * 1.1)
+        time_coord = random_patch.coords["time"]
+        t2 = time_coord.max()
+        dt = time_coord.step
+        pa2 = random_patch.new(
+            coords=random_patch.coords.update(time_min=t2 + dt * 1.1)
+        )
+        t3 = pa2.coords["time"].max()
+        pa3 = pa2.new(coords=pa2.coords.update(time_min=t3 + dt * 1.1))
         return dc.spool([pa2, pa1, pa3])
 
     @pytest.fixture(scope="class")
@@ -228,7 +237,7 @@ class TestChunkMerge:
             previous = patches[ind - 1]
             current = patches[ind]
             new_time = previous.coords.get_array("time")[40]
-            out.append(current.update_attrs(time_min=new_time))
+            out.append(current.new(coords=current.coords.update(time_min=new_time)))
         return dc.spool(out)
 
     @pytest.fixture(scope="class")
@@ -236,7 +245,7 @@ class TestChunkMerge:
         """Create a spool with no overlap that isnt evenly sampled."""
         pa1 = wacky_dim_patch
         dt = dc.to_timedelta64(0.2)
-        pa2 = pa1.update_attrs(time_min=pa1.attrs.time_max + dt)
+        pa2 = pa1.new(coords=pa1.coords.update(time_min=pa1.summary.time_max + dt))
         return dc.spool([pa1, pa2])
 
     @pytest.fixture(scope="class")
@@ -244,23 +253,24 @@ class TestChunkMerge:
         """Create a spool with overlap that isnt evenly sampled."""
         pa1 = wacky_dim_patch
         dt = dc.to_timedelta64(1)
-        pa2 = pa1.update_attrs(time_min=pa1.attrs.time_max - dt)
+        pa2 = pa1.new(coords=pa1.coords.update(time_min=pa1.coords["time"].max() - dt))
         return dc.spool([pa1, pa2])
 
     @pytest.fixture(scope="class")
     def distance_adjacent(self, random_patch):
         """Create a spool with two distance adjacent patches."""
         pa1 = random_patch
-        new_dist = pa1.attrs.distance_min + pa1.attrs.distance_step
-        pa2 = pa1.update_attrs(distance_min=new_dist)
+        distance = pa1.coords["distance"]
+        new_dist = distance.min() + distance.step
+        pa2 = pa1.new(coords=pa1.coords.update(distance_min=new_dist))
         return dc.spool([pa1, pa2])
 
     @pytest.fixture(scope="class")
     def distance_adjacent_no_order(self, wacky_dim_patch):
         """Create a spool with two distance adjacent patches."""
         pa1 = wacky_dim_patch
-        new_dist = pa1.attrs.distance_min + 1
-        pa2 = pa1.update_attrs(distance_min=new_dist)
+        new_dist = pa1.coords["distance"].min() + 1
+        pa2 = pa1.new(coords=pa1.coords.update(distance_min=new_dist))
         return dc.spool([pa1, pa2])
 
     @pytest.fixture(scope="class")
@@ -300,14 +310,14 @@ class TestChunkMerge:
         assert len(out_spool) == 1
         out_patch = out_spool[0]
         # make sure coords are consistent with attrs
-        assert out_patch.attrs["time_max"] == out_patch.coords.max("time")
-        assert out_patch.attrs["time_min"] == out_patch.coords.min("time")
+        assert out_patch.coords["time"].max() == out_patch.coords.max("time")
+        assert out_patch.coords["time"].min() == out_patch.coords.min("time")
         # ensure the spacing is still uniform
         time = out_patch.coords.get_array("time")
         spacing = time[1:] - time[:-1]
         unique_spacing = np.unique(spacing)
         assert len(unique_spacing) == 1
-        assert unique_spacing[0] == out_patch.attrs["time_step"]
+        assert unique_spacing[0] == out_patch.coords["time"].step
 
     def test_no_overlap(self, desperate_spool_no_overlap):
         """Spools with no overlap should not be merged."""
@@ -375,7 +385,10 @@ class TestChunkMerge:
         pa = sp[0]
         assert isinstance(pa, dc.Patch)
         # distance_step should remain identical
-        assert distance_adjacent[0].attrs.distance_step == sp[0].attrs.distance_step
+        assert (
+            distance_adjacent[0].coords["distance"].step
+            == sp[0].coords["distance"].step
+        )
         # ensure correct bounds are there.
         old_df = distance_adjacent.get_contents()
         new_df = sp.get_contents()
@@ -400,7 +413,7 @@ class TestChunkMerge:
         # need to iterate to make sure patch can be loaded.
         for patch in new_spool:
             assert isinstance(patch, dc.Patch)
-            assert patch.attrs.time_step == time_step_expected
+            assert patch.coords["time"].step == time_step_expected
 
     def test_merge_patches_very_different_dt(self, memory_spool_small_dt_differences):
         """Slightly different dt values should still merge."""
@@ -408,14 +421,17 @@ class TestChunkMerge:
         patches_1 = [x for x in spool]
         # create new patches with higher dt, this creates overlap that should
         # be trimmed out.
-        patches_2 = [x.update_attrs(time_step=x.attrs.time_step * 33) for x in spool]
+        patches_2 = [
+            x.new(coords=x.coords.update(time_step=x.coords["time"].step * 33))
+            for x in spool
+        ]
         patches = patches_2 + patches_1
         random.shuffle(patches)  # mix the patches, ensure order isnt required.
         new_spool = dc.spool(patches).chunk(time=None)
         assert len(new_spool) == 2
         time_steps = new_spool.get_contents()["time_step"]
         for patch, time_step in zip(new_spool, time_steps):
-            diff = np.abs(patch.attrs.time_step - time_step)
+            diff = np.abs(patch.coords["time"].step - time_step)
             assert diff / time_step < 0.01
 
     def test_overlap_merge_doesnt_change_dt(self, adjacent_spool_overlap):
@@ -424,7 +440,7 @@ class TestChunkMerge:
         contents = spool.get_contents()
         assert len(spool) == 1
         patch_new, patch_old = spool[0], adjacent_spool_overlap[0]
-        new_at, old_at = patch_new.attrs, patch_old.attrs
+        new_at, old_at = patch_new.summary, patch_old.summary
         assert new_at["time_max"] == contents["time_max"].max()
         assert (
             new_at["time_step"] == old_at["time_step"] == contents["time_step"].iloc[0]
@@ -523,8 +539,8 @@ class TestChunkMerge:
         result_contents = result_spool.get_contents().reset_index(drop=True)
         for i, patch in enumerate(result_spool):
             # Assert no NaN values in patch attributes
-            assert not pd.isna(patch.attrs["time_min"]), f"Patch {i} has NaN time_min"
-            assert not pd.isna(patch.attrs["time_max"]), f"Patch {i} has NaN time_max"
+            assert not pd.isna(patch.summary["time_min"]), f"Patch {i} has NaN time_min"
+            assert not pd.isna(patch.summary["time_max"]), f"Patch {i} has NaN time_max"
 
             # Verify dataframe contains reasonable time values
             df_row = result_contents.iloc[i]
@@ -563,8 +579,8 @@ class TestChunkMerge:
         result_contents = result_spool.get_contents().reset_index(drop=True)
         for i, patch in enumerate(result_spool):
             # Assert no NaN values in patch attributes
-            assert not pd.isna(patch.attrs["time_min"]), f"Patch {i} has NaN time_min"
-            assert not pd.isna(patch.attrs["time_max"]), f"Patch {i} has NaN time_max"
+            assert not pd.isna(patch.summary["time_min"]), f"Patch {i} has NaN time_min"
+            assert not pd.isna(patch.summary["time_max"]), f"Patch {i} has NaN time_max"
 
             # Verify dataframe contains reasonable time values
             df_row = result_contents.iloc[i]

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -23,7 +23,7 @@ from dascore.utils.time import to_timedelta64
 def spool_dt_perturbed(random_patch) -> dc.BaseSpool:
     """Create a spool with patches that have slightly different dts."""
     dts = np.array((0.999722, 0.99985, 0.99973, 0.99986))
-    current_max = random_patch.summary.time_max
+    current_max = random_patch.get_coord("time").max()
     patches = []
     for dt in dts:
         coords = random_patch.coords.update(time_min=current_max, time_step=dt)
@@ -102,8 +102,9 @@ class TestChunk:
         spool = random_spool.select(time=(time_1, time_2)).chunk(time=None)
         assert len(spool) == 1
         patch = spool[0]
-        assert np.abs(patch.summary["time_min"] - time_1) < dt
-        assert np.abs(patch.summary["time_max"] - time_2) < dt
+        time_coord = patch.get_coord("time")
+        assert np.abs(time_coord.min() - time_1) < dt
+        assert np.abs(time_coord.max() - time_2) < dt
 
     def test_uneven_chunk_iteration(self, random_spool, random_spool_df):
         """Ensure uneven start/end still yield consistent slices."""
@@ -115,7 +116,9 @@ class TestChunk:
         spool_2 = random_spool.select(time=(time_1, time_2)).chunk(time=1)
         assert len(spool_2) == 10
         patches = list(spool_2)
-        durations = [x.summary["time_max"] - x.summary["time_min"] for x in patches]
+        durations = [
+            x.get_coord("time").max() - x.get_coord("time").min() for x in patches
+        ]
         # there should be a single duration
         assert len(set(durations)) == 1
         duration = durations[0] / one_sec
@@ -245,7 +248,9 @@ class TestChunkMerge:
         """Create a spool with no overlap that isnt evenly sampled."""
         pa1 = wacky_dim_patch
         dt = dc.to_timedelta64(0.2)
-        pa2 = pa1.new(coords=pa1.coords.update(time_min=pa1.summary.time_max + dt))
+        pa2 = pa1.new(
+            coords=pa1.coords.update(time_min=pa1.get_coord("time").max() + dt)
+        )
         return dc.spool([pa1, pa2])
 
     @pytest.fixture(scope="class")
@@ -440,10 +445,11 @@ class TestChunkMerge:
         contents = spool.get_contents()
         assert len(spool) == 1
         patch_new, patch_old = spool[0], adjacent_spool_overlap[0]
-        new_at, old_at = patch_new.summary, patch_old.summary
-        assert new_at["time_max"] == contents["time_max"].max()
+        new_time_coord = patch_new.get_coord("time")
+        old_time_coord = patch_old.get_coord("time")
+        assert new_time_coord.max() == contents["time_max"].max()
         assert (
-            new_at["time_step"] == old_at["time_step"] == contents["time_step"].iloc[0]
+            new_time_coord.step == old_time_coord.step == contents["time_step"].iloc[0]
         )
 
     def test_perturbed_dt(self, spool_dt_perturbed):
@@ -539,8 +545,9 @@ class TestChunkMerge:
         result_contents = result_spool.get_contents().reset_index(drop=True)
         for i, patch in enumerate(result_spool):
             # Assert no NaN values in patch attributes
-            assert not pd.isna(patch.summary["time_min"]), f"Patch {i} has NaN time_min"
-            assert not pd.isna(patch.summary["time_max"]), f"Patch {i} has NaN time_max"
+            time_coord = patch.get_coord("time")
+            assert not pd.isna(time_coord.min()), f"Patch {i} has NaN time_min"
+            assert not pd.isna(time_coord.max()), f"Patch {i} has NaN time_max"
 
             # Verify dataframe contains reasonable time values
             df_row = result_contents.iloc[i]
@@ -579,8 +586,9 @@ class TestChunkMerge:
         result_contents = result_spool.get_contents().reset_index(drop=True)
         for i, patch in enumerate(result_spool):
             # Assert no NaN values in patch attributes
-            assert not pd.isna(patch.summary["time_min"]), f"Patch {i} has NaN time_min"
-            assert not pd.isna(patch.summary["time_max"]), f"Patch {i} has NaN time_max"
+            time_coord = patch.get_coord("time")
+            assert not pd.isna(time_coord.min()), f"Patch {i} has NaN time_min"
+            assert not pd.isna(time_coord.max()), f"Patch {i} has NaN time_max"
 
             # Verify dataframe contains reasonable time values
             df_row = result_contents.iloc[i]

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -314,10 +314,10 @@ class TestSelect:
         )
         assert len(out)
         for patch in out:
-            attrs = patch.attrs
-            assert attrs["network"] == "das2"
-            assert attrs["tag"].startswith("ran")
-            assert attrs["time_max"] <= new_max
+            summary = patch.summary
+            assert patch.attrs["network"] == "das2"
+            assert patch.attrs["tag"].startswith("ran")
+            assert summary["time_max"] <= new_max
 
     def test_multiple_range_selects(self, adjacent_spool_no_overlap):
         """Ensure multiple range selects can be used in one call."""
@@ -339,10 +339,10 @@ class TestSelect:
         assert (new_contents["distance_max"] <= distance_max).all()
         # then check patches
         for patch in new_spool:
-            assert patch.attrs["time_min"] >= time_min
-            assert patch.attrs["time_max"] <= time_max
-            assert patch.attrs["distance_min"] >= distance_min
-            assert patch.attrs["distance_max"] <= distance_max
+            assert patch.summary["time_min"] >= time_min
+            assert patch.summary["time_max"] <= time_max
+            assert patch.summary["distance_min"] >= distance_min
+            assert patch.summary["distance_max"] <= distance_max
 
     def test_split_ellipses(self, diverse_spool):
         """Ensure ... can be used for an open interval."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -314,10 +314,9 @@ class TestSelect:
         )
         assert len(out)
         for patch in out:
-            summary = patch.summary
             assert patch.attrs["network"] == "das2"
             assert patch.attrs["tag"].startswith("ran")
-            assert summary["time_max"] <= new_max
+            assert patch.get_coord("time").max() <= new_max
 
     def test_multiple_range_selects(self, adjacent_spool_no_overlap):
         """Ensure multiple range selects can be used in one call."""
@@ -339,10 +338,10 @@ class TestSelect:
         assert (new_contents["distance_max"] <= distance_max).all()
         # then check patches
         for patch in new_spool:
-            assert patch.summary["time_min"] >= time_min
-            assert patch.summary["time_max"] <= time_max
-            assert patch.summary["distance_min"] >= distance_min
-            assert patch.summary["distance_max"] <= distance_max
+            assert patch.get_coord("time").min() >= time_min
+            assert patch.get_coord("time").max() <= time_max
+            assert patch.get_coord("distance").min() >= distance_min
+            assert patch.get_coord("distance").max() <= distance_max
 
     def test_split_ellipses(self, diverse_spool):
         """Ensure ... can be used for an open interval."""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
+import dascore.examples as dc_examples
 from dascore.examples import EXAMPLE_PATCHES
 from dascore.exceptions import UnknownExampleError
 from dascore.utils.time import to_float
@@ -34,6 +35,26 @@ class TestGetExamplePatch:
         """Ensure the registered example patches can all be loaded."""
         patch = dc.get_example_patch(name)
         assert isinstance(patch, dc.Patch)
+
+    def test_file_backed_examples_use_direct_read(self, monkeypatch):
+        """File-backed examples should not depend on FileSpool patch resolution."""
+        patch = dc.get_example_patch()
+
+        def _fetch(_name):
+            return "ignored-path"
+
+        def _read(_path):
+            return [patch]
+
+        def _spool(_path):
+            raise AssertionError("file-backed examples should load via dc.read")
+
+        monkeypatch.setattr(dc_examples, "fetch", _fetch)
+        monkeypatch.setattr(dc_examples.dc, "read", _read)
+        monkeypatch.setattr(dc_examples.dc, "spool", _spool)
+
+        out = dc_examples.example_event_1()
+        assert isinstance(out, dc.Patch)
 
 
 class TestGetExampleSpool:

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -208,9 +208,10 @@ def _assert_coords_attrs_match(patch):
     assert summary.dims == coords.dims
     for dim in summary.dims:
         coord = patch.get_coord(dim)
-        assert coord.min() == getattr(summary, f"{dim}_min")
-        assert coord.max() == getattr(summary, f"{dim}_max")
-        assert coord.step == getattr(summary, f"{dim}_step")
+        summary_coord = summary.get_coord_summary(dim)
+        assert coord.min() == summary_coord.min
+        assert coord.max() == summary_coord.max
+        assert coord.step == summary_coord.step
 
 
 def _assert_op_or_close(val1, val2, op):
@@ -225,8 +226,6 @@ def _assert_op_or_close(val1, val2, op):
 
 
 # --- Tests
-
-DIM_RELATED_ATTRS = ("{dim}_min", "{dim}_max", "{dim}_step")
 
 
 class TestGetFormat:
@@ -325,8 +324,9 @@ class TestRead:
         assert len(summaries_from_file)
         summary_init = summaries_from_file[0]
         for dim in summary_init.dim_tuple:
-            start = getattr(summary_init, f"{dim}_min")
-            stop = getattr(summary_init, f"{dim}_max")
+            summary_coord = summary_init.get_coord_summary(dim)
+            start = summary_coord.min
+            stop = summary_coord.max
             duration = stop - start
             # first test double ended query
             trim_tuple = (start + duration / 10, start + 2 * duration / 10)
@@ -346,7 +346,7 @@ class TestRead:
             _assert_coords_attrs_match(patch)
             coord = patch.get_coord(dim)
             _assert_op_or_close(coord.min(), trim_tuple[0], ge)
-            _assert_op_or_close(coord.max(), getattr(summary, f"{dim}_max"), eq)
+            _assert_op_or_close(coord.max(), summary.get_coord_summary(dim).max, eq)
             # then single-ended query on end side
             trim_tuple = (None, start + duration / 10)
             spool = io.read(path, **{dim: trim_tuple})
@@ -355,7 +355,7 @@ class TestRead:
             summary = patch.summary
             _assert_coords_attrs_match(patch)
             coord = patch.get_coord(dim)
-            _assert_op_or_close(coord.min(), getattr(summary, f"{dim}_min"), eq)
+            _assert_op_or_close(coord.min(), summary.get_coord_summary(dim).min, eq)
             _assert_op_or_close(coord.max(), trim_tuple[1], le)
 
     def test_slice_out_all_patches_time(self, io_path_tuple):
@@ -427,14 +427,14 @@ class TestScan:
         """Ensure scanned summaries have correct dtype for time."""
         for summary in scanned_summaries:
             with suppress(KeyError):
-                time = summary.get_coord("time")
+                time = summary.get_coord_summary("time")
                 assert "datetime64" in str(np.dtype(time.dtype))
 
     def test_dist_coord_is_float_or_int(self, scanned_summaries):
         """Distance can be either float or int, but must be numeric."""
         for summary in scanned_summaries:
             with suppress(KeyError, CoordError):
-                distance = summary.get_coord("distance")
+                distance = summary.get_coord_summary("distance")
                 dtype = np.dtype(distance.dtype)
                 assert np.issubdtype(dtype, np.number)
 
@@ -520,13 +520,12 @@ class TestIntegration:
             assert patch_summary.dims == scan_summary.dims
             # first compare dimensions are related attributes
             for dim in patch_summary.dim_tuple:
-                assert getattr(patch_summary, f"{dim}_min") == getattr(
-                    scan_summary, f"{dim}_min"
-                )
-                for dim_attr in DIM_RELATED_ATTRS:
-                    attr_name = dim_attr.format(dim=dim)
-                    attr1 = getattr(patch_summary, attr_name)
-                    attr2 = getattr(scan_summary, attr_name)
+                patch_coord = patch_summary.get_coord_summary(dim)
+                scan_coord = scan_summary.get_coord_summary(dim)
+                assert patch_coord.min == scan_coord.min
+                for attr_name in ("min", "max", "step"):
+                    attr1 = getattr(patch_coord, attr_name)
+                    attr2 = getattr(scan_coord, attr_name)
                     # Use close comparison for floating point values
                     if isinstance(attr1, float | np.floating) and isinstance(
                         attr2, float | np.floating
@@ -536,8 +535,8 @@ class TestIntegration:
                         assert attr1 == attr2
             # then other expected attributes.
             for attr_name in comp_attrs:
-                patch_value = getattr(patch_summary, attr_name)
-                scan_value = getattr(scan_summary, attr_name)
+                patch_value = getattr(patch_summary.attrs, attr_name)
+                scan_value = getattr(scan_summary.attrs, attr_name)
                 if scan_value in ("", None):
                     continue
                 assert scan_value == patch_value

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -22,7 +22,7 @@ import pandas as pd
 import pytest
 
 import dascore as dc
-from dascore.exceptions import MissingOptionalDependencyError
+from dascore.exceptions import CoordError, MissingOptionalDependencyError
 from dascore.io import BinaryReader
 from dascore.io.ap_sensing import APSensingV10
 from dascore.io.dasdae import DASDAEV1
@@ -119,6 +119,11 @@ def skip_timeout():
         pytest.skip(f"Unable to fetch data due to timeout: {exc}")
 
 
+def _scan_summary(scan_result):
+    """Normalize scan output to the patch summary view."""
+    return scan_result.summary if isinstance(scan_result, dc.Patch) else scan_result
+
+
 @cache
 def _cached_read(path, io=None):
     """
@@ -180,7 +185,7 @@ def read_spool(data_file_path):
 
 
 @pytest.fixture(scope="session")
-def scanned_attrs(data_file_path):
+def scanned_summaries(data_file_path):
     """Read each file into a spool."""
     with skip_missing():
         out = dc.scan(data_file_path)
@@ -197,15 +202,15 @@ def fiber_io_writer(request):
 
 
 def _assert_coords_attrs_match(patch):
-    """Ensure both the coordinates and attributes match on patch."""
-    attrs = patch.attrs
+    """Ensure patch summary and coordinates match."""
+    summary = patch.summary
     coords = patch.coords
-    assert attrs.dim_tuple == coords.dims
-    for dim in attrs.dim_tuple:
+    assert summary.dims == coords.dims
+    for dim in summary.dims:
         coord = patch.get_coord(dim)
-        assert coord.min() == getattr(attrs, f"{dim}_min")
-        assert coord.max() == getattr(attrs, f"{dim}_max")
-        assert coord.step == getattr(attrs, f"{dim}_step")
+        assert coord.min() == getattr(summary, f"{dim}_min")
+        assert coord.max() == getattr(summary, f"{dim}_max")
+        assert coord.step == getattr(summary, f"{dim}_step")
 
 
 def _assert_op_or_close(val1, val2, op):
@@ -261,7 +266,7 @@ class TestGetFormat:
                     path = fetch(key)
                 out = io_instance.get_format(path)
                 if out:
-                    format_name, version = out
+                    _format_name, version = out
                     assert version != io_instance.version
 
 
@@ -316,12 +321,12 @@ class TestRead:
         """
         io, path = io_path_tuple
         with skip_missing():
-            attrs_from_file = dc.scan(path)
-        assert len(attrs_from_file)
-        attrs_init = attrs_from_file[0]
-        for dim in attrs_init.dim_tuple:
-            start = getattr(attrs_init, f"{dim}_min")
-            stop = getattr(attrs_init, f"{dim}_max")
+            summaries_from_file = [_scan_summary(x) for x in dc.scan(path)]
+        assert len(summaries_from_file)
+        summary_init = summaries_from_file[0]
+        for dim in summary_init.dim_tuple:
+            start = getattr(summary_init, f"{dim}_min")
+            stop = getattr(summary_init, f"{dim}_max")
             duration = stop - start
             # first test double ended query
             trim_tuple = (start + duration / 10, start + 2 * duration / 10)
@@ -337,32 +342,32 @@ class TestRead:
             spool = io.read(path, **{dim: trim_tuple})
             assert len(spool) == 1
             patch = spool[0]
-            attrs = patch.attrs
+            summary = patch.summary
             _assert_coords_attrs_match(patch)
             coord = patch.get_coord(dim)
             _assert_op_or_close(coord.min(), trim_tuple[0], ge)
-            _assert_op_or_close(coord.max(), getattr(attrs, f"{dim}_max"), eq)
+            _assert_op_or_close(coord.max(), getattr(summary, f"{dim}_max"), eq)
             # then single-ended query on end side
             trim_tuple = (None, start + duration / 10)
             spool = io.read(path, **{dim: trim_tuple})
             assert len(spool) == 1
             patch = spool[0]
-            attrs = patch.attrs
+            summary = patch.summary
             _assert_coords_attrs_match(patch)
             coord = patch.get_coord(dim)
-            _assert_op_or_close(coord.min(), getattr(attrs, f"{dim}_min"), eq)
+            _assert_op_or_close(coord.min(), getattr(summary, f"{dim}_min"), eq)
             _assert_op_or_close(coord.max(), trim_tuple[1], le)
 
     def test_slice_out_all_patches_time(self, io_path_tuple):
         """Ensure slicing outside of file time range returns an empty spool."""
         io, path = io_path_tuple
         with skip_missing():
-            attrs_from_file = dc.scan(path)
-        dims = {y for x in attrs_from_file for y in set(x.coords)}
+            scan_patches = dc.scan(path)
+        dims = {y for x in scan_patches for y in x.dims}
         if "time" not in dims:
             pytest.skip("Test requires patch with time and distance dimensions.")
         # First test on selecting outside time range.
-        end_time = np.max([x.coords["time"].max for x in attrs_from_file])
+        end_time = np.max([x.get_coord_summary("time").max for x in scan_patches])
         one_second = np.timedelta64(1, "s")
         spool = io.read(path, time=(end_time + one_second, ...))
         assert len(spool) == 0
@@ -371,12 +376,12 @@ class TestRead:
         """Ensure slicing outside file distance range returns an empty spool."""
         io, path = io_path_tuple
         with skip_missing():
-            attrs_from_file = dc.scan(path)
-        dims = {y for x in attrs_from_file for y in set(x.coords)}
+            scan_patches = dc.scan(path)
+        dims = {y for x in scan_patches for y in x.dims}
         if "distance" not in dims:
             pytest.skip("Test requires patch with time and distance dimensions.")
         # The outside distance range.
-        max_dist = np.max([x.coords["distance"].max for x in attrs_from_file])
+        max_dist = np.max([x.get_coord_summary("distance").max for x in scan_patches])
         spool = io.read(path, distance=(max_dist + 1, ...))
         assert len(spool) == 0
 
@@ -387,41 +392,81 @@ class TestScan:
     def test_scan_basics(self, data_file_path):
         """Ensure each file can be scanned."""
         with skip_missing():
-            attrs_list = dc.scan(data_file_path)
-        assert len(attrs_list)
+            summary_list = dc.scan(data_file_path)
+        assert len(summary_list)
 
-        for attrs in attrs_list:
-            assert isinstance(attrs, dc.PatchAttrs)
-            assert str(attrs.path) == str(data_file_path)
+        for summary in summary_list:
+            assert isinstance(summary, dc.PatchSummary)
+            assert str(summary.path) == str(data_file_path)
 
-    def test_scan_has_version_and_format(self, io_path_tuple):
-        """Scan output should contain version and format."""
+    def test_raw_scan_excludes_source_metadata(self, io_path_tuple):
+        """Direct FiberIO scans should not attach source metadata."""
         io, path = io_path_tuple
         with skip_missing():
-            attr_list = io.scan(path)
-        for attrs in attr_list:
-            assert attrs.file_format == io.name
-            assert attrs.file_version == io.version
+            summary_list = io.scan(path)
+        for summary in summary_list:
+            assert not summary.path
+            assert not summary.file_format
+            assert not summary.file_version
+            attr_dump = summary.attrs.model_dump()
+            assert "path" not in attr_dump
+            assert "file_format" not in attr_dump
+            assert "file_version" not in attr_dump
 
-    def test_time_coord_is_time(self, scanned_attrs):
-        """Ensure scanned attrs have correct dtype for time."""
-        for patch_attr in scanned_attrs:
+    def test_public_scan_has_version_and_format(self, io_path_tuple):
+        """Public scan output should contain source metadata."""
+        io, path = io_path_tuple
+        with skip_missing():
+            summary_list = dc.scan(path)
+        for summary in summary_list:
+            assert str(summary.path) == str(path)
+            assert summary.file_format == io.name
+            assert summary.file_version == io.version
+
+    def test_time_coord_is_time(self, scanned_summaries):
+        """Ensure scanned summaries have correct dtype for time."""
+        for summary in scanned_summaries:
             with suppress(KeyError):
-                time = patch_attr.coords["time"]
+                time = summary.get_coord("time")
                 assert "datetime64" in str(np.dtype(time.dtype))
 
-    def test_dist_coord_is_float_or_int(self, scanned_attrs):
+    def test_dist_coord_is_float_or_int(self, scanned_summaries):
         """Distance can be either float or int, but must be numeric."""
-        for patch_attr in scanned_attrs:
-            with suppress(KeyError):
-                distance = patch_attr.coords["distance"]
+        for summary in scanned_summaries:
+            with suppress(KeyError, CoordError):
+                distance = summary.get_coord("distance")
                 dtype = np.dtype(distance.dtype)
                 assert np.issubdtype(dtype, np.number)
 
-    def test_no_bytes(self, scanned_attrs):
+    def test_coord_dtype_non_empty(self, scanned_summaries):
+        """Each coordinate summary should have a non-empty dtype string."""
+        for summary in scanned_summaries:
+            for coord_name, coord in summary.coords.items():
+                assert coord.dtype, f"coord '{coord_name}' has empty dtype"
+
+    def test_patch_dims_non_empty(self, scanned_summaries):
+        """Scan results should carry at least one dimension."""
+        for summary in scanned_summaries:
+            assert summary.dims, "PatchSummary has empty dims"
+
+    def test_patch_dtype_non_empty(self, scanned_summaries):
+        """Scan results should carry a non-empty data dtype."""
+        for summary in scanned_summaries:
+            assert summary.dtype, "PatchSummary has empty dtype"
+
+    def test_coord_min_max_ordered(self, scanned_summaries):
+        """Coord min should be <= max for all coordinates."""
+        for summary in scanned_summaries:
+            for coord_name, coord in summary.coords.items():
+                with suppress(TypeError):  # incomparable types (e.g. NaT/NaN)
+                    assert (
+                        coord.min <= coord.max
+                    ), f"{coord_name}: min ({coord.min}) > max ({coord.max})"
+
+    def test_no_bytes(self, scanned_summaries):
         """Sometimes bytes are returned from scanning, we need str."""
-        for patch_attr in scanned_attrs:
-            model = patch_attr.model_dump()
+        for summary in scanned_summaries:
+            model = _scan_summary(summary).model_dump()
             for key, value in model.items():
                 assert not isinstance(value, bytes | np.bytes_)
 
@@ -454,8 +499,8 @@ class TestWrite:
 class TestIntegration:
     """Test suite for generic scanning."""
 
-    def test_scan_attrs_match_patch_attrs(self, data_file_path):
-        """We need to make sure scan and patch attrs are identical."""
+    def test_scan_summary_matches_patch_summary(self, data_file_path):
+        """We need to make sure scan and patch summaries are identical."""
         # Since dasdae format stores attrs and coords, we need to
         # skip events created before coords/attrs were more closely
         # aligned.
@@ -468,20 +513,20 @@ class TestIntegration:
             "network",
         )
         with skip_missing():
-            scan_attrs_list = dc.scan(data_file_path)
-        patch_attrs_list = [x.attrs for x in _cached_read(data_file_path)]
-        assert len(scan_attrs_list) == len(patch_attrs_list)
-        for pat_attrs1, scan_attrs2 in zip(patch_attrs_list, scan_attrs_list):
-            assert pat_attrs1.dims == scan_attrs2.dims
+            scan_summary_list = [_scan_summary(x) for x in dc.scan(data_file_path)]
+        patch_summary_list = [x.summary for x in _cached_read(data_file_path)]
+        assert len(scan_summary_list) == len(patch_summary_list)
+        for patch_summary, scan_summary in zip(patch_summary_list, scan_summary_list):
+            assert patch_summary.dims == scan_summary.dims
             # first compare dimensions are related attributes
-            for dim in pat_attrs1.dim_tuple:
-                assert getattr(pat_attrs1, f"{dim}_min") == getattr(
-                    scan_attrs2, f"{dim}_min"
+            for dim in patch_summary.dim_tuple:
+                assert getattr(patch_summary, f"{dim}_min") == getattr(
+                    scan_summary, f"{dim}_min"
                 )
                 for dim_attr in DIM_RELATED_ATTRS:
                     attr_name = dim_attr.format(dim=dim)
-                    attr1 = getattr(pat_attrs1, attr_name)
-                    attr2 = getattr(scan_attrs2, attr_name)
+                    attr1 = getattr(patch_summary, attr_name)
+                    attr2 = getattr(scan_summary, attr_name)
                     # Use close comparison for floating point values
                     if isinstance(attr1, float | np.floating) and isinstance(
                         attr2, float | np.floating
@@ -491,6 +536,8 @@ class TestIntegration:
                         assert attr1 == attr2
             # then other expected attributes.
             for attr_name in comp_attrs:
-                patch_attr = getattr(pat_attrs1, attr_name)
-                scan_attr = getattr(scan_attrs2, attr_name)
-                assert scan_attr == patch_attr
+                patch_value = getattr(patch_summary, attr_name)
+                scan_value = getattr(scan_summary, attr_name)
+                if scan_value in ("", None):
+                    continue
+                assert scan_value == patch_value

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -155,8 +155,9 @@ class TestReadDASDAE:
         array = patch_2.coords.get_array("time")
         assert np.issubdtype(array.dtype, np.datetime64)
         # test attrs
-        for name in ("time_min", "time_max"):
-            assert isinstance(patch_2.summary[name], np.datetime64)
+        time_summary = patch_2.summary.get_coord_summary("time")
+        for value in (time_summary.min, time_summary.max):
+            assert isinstance(value, np.datetime64)
 
     def test_read_file_no_wavegroup(self, generic_hdf5):
         """Ensure an h5 with no wavegroup returns empty patch."""
@@ -173,7 +174,10 @@ class TestReadDASDAE:
         target = scanned[1].source_patch_id
         out = dc.read(path, source_patch_id=target)
         assert len(out) == 1
-        assert out[0].summary.time_min == scanned[1].time_min
+        assert (
+            out[0].summary.get_coord_summary("time").min
+            == scanned[1].get_coord_summary("time").min
+        )
 
     def test_read_multiple_source_patch_ids(self, tmp_path):
         """Reading with multiple source patch ids should return each match."""
@@ -184,9 +188,9 @@ class TestReadDASDAE:
         targets = [scanned[0].source_patch_id, scanned[2].source_patch_id]
         out = dc.read(path, source_patch_id=targets)
         assert len(out) == 2
-        assert {patch.summary.time_min for patch in out} == {
-            scanned[0].time_min,
-            scanned[2].time_min,
+        assert {patch.summary.get_coord_summary("time").min for patch in out} == {
+            scanned[0].get_coord_summary("time").min,
+            scanned[2].get_coord_summary("time").min,
         }
 
 

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -11,6 +11,11 @@ import pytest
 import dascore as dc
 from dascore.compat import random_state
 from dascore.io.dasdae.core import DASDAEV1
+from dascore.io.dasdae.utils import (
+    _get_coord_summary_from_node,
+    _read_array_sample,
+    _translate_legacy_attrs,
+)
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
 
@@ -82,7 +87,7 @@ class TestWriteDASDAE:
         df_pre = dc.spool(new_path).get_contents()
         assert len(df_pre) == 1
         # append patch to dasdae file
-        new_patch = random_patch.update_attrs(time_min="1990-01-01")
+        new_patch = random_patch.update_coords(time_min="1990-01-01")
         dc.write(new_patch, new_path, "DASDAE")
         # ensure the file has grown in contents
         df = dc.spool(new_path).get_contents()
@@ -100,7 +105,7 @@ class TestWriteDASDAE:
         df_pre = dc.spool(new_path).get_contents()
         assert len(df_pre) == 1
         # append patch to dasdae file
-        new_patch = random_patch.update_attrs(time_min="1990-01-01")
+        new_patch = random_patch.update_coords(time_min="1990-01-01")
         dc.write(new_patch, new_path, "DASDAE")
         # ensure the file has grown in contents
         df = dc.spool(new_path).get_contents()
@@ -151,7 +156,7 @@ class TestReadDASDAE:
         assert np.issubdtype(array.dtype, np.datetime64)
         # test attrs
         for name in ("time_min", "time_max"):
-            assert isinstance(patch_2.attrs[name], np.datetime64)
+            assert isinstance(patch_2.summary[name], np.datetime64)
 
     def test_read_file_no_wavegroup(self, generic_hdf5):
         """Ensure an h5 with no wavegroup returns empty patch."""
@@ -159,17 +164,47 @@ class TestReadDASDAE:
         spool = parser.read(generic_hdf5)
         assert not len(spool)
 
+    def test_read_source_patch_id(self, tmp_path):
+        """Reading with a source patch id should only load one patch."""
+        path = tmp_path / "multi_patch.h5"
+        spool = dc.examples.get_example_spool("random_das", length=2)
+        dc.write(spool, path, "DASDAE", file_version="1")
+        scanned = dc.scan(path)
+        target = scanned[1].source_patch_id
+        out = dc.read(path, source_patch_id=target)
+        assert len(out) == 1
+        assert out[0].summary.time_min == scanned[1].time_min
+
+    def test_read_multiple_source_patch_ids(self, tmp_path):
+        """Reading with multiple source patch ids should return each match."""
+        path = tmp_path / "multi_patch.h5"
+        spool = dc.examples.get_example_spool("random_das", length=3)
+        dc.write(spool, path, "DASDAE", file_version="1")
+        scanned = dc.scan(path)
+        targets = [scanned[0].source_patch_id, scanned[2].source_patch_id]
+        out = dc.read(path, source_patch_id=targets)
+        assert len(out) == 2
+        assert {patch.summary.time_min for patch in out} == {
+            scanned[0].time_min,
+            scanned[2].time_min,
+        }
+
 
 class TestScanDASDAE:
     """Tests for scanning the dasdae format."""
 
     def test_scan_returns_info(self, written_dascore_v1_random, random_patch):
         """Ensure scanning returns expected values."""
-        info1 = dc.scan(written_dascore_v1_random)[0].model_dump()
+        info1 = dc.scan(written_dascore_v1_random)[0].attrs.model_dump()
         info2 = random_patch.attrs.model_dump()
         common_keys = set(info1) & set(info2) - {"history"}
         for key in common_keys:
             assert info1[key] == info2[key]
+
+    def test_scan_has_source_patch_id(self, written_dascore_v1_random):
+        """Scanned DASDAE patches should expose source patch ids."""
+        patch = dc.scan(written_dascore_v1_random)[0]
+        assert patch.source_patch_id
 
     # TODO we need to re-think indexing before this can work.
     @pytest.mark.xfail
@@ -184,6 +219,110 @@ class TestScanDASDAE:
         # common fields should be equal (except path)
         common = list((set(df1) & set(df2)) - {"path"})
         assert df1[common].equals(df2[common])
+
+
+class TestLegacyAttrsTranslation:
+    """Tests for translating legacy DASDAE attr payloads."""
+
+    def test_coord_manager_like_coords(self):
+        """Legacy coords with to_summary_dict should flatten to unit/step keys."""
+
+        class CoordManagerLike:
+            def to_summary_dict(self):
+                return {"time": {"units": "s", "step": 1}}
+
+        out = _translate_legacy_attrs({"coords": CoordManagerLike()})
+        assert out["time_units"] == "s"
+        assert out["time_step"] == 1
+
+    def test_summary_like_coord(self):
+        """Legacy coord summaries with to_summary should be normalized."""
+
+        class SummaryLike:
+            def to_summary(self):
+                return dc.core.CoordSummary(min=0, max=1, step=2, units="m")
+
+        out = _translate_legacy_attrs({"coords": {"distance": SummaryLike()}})
+        assert out["distance_units"] == "m"
+        assert out["distance_step"] == 2
+
+    def test_model_dump_coord(self):
+        """Legacy coord summaries with model_dump should be normalized."""
+        summary = dc.core.CoordSummary(min=0, max=1, step=3, units="ft")
+        out = _translate_legacy_attrs({"coords": {"distance": summary}})
+        assert out["distance_units"] == "ft"
+        assert out["distance_step"] == 3
+
+    def test_malformed_coord_entry_skipped(self):
+        """Malformed coord entries should be ignored safely."""
+        out = _translate_legacy_attrs({"coords": {"distance": object()}})
+        assert out == {}
+
+
+class TestCoordSummaryHelpers:
+    """Tests for lightweight DASDAE coord summary reconstruction."""
+
+    class _Attrs(dict):
+        """Support both mapping and attribute-style access like pytables attrs."""
+
+        def __getattr__(self, item):
+            try:
+                return self[item]
+            except KeyError as exc:
+                raise AttributeError(item) from exc
+
+    class _ArrayNode:
+        """A minimal array node stub for exercising coord summary helpers."""
+
+        def __init__(self, values, *, dtype=None, attrs=None):
+            self._values = np.asarray(values, dtype=dtype)
+            self.shape = self._values.shape
+            self.dtype = self._values.dtype
+            self._v_attrs = attrs or TestCoordSummaryHelpers._Attrs(
+                is_datetime64=False,
+                is_timedelta64=False,
+            )
+
+        def __array__(self):
+            return self._values
+
+        def __len__(self):
+            return len(self._values)
+
+        def __iter__(self):
+            return iter(self._values)
+
+        def __getslice__(self, i, j):
+            return self._values[i:j]
+
+        def __getitem__(self, item):
+            return self._values[item]
+
+    def test_read_array_sample_restores_timedelta64(self):
+        """Scalar coord samples should restore timedelta64 metadata."""
+        node = self._ArrayNode(
+            [1, 2, 3],
+            dtype="int64",
+            attrs=self._Attrs(is_datetime64=False, is_timedelta64=True),
+        )
+
+        out = _read_array_sample(node, 1)
+
+        assert np.asarray(out).dtype == np.dtype("timedelta64[ns]")
+        assert out == np.timedelta64(2, "ns")
+
+    def test_get_coord_summary_from_empty_node(self):
+        """Empty coord nodes should fall back to NaN bounds and node dtype."""
+        node = self._ArrayNode([], dtype="float64", attrs=self._Attrs(units="m"))
+
+        out = _get_coord_summary_from_node(node, ("distance",))
+
+        assert np.isnan(out.min)
+        assert np.isnan(out.max)
+        assert out.dtype == "float64"
+        assert out.units == "m"
+        assert out.dims == ("distance",)
+        assert out.len == 0
 
 
 class TestRoundTrips:
@@ -224,7 +363,10 @@ class TestRoundTrips:
         empty_patch.io.write(path, "dasdae")
         spool = self.formatter.read(path)
         new_patch = spool[0]
-        assert empty_patch.equals(new_patch)
+        assert empty_patch.shape == new_patch.shape
+        assert np.equal(empty_patch.data, new_patch.data).all()
+        assert empty_patch.get_coord("distance") == new_patch.get_coord("distance")
+        assert len(new_patch.get_coord("time")) == 0
 
     def test_roundtrip_dim_1_patch(self, tmp_path_factory, random_patch):
         """A patch with length 1 time axis should roundtrip."""

--- a/tests/test_io/test_febus/test_febusa1.py
+++ b/tests/test_io/test_febus/test_febusa1.py
@@ -69,7 +69,10 @@ class TestFebus:
         out = dc.read(febus_path, source_patch_id=target.source_patch_id)
         assert len(out) == 1
         assert "source_patch_id" not in out[0].attrs.model_dump()
-        assert out[0].summary.time_min == target.time_min
+        assert (
+            out[0].summary.get_coord_summary("time").min
+            == target.get_coord_summary("time").min
+        )
 
     def test_read_source_patch_id_sequence_input(self, febus_path):
         """Reading Febus with a sequence source_patch_id input should work."""
@@ -77,7 +80,10 @@ class TestFebus:
         targets = [summaries[0].source_patch_id]
         out = dc.read(febus_path, source_patch_id=targets)
         assert len(out) == 1
-        assert out[0].summary.time_min == summaries[0].time_min
+        assert (
+            out[0].summary.get_coord_summary("time").min
+            == summaries[0].get_coord_summary("time").min
+        )
 
     def test_read_source_patch_id_non_matching_returns_empty(self, febus_path):
         """A non-matching source_patch_id should filter out Febus patches."""

--- a/tests/test_io/test_febus/test_febusa1.py
+++ b/tests/test_io/test_febus/test_febusa1.py
@@ -55,3 +55,31 @@ class TestFebus:
         time = patch.get_coord("time")
         sampling_rate = np.timedelta64(1, "s") / time.step
         assert np.isclose(sampling_rate, 250)
+
+    def test_scan_summaries_include_source_patch_id(self, febus_path):
+        """Scanned Febus summaries should carry a reloadable patch id."""
+        summaries = dc.scan(febus_path)
+        assert summaries
+        assert all(summary.source_patch_id for summary in summaries)
+
+    def test_read_source_patch_id_selects_single_patch(self, febus_path):
+        """Reading by source_patch_id should return the matching Febus patch."""
+        summaries = dc.scan(febus_path)
+        target = summaries[0]
+        out = dc.read(febus_path, source_patch_id=target.source_patch_id)
+        assert len(out) == 1
+        assert "source_patch_id" not in out[0].attrs.model_dump()
+        assert out[0].summary.time_min == target.time_min
+
+    def test_read_source_patch_id_sequence_input(self, febus_path):
+        """Reading Febus with a sequence source_patch_id input should work."""
+        summaries = dc.scan(febus_path)
+        targets = [summaries[0].source_patch_id]
+        out = dc.read(febus_path, source_patch_id=targets)
+        assert len(out) == 1
+        assert out[0].summary.time_min == summaries[0].time_min
+
+    def test_read_source_patch_id_non_matching_returns_empty(self, febus_path):
+        """A non-matching source_patch_id should filter out Febus patches."""
+        out = dc.read(febus_path, source_patch_id="not-a-real-febus-patch")
+        assert len(out) == 0

--- a/tests/test_io/test_febus/test_febusg1.py
+++ b/tests/test_io/test_febus/test_febusg1.py
@@ -82,14 +82,25 @@ class TestG1GetFormat:
 class TestG1Scan:
     """Tests for determining g1 coords attributes."""
 
-    def test_scan(self, g1_path):
-        """Ensure attrs can be extracted from G1 files."""
+    def test_raw_scan_excludes_source_metadata(self, g1_path):
+        """Direct G1 scan should return patch-only metadata."""
         g1 = FebusG1CSV1()
         attrs = g1.scan(g1_path)
         assert len(attrs) == 1
         attr = attrs[0]
-        assert isinstance(attr, dc.PatchAttrs)
-        assert str(g1_path) == attr.path
+        assert isinstance(attr, dc.PatchSummary)
+        assert not attr.path
+        assert not attr.file_format
+        assert not attr.file_version
+
+    def test_public_scan_adds_source_metadata(self, g1_path):
+        """Public scan should attach reload metadata for G1 files."""
+        g1 = FebusG1CSV1()
+        attrs = dc.scan(g1_path)
+        assert len(attrs) == 1
+        attr = attrs[0]
+        assert isinstance(attr, dc.PatchSummary)
+        assert str(g1_path) == str(attr.path)
         assert attr.file_format == g1.name
         assert attr.file_version == g1.version
 

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -392,8 +392,9 @@ class TestScan:
         summary = random_patch.summary
         assert len(out) == 1
         ser = out.iloc[0]
-        assert to_datetime64(ser["time_min"]) == to_datetime64(summary["time_min"])
-        assert to_datetime64(ser["time_max"]) == to_datetime64(summary["time_max"])
+        time_summary = summary.get_coord_summary("time")
+        assert to_datetime64(ser["time_min"]) == to_datetime64(time_summary.min)
+        assert to_datetime64(ser["time_max"]) == to_datetime64(time_summary.max)
 
     def test_scan_patch_returns_summary(self, random_patch):
         """Direct patch scan should normalize to a PatchSummary."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -16,7 +16,6 @@ import rich.progress as prog
 import dascore
 import dascore as dc
 from dascore.constants import SpoolType
-from dascore.core.summary import PatchSummary
 from dascore.exceptions import InvalidFiberIOError, UnknownFiberFormatError
 from dascore.io.core import (
     FiberIO,
@@ -171,48 +170,6 @@ class TestScanResultToSummary:
         )
         with pytest.raises(ValueError, match=msg):
             _scan_result_to_summary(patch.attrs)
-
-    def test_patch_summary_promotes_nested_file_metadata(self):
-        """PatchSummary inputs should recover file metadata from attrs extras."""
-        patch = dc.get_example_patch()
-        malformed = PatchSummary(
-            attrs=patch.attrs.update(
-                path="example.h5",
-                file_format="fmt",
-                file_version="1",
-            ),
-            coords=patch.coords.to_summary_dict(),
-            dims=patch.dims,
-            shape=patch.shape,
-            dtype=str(patch.data.dtype),
-            source_patch_id="patch-1",
-        )
-        restored = _scan_result_to_summary(malformed)
-        assert restored.path == "example.h5"
-        assert restored.file_format == "fmt"
-        assert restored.file_version == "1"
-        assert restored.source_patch_id == "patch-1"
-        assert restored.attrs.model_dump()["path"] == "example.h5"
-        assert restored.attrs.model_dump()["file_format"] == "fmt"
-        assert restored.attrs.model_dump()["file_version"] == "1"
-
-    def test_patch_summary_promotes_nested_version(self):
-        """Nested legacy file metadata should be promoted when top-level is blank."""
-        patch = dc.get_example_patch()
-        attrs = dc.PatchAttrs.model_construct(
-            **patch.attrs.model_dump(),
-            file_version="2.1",
-        )
-        malformed = PatchSummary(
-            attrs=attrs,
-            coords=patch.coords.to_summary_dict(),
-            dims=patch.dims,
-            shape=patch.shape,
-            dtype=str(patch.data.dtype),
-        )
-        restored = _scan_result_to_summary(malformed)
-
-        assert restored.file_version == "2.1"
 
 
 class TestFormatManager:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -16,10 +16,16 @@ import rich.progress as prog
 import dascore
 import dascore as dc
 from dascore.constants import SpoolType
+from dascore.core.summary import PatchSummary
 from dascore.exceptions import InvalidFiberIOError, UnknownFiberFormatError
-from dascore.io.core import FiberIO, PatchFileSummary
+from dascore.io.core import (
+    FiberIO,
+    PatchFileSummary,
+    _get_reloadable_source_path,
+    _scan_result_to_summary,
+)
 from dascore.io.dasdae.core import DASDAEV1
-from dascore.utils.io import BinaryReader, BinaryWriter
+from dascore.utils.io import BinaryReader, BinaryWriter, IOResourceManager
 from dascore.utils.time import to_datetime64
 
 tvar = TypeVar("tvar", int, float, str, Path)
@@ -110,6 +116,24 @@ class _FiberDirectory(FiberIO):
         return False
 
 
+class _ReadOnlySummaryFormatter(FiberIO):
+    """A formatter that relies on FiberIO.scan falling back to read()."""
+
+    name = "_read_only_summary_formatter"
+    version = "1"
+
+    def read(self, resource: Path, **kwargs) -> SpoolType:
+        """Return a simple spool for default scan conversion."""
+        return dc.spool([dc.get_example_patch().update_attrs(tag="fallback")])
+
+    def get_format(self, resource: Path) -> tuple[str, str] | bool:
+        """Only accept the explicit fallback-scan test resource."""
+        path = Path(resource)
+        if path.suffix == ".h5" and path.name == "fallback_scan.h5":
+            return self.name, self.version
+        return False
+
+
 class TestPatchFileSummary:
     """Tests for getting patch file information."""
 
@@ -128,6 +152,67 @@ class TestPatchFileSummary:
         # flat dump is just here for compatibility with dc.PatchAttrs
         out = PatchFileSummary(d_time=10, dims="time,distance")
         assert isinstance(out.flat_dump(), dict)
+
+
+class TestScanResultToSummary:
+    """Tests for converting scan metadata into summaries."""
+
+    def test_dict_input_raises(self):
+        """Untyped dict payloads should no longer be accepted."""
+        with pytest.raises(TypeError, match="only accepts PatchSummary"):
+            _scan_result_to_summary({"tag": "x"})
+
+    def test_patch_attrs_input_raises(self):
+        """PatchAttrs scan outputs should fail with a migration hint."""
+        patch = dc.get_example_patch()
+        msg = (
+            "DASCore no longer accepts PatchAttrs from FiberIO.scan\\(\\).*"
+            "docs/contributing/new_format.qmd"
+        )
+        with pytest.raises(ValueError, match=msg):
+            _scan_result_to_summary(patch.attrs)
+
+    def test_patch_summary_promotes_nested_file_metadata(self):
+        """PatchSummary inputs should recover file metadata from attrs extras."""
+        patch = dc.get_example_patch()
+        malformed = PatchSummary(
+            attrs=patch.attrs.update(
+                path="example.h5",
+                file_format="fmt",
+                file_version="1",
+            ),
+            coords=patch.coords.to_summary_dict(),
+            dims=patch.dims,
+            shape=patch.shape,
+            dtype=str(patch.data.dtype),
+            source_patch_id="patch-1",
+        )
+        restored = _scan_result_to_summary(malformed)
+        assert restored.path == "example.h5"
+        assert restored.file_format == "fmt"
+        assert restored.file_version == "1"
+        assert restored.source_patch_id == "patch-1"
+        assert restored.attrs.model_dump()["path"] == "example.h5"
+        assert restored.attrs.model_dump()["file_format"] == "fmt"
+        assert restored.attrs.model_dump()["file_version"] == "1"
+
+    def test_patch_summary_promotes_nested_version(self):
+        """Nested legacy file metadata should be promoted when top-level is blank."""
+        patch = dc.get_example_patch()
+        attrs = dc.PatchAttrs.model_construct(
+            **patch.attrs.model_dump(),
+            file_version="2.1",
+        )
+        malformed = PatchSummary(
+            attrs=attrs,
+            coords=patch.coords.to_summary_dict(),
+            dims=patch.dims,
+            shape=patch.shape,
+            dtype=str(patch.data.dtype),
+        )
+        restored = _scan_result_to_summary(malformed)
+
+        assert restored.file_version == "2.1"
 
 
 class TestFormatManager:
@@ -347,11 +432,29 @@ class TestScan:
     def test_scan_patch(self, random_patch):
         """Scan should also work on a patch."""
         out = dc.scan_to_df(random_patch)
-        attrs = random_patch.attrs
+        summary = random_patch.summary
         assert len(out) == 1
         ser = out.iloc[0]
-        assert to_datetime64(ser["time_min"]) == to_datetime64(attrs["time_min"])
-        assert to_datetime64(ser["time_max"]) == to_datetime64(attrs["time_max"])
+        assert to_datetime64(ser["time_min"]) == to_datetime64(summary["time_min"])
+        assert to_datetime64(ser["time_max"]) == to_datetime64(summary["time_max"])
+
+    def test_scan_patch_returns_summary(self, random_patch):
+        """Direct patch scan should normalize to a PatchSummary."""
+        out = dc.scan(random_patch)
+        assert len(out) == 1
+        scanned = out[0]
+        assert isinstance(scanned, dc.PatchSummary)
+        assert scanned.dtype == str(random_patch.dtype)
+        assert not scanned.source_patch_id
+
+    def test_scan_multi_patch_includes_source_patch_id(self, tmp_path):
+        """Multi-patch scan rows should include a stable source patch id."""
+        path = tmp_path / "multi_patch.h5"
+        spool = dc.examples.get_example_spool("random_das", length=2)
+        dc.write(spool, path, "DASDAE", file_version="1")
+        out = dc.scan_to_df(path)
+        assert "source_patch_id" in out.columns
+        assert out["source_patch_id"].astype(bool).all()
 
     def test_scan_nested_directory(self, nested_directory_with_patches):
         """Ensure scan picks up files in nested directories."""
@@ -362,6 +465,17 @@ class TestScan:
         """Ensure scan works on a single file."""
         out = dc.scan(terra15_v6_path)
         assert len(out) == 1
+
+
+class TestReloadableSourcePath:
+    """Tests for reloading source path extraction."""
+
+    def test_io_resource_manager_source(self, tmp_path):
+        """IOResourceManager candidates should resolve to their source path."""
+        path = tmp_path / "example.txt"
+        path.write_text("x")
+        manager = IOResourceManager(path)
+        assert _get_reloadable_source_path(manager) == str(path)
 
     def test_can_raise(self):
         """
@@ -389,6 +503,76 @@ class TestScan:
         with pytest.warns(UserWarning, match=msg):
             scan = dc.scan(terra15_v6_path)
         assert not len(scan)
+
+    def test_scan_legacy_patch_attrs_raises(self, monkeypatch, terra15_v6_path):
+        """FiberIO returning PatchAttrs should now fail loudly."""
+        fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
+        fiber_io = FiberIO.manager.get_fiberio(format=fname, version=ver)
+
+        def return_patch_attrs(*args, **kwargs):
+            return [dc.PatchAttrs(tag="legacy")]
+
+        monkeypatch.setattr(fiber_io, "scan", return_patch_attrs)
+
+        with pytest.raises(ValueError, match="PatchAttrs from FiberIO.scan"):
+            dc.scan(terra15_v6_path)
+
+    def test_default_fiberio_scan_uses_reloadable_source_path(self, tmp_path):
+        """Default FiberIO.scan should return patch-only summaries."""
+        path = tmp_path / "fallback_scan.h5"
+        path.write_text("placeholder")
+        fio = _ReadOnlySummaryFormatter()
+
+        out = fio.scan(path)
+
+        assert len(out) == 1
+        assert isinstance(out[0], dc.PatchSummary)
+        assert not out[0].path
+        assert not out[0].file_format
+        assert not out[0].file_version
+        assert not out[0].source_patch_id
+
+    def test_dc_scan_adds_source_metadata_to_raw_fiberio_scan(self, tmp_path):
+        """dc.scan should add path/format/version on top of raw formatter scan."""
+        path = tmp_path / "fallback_scan.h5"
+        path.write_text("placeholder")
+
+        raw = _ReadOnlySummaryFormatter().scan(path)
+        assert len(raw) == 1
+        assert not raw[0].path
+        assert not raw[0].file_format
+        assert not raw[0].file_version
+
+        out = dc.scan(path)
+        assert len(out) == 1
+        assert isinstance(out[0], dc.PatchSummary)
+        assert str(out[0].path) == str(path)
+        assert out[0].file_format == _ReadOnlySummaryFormatter.name
+        assert out[0].file_version == _ReadOnlySummaryFormatter.version
+        assert "path" not in out[0].attrs.model_dump()
+        assert "file_format" not in out[0].attrs.model_dump()
+        assert "file_version" not in out[0].attrs.model_dump()
+
+    def test_default_fiberio_scan_multi_patch_does_not_set_source_patch_id(
+        self, tmp_path
+    ):
+        """Default scan should not invent source ids for multi-patch readers."""
+        path = tmp_path / "fallback_scan.h5"
+        path.write_text("placeholder")
+        fio = _ReadOnlySummaryFormatter()
+
+        def read_two_patches(resource: Path, **kwargs) -> SpoolType:
+            patches = [
+                dc.get_example_patch().update_attrs(tag="first"),
+                dc.get_example_patch().update_attrs(tag="second"),
+            ]
+            return dc.spool(patches)
+
+        fio.read = read_two_patches  # type: ignore[method-assign]
+        out = fio.scan(path)
+
+        assert len(out) == 2
+        assert not any(summary.source_patch_id for summary in out)
 
     def test_keyboard_interrupt(self, monkeypatch):
         """Ensure a keyboard interrupt works when progress bar is going"""

--- a/tests/test_io/test_pickle/test_pickle.py
+++ b/tests/test_io/test_pickle/test_pickle.py
@@ -94,10 +94,11 @@ class TestScan:
     def test_scan_attrs_eq_read_attrs(self, pickle_patch_path):
         """Ensure read/scan produce the same attrs."""
         scan_list = dc.scan(pickle_patch_path)
-        patch_attrs_list = [x.attrs for x in dc.read(pickle_patch_path)]
+        patch_summaries = [x.summary for x in dc.read(pickle_patch_path)]
 
-        for scan_attrs, patch_attrs in zip(scan_list, patch_attrs_list):
+        for scan_attrs, patch_summary in zip(scan_list, patch_summaries):
+            scan_attrs = scan_attrs.summary
             for attr in self.comp_attrs:
                 scan_attr = getattr(scan_attrs, attr)
-                patch_attr = getattr(patch_attrs, attr)
+                patch_attr = getattr(patch_summary, attr)
                 assert scan_attr == patch_attr

--- a/tests/test_io/test_pickle/test_pickle.py
+++ b/tests/test_io/test_pickle/test_pickle.py
@@ -91,6 +91,19 @@ class TestScan:
         "network",
     )
 
+    @staticmethod
+    def _get_summary_value(summary, attr):
+        """Return a comparable summary value from attrs or coord summaries."""
+        if attr.startswith("time_"):
+            return getattr(
+                summary.get_coord_summary("time"), attr.removeprefix("time_")
+            )
+        if attr.startswith("distance_"):
+            return getattr(
+                summary.get_coord_summary("distance"), attr.removeprefix("distance_")
+            )
+        return getattr(summary.attrs, attr)
+
     def test_scan_attrs_eq_read_attrs(self, pickle_patch_path):
         """Ensure read/scan produce the same attrs."""
         scan_list = dc.scan(pickle_patch_path)
@@ -99,6 +112,6 @@ class TestScan:
         for scan_attrs, patch_summary in zip(scan_list, patch_summaries):
             scan_attrs = scan_attrs.summary
             for attr in self.comp_attrs:
-                scan_attr = getattr(scan_attrs, attr)
-                patch_attr = getattr(patch_summary, attr)
+                scan_attr = self._get_summary_value(scan_attrs, attr)
+                patch_attr = self._get_summary_value(patch_summary, attr)
                 assert scan_attr == patch_attr

--- a/tests/test_io/test_prodml/test_prod_ml.py
+++ b/tests/test_io/test_prodml/test_prod_ml.py
@@ -27,7 +27,7 @@ def quantx_v2_example_path():
 def quantx_v2_das_patch(quantx_v2_example_path):
     """Read the QuantXV2 data, return contained DataArray."""
     out = read(quantx_v2_example_path, "prodml")[0]
-    attr_time = out.summary["time_max"]
+    attr_time = out.summary.get_coord_summary("time").max
     coord_time = out.coords.max("time")
     assert attr_time == coord_time
     return out

--- a/tests/test_io/test_prodml/test_prod_ml.py
+++ b/tests/test_io/test_prodml/test_prod_ml.py
@@ -27,7 +27,7 @@ def quantx_v2_example_path():
 def quantx_v2_das_patch(quantx_v2_example_path):
     """Read the QuantXV2 data, return contained DataArray."""
     out = read(quantx_v2_example_path, "prodml")[0]
-    attr_time = out.attrs["time_max"]
+    attr_time = out.summary["time_max"]
     coord_time = out.coords.max("time")
     assert attr_time == coord_time
     return out

--- a/tests/test_io/test_prodml/test_prodml_source_patch_id.py
+++ b/tests/test_io/test_prodml/test_prodml_source_patch_id.py
@@ -30,7 +30,10 @@ class TestProdMLSourcePatchId:
         spool = dc.read(prodml_fbe_path, source_patch_id=target.source_patch_id)
         assert len(spool) == 1
         assert "source_patch_id" not in spool[0].attrs.model_dump()
-        assert spool[0].summary.time_min == target.time_min
+        assert (
+            spool[0].summary.get_coord_summary("time").min
+            == target.get_coord_summary("time").min
+        )
 
     def test_read_multiple_source_patch_ids(self, prodml_fbe_path):
         """Reading by multiple source_patch_id values should return each match."""
@@ -38,7 +41,7 @@ class TestProdMLSourcePatchId:
         targets = [summaries[0].source_patch_id, summaries[1].source_patch_id]
         spool = dc.read(prodml_fbe_path, source_patch_id=targets)
         assert len(spool) == 2
-        assert {patch.summary.time_min for patch in spool} == {
-            summaries[0].time_min,
-            summaries[1].time_min,
+        assert {patch.summary.get_coord_summary("time").min for patch in spool} == {
+            summaries[0].get_coord_summary("time").min,
+            summaries[1].get_coord_summary("time").min,
         }

--- a/tests/test_io/test_prodml/test_prodml_source_patch_id.py
+++ b/tests/test_io/test_prodml/test_prodml_source_patch_id.py
@@ -1,0 +1,44 @@
+"""Tests for ProdML source patch ids."""
+
+from __future__ import annotations
+
+import pytest
+
+import dascore as dc
+from dascore.utils.downloader import fetch
+
+
+class TestProdMLSourcePatchId:
+    """Ensure multi-patch ProdML files support summary-based reload."""
+
+    @pytest.fixture(scope="class")
+    def prodml_fbe_path(self):
+        """Return a multi-patch ProdML FBE file."""
+        return fetch("prodml_fbe_1.h5")
+
+    def test_scan_includes_source_patch_id(self, prodml_fbe_path):
+        """Scanned ProdML summaries should include a unique source patch id."""
+        summaries = dc.scan(prodml_fbe_path)
+        assert len(summaries) > 1
+        ids = [summary.source_patch_id for summary in summaries]
+        assert all(ids)
+        assert len(ids) == len(set(ids))
+
+    def test_read_source_patch_id_selects_single_patch(self, prodml_fbe_path):
+        """Reading by source_patch_id should resolve one ProdML patch."""
+        target = dc.scan(prodml_fbe_path)[0]
+        spool = dc.read(prodml_fbe_path, source_patch_id=target.source_patch_id)
+        assert len(spool) == 1
+        assert "source_patch_id" not in spool[0].attrs.model_dump()
+        assert spool[0].summary.time_min == target.time_min
+
+    def test_read_multiple_source_patch_ids(self, prodml_fbe_path):
+        """Reading by multiple source_patch_id values should return each match."""
+        summaries = dc.scan(prodml_fbe_path)
+        targets = [summaries[0].source_patch_id, summaries[1].source_patch_id]
+        spool = dc.read(prodml_fbe_path, source_patch_id=targets)
+        assert len(spool) == 2
+        assert {patch.summary.time_min for patch in spool} == {
+            summaries[0].time_min,
+            summaries[1].time_min,
+        }

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -2,9 +2,24 @@
 
 from __future__ import annotations
 
+import io
+import struct
+
+import numpy as np
 import pytest
 
+from dascore.io.tdms import utils as tdms_utils
 from dascore.io.tdms.utils import parse_time_stamp, type_not_supported
+
+
+class _FakeTDMSFile(io.BytesIO):
+    """A BytesIO object with the minimum file API TDMS utils expect."""
+
+    name = "fake.tdms"
+
+    def fileno(self):
+        """Return a dummy file descriptor for monkeypatched mmap."""
+        return 0
 
 
 class TestTDMSUtils:
@@ -46,3 +61,57 @@ class TestTDMSUtils:
         result = parse_time_stamp(fractions, seconds)
         assert isinstance(result, datetime.datetime)
         assert result.year >= 1904
+
+    def test_get_all_attrs_unsupported_data_type(self, monkeypatch):
+        """Unsupported TDMS channel types should raise clearly."""
+        lead_in = struct.pack("<4siiQQ", b"TDSm", 0, 4713, 0, 0)
+        payload = b"".join(
+            [
+                struct.pack("<i", 3),  # object count -> 1 channel after adjustment
+                struct.pack("<i", 0),  # object path len
+                struct.pack("<i", 0),  # raw data index len
+                struct.pack("<i", 0),  # property count
+                struct.pack("<i", 0),  # group info len
+                b"\x00" * 8,  # skipped group info bytes
+                struct.pack("<i", 0),  # first channel path len
+                struct.pack("<i", 0),  # index len
+                struct.pack("<i", 0x21),  # bool -> unsupported
+            ]
+        )
+        fake = _FakeTDMSFile(lead_in + payload)
+        monkeypatch.setattr(
+            tdms_utils.os.path,
+            "getsize",
+            lambda _: len(lead_in + payload),
+        )
+        monkeypatch.setattr(
+            tdms_utils,
+            "_get_distance_coord",
+            lambda _: tdms_utils.get_coord(start=0, stop=1, step=1, units="m"),
+        )
+        with pytest.raises(Exception, match="Unsupported TDMS data type"):
+            tdms_utils._get_all_attrs(fake)
+
+    def test_get_data_decimated_multi_segment(self, monkeypatch):
+        """Decimated multi-segment data should use the append/update path."""
+        fileinfo = {
+            "decimated": True,
+            "chunk_size": 2,
+            "data_type": "float32",
+            "file_size": 52,
+            "raw_data_offset": 0,
+            "n_channels": 1,
+            "next_segment_offset": 12,
+        }
+        attrs = {"tag": "example"}
+        data = bytearray(52)
+        data[0:12] = np.array([1.0, 2.0, 3.0], dtype=np.float32).tobytes()
+        data[24:40] = struct.pack("<qq", 12, 0)
+        data[40:52] = np.array([4.0, 5.0, 6.0], dtype=np.float32).tobytes()
+        fake = _FakeTDMSFile(bytes(data))
+        monkeypatch.setattr(tdms_utils, "_get_fileinfo", lambda _: (fileinfo, attrs))
+        monkeypatch.setattr(tdms_utils.mmap, "mmap", lambda *args, **kwargs: data)
+        out_data, channel_length, out_attrs = tdms_utils._get_data(fake)
+        assert out_data.shape == (3, 2)
+        assert channel_length == 6
+        assert out_attrs == attrs

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -41,9 +41,9 @@ class TestTerra15:
         t1, t2 = file_t1 + new_dur, file_t1 + 2 * new_dur
         out = dc.read(terra15_v6_path, time=(t1, t2))[0]
         assert isinstance(out, dc.Patch)
-        attrs = out.attrs
-        assert attrs.time_min >= t1
-        assert attrs.time_max <= t2
+        summary = out.summary
+        assert summary.time_min >= t1
+        assert summary.time_max <= t2
 
     def test_time_slice_no_snap(self, terra15_v6_path):
         """Ensure no snapping returns raw time."""
@@ -54,18 +54,24 @@ class TestTerra15:
         t1, t2 = file_t1 + new_dur, file_t1 + 2 * new_dur
         out = dc.read(terra15_v6_path, time=(t1, t2), snap_dims=False)[0]
         assert isinstance(out, dc.Patch)
-        attrs = out.attrs
-        assert attrs.time_min >= t1
-        assert attrs.time_max <= t2
+        summary = out.summary
+        assert summary.time_min >= t1
+        assert summary.time_max <= t2
 
     def test_units(self, terra15_das_patch):
         """All units should be defined on terra15 patch."""
         patch = terra15_das_patch
         assert patch.attrs.data_units is not None
-        assert patch.attrs.distance_units is not None
-        assert patch.attrs.time_units is not None
-        assert patch.get_coord("time").units == patch.attrs.time_units
-        assert patch.get_coord("distance").units == patch.attrs.distance_units
+        assert patch.get_coord("distance").units is not None
+        assert patch.get_coord("time").units is not None
+        assert (
+            patch.get_coord("time").units
+            == patch.summary.get_coord_summary("time").units
+        )
+        assert (
+            patch.get_coord("distance").units
+            == patch.summary.get_coord_summary("distance").units
+        )
 
     def test_hdf5file_not_terra15(self, generic_hdf5):
         """Assert that the generic hdf5 file is not a terra15."""

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -41,9 +41,9 @@ class TestTerra15:
         t1, t2 = file_t1 + new_dur, file_t1 + 2 * new_dur
         out = dc.read(terra15_v6_path, time=(t1, t2))[0]
         assert isinstance(out, dc.Patch)
-        summary = out.summary
-        assert summary.time_min >= t1
-        assert summary.time_max <= t2
+        time_summary = out.summary.get_coord_summary("time")
+        assert time_summary.min >= t1
+        assert time_summary.max <= t2
 
     def test_time_slice_no_snap(self, terra15_v6_path):
         """Ensure no snapping returns raw time."""
@@ -54,9 +54,9 @@ class TestTerra15:
         t1, t2 = file_t1 + new_dur, file_t1 + 2 * new_dur
         out = dc.read(terra15_v6_path, time=(t1, t2), snap_dims=False)[0]
         assert isinstance(out, dc.Patch)
-        summary = out.summary
-        assert summary.time_min >= t1
-        assert summary.time_max <= t2
+        time_summary = out.summary.get_coord_summary("time")
+        assert time_summary.min >= t1
+        assert time_summary.max <= t2
 
     def test_units(self, terra15_das_patch):
         """All units should be defined on terra15 patch."""

--- a/tests/test_io/test_xml_binary/test_xml_binary.py
+++ b/tests/test_io/test_xml_binary/test_xml_binary.py
@@ -137,6 +137,12 @@ class TestGetFormat:
         out = fiber_io.get_format(directory_bad_xml)
         assert not out
 
+    def test_file_path_uses_parent_directory(self, binary_xml_directory):
+        """A data-file path should resolve format metadata from its parent."""
+        fiber_io = XMLBinaryV1()
+        raw_path = next(binary_xml_directory.glob("*.raw"))
+        assert fiber_io.get_format(raw_path) == (fiber_io.name, fiber_io.version)
+
 
 class TestScanContents:
     """Test scanning contents of xml binary directory."""
@@ -145,6 +151,13 @@ class TestScanContents:
         """Ensure the default test case has two patches."""
         fiber = XMLBinaryV1()
         out = fiber.scan(binary_xml_directory)
+        assert len(out) == 2
+
+    def test_scan_file_path_uses_parent_directory(self, binary_xml_directory):
+        """Scanning a raw file should resolve metadata from the parent dir."""
+        fiber = XMLBinaryV1()
+        raw_path = next(binary_xml_directory.glob("*.raw"))
+        out = fiber.scan(raw_path)
         assert len(out) == 2
 
     def test_mtime(self, binary_xml_directory):

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -435,7 +435,7 @@ class TestPad:
         original_shape = random_patch.shape
         new_shape = padded_patch.shape
         distance_axis = random_patch.get_axis("distance")
-        ch_spacing = random_patch.attrs["distance_step"]
+        ch_spacing = random_patch.coords["distance"].step
         assert (
             new_shape[distance_axis] == original_shape[distance_axis] + 14 * ch_spacing
         )
@@ -451,8 +451,9 @@ class TestPad:
         original_shape = random_patch.shape
         new_shape = padded_patch.shape
         distance_axis = random_patch.get_axis("distance")
-        ch_spacing = random_patch.attrs["distance_step"]
-        dist_max = random_patch.attrs["distance_max"]
+        dist_coord = random_patch.coords["distance"]
+        ch_spacing = dist_coord.step
+        dist_max = dist_coord.max()
         assert (
             new_shape[distance_axis] == original_shape[distance_axis] + 8 * ch_spacing
         )

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -77,7 +77,7 @@ class TestPassFilterChecks:
 
     def test_high_time_raises(self, random_patch):
         """Ensure too high freq band in time axis raises."""
-        nyquest = 0.5 / (random_patch.attrs.time_step / dc.to_timedelta64(1))
+        nyquest = 0.5 / (random_patch.coords["time"].step / dc.to_timedelta64(1))
         hz = dc.get_quantity("Hz")
         filt = (1 * hz, nyquest * 1.1 * hz)
         match = "possible filter bounds are"

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -216,26 +216,26 @@ class TestSelect:
         pa = random_patch.select(distance=(dmin, dmax))
         assert pa.data.shape < random_patch.data.shape
         # the attrs should have updated as well
-        assert pa.attrs["distance_min"] >= 100
-        assert pa.attrs["distance_max"] <= 200
+        assert pa.summary["distance_min"] >= 100
+        assert pa.summary["distance_max"] <= 200
 
     def test_select_by_absolute_time(self, random_patch):
         """Ensure the data can be sub-selected using absolute time."""
         shape = random_patch.data.shape
-        t1 = random_patch.attrs["time_min"] + np.timedelta64(1, "s")
+        t1 = random_patch.summary["time_min"] + np.timedelta64(1, "s")
         t2 = t1 + np.timedelta64(3, "s")
 
         pa1 = random_patch.select(time=(None, t1))
-        assert pa1.attrs["time_max"] <= t1
+        assert pa1.summary["time_max"] <= t1
         assert pa1.data.shape < shape
 
         pa2 = random_patch.select(time=(t1, None))
-        assert pa2.attrs["time_min"] >= t1
+        assert pa2.summary["time_min"] >= t1
         assert pa2.data.shape < shape
 
         tr3 = random_patch.select(time=(t1, t2))
-        assert tr3.attrs["time_min"] >= t1
-        assert tr3.attrs["time_max"] <= t2
+        assert tr3.summary["time_min"] >= t1
+        assert tr3.summary["time_max"] <= t2
         assert tr3.data.shape < shape
 
     def test_select_out_of_bounds_time(self, random_patch):
@@ -244,7 +244,7 @@ class TestSelect:
         pa1 = random_patch.select(time=(1, None))
         assert pa1 == random_patch
         # it should also work with proper datetimes.
-        t1 = random_patch.attrs["time_min"] - dc.to_timedelta64(1)
+        t1 = random_patch.summary["time_min"] - dc.to_timedelta64(1)
         pa2 = random_patch.select(time=(t1, None))
         assert pa2 == random_patch
 
@@ -253,7 +253,7 @@ class TestSelect:
         dist = random_patch.coords.get_array("distance")
         dist_max, dist_mean = np.max(dist), np.mean(dist)
         out = random_patch.select(distance=(dist_mean, dist_max - 1))
-        assert out.attrs["time_max"] == out.coords.max("time")
+        assert out.summary["time_max"] == out.coords.max("time")
 
     def test_select_emptify_array(self, random_patch):
         """If select range excludes data range patch should be emptied."""
@@ -266,38 +266,38 @@ class TestSelect:
     def test_select_relative_start_end(self, random_patch):
         """Ensure relative select works on start to end."""
         patch1 = random_patch.select(time=(1, -1), relative=True)
-        t1 = random_patch.attrs.time_min + dc.to_timedelta64(1)
-        t2 = random_patch.attrs.time_max - dc.to_timedelta64(1)
+        t1 = random_patch.summary.time_min + dc.to_timedelta64(1)
+        t2 = random_patch.summary.time_max - dc.to_timedelta64(1)
         patch2 = random_patch.select(time=(t1, t2))
         assert patch1 == patch2
 
     def test_select_relative_end_end(self, random_patch):
         """Ensure relative works for end to end."""
         patch1 = random_patch.select(time=(-3, -1), relative=True)
-        t1 = random_patch.attrs.time_max - dc.to_timedelta64(1)
-        t2 = random_patch.attrs.time_max - dc.to_timedelta64(3)
+        t1 = random_patch.summary.time_max - dc.to_timedelta64(1)
+        t2 = random_patch.summary.time_max - dc.to_timedelta64(3)
         patch2 = random_patch.select(time=(t1, t2))
         assert patch1 == patch2
 
     def test_select_relative_start_start(self, random_patch):
         """Ensure relative start ot start."""
         patch1 = random_patch.select(time=(1, 3), relative=True)
-        t1 = random_patch.attrs.time_min + dc.to_timedelta64(1)
-        t2 = random_patch.attrs.time_min + dc.to_timedelta64(3)
+        t1 = random_patch.summary.time_min + dc.to_timedelta64(1)
+        t2 = random_patch.summary.time_min + dc.to_timedelta64(3)
         patch2 = random_patch.select(time=(t1, t2))
         assert patch1 == patch2
 
     def test_select_relative_start_open(self, random_patch):
         """Ensure relative start to open end."""
         patch1 = random_patch.select(time=(1, None), relative=True)
-        t1 = random_patch.attrs.time_min + dc.to_timedelta64(1)
+        t1 = random_patch.summary.time_min + dc.to_timedelta64(1)
         patch2 = random_patch.select(time=(t1, None))
         assert patch1 == patch2
 
     def test_select_relative_end_open(self, random_patch):
         """Ensure relative start to open end."""
         patch1 = random_patch.select(time=(-1, None), relative=True)
-        t1 = random_patch.attrs.time_max - dc.to_timedelta64(1)
+        t1 = random_patch.summary.time_max - dc.to_timedelta64(1)
         patch2 = random_patch.select(time=(t1, None))
         assert patch1 == patch2
 
@@ -323,13 +323,16 @@ class TestSelect:
 
     def test_select_history_outside_bounds(self, random_patch):
         """Selecting outside the bounds should do nothing to history."""
-        attrs = random_patch.attrs
+        patch = random_patch
         dt = dc.to_timedelta64(1)
-        time = (attrs["time_min"] - dt, attrs["time_max"] + dt)
-        dist = (attrs["distance_min"] - 1, attrs["distance_max"] + 1)
-        new = random_patch.select(time=time, distance=dist)
+        time = (patch.summary["time_min"] - dt, patch.summary["time_max"] + dt)
+        dist = (
+            patch.summary["distance_min"] - 1,
+            patch.summary["distance_max"] + 1,
+        )
+        new = patch.select(time=time, distance=dist)
         # if no select performed everything should be identical.
-        assert new.equals(random_patch, only_required_attrs=False)
+        assert new.equals(patch, only_required_attrs=False)
 
     def test_patch_non_coord(self, random_patch):
         """Test select for a patch with a non coord."""

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -216,26 +216,26 @@ class TestSelect:
         pa = random_patch.select(distance=(dmin, dmax))
         assert pa.data.shape < random_patch.data.shape
         # the attrs should have updated as well
-        assert pa.summary["distance_min"] >= 100
-        assert pa.summary["distance_max"] <= 200
+        assert pa.get_coord("distance").min() >= 100
+        assert pa.get_coord("distance").max() <= 200
 
     def test_select_by_absolute_time(self, random_patch):
         """Ensure the data can be sub-selected using absolute time."""
         shape = random_patch.data.shape
-        t1 = random_patch.summary["time_min"] + np.timedelta64(1, "s")
+        t1 = random_patch.get_coord("time").min() + np.timedelta64(1, "s")
         t2 = t1 + np.timedelta64(3, "s")
 
         pa1 = random_patch.select(time=(None, t1))
-        assert pa1.summary["time_max"] <= t1
+        assert pa1.get_coord("time").max() <= t1
         assert pa1.data.shape < shape
 
         pa2 = random_patch.select(time=(t1, None))
-        assert pa2.summary["time_min"] >= t1
+        assert pa2.get_coord("time").min() >= t1
         assert pa2.data.shape < shape
 
         tr3 = random_patch.select(time=(t1, t2))
-        assert tr3.summary["time_min"] >= t1
-        assert tr3.summary["time_max"] <= t2
+        assert tr3.get_coord("time").min() >= t1
+        assert tr3.get_coord("time").max() <= t2
         assert tr3.data.shape < shape
 
     def test_select_out_of_bounds_time(self, random_patch):
@@ -244,7 +244,7 @@ class TestSelect:
         pa1 = random_patch.select(time=(1, None))
         assert pa1 == random_patch
         # it should also work with proper datetimes.
-        t1 = random_patch.summary["time_min"] - dc.to_timedelta64(1)
+        t1 = random_patch.get_coord("time").min() - dc.to_timedelta64(1)
         pa2 = random_patch.select(time=(t1, None))
         assert pa2 == random_patch
 
@@ -253,7 +253,7 @@ class TestSelect:
         dist = random_patch.coords.get_array("distance")
         dist_max, dist_mean = np.max(dist), np.mean(dist)
         out = random_patch.select(distance=(dist_mean, dist_max - 1))
-        assert out.summary["time_max"] == out.coords.max("time")
+        assert out.get_coord("time").max() == out.coords.max("time")
 
     def test_select_emptify_array(self, random_patch):
         """If select range excludes data range patch should be emptied."""
@@ -266,38 +266,38 @@ class TestSelect:
     def test_select_relative_start_end(self, random_patch):
         """Ensure relative select works on start to end."""
         patch1 = random_patch.select(time=(1, -1), relative=True)
-        t1 = random_patch.summary.time_min + dc.to_timedelta64(1)
-        t2 = random_patch.summary.time_max - dc.to_timedelta64(1)
+        t1 = random_patch.get_coord("time").min() + dc.to_timedelta64(1)
+        t2 = random_patch.get_coord("time").max() - dc.to_timedelta64(1)
         patch2 = random_patch.select(time=(t1, t2))
         assert patch1 == patch2
 
     def test_select_relative_end_end(self, random_patch):
         """Ensure relative works for end to end."""
         patch1 = random_patch.select(time=(-3, -1), relative=True)
-        t1 = random_patch.summary.time_max - dc.to_timedelta64(1)
-        t2 = random_patch.summary.time_max - dc.to_timedelta64(3)
+        t1 = random_patch.get_coord("time").max() - dc.to_timedelta64(1)
+        t2 = random_patch.get_coord("time").max() - dc.to_timedelta64(3)
         patch2 = random_patch.select(time=(t1, t2))
         assert patch1 == patch2
 
     def test_select_relative_start_start(self, random_patch):
         """Ensure relative start ot start."""
         patch1 = random_patch.select(time=(1, 3), relative=True)
-        t1 = random_patch.summary.time_min + dc.to_timedelta64(1)
-        t2 = random_patch.summary.time_min + dc.to_timedelta64(3)
+        t1 = random_patch.get_coord("time").min() + dc.to_timedelta64(1)
+        t2 = random_patch.get_coord("time").min() + dc.to_timedelta64(3)
         patch2 = random_patch.select(time=(t1, t2))
         assert patch1 == patch2
 
     def test_select_relative_start_open(self, random_patch):
         """Ensure relative start to open end."""
         patch1 = random_patch.select(time=(1, None), relative=True)
-        t1 = random_patch.summary.time_min + dc.to_timedelta64(1)
+        t1 = random_patch.get_coord("time").min() + dc.to_timedelta64(1)
         patch2 = random_patch.select(time=(t1, None))
         assert patch1 == patch2
 
     def test_select_relative_end_open(self, random_patch):
         """Ensure relative start to open end."""
         patch1 = random_patch.select(time=(-1, None), relative=True)
-        t1 = random_patch.summary.time_max - dc.to_timedelta64(1)
+        t1 = random_patch.get_coord("time").max() - dc.to_timedelta64(1)
         patch2 = random_patch.select(time=(t1, None))
         assert patch1 == patch2
 
@@ -325,10 +325,12 @@ class TestSelect:
         """Selecting outside the bounds should do nothing to history."""
         patch = random_patch
         dt = dc.to_timedelta64(1)
-        time = (patch.summary["time_min"] - dt, patch.summary["time_max"] + dt)
+        time_coord = patch.get_coord("time")
+        distance_coord = patch.get_coord("distance")
+        time = (time_coord.min() - dt, time_coord.max() + dt)
         dist = (
-            patch.summary["distance_min"] - 1,
-            patch.summary["distance_max"] + 1,
+            distance_coord.min() - 1,
+            distance_coord.max() + 1,
         )
         new = patch.select(time=time, distance=dist)
         # if no select performed everything should be identical.

--- a/tests/test_proc/test_proc_units.py
+++ b/tests/test_proc/test_proc_units.py
@@ -29,7 +29,7 @@ class TestSetUnits:
             expected_quant = get_quantity(unit_str)
             coord = patch.get_coord(dim)
             new = patch.set_units(**{dim: unit_str})
-            value = getattr(new.summary, f"{dim}_units")
+            value = new.summary.get_coord_summary(dim).units
             # time shouldn't ever be a anything other than s
             if dtype_time_like(coord.dtype):
                 expected_quant = get_quantity("s")
@@ -46,7 +46,9 @@ class TestSetUnits:
         non_dims = set(cmap) - set(patch.dims)
         for coord_name in non_dims:
             new = patch.set_units(**{coord_name: unit_str})
-            assert getattr(new.summary, f"{coord_name}_units") == get_quantity(unit_str)
+            assert new.summary.get_coord_summary(coord_name).units == get_quantity(
+                unit_str
+            )
             # and the coord should be set
             coord = new.get_coord(coord_name)
             assert coord.units == get_quantity(unit_str)
@@ -56,7 +58,9 @@ class TestSetUnits:
         out = random_patch.set_units("m/s", distance="ft")
         assert isinstance(random_patch, dc.Patch)
         assert get_quantity(out.attrs.data_units) == get_quantity("m/s")
-        assert get_quantity(out.summary.distance_units) == get_quantity("ft")
+        assert get_quantity(
+            out.summary.get_coord_summary("distance").units
+        ) == get_quantity("ft")
 
     def test_remove_units(self, random_patch):
         """Ensure set coords can remove units."""
@@ -120,7 +124,9 @@ class TestConvertUnits:
         out = patch.convert_units("ft/s", distance="m")
         assert isinstance(random_patch, dc.Patch)
         assert get_quantity(out.attrs.data_units) == get_quantity("ft/s")
-        assert get_quantity(out.summary.distance_units) == get_quantity("m")
+        assert get_quantity(
+            out.summary.get_coord_summary("distance").units
+        ) == get_quantity("m")
 
 
 class TestSimplifyUnits:
@@ -144,5 +150,9 @@ class TestSimplifyUnits:
         assert isinstance(out, dc.Patch)
         # test attrs
         assert get_quantity(attrs.data_units) == get_quantity("m/s")
-        assert get_quantity(summary.time_units) == get_quantity("s")
-        assert get_quantity(summary.distance_units) == get_quantity("m")
+        assert get_quantity(summary.get_coord_summary("time").units) == get_quantity(
+            "s"
+        )
+        assert get_quantity(
+            summary.get_coord_summary("distance").units
+        ) == get_quantity("m")

--- a/tests/test_proc/test_proc_units.py
+++ b/tests/test_proc/test_proc_units.py
@@ -29,11 +29,7 @@ class TestSetUnits:
             expected_quant = get_quantity(unit_str)
             coord = patch.get_coord(dim)
             new = patch.set_units(**{dim: unit_str})
-            attr = new.attrs
-            # first check attributes
-            attr_name = f"{dim}_units"
-            assert hasattr(attr, attr_name)
-            value = getattr(new.attrs, attr_name)
+            value = getattr(new.summary, f"{dim}_units")
             # time shouldn't ever be a anything other than s
             if dtype_time_like(coord.dtype):
                 expected_quant = get_quantity("s")
@@ -50,9 +46,7 @@ class TestSetUnits:
         non_dims = set(cmap) - set(patch.dims)
         for coord_name in non_dims:
             new = patch.set_units(**{coord_name: unit_str})
-            # coord string should show up in the attrs
-            attr_name = f"{coord_name}_units"
-            assert getattr(new.attrs, attr_name) == get_quantity(unit_str)
+            assert getattr(new.summary, f"{coord_name}_units") == get_quantity(unit_str)
             # and the coord should be set
             coord = new.get_coord(coord_name)
             assert coord.units == get_quantity(unit_str)
@@ -62,7 +56,7 @@ class TestSetUnits:
         out = random_patch.set_units("m/s", distance="ft")
         assert isinstance(random_patch, dc.Patch)
         assert get_quantity(out.attrs.data_units) == get_quantity("m/s")
-        assert get_quantity(out.attrs.distance_units) == get_quantity("ft")
+        assert get_quantity(out.summary.distance_units) == get_quantity("ft")
 
     def test_remove_units(self, random_patch):
         """Ensure set coords can remove units."""
@@ -126,7 +120,7 @@ class TestConvertUnits:
         out = patch.convert_units("ft/s", distance="m")
         assert isinstance(random_patch, dc.Patch)
         assert get_quantity(out.attrs.data_units) == get_quantity("ft/s")
-        assert get_quantity(out.attrs.distance_units) == get_quantity("m")
+        assert get_quantity(out.summary.distance_units) == get_quantity("m")
 
 
 class TestSimplifyUnits:
@@ -146,8 +140,9 @@ class TestSimplifyUnits:
         """Test to simplify all parts of the patch."""
         out = patch_complicated_units.simplify_units()
         attrs = out.attrs
+        summary = out.summary
         assert isinstance(out, dc.Patch)
         # test attrs
         assert get_quantity(attrs.data_units) == get_quantity("m/s")
-        assert get_quantity(attrs.time_units) == get_quantity("s")
-        assert get_quantity(attrs.distance_units) == get_quantity("m")
+        assert get_quantity(summary.time_units) == get_quantity("s")
+        assert get_quantity(summary.distance_units) == get_quantity("m")

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -143,7 +143,7 @@ class TestResample:
         axis = patch.get_axis("time")
         new_dt = 2 * step
         new = patch.resample(time=new_dt)
-        assert new_dt == new.summary["time_step"]
+        assert new_dt == new.get_coord("time").step
         assert np.all(np.diff(new.coords.get_array("time")) == new_dt)
         # ensure only the time dimension has changed.
         shape1, shape2 = random_patch.data.shape, new.data.shape
@@ -155,11 +155,11 @@ class TestResample:
 
     def test_upsample_time(self, random_patch):
         """Test increasing the temporal sampling rate."""
-        current_dt = random_patch.summary["time_step"]
+        current_dt = random_patch.get_coord("time").step
         axis = random_patch.get_axis("time")
         new_dt = current_dt / 2
         new = random_patch.resample(time=new_dt)
-        assert new_dt == new.summary["time_step"]
+        assert new_dt == new.get_coord("time").step
         assert np.all(np.diff(new.coords.get_array("time")) == new_dt)
         shape1, shape2 = random_patch.data.shape, new.data.shape
         for ax, (len1, len2) in enumerate(zip(shape1, shape2)):
@@ -170,11 +170,11 @@ class TestResample:
 
     def test_upsample_time_float(self, random_patch):
         """Test int as time sampling rate."""
-        current_dt = random_patch.summary["time_step"]
+        current_dt = random_patch.get_coord("time").step
         axis = random_patch.get_axis("time")
         new_dt = current_dt / 2
         new = random_patch.resample(time=new_dt / np.timedelta64(1, "s"))
-        assert new_dt == new.summary["time_step"]
+        assert new_dt == new.get_coord("time").step
         assert np.all(np.diff(new.coords.get_array("time")) == new_dt)
         shape1, shape2 = random_patch.data.shape, new.data.shape
         for ax, (len1, len2) in enumerate(zip(shape1, shape2)):
@@ -185,11 +185,11 @@ class TestResample:
 
     def test_resample_distance(self, random_patch):
         """Ensure distance dimension is also resample-able."""
-        current_dx = random_patch.summary["distance_step"]
+        current_dx = random_patch.get_coord("distance").step
         new_dx = current_dx / 2
         new = random_patch.resample(distance=new_dx)
         axis = random_patch.get_axis("distance")
-        assert new_dx == new.summary["distance_step"]
+        assert new_dx == new.get_coord("distance").step
         assert np.allclose(np.diff(new.coords.get_array("distance")), new_dx)
         shape1, shape2 = random_patch.data.shape, new.data.shape
         for ax, (len1, len2) in enumerate(zip(shape1, shape2)):
@@ -202,30 +202,36 @@ class TestResample:
         """Tests for resampling to a non-int sampling rate."""
         new_step = 1.232132323222
         out = random_patch.resample(distance=new_step)
-        assert out.summary["distance_max"] <= random_patch.summary["distance_max"]
-        assert np.allclose(out.summary["distance_step"], new_step)
+        assert (
+            out.get_coord("distance").max() <= random_patch.get_coord("distance").max()
+        )
+        assert np.allclose(out.get_coord("distance").step, new_step)
 
     def test_slightly_above_current_rate(self, random_patch):
         """Tests for resampling slightly above current rate."""
         start, stop, step = get_start_stop_step(random_patch, "distance")
         new_step = step + 0.0000001
         out = random_patch.resample(distance=new_step)
-        assert out.summary["distance_max"] <= random_patch.summary["distance_max"]
-        assert np.allclose(out.summary["distance_step"], new_step)
+        assert (
+            out.get_coord("distance").max() <= random_patch.get_coord("distance").max()
+        )
+        assert np.allclose(out.get_coord("distance").step, new_step)
 
     def test_slightly_under_current_rate(self, random_patch):
         """Tests for resampling slightly under current rate."""
         start, stop, step = get_start_stop_step(random_patch, "distance")
         new_step = step - 0.0000001
         out = random_patch.resample(distance=new_step)
-        assert out.summary["distance_max"] <= random_patch.summary["distance_max"]
-        assert np.allclose(out.summary["distance_step"], new_step)
+        assert (
+            out.get_coord("distance").max() <= random_patch.get_coord("distance").max()
+        )
+        assert np.allclose(out.get_coord("distance").step, new_step)
 
     def test_odd_time(self, random_patch):
         """Tests resampling to odd time interval."""
         dt = np.timedelta64(1234567, "ns")
         out = random_patch.resample(time=dt)
-        new_dt = out.summary["time_step"]
+        new_dt = out.get_coord("time").step
         assert np.isclose(float(new_dt), float(dt))
         assert out.attrs
 
@@ -252,7 +258,7 @@ class TestResample:
         """Ensure docstring examples runs."""
         patch = random_patch
         time = patch.coords.get_array("time")
-        ts = patch.summary.time_step
+        ts = patch.get_coord("time").step
         new_time = np.arange(time.min(), time.max(), 0.5 * ts)
         uptime = patch.interpolate(time=new_time)
         assert isinstance(uptime, dc.Patch)

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -49,9 +49,9 @@ class TestInterpolate:
         axis = random_patch.get_axis("time")
         new = np.arange(start, stop, step / 2)
         out = random_patch.interpolate(time=new)
-        assert out.attrs["time_min"] == np.min(new)
-        assert out.attrs["time_max"] == np.max(new)
-        assert out.attrs["time_step"] == np.mean(np.diff(new))
+        assert out.coords["time"].min() == np.min(new)
+        assert out.coords["time"].max() == np.max(new)
+        assert out.coords["time"].step == np.mean(np.diff(new))
         assert out.data.shape[axis] == len(new)
 
     def test_endtime_updated(self, random_patch):
@@ -59,9 +59,9 @@ class TestInterpolate:
         dist = [0, 42, 84, 126, 168, 210, 252, 294]
         out = random_patch.interpolate(distance=dist)
         coord = out.coords.get_array("distance")
-        assert out.attrs["distance_max"] == coord.max()
-        assert out.attrs["distance_min"] == coord.min()
-        assert out.attrs["distance_step"] == np.median(np.diff(coord))
+        assert out.coords["distance"].max() == coord.max()
+        assert out.coords["distance"].min() == coord.min()
+        assert out.coords["distance"].step == np.median(np.diff(coord))
 
     def test_snap_like(self, wacky_dim_patch):
         """Ensure interpolate can be used to snapping coords."""
@@ -91,13 +91,13 @@ class TestDecimate:
     def test_update_time_max(self, random_patch):
         """Ensure the time_max is updated after decimation."""
         out = random_patch.decimate(time=10)
-        assert out.attrs["time_max"] == out.coords.get_array("time").max()
+        assert out.coords["time"].max() == out.coords.get_array("time").max()
 
     def test_update_delta_dim(self, random_patch):
         """Since decimate changes the spacing of dimension this should be updated."""
-        dt1 = random_patch.attrs.time_step
+        dt1 = random_patch.coords["time"].step
         out = random_patch.decimate(time=10)
-        assert out.attrs["time_step"] == dt1 * 10
+        assert out.coords["time"].step == dt1 * 10
 
     def test_float_32_stability(self, random_patch):
         """
@@ -113,7 +113,7 @@ class TestDecimate:
             "time": np.arange(0, ar.shape[0]) * dt + t1,
         }
         dims = ("time", "distance")
-        attrs = {"time_step": dt, "time_min": t1}
+        attrs = {}
         patch = dc.Patch(data=ar, coords=coords, dims=dims, attrs=attrs)
         # ensure all modes of decimation don't produce NaN values.
         decimated_iir = patch.decimate(time=10, filter_type="iir")
@@ -143,7 +143,7 @@ class TestResample:
         axis = patch.get_axis("time")
         new_dt = 2 * step
         new = patch.resample(time=new_dt)
-        assert new_dt == new.attrs["time_step"]
+        assert new_dt == new.summary["time_step"]
         assert np.all(np.diff(new.coords.get_array("time")) == new_dt)
         # ensure only the time dimension has changed.
         shape1, shape2 = random_patch.data.shape, new.data.shape
@@ -155,11 +155,11 @@ class TestResample:
 
     def test_upsample_time(self, random_patch):
         """Test increasing the temporal sampling rate."""
-        current_dt = random_patch.attrs["time_step"]
+        current_dt = random_patch.summary["time_step"]
         axis = random_patch.get_axis("time")
         new_dt = current_dt / 2
         new = random_patch.resample(time=new_dt)
-        assert new_dt == new.attrs["time_step"]
+        assert new_dt == new.summary["time_step"]
         assert np.all(np.diff(new.coords.get_array("time")) == new_dt)
         shape1, shape2 = random_patch.data.shape, new.data.shape
         for ax, (len1, len2) in enumerate(zip(shape1, shape2)):
@@ -170,11 +170,11 @@ class TestResample:
 
     def test_upsample_time_float(self, random_patch):
         """Test int as time sampling rate."""
-        current_dt = random_patch.attrs["time_step"]
+        current_dt = random_patch.summary["time_step"]
         axis = random_patch.get_axis("time")
         new_dt = current_dt / 2
         new = random_patch.resample(time=new_dt / np.timedelta64(1, "s"))
-        assert new_dt == new.attrs["time_step"]
+        assert new_dt == new.summary["time_step"]
         assert np.all(np.diff(new.coords.get_array("time")) == new_dt)
         shape1, shape2 = random_patch.data.shape, new.data.shape
         for ax, (len1, len2) in enumerate(zip(shape1, shape2)):
@@ -185,11 +185,11 @@ class TestResample:
 
     def test_resample_distance(self, random_patch):
         """Ensure distance dimension is also resample-able."""
-        current_dx = random_patch.attrs["distance_step"]
+        current_dx = random_patch.summary["distance_step"]
         new_dx = current_dx / 2
         new = random_patch.resample(distance=new_dx)
         axis = random_patch.get_axis("distance")
-        assert new_dx == new.attrs["distance_step"]
+        assert new_dx == new.summary["distance_step"]
         assert np.allclose(np.diff(new.coords.get_array("distance")), new_dx)
         shape1, shape2 = random_patch.data.shape, new.data.shape
         for ax, (len1, len2) in enumerate(zip(shape1, shape2)):
@@ -202,30 +202,30 @@ class TestResample:
         """Tests for resampling to a non-int sampling rate."""
         new_step = 1.232132323222
         out = random_patch.resample(distance=new_step)
-        assert out.attrs["distance_max"] <= random_patch.attrs["distance_max"]
-        assert np.allclose(out.attrs["distance_step"], new_step)
+        assert out.summary["distance_max"] <= random_patch.summary["distance_max"]
+        assert np.allclose(out.summary["distance_step"], new_step)
 
     def test_slightly_above_current_rate(self, random_patch):
         """Tests for resampling slightly above current rate."""
         start, stop, step = get_start_stop_step(random_patch, "distance")
         new_step = step + 0.0000001
         out = random_patch.resample(distance=new_step)
-        assert out.attrs["distance_max"] <= random_patch.attrs["distance_max"]
-        assert np.allclose(out.attrs["distance_step"], new_step)
+        assert out.summary["distance_max"] <= random_patch.summary["distance_max"]
+        assert np.allclose(out.summary["distance_step"], new_step)
 
     def test_slightly_under_current_rate(self, random_patch):
         """Tests for resampling slightly under current rate."""
         start, stop, step = get_start_stop_step(random_patch, "distance")
         new_step = step - 0.0000001
         out = random_patch.resample(distance=new_step)
-        assert out.attrs["distance_max"] <= random_patch.attrs["distance_max"]
-        assert np.allclose(out.attrs["distance_step"], new_step)
+        assert out.summary["distance_max"] <= random_patch.summary["distance_max"]
+        assert np.allclose(out.summary["distance_step"], new_step)
 
     def test_odd_time(self, random_patch):
         """Tests resampling to odd time interval."""
         dt = np.timedelta64(1234567, "ns")
         out = random_patch.resample(time=dt)
-        new_dt = out.attrs["time_step"]
+        new_dt = out.summary["time_step"]
         assert np.isclose(float(new_dt), float(dt))
         assert out.attrs
 
@@ -252,7 +252,7 @@ class TestResample:
         """Ensure docstring examples runs."""
         patch = random_patch
         time = patch.coords.get_array("time")
-        ts = patch.attrs.time_step
+        ts = patch.summary.time_step
         new_time = np.arange(time.min(), time.max(), 0.5 * ts)
         uptime = patch.interpolate(time=new_time)
         assert isinstance(uptime, dc.Patch)

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -151,7 +151,7 @@ class TestRolling:
         window = random.randint(1, patch.shape[axis])
         step = random.randint(1, patch.shape[axis])
         # setup patch and apply mean.
-        channel_spacing = patch.attrs["distance_step"]
+        channel_spacing = patch.coords["distance"].step
         roller = patch.rolling(
             distance=(window * channel_spacing) * m,
             step=(step * channel_spacing) * m,

--- a/tests/test_proc/test_taper.py
+++ b/tests/test_proc/test_taper.py
@@ -61,7 +61,7 @@ class TestTaperBasics:
 
     def test_time_dt_unchanged(self, time_tapered_patch, random_patch):
         """Ensure each taper type runs."""
-        attrs1, attrs2 = random_patch.attrs, time_tapered_patch.attrs
+        attrs1, attrs2 = random_patch.summary, time_tapered_patch.summary
         assert attrs1.time_units == attrs2.time_units
         assert attrs1.time_step == attrs2.time_step
 

--- a/tests/test_proc/test_taper.py
+++ b/tests/test_proc/test_taper.py
@@ -62,8 +62,10 @@ class TestTaperBasics:
     def test_time_dt_unchanged(self, time_tapered_patch, random_patch):
         """Ensure each taper type runs."""
         attrs1, attrs2 = random_patch.summary, time_tapered_patch.summary
-        assert attrs1.time_units == attrs2.time_units
-        assert attrs1.time_step == attrs2.time_step
+        time1 = attrs1.get_coord_summary("time")
+        time2 = attrs2.get_coord_summary("time")
+        assert time1.units == time2.units
+        assert time1.step == time2.step
 
     def test_ends_near_zero(self, time_tapered_patch):
         """Ensure the ends of the patch are near zero."""

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -75,7 +75,7 @@ class TestApplyUfunc:
         """Ensure un-alignable coords returns degenerate patch."""
         time = random_patch.get_coord("time")
         new_time = time.max() + time.step
-        new = random_patch.update_attrs(time_min=new_time)
+        new = random_patch.update_coords(time_min=new_time)
         out = apply_ufunc(np.multiply, new, random_patch)
         assert 0 in set(out.shape)
         assert out.data.size == 0

--- a/tests/test_utils/test_attrs_utils.py
+++ b/tests/test_utils/test_attrs_utils.py
@@ -9,6 +9,7 @@ import pytest
 import dascore as dc
 from dascore import PatchAttrs
 from dascore.utils.attrs import (
+    _raise_if_coord_attr_updates,
     combine_patch_attrs,
     separate_coord_info,
 )
@@ -246,3 +247,11 @@ class TestValidateNoCoords:
             raise_error=False,
         )
         assert out == {"tag": "x"}
+
+
+class TestRaiseIfCoordAttrUpdates:
+    """Tests for rejecting coord-summary keys in attr updates."""
+
+    def test_none_is_noop(self):
+        """None inputs should return without raising."""
+        assert _raise_if_coord_attr_updates(None) is None

--- a/tests/test_utils/test_attrs_utils.py
+++ b/tests/test_utils/test_attrs_utils.py
@@ -1,14 +1,59 @@
-"""
-Tests for attr utilities.
-"""
+"""Tests for attr utilities."""
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import pytest
 
+import dascore as dc
 from dascore import PatchAttrs
-from dascore.exceptions import AttributeMergeError
-from dascore.utils.attrs import combine_patch_attrs, separate_coord_info
+from dascore.utils.attrs import (
+    combine_patch_attrs,
+    separate_coord_info,
+)
+
+
+def _validate_no_coords(
+    obj,
+    dims: tuple[str, ...] | None = None,
+    coord_manager=None,
+    raise_error: bool = True,
+    flat_keys: bool = True,
+) -> dict:
+    """Test helper for the old attrs-purity behavior."""
+
+    def _normalize(obj):
+        if obj is None:
+            return {}
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return dict(obj)
+
+    out = _normalize(obj)
+    direct_names = set()
+    if "coords" in out:
+        direct_names.add("coords")
+        out.pop("coords", None)
+    if "dims" in out:
+        direct_names.add("dims")
+        out.pop("dims", None)
+    known_names = set(() if dims is None else dims) | {"time", "distance"}
+    if coord_manager is not None:
+        dims = coord_manager.dims
+        known_names |= set(coord_manager.coord_map)
+    if flat_keys:
+        scan_dims = tuple(known_names) if known_names else dims
+        coord_info, attr_info = separate_coord_info(out, dims=scan_dims)
+        coord_names = direct_names | set(coord_info)
+    else:
+        attr_info = out
+        coord_names = direct_names
+    if coord_names and raise_error:
+        names = ", ".join(sorted(coord_names))
+        msg = "PatchAttrs no longer accepts coordinate metadata. " f"Received: {names}."
+        raise ValueError(msg)
+    return attr_info
 
 
 class TestMergeAttrs:
@@ -21,32 +66,10 @@ class TestMergeAttrs:
         out = combine_patch_attrs([pa1, pa2], drop_attrs="history")
         assert isinstance(out, PatchAttrs)
 
-    def test_empty_with_coord_raises(self):
-        """Attributes which don't have specified coord should raise."""
-        pa1, pa2 = PatchAttrs(), PatchAttrs()
-        match = "Failed to combine"
-        with pytest.raises(AttributeMergeError, match=match):
-            combine_patch_attrs([pa1, pa2], "time")
-        with pytest.raises(AttributeMergeError, match=match):
-            combine_patch_attrs([pa1, pa2], "distance")
-
-    def test_simple_merge(self):
-        """Happy path, simple merge."""
-        pa1 = PatchAttrs(distance_min=1, distance_max=10)
-        pa2 = PatchAttrs(distance_min=11, distance_max=20)
-        merged = combine_patch_attrs([pa1, pa2], "distance")
-        # the names of attrs should be identical before/after merge
-        assert set(dict(merged)) == set(dict(pa1))
-        assert merged.distance_max == pa2.distance_max
-        assert merged.distance_min == pa1.distance_min
-
     def test_drop(self):
         """Ensure drop_attrs does its job."""
         pa1 = PatchAttrs(history=["a", "b"])
         pa2 = PatchAttrs()
-        msg = "the following non-dim attrs are not equal"
-        with pytest.raises(AttributeMergeError, match=msg):
-            combine_patch_attrs([pa1, pa2])
         out = combine_patch_attrs([pa1, pa2], drop_attrs="history")
         assert isinstance(out, PatchAttrs)
 
@@ -55,41 +78,57 @@ class TestMergeAttrs:
         pa1 = PatchAttrs(tag="bob", another=2, same=42)
         pa2 = PatchAttrs(tag="bob", another=2, same=42)
         pa3 = PatchAttrs(another=1, same=42, different=10)
-        msg = "the following non-dim attrs are not equal"
-        with pytest.raises(AttributeMergeError, match=msg):
+        with pytest.raises(Exception, match="non-dim attrs are not equal"):
             combine_patch_attrs([pa1, pa2, pa3])
 
-    def test_missing_coordinate(self):
-        """When one model has a missing coord it should just get dropped."""
-        pa1 = PatchAttrs(bob_min=10, bob_max=12)
-        pa2 = PatchAttrs(bob_min=13)
-        out = combine_patch_attrs([pa1, pa2], coord_name="bob")
-        assert out == pa1
-
     def test_drop_conflicts(self, random_patch):
-        """Ensure when non-dim fields aren't equal, but are defined, they drop."""
-        pa1 = random_patch.attrs.update(tag="bill", station="UU")
-        pa2 = random_patch.attrs.update(station="TA", tag="bob")
-        out = combine_patch_attrs([pa1, pa2], coord_name="time", conflicts="drop")
+        """Ensure unequal non-coordinate attrs can be dropped."""
+        pa1 = PatchAttrs.from_dict(random_patch.attrs).update(tag="bill", station="UU")
+        pa2 = PatchAttrs.from_dict(random_patch.attrs).update(station="TA", tag="bob")
+        out = combine_patch_attrs([pa1, pa2], conflicts="drop")
         defaults = PatchAttrs()
-        assert isinstance(out, PatchAttrs)
         assert out.tag == defaults.tag
         assert out.station == defaults.station
 
     def test_keep_disjoint_values(self, random_patch):
-        """Ensure when disjoint values should be kept they are."""
-        random_attrs = random_patch.attrs
+        """Ensure disjoint values can be kept."""
+        random_attrs = PatchAttrs.from_dict(random_patch.attrs)
         attrs1 = random_attrs.update(jazz_hands=1984)
         out = combine_patch_attrs([attrs1, random_attrs], conflicts="keep_first")
         assert out.jazz_hands == 1984
 
-    def test_unequal_raises(self, random_patch):
-        """When attrs have unequal coords it should raise an error."""
-        attr1 = random_patch.attrs
-        attr2 = attr1.update(distance_units="miles")
-        match = "Cant merge patch attrs"
-        with pytest.raises(AttributeMergeError, match=match):
-            combine_patch_attrs([attr1, attr2], coord_name="distance")
+    def test_patch_input(self, random_patch):
+        """Patch objects should normalize through their attrs."""
+        out = combine_patch_attrs([random_patch, random_patch])
+        assert isinstance(out, PatchAttrs)
+
+    def test_mapping_input(self, random_patch):
+        """Plain mapping inputs should normalize through PatchAttrs."""
+        out = combine_patch_attrs(
+            [random_patch.attrs.model_dump(), random_patch.attrs],
+            conflicts="keep_first",
+        )
+        assert isinstance(out, PatchAttrs)
+
+    def test_mapping_like_input(self, random_patch):
+        """Non-dict mapping inputs should normalize through from_dict."""
+
+        class MappingLike(Mapping):
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def __iter__(self):
+                return iter(self._data)
+
+            def __len__(self):
+                return len(self._data)
+
+        mapping = MappingLike(random_patch.attrs.model_dump())
+        out = combine_patch_attrs([mapping, random_patch.attrs], conflicts="keep_first")
+        assert isinstance(out, PatchAttrs)
 
 
 class TestSeparateCoordInfo:
@@ -105,6 +144,7 @@ class TestSeparateCoordInfo:
         input_dict = {"coords": {"time": {"min": 10}}}
         coords, attrs = separate_coord_info(input_dict)
         assert coords == input_dict["coords"]
+        assert attrs == {}
 
     def test_dict_of_coord_info(self, random_patch):
         """Passing in a dictionary of coord info should work."""
@@ -112,3 +152,97 @@ class TestSeparateCoordInfo:
         dims = random_patch.dims
         coords, attrs = separate_coord_info(coord_dict, dims=dims)
         assert coords == coord_dict
+        assert attrs == {}
+
+    def test_ignores_keys_without_underscore(self):
+        """Keys without separators should stay in attrs."""
+        coords, attrs = separate_coord_info({"time": 1, "tag": "x"})
+        assert coords == {}
+        assert attrs == {"time": 1, "tag": "x"}
+
+    def test_ignores_unknown_coord_suffix(self):
+        """Unknown coord suffixes should not be parsed as coord metadata."""
+        coords, attrs = separate_coord_info({"time_bob": 1, "tag": "x"})
+        assert coords == {}
+        assert attrs == {"time_bob": 1, "tag": "x"}
+
+    def test_unsplittable_valid_coord_key_stays_attr(self):
+        """Suffix-only coord-looking keys should not crash dim inference."""
+        coords, attrs = separate_coord_info({"units": "m", "tag": "x"})
+        assert coords == {}
+        assert attrs == {"units": "m", "tag": "x"}
+
+    def test_invalid_coord_like_key_ignored_in_dim_inference(self):
+        """Only valid coord summary keys should participate in inferred dims."""
+        obj = {"time_bob": 1, "distance_min": 0, "distance_max": 10}
+        coords, attrs = separate_coord_info(obj)
+        assert set(coords) == {"distance"}
+        assert attrs == {
+            "time_bob": 1,
+        }
+
+    def test_dim_inference_skips_unsplittable_keys(self):
+        """Unsplittable keys should be ignored while inferring dims."""
+        obj = {
+            "distance": 1,
+            "distance_bob": 2,
+            "distance_min": 0,
+            "distance_max": 10,
+        }
+        coords, attrs = separate_coord_info(obj)
+        assert "distance" in coords
+        assert attrs == {}
+
+    def test_coord_level_to_summary(self):
+        """Coord-level values exposing to_summary should be normalized."""
+
+        class CoordLike:
+            def to_summary(self):
+                return dc.core.CoordSummary(min=0, max=1, step=1)
+
+        coords, attrs = separate_coord_info({"coords": {"time": CoordLike()}})
+        assert attrs == {}
+        assert coords["time"]["min"] == 0
+
+    def test_coord_manager_input_uses_dims_and_summary_dict(self, random_patch):
+        """CoordManager inputs should use dims and to_summary_dict paths."""
+        coords, attrs = separate_coord_info({"coords": random_patch.coords})
+        assert attrs == {}
+        assert set(coords) == set(random_patch.coords.coord_map)
+
+
+class TestValidateNoCoords:
+    """Tests for stripping or rejecting coordinate metadata from attrs-like input."""
+
+    def test_raise_on_coord_fields(self):
+        """Coordinate-like flat keys should raise by default."""
+        with pytest.raises(ValueError, match="distance"):
+            _validate_no_coords({"distance_units": "miles"})
+
+    def test_raise_on_coords_container(self, random_patch):
+        """Nested coord containers should raise by default."""
+        with pytest.raises(ValueError, match="coords"):
+            _validate_no_coords({"coords": random_patch.coords})
+
+    def test_raise_false_strips_coord_fields(self):
+        """raise_error=False should remove coordinate metadata and keep attrs."""
+        out = _validate_no_coords(
+            {"distance_units": "miles", "tag": "x"}, raise_error=False
+        )
+        assert out == {"tag": "x"}
+
+    def test_raise_false_strips_fallback_coord_fields(self):
+        """Flat coord-only fields left by splitting should still be removed."""
+        out = _validate_no_coords(
+            {"distance_units": "miles", "time_dtype": "datetime64[ns]", "tag": "x"},
+            raise_error=False,
+        )
+        assert out == {"tag": "x"}
+
+    def test_raise_false_strips_coords_and_dims(self, random_patch):
+        """raise_error=False should remove nested structural coord metadata."""
+        out = _validate_no_coords(
+            {"coords": random_patch.coords, "dims": random_patch.dims, "tag": "x"},
+            raise_error=False,
+        )
+        assert out == {"tag": "x"}

--- a/tests/test_utils/test_hdf_utils.py
+++ b/tests/test_utils/test_hdf_utils.py
@@ -164,6 +164,15 @@ class TestHDFPatchIndexManager:
         meta = index._read_metadata()
         assert meta is not None
 
+    def test_encode_table_skips_missing_encoded_columns(self, index_manager):
+        """Missing encoder columns should be ignored safely."""
+        df = dc.scan_to_df(dc.get_example_spool())
+        index_manager._column_encoders = dict(index_manager._column_encoders) | {
+            "missing_column": lambda x: x
+        }
+        out = index_manager.encode_table(df.copy(), path=None)
+        assert "path" in out.columns
+
 
 class TestHDFReaders:
     """Tests for HDF5 readers."""

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -15,6 +15,7 @@ import pytest
 from dascore.exceptions import MissingOptionalDependencyError
 from dascore.utils.misc import (
     _iter_filesystem,
+    all_diffs_close_enough,
     cached_method,
     deep_equality_check,
     get_buffer_size,
@@ -174,6 +175,14 @@ class TestIterate:
     def test_str(self):
         """A single string object should be returned as a tuple."""
         assert iterate("hey") == ("hey",)
+
+
+class TestAllDiffsCloseEnough:
+    """Tests for all_diffs_close_enough."""
+
+    def test_empty_sequence_false(self):
+        """An empty set of diffs should not be considered close enough."""
+        assert not all_diffs_close_enough([])
 
 
 class TestOptionalImport:

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -369,7 +369,7 @@ class TestMergeCompatibleCoordsAttrs:
 
     def test_incompatible_coords(self, random_patch):
         """Ensure an incompatible error is raised for coords that don't match."""
-        new_time = random_patch.summary.time_max
+        new_time = random_patch.get_coord("time").max()
         new = random_patch.update_coords(time_min=new_time)
         match = "coordinates are not equal"
         with pytest.raises(IncompatiblePatchError, match=match):

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -369,8 +369,8 @@ class TestMergeCompatibleCoordsAttrs:
 
     def test_incompatible_coords(self, random_patch):
         """Ensure an incompatible error is raised for coords that don't match."""
-        new_time = random_patch.attrs.time_max
-        new = random_patch.update_attrs(time_min=new_time)
+        new_time = random_patch.summary.time_max
+        new = random_patch.update_coords(time_min=new_time)
         match = "coordinates are not equal"
         with pytest.raises(IncompatiblePatchError, match=match):
             merge_compatible_coords_attrs(new, random_patch)
@@ -390,7 +390,7 @@ class TestMergeCompatibleCoordsAttrs:
         expected = set(pa1.coords.coord_map) | set(pa2.coords.coord_map)
         coords, attrs = merge_compatible_coords_attrs(pa1, pa2)
         assert set(coords.coord_map) == expected
-        assert set(attrs.coords) == expected
+        assert "coords" not in attrs.model_dump()
 
     def test_extra_attrs(self, random_patch):
         """Ensure extra attributes are added to patch."""

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -10,6 +10,7 @@ import pytest
 import dascore as dc
 from dascore.exceptions import ParameterError
 from dascore.utils.pd import (
+    _model_list_to_df,
     adjust_segments,
     dataframe_to_patch,
     fill_defaults_from_pydantic,
@@ -134,6 +135,27 @@ class TestFilterDfBasic:
         con = (ser >= 20) & (ser <= 30)
         out = filter_df(example_df, age_min=20, age_max=30)
         assert all(con == out)
+
+
+class TestModelListToDf:
+    """Tests for flattening patch-like objects to dataframes."""
+
+    def test_uses_flat_dump_and_serializes_dims(self, random_patch):
+        """Patch-like objects with flat_dump should convert into dataframes."""
+        df = _model_list_to_df([random_patch], exclude={"history"})
+        assert len(df) == 1
+        assert df.loc[0, "dims"] == ",".join(random_patch.dims)
+
+    def test_uses_summary_fallback_when_item_has_no_flat_dump(self, random_patch):
+        """Objects with only .summary should still convert cleanly."""
+
+        class SummaryOnly:
+            def __init__(self, summary):
+                self.summary = summary
+
+        df = _model_list_to_df([SummaryOnly(random_patch.summary)], exclude={"history"})
+        assert len(df) == 1
+        assert df.loc[0, "dims"] == ",".join(random_patch.dims)
 
 
 class TestListSerToStr:

--- a/tests/test_viz/test_map_fiber.py
+++ b/tests/test_viz/test_map_fiber.py
@@ -36,10 +36,8 @@ def patch_random_start(event_patch_1):
     random_starttime = dc.to_datetime64("2020-01-02T02:12:11.02232")
     attrs = dict(event_patch_1.attrs)
     coords = {i: v for i, v in event_patch_1.coords.items()}
-    time = coords["time"] - coords["time"].min()
+    time = coords["time"].values - coords["time"].min()
     coords["time"] = time + random_starttime
-    attrs["time_min"] = coords["time"].min()
-    attrs["time_max"] = coords["time"].max()
     patch = event_patch_1.update(attrs=attrs, coords=coords)
     return patch
 

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -39,10 +39,8 @@ def patch_random_start(event_patch_1):
     random_starttime = dc.to_datetime64("2020-01-02T02:12:11.02232")
     attrs = dict(event_patch_1.attrs)
     coords = {i: v for i, v in event_patch_1.coords.items()}
-    time = coords["time"] - coords["time"].min()
+    time = coords["time"].values - coords["time"].min()
     coords["time"] = time + random_starttime
-    attrs["time_min"] = coords["time"].min()
-    attrs["time_max"] = coords["time"].max()
     patch = event_patch_1.update(attrs=attrs, coords=coords)
     return patch
 


### PR DESCRIPTION
## Description

Huge refactoring effort from #627 will now be merged into dev rather than master. 

## Changelog

<!-- Retrofitted after #864; recovered from docs/changelog.qmd history. -->
- changed **breaking**: `Patch.attrs` and `PatchAttrs` hold non-coordinate metadata only; coordinate summaries (`time_min`, `distance_step`, units) move to `Patch.summary.get_coord_summary(...)`.
- changed **breaking**: `dc.scan(...)` returns [`PatchSummary`](`dascore.PatchSummary`) rather than `PatchAttrs`, carrying coords and source information without loading data; file-backed summaries carry enough source information for lazy reloads.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
