### PR TITLE
Added typical IDE project files to be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,6 @@ target/
 # pyenv python configuration file
 .python-version
 
-# pycharm
-.idea
-
 # Ipython stuff
 .ipynb_checkpoints
 

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,11 @@ CLAUDE.md
 
 # profile stuff
 prof/
+
+## Common IDE project files
+#Spyder
+*.spyproject
+#VScode
+.vscode/
+#JetBrains
+.idea/


### PR DESCRIPTION
Some users might use common IDEs for developments, and add DAScore as one of their projects.
These IDEs then add files or folders to the main directory of DAScore.

this fix adds ignore-entries for the most common IDE projects (according to ChatGPT): VScode, Spyder, and JetBrains


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ X] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized `.gitignore` to consolidate IDE-specific entries into a unified section, improving support coverage for PyCharm, VS Code, Spyder, and other JetBrains IDEs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->