### PR TITLE
fix hampel bottleneck median centering

### DIFF
--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -15,8 +15,7 @@ from dascore.utils.patch import get_patch_window_size, patch_function
 
 def _separable_median(data, size, mode, out):
     """
-    Calculate the median along each dimension sequentially using bottleneck
-    (optimized for speed).
+    Calculate centered medians along each dimension sequentially.
     """
     # Start by copying input data to output buffer
     np.copyto(out, data)
@@ -146,8 +145,8 @@ def hampel_filter(
 
     **Performance:**
     - `approximate=True` provides 3-4x speedup over exact calculations
-    - Installing `bottleneck` package can further improve performance (~50%)
-      which applies to both approximate and exact modes.
+    - Installing `bottleneck` package can further improve approximate-mode
+      performance.
 
     See Also
     --------

--- a/dascore/utils/moving.py
+++ b/dascore/utils/moving.py
@@ -3,7 +3,8 @@ Unified interface for moving window operations with automatic engine selection.
 
 This module provides a generic interface for 1D moving window operations
 that can use either scipy or bottleneck backends, with automatic fallback
-when optional dependencies are missing.
+when optional dependencies are missing. Bottleneck median windows are aligned
+with centered scipy semantics away from edges.
 """
 
 from __future__ import annotations
@@ -51,18 +52,27 @@ OPERATION_REGISTRY = {
 
 
 def _apply_scipy_operation(
-    data: np.ndarray, window: int, operation: str, axis: int, **kwargs
+    data: np.ndarray,
+    window: int,
+    operation: str,
+    axis: int,
+    mode: str = "reflect",
+    cval: float = 0.0,
+    origin: int = 0,
+    min_count: int = 1,
+    ddof: int = 0,
 ) -> np.ndarray:
     """Apply scipy operation with proper handling."""
     module_name, func_name = OPERATION_REGISTRY[operation]["scipy"]
     func = _get_engine_function("scipy", operation)
+    scipy_kwargs = {"mode": mode, "cval": cval, "origin": origin}
 
     # Apply function with appropriate parameters
     if func_name == "uniform_filter1d":
         # Only promote integer or boolean dtypes to float, preserve float/complex
         data_kind = data.dtype.kind
         data = data.astype(np.float64) if data_kind in {"i", "b", "u"} else data
-        uniform = func(data, size=window, axis=axis, **kwargs)
+        uniform = func(data, size=window, axis=axis, **scipy_kwargs)
         if operation.lower() == "sum":
             # For sum, uniform_filter1d computes mean, so we scale by window size
             uniform *= window
@@ -71,28 +81,73 @@ def _apply_scipy_operation(
         # Need full size tuple for median_filter
         size = [1] * data.ndim
         size[axis] = window
-        return func(data, size=tuple(size), **kwargs)
+        return func(data, size=tuple(size), **scipy_kwargs)
     else:
         # 1D filters (minimum_filter1d, maximum_filter1d)
-        return func(data, size=window, axis=axis, **kwargs)
+        return func(data, size=window, axis=axis, **scipy_kwargs)
+
+
+def _apply_bottleneck_median(
+    data: np.ndarray,
+    window: int,
+    axis: int,
+    mode: str = "reflect",
+    cval: float = 0.0,
+    origin: int = 0,
+    min_count: int = 1,
+) -> np.ndarray:
+    """Apply bottleneck median with interior centered-window alignment."""
+    if mode != "reflect" or cval != 0.0 or origin != 0:
+        return _apply_scipy_operation(
+            data,
+            window,
+            "median",
+            axis,
+            mode=mode,
+            cval=cval,
+            origin=origin,
+            min_count=min_count,
+        )
+
+    func = _get_engine_function("bottleneck", "median")
+    result = func(data, window=window, axis=axis, min_count=min_count)
+    half_window = window // 2
+    if half_window:
+        destination = [slice(None)] * data.ndim
+        source = [slice(None)] * data.ndim
+        destination[axis] = slice(0, -half_window)
+        source[axis] = slice(half_window, None)
+        result[tuple(destination)] = result[tuple(source)]
+    return result
 
 
 def _apply_bottleneck_operation(
-    data: np.ndarray, window: int, operation: str, axis: int, **kwargs
+    data: np.ndarray,
+    window: int,
+    operation: str,
+    axis: int,
+    mode: str = "reflect",
+    cval: float = 0.0,
+    origin: int = 0,
+    min_count: int = 1,
+    ddof: int = 0,
 ) -> np.ndarray:
     """Apply bottleneck operation with error handling."""
+    if operation == "median":
+        return _apply_bottleneck_median(
+            data,
+            window,
+            axis,
+            mode=mode,
+            cval=cval,
+            origin=origin,
+            min_count=min_count,
+        )
+
     func = _get_engine_function("bottleneck", operation)
 
-    # Extract user-specified min_count with default of 1
-    min_count = kwargs.pop("min_count", 1)
-
-    # Filter out scipy-specific kwargs that bottleneck doesn't accept
-    scipy_only_kwargs = {"mode", "origin", "cval"}
-    bottleneck_kwargs = {k: v for k, v in kwargs.items() if k not in scipy_only_kwargs}
-
-    result = func(
-        data, window=window, axis=axis, min_count=min_count, **bottleneck_kwargs
-    )
+    extra_kwargs = {"ddof": ddof} if operation == "std" else {}
+    result = func(data, window=window, axis=axis, min_count=min_count, **extra_kwargs)
     return result
 
 
@@ -153,7 +208,11 @@ def moving_window(
     operation: str,
     axis: int = 0,
     engine: Literal["auto", "scipy", "bottleneck"] = "auto",
-    **kwargs,
+    mode: str = "reflect",
+    cval: float = 0.0,
+    origin: int = 0,
+    min_count: int = 1,
+    ddof: int = 0,
 ) -> np.ndarray:
     """
     Generic moving window operation with automatic engine selection.
@@ -170,8 +229,16 @@ def moving_window(
         Axis along which to operate
     engine : {"auto", "scipy", "bottleneck"}, default "auto"
         Engine to use
-    **kwargs
-        Additional arguments passed to the engine function
+    mode
+        Boundary mode for scipy operations.
+    cval
+        Fill value for scipy operations with ``mode="constant"``.
+    origin
+        Filter placement for scipy operations.
+    min_count
+        Minimum number of observations in a Bottleneck window.
+    ddof
+        Delta degrees of freedom for Bottleneck standard deviation.
 
     Returns
     -------
@@ -195,47 +262,149 @@ def moving_window(
     selected_engine = _select_engine(engine, operation)
     wrapper_func = ENGINE_WRAPPERS[selected_engine]
 
-    return wrapper_func(data, window, operation, axis, **kwargs)
+    return wrapper_func(
+        data,
+        window,
+        operation,
+        axis,
+        mode=mode,
+        cval=cval,
+        origin=origin,
+        min_count=min_count,
+        ddof=ddof,
+    )
 
 
 # Convenience functions - much simpler now!
 def move_median(
-    data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs
+    data: np.ndarray,
+    window: int,
+    axis: int = 0,
+    engine: str = "auto",
+    mode: str = "reflect",
+    cval: float = 0.0,
+    origin: int = 0,
+    min_count: int = 1,
 ) -> np.ndarray:
     """Moving median filter."""
-    return moving_window(data, window, "median", axis, engine, **kwargs)
+    return moving_window(
+        data,
+        window,
+        "median",
+        axis,
+        engine,
+        mode=mode,
+        cval=cval,
+        origin=origin,
+        min_count=min_count,
+    )
 
 
 def move_mean(
-    data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs
+    data: np.ndarray,
+    window: int,
+    axis: int = 0,
+    engine: str = "auto",
+    mode: str = "reflect",
+    cval: float = 0.0,
+    origin: int = 0,
+    min_count: int = 1,
 ) -> np.ndarray:
     """Moving mean filter."""
-    return moving_window(data, window, "mean", axis, engine, **kwargs)
+    return moving_window(
+        data,
+        window,
+        "mean",
+        axis,
+        engine,
+        mode=mode,
+        cval=cval,
+        origin=origin,
+        min_count=min_count,
+    )
 
 
 def move_std(
-    data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs
+    data: np.ndarray,
+    window: int,
+    axis: int = 0,
+    engine: str = "auto",
+    min_count: int = 1,
+    ddof: int = 0,
 ) -> np.ndarray:
     """Moving standard deviation filter."""
-    return moving_window(data, window, "std", axis, engine, **kwargs)
+    return moving_window(
+        data, window, "std", axis, engine, min_count=min_count, ddof=ddof
+    )
 
 
 def move_sum(
-    data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs
+    data: np.ndarray,
+    window: int,
+    axis: int = 0,
+    engine: str = "auto",
+    mode: str = "reflect",
+    cval: float = 0.0,
+    origin: int = 0,
+    min_count: int = 1,
 ) -> np.ndarray:
     """Moving sum filter."""
-    return moving_window(data, window, "sum", axis, engine, **kwargs)
+    return moving_window(
+        data,
+        window,
+        "sum",
+        axis,
+        engine,
+        mode=mode,
+        cval=cval,
+        origin=origin,
+        min_count=min_count,
+    )
 
 
 def move_min(
-    data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs
+    data: np.ndarray,
+    window: int,
+    axis: int = 0,
+    engine: str = "auto",
+    mode: str = "reflect",
+    cval: float = 0.0,
+    origin: int = 0,
+    min_count: int = 1,
 ) -> np.ndarray:
     """Moving minimum filter."""
-    return moving_window(data, window, "min", axis, engine, **kwargs)
+    return moving_window(
+        data,
+        window,
+        "min",
+        axis,
+        engine,
+        mode=mode,
+        cval=cval,
+        origin=origin,
+        min_count=min_count,
+    )
 
 
 def move_max(
-    data: np.ndarray, window: int, axis: int = 0, engine: str = "auto", **kwargs
+    data: np.ndarray,
+    window: int,
+    axis: int = 0,
+    engine: str = "auto",
+    mode: str = "reflect",
+    cval: float = 0.0,
+    origin: int = 0,
+    min_count: int = 1,
 ) -> np.ndarray:
     """Moving maximum filter."""
-    return moving_window(data, window, "max", axis, engine, **kwargs)
+    return moving_window(
+        data,
+        window,
+        "max",
+        axis,
+        engine,
+        mode=mode,
+        cval=cval,
+        origin=origin,
+        min_count=min_count,
+    )

--- a/dascore/utils/moving.py
+++ b/dascore/utils/moving.py
@@ -87,6 +87,11 @@ def _apply_scipy_operation(
         return func(data, size=window, axis=axis, **scipy_kwargs)
 
 
+def _requires_scipy_boundary(mode: str, origin: int) -> bool:
+    """Return True if scipy boundary handling is explicitly requested."""
+    return mode != "reflect" or origin != 0
+
+
 def _apply_bottleneck_median(
     data: np.ndarray,
     window: int,
@@ -97,7 +102,7 @@ def _apply_bottleneck_median(
     min_count: int = 1,
 ) -> np.ndarray:
     """Apply bottleneck median with interior centered-window alignment."""
-    if mode != "reflect" or cval != 0.0 or origin != 0:
+    if window % 2 == 0 or _requires_scipy_boundary(mode, origin):
         return _apply_scipy_operation(
             data,
             window,
@@ -111,12 +116,12 @@ def _apply_bottleneck_median(
 
     func = _get_engine_function("bottleneck", "median")
     result = func(data, window=window, axis=axis, min_count=min_count)
-    half_window = window // 2
-    if half_window:
+    shift = window // 2
+    if shift:
         destination = [slice(None)] * data.ndim
         source = [slice(None)] * data.ndim
-        destination[axis] = slice(0, -half_window)
-        source[axis] = slice(half_window, None)
+        destination[axis] = slice(0, -shift)
+        source[axis] = slice(shift, None)
         result[tuple(destination)] = result[tuple(source)]
     return result
 
@@ -145,6 +150,24 @@ def _apply_bottleneck_operation(
         )
 
     func = _get_engine_function("bottleneck", operation)
+    if _requires_scipy_boundary(mode, origin):
+        if OPERATION_REGISTRY[operation]["scipy"] is None:
+            msg = (
+                f"Operation '{operation}' cannot use scipy boundary options with "
+                "the bottleneck engine."
+            )
+            raise ParameterError(msg)
+        return _apply_scipy_operation(
+            data,
+            window,
+            operation,
+            axis,
+            mode=mode,
+            cval=cval,
+            origin=origin,
+            min_count=min_count,
+            ddof=ddof,
+        )
 
     extra_kwargs = {"ddof": ddof} if operation == "std" else {}
     result = func(data, window=window, axis=axis, min_count=min_count, **extra_kwargs)
@@ -230,11 +253,13 @@ def moving_window(
     engine : {"auto", "scipy", "bottleneck"}, default "auto"
         Engine to use
     mode
-        Boundary mode for scipy operations.
+        Boundary mode. Non-default values use scipy for operations where
+        bottleneck cannot preserve scipy boundary semantics.
     cval
-        Fill value for scipy operations with ``mode="constant"``.
+        Fill value when ``mode="constant"``.
     origin
-        Filter placement for scipy operations.
+        Filter placement. Nonzero values use scipy for operations where
+        bottleneck cannot preserve scipy boundary semantics.
     min_count
         Minimum number of observations in a Bottleneck window.
     ddof

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -212,6 +212,25 @@ class TestHampelFilter:
                 )
                 assert reduction_ratio > 0.5, msg
 
+    def test_approximate_single_dimension_matches_exact_interior(
+        self, patch_with_spikes
+    ):
+        """A 1D approximate Hampel filter should be centered in the interior."""
+        pytest.importorskip("bottleneck")
+        result_standard = patch_with_spikes.hampel_filter(
+            time=0.6, threshold=3.5, approximate=False
+        )
+        result_approximate = patch_with_spikes.hampel_filter(
+            time=0.6, threshold=3.5, approximate=True
+        )
+        axis = patch_with_spikes.dims.index("time")
+        indexer = [slice(None)] * result_approximate.data.ndim
+        indexer[axis] = slice(2, -2)
+        np.testing.assert_array_equal(
+            result_approximate.data[tuple(indexer)],
+            result_standard.data[tuple(indexer)],
+        )
+
     def test_zero_mad_handling(self, patch_uniform_data):
         """Test handling of zero MAD values."""
         # Uniform data should have MAD = 0, test that eps is used

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -212,20 +212,23 @@ class TestHampelFilter:
                 )
                 assert reduction_ratio > 0.5, msg
 
+    @pytest.mark.parametrize("dim, window", [("time", 3), ("time", 5), ("distance", 3)])
     def test_approximate_single_dimension_matches_exact_interior(
-        self, patch_with_spikes
+        self, patch_with_spikes, dim, window
     ):
         """A 1D approximate Hampel filter should be centered in the interior."""
         pytest.importorskip("bottleneck")
+        kwargs = {dim: window}
         result_standard = patch_with_spikes.hampel_filter(
-            time=0.6, threshold=3.5, approximate=False
+            samples=True, threshold=3.5, approximate=False, **kwargs
         )
         result_approximate = patch_with_spikes.hampel_filter(
-            time=0.6, threshold=3.5, approximate=True
+            samples=True, threshold=3.5, approximate=True, **kwargs
         )
-        axis = patch_with_spikes.dims.index("time")
+        axis = patch_with_spikes.dims.index(dim)
         indexer = [slice(None)] * result_approximate.data.ndim
-        indexer[axis] = slice(2, -2)
+        edge = window - 1
+        indexer[axis] = slice(edge, -edge)
         np.testing.assert_array_equal(
             result_approximate.data[tuple(indexer)],
             result_standard.data[tuple(indexer)],

--- a/tests/test_utils/test_moving.py
+++ b/tests/test_utils/test_moving.py
@@ -276,7 +276,7 @@ class TestMovingWindow:
             ]
         )
 
-        for axis, window in ((0, 3), (1, 5)):
+        for axis, window in ((0, 3), (1, 5), (0, 4), (1, 4)):
             result_scipy = move_median(data, window, axis=axis, engine="scipy")
             result_bn = move_median(data, window, axis=axis, engine="bottleneck")
             half_window = window // 2
@@ -286,7 +286,7 @@ class TestMovingWindow:
                 result_bn[tuple(indexer)], result_scipy[tuple(indexer)]
             )
 
-    def test_bottleneck_median_respects_scipy_boundary_options(self):
+    def test_bottleneck_median_boundary_options(self):
         """Non-default scipy boundary options should not be ignored."""
         pytest.importorskip("bottleneck")
         data = np.array([1.0, 5.0, 2.0, 4.0, 3.0])
@@ -294,6 +294,22 @@ class TestMovingWindow:
         result_scipy = move_median(data, 3, engine="scipy", **kwargs)
         result_bn = move_median(data, 3, engine="bottleneck", **kwargs)
         np.testing.assert_array_equal(result_bn, result_scipy)
+
+        result_bn = move_median(data, 3, engine="bottleneck", cval=-10.0)
+        result_default = move_median(data, 3, engine="bottleneck")
+        np.testing.assert_array_equal(result_bn, result_default)
+
+    def test_bottleneck_non_median_respects_scipy_boundary_options(self):
+        """Non-median operations should also honor requested boundary options."""
+        pytest.importorskip("bottleneck")
+        data = np.array([1.0, 5.0, 2.0, 4.0, 3.0])
+        kwargs = {"mode": "constant", "cval": -10.0}
+        result_scipy = move_mean(data, 3, engine="scipy", **kwargs)
+        result_bn = move_mean(data, 3, engine="bottleneck", **kwargs)
+        np.testing.assert_array_equal(result_bn, result_scipy)
+
+        with pytest.raises(ParameterError, match="cannot use scipy boundary options"):
+            moving_window(data, 3, "std", engine="bottleneck", mode="constant")
 
     def test_engine_consistency(self, test_data, available_engines):
         """Test consistency between engines where applicable."""

--- a/tests/test_utils/test_moving.py
+++ b/tests/test_utils/test_moving.py
@@ -263,6 +263,38 @@ class TestMovingWindow:
         # Check interior values
         np.testing.assert_allclose(result_mean[1:4], expected_mean, rtol=1e-12)
 
+    def test_bottleneck_median_is_centered(self):
+        """Bottleneck median should match scipy away from edge regions."""
+        pytest.importorskip("bottleneck")
+        data = np.array(
+            [
+                [0.0, 3.0, 1.0, 8.0, 4.0, 2.0, 6.0],
+                [5.0, 4.0, 9.0, 1.0, 7.0, 3.0, 2.0],
+                [2.0, 8.0, 4.0, 6.0, 0.0, 5.0, 1.0],
+                [7.0, 1.0, 5.0, 2.0, 9.0, 6.0, 3.0],
+                [4.0, 6.0, 2.0, 5.0, 3.0, 1.0, 8.0],
+            ]
+        )
+
+        for axis, window in ((0, 3), (1, 5)):
+            result_scipy = move_median(data, window, axis=axis, engine="scipy")
+            result_bn = move_median(data, window, axis=axis, engine="bottleneck")
+            half_window = window // 2
+            indexer = [slice(None)] * data.ndim
+            indexer[axis] = slice(half_window, -half_window)
+            np.testing.assert_array_equal(
+                result_bn[tuple(indexer)], result_scipy[tuple(indexer)]
+            )
+
+    def test_bottleneck_median_respects_scipy_boundary_options(self):
+        """Non-default scipy boundary options should not be ignored."""
+        pytest.importorskip("bottleneck")
+        data = np.array([1.0, 5.0, 2.0, 4.0, 3.0])
+        kwargs = {"mode": "constant", "cval": -10.0}
+        result_scipy = move_median(data, 3, engine="scipy", **kwargs)
+        result_bn = move_median(data, 3, engine="bottleneck", **kwargs)
+        np.testing.assert_array_equal(result_bn, result_scipy)
+
     def test_engine_consistency(self, test_data, available_engines):
         """Test consistency between engines where applicable."""
         if "bottleneck" not in available_engines:


### PR DESCRIPTION
 This PR fixes backend-dependent behavior in the Hampel filter’s approximate path.

  Previously, `hampel_filter(..., approximate=True)` used sequential 1D `move_median(..., engine="auto")` calls. When Bottleneck was installed, `move_median` used `bottleneck.move_median`, which is trailing-window based
  rather than centered. This made approximate Hampel output depend on whether Bottleneck was installed and introduced a phase/causal shift relative to the SciPy centered median behavior.

  This change updates the Bottleneck median path to align the interior of the trailing median output with centered-window semantics while preserving the low-memory fast path. Edge behavior remains approximate for the
  default fast path. If callers request non-default SciPy boundary behavior via `mode`, `cval`, or `origin`, the Bottleneck median path now falls back to SciPy so those options are respected.

  Also included:
  - explicit moving-window backend arguments instead of filtering/mutating generic `kwargs`
  - regression tests for Bottleneck median interior centering
  - regression tests for SciPy boundary option fallback
  - Hampel test coverage for centered interior behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Moving-window functions now use explicit parameters for boundary handling, fill values, window alignment, minimum counts and ddof, replacing generic passthrough for clearer, safer calls. Some engine/boundary combinations now raise an error when unsupported.

* **Documentation**
  * Clarified Hampel filter docs to narrow which modes benefit from optional speed optimizations.

* **Tests**
  * Added tests verifying median/mean/std behavior and engine compatibility, including interior-equality and boundary-handling assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->