### PR TITLE
allow array_likes to pass through patch creation

### DIFF
--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -27,17 +27,54 @@ class DataArray:
 with suppress(ImportError):
     from xarray import DataArray  # NOQA
 
+H5Dataset = ()
+
+with suppress(ImportError):
+    from h5py import Dataset as H5Dataset  # type: ignore[assignment]
+
+
+def is_array_like(maybe_array):
+    """Determine if an object looks like an array without materializing it."""
+    if H5Dataset and isinstance(maybe_array, H5Dataset):
+        return False
+    attrs = ("shape", "dtype")
+    protocols = (
+        "__array__",
+        "__array_ufunc__",
+        "__array_function__",
+        "__dlpack__",
+        "__array_namespace__",
+    )
+    return all(hasattr(maybe_array, attr) for attr in attrs) and any(
+        hasattr(maybe_array, protocol) for protocol in protocols
+    )
+
+
+def _make_immutable(maybe_array):
+    """Set writable flag to false if the array exposes one."""
+    flags = getattr(maybe_array, "flags", None)
+    if flags is None or not hasattr(flags, "writeable"):
+        return maybe_array
+    with suppress(AttributeError, ValueError):
+        maybe_array.flags.writeable = False
+    return maybe_array
+
 
 def array(array):
-    """Wrapper function for creating 'immutable' arrays."""
-    out = np.asarray(array)
-    # Setting the write flag to false makes the array immutable unless
-    # the flag is switched back.
-    out.setflags(write=False)
-    return out
+    """
+    Preserve array-like inputs for patch creation and reconstruction.
+
+    NumPy arrays and array-likes with a writable flag are marked read-only when
+    possible. Other preserved array-likes are treated as logically immutable,
+    but DASCore does not guarantee physical immutability for them.
+    """
+    out = array if is_array_like(array) else np.asarray(array)
+    return _make_immutable(out)
 
 
 def is_array(maybe_array):
-    """Determine if an object is array like."""
+    """
+    Determine if an object is a numpy array.
+    """
     # This is here so that we can support other array types in the future.
     return isinstance(maybe_array, np.ndarray)

--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from contextlib import suppress
 
 import numpy as np
+from h5py import Dataset as H5Dataset
 from numpy import floor, interp, ndarray  # NOQA
 from numpy.random import RandomState
 from rich.progress import Progress  # NOQA
@@ -27,15 +28,14 @@ class DataArray:
 with suppress(ImportError):
     from xarray import DataArray  # NOQA
 
-H5Dataset = ()
-
-with suppress(ImportError):
-    from h5py import Dataset as H5Dataset  # type: ignore[assignment]
+MATERIALIZE_NOW = (H5Dataset,)
 
 
 def is_array_like(maybe_array):
     """Determine if an object looks like an array without materializing it."""
