### PR TITLE
workaround for dasvader HDF2 compatibility issue.

### DIFF
--- a/benchmarks/test_io_benchmarks.py
+++ b/benchmarks/test_io_benchmarks.py
@@ -8,7 +8,7 @@ from functools import cache
 import pytest
 
 import dascore as dc
-from dascore.exceptions import MissingOptionalDependencyError
+from dascore.exceptions import DependencyError
 from dascore.utils.downloader import fetch, get_registry_df
 
 
@@ -33,33 +33,33 @@ class TestIOBenchmarks:
     def test_scan(self, test_file_paths):
         """Time for basic scanning of all datafiles."""
         for path in test_file_paths.values():
-            with suppress(MissingOptionalDependencyError):
+            with suppress(DependencyError):
                 dc.scan(path)
 
     @pytest.mark.benchmark
     def test_scan_df(self, test_file_paths):
         """Time for basic scanning of all datafiles to DataFrame."""
         for path in test_file_paths.values():
-            with suppress(MissingOptionalDependencyError):
+            with suppress(DependencyError):
                 dc.scan_to_df(path)
 
     @pytest.mark.benchmark
     def test_get_format(self, test_file_paths):
         """Time for format detection of all datafiles."""
         for path in test_file_paths.values():
-            with suppress(MissingOptionalDependencyError):
+            with suppress(DependencyError):
                 dc.get_format(path)
 
     @pytest.mark.benchmark
     def test_read(self, test_file_paths):
         """Time for basic reading of all datafiles."""
         for path in test_file_paths.values():
-            with suppress(MissingOptionalDependencyError):
+            with suppress(DependencyError):
                 dc.read(path)[0]
 
     @pytest.mark.benchmark
     def test_spool(self, test_file_paths):
         """Time for creating spools from all datafiles."""
         for path in test_file_paths.values():
-            with suppress(MissingOptionalDependencyError):
-                dc.spool(path)[0]
+            with suppress(DependencyError):
+                dc.spool(path)

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -7,6 +7,10 @@ class DASCoreError(Exception):
     """Base class for dascore errors."""
 
 
+class DependencyError(DASCoreError):
+    """Raised when functionality depends on an unavailable compatibility stack."""
+
+
 class InvalidFiberIOError(ValueError, DASCoreError):
     """Raised when an invalid Fiber IO is defined or used."""
 
@@ -95,8 +99,12 @@ class InvalidIndexVersionError(ValueError, DASCoreError):
     """Raised when a version mismatch occurs in index."""
 
 
-class MissingOptionalDependencyError(ImportError, DASCoreError):
+class MissingOptionalDependencyError(ImportError, DependencyError):
     """Raised when an optional package needed for some functionality is missing."""
+
+
+class DASVaderCompatibilityError(InvalidFiberFileError, DependencyError):
+    """Raised when a legacy DASVader file needs an older HDF5 compatibility stack."""
 
 
 class InvalidSpoolError(ValueError, DASCoreError):

