### PR TITLE
Fix/capitalise plot labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,11 @@ CLAUDE.md
 
 # profile stuff
 prof/
+
+## Common IDE project files
+#Spyder
+*.spyproject
+#VScode
+.vscode/
+#JetBrains
+.idea/

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import string
+
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,8 +17,8 @@ def _get_dim_label(patch, dim):
     """Create a label for the given dimension, including units if defined."""
     attrs = patch.attrs
     maybe_units = attrs.get(f"{dim}_units")
-    unit_str = f"({get_quantity_str(maybe_units)})" if maybe_units else ""
-    return str(dim) + unit_str
+    unit_str = f" [{get_quantity_str(maybe_units)}]" if maybe_units else ""
+    return string.capwords(str(dim)) + unit_str
 
 
 def _get_cmap(cmap):


### PR DESCRIPTION
This is a style issue:
In DAScore, axis labels are taken directly from the coordinate unit description. These are however all lower-case by definition.

publication style guides typically require Title case: Capitalize the first letter of every major word
https://apastyle.apa.org/style-grammar-guidelines/tables-figures/figures

Other styles exist, but all have at least the first letter capitalised.


Also units should be in square brackets, not round  according to NIST (#17) 
https://physics.nist.gov/cuu/Units/checklist.html


This PR implements these recommendation



## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.