-    if H5Dataset and isinstance(maybe_array, H5Dataset):
+    # Some array-like types depend on external resources and must be converted
+    # immediately rather than preserved by reference.
+    if MATERIALIZE_NOW and isinstance(maybe_array, MATERIALIZE_NOW):
         return False
     attrs = ("shape", "dtype")
     protocols = (

--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -33,6 +33,10 @@ MATERIALIZE_NOW = (H5Dataset,)
 
 def is_array_like(maybe_array):
     """Determine if an object looks like an array without materializing it."""
+    # NumPy scalars should still materialize to 0-D ndarrays for reduction and
+    # reassembly paths that expect an indexable array result.
+    if isinstance(maybe_array, np.generic):
+        return False
     # Some array-like types depend on external resources and must be converted
     # immediately rather than preserved by reference.
     if MATERIALIZE_NOW and isinstance(maybe_array, MATERIALIZE_NOW):

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -819,9 +819,10 @@ class CoordManager(DascoreBaseModel):
     def validate_data(self, data):
         """Ensure data conforms to coordinates."""
         data = np.asarray([]) if data is None else data
-        if self.shape != data.shape:
+        shape = tuple(data.shape)
+        if self.shape != shape:
             msg = (
-                f"Data array has a shape of {data.shape} which doesnt match "
+                f"Data array has a shape of {shape} which doesnt match "
                 f"the coordinate manager shape of {self.shape}."
             )
             raise CoordDataError(msg)

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -182,14 +182,13 @@ class Patch(NamespaceOwner):
 
     def __array__(self, dtype=None, copy=None):
         """Used to convert Patches to arrays."""
-        data = self.data
+        data = np.asarray(self.data)
         # dascore.utils.misc.to_object_array stores patch references in numpy
         # object arrays. When that function is called it tries to make a copy
         # of the array data with dtype == object, which takes a TON of memory.
         # For now, just don't let this method convert to object dtype arrays.
-        if np.issubdtype(dtype, np.dtype(object)):
-            dtype = None
-        out = data.astype(dtype) if dtype is not None else data
+        is_object_dtype = dtype is not None and np.issubdtype(dtype, np.dtype(object))
+        out = data if dtype is None or is_object_dtype else data.astype(dtype)
         out = out if not copy else np.copy(out)
         return out
 

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -743,6 +743,8 @@ def where(
         if isinstance(cond, cls):
             patch, cond = align_patch_coords(patch, cond)
 
+    cond = cond.data if isinstance(cond, cls) else cond
+    other = other.data if isinstance(other, cls) else other
     cond_array, other_array = array(cond), array(other)
 
     # Ensure condition is boolean

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -726,7 +726,8 @@ def to_object_array(object_sequence):
     This is useful, eg, for storing an object array in a dataframe.
     """
     out = np.empty(len(object_sequence), dtype=object)
-    out[:] = object_sequence
+    for num, value in enumerate(object_sequence):
+        out[num] = value
     return out
 
 

--- a/dascore/utils/models.py
+++ b/dascore/utils/models.py
@@ -11,7 +11,7 @@ import pandas as pd
 from pydantic import BaseModel, ConfigDict, PlainSerializer, PlainValidator
 from typing_extensions import Self
 
-from dascore.compat import array, is_array
+from dascore.compat import array, is_array_like
 from dascore.units import Quantity, get_quantity, get_quantity_str
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import _all_null, all_close, to_str, unbyte
@@ -37,7 +37,7 @@ TimeDelta64 = Annotated[
 ]
 
 ArrayLike = Annotated[
-    np.ndarray,
+    object,
     PlainValidator(array),
 ]
 
@@ -76,7 +76,7 @@ def sensible_model_equals(
     for name in set(x for x in d1 if not x.startswith("_")):
         # skip any private attributes.
         val1, val2 = d1[name], d2[name]
-        if is_array(val1):
+        if is_array_like(val1):
             if not all_close(val1, val2):
                 return False
         else:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,3 +1,150 @@
 """
 Tests for compatibility module.
 """
+
+from __future__ import annotations
+
+import numpy as np
+
+from dascore.compat import array, is_array_like
+
+
+class ArrayWithFlags:
+    """Array-like object exposing array protocol and writable flags."""
+
+    def __init__(self, data):
+        self._data = data
+        self.shape = data.shape
+        self.dtype = data.dtype
+        self.flags = type("Flags", (), {"writeable": True})()
+
+    def __array__(self, dtype=None, copy=None):
+        out = self._data
+        if dtype is not None:
+            out = out.astype(dtype)
+        if copy:
+            out = out.copy()
+        return out
+
+
+class ArrayNoFlags:
+    """Array-like object exposing array protocol without writable flags."""
+
+    def __init__(self, data):
+        self._data = data
+        self.shape = data.shape
+        self.dtype = data.dtype
+
+    def __array__(self, dtype=None, copy=None):
+        out = self._data
+        if dtype is not None:
+            out = out.astype(dtype)
+        if copy:
+            out = out.copy()
+        return out
+
+
+class ArrayNamespaceOnly:
+    """Array-like object identified through the array API namespace hook."""
+
+    def __init__(self, data):
+        self.shape = data.shape
+        self.dtype = data.dtype
+
+    def __array_namespace__(self):
+        return np
+
+
+class ReadOnlyFlags:
+    """Simple flags object exposing a writable attribute."""
+
+    def __init__(self, writeable=False):
+        self.writeable = writeable
+
+
+class RaisingFlags:
+    """Flags object whose writable setter always raises."""
+
+    @property
+    def writeable(self):
+        return True
+
+    @writeable.setter
+    def writeable(self, value):
+        raise ValueError("cannot change writeable")
+
+
+class ArraySubclass(np.ndarray):
+    """Simple ndarray subclass for compatibility tests."""
+
+
+class TestIsArrayLike:
+    """Tests for identifying array-like objects."""
+
+    def test_array_protocol_object(self):
+        """Objects with array protocol should be considered array-like."""
+        wrapped = ArrayNoFlags(np.arange(6).reshape(2, 3))
+        assert is_array_like(wrapped)
+
+    def test_array_namespace_object(self):
+        """Objects with array API namespace hook should be array-like."""
+        wrapped = ArrayNamespaceOnly(np.arange(6).reshape(2, 3))
+        assert is_array_like(wrapped)
+
+    def test_non_array_like_object(self):
+        """Objects without required attrs/protocols should not pass."""
+        assert not is_array_like(object())
+
+
+class TestArray:
+    """Tests for creating immutable arrays."""
+
+    def test_numpy_array_is_marked_read_only(self):
+        """Ensure plain numpy arrays remain immutable."""
+        data = np.arange(5.0)
+        out = array(data)
+        assert out is data
+        assert not out.flags.writeable
+
+    def test_numpy_subclass_is_preserved_and_marked_read_only(self):
+        """Ensure numpy subclasses retain their type and become read-only."""
+        data = np.arange(5.0).view(ArraySubclass)
+        out = array(data)
+        assert type(out) is ArraySubclass
+        assert out is data
+        assert not out.flags.writeable
+
+    def test_array_like_with_flags_has_writeable_disabled(self):
+        """Ensure array-like objects with flags get writeable set to false."""
+        wrapped = ArrayWithFlags(np.arange(6).reshape(2, 3))
+        out = array(wrapped)
+        assert out is wrapped
+        assert not out.flags.writeable
+
+    def test_array_like_with_read_only_flags_is_unchanged(self):
+        """Ensure already read-only flags stay read-only without error."""
+        wrapped = ArrayWithFlags(np.arange(6).reshape(2, 3))
+        wrapped.flags = ReadOnlyFlags(writeable=False)
+        out = array(wrapped)
+        assert out is wrapped
+        assert not out.flags.writeable
+
+    def test_array_like_with_raising_flag_setter_is_preserved(self):
+        """Ensure failing writable setters do not force coercion or raise."""
+        wrapped = ArrayWithFlags(np.arange(6).reshape(2, 3))
+        wrapped.flags = RaisingFlags()
+        out = array(wrapped)
+        assert out is wrapped
+        assert out.flags.writeable
+
+    def test_array_like_without_flags_is_preserved(self):
+        """Ensure array-like objects without flags are preserved as-is."""
+        wrapped = ArrayNoFlags(np.arange(6).reshape(2, 3))
+        out = array(wrapped)
+        assert out is wrapped
+
+    def test_non_array_like_is_converted_to_numpy_array(self):
+        """Ensure non-array-like inputs still get converted to numpy arrays."""
+        out = array([1, 2, 3])
+        assert isinstance(out, np.ndarray)
+        assert not out.flags.writeable

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -67,6 +67,7 @@ class RaisingFlags:
 
     @property
     def writeable(self):
+        """Flag to indicate the array is mutable."""
         return True
 
     @writeable.setter

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -149,3 +149,10 @@ class TestArray:
         out = array([1, 2, 3])
         assert isinstance(out, np.ndarray)
         assert not out.flags.writeable
+
+    def test_numpy_scalar_materializes_to_zero_dim_array(self):
+        """Ensure numpy scalar objects still become 0-D ndarrays."""
+        out = array(np.float64(1.5))
+        assert isinstance(out, np.ndarray)
+        assert out.shape == ()
+        assert not out.flags.writeable

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -133,7 +133,6 @@ class TestInit:
 
     def test_init_from_array_protocol_object(self, random_patch):
         """Ensure array-like objects can initialize a Patch without casting."""
-
         wrapped = ArrayProtocolWrapper(random_patch.data.copy())
         patch = dc.Patch(
             data=wrapped,
@@ -148,7 +147,6 @@ class TestInit:
 
     def test_update_from_array_protocol_object(self, random_patch):
         """Ensure update preserves non-numpy array-like payload types."""
-
         wrapped = ArrayProtocolWrapper(random_patch.data.copy())
         patch = random_patch.update(data=wrapped)
 

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -19,6 +19,23 @@ from dascore.proc.basic import apply_operator
 from dascore.utils.misc import suppress_warnings
 
 
+class ArrayProtocolWrapper:
+    """Minimal non-numpy array-like object for patch initialization tests."""
+
+    def __init__(self, data):
+        self._data = data
+        self.shape = data.shape
+        self.dtype = data.dtype
+
+    def __array__(self, dtype=None, copy=None):
+        out = self._data
+        if dtype is not None:
+            out = out.astype(dtype)
+        if copy:
+            out = out.copy()
+        return out
+
+
 def get_simple_patch() -> Patch:
     """
     Return a small simple array for memory testing.
@@ -113,6 +130,46 @@ class TestInit:
     def test_init_from_array(self, random_patch):
         """Ensure a trace can be created from raw components; array, coords, attrs."""
         assert isinstance(random_patch, Patch)
+
+    def test_init_from_array_protocol_object(self, random_patch):
+        """Ensure array-like objects can initialize a Patch without casting."""
+
+        wrapped = ArrayProtocolWrapper(random_patch.data.copy())
+        patch = dc.Patch(
+            data=wrapped,
+            coords=random_patch.coords,
+            dims=random_patch.dims,
+            attrs=random_patch.attrs,
+        )
+
+        assert isinstance(patch, Patch)
+        assert type(patch.data) is type(wrapped)
+        assert np.array_equal(patch.data, random_patch.data)
+
+    def test_update_from_array_protocol_object(self, random_patch):
+        """Ensure update preserves non-numpy array-like payload types."""
+
+        wrapped = ArrayProtocolWrapper(random_patch.data.copy())
+        patch = random_patch.update(data=wrapped)
+
+        assert isinstance(patch, Patch)
+        assert type(patch.data) is type(wrapped)
+        assert np.array_equal(patch.data, random_patch.data)
+
+    def test_numpy_input_remains_immutable(self, random_patch):
+        """Ensure numpy arrays are still marked read-only on patch creation."""
+        data = random_patch.data.copy()
+        assert data.flags.writeable
+
+        patch = dc.Patch(
+            data=data,
+            coords=random_patch.coords,
+            dims=random_patch.dims,
+            attrs=random_patch.attrs,
+        )
+
+        assert isinstance(patch.data, np.ndarray)
+        assert not patch.data.flags.writeable
 
     def test_max_time_populated(self, random_patch):
         """Ensure the time_max is populated when not explicitly given."""


### PR DESCRIPTION
  ## Summary

  Preserve non-NumPy array-like payloads through Patch creation and reconstruction instead of eagerly coercing them to np.ndarray.

  This lets dc.Patch(...) and patch.update(...) accept array-protocol objects while keeping current NumPy behavior intact:

  - NumPy arrays are still marked read-only
  - non-NumPy array-likes are preserved when possible
  - h5py.Dataset inputs are still materialized to avoid retaining closed dataset handles after IO closes

  ## Changes

  - Added dascore.compat.is_array_like as a cheap structural check for array-like payloads.
  - Updated dascore.compat.array(...) to preserve array-like inputs instead of always calling np.asarray(...).
  - Kept is_array(...) strict as NumPy-only so existing indexing/selection behavior does not change.
  - Updated Patch/model validation paths so direct construction and reconstruction preserve supported foreign array types.
  - Excluded h5py.Dataset from preservation to avoid invalid file-backed handles in patches.
  - Updated Patch.__array__ and object-array handling so NumPy interop still works when patch.data is not a NumPy array.
  - Fixed Patch.where(...) to unwrap aligned patch operands to .data before calling np.where(...).

  ## Tests

  Added coverage for:

  - initializing a Patch from a non-NumPy array-protocol object
  - preserving that type through patch.update(...)
  - keeping NumPy inputs read-only
  - compat.array(...) behavior for NumPy arrays, NumPy subclasses, array-likes with flags, array-likes without flags, and fallback conversion


  ## Notes

  This preserves foreign array types for patch creation/reconstruction only. DASCore does not yet guarantee container-type preservation across all processing operations. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended array support to include HDF5 datasets and custom array-like objects beyond NumPy arrays.
  * Arrays are now automatically enforced as read-only to prevent unintended data modification.

* **Tests**
  * Added comprehensive test coverage for array-like object handling, immutability enforcement, and data preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->