### PR TITLE
support universal paths

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -64,6 +64,8 @@ For doctests:
 pytest dascore --doctest-modules
 ```
 
+Unless otherwise specified, A job is not finished until the the tests pass. 
+
 ## Test authoring conventions
 
 - Put tests under `tests/` mirroring package structure.
@@ -84,6 +86,7 @@ pytest dascore --doctest-modules
 - Use NumPy-style docstrings for public APIs.
 - Add a short explanatory comment for private helpers when intent is not obvious.
 - Keep comments meaningful; do not restate obvious code.
+- Always use dascore.utils.misc:suppress_warnings to suppress warnings. 
 
 ## Documentation changes
 

--- a/.github/actions/load-shared-vars/action.yml
+++ b/.github/actions/load-shared-vars/action.yml
@@ -10,6 +10,9 @@ outputs:
   python-min-deps-matrix:
     description: "Python version matrix for minimum dependency tests"
     value: ${{ steps.load.outputs.python-min-deps-matrix }}
+  test-os-matrix:
+    description: "OS matrix for test workflows"
+    value: ${{ steps.load.outputs.test-os-matrix }}
 
 runs:
   using: "composite"
@@ -19,9 +22,10 @@ runs:
       shell: bash
       run: |
         python_default="3.13"
-        python_test_matrix='["3.11","3.12","3.13","3.14"]'
         python_min_deps_matrix='["3.13","3.14"]'
-
+        python_test_matrix='["3.11","3.12","3.13","3.14"]'
+        test_os_matrix='["ubuntu-latest","macos-latest","windows-latest"]'
         echo "PYTHON_DEFAULT=$python_default" >> "$GITHUB_ENV"
         echo "python-test-matrix=$python_test_matrix" >> "$GITHUB_OUTPUT"
         echo "python-min-deps-matrix=$python_min_deps_matrix" >> "$GITHUB_OUTPUT"
+        echo "test-os-matrix=$test_os_matrix" >> "$GITHUB_OUTPUT"

--- a/.github/actions/prep_doc_build/action.yml
+++ b/.github/actions/prep_doc_build/action.yml
@@ -8,7 +8,6 @@ runs:
       uses: quarto-dev/quarto-actions/setup@v2
       with:
         version: 1.3.450
-        tinytex: true
 
     - name: print quarto version
       shell: bash -l {0}

--- a/.github/scripts/cache_test_data.py
+++ b/.github/scripts/cache_test_data.py
@@ -1,4 +1,4 @@
-"""Populate the pooch cache with every file in dascore's data registry."""
+"""Populate the pooch cache with the default non-large DASCore test data."""
 
 from __future__ import annotations
 
@@ -13,8 +13,8 @@ from dascore.utils.downloader import fetch, get_registry_df  # noqa: E402
 
 
 def main() -> None:
-    """Fetch every registered test-data file into the local pooch cache."""
-    registry = get_registry_df()
+    """Fetch the default non-large registered test data into the local cache."""
+    registry = get_registry_df(exclude_large=True)
     total = len(registry)
     print(f"Priming DASCore test-data cache with {total} files")  # noqa
     for index, name in enumerate(registry["name"], start=1):

--- a/.github/workflows/build_deploy_master_docs.yaml
+++ b/.github/workflows/build_deploy_master_docs.yaml
@@ -1,12 +1,12 @@
 # This action renders and publishes the development docs whenever
-# new commits are added to the master or dev branch.
+# new commits are added to the master branch.
 
-name: BuildDeployDevDocs
+name: BuildDeployMasterDocs
 
 on:
-  # Runs on pushes targeting the development branches
+  # Runs on pushes targeting the master branch
   push:
-    branches: ["master", "dev"]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       # Shared values live in .github/actions/load-shared-vars/action.yml
       python-matrix: ${{ steps.load-vars.outputs.python-min-deps-matrix }}
+      os-matrix: ${{ steps.load-vars.outputs.test-os-matrix }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/load-shared-vars
@@ -39,16 +40,21 @@ jobs:
 
   test_code_min_deps:
     needs: setup
-    timeout-minutes: 25
+    timeout-minutes: 35
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        # Defined in .github/actions/load-shared-vars/action.yml
+        os: ${{ fromJson(needs.setup.outputs.os-matrix) }}
         # Defined in .github/actions/load-shared-vars/action.yml
         python-version: ${{ fromJson(needs.setup.outputs.python-matrix) }}
 
     # only run if CI isn't turned off
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')
+
+    env:
+      # Determine if this should drop into a debugger if any tests fail.
+      debug_enabled: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'debug') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -66,10 +72,28 @@ jobs:
 
       # Runs test suite and calculates coverage
       - name: run test suite
+        id: run_test_suite
+        continue-on-error: ${{ env.debug_enabled == 'true' }}
         shell: bash -el {0}
         run: ./.github/test_code.sh
 
       # Runs examples in docstrings
       - name: test docstrings
+        id: run_docstrings
+        continue-on-error: ${{ env.debug_enabled == 'true' }}
         shell: bash -el {0}
         run: ./.github/test_code.sh doctest
+
+      # Debug access is limited to the workflow actor's GitHub SSH keys.
+      # Connect from a machine that has the matching private key loaded.
+      - name: Setup tmate session
+        if: env.debug_enabled == 'true' && (steps.run_test_suite.outcome == 'failure' || steps.run_docstrings.outcome == 'failure')
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
+        with:
+          limit-access-to-actor: true
+
+      - name: fail job after debug session if tests failed
+        if: steps.run_test_suite.outcome == 'failure' || steps.run_docstrings.outcome == 'failure'
+        shell: bash -el {0}
+        run: exit 1

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -55,6 +55,7 @@ jobs:
     env:
       # Determine if this should drop into a debugger if any tests fail.
       debug_enabled: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'debug') }}
+      PYTEST_ADDOPTS: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'debug') && '-vv --durations=100' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -34,6 +34,7 @@ jobs:
     outputs:
       # Shared values live in .github/actions/load-shared-vars/action.yml
       python-matrix: ${{ steps.load-vars.outputs.python-test-matrix }}
+      os-matrix: ${{ steps.load-vars.outputs.test-os-matrix }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/load-shared-vars
@@ -41,11 +42,12 @@ jobs:
 
   test_code:
     needs: setup
-    timeout-minutes: 25
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Defined in .github/actions/load-shared-vars/action.yml
+        os: ${{ fromJson(needs.setup.outputs.os-matrix) }}
         # Defined in .github/actions/load-shared-vars/action.yml
         python-version: ${{ fromJson(needs.setup.outputs.python-matrix) }}
 
@@ -55,6 +57,7 @@ jobs:
     env:
       # set conda environment file with dependencies
       env_file: 'environment.yml'
+      debug_enabled: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'debug') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -70,13 +73,32 @@ jobs:
 
       # Runs test suite and calculates coverage
       - name: run test suite
+        id: run_test_suite
+        continue-on-error: ${{ env.debug_enabled == 'true' }}
         shell: bash -el {0}
         run: ./.github/test_code.sh
 
       # Runs examples in docstrings
       - name: test docstrings
+        id: run_docstrings
+        continue-on-error: ${{ env.debug_enabled == 'true' }}
         shell: bash -el {0}
         run: ./.github/test_code.sh doctest
+
+      - name: note SSH key requirement for debug access
+        if: env.debug_enabled == 'true' && (steps.run_test_suite.outcome == 'failure' || steps.run_docstrings.outcome == 'failure')
+        shell: bash
+        run: |
+          message="Debug access is limited to the workflow actor's GitHub SSH keys. Connect from a machine that has the matching private key loaded."
+          echo "$message"
+          echo "$message" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Setup tmate session
+        if: env.debug_enabled == 'true' && (steps.run_test_suite.outcome == 'failure' || steps.run_docstrings.outcome == 'failure')
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
+        with:
+          limit-access-to-actor: true
 
       # Upload coverage files
       - uses: codecov/codecov-action@v4
@@ -86,10 +108,8 @@ jobs:
           flags: unittests
           name: PR_tests
           token: ${{ secrets.CODECOV_TOKEN }}
-      
-            
-# This is a very useful step for debugging, it allows you to ssh into the CI
-# machine (https://github.com/marketplace/actions/debugging-with-tmate).
-#
-#- name: Setup tmate session
-#  uses: mxschmitt/action-tmate@v3
+
+      - name: fail job after debug session if tests failed
+        if: steps.run_test_suite.outcome == 'failure' || steps.run_docstrings.outcome == 'failure'
+        shell: bash
+        run: exit 1

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -58,6 +58,7 @@ jobs:
       # set conda environment file with dependencies
       env_file: 'environment.yml'
       debug_enabled: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'debug') }}
+      PYTEST_ADDOPTS: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'debug') && '-vv --durations=100' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ docs/index_files
 docs/index.quarto_ipynb
 
 # Agent stuff
+.codex
 .claude
 CLAUDE.md
 .agents/worktrees/

--- a/benchmarks/readme.md
+++ b/benchmarks/readme.md
@@ -29,6 +29,8 @@ Benchmarks are now organized as pytest tests in the `benchmarks/` directory:
 
 Each benchmark uses the `@pytest.mark.benchmark` decorator to automatically measure performance.
 
+The IO benchmark and CI test-data priming use the default registry view, which excludes entries listed in `dascore.utils.downloader.LARGE_REGISTRY_FILES`. Large assets remain fetchable explicitly, but they are not downloaded by default during benchmark setup.
+
 ## Continuous Performance Monitoring
 
 Benchmarks automatically run on:

--- a/benchmarks/test_io_benchmarks.py
+++ b/benchmarks/test_io_benchmarks.py
@@ -8,6 +8,7 @@ from functools import cache
 import pytest
 
 import dascore as dc
+from dascore.config import set_config
 from dascore.exceptions import DependencyError
 from dascore.utils.downloader import fetch, get_registry_df
 
@@ -15,7 +16,9 @@ from dascore.utils.downloader import fetch, get_registry_df
 @cache
 def get_test_file_paths():
     """Get a dict of name: path for all files in data registry."""
-    df = get_registry_df().loc[lambda x: ~x["name"].str.endswith(".csv")]
+    df = get_registry_df(exclude_large=True).loc[
+        lambda x: ~x["name"].str.endswith(".csv")
+    ]
     out = {row["name"]: fetch(row["name"]) for _, row in df.iterrows()}
     return out
 
@@ -24,6 +27,13 @@ def get_test_file_paths():
 def test_file_paths():
     """Get paths of test files."""
     return get_test_file_paths()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def allow_legacy_dasdae_coord_unpickle():
+    """Benchmarks include trusted historical DASDAE fixtures from the registry."""
+    with set_config(allow_dasdae_format_unpickle=True):
+        yield
 
 
 class TestIOBenchmarks:

--- a/dascore/__init__.py
+++ b/dascore/__init__.py
@@ -18,8 +18,5 @@ from dascore.utils.patch import patch_function
 from dascore.utils.time import to_datetime64, to_timedelta64, to_float
 from dascore.version import __last_version__, __version__
 
-# flag for disabling progress bar when debugging
-_debug = False
-
 # Ensure warnings are issued only once (per warning/line)
 warnings.filterwarnings("once", category=UserWarning, module=r"dascore\..*")

--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -13,6 +13,7 @@ import pandas as pd
 from rich.text import Text
 from typing_extensions import Self
 
+from dascore.compat import UPath
 from dascore.constants import PROGRESS_LEVELS
 from dascore.core.spool import BaseSpool, DataFrameSpool
 from dascore.io.indexer import AbstractIndexer, DirectoryIndexer
@@ -45,7 +46,7 @@ class DirectorySpool(DataFrameSpool):
 
     def __init__(
         self,
-        base_path: str | Path | Self | AbstractIndexer = ".",
+        base_path: str | Path | UPath | Self | AbstractIndexer = ".",
         *,
         index_path: Path | None = None,
         preferred_format: str | None = None,
@@ -60,7 +61,7 @@ class DirectorySpool(DataFrameSpool):
         # Init file spool from indexer
         elif isinstance(base_path, AbstractIndexer):
             self.indexer = base_path
-        elif isinstance(base_path, Path | str):
+        elif isinstance(base_path, Path | str | UPath):
             self.indexer = DirectoryIndexer(base_path, index_path=index_path)
         assert hasattr(self, "indexer"), "indexer not set."
         self._preferred_format = preferred_format

--- a/dascore/clients/filespool.py
+++ b/dascore/clients/filespool.py
@@ -9,6 +9,7 @@ from rich.text import Text
 from typing_extensions import Self
 
 import dascore as dc
+from dascore.compat import UPath
 from dascore.constants import PROGRESS_LEVELS, SpoolType
 from dascore.core.spool import BaseSpool, DataFrameSpool
 from dascore.io.core import FiberIO
@@ -38,7 +39,7 @@ class FileSpool(DataFrameSpool):
 
     def __init__(
         self,
-        path: str | Path,
+        path: str | Path | UPath,
         file_format: str | None = None,
         file_version: str | None = None,
     ):
@@ -47,7 +48,8 @@ class FileSpool(DataFrameSpool):
         if isinstance(path, self.__class__):
             self.__dict__.update(copy.deepcopy(path.__dict__))
             return
-        self._path = Path(path)
+        # Support UPaths, but keep standard Path support here because it is faster
+        self._path = path if isinstance(path, UPath) else Path(path)
         if not self._path.exists() or self._path.is_dir():
             msg = f"{path} does not exist or is a directory"
             raise FileNotFoundError(msg)
@@ -73,9 +75,6 @@ class FileSpool(DataFrameSpool):
     def update(self: SpoolType, progress: PROGRESS_LEVELS = "standard") -> Self:
         """
         {doc}.
-
-        Note: If the file format supports indexing (e.g. DASDAE) this will
-        trigger an indexing of the file.
         """
         formatter = FiberIO.manager.get_fiberio(
             format=self._file_format, version=self._file_version

--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -16,6 +16,7 @@ from rich.progress import Progress  # NOQA
 from scipy.interpolate import interp1d  # NOQA
 from scipy.ndimage import zoom  # NOQA
 from scipy.signal import decimate, resample, resample_poly  # NOQA
+from upath import UPath  # NOQA
 
 random_state = RandomState(42)
 

--- a/dascore/config.py
+++ b/dascore/config.py
@@ -50,7 +50,7 @@ class DascoreConfig(BaseModel):
     )
     directory_index_map_path: Path = Field(
         default_factory=lambda: _get_cache_root() / "indexes" / "cache_paths.json",
-        description="Path to the JSON cache that records external index-file locations.",
+        description="Path to the cache that records external index-file locations.",
     )
     index_query_buffer: np.timedelta64 = Field(
         default=np.timedelta64(1, "s"),

--- a/dascore/config.py
+++ b/dascore/config.py
@@ -1,0 +1,183 @@
+"""Runtime configuration for DASCore."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import gettempdir
+
+import numpy as np
+import pooch
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _get_cache_root() -> Path:
+    """Return the base cache directory for DASCore."""
+    return Path(pooch.os_cache("dascore"))
+
+
+def _get_remote_cache_root() -> Path:
+    """Return the OS-appropriate temp directory used for remote-file caching."""
+    return Path(gettempdir()) / "dascore" / "remote_cache"
+
+
+class DascoreConfig(BaseModel):
+    """Container for runtime configuration values."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        validate_default=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
+    debug: bool = Field(default=False, description="Enable DASCore debug behavior.")
+    display_float_precision: int = Field(
+        default=3,
+        description="Number of decimal places to show in numeric displays.",
+    )
+    display_array_threshold: int = Field(
+        default=100,
+        description="Maximum array size to display before summarizing values.",
+    )
+    display_patch_history_array_threshold: int = Field(
+        default=10,
+        description="Maximum history length to display before summarizing entries.",
+    )
+    downloader_cache_dir: Path = Field(
+        default_factory=lambda: _get_cache_root() / "data",
+        description="Persistent directory used to cache downloaded example data.",
+    )
+    directory_index_map_path: Path = Field(
+        default_factory=lambda: _get_cache_root() / "indexes" / "cache_paths.json",
+        description="Path to the JSON cache that records external index-file locations.",
+    )
+    index_query_buffer: np.timedelta64 = Field(
+        default=np.timedelta64(1, "s"),
+        description="Time buffer applied when querying cached directory indexes.",
+    )
+    hdf_index_complib: str = Field(
+        default="blosc:lz4",
+        description="Compression library used when writing DASCore HDF index files.",
+    )
+    hdf_index_complevel: int = Field(
+        default=5,
+        description="Compression level used when writing DASCore HDF index files.",
+    )
+    hdf_index_max_retries: int = Field(
+        default=3,
+        description="Maximum number of retries for concurrent HDF index access.",
+    )
+    progress_basic_refresh_per_second: float = Field(
+        default=0.25,
+        description="Refresh rate for basic progress display updates.",
+    )
+    remote_cache_dir: Path = Field(
+        default_factory=_get_remote_cache_root,
+        description="Temporary directory used to materialize remote files locally.",
+    )
+    allow_remote_cache: bool = Field(
+        default=True,
+        description="Allow DASCore to cache remote files to local temporary storage.",
+    )
+    allow_remote_cache_for_metadata: bool = Field(
+        default=False,
+        description="Allow local caching of remote files when only metadata is needed.",
+    )
+    warn_on_remote_cache: bool = Field(
+        default=True,
+        description="Warn when DASCore falls back to caching a remote file locally.",
+    )
+    allow_dasdae_format_unpickle: bool = Field(
+        default=False,
+        description=(
+            "Allow legacy DASDAE files to unpickle embedded coord metadata for "
+            "compatibility with trusted historical files."
+        ),
+    )
+    remote_download_block_size: int = Field(
+        default=1_048_576,
+        description="Block size in bytes for general remote file downloads.",
+    )
+    remote_hdf5_block_size: int = Field(
+        default=5_242_880,
+        description="Block size in bytes for remote HDF5 access on tuned protocols.",
+    )
+
+    @field_validator(
+        "downloader_cache_dir",
+        "directory_index_map_path",
+        "remote_cache_dir",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_path(cls, value):
+        """Normalize configured path values."""
+        return Path(value).expanduser()
+
+    @field_validator("index_query_buffer", mode="before")
+    @classmethod
+    def _coerce_timedelta(cls, value):
+        """Normalize timedelta-like config values."""
+        return np.timedelta64(value)
+
+
+_CONFIG = DascoreConfig()
+
+
+class _ConfigDescriptor:
+    """Descriptor for attributes that should always reflect runtime config."""
+
+    def __init__(self, attr_name: str):
+        self.attr_name = attr_name
+
+    def __get__(self, _instance, _owner=None):
+        """Return the current configured value for the target attribute."""
+        return getattr(get_config(), self.attr_name)
+
+
+def config_attr(attr_name: str):
+    """Return a descriptor bound to one field on the active runtime config."""
+    return _ConfigDescriptor(attr_name)
+
+
+def get_config() -> DascoreConfig:
+    """Return the active runtime configuration."""
+    return _CONFIG
+
+
+@contextmanager
+def _restore_config(previous: DascoreConfig):
+    """Restore the previous config when exiting a context manager."""
+    global _CONFIG
+    try:
+        yield _CONFIG
+    finally:
+        _CONFIG = previous
+
+
+def set_config(
+    new_config: DascoreConfig | None = None, **kwargs
+):  # pragma: no cover - exercised via context manager use
+    """Set the active runtime config and return a restoring context manager."""
+    global _CONFIG
+    previous = _CONFIG
+    if new_config is not None and kwargs:
+        msg = "Cannot supply both new_config and keyword overrides."
+        raise ValueError(msg)
+    if new_config is None:
+        payload = previous.model_dump()
+        payload.update(kwargs)
+        new_config = DascoreConfig(**payload)
+    elif not isinstance(new_config, DascoreConfig):
+        msg = "new_config must be an instance of DascoreConfig."
+        raise TypeError(msg)
+    _CONFIG = new_config
+    return _restore_config(previous)
+
+
+def reset_config() -> DascoreConfig:
+    """Reset the active runtime config to defaults."""
+    global _CONFIG
+    _CONFIG = DascoreConfig()
+    return _CONFIG

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 
 import dascore as dc
+from dascore.compat import UPath
 
 PatchType = TypeVar("PatchType", bound="dc.Patch")
 
@@ -43,7 +44,12 @@ MININT64 = np.iinfo(np.int64).min
 MAXINT64 = np.iinfo(np.int64).max
 
 # types used to represent paths
-path_types = str | Path
+path_types = str | Path | UPath
+
+# Remote protocols that should use DASCore's smaller HDF5 readahead blocks.
+# h5py performs many small metadata reads while opening files, and some S3-like
+# backends default to large readahead chunks that overfetch remote data.
+remote_hdf5_tuned_protocols = ("s3", "s3a", "s3n")
 
 # One second in numpy timedelta speak
 ONE_SECOND = np.timedelta64(1, "s")
@@ -56,9 +62,6 @@ ONE_BILLION = 1_000_000_000
 
 # One second with a precision of nano seconds
 ONE_SECOND_IN_NS = np.timedelta64(ONE_BILLION, "ns")
-
-# Float printing precision
-FLOAT_PRECISION = 3
 
 # Valid strings for "datatype" attribute
 VALID_DATA_TYPES = (
@@ -168,8 +171,6 @@ check_behavior
 
 # Rich styles for various object displays.
 dascore_styles = dict(
-    np_array_threshold=100,  # max number of elements to show in array
-    patch_history_array_threshold=10,  # max elements of array in hist str.
     dc_blue="blue",
     dc_red="red",
     dc_yellow="yellow",

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -623,7 +623,6 @@ class CoordManager(DascoreBaseModel):
             array = _apply_union_indexers(indexers, array)
         return self, array
 
-    @compose_docstring(select_desc=select_values_description)
     def order(
         self, array: MaybeArray = None, relative=False, samples=False, **kwargs
     ) -> tuple[Self, MaybeArray]:

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -15,7 +15,7 @@ from rich.text import Text
 from typing_extensions import Self
 
 import dascore as dc
-from dascore.compat import is_array
+from dascore.compat import UPath, is_array
 from dascore.constants import (
     PROGRESS_LEVELS,
     WARN_LEVELS,
@@ -23,6 +23,7 @@ from dascore.constants import (
     PatchType,
     attr_conflict_description,
     numeric_types,
+    path_types,
     timeable_types,
 )
 from dascore.exceptions import InvalidSpoolError, ParameterError
@@ -40,6 +41,7 @@ from dascore.utils.patch import (
     patches_to_df,
     stack_patches,
 )
+from dascore.utils.paths import coerce_to_upath, requires_local_directory
 from dascore.utils.pd import (
     _column_or_value,
     _convert_min_max_in_kwargs,
@@ -713,7 +715,7 @@ class MemorySpool(DataFrameSpool):
 
 
 @singledispatch
-def spool(obj: Path | str | BaseSpool | Sequence[PatchType], **kwargs) -> BaseSpool:
+def spool(obj: path_types | BaseSpool | Sequence[PatchType], **kwargs) -> BaseSpool:
     """
     Create a spool from a data source.
 
@@ -747,11 +749,13 @@ def spool(obj: Path | str | BaseSpool | Sequence[PatchType], **kwargs) -> BaseSp
 
 @spool.register(str)
 @spool.register(Path)
+@spool.register(UPath)
 def _spool_from_str(path, **kwargs):
     """Get a spool from a path."""
-    path = Path(path)
+    path = coerce_to_upath(path)
     # A directory was passed, create Directory Spool
     if path.is_dir():
+        requires_local_directory(path, label="Directory spool")
         from dascore.clients.dirspool import DirectorySpool
 
         return DirectorySpool(path, **kwargs)

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -7,13 +7,13 @@ split between metadata-driven summaries and full-data coord reconstruction.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from pathlib import Path
 from typing import Any
 
 import numpy as np
 from pydantic import ConfigDict, Field, model_validator
 
 import dascore as dc
+from dascore.constants import path_types
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coords import (
     BaseCoord,
@@ -23,6 +23,7 @@ from dascore.core.coords import (
 )
 from dascore.utils.attrs import separate_coord_info
 from dascore.utils.models import DascoreBaseModel
+from dascore.utils.paths import coerce_to_upath, is_pathlike
 
 
 def _to_coord_summary(value: Any, dims: tuple[str, ...] = ()) -> CoordSummary:
@@ -290,23 +291,40 @@ def _build_patch_summary_payload(
     dims: tuple[str, ...] = (),
     shape=(),
     dtype="",
-    path="",
-    file_format="",
-    file_version="",
+    source_path="",
+    source_format="",
+    source_version="",
     source_patch_id="",
 ) -> dict[str, Any]:
     """Build the canonical structured payload used to validate PatchSummary."""
     attrs, source_patch_id = _normalize_source_patch_id(attrs, source_patch_id)
     dims = dims or _infer_dims_from_coords(coords)
+    # Only preserve source metadata when the caller already supplied a cheap,
+    # path-like reload target. Validation should not touch the filesystem.
+    if source_path in (None, ""):
+        normalized_source_path = ""
+    elif is_pathlike(source_path):
+        normalized_source_path = coerce_to_upath(source_path)
+    else:
+        normalized_source_path = ""
+    normalized_source_format = "" if source_format in (None, "") else str(source_format)
+    normalized_source_version = (
+        "" if source_version in (None, "") else str(source_version)
+    )
+    # If the source path is not reloadable, drop the paired source metadata too
+    # so summary objects only expose coherent reload information.
+    if not normalized_source_path:
+        normalized_source_format = ""
+        normalized_source_version = ""
     return {
         "attrs": attrs,
         "coords": coords,
         "dims": dims,
         "shape": tuple(shape),
         "dtype": str(dtype),
-        "path": path,
-        "file_format": file_format,
-        "file_version": file_version,
+        "source_path": normalized_source_path,
+        "source_format": normalized_source_format,
+        "source_version": normalized_source_version,
         "source_patch_id": source_patch_id,
     }
 
@@ -321,9 +339,9 @@ class PatchSummary(DascoreBaseModel):
     dims: tuple[str, ...] = ()
     shape: tuple[int, ...] = ()
     dtype: str = ""
-    path: str | Path = ""
-    file_format: str = ""
-    file_version: str = ""
+    source_path: path_types = ""
+    source_format: str = ""
+    source_version: str = ""
     source_patch_id: str = ""
 
     @model_validator(mode="before")
@@ -345,9 +363,9 @@ class PatchSummary(DascoreBaseModel):
                 dims=_normalize_dims(data.get("dims", ())),
                 shape=data.get("shape", ()),
                 dtype=data.get("dtype", ""),
-                path=data.get("path", ""),
-                file_format=data.get("file_format", ""),
-                file_version=data.get("file_version", ""),
+                source_path=data.get("source_path", data.get("path", "")),
+                source_format=data.get("source_format", data.get("file_format", "")),
+                source_version=data.get("source_version", data.get("file_version", "")),
                 source_patch_id=data.get("source_patch_id", ""),
             )
         # Flat inputs still use scan/index-style keys such as time_min/time_max.
@@ -364,9 +382,9 @@ class PatchSummary(DascoreBaseModel):
             dims=dims,
             shape=data.get("shape", ()),
             dtype=data.get("dtype", ""),
-            path=data.get("path", ""),
-            file_format=data.get("file_format", ""),
-            file_version=data.get("file_version", ""),
+            source_path=data.get("source_path", data.get("path", "")),
+            source_format=data.get("source_format", data.get("file_format", "")),
+            source_version=data.get("source_version", data.get("file_version", "")),
             source_patch_id=data.get("source_patch_id", ""),
         )
 
@@ -395,9 +413,11 @@ class PatchSummary(DascoreBaseModel):
         summary_meta = {
             "dims": ",".join(self.dims),
             "dtype": self.dtype,
-            "path": self.path,
-            "file_format": self.file_format,
-            "file_version": self.file_version,
+            # TODO: Replace these to source_path, source_format, and source_version
+            # when redoing the indexer.
+            "path": str(self.source_path) if self.source_path else "",
+            "file_format": self.source_format,
+            "file_version": self.source_version,
             "source_patch_id": self.source_patch_id,
             "coord_names": ",".join(self.coords),
         }

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -14,8 +14,8 @@ from scipy.signal import chirp as spy_chirp
 import dascore as dc
 import dascore.core
 from dascore.compat import random_state
+from dascore.config import set_config
 from dascore.exceptions import UnknownExampleError
-from dascore.utils.docs import compose_docstring
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import iterate, register_func
 from dascore.utils.patch import get_patch_names
@@ -27,7 +27,8 @@ EXAMPLE_SPOOLS = {}
 
 def _load_example_patch_from_file(path: str | Path) -> dc.Patch:
     """Load the first patch from an example file without FileSpool indirection."""
-    return dc.read(path)[0]
+    with set_config(allow_dasdae_format_unpickle=True):
+        return dc.read(path)[0]
 
 
 @register_func(EXAMPLE_PATCHES, key="random_das")
@@ -657,7 +658,6 @@ def spool_to_directory(spool, path=None, file_format="DASDAE", extension="hdf5")
     return path
 
 
-@compose_docstring(examples=", ".join(list(EXAMPLE_PATCHES)))
 def get_example_patch(example_name="random_das", **kwargs) -> dc.Patch:
     """
     Load an example Patch.
@@ -708,7 +708,6 @@ def get_example_patch(example_name="random_das", **kwargs) -> dc.Patch:
     return EXAMPLE_PATCHES[example_name](**kwargs)
 
 
-@compose_docstring(examples=", ".join(list(EXAMPLE_SPOOLS)))
 def get_example_spool(example_name="random_das", **kwargs) -> dc.BaseSpool:
     """
     Load an example Spool.

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -549,7 +549,7 @@ def dispersion_event():
     A synthetic shot record that exhibits dispersion.
     """
     path = fetch("dispersion_event.h5")
-    return dc.spool(path)[0]
+    return _load_example_patch_from_file(path)
 
 
 @register_func(EXAMPLE_SPOOLS, key="random_das")
@@ -699,7 +699,7 @@ def get_example_patch(example_name="random_das", **kwargs) -> dc.Patch:
     if example_name not in EXAMPLE_PATCHES:
         # Allow the example name to be a data registry entry.
         with suppress(ValueError):
-            return dc.spool(fetch(example_name))[0]
+            return _load_example_patch_from_file(fetch(example_name))
         msg = (
             f"No example patch registered with name {example_name} "
             f"Registered example patches are {list(EXAMPLE_PATCHES)}"

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -121,3 +121,7 @@ class AttributeMergeError(ValueError, DASCoreError):
 
 class DASCorePluginError(AttributeError, DASCoreError):
     """Raised when something is wrong with plugins."""
+
+
+class RemoteCacheError(IOError, DASCoreError):
+    """Raised when DASCore cannot satisfy remote cache requirements."""

--- a/dascore/io/__init__.py
+++ b/dascore/io/__init__.py
@@ -7,10 +7,6 @@ import dascore.utils.pd
 from dascore.io.core import FiberIO, read, scan, scan_to_df, write, PatchFileSummary
 from dascore.utils.io import BinaryReader, BinaryWriter
 from dascore.utils.hdf5 import (
-    HDF5Writer,
-    HDF5Reader,
-    PyTablesWriter,
-    PyTablesReader,
     H5Reader,
     H5Writer,
 )

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -6,7 +6,6 @@ Das Data.
 from __future__ import annotations
 
 import inspect
-import os.path
 import warnings
 from collections import defaultdict
 from collections.abc import Generator
@@ -19,7 +18,7 @@ import pandas as pd
 from pydantic import ConfigDict, Field, model_validator
 
 import dascore as dc
-from dascore.compat import Progress
+from dascore.compat import Progress, UPath
 from dascore.constants import (
     PROGRESS_LEVELS,
     VALID_DATA_CATEGORIES,
@@ -27,6 +26,7 @@ from dascore.constants import (
     PatchType,
     SpoolType,
     max_lens,
+    path_types,
     timeable_types,
 )
 from dascore.core.attrs import str_validator
@@ -38,6 +38,7 @@ from dascore.exceptions import (
     InvalidFiberIOError,
     MissingOptionalDependencyError,
     PatchAttributeError,
+    RemoteCacheError,
     UnknownFiberFormatError,
 )
 from dascore.utils.io import IOResourceManager, get_handle_from_resource
@@ -49,8 +50,10 @@ from dascore.utils.models import (
     DateTime64,
     TimeDelta64,
 )
+from dascore.utils.paths import coerce_to_upath, is_local_path
 from dascore.utils.plugins import get_entry_point_loaders
 from dascore.utils.progress import track
+from dascore.utils.remote_io import get_remote_cache_scope, remote_cache_scope
 
 
 class PatchFileSummary(DascoreBaseModel):
@@ -106,20 +109,20 @@ class PatchFileSummary(DascoreBaseModel):
 def _scan_result_to_summary(
     attrs: PatchSummary,
     *,
-    path: str | Path | None = None,
-    file_format: str | None = None,
-    file_version: str | None = None,
+    source_path: str | Path | UPath | None = None,
+    source_format: str | None = None,
+    source_version: str | None = None,
     source_patch_id: str | None = None,
 ) -> PatchSummary:
     """Convert scan metadata into a patch summary."""
     if isinstance(attrs, PatchSummary) and all(
         value in (None, "")
-        for value in (path, file_format, file_version, source_patch_id)
+        for value in (source_path, source_format, source_version, source_patch_id)
     ):
         return attrs
-    summary_path = "" if path in (None, "") else path
-    summary_format = "" if file_format in (None, "") else file_format
-    summary_version = "" if file_version in (None, "") else file_version
+    normalized_source_path = "" if source_path in (None, "") else source_path
+    normalized_source_format = "" if source_format in (None, "") else source_format
+    normalized_source_version = "" if source_version in (None, "") else source_version
     summary_source_patch_id = (
         "" if source_patch_id in (None, "") else str(source_patch_id)
     )
@@ -130,9 +133,9 @@ def _scan_result_to_summary(
             dims=tuple(attrs.dims),
             shape=tuple(attrs.shape),
             dtype=attrs.dtype,
-            path=summary_path or attrs.path,
-            file_format=summary_format or attrs.file_format,
-            file_version=summary_version or attrs.file_version,
+            source_path=normalized_source_path or attrs.source_path,
+            source_format=normalized_source_format or attrs.source_format,
+            source_version=normalized_source_version or attrs.source_version,
             source_patch_id=summary_source_patch_id or attrs.source_patch_id,
         )
     if isinstance(attrs, dc.PatchAttrs):
@@ -151,16 +154,16 @@ def _scan_result_to_summary(
 def _patch_to_summary(
     patch: dc.Patch,
     *,
-    path: str | Path | None = None,
-    file_format: str | None = None,
-    file_version: str | None = None,
+    source_path: str | Path | UPath | None = None,
+    source_format: str | None = None,
+    source_version: str | None = None,
 ) -> PatchSummary:
     """Convert a loaded patch into a summary tied to its source."""
     return _scan_result_to_summary(
         patch.summary,
-        path=path or "",
-        file_format=file_format,
-        file_version=file_version,
+        source_path=source_path or "",
+        source_format=source_format,
+        source_version=source_version,
     )
 
 
@@ -196,9 +199,9 @@ def _load_patch_summary(summary: PatchSummary, **kwargs) -> dc.Patch:
     """Internal helper for reloading a patch from a PatchSummary."""
     source_patch_id = summary.source_patch_id
     read_kwargs = {
-        "path": summary.path,
-        "file_format": summary.file_format or None,
-        "file_version": summary.file_version or None,
+        "path": summary.source_path,
+        "file_format": summary.source_format or None,
+        "file_version": summary.source_version or None,
         "source_patch_id": source_patch_id or None,
     }
     read_kwargs.update(kwargs)
@@ -214,18 +217,20 @@ def _load_patch_summary(summary: PatchSummary, **kwargs) -> dc.Patch:
         raise PatchAttributeError(msg) from exc
 
 
-def _get_reloadable_source_path(resource, fallback: str | Path | None = None) -> str:
-    """Return a reloadable filesystem path for resources that expose one."""
+def _get_reloadable_source_path(
+    resource, fallback: str | Path | UPath | None = None
+) -> UPath | str:
+    """Return a normalized reloadable path for resources that expose one."""
     candidates = [fallback, resource]
     for name in ("source", "filename", "name", "path"):
         candidates.append(getattr(resource, name, None))
     for candidate in candidates:
-        if candidate in (None, ""):
+        if candidate in {None, ""}:
             continue
         if isinstance(candidate, IOResourceManager):
             candidate = candidate.source
-        if isinstance(candidate, str | Path):
-            return str(candidate)
+        if isinstance(candidate, str | Path | UPath):
+            return coerce_to_upath(candidate)
     return ""
 
 
@@ -463,10 +468,18 @@ class _FiberIOManager:
         """
         with IOResourceManager(path) as man:
             path = man.source
-            if not os.path.exists(path):
+            if isinstance(path, UPath):
+                exists = path.exists()
+                suffix = path.suffix
+            else:
+                local_path = (
+                    coerce_to_upath(path) if not is_local_path(path) else Path(path)
+                )
+                exists = local_path.exists()
+                suffix = local_path.suffix
+            if not exists:
                 raise FileNotFoundError(f"{path} does not exist.")
             # get extension (str minus .)
-            suffix = Path(path).suffix
             ext = suffix[1:] if suffix else None
             input_type = self._get_input_type_name(path)
             iterator = self.yield_fiberio(
@@ -488,6 +501,8 @@ class _FiberIOManager:
                     # raise, in which case the format doesn't belong.
                     func_input = man.get_resource(required_type)
                     format_version = func(func_input, _pre_cast=True)
+                except RemoteCacheError:
+                    raise
                 # For robustness, we need to catch everything else here.
                 except Exception:
                     continue
@@ -505,8 +520,10 @@ class _FiberIOManager:
         # This effectively acts as a dispatch to determine which type of
         # FiberIO could possibly read the obj.
         out = "file"
-        if isinstance(obj, str | Path) and (path := Path(obj)).exists():
-            out = "directory" if path.is_dir() else "file"
+        if isinstance(obj, str | Path | UPath):
+            path = coerce_to_upath(obj)
+            if path.exists():
+                out = "directory" if path.is_dir() else "file"
         return out
 
 
@@ -691,7 +708,20 @@ class FiberIO:
         """Determine if the resource was updated after specified mtime."""
         if not timestamp:
             return True
-        return Path(resource).stat().st_mtime > timestamp
+        is_remote = not is_local_path(resource)
+        try:
+            path = coerce_to_upath(resource) if is_remote else Path(resource)
+            return path.stat().st_mtime > timestamp
+        except Exception:
+            if not is_remote:
+                return False
+            warnings.warn(
+                "Remote path backend does not expose reliable mtime; "
+                "continuing scan without timestamp filtering.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return True
 
     def __hash__(self):
         """FiberIO instances should be uniquely defined by (format, version)."""
@@ -717,7 +747,7 @@ class FiberIO:
 
 
 def read(
-    path: str | Path | IOResourceManager,
+    path: path_types | IOResourceManager,
     file_format: str | None = None,
     file_version: str | None = None,
     time: tuple[timeable_types | None, timeable_types | None] | None = None,
@@ -761,31 +791,34 @@ def read(
     >>>
     >>> patch = dc.read(file_path)
     """
-    with IOResourceManager(path) as man:
-        if not file_format or not file_version:
-            file_format, file_version = get_format(
-                man,
-                file_format=file_format,
-                file_version=file_version,
+    with remote_cache_scope("read"):
+        with IOResourceManager(path) as man:
+            if not file_format or not file_version:
+                file_format, file_version = get_format(
+                    man,
+                    file_format=file_format,
+                    file_version=file_version,
+                )
+            fiber_io = FiberIO.manager.get_fiberio(
+                format=file_format, version=file_version
             )
-        fiber_io = FiberIO.manager.get_fiberio(format=file_format, version=file_version)
-        required_type = fiber_io.read._required_type
-        path = man.get_resource(required_type)
-        out = fiber_io.read(
-            path,
-            file_version=file_version,
-            time=time,
-            distance=distance,
-            _pre_cast=True,
-            **kwargs,
-        )
-        # if resource has a seek go back to 0 so this stream can be re-used.
-        getattr(path, "seek", lambda x: None)(0)
-        return out
+            required_type = fiber_io.read._required_type
+            path = man.get_resource(required_type)
+            out = fiber_io.read(
+                path,
+                file_version=file_version,
+                time=time,
+                distance=distance,
+                _pre_cast=True,
+                **kwargs,
+            )
+            # if resource has a seek go back to 0 so this stream can be re-used.
+            getattr(path, "seek", lambda x: None)(0)
+            return out
 
 
 def scan_to_df(
-    path: Path | str | PatchType | SpoolType | IOResourceManager | pd.DataFrame,
+    path: path_types | PatchType | SpoolType | IOResourceManager | pd.DataFrame,
     file_format: str | None = None,
     file_version: str | None = None,
     ext: str | None = None,
@@ -843,13 +876,27 @@ def scan_to_df(
 def _iterate_scan_inputs(patch_source, ext, mtime, include_directories=True, **kwargs):
     """Yield scan candidates."""
     for el in iterate(patch_source):
-        if isinstance(el, str | Path) and (path := Path(el)).exists():
-            generator = _iter_filesystem(
-                path, ext=ext, timestamp=mtime, include_directories=include_directories
-            )
-            yield from generator
-        else:
-            yield el
+        if isinstance(el, str | Path | UPath):
+            path = coerce_to_upath(el) if not is_local_path(el) else Path(el)
+            if path.exists():
+                generator = _iter_filesystem(
+                    path,
+                    ext=ext,
+                    timestamp=mtime,
+                    include_directories=include_directories,
+                )
+                try:
+                    candidate = next(generator)
+                except StopIteration:
+                    continue
+                while True:
+                    signal = yield candidate
+                    try:
+                        candidate = generator.send(signal)
+                    except StopIteration:
+                        break
+                continue
+        yield el
 
 
 def _get_fiber_io_and_req_type(
@@ -920,7 +967,7 @@ def _handle_missing_optionals(outputs, optional_dep_dict):
 
 
 def scan(
-    path: Path | str | PatchType | SpoolType | IOResourceManager,
+    path: path_types | PatchType | SpoolType | IOResourceManager,
     file_format: str | None = None,
     file_version: str | None = None,
     ext: str | None = None,
@@ -978,7 +1025,7 @@ def scan(
     length = _count_generator(_generator)
     generator = _iterate_scan_inputs(path, ext=ext, mtime=timestamp)
     # We want to avoid printing long object str reprs, so only print paths.
-    resource_str = path if isinstance(path, str | Path) else ""
+    resource_str = path if isinstance(path, str | Path | UPath) else ""
     tracker = track(
         generator,
         f"scan {resource_str}",
@@ -987,71 +1034,80 @@ def scan(
         min_length=20,
     )
     try:
-        for patch_source in tracker:
-            # Normalize direct patch inputs to summary objects.
-            if isinstance(patch_source, dc.Patch):
-                out.append(
-                    _patch_to_summary(
-                        patch_source,
-                        path=_get_reloadable_source_path(
-                            patch_source.summary.path,
-                            fallback=patch_source.summary.path,
-                        ),
-                    )
-                )
-                continue
-            with IOResourceManager(patch_source) as man:
-                try:
-                    fiber_io, resource = _get_fiber_io_and_req_type(
-                        man,
-                        file_format=file_format,
-                        file_version=file_version,
-                        fiber_io_hint=fiber_io_hint,
-                    )
-                except UnknownFiberFormatError:  # skip bad entities
-                    continue
-                # Cache this fiber io to given preferential treatment next
-                # iteration. This speeds up the common case of many files
-                # with the same format.
-                fiber_io_hint[fiber_io.input_type] = fiber_io
-                # Special handling of directory FiberIOs.
-                if fiber_io.input_type == "directory":
-                    # Directory fiber_io should send skip signal back to generator
-                    # so that no files/sub directories are scanned.
-                    generator.send("skip")
-                    if not fiber_io._updated_after(resource, timestamp):
-                        continue
-                    # Directory FiberIO may need to know the time after which
-                    # contents should be returned.
-                    source = fiber_io.scan(
-                        resource, timestamp=timestamp, _pre_cast=True
-                    )
-                else:
-                    try:
-                        source = fiber_io.scan(resource, _pre_cast=True)
-                    except MissingOptionalDependencyError as ex:
-                        missing_optional_deps[ex.msg.split(" ")[0]] += 1
-                        continue
-                    # scan() is best-effort across many resources, so surface
-                    # dependency/compatibility problems as warnings and keep
-                    # scanning the remaining files.
-                    except DependencyError as exc:
-                        warnings.warn(str(exc), UserWarning, stacklevel=2)
-                        continue
-                    # This happens if the file is corrupt see #346.
-                    except (OSError, InvalidFiberFileError, ValueError, TypeError):
-                        warnings.warn(f"Failed to scan {resource}", UserWarning)
-                        continue
-                source_path = _get_reloadable_source_path(resource, fallback=man.source)
-                for attr in source:
+        with remote_cache_scope("metadata"):
+            for patch_source in tracker:
+                # Normalize direct patch inputs to summary objects.
+                if isinstance(patch_source, dc.Patch):
                     out.append(
-                        _scan_result_to_summary(
-                            attr,
-                            path=source_path,
-                            file_format=fiber_io.name,
-                            file_version=fiber_io.version,
+                        _patch_to_summary(
+                            patch_source,
+                            source_path=_get_reloadable_source_path(
+                                patch_source.summary.source_path
+                            ),
                         )
                     )
+                    continue
+                with IOResourceManager(patch_source) as man:
+                    try:
+                        fiber_io, resource = _get_fiber_io_and_req_type(
+                            man,
+                            file_format=file_format,
+                            file_version=file_version,
+                            fiber_io_hint=fiber_io_hint,
+                        )
+                    except UnknownFiberFormatError:  # skip bad entities
+                        continue
+                    # Cache this fiber io to given preferential treatment next
+                    # iteration. This speeds up the common case of many files
+                    # with the same format.
+                    fiber_io_hint[fiber_io.input_type] = fiber_io
+                    # Special handling of directory FiberIOs.
+                    if fiber_io.input_type == "directory":
+                        # Directory fiber_io should send skip signal back to generator
+                        # so that no files/sub directories are scanned.
+                        generator.send("skip")
+                        if not fiber_io._updated_after(resource, timestamp):
+                            continue
+                        # Directory FiberIO may need to know the time after which
+                        # contents should be returned.
+                        source = fiber_io.scan(
+                            resource, timestamp=timestamp, _pre_cast=True
+                        )
+                    else:
+                        try:
+                            source = fiber_io.scan(resource, _pre_cast=True)
+                        except MissingOptionalDependencyError as ex:
+                            missing_optional_deps[ex.msg.split(" ")[0]] += 1
+                            continue
+                        # scan() is best-effort across many resources, so surface
+                        # dependency/compatibility problems as warnings and keep
+                        # scanning the remaining files.
+                        except DependencyError as exc:
+                            warnings.warn(str(exc), UserWarning, stacklevel=2)
+                            continue
+                        except RemoteCacheError:
+                            raise
+                        # This happens if the file is corrupt see #346.
+                        except (
+                            OSError,
+                            InvalidFiberFileError,
+                            ValueError,
+                            TypeError,
+                        ):
+                            warnings.warn(f"Failed to scan {resource}", UserWarning)
+                            continue
+                    source_path = _get_reloadable_source_path(
+                        resource, fallback=man.source
+                    )
+                    for attr in source:
+                        out.append(
+                            _scan_result_to_summary(
+                                attr,
+                                source_path=source_path,
+                                source_format=fiber_io.name,
+                                source_version=fiber_io.version,
+                            )
+                        )
     # Ensure ctl + c exists scan.
     except KeyboardInterrupt:
         getattr(progress, "stop", lambda: None)()
@@ -1062,7 +1118,7 @@ def scan(
 
 
 def get_format(
-    path: str | Path | IOResourceManager,
+    path: path_types | IOResourceManager,
     file_format: str | None = None,
     file_version: str | None = None,
     fiber_io_hint: dict[str, FiberIO] | None = None,
@@ -1101,15 +1157,21 @@ def get_format(
     >>>
     >>> file_format, file_version = dc.get_format(file_path)
     """
-    out = FiberIO.manager._get_format(
-        path, file_format, file_version, fiber_io_hint, **kwargs
-    )
+    scope = get_remote_cache_scope()
+    if scope == "read":
+        return FiberIO.manager._get_format(
+            path, file_format, file_version, fiber_io_hint, **kwargs
+        )
+    with remote_cache_scope("metadata"):
+        out = FiberIO.manager._get_format(
+            path, file_format, file_version, fiber_io_hint, **kwargs
+        )
     return out
 
 
 def write(
     patch_or_spool,
-    path: str | Path,
+    path: path_types,
     file_format: str,
     file_version: str | None = None,
     **kwargs,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -793,12 +793,18 @@ def read(
     """
     with remote_cache_scope("read"):
         with IOResourceManager(path) as man:
+            inferred_format = not file_format or not file_version
             if not file_format or not file_version:
                 file_format, file_version = get_format(
                     man,
                     file_format=file_format,
                     file_version=file_version,
                 )
+            # If we had to probe metadata first, reopen the resource for the
+            # actual read. Some remote HDF5/fileobj stacks do not reliably
+            # tolerate reusing the same handle across sniffing and full reads.
+            if inferred_format:
+                man.clear_cache()
             fiber_io = FiberIO.manager.get_fiberio(
                 format=file_format, version=file_version
             )

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -8,20 +8,14 @@ import pandas as pd
 
 import dascore as dc
 from dascore.constants import SpoolType
-from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
-from dascore.utils.hdf5 import (
-    H5Reader,
-    HDFPatchIndexManager,
-    NodeError,
-    PyTablesReader,
-    PyTablesWriter,
-)
-from dascore.utils.misc import iterate, unbyte
+from dascore.utils.hdf5 import H5Reader, H5Writer
+from dascore.utils.io import _normalize_source_patch_ids
+from dascore.utils.misc import unbyte
 from dascore.utils.patch import get_patch_names
 
 from .utils import (
-    _get_contents_from_patch_groups,
+    _get_contents_from_patch_groups_generic,
     _kwargs_empty,
     _read_patch,
     _save_patch,
@@ -54,7 +48,7 @@ class DASDAEV1(FiberIO):
     preferred_extensions = ("h5", "hdf5")
     version = "1"
 
-    def write(self, spool: SpoolType, resource: PyTablesWriter, index=False, **kwargs):
+    def write(self, spool: SpoolType, resource: H5Writer, **kwargs):
         """
         Write a collection of patches to a DASDAE file.
 
@@ -64,29 +58,18 @@ class DASDAEV1(FiberIO):
             A collection of patches or a spool (same thing).
         resource
             The path to the file.
-        index
-            If True, create an index for the file. This slows down
-            writing but will make reading/scanning the file more efficient.
-            This is recommended for files with many patches and not recommended
-            for files with few patches.
         """
         # write out patches
         _write_meta(resource, self.version)
         # get an iterable of patches and save them
         patches = [spool] if isinstance(spool, dc.Patch) else spool
-        # create new node called waveforms, else suppress error if it
-        # already exists.
-        with contextlib.suppress(NodeError):
-            resource.create_group(resource.root, "waveforms")
-        waveforms = resource.get_node("/waveforms")
+        with contextlib.suppress(ValueError):
+            resource.create_group("waveforms")
+        waveforms = resource["waveforms"]
         # write new patches to file
         patch_names = get_patch_names(patches).values
         for patch, name in zip(patches, patch_names):
-            _save_patch(patch, waveforms, resource, name)
-        indexer = HDFPatchIndexManager(resource)
-        if index or indexer.has_index:
-            df = self._get_patch_summary(patches)
-            indexer.write_update(df)
+            _save_patch(patch, waveforms, name)
 
     def _get_patch_summary(self, patches) -> pd.DataFrame:
         """Get a patch summary to put into index."""
@@ -111,20 +94,17 @@ class DASDAEV1(FiberIO):
         version = unbyte(attrs.get("__DASDAE_version__", ""))
         return file_format, version
 
-    def read(self, resource: PyTablesReader, **kwargs) -> SpoolType:
+    def read(self, resource: H5Reader, source_patch_id=(), **kwargs) -> SpoolType:
         """Read a dascore file."""
         patches = []
-        source_patch_ids = {
-            str(value)
-            for value in iterate(kwargs.pop("source_patch_id", None))
-            if value not in (None, "")
-        }
+        source_patch_ids = _normalize_source_patch_ids(source_patch_id)
         try:
-            waveform_group = resource.root["/waveforms"]
+            waveform_group = resource["waveforms"]
         except (KeyError, IndexError):
             return dc.spool([])
-        for patch_group in waveform_group:
-            if source_patch_ids and patch_group._v_name not in source_patch_ids:
+        for patch_group in waveform_group.values():
+            patch_name = str(patch_group.name).rsplit("/", maxsplit=1)[-1]
+            if source_patch_ids and patch_name not in source_patch_ids:
                 continue
             patch = _read_patch(patch_group, **kwargs)
             if not patch.data.size and not _kwargs_empty(kwargs):
@@ -132,34 +112,13 @@ class DASDAEV1(FiberIO):
             patches.append(patch)
         return dc.spool(patches)
 
-    def scan(self, resource: PyTablesReader, **kwargs):
+    def scan(self, resource: H5Reader, **kwargs):
         """
-        Get the patch info from the file.
-
-        First we check if the file is using an index. If so, the index is
-        returned. Otherwise, iterate over each waveform group and assemble
-        content information.
+        Get patch info by iterating waveform groups in the file.
 
         Parameters
         ----------
         resource
             A path to the file.
         """
-        indexer = HDFPatchIndexManager(resource.filename)
-        if indexer.has_index:
-            records = (
-                indexer.get_index()
-                .drop(columns=["path", "file_format", "file_version"], errors="ignore")
-                .to_dict("records")
-            )
-            return [PatchSummary(**record) for record in records]
-        else:
-            version = resource.root._v_attrs.__DASDAE_version__
-            return _get_contents_from_patch_groups(resource, version)
-
-    def index(self, path):
-        """Index the dasdae file."""
-        indexer = HDFPatchIndexManager(path)
-        if not indexer.has_index:
-            df = dc.scan_to_df(path)
-            indexer.write_update(df)
+        return _get_contents_from_patch_groups_generic(resource)

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -6,10 +6,14 @@ coord-summary fast path and string-serialization design notes used here.
 
 from __future__ import annotations
 
+import contextlib
+import json
+import pickle
+
 import numpy as np
-from tables import NodeError
 
 import dascore as dc
+from dascore.config import get_config
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import CoordSummary, get_coord
@@ -19,48 +23,30 @@ from dascore.core.summary import (
     coord_summary_from_available,
     coord_summary_from_metadata,
 )
+from dascore.exceptions import InvalidFiberFileError
 from dascore.utils.array import (
     convert_bytes_to_strings,
     convert_strings_to_bytes,
     is_string_byte_serializable_array,
 )
 from dascore.utils.attrs import separate_coord_info
-from dascore.utils.misc import suppress_warnings
+from dascore.utils.misc import unbyte
 from dascore.utils.time import to_int
 
 # Keys not counted as true kwargs for determining if patch is filtered/selected.
 _KWARG_NON_KEYS = {"file_version", "file_format", "path", "source_patch_id"}
+_ATTR_PREFIX = "_attrs_"
+_ATTR_TYPE_PREFIX = "_attr_type_"
 
 
 # --- Functions for writing DASDAE format
 
 
-def _create_or_get_group(h5, group, name):
-    """Create a new group or get existing."""
-    try:
-        group = h5.create_group(group, name)
-    except NodeError:
-        group = getattr(group, name)
-    return group
-
-
-def _create_or_squash_array(h5, group, name, data):
-    """Create a new array, if it exists delete and re-create."""
-    try:
-        array = h5.create_array(group, name, data)
-    except NodeError:
-        old_node = getattr(group, name)
-        h5.remove_node(old_node)
-        array = h5.create_array(group, name, data)
-    return array
-
-
 def _write_meta(hfile, file_version):
     """Write metadata to hdf5 file."""
-    attrs = hfile.root._v_attrs
-    attrs["__format__"] = "DASDAE"
-    attrs["__DASDAE_version__"] = file_version
-    attrs["__dascore__version__"] = dc.__version__
+    hfile.attrs["__format__"] = "DASDAE"
+    hfile.attrs["__DASDAE_version__"] = file_version
+    hfile.attrs["__dascore__version__"] = dc.__version__
 
 
 def _save_attrs_and_dims(patch, patch_group):
@@ -69,11 +55,14 @@ def _save_attrs_and_dims(patch, patch_group):
     # TODO will need to test if objects are serializable
     attr_dict = patch.attrs.model_dump(exclude_unset=True)
     for i, v in attr_dict.items():
-        patch_group._v_attrs[f"_attrs_{i}"] = v
-    patch_group._v_attrs["_dims"] = ",".join(patch.dims)
+        encoded, attr_type = _encode_attr_value(i, v)
+        patch_group.attrs[f"{_ATTR_PREFIX}{i}"] = encoded
+        if attr_type is not None:
+            patch_group.attrs[f"{_ATTR_TYPE_PREFIX}{i}"] = attr_type
+    patch_group.attrs["_dims"] = ",".join(patch.dims)
 
 
-def _save_array(data, name, group, h5):
+def _save_array(data, name, group):
     """Save an array to a group, handling datetime and string values."""
     data = np.asarray(data)
     is_dt = np.issubdtype(data.dtype, np.datetime64)
@@ -84,16 +73,19 @@ def _save_array(data, name, group, h5):
         data = to_int(data)
     elif is_str:
         data = convert_strings_to_bytes(data)
-    array_node = _create_or_squash_array(h5, group, name, data)
-    array_node._v_attrs["is_datetime64"] = is_dt
-    array_node._v_attrs["is_timedelta64"] = is_td
-    array_node._v_attrs["is_string"] = is_str
+    if name in group:
+        # Overwrite the dataset in place when callers resave the same array node.
+        del group[name]
+    array_node = group.create_dataset(name, data=data)
+    array_node.attrs["is_datetime64"] = is_dt
+    array_node.attrs["is_timedelta64"] = is_td
+    array_node.attrs["is_string"] = is_str
     if is_str:
-        array_node._v_attrs["original_string_dtype"] = original_string_dtype
+        array_node.attrs["original_string_dtype"] = original_string_dtype
     return array_node
 
 
-def _save_coords(patch, patch_group, h5):
+def _save_coords(patch, patch_group):
     """Save coordinates."""
     cm = patch.coords
     for name, coord in cm.coord_map.items():
@@ -101,27 +93,30 @@ def _save_coords(patch, patch_group, h5):
         # First save coordinate arrays
         data = coord.values
         save_name = f"_coord_{name}"
-        array_node = _save_array(data, save_name, patch_group, h5)
+        array_node = _save_array(data, save_name, patch_group)
         step = coord.step
         if step is not None:
             is_td = np.issubdtype(np.asarray(step).dtype, np.timedelta64)
-            array_node._v_attrs["step"] = to_int(step) if is_td else step
-            array_node._v_attrs["step_is_timedelta64"] = is_td
+            array_node.attrs["step"] = to_int(step) if is_td else step
+            array_node.attrs["step_is_timedelta64"] = is_td
         if coord.units is not None:
-            array_node._v_attrs["units"] = str(coord.units)
+            array_node.attrs["units"] = str(coord.units)
         # then save dimensions of coordinates
         save_name = f"_cdims_{name}"
-        patch_group._v_attrs[save_name] = ",".join(dims)
+        patch_group.attrs[save_name] = ",".join(dims)
 
 
-def _save_patch(patch, wave_group, h5, name):
+def _save_patch(patch, wave_group, name):
     """Save the patch to disk."""
-    patch_group = _create_or_get_group(h5, wave_group, name)
+    if name in wave_group:
+        # Replace the entire patch group so stale datasets/attrs can't survive.
+        del wave_group[name]
+    patch_group = wave_group.create_group(name)
     _save_attrs_and_dims(patch, patch_group)
-    _save_coords(patch, patch_group, h5)
+    _save_coords(patch, patch_group)
     # add data
     if patch.data.shape:
-        _create_or_squash_array(h5, patch_group, "data", patch.data)
+        _save_array(patch.data, "data", group=patch_group)
 
 
 # --- Functions for reading
@@ -130,27 +125,27 @@ def _save_patch(patch, wave_group, h5, name):
 def _get_attrs(patch_group):
     """Get the saved attributes form the group attrs."""
     out = {}
-    attrs = [x for x in patch_group._v_attrs._f_list() if x.startswith("_attrs_")]
-    with suppress_warnings(DeprecationWarning):
-        for attr_name in attrs:
-            key = attr_name.replace("_attrs_", "")
-            val = patch_group._v_attrs[attr_name]
-            # need to unpack one value arrays
-            if isinstance(val, np.ndarray) and not val.shape:
-                val = np.asarray([val])[0]
-            out[key] = val
+    attrs = [x for x in patch_group.attrs if x.startswith(_ATTR_PREFIX)]
+    for attr_name in attrs:
+        key = attr_name.replace(_ATTR_PREFIX, "")
+        val = _decode_attr_value(patch_group.attrs, key, patch_group.attrs[attr_name])
+        # need to unpack one value arrays
+        if isinstance(val, np.ndarray) and not val.shape:
+            val = np.asarray([val])[0]
+        out[key] = val
     return out
 
 
 def _read_array(table_array):
     """Read an array into numpy."""
     data = table_array[:]
-    if getattr(table_array._v_attrs, "is_datetime64", False):
+    attrs = table_array.attrs
+    if attrs.get("is_datetime64"):
         data = data.view("datetime64[ns]")
-    if getattr(table_array._v_attrs, "is_timedelta64", False):
+    if attrs.get("is_timedelta64"):
         data = data.view("timedelta64[ns]")
-    if getattr(table_array._v_attrs, "is_string", False):
-        original_dtype = getattr(table_array._v_attrs, "original_string_dtype", "")
+    if attrs.get("is_string"):
+        original_dtype = unbyte(attrs.get("original_string_dtype", ""))
         data = convert_bytes_to_strings(data, original_dtype)
     return data
 
@@ -159,8 +154,36 @@ def _translate_legacy_attrs(attrs):
     """Normalize legacy DASDAE attr payloads to flat coord metadata."""
     out = dict(attrs)
     coords = out.pop("coords", {})
+    if isinstance(coords, str):
+        # Older DASDAE files stored the coord-summary payload as a pickled
+        # string attr. Decode only this legacy coord metadata so scan/read can
+        # recover units and steps without reviving general legacy attr unpickling.
+        with contextlib.suppress(
+            AttributeError,
+            EOFError,
+            KeyError,
+            pickle.PickleError,
+            TypeError,
+            UnicodeError,
+            ValueError,
+        ):
+            decoded = pickle.loads(coords.encode("latin1"))
+            if (
+                hasattr(decoded, "items")
+                and not get_config().allow_dasdae_format_unpickle
+            ):
+                msg = (
+                    "This DASDAE file contains legacy pickled coordinate metadata. "
+                    "Unpickling DASDAE format metadata is disabled by default for "
+                    "security. If you trust this file, enable legacy compatibility "
+                    "with set_config(allow_dasdae_format_unpickle=True)."
+                )
+                raise InvalidFiberFileError(msg)
+            coords = decoded
     if hasattr(coords, "to_summary_dict"):
         coords = coords.to_summary_dict()
+    if not hasattr(coords, "items"):
+        coords = {}
     for name, summary in coords.items():
         if hasattr(summary, "to_summary"):
             summary = summary.to_summary()
@@ -168,7 +191,7 @@ def _translate_legacy_attrs(attrs):
             summary = summary.model_dump()
         if not isinstance(summary, dict):
             continue
-        for field in ("units", "step"):
+        for field in ("min", "max", "step", "units", "dtype", "len"):
             key = f"{name}_{field}"
             value = summary.get(field)
             if key not in out and value not in (None, ""):
@@ -187,12 +210,16 @@ def _get_coords(patch_group, dims, attrs2):
     """Get the coordinates from a patch group."""
     coord_dict = {}  # just store coordinates here
     coord_dim_dict = {}  # stores {coord_name: ((dims, ...), coord)}
-    for coord in [x for x in patch_group if x.name.startswith("_coord_")]:
-        name = coord.name.replace("_coord_", "")
+    for coord in patch_group.values():
+        name = coord.name.rsplit("/", maxsplit=1)[-1]
+        if not name.startswith("_coord_"):
+            continue
+        name = name.replace("_coord_", "")
         array = _read_array(coord)
-        units = getattr(coord._v_attrs, "units", None)
-        step = getattr(coord._v_attrs, "step", None)
-        if getattr(coord._v_attrs, "step_is_timedelta64", False):
+        node_attrs = coord.attrs
+        units = node_attrs.get("units", None)
+        step = node_attrs.get("step", None)
+        if node_attrs.get("step_is_timedelta64", False):
             step = np.timedelta64(step, "ns")
         coord = get_coord(
             data=array,
@@ -201,10 +228,11 @@ def _get_coords(patch_group, dims, attrs2):
         )
         coord_dict[name] = coord
     # associates coordinates with dimensions
-    c_dims = [x for x in patch_group._v_attrs._f_list() if x.startswith("_cdims")]
+    group_attrs = patch_group.attrs
+    c_dims = [x for x in group_attrs if x.startswith("_cdims")]
     for coord_name in c_dims:
         name = coord_name.replace("_cdims_", "")
-        value = patch_group._v_attrs[coord_name]
+        value = unbyte(group_attrs[coord_name])
         assert name in coord_dict, "Should already have loaded coordinate array"
         coord_dim_dict[name] = (tuple(value.split(",")), coord_dict[name])
         # add dimensions to coordinates that have them.
@@ -214,7 +242,7 @@ def _get_coords(patch_group, dims, attrs2):
 
 def _get_dims(patch_group):
     """Get the dims tuple from the patch group."""
-    dims = patch_group._v_attrs["_dims"]
+    dims = unbyte(patch_group.attrs["_dims"])
     if not dims:
         out = ()
     else:
@@ -228,7 +256,7 @@ def _read_patch(patch_group, **kwargs):
     dims = _get_dims(patch_group)
     coords = _get_coords(patch_group, dims, attrs)
     _, attr_info = separate_coord_info(attrs, dims=dims)
-    attr_info["_source_patch_id"] = patch_group._v_name
+    attr_info["_source_patch_id"] = patch_group.name.rsplit("/", maxsplit=1)[-1]
     attrs = PatchAttrs.from_dict(attr_info)
     # Note, previously this was wrapped with try, except (Index, KeyError)
     # and the data = np.array(None) in except block. Not sure, why, removed
@@ -253,20 +281,6 @@ def _read_patch(patch_group, **kwargs):
     return dc.Patch(data=data, coords=coords, dims=dims, attrs=attrs)
 
 
-def _get_contents_from_patch_groups(h5, file_version, file_format="DASDAE"):
-    """Get the contents from each patch group."""
-    out = []
-    for group in h5.iter_nodes("/waveforms"):
-        out.append(
-            _get_patch_content_from_group(
-                group,
-                file_version=file_version,
-                file_format=file_format,
-            )
-        )
-    return out
-
-
 def _kwargs_empty(kwargs) -> bool:
     """Determine if the keyword arguments are *effectively* empty."""
     # These keys get passed in from some spools, so don't count them.
@@ -280,27 +294,28 @@ def _kwargs_empty(kwargs) -> bool:
 def _read_array_sample(table_array, index):
     """Read one array sample and restore datetime-like dtypes when needed."""
     out = table_array[index]
-    if getattr(table_array._v_attrs, "is_datetime64", False):
+    attrs = table_array.attrs
+    if attrs.get("is_datetime64"):
         out = np.asarray([out]).view("datetime64[ns]")[0]
-    if getattr(table_array._v_attrs, "is_timedelta64", False):
+    if attrs.get("is_timedelta64"):
         out = np.asarray([out]).view("timedelta64[ns]")[0]
     return out
 
 
 def _get_coord_node_metadata(coord_node) -> dict[str, object]:
     """Extract normalized metadata from a stored coord node."""
-    attrs = coord_node._v_attrs
-    units = getattr(attrs, "units", None)
-    step = getattr(attrs, "step", None)
-    if getattr(attrs, "step_is_timedelta64", False):
+    attrs = coord_node.attrs
+    units = attrs.get("units", None)
+    step = attrs.get("step", None)
+    if attrs.get("step_is_timedelta64", False):
         step = np.timedelta64(step, "ns")
-    is_string = bool(getattr(attrs, "is_string", False))
+    is_string = bool(attrs.get("is_string", False))
     dtype = _normalize_coord_summary_dtype(
         str(coord_node.dtype).split("[")[0],
-        is_datetime=bool(getattr(attrs, "is_datetime64", False)),
-        is_timedelta=bool(getattr(attrs, "is_timedelta64", False)),
+        is_datetime=bool(attrs.get("is_datetime64", False)),
+        is_timedelta=bool(attrs.get("is_timedelta64", False)),
         is_string=is_string,
-        original_dtype=getattr(attrs, "original_string_dtype", ""),
+        original_dtype=unbyte(attrs.get("original_string_dtype", "")),
     )
     length = int(np.prod(coord_node.shape, dtype=int)) if coord_node.shape else 0
     return {
@@ -345,38 +360,131 @@ def _get_coord_summary_from_node(coord_node, dims):
     )
 
 
-def _get_patch_content_from_group(group, file_version="", file_format="DASDAE"):
-    """Get patch content from a single node."""
-    attrs = group._v_attrs
+def _get_patch_summary_from_group(group):
+    """Build a patch summary from one stored DASDAE patch group."""
+    attrs = group.attrs
     out = {}
-    for key in attrs._f_list():
-        value = getattr(attrs, key)
-        new_key = key.replace("_attrs_", "")
+    # First recover the flat attr payload saved on the patch group itself.
+    for key in attrs:
+        if not key.startswith(_ATTR_PREFIX):
+            continue
+        value = _decode_attr_value(attrs, key.replace(_ATTR_PREFIX, ""), attrs[key])
+        new_key = key.replace(_ATTR_PREFIX, "")
         # need to unpack 0 dim arrays.
         if isinstance(value, np.ndarray) and not value.shape:
             value = np.atleast_1d(value)[0]
-        out[new_key] = value
+        out[new_key] = unbyte(value)
     # rename dims
-    out["dims"] = out.pop("_dims")
+    out["dims"] = unbyte(attrs["_dims"])
     out = _translate_legacy_attrs(out)
-    dims = tuple(out["dims"].split(","))
+    dims_str = out["dims"]
+    dims = tuple(dims_str.split(",")) if dims_str else ()
+    # Split flattened coord metadata from the remaining patch attrs.
     legacy_coords, attr_info = separate_coord_info(out, dims=dims)
     coord_map = {}
     for name, summary in legacy_coords.items():
         if {"min", "max"} <= set(summary):
             coord_map[name] = CoordSummary(**summary)
-    for coord_node in [x for x in group if x.name.startswith("_coord_")]:
-        name = coord_node.name.replace("_coord_", "")
-        coord_dims = tuple(getattr(attrs, f"_cdims_{name}", "").split(","))
-        summary = _get_coord_summary_from_node(coord_node, coord_dims)
-        coord_map[name] = summary
-    data_nodes = [x for x in group if x.name == "data"]
-    dtype = str(data_nodes[0].dtype) if data_nodes else ""
-    attr_info["_source_patch_id"] = group._v_name
+    # Prefer coord summaries reconstructed from stored coord nodes when present.
+    for coord_node in group.values():
+        name = coord_node.name.rsplit("/", maxsplit=1)[-1]
+        if not name.startswith("_coord_"):
+            continue
+        name = name.replace("_coord_", "")
+        coord_dims_str = unbyte(attrs.get(f"_cdims_{name}", ""))
+        coord_dims = tuple(coord_dims_str.split(",")) if coord_dims_str else ()
+        node_summary = _get_coord_summary_from_node(coord_node, coord_dims)
+        legacy_summary = coord_map.get(name)
+        if legacy_summary is not None:
+            payload = node_summary.model_dump()
+            if payload.get("units") in (None, "") and legacy_summary.units not in (
+                None,
+                "",
+            ):
+                payload["units"] = legacy_summary.units
+            if payload.get("step") in (None, "") and legacy_summary.step not in (
+                None,
+                "",
+            ):
+                payload["step"] = legacy_summary.step
+            node_summary = CoordSummary(**payload)
+        coord_map[name] = node_summary
+    # Data shape/dtype come from the stored data node without loading the array.
+    data_node = group.get("data")
+    dtype = str(data_node.dtype) if data_node is not None else ""
+    shape = tuple(data_node.shape) if data_node is not None else ()
     return PatchSummary(
         attrs=PatchAttrs.from_dict(attr_info),
         coords=coord_map,
         dims=dims,
-        shape=(),
+        shape=shape,
         dtype=dtype,
+        source_patch_id=group.name.rsplit("/", maxsplit=1)[-1],
     )
+
+
+def _encode_history_attr(value):
+    """Serialize history as one flat JSON string for DASDAE storage."""
+    if value in (None, "", (), []):
+        return "[]", "history_json"
+    if isinstance(value, str):
+        payload = [value]
+    else:
+        payload = [str(item) for item in value]
+    return json.dumps(payload), "history_json"
+
+
+def _encode_attr_value(key, value):
+    """Encode a patch attr into an HDF5-attr-safe representation."""
+    if key == "history":
+        return _encode_history_attr(value)
+    if value is None:
+        return "", "none"
+    if isinstance(value, np.datetime64):
+        return to_int(value), "datetime64[ns]"
+    if isinstance(value, np.timedelta64):
+        return to_int(value), "timedelta64[ns]"
+    return value, None
+
+
+def _decode_attr_value(attrs, key, value):
+    """Decode one stored attr value using saved type metadata when present."""
+    attr_type = unbyte(attrs.get(f"{_ATTR_TYPE_PREFIX}{key}", None))
+    if attr_type is None:
+        return _decode_legacy_attr_value(value)
+    if attr_type == "none":
+        return None
+    if attr_type == "datetime64[ns]":
+        return np.asarray([value], dtype="int64").view("datetime64[ns]")[0]
+    if attr_type == "timedelta64[ns]":
+        return np.asarray([value], dtype="int64").view("timedelta64[ns]")[0]
+    if attr_type == "history_json":
+        return tuple(json.loads(unbyte(value) or "[]"))
+    return value
+
+
+def _decode_legacy_attr_value(value):
+    """Decode legacy DASDAE attrs still used by the shipped fixture files."""
+    if value.__class__.__name__ == "Empty":
+        return ""
+    if isinstance(value, np.ndarray) and not value.shape:
+        value = np.asarray([value])[0]
+    if isinstance(value, np.bytes_ | bytes):
+        try:
+            return unbyte(value)
+        except UnicodeDecodeError:
+            return bytes(value).decode("latin1")
+    return value
+
+
+def _get_file_version(h5):
+    """Return the DASDAE file version from a generic HDF5 handle."""
+    return unbyte(h5.attrs.get("__DASDAE_version__", ""))
+
+
+def _get_contents_from_patch_groups_generic(h5):
+    """Get DASDAE scan summaries from a generic HDF5 handle."""
+    waveforms = h5.get("waveforms")
+    if waveforms is None:
+        return []
+    return [_get_patch_summary_from_group(group) for group in waveforms.values()]

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -10,10 +10,10 @@ import numpy as np
 import dascore as dc
 from dascore.core import get_coord, get_coord_manager
 from dascore.core.coordmanager import CoordManager
+from dascore.utils.io import _normalize_source_patch_ids
 from dascore.utils.misc import (
     _maybe_unpack,
     broadcast_for_index,
-    iterate,
     maybe_get_items,
     tukey_fence,
     unbyte,
@@ -369,9 +369,7 @@ def _read_febus(
 ):
     """Read the febus values into a patch."""
     out = []
-    source_patch_ids = {
-        str(value) for value in iterate(source_patch_id) if value not in (None, "")
-    }
+    source_patch_ids = _normalize_source_patch_ids(source_patch_id)
     for attr, cm, febus in _yield_attrs_coords(fi):
         patch_id = _get_source_patch_id(febus)
         if source_patch_ids and patch_id not in source_patch_ids:

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -99,6 +99,7 @@ class Febus2(FiberIO):
         resource: H5Reader,
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
+        source_patch_id=(),
         **kwargs,
     ) -> dc.BaseSpool:
         """Read a febus spool of patches."""
@@ -106,7 +107,7 @@ class Febus2(FiberIO):
             resource,
             time=time,
             distance=distance,
-            source_patch_id=kwargs.get("source_patch_id"),
+            source_patch_id=source_patch_id,
             attr_cls=FebusPatchAttrs,
         )
         return dc.spool(patches)

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -6,7 +6,7 @@ import dascore as dc
 from dascore.constants import SpoolType
 from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
-from dascore.utils.hdf5 import H5Reader, PyTablesReader
+from dascore.utils.hdf5 import H5Reader
 
 from .utils import _get_attrs_coords_and_data, _is_h5simple, _maybe_trim_data
 
@@ -24,7 +24,7 @@ class H5Simple(FiberIO):
             return self.name, self.version
         return False
 
-    def read(self, resource: PyTablesReader, snap=True, **kwargs) -> SpoolType:
+    def read(self, resource: H5Reader, snap=True, **kwargs) -> SpoolType:
         """
         Read a simple h5 file.
 
@@ -44,7 +44,7 @@ class H5Simple(FiberIO):
         patch = dc.Patch(coords=new_cm, data=new_data[:], attrs=attrs)
         return dc.spool([patch])
 
-    def scan(self, resource: PyTablesReader, snap=True, **kwargs) -> list[PatchSummary]:
+    def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[PatchSummary]:
         """Get the attributes of a h5simple file."""
         attrs, cm, data = _get_attrs_coords_and_data(resource, snap, self)
         attrs.pop("file_format", None)

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import dascore as dc
 from dascore.core import get_coord
+from dascore.utils.misc import unbyte
 
 # --- Getting format/version
 
@@ -17,6 +18,32 @@ FILE_FORMAT_ATTR_NAMES = frozenset(("__format__", "file_format", "format"))
 DEFAULT_ATTRS = frozenset(("CLASS", "PYTABLES_FORMAT_VERSION", "TITLE", "VERSION"))
 
 
+def _get_root_attrs(h5):
+    """Return a mapping-like object for root attrs for either HDF5 backend."""
+    if hasattr(h5, "root"):
+        return h5.root._v_attrs
+    return h5.attrs
+
+
+def _iter_root_arrays(h5):
+    """Yield ``(name, node)`` pairs for array-like nodes at the HDF5 root."""
+    if hasattr(h5, "list_nodes"):
+        for node in h5.list_nodes("/"):
+            if hasattr(node, "shape"):
+                yield node.name, node
+        return
+    for name, node in h5.items():
+        if hasattr(node, "shape"):
+            yield name, node
+
+
+def _get_attr_names(attrs):
+    """Return the set of attribute names from either backend."""
+    if hasattr(attrs, "_v_attrnames"):
+        return set(attrs._v_attrnames)
+    return set(attrs)
+
+
 def _maybe_trim_data(cm, data, kwargs):
     """Maybe use kwargs to trim data array."""
     new_cm, new_data = cm.select(array=data, **kwargs)
@@ -25,9 +52,12 @@ def _maybe_trim_data(cm, data, kwargs):
 
 def _get_attrs_coords_and_data(h5, snap, fiber_io):
     """Return attrs, coordinate manager, and data node."""
-    attrs = h5.root._v_attrs
-    attr_names = set(attrs._v_attrnames) - DEFAULT_ATTRS
-    attr_dict = {x: getattr(attrs, x) for x in attr_names}
+    attrs = _get_root_attrs(h5)
+    attr_names = _get_attr_names(attrs) - DEFAULT_ATTRS
+    attr_dict = {
+        x: unbyte(attrs[x] if not hasattr(attrs, "_v_attrnames") else getattr(attrs, x))
+        for x in attr_names
+    }
     attr_dict["file_version"] = fiber_io.version
     attr_dict["file_format"] = fiber_io.name
     cm, data = _get_cm_and_data(h5, snap, dims=attr_dict.get("dims"))
@@ -94,7 +124,8 @@ def _get_coords_and_dims(data_node, time_node, other_nodes, snap=True, dims=None
 
 def _get_cm_and_data(h5, snap=False, dims=None):
     """Extract coordinate manager and data node."""
-    array_names = {x.name for x in h5.list_nodes("/") if hasattr(x, "shape")}
+    root_nodes = dict(_iter_root_arrays(h5))
+    array_names = set(root_nodes)
     data_node_name = array_names & DATA_ARRAY_NAMES
     time_node_name = array_names & TIME_ARRAY_NAMES
     other_node_names = array_names - data_node_name - time_node_name
@@ -102,9 +133,9 @@ def _get_cm_and_data(h5, snap=False, dims=None):
     assert len(data_node_name) == 1, f"{h5} doesn't have exactly one data node."
     assert len(time_node_name) == 1, f"{h5} doesn't have exactly one time node"
 
-    data_node = getattr(h5.root, next(iter(data_node_name)))
-    time_node = getattr(h5.root, next(iter(time_node_name)))
-    other_nodes = {x: getattr(h5.root, x) for x in other_node_names}
+    data_node = root_nodes[next(iter(data_node_name))]
+    time_node = root_nodes[next(iter(time_node_name))]
+    other_nodes = {x: root_nodes[x] for x in other_node_names}
 
     dims, coords = _get_coords_and_dims(data_node, time_node, other_nodes, snap, dims)
     return dc.core.get_coord_manager(coords, dims=dims), data_node

--- a/dascore/io/indexer.py
+++ b/dascore/io/indexer.py
@@ -12,14 +12,16 @@ from functools import cache
 from pathlib import Path
 
 import pandas as pd
-import pooch
 from typing_extensions import Self
 
 import dascore as dc
-from dascore.constants import ONE_SECOND_IN_NS, PROGRESS_LEVELS
+from dascore.compat import UPath
+from dascore.config import config_attr, get_config
+from dascore.constants import PROGRESS_LEVELS
 from dascore.exceptions import InvalidIndexVersionError
 from dascore.utils.hdf5 import HDFPatchIndexManager
 from dascore.utils.misc import iterate
+from dascore.utils.paths import requires_local_directory
 from dascore.utils.pd import filter_df
 from dascore.utils.time import get_max_min_times, to_timedelta64
 
@@ -116,13 +118,13 @@ class DirectoryIndexer(AbstractIndexer):
     _namespace = ""
     _index_name = ".dascore_index.h5"  # name of index file
 
-    # A user-specific file which tracks where indices are stored if not on
-    # the same directory as the path to index.
-    index_map_path = pooch.os_cache("dascore") / "caches" / "cache_paths.json"
-
     def __init__(self, path: str | Path, cache_size: int = 5, index_path=None):
         self.max_size = cache_size
-        self.path = Path(path).absolute()
+        self.path = (
+            UPath(path).absolute() if isinstance(path, UPath) else Path(path).absolute()
+        )
+        requires_local_directory(self.path, label="DirectoryIndexer")
+        self.path = Path(self.path).absolute()
         self.index_path = Path(self._find_index_file(self.path, index_path))
         self._current_index = 0
         self._index_table = HDFPatchIndexManager(
@@ -132,6 +134,8 @@ class DirectoryIndexer(AbstractIndexer):
         self.cache = pd.DataFrame(
             index=range(cache_size), columns="t1 t2 kwargs cindex".split()
         )
+
+    index_map_path: Path = config_attr("directory_index_map_path")
 
     def _find_index_file(self, data_path, index_path=None):
         """Find the path to the index file."""
@@ -161,7 +165,7 @@ class DirectoryIndexer(AbstractIndexer):
             index_path = data_path / self._index_name
         return index_path
 
-    def get_contents(self, buffer=ONE_SECOND_IN_NS, **kwargs) -> pd.DataFrame:
+    def get_contents(self, buffer=None, **kwargs) -> pd.DataFrame:
         """
         Get contents of directory with specific query params.
 
@@ -181,6 +185,7 @@ class DirectoryIndexer(AbstractIndexer):
             return pd.DataFrame(columns=self._index_table.index_columns)
         time_min, time_max = get_max_min_times(kwargs.pop("time", None))
         hdf5_kwargs, kwargs = self._separate_hdf5_kwargs(kwargs)
+        buffer = get_config().index_query_buffer if buffer is None else buffer
         buffer = to_timedelta64(buffer)
         # find out if the query falls within one cached times
         con1 = self.cache.t1 <= time_min

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -65,6 +65,7 @@ class ProdMLV2_0(FiberIO):  # noqa
         resource: H5Reader,
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
+        source_patch_id=(),
         **kwargs,
     ) -> dc.BaseSpool:
         """Read a ProdML file."""
@@ -72,7 +73,7 @@ class ProdMLV2_0(FiberIO):  # noqa
             resource,
             time=time,
             distance=distance,
-            source_patch_id=kwargs.get("source_patch_id"),
+            source_patch_id=source_patch_id,
         )
         return dc.spool(patches)
 

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -11,6 +11,7 @@ import numpy as np
 import dascore as dc
 from dascore.constants import VALID_DATA_TYPES
 from dascore.core.coords import get_coord
+from dascore.utils.io import _normalize_source_patch_ids
 from dascore.utils.misc import iterate, maybe_get_items, register_func, unbyte
 from dascore.utils.models import UnitQuantity, UTF8Str
 
@@ -314,9 +315,7 @@ def _read_prodml(fi, distance=None, time=None, source_patch_id=None):
     acq = fi["Acquisition"]
     base_info = maybe_get_items(acq.attrs, _ROOT_ATTRS)
     d_coord = _get_distance_coord(acq)
-    source_patch_ids = {
-        str(value) for value in iterate(source_patch_id) if value not in (None, "")
-    }
+    source_patch_ids = _normalize_source_patch_ids(source_patch_id)
     for info in _yield_data_nodes(fi):
         if source_patch_ids and info.name not in source_patch_ids:
             continue

--- a/dascore/io/rsf/core.py
+++ b/dascore/io/rsf/core.py
@@ -9,9 +9,15 @@ import numpy as np
 
 import dascore as dc
 from dascore.io.core import FiberIO
+from dascore.utils.paths import coerce_to_upath, is_local_path
 from dascore.utils.time import to_float
 
 RSFKEYS_WRITE = ("in", "esize", "data_format")
+
+
+def _coerce_output_path(path):
+    """Return a local Path or remote UPath-like path for writing."""
+    return Path(path) if is_local_path(path) else coerce_to_upath(path)
 
 
 class RSFV1(FiberIO):
@@ -93,24 +99,22 @@ class RSFV1(FiberIO):
 
         if data_path is not None:
             # outputs header and binary separately (.rsf and .rsf@)
-            outdatapath = Path(str(data_path) + "@")
+            outdatapath = _coerce_output_path(str(data_path) + "@")
             outdatapath.parent.mkdir(exist_ok=True, parents=True)
             hdr_info.append(f'in="{data_path}@"')
             with outdatapath.open("wb") as fi:
                 fi.write(data_bytes)
             out = "\n".join(hdr_info)
-            outpath = Path(str(path))
+            outpath = _coerce_output_path(path)
             outpath.parent.mkdir(exist_ok=True, parents=True)
             with outpath.open("w") as fi:
                 fi.write(out)
         else:
             # outputs header and binary combined (.rsf with both hdr and bin)
             hdr_info.append('in="stdin"\n\n')
-            # hdr_info.append(data)
-            out = "\n".join(hdr_info)
-            outpath = Path(str(path))
+            out = "\n".join(hdr_info).encode()
+            outpath = _coerce_output_path(path)
             outpath.parent.mkdir(exist_ok=True, parents=True)
-            with outpath.open("w") as fi:
+            with outpath.open("wb") as fi:
                 fi.write(out)
-            with outpath.open("ab") as fi:
                 fi.write(data_bytes)

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dascore as dc
 from dascore.core.summary import PatchSummary
 from dascore.io.core import FiberIO
-from dascore.utils.io import BinaryReader
+from dascore.utils.io import LocalBinaryReader, LocalPath
 from dascore.utils.misc import optional_import
 
 from .utils import (
@@ -29,11 +29,11 @@ class SegyV1_0(FiberIO):  # noqa
     # subclassed and this changed for debugging reasons.
     _package_name = "segyio"
 
-    def get_format(self, fp: BinaryReader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(self, fp: LocalBinaryReader, **kwargs) -> tuple[str, str] | bool:
         """Make sure input is segy."""
         return _get_segy_version(fp)
 
-    def read(self, path, time=None, channel=None, **kwargs):
+    def read(self, path: LocalPath, time=None, channel=None, **kwargs):
         """
         Read should take a path and return a patch or sequence of patches.
 
@@ -42,6 +42,7 @@ class SegyV1_0(FiberIO):  # noqa
         be implemented as well.
         """
         segyio = optional_import(self._package_name)
+        path = str(path)
         with segyio.open(path, ignore_geometry=True) as fi:
             coords = _get_coords(fi)
             attrs = _get_attrs(fi, coords, path, self, include_source=True)
@@ -54,13 +55,14 @@ class SegyV1_0(FiberIO):  # noqa
         patch = dc.Patch(coords=coords, data=data, attrs=attrs)
         return dc.spool([patch])
 
-    def scan(self, path, **kwargs) -> list[PatchSummary]:
+    def scan(self, path: LocalPath, **kwargs) -> list[PatchSummary]:
         """
         Used to get metadata about a file without reading the whole file.
 
         Returns lightweight scan metadata without loading the data array.
         """
         segyio = optional_import(self._package_name)
+        path = str(path)
         with segyio.open(path, ignore_geometry=True) as fi:
             coords = _get_coords(fi)
             attrs = _get_attrs(fi, coords, path, self)

--- a/dascore/io/sentek/core.py
+++ b/dascore/io/sentek/core.py
@@ -6,8 +6,8 @@ import numpy as np
 
 import dascore as dc
 from dascore.core.summary import PatchSummary
-from dascore.io import BinaryReader
 from dascore.io.core import FiberIO
+from dascore.utils.io import BinaryReader, LocalBinaryReader
 
 from .utils import _get_patch_attrs, _get_version
 
@@ -21,7 +21,7 @@ class SentekV5(FiberIO):
 
     def read(
         self,
-        resource: BinaryReader,
+        resource: LocalBinaryReader,
         time=None,
         distance=None,
         **kwargs,
@@ -32,9 +32,10 @@ class SentekV5(FiberIO):
         array = np.fromfile(resource, dtype=np.float32, count=offsets[1] * offsets[2])
         array = np.reshape(array, (offsets[1], offsets[2])).T
         patch = dc.Patch(data=array, attrs=attrs, coords=coords, dims=coords.dims)
-        # Note: we are being a bit sloppy here in that selecting on time/distance
-        # doesn't actually affect how much data is read from the binary file. This
-        # is probably ok though since Sentek files tend to be quite small.
+        # Note: we are being a bit sloppy here in that selecting on
+        # time/distance doesn't actually affect how much data is read from
+        # the binary file. This is probably ok though since Sentek files
+        # tend to be quite small.
         return dc.spool(patch).select(time=time, distance=distance)
 
     def get_format(self, resource: BinaryReader, **kwargs) -> tuple[str, str] | bool:

--- a/dascore/io/sentek/utils.py
+++ b/dascore/io/sentek/utils.py
@@ -10,25 +10,33 @@ import dascore as dc
 from dascore.core import get_coord, get_coord_manager
 
 
+def _read_float32(fid, count=1):
+    """Read one or more float32 values from a binary stream."""
+    size = np.dtype(np.float32).itemsize * count
+    data = fid.read(size)
+    return np.frombuffer(data, dtype=np.float32, count=count)
+
+
 def _get_version(fid):
     """Determine if Sentek file."""
-    name = fid.name
+    name = getattr(fid, "name", None) or getattr(fid, "path", None)
+    name = name or getattr(fid, "_dascore_source_path", "")
     # Sentek files cannot change the extension, or file name.
-    sw_data = name.endswith(".das")
+    sw_data = str(name).endswith(".das")
     fid.seek(0)
     # There isn't anything in the header particularly useful for determining
     # if it is a Sentek file, so we do what we can here.
     # First check if sensor_num and measurement_count are positive and nearly
     # ints.
-    sensor_num = np.fromfile(fid, dtype=np.float32, count=1)[0]
-    measurement_count = np.fromfile(fid, dtype=np.float32, count=1)[0]
-    _ = np.fromfile(fid, dtype=np.float32, count=1)[0]  # sampling_interval
+    sensor_num = _read_float32(fid)[0]
+    measurement_count = _read_float32(fid)[0]
+    _ = _read_float32(fid)[0]  # sampling_interval
     is_positive = (sensor_num > 1) and (measurement_count > 1)
     sens_nearly_int = np.round(sensor_num, 5) == np.round(sensor_num)
     meas_nearly_int = np.round(measurement_count, 5) == np.round(measurement_count)
     nearly_ints = sens_nearly_int and meas_nearly_int
     # Then check if strain_rate value is valid.
-    strain_rate = int(np.fromfile(fid, dtype=np.float32, count=1)[0])
+    strain_rate = int(_read_float32(fid)[0])
     proper_strain_rate = strain_rate in {0, 1}
     # Note: We will need to modify this later for different versions of the
     # sentek data, but for now we only support 5.
@@ -66,23 +74,25 @@ def _get_patch_attrs(fid, extras=None):
     decimation_factor: decimation factor (integer)
     """
     fid.seek(0)
-    sensor_num = np.fromfile(fid, dtype=np.float32, count=1)[0]
-    measurement_count = np.fromfile(fid, dtype=np.float32, count=1)[0]
-    _ = np.fromfile(fid, dtype=np.float32, count=1)[0]  # sampling_interval
-    strain_rate = np.fromfile(fid, dtype=np.float32, count=1)[0]
-    _ = np.fromfile(fid, dtype=np.float32, count=1)[0]  # trigger_position
-    _ = np.fromfile(fid, dtype=np.float32, count=1)[0]  # decimation_factor
+    sensor_num = _read_float32(fid)[0]
+    measurement_count = _read_float32(fid)[0]
+    _ = _read_float32(fid)[0]  # sampling_interval
+    strain_rate = _read_float32(fid)[0]
+    _ = _read_float32(fid)[0]  # trigger_position
+    _ = _read_float32(fid)[0]  # decimation_factor
     # create distance coordinate
-    distance_start = np.fromfile(fid, dtype=np.float32, count=1)[0]
+    distance_start = _read_float32(fid)[0]
     fid.seek(int(sensor_num - 1) * 4)
-    distance_stop = np.fromfile(fid, dtype=np.float32, count=1)[0]
+    distance_stop = _read_float32(fid)[0]
     distance_step = (distance_stop - distance_start) / sensor_num
     dist = get_coord(start=distance_start, stop=distance_stop, step=distance_step)
     # create time coord
-    file_time = _get_time_from_file_name(Path(fid.name).name)
-    offset_start = np.fromfile(fid, dtype=np.float32, count=1)[0]
+    name = getattr(fid, "name", None) or getattr(fid, "path", None)
+    name = name or getattr(fid, "_dascore_source_path", "")
+    file_time = _get_time_from_file_name(Path(str(name)).name)
+    offset_start = _read_float32(fid)[0]
     fid.seek(int(measurement_count - 1) * 4)
-    offset_stop = np.fromfile(fid, dtype=np.float32, count=1)[0]
+    offset_stop = _read_float32(fid)[0]
     time_start = file_time + dc.to_timedelta64(offset_start)
     time_stop = file_time + dc.to_timedelta64(offset_stop)
     time_step = (time_stop - time_start) / measurement_count

--- a/dascore/io/sintela_binary/core.py
+++ b/dascore/io/sintela_binary/core.py
@@ -10,7 +10,7 @@ import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
-from dascore.utils.io import BinaryReader
+from dascore.utils.io import BinaryReader, LocalBinaryReader
 
 from .utils import (
     _HEADER_SIZES,
@@ -69,7 +69,7 @@ class SintelaBinaryV3(FiberIO):
 
     def read(
         self,
-        resource: BinaryReader,
+        resource: LocalBinaryReader,
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,

--- a/dascore/io/sintela_binary/utils.py
+++ b/dascore/io/sintela_binary/utils.py
@@ -101,7 +101,8 @@ _DATA_TYPE_MAP = {
 
 def _read_base_header(fid):
     """Return the first 3 elements of the sintela header."""
-    array = np.fromfile(fid, dtype=base_header_dtypes, count=1)
+    data = fid.read(base_header_dtypes.itemsize)
+    array = np.frombuffer(data, dtype=base_header_dtypes, count=1)
     out = {x: y for x, y in zip(array.dtype.names, array[0])}
     return out
 
@@ -127,7 +128,8 @@ def _read_remaining_header(fid, base):
     expected_size = _HEADER_SIZES.get(version, -1)
     assert header_size == expected_size
     dtype = _HEADER_DTYPES[version]
-    buf = np.fromfile(fid, dtype=dtype, count=1)
+    data = fid.read(dtype.itemsize)
+    buf = np.frombuffer(data, dtype=dtype, count=1)
     header = {x: y for x, y in zip(buf.dtype.names, buf[0])}
     assert version == "3", "only 3 support for now,"
     header["num_packets"] = _get_number_of_packets(fid, header, header_size)

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -8,7 +8,8 @@ import dascore as dc
 from dascore.constants import timeable_types
 from dascore.core import Patch
 from dascore.core.summary import PatchSummary
-from dascore.io import BinaryReader, FiberIO
+from dascore.io import FiberIO
+from dascore.utils.io import BinaryReader, LocalBinaryReader
 
 from .utils import _get_all_attrs, _get_data, _get_default_attrs, _get_version_str
 
@@ -56,7 +57,7 @@ class TDMSFormatterV4713(FiberIO):
 
     def read(
         self,
-        resource: BinaryReader,
+        resource: LocalBinaryReader,
         time: tuple[timeable_types, timeable_types] | None = None,
         distance: tuple[float, float] | None = None,
         **kwargs,

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import datetime
 import mmap
-import os
 import struct
 
 import numpy as np
 
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coords import get_coord
+from dascore.utils.misc import get_buffer_size
 from dascore.utils.time import to_datetime64, to_timedelta64
 
 DEFAULT_ATTRS = set(PatchAttrs.model_fields)
@@ -181,7 +181,7 @@ def _get_all_attrs(tdms_file, lead_in_length=28):
     # Make offsets relative to beginning of file:
     fileinfo["next_segment_offset"] += lead_in_length
     fileinfo["raw_data_offset"] += lead_in_length
-    fileinfo["file_size"] = os.path.getsize(tdms_file.name)
+    fileinfo["file_size"] = get_buffer_size(tdms_file)
     # Make sure next segment does not go beyond file capacity
     if fileinfo["next_segment_offset"] > fileinfo["file_size"]:
         fileinfo["next_segment_offset"] = fileinfo["file_size"]

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -10,6 +10,7 @@ from scipy.io.wavfile import write
 from dascore.constants import ONE_SECOND, SpoolType
 from dascore.io.core import FiberIO
 from dascore.utils.patch import check_patch_coords
+from dascore.utils.paths import coerce_to_upath, is_local_path
 
 
 class WavIO(FiberIO):
@@ -53,13 +54,16 @@ class WavIO(FiberIO):
             rate is 44100, in this case just set resample_frequency=44100 to
             see if this fixes the issue.
         """
-        resource = Path(resource)
+        resource = (
+            Path(resource) if is_local_path(resource) else coerce_to_upath(resource)
+        )
         assert len(spool) == 1, "Only single patch spools can be written to wav"
         patch = spool[0]
         # write a single wav file, maybe multi-channeled.
         data, sr = self._get_wav_data(patch, resample_frequency)
         if resource.name.endswith(".wav"):
-            write(filename=str(resource), rate=int(sr), data=data)
+            with resource.open("wb") as fi:
+                write(filename=fi, rate=int(sr), data=data)
         else:  # write data to directory, one file for each non-time
             resource.mkdir(exist_ok=True, parents=True)
             non_time_set = set(patch.dims) - {"time"}
@@ -68,7 +72,8 @@ class WavIO(FiberIO):
             for ind, val in enumerate(non_time):
                 sub_data = np.take(data, ind, axis=1)
                 sub_path = resource / f"{non_time_name}_{val}.wav"
-                write(filename=str(sub_path), rate=int(sr), data=sub_data)
+                with sub_path.open("wb") as fi:
+                    write(filename=fi, rate=int(sr), data=sub_data)
 
     @staticmethod
     def _get_wav_data(patch, resample):

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from xml.etree.ElementTree import ParseError
 
 import numpy as np
@@ -12,6 +11,7 @@ import dascore as dc
 from dascore.core.summary import PatchSummary
 from dascore.io import FiberIO
 from dascore.utils.models import UTF8Str
+from dascore.utils.paths import coerce_to_upath
 
 from .utils import _load_patches, _paths_to_scan_patches, _read_xml_metadata
 
@@ -36,11 +36,15 @@ class XMLBinaryV1(FiberIO):
     # File extension for data files.
     _data_extension = ".raw"
 
+    @staticmethod
+    def _get_base_path(resource):
+        """Return the directory containing xml metadata and raw files."""
+        path = coerce_to_upath(resource)
+        return path if path.is_dir() else path.parent
+
     def scan(self, resource, timestamp=None, **kwargs) -> list[PatchSummary]:
         """Scan the contents of the directory."""
-        path = Path(resource)
-        if path.is_file():
-            path = path.parent
+        path = self._get_base_path(resource)
         metadata = _read_xml_metadata(path / self._metadata_name)
         data_files = list(path.glob(f"*{self._data_extension}"))
         # Need to update time
@@ -66,8 +70,8 @@ class XMLBinaryV1(FiberIO):
         **kwargs
             Extra keyword arguments are ignored.
         """
-        path = Path(resource)
-        base_path = path if path.is_dir() else path.parent
+        path = coerce_to_upath(resource)
+        base_path = self._get_base_path(path)
         meta_data = _read_xml_metadata(base_path / self._metadata_name)
         if path.is_dir():
             path = list(path.glob(f"*{self._data_extension}"))
@@ -83,9 +87,7 @@ class XMLBinaryV1(FiberIO):
 
     def get_format(self, resource, **kwargs) -> tuple[str, str] | bool:
         """Determine if directory is an XML Binary type."""
-        path = Path(resource)
-        if path.is_file():
-            path = path.parent
+        path = self._get_base_path(resource)
         index_path = path / self._metadata_name
         if not index_path.exists():
             return False

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -12,10 +12,12 @@ from pydantic import ConfigDict
 from pydantic.alias_generators import to_pascal
 
 import dascore as dc
+from dascore.compat import UPath
 from dascore.core import get_coord, get_coord_manager
 from dascore.utils.misc import iterate
 from dascore.utils.models import BaseModel, DateTime64
 from dascore.utils.pd import adjust_segments, filter_df
+from dascore.utils.remote_io import ensure_local_file
 from dascore.utils.time import to_float
 from dascore.utils.xml import xml_to_dict
 
@@ -67,7 +69,7 @@ class XMLBinaryInfo(_XMLModel):
 @lru_cache
 def _read_xml_metadata(path):
     """A function to read metadata from the xml file."""
-    contents = xml_to_dict(path.read_bytes())
+    contents = xml_to_dict(ensure_local_file(path).read_bytes())
     return XMLBinaryInfo.model_validate(contents)
 
 
@@ -182,7 +184,8 @@ def _read_single_file(path, metadata, time, distance, attr_cls):
         {"time": time_coord, "distance": distance_coord},
         dims=STANDARD_DIMS,
     )
-    memmap = np.memmap(path, dtype=metadata.data_type)
+    local_path = ensure_local_file(path) if isinstance(path, UPath) else Path(path)
+    memmap = np.memmap(local_path, dtype=metadata.data_type)
     size = np.prod(cm.shape)
     assert memmap.size == size, f"wrong data shape for {path}"
     data = memmap.reshape(cm.shape)
@@ -199,7 +202,7 @@ def _read_single_file(path, metadata, time, distance, attr_cls):
 def _load_patches(paths, metadata, time, distance, attr_cls):
     """Load the data file or file into a patch."""
     # Fast case for single file.
-    if isinstance(paths, Path) and paths.is_file():
+    if isinstance(paths, Path | UPath) and paths.is_file():
         return _read_single_file(paths, metadata, time, distance, attr_cls)
     # Since there could be **MANY** files, we have to create a mini-index
     # here to determine which files to read. Under normal circumstances
@@ -212,7 +215,7 @@ def _load_patches(paths, metadata, time, distance, attr_cls):
     # Then we can just recurse into this function.
     out = [
         _load_patches(
-            Path(ser["path"]),
+            ser["path"],
             metadata=metadata,
             time=time,
             distance=distance,
@@ -235,7 +238,7 @@ def _paths_to_scan_patches(
     paths = list(iterate(paths))
     if timestamp is not None:
         ts = to_float(timestamp)
-        paths = [x for x in paths if Path(x).stat().st_mtime >= ts]
+        paths = [x for x in paths if x.stat().st_mtime >= ts]
     if not paths:
         return []
     base_attrs = _make_base_attrs_dict(metadata)

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -525,7 +525,6 @@ def select(
 
 
 @patch_function(history=None)
-@compose_docstring(select_params=select_values_description)
 def order(
     patch: PatchType, *, copy=False, relative=False, samples=False, **kwargs
 ) -> PatchType:

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -217,7 +217,7 @@ def median_filter(
     patch
         The patch to filter
     samples
-        {sample_explination}
+        {sample_explanation}
     mode
         The mode for handling edges.
     cval
@@ -346,8 +346,7 @@ def savgol_filter(
     polyorder
         Order of polynomial
     samples
-        If True samples are specified
-        If False coordinate of dimension
+        {sample_explanation}
     mode
         The mode for handling edges.
     cval
@@ -409,8 +408,7 @@ def gaussian_filter(
     patch
         The patch to filter
     samples
-        If True samples are specified
-        If False coordinate of dimension
+        {sample_explanation}
     mode
         The mode for handling edges.
     cval

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -243,7 +243,7 @@ def rolling(
         If step > 10 samples, or `apply` is the desired rolling operation, numpy
         is probably better.
     samples
-        {sample_explination}
+        {sample_explanation}
     **kwargs
         Used to pass dimension and window size.
         For example `time=10` represents window size of

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -11,7 +11,8 @@ from rich.style import Style
 from rich.text import Text
 
 import dascore as dc
-from dascore.constants import FLOAT_PRECISION, dascore_styles
+from dascore.config import get_config
+from dascore.constants import dascore_styles
 from dascore.units import get_quantity_str
 
 
@@ -39,7 +40,7 @@ def get_nice_text(value, style=None) -> Text:
 @get_nice_text.register(np.float64)
 def _nice_float_string(value, style=None):
     """Nice print value for floats."""
-    fmt_str = f".{FLOAT_PRECISION}"
+    fmt_str = f".{get_config().display_float_precision}f"
     return get_nice_text(Text(f"{float(value):{fmt_str}}"), style)
 
 
@@ -120,11 +121,11 @@ def array_to_text(data, units=None) -> Text:
     header = Text("➤ ") + Text("Data", style=dascore_styles["dc_red"])
     unitstr = Text("") if units is None else Text(f", units: {units}")
     header += Text(f" ({data.dtype}") + unitstr + Text(")")
-    threshold = dascore_styles["np_array_threshold"]
+    config = get_config()
     np_str = np.array2string(
         data,
-        precision=FLOAT_PRECISION,
-        threshold=threshold,
+        precision=config.display_float_precision,
+        threshold=config.display_array_threshold,
     )
     numpy_format = textwrap.indent(np_str, "   ")
     return header + Text("\n") + Text(numpy_format)

--- a/dascore/utils/docs.py
+++ b/dascore/utils/docs.py
@@ -75,6 +75,7 @@ def compose_docstring(**kwargs: str | Sequence[str]):
     def _wrap(func):
         docstring = func.__doc__
         assert isinstance(docstring, str)
+        used_keys = set()
         # iterate each provided value and look for it in the docstring
         for key, value in kwargs.items():
             value = value if isinstance(value, str) else "\n".join(value)
@@ -83,6 +84,8 @@ def compose_docstring(**kwargs: str | Sequence[str]):
             search_value = f"{{{key}}}"
             # find all lines that match values
             lines = [x for x in docstring.split("\n") if search_value in x]
+            if lines:
+                used_keys.add(key)
             for line in lines:
                 # determine number of spaces used before matching character
                 spaces = line.split(search_value)[0]
@@ -90,6 +93,20 @@ def compose_docstring(**kwargs: str | Sequence[str]):
                 assert set(spaces) == {" "} or not len(spaces)
                 new = textwrap.indent(textwrap.dedent(value), spaces)
                 docstring = docstring.replace(line, new)
+        if kwargs and not used_keys:
+            msg = (
+                f"compose_docstring did not replace any placeholders on "
+                f"{func.__name__}."
+            )
+            raise ValueError(msg)
+        unused_keys = sorted(set(kwargs) - used_keys)
+        if unused_keys:
+            unused_str = ", ".join(unused_keys)
+            msg = (
+                f"compose_docstring received unused keys for {func.__name__}: "
+                f"{unused_str}."
+            )
+            raise ValueError(msg)
 
         func.__doc__ = docstring
         return func

--- a/dascore/utils/downloader.py
+++ b/dascore/utils/downloader.py
@@ -11,19 +11,41 @@ from pathlib import Path
 import pandas as pd
 import pooch
 
+from dascore.config import get_config
 from dascore.constants import DATA_VERSION
 
 REGISTRY_PATH = Path(files("dascore").joinpath("data_registry.txt"))
+LARGE_REGISTRY_FILES = frozenset({"whale_1.hdf5"})
 
-# Create a pooch for fetching data files
-fetcher = pooch.create(
-    path=pooch.os_cache("dascore"),
-    base_url="https://github.com/d-chambers/dascore",
-    version=DATA_VERSION,
-    version_dev="master",
-    env="DFS_DATA_DIR",
-)
-fetcher.load_registry(REGISTRY_PATH)
+
+@cache
+def _get_fetcher(cache_dir: str) -> pooch.Pooch:
+    """Create and cache one pooch fetcher for a specific cache directory."""
+    fetcher = pooch.create(
+        path=Path(cache_dir),
+        base_url="https://github.com/d-chambers/dascore",
+        version=DATA_VERSION,
+        version_dev="master",
+        env="DFS_DATA_DIR",
+    )
+    fetcher.load_registry(REGISTRY_PATH)
+    return fetcher
+
+
+def get_fetcher() -> pooch.Pooch:
+    """Return the downloader fetcher for the active runtime configuration."""
+    return _get_fetcher(str(get_config().downloader_cache_dir))
+
+
+class _FetcherProxy:
+    """Proxy ``fetcher`` access through the active runtime configuration."""
+
+    def __getattr__(self, item):
+        """Delegate attribute access to the active fetcher."""
+        return getattr(get_fetcher(), item)
+
+
+fetcher = _FetcherProxy()
 
 
 @dataclass(frozen=True)
@@ -43,9 +65,10 @@ class TestDataCacheInfo:
 
 
 @cache
-def get_test_data_cache_info() -> TestDataCacheInfo:
+def _get_test_data_cache_info(cache_dir: str) -> TestDataCacheInfo:
     """Return the metadata needed to populate the CI test-data cache."""
     registry_path = Path(REGISTRY_PATH)
+    fetcher = _get_fetcher(cache_dir)
     return TestDataCacheInfo(
         registry_path=registry_path,
         cache_path=Path(fetcher.path).parent,
@@ -54,19 +77,31 @@ def get_test_data_cache_info() -> TestDataCacheInfo:
     )
 
 
+def get_test_data_cache_info() -> TestDataCacheInfo:
+    """Return the metadata needed to populate the CI test-data cache."""
+    return _get_test_data_cache_info(str(get_config().downloader_cache_dir))
+
+
 @cache
-def get_registry_df() -> pd.DataFrame:
-    """Returns a dataframe of all files in the data registry."""
+def get_registry_df(*, exclude_large: bool = False) -> pd.DataFrame:
+    """Return a dataframe of files in the data registry."""
     names = (
         "name",
         "hash",
         "url",
     )
     df = pd.read_csv(REGISTRY_PATH, sep=r"\s+", skiprows=1, names=names)
+    if exclude_large:
+        df = df.loc[~df["name"].isin(LARGE_REGISTRY_FILES)]
     return df
 
 
 @cache
+def _fetch_cached(name: str, cache_dir: str) -> Path:
+    """Fetch one named file for a specific downloader cache directory."""
+    return Path(_get_fetcher(cache_dir).fetch(name))
+
+
 def fetch(name: Path | str, **kwargs) -> Path:
     """
     Fetch a data file from the registry.
@@ -77,7 +112,7 @@ def fetch(name: Path | str, **kwargs) -> Path:
         The name of the file to fetch. Must be in the data registry or a
         path which exists.
     kwargs
-        Left for compatibility reasons.
+        Ignored and kept only for compatibility with older call sites.
 
     Returns
     -------
@@ -85,4 +120,6 @@ def fetch(name: Path | str, **kwargs) -> Path:
     """
     if (existing_path := Path(name)).exists():
         return existing_path
-    return Path(fetcher.fetch(name, **kwargs))
+    return _fetch_cached(
+        name=str(name), cache_dir=str(get_config().downloader_cache_dir)
+    )

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -7,6 +7,10 @@ out the hdf5 backend in the future.
 
 from __future__ import annotations
 
+import io
+import os
+import shutil
+import tempfile
 import time
 import warnings
 from collections.abc import Sequence
@@ -25,7 +29,9 @@ from tables import ClosedNodeError
 from tables import File as PyTablesFile
 
 import dascore as dc
-from dascore.constants import ONE_SECOND_IN_NS, max_lens
+from dascore.compat import UPath
+from dascore.config import config_attr, get_config
+from dascore.constants import max_lens, remote_hdf5_tuned_protocols
 from dascore.exceptions import InvalidFileHandlerError, InvalidIndexVersionError
 from dascore.io.core import PatchFileSummary
 from dascore.utils.mapping import FrozenDict
@@ -40,6 +46,12 @@ from dascore.utils.pd import (
     _remove_base_path,
     fill_defaults_from_pydantic,
     list_ser_to_str,
+)
+from dascore.utils.remote_io import (
+    FallbackFileObj,
+    ensure_local_file,
+    get_local_handle,
+    is_no_range_http_error,
 )
 from dascore.utils.time import get_max_min_times, to_datetime64, to_int, to_timedelta64
 
@@ -57,7 +69,7 @@ class _HDF5Store(pd.HDFStore):
     pytables.File objects.
     """
 
-    def __init__(
+    def __init__(  # pragma: no cover
         self,
         path,
         mode: str = "a",
@@ -155,10 +167,6 @@ class HDFPatchIndexManager:
     stamp of the last time it was updated.
     """
 
-    _complib = "blosc"
-    _complevel = 9
-    # attributes subclasses need to define
-    buffer = ONE_SECOND_IN_NS
     # string column sizes in hdf5 table
     _min_itemsize = max_lens
     # columns which should be indexed for fast querying
@@ -188,8 +196,6 @@ class HDFPatchIndexManager:
     # The minimum version of dascore required to read this index. If an older
     # version is used an error will be raised.
     _min_version = "0.0.13"
-    # max number of retries for closed node files
-    _max_retries = 10
 
     def __init__(self, path, namespace=""):
         super().__init__()
@@ -201,6 +207,11 @@ class HDFPatchIndexManager:
         """Get the columns used for indexing."""
         out = set(self._base_model.model_fields) - set(self._skip_fields)
         return tuple(out)
+
+    buffer: np.timedelta64 = config_attr("index_query_buffer")
+    complib: str = config_attr("hdf_index_complib")
+    complevel: int = config_attr("hdf_index_complevel")
+    max_retries: int = config_attr("hdf_index_max_retries")
 
     # columns which should be indexed for fast querying
     @property
@@ -264,7 +275,7 @@ class HDFPatchIndexManager:
                 # Sometimes in concurrent updates the nodes need time to open/close
                 # so we implement a simply "wait and retry" strategy.
                 # This is a bit wonky but we have found it to work well in practice.
-                if fail_counts > self._max_retries:
+                if fail_counts >= self.max_retries:
                     raise e
                 time.sleep(0.1)
                 return _get_index(where, fail_counts=fail_counts + 1, **kwargs)
@@ -349,8 +360,8 @@ class HDFPatchIndexManager:
     def hdf_kwargs(self) -> dict:
         """A dict of hdf_kwargs to pass to PyTables."""
         return dict(
-            complib=self._complib,
-            complevel=self._complevel,
+            complib=self.complib,
+            complevel=self.complevel,
             format="table",
             data_columns=list(self._query_columns),
         )
@@ -437,6 +448,15 @@ class PyTablesReader(PyTablesFile):
             raise NotImplementedError(msg)
 
 
+class LocalPyTablesReader(PyTablesReader):
+    """A PyTables reader which first materializes remote resources locally."""
+
+    @classmethod
+    def get_handle(cls, resource):
+        """Get a local-file-backed PyTables handle."""
+        return get_local_handle(resource, super().get_handle)
+
+
 class PyTablesWriter(PyTablesReader):
     """A thin wrapper around pytables File object for writing."""
 
@@ -444,16 +464,152 @@ class PyTablesWriter(PyTablesReader):
 
 
 class H5Reader(PyTablesReader):
-    """A thin wrapper around h5py for reading files."""
+    """A thin wrapper around h5py for reading files.
+
+    Remote UPath resources stay remote-first and transparently retry against
+    a cached local file when no-range HTTP access prevents later random reads.
+    """
 
     mode = "r"
     constructor = H5pyFile
+
+    @staticmethod
+    def _get_open_kwargs(resource: UPath) -> dict[str, object]:
+        """Return backend-specific kwargs for remote HDF5 file objects."""
+        protocol = getattr(resource, "protocol", None)
+        if protocol in remote_hdf5_tuned_protocols:
+            # h5py performs many small seeks while opening HDF5 metadata.
+            # s3fs defaults to 50 MB readahead blocks, which can pull most of
+            # a large remote file just to satisfy metadata probes.
+            return {
+                "block_size": get_config().remote_hdf5_block_size,
+                "cache_type": "readahead",
+            }
+        return {}
+
+    @classmethod
+    def get_handle(cls, resource):
+        """
+        Get the HDF5 handle from local paths, remote paths, or open handles.
+
+        Unlike PyTablesReader, h5py can consume a binary file object via the
+        ``fileobj`` driver, so remote UPath inputs stay streaming-based here.
+        """
+        if isinstance(resource, cls | H5pyFile):
+            return resource
+        if isinstance(resource, io.IOBase):
+            return cls.constructor(resource, mode=cls.mode, driver="fileobj")
+        if isinstance(resource, UPath):
+            mode = "rb" if cls.mode == "r" else "r+b"
+            open_kwargs = cls._get_open_kwargs(resource)
+            handle = FallbackFileObj(
+                remote_opener=lambda: resource.open(mode, **open_kwargs),
+                local_opener=lambda: ensure_local_file(resource).open(mode),
+                error_predicate=is_no_range_http_error,
+            )
+            try:
+                return cls.constructor(handle, mode=cls.mode, driver="fileobj")
+            except Exception:
+                handle.close()
+                raise
+        return super().get_handle(resource)
+
+
+class LocalH5Reader(H5Reader):
+    """An h5py reader which first materializes remote resources locally."""
+
+    @classmethod
+    def get_handle(cls, resource):
+        """Get a local-file-backed h5py handle."""
+        return get_local_handle(resource, super().get_handle)
 
 
 class H5Writer(H5Reader):
     """A thin wrapper around h5py for writing files."""
 
     mode = "a"
+
+    class _RemoteH5Writer:
+        """Wrap a local h5py file and upload it back to the remote resource."""
+
+        def __init__(self, resource: UPath, mode: str):  # pragma: no cover
+            self._resource = resource
+            suffix = resource.suffix or ".h5"
+            fd, temp_name = tempfile.mkstemp(suffix=suffix)
+            os.close(fd)
+            self._temp_path = Path(temp_name)
+            self._closed = False
+            try:
+                if mode != "w" and resource.exists():
+                    with resource.open("rb") as src, self._temp_path.open("wb") as dst:
+                        shutil.copyfileobj(src, dst)
+                local_mode = (
+                    "a"
+                    if self._temp_path.exists() and self._temp_path.stat().st_size
+                    else "w"
+                )
+                self._handle = H5pyFile(self._temp_path, mode=local_mode)
+            except Exception:
+                self._temp_path.unlink(missing_ok=True)
+                raise
+
+        def __getitem__(self, item):
+            return self._handle[item]
+
+        def __setitem__(self, key, value):  # pragma: no cover
+            self._handle[key] = value
+
+        def __contains__(self, item):  # pragma: no cover
+            return item in self._handle
+
+        def commit(self):
+            """Finalize local writes, then upload the temp file to the remote path."""
+            if self._closed:
+                return
+            self._handle.close()
+            # The upload happens only after closing the local h5py handle because
+            # h5py persists metadata and final file structure on close. Remote
+            # backends are written back from the completed temp file as one blob.
+            with self._temp_path.open("rb") as src, self._resource.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+            self._temp_path.unlink(missing_ok=True)
+            self._closed = True
+
+        def close(self):
+            """Commit remote writes on close to preserve normal file-like semantics."""
+            self.commit()
+
+        def abort(self):
+            """Close and discard the local temp file without uploading it."""
+            if self._closed:
+                return
+            self._handle.close()
+            self._temp_path.unlink(missing_ok=True)
+            self._closed = True
+
+        def _abort(self):
+            """Backward-compatible alias for abort()."""
+            self.abort()
+
+        def __enter__(self):  # pragma: no cover
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # pragma: no cover
+            if exc_type is None:
+                self.commit()
+            else:
+                self.abort()
+            return False
+
+        def __getattr__(self, item):
+            return getattr(self._handle, item)
+
+    @classmethod
+    def get_handle(cls, resource):
+        """Return an HDF5 writer handle for local or remote resources."""
+        if isinstance(resource, UPath):
+            return cls._RemoteH5Writer(resource, cls.mode)
+        return super().get_handle(resource)
 
 
 # These are left here for backward compatibility, but should not be

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import typing
+from contextlib import suppress
 from functools import cache
 from inspect import isfunction, ismethod
 from pathlib import Path
@@ -12,22 +13,76 @@ from typing import Any, get_type_hints
 import numpy as np
 
 import dascore as dc
+from dascore.compat import UPath
 from dascore.constants import PatchType
 from dascore.exceptions import PatchConversionError
 from dascore.utils.misc import (
     _maybe_make_parent_directory,
     cached_method,
+    iterate,
     optional_import,
 )
+from dascore.utils.paths import coerce_to_upath, is_local_path, is_pathlike
+from dascore.utils.remote_io import ensure_local_file as _ensure_local_file
+from dascore.utils.remote_io import get_local_handle
 from dascore.utils.time import to_float
 
 HANDLE_FUNCTIONS = {
-    str: lambda x: str(x),
     Path: lambda x: Path(x),
+    UPath: lambda x: coerce_to_upath(x),
 }
 
 
 RequiredType = typing.TypeVar("RequiredType")
+
+
+def ensure_local_file(resource) -> Path:
+    """Return a stable local path for one resource for the current session."""
+    if isinstance(resource, IOResourceManager):
+        resource = resource.source
+    return _ensure_local_file(resource)
+
+
+def _normalize_resource_identity(resource):
+    """Normalize one pathlike input to a local Path or remote UPath."""
+    if is_local_path(resource):
+        return Path(resource)
+    return coerce_to_upath(resource)
+
+
+def _resolve_resource(resource, required_type):
+    """Resolve resource to a form suitable for required_type."""
+    # already have a resource thing of some kind; just pass through.
+    if not is_pathlike(resource):
+        return resource
+    # Otherwise get Upath or Path, if Path ensure it is downloaded.
+    resource = _normalize_resource_identity(resource)
+    if isinstance(resource, Path):
+        return resource
+    if required_type is Path:
+        return ensure_local_file(resource)
+    return resource
+
+
+def _annotate_handle_path(handle, resource):  # pragma: no cover
+    """Attach lightweight source-path metadata to a remote handle when absent."""
+    path_str = str(resource)
+    # This is intentionally a small compatibility hack for readers that still
+    # inspect handle.name/path metadata. Some remote text handles come back as
+    # TextIOWrapper(name=None), and that name attribute may not be writable, so
+    # we keep a private fallback for downstream format sniffers.
+    for attr_name in ("_dascore_source_path",):
+        with suppress(AttributeError, TypeError):
+            setattr(handle, attr_name, path_str)
+    if getattr(handle, "name", None) in (None, ""):
+        with suppress(AttributeError, TypeError):
+            setattr(handle, "name", path_str)
+    return handle
+
+
+def _normalize_source_patch_ids(source_patch_id) -> set[str]:
+    """Coerce source patch identifiers into a deduplicated set of strings."""
+    return {str(value) for value in iterate(source_patch_id) if value not in (None, "")}
 
 
 class BinaryReader(io.BytesIO):
@@ -43,6 +98,8 @@ class BinaryReader(io.BytesIO):
             if cls.reset_offset:
                 resource.seek(0)  # reset byte offset
             return resource
+        if isinstance(resource, UPath):
+            return _annotate_handle_path(resource.open(cls.mode), resource)
         try:
             _maybe_make_parent_directory(resource)
             return open(resource, mode=cls.mode)
@@ -51,10 +108,23 @@ class BinaryReader(io.BytesIO):
             raise NotImplementedError(msg)
 
 
+class LocalBinaryReader(BinaryReader):
+    """A binary reader which first materializes remote resources locally."""
+
+    @classmethod
+    def get_handle(cls, resource):
+        """Get the binary handle, materializing remote resources if needed."""
+        if isinstance(resource, cls | io.BufferedIOBase):
+            if cls.reset_offset:
+                resource.seek(0)
+            return resource
+        return get_local_handle(resource, super().get_handle)
+
+
 class BinaryWriter(BinaryReader):
     """Dummy class for streams which write binary."""
 
-    mode = "ab"
+    mode = "wb"
     reset_offset = False
 
 
@@ -70,6 +140,10 @@ class TextReader(BinaryReader):
             if cls.reset_offset:
                 resource.seek(0)
             return resource
+        if isinstance(resource, UPath):
+            return _annotate_handle_path(
+                resource.open(cls.mode, encoding="utf-8"), resource
+            )
         try:
             _maybe_make_parent_directory(resource)
             return open(resource, mode=cls.mode, encoding="utf-8")
@@ -81,7 +155,16 @@ class TextReader(BinaryReader):
 class TextWriter(BinaryWriter):
     """Base class for writing text files."""
 
-    mode = "a"
+    mode = "w"
+
+
+class LocalPath:
+    """A local path adapter for callsites that require a concrete filename."""
+
+    @classmethod
+    def get_handle(cls, resource):
+        """Return a local path for the supplied resource."""
+        return get_local_handle(resource, Path)
 
 
 @cache
@@ -102,8 +185,8 @@ def get_handle_from_resource(uri, required_type):
     """
     Get a handle for a file of preferred type.
 
-    return uri if required type is not specified or supported in either
-    handle function or has a `get_handle` method.
+    Return uri unchanged if required type is not specified or supported in
+    either handle functions or has no `get_handle` method.
     """
     if hasattr(required_type, "get_handle"):
         uri = required_type.get_handle(uri)
@@ -142,7 +225,8 @@ class IOResourceManager:
             return self._source.get_resource(required_type)
         required_type = _get_required_type(required_type)
         if required_type not in self._cache:
-            out = get_handle_from_resource(self._source, required_type)
+            source = _resolve_resource(self._source, required_type)
+            out = get_handle_from_resource(source, required_type)
             self._cache[required_type] = out
         return self._cache[required_type]
 

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -235,6 +235,11 @@ class IOResourceManager:
         for handle in self._cache.values():
             getattr(handle, "close", lambda: None)()
 
+    def clear_cache(self):
+        """Close and forget any cached resources so they can be reopened fresh."""
+        self.close_all()
+        self._cache.clear()
+
     def __enter__(self):
         """Entering context manager."""
         return self

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -61,19 +61,33 @@ def register_func(list_or_dict: list | dict, key=None):
 
 
 @contextlib.contextmanager
-def suppress_warnings(category=Warning):
+def suppress_warnings(
+    category=Warning,
+    message: str | None = None,
+    action: str = "ignore",
+    record: bool = False,
+):
     """
-    Context manager for suppressing warnings.
+    Context manager for configuring warnings inside a local scope.
 
     Parameters
     ----------
     category
         The types of warnings to suppress. Must be a subclass of Warning.
+    message
+        Optional regex used to match warning messages.
+    action
+        The warning action to apply, such as ``"ignore"``, ``"error"``,
+        or ``"always"``.
+    record
+        If True, yield the recorded warning list from ``catch_warnings``.
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=category)
-        yield
-    return None
+    with warnings.catch_warnings(record=record) as caught:
+        if message is None:
+            warnings.simplefilter(action, category=category)
+        else:
+            warnings.filterwarnings(action, message=message, category=category)
+        yield caught if record else None
 
 
 def warn_or_raise(

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -6,6 +6,7 @@ import contextlib
 import functools
 import importlib
 import inspect
+import itertools
 import os
 import re
 import warnings
@@ -22,13 +23,14 @@ from scipy.linalg import solve
 from scipy.special import factorial
 
 import dascore as dc
-from dascore.compat import is_array
+from dascore.compat import UPath, is_array
 from dascore.constants import WARN_LEVELS
 from dascore.exceptions import (
     FilterValueError,
     MissingOptionalDependencyError,
     ParameterError,
 )
+from dascore.utils.paths import coerce_to_upath, is_local_path, is_pathlike
 from dascore.utils.progress import track
 
 
@@ -162,12 +164,13 @@ def _get_nullish(dtype=np.floating):
 
 
 def _iter_filesystem(
-    paths: str | Path | Iterable[str | Path],
+    paths: str | Path | UPath | Iterable[str | Path | UPath],
     ext: str | None = None,
     timestamp: float | None = None,
     skip_hidden: bool = True,
     include_directories: bool = False,
-) -> Generator[str, str, None]:
+    _warned_timestamp_paths: set[str] | None = None,
+) -> Generator[Path | UPath | None, str, None]:
     """
     Iterate contents of a filesystem like thing.
 
@@ -188,37 +191,216 @@ def _iter_filesystem(
         If True, also yield directories. In this case, a "skip" can be
         passed back to the generator to indicate the rest of the directory
         contents should be skipped.
+    _warned_timestamp_paths
+        Internal accumulator used to avoid repeating timestamp-filter warnings
+        while recursing through one remote traversal.
 
     Yields
     ------
-    Paths, as strings, meeting requirements.
+    Local paths as ``Path`` objects and remote paths as ``UPath`` objects.
     """
-    # handle returning directories if requested.
-    if include_directories and os.path.isdir(paths):
-        if not (skip_hidden and str(paths).startswith(".")):
-            signal = yield paths
+    warned_timestamp_paths = (
+        set() if _warned_timestamp_paths is None else _warned_timestamp_paths
+    )
+
+    if is_pathlike(paths):
+        if is_local_path(paths):
+            yield from _iter_local_filesystem(
+                Path(paths),
+                ext=ext,
+                timestamp=timestamp,
+                skip_hidden=skip_hidden,
+                include_directories=include_directories,
+                warned_timestamp_paths=warned_timestamp_paths,
+            )
+            return
+
+        yield from _iter_remote_filesystem(
+            coerce_to_upath(paths),
+            ext=ext,
+            timestamp=timestamp,
+            skip_hidden=skip_hidden,
+            include_directories=include_directories,
+            warned_timestamp_paths=warned_timestamp_paths,
+        )
+        return
+
+    for path in paths:
+        yield from _iter_filesystem(
+            path,
+            ext=ext,
+            timestamp=timestamp,
+            skip_hidden=skip_hidden,
+            include_directories=include_directories,
+            _warned_timestamp_paths=warned_timestamp_paths,
+        )
+
+
+def _name_is_hidden(path_like) -> bool:
+    """Return True if a path-like object's display name starts with a dot."""
+    name = getattr(path_like, "name", "") or Path(str(path_like)).name
+    return name.startswith(".")
+
+
+def _passes_iter_filesystem_filters(
+    path_like,
+    *,
+    ext: str | None,
+    timestamp: float | None,
+    skip_hidden: bool,
+    warned_timestamp_paths: set[str],
+    on_timestamp_failure: str,
+) -> bool:
+    """Apply extension, hidden-file, and timestamp filters for traversal."""
+    if ext is not None and not str(path_like).endswith(ext):
+        return False
+    if skip_hidden and _name_is_hidden(path_like):
+        return False
+    if timestamp is None:
+        return True
+    try:
+        return path_like.stat().st_mtime >= timestamp
+    except (AttributeError, NotImplementedError, OSError):
+        if on_timestamp_failure not in warned_timestamp_paths:
+            msg = (
+                f"Remote filesystem path {on_timestamp_failure} does not "
+                "expose reliable mtime; ignoring timestamp filter."
+            )
+            warnings.warn(msg, UserWarning)
+            warned_timestamp_paths.add(on_timestamp_failure)
+        return True
+
+
+def _iter_local_filesystem(
+    path,
+    *,
+    ext: str | None,
+    timestamp: float | None,
+    skip_hidden: bool,
+    include_directories: bool,
+    warned_timestamp_paths: set[str],
+) -> Generator[Path | None, str, None]:
+    """Traverse one local path or directory tree."""
+    # Local paths use scandir directly so we can recurse cheaply and keep the
+    # hidden/timestamp checks close to the yielded entries.
+    path = Path(path)
+    if include_directories and os.path.isdir(path):
+        if not (skip_hidden and path.name.startswith(".")):
+            signal = yield path
             if signal is not None and signal == "skip":
                 yield None
                 return
-    try:  # a single path was passed
-        for entry in os.scandir(paths):
+    try:
+        for entry in os.scandir(path):
             if entry.is_file() and (ext is None or entry.name.endswith(ext)):
                 if timestamp is None or entry.stat().st_mtime >= timestamp:
                     if entry.name[0] != "." or not skip_hidden:
-                        yield entry.path
+                        yield Path(entry.path)
             elif entry.is_dir() and not (skip_hidden and entry.name[0] == "."):
-                yield from _iter_filesystem(
-                    entry.path,
+                yield from _iter_local_filesystem(
+                    Path(entry.path),
                     ext=ext,
                     timestamp=timestamp,
                     skip_hidden=skip_hidden,
                     include_directories=include_directories,
+                    warned_timestamp_paths=warned_timestamp_paths,
                 )
-    except (TypeError, AttributeError):  # multiple paths were passed
-        for path in paths:
-            yield from _iter_filesystem(path, ext, timestamp, skip_hidden)
-    except NotADirectoryError:  # a file path was passed, just return it
-        yield paths
+    except NotADirectoryError:
+        if _passes_iter_filesystem_filters(
+            path,
+            ext=ext,
+            timestamp=timestamp,
+            skip_hidden=skip_hidden,
+            warned_timestamp_paths=warned_timestamp_paths,
+            on_timestamp_failure=str(path),
+        ):
+            yield path
+
+
+def _iter_remote_filesystem(
+    path: UPath,
+    *,
+    ext: str | None,
+    timestamp: float | None,
+    skip_hidden: bool,
+    include_directories: bool,
+    warned_timestamp_paths: set[str],
+) -> Generator[UPath | None, str, None]:
+    """Traverse one remote path defensively across backend quirks."""
+    # Remote traversal has to be more defensive because some backends have
+    # partial directory support and may not expose reliable stat metadata.
+    remote_is_dir = path.is_dir()
+    if include_directories and remote_is_dir:
+        if not (skip_hidden and _name_is_hidden(path)):
+            signal = yield path
+            if signal is not None and signal == "skip":
+                yield None
+                return
+    # Some remote backends can report directory URLs as both files and
+    # directories. Prefer directory traversal so recursion still works.
+    elif path.is_file():
+        if _passes_iter_filesystem_filters(
+            path,
+            ext=ext,
+            timestamp=timestamp,
+            skip_hidden=skip_hidden,
+            warned_timestamp_paths=warned_timestamp_paths,
+            on_timestamp_failure=str(path),
+        ):
+            yield path
+        return
+    # Only probe directory contents after ruling out the simple file case; some
+    # remote backends raise here instead of answering is_dir/is_file.
+    try:
+        entries = iter(path.iterdir())
+        first_entry = next(entries)
+    except StopIteration:
+        return
+    except (
+        AttributeError,
+        FileNotFoundError,
+        NotADirectoryError,
+        NotImplementedError,
+        OSError,
+    ):
+        if not path.exists():
+            return
+        raise
+    # Once we have one entry, recurse through remote directories and apply the
+    # same file filters to leaf files.
+    for entry in itertools.chain((first_entry,), entries):
+        if skip_hidden and _name_is_hidden(entry):
+            continue
+        entry_is_file = entry.is_file()
+        entry_is_dir = entry.is_dir()
+        if not entry_is_file and not entry_is_dir:
+            try:
+                next(entry.iterdir())
+            except (AttributeError, NotImplementedError, OSError, StopIteration):
+                entry_is_dir = False
+            else:
+                entry_is_dir = True
+        if entry_is_dir:
+            yield from _iter_remote_filesystem(
+                entry,
+                ext=ext,
+                timestamp=timestamp,
+                skip_hidden=skip_hidden,
+                include_directories=include_directories,
+                warned_timestamp_paths=warned_timestamp_paths,
+            )
+            continue
+        if not entry_is_file:
+            continue
+        if _passes_iter_filesystem_filters(
+            entry,
+            ext=ext,
+            timestamp=timestamp,
+            skip_hidden=skip_hidden,
+            warned_timestamp_paths=warned_timestamp_paths,
+            on_timestamp_failure=str(path),
+        ):
+            yield entry
 
 
 def iterate(obj):
@@ -746,13 +928,15 @@ def get_buffer_size(fid: IOBase):
         A buffered reader, e.g. from open(file) as fid.
     """
     path = getattr(fid, "name", None)
-    if path is None:
-        cur = fid.tell()
-        fid.seek(0, 2)  # end
-        file_size = fid.tell()
-        fid.seek(cur, 0)
-    else:
-        file_size = Path(path).stat().st_size
+    if path is not None and is_local_path(path):
+        try:
+            return Path(path).stat().st_size
+        except (OSError, TypeError, ValueError):
+            pass
+    cur = fid.tell()
+    fid.seek(0, 2)  # end
+    file_size = fid.tell()
+    fid.seek(cur, 0)
     return file_size
 
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -16,14 +16,13 @@ import pydantic
 from pydantic import TypeAdapter
 
 import dascore as dc
+from dascore.config import get_config
 from dascore.constants import (
     DEFAULT_ATTRS_TO_IGNORE,
-    FLOAT_PRECISION,
     WARN_LEVELS,
     PatchType,
     SpoolType,
     check_behavior_description,
-    dascore_styles,
 )
 from dascore.exceptions import (
     CoordDataError,
@@ -61,10 +60,11 @@ def _format_values(val):
         out = f"({out})" if isinstance(val, tuple) else f"[{out}]"
     elif isinstance(val, np.ndarray):
         # make sure numpy strings aren't too long!
+        config = get_config()
         out = np.array2string(
             val,
-            precision=FLOAT_PRECISION,
-            threshold=dascore_styles["patch_history_array_threshold"],
+            precision=config.display_float_precision,
+            threshold=config.display_patch_history_array_threshold,
         )
     elif isinstance(val, dc.Patch):
         # Truncate patch representations in history (issue #529)

--- a/dascore/utils/paths.py
+++ b/dascore/utils/paths.py
@@ -1,0 +1,44 @@
+"""Utilities for classifying DASCore path inputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dascore.compat import UPath
+from dascore.exceptions import InvalidSpoolError
+
+
+def is_pathlike(resource) -> bool:
+    """Return True if resource is supported path-like input."""
+    return isinstance(resource, str | Path | UPath)
+
+
+def coerce_to_upath(resource) -> UPath:
+    """Return a UPath for path-like resources."""
+    return resource if isinstance(resource, UPath) else UPath(resource)
+
+
+def get_path_protocol(resource) -> str | None:
+    """Return the normalized protocol for path-like resources."""
+    if isinstance(resource, Path):
+        return "file"
+    if isinstance(resource, UPath):
+        protocol = getattr(resource, "protocol", "file")
+        return protocol or "file"
+    if isinstance(resource, str):
+        return "file" if "://" not in resource else coerce_to_upath(resource).protocol
+    return None
+
+
+def is_local_path(resource) -> bool:
+    """Return True if resource refers to the local filesystem."""
+    if not is_pathlike(resource):
+        return False
+    return get_path_protocol(resource) in {"", "file", "local"}
+
+
+def requires_local_directory(resource, *, label: str):
+    """Raise when directory operations are requested on non-local filesystems."""
+    if is_pathlike(resource) and not is_local_path(resource):
+        msg = f"{label} only supports local filesystem paths."
+        raise InvalidSpoolError(msg)

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -7,8 +7,8 @@ from contextlib import suppress
 
 import rich.progress as prog
 
-import dascore as dc
 from dascore.compat import Progress
+from dascore.config import get_config
 from dascore.constants import PROGRESS_LEVELS
 
 
@@ -31,7 +31,7 @@ def get_progress_instance(progress: PROGRESS_LEVELS | Progress = "standard"):
     ]
     if progress == "basic":
         # set the refresh rate very low and eliminate the spinner
-        kwargs["refresh_per_second"] = 0.25
+        kwargs["refresh_per_second"] = get_config().progress_basic_refresh_per_second
         progress_list = progress_list[1:]
     return Progress(*progress_list, **kwargs)
 
@@ -70,7 +70,7 @@ def track(
     # This is a dirty hack to allow debugging while running tests.
     # Otherwise, pdb doesn't work in any tracking scope.
     # See: https://github.com/Textualize/rich/issues/1053
-    if dc._debug or not length or progress is None:
+    if get_config().debug or not length or progress is None:
         yield from sequence
         return
     update = 1.0 if isinstance(progress, str) and progress == "standard" else 5.0

--- a/dascore/utils/remote_io.py
+++ b/dascore/utils/remote_io.py
@@ -1,0 +1,319 @@
+"""Utilities for session-scoped remote IO caching and fallback."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import warnings
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import lru_cache
+from hashlib import sha256
+from pathlib import Path
+
+from dascore.compat import UPath
+from dascore.config import get_config
+from dascore.exceptions import RemoteCacheError
+from dascore.utils.paths import coerce_to_upath, is_local_path, is_pathlike
+
+_HTTP_PROTOCOLS = {"http", "https"}
+_NO_RANGE_HTTP_PATTERNS = (
+    "doesn't appear to support range requests",
+    "only reading this file from the beginning is supported",
+)
+_REMOTE_RESOURCE_CACHE: dict[str, UPath] = {}
+_REMOTE_CACHE_SCOPE: ContextVar[str] = ContextVar(
+    "remote_cache_scope", default="default"
+)
+
+
+@contextmanager
+def remote_cache_scope(scope: str):
+    """Temporarily set the current remote-cache policy scope."""
+    token = _REMOTE_CACHE_SCOPE.set(scope)
+    try:
+        yield
+    finally:
+        _REMOTE_CACHE_SCOPE.reset(token)
+
+
+def get_remote_cache_scope() -> str:
+    """Return the current remote-cache policy scope."""
+    return _REMOTE_CACHE_SCOPE.get()
+
+
+def get_remote_cache_path() -> Path:
+    """Return the on-disk directory used for remote file caching."""
+    path = get_config().remote_cache_dir
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _safe_remote_name(path: UPath) -> str:
+    """Return a basename suitable for a cached local copy."""
+    name = path.name or f"remote-file{path.suffix or '.tmp'}"
+    return Path(name).name
+
+
+def normalize_remote_id(path) -> str:
+    """Return a stable identifier for a remote path."""
+    resource = coerce_to_upath(path)
+    storage_options = getattr(resource, "storage_options", None) or {}
+    options_suffix = ""
+    if storage_options:
+        serialized = json.dumps(storage_options, sort_keys=True, default=str)
+        options_suffix = f"#{sha256(serialized.encode()).hexdigest()}"
+    remote_id = f"{resource}{options_suffix}"
+    _REMOTE_RESOURCE_CACHE[remote_id] = resource
+    return remote_id
+
+
+def _get_remote_cache_dir(remote_id: str) -> Path:  # pragma: no cover
+    """Return the cache directory for a normalized remote identifier."""
+    return get_remote_cache_path() / sha256(remote_id.encode()).hexdigest()
+
+
+def _normalize_cache_root(cache_root: Path | str) -> Path:
+    """Return one normalized cache-root path."""
+    return Path(cache_root).expanduser()
+
+
+def _redact_remote_resource(resource: UPath | str) -> str:
+    """Return a minimally identifying label for remote-cache messages."""
+    path = coerce_to_upath(resource)
+    protocol = getattr(path, "protocol", "remote")
+    name = path.name or f"remote-file{path.suffix or ''}"
+    if isinstance(protocol, list | tuple):
+        protocol = "+".join(str(x) for x in protocol)
+    return f"{protocol}://.../{name}"
+
+
+def _warn_remote_cache_download(resource: UPath, local_path: Path):
+    """Warn that DASCore is downloading a remote file into the local cache."""
+    scope = get_remote_cache_scope()
+    if scope == "metadata":
+        guidance = (
+            "Set `warn_on_remote_cache=False` to silence this warning or "
+            "`allow_remote_cache_for_metadata=False` to disallow metadata-time "
+            "remote-file caching."
+        )
+    else:
+        guidance = (
+            "Set `warn_on_remote_cache=False` to silence this warning or "
+            "`allow_remote_cache=False` to disallow local remote-file caching."
+        )
+    msg = (
+        "Downloading remote file "
+        f"{_redact_remote_resource(resource)} to local cache at {local_path}. "
+        "This may be slow and consume local disk space. "
+        f"{guidance}"
+    )
+    warnings.warn(msg, UserWarning, stacklevel=4)
+
+
+def clear_remote_file_cache():
+    """Remove all locally cached remote files and memoized paths."""
+    shutil.rmtree(get_remote_cache_path(), ignore_errors=True)
+    get_remote_cache_path().mkdir(parents=True, exist_ok=True)
+    _materialize_remote_file.cache_clear()
+    _REMOTE_RESOURCE_CACHE.clear()
+
+
+def _download_remote_file(path, local_path: Path):
+    """Download a remote path into its cache location."""
+    resource = coerce_to_upath(path)
+    protocol = getattr(resource, "protocol", None)
+    open_kwargs = {"block_size": 0} if protocol in _HTTP_PROTOCOLS else {}
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(
+        dir=local_path.parent,
+        prefix=f"{local_path.stem}.",
+        suffix=f"{local_path.suffix}.part",
+    )
+    os.close(fd)
+    tmp_path = Path(temp_name)
+    try:
+        with (
+            resource.open("rb", **open_kwargs) as remote_fi,
+            tmp_path.open("wb") as local_fi,
+        ):
+            while chunk := remote_fi.read(get_config().remote_download_block_size):
+                local_fi.write(chunk)
+        tmp_path.replace(local_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+@lru_cache
+def _materialize_remote_file(  # pragma: no cover
+    remote_id: str, cache_root: Path
+) -> Path:
+    """Materialize one remote resource to a stable local cache path."""
+    resource = _REMOTE_RESOURCE_CACHE.get(remote_id)
+    if resource is None:
+        resource = coerce_to_upath(remote_id.split("#", maxsplit=1)[0])
+    local_path = (
+        cache_root
+        / sha256(remote_id.encode()).hexdigest()
+        / _safe_remote_name(resource)
+    )
+    if not local_path.exists():
+        config = get_config()
+        scope = get_remote_cache_scope()
+        if scope == "metadata" and not config.allow_remote_cache_for_metadata:
+            msg = (
+                "Remote metadata access requires a local cached file for "
+                f"{_redact_remote_resource(resource)}, "
+                "but DASCore does not download remote files during "
+                "`scan()` or public `get_format()` by default. Set "
+                "`allow_remote_cache_for_metadata=True` to opt in to metadata-time "
+                "remote caching."
+            )
+            raise RemoteCacheError(msg)
+        if scope != "metadata" and not config.allow_remote_cache:
+            msg = (
+                f"Remote caching is disabled, but DASCore needs a local file for "
+                f"{_redact_remote_resource(resource)}. "
+                "Set `allow_remote_cache=True` to permit downloading "
+                "remote files into the local cache."
+            )
+            raise RemoteCacheError(msg)
+        if config.warn_on_remote_cache:
+            _warn_remote_cache_download(resource, local_path)
+        _download_remote_file(resource, local_path)
+    return local_path
+
+
+def ensure_local_file(resource) -> Path:
+    """Return a stable local path for one resource for the current session."""
+    if is_pathlike(resource) and is_local_path(resource):
+        return Path(resource)
+    if is_pathlike(resource):
+        cache_root = _normalize_cache_root(get_remote_cache_path())
+        remote_id = normalize_remote_id(resource)
+        return _materialize_remote_file(remote_id, cache_root)
+    name = getattr(resource, "name", None)
+    if name and is_local_path(name):
+        return Path(name)
+    msg = f"Cannot ensure a local file for resource {resource!r}"
+    raise TypeError(msg)
+
+
+def get_local_handle(resource, opener):
+    """Materialize a resource locally, then pass it to an opener."""
+    return opener(ensure_local_file(resource))
+
+
+def is_no_range_http_error(exc: Exception) -> bool:
+    """Return True when an exception indicates no-range HTTP random access."""
+    message = str(exc).lower()
+    return isinstance(exc, ValueError) and all(
+        pattern in message for pattern in _NO_RANGE_HTTP_PATTERNS
+    )
+
+
+class FallbackFileObj:
+    """A file-like object that switches from remote to local on one error."""
+
+    def __init__(self, remote_opener, local_opener, error_predicate):
+        self._remote_opener = remote_opener
+        self._local_opener = local_opener
+        self._error_predicate = error_predicate
+        self._closed = False
+        self._using_local = False
+        self._handle = self._remote_opener()
+        self._pos = 0
+
+    def _set_pos_from_handle(self, fallback=None):
+        """Synchronize the tracked position with the wrapped handle."""
+        try:
+            self._pos = self._handle.tell()
+        except Exception:
+            if fallback is not None:
+                self._pos = fallback
+
+    def _switch_to_local(self):
+        """Swap the backing handle to the cached local file."""
+        if self._using_local:
+            return
+        old_handle = self._handle
+        self._handle = self._local_opener()
+        self._handle.seek(self._pos)
+        self._using_local = True
+        old_handle.close()
+
+    def _with_fallback(self, func, fallback_pos=None):
+        """Run an operation and retry against the cached local file if needed."""
+        try:
+            return func()
+        except Exception as exc:
+            if not self._error_predicate(exc):
+                raise
+            self._switch_to_local()
+            result = func()
+            self._set_pos_from_handle(fallback=fallback_pos)
+            return result
+
+    def read(self, size=-1):
+        """Read bytes from the file-like object."""
+        out = self._with_fallback(lambda: self._handle.read(size))
+        self._set_pos_from_handle(
+            fallback=self._pos + (len(out) if size != -1 and out is not None else 0)
+        )
+        return out
+
+    def readinto(self, b):
+        """Read bytes into a writable buffer."""
+        out = self._with_fallback(lambda: self._handle.readinto(b))
+        if out is not None:
+            self._set_pos_from_handle(fallback=self._pos + out)
+        return out
+
+    def seek(self, offset, whence=0):
+        """Move the file cursor."""
+        out = self._with_fallback(lambda: self._handle.seek(offset, whence))
+        self._set_pos_from_handle(fallback=out)
+        return out
+
+    def tell(self):
+        """Return the current file position."""
+        out = self._handle.tell()
+        self._pos = out
+        return out
+
+    def close(self):
+        """Close the backing handle."""
+        if self._closed:
+            return
+        self._handle.close()
+        self._closed = True
+
+    @property
+    def closed(self):
+        """Return True if the wrapper has been closed."""
+        return self._closed
+
+    def seekable(self):
+        """Indicate the wrapped handle is seekable."""
+        return True
+
+    def readable(self):
+        """Indicate the wrapped handle is readable."""
+        return True
+
+    def writable(self):
+        """Delegate writability if the wrapped handle exposes it."""
+        writable = getattr(self._handle, "writable", None)
+        if callable(writable):
+            return writable()
+        return False
+
+    def flush(self):
+        """Flush the backing handle."""
+        return getattr(self._handle, "flush", lambda: None)()
+
+    def __getattr__(self, item):
+        """Delegate unknown attributes to the backing handle."""
+        return getattr(self._handle, item)

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -4,9 +4,11 @@ The [releases page](https://github.com/DASDAE/dascore/releases) tracks changes f
 
 ## Unreleased API Changes
 
+- DASCore file I/O now accepts `UPath` resources across the main read, scan, spool, and write workflows. Remote file backends such as `memory://` can be used directly for supported formats, and remote directory-based formats such as `XMLBinary` now work when the backend supports listing and file reads. See the file I/O and spool tutorials for examples and current limitations.
 - `dc.scan(...)` now returns [`PatchSummary`](`dascore.PatchSummary`) objects rather than `PatchAttrs`.
 - Scan results carry metadata, coordinates, and source information without loading data. File-backed summaries contain enough source information for lazy reloads.
 - `Patch.attrs` now contains non-coordinate metadata only.
+- DASDAE now stores `history` as a flat string payload on disk. Older DASDAE files that relied on legacy pickled history attrs remain readable, but their original history strings are no longer restored exactly.
 - Coordinate summaries such as `time_min`, `time_max`, `distance_step`, and coordinate units are exposed through `Patch.summary.get_coord_summary(...)`, not through `Patch.attrs`.
 - `Patch.attrs` and `PatchAttrs` no longer own coordinate summaries. Use [`PatchSummary`](`dascore.PatchSummary`) values exposed through [`PatchSummary.get_coord_summary(...)`](`dascore.PatchSummary.get_coord_summary`) for metadata views and coordinate APIs such as [`Patch.update_coords`](`dascore.Patch.update_coords`) for coordinate changes.
 

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -150,9 +150,6 @@ To make this easy, DASCore will automatically manage and serve the right input t
 
 4. [H5Writer](`dascore.io.H5Writer`) - An instance of `h5py.File` which is open in append mode.
 
-5. [PyTablesReader](`dascore.io.PyTablesReader`) - An instance of `pytables.File` which is open in read mode.
-
-6. [PyTablesWriter](`dascore.io.PyTablesWriter`) - An instance of `pytables.File` which is open in append mode.
 
 Deciding which to use depends on whether the file is an HDF5-based or binary format, and which hdf5 library you want to use.
 

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -1,0 +1,21 @@
+# Runtime Configuration
+
+DASCore exposes a small runtime configuration surface through `dascore.config`.
+
+```python
+from pathlib import Path
+
+from dascore.config import get_config, set_config
+
+print(get_config().remote_cache_dir)
+
+with set_config(remote_cache_dir=Path("/tmp/dascore-remote-cache")):
+    ...
+```
+
+Configuration changes affect subsequent operations only. For example, changing `remote_cache_dir` changes where future remote-file materializations are cached.
+
+For remote IO settings such as `allow_remote_cache`,
+`allow_remote_cache_for_metadata`, and `warn_on_remote_cache`, plus examples
+of metadata-only vs read-time behavior, see
+[Working with Remote Patches](remote_patches.qmd).

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -30,7 +30,7 @@ dc.write(source, remote_path, "DASDAE")
 summary = dc.scan(remote_path)[0]
 loaded = dc.read(remote_path)[0]
 
-print(summary.path)
+print(summary.source_path)
 print(loaded.dims)
 ```
 
@@ -80,7 +80,7 @@ from dascore.utils.downloader import fetch
 path = fetch("terra15_das_1_trimmed.hdf5")
 scan_patch = dc.scan(path)[0]
 
-print(scan_patch.path)
+print(scan_patch.source_path)
 print(scan_patch.get_coord_summary("time").min)
 ```
 
@@ -88,9 +88,9 @@ Scan results are useful for listing contents, building dataframes, and deciding 
 
 ```{python}
 loaded_patch = dc.read(
-    scan_patch.path,
-    file_format=scan_patch.file_format,
-    file_version=scan_patch.file_version,
+    scan_patch.source_path,
+    file_format=scan_patch.source_format,
+    file_version=scan_patch.source_version,
     source_patch_id=scan_patch.source_patch_id or None,
 )[0]
 print(loaded_patch.data.shape)

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -6,6 +6,33 @@ execute:
 
 The following highlights some DASCore features for working with IO.
 
+:::{.callout-note}
+If you are working with remote `UPath` resources, especially HTTP or object
+store backends, see the [Working with Remote Patches](remote_patches.qmd)
+tutorial for examples, cache settings, and metadata-vs-read behavior.
+:::
+
+## Using UPath Resources
+
+DASCore accepts both `pathlib.Path` and [`UPath`](https://pypi.org/project/universal-pathlib/) inputs for many file-backed workflows. This is useful when your data lives on a non-local backend supported by `fsspec`.
+
+The example below uses `memory://` so it can run without any external network access.
+
+```{python}
+from upath import UPath
+import dascore as dc
+
+source = dc.get_example_patch()
+remote_path = UPath("memory://dascore/tutorial/example_patch.h5")
+
+dc.write(source, remote_path, "DASDAE")
+
+summary = dc.scan(remote_path)[0]
+loaded = dc.read(remote_path)[0]
+
+print(summary.path)
+print(loaded.dims)
+```
 
 ## Writing Patches to Disk
 
@@ -25,6 +52,21 @@ patch.io.write(write_path, "dasdae")
 #| echo: false
 if write_path.exists():
     write_path.unlink()
+```
+
+Remote-style `UPath` destinations also work for supported formats.
+
+```{python}
+from upath import UPath
+import dascore as dc
+
+patch = dc.get_example_patch()
+remote_write_path = UPath("memory://dascore/tutorial/output_file.pkl")
+
+patch.io.write(remote_write_path, "pickle")
+
+round_trip = dc.read(remote_write_path)[0]
+print(round_trip.dims)
 ```
 
 ## Scan Metadata Without Loading Data

--- a/docs/tutorial/remote_patches.qmd
+++ b/docs/tutorial/remote_patches.qmd
@@ -28,7 +28,7 @@ summary = dc.scan(remote_path)[0]
 loaded = dc.read(remote_path)[0]
 spool = dc.spool(remote_path)
 
-print(summary.path)
+print(summary.source_path)
 print(loaded.dims)
 print(len(spool))
 ```
@@ -71,7 +71,7 @@ When a backend can satisfy metadata access directly, `dc.scan(...)` and `dc.get_
 
 ```{python}
 print(dc.get_format(remote_path))
-print(dc.scan(remote_path)[0].file_format)
+print(dc.scan(remote_path)[0].source_format)
 ```
 
 If answering a metadata query would require downloading the file first, DASCore raises [`RemoteCacheError`](`dascore.exceptions.RemoteCacheError`) instead of silently materializing it.
@@ -105,7 +105,7 @@ with set_config(allow_remote_cache_for_metadata=True):
     summary = dc.scan(http_path)[0]
 
 print(fmt)
-print(summary.path)
+print(summary.source_path)
 ```
 
 When metadata-time caching is enabled, DASCore may warn on the first download if `warn_on_remote_cache=True`.

--- a/docs/tutorial/remote_patches.qmd
+++ b/docs/tutorial/remote_patches.qmd
@@ -1,0 +1,130 @@
+---
+title: Working with Remote Patches
+execute:
+  warning: false
+---
+
+DASCore can work directly with remote resources exposed through [`UPath`](https://pypi.org/project/universal-pathlib/), and is currently tested with backends such as `memory://`, `s3://`, and `http://`.
+
+The main distinction is simple:
+
+- metadata operations such as [`dc.scan(...)`](`dascore.scan`) and public [`dc.get_format(...)`](`dascore.get_format`) stay conservative by default
+- data-loading operations such as [`dc.read(...)`](`dascore.read`) and patch access through [`dc.spool(...)`](`dascore.spool`) are allowed to do heavier IO when needed
+
+## Basic Remote Example
+
+The example below uses `memory://` so it can run without external network access.
+
+```{python}
+from upath import UPath
+import dascore as dc
+
+patch = dc.get_example_patch()
+remote_path = UPath("memory://dascore/tutorial/remote_patch.h5")
+
+dc.write(patch, remote_path, "DASDAE")
+
+summary = dc.scan(remote_path)[0]
+loaded = dc.read(remote_path)[0]
+spool = dc.spool(remote_path)
+
+print(summary.path)
+print(loaded.dims)
+print(len(spool))
+```
+
+For backends that support direct remote access, DASCore can often scan and read without creating a local cached copy.
+
+## Remote Cache Settings
+
+The relevant runtime config values live in `dascore.config`.
+
+```{python}
+from pathlib import Path
+
+from dascore.config import get_config, set_config
+
+config = get_config()
+
+print(config.remote_cache_dir)
+print(config.allow_remote_cache)
+print(config.allow_remote_cache_for_metadata)
+print(config.warn_on_remote_cache)
+
+with set_config(
+    remote_cache_dir=Path("/tmp/dascore-remote-cache"),
+    allow_remote_cache=True,
+    allow_remote_cache_for_metadata=False,
+    warn_on_remote_cache=True,
+):
+    ...
+```
+
+- `remote_cache_dir` is the local directory DASCore uses when it has to materialize a remote file.
+- `allow_remote_cache=True` allows local materialization for real read operations.
+- `allow_remote_cache_for_metadata=False` keeps metadata operations predictable by default.
+- `warn_on_remote_cache=True` emits a warning the first time DASCore downloads a remote file into the local cache.
+
+## Metadata By Default
+
+When a backend can satisfy metadata access directly, `dc.scan(...)` and `dc.get_format(...)` work as usual.
+
+```{python}
+print(dc.get_format(remote_path))
+print(dc.scan(remote_path)[0].file_format)
+```
+
+If answering a metadata query would require downloading the file first, DASCore raises [`RemoteCacheError`](`dascore.exceptions.RemoteCacheError`) instead of silently materializing it.
+
+```python
+from dascore.exceptions import RemoteCacheError
+from upath import UPath
+import dascore as dc
+
+http_path = UPath("http://example.com/data/prodml_2.1.h5")
+
+try:
+    dc.get_format(http_path)
+except RemoteCacheError as exc:
+    print(exc)
+```
+
+## Opt In When Metadata Caching Is Acceptable
+
+If you know a metadata operation may need local caching, opt in explicitly.
+
+```python
+from dascore.config import set_config
+from upath import UPath
+import dascore as dc
+
+http_path = UPath("http://example.com/data/prodml_2.1.h5")
+
+with set_config(allow_remote_cache_for_metadata=True):
+    fmt = dc.get_format(http_path)
+    summary = dc.scan(http_path)[0]
+
+print(fmt)
+print(summary.path)
+```
+
+When metadata-time caching is enabled, DASCore may warn on the first download if `warn_on_remote_cache=True`.
+
+## Reads And Spools
+
+[`dc.read(...)`](`dascore.read`) remains the escape hatch for remote data that genuinely needs heavier IO. If a backend requires a local cached file to complete the read, DASCore may materialize it locally when `allow_remote_cache=True`.
+
+```python
+from upath import UPath
+import dascore as dc
+
+http_path = UPath("http://example.com/data/prodml_2.1.h5")
+patch = dc.read(http_path)[0]
+print(patch.data.shape)
+```
+
+The same distinction applies to spools:
+
+- `spool.get_contents()` relies on summary metadata
+- `spool[0]` or iteration loads patch data
+- if a remote backend cannot answer the metadata side without a download, use `allow_remote_cache_for_metadata=True`

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -26,6 +26,7 @@ spool1 = dc.spool(patch_list)
 
 ```{python}
 import dascore as dc
+from upath import UPath
 # Import fetch to read DASCore example files 
 from dascore.utils.downloader import fetch
 
@@ -34,6 +35,11 @@ path_to_das_file = fetch("terra15_das_1_trimmed.hdf5")
 # path_to_das_file = "/path/to/data/directory/data.EXT"
 
 spool2 = dc.spool(path_to_das_file)
+
+# UPath-backed resources also work for file-backed spools.
+remote_file = UPath("memory://dascore/tutorial/spool_file.h5")
+dc.write(dc.get_example_patch(), remote_file, "DASDAE")
+spool2_remote = dc.spool(remote_file)
 ```
 
 ## A directory of DAS files
@@ -81,6 +87,16 @@ It is best not to delete files once added to a directory managed by DASCore.
 :::
 
 Despite some implementation differences, all spools have common behavior/methods.
+
+:::{.callout-note}
+Remote file resources work with `dc.spool(...)`, `dc.read(...)`, and `dc.scan(...)`. 
+:::
+
+:::{.callout-note}
+For remote `UPath` resources, DASCore treats metadata operations differently
+from full reads. See the [Working with Remote Patches](remote_patches.qmd)
+tutorial for the remote-cache policy, spool implications, and examples.
+:::
 
 # Accessing patches
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
      "rich",
      "tables>=3.7",
      "typing_extensions>=4.12",
+     "universal-pathlib",
      "pint",
      "scipy>=1.15",
 ]
@@ -77,13 +78,17 @@ docs = [
 ]
 
 test = [
+    "aiohttp",
     "coverage>=7.4,<8",
     "pytest-cov>=4",
     "pre-commit",
     "pytest",
     "pytest-codeblocks",
     "pytest-cov",
+    "s3fs",
+    "starlette",
     "twine",
+    "uvicorn",
 ]
 
 profile_base = [
@@ -215,6 +220,11 @@ convention = "numpy"
 filterwarnings = [
     # Ignore hdf5 warnings from pytables, See pytables #1035
     'ignore::Warning:tables:'
+]
+markers = [
+    "network: tests that require network-style filesystem access",
+    "slow: tests skipped by default unless explicitly selected with -m slow",
+    "benchmark: performance benchmark tests",
 ]
 
 [tool.ruff.format]

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -115,6 +115,12 @@ website:
         - text: File IO
           href: tutorial/file_io.qmd
 
+        - text: Working with Remote Patches
+          href: tutorial/remote_patches.qmd
+
+        - text: Configuration
+          href: tutorial/configuration.qmd
+
         - text: Coordinates
           href: tutorial/coords.qmd
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,11 @@ import dascore as dc
 import dascore.examples as ex
 from dascore.clients.dirspool import DirectorySpool
 from dascore.compat import random_state
+from dascore.config import set_config
 from dascore.constants import SpoolType
 from dascore.core import Patch
 from dascore.examples import get_example_patch
 from dascore.io.core import read
-from dascore.io.indexer import DirectoryIndexer
 from dascore.utils.coordmanager import merge_coord_managers
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import register_func
@@ -60,6 +60,11 @@ def pytest_collection_modifyitems(config, items):
     if not config.getoption("--integration"):
         msg = "needs --integration option to run"
         marks["integration"] = pytest.mark.skip(reason=msg)
+    markexpr = getattr(config.option, "markexpr", "") or ""
+    # Skip slow tests by default
+    if "slow" not in markexpr:
+        msg = "needs -m slow to run"
+        marks["slow"] = pytest.mark.skip(reason=msg)
 
     for item in items:
         marks_to_apply = set(marks)
@@ -83,15 +88,29 @@ def pytest_sessionstart(session):
     # need to set nodes to 32 to avoid crash on p3.11. See pytables#977.
     tables.parameters.NODE_CACHE_SLOTS = 32
 
-    # Ensure debug is set. This disables progress bars which disrupt debugging.
-    dc._debug = True
+    # Test-time debug defaults are applied by fixture to avoid state leakage.
+
+
+@pytest.fixture(autouse=True)
+def use_test_config():
+    """Run tests with debug mode enabled unless overridden locally."""
+    with set_config(debug=True):
+        yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def allow_legacy_dasdae_coord_unpickle():
+    """Test fixtures may rely on trusted historical DASDAE coord payloads."""
+    with set_config(allow_dasdae_format_unpickle=True):
+        yield
 
 
 @pytest.fixture(scope="session", autouse=True)
 def swap_index_map_path(tmp_path_factory):
     """For all tests cases, use a temporary index file."""
     tmp_map_path = tmp_path_factory.mktemp("cache_paths") / "cache_paths.json"
-    setattr(DirectoryIndexer, "index_map_path", tmp_map_path)
+    with set_config(directory_index_map_path=tmp_map_path):
+        yield
 
 
 # --- Coordinate fixtures

--- a/tests/test_clients/test_filespool.py
+++ b/tests/test_clients/test_filespool.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import pytest
+from upath import UPath
 
 import dascore as dc
 from dascore.clients.filespool import FileSpool
 from dascore.exceptions import PatchAttributeError
-from dascore.utils.hdf5 import HDFPatchIndexManager
 
 
 class TestBasic:
@@ -34,15 +34,12 @@ class TestBasic:
         assert "FileSpool" in out
 
     def test_update(self, tmp_path_factory, random_patch):
-        """Update should trigger indexing on formats that support it."""
+        """Update should preserve contents even when a format index hook is a no-op."""
         path = tmp_path_factory.mktemp("update_test") / "random.h5"
         dc.write(random_patch, path, "dasdae", "1")
-        # pre-update
         spool = dc.spool(path)
         contents = spool.get_contents()
-        assert not HDFPatchIndexManager(path).has_index
         new_spool = spool.update()
-        assert HDFPatchIndexManager(path).has_index
         new_contents = new_spool.get_contents()
         assert contents.equals(new_contents)
 
@@ -50,6 +47,12 @@ class TestBasic:
         """Simply ensures a bad file will raise."""
         with pytest.raises(FileNotFoundError, match="does not exist"):
             FileSpool("/not/a/directory")
+
+    def test_local_upath_file(self, terra15_v5_path):
+        """Ensure FileSpool accepts local UPath inputs."""
+        spool = FileSpool(UPath(terra15_v5_path))
+        assert isinstance(spool, FileSpool)
+        assert len(spool)
 
     def test_chunk(self, terra15_file_spool):
         """Ensure chunking along time axis works with FileSpool."""

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import datetime
 import pickle
 import re
-import warnings
 from functools import partial
 from io import BytesIO
 from typing import ClassVar
@@ -32,7 +31,7 @@ from dascore.core.coords import (
 from dascore.exceptions import CoordError, ParameterError
 from dascore.units import get_quantity, percent
 from dascore.utils.array import _coerce_text_array, _is_text_coercible_array
-from dascore.utils.misc import all_close, register_func
+from dascore.utils.misc import all_close, register_func, suppress_warnings
 from dascore.utils.time import dtype_time_like, is_datetime64, is_timedelta64, to_float
 
 COORDS = []
@@ -1140,8 +1139,9 @@ class TestCoordRange:
 
     def test_len_one_array_like_start_no_deprecation(self):
         """Array-like scalar start should not emit numpy scalar conversion warning."""
-        with warnings.catch_warnings(record=True) as records:
-            warnings.simplefilter("always", DeprecationWarning)
+        with suppress_warnings(
+            action="always", category=DeprecationWarning, record=True
+        ) as records:
             coord = get_coord(shape=601, start=np.array([0]), step=1)
         assert coord.start == 0
         assert coord.stop == 601

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -270,9 +270,9 @@ class TestInit:
             dims=patch.dims,
             shape=patch.shape,
             dtype=str(np.dtype(patch.data.dtype)),
-            path=Path("/tmp/example.h5"),
-            file_format="PRODML",
-            file_version="2.1",
+            source_path=Path("/tmp/example.h5"),
+            source_format="PRODML",
+            source_version="2.1",
             source_patch_id="node-1",
         )
         called = {}
@@ -285,7 +285,7 @@ class TestInit:
         monkeypatch.setattr(dc, "read", fake_read)
         with pytest.raises(PatchAttributeError, match="uniquely resolved"):
             _load_patch_summary(summary)
-        assert called["path"] == summary.path
+        assert called["path"] == summary.source_path
         assert called["kwargs"]["source_patch_id"] == "node-1"
 
     def test_load_patch_summary_empty_filtered_read_raises(self, tmp_path):
@@ -649,9 +649,24 @@ class TestPatchSummary:
     def test_scan_result_to_summary_override_returns_new_summary(self, random_patch):
         """Summary conversion should still apply explicit source overrides."""
         summary = random_patch.summary
-        out = _scan_result_to_summary(summary, path="some_path")
+        out = _scan_result_to_summary(summary, source_path="some_path")
         assert out is not summary
-        assert out.path == "some_path"
+        assert str(out.source_path) == "some_path"
+
+    def test_patch_summary_non_pathlike_source_metadata_is_dropped(self):
+        """Non-pathlike source metadata should normalize to a detached summary."""
+        out = dc.PatchSummary.model_validate(
+            {
+                "attrs": {"tag": "x"},
+                "coords": {},
+                "source_path": object(),
+                "source_format": "PRODML",
+                "source_version": "2.1",
+            }
+        )
+        assert not out.source_path
+        assert not out.source_format
+        assert not out.source_version
 
     def test_non_mapping_validate_passthrough_raises(self):
         """Non-mapping validation should fall through to pydantic errors."""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,6 +30,11 @@ class TestGetExamplePatch:
         spool = dc.get_example_spool("dispersion_event.h5")
         assert isinstance(spool, dc.BaseSpool)
 
+    def test_get_example_patch_data_file_name(self):
+        """Ensure get_example_patch can load file-backed registry entries."""
+        patch = dc.get_example_patch("dispersion_event.h5")
+        assert isinstance(patch, dc.Patch)
+
     @pytest.mark.parametrize("name", EXAMPLE_PATCHES)
     def test_load_example_patch(self, name):
         """Ensure the registered example patches can all be loaded."""
@@ -54,6 +59,26 @@ class TestGetExamplePatch:
         monkeypatch.setattr(dc_examples.dc, "spool", _spool)
 
         out = dc_examples.example_event_1()
+        assert isinstance(out, dc.Patch)
+
+    def test_file_backed_registry_examples_use_direct_read(self, monkeypatch):
+        """Registry-backed patch examples should load via direct read."""
+        patch = dc.get_example_patch()
+
+        def _fetch(_name):
+            return "ignored-path"
+
+        def _read(_path):
+            return [patch]
+
+        def _spool(_path):
+            raise AssertionError("registry-backed examples should load via dc.read")
+
+        monkeypatch.setattr(dc_examples, "fetch", _fetch)
+        monkeypatch.setattr(dc_examples.dc, "read", _read)
+        monkeypatch.setattr(dc_examples.dc, "spool", _spool)
+
+        out = dc.get_example_patch("dispersion_event.h5")
         assert isinstance(out, dc.Patch)
 
 

--- a/tests/test_integrations/test_misc_integrations.py
+++ b/tests/test_integrations/test_misc_integrations.py
@@ -12,8 +12,7 @@ from dascore.utils.downloader import fetch
 @pytest.fixture(scope="module")
 def train_patch():
     """Get an example patch with trains in it."""
-    out = dc.spool(fetch("UoU_lf_urban.hdf5"))[0]
-    return out
+    return dc.spool(fetch("UoU_lf_urban.hdf5"))[0]
 
 
 class TestFilterInteractions:

--- a/tests/test_io/_common_io_test_utils.py
+++ b/tests/test_io/_common_io_test_utils.py
@@ -1,0 +1,98 @@
+"""Shared helpers for common IO test matrices.
+
+This module includes timeout guards used by localhost-backed remote tests so
+fixture or IO hangs fail quickly instead of stalling the suite.
+"""
+
+from __future__ import annotations
+
+import signal as signal_mod
+import socket
+import threading
+from contextlib import contextmanager
+from urllib import error as urllib_error
+
+import pytest
+
+import dascore as dc
+from dascore.exceptions import MissingOptionalDependencyError
+from dascore.utils.misc import iterate
+
+
+@contextmanager
+def skip_missing():
+    """Skip if missing dependencies found."""
+    try:
+        yield
+    except MissingOptionalDependencyError as exc:
+        pytest.skip(f"Missing optional dependency required to read file: {exc}")
+    except TimeoutError as exc:
+        pytest.skip(f"Unable to fetch data due to timeout: {exc}")
+
+
+@contextmanager
+def skip_timeout():
+    """Skip if downloading file times out."""
+    try:
+        yield
+    except (TimeoutError, urllib_error.URLError) as exc:
+        if not _is_timeout_error(exc):
+            raise
+        pytest.skip(f"Unable to fetch data due to timeout: {exc}")
+
+
+def _is_timeout_error(exc: BaseException) -> bool:
+    """Return True if the exception chain indicates a timeout."""
+    if isinstance(exc, TimeoutError | socket.timeout):
+        return True
+    if isinstance(exc, urllib_error.URLError):
+        reason = exc.reason
+        return isinstance(reason, TimeoutError | socket.timeout)
+    return False
+
+
+def get_flat_io_test(common_io_read_tests: dict) -> list[list[dc.FiberIO | str]]:
+    """Flatten the common IO matrix for parametrized tests."""
+    flat_io = []
+    for io, fetch_name_list in common_io_read_tests.items():
+        for fetch_name in iterate(fetch_name_list):
+            flat_io.append([io, fetch_name])
+    return flat_io
+
+
+def get_representative_io_test(
+    common_io_read_tests: dict,
+) -> list[list[dc.FiberIO | str]]:
+    """Return one deterministic representative file for each FiberIO entry."""
+    out = []
+    for io, fetch_name_list in common_io_read_tests.items():
+        out.append([io, next(iter(iterate(fetch_name_list)))])
+    return out
+
+
+@contextmanager
+def fail_on_timeout(seconds: float, label: str):
+    """Fail the current test if the enclosed block exceeds the timeout."""
+    if (
+        threading.current_thread() is not threading.main_thread()
+        or not hasattr(signal_mod, "SIGALRM")
+        or not hasattr(signal_mod, "ITIMER_REAL")
+        or not hasattr(signal_mod, "setitimer")
+    ):
+        yield
+        return
+
+    previous_handler = signal_mod.getsignal(signal_mod.SIGALRM)
+
+    def _handle_timeout(signum, frame):
+        raise TimeoutError(f"{label} exceeded {seconds} seconds")
+
+    try:
+        signal_mod.signal(signal_mod.SIGALRM, _handle_timeout)
+        signal_mod.setitimer(signal_mod.ITIMER_REAL, seconds)
+        yield
+    except TimeoutError as exc:
+        pytest.fail(str(exc))
+    finally:
+        signal_mod.setitimer(signal_mod.ITIMER_REAL, 0)
+        signal_mod.signal(signal_mod.SIGALRM, previous_handler)

--- a/tests/test_io/conftest.py
+++ b/tests/test_io/conftest.py
@@ -254,7 +254,9 @@ def http_range_das_path(http_test_data_root, ensure_http_fetch_file):
                 except (URLError, OSError):
                     time.sleep(0.1)
             else:
-                pytest.fail("Range-capable HTTP test server did not become ready in time.")
+                pytest.fail(
+                    "Range-capable HTTP test server did not become ready in time."
+                )
         yield UPath(f"http://{host}:{port}/das")
     finally:
         with fail_on_timeout(10, "http_range_das_path teardown"):

--- a/tests/test_io/conftest.py
+++ b/tests/test_io/conftest.py
@@ -234,6 +234,9 @@ def http_range_das_path(http_test_data_root, ensure_http_fetch_file):
         port=0,
         log_level="warning",
         ws="none",
+        # Avoid indefinite teardown hangs if a client leaves a keep-alive
+        # connection open when the fixture shuts the server down.
+        timeout_graceful_shutdown=1,
     )
     server = uvicorn.Server(config)
     sock = config.bind_socket()

--- a/tests/test_io/conftest.py
+++ b/tests/test_io/conftest.py
@@ -1,0 +1,299 @@
+"""Fixtures for IO tests, including local HTTP-backed remote paths.
+
+These remote-style tests share the on-disk DASCore remote cache under ``/tmp``.
+Running remote suites in separate processes is fine when each process uses an
+isolated cache directory. The current cache behavior should not be treated as
+safe for concurrent threaded access within a single process.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import threading
+import time
+from collections.abc import Callable
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import pytest
+
+from dascore.compat import UPath
+from dascore.utils.downloader import fetch
+from tests.test_io._common_io_test_utils import fail_on_timeout
+
+
+class _SilentSimpleHTTPRequestHandler(SimpleHTTPRequestHandler):
+    """A simple HTTP handler that suppresses request noise in tests."""
+
+    def log_message(self, format, *args):
+        """Silence request logs during localhost-backed tests."""
+        return None
+
+    def copyfile(self, source, outputfile):
+        """Silence BrokenPipeError/ConnectionResetError from test clients."""
+        try:
+            return super().copyfile(source, outputfile)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            return None
+
+
+def _link_or_copy(source: Path, dest: Path) -> None:
+    """Populate one served file path using the cheapest available local copy."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        return
+    try:
+        dest.hardlink_to(source)
+        return
+    except OSError:
+        pass
+    try:
+        dest.symlink_to(source)
+        return
+    except OSError:
+        pass
+    shutil.copy2(source, dest)
+
+
+def _prime_http_test_tree(
+    ensure_file: Callable[[str, str | Path | None], Path],
+) -> None:
+    """Populate the fixed files used by the dedicated HTTP regression tests."""
+    ensure_file("example_dasdae_event_1.h5")
+    ensure_file(
+        "example_dasdae_event_1.h5",
+        Path("nested") / "example_dasdae_event_2.h5",
+    )
+
+
+def _coerce_http_relative_path(path_or_name: str | Path) -> Path:
+    """Map fixture inputs onto paths within the served HTTP tree."""
+    path = Path(path_or_name)
+    if path.is_absolute():
+        return Path(path.name)
+    return path if len(path.parts) > 1 else Path(path.name)
+
+
+def _wait_for_http_path(path: UPath, timeout: float = 5.0) -> None:
+    """Probe one served HTTP path until it is reachable."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(str(path), timeout=5):
+                return
+        except (URLError, OSError):
+            time.sleep(0.1)
+    pytest.fail(f"HTTP fixture path did not become ready in time: {path}")
+
+
+@pytest.fixture(scope="session")
+def http_test_data_root(tmp_path_factory):
+    """Return a lazy local directory tree served over HTTP."""
+    root = tmp_path_factory.mktemp("http_test_data") / "served_root" / "das"
+    (root / "nested").mkdir(parents=True, exist_ok=True)
+    return root.parent
+
+
+@pytest.fixture(scope="session")
+def ensure_http_fetch_file(http_test_data_root):
+    """Materialize one fetched file into the served HTTP tree on demand."""
+    served_root = Path(http_test_data_root) / "das"
+
+    def _ensure(fetch_name: str, relative_path: str | Path | None = None) -> Path:
+        source = Path(fetch(fetch_name))
+        dest = served_root / Path(relative_path or source.name)
+        _link_or_copy(source, dest)
+        return dest
+
+    # Pre-materialize the fixed files used directly by the HTTP regression suite.
+    _prime_http_test_tree(_ensure)
+    return _ensure
+
+
+@pytest.fixture(scope="session")
+def http_das_path(http_test_data_root, ensure_http_fetch_file):
+    """Return a UPath pointing at a localhost HTTP view of DAS test data."""
+    handler = partial(
+        _SilentSimpleHTTPRequestHandler,
+        directory=str(http_test_data_root),
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    probe_path = "example_dasdae_event_1.h5"
+    try:
+        host, port = server.server_address
+        probe_url = f"http://{host}:{port}/das/{probe_path}"
+        with fail_on_timeout(10, "http_das_path readiness probe"):
+            for _ in range(50):
+                try:
+                    with urlopen(probe_url, timeout=5):
+                        break
+                except (URLError, OSError):
+                    time.sleep(0.1)
+            else:
+                pytest.fail("HTTP test server did not become ready in time.")
+        yield UPath(f"http://{host}:{port}/das")
+    finally:
+        with fail_on_timeout(10, "http_das_path teardown"):
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+        if thread.is_alive():
+            pytest.fail("HTTP test server thread did not exit cleanly.")
+
+
+@pytest.fixture(scope="session")
+def http_regression_data_root(tmp_path_factory):
+    """Return an isolated local directory tree for remote HTTP regression tests."""
+    root = tmp_path_factory.mktemp("http_regression_data") / "served_root" / "das"
+    (root / "nested").mkdir(parents=True, exist_ok=True)
+    return root.parent
+
+
+@pytest.fixture(scope="session")
+def ensure_http_regression_file(http_regression_data_root):
+    """Materialize only the fixed regression files into the isolated HTTP tree."""
+    served_root = Path(http_regression_data_root) / "das"
+
+    def _ensure(fetch_name: str, relative_path: str | Path | None = None) -> Path:
+        source = Path(fetch(fetch_name))
+        dest = served_root / Path(relative_path or source.name)
+        _link_or_copy(source, dest)
+        return dest
+
+    _prime_http_test_tree(_ensure)
+    return _ensure
+
+
+@pytest.fixture(scope="session")
+def http_regression_das_path(http_regression_data_root, ensure_http_regression_file):
+    """Return an isolated HTTP tree containing only the regression fixtures."""
+    handler = partial(
+        _SilentSimpleHTTPRequestHandler,
+        directory=str(http_regression_data_root),
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    probe_path = "example_dasdae_event_1.h5"
+    try:
+        host, port = server.server_address
+        probe_url = f"http://{host}:{port}/das/{probe_path}"
+        with fail_on_timeout(10, "http_regression_das_path readiness probe"):
+            for _ in range(50):
+                try:
+                    with urlopen(probe_url, timeout=5):
+                        break
+                except (URLError, OSError):
+                    time.sleep(0.1)
+            else:
+                pytest.fail("HTTP test server did not become ready in time.")
+        yield UPath(f"http://{host}:{port}/das")
+    finally:
+        with fail_on_timeout(10, "http_regression_das_path teardown"):
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+        if thread.is_alive():
+            pytest.fail("HTTP regression server thread did not exit cleanly.")
+
+
+@pytest.fixture(scope="session")
+def http_range_das_path(http_test_data_root, ensure_http_fetch_file):
+    """Return a UPath pointing at a localhost HTTP server with range support."""
+    uvicorn = pytest.importorskip("uvicorn")
+    starlette_cls = pytest.importorskip("starlette.applications").Starlette
+    responses = pytest.importorskip("starlette.responses")
+    file_response_cls = responses.FileResponse
+    response_cls = responses.Response
+    route_cls = pytest.importorskip("starlette.routing").Route
+    served_root = Path(http_test_data_root)
+
+    async def _serve_file(request):
+        rel_path = Path(request.path_params["path"])
+        file_path = served_root / rel_path
+        root_path = os.path.abspath(served_root)
+        candidate_path = os.path.abspath(file_path)
+        if os.path.commonpath([root_path, candidate_path]) != root_path:
+            return response_cls(status_code=404)
+        if not file_path.exists() or not file_path.is_file():
+            return response_cls(status_code=404)
+        return file_response_cls(file_path)
+
+    app = starlette_cls(routes=[route_cls("/{path:path}", _serve_file)])
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=0,
+        log_level="warning",
+        ws="none",
+    )
+    server = uvicorn.Server(config)
+    sock = config.bind_socket()
+    host, port = sock.getsockname()[:2]
+
+    def _run():
+        server.run(sockets=[sock])
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    try:
+        probe_url = f"http://{host}:{port}/das/example_dasdae_event_1.h5"
+        with fail_on_timeout(10, "http_range_das_path readiness probe"):
+            for _ in range(50):
+                try:
+                    with urlopen(probe_url, timeout=5):
+                        break
+                except (URLError, OSError):
+                    time.sleep(0.1)
+            else:
+                pytest.fail("Range-capable HTTP test server did not become ready in time.")
+        yield UPath(f"http://{host}:{port}/das")
+    finally:
+        with fail_on_timeout(10, "http_range_das_path teardown"):
+            server.should_exit = True
+            thread.join(timeout=5)
+        if thread.is_alive():
+            sock.close()
+            thread.join(timeout=1)
+            pytest.fail("Range-capable HTTP server thread did not exit cleanly.")
+
+
+@pytest.fixture(scope="session")
+def to_http_path(
+    ensure_http_fetch_file, http_das_path
+) -> Callable[[str | Path], UPath]:
+    """Convert a local fixture path or fetch name to its HTTP-backed UPath."""
+
+    def _convert(path_or_name: str | Path) -> UPath:
+        path = Path(path_or_name)
+        relative_path = _coerce_http_relative_path(path_or_name)
+        ensure_http_fetch_file(path.name, relative_path)
+        out = http_das_path / relative_path
+        _wait_for_http_path(out)
+        return out
+
+    return _convert
+
+
+@pytest.fixture(scope="session")
+def to_http_range_path(
+    ensure_http_fetch_file, http_range_das_path
+) -> Callable[[str | Path], UPath]:
+    """Convert a local fixture path or fetch name to its range-capable HTTP UPath."""
+
+    def _convert(path_or_name: str | Path) -> UPath:
+        relative_path = _coerce_http_relative_path(path_or_name)
+        ensure_http_fetch_file(Path(path_or_name).name, relative_path)
+        out = http_range_das_path / relative_path
+        _wait_for_http_path(out)
+        return out
+
+    return _convert

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -10,19 +10,18 @@ test_io_core.py
 
 from __future__ import annotations
 
-from contextlib import contextmanager, suppress
+from contextlib import suppress
 from functools import cache
 from io import BytesIO, UnsupportedOperation
 from operator import eq, ge, le
 from pathlib import Path
-from urllib import error as urllib_error
 
 import numpy as np
 import pandas as pd
 import pytest
 
 import dascore as dc
-from dascore.exceptions import CoordError, DependencyError
+from dascore.exceptions import CoordError
 from dascore.io import BinaryReader
 from dascore.io.ap_sensing import APSensingV10
 from dascore.io.dasdae import DASDAEV1
@@ -46,6 +45,11 @@ from dascore.io.terra15 import (
 )
 from dascore.utils.downloader import fetch, get_registry_df
 from dascore.utils.misc import all_close, iterate
+from tests.test_io._common_io_test_utils import (
+    get_flat_io_test,
+    skip_missing,
+    skip_timeout,
+)
 
 # --- Fixtures
 
@@ -99,26 +103,6 @@ COMMON_IO_WRITE_TESTS = (
 SKIP_DATA_FILES = {"whale_1.hdf5", "brady_hs_DAS_DTS_coords.csv", "das_vader_1.jld2"}
 
 
-@contextmanager
-def skip_missing():
-    """Skip if missing dependencies found."""
-    try:
-        yield
-    except DependencyError as exc:
-        pytest.skip(str(exc))
-    except TimeoutError as exc:
-        pytest.skip(f"Unable to fetch data due to timeout: {exc}")
-
-
-@contextmanager
-def skip_timeout():
-    """Skip if downloading file times out."""
-    try:
-        yield
-    except (TimeoutError, urllib_error.URLError) as exc:
-        pytest.skip(f"Unable to fetch data due to timeout: {exc}")
-
-
 def _scan_summary(scan_result):
     """Normalize scan output to the patch summary view."""
     return scan_result.summary if isinstance(scan_result, dc.Patch) else scan_result
@@ -139,22 +123,13 @@ def _cached_read(path, io=None):
     return out
 
 
-def _get_flat_io_test():
-    """Flatten list to [(fiberio, path)] so it can be parametrized."""
-    flat_io = []
-    for io, fetch_name_list in COMMON_IO_READ_TESTS.items():
-        for fetch_name in iterate(fetch_name_list):
-            flat_io.append([io, fetch_name])
-    return flat_io
-
-
 @pytest.fixture(scope="session", params=list(COMMON_IO_READ_TESTS))
 def io_instance(request):
     """Fixture for returning fiber io instances."""
     return request.param
 
 
-@pytest.fixture(scope="session", params=_get_flat_io_test())
+@pytest.fixture(scope="session", params=get_flat_io_test(COMMON_IO_READ_TESTS))
 def io_path_tuple(request):
     """
     A fixture which returns io instance, path_to_file.
@@ -165,7 +140,7 @@ def io_path_tuple(request):
         return io, fetch(fetch_name)
 
 
-@pytest.fixture(scope="session", params=get_registry_df()["name"])
+@pytest.fixture(scope="session", params=get_registry_df(exclude_large=True)["name"])
 def data_file_path(request):
     """A fixture of all data files. Will download if needed."""
     param = request.param
@@ -397,7 +372,7 @@ class TestScan:
 
         for summary in summary_list:
             assert isinstance(summary, dc.PatchSummary)
-            assert str(summary.path) == str(data_file_path)
+            assert str(summary.source_path) == str(data_file_path)
 
     def test_raw_scan_excludes_source_metadata(self, io_path_tuple):
         """Direct FiberIO scans should not attach source metadata."""
@@ -405,9 +380,9 @@ class TestScan:
         with skip_missing():
             summary_list = io.scan(path)
         for summary in summary_list:
-            assert not summary.path
-            assert not summary.file_format
-            assert not summary.file_version
+            assert not summary.source_path
+            assert not summary.source_format
+            assert not summary.source_version
             attr_dump = summary.attrs.model_dump()
             assert "path" not in attr_dump
             assert "file_format" not in attr_dump
@@ -419,9 +394,9 @@ class TestScan:
         with skip_missing():
             summary_list = dc.scan(path)
         for summary in summary_list:
-            assert str(summary.path) == str(path)
-            assert summary.file_format == io.name
-            assert summary.file_version == io.version
+            assert str(summary.source_path) == str(path)
+            assert summary.source_format == io.name
+            assert summary.source_version == io.version
 
     def test_time_coord_is_time(self, scanned_summaries):
         """Ensure scanned summaries have correct dtype for time."""

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -2,27 +2,39 @@
 
 from __future__ import annotations
 
+import pickle
 import shutil
 from pathlib import Path
+from typing import ClassVar
 
+import h5py
 import numpy as np
 import pandas as pd
 import pytest
-import tables
 
 import dascore as dc
 from dascore.compat import random_state
+from dascore.config import set_config
 from dascore.core.coords import CoordString
+from dascore.exceptions import InvalidFiberFileError
 from dascore.io import dasdae as dasdae_mod
 from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.dasdae.utils import (
+    _decode_attr_value,
+    _decode_legacy_attr_value,
+    _encode_attr_value,
     _get_attrs,
+    _get_contents_from_patch_groups_generic,
     _get_coord_node_metadata,
     _get_coord_summary_from_node,
+    _get_file_version,
+    _get_patch_summary_from_group,
     _read_array_sample,
     _save_array,
+    _save_patch,
     _translate_legacy_attrs,
 )
+from dascore.utils.downloader import fetch
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
 
@@ -41,12 +53,10 @@ def written_dascore_v1_random(random_patch, tmp_path_factory):
 
 @pytest.fixture(scope="class")
 @register_func(WRITTEN_FILES)
-def written_dascore_v1_random_indexed(written_dascore_v1_random, tmp_path_factory):
-    """Copy the previous dasdae file and create an index."""
-    new_path = tmp_path_factory.mktemp("dasdae_test_path") / "indexed_dasdae.h5"
+def written_dascore_v1_random_copy(written_dascore_v1_random, tmp_path_factory):
+    """Copy the previous DASDAE file for compatibility-oriented tests."""
+    new_path = tmp_path_factory.mktemp("dasdae_test_path") / "copied_dasdae.h5"
     shutil.copy(written_dascore_v1_random, new_path)
-    # index new path
-    DASDAEV1().index(new_path)
     return new_path
 
 
@@ -101,13 +111,13 @@ class TestWriteDASDAE:
         assert len(df) == len(df_pre) + 1
         assert (df["time_min"] == to_datetime64("1990-01-01")).any()
 
-    def test_append_with_index(
-        self, written_dascore_v1_random_indexed, tmp_path_factory, random_patch
+    def test_append_after_copy(
+        self, written_dascore_v1_random_copy, tmp_path_factory, random_patch
     ):
-        """Ensure patches can be appended to indexed dasdae file."""
+        """Ensure append still works on a copied DASDAE file."""
         # make a copy of the dasdae file.
         new_path = tmp_path_factory.mktemp("dasdae_append") / "tmp.h5"
-        shutil.copy(written_dascore_v1_random_indexed, new_path)
+        shutil.copy(written_dascore_v1_random_copy, new_path)
         # ensure the patch exists in the copied spool.
         df_pre = dc.spool(new_path).get_contents()
         assert len(df_pre) == 1
@@ -147,6 +157,14 @@ class TestReadDASDAE:
         spool = dc.read(written_dascore_v1_empty)
         assert len(spool) == 1
         spool[0].equals(dc.Patch())
+
+    def test_reads_legacy_fixture(self):
+        """Legacy DASDAE fixtures still need to remain readable."""
+        path = fetch("example_dasdae_event_1.h5")
+        with set_config(allow_dasdae_format_unpickle=True):
+            spool = dc.read(path, file_format="DASDAE")
+        assert len(spool) == 1
+        assert spool[0].dims
 
     def test_datetimes(self, tmp_path_factory, random_patch):
         """Ensure the datetimes in the attrs come back as datetimes."""
@@ -231,26 +249,31 @@ class TestScanDASDAE:
         patch = dc.scan(written_dascore_v1_random)[0]
         assert patch.source_patch_id
 
-    # TODO we need to re-think indexing before this can work.
-    @pytest.mark.xfail
-    def test_indexed_vs_unindexed(
+    def test_copied_fixture_matches_original(
         self,
         written_dascore_v1_random,
-        written_dascore_v1_random_indexed,
+        written_dascore_v1_random_copy,
     ):
-        """Whether the file is indexed or not the summary should be the same."""
+        """Copying a DASDAE file should not change scan output."""
         df1 = dc.scan_to_df(written_dascore_v1_random)
-        df2 = dc.scan_to_df(written_dascore_v1_random_indexed)
+        df2 = dc.scan_to_df(written_dascore_v1_random_copy)
         # common fields should be equal (except path)
         common = list((set(df1) & set(df2)) - {"path"})
         assert df1[common].equals(df2[common])
 
+    def test_get_patch_summary_has_file_metadata(self, random_spool):
+        """The summary helper should stamp DASDAE metadata on each row."""
+        out = DASDAEV1()._get_patch_summary(random_spool)
+        assert set(out["file_format"]) == {"DASDAE"}
+        assert set(out["file_version"]) == {"1"}
+        assert out["source_patch_id"].notnull().all()
 
-class TestLegacyAttrsTranslation:
-    """Tests for translating legacy DASDAE attr payloads."""
 
-    def test_coord_manager_like_coords(self):
-        """Legacy coords with to_summary_dict should flatten to unit/step keys."""
+class TestLegacyFixtureCompatibility:
+    """Tests for the retained legacy DASDAE fixture compatibility helpers."""
+
+    def test_translate_legacy_attrs_coord_manager_like_coords(self):
+        """Legacy coord managers should still flatten via to_summary_dict."""
 
         class CoordManagerLike:
             def to_summary_dict(self):
@@ -260,41 +283,234 @@ class TestLegacyAttrsTranslation:
         assert out["time_units"] == "s"
         assert out["time_step"] == 1
 
-    def test_summary_like_coord(self):
-        """Legacy coord summaries with to_summary should be normalized."""
+    def test_translate_legacy_attrs_summary_like_coord(self):
+        """Legacy coord summaries should normalize via to_summary/model_dump."""
 
         class SummaryLike:
             def to_summary(self):
                 return dc.core.CoordSummary(min=0, max=1, step=2, units="m")
 
-        out = _translate_legacy_attrs({"coords": {"distance": SummaryLike()}})
+        out = _translate_legacy_attrs(
+            {
+                "coords": {"distance": SummaryLike(), "time": object()},
+                "dims": "distance,time",
+                "d_time": 3,
+            }
+        )
         assert out["distance_units"] == "m"
         assert out["distance_step"] == 2
+        assert out["time_step"] == 3
 
-    def test_model_dump_coord(self):
-        """Legacy coord summaries with model_dump should be normalized."""
-        summary = dc.core.CoordSummary(min=0, max=1, step=3, units="ft")
-        out = _translate_legacy_attrs({"coords": {"distance": summary}})
-        assert out["distance_units"] == "ft"
-        assert out["distance_step"] == 3
+    def test_translate_legacy_attrs_ignores_non_mapping_coords(self):
+        """Legacy stringified coord payloads should be ignored, not crash."""
+        out = _translate_legacy_attrs({"coords": "pickled-coords-placeholder"})
+        assert "coords" not in out
 
-    def test_malformed_coord_entry_skipped(self):
-        """Malformed coord entries should be ignored safely."""
-        out = _translate_legacy_attrs({"coords": {"distance": object()}})
-        assert out == {}
+    def test_translate_legacy_attrs_decodes_pickled_coord_payload(self):
+        """Legacy pickled coord payloads should still restore coord metadata."""
+        payload = pickle.dumps({"distance": {"min": 0, "max": 1, "units": "m"}})
+        out = _translate_legacy_attrs({"coords": payload.decode("latin1")})
+        assert out["distance_units"] == "m"
+        assert out["distance_min"] == 0
+        assert out["distance_max"] == 1
+
+    def test_scan_preserves_legacy_coord_units_from_attr_payload(self):
+        """Legacy attr coord units should backfill missing coord-node units."""
+        with set_config(allow_dasdae_format_unpickle=True):
+            summary = dc.scan(fetch("UoU_lf_urban.hdf5"))[0]
+        assert str(summary.coords["distance"].units) == "1 m"
+
+    def test_read_legacy_coord_payload_requires_opt_in(self):
+        """Legacy pickled coord metadata should fail closed by default."""
+        with set_config(allow_dasdae_format_unpickle=False):
+            with pytest.raises(
+                InvalidFiberFileError, match="allow_dasdae_format_unpickle=True"
+            ):
+                dc.read(fetch("UoU_lf_urban.hdf5"))
+
+    def test_scan_backfills_legacy_coord_step_when_node_step_missing(self, tmp_path):
+        """Legacy coord summaries should backfill step when node metadata lacks it."""
+        path = tmp_path / "legacy_coord_step.h5"
+        payload = pickle.dumps(
+            {
+                "distance": {
+                    "min": 0.0,
+                    "max": 3.0,
+                    "step": 1.0,
+                    "units": "m",
+                    "dtype": "float64",
+                }
+            }
+        )
+        with h5py.File(path, "w") as h5:
+            h5.attrs["__format__"] = "DASDAE"
+            h5.attrs["__DASDAE_version__"] = "1"
+            waveforms = h5.create_group("waveforms")
+            group = waveforms.create_group("patch")
+            group.attrs["_dims"] = "distance"
+            group.attrs["_attrs_coords"] = np.bytes_(payload)
+            group.attrs["_cdims_distance"] = "distance"
+            group.create_dataset("_coord_distance", data=np.array([0.0, 1.0, 3.0]))
+            summary = _get_patch_summary_from_group(group)
+        assert summary.coords["distance"].step == 1.0
+
+    def test_decode_legacy_attr_bytes_falls_back_to_text(self):
+        """Undecodable legacy bytes should fall back to plain text."""
+        assert _decode_legacy_attr_value(b"abc") == "abc"
+
+    def test_decode_legacy_attr_pickled_bytes_fall_back_to_text(self):
+        """Legacy pickled attrs should no longer be unpickled."""
+        payload = pickle.dumps(("a", "b"))
+        assert isinstance(_decode_legacy_attr_value(payload), str)
+
+    def test_decode_legacy_attr_unboxes_scalar_arrays(self):
+        """Scalar legacy arrays should be unpacked back to scalars."""
+        assert _decode_legacy_attr_value(np.asarray(5)) == 5
+
+
+class TestDASDAEInternalHelpers:
+    """Direct tests for h5py-backed DASDAE helper branches."""
+
+    def test_save_array_overwrites_existing_dataset(self, tmp_path):
+        """Saving to an existing dataset name should replace it."""
+        path = tmp_path / "overwrite_array.h5"
+        with h5py.File(path, "w") as h5:
+            group = h5.create_group("waveforms")
+            _save_array(np.arange(2), "data", group=group)
+            _save_array(np.arange(3), "data", group=group)
+            assert np.array_equal(group["data"][:], np.arange(3))
+
+    def test_save_patch_overwrites_existing_group(self, random_patch, tmp_path):
+        """Saving a patch with the same name should replace the old group."""
+        path = tmp_path / "overwrite_patch.h5"
+        with h5py.File(path, "w") as h5:
+            waveforms = h5.create_group("waveforms")
+            _save_patch(random_patch, waveforms, "patch_0")
+            _save_patch(random_patch.update_attrs(tag="new"), waveforms, "patch_0")
+            attrs = _get_attrs(waveforms["patch_0"])
+            assert attrs["tag"] == "new"
+
+    def test_get_patch_summary_unpacks_scalar_attr_array(self, tmp_path):
+        """Scalar encoded attrs should be unpacked in patch summaries."""
+        path = tmp_path / "summary_scalar.h5"
+        with h5py.File(path, "w") as h5:
+            group = h5.create_group("waveforms").create_group("patch_0")
+            group.attrs["_dims"] = "time"
+            group.attrs["_attrs_station"] = np.asarray("A01", dtype=h5py.string_dtype())
+            summary = _get_patch_summary_from_group(group)
+        assert summary.attrs.station == "A01"
+        assert summary.dtype == ""
+
+    def test_get_attrs_unpacks_scalar_attr_arrays(self, monkeypatch):
+        """Scalar arrays returned by attr decoding should be unpacked."""
+
+        class _Group:
+            attrs: ClassVar[dict[str, str]] = {"_attrs_station": "unused"}
+
+        monkeypatch.setattr(
+            dasdae_mod.utils,
+            "_decode_attr_value",
+            lambda *_args, **_kwargs: np.asarray("A01"),
+        )
+        assert _get_attrs(_Group()) == {"station": "A01"}
+
+    def test_get_patch_summary_unpacks_scalar_arrays_from_decoder(
+        self, tmp_path, monkeypatch
+    ):
+        """Patch summaries should unpack scalar arrays returned by decoding."""
+        path = tmp_path / "summary_scalar_decoder.h5"
+        with h5py.File(path, "w") as h5:
+            group = h5.create_group("waveforms").create_group("patch_0")
+            group.attrs["_dims"] = "time"
+            group.attrs["_attrs_station"] = "unused"
+            monkeypatch.setattr(
+                dasdae_mod.utils,
+                "_decode_attr_value",
+                lambda *_args, **_kwargs: np.asarray("A01"),
+            )
+            summary = _get_patch_summary_from_group(group)
+        assert summary.attrs.station == "A01"
+
+    def test_get_patch_summary_preserves_empty_dims_and_shape(self, tmp_path):
+        """Empty stored dims should remain empty tuples in summaries."""
+        path = tmp_path / "summary_empty_dims.h5"
+        with h5py.File(path, "w") as h5:
+            group = h5.create_group("waveforms").create_group("patch_0")
+            group.attrs["_dims"] = ""
+            group.create_dataset("data", data=np.arange(6).reshape(2, 3))
+            summary = _get_patch_summary_from_group(group)
+        assert summary.dims == ()
+        assert summary.shape == (2, 3)
+
+    def test_get_contents_from_patch_groups_returns_empty_without_waveforms(
+        self, tmp_path
+    ):
+        """Files without waveforms should scan as empty."""
+        path = tmp_path / "empty_scan.h5"
+        with h5py.File(path, "w") as h5:
+            out = _get_contents_from_patch_groups_generic(h5)
+            assert out == []
+
+    @pytest.mark.parametrize(
+        ("key", "value", "expected_type", "expected_value"),
+        [
+            ("history", ("a", "b"), "history_json", ("a", "b")),
+            (
+                "value",
+                np.timedelta64(5, "ns"),
+                "timedelta64[ns]",
+                np.timedelta64(5, "ns"),
+            ),
+        ],
+    )
+    def test_encode_decode_attr_value_round_trip(
+        self, key, value, expected_type, expected_value
+    ):
+        """Canonical attr encoding should round-trip supported rich types."""
+        encoded, attr_type = _encode_attr_value(key, value)
+        decoded = _decode_attr_value(
+            {f"_attr_type_{key}": attr_type},
+            key,
+            encoded,
+        )
+        assert attr_type == expected_type
+        assert decoded == expected_value
+
+    def test_encode_attr_value_empty_history(self):
+        """Empty history should still use the dedicated JSON history branch."""
+        encoded, attr_type = _encode_attr_value("history", [])
+        assert attr_type == "history_json"
+        assert encoded == "[]"
+
+    def test_encode_attr_value_string_history_uses_single_entry_json(self):
+        """String history should serialize as a one-entry JSON list."""
+        encoded, attr_type = _encode_attr_value("history", "one step")
+        assert attr_type == "history_json"
+        assert encoded == '["one step"]'
+
+    def test_encode_attr_value_generic_sequence_is_not_special_cased(self):
+        """Non-history sequences should use default passthrough handling."""
+        encoded, attr_type = _encode_attr_value("value", [1, 2])
+        assert attr_type is None
+        assert encoded == [1, 2]
+
+    def test_decode_attr_value_unknown_type_returns_value(self):
+        """Unknown attr types should pass values through unchanged."""
+        value = "abc"
+        assert (
+            _decode_attr_value({"_attr_type_value": "mystery"}, "value", value) == value
+        )
+
+    def test_get_file_version_reads_dasdae_attr(self, tmp_path):
+        """The DASDAE version helper should read the file-level version attr."""
+        path = tmp_path / "versioned.h5"
+        with h5py.File(path, "w") as h5:
+            h5.attrs["__DASDAE_version__"] = "9"
+            assert _get_file_version(h5) == "9"
 
 
 class TestCoordSummaryHelpers:
     """Tests for lightweight DASDAE coord summary reconstruction."""
-
-    class _Attrs(dict):
-        """Support both mapping and attribute-style access like pytables attrs."""
-
-        def __getattr__(self, item):
-            try:
-                return self[item]
-            except KeyError as exc:
-                raise AttributeError(item) from exc
 
     class _ArrayNode:
         """A minimal array node stub for exercising coord summary helpers."""
@@ -304,10 +520,10 @@ class TestCoordSummaryHelpers:
             self.shape = self._values.shape
             self.dtype = self._values.dtype
             self.forbid_full_read = forbid_full_read
-            self._v_attrs = attrs or TestCoordSummaryHelpers._Attrs(
-                is_datetime64=False,
-                is_timedelta64=False,
-            )
+            self.attrs = attrs or {
+                "is_datetime64": False,
+                "is_timedelta64": False,
+            }
 
         def __array__(self):
             return self._values
@@ -336,7 +552,7 @@ class TestCoordSummaryHelpers:
         node = self._ArrayNode(
             [1, 2, 3],
             dtype="int64",
-            attrs=self._Attrs(is_datetime64=False, is_timedelta64=True),
+            attrs={"is_datetime64": False, "is_timedelta64": True},
         )
 
         out = _read_array_sample(node, 1)
@@ -349,7 +565,7 @@ class TestCoordSummaryHelpers:
         node = self._ArrayNode(
             [1, 2, 3],
             dtype="int64",
-            attrs=self._Attrs(is_datetime64=True, is_timedelta64=False),
+            attrs={"is_datetime64": True, "is_timedelta64": False},
         )
 
         out = _read_array_sample(node, 1)
@@ -359,7 +575,7 @@ class TestCoordSummaryHelpers:
 
     def test_read_array_sample_missing_attrs_is_backward_compatible(self):
         """Old files without datetime/timedelta attrs should not error."""
-        node = self._ArrayNode([1, 2, 3], dtype="int64", attrs=self._Attrs())
+        node = self._ArrayNode([1, 2, 3], dtype="int64", attrs={})
 
         out = _read_array_sample(node, 1)
 
@@ -367,7 +583,7 @@ class TestCoordSummaryHelpers:
 
     def test_get_coord_summary_from_empty_node(self):
         """Empty coord nodes should fall back to NaN bounds and node dtype."""
-        node = self._ArrayNode([], dtype="float64", attrs=self._Attrs(units="m"))
+        node = self._ArrayNode([], dtype="float64", attrs={"units": "m"})
 
         out = _get_coord_summary_from_node(node, ("distance",))
 
@@ -383,14 +599,14 @@ class TestCoordSummaryHelpers:
         node = self._ArrayNode(
             [b"alpha", b"beta"],
             dtype="S5",
-            attrs=self._Attrs(
-                units=None,
-                step=None,
-                is_string=True,
-                original_string_dtype="<U8",
-                is_datetime64=False,
-                is_timedelta64=False,
-            ),
+            attrs={
+                "units": None,
+                "step": None,
+                "is_string": True,
+                "original_string_dtype": "<U8",
+                "is_datetime64": False,
+                "is_timedelta64": False,
+            },
         )
 
         out = _get_coord_node_metadata(node)
@@ -404,14 +620,14 @@ class TestCoordSummaryHelpers:
         node = self._ArrayNode(
             [1, 2],
             dtype="int64",
-            attrs=self._Attrs(
-                units="s",
-                step=1,
-                step_is_timedelta64=True,
-                is_string=False,
-                is_datetime64=True,
-                is_timedelta64=False,
-            ),
+            attrs={
+                "units": "s",
+                "step": 1,
+                "step_is_timedelta64": True,
+                "is_string": False,
+                "is_datetime64": True,
+                "is_timedelta64": False,
+            },
         )
 
         out = _get_coord_node_metadata(node)
@@ -424,14 +640,14 @@ class TestCoordSummaryHelpers:
         node = self._ArrayNode(
             [1, 2],
             dtype="int64",
-            attrs=self._Attrs(
-                units="s",
-                step=1,
-                step_is_timedelta64=True,
-                is_string=False,
-                is_datetime64=False,
-                is_timedelta64=True,
-            ),
+            attrs={
+                "units": "s",
+                "step": 1,
+                "step_is_timedelta64": True,
+                "is_string": False,
+                "is_datetime64": False,
+                "is_timedelta64": True,
+            },
         )
 
         out = _get_coord_node_metadata(node)
@@ -444,14 +660,14 @@ class TestCoordSummaryHelpers:
         node = self._ArrayNode(
             [10, 20, 30, 40],
             dtype="int64",
-            attrs=self._Attrs(
-                units="m",
-                step=10,
-                step_is_timedelta64=False,
-                is_datetime64=False,
-                is_timedelta64=False,
-                is_string=False,
-            ),
+            attrs={
+                "units": "m",
+                "step": 10,
+                "step_is_timedelta64": False,
+                "is_datetime64": False,
+                "is_timedelta64": False,
+                "is_string": False,
+            },
             forbid_full_read=True,
         )
 
@@ -467,14 +683,14 @@ class TestCoordSummaryHelpers:
         node = self._ArrayNode(
             [b"gamma", b"alpha", b"beta"],
             dtype="S5",
-            attrs=self._Attrs(
-                units=None,
-                step=None,
-                is_string=True,
-                original_string_dtype="<U8",
-                is_datetime64=False,
-                is_timedelta64=False,
-            ),
+            attrs={
+                "units": None,
+                "step": None,
+                "is_string": True,
+                "original_string_dtype": "<U8",
+                "is_datetime64": False,
+                "is_timedelta64": False,
+            },
         )
 
         out = _get_coord_summary_from_node(node, ("station",))
@@ -670,37 +886,7 @@ class TestStringArrayHelpers:
         monkeypatch.setattr(
             dasdae_mod.utils, "convert_strings_to_bytes", _raise_if_called
         )
-        with tables.open_file(path, mode="w") as h5:
-            group = h5.create_group("/", "waveforms")
-            with pytest.raises(TypeError, match="object arrays"):
-                _save_array(data, "obj", group=group, h5=h5)
-
-
-class TestAttrReading:
-    """Tests for DASDAE attr extraction helpers."""
-
-    class _Attrs(dict):
-        """Support pytables-like attr access with warning side effects."""
-
-        def _f_list(self):
-            return list(self)
-
-        def __getitem__(self, item):
-            import warnings
-
-            warnings.warn("deprecated attr read", DeprecationWarning, stacklevel=2)
-            return super().__getitem__(item)
-
-    class _Group:
-        """Minimal patch-group stub for _get_attrs."""
-
-        def __init__(self, attrs):
-            self._v_attrs = attrs
-
-    def test_get_attrs_suppresses_deprecation_warning(self):
-        """Deprecation warnings from attr reads should be suppressed in the loop."""
-        group = self._Group(self._Attrs(_attrs_station="A01"))
-
-        out = _get_attrs(group)
-
-        assert out == {"station": "A01"}
+        with h5py.File(path, mode="w") as h5:
+            group = h5.create_group("waveforms")
+            with pytest.raises(TypeError, match="Object dtype|object arrays"):
+                _save_array(data, "obj", group=group)

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -13,7 +13,7 @@ import pytest
 from h5py.h5r import Reference
 
 import dascore as dc
-from dascore.exceptions import DependencyError
+from dascore.exceptions import DependencyError, UnknownFiberFormatError
 from dascore.io.dasvader.utils import _dereference, _julia_ms_to_datetime64
 from dascore.utils.downloader import fetch
 
@@ -212,12 +212,20 @@ class TestDASVader:
             out = dc.scan(legacy_das_vader_path)
         assert out == []
 
+    def test_non_dasvader_jld2_is_not_claimed(self, tmp_path):
+        """Non-DASVader JLD2/HDF5 files should not be identified as DASVader."""
+        path = tmp_path / "not_dasvader.jld2"
+        with h5py.File(path, "w") as fi:
+            fi.create_dataset("not_dDAS", data=np.arange(3))
+        with pytest.raises(UnknownFiberFormatError):
+            dc.get_format(path)
+
     def test_modern_file_scan_and_slice(self, dasvader_modern_path):
         """Named-reference DASVader files should still support scan and read."""
         scanned = dc.scan(dasvader_modern_path)
         assert len(scanned) == 1
         summary = scanned[0]
-        assert summary.file_format == "DASVader"
+        assert summary.source_format == "DASVader"
         assert summary.attrs.gauge_length == MODERN_DASVADER.gauge_length
         assert summary.attrs.host_name == MODERN_DASVADER.host_name
         assert summary.attrs.pipeline_tracker == MODERN_DASVADER.pipeline_tracker

--- a/tests/test_io/test_febus/test_febusg1.py
+++ b/tests/test_io/test_febus/test_febusg1.py
@@ -89,9 +89,9 @@ class TestG1Scan:
         assert len(attrs) == 1
         attr = attrs[0]
         assert isinstance(attr, dc.PatchSummary)
-        assert not attr.path
-        assert not attr.file_format
-        assert not attr.file_version
+        assert not attr.source_path
+        assert not attr.source_format
+        assert not attr.source_version
 
     def test_public_scan_adds_source_metadata(self, g1_path):
         """Public scan should attach reload metadata for G1 files."""
@@ -100,9 +100,9 @@ class TestG1Scan:
         assert len(attrs) == 1
         attr = attrs[0]
         assert isinstance(attr, dc.PatchSummary)
-        assert str(g1_path) == str(attr.path)
-        assert attr.file_format == g1.name
-        assert attr.file_version == g1.version
+        assert str(g1_path) == str(attr.source_path)
+        assert attr.source_format == g1.name
+        assert attr.source_version == g1.version
 
 
 class TestG1Read:

--- a/tests/test_io/test_h5simple/test_h5simple.py
+++ b/tests/test_io/test_h5simple/test_h5simple.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 import shutil
 
+import h5py
+import numpy as np
 import pytest
 import tables
 
 import dascore as dc
+from dascore.io.h5simple.utils import (
+    _get_attr_names,
+    _get_root_attrs,
+    _iter_root_arrays,
+)
 from dascore.utils.downloader import fetch
 
 
@@ -39,3 +46,55 @@ class TestH5Simple:
         """Ensure if 'dims' is in attrs it gets used."""
         patch = dc.spool(h5simple_with_dim_attrs_path, file_format="h5simple")[0]
         assert isinstance(patch, dc.Patch)
+
+
+class TestH5SimpleInternalHelpers:
+    """Direct tests for helper branches that still support PyTables fixtures."""
+
+    def test_get_root_attrs_supports_pytables(self, tmp_path):
+        """PyTables handles should expose root attrs through the helper."""
+        path = tmp_path / "root_attrs.h5"
+        with tables.open_file(path, "w") as h5:
+            h5.root._v_attrs["dims"] = "distance,time"
+            attrs = _get_root_attrs(h5)
+            assert attrs.dims == "distance,time"
+
+    def test_iter_root_arrays_supports_pytables(self, tmp_path):
+        """PyTables root arrays should still be discoverable by helper code."""
+        path = tmp_path / "root_arrays.h5"
+        with tables.open_file(path, "w") as h5:
+            h5.create_array("/", "data", obj=np.arange(3))
+            names = [name for name, _node in _iter_root_arrays(h5)]
+        assert names == ["data"]
+
+    def test_get_attr_names_supports_pytables_attrs(self, tmp_path):
+        """PyTables attr containers should still expose their stored keys."""
+        path = tmp_path / "attr_names.h5"
+        with tables.open_file(path, "w") as h5:
+            h5.root._v_attrs["dims"] = "distance,time"
+            out = _get_attr_names(h5.root._v_attrs)
+        assert "dims" in out
+
+    def test_get_root_attrs_supports_h5py(self, tmp_path):
+        """h5py files should continue to use the attrs mapping directly."""
+        path = tmp_path / "h5py_attrs.h5"
+        with h5py.File(path, "w") as h5:
+            h5.attrs["dims"] = "distance,time"
+            attrs = _get_root_attrs(h5)
+            assert attrs["dims"] == "distance,time"
+
+    def test_iter_root_arrays_supports_h5py(self, tmp_path):
+        """h5py root arrays should still be discoverable by helper code."""
+        path = tmp_path / "h5py_root_arrays.h5"
+        with h5py.File(path, "w") as h5:
+            h5.create_dataset("data", data=np.arange(3))
+            names = [name for name, _node in _iter_root_arrays(h5)]
+        assert names == ["data"]
+
+    def test_get_attr_names_supports_h5py_attrs(self, tmp_path):
+        """h5py attr containers should still expose their stored keys."""
+        path = tmp_path / "h5py_attr_names.h5"
+        with h5py.File(path, "w") as h5:
+            h5.attrs["dims"] = "distance,time"
+            out = _get_attr_names(h5.attrs)
+        assert "dims" in out

--- a/tests/test_io/test_indexer.py
+++ b/tests/test_io/test_indexer.py
@@ -8,13 +8,18 @@ import shutil
 from contextlib import suppress
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 from packaging.version import parse as get_version
+from upath import UPath
 
 import dascore as dc
+from dascore.config import set_config
 from dascore.examples import spool_to_directory
+from dascore.exceptions import InvalidSpoolError
 from dascore.io.indexer import DirectoryIndexer
+from dascore.utils.hdf5 import HDFPatchIndexManager
 from dascore.utils.patch import get_patch_names
 
 
@@ -83,11 +88,7 @@ class TestFindIndex:
 
         with cache_path.open("wt") as fi:
             fi.write("{'bad': 'json'")
-
-        class SubIndexer(DirectoryIndexer):
-            index_map_path = cache_path
-
-        return SubIndexer
+        return cache_path
 
     def test_directory_cant_write(self, unwritable_directory):
         """Ensure correct path is found when a read-only directory is used."""
@@ -128,9 +129,30 @@ class TestFindIndex:
         """Ensure a corrupted cache doesnt crash indexing. See #508."""
         path = tmp_path_factory.mktemp("corrupt_cache_test")
         # Test passes if this doesn't raise should not raise.
-        assert directory_indexer_bad_cache.index_map_path.exists()
-        directory_indexer_bad_cache(path)
-        assert not directory_indexer_bad_cache.index_map_path.exists()
+        assert directory_indexer_bad_cache.exists()
+        with set_config(directory_index_map_path=directory_indexer_bad_cache):
+            DirectoryIndexer(path)
+        assert not directory_indexer_bad_cache.exists()
+
+    def test_remote_directory_not_supported(self):
+        """Remote directory indexing should fail fast."""
+        path = UPath("memory://dascore/indexer")
+        (path / "file.txt").write_text("x")
+        with pytest.raises(InvalidSpoolError, match="local filesystem"):
+            DirectoryIndexer(path)
+
+    def test_local_upath_normalized_to_path(self, tmp_path):
+        """Local UPath inputs should normalize to pathlib.Path internally."""
+        out = DirectoryIndexer(UPath(tmp_path))
+        assert isinstance(out.path, Path)
+        assert out.path == Path(tmp_path).absolute()
+
+    def test_index_map_path_comes_from_config(self, tmp_path):
+        """Index map paths should be sourced from runtime configuration."""
+        index_map_path = tmp_path / "cache_paths.json"
+        with set_config(directory_index_map_path=index_map_path):
+            out = DirectoryIndexer(tmp_path)
+            assert out.index_map_path == index_map_path
 
 
 class TestBasics:
@@ -194,6 +216,45 @@ class TestGetContents:
         """An empty index should return an empty dataframe."""
         df = empty_index()
         assert df.empty
+
+    def test_default_buffer_comes_from_config(self, basic_indexer, monkeypatch):
+        """Configured index buffer should be used when no explicit buffer is passed."""
+        seen = {}
+
+        def _fake_to_timedelta64(value):
+            seen["buffer"] = value
+            return value
+
+        monkeypatch.setattr("dascore.io.indexer.to_timedelta64", _fake_to_timedelta64)
+        with set_config(index_query_buffer=np.timedelta64(5, "s")):
+            basic_indexer.get_contents()
+        assert seen["buffer"] == np.timedelta64(5, "s")
+
+    def test_explicit_buffer_overrides_config(self, basic_indexer):
+        """Explicit get_contents buffer should override config defaults."""
+        seen = {}
+
+        def _fake_to_timedelta64(value):
+            seen["buffer"] = value
+            return value
+
+        with set_config(index_query_buffer=np.timedelta64(10, "s")):
+            with pytest.MonkeyPatch.context() as monkeypatch:
+                monkeypatch.setattr(
+                    "dascore.io.indexer.to_timedelta64", _fake_to_timedelta64
+                )
+                basic_indexer.get_contents(buffer=np.timedelta64(0, "s"))
+        assert seen["buffer"] == np.timedelta64(0, "s")
+
+
+class TestHDFPatchIndexManager:
+    """Tests for config-backed HDF index defaults."""
+
+    def test_buffer_comes_from_config(self, tmp_path):
+        """Index manager buffer property should reflect runtime config."""
+        manager = HDFPatchIndexManager(tmp_path / "index.h5")
+        with set_config(index_query_buffer=np.timedelta64(7, "s")):
+            assert manager.buffer == np.timedelta64(7, "s")
 
 
 class TestUpdate:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import io
+import warnings
 from pathlib import Path
 from typing import TypeVar
 
@@ -12,13 +13,15 @@ import numpy as np
 import pandas as pd
 import pytest
 import rich.progress as prog
+from upath import UPath
 
-import dascore
 import dascore as dc
+from dascore.config import set_config
 from dascore.constants import SpoolType
 from dascore.exceptions import (
     InvalidFiberIOError,
     MissingOptionalDependencyError,
+    RemoteCacheError,
     UnknownFiberFormatError,
 )
 from dascore.io.core import (
@@ -398,10 +401,29 @@ class TestGetFormat:
         assert fiber_io.name == name
         assert fiber_io.version == version
 
-    def test_empty_hdf5_no_format(self, empty_h5_path):
-        """Ensure the empty hdf5 dorsen't have a format."""
-        with pytest.raises(UnknownFiberFormatError):
-            dc.get_format(empty_h5_path)
+    def test_manager_get_format_invokes_fiberio_get_format(self, monkeypatch, tmp_path):
+        """Manager format detection should execute FiberIO get_format loop bodies."""
+        path = tmp_path / "format_loop.h5"
+        path.write_text("placeholder")
+        fiber_io = _ReadOnlySummaryFormatter()
+        seen = {}
+
+        def _yield_fiberio(*_args, **_kwargs):
+            yield fiber_io
+
+        def _get_format(resource, **_kwargs):
+            seen["resource"] = resource
+            return (fiber_io.name, fiber_io.version)
+
+        monkeypatch.setattr(FiberIO.manager, "yield_fiberio", _yield_fiberio)
+        monkeypatch.setattr(fiber_io, "get_format", _get_format)
+        fiber_io.get_format._required_type = Path
+
+        assert FiberIO.manager._get_format(path=path) == (
+            fiber_io.name,
+            fiber_io.version,
+        )
+        assert seen["resource"] == path
 
 
 class TestScan:
@@ -497,7 +519,54 @@ class TestScan:
             out = dc.scan([missing_path, readable_path])
 
         assert len(out) == 1
-        assert out[0].file_format == _ReadOnlySummaryFormatter.name
+        assert out[0].source_format == _ReadOnlySummaryFormatter.name
+
+    def test_local_upath_file_interfaces(self, terra15_v6_path):
+        """Ensure core file IO accepts local UPath inputs."""
+        path = UPath(terra15_v6_path)
+        file_format, file_version = dc.get_format(path)
+        assert file_format
+        assert file_version
+        assert len(dc.scan(path)) == 1
+        assert len(dc.read(path)) == 1
+
+    def test_updated_after_warns_when_remote_mtime_missing(self, monkeypatch):
+        """Timestamp filtering should warn and continue on unsupported backends."""
+        fiber_io = _FiberFormatTestV1()
+        resource = UPath("memory://dascore/fiberio/mtime.txt")
+        resource.write_text("x")
+        path_type = type(resource)
+        original_stat = path_type.stat
+
+        def _stat(self, *args, **kwargs):
+            raise OSError("no mtime")
+
+        monkeypatch.setattr(path_type, "stat", _stat)
+        with pytest.warns(UserWarning, match="does not expose reliable mtime"):
+            assert fiber_io._updated_after(resource, 1) is True
+        monkeypatch.setattr(path_type, "stat", original_stat)
+
+    def test_local_stat_failure_returns_false(self, monkeypatch, tmp_path):
+        """Local stat failures should conservatively skip timestamp-matched scans.
+
+        Remote backends sometimes cannot provide mtimes at all, so DASCore warns
+        and continues scanning in that case. For local files, a failed ``stat``
+        usually means the path disappeared or became unreadable, so
+        ``_updated_after`` should return ``False`` instead of treating that as an
+        implicit update.
+        """
+        fiber_io = _FiberFormatTestV1()
+        path = tmp_path / "mtime.txt"
+        path.write_text("x")
+
+        def _stat(_self, *args, **kwargs):
+            raise OSError("no stat")
+
+        monkeypatch.setattr(Path, "stat", _stat)
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            assert fiber_io._updated_after(path, 1) is False
+        assert not record
 
 
 class TestReloadableSourcePath:
@@ -508,7 +577,9 @@ class TestReloadableSourcePath:
         path = tmp_path / "example.txt"
         path.write_text("x")
         manager = IOResourceManager(path)
-        assert _get_reloadable_source_path(manager) == str(path)
+        out = _get_reloadable_source_path(manager)
+        assert isinstance(out, UPath)
+        assert out == UPath(path)
 
     def test_can_raise(self):
         """
@@ -537,6 +608,19 @@ class TestReloadableSourcePath:
             scan = dc.scan(terra15_v6_path)
         assert not len(scan)
 
+    def test_remote_cache_error_is_not_swallowed(self, monkeypatch, terra15_v6_path):
+        """Remote cache policy errors during scan should propagate to callers."""
+        fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
+        fiber_io = FiberIO.manager.get_fiberio(format=fname, version=ver)
+
+        def raise_remote_cache_error(*args, **kwargs):
+            raise RemoteCacheError("metadata cache blocked")
+
+        monkeypatch.setattr(fiber_io, "scan", raise_remote_cache_error)
+
+        with pytest.raises(RemoteCacheError, match="metadata cache blocked"):
+            dc.scan(terra15_v6_path)
+
     def test_scan_legacy_patch_attrs_raises(self, monkeypatch, terra15_v6_path):
         """FiberIO returning PatchAttrs should now fail loudly."""
         fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
@@ -547,7 +631,7 @@ class TestReloadableSourcePath:
 
         monkeypatch.setattr(fiber_io, "scan", return_patch_attrs)
 
-        with pytest.raises(ValueError, match="PatchAttrs from FiberIO.scan"):
+        with pytest.raises(ValueError, match=r"PatchAttrs from FiberIO\.scan"):
             dc.scan(terra15_v6_path)
 
     def test_default_fiberio_scan_uses_reloadable_source_path(self, tmp_path):
@@ -560,9 +644,9 @@ class TestReloadableSourcePath:
 
         assert len(out) == 1
         assert isinstance(out[0], dc.PatchSummary)
-        assert not out[0].path
-        assert not out[0].file_format
-        assert not out[0].file_version
+        assert not out[0].source_path
+        assert not out[0].source_format
+        assert not out[0].source_version
         assert not out[0].source_patch_id
 
     def test_dc_scan_adds_source_metadata_to_raw_fiberio_scan(self, tmp_path):
@@ -572,16 +656,16 @@ class TestReloadableSourcePath:
 
         raw = _ReadOnlySummaryFormatter().scan(path)
         assert len(raw) == 1
-        assert not raw[0].path
-        assert not raw[0].file_format
-        assert not raw[0].file_version
+        assert not raw[0].source_path
+        assert not raw[0].source_format
+        assert not raw[0].source_version
 
         out = dc.scan(path)
         assert len(out) == 1
         assert isinstance(out[0], dc.PatchSummary)
-        assert str(out[0].path) == str(path)
-        assert out[0].file_format == _ReadOnlySummaryFormatter.name
-        assert out[0].file_version == _ReadOnlySummaryFormatter.version
+        assert str(out[0].source_path) == str(path)
+        assert out[0].source_format == _ReadOnlySummaryFormatter.name
+        assert out[0].source_version == _ReadOnlySummaryFormatter.version
         assert "path" not in out[0].attrs.model_dump()
         assert "file_format" not in out[0].attrs.model_dump()
         assert "file_version" not in out[0].attrs.model_dump()
@@ -618,11 +702,11 @@ class TestReloadableSourcePath:
                 raise KeyboardInterrupt("test interrupt")
 
         # Switch off debug to force progress bar, then make contents to scan.
-        monkeypatch.setattr(dascore, "_debug", False)
         contents = list(dc.examples.get_example_spool(length=22))
 
-        with pytest.raises(KeyboardInterrupt, match="test interrupt"):
-            dc.scan(contents, progress=Progress())
+        with set_config(debug=False):
+            with pytest.raises(KeyboardInterrupt, match="test interrupt"):
+                dc.scan(contents, progress=Progress())
 
 
 class TestScanToDF:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import copy
 import io
-import warnings
 from pathlib import Path
 from typing import TypeVar
 
@@ -32,6 +31,7 @@ from dascore.io.core import (
 )
 from dascore.io.dasdae.core import DASDAEV1
 from dascore.utils.io import BinaryReader, BinaryWriter, IOResourceManager
+from dascore.utils.misc import suppress_warnings
 from dascore.utils.time import to_datetime64
 
 tvar = TypeVar("tvar", int, float, str, Path)
@@ -563,8 +563,7 @@ class TestScan:
             raise OSError("no stat")
 
         monkeypatch.setattr(Path, "stat", _stat)
-        with warnings.catch_warnings(record=True) as record:
-            warnings.simplefilter("always")
+        with suppress_warnings(action="always", record=True) as record:
             assert fiber_io._updated_after(path, 1) is False
         assert not record
 

--- a/tests/test_io/test_remote_common_io.py
+++ b/tests/test_io/test_remote_common_io.py
@@ -1,0 +1,113 @@
+"""Common remote IO tests for localhost HTTP-backed paths."""
+
+from __future__ import annotations
+
+import pytest
+
+import dascore as dc
+from dascore.config import set_config
+from dascore.utils.misc import suppress_warnings
+from tests.test_io._common_io_test_utils import (
+    fail_on_timeout,
+    get_flat_io_test,
+    get_representative_io_test,
+    skip_missing,
+    skip_timeout,
+)
+from tests.test_io.test_common_io import COMMON_IO_READ_TESTS
+
+pytestmark = pytest.mark.network
+
+REMOTE_GET_FORMAT_CASES = get_flat_io_test(COMMON_IO_READ_TESTS)
+REMOTE_REPRESENTATIVE_CASES = get_representative_io_test(COMMON_IO_READ_TESTS)
+
+
+@pytest.fixture(autouse=True)
+def suppress_expected_remote_cache_warnings():
+    """Keep expected remote-cache download warnings out of test output."""
+    with suppress_warnings(UserWarning):
+        yield
+
+
+@pytest.fixture(scope="module", autouse=True)
+def isolated_remote_cache(tmp_path_factory):
+    """Keep the common remote matrix in its own cache root."""
+    with set_config(
+        remote_cache_dir=tmp_path_factory.mktemp("remote_common_cache"),
+        allow_remote_cache_for_metadata=True,
+    ):
+        yield
+
+
+def _get_remote_case(fetch_name: str, to_http_range_path):
+    """Return a range-capable HTTP path for one fetched local test file."""
+    with skip_timeout():
+        local_path = dc.utils.downloader.fetch(fetch_name)
+    return to_http_range_path(local_path)
+
+
+@pytest.fixture(
+    scope="session",
+    params=REMOTE_GET_FORMAT_CASES,
+    ids=lambda case: f"{case[0].name}-{case[0].version}-{case[1]}",
+)
+def remote_get_format_case(request, to_http_range_path):
+    """Return one remote get-format case per IO/file pairing."""
+    io, fetch_name = request.param
+    return io, _get_remote_case(fetch_name, to_http_range_path)
+
+
+@pytest.fixture(scope="session", params=REMOTE_REPRESENTATIVE_CASES)
+def remote_read_case(request, to_http_range_path):
+    """Return one representative remote read case per FiberIO entry."""
+    io, fetch_name = request.param
+    return io, _get_remote_case(fetch_name, to_http_range_path)
+
+
+@pytest.fixture(scope="session", params=REMOTE_REPRESENTATIVE_CASES)
+def remote_scan_case(request, to_http_range_path):
+    """Return one representative remote scan case per FiberIO entry."""
+    io, fetch_name = request.param
+    return io, _get_remote_case(fetch_name, to_http_range_path)
+
+
+class TestRemoteGetFormat:
+    """Test remote format detection against the local IO support matrix."""
+
+    def test_expected_version(self, remote_get_format_case):
+        """Each IO should identify its own remote test fixture."""
+        io, path = remote_get_format_case
+        with skip_missing():
+            with fail_on_timeout(30, f"dc.get_format({path})"):
+                out = dc.get_format(path)
+        assert out == (io.name, io.version)
+
+
+class TestRemoteRead:
+    """Test remote reads against the local IO support matrix."""
+
+    def test_read_returns_spools(self, remote_read_case):
+        """Each remotely supported file should read into a spool."""
+        _io, path = remote_read_case
+        with skip_missing():
+            with fail_on_timeout(30, f"dc.read({path})"):
+                out = dc.read(path)
+        assert isinstance(out, dc.BaseSpool)
+        assert len(out) > 0
+        assert all(isinstance(x, dc.Patch) for x in out)
+
+
+class TestRemoteScan:
+    """Test remote scans against the local IO support matrix."""
+
+    def test_scan_has_source_metadata(self, remote_scan_case):
+        """Public scans of remote files should retain source metadata."""
+        io, path = remote_scan_case
+        with skip_missing():
+            with fail_on_timeout(30, f"dc.scan({path})"):
+                summary_list = dc.scan(path)
+        assert len(summary_list) > 0
+        for summary in summary_list:
+            assert str(summary.source_path) == str(path)
+            assert summary.source_format == io.name
+            assert summary.source_version == io.version

--- a/tests/test_io/test_remote_http.py
+++ b/tests/test_io/test_remote_http.py
@@ -1,0 +1,177 @@
+"""Remote HTTP path tests for universal_pathlib support."""
+
+from __future__ import annotations
+
+import warnings
+from urllib.request import Request, urlopen
+
+import pytest
+from upath import UPath
+
+import dascore as dc
+from dascore.config import set_config
+from dascore.exceptions import InvalidSpoolError, RemoteCacheError
+from dascore.utils.remote_io import clear_remote_file_cache, get_remote_cache_path
+
+pytestmark = pytest.mark.network
+
+
+@pytest.fixture(autouse=True)
+def suppress_expected_remote_cache_warnings(request):
+    """Keep expected remote-cache download warnings out of test output."""
+    if (
+        request.node.name
+        == "test_http_hdf5_fallback_warns_once_and_reuses_cached_local_copy"
+    ):
+        yield
+        return
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Downloading remote file .* to local cache at .*",
+            category=UserWarning,
+        )
+        yield
+
+
+@pytest.fixture(autouse=True)
+def isolated_remote_cache(tmp_path):
+    """Use one isolated remote cache per test to avoid suite-order slowdowns."""
+    with set_config(remote_cache_dir=tmp_path / "remote_cache"):
+        clear_remote_file_cache()
+        yield
+        clear_remote_file_cache()
+
+
+class TestHTTPRead:
+    """Tests for reading DAS files over a local HTTP backend."""
+
+    def test_read_dasdae_from_http(self, http_regression_das_path):
+        """Ensure a top-level DASDAE file can be read from the HTTP tree."""
+        path = http_regression_das_path / "example_dasdae_event_1.h5"
+        spool = dc.read(path)
+        assert len(spool) > 0
+        assert spool[0].dims == ("distance", "time")
+
+    def test_read_nested_dasdae_from_http(self, http_regression_das_path):
+        """Ensure a nested DASDAE file can be read from the HTTP tree."""
+        path = http_regression_das_path / "nested" / "example_dasdae_event_2.h5"
+        spool = dc.read(path)
+        assert len(spool) > 0
+        assert spool[0].dims == ("distance", "time")
+
+
+class TestHTTPScan:
+    """Tests for scanning DAS files from a local HTTP backend."""
+
+    def test_scan_top_level_dasdae_from_http(self, http_regression_das_path):
+        """Ensure a top-level DASDAE file can be scanned from the HTTP tree."""
+        path = http_regression_das_path / "example_dasdae_event_1.h5"
+        attrs = dc.scan(path)
+        assert len(attrs) > 0
+        assert attrs[0].source_format == "DASDAE"
+        assert isinstance(attrs[0].source_path, UPath)
+        assert attrs[0].source_path == path
+
+    def test_scan_nested_dasdae_from_http(self, http_regression_das_path):
+        """Ensure a nested DASDAE file can be scanned from the HTTP tree."""
+        path = http_regression_das_path / "nested" / "example_dasdae_event_2.h5"
+        attrs = dc.scan(path)
+        assert len(attrs) > 0
+        assert attrs[0].source_format == "DASDAE"
+        assert isinstance(attrs[0].source_path, UPath)
+        assert attrs[0].source_path == path
+
+    def test_scan_http_string_path_promotes_to_upath(self, http_regression_das_path):
+        """HTTP URL strings should be preserved as UPath on summaries."""
+        path = http_regression_das_path / "example_dasdae_event_1.h5"
+        attrs = dc.scan(str(path))
+        assert len(attrs) > 0
+        assert isinstance(attrs[0].source_path, UPath)
+        assert attrs[0].source_path == path
+
+    def test_scan_http_directory_traverses_nested_files(self, http_regression_das_path):
+        """Ensure directory scans recurse through HTTP directory listings."""
+        attrs = dc.scan(http_regression_das_path)
+        paths = {str(x.source_path) for x in attrs}
+        assert str(http_regression_das_path / "example_dasdae_event_1.h5") in paths
+        assert (
+            str(http_regression_das_path / "nested" / "example_dasdae_event_2.h5")
+            in paths
+        )
+
+
+class TestHTTPFormatAndSpool:
+    """Tests for format detection and spool behavior over HTTP."""
+
+    def test_get_format_from_http(self, http_regression_das_path):
+        """Ensure format detection works for HTTP-served DASDAE files."""
+        path = http_regression_das_path / "example_dasdae_event_1.h5"
+        out = dc.get_format(path)
+        assert out == ("DASDAE", "1")
+
+    def test_http_hdf5_get_format_requires_metadata_cache_opt_in(
+        self, http_regression_das_path, ensure_http_regression_file
+    ):
+        """Plain HTTP HDF5 metadata access should fail unless opted in."""
+        ensure_http_regression_file("prodml_2.1.h5")
+        path = http_regression_das_path / "prodml_2.1.h5"
+        with pytest.raises(RemoteCacheError, match="allow_remote_cache_for_metadata"):
+            dc.get_format(path)
+
+    def test_http_hdf5_fallback_warns_once_and_reuses_cached_local_copy(
+        self, http_regression_das_path, ensure_http_regression_file
+    ):
+        """First local cache materialization should warn, then reuse the artifact."""
+        ensure_http_regression_file("prodml_2.1.h5")
+        path = http_regression_das_path / "prodml_2.1.h5"
+        with set_config(
+            allow_remote_cache_for_metadata=True, warn_on_remote_cache=True
+        ):
+            with pytest.warns(UserWarning, match="Downloading remote file"):
+                assert dc.get_format(path) == ("PRODML", "2.1")
+        cached_files = list(get_remote_cache_path().rglob("prodml_2.1.h5"))
+        assert len(cached_files) <= 1
+        assert dc.read(path)
+        cached_files_2 = list(get_remote_cache_path().rglob("prodml_2.1.h5"))
+        assert len(cached_files_2) == 1
+        assert cached_files_2[0].exists()
+        assert dc.read(path)
+        cached_files_3 = list(get_remote_cache_path().rglob("prodml_2.1.h5"))
+        assert cached_files_3 == cached_files_2
+
+    def test_http_range_server_supports_partial_reads(
+        self, http_range_das_path, ensure_http_fetch_file
+    ):
+        """The ranged HTTP fixture should respond with partial content."""
+        ensure_http_fetch_file("prodml_2.1.h5")
+        url = str(http_range_das_path / "prodml_2.1.h5")
+        request = Request(url, headers={"Range": "bytes=0-15"})
+        with urlopen(request) as response:
+            data = response.read()
+            assert response.status == 206
+            assert response.headers["Accept-Ranges"] == "bytes"
+            assert response.headers["Content-Range"].startswith("bytes 0-15/")
+            assert len(data) == 16
+
+    def test_http_range_hdf5_read_succeeds(
+        self, http_range_das_path, ensure_http_fetch_file
+    ):
+        """Range-capable HTTP servers should support DASCore HDF5 reads."""
+        ensure_http_fetch_file("prodml_2.1.h5")
+        path = http_range_das_path / "prodml_2.1.h5"
+        assert dc.get_format(path) == ("PRODML", "2.1")
+        assert dc.read(path)
+        assert not list(get_remote_cache_path().rglob("prodml_2.1.h5"))
+
+    def test_spool_file_path(self, http_regression_das_path):
+        """A remote HTTP file should still produce a file-backed spool."""
+        path = http_regression_das_path / "nested" / "example_dasdae_event_2.h5"
+        spool = dc.spool(path)
+        assert len(spool) == 1
+        assert spool[0].dims == ("distance", "time")
+
+    def test_spool_directory_rejected(self, http_regression_das_path):
+        """Remote HTTP directories should remain unsupported for spooling."""
+        with pytest.raises(InvalidSpoolError, match="local filesystem"):
+            dc.spool(http_regression_das_path)

--- a/tests/test_io/test_remote_http.py
+++ b/tests/test_io/test_remote_http.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from urllib.request import Request, urlopen
 
 import pytest
@@ -11,6 +10,7 @@ from upath import UPath
 import dascore as dc
 from dascore.config import set_config
 from dascore.exceptions import InvalidSpoolError, RemoteCacheError
+from dascore.utils.misc import suppress_warnings
 from dascore.utils.remote_io import clear_remote_file_cache, get_remote_cache_path
 
 pytestmark = pytest.mark.network
@@ -19,18 +19,15 @@ pytestmark = pytest.mark.network
 @pytest.fixture(autouse=True)
 def suppress_expected_remote_cache_warnings(request):
     """Keep expected remote-cache download warnings out of test output."""
+    # This test is supposed to raise warning.
     if (
         request.node.name
         == "test_http_hdf5_fallback_warns_once_and_reuses_cached_local_copy"
     ):
         yield
         return
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r"Downloading remote file .* to local cache at .*",
-            category=UserWarning,
-        )
+    msg = "Downloading remote file .* to local cache at .*"
+    with suppress_warnings(message=msg):
         yield
 
 
@@ -123,21 +120,23 @@ class TestHTTPFormatAndSpool:
         self, http_regression_das_path, ensure_http_regression_file
     ):
         """First local cache materialization should warn, then reuse the artifact."""
-        ensure_http_regression_file("prodml_2.1.h5")
-        path = http_regression_das_path / "prodml_2.1.h5"
+        fname = "prodml_2.1.h5"
+        ensure_http_regression_file(fname)
+        path = http_regression_das_path / fname
         with set_config(
             allow_remote_cache_for_metadata=True, warn_on_remote_cache=True
         ):
             with pytest.warns(UserWarning, match="Downloading remote file"):
-                assert dc.get_format(path) == ("PRODML", "2.1")
-        cached_files = list(get_remote_cache_path().rglob("prodml_2.1.h5"))
+                dc.get_format(path)
+        cached_files = list(get_remote_cache_path().rglob(fname))
         assert len(cached_files) <= 1
-        assert dc.read(path)
-        cached_files_2 = list(get_remote_cache_path().rglob("prodml_2.1.h5"))
+        assert len(dc.read(path))
+
+        cached_files_2 = list(get_remote_cache_path().rglob(fname))
         assert len(cached_files_2) == 1
         assert cached_files_2[0].exists()
         assert dc.read(path)
-        cached_files_3 = list(get_remote_cache_path().rglob("prodml_2.1.h5"))
+        cached_files_3 = list(get_remote_cache_path().rglob(fname))
         assert cached_files_3 == cached_files_2
 
     def test_http_range_server_supports_partial_reads(

--- a/tests/test_io/test_remote_memory.py
+++ b/tests/test_io/test_remote_memory.py
@@ -1,0 +1,229 @@
+"""Deterministic remote-path tests using an in-memory filesystem."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from upath import UPath
+
+import dascore as dc
+from dascore.config import set_config
+from dascore.exceptions import InvalidSpoolError
+from dascore.utils.downloader import fetch
+from dascore.utils.remote_io import clear_remote_file_cache, get_remote_cache_path
+
+
+def _copy_file_to_memory(source: Path, dest: UPath) -> UPath:
+    """Copy a local file into the in-memory remote filesystem."""
+    with source.open("rb") as src, dest.open("wb") as dst:
+        dst.write(src.read())
+    return dest
+
+
+@pytest.fixture()
+def memory_prodml_path():
+    """Return a remote memory-backed ProdML file path."""
+    source = Path(fetch("prodml_2.1.h5"))
+    dest = UPath("memory://dascore/remote/prodml_2.1.h5")
+    return _copy_file_to_memory(source, dest)
+
+
+@pytest.fixture(autouse=True)
+def isolated_remote_cache(tmp_path):
+    """Use one isolated remote cache per test to avoid cross-test cleanup cost."""
+    with set_config(remote_cache_dir=tmp_path / "remote_cache"):
+        clear_remote_file_cache()
+        yield
+        clear_remote_file_cache()
+
+
+@pytest.fixture()
+def memory_dasdae_path(tmp_path):
+    """Return a remote memory-backed DASDAE file path."""
+    source = tmp_path / "example_dasdae_event_1.h5"
+    dc.write(dc.get_example_patch(), source, "DASDAE")
+    dest = UPath("memory://dascore/remote/example_dasdae_event_1.h5")
+    return _copy_file_to_memory(source, dest)
+
+
+class TestMemoryRemoteRead:
+    """Tests for reading remote files from an in-memory backend."""
+
+    def test_read_prodml(self, memory_prodml_path):
+        """ProdML files should be readable through a remote UPath."""
+        spool = dc.read(memory_prodml_path)
+        assert len(spool) > 0
+        assert spool[0].dims
+
+    def test_read_dasdae(self, memory_dasdae_path):
+        """DASDAE files should be readable through a remote UPath."""
+        spool = dc.read(memory_dasdae_path)
+        assert len(spool) == 1
+        assert spool[0].dims == ("distance", "time")
+
+
+class TestMemoryRemoteWrite:
+    """Tests for writing remote files to an in-memory backend."""
+
+    def test_write_pickle_round_trip(self):
+        """Pickle writes should support remote UPath destinations."""
+        path = UPath("memory://dascore/remote/write_patch.pkl")
+        patch = dc.get_example_patch()
+        dc.write(patch, path, "pickle")
+        assert path.exists()
+        spool = dc.read(path)
+        assert len(spool) == 1
+        assert spool[0].dims == patch.dims
+
+    def test_write_dasdae_round_trip(self):
+        """DASDAE writes should support remote UPath destinations."""
+        path = UPath("memory://dascore/remote/write_patch.h5")
+        patch = dc.get_example_patch()
+        dc.write(patch, path, "DASDAE")
+        assert path.exists()
+        spool = dc.read(path)
+        assert len(spool) == 1
+        assert spool[0].dims == patch.dims
+
+
+class TestMemoryRemoteScan:
+    """Tests for scanning remote files from an in-memory backend."""
+
+    def test_scan_prodml(self, memory_prodml_path):
+        """ProdML files should be scannable through a remote UPath."""
+        attrs = dc.scan(memory_prodml_path)
+        assert len(attrs) > 0
+        assert attrs[0].source_format == "PRODML"
+        assert isinstance(attrs[0].source_path, UPath)
+        assert attrs[0].source_path == memory_prodml_path
+        assert attrs[0].get_coord_summary("time").min is not None
+
+    def test_scan_dasdae(self, memory_dasdae_path):
+        """DASDAE files should be scannable through a remote UPath."""
+        attrs = dc.scan(memory_dasdae_path)
+        assert len(attrs) == 1
+        assert attrs[0].source_format == "DASDAE"
+        assert isinstance(attrs[0].source_path, UPath)
+        assert attrs[0].source_path == memory_dasdae_path
+
+    def test_scan_remote_directory_string_path(self, memory_dasdae_path):
+        """Remote directory strings should recurse via UPath-aware scanning."""
+        root = str(memory_dasdae_path.parent)
+        attrs = dc.scan(root)
+        paths = {str(x.source_path) for x in attrs}
+        assert str(memory_dasdae_path) in paths
+
+    def test_scan_remote_directory_timestamp_warns_once_without_mtime(
+        self, monkeypatch, tmp_path
+    ):
+        """Remote directory scans should warn once when mtime is unavailable."""
+        source = tmp_path / "example_dasdae_event_1.h5"
+        dc.write(dc.get_example_patch(), source, "DASDAE")
+        path = _copy_file_to_memory(
+            source, UPath("memory://dascore/remote_timestamp/example_dasdae_event_1.h5")
+        )
+        root = path.parent
+        upath_type = type(path)
+        original_stat = upath_type.stat
+
+        def _stat(self, *args, **kwargs):
+            if self.name == path.name:
+                raise OSError("mtime unavailable")
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(upath_type, "stat", _stat)
+
+        with pytest.warns(
+            UserWarning, match="does not expose reliable mtime"
+        ) as record:
+            attrs = dc.scan(root, timestamp=0)
+
+        assert len(attrs) == 1
+        assert attrs[0].source_path == path
+        assert len(record) >= 1
+
+    def test_scan_remote_string_path_promotes_to_upath(self, memory_dasdae_path):
+        """Remote URL strings should be preserved as UPath on summaries."""
+        attrs = dc.scan(str(memory_dasdae_path))
+        assert len(attrs) == 1
+        assert isinstance(attrs[0].source_path, UPath)
+        assert attrs[0].source_path == memory_dasdae_path
+
+
+class TestMemoryRemoteSpool:
+    """Tests for spool behavior on remote memory-backed paths."""
+
+    def test_spool_file_path(self, memory_dasdae_path):
+        """A remote file path should still produce a file-backed spool."""
+        spool = dc.spool(memory_dasdae_path)
+        assert len(spool) == 1
+        assert spool[0].dims == ("distance", "time")
+
+    def test_spool_file_string_path(self, memory_dasdae_path):
+        """A remote file URL string should route through UPath handling."""
+        spool = dc.spool(str(memory_dasdae_path))
+        assert len(spool) == 1
+        assert spool[0].dims == ("distance", "time")
+
+    def test_spool_directory_rejected(self):
+        """Remote directories should remain unsupported for directory spools."""
+        root = UPath("memory://dascore/remote_dir")
+        (root / "file.txt").write_text("x")
+        with pytest.raises(InvalidSpoolError, match="local filesystem"):
+            dc.spool(root)
+
+
+class TestMemoryRemoteMetadataAccess:
+    """Tests for remote-first metadata access on in-memory filesystems."""
+
+    @pytest.mark.parametrize(
+        ("fetch_name", "expected"),
+        [
+            ("h5_simple_2.h5", ("H5Simple", "1")),
+            ("sample_tdms_file_v4713.tdms", ("TDMS", "4713")),
+            ("DASDMSShot00_20230328155653619.das", ("sentek", "5")),
+            ("sintela_binary_v3_test_1.raw", ("Sintela_Binary", "3")),
+        ],
+    )
+    def test_get_format_avoids_local_cache(self, fetch_name, expected):
+        """Remote-first get_format paths should not materialize local cache files."""
+        source = Path(fetch(fetch_name))
+        path = _copy_file_to_memory(
+            source, UPath(f"memory://dascore/meta/{source.name}")
+        )
+        assert dc.get_format(path) == expected
+        assert not list(get_remote_cache_path().rglob(source.name))
+
+    @pytest.mark.parametrize(
+        ("fetch_name", "expected"),
+        [
+            ("h5_simple_2.h5", ("H5Simple", "1")),
+            ("sample_tdms_file_v4713.tdms", ("TDMS", "4713")),
+            ("DASDMSShot00_20230328155653619.das", ("sentek", "5")),
+            ("sintela_binary_v3_test_1.raw", ("Sintela_Binary", "3")),
+        ],
+    )
+    def test_scan_avoids_local_cache(self, fetch_name, expected):
+        """Remote-first scans should not materialize local cache files."""
+        source = Path(fetch(fetch_name))
+        path = _copy_file_to_memory(
+            source, UPath(f"memory://dascore/scan/{source.name}")
+        )
+        attrs = dc.scan(path)
+        assert len(attrs) > 0
+        assert attrs[0].source_format == expected[0]
+        assert attrs[0].source_version == expected[1]
+        assert not list(get_remote_cache_path().rglob(source.name))
+
+    def test_dasdae_get_format_avoids_local_cache(self, memory_dasdae_path):
+        """DASDAE format detection should stay remote-first."""
+        assert dc.get_format(memory_dasdae_path) == ("DASDAE", "1")
+        assert not list(get_remote_cache_path().rglob(memory_dasdae_path.name))
+
+    def test_dasdae_scan_avoids_local_cache(self, memory_dasdae_path):
+        """DASDAE scan should not materialize a local cache file."""
+        attrs = dc.scan(memory_dasdae_path)
+        assert len(attrs) == 1
+        assert attrs[0].source_format == "DASDAE"
+        assert not list(get_remote_cache_path().rglob(memory_dasdae_path.name))

--- a/tests/test_io/test_rsf/test_rsf.py
+++ b/tests/test_io/test_rsf/test_rsf.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from upath import UPath
 
 import dascore as dc
 from dascore.io.rsf import RSFV1
@@ -75,3 +76,26 @@ class TestRsfWrite:
         file_esize = dtype.itemsize
         datasize = test_data.size * file_esize
         assert os.path.getsize(newdatapath) == datasize
+
+    def test_write_remote_memory_combined(self, random_patch):
+        """Combined RSF output should support remote UPath destinations."""
+        spool = dc.spool(random_patch)
+        path = UPath("memory://dascore/test_hdrdata_remote.rsf")
+        RSFV1().write(spool, path)
+        assert path.exists()
+        test_data = random_patch.data.astype(np.float32)
+        datasize = test_data.size * np.dtype(test_data.dtype).itemsize
+        assert path.stat().st_size >= datasize
+
+    def test_write_remote_memory_split(self, random_patch):
+        """Split RSF output should support remote UPath destinations."""
+        spool = dc.spool(random_patch)
+        path = UPath("memory://dascore/test_hdr_remote.rsf")
+        datapath = UPath("memory://dascore/binary/test_data_remote.rsf")
+        RSFV1().write(spool, path, data_path=datapath)
+        assert path.exists()
+        newdatapath = UPath(str(datapath) + "@")
+        assert newdatapath.exists()
+        test_data = random_patch.data.astype(np.float32)
+        datasize = test_data.size * np.dtype(test_data.dtype).itemsize
+        assert newdatapath.stat().st_size == datasize

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -80,8 +80,8 @@ class TestTDMSUtils:
         )
         fake = _FakeTDMSFile(lead_in + payload)
         monkeypatch.setattr(
-            tdms_utils.os.path,
-            "getsize",
+            tdms_utils,
+            "get_buffer_size",
             lambda _: len(lead_in + payload),
         )
         monkeypatch.setattr(

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from scipy.io.wavfile import read as read_wav
+from upath import UPath
 
 import dascore as dc
 from dascore.constants import ONE_SECOND
@@ -44,6 +45,18 @@ class TestWriteWav:
         dc.write(audio_patch, path, "wav")
         assert path.exists()
 
+    def test_write_single_local_upath(self, audio_patch, tmp_path_factory):
+        """Local UPath file destinations should work for wav writes."""
+        path = UPath(tmp_path_factory.mktemp("wave_temp_upath") / "temp.wav")
+        dc.write(audio_patch, path, "wav")
+        assert path.exists()
+
+    def test_write_single_remote_upath(self, audio_patch):
+        """Remote UPath file destinations should work for wav writes."""
+        path = UPath("memory://dascore/temp.wav")
+        dc.write(audio_patch, path, "wav")
+        assert path.exists()
+
     def test_resample(self, audio_patch, tmp_path_factory):
         """Ensure resampling changes sampling rate in file."""
         path = tmp_path_factory.mktemp("wav_resample") / "resampled.wav"
@@ -68,3 +81,11 @@ class TestWriteWav:
             # Verify content of first file
             sr, data = read_wav(str(wavs[0]))
         assert sr == int(ONE_SECOND / patch.get_coord("time").step)
+
+    def test_write_remote_directory(self, audio_patch_non_distance_dim):
+        """Remote directory destinations should work for wav writes."""
+        path = UPath("memory://dascore/wav_dir")
+        patch = audio_patch_non_distance_dim
+        patch.io.write(path, "wav")
+        wavs = list(path.glob("*.wav"))
+        assert len(wavs) == len(patch.coords.get_array("microphone"))

--- a/tests/test_io/test_xml_binary/test_xml_binary.py
+++ b/tests/test_io/test_xml_binary/test_xml_binary.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from upath import UPath
 
 import dascore as dc
 from dascore.exceptions import UnknownFiberFormatError
@@ -103,6 +104,16 @@ def directory_bad_xml(tmp_path_factory):
     return new
 
 
+@pytest.fixture(scope="session")
+def remote_binary_xml_directory(binary_xml_directory):
+    """Create an in-memory remote XMLBinary directory."""
+    root = UPath("memory://dascore/xml_binary_remote")
+    root.mkdir(parents=True, exist_ok=True)
+    for path in Path(binary_xml_directory).iterdir():
+        (root / path.name).write_bytes(path.read_bytes())
+    return root
+
+
 class TestReadXMLMetadata:
     """Misc tests reading xml metadata."""
 
@@ -143,6 +154,14 @@ class TestGetFormat:
         raw_path = next(binary_xml_directory.glob("*.raw"))
         assert fiber_io.get_format(raw_path) == (fiber_io.name, fiber_io.version)
 
+    def test_remote_directory_upath(self, remote_binary_xml_directory):
+        """Remote UPath directories should be format-detectable."""
+        fiber_io = XMLBinaryV1()
+        assert fiber_io.get_format(remote_binary_xml_directory) == (
+            fiber_io.name,
+            fiber_io.version,
+        )
+
 
 class TestScanContents:
     """Test scanning contents of xml binary directory."""
@@ -171,6 +190,24 @@ class TestScanContents:
         assert not len(scan2)
         scan3 = dc.scan(binary_xml_directory, timestamp=mtime - 50)
         assert len(scan3) == 2
+
+    def test_remote_directory(self, remote_binary_xml_directory):
+        """Remote XMLBinary directories should be scannable."""
+        fiber = XMLBinaryV1()
+        out = fiber.scan(remote_binary_xml_directory)
+        assert len(out) == 2
+
+    def test_remote_directory_timestamp(self, remote_binary_xml_directory):
+        """Timestamp-filtered remote directory scans should not crash."""
+        out = dc.scan(remote_binary_xml_directory, timestamp=0)
+        assert len(out) == 2
+
+    def test_remote_file_path_uses_parent_directory(self, remote_binary_xml_directory):
+        """Remote raw file scans should resolve metadata from the parent dir."""
+        fiber = XMLBinaryV1()
+        raw_path = next(remote_binary_xml_directory.glob("*.raw"))
+        out = fiber.scan(raw_path)
+        assert len(out) == 2
 
 
 class TestRead:
@@ -227,3 +264,18 @@ class TestRead:
         path = Path(xml_directory_no_data)
         out = fiberio.read(path)
         assert not len(out)
+
+    def test_read_remote_directory(self, remote_binary_xml_directory):
+        """Remote XMLBinary directories should read into patches."""
+        fiber_io = XMLBinaryV1()
+        spool = fiber_io.read(remote_binary_xml_directory)
+        assert len(spool) == 2
+        assert all(isinstance(patch, dc.Patch) for patch in spool)
+
+    def test_read_remote_single_file(self, remote_binary_xml_directory):
+        """Remote raw-file inputs should resolve and read through the parent dir."""
+        fiber_io = XMLBinaryV1()
+        path = next(remote_binary_xml_directory.glob("*.raw"))
+        out = fiber_io.read(path)
+        assert isinstance(out, dc.BaseSpool)
+        assert len(out) == 1

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -1,0 +1,65 @@
+"""Tests for runtime configuration helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from dascore.config import (
+    DascoreConfig,
+    config_attr,
+    get_config,
+    reset_config,
+    set_config,
+)
+
+
+class TestSetConfig:
+    """Tests for updating runtime configuration."""
+
+    def teardown_method(self):
+        """Reset global config after each test."""
+        reset_config()
+
+    def test_accepts_direct_config_instance(self):
+        """Passing a validated config should install it."""
+        previous = get_config()
+        new = DascoreConfig(debug=True)
+        with set_config(new):
+            assert get_config().debug is True
+        assert get_config() == previous
+
+    def test_invalid_new_config_raises(self):
+        """Arbitrary objects should not be accepted as configs."""
+        with pytest.raises(TypeError, match="DascoreConfig"):
+            set_config(object())
+
+    def test_new_config_and_kwargs_raise(self):
+        """Direct config replacement should not mix with overrides."""
+        with pytest.raises(ValueError, match="new_config"):
+            set_config(DascoreConfig(), debug=True)
+
+    def test_remote_cache_controls_can_be_overridden(self):
+        """Remote cache policy config should round-trip through set_config."""
+        previous = get_config()
+        with set_config(
+            allow_remote_cache=False,
+            allow_remote_cache_for_metadata=True,
+            warn_on_remote_cache=False,
+            allow_dasdae_format_unpickle=True,
+        ):
+            config = get_config()
+            assert config.allow_remote_cache is False
+            assert config.allow_remote_cache_for_metadata is True
+            assert config.warn_on_remote_cache is False
+            assert config.allow_dasdae_format_unpickle is True
+        assert get_config() == previous
+
+    def test_config_attr_reflects_runtime_config(self):
+        """Config descriptors should resolve against the active runtime config."""
+
+        class _UsesConfig:
+            value = config_attr("display_float_precision")
+
+        assert _UsesConfig().value == get_config().display_float_precision
+        with set_config(display_float_precision=7):
+            assert _UsesConfig().value == 7

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -6,7 +6,9 @@ import numpy as np
 import pandas as pd
 
 import dascore as dc
-from dascore.utils.display import get_nice_text
+from dascore.config import set_config
+from dascore.utils.display import array_to_text, get_nice_text
+from dascore.utils.patch import _format_values
 
 
 class TestGetNiceText:
@@ -36,3 +38,30 @@ class TestGetNiceText:
         ts = pd.Timestamp("2012-01-10")
         txt = get_nice_text(ts)
         assert str(txt) == "2012-01-10"
+
+    def test_float_precision_config(self):
+        """Float display precision should come from runtime config."""
+        with set_config(display_float_precision=1):
+            txt = get_nice_text(1.234)
+        assert str(txt) == "1.2"
+
+
+class TestArrayFormatting:
+    """Tests for config-backed array formatting behavior."""
+
+    def test_array_threshold_config(self):
+        """Array display truncation threshold should be configurable."""
+        data = np.arange(10)
+        with set_config(display_array_threshold=3):
+            txt = array_to_text(data)
+        assert "..." in str(txt)
+
+    def test_patch_history_threshold_config(self):
+        """Patch history formatting should use the configured threshold."""
+        data = np.arange(10)
+        with set_config(
+            display_float_precision=0,
+            display_patch_history_array_threshold=3,
+        ):
+            out = _format_values(data)
+        assert "..." in out

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import textwrap
 
 import pandas as pd
+import pytest
 
 from dascore.core.attrs import PatchAttrs
 from dascore.examples import EXAMPLE_PATCHES
@@ -77,6 +78,26 @@ class TestDocsting:
         white_space_counts = [self.count_white_space(x) for x in list_lines]
         # all whitespace counts should be the same for the list lines.
         assert len(set(white_space_counts)) == 1
+
+    def test_raises_when_no_placeholders_are_replaced(self):
+        """Unused substitutions should fail if nothing in the docstring matches."""
+        with pytest.raises(ValueError, match="did not replace any placeholders"):
+
+            @compose_docstring(params="value")
+            def dummy_func():
+                """A docstring with no replacement slots."""
+
+    def test_raises_when_some_placeholders_are_unused(self):
+        """Providing extra substitution keys should fail loudly."""
+        with pytest.raises(ValueError, match="unused keys.*extra"):
+
+            @compose_docstring(params="value", extra="not-used")
+            def dummy_func():
+                """
+                A docstring with one replacement slot.
+
+                {params}
+                """
 
 
 class TestGetPluginTable:

--- a/tests/test_utils/test_downloader.py
+++ b/tests/test_utils/test_downloader.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+from dascore.config import set_config
 from dascore.constants import DATA_VERSION
 from dascore.utils.downloader import (
+    LARGE_REGISTRY_FILES,
     REGISTRY_PATH,
+    _fetch_cached,
     fetch,
     fetcher,
+    get_fetcher,
     get_registry_df,
     get_test_data_cache_info,
 )
@@ -30,6 +34,14 @@ class TestRegistryDF:
         assert len(registry_df)
         assert isinstance(registry_df, pd.DataFrame)
 
+    def test_exclude_large_filters_large_entries(self):
+        """Large registry files should be excluded only when requested."""
+        all_df = get_registry_df()
+        filtered_df = get_registry_df(exclude_large=True)
+
+        assert LARGE_REGISTRY_FILES <= set(all_df["name"])
+        assert not (LARGE_REGISTRY_FILES & set(filtered_df["name"]))
+
 
 class TestFetch:
     """Tests for fetching filepaths of test files."""
@@ -43,6 +55,31 @@ class TestFetch:
         """Ensure an existing file just returns."""
         path = fetch(registry_df["name"].iloc[0])
         assert fetch(path) == path
+
+    def test_fetcher_path_comes_from_config(self, tmp_path):
+        """Downloader fetchers should honor the configured cache directory."""
+        cache_dir = tmp_path / "downloads"
+        with set_config(downloader_cache_dir=cache_dir):
+            active_fetcher = get_fetcher()
+            assert fetcher.path == active_fetcher.path
+            assert active_fetcher.path.parent == cache_dir
+
+    def test_fetch_cached_fetches_by_name_and_cache_dir(self, monkeypatch, tmp_path):
+        """The cached fetch wrapper should call pooch with the requested name."""
+
+        class _Fetcher:
+            def fetch(self, name):
+                assert name == "example.dat"
+                return tmp_path / name
+
+        monkeypatch.setattr(
+            "dascore.utils.downloader._get_fetcher",
+            lambda _cache_dir: _Fetcher(),
+        )
+
+        out = _fetch_cached(name="example.dat", cache_dir=str(tmp_path))
+
+        assert out == tmp_path / "example.dat"
 
 
 class TestTestDataCacheInfo:
@@ -64,3 +101,10 @@ class TestTestDataCacheInfo:
         out = info.get_key(runner_os="Linux", cache_number=7)
 
         assert out == f"data-Linux-{DATA_VERSION}-{info.registry_hash}-7"
+
+    def test_cache_info_respects_configured_cache_dir(self, tmp_path):
+        """Cache info should reflect the configured downloader cache root."""
+        cache_dir = tmp_path / "downloads"
+        with set_config(downloader_cache_dir=cache_dir):
+            info = get_test_data_cache_info()
+        assert info.cache_path == cache_dir

--- a/tests/test_utils/test_hdf_utils.py
+++ b/tests/test_utils/test_hdf_utils.py
@@ -12,10 +12,12 @@ import tables
 from tables.exceptions import ClosedNodeError
 
 import dascore as dc
+from dascore.config import set_config
 from dascore.exceptions import InvalidFileHandlerError
 from dascore.utils.downloader import fetch
 from dascore.utils.hdf5 import (
     HDFPatchIndexManager,
+    LocalPyTablesReader,
     PyTablesWriter,
     extract_h5_attrs,
     h5_matches_structure,
@@ -150,10 +152,9 @@ class TestHDFPatchIndexManager:
 
         # now insure the exception propagates
         failed_count = 0
-        monkeypatch.setattr(index_manager_with_content, "_max_retries", -1)
-
-        with pytest.raises(ClosedNodeError):
-            index_manager_with_content.get_index()
+        with set_config(hdf_index_max_retries=0):
+            with pytest.raises(ClosedNodeError):
+                index_manager_with_content.get_index()
 
     def test_metadata_created(self, tmp_path_factory):
         """Tests for getting info from a index that doesnt yet exist."""
@@ -173,6 +174,13 @@ class TestHDFPatchIndexManager:
         out = index_manager.encode_table(df.copy(), path=None)
         assert "path" in out.columns
 
+    def test_hdf_kwargs_come_from_config(self, index_manager):
+        """Compression defaults should come from runtime configuration."""
+        with set_config(hdf_index_complib="zlib", hdf_index_complevel=1):
+            out = index_manager.hdf_kwargs
+        assert out["complib"] == "zlib"
+        assert out["complevel"] == 1
+
 
 class TestHDFReaders:
     """Tests for HDF5 readers."""
@@ -184,6 +192,14 @@ class TestHDFReaders:
             assert isinstance(handle, tables.File)
             handle_2 = PyTablesWriter.get_handle(handle)
             assert isinstance(handle_2, tables.File)
+
+    def test_local_pytables_reader_get_handle(self, tmp_path):
+        """The local-materializing reader should open local files directly."""
+        path = tmp_path / "local_reader.h5"
+        with tables.open_file(path, mode="w") as h5:
+            h5.create_group("/", "waveforms")
+        with closing(LocalPyTablesReader.get_handle(path)) as handle:
+            assert isinstance(handle, tables.File)
 
 
 class TestH5MatchesStructure:

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from contextlib import closing
 from io import BufferedReader, BufferedWriter, BytesIO, StringIO, TextIOBase
 from pathlib import Path
@@ -33,6 +32,7 @@ from dascore.utils.io import (
     ensure_local_file,
     get_handle_from_resource,
 )
+from dascore.utils.misc import suppress_warnings
 from dascore.utils.remote_io import (
     FallbackFileObj,
     clear_remote_file_cache,
@@ -620,8 +620,7 @@ class TestIOResourceManager:
         with set_config(warn_on_remote_cache=True):
             with pytest.warns(UserWarning, match="Downloading remote file"):
                 first = ensure_local_file(path)
-            with warnings.catch_warnings(record=True) as record:
-                warnings.simplefilter("always")
+            with suppress_warnings(action="always", record=True) as record:
                 second = ensure_local_file(path)
         assert not record
         assert first == second
@@ -631,8 +630,7 @@ class TestIOResourceManager:
         path = UPath("memory://dascore/io_resource_test_warn_off.txt")
         path.write_text("hello")
         with set_config(warn_on_remote_cache=False):
-            with warnings.catch_warnings(record=True) as record:
-                warnings.simplefilter("always")
+            with suppress_warnings(action="always", record=True) as record:
                 local_path = ensure_local_file(path)
         assert not record
         assert local_path.exists()

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -2,22 +2,44 @@
 
 from __future__ import annotations
 
+import warnings
 from contextlib import closing
 from io import BufferedReader, BufferedWriter, BytesIO, StringIO, TextIOBase
 from pathlib import Path
 
+import h5py
 import pytest
 from tables import File
+from upath import UPath
 
 import dascore as dc
-from dascore.exceptions import PatchConversionError
-from dascore.utils.hdf5 import HDF5Reader, HDF5Writer
+import dascore.utils.remote_io as remote_io
+from dascore.config import set_config
+from dascore.exceptions import PatchConversionError, RemoteCacheError
+from dascore.utils.hdf5 import (
+    H5Reader,
+    H5Writer,
+    HDF5Reader,
+    HDF5Writer,
+    LocalH5Reader,
+)
 from dascore.utils.io import (
     BinaryReader,
     BinaryWriter,
     IOResourceManager,
+    LocalBinaryReader,
+    LocalPath,
     TextReader,
+    ensure_local_file,
     get_handle_from_resource,
+)
+from dascore.utils.remote_io import (
+    FallbackFileObj,
+    clear_remote_file_cache,
+    get_remote_cache_path,
+    get_remote_cache_scope,
+    is_no_range_http_error,
+    remote_cache_scope,
 )
 
 
@@ -25,8 +47,59 @@ class _BadType:
     """A dummy type for testing."""
 
 
-def _dummy_func(arg: str, arg2: _BadType) -> int:
+def _dummy_func(arg: Path, arg2: _BadType) -> int:
     """A dummy function."""
+
+
+class _FailOnSeek(BytesIO):
+    """A test handle which raises once on seek."""
+
+    def __init__(self, data: bytes, exc: Exception):
+        super().__init__(data)
+        self._exc = exc
+        self.triggered = False
+
+    def seek(self, offset, whence=0):
+        """Raise once, then defer to BytesIO."""
+        if not self.triggered:
+            self.triggered = True
+            raise self._exc
+        return super().seek(offset, whence)
+
+
+class _NoTellHandle(BytesIO):
+    """A test handle whose tell method fails."""
+
+    def tell(self):
+        """Raise to exercise fallback position tracking."""
+        raise OSError("tell failed")
+
+
+class _PlainHandle:
+    """A simple handle without writable/flush helpers."""
+
+    def __init__(self):
+        self.closed = False
+        self.extra_attr = "value"
+
+    def read(self, _size=-1):
+        return b""
+
+    def seek(self, offset, _whence=0):
+        return offset
+
+    def tell(self):
+        return 0
+
+    def close(self):
+        self.closed = True
+
+
+class _WritableHandle(_PlainHandle):
+    """A handle exposing a writable method."""
+
+    def writable(self):
+        return True
 
 
 class TestGetHandleFromResource:
@@ -88,9 +161,15 @@ class TestGetHandleFromResource:
         assert isinstance(path, Path)
 
     def test_get_str(self, tmp_path):
-        """Ensure we can get a string."""
-        my_str = get_handle_from_resource(tmp_path, str)
-        assert isinstance(my_str, str)
+        """Unsupported string targets should keep richer path objects."""
+        out = get_handle_from_resource(tmp_path, str)
+        assert isinstance(out, Path)
+        assert out == tmp_path
+
+    def test_get_upath(self, tmp_path):
+        """Ensure we can get a UPath."""
+        path = get_handle_from_resource(tmp_path, UPath)
+        assert isinstance(path, UPath)
 
     def test_already_file_handle(self, tmp_path):
         """Ensure an input that is already the requested type works."""
@@ -98,6 +177,159 @@ class TestGetHandleFromResource:
         with open(path, "wb") as fi:
             out = get_handle_from_resource(fi, BinaryWriter)
             assert out is fi
+
+    def test_binary_reader_from_upath(self, tmp_path):
+        """Ensure binary readers can open UPath resources directly."""
+        path = UPath(tmp_path / "upath.bin")
+        path.write_bytes(b"abc")
+        with closing(get_handle_from_resource(path, BinaryReader)) as handle:
+            assert handle.read() == b"abc"
+
+    def test_binary_reader_resets_buffered_stream(self):
+        """Ensure BinaryReader resets offsets on binary streams."""
+        resource = BytesIO(b"abc")
+        _ = resource.read(1)
+        out = BinaryReader.get_handle(resource)
+        assert out is resource
+        assert out.tell() == 0
+        assert out.read(1) == b"a"
+
+    def test_text_reader_from_upath(self, tmp_path):
+        """Ensure text readers can open UPath resources directly."""
+        path = UPath(tmp_path / "upath.txt")
+        path.write_text("abc")
+        with closing(get_handle_from_resource(path, TextReader)) as handle:
+            assert handle.read() == "abc"
+
+    def test_binary_writer_to_remote_upath(self):
+        """Binary writers should create remote UPath files."""
+        path = UPath("memory://dascore/upath-write.bin")
+        with closing(get_handle_from_resource(path, BinaryWriter)) as handle:
+            handle.write(b"abc")
+        assert path.read_bytes() == b"abc"
+
+    def test_local_binary_reader_passthrough_resets_offset(self):
+        """Ensure LocalBinaryReader preserves passthrough stream behavior."""
+        resource = BytesIO(b"abc")
+        _ = resource.read(1)
+        out = LocalBinaryReader.get_handle(resource)
+        assert out is resource
+        assert out.tell() == 0
+
+    def test_h5_reader_from_open_file_handle(self, tmp_path):
+        """Ensure h5py-backed readers support open file handles."""
+        path = tmp_path / "handle.h5"
+        with h5py.File(path, "w") as handle:
+            handle.create_dataset("data", data=[1, 2, 3])
+        with open(path, "rb") as raw:
+            handle = H5Reader.get_handle(raw)
+            try:
+                assert list(handle["data"][:]) == [1, 2, 3]
+            finally:
+                handle.close()
+
+    def test_h5_reader_passthrough_h5py_handle(self, tmp_path):
+        """Ensure h5py-backed readers return open handles unchanged."""
+        path = tmp_path / "passthrough.h5"
+        with h5py.File(path, "w") as handle:
+            handle.create_dataset("data", data=[1, 2, 3])
+        with h5py.File(path, "r") as raw:
+            assert H5Reader.get_handle(raw) is raw
+
+    def test_local_h5_reader_materializes_local_path(self, tmp_path):
+        """Ensure LocalH5Reader can open a local path through its adapter."""
+        path = tmp_path / "local_h5_reader.h5"
+        with h5py.File(path, "w") as handle:
+            handle.create_dataset("data", data=[1, 2, 3])
+        handle = LocalH5Reader.get_handle(path)
+        try:
+            assert list(handle["data"][:]) == [1, 2, 3]
+        finally:
+            handle.close()
+
+    def test_h5_reader_closes_upath_handle_on_constructor_error(
+        self, tmp_path, monkeypatch
+    ):
+        """Ensure constructor failures close UPath-opened file handles."""
+
+        class _DummyHandle:
+            closed = False
+
+            def close(self):
+                self.closed = True
+
+        handle = _DummyHandle()
+        path = UPath(tmp_path / "error.h5")
+        path.write_bytes(b"not an hdf5")
+        monkeypatch.setattr(type(path), "open", lambda self, *args, **kwargs: handle)
+        monkeypatch.setattr(
+            H5Reader,
+            "constructor",
+            staticmethod(
+                lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
+            ),
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            H5Reader.get_handle(path)
+        assert handle.closed
+
+    def test_h5_reader_uses_small_blocks_for_s3_upath(self, monkeypatch):
+        """S3-backed HDF5 readers should override s3fs's large default block."""
+
+        class _DummyHandle:
+            closed = False
+
+            def close(self):
+                self.closed = True
+
+        opened = {}
+        handle = _DummyHandle()
+        path = UPath("s3://example-bucket/example.h5", anon=True)
+
+        def _open(_self, _mode, **kwargs):
+            opened.update(kwargs)
+            return handle
+
+        monkeypatch.setattr(type(path), "open", _open)
+        monkeypatch.setattr(
+            H5Reader,
+            "constructor",
+            staticmethod(lambda *args, **kwargs: object()),
+        )
+        with set_config(remote_hdf5_block_size=1234):
+            H5Reader.get_handle(path)
+        assert opened["block_size"] == 1234
+        assert opened["cache_type"] == "readahead"
+
+    def test_h5_writer_to_remote_upath(self):
+        """HDF5 writers should create remote UPath files via write-back."""
+        path = UPath("memory://dascore/upath-write.h5")
+        handle = H5Writer.get_handle(path)
+        try:
+            handle.create_dataset("data", data=[1, 2, 3])
+        finally:
+            handle.close()
+        with path.open("rb") as raw:
+            with h5py.File(raw, "r", driver="fileobj") as reopened:
+                assert list(reopened["data"][:]) == [1, 2, 3]
+
+    def test_h5_writer_to_remote_upath_aborts_on_context_error(self):
+        """Remote HDF5 writers should not upload partial files on exceptions."""
+        path = UPath("memory://dascore/upath-write-abort.h5")
+        with pytest.raises(RuntimeError, match="boom"):
+            with H5Writer.get_handle(path) as handle:
+                handle.create_dataset("data", data=[1, 2, 3])
+                raise RuntimeError("boom")
+        assert not path.exists()
+
+    def test_h5_writer_remote_abort_is_idempotent(self):
+        """Remote writer aborts should be safe to call more than once."""
+        path = UPath("memory://dascore/upath-write-abort-twice.h5")
+        handle = H5Writer.get_handle(path)
+        handle.create_dataset("data", data=[1, 2, 3])
+        handle._abort()
+        handle._abort()
+        assert not path.exists()
 
     def test_not_implemented(self):
         """Tests for raising not implemented errors for types not supported."""
@@ -115,13 +347,21 @@ class TestGetHandleFromResource:
 class TestIOResourceManager:
     """Tests for the IO resource manager."""
 
+    @pytest.fixture(autouse=True)
+    def clear_remote_cache(self):
+        """Ensure remote cache state doesn't leak between tests."""
+        with set_config(warn_on_remote_cache=False):
+            clear_remote_file_cache()
+            yield
+            clear_remote_file_cache()
+
     def test_basic_context_manager(self, tmp_path):
         """Ensure it works as a context manager."""
         write_path = tmp_path / "io_writer"
 
         with IOResourceManager(write_path) as man:
-            my_str = man.get_resource(_dummy_func)
-            assert isinstance(my_str, str)
+            path_from_hint = man.get_resource(_dummy_func)
+            assert isinstance(path_from_hint, Path)
             path = man.get_resource(Path)
             assert isinstance(path, Path)
             hf = man.get_resource(HDF5Writer)
@@ -132,6 +372,19 @@ class TestIOResourceManager:
         # after the context manager exists everything should be closed.
         assert not hf.isopen
         assert fi.closed
+
+    def test_get_none_resource_returns_source(self):
+        """Requesting no specific resource should return the original source."""
+        source = object()
+        with IOResourceManager(source) as man:
+            assert man.get_resource(None) is source
+
+    def test_non_pathlike_resource_passthrough(self):
+        """Non-pathlike resources should bypass path coercion entirely."""
+        source = BytesIO(b"abc")
+        with IOResourceManager(source) as man:
+            out = man.get_resource(BinaryReader)
+            assert out is source
 
     def test_nested_context(self, tmp_path):
         """Ensure nested context works as well."""
@@ -157,6 +410,458 @@ class TestIOResourceManager:
                 raise ValueError("Waaagh!")
         except ValueError:
             assert fi.closed
+
+    def test_remote_path_is_materialized_in_cache(self):
+        """Remote resources that need local paths should be cache-backed."""
+        path = UPath("memory://dascore/io_resource_test.txt")
+        path.write_text("hello")
+        with IOResourceManager(path) as man:
+            local_path = man.get_resource(Path)
+            assert isinstance(local_path, Path)
+            assert local_path.exists()
+            assert local_path.read_text() == "hello"
+        assert local_path.exists()
+        assert get_remote_cache_path() in local_path.parents
+
+    def test_remote_cache_dir_comes_from_config(self, tmp_path):
+        """Configured remote cache directories should be used for materialization."""
+        path = UPath("memory://dascore/io_resource_test_custom_cache.txt")
+        path.write_text("hello")
+        cache_dir = tmp_path / "remote-cache"
+        with set_config(remote_cache_dir=cache_dir):
+            local_path = ensure_local_file(path)
+        assert cache_dir in local_path.parents
+        assert local_path.exists()
+
+    def test_remote_path_can_return_upath(self):
+        """Remote resources should be returned unchanged for UPath consumers."""
+        path = UPath("memory://dascore/io_resource_test_upath.txt")
+        path.write_text("hello")
+        with IOResourceManager(path) as man:
+            out = man.get_resource(UPath)
+            assert isinstance(out, UPath)
+            assert out == path
+
+    def test_remote_path_as_string_preserves_remote_identity(self):
+        """Remote string requests should preserve remote identity without caching."""
+        path = UPath("memory://dascore/io_resource_test_str.txt")
+        path.write_text("hello")
+        with IOResourceManager(path) as man:
+            out = man.get_resource(str)
+            assert isinstance(out, UPath)
+            assert out == path
+        assert not list(get_remote_cache_path().rglob(path.name))
+
+    def test_remote_path_to_binary_reader(self):
+        """Binary readers should consume remote resources directly when possible."""
+        path = UPath("memory://dascore/io_resource_test_binary.bin")
+        path.write_bytes(b"abc")
+        with IOResourceManager(path) as man:
+            out = man.get_resource(BinaryReader)
+            assert out.read() == b"abc"
+
+    def test_remote_path_to_local_binary_reader(self):
+        """Local binary readers should materialize remote resources once."""
+        path = UPath("memory://dascore/io_resource_test_local_binary.bin")
+        path.write_bytes(b"abc")
+        with IOResourceManager(path) as man:
+            out = man.get_resource(LocalBinaryReader)
+            assert out.read() == b"abc"
+        cached_files = list(
+            get_remote_cache_path().rglob("io_resource_test_local_binary.bin")
+        )
+        assert len(cached_files) == 1
+
+    def test_remote_path_to_local_path(self):
+        """LocalPath should return a cache-backed local path."""
+        path = UPath("memory://dascore/io_resource_test_local_path.bin")
+        path.write_text("hello")
+        with IOResourceManager(path) as man:
+            out = man.get_resource(LocalPath)
+            assert isinstance(out, Path)
+            assert out.exists()
+            assert out.read_text() == "hello"
+
+    def test_remote_path_reuses_cached_local_file(self):
+        """Repeated materialization of one remote file should reuse the cache entry."""
+        path = UPath("memory://dascore/io_resource_test_reuse.txt")
+        path.write_text("hello")
+        with IOResourceManager(path) as man:
+            first = man.get_resource(Path)
+        with IOResourceManager(path) as man:
+            second = man.get_resource(Path)
+        assert first == second
+        assert first.exists()
+
+    def test_clear_remote_cache_removes_cached_files(self):
+        """Clearing the remote cache should remove cached local artifacts."""
+        path = UPath("memory://dascore/io_resource_test_clear.txt")
+        path.write_text("hello")
+        with IOResourceManager(path) as man:
+            local_path = man.get_resource(Path)
+            assert local_path.exists()
+        clear_remote_file_cache()
+        assert not local_path.exists()
+
+    def test_ensure_local_file_reuses_cached_path(self):
+        """Repeated ensure_local_file calls should return one stable local path."""
+        path = UPath("memory://dascore/io_resource_test_ensure.txt")
+        path.write_text("hello")
+        first = ensure_local_file(path)
+        second = ensure_local_file(path)
+        assert first == second
+        assert first.exists()
+        assert first.read_text() == "hello"
+
+    def test_ensure_local_file_respects_cache_dir_changes(self, tmp_path):
+        """Changing the configured cache dir should change future materialization."""
+        path = UPath("memory://dascore/io_resource_test_reconfigure.txt")
+        path.write_text("hello")
+        first_cache = tmp_path / "remote-cache-a"
+        second_cache = tmp_path / "remote-cache-b"
+
+        with set_config(remote_cache_dir=first_cache):
+            first = ensure_local_file(path)
+        with set_config(remote_cache_dir=second_cache):
+            second = ensure_local_file(path)
+
+        assert first_cache in first.parents
+        assert second_cache in second.parents
+        assert first != second
+        assert first.exists()
+        assert second.exists()
+        assert first.read_text() == "hello"
+        assert second.read_text() == "hello"
+
+    def test_ensure_local_file_preserves_upath_storage_options(self, monkeypatch):
+        """Remote cache materialization should keep UPath storage options intact."""
+        path = UPath(
+            "s3://gdr-data-lake/soda_lake/raw_seismic/2010/v1.0.0/F1000R1.SGY",
+            anon=True,
+        )
+        seen = {}
+
+        def _fake_download(resource, local_path):
+            seen["storage_options"] = dict(resource.storage_options)
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            local_path.write_bytes(b"abc")
+
+        monkeypatch.setattr(remote_io, "_download_remote_file", _fake_download)
+        local_path = ensure_local_file(path)
+        assert local_path.exists()
+        assert local_path.read_bytes() == b"abc"
+        assert seen["storage_options"] == {"anon": True}
+
+    def test_remote_download_uses_configured_block_size(self, monkeypatch):
+        """Remote file materialization should honor configured read chunk size."""
+
+        class _RemoteHandle:
+            def __init__(self):
+                self.read_sizes = []
+
+            def read(self, size=-1):
+                self.read_sizes.append(size)
+                return b"a" if len(self.read_sizes) == 1 else b""
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        handle = _RemoteHandle()
+        path = UPath("memory://dascore/io_resource_test_block_size.bin")
+        monkeypatch.setattr(type(path), "open", lambda *_args, **_kwargs: handle)
+
+        with set_config(remote_download_block_size=321):
+            local_path = ensure_local_file(path)
+
+        assert local_path.exists()
+        assert local_path.read_bytes() == b"a"
+        assert handle.read_sizes == [321, 321]
+
+    def test_ensure_local_file_can_unwrap_io_resource_manager(self):
+        """ensure_local_file should accept IOResourceManager instances."""
+        path = UPath("memory://dascore/io_resource_test_manager.txt")
+        path.write_text("hello")
+        with IOResourceManager(path) as man:
+            local_path = ensure_local_file(man)
+        assert local_path.exists()
+        assert local_path.read_text() == "hello"
+
+    def test_ensure_local_file_uses_local_named_resource(self, tmp_path):
+        """Local named resources should resolve to their local file path."""
+        path = tmp_path / "named_resource.txt"
+        path.write_text("hello")
+        with path.open() as handle:
+            assert ensure_local_file(handle) == path
+
+    def test_ensure_local_file_invalid_resource_raises(self):
+        """Objects without local or remote path semantics should fail."""
+        with pytest.raises(TypeError, match="Cannot ensure a local file"):
+            ensure_local_file(object())
+
+    def test_ensure_local_file_warns_on_first_remote_download(self):
+        """First-time remote cache materialization should warn."""
+        path = UPath("memory://dascore/io_resource_test_warn.txt")
+        path.write_text("hello")
+        with set_config(warn_on_remote_cache=True):
+            with pytest.warns(
+                UserWarning,
+                match=r"Downloading remote file memory://\.\.\./io_resource_test_warn\.txt",
+            ):
+                local_path = ensure_local_file(path)
+        assert local_path.exists()
+
+    def test_ensure_local_file_reuse_is_silent_after_first_download(self):
+        """Cache hits should not warn after a remote file is already cached."""
+        path = UPath("memory://dascore/io_resource_test_warn_reuse.txt")
+        path.write_text("hello")
+        with set_config(warn_on_remote_cache=True):
+            with pytest.warns(UserWarning, match="Downloading remote file"):
+                first = ensure_local_file(path)
+            with warnings.catch_warnings(record=True) as record:
+                warnings.simplefilter("always")
+                second = ensure_local_file(path)
+        assert not record
+        assert first == second
+
+    def test_ensure_local_file_warning_can_be_disabled(self):
+        """Configured warning suppression should keep downloads silent."""
+        path = UPath("memory://dascore/io_resource_test_warn_off.txt")
+        path.write_text("hello")
+        with set_config(warn_on_remote_cache=False):
+            with warnings.catch_warnings(record=True) as record:
+                warnings.simplefilter("always")
+                local_path = ensure_local_file(path)
+        assert not record
+        assert local_path.exists()
+
+    def test_remote_warning_redacts_multi_protocol_names(self, monkeypatch):
+        """Warning messages should redact tuple/list-style protocol values."""
+
+        class _Resource:
+            protocol = ("zip", "s3")
+            name = "archive.h5"
+            suffix = ".h5"
+
+        monkeypatch.setattr(remote_io, "coerce_to_upath", lambda resource: resource)
+        out = remote_io._redact_remote_resource(_Resource())
+        assert out == "zip+s3://.../archive.h5"
+
+    def test_ensure_local_file_raises_when_remote_cache_disabled(self):
+        """Disabling remote caching should block local materialization."""
+        path = UPath("memory://dascore/io_resource_test_disabled.txt")
+        path.write_text("hello")
+        with set_config(allow_remote_cache=False):
+            with pytest.raises(RemoteCacheError, match="Remote caching is disabled"):
+                ensure_local_file(path)
+        assert not list(get_remote_cache_path().rglob(path.name))
+
+    def test_metadata_scope_raises_when_metadata_cache_disabled(self):
+        """Metadata scope should reject downloads unless explicitly enabled."""
+        path = UPath("memory://dascore/io_resource_test_metadata_disabled.txt")
+        path.write_text("hello")
+        with remote_cache_scope("metadata"):
+            with pytest.raises(
+                RemoteCacheError, match="allow_remote_cache_for_metadata"
+            ):
+                ensure_local_file(path)
+        assert not list(get_remote_cache_path().rglob(path.name))
+
+    def test_metadata_scope_allows_download_when_enabled(self):
+        """Metadata scope should permit downloads when opted in."""
+        path = UPath("memory://dascore/io_resource_test_metadata_enabled.txt")
+        path.write_text("hello")
+        with set_config(
+            allow_remote_cache_for_metadata=True, warn_on_remote_cache=False
+        ):
+            with remote_cache_scope("metadata"):
+                local_path = ensure_local_file(path)
+        assert local_path.exists()
+
+    def test_read_scope_overrides_metadata_default(self):
+        """Read scope should still allow downloads with default metadata policy."""
+        path = UPath("memory://dascore/io_resource_test_read_scope.txt")
+        path.write_text("hello")
+        with remote_cache_scope("read"):
+            assert get_remote_cache_scope() == "read"
+            local_path = ensure_local_file(path)
+        assert local_path.exists()
+
+
+class TestRemoteIOFallback:
+    """Tests for remote fallback helpers."""
+
+    def test_no_range_error_predicate_matches_expected_message(self):
+        """The helper should only match the known no-range HTTP failure."""
+        exc = ValueError(
+            "The HTTP server doesn't appear to support range requests. "
+            "Only reading this file from the beginning is supported."
+        )
+        assert is_no_range_http_error(exc)
+        assert not is_no_range_http_error(ValueError("different error"))
+        assert not is_no_range_http_error(RuntimeError("range requests"))
+
+    def test_fallback_file_obj_switches_once_and_preserves_position(self):
+        """FallbackFileObj should retry on the local file and preserve cursor."""
+        remote = _FailOnSeek(
+            b"abcdef",
+            ValueError(
+                "The HTTP server doesn't appear to support range requests. "
+                "Only reading this file from the beginning is supported."
+            ),
+        )
+        local_handles = []
+
+        def _open_local():
+            handle = BytesIO(b"abcdef")
+            local_handles.append(handle)
+            return handle
+
+        handle = FallbackFileObj(
+            remote_opener=lambda: remote,
+            local_opener=_open_local,
+            error_predicate=is_no_range_http_error,
+        )
+        try:
+            assert handle.read(2) == b"ab"
+            assert handle.seek(4) == 4
+            assert handle.read(2) == b"ef"
+            assert len(local_handles) == 1
+        finally:
+            handle.close()
+
+    def test_fallback_file_obj_uses_fallback_position_when_tell_fails(self):
+        """Fallback position should be used if the wrapped handle cannot tell."""
+        handle = FallbackFileObj(
+            remote_opener=lambda: _NoTellHandle(b"abcdef"),
+            local_opener=lambda: BytesIO(b"abcdef"),
+            error_predicate=is_no_range_http_error,
+        )
+        handle._handle = _NoTellHandle(b"abcdef")
+        handle._set_pos_from_handle(fallback=3)
+        assert handle._pos == 3
+        handle.close()
+
+    def test_fallback_file_obj_switch_to_local_is_idempotent(self):
+        """A second local switch should return immediately."""
+        remote = _PlainHandle()
+        local_handles = []
+
+        def _open_local():
+            handle = _PlainHandle()
+            local_handles.append(handle)
+            return handle
+
+        handle = FallbackFileObj(
+            remote_opener=lambda: remote,
+            local_opener=_open_local,
+            error_predicate=is_no_range_http_error,
+        )
+        try:
+            handle._switch_to_local()
+            handle._switch_to_local()
+            assert len(local_handles) == 1
+        finally:
+            handle.close()
+
+    def test_fallback_file_obj_propagates_non_matching_errors(self):
+        """FallbackFileObj should not hide unrelated transport errors."""
+        handle = FallbackFileObj(
+            remote_opener=lambda: _FailOnSeek(b"abcdef", RuntimeError("boom")),
+            local_opener=lambda: BytesIO(b"abcdef"),
+            error_predicate=is_no_range_http_error,
+        )
+        try:
+            with pytest.raises(RuntimeError, match="boom"):
+                handle.seek(1)
+        finally:
+            handle.close()
+
+    def test_fallback_file_obj_exposes_basic_handle_state(self):
+        """Basic helpers should proxy or report sensible state."""
+        plain = _PlainHandle()
+        handle = FallbackFileObj(
+            remote_opener=lambda: plain,
+            local_opener=lambda: _PlainHandle(),
+            error_predicate=is_no_range_http_error,
+        )
+        try:
+            assert handle.seekable() is True
+            assert handle.readable() is True
+            assert handle.writable() is False
+            assert handle.extra_attr == "value"
+            assert handle.closed is False
+            assert handle.flush() is None
+            handle.close()
+            assert handle.closed is True
+            handle.close()
+        finally:
+            if not handle.closed:
+                handle.close()
+
+    def test_fallback_file_obj_uses_wrapped_writable_when_available(self):
+        """The writable helper should defer to the wrapped handle when present."""
+        handle = FallbackFileObj(
+            remote_opener=lambda: _WritableHandle(),
+            local_opener=lambda: _WritableHandle(),
+            error_predicate=is_no_range_http_error,
+        )
+        try:
+            assert handle.writable() is True
+        finally:
+            handle.close()
+
+    def test_h5_reader_warns_when_no_range_fallback_downloads(self, monkeypatch):
+        """HDF5 remote fallback should warn when it materializes a local cache file."""
+        path = UPath("memory://dascore/io_resource_test_fallback_warn.h5")
+        path.write_bytes(b"abcdef")
+        monkeypatch.setattr(
+            type(path),
+            "open",
+            lambda *_args, **_kwargs: _FailOnSeek(
+                b"abcdef",
+                ValueError(
+                    "The HTTP server doesn't appear to support range requests. "
+                    "Only reading this file from the beginning is supported."
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            H5Reader,
+            "constructor",
+            staticmethod(lambda handle, **_kwargs: handle.seek(1) or object()),
+        )
+
+        with set_config(warn_on_remote_cache=True):
+            with pytest.warns(UserWarning, match="Downloading remote file"):
+                H5Reader.get_handle(path)
+
+    def test_h5_reader_raises_when_no_range_fallback_cache_disabled(self, monkeypatch):
+        """HDF5 remote fallback should fail fast when remote caching is disabled."""
+        path = UPath("memory://dascore/io_resource_test_fallback_disabled.h5")
+        path.write_bytes(b"abcdef")
+        monkeypatch.setattr(
+            type(path),
+            "open",
+            lambda *_args, **_kwargs: _FailOnSeek(
+                b"abcdef",
+                ValueError(
+                    "The HTTP server doesn't appear to support range requests. "
+                    "Only reading this file from the beginning is supported."
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            H5Reader,
+            "constructor",
+            staticmethod(lambda handle, **_kwargs: handle.seek(1) or object()),
+        )
+
+        with set_config(allow_remote_cache=False):
+            with pytest.raises(RemoteCacheError, match="Remote caching is disabled"):
+                H5Reader.get_handle(path)
 
 
 class TestTextReader:

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -11,13 +11,16 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+from upath import UPath
 
 from dascore.exceptions import MissingOptionalDependencyError
 from dascore.utils.misc import (
     _iter_filesystem,
+    _spool_map,
     all_diffs_close_enough,
     cached_method,
     deep_equality_check,
+    get_2d_line_intersection,
     get_buffer_size,
     get_stencil_coefs,
     iterate,
@@ -36,6 +39,54 @@ class TestIterFS:
 
     sub = {"D": {"C": ".mseed"}, "F": ".json", "G": {"H": ".txt"}}  # noqa
     file_paths = {"A": ".txt", "B": sub}  # noqa
+
+    class _FakeRemoteEntry:
+        """Minimal remote path stand-in for traversal edge-case tests."""
+
+        def __init__(
+            self,
+            name,
+            *,
+            scheme="memory",
+            is_file=False,
+            is_dir=False,
+            exists=True,
+            children=(),
+            stat_mtime=0,
+            iterdir_error=None,
+        ):
+            self.name = name
+            self._scheme = scheme
+            self._is_file = is_file
+            self._is_dir = is_dir
+            self._exists = exists
+            self._children = tuple(children)
+            self._stat_mtime = stat_mtime
+            self._iterdir_error = iterdir_error
+
+        def __str__(self):
+            return f"{self._scheme}://dascore/iterfs/{self.name}"
+
+        def is_file(self):
+            return self._is_file
+
+        def is_dir(self):
+            return self._is_dir
+
+        def exists(self):
+            return self._exists
+
+        def stat(self):
+            class _Stat:
+                def __init__(self, st_mtime):
+                    self.st_mtime = st_mtime
+
+            return _Stat(self._stat_mtime)
+
+        def iterdir(self):
+            if self._iterdir_error is not None:
+                raise self._iterdir_error
+            yield from self._children
 
     # --- helper functions
     def setup_test_directory(self, some_dict: dict, path: Path):
@@ -74,7 +125,7 @@ class TestIterFS:
     def test_basic(self, simple_dir):
         """Test basic usage of iterfiles."""
         files = set(self.get_file_paths(self.file_paths, simple_dir))
-        out = {Path(x) for x in _iter_filesystem(simple_dir)}
+        out = set(_iter_filesystem(simple_dir))
         assert files == out
 
     def test_one_subdir(self, simple_dir):
@@ -87,7 +138,7 @@ class TestIterFS:
         """Test with multiple sub directories."""
         path1 = simple_dir / "B" / "D"
         path2 = simple_dir / "B" / "G"
-        out = {Path(x) for x in _iter_filesystem([path1, path2])}
+        out = set(_iter_filesystem([path1, path2]))
         files = self.get_file_paths(self.file_paths, simple_dir)
         expected = {
             x
@@ -100,7 +151,7 @@ class TestIterFS:
         """Test filtering based on extension."""
         out = set(_iter_filesystem(simple_dir, ext=".txt"))
         for val in out:
-            assert val.endswith(".txt")
+            assert str(val).endswith(".txt")
 
     def test_mtime(self, simple_dir):
         """Test filtering based on modified time."""
@@ -112,16 +163,16 @@ class TestIterFS:
         # get output make sure it only returned first file
         out = list(_iter_filesystem(simple_dir, timestamp=now + 5))
         assert len(out) == 1
-        assert Path(out[0]) == first_file
+        assert out[0] == first_file
 
     def test_skips_files_in_hidden_directory(self, dir_with_hidden_dir):
         """Hidden directory files should be skipped."""
         out1 = list(_iter_filesystem(dir_with_hidden_dir))
-        has_hidden_by_parent = ["hidden_by_parent" in x for x in out1]
+        has_hidden_by_parent = ["hidden_by_parent" in str(x) for x in out1]
         assert not any(has_hidden_by_parent)
         # But if skip_hidden is False it should be there
         out2 = list(_iter_filesystem(dir_with_hidden_dir, skip_hidden=False))
-        has_hidden_by_parent = ["hidden_by_parent" in x for x in out2]
+        has_hidden_by_parent = ["hidden_by_parent" in str(x) for x in out2]
         assert sum(has_hidden_by_parent) == 1
 
     def test_pass_file(self, dummy_text_file):
@@ -130,16 +181,24 @@ class TestIterFS:
         assert len(out) == 1
         assert out[0] == dummy_text_file
 
+    def test_pass_file_respects_extension_filter(self, dummy_text_file):
+        """Direct local file inputs should still honor extension filtering."""
+        assert list(_iter_filesystem(dummy_text_file, ext=".json")) == []
+
+    def test_pass_file_respects_timestamp_filter(self, dummy_text_file):
+        """Direct local file inputs should still honor timestamp filtering."""
+        assert list(_iter_filesystem(dummy_text_file, timestamp=time.time() + 60)) == []
+
     def test_no_directories(self, simple_dir):
         """Ensure no directories are included when include_directories=False."""
         out = list(_iter_filesystem(simple_dir, include_directories=False))
-        has_dirs = [Path(x).is_dir() for x in out]
+        has_dirs = [x.is_dir() for x in out]
         assert not any(has_dirs)
 
     def test_include_directories(self, simple_dir):
         """Ensure we can get directories back."""
         out = list(_iter_filesystem(simple_dir, include_directories=True))
-        returned_dirs = [Path(x) for x in out if Path(x).is_dir()]
+        returned_dirs = [x for x in out if x.is_dir()]
         assert len(returned_dirs)
         # The top level directory should have been included
         assert simple_dir in returned_dirs
@@ -153,12 +212,154 @@ class TestIterFS:
         out = []
         iterator = _iter_filesystem(simple_dir, include_directories=True)
         for path in iterator:
-            if Path(path).name == "B":
+            if path.name == "B":
                 iterator.send("skip")
             out.append(path)
-        names = {Path(x).name.split(".")[0] for x in out}
+        names = {x.name.split(".")[0] for x in out}
         # Anything after B should have been skipped
         assert {"C", "D", "E", "F"}.isdisjoint(names)
+
+    def test_remote_file(self):
+        """Ensure remote file paths are yielded directly."""
+        path = UPath("memory://dascore/iterfs/file.txt")
+        path.write_text("hello")
+        assert list(_iter_filesystem(path)) == [path]
+
+    def test_remote_directory(self):
+        """Ensure remote directories are traversed with the generic iterator."""
+        root = UPath("memory://dascore/iterfs/root")
+        (root / "sub").mkdir(parents=True, exist_ok=True)
+        (root / ".hidden").mkdir(parents=True, exist_ok=True)
+        (root / "a.txt").write_text("a")
+        (root / "sub" / "b.txt").write_text("b")
+        (root / ".hidden" / "skip.txt").write_text("x")
+        out = list(_iter_filesystem(root, include_directories=True))
+        assert root in out
+        assert root / "a.txt" in out
+        assert root / "sub" / "b.txt" in out
+        assert root / ".hidden" / "skip.txt" not in out
+
+    def test_remote_directory_skip_signal(self):
+        """Ensure skip signals also work on remote directory traversal."""
+        root = UPath("memory://dascore/iterfs/skip")
+        (root / "sub").mkdir(parents=True, exist_ok=True)
+        (root / "sub" / "b.txt").write_text("b")
+        iterator = _iter_filesystem(root, include_directories=True)
+        first = next(iterator)
+        assert first == root
+        assert iterator.send("skip") is None
+        with pytest.raises(StopIteration):
+            next(iterator)
+
+    def test_remote_directory_uses_timestamp_when_backend_supports_mtime(
+        self, monkeypatch
+    ):
+        """Remote iteration should respect timestamps when stat exposes mtime."""
+        root = UPath("memory://dascore/iterfs/timestamp")
+        (root / "old.txt").write_text("old")
+        (root / "new.txt").write_text("new")
+        upath_type = type(root / "old.txt")
+        original_stat = upath_type.stat
+
+        class _Stat:
+            def __init__(self, st_mtime):
+                self.st_mtime = st_mtime
+
+        def _stat(self, *args, **kwargs):
+            name = self.name
+            if name == "old.txt":
+                return _Stat(5)
+            if name == "new.txt":
+                return _Stat(20)
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(upath_type, "stat", _stat)
+        out = list(_iter_filesystem(root, timestamp=10))
+        assert out == [root / "new.txt"]
+
+    def test_remote_file_skips_hidden_name(self):
+        """Direct remote file iteration should respect hidden-name filtering."""
+        path = UPath("memory://dascore/iterfs/.hidden.txt")
+        path.write_text("x")
+        assert list(_iter_filesystem(path)) == []
+
+    def test_remote_file_skips_extension_mismatch(self):
+        """Direct remote file iteration should respect extension filters."""
+        path = UPath("memory://dascore/iterfs/file.bin")
+        path.write_text("x")
+        assert list(_iter_filesystem(path, ext=".txt")) == []
+
+    def test_remote_missing_path_returns_empty(self):
+        """Missing remote paths should simply yield no results."""
+        path = UPath("memory://dascore/iterfs/does_not_exist.txt")
+        assert list(_iter_filesystem(path)) == []
+
+    def test_remote_empty_directory_returns_empty(self):
+        """Remote empty directories should yield no results."""
+        root = UPath("memory://dascore/iterfs/empty")
+        root.mkdir(parents=True, exist_ok=True)
+        assert list(_iter_filesystem(root)) == []
+
+    def test_remote_directory_handles_unknown_entry_kinds(self, monkeypatch):
+        """Remote traversal should probe ambiguous entries before skipping them."""
+        directory_child = self._FakeRemoteEntry(
+            "maybe_dir",
+            children=(self._FakeRemoteEntry("nested.txt", is_file=True),),
+        )
+        skipped_child = self._FakeRemoteEntry("maybe_other")
+        root = self._FakeRemoteEntry(
+            "root",
+            is_dir=True,
+            children=(directory_child, skipped_child),
+        )
+
+        monkeypatch.setattr("dascore.utils.misc.is_pathlike", lambda value: True)
+        monkeypatch.setattr("dascore.utils.misc.is_local_path", lambda value: False)
+        monkeypatch.setattr("dascore.utils.misc.coerce_to_upath", lambda value: value)
+
+        out = list(_iter_filesystem(root))
+        assert directory_child._children[0] in out
+        assert all("maybe_other" not in str(item) for item in out)
+
+    def test_remote_directory_iterdir_fallback_when_exists_is_false(self, monkeypatch):
+        """Remote traversal should still descend when exists() is unreliable."""
+        nested_file = self._FakeRemoteEntry(
+            "nested.txt",
+            scheme="http",
+            exists=True,
+            is_file=True,
+        )
+        root = self._FakeRemoteEntry(
+            "root",
+            scheme="http",
+            exists=False,
+            children=(nested_file,),
+        )
+
+        monkeypatch.setattr("dascore.utils.misc.is_pathlike", lambda value: True)
+        monkeypatch.setattr("dascore.utils.misc.is_local_path", lambda value: False)
+        monkeypatch.setattr("dascore.utils.misc.coerce_to_upath", lambda value: value)
+
+        out = list(_iter_filesystem(root))
+        assert nested_file in out
+
+    def test_remote_directory_iterdir_error_raises_when_path_still_exists(
+        self, monkeypatch
+    ):
+        """Unexpected remote traversal errors should surface for existing paths."""
+        root = self._FakeRemoteEntry(
+            "root",
+            scheme="http",
+            exists=True,
+            iterdir_error=OSError("backend exploded"),
+        )
+        # TODO a lot of monkey patching here. Maybe revisit to make less cringy.
+        monkeypatch.setattr("dascore.utils.misc.is_pathlike", lambda value: True)
+        monkeypatch.setattr("dascore.utils.misc.is_local_path", lambda value: False)
+        monkeypatch.setattr("dascore.utils.misc.coerce_to_upath", lambda value: value)
+
+        with pytest.raises(OSError, match="backend exploded"):
+            list(_iter_filesystem(root))
 
 
 class TestIterate:
@@ -349,6 +550,66 @@ class TestToObjectArray:
         assert isinstance(out, np.ndarray)
 
 
+class TestSpoolMap:
+    """Tests for the private spool mapping helper."""
+
+    def test_without_client(self, random_spool):
+        """A missing client should use direct iteration over the spool."""
+        spool = random_spool[:3]
+        out = _spool_map(
+            spool,
+            lambda patch, value=1: len(patch.dims) + value,
+            progress=False,
+        )
+        assert out == [3, 3, 3]
+
+    def test_with_client(self, random_spool, monkeypatch):
+        """A client should receive split spools and flatten mapped outputs."""
+        seen = []
+
+        def fake_track(iterable, desc):
+            seen.append(desc)
+            return iterable
+
+        class DummyClient:
+            def map(self, func, spools):
+                return [func(spool) for spool in spools]
+
+        monkeypatch.setattr("dascore.utils.misc.track", fake_track)
+        monkeypatch.setattr("dascore.utils.misc.os.cpu_count", lambda: 2)
+        out = _spool_map(
+            random_spool[:4],
+            lambda patch, value=1: len(patch.dims) + value,
+            client=DummyClient(),
+            size=None,
+            progress=True,
+        )
+        assert out == [3, 3, 3]
+        assert seen == ["Applying <lambda> to spool"]
+
+
+class Test2DLineIntersection:
+    """Tests for 2D line intersection helper."""
+
+    def test_non_parallel_lines(self):
+        """Non-parallel lines should return their intersection."""
+        p1 = np.array([0.0, 0.0])
+        p2 = np.array([2.0, 2.0])
+        p3 = np.array([0.0, 2.0])
+        p4 = np.array([2.0, 0.0])
+        out = get_2d_line_intersection(p1, p2, p3, p4)
+        assert np.allclose(out, [1.0, 1.0])
+
+    def test_parallel_lines(self):
+        """Parallel lines should return NaN coordinates."""
+        p1 = np.array([0.0, 0.0])
+        p2 = np.array([1.0, 1.0])
+        p3 = np.array([0.0, 1.0])
+        p4 = np.array([1.0, 2.0])
+        out = get_2d_line_intersection(p1, p2, p3, p4)
+        assert np.isnan(out).all()
+
+
 class TestGetBufferSize:
     """Ensure we can get the size of various buffers."""
 
@@ -367,6 +628,15 @@ class TestGetBufferSize:
         bio.seek(0)
         size2 = get_buffer_size(bio)
         assert size1 == size2 == 4
+
+    def test_named_buffer_falls_back_when_stat_fails(self):
+        """Handles with unusable .name values should still use tell/seek."""
+
+        class _NamedBytesIO(BytesIO):
+            name = "not-a-real-path"
+
+        bio = _NamedBytesIO(b"1234")
+        assert get_buffer_size(bio) == 4
 
 
 class TestMaybeMemMap:

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import time
-import warnings
 from io import BytesIO
 from pathlib import Path
 
@@ -535,8 +534,7 @@ class TestWarnOrRaise:
         """Ensure when  None does nothing."""
         msg = "Big nothing burger"
         # Now exceptions or warnings will crash the program.
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
+        with suppress_warnings(action="error"):
             warn_or_raise(msg, behavior=None)
 
 

--- a/tests/test_utils/test_namespace.py
+++ b/tests/test_utils/test_namespace.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import ClassVar
 
 import pandas as pd
@@ -10,6 +9,7 @@ import pytest
 
 import dascore.utils.namespace as ns_module
 from dascore.exceptions import DASCorePluginError
+from dascore.utils.misc import suppress_warnings
 from dascore.utils.namespace import (
     NamespaceOwner,
     _load_plugin_registry,
@@ -163,8 +163,7 @@ class TestNamespace:
         class DistinctBase(_MethodNameSpace):
             entry_point_group = "dascore.distinct_test"
 
-        with warnings.catch_warnings(record=True) as record:
-            warnings.simplefilter("always")
+        with suppress_warnings(action="always", record=True) as record:
 
             class FirstNamespace(DistinctBase):
                 name = "first"

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -841,10 +841,7 @@ class TestGetPatchWindowSize:
 
     def test_no_warning_under_threshold(self, simple_patch):
         """Test no warning for window sizes under threshold."""
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")  # Turn warnings into errors
+        with dc.utils.misc.suppress_warnings(action="error"):
             # This should not raise (no warning)
             size = get_patch_window_size(
                 simple_patch, {"time": 5}, samples=True, warn_above=10

--- a/tests/test_utils/test_paths.py
+++ b/tests/test_utils/test_paths.py
@@ -1,0 +1,68 @@
+"""Tests for path classification helpers."""
+
+from __future__ import annotations
+
+import pytest
+from upath import UPath
+
+from dascore.exceptions import InvalidSpoolError
+from dascore.utils.paths import (
+    coerce_to_upath,
+    get_path_protocol,
+    is_local_path,
+    is_pathlike,
+    requires_local_directory,
+)
+
+
+class TestIsPathlike:
+    """Tests for ``is_pathlike``."""
+
+    def test_is_pathlike(self, tmp_path):
+        """Recognized path-like values should return True."""
+        assert is_pathlike("a.txt")
+        assert is_pathlike(tmp_path)
+        assert is_pathlike(UPath(tmp_path))
+        assert not is_pathlike(object())
+
+
+class TestCoerceToUPath:
+    """Tests for ``coerce_to_upath``."""
+
+    def test_coerce_path(self, tmp_path):
+        """Path-like inputs should coerce to UPath."""
+        out = coerce_to_upath(tmp_path)
+        assert isinstance(out, UPath)
+
+
+class TestGetPathProtocol:
+    """Tests for ``get_path_protocol``."""
+
+    def test_get_path_protocol(self, tmp_path):
+        """Protocols should normalize for local and remote paths."""
+        assert get_path_protocol(tmp_path) == "file"
+        assert get_path_protocol("local.txt") == "file"
+        assert get_path_protocol("memory://dascore/test.txt") == "memory"
+        assert get_path_protocol(object()) is None
+
+
+class TestIsLocalPath:
+    """Tests for ``is_local_path``."""
+
+    def test_is_local_path(self, tmp_path):
+        """Local and remote path classification should be correct."""
+        assert is_local_path(tmp_path)
+        assert not is_local_path("memory://dascore/test.txt")
+        assert not is_local_path(object())
+
+
+class TestRequiresLocalDirectory:
+    """Tests for ``requires_local_directory``."""
+
+    def test_requires_local_directory(self):
+        """Remote directories should be rejected by policy helpers."""
+        with pytest.raises(InvalidSpoolError, match="local filesystem"):
+            requires_local_directory(
+                UPath("memory://dascore/testdir"),
+                label="Directory spool",
+            )

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -4,20 +4,33 @@ from __future__ import annotations
 
 from rich.progress import Progress
 
-import dascore as dc
+from dascore.config import set_config
 from dascore.utils.progress import get_progress_instance, track
 
 
 class TestProgressBar:
     """Tests for the rich progress bar."""
 
-    def test_progressbar_shows(self, monkeypatch):
+    def test_progressbar_shows(self):
         """Undo debug patch to progress bar shows."""
-        monkeypatch.setattr(dc, "_debug", False)
-        for _ in track([1, 2, 3], "testing_tracker"):
-            pass
+        with set_config(debug=False):
+            for _ in track([1, 2, 3], "testing_tracker"):
+                pass
 
     def test_get_basic_progress(self):
         """Ensure we can return a basic progress bar."""
         pbar = get_progress_instance("basic")
         assert isinstance(pbar, Progress)
+
+    def test_basic_progress_refresh_rate_comes_from_config(self, monkeypatch):
+        """The basic progress bar should honor the configured refresh rate."""
+        seen = {}
+
+        class DummyProgress:
+            def __init__(self, *_args, **kwargs):
+                seen.update(kwargs)
+
+        monkeypatch.setattr("dascore.utils.progress.Progress", DummyProgress)
+        with set_config(progress_basic_refresh_per_second=0.5):
+            get_progress_instance("basic")
+        assert seen["refresh_per_second"] == 0.5


### PR DESCRIPTION
 ## Description

  - Add universal-pathlib as a runtime dependency and extend DASCore path handling so str, Path, and UPath inputs work consistently across public IO entry points.
 
  - Teach dc.read, dc.scan, dc.spool, dc.get_format, FileSpool, and related internals to preserve remote paths, normalize local-vs-remote behavior, and reject directory-only operations when the backend is not a local
    filesystem.
  - Introduce shared remote IO/cache utilities for:
      - normalizing remote resource IDs
      - materializing remote files into a stable local cache when required
      - controlling cache behavior through runtime config
      - supporting metadata-time cache opt-in separately from general read-time cache use
  - Update HDF5-based readers to prefer remote-first access and only fall back to a cached local file when a backend, especially plain HTTP, does not support the random-access behavior needed by h5py/PyTables.
  - Add runtime config support for remote cache settings and related display/progress configuration, plus docs/tutorial updates covering remote patches, remote file IO, and runtime configuration.
  - Expand test coverage for:
      - local UPath inputs
      - remote HTTP reads/scans/get-format behavior
      - in-memory remote filesystems
      - remote directory traversal and timestamp handling
      - remote cache warnings, cache policy, and fallback behavior
  - Include follow-up cleanup and stability fixes:
      - move shared IO test helpers into an explicit helper module
      - scope optional HTTP test dependencies to fixtures
      - standardize warning suppression through suppress_warnings
      - fix a full-suite intermittent hang by reopening the IO resource after format inference before the actual read, instead of reusing the same HDF5/fileobj stack across both phases

edit: updated according to current branch state. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class UPath (remote URI) support across IO: read/scan/spool/write
  * Remote-file materialization, caching controls, and HDF5 read/write adapters
  * Runtime configuration API (get_config / set_config) for IO, caching, and display
  * New utilities to manage remote cache and ensure local copies; new RemoteCacheError

* **Documentation**
  * Tutorials: "Working with Remote Patches" and runtime configuration examples

* **Tests**
  * Extensive remote I/O coverage (HTTP, memory, range, caching)

* **Chores**
  * Added universal-pathlib dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Changelog

<!-- Retrofitted after #864; recovered from docs/changelog.qmd history. -->
- added: `UPath` resources work across `read`, `scan`, `spool`, and `write`, including remote backends such as `memory://`.
- changed **breaking**: DASDAE stores `history` as a flat string payload; older files stay readable but their original history strings are no longer restored exactly.
