### PR TITLE
new patch functions for demean and demedian

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -404,6 +404,8 @@ class Patch(NamespaceOwner):
     correlate = dascore.proc.correlate
     correlate_shift = dascore.proc.correlate_shift
     decimate = dascore.proc.decimate
+    demean = dascore.proc.demean
+    demedian = dascore.proc.demedian
     detrend = dascore.proc.detrend
     dropna = dascore.proc.dropna
     fillna = dascore.proc.fillna

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -854,7 +854,7 @@ def demedian(patch, dim: str = "time"):
     >>>
     >>> # Show patch with common-mode noise
     >>> ax0 = patch0.viz.waterfall(ax = axs[0], show=False)
-    >>> ax0.set_title('Original with common-mode noise')
+    >>> _ = ax0.set_title('Original with common-mode noise')
     >>>
     >>> # Show demedian applied patch
     >>> patch1 = patch0.demedian(dim='distance')
@@ -863,7 +863,7 @@ def demedian(patch, dim: str = "time"):
     >>>
     >>> # Show difference
     >>> ax2 = (patch0-patch1).viz.waterfall(ax = axs[2], show=False)
-    >>> ax2.set_title('difference')
+    >>> _ = ax2.set_title('Difference')
     >>>
     >>> plt.show()
     """
@@ -921,11 +921,11 @@ def demean(patch, dim: str = "time"):
     >>> # Show demean applied patch
     >>> patch1 = patch0.demean(dim='distance')
     >>> ax1 =  patch1.viz.waterfall(ax = axs[1], show=False)
-    >>> ax1.set_title('Removed common-mode noise')
+    >>> _ = ax1.set_title('Removed common-mode noise')
     >>>
     >>> # Show difference
     >>> ax2 = (patch0-patch1).viz.waterfall(ax = axs[2], show=False)
-    >>> ax2.set_title('difference')
+    >>> _ = ax2.set_title('Difference')
     >>>
     >>> plt.show()
     """

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -819,3 +819,127 @@ def full(patch, fill_value):
     """
     array = np.full(patch.data.shape, fill_value)
     return patch.update(data=array)
+
+
+@patch_function()
+def demedian(patch, dim: str = "time"):
+    """
+    Remove the median along a given dimension of a DASCore patch.
+
+    Parameters
+    ----------
+    patch :
+        The patch to remove the median from.
+    dim : str
+        Dimension name (e.g., "time", "distance").
+
+    Example
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> import dascore as dc
+    >>> import numpy as np
+    >>>
+    >>> patch = dc.get_example_patch('example_event_2')
+    >>> nx,nt = patch.data.shape
+    >>>
+    >>> # Add some periodic common-mode noise
+    >>> x = np.linspace(0, 6 * np.pi, nt)
+    >>> y = np.sin(x) * patch.data.max() / 30
+    >>> Y = y[np.newaxis, :] * np.ones((nx,nt), dtype=float)
+    >>> patch0 = patch + Y
+    >>>
+    >>>
+    >>> # Prepare figure
+    >>> fig, axs = plt.subplots(1, 3, figsize=(20,8), layout='constrained')
+    >>>
+    >>> # Show patch with common-mode noise
+    >>> ax0 = patch0.viz.waterfall(ax = axs[0], show=False)
+    >>> ax0.set_title('Original with common-mode noise')
+    >>>
+    >>> # Show demedian applied patch
+    >>> patch1 = patch0.demedian(dim='distance')
+    >>> ax1 =  patch1.viz.waterfall(ax = axs[1], show=False)
+    >>> ax1.set_title('Removed common-mode noise')
+    >>>
+    >>> # Show difference
+    >>> ax2 = (patch0-patch1).viz.waterfall(ax = axs[2], show=False)
+    >>> ax2.set_title('difference')
+    >>>
+    >>> plt.show()
+    """
+    if dim not in patch.dims:
+        raise ValueError(f"Dimension '{dim}' not found in patch.dims={patch.dims}")
+
+    axis = patch.dims.index(dim)
+
+    data = np.asarray(patch.data)
+
+    # Compute median along axis, keep dims for broadcasting
+    med = np.median(data, axis=axis, keepdims=True)
+
+    new_data = data - med
+
+    # Return a new patch with updated data
+    return patch.new(data=new_data)
+
+
+@patch_function()
+def demean(patch, dim: str = "time"):
+    """
+    Remove the mean along a given dimension of a DASCore patch.
+
+    Parameters
+    ----------
+    patch :
+        The patch to remove the mean from.
+    dim : str
+        Dimension name (e.g., "time", "distance").
+
+    Example (note that the example patch is not ideal, but still shows improvements)
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> import dascore as dc
+    >>> import numpy as np
+    >>>
+    >>> patch = dc.get_example_patch('example_event_2')
+    >>> nx,nt = patch.data.shape
+    >>>
+    >>> # Add some periodic common-mode noise
+    >>> x = np.linspace(0, 6 * np.pi, nt)
+    >>> y = np.sin(x) * patch.data.max() / 30
+    >>> Y = y[np.newaxis, :] * np.ones((nx,nt), dtype=float)
+    >>> patch0 = patch + Y
+    >>>
+    >>>
+    >>> # Prepare figure
+    >>> fig, axs = plt.subplots(1, 3, figsize=(20,8), layout='constrained')
+    >>>
+    >>> # Show patch with common-mode noise
+    >>> ax0 = patch0.viz.waterfall(ax = axs[0], show=False)
+    >>> ax0.set_title('Original with common-mode noise')
+    >>>
+    >>> # Show demean applied patch
+    >>> patch1 = patch0.demean(dim='distance')
+    >>> ax1 =  patch1.viz.waterfall(ax = axs[1], show=False)
+    >>> ax1.set_title('Removed common-mode noise')
+    >>>
+    >>> # Show difference
+    >>> ax2 = (patch0-patch1).viz.waterfall(ax = axs[2], show=False)
+    >>> ax2.set_title('difference')
+    >>>
+    >>> plt.show()
+    """
+    if dim not in patch.dims:
+        raise ValueError(f"Dimension '{dim}' not found in patch.dims={patch.dims}")
+
+    axis = patch.dims.index(dim)
+
+    data = np.asarray(patch.data)
+
+    # Compute median along axis, keep dims for broadcasting
+    med = np.mean(data, axis=axis, keepdims=True)
+
+    new_data = data - med
+
+    # Return a new patch with updated data
+    return patch.new(data=new_data)

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -834,3 +834,27 @@ class TestFull:
         patch = random_patch.full(1.0)
         assert patch.coords == random_patch.coords
         assert np.allclose(patch.data, 1.0)
+
+
+class TestDemedian:
+    """Tests for demedian of data."""
+
+    def test_demedian(self, random_patch):
+        """Ensure detrending removes median."""
+        new = random_patch.new(data=random_patch.data + 10)
+        # perform detrend, ensure all mean values are close to zero
+        dem = new.demedian(dim="time")
+        medians = np.median(dem.data, axis=dem.get_axis("time"))
+        assert np.allclose(medians, 0)
+
+
+class TestDemean:
+    """Tests for demedian of data."""
+
+    def test_demean(self, random_patch):
+        """Ensure detrending removes mean."""
+        new = random_patch.new(data=random_patch.data + 10)
+        # perform detrend, ensure all mean values are close to zero
+        dem = new.demean(dim="time")
+        means = np.mean(dem.data, axis=dem.get_axis("time"))
+        assert np.allclose(means, 0)


### PR DESCRIPTION
Two very simple patch-functions: demean and demedian. They remove statics.
detrend( "linear") also removed the mean, but having a dedicated function is perhaps more intuitive.

Note that we found that demedian often works better than demean to remove common-mode noise, i.e. applying the function to the distance axis

Checklist
I have (if applicable):

 referenced the GitHub issue this PR closes.
[ X] documented the new feature with docstrings and/or appropriate doc page.
[ X] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
[ X] added the "ready_for_review" tag once the PR is ready to be reviewed.
