### PR TITLE
Plugin registry

### DIFF
--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -109,3 +109,7 @@ class UnitError(ValueError, DASCoreError):
 
 class AttributeMergeError(ValueError, DASCoreError):
     """Raised when something is wrong with combining attributes."""
+
+
+class DASCorePluginError(ValueError, DASCoreError):
+    """Raised when something is wrong with plugins."""

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -111,5 +111,5 @@ class AttributeMergeError(ValueError, DASCoreError):
     """Raised when something is wrong with combining attributes."""
 
 
-class DASCorePluginError(ValueError, DASCoreError):
+class DASCorePluginError(AttributeError, DASCoreError):
     """Raised when something is wrong with plugins."""

--- a/dascore/plugin_registry/patch.csv
+++ b/dascore/plugin_registry/patch.csv
@@ -1,0 +1,1 @@
+package_name,package_url,namespace

--- a/dascore/plugin_registry/patch.csv
+++ b/dascore/plugin_registry/patch.csv
@@ -1,2 +1,2 @@
 package_name,package_url,namespace
-derzug,https://github.com/dasdae/derzug,derzug
+derzug,https://github.com/dasdae/derzug,zug

--- a/dascore/plugin_registry/patch.csv
+++ b/dascore/plugin_registry/patch.csv
@@ -1,1 +1,2 @@
 package_name,package_url,namespace
+derzug,https://github.com/dasdae/derzug,derzug

--- a/dascore/plugin_registry/spool.csv
+++ b/dascore/plugin_registry/spool.csv
@@ -1,0 +1,1 @@
+package_name,package_url,namespace

--- a/dascore/plugin_registry/spool.csv
+++ b/dascore/plugin_registry/spool.csv
@@ -1,2 +1,2 @@
 package_name,package_url,namespace
-derzug,https://github.com/dasdae/derzug,derzug
+derzug,https://github.com/dasdae/derzug,zug

--- a/dascore/plugin_registry/spool.csv
+++ b/dascore/plugin_registry/spool.csv
@@ -1,1 +1,2 @@
 package_name,package_url,namespace
+derzug,https://github.com/dasdae/derzug,derzug

--- a/dascore/utils/docs.py
+++ b/dascore/utils/docs.py
@@ -97,6 +97,35 @@ def compose_docstring(**kwargs: str | Sequence[str]):
     return _wrap
 
 
+def get_plugin_table_str() -> str:
+    """
+    Return a markdown table string of registered third-party plugins.
+
+    Reads all CSV files in the plugin registry, deduplicates on namespace,
+    sorts alphabetically, and renders a single markdown table with the
+    namespace name and a hyperlinked package name.
+    """
+    from dascore.utils.namespace import _PLUGIN_REGISTRY_DIR
+
+    frames = [pd.read_csv(p) for p in sorted(_PLUGIN_REGISTRY_DIR.glob("*.csv"))]
+    if not frames:
+        return "No third-party plugins registered yet."
+    combined = (
+        pd.concat(frames, ignore_index=True)
+        .drop_duplicates(subset="namespace")
+        .sort_values("namespace")[["namespace", "package_name", "package_url"]]
+    )
+    combined["package_name"] = combined.apply(
+        lambda r: f"[{r['package_name']}]({r['package_url']})", axis=1
+    )
+    return (
+        combined[["namespace", "package_name"]].to_markdown(
+            index=False, stralign="center"
+        )
+        + "\n: {.striped}"
+    )
+
+
 def objs_to_doc_df(doc_dict, cross_reference=True):
     """
     Convert a dictionary of documentable entities to a pandas dataframe.

--- a/dascore/utils/docs.py
+++ b/dascore/utils/docs.py
@@ -97,32 +97,24 @@ def compose_docstring(**kwargs: str | Sequence[str]):
     return _wrap
 
 
-def get_plugin_table_str() -> str:
+def get_plugin_table() -> pd.DataFrame:
     """
-    Return a markdown table string of registered third-party plugins.
+    Return a DataFrame of registered third-party plugins.
 
     Reads all CSV files in the plugin registry, deduplicates on namespace,
