### PR TITLE
axis lables are now capitalised, and unit in square brackets

### DIFF
--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import string
+
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,8 +17,9 @@ def _get_dim_label(patch, dim):
     """Create a label for the given dimension, including units if defined."""
     attrs = patch.attrs
     maybe_units = attrs.get(f"{dim}_units")
-    unit_str = f"({get_quantity_str(maybe_units)})" if maybe_units else ""
-    return str(dim) + unit_str
+    dim_str = string.capwords(str(dim))
+    unit_str = f" [{get_quantity_str(maybe_units)}]" if maybe_units else ""
+    return dim_str + unit_str
 
 
 def _get_cmap(cmap):

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -92,7 +92,8 @@ def _format_time_axis(ax, dim, axis_name):
     start time.
     """
     # Set label to not include units
-    getattr(ax, f"set_{axis_name}label")(dim)
+    dim_str = string.capwords(str(dim))
+    getattr(ax, f"set_{axis_name}label")(dim_str)
     # set date time formatting so MPL knows this axis is a date
     getattr(ax, f"{axis_name}axis_date")()
     # Set intelligent, zoom-in-able date formatter

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -137,8 +137,8 @@ class TestWaterfall:
         pa = patch_two_times
         dims = pa.dims
         ax = pa.viz.waterfall()
-        assert ax.get_xlabel() == dims[1]
-        assert ax.get_ylabel() == dims[0]
+        assert ax.get_xlabel().casefold() == dims[1].casefold()
+        assert ax.get_ylabel().casefold() == dims[0].casefold()
 
     def test_patch_with_data_type(self, random_patch):
         """Ensure a patch with data_type titles the colorbar."""

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -47,8 +47,8 @@ class TestWiggle:
         """Ensure another dimension works."""
         sub_patch = random_patch.select(time=(10, 20), samples=True)
         ax = sub_patch.viz.wiggle(dim="distance")
-        assert "distance" in str(ax.get_xlabel())
-        assert "time" in str(ax.get_ylabel())
+        assert "Distance [m]" in str(ax.get_xlabel())
+        assert "Time" in str(ax.get_ylabel())
 
     def test_show(self, random_patch, monkeypatch):
         """Ensure show path is callable."""


### PR DESCRIPTION
This is more of a beautifying PR

Axis labels in DAScore are generated automatically from the dimension name. These are all stored internally in lower-case.
However most publication style guide require "Sentence capitalized" or "Word Capitalized"
https://apastyle.apa.org/style-grammar-guidelines/tables-figures/figures
https://academia.stackexchange.com/questions/30933/should-the-first-letter-of-the-axis-label-be-uppercase

Also NIST suggest to use square backets for indicating physical units (see #17)
https://physics.nist.gov/cuu/Units/checklist.html

This PR implements these two style changes. Feel free to reject if there are other reasons to keep it the current way


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved axis label formatting in visualizations - units now display in square brackets (e.g., `Distance [m]`) and dimension names are properly capitalized for better readability.

* **Tests**
  * Updated test cases to validate the new axis label formatting in plot visualizations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->