### PR TITLE
pass_filter to avoid upcasting float32 to float64

### DIFF
--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -140,11 +140,13 @@ def pass_filter(
     sr = get_dim_sampling_rate(patch, dim)
     # get nyquist and low/high in terms of nyquist
     sos = _get_sos(sr, filt_min, filt_max, corners)
+    if patch.data.dtype == np.float32:
+        sos = sos.astype(np.float32, copy=False)
     if zerophase:
         out = sosfiltfilt(sos, patch.data, axis=axis)
     else:
         out = sosfilt(sos, patch.data, axis=axis)
-    return dc.Patch(data=out, coords=patch.coords, attrs=patch.attrs, dims=patch.dims)
+    return patch.new(data=out)
 
 
 @patch_function()

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -88,6 +88,11 @@ class TestPassFilterChecks:
 class TestPassFilter:
     """Simple tests to make sure filter logic runs."""
 
+    @staticmethod
+    def _get_float32_patch(random_patch):
+        """Return a patch with float32 data for dtype regression tests."""
+        return random_patch.new(data=random_patch.data.astype(np.float32))
+
     def test_time_bandpass_runs(self, random_patch):
         """Ensure filtering along time_axis works."""
         out = random_patch.pass_filter(time=(10, 100))
@@ -162,6 +167,24 @@ class TestPassFilter:
         """Ensure non-zero-phase filter logic runs."""
         out = random_patch.pass_filter(time=(..., 20), zerophase=False)
         assert isinstance(out, dc.Patch)
+
+    def test_float32_dtype_preserved_zero_phase(self, random_patch):
+        """Ensure zero-phase pass_filter preserves float32 payloads."""
+        patch = self._get_float32_patch(random_patch)
+        out = patch.pass_filter(time=(None, 20), zerophase=True)
+        assert isinstance(out, dc.Patch)
+        assert out.shape == patch.shape
+        assert out.data.dtype == np.float32
+        assert not np.any(pd.isnull(out.data))
+
+    def test_float32_dtype_preserved_single_pass(self, random_patch):
+        """Ensure single-pass pass_filter preserves float32 payloads."""
+        patch = self._get_float32_patch(random_patch)
+        out = patch.pass_filter(time=(None, 20), zerophase=False)
+        assert isinstance(out, dc.Patch)
+        assert out.shape == patch.shape
+        assert out.data.dtype == np.float32
+        assert not np.any(pd.isnull(out.data))
 
 
 class TestSobelFilter:


### PR DESCRIPTION
## Description

This PR just ensures that patch's with float32 payloads dont get silently up-cast to float64 in the pass_filter method. This can be important for handling large arrays. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pass_filter` to properly preserve 32-bit floating-point data types during filtering operations.
  * Ensured filtering operations do not introduce null or NaN values.

* **Tests**
  * Added test coverage for 32-bit floating-point data type handling in filtering with both zero-phase and single-pass modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->