### PR TITLE
Document dascorepy namespace plugin

### DIFF
--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -100,6 +100,14 @@ my_ext = "dascore_extra.patch_namespace:MyPatchNamespace"
 
 After installation, DASCore loads the namespace the first time `patch.my_ext` is accessed.
 
+## Registered namespace plugins
+
+DASCore discovers namespace plugins from installed Python packages through entry points. These plugins are distributed separately from DASCore, so install the package you need before using its namespace.
+
+| Package | Namespace | Entry point | Purpose |
+| --- | --- | --- | --- |
+| [`dascorepy`](https://dasdae.github.io/dascorepy/) | `patch.daspy` | `dascore.patch_namespace` | DASPy algorithms exposed on DASCore patches. |
+
 ### Spool namespaces
 
 Spool namespaces use the same pattern. The only changes are:


### PR DESCRIPTION
## Summary

- Add dascorepy to the registered namespace plugin table in the extension guide
- List its `patch.daspy` namespace and `dascore.patch_namespace` entry point group




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on registered namespace plugins, explaining how DASCore discovers and registers plugins through Python package entry points, with configuration examples for plugin developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->