### PR TITLE
introduce patch id private attr

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -624,15 +624,19 @@ class DataFrameSpool(BaseSpool):
                 raise IndexError(msg)
 
         # get a mapping from the old current index to the sorted ones
-        sorted_df = df.sort_values(attribute).reset_index(drop=True)
-        old_indices = df.index
-        new_indices = np.arange(len(df))
-        mapper = pd.Series(new_indices, index=old_indices)
+        sorted_df = df.sort_values(attribute)
+        sorted_original_indices = sorted_df.index
+        sorted_df = sorted_df.reset_index(drop=True)
+        mapper = pd.Series(np.arange(len(sorted_df)), index=sorted_original_indices)
         # swap out all the old values with new ones
         new_current_index = inst_df["current_index"].map(mapper)
         new_instruction_df = inst_df.assign(current_index=new_current_index)
         # create new spool from new dataframes
-        return self.new_from_df(df=sorted_df, instruction_df=new_instruction_df)
+        return self.new_from_df(
+            df=sorted_df,
+            source_df=self._source_df,
+            instruction_df=new_instruction_df,
+        )
 
     @compose_docstring(doc=BaseSpool.split.__doc__)
     def split(

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -52,6 +52,20 @@ def _normalize_dims(dims: Any) -> tuple[str, ...]:
     return tuple(dims)
 
 
+def _normalize_source_patch_id(
+    attrs: PatchAttrs, source_patch_id: Any = ""
+) -> tuple[PatchAttrs, str]:
+    """Normalize summary and private attr source ids to one value."""
+    summary_source_patch_id = (
+        "" if source_patch_id in (None, "") else str(source_patch_id)
+    )
+    attrs_source_patch_id = str(attrs.get("_source_patch_id", "") or "")
+    normalized = summary_source_patch_id or attrs_source_patch_id
+    if normalized:
+        attrs = attrs.update(_source_patch_id=normalized)
+    return attrs, normalized
+
+
 class PatchSummary(DascoreBaseModel):
     """A metadata-only summary of a patch."""
 
@@ -81,6 +95,9 @@ class PatchSummary(DascoreBaseModel):
         # summaries, so we only need to normalize nested coord values and dims.
         if "attrs" in data or "coords" in data:
             attrs = PatchAttrs.from_dict(data.get("attrs"))
+            attrs, source_patch_id = _normalize_source_patch_id(
+                attrs, data.get("source_patch_id", "")
+            )
             dims = _normalize_dims(data.get("dims", ()))
             coord_map = {
                 name: _to_coord_summary(
@@ -101,7 +118,7 @@ class PatchSummary(DascoreBaseModel):
                 "path": data.get("path", ""),
                 "file_format": data.get("file_format", ""),
                 "file_version": data.get("file_version", ""),
-                "source_patch_id": data.get("source_patch_id", ""),
+                "source_patch_id": source_patch_id,
             }
         # Flat inputs still use scan/index-style keys such as time_min/time_max.
         # Split those into coordinate summaries plus pure attrs before building
@@ -112,6 +129,9 @@ class PatchSummary(DascoreBaseModel):
             dims=dims or None,
         )
         attrs = PatchAttrs.from_dict(attr_info)
+        attrs, source_patch_id = _normalize_source_patch_id(
+            attrs, data.get("source_patch_id", "")
+        )
         coord_map = {
             name: _to_coord_summary(
                 summary,
@@ -131,18 +151,19 @@ class PatchSummary(DascoreBaseModel):
             "path": data.get("path", ""),
             "file_format": data.get("file_format", ""),
             "file_version": data.get("file_version", ""),
-            "source_patch_id": data.get("source_patch_id", ""),
+            "source_patch_id": source_patch_id,
         }
 
     @classmethod
     def from_patch(cls, patch: dc.Patch) -> PatchSummary:
         """Create a summary from a loaded patch."""
-        return cls.model_construct(
+        return cls(
             attrs=patch.attrs,
             coords=patch.coords.to_summary_dict(),
             dims=patch.dims,
             shape=patch.shape,
             dtype=str(np.dtype(patch.data.dtype)),
+            source_patch_id=patch.attrs.get("_source_patch_id", ""),
         )
 
     def dump_structured(self) -> dict[str, Any]:

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -123,7 +123,7 @@ def _scan_result_to_summary(
         "" if source_patch_id in (None, "") else str(source_patch_id)
     )
     if isinstance(attrs, PatchSummary):
-        return PatchSummary.model_construct(
+        return PatchSummary(
             attrs=attrs.attrs,
             coords=dict(attrs.coords),
             dims=tuple(attrs.dims),

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -322,11 +322,11 @@ def _get_patch_content_from_group(group, file_version="", file_format="DASDAE"):
         coord_map[name] = _get_coord_summary_from_node(coord_node, coord_dims)
     data_nodes = [x for x in group if x.name == "data"]
     dtype = str(data_nodes[0].dtype) if data_nodes else ""
-    return PatchSummary.model_construct(
+    attr_info["_source_patch_id"] = group._v_name
+    return PatchSummary(
         attrs=PatchAttrs.from_dict(attr_info),
         coords=coord_map,
         dims=dims,
         shape=(),
         dtype=dtype,
-        source_patch_id=group._v_name,
     )

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -202,6 +202,7 @@ def _read_patch(patch_group, **kwargs):
     dims = _get_dims(patch_group)
     coords = _get_coords(patch_group, dims, attrs)
     _, attr_info = separate_coord_info(attrs, dims=dims)
+    attr_info["_source_patch_id"] = patch_group._v_name
     attrs = PatchAttrs.from_dict(attr_info)
     # Note, previously this was wrapped with try, except (Index, KeyError)
     # and the data = np.array(None) in except block. Not sure, why, removed

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -373,10 +373,14 @@ def _read_febus(
         str(value) for value in iterate(source_patch_id) if value not in (None, "")
     }
     for attr, cm, febus in _yield_attrs_coords(fi):
-        if source_patch_ids and _get_source_patch_id(febus) not in source_patch_ids:
+        patch_id = _get_source_patch_id(febus)
+        if source_patch_ids and patch_id not in source_patch_ids:
             continue
         data, new_cm = _get_data_new_cm(cm, febus, distance=distance, time=time)
         if data.size:
-            patch = dc.Patch(data=data, coords=new_cm, attrs=attr_cls.from_dict(attr))
+            attr_info = dict(attr)
+            attr_info["_source_patch_id"] = patch_id
+            attrs = attr_cls.from_dict(attr_info)
+            patch = dc.Patch(data=data, coords=new_cm, attrs=attrs)
             out.append(patch)
     return out

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -80,14 +80,16 @@ class Febus2(FiberIO):
         """Scan a febus file, return summary information about the file's contents."""
         out = []
         for attr, cm, feb in _yield_attrs_coords(resource):
+            attrs = FebusPatchAttrs.from_dict(attr).update(
+                _source_patch_id=_get_source_patch_id(feb)
+            )
             out.append(
-                PatchSummary.model_construct(
-                    attrs=FebusPatchAttrs.from_dict(attr),
+                PatchSummary(
+                    attrs=attrs,
                     coords=cm.to_summary_dict(),
                     dims=cm.dims,
                     shape=cm.shape,
                     dtype=str(feb.zone[feb.data_name].dtype),
-                    source_patch_id=_get_source_patch_id(feb),
                 )
             )
         return out

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -48,14 +48,14 @@ class ProdMLV2_0(FiberIO):  # noqa
         """Scan a prodml file, return summary information about the file's contents."""
         out = []
         for attr, coords, source_patch_id in _yield_prodml_attrs_coords(resource):
+            attrs = attr.update(_source_patch_id=source_patch_id)
             out.append(
-                PatchSummary.model_construct(
-                    attrs=attr,
+                PatchSummary(
+                    attrs=attrs,
                     coords=coords.to_summary_dict(),
                     dims=coords.dims,
                     shape=coords.shape,
-                    dtype=attr.get("dtype", ""),
-                    source_patch_id=source_patch_id,
+                    dtype=attrs.get("dtype", ""),
                 )
             )
         return out

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -224,6 +224,7 @@ def _get_raw_node_attr_coords(node_info, d_coord, base_info):
     t_coord = _get_time_coord(node_info.node)
     info.update(_get_data_unit_and_type(node_info.node))
     info["dtype"] = str(node_info.node["RawData"].dtype)
+    info["_source_patch_id"] = node_info.name
     coords = dc.get_coord_manager(
         coords={"time": t_coord, "distance": d_coord},
         dims=_get_dims_from_attrs(node_info.node["RawData"].attrs),
@@ -238,6 +239,7 @@ def _get_processed_node_attr_coords(node_info, d_coord, base_info):
     t_coord = _get_time_coord(node_info.parent_node)
     out.update(_get_data_unit_and_type(node_info.node))
     out["dtype"] = str(node_info.node.dtype)
+    out["_source_patch_id"] = node_info.name
     out.update(maybe_get_items(node_info.node.attrs, _FBE_NODE_ATTRS))
     out.update(maybe_get_items(node_info.parent_node.attrs, _FBE_PARENT_ATTRS))
     # For some reason, the distance coords in raw and fbe data are not the

--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -49,10 +49,17 @@ def combine_patch_attrs(
             return model
         return dc.PatchAttrs.from_dict(model)
 
+    def _drop_private_keys(model_dict):
+        """Remove private attrs so they don't affect compatibility merges."""
+        return {
+            key: value for key, value in model_dict.items() if not key.startswith("_")
+        }
+
     def _get_model_dict_list(mod_list):
         """Get list of model dicts with optional dropped attrs."""
         model_dicts = [
-            _to_patch_attrs(x).model_dump(exclude_defaults=True) for x in mod_list
+            _drop_private_keys(_to_patch_attrs(x).model_dump(exclude_defaults=True))
+            for x in mod_list
         ]
         # drop attributes specified.
         if drop := set(iterate(drop_attrs)):

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -993,8 +993,12 @@ def _merge_models(attrs1, attrs2, attrs_to_ignore=DEFAULT_ATTRS_TO_IGNORE):
     no_comp_keys = set(attrs_to_ignore)
     if attrs1 == attrs2:
         return attrs1
-    dict1 = dict(attrs1)
-    dict2 = dict(attrs2)
+    dict1 = {
+        key: value for key, value in dict(attrs1).items() if not key.startswith("_")
+    }
+    dict2 = {
+        key: value for key, value in dict(attrs2).items() if not key.startswith("_")
+    }
     common_keys = set(dict1) & set(dict2)
     ne_attrs = []
     for key in common_keys:

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -124,7 +124,10 @@ The rule is simple:
 
 - `scan()` should emit a stable `source_patch_id` for each patch.
 - `read(..., source_patch_id=...)` should use that value to return the matching patch, or patches if given multiple ids.
-- `source_patch_id` belongs on the summary/reload path, not on patch attrs.
+- `source_patch_id` belongs on the summary/reload path, not as a public patch attr contract.
+- If your `FiberIO` can return multiple patches from one resource, loaded patches should also carry the resolved id as a private attr on `PatchAttrs`, typically `_source_patch_id`.
+- Add that private attr before constructing the final `PatchAttrs` instance for the loaded patch.
+- Private attrs should not participate in normal patch compatibility checks.
 - `path`, `file_format`, and `file_version` are owned by the calling DASCore scan layer, not by `FiberIO.scan()`.
 
 For some formats, a numeric patch index is enough if patch ordering is stable. For others, a native identifier such as a group name, node name, or source/zone tuple is better. If your format only ever produces one patch per file, you usually do not need to set `source_patch_id`.

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -123,10 +123,10 @@ If a single file can produce more than one patch, your format should usually pro
 The rule is simple:
 
 - `scan()` should emit a stable `source_patch_id` for each patch.
+- For FiberIO implementation, prefer setting `attrs["_source_patch_id"]` on both scan summaries and loaded patches; DASCore will normalize that onto `PatchSummary.source_patch_id` when summaries are built.
 - `read(..., source_patch_id=...)` should use that value to return the matching patch, or patches if given multiple ids.
-- `source_patch_id` belongs on the summary/reload path, not as a public patch attr contract.
-- If your `FiberIO` can return multiple patches from one resource, loaded patches should also carry the resolved id as a private attr on `PatchAttrs`, typically `_source_patch_id`.
-- Add that private attr before constructing the final `PatchAttrs` instance for the loaded patch.
+- `source_patch_id` remains the public summary/reload field, while `_source_patch_id` remains the private attr-level field FiberIO authors should set directly.
+- If both are provided when constructing a `PatchSummary`, `source_patch_id` wins and is copied back onto `attrs["_source_patch_id"]`.
 - Private attrs should not participate in normal patch compatibility checks.
 - `path`, `file_format`, and `file_version` are owned by the calling DASCore scan layer, not by `FiberIO.scan()`.
 

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -412,6 +412,21 @@ class TestIndexing:
             patch = sub[ind]
             assert isinstance(patch, dc.Patch)
 
+    def test_sorted_chunked_selected_spool_can_load_patches(
+        self, diverse_directory_spool
+    ):
+        """Sorted chunked selections should still reload patches."""
+        chunked = (
+            diverse_directory_spool.select(distance=(100, 200))
+            .chunk(time=None, conflict="keep_first")
+            .sort("time_min")
+        )
+        assert len(chunked) > 0
+        patch_time_mins = [patch.attrs.time_min for patch in chunked]
+        assert patch_time_mins == sorted(patch_time_mins)
+        assert isinstance(chunked[0], dc.Patch)
+        assert all(isinstance(patch, dc.Patch) for patch in chunked)
+
 
 class TestFileSpoolIntegrations:
     """Small integration tests for the file spool."""

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -426,7 +426,7 @@ class TestIndexing:
             .sort("time_min")
         )
         assert len(chunked) > 0
-        patch_time_mins = [patch.attrs.time_min for patch in chunked]
+        patch_time_mins = [patch.get_coord("time").min() for patch in chunked]
         assert patch_time_mins == sorted(patch_time_mins)
         assert isinstance(chunked[0], dc.Patch)
         assert all(isinstance(patch, dc.Patch) for patch in chunked)

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -293,6 +293,15 @@ class TestInit:
                 scanned, time=(np.datetime64("1900-01-01"), np.datetime64("1900-01-02"))
             )
 
+    def test_patch_summary_from_patch_copies_private_source_patch_id(
+        self, random_patch
+    ):
+        """Patch summaries built from patches should expose the private source id."""
+        patch = random_patch.update_attrs(_source_patch_id="node-3")
+        summary = PatchSummary.from_patch(patch)
+        assert summary.source_patch_id == "node-3"
+        assert summary.attrs["_source_patch_id"] == "node-3"
+
     def test_non_time_distance_dims(self):
         """Ensure dimensions other than time/distance work."""
         x = np.arange(10) * 2
@@ -581,6 +590,19 @@ class TestPatchSummary:
             {"time_min": 1.0, "time_max": 2.0, "dims": ("time",)}
         )
         assert out.dims == ("time",)
+
+    def test_flat_summary_preserves_explicit_coord_dims(self):
+        """Flat summary normalization should preserve dims on coord mappings."""
+        out = dc.PatchSummary.model_validate(
+            {
+                "dims": ("time", "distance"),
+                "time": {"min": 1.0, "max": 2.0, "step": 1.0, "dims": ("time",)},
+                "distance": {"min": 0.0, "max": 10.0, "step": 5.0},
+            }
+        )
+        assert out.coords["time"].dims == ("time",)
+        assert out.coords["distance"].dims == ("distance",)
+        assert out.dims == ("time", "distance")
 
 
 class TestDisplay:

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -383,6 +383,12 @@ class TestSort:
         df = sorted_spool.get_contents()
         assert df["time_min"].is_monotonic_increasing
 
+    def test_sorted_spool_iteration_matches_sorted_contents(self, diverse_spool):
+        """Sorting should reorder loaded patches, not just the contents dataframe."""
+        sorted_spool = diverse_spool.sort("time_min")
+        patch_time_mins = [patch.attrs.time_min for patch in sorted_spool]
+        assert patch_time_mins == sorted(patch_time_mins)
+
     def test_sorting_attr_time(self, diverse_spool):
         """Test sorting by the 'time' attribute that that may not be in the df."""
         sorted_spool = diverse_spool.sort("time")

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -385,7 +385,7 @@ class TestSort:
     def test_sorted_spool_iteration_matches_sorted_contents(self, diverse_spool):
         """Sorting should reorder loaded patches, not just the contents dataframe."""
         sorted_spool = diverse_spool.sort("time_min")
-        patch_time_mins = [patch.attrs.time_min for patch in sorted_spool]
+        patch_time_mins = [patch.get_coord("time").min() for patch in sorted_spool]
         assert patch_time_mins == sorted(patch_time_mins)
 
     def test_sorting_attr_time(self, diverse_spool):

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -175,6 +175,7 @@ class TestReadDASDAE:
         out = dc.read(path, source_patch_id=target)
         assert len(out) == 1
         assert out[0].attrs["_source_patch_id"] == target
+        assert out[0].summary.source_patch_id == out[0].attrs["_source_patch_id"]
         assert (
             out[0].summary.get_coord_summary("time").min
             == scanned[1].get_coord_summary("time").min

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -174,6 +174,7 @@ class TestReadDASDAE:
         target = scanned[1].source_patch_id
         out = dc.read(path, source_patch_id=target)
         assert len(out) == 1
+        assert out[0].attrs["_source_patch_id"] == target
         assert (
             out[0].summary.get_coord_summary("time").min
             == scanned[1].get_coord_summary("time").min
@@ -188,6 +189,7 @@ class TestReadDASDAE:
         targets = [scanned[0].source_patch_id, scanned[2].source_patch_id]
         out = dc.read(path, source_patch_id=targets)
         assert len(out) == 2
+        assert {patch.attrs["_source_patch_id"] for patch in out} == set(targets)
         assert {patch.summary.get_coord_summary("time").min for patch in out} == {
             scanned[0].get_coord_summary("time").min,
             scanned[2].get_coord_summary("time").min,

--- a/tests/test_io/test_febus/test_febusa1.py
+++ b/tests/test_io/test_febus/test_febusa1.py
@@ -68,7 +68,7 @@ class TestFebus:
         target = summaries[0]
         out = dc.read(febus_path, source_patch_id=target.source_patch_id)
         assert len(out) == 1
-        assert "source_patch_id" not in out[0].attrs.model_dump()
+        assert out[0].attrs["_source_patch_id"] == target.source_patch_id
         assert (
             out[0].summary.get_coord_summary("time").min
             == target.get_coord_summary("time").min
@@ -80,6 +80,7 @@ class TestFebus:
         targets = [summaries[0].source_patch_id]
         out = dc.read(febus_path, source_patch_id=targets)
         assert len(out) == 1
+        assert out[0].attrs["_source_patch_id"] == targets[0]
         assert (
             out[0].summary.get_coord_summary("time").min
             == summaries[0].get_coord_summary("time").min

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -171,6 +171,32 @@ class TestScanResultToSummary:
         with pytest.raises(ValueError, match=msg):
             _scan_result_to_summary(patch.attrs)
 
+    def test_summary_source_patch_id_sets_private_attr(self):
+        """Summary source ids should be copied onto private attrs."""
+        summary = dc.PatchSummary(
+            attrs=dc.PatchAttrs(tag="x"),
+            source_patch_id="node-1",
+        )
+        assert summary.source_patch_id == "node-1"
+        assert summary.attrs["_source_patch_id"] == "node-1"
+
+    def test_private_attr_source_patch_id_sets_summary(self):
+        """Private attr source ids should populate the summary field."""
+        summary = dc.PatchSummary(
+            attrs=dc.PatchAttrs(tag="x", _source_patch_id="node-2"),
+        )
+        assert summary.source_patch_id == "node-2"
+        assert summary.attrs["_source_patch_id"] == "node-2"
+
+    def test_summary_source_patch_id_wins_on_conflict(self):
+        """Conflicting ids should resolve in favor of the summary field."""
+        summary = dc.PatchSummary(
+            attrs=dc.PatchAttrs(tag="x", _source_patch_id="attrs-id"),
+            source_patch_id="summary-id",
+        )
+        assert summary.source_patch_id == "summary-id"
+        assert summary.attrs["_source_patch_id"] == "summary-id"
+
 
 class TestFormatManager:
     """Tests for the format manager."""

--- a/tests/test_io/test_prodml/test_prodml_source_patch_id.py
+++ b/tests/test_io/test_prodml/test_prodml_source_patch_id.py
@@ -29,7 +29,7 @@ class TestProdMLSourcePatchId:
         target = dc.scan(prodml_fbe_path)[0]
         spool = dc.read(prodml_fbe_path, source_patch_id=target.source_patch_id)
         assert len(spool) == 1
-        assert "source_patch_id" not in spool[0].attrs.model_dump()
+        assert spool[0].attrs["_source_patch_id"] == target.source_patch_id
         assert (
             spool[0].summary.get_coord_summary("time").min
             == target.get_coord_summary("time").min
@@ -41,6 +41,7 @@ class TestProdMLSourcePatchId:
         targets = [summaries[0].source_patch_id, summaries[1].source_patch_id]
         spool = dc.read(prodml_fbe_path, source_patch_id=targets)
         assert len(spool) == 2
+        assert {patch.attrs["_source_patch_id"] for patch in spool} == set(targets)
         assert {patch.summary.get_coord_summary("time").min for patch in spool} == {
             summaries[0].get_coord_summary("time").min,
             summaries[1].get_coord_summary("time").min,

--- a/tests/test_utils/test_attrs_utils.py
+++ b/tests/test_utils/test_attrs_utils.py
@@ -131,6 +131,13 @@ class TestMergeAttrs:
         out = combine_patch_attrs([mapping, random_patch.attrs], conflicts="keep_first")
         assert isinstance(out, PatchAttrs)
 
+    def test_private_attrs_are_ignored_for_merge_conflicts(self, random_patch):
+        """Private attrs should not block attr merging."""
+        attrs1 = random_patch.attrs.update(_source_patch_id="one")
+        attrs2 = random_patch.attrs.update(_source_patch_id="two")
+        out = combine_patch_attrs([attrs1, attrs2])
+        assert "_source_patch_id" not in out.model_dump()
+
 
 class TestSeparateCoordInfo:
     """Tests for separating coord info from attr dict."""

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -220,6 +220,22 @@ class TestMergePatches:
         with pytest.warns(DeprecationWarning, match="merge_patches is deprecated"):
             merge_patches(random_patch)
 
+    def test_merge_compatible_coords_attrs_ignores_private_attrs(self, random_patch):
+        """Private attrs should not make otherwise compatible patches fail."""
+        patch_1 = random_patch.update_attrs(_source_patch_id="one")
+        patch_2 = random_patch.update_attrs(_source_patch_id="two")
+        coords, attrs = merge_compatible_coords_attrs(patch_1, patch_2)
+        assert coords == random_patch.coords
+        assert attrs["_source_patch_id"] == "one"
+
+    def test_binary_ops_ignore_private_attrs(self, random_patch):
+        """Binary ops should work on patches with different private ids."""
+        patch_1 = random_patch.update_attrs(_source_patch_id="one")
+        patch_2 = random_patch.update_attrs(_source_patch_id="two")
+        out = patch_1 + patch_2
+        assert isinstance(out, dc.Patch)
+        assert out.attrs["_source_patch_id"] == "one"
+
 
 class TestGetDimAxisValue:
     """Tests for getting the dimension name, axis, and value."""
@@ -432,6 +448,19 @@ class TestConcatenate:
         val1, val2 = patch.get_array("time"), random_patch.get_array("time")
         assert np.all(val1[: len(val2)] == val2)
         assert np.all(val1[len(val2) :] == val2)
+
+    def test_concatenate_ignores_private_attrs(self, random_patch):
+        """Private ids should not block concatenation of compatible patches."""
+        patch_1 = random_patch.update_attrs(_source_patch_id="one")
+        shifted = (
+            random_patch.coords.get_array("time") + random_patch.get_coord("time").step
+        )
+        patch_2 = random_patch.update_coords(time=shifted).update_attrs(
+            _source_patch_id="two"
+        )
+        out = concatenate_patches([patch_1, patch_2], time=None)
+        assert len(out) == 1
+        assert out[0].attrs["_source_patch_id"] == "one"
 
     def test_different_lens(self, random_patch):
         """Ensure different lengths can be chunked on same dim."""


### PR DESCRIPTION
 ## Description

  This PR fixes PatchSummary source patch id normalization so metadata-only summaries preserve reloadable patch identity consistently.

  Specifically:

  - normalize source_patch_id from either the public summary field or the private _source_patch_id attr during summary validation
  - ensure PatchSummary.from_patch(...) carries _source_patch_id into source_patch_id
  - preserve explicit coord dims when validating flat summary payloads
  - remove the unreachable stale-private-id cleanup branch from _normalize_source_patch_id

  This keeps summary-based reload paths aligned across patch-backed and scan-backed summary construction.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

  ## Checklist

  I have (if applicable):

  - [ ] referenced the GitHub issue this PR closes.
  - [ ] documented the new feature with docstrings and/or appropriate doc page.
  - [x] included tests. See testing guidelines (https://dascore.org/contributing/testing.html).
  - [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
