### PR TITLE
Fix #662

### DIFF
--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -29,6 +29,8 @@ from dascore.utils.time import (
     to_timedelta64,
 )
 
+_DEFAULT_TOLERANCE = 1.5
+
 
 def get_intervals(
     start,
@@ -150,7 +152,7 @@ class ChunkManager:
         group_columns: Collection[str] | None = None,
         keep_partial=False,
         snap_coords=True,
-        tolerance=1.5,
+        tolerance=_DEFAULT_TOLERANCE,
         conflict="raise",
         **kwargs,
     ):
@@ -206,15 +208,23 @@ class ChunkManager:
         stop_cum_max = stop_sorted.cummax()
         end_markers = stop_cum_max.shift() + step_sorted * self._tolerance
         has_gap = start_sorted > end_markers
-        if has_gap.any():
-            msg = (
-                f"There is a gap in the patch along dimension {self._name}. "
-                f"As a result, some patches in the chunked spool may be "
-                f"unevenly sampled. However, they are still considered "
-                f"contiguous because a tolerance of {self._tolerance} "
-                f"was used in the chunk function."
-            )
-            warnings.warn(msg, UserWarning, stacklevel=3)
+
+        # Check for merging that might change coordinates from evenly sorted
+        # to simply monotonic. See #662.
+        if self._tolerance > _DEFAULT_TOLERANCE:
+            # See if gaps would have formed by default. Then alert on difference.
+            end_markers_d = stop_cum_max.shift() + step_sorted * _DEFAULT_TOLERANCE
+            has_gap_d = start_sorted > end_markers_d
+
+            if (has_gap != has_gap_d).any():
+                msg = (
+                    f"There is a gap in the patch along dimension {self._name} "
+                    f"but a merge tolerance of {self._tolerance} was used to force "
+                    "merging the patches. As a result, some patches in the chunked "
+                    "spool may be unevenly sampled, or have their sampling rate "
+                    "increased."
+                )
+                warnings.warn(msg, UserWarning, stacklevel=3)
         group_num = has_gap.astype(np.int64).cumsum()
         return group_num[start.index]
 
@@ -324,8 +334,10 @@ class ChunkManager:
         # need to make sure we don't have overlaps in source df. This implicitly
         # handles merging.
         sub_source = _remove_overlaps(sub_source, self._name)
-        src1, src2, src_step = get_interval_columns(sub_source, self._name, arrays=True)
-        chu1, chu2, chu_step = get_interval_columns(sub_chunk, self._name, arrays=True)
+        src1, src2, _src_step = get_interval_columns(
+            sub_source, self._name, arrays=True
+        )
+        chu1, chu2, _chu_step = get_interval_columns(sub_chunk, self._name, arrays=True)
         dims = get_dim_names_from_columns(sub_source)
         cols2keep = get_column_names_from_dim(dims)
         # next get index range for which chunk times belong to.

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -194,8 +194,11 @@ class ChunkManager:
             msg = "Chunk value must be greater than 0."
             raise ParameterError(msg)
 
-    def _get_continuity_group_number(self, start, stop, step) -> pd.Series:
+    def _get_continuity_group_number(
+        self, start, stop, step, tolerance=None
+    ) -> pd.Series:
         """Return a series of ints indicating continuity group."""
+        tolerance = self._tolerance if tolerance is None else tolerance
         # start by sorting according to start time
         # Use positional argsort to avoid pandas label/return-type changes
         args = np.argsort(start.to_numpy())
@@ -206,25 +209,8 @@ class ChunkManager:
         )
         # next get cummax of endtimes and detect gaps
         stop_cum_max = stop_sorted.cummax()
-        end_markers = stop_cum_max.shift() + step_sorted * self._tolerance
+        end_markers = stop_cum_max.shift() + step_sorted * tolerance
         has_gap = start_sorted > end_markers
-
-        # Check for merging that might change coordinates from evenly sorted
-        # to simply monotonic. See #662.
-        if self._tolerance > _DEFAULT_TOLERANCE:
-            # See if gaps would have formed by default. Then alert on difference.
-            end_markers_d = stop_cum_max.shift() + step_sorted * _DEFAULT_TOLERANCE
-            has_gap_d = start_sorted > end_markers_d
-
-            if (has_gap != has_gap_d).any():
-                msg = (
-                    f"There is a gap in the patch along dimension {self._name} "
-                    f"but a merge tolerance of {self._tolerance} was used to force "
-                    "merging the patches. As a result, some patches in the chunked "
-                    "spool may be unevenly sampled, or have their sampling rate "
-                    "increased."
-                )
-                warnings.warn(msg, UserWarning, stacklevel=3)
         group_num = has_gap.astype(np.int64).cumsum()
         return group_num[start.index]
 
@@ -408,6 +394,11 @@ class ChunkManager:
         col_g = cont_g * 0 if not columns else df.groupby(columns).ngroup()
         return col_g
 
