### PR TITLE
Fix/febus sampling rate

### DIFF
--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -76,13 +76,12 @@ def _get_zone_time(feb):
     else:
         # In these versions of the files the extents appear to be wrong, but
         # they don't have overlaps so we can just use the shape.
-        dt = 1 / float(_maybe_unpack(zone.attrs["SamplingRate"]))
 
         # Really early versions (< 2021) seem to have a hardcoded value of
         # 250000000 stored in zone.attrs["SamplingRate"]
-        # We then use the second spacing instead
-        if dt < 1e-8:
-            dt = float(_maybe_unpack(zone.attrs["Spacing"][1])) / 1_000.
+        # We then use then spacing[1] instead (converted from milli-seconds)
+        fsamp = float(_maybe_unpack(zone.attrs["SamplingRate"]))
+        dt = 1/fsamp if fsamp<1e8 else float(_maybe_unpack(zone.attrs["Spacing"][1])) / 1_000.
         block_pad = shape[1]
 
     # Apparently, if the extents are set to 0 the overlapping edges are still

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -64,8 +64,6 @@ def _get_zone_time(feb):
     #if neither exist, default to 100 (according to the FEBUS template)
     overlap_attr = zone.attrs.get("Overlap", zone.attrs.get("BlockOverlap", 100))
     overlap = np.atleast_1d(_maybe_unpack(overlap_attr))[0]
-
-
     shape = feb.zone[feb.data_name].shape
     # We need to determine if this a v1 file (no version in attrs). See # 589
     # and # 587. This could perhaps be made more robust in the future.
@@ -370,7 +368,6 @@ def _read_febus(fi, distance=None, time=None, attr_cls=dc.PatchAttrs):
     """Read the febus values into a patch."""
     out = []
     for attr, cm, febus in _yield_attrs_coords(fi):
-
         data, new_cm = _get_data_new_cm(cm, febus, distance=distance, time=time)
         if data.size:
             patch = dc.Patch(data=data, coords=new_cm, attrs=attr_cls(**attr))

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -60,8 +60,12 @@ def _get_zone_time(feb):
     zone = feb.zone
     block_time = _get_block_time(feb)
     extents, spacing = zone.attrs["Extent"], zone.attrs["Spacing"]
-    overlap_attr = zone.attrs.get("Overlap", zone.attrs.get("BlockOverlap", 0))
+    #different version use "Overlap" or "BlockOverlap"
+    #if neither exist, default to 100 (according to the FEBUS template)
+    overlap_attr = zone.attrs.get("Overlap", zone.attrs.get("BlockOverlap", 100))
     overlap = np.atleast_1d(_maybe_unpack(overlap_attr))[0]
+
+
     shape = feb.zone[feb.data_name].shape
     # We need to determine if this a v1 file (no version in attrs). See # 589
     # and # 587. This could perhaps be made more robust in the future.
@@ -74,8 +78,10 @@ def _get_zone_time(feb):
     else:
         # In these versions of the files the extents appear to be wrong, but
         # they don't have overlaps so we can just use the shape.
-        dt = 1 / float(_maybe_unpack(zone.attrs["SamplingRate"]))
+        #some versions have the SamplingRate attribute wrong. using spacing[1] is safer
+        dt = float(_maybe_unpack(zone.attrs["Spacing"][1])) / 1_000.
         block_pad = shape[1]
+
     # Apparently, if the extents are set to 0 the overlapping edges are still
     # in the file, otherwise they have been removed.
     # This does not, however, mean the block dimension match the actual

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -209,6 +209,8 @@ def _get_febus_attrs(feb: _FebusSlice) -> dict:
     out["zone"] = feb.zone_name
     out["schema_version"] = out.get("folog_a1_software_version", "").split(".")[0]
     out["dims"] = ("time", "distance")
+    out['data_type'] = 'strainrate'
+    out['data_units'] = 'nanostrain/s'
     return out
 
 
@@ -368,6 +370,7 @@ def _read_febus(fi, distance=None, time=None, attr_cls=dc.PatchAttrs):
     """Read the febus values into a patch."""
     out = []
     for attr, cm, febus in _yield_attrs_coords(fi):
+
         data, new_cm = _get_data_new_cm(cm, febus, distance=distance, time=time)
         if data.size:
             patch = dc.Patch(data=data, coords=new_cm, attrs=attr_cls(**attr))

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -76,8 +76,13 @@ def _get_zone_time(feb):
     else:
         # In these versions of the files the extents appear to be wrong, but
         # they don't have overlaps so we can just use the shape.
-        #some versions have the SamplingRate attribute wrong. using spacing[1] is safer
-        dt = float(_maybe_unpack(zone.attrs["Spacing"][1])) / 1_000.
+        dt = 1 / float(_maybe_unpack(zone.attrs["SamplingRate"]))
+
+        # Really early versions (< 2021) seem to have a hardcoded value of
+        # 250000000 stored in zone.attrs["SamplingRate"]
+        # We then use the second spacing instead
+        if dt < 1e-8:
+            dt = float(_maybe_unpack(zone.attrs["Spacing"][1])) / 1_000.
         block_pad = shape[1]
 
     # Apparently, if the extents are set to 0 the overlapping edges are still


### PR DESCRIPTION

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

I have testes with my own data and the Valencia data provided in with DAScore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FEBUS data parsing now handles missing overlap attributes gracefully with automatic defaults, improving file compatibility.
  * Refined time-step calculations for enhanced FEBUS file format support.

* **New Features**
  * Added strain rate metadata fields to FEBUS data output for improved data documentation and characterization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->