### PR TITLE
Skip flaky network tests

### DIFF
--- a/tests/test_io/_common_io_test_utils.py
+++ b/tests/test_io/_common_io_test_utils.py
@@ -67,8 +67,8 @@ def get_representative_io_test(
 
 
 @contextmanager
-def fail_on_timeout(seconds: float, label: str):
-    """Fail fast around fixture lifecycle work when it exceeds a time budget."""
+def skip_on_timeout(seconds: float, label: str):
+    """Skip flaky network-bound fixture lifecycle work when it exceeds a time budget."""
     if (
         threading.current_thread() is not threading.main_thread()
         or not hasattr(signal_mod, "SIGALRM")
@@ -88,7 +88,7 @@ def fail_on_timeout(seconds: float, label: str):
         signal_mod.setitimer(signal_mod.ITIMER_REAL, seconds)
         yield
     except TimeoutError as exc:
-        pytest.fail(str(exc))
+        pytest.skip(str(exc))
     finally:
         signal_mod.setitimer(signal_mod.ITIMER_REAL, 0)
         signal_mod.signal(signal_mod.SIGALRM, previous_handler)

--- a/tests/test_io/_common_io_test_utils.py
+++ b/tests/test_io/_common_io_test_utils.py
@@ -75,7 +75,10 @@ def skip_on_timeout(seconds: float, label: str):
         or not hasattr(signal_mod, "ITIMER_REAL")
         or not hasattr(signal_mod, "setitimer")
     ):
-        yield
+        try:
+            yield
+        except TimeoutError as exc:
+            pytest.skip(str(exc))
         return
 
     previous_handler = signal_mod.getsignal(signal_mod.SIGALRM)

--- a/tests/test_io/conftest.py
+++ b/tests/test_io/conftest.py
@@ -24,7 +24,7 @@ import pytest
 
 from dascore.compat import UPath
 from dascore.utils.downloader import fetch
-from tests.test_io._common_io_test_utils import fail_on_timeout
+from tests.test_io._common_io_test_utils import skip_on_timeout
 
 
 class _SilentSimpleHTTPRequestHandler(SimpleHTTPRequestHandler):
@@ -209,7 +209,13 @@ def _wait_for_http_path(path: UPath, timeout: float = 5.0) -> None:
                 return
         except (URLError, OSError):
             time.sleep(0.1)
-    pytest.fail(f"HTTP fixture path did not become ready in time: {path}")
+    raise TimeoutError(f"HTTP fixture path did not become ready in time: {path}")
+
+
+def _wait_for_http_server(url: str, label: str, timeout: float = 10.0) -> None:
+    """Wait for one localhost HTTP fixture to accept requests."""
+    with skip_on_timeout(timeout, label):
+        _wait_for_http_path(UPath(url), timeout=timeout)
 
 
 @pytest.fixture(scope="session")
@@ -251,23 +257,15 @@ def http_das_path(http_test_data_root, ensure_http_fetch_file):
     try:
         host, port = server.server_address
         probe_url = f"http://{host}:{port}/das/{probe_path}"
-        with fail_on_timeout(10, "http_das_path readiness probe"):
-            for _ in range(50):
-                try:
-                    with urlopen(probe_url, timeout=5):
-                        break
-                except (URLError, OSError):
-                    time.sleep(0.1)
-            else:
-                pytest.fail("HTTP test server did not become ready in time.")
+        _wait_for_http_server(probe_url, "http_das_path readiness probe")
         yield UPath(f"http://{host}:{port}/das")
     finally:
-        with fail_on_timeout(10, "http_das_path teardown"):
+        with skip_on_timeout(10, "http_das_path teardown"):
             server.shutdown()
             server.server_close()
             thread.join(timeout=5)
-        if thread.is_alive():
-            pytest.fail("HTTP test server thread did not exit cleanly.")
+            if thread.is_alive():
+                raise TimeoutError("HTTP test server thread did not exit cleanly.")
 
 
 @pytest.fixture(scope="session")
@@ -307,23 +305,17 @@ def http_regression_das_path(http_regression_data_root, ensure_http_regression_f
     try:
         host, port = server.server_address
         probe_url = f"http://{host}:{port}/das/{probe_path}"
-        with fail_on_timeout(10, "http_regression_das_path readiness probe"):
-            for _ in range(50):
-                try:
-                    with urlopen(probe_url, timeout=5):
-                        break
-                except (URLError, OSError):
-                    time.sleep(0.1)
-            else:
-                pytest.fail("HTTP test server did not become ready in time.")
+        _wait_for_http_server(probe_url, "http_regression_das_path readiness probe")
         yield UPath(f"http://{host}:{port}/das")
     finally:
-        with fail_on_timeout(10, "http_regression_das_path teardown"):
+        with skip_on_timeout(10, "http_regression_das_path teardown"):
             server.shutdown()
             server.server_close()
             thread.join(timeout=5)
-        if thread.is_alive():
-            pytest.fail("HTTP regression server thread did not exit cleanly.")
+            if thread.is_alive():
+                raise TimeoutError(
+                    "HTTP regression server thread did not exit cleanly."
+                )
 
 
 @pytest.fixture(scope="session")
@@ -336,25 +328,17 @@ def http_range_das_path(http_test_data_root, ensure_http_fetch_file):
     try:
         host, port = server.server_address
         probe_url = f"http://{host}:{port}/das/example_dasdae_event_1.h5"
-        with fail_on_timeout(10, "http_range_das_path readiness probe"):
-            for _ in range(50):
-                try:
-                    with urlopen(probe_url, timeout=5):
-                        break
-                except (URLError, OSError):
-                    time.sleep(0.1)
-            else:
-                pytest.fail(
-                    "Range-capable HTTP test server did not become ready in time."
-                )
+        _wait_for_http_server(probe_url, "http_range_das_path readiness probe")
         yield UPath(f"http://{host}:{port}/das")
     finally:
-        with fail_on_timeout(10, "http_range_das_path teardown"):
+        with skip_on_timeout(10, "http_range_das_path teardown"):
             server.shutdown()
             server.server_close()
             thread.join(timeout=5)
-        if thread.is_alive():
-            pytest.fail("Range-capable HTTP server thread did not exit cleanly.")
+            if thread.is_alive():
+                raise TimeoutError(
+                    "Range-capable HTTP server thread did not exit cleanly."
+                )
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_io/conftest.py
+++ b/tests/test_io/conftest.py
@@ -352,7 +352,8 @@ def to_http_path(
         relative_path = _coerce_http_relative_path(path_or_name)
         ensure_http_fetch_file(path.name, relative_path)
         out = http_das_path / relative_path
-        _wait_for_http_path(out)
+        with skip_on_timeout(5, f"HTTP fixture path readiness probe: {out}"):
+            _wait_for_http_path(out)
         return out
 
     return _convert
@@ -368,7 +369,8 @@ def to_http_range_path(
         relative_path = _coerce_http_relative_path(path_or_name)
         ensure_http_fetch_file(Path(path_or_name).name, relative_path)
         out = http_range_das_path / relative_path
-        _wait_for_http_path(out)
+        with skip_on_timeout(5, f"HTTP fixture path readiness probe: {out}"):
+            _wait_for_http_path(out)
         return out
 
     return _convert

--- a/tests/test_io/test_timeout_skips.py
+++ b/tests/test_io/test_timeout_skips.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import signal as signal_mod
 from itertools import chain, repeat
 from urllib.error import URLError
 
@@ -17,6 +18,9 @@ class TestTimeoutSkipHelpers:
 
     def test_skip_on_timeout_skips(self):
         """Timeouts in fixture lifecycle helpers should skip the test."""
+        required_attrs = ("SIGALRM", "ITIMER_REAL", "setitimer")
+        if not all(hasattr(signal_mod, attr) for attr in required_attrs):
+            pytest.skip("skip_on_timeout skip behavior requires SIGALRM support")
         with pytest.raises(pytest.skip.Exception, match="fixture setup timed out"):
             with skip_on_timeout(1, "fixture setup"):
                 raise TimeoutError("fixture setup timed out")

--- a/tests/test_io/test_timeout_skips.py
+++ b/tests/test_io/test_timeout_skips.py
@@ -9,6 +9,7 @@ from urllib.error import URLError
 import pytest
 from upath import UPath
 
+from tests.test_io import _common_io_test_utils as io_test_utils
 from tests.test_io import conftest as io_conftest
 from tests.test_io._common_io_test_utils import skip_on_timeout
 
@@ -25,9 +26,17 @@ class TestTimeoutSkipHelpers:
             with skip_on_timeout(1, "fixture setup"):
                 raise TimeoutError("fixture setup timed out")
 
+    def test_skip_on_timeout_skips_without_signal_support(self, monkeypatch):
+        """Platforms without SIGALRM support should still skip on timeout."""
+        monkeypatch.setattr(io_test_utils.threading, "main_thread", lambda: object())
+
+        with pytest.raises(pytest.skip.Exception, match="fixture setup timed out"):
+            with skip_on_timeout(1, "fixture setup"):
+                raise TimeoutError("fixture setup timed out")
+
     def test_wait_for_http_path_raises_timeout(self, monkeypatch):
         """The low-level probe helper should only report a timeout condition."""
-        values = chain([0.0, 6.0], repeat(6.0))
+        values = chain([0.0, 0.1, 6.0], repeat(6.0))
 
         def _fake_monotonic():
             return next(values)

--- a/tests/test_io/test_timeout_skips.py
+++ b/tests/test_io/test_timeout_skips.py
@@ -1,0 +1,39 @@
+"""Tests for timeout handling in IO network fixtures."""
+
+from __future__ import annotations
+
+from itertools import chain, repeat
+from urllib.error import URLError
+
+import pytest
+from upath import UPath
+
+from tests.test_io import conftest as io_conftest
+from tests.test_io._common_io_test_utils import skip_on_timeout
+
+
+class TestTimeoutSkipHelpers:
+    """Ensure flaky timeout paths skip rather than fail."""
+
+    def test_skip_on_timeout_skips(self):
+        """Timeouts in fixture lifecycle helpers should skip the test."""
+        with pytest.raises(pytest.skip.Exception, match="fixture setup timed out"):
+            with skip_on_timeout(1, "fixture setup"):
+                raise TimeoutError("fixture setup timed out")
+
+    def test_wait_for_http_path_raises_timeout(self, monkeypatch):
+        """The low-level probe helper should only report a timeout condition."""
+        values = chain([0.0, 6.0], repeat(6.0))
+
+        def _fake_monotonic():
+            return next(values)
+
+        def _fake_urlopen(*args, **kwargs):
+            raise URLError(TimeoutError("timed out"))
+
+        monkeypatch.setattr(io_conftest.time, "monotonic", _fake_monotonic)
+        monkeypatch.setattr(io_conftest.time, "sleep", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(io_conftest, "urlopen", _fake_urlopen)
+
+        with pytest.raises(TimeoutError, match="HTTP fixture path did not become ready"):
+            io_conftest._wait_for_http_path(UPath("http://example.com/das/test.h5"))

--- a/tests/test_io/test_timeout_skips.py
+++ b/tests/test_io/test_timeout_skips.py
@@ -35,5 +35,7 @@ class TestTimeoutSkipHelpers:
         monkeypatch.setattr(io_conftest.time, "sleep", lambda *_args, **_kwargs: None)
         monkeypatch.setattr(io_conftest, "urlopen", _fake_urlopen)
 
-        with pytest.raises(TimeoutError, match="HTTP fixture path did not become ready"):
+        with pytest.raises(
+            TimeoutError, match="HTTP fixture path did not become ready"
+        ):
             io_conftest._wait_for_http_path(UPath("http://example.com/das/test.h5"))


### PR DESCRIPTION

# Description

This PR cleans up timeout handling in the tests/test_io network fixtures so flaky localhost HTTP setup/teardown timeouts are skipped consistently instead of failing the suite.

This PR also adds focused tests covering the timeout helpers directly, rather than relying on the broader remote IO matrix to verify skip behavior.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified HTTP fixture timeout handling to skip tests instead of failing when timeouts occur, improving support for flaky test scenarios.
  * Added test coverage for timeout skip behavior in IO fixture helpers.
  * Consolidated HTTP fixture readiness probe logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->