+    def _get_final_group(self, samp_g, col_g, cont_g):
+        """Combine grouping components into final group labels."""
+        group_series = [x.astype(str) for x in [samp_g, col_g, cont_g]]
+        return reduce(lambda x, y: x + "_" + y, group_series)
+
     def _get_group(self, df, start, stop, step):
         """
         Get the group designation for df. This accounts for both time intervals
@@ -416,8 +407,31 @@ class ChunkManager:
         cont_g = self._get_continuity_group_number(start, stop, step)
         samp_g = self._get_sampling_group_num(step)
         col_g = self._get_col_group(df, cont_g)
-        group_series = [x.astype(str) for x in [samp_g, col_g, cont_g]]
-        group = reduce(lambda x, y: x + "_" + y, group_series)
+        group = self._get_final_group(samp_g, col_g, cont_g)
+
+        # Check for final merges that only occur because of a non-default
+        # tolerance. See #662.
+        if self._tolerance > _DEFAULT_TOLERANCE:
+            default_cont_g = self._get_continuity_group_number(
+                start, stop, step, tolerance=_DEFAULT_TOLERANCE
+            )
+            default_group = self._get_final_group(samp_g, col_g, default_cont_g)
+            merges_default_groups = (
+                pd.DataFrame({"group": group, "default_group": default_group})
+                .groupby("group")["default_group"]
+                .nunique()
+                .gt(1)
+                .any()
+            )
+            if merges_default_groups:
+                msg = (
+                    f"There is a gap in the patch along dimension {self._name} "
+                    f"but a merge tolerance of {self._tolerance} was used to force "
+                    "merging the patches. As a result, some patches in the chunked "
+                    "spool may be unevenly sampled, or have their sampling rate "
+                    "increased."
+                )
+                warnings.warn(msg, UserWarning, stacklevel=3)
         return group
 
     def _get_group_dfs(self, group, dur, overlap, group_mins, group_maxs, df, step):

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -399,6 +399,19 @@ class ChunkManager:
         group_series = [x.astype(str) for x in [samp_g, col_g, cont_g]]
         return reduce(lambda x, y: x + "_" + y, group_series)
 
+    def _groups_merge_default_groups(self, group, default_cont_g) -> bool:
+        """Return True if any final group contains multiple default groups."""
+        group_codes = pd.factorize(group, sort=False)[0]
+        default_codes = pd.factorize(default_cont_g, sort=False)[0]
+        order = np.argsort(group_codes, kind="stable")
+        group_sorted = group_codes[order]
+        default_sorted = default_codes[order]
+        new_group = np.r_[True, group_sorted[1:] != group_sorted[:-1]]
+        group_starts = np.flatnonzero(new_group)
+        default_min = np.minimum.reduceat(default_sorted, group_starts)
+        default_max = np.maximum.reduceat(default_sorted, group_starts)
+        return bool(np.any(default_min != default_max))
+
     def _get_group(self, df, start, stop, step):
         """
         Get the group designation for df. This accounts for both time intervals
@@ -415,15 +428,7 @@ class ChunkManager:
             default_cont_g = self._get_continuity_group_number(
                 start, stop, step, tolerance=_DEFAULT_TOLERANCE
             )
-            default_group = self._get_final_group(samp_g, col_g, default_cont_g)
-            merges_default_groups = (
-                pd.DataFrame({"group": group, "default_group": default_group})
-                .groupby("group")["default_group"]
-                .nunique()
-                .gt(1)
-                .any()
-            )
-            if merges_default_groups:
+            if self._groups_merge_default_groups(group, default_cont_g):
                 msg = (
                     f"There is a gap in the patch along dimension {self._name} "
                     f"but a merge tolerance of {self._tolerance} was used to force "
@@ -431,7 +436,7 @@ class ChunkManager:
                     "spool may be unevenly sampled, or have their sampling rate "
                     "increased."
                 )
-                warnings.warn(msg, UserWarning, stacklevel=3)
+                warnings.warn(msg, UserWarning, stacklevel=4)
         return group
 
     def _get_group_dfs(self, group, dur, overlap, group_mins, group_maxs, df, step):

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -609,6 +609,10 @@ class TestChunkMerge:
 
         # Case 3: The patches should merge and a warning issued.
         match = "There is a gap in the patch along dimension time"
-        with pytest.warns(UserWarning, match=match):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
             out = dc.spool((base, patch_w_gap)).chunk(time=None, tolerance=10)
+        assert len(caught_warnings) == 1
+        assert match in str(caught_warnings[0].message)
+        assert caught_warnings[0].filename == __file__
         assert len(out) == 1

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -8,6 +8,7 @@ extensive.
 from __future__ import annotations
 
 import random
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -575,3 +576,39 @@ class TestChunkMerge:
             assert not pd.isna(df_time_min), f"DF row {i} has NaN time_min"
             assert not pd.isna(df_time_max), f"DF row {i} has NaN time_max"
             assert df_time_min <= df_time_max, f"DF row {i} has invalid time range"
