### PR TITLE
fix(chunk): clarify gap warning - patches stay separate, are not merged (#662)

### DIFF
--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -208,11 +208,11 @@ class ChunkManager:
         has_gap = start_sorted > end_markers
         if has_gap.any():
             msg = (
-                f"There is a gap in the patch along dimension {self._name}. "
-                f"As a result, some patches in the chunked spool may be "
-                f"unevenly sampled. However, they are still considered "
-                f"contiguous because a tolerance of {self._tolerance} "
-                f"was used in the chunk function."
+                f"There is a gap in the patch along dimension {self._name} "
+                f"larger than the configured tolerance of {self._tolerance}. "
+                f"The chunked spool keeps the gapped patches as separate "
+                f"groups (they are not merged); raise the tolerance if you "
+                f"want them treated as contiguous."
             )
             warnings.warn(msg, UserWarning, stacklevel=3)
         group_num = has_gap.astype(np.int64).cumsum()


### PR DESCRIPTION
Fixes #662. The gap warning emitted by `_get_group` (`dascore/utils/chunk.py:209-216`) was incorrect: it told the user that patches with a gap exceeding the tolerance were 'still considered contiguous'. In fact `group_num = has_gap.astype(np.int64).cumsum()` increments at each gap, so the gapped patches end up in **separate** groups and are NOT merged. The reporter's example (`Spool.chunk(time=None)` with a 1-hour gap) confirmed the patches stay split while the warning suggested otherwise.

## Change

Rewrite the warning message to reflect actual behaviour:

> There is a gap in the patch along dimension {name} larger than the configured tolerance of {tolerance}. The chunked spool keeps the gapped patches as separate groups (they are not merged); raise the tolerance if you want them treated as contiguous.

The opening phrase `There is a gap in the patch` is preserved so the existing `tests/test_utils/test_chunk.py:262` regex (`r"There is a gap in the patch"`) still matches.

## Test plan

- [x] `pytest tests/test_utils/test_chunk.py -k gap` — 2/2 pass
- [x] No code-path change; warning text only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning messages when continuity gaps are detected to clarify how tolerance thresholds work and provide guidance on adjusting settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->