--- a/dascore/io/dasvader/core.py
+++ b/dascore/io/dasvader/core.py
@@ -8,6 +8,7 @@ from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader
 
 from .utils import (
+    _dereference,
     _get_attr_dict,
     _get_coord_manager,
     _get_reference_names,
@@ -50,7 +51,11 @@ class DASVaderV1(FiberIO):
         rec = resource["dDAS"][()]
         cm = _get_coord_manager(resource, rec)
         ref_names = set(_get_reference_names(resource))
-        attrs = _get_attr_dict(resource[rec["atrib"]]) if "atrib" in ref_names else {}
+        attrs = (
+            _get_attr_dict(_dereference(resource, rec["atrib"], "atrib"))
+            if "atrib" in ref_names
+            else {}
+        )
         attrs.update(
             {
                 "path": resource.filename,

--- a/dascore/io/dasvader/core.py
+++ b/dascore/io/dasvader/core.py
@@ -17,7 +17,16 @@ from .utils import (
 
 
 class DASVaderV1(FiberIO):
-    """Support for DASVader JLD2 files."""
+    """
+    Support for DASVader JLD2 files.
+
+    Notes
+    -----
+    Legacy DASVader files may contain anonymous JLD2 object references. DASCore
+    detects those files and raises `DASVaderCompatibilityError` with compatibility
+    instructions instead of failing inside `h5py`. A known working stack for
+    such legacy files is `h5py<3.16` with `HDF5 1.14.x`.
+    """
 
     name = "DASVader"
     preferred_extensions = ("jld2",)

--- a/dascore/io/dasvader/utils.py
+++ b/dascore/io/dasvader/utils.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import h5py
 import numpy as np
+from h5py import h5r
 from h5py.h5r import Reference
 
 import dascore as dc
 from dascore.compat import array
 from dascore.core.coords import get_coord
+from dascore.exceptions import DASVaderCompatibilityError
 from dascore.utils.misc import maybe_get_items, unbyte
 
 # Julia DateTime "instant" values (Dates.value) are milliseconds since
@@ -60,6 +63,28 @@ def _julia_ms_to_datetime64(ms_values):
     return dc.to_datetime64(unix_ms / 1_000)
 
 
+def _raise_legacy_ref_error(h5, field_name: str) -> None:
+    """Raise a clear error for legacy DASVader files with anonymous refs."""
+    filename = getattr(h5, "filename", "<unknown>")
+    version = f"h5py {h5py.__version__} / HDF5 {h5py.version.hdf5_version}"
+    msg = (
+        f"{filename} is a legacy DASVader JLD2 file with anonymous object "
+        f"references in '{field_name}'. This file class is not supported by "
+        f"the current HDF5 stack ({version}). Install a compatibility stack "
+        f"such as h5py<3.16 with HDF5 1.14.x, then retry."
+    )
+    raise DASVaderCompatibilityError(msg)
+
+
+def _dereference(h5, value, field_name: str):
+    """Resolve an HDF5 reference, rejecting legacy anonymous DASVader refs."""
+    if not isinstance(value, Reference):
+        return value
+    if h5r.get_name(value, h5.id) is None:
+        _raise_legacy_ref_error(h5, field_name)
+    return h5[value]
+
+
 # --- Metadata parsing
 
 
@@ -68,11 +93,11 @@ def _dataset_to_dict(atrib) -> dict:
     Convert the compound dataset to a python dict.
     """
 
-    def _resolve_ref(h5, value):
+    def _resolve_ref(h5, value, field_name):
         """Resolve h5py references to concrete values."""
         if not isinstance(value, Reference):
             return value
-        obj = h5[value]
+        obj = _dereference(h5, value, field_name)
         out = obj[()]
         if isinstance(out, np.ndarray) and out.size == 1:
             return out.item()
@@ -83,7 +108,7 @@ def _dataset_to_dict(atrib) -> dict:
     h5 = atrib.file
     out = {}
     for name in data.dtype.names:
-        val = _resolve_ref(h5, data[name])
+        val = _resolve_ref(h5, data[name], name)
         out[name] = unbyte(val)
     return out
 
@@ -100,7 +125,7 @@ def _get_attr_dict(atrib) -> dict:
 def _get_time_coord(h5, rec):
     """Build the time coordinate from htime or time struct."""
     time_struct = rec["time"]
-    htime_node = h5[rec["htime"]]
+    htime_node = _dereference(h5, rec["htime"], "htime")
     start_htime = _julia_ms_to_datetime64(htime_node[0])
     _start, _step, time_len = _step_range_len_to_params(time_struct)
     _end = _start + time_len * _step
@@ -168,13 +193,17 @@ def _read_dasvader(h5, distance=None, time=None):
     ref_names = set(_get_reference_names(h5))
     data_name = "data" if "data" in ref_names else next(iter(DATA_NAMES & ref_names))
     # data is a reference here; need to resolve it with h5 File.
-    data = h5[rec[data_name]]
+    data = _dereference(h5, rec[data_name], data_name)
     if distance is not None or time is not None:
         cm, data = cm.select(data, distance=distance, time=time)
     data = array(data)
     if not data.size:
         return []
-    attrs = _get_attr_dict(h5[rec["atrib"]]) if "atrib" in ref_names else {}
+    attrs = (
+        _get_attr_dict(_dereference(h5, rec["atrib"], "atrib"))
+        if "atrib" in ref_names
+        else {}
+    )
     # attrs["coords"] = cm.to_summary_dict()
     # attrs["dims"] = cm.dims
     return [dc.Patch(data=data, coords=cm, attrs=dc.PatchAttrs(**attrs))]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import warnings
 from contextlib import suppress
 from pathlib import Path
 
-import h5py
 import matplotlib
 import numpy as np
 import pandas as pd
@@ -250,81 +249,6 @@ def brady_hs_das_dts_coords_path():
     out = fetch("brady_hs_DAS_DTS_coords.csv")
     assert out.exists()
     return out
-
-
-def _write_dasvader_file(
-    path: Path, data_name: str = "data", include_attrib: bool = True
-) -> Path:
-    """Write a DASVader file using named datasets and references."""
-    tp_dtype = np.dtype([("hi", "<f8"), ("lo", "<f8")])
-    sr_dtype = np.dtype(
-        [("ref", tp_dtype), ("step", tp_dtype), ("len", "<i8"), ("offset", "<i8")]
-    )
-    ddas_fields = [
-        (data_name, h5py.ref_dtype),
-        ("time", sr_dtype),
-        ("htime", h5py.ref_dtype),
-        ("offset", sr_dtype),
-    ]
-    if include_attrib:
-        ddas_fields.append(("atrib", h5py.ref_dtype))
-    ddas_dtype = np.dtype(ddas_fields)
-
-    with h5py.File(path, "w") as fi:
-        ntime, ndistance = 8, 20
-        shape = (ndistance, ntime) if data_name == "data" else (ntime, ndistance)
-        data = fi.create_dataset(
-            data_name, data=np.arange(ntime * ndistance).reshape(shape)
-        )
-        htime = fi.create_dataset("htime", data=np.array([62_135_683_200_000]))
-
-        ddas = np.zeros((), dtype=ddas_dtype)
-        ddas[data_name] = data.ref
-        ddas["htime"] = htime.ref
-        ddas["time"]["ref"]["hi"] = 0.0
-        ddas["time"]["step"]["hi"] = 1.0
-        ddas["time"]["len"] = ntime
-        ddas["time"]["offset"] = 1
-        ddas["offset"]["ref"]["hi"] = 0.0
-        ddas["offset"]["step"]["hi"] = 0.5
-        ddas["offset"]["len"] = ndistance
-        ddas["offset"]["offset"] = 1
-
-        if include_attrib:
-            atrib_dtype = np.dtype(
-                [
-                    ("GaugeLength", h5py.ref_dtype),
-                    ("Hostname", h5py.ref_dtype),
-                    ("PipelineTracker", h5py.ref_dtype),
-                    ("PulseRateFreq", "<f8"),
-                ]
-            )
-            gauge = fi.create_dataset("GaugeLength", data=np.array([10.0]))
-            host = fi.create_dataset(
-                "Hostname", data="test-host", dtype=h5py.string_dtype(encoding="utf-8")
-            )
-            tracker = fi.create_dataset(
-                "PipelineTracker",
-                data="tracker-1",
-                dtype=h5py.string_dtype(encoding="utf-8"),
-            )
-            atrib = np.zeros((), dtype=atrib_dtype)
-            atrib["GaugeLength"] = gauge.ref
-            atrib["Hostname"] = host.ref
-            atrib["PipelineTracker"] = tracker.ref
-            atrib["PulseRateFreq"] = 5000.0
-            atrib_ds = fi.create_dataset("atrib", data=atrib)
-            ddas["atrib"] = atrib_ds.ref
-
-        fi.create_dataset("dDAS", data=ddas)
-    return path
-
-
-@pytest.fixture(scope="session")
-def dasvader_modern_path(tmp_path_factory):
-    """Create a readable DASVader file with named datasets."""
-    path = tmp_path_factory.mktemp("dasvader_modern") / "modern_named_refs.jld2"
-    return _write_dasvader_file(path)
 
 
 # --- Patch fixtures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import warnings
 from contextlib import suppress
 from pathlib import Path
 
+import h5py
 import matplotlib
 import numpy as np
 import pandas as pd
@@ -249,6 +250,81 @@ def brady_hs_das_dts_coords_path():
     out = fetch("brady_hs_DAS_DTS_coords.csv")
     assert out.exists()
     return out
+
+
+def _write_dasvader_file(
+    path: Path, data_name: str = "data", include_attrib: bool = True
+) -> Path:
+    """Write a DASVader file using named datasets and references."""
+    tp_dtype = np.dtype([("hi", "<f8"), ("lo", "<f8")])
+    sr_dtype = np.dtype(
+        [("ref", tp_dtype), ("step", tp_dtype), ("len", "<i8"), ("offset", "<i8")]
+    )
+    ddas_fields = [
+        (data_name, h5py.ref_dtype),
+        ("time", sr_dtype),
+        ("htime", h5py.ref_dtype),
+        ("offset", sr_dtype),
+    ]
+    if include_attrib:
+        ddas_fields.append(("atrib", h5py.ref_dtype))
+    ddas_dtype = np.dtype(ddas_fields)
+
+    with h5py.File(path, "w") as fi:
+        ntime, ndistance = 8, 20
+        shape = (ndistance, ntime) if data_name == "data" else (ntime, ndistance)
+        data = fi.create_dataset(
+            data_name, data=np.arange(ntime * ndistance).reshape(shape)
+        )
+        htime = fi.create_dataset("htime", data=np.array([62_135_683_200_000]))
+
+        ddas = np.zeros((), dtype=ddas_dtype)
+        ddas[data_name] = data.ref
+        ddas["htime"] = htime.ref
+        ddas["time"]["ref"]["hi"] = 0.0
+        ddas["time"]["step"]["hi"] = 1.0
+        ddas["time"]["len"] = ntime
+        ddas["time"]["offset"] = 1
+        ddas["offset"]["ref"]["hi"] = 0.0
+        ddas["offset"]["step"]["hi"] = 0.5
+        ddas["offset"]["len"] = ndistance
+        ddas["offset"]["offset"] = 1
+
+        if include_attrib:
+            atrib_dtype = np.dtype(
+                [
+                    ("GaugeLength", h5py.ref_dtype),
+                    ("Hostname", h5py.ref_dtype),
+                    ("PipelineTracker", h5py.ref_dtype),
+                    ("PulseRateFreq", "<f8"),
+                ]
+            )
+            gauge = fi.create_dataset("GaugeLength", data=np.array([10.0]))
+            host = fi.create_dataset(
+                "Hostname", data="test-host", dtype=h5py.string_dtype(encoding="utf-8")
+            )
+            tracker = fi.create_dataset(
+                "PipelineTracker",
+                data="tracker-1",
+                dtype=h5py.string_dtype(encoding="utf-8"),
+            )
+            atrib = np.zeros((), dtype=atrib_dtype)
+            atrib["GaugeLength"] = gauge.ref
+            atrib["Hostname"] = host.ref
+            atrib["PipelineTracker"] = tracker.ref
+            atrib["PulseRateFreq"] = 5000.0
+            atrib_ds = fi.create_dataset("atrib", data=atrib)
+            ddas["atrib"] = atrib_ds.ref
+
+        fi.create_dataset("dDAS", data=ddas)
+    return path
+
+
+@pytest.fixture(scope="session")
+def dasvader_modern_path(tmp_path_factory):
+    """Create a readable DASVader file with named datasets."""
+    path = tmp_path_factory.mktemp("dasvader_modern") / "modern_named_refs.jld2"
+    return _write_dasvader_file(path)
 
 
 # --- Patch fixtures

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -22,7 +22,7 @@ import pandas as pd
 import pytest
 
 import dascore as dc
-from dascore.exceptions import MissingOptionalDependencyError
+from dascore.exceptions import DependencyError
 from dascore.io import BinaryReader
 from dascore.io.ap_sensing import APSensingV10
 from dascore.io.dasdae import DASDAEV1
@@ -104,8 +104,8 @@ def skip_missing():
     """Skip if missing dependencies found."""
     try:
         yield
-    except MissingOptionalDependencyError as exc:
-        pytest.skip(f"Missing optional dependency required to read file: {exc}")
+    except DependencyError as exc:
+        pytest.skip(str(exc))
     except TimeoutError as exc:
         pytest.skip(f"Unable to fetch data due to timeout: {exc}")
 
@@ -156,6 +156,8 @@ def io_path_tuple(request):
     This is used for common testing.
     """
     io, fetch_name = request.param
+    if isinstance(io, DASVaderV1) and fetch_name == "das_vader_1.jld2":
+        return io, request.getfixturevalue("dasvader_modern_path")
     with skip_timeout():
         return io, fetch(fetch_name)
 
@@ -164,6 +166,8 @@ def io_path_tuple(request):
 def data_file_path(request):
     """A fixture of all data files. Will download if needed."""
     param = request.param
+    if str(param) == "das_vader_1.jld2":
+        return request.getfixturevalue("dasvader_modern_path")
     # Some files should be skipped if not DAS or too big.
     if str(param) in SKIP_DATA_FILES:
         pytest.skip(f"Skipping {param}")

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -27,7 +27,6 @@ from dascore.io import BinaryReader
 from dascore.io.ap_sensing import APSensingV10
 from dascore.io.dasdae import DASDAEV1
 from dascore.io.dashdf5 import DASHDF5
-from dascore.io.dasvader import DASVaderV1
 from dascore.io.febus import Febus1, Febus2
 from dascore.io.gdr import GDR_V1
 from dascore.io.h5simple import H5Simple
@@ -61,7 +60,6 @@ COMMON_IO_READ_TESTS = {
     APSensingV10(): ("ap_sensing_1.hdf5",),
     DASDAEV1(): ("example_dasdae_event_1.h5",),
     DASHDF5(): ("PoroTomo_iDAS_1.h5",),
-    DASVaderV1(): ("das_vader_1.jld2",),
     Febus1(): ("valencia_febus_example.h5",),
     Febus2(): ("febus_1.h5", "febus_2.h5"),
     GDR_V1(): ("gdr_1.h5",),
@@ -96,7 +94,9 @@ COMMON_IO_WRITE_TESTS = (
 )
 
 # Specifies data registry entries which should not be tested.
-SKIP_DATA_FILES = {"whale_1.hdf5", "brady_hs_DAS_DTS_coords.csv"}
+# DASVader is covered in its own test module to isolate its compatibility-path
+# testing from the shared common-IO matrix.
+SKIP_DATA_FILES = {"whale_1.hdf5", "brady_hs_DAS_DTS_coords.csv", "das_vader_1.jld2"}
 
 
 @contextmanager
@@ -156,8 +156,6 @@ def io_path_tuple(request):
     This is used for common testing.
     """
     io, fetch_name = request.param
-    if isinstance(io, DASVaderV1) and fetch_name == "das_vader_1.jld2":
-        return io, request.getfixturevalue("dasvader_modern_path")
     with skip_timeout():
         return io, fetch(fetch_name)
 
@@ -166,8 +164,6 @@ def io_path_tuple(request):
 def data_file_path(request):
     """A fixture of all data files. Will download if needed."""
     param = request.param
-    if str(param) == "das_vader_1.jld2":
-        return request.getfixturevalue("dasvader_modern_path")
     # Some files should be skipped if not DAS or too big.
     if str(param) in SKIP_DATA_FILES:
         pytest.skip(f"Skipping {param}")

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -68,7 +68,7 @@ class TestDASVader:
     def test_all_attrs_resolved(self, dasvader_modern_path):
         """Ensure all attributes are resolved (no hdf5 references)"""
         das_vader_patch = dc.read(dasvader_modern_path)[0]
-        for attr, value in das_vader_patch.attrs.items():
+        for _, value in das_vader_patch.attrs.items():
             assert not isinstance(value, Reference)
 
     def test_legacy_file_raises_clear_error(self, legacy_das_vader_path):

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -2,21 +2,26 @@
 Tests specific to DASvader format.
 """
 
+from __future__ import annotations
+
 import h5py
 import numpy as np
 import pytest
 from h5py.h5r import Reference
 
 import dascore as dc
+from dascore.exceptions import DependencyError
+from dascore.io.dasvader.utils import _dereference, _julia_ms_to_datetime64
+from dascore.utils.downloader import fetch
 
 
 class TestDASVader:
     """Test case for dasvader."""
 
     @pytest.fixture(scope="session")
-    def das_vader_patch(self):
-        """Get the dasvader patch."""
-        return dc.get_example_patch("das_vader_1.jld2")
+    def legacy_das_vader_path(self):
+        """Get the legacy DASVader file path."""
+        return fetch("das_vader_1.jld2")
 
     @pytest.fixture(scope="class")
     def das_vader_strainrate_no_attrib_path(self, tmp_path_factory):
@@ -60,10 +65,33 @@ class TestDASVader:
             fi.create_dataset("dDAS", data=ddas)
         return path
 
-    def test_all_attrs_resolved(self, das_vader_patch):
+    def test_all_attrs_resolved(self, dasvader_modern_path):
         """Ensure all attributes are resolved (no hdf5 references)"""
+        das_vader_patch = dc.read(dasvader_modern_path)[0]
         for attr, value in das_vader_patch.attrs.items():
             assert not isinstance(value, Reference)
+
+    def test_legacy_file_raises_clear_error(self, legacy_das_vader_path):
+        """Skip on incompatible stacks, otherwise ensure the file still reads."""
+        try:
+            patch = dc.read(legacy_das_vader_path)[0]
+        except DependencyError as exc:
+            pytest.skip(str(exc))
+        assert patch.attrs is not None
+
+    def test_modern_file_scan_and_slice(self, dasvader_modern_path):
+        """Named-reference DASVader files should still support scan and read."""
+        scanned = dc.scan(dasvader_modern_path)
+        assert len(scanned) == 1
+        attrs = scanned[0]
+        assert attrs.file_format == "DASVader"
+        assert attrs.gauge_length == 10.0
+        assert attrs.host_name == "test-host"
+        patch = dc.read(
+            dasvader_modern_path, time=(attrs.time_min + dc.to_timedelta64(1), ...)
+        )[0]
+        assert patch.dims == ("distance", "time")
+        assert patch.attrs.gauge_length == 10.0
 
     def test_strainrate_without_atrib(self, das_vader_strainrate_no_attrib_path):
         """Ensure parsing works when data is `strainrate` and `atrib` is absent."""
@@ -72,3 +100,17 @@ class TestDASVader:
         assert "gauge_length" not in patch.attrs.model_dump()
         scanned = dc.scan(das_vader_strainrate_no_attrib_path)
         assert len(scanned) == 1
+
+    def test_julia_ms_to_datetime64_unwraps_nested_void(self):
+        """Ensure nested JLD2-style void values are unwrapped."""
+        value = np.array(
+            [[(62_135_683_200_000,)]],
+            dtype=[("instant", [("periods", [("value", "<i8")])])],
+        )[0, 0]
+        out = _julia_ms_to_datetime64(value)
+        assert out == np.datetime64("1970-01-01T00:00:00")
+
+    def test_dereference_returns_non_reference(self):
+        """Non-reference values should be returned unchanged."""
+        value = np.float64(5_000.0)
+        assert _dereference(None, value, "PulseRateFreq") == value

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -4,6 +4,9 @@ Tests specific to DASvader format.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+
 import h5py
 import numpy as np
 import pytest
@@ -15,6 +18,102 @@ from dascore.io.dasvader.utils import _dereference, _julia_ms_to_datetime64
 from dascore.utils.downloader import fetch
 
 
+@dataclass(frozen=True)
+class _ModernDASVaderValues:
+    """Constants for the synthetic DASVader file used in these tests."""
+
+    ntime: int = 8
+    ndistance: int = 20
+    time_step: float = 1.0
+    distance_step: float = 0.5
+    gauge_length: float = 10.0
+    host_name: str = "test-host"
+    pipeline_tracker: str = "tracker-1"
+    pulse_rate_freq: float = 5000.0
+    htime_ms: int = 62_135_683_200_000
+
+
+MODERN_DASVADER = _ModernDASVaderValues()
+
+
+def _write_modern_dasvader_file(
+    path: Path, data_name: str = "data", include_attrib: bool = True
+) -> Path:
+    """Write a readable DASVader file with named datasets and references."""
+    tp_dtype = np.dtype([("hi", "<f8"), ("lo", "<f8")])
+    sr_dtype = np.dtype(
+        [("ref", tp_dtype), ("step", tp_dtype), ("len", "<i8"), ("offset", "<i8")]
+    )
+    ddas_fields = [
+        (data_name, h5py.ref_dtype),
+        ("time", sr_dtype),
+        ("htime", h5py.ref_dtype),
+        ("offset", sr_dtype),
+    ]
+    if include_attrib:
+        ddas_fields.append(("atrib", h5py.ref_dtype))
+    ddas_dtype = np.dtype(ddas_fields)
+
+    with h5py.File(path, "w") as fi:
+        shape = (
+            (MODERN_DASVADER.ndistance, MODERN_DASVADER.ntime)
+            if data_name == "data"
+            else (MODERN_DASVADER.ntime, MODERN_DASVADER.ndistance)
+        )
+        data = fi.create_dataset(
+            data_name,
+            data=np.arange(MODERN_DASVADER.ntime * MODERN_DASVADER.ndistance).reshape(
+                shape
+            ),
+        )
+        htime = fi.create_dataset("htime", data=np.array([MODERN_DASVADER.htime_ms]))
+
+        ddas = np.zeros((), dtype=ddas_dtype)
+        ddas[data_name] = data.ref
+        ddas["htime"] = htime.ref
+        ddas["time"]["ref"]["hi"] = 0.0
+        ddas["time"]["step"]["hi"] = MODERN_DASVADER.time_step
+        ddas["time"]["len"] = MODERN_DASVADER.ntime
+        ddas["time"]["offset"] = 1
+        ddas["offset"]["ref"]["hi"] = 0.0
+        ddas["offset"]["step"]["hi"] = MODERN_DASVADER.distance_step
+        ddas["offset"]["len"] = MODERN_DASVADER.ndistance
+        ddas["offset"]["offset"] = 1
+
+        if include_attrib:
+            atrib_dtype = np.dtype(
+                [
+                    ("GaugeLength", h5py.ref_dtype),
+                    ("Hostname", h5py.ref_dtype),
+                    ("PipelineTracker", h5py.ref_dtype),
+                    ("PulseRateFreq", "<f8"),
+                ]
+            )
+            gauge = fi.create_dataset(
+                "GaugeLength", data=np.array([MODERN_DASVADER.gauge_length])
+            )
+            host = fi.create_dataset(
+                "Hostname",
+                data=MODERN_DASVADER.host_name,
+                dtype=h5py.string_dtype(encoding="utf-8"),
+            )
+            tracker = fi.create_dataset(
+                "PipelineTracker",
+                data=MODERN_DASVADER.pipeline_tracker,
+                dtype=h5py.string_dtype(encoding="utf-8"),
+            )
+            atrib = np.zeros((), dtype=atrib_dtype)
+            atrib["GaugeLength"] = gauge.ref
+            atrib["Hostname"] = host.ref
+            atrib["PipelineTracker"] = tracker.ref
+            atrib["PulseRateFreq"] = MODERN_DASVADER.pulse_rate_freq
+            atrib_ds = fi.create_dataset("atrib", data=atrib)
+            ddas["atrib"] = atrib_ds.ref
+
+        fi.create_dataset("dDAS", data=ddas)
+    return path
+
+
 class TestDASVader:
     """Test case for dasvader."""
 
@@ -22,6 +121,12 @@ class TestDASVader:
     def legacy_das_vader_path(self):
         """Get the legacy DASVader file path."""
         return fetch("das_vader_1.jld2")
+
+    @pytest.fixture(scope="session")
+    def dasvader_modern_path(self, tmp_path_factory):
+        """Create a readable DASVader file with named datasets."""
+        path = tmp_path_factory.mktemp("dasvader_modern") / "modern_named_refs.jld2"
+        return _write_modern_dasvader_file(path)
 
     @pytest.fixture(scope="class")
     def das_vader_strainrate_no_attrib_path(self, tmp_path_factory):
@@ -85,13 +190,25 @@ class TestDASVader:
         assert len(scanned) == 1
         attrs = scanned[0]
         assert attrs.file_format == "DASVader"
-        assert attrs.gauge_length == 10.0
-        assert attrs.host_name == "test-host"
+        assert attrs.gauge_length == MODERN_DASVADER.gauge_length
+        assert attrs.host_name == MODERN_DASVADER.host_name
+        assert attrs.pipeline_tracker == MODERN_DASVADER.pipeline_tracker
+        assert attrs.pulse_rate_frequency == MODERN_DASVADER.pulse_rate_freq
         patch = dc.read(
-            dasvader_modern_path, time=(attrs.time_min + dc.to_timedelta64(1), ...)
+            dasvader_modern_path,
+            time=(attrs.time_min + dc.to_timedelta64(MODERN_DASVADER.time_step), ...),
         )[0]
         assert patch.dims == ("distance", "time")
-        assert patch.attrs.gauge_length == 10.0
+        assert patch.attrs.gauge_length == MODERN_DASVADER.gauge_length
+
+    def test_modern_file_out_of_range_read_is_empty(self, dasvader_modern_path):
+        """Out-of-range selections should return an empty spool."""
+        scanned = dc.scan(dasvader_modern_path)[0]
+        out = dc.read(
+            dasvader_modern_path,
+            distance=(scanned.distance_max + MODERN_DASVADER.distance_step, ...),
+        )
+        assert len(out) == 0
 
     def test_strainrate_without_atrib(self, das_vader_strainrate_no_attrib_path):
         """Ensure parsing works when data is `strainrate` and `atrib` is absent."""
@@ -102,9 +219,17 @@ class TestDASVader:
         assert len(scanned) == 1
 
     def test_julia_ms_to_datetime64_unwraps_nested_void(self):
-        """Ensure nested JLD2-style void values are unwrapped."""
+        """
+        Ensure nested JLD2-style void values are unwrapped.
+
+        JLD2 stores Julia structs as nested compound values. When h5py reads a
+        scalar field from such a compound dataset it can surface as nested
+        ``np.void`` wrappers rather than a plain integer. This test uses the
+        Julia ``DateTime -> Instant -> Periods -> value`` shape to verify the
+        helper unwraps those layers before converting milliseconds.
+        """
         value = np.array(
-            [[(62_135_683_200_000,)]],
+            [[(MODERN_DASVADER.htime_ms,)]],
             dtype=[("instant", [("periods", [("value", "<i8")])])],
         )[0, 0]
         out = _julia_ms_to_datetime64(value)


### PR DESCRIPTION
 • ## Description

  This PR makes DASVader legacy JLD2 handling explicit on newer HDF5 stacks.

  Legacy DASVader files can contain anonymous JLD2 object references which read successfully on older stacks but fail on newer h5py/HDF5 combinations. Instead of letting those failures surface as low-level h5py errors, this PR adds a dedicated compatibility error path and treats it as a dependency/compatibility issue in tests and benchmarks.

  Changes included:

  - add a shared DependencyError base in dascore.exceptions
  - add DASVaderCompatibilityError for legacy DASVader files that require an older HDF5 stack
  - detect anonymous DASVader JLD2 refs in the reader and raise a clear compatibility message with install guidance
  - document the compatibility note in the DASVader reader docstring
  - add a synthetic modern DASVader fixture with named references so DASVader read/scan/common-IO coverage still runs on newer stacks
  - update DASVader tests to skip on compatibility-stack errors instead of failing
  - simplify benchmark exception handling to suppress DependencyError, which now covers both missing optional deps and DASVader compatibility issues


  ## Checklist

  I have (if applicable):

  - [ ] referenced the GitHub issue this PR closes.
  - [x] documented the new feature with docstrings and/or appropriate doc page.
  - [x] included tests. See testing guidelines (https://dascore.org/contributing/testing.html).
  - [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced error handling and reporting for dependency-related compatibility issues

* **Bug Fixes**
  * Improved detection of legacy file format incompatibilities with more informative error messages

* **Tests**
  * Expanded test coverage to verify handling of both modern and legacy file formats, including edge cases like out-of-range read operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->