+
+    def test_chunk_non_adjacent_within_tolerance_warns(self, random_patch):
+        """
+        Non-adjacent patches can still merge, but the coordinate type may change.
+
+        In this case a warning should be issued. See #662.
+        """
+        base = random_patch.update_attrs(history="")
+        time = random_patch.get_coord("time")
+
+        # Case 1: the patches should in fact merge with no warning.
+        patch_no_gap = base.update_coords(time_min=time.max() + time.step).update_attrs(
+            history=""
+        )
+        # No warning should be raised.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error")
+            out = dc.spool((base, patch_no_gap)).chunk(time=None)
+        assert len(out) == 1
+        assert out[0].get_coord("time").step is not None
+
+        # Case 2: The patches should not merge.
+        patch_w_gap = base.update_coords(
+            time_min=time.max() + time.step * 5,
+        ).update_attrs(history="")
+        # No warning, no merge.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error")
+            out = dc.spool((base, patch_w_gap)).chunk(time=None)
+        assert len(out) == 2
+
+        # Case 3: The patches should merge and a warning issued.
+        match = "There is a gap in the patch along dimension time"
+        with pytest.warns(UserWarning, match=match):
+            out = dc.spool((base, patch_w_gap)).chunk(time=None, tolerance=10)
+        assert len(out) == 1

--- a/tests/test_io/test_febus/test_febusg1.py
+++ b/tests/test_io/test_febus/test_febusg1.py
@@ -123,7 +123,9 @@ class TestMisc:
         """Ensure chunk(time=None) merges both g1 files into one patch."""
         spool = dc.spool(g1_two_file_directory)
         # These weren't directly adjacent files so we adjust the tolerance.
-        merged = spool.chunk(time=None, tolerance=3)
+        match = "There is a gap in the patch along dimension time"
+        with pytest.warns(UserWarning, match=match):
+            merged = spool.chunk(time=None, tolerance=3)
         assert len(merged) == 1
 
     def test_mtx_read_raises(self, g1_mtx_buffer):

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -258,9 +258,6 @@ class TestChunkToMerge:
         expected_durations = gapy_df["time_max"] - gapy_df["time_min"]
         durations = out["time_max"] - out["time_min"]
         assert expected_durations.equals(durations)
-        # Assert a UserWarning about gaps is raised
-        with pytest.warns(UserWarning, match=r"There is a gap in the patch"):
-            _, out = cm.chunk(gapy_df)
 
     def test_doesnt_merge_unordered_gappy_df(self, gapy_df_unordered):
         """Ensure the gappy dataframe doesn't get merged."""

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -268,6 +270,22 @@ class TestChunkToMerge:
         expected_durations = df["time_max"] - df["time_min"]
         durations = out["time_max"] - out["time_min"]
         assert expected_durations.equals(durations)
+
+    def test_no_warning_when_final_groups_stay_separate(self, contiguous_df):
+        """No warning if other group components prevent final forced merge."""
+        df = contiguous_df.iloc[:2].copy()
+        step = df["time_step"]
+        df.loc[0, "time_max"] = df.loc[0, "time_min"] + 10 * step.iloc[0]
+        df.loc[1, "time_min"] = df.loc[0, "time_max"] + 5 * step.iloc[0]
+        df.loc[1, "time_max"] = df.loc[1, "time_min"] + 10 * step.iloc[1]
+        df["station"] = ["sta1", "sta2"]
+        cm = ChunkManager(time=None, tolerance=10, group_columns=("station",))
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error")
+            _, out = cm.chunk(df)
+
+        assert len(out) == 2
 
     def test_modified_flag_after_merge(self, contiguous_df):
         """Test that the modified flag shows False for simple merge."""


### PR DESCRIPTION
# Description

Fixes #662.

  This updates spool chunk merging so a `UserWarning` is only emitted when a larger-than-default merge tolerance actually forces patches across a gap into the same chunk. Ordinary gaps that remain split no longer warn.

  Changes included:

  - Added a shared default chunk tolerance constant.
  - Compared merge grouping against the default tolerance when a larger tolerance is used.
  - Warn only when the larger tolerance changes grouping by merging across a gap.
  - Fixed the warning text so the tolerance value is interpolated correctly.
  - Added coverage for adjacent patches, gapped non-merged patches, and gapped forced-merge patches.
  - Updated the FEBUS G1 merge test to assert the expected warning.

  ## Checklist

  I have (if applicable):

  - [x] referenced the GitHub issue this PR closes.
  - [ ] documented the new feature with docstrings and/or appropriate doc page.
  - [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
  - [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced gap detection warnings in chunking operations to be more precise. Warnings about dimensional gaps now only appear when gaps would actually occur under the user-specified tolerance threshold, reducing unnecessary alerts while ensuring data integrity concerns are properly flagged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->