-    sorts alphabetically, and renders a single markdown table with the
-    namespace name and a hyperlinked package name.
+    and sorts alphabetically. Columns are ``namespace``, ``package_name``,
+    and ``package_url``.
     """
     from dascore.utils.namespace import _PLUGIN_REGISTRY_DIR
 
     frames = [pd.read_csv(p) for p in sorted(_PLUGIN_REGISTRY_DIR.glob("*.csv"))]
     if not frames:
-        return "No third-party plugins registered yet."
-    combined = (
+        return pd.DataFrame(columns=["namespace", "package_name", "package_url"])
+    return (
         pd.concat(frames, ignore_index=True)
         .drop_duplicates(subset="namespace")
         .sort_values("namespace")[["namespace", "package_name", "package_url"]]
-    )
-    combined["package_name"] = combined.apply(
-        lambda r: f"[{r['package_name']}]({r['package_url']})", axis=1
-    )
-    return (
-        combined[["namespace", "package_name"]].to_markdown(
-            index=False, stralign="center"
-        )
-        + "\n: {.striped}"
+        .reset_index(drop=True)
     )
 
 

--- a/dascore/utils/namespace.py
+++ b/dascore/utils/namespace.py
@@ -5,10 +5,40 @@ from __future__ import annotations
 import functools
 import warnings
 from collections import defaultdict
+from pathlib import Path
 from typing import ClassVar
 
+import pandas as pd
+
+from dascore.exceptions import DASCorePluginError
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.plugins import maybe_load_entry_point
+
+_PLUGIN_REGISTRY_DIR = Path(__file__).parent.parent / "plugin_registry"
+
+
+@functools.cache
+def _load_plugin_registry(entry_point_group: str | None) -> dict[str, tuple[str, str]]:
+    """Load plugin registry CSV for the given entry point group.
+
+    Parameters
+    ----------
+    entry_point_group
+        The entry point group string (e.g. "dascore.patch_namespace").
+
+    Returns
+    -------
+    A mapping of namespace name to (package_name, package_url).
+    """
+    if entry_point_group is None:
+        return {}
+    # "dascore.patch_namespace" -> "patch"
+    stem = entry_point_group.split(".")[-1].replace("_namespace", "")
+    csv_path = _PLUGIN_REGISTRY_DIR / f"{stem}.csv"
+    if not csv_path.exists():
+        return {}
+    df = pd.read_csv(csv_path)
+    return dict(zip(df["namespace"], zip(df["package_name"], df["package_url"])))
 
 
 def _pass_to_host_method(func):
@@ -112,6 +142,17 @@ class NamespaceOwner:
             instance = registry[item](self)
             self.__dict__[item] = instance
             return instance
+
+        # Check plugin registry for a known third-party package that provides this.
+        plugin_registry = _load_plugin_registry(self._namespace_entry_point_group)
+        if item in plugin_registry:
+            package_name, package_url = plugin_registry[item]
+            msg = (
+                f"{self.__class__.__name__} has a registered namespace of '{item}' "
+                f"provided by '{package_name}' but it is not installed. "
+                f"Install it from: {package_url}"
+            )
+            raise DASCorePluginError(msg)
 
         # If that fails, see if there is anything specific for this name to raise.
         if item in self._namespace_attr_errors:

--- a/dascore/utils/namespace.py
+++ b/dascore/utils/namespace.py
@@ -38,7 +38,13 @@ def _load_plugin_registry(entry_point_group: str | None) -> dict[str, tuple[str,
     if not csv_path.exists():
         return {}
     df = pd.read_csv(csv_path)
-    return dict(zip(df["namespace"], zip(df["package_name"], df["package_url"])))
+    return dict(
+        zip(
+            df["namespace"],
+            zip(df["package_name"], df["package_url"], strict=True),
+            strict=True,
+        )
+    )
 
 
 def _pass_to_host_method(func):

--- a/dascore/utils/namespace.py
+++ b/dascore/utils/namespace.py
@@ -38,13 +38,7 @@ def _load_plugin_registry(entry_point_group: str | None) -> dict[str, tuple[str,
     if not csv_path.exists():
         return {}
     df = pd.read_csv(csv_path)
-    return dict(
-        zip(
-            df["namespace"],
-            zip(df["package_name"], df["package_url"], strict=True),
-            strict=True,
-        )
-    )
+    return dict(zip(df["namespace"], zip(df["package_name"], df["package_url"])))
 
 
 def _pass_to_host_method(func):

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -100,6 +100,25 @@ my_ext = "dascore_extra.patch_namespace:MyPatchNamespace"
 
 After installation, DASCore loads the namespace the first time `patch.my_ext` is accessed.
 
+### Registering your plugin with DASCore
+
+Once your package is published, consider opening a pull request to [DASCore](https://github.com/DASDAE/dascore) to add it to the plugin registry. This lets users see a helpful message pointing to your package when they try to use your namespace without having it installed.
+
+Add a row to `dascore/plugin_registry/patch.csv` (or `spool.csv` for a spool namespace):
+
+```
+package_name,package_url,namespace
+dascore-extra,https://github.com/yourorg/dascore-extra,my_ext
+```
+
+With that row in place, `patch.my_ext` raises a descriptive error for users who have not yet installed your package:
+
+```
+DASCorePluginError: Patch has a registered namespace of 'my_ext' provided by
+'dascore-extra' but it is not installed. Install it from:
+https://github.com/yourorg/dascore-extra
+```
+
 ### Spool namespaces
 
 Spool namespaces use the same pattern. The only changes are:

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -14,9 +14,9 @@ Version-specific documentation builds are attached to the [release pages](https:
 DASCore is a Python library for distributed acoustic sensing (DAS). It provides:
 
 1. IO support for [many DAS data formats](supported_formats.qmd)
-2. Plugin support for [known third-party namespaces](supported_plugins.qmd)
-3. Common processing routines
-4. Basic visualizations
+2. Common processing routines
+3. Basic visualizations
+4. Plugin support for [known third-party namespaces](supported_plugins.qmd)
 
 :::{.callout-note}
 DASCore is part of the [DAS Data Analysis Ecosystem (DASDAE)](https://dasdae.org). 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -14,8 +14,9 @@ Version-specific documentation builds are attached to the [release pages](https:
 DASCore is a Python library for distributed acoustic sensing (DAS). It provides:
 
 1. IO support for [many DAS data formats](supported_formats.qmd)
-2. Common processing routines
-3. Basic visualizations
+2. Plugin support for [known third-party namespaces](supported_plugins.qmd)
+3. Common processing routines
+4. Basic visualizations
 
 :::{.callout-note}
 DASCore is part of the [DAS Data Analysis Ecosystem (DASDAE)](https://dasdae.org). 

--- a/docs/supported_plugins.qmd
+++ b/docs/supported_plugins.qmd
@@ -19,6 +19,7 @@ if frames:
     combined = (
         pd.concat(frames, ignore_index=True)
         .drop_duplicates(subset="namespace")
+        .sort_values("namespace")
         [["namespace", "package_name", "package_url"]]
     )
     combined["package_name"] = combined.apply(

--- a/docs/supported_plugins.qmd
+++ b/docs/supported_plugins.qmd
@@ -9,24 +9,6 @@ Known third-party packages that provide namespaces for DASCore's `Patch` and `Sp
 ```{python}
 #| echo: false
 #| output: asis
-import pandas as pd
-from pathlib import Path
-
-registry_dir = Path("../dascore/plugin_registry")
-frames = [pd.read_csv(p) for p in sorted(registry_dir.glob("*.csv"))]
-
-if frames:
-    combined = (
-        pd.concat(frames, ignore_index=True)
-        .drop_duplicates(subset="namespace")
-        .sort_values("namespace")
-        [["namespace", "package_name", "package_url"]]
-    )
-    combined["package_name"] = combined.apply(
-        lambda r: f"[{r['package_name']}]({r['package_url']})", axis=1
-    )
-    out = combined[["namespace", "package_name"]].to_markdown(index=False, stralign="center")
-    print(out + "\n: {.striped}")
-else:
-    print("No third-party plugins registered yet.")
+from dascore.utils.docs import get_plugin_table_str
+print(get_plugin_table_str())
 ```

--- a/docs/supported_plugins.qmd
+++ b/docs/supported_plugins.qmd
@@ -9,6 +9,11 @@ Known third-party packages that provide namespaces for DASCore's `Patch` and `Sp
 ```{python}
 #| echo: false
 #| output: asis
-from dascore.utils.docs import get_plugin_table_str
-print(get_plugin_table_str())
+from dascore.utils.docs import get_plugin_table
+
+df = get_plugin_table()
+df["package_name"] = df.apply(
+    lambda r: f"[{r['package_name']}]({r['package_url']})", axis=1
+)
+print(df[["namespace", "package_name"]].to_markdown(index=False, stralign="center") + "\n: {.striped}")
 ```

--- a/docs/supported_plugins.qmd
+++ b/docs/supported_plugins.qmd
@@ -1,0 +1,27 @@
+---
+title: Supported Third-Party Plugins
+execute:
+    warning: false
+---
+
+Known third-party packages that provide namespaces for DASCore's `Patch` and `Spool` objects.
+
+```{python}
+#| echo: false
+#| output: asis
+import pandas as pd
+from pathlib import Path
+
+registry_dir = Path("../dascore/plugin_registry")
+frames = []
+for csv_path in sorted(registry_dir.glob("*.csv")):
+    df = pd.read_csv(csv_path)
+    df.insert(0, "type", csv_path.stem.capitalize())
+    frames.append(df)
+
+if frames:
+    combined = pd.concat(frames, ignore_index=True)
+    print(combined.to_markdown(index=False, stralign="center") + "\n: {.striped}")
+else:
+    print("No third-party plugins registered yet.")
+```

--- a/docs/supported_plugins.qmd
+++ b/docs/supported_plugins.qmd
@@ -13,15 +13,19 @@ import pandas as pd
 from pathlib import Path
 
 registry_dir = Path("../dascore/plugin_registry")
-frames = []
-for csv_path in sorted(registry_dir.glob("*.csv")):
-    df = pd.read_csv(csv_path)
-    df.insert(0, "type", csv_path.stem.capitalize())
-    frames.append(df)
+frames = [pd.read_csv(p) for p in sorted(registry_dir.glob("*.csv"))]
 
 if frames:
-    combined = pd.concat(frames, ignore_index=True)
-    print(combined.to_markdown(index=False, stralign="center") + "\n: {.striped}")
+    combined = (
+        pd.concat(frames, ignore_index=True)
+        .drop_duplicates(subset="namespace")
+        [["namespace", "package_name", "package_url"]]
+    )
+    combined["package_name"] = combined.apply(
+        lambda r: f"[{r['package_name']}]({r['package_url']})", axis=1
+    )
+    out = combined[["namespace", "package_name"]].to_markdown(index=False, stralign="center")
+    print(out + "\n: {.striped}")
 else:
     print("No third-party plugins registered yet.")
 ```

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -79,6 +79,9 @@ website:
         - text: Formats
           href: supported_formats.qmd
 
+        - text: Plugins
+          href: supported_plugins.qmd
+
         - text: Changelog
           href: changelog.qmd
 

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -8,7 +8,12 @@ import pandas as pd
 
 from dascore.core.attrs import PatchAttrs
 from dascore.examples import EXAMPLE_PATCHES
-from dascore.utils.docs import compose_docstring, format_dtypes, objs_to_doc_df
+from dascore.utils.docs import (
+    compose_docstring,
+    format_dtypes,
+    get_plugin_table_str,
+    objs_to_doc_df,
+)
 
 
 class TestFormatDtypes:
@@ -72,6 +77,16 @@ class TestDocsting:
         white_space_counts = [self.count_white_space(x) for x in list_lines]
         # all whitespace counts should be the same for the list lines.
         assert len(set(white_space_counts)) == 1
+
+
+class TestGetPluginTableStr:
+    """Tests for get_plugin_table_str."""
+
+    def test_contains_registered_namespace(self):
+        """Registered namespaces should appear in the table string."""
+        out = get_plugin_table_str()
+        assert "zug" in out
+        assert "derzug" in out
 
 
 class TestObjToDocDF:

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -88,6 +88,15 @@ class TestGetPluginTable:
         assert "zug" in df["namespace"].values
         assert "derzug" in df["package_name"].values
 
+    def test_empty_registry_returns_empty_dataframe(self, monkeypatch, tmp_path):
+        """An empty registry directory returns a DataFrame with the correct columns."""
+        import dascore.utils.namespace as ns_module
+
+        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
+        df = get_plugin_table()
+        assert list(df.columns) == ["namespace", "package_name", "package_url"]
+        assert df.empty
+
 
 class TestObjToDocDF:
     """Tests for generating documentation dataframes."""

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -11,7 +11,7 @@ from dascore.examples import EXAMPLE_PATCHES
 from dascore.utils.docs import (
     compose_docstring,
     format_dtypes,
-    get_plugin_table_str,
+    get_plugin_table,
     objs_to_doc_df,
 )
 
@@ -79,14 +79,14 @@ class TestDocsting:
         assert len(set(white_space_counts)) == 1
 
 
-class TestGetPluginTableStr:
-    """Tests for get_plugin_table_str."""
+class TestGetPluginTable:
+    """Tests for get_plugin_table."""
 
     def test_contains_registered_namespace(self):
-        """Registered namespaces should appear in the table string."""
-        out = get_plugin_table_str()
-        assert "zug" in out
-        assert "derzug" in out
+        """Registered namespaces should appear in the returned DataFrame."""
+        df = get_plugin_table()
+        assert "zug" in df["namespace"].values
+        assert "derzug" in df["package_name"].values
 
 
 class TestObjToDocDF:

--- a/tests/test_utils/test_namespace.py
+++ b/tests/test_utils/test_namespace.py
@@ -214,6 +214,20 @@ class TestPluginRegistry:
         yield
         _load_plugin_registry.cache_clear()
 
+    @pytest.fixture()
+    def parent_class_registry(self, monkeypatch, tmp_path):
+        """Patch _PLUGIN_REGISTRY_DIR with a CSV for ParentClass containing cool_ns."""
+        df = pd.DataFrame(
+            {
+                "package_name": ["coolpkg"],
+                "package_url": ["https://example.com/coolpkg"],
+                "namespace": ["cool_ns"],
+            }
+        )
+        df.to_csv(tmp_path / "ParentClass.csv", index=False)
+        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
+        return ParentClass()
+
     def test_none_group_returns_empty(self):
         """_load_plugin_registry returns empty dict when group is None."""
         result = _load_plugin_registry(None)
@@ -225,57 +239,17 @@ class TestPluginRegistry:
         result = _load_plugin_registry("dascore.nofile_namespace")
         assert result == {}
 
-    def test_valid_csv_returns_mapping(self, monkeypatch, tmp_path):
-        """_load_plugin_registry parses CSV into a namespace → (pkg, url) mapping."""
-        csv_path = tmp_path / "myplugin.csv"
-        df = pd.DataFrame(
-            {
-                "package_name": ["mypkg"],
-                "package_url": ["https://example.com/mypkg"],
-                "namespace": ["myns"],
-            }
-        )
-        df.to_csv(csv_path, index=False)
-        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
-        result = _load_plugin_registry("dascore.myplugin_namespace")
-        assert result == {"myns": ("mypkg", "https://example.com/mypkg")}
-
-    def test_getattr_plugin_hit_raises_helpful_error(self, monkeypatch, tmp_path):
+    def test_getattr_plugin_hit_raises_helpful_error(self, parent_class_registry):
         """__getattr__ raises DASCorePluginError with package info for known plugins."""
-        csv_path = tmp_path / "ParentClass.csv"
-        df = pd.DataFrame(
-            {
-                "package_name": ["coolpkg"],
-                "package_url": ["https://example.com/coolpkg"],
-                "namespace": ["cool_ns"],
-            }
-        )
-        df.to_csv(csv_path, index=False)
-        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
-        inst = ParentClass()
         msg = (
             "ParentClass has a registered namespace of 'cool_ns' "
             "provided by 'coolpkg' but it is not installed. "
             "Install it from: https://example.com/coolpkg"
         )
         with pytest.raises(DASCorePluginError) as exc_info:
-            inst.cool_ns
+            parent_class_registry.cool_ns
         assert str(exc_info.value) == msg
-
-    def test_getattr_plugin_hit_hasattr_returns_false(self, monkeypatch, tmp_path):
-        """Hasattr returns False for a registered-but-uninstalled namespace."""
-        csv_path = tmp_path / "ParentClass.csv"
-        df = pd.DataFrame(
-            {
-                "package_name": ["coolpkg"],
-                "package_url": ["https://example.com/coolpkg"],
-                "namespace": ["cool_ns"],
-            }
-        )
-        df.to_csv(csv_path, index=False)
-        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
-        inst = ParentClass()
-        assert not hasattr(inst, "cool_ns")
+        assert not hasattr(parent_class_registry, "cool_ns")
 
     def test_getattr_unknown_attr_raises_default_error(self, monkeypatch, tmp_path):
         """__getattr__ raises default AttributeError when attr not in CSV."""

--- a/tests/test_utils/test_namespace.py
+++ b/tests/test_utils/test_namespace.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import warnings
 from typing import ClassVar
 
+import pandas as pd
 import pytest
 
+import dascore.utils.namespace as ns_module
 from dascore.utils.namespace import (
     NamespaceOwner,
+    _load_plugin_registry,
     _MethodNameSpace,
 )
 
@@ -192,3 +195,109 @@ class TestNamespace:
         assert CooperativeNamespace.hook_called
         out = CooperativeBase._registry["dascore.cooperative_test"]
         assert out["cooperative"] is CooperativeNamespace
+
+    def test_custom_attr_error_message(self):
+        """Ensure _namespace_attr_errors messages are raised verbatim."""
+        inst = ParentClass()
+        with pytest.raises(AttributeError, match="test_error emitted"):
+            inst.test_error
+
+
+@pytest.fixture(autouse=False)
+def _clear_registry_cache():
+    """Clear the _load_plugin_registry LRU cache before and after each test."""
+    _load_plugin_registry.cache_clear()
+    yield
+    _load_plugin_registry.cache_clear()
+
+
+class TestPluginRegistry:
+    """Tests for the plugin registry CSV lookup."""
+
+    def test_none_group_returns_empty(self, _clear_registry_cache):
+        """_load_plugin_registry returns empty dict when group is None."""
+        result = _load_plugin_registry(None)
+        assert result == {}
+
+    def test_nonexistent_csv_returns_empty(
+        self, _clear_registry_cache, monkeypatch, tmp_path
+    ):
+        """_load_plugin_registry returns empty dict when CSV does not exist."""
+        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
+        result = _load_plugin_registry("dascore.nofile_namespace")
+        assert result == {}
+
+    def test_valid_csv_returns_mapping(
+        self, _clear_registry_cache, monkeypatch, tmp_path
+    ):
+        """_load_plugin_registry parses CSV into a namespace → (pkg, url) mapping."""
+        csv_path = tmp_path / "myplugin.csv"
+        df = pd.DataFrame(
+            {
+                "package_name": ["mypkg"],
+                "package_url": ["https://example.com/mypkg"],
+                "namespace": ["myns"],
+            }
+        )
+        df.to_csv(csv_path, index=False)
+        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
+        result = _load_plugin_registry("dascore.myplugin_namespace")
+        assert result == {"myns": ("mypkg", "https://example.com/mypkg")}
+
+    def test_multiple_rows_all_returned(
+        self, _clear_registry_cache, monkeypatch, tmp_path
+    ):
+        """_load_plugin_registry returns all rows when CSV has multiple entries."""
+        csv_path = tmp_path / "multi.csv"
+        df = pd.DataFrame(
+            {
+                "package_name": ["pkgA", "pkgB"],
+                "package_url": ["https://a.com", "https://b.com"],
+                "namespace": ["nsA", "nsB"],
+            }
+        )
+        df.to_csv(csv_path, index=False)
+        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
+        result = _load_plugin_registry("dascore.multi_namespace")
+        assert result == {
+            "nsA": ("pkgA", "https://a.com"),
+            "nsB": ("pkgB", "https://b.com"),
+        }
+
+    def test_getattr_plugin_hit_raises_helpful_error(
+        self, _clear_registry_cache, monkeypatch, tmp_path
+    ):
+        """__getattr__ raises AttributeError with package info for known plugins."""
+        csv_path = tmp_path / "ParentClass.csv"
+        df = pd.DataFrame(
+            {
+                "package_name": ["coolpkg"],
+                "package_url": ["https://example.com/coolpkg"],
+                "namespace": ["cool_ns"],
+            }
+        )
+        df.to_csv(csv_path, index=False)
+        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
+        inst = ParentClass()
+        msg = (
+            "ParentClass has no attribute 'cool_ns'. "
+            "It is provided by the 'coolpkg' package. "
+            "Install it from: https://example.com/coolpkg"
+        )
+        with pytest.raises(AttributeError, match="coolpkg"):
+            inst.cool_ns
+        # Verify the full message structure.
+        with pytest.raises(AttributeError) as exc_info:
+            inst.cool_ns
+        assert str(exc_info.value) == msg
+
+    def test_getattr_unknown_attr_raises_default_error(
+        self, _clear_registry_cache, monkeypatch, tmp_path
+    ):
+        """__getattr__ raises default AttributeError when attr not in CSV."""
+        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
+        inst = ParentClass()
+        with pytest.raises(
+            AttributeError, match="ParentClass has no attribute 'totally_unknown'"
+        ):
+            inst.totally_unknown

--- a/tests/test_utils/test_namespace.py
+++ b/tests/test_utils/test_namespace.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 import dascore.utils.namespace as ns_module
+from dascore.exceptions import DASCorePluginError
 from dascore.utils.namespace import (
     NamespaceOwner,
     _load_plugin_registry,
@@ -280,14 +281,14 @@ class TestPluginRegistry:
         monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
         inst = ParentClass()
         msg = (
-            "ParentClass has no attribute 'cool_ns'. "
-            "It is provided by the 'coolpkg' package. "
+            "ParentClass has a registered namespace of 'cool_ns' "
+            "provided by 'coolpkg' but it is not installed. "
             "Install it from: https://example.com/coolpkg"
         )
-        with pytest.raises(AttributeError, match="coolpkg"):
+        with pytest.raises(DASCorePluginError, match="coolpkg"):
             inst.cool_ns
         # Verify the full message structure.
-        with pytest.raises(AttributeError) as exc_info:
+        with pytest.raises(DASCorePluginError) as exc_info:
             inst.cool_ns
         assert str(exc_info.value) == msg
 

--- a/tests/test_utils/test_namespace.py
+++ b/tests/test_utils/test_namespace.py
@@ -204,33 +204,28 @@ class TestNamespace:
             inst.test_error
 
 
-@pytest.fixture(autouse=False)
-def _clear_registry_cache():
-    """Clear the _load_plugin_registry LRU cache before and after each test."""
-    _load_plugin_registry.cache_clear()
-    yield
-    _load_plugin_registry.cache_clear()
-
-
 class TestPluginRegistry:
     """Tests for the plugin registry CSV lookup."""
 
-    def test_none_group_returns_empty(self, _clear_registry_cache):
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """Clear the _load_plugin_registry LRU cache before and after each test."""
+        _load_plugin_registry.cache_clear()
+        yield
+        _load_plugin_registry.cache_clear()
+
+    def test_none_group_returns_empty(self):
         """_load_plugin_registry returns empty dict when group is None."""
         result = _load_plugin_registry(None)
         assert result == {}
 
-    def test_nonexistent_csv_returns_empty(
-        self, _clear_registry_cache, monkeypatch, tmp_path
-    ):
+    def test_nonexistent_csv_returns_empty(self, monkeypatch, tmp_path):
         """_load_plugin_registry returns empty dict when CSV does not exist."""
         monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
         result = _load_plugin_registry("dascore.nofile_namespace")
         assert result == {}
 
-    def test_valid_csv_returns_mapping(
-        self, _clear_registry_cache, monkeypatch, tmp_path
-    ):
+    def test_valid_csv_returns_mapping(self, monkeypatch, tmp_path):
         """_load_plugin_registry parses CSV into a namespace → (pkg, url) mapping."""
         csv_path = tmp_path / "myplugin.csv"
         df = pd.DataFrame(
@@ -245,30 +240,8 @@ class TestPluginRegistry:
         result = _load_plugin_registry("dascore.myplugin_namespace")
         assert result == {"myns": ("mypkg", "https://example.com/mypkg")}
 
-    def test_multiple_rows_all_returned(
-        self, _clear_registry_cache, monkeypatch, tmp_path
-    ):
-        """_load_plugin_registry returns all rows when CSV has multiple entries."""
-        csv_path = tmp_path / "multi.csv"
-        df = pd.DataFrame(
-            {
-                "package_name": ["pkgA", "pkgB"],
-                "package_url": ["https://a.com", "https://b.com"],
-                "namespace": ["nsA", "nsB"],
-            }
-        )
-        df.to_csv(csv_path, index=False)
-        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
-        result = _load_plugin_registry("dascore.multi_namespace")
-        assert result == {
-            "nsA": ("pkgA", "https://a.com"),
-            "nsB": ("pkgB", "https://b.com"),
-        }
-
-    def test_getattr_plugin_hit_raises_helpful_error(
-        self, _clear_registry_cache, monkeypatch, tmp_path
-    ):
-        """__getattr__ raises AttributeError with package info for known plugins."""
+    def test_getattr_plugin_hit_raises_helpful_error(self, monkeypatch, tmp_path):
+        """__getattr__ raises DASCorePluginError with package info for known plugins."""
         csv_path = tmp_path / "ParentClass.csv"
         df = pd.DataFrame(
             {
@@ -285,16 +258,11 @@ class TestPluginRegistry:
             "provided by 'coolpkg' but it is not installed. "
             "Install it from: https://example.com/coolpkg"
         )
-        with pytest.raises(DASCorePluginError, match="coolpkg"):
-            inst.cool_ns
-        # Verify the full message structure.
         with pytest.raises(DASCorePluginError) as exc_info:
             inst.cool_ns
         assert str(exc_info.value) == msg
 
-    def test_getattr_plugin_hit_hasattr_returns_false(
-        self, _clear_registry_cache, monkeypatch, tmp_path
-    ):
+    def test_getattr_plugin_hit_hasattr_returns_false(self, monkeypatch, tmp_path):
         """Hasattr returns False for a registered-but-uninstalled namespace."""
         csv_path = tmp_path / "ParentClass.csv"
         df = pd.DataFrame(
@@ -309,9 +277,7 @@ class TestPluginRegistry:
         inst = ParentClass()
         assert not hasattr(inst, "cool_ns")
 
-    def test_getattr_unknown_attr_raises_default_error(
-        self, _clear_registry_cache, monkeypatch, tmp_path
-    ):
+    def test_getattr_unknown_attr_raises_default_error(self, monkeypatch, tmp_path):
         """__getattr__ raises default AttributeError when attr not in CSV."""
         monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
         inst = ParentClass()

--- a/tests/test_utils/test_namespace.py
+++ b/tests/test_utils/test_namespace.py
@@ -292,6 +292,23 @@ class TestPluginRegistry:
             inst.cool_ns
         assert str(exc_info.value) == msg
 
+    def test_getattr_plugin_hit_hasattr_returns_false(
+        self, _clear_registry_cache, monkeypatch, tmp_path
+    ):
+        """Hasattr returns False for a registered-but-uninstalled namespace."""
+        csv_path = tmp_path / "ParentClass.csv"
+        df = pd.DataFrame(
+            {
+                "package_name": ["coolpkg"],
+                "package_url": ["https://example.com/coolpkg"],
+                "namespace": ["cool_ns"],
+            }
+        )
+        df.to_csv(csv_path, index=False)
+        monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
+        inst = ParentClass()
+        assert not hasattr(inst, "cool_ns")
+
     def test_getattr_unknown_attr_raises_default_error(
         self, _clear_registry_cache, monkeypatch, tmp_path
     ):


### PR DESCRIPTION

## Description

Adds a more structured registry for DASCore plug ins. 

Replaces #640.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
- added: a plugin registry and a "supported plugins" documentation page listing third-party DASCore extensions.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
