### PR TITLE
Fix lint on master, ensure lint workflow runs on PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 # Lint the code using the defined pre-commits
 name: LintCode
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   lint_code:

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -60,8 +60,8 @@ def _get_zone_time(feb):
     zone = feb.zone
     block_time = _get_block_time(feb)
     extents, spacing = zone.attrs["Extent"], zone.attrs["Spacing"]
-    #different version use "Overlap" or "BlockOverlap"
-    #if neither exist, default to 100 (according to the FEBUS template)
+    # different version use "Overlap" or "BlockOverlap"
+    # if neither exist, default to 100 (according to the FEBUS template)
     overlap_attr = zone.attrs.get("Overlap", zone.attrs.get("BlockOverlap", 100))
     overlap = np.atleast_1d(_maybe_unpack(overlap_attr))[0]
     shape = feb.zone[feb.data_name].shape
@@ -81,7 +81,11 @@ def _get_zone_time(feb):
         # 250000000 stored in zone.attrs["SamplingRate"]
         # We then use then spacing[1] instead (converted from milli-seconds)
         fsamp = float(_maybe_unpack(zone.attrs["SamplingRate"]))
-        dt = 1/fsamp if fsamp<1e8 else float(_maybe_unpack(zone.attrs["Spacing"][1])) / 1_000.
+        dt = (
+            1 / fsamp
+            if fsamp < 1e8
+            else float(_maybe_unpack(zone.attrs["Spacing"][1])) / 1_000.0
+        )
         block_pad = shape[1]
 
     # Apparently, if the extents are set to 0 the overlapping edges are still
@@ -211,8 +215,8 @@ def _get_febus_attrs(feb: _FebusSlice) -> dict:
     out["zone"] = feb.zone_name
     out["schema_version"] = out.get("folog_a1_software_version", "").split(".")[0]
     out["dims"] = ("time", "distance")
-    out['data_type'] = 'strainrate'
-    out['data_units'] = 'nanostrain/s'
+    out["data_type"] = "strainrate"
+    out["data_units"] = "nanostrain/s"
     return out
 
 


### PR DESCRIPTION

## Description

PR #671 introduced a lint issue that was not caught before merge because .github/workflows/lint.yml only ran on push. The PR checks  were green, but the post-merge push to master triggered lint and  failed.

This change: 

  - Fixed the linewidth issue triggering the lint failure
  - Update LintCode workflow to run on PRs targeting master

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to run linting on both push and pull request events to the master branch.
  * Improved code clarity in internal utilities with refactored conditional logic and adjusted formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->