### PR TITLE
added example to the docstring for rolling with parameters

### DIFF
--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -334,18 +334,18 @@ def rolling(
     def _rolling_percentile(windowed_data, axis=None, p=None):
         return np.percentile(windowed_data, p, axis=axis)
 
-    # create a "partial" function to allow arguments being parsed
-    # to the "apply" method or the rolling function
+    # create a "partial" function to allow arguments being passed
+    # to the rolling apply function
     _fun  = partial( _rolling_percentile, p=percentile)
 
-    # now get the patch, and apply the rolling percentile ot the absolute amplitude
+    # now get the patch, and apply the rolling percentile to the absolute amplitude
     patch = dc.get_example_patch('example_event_2')
-    med_patch = patch.abs().rolling(time=50, step=10, samples=True).apply(_fun)
+    perc_patch = patch.abs().rolling(time=50, step=10, samples=True).apply(_fun)
 
     # plot
     fig, axs = plt.subplots(1, 2, figsize=(12,8), layout='constrained')
     ax1 = patch.viz.waterfall(ax=axs[0])
-    ax2 = med_patch.viz.waterfall(ax=axs[1], cmap='magma')
+    ax2 = perc_patch.viz.waterfall(ax=axs[1], cmap='magma')
     ```
 
 

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -314,6 +314,42 @@ def rolling(
     zcr_patch = patch.rolling(time=100, step=2, samples=True).apply(zcr_std)
     ```
 
+
+
+
+
+    If you want to pass additional arguments, you need a workaround using
+    [functools.partial](https://docs.python.org/3/library/functools.html#functools.partial)
+
+    ```python
+    import dascore as dc
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from functools import partial
+
+    # set parameter to input to the rolling function
+    percentile = 80
+
+    # define the function to apply
+    def _rolling_percentile(windowed_data, axis=None, p=None):
+        return np.percentile(windowed_data, p, axis=axis)
+
+    # create a "partial" function to allow arguments being parsed
+    # to the "apply" method or the rolling function
+    _fun  = partial( _rolling_percentile, p=percentile)
+
+    # now get the patch, and apply the rolling percentile ot the absolute amplitude
+    patch = dc.get_example_patch('example_event_2')
+    med_patch = patch.abs().rolling(time=50, step=10, samples=True).apply(_fun)
+
+    # plot
+    fig, axs = plt.subplots(1, 2, figsize=(12,8), layout='constrained')
+    ax1 = patch.viz.waterfall(ax=axs[0])
+    ax2 = med_patch.viz.waterfall(ax=axs[1], cmap='magma')
+    ```
+
+
+
     Examples
     --------
     >>> import dascore as dc


### PR DESCRIPTION
This is updated documentation based on my experience. The rolling-function example currently does not explain how to implement a custom function with additional parameters.

Maybe there is a more efficient way to do it than the solution here? 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the `rolling` function documentation with a new example demonstrating how to use custom functions with additional parameters in rolling operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->