### PR TITLE
  Update agent workflow guidance and worktree path

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -2,7 +2,6 @@
 
 This file gives AI/code agents a practical checklist for contributing safely to DASCore.
 
-Keep Markdown prose unwrapped. Do not hard-wrap paragraphs in `.md` files unless a specific format requires it.
 
 ## Scope and priorities
 
@@ -18,9 +17,7 @@ Keep Markdown prose unwrapped. Do not hard-wrap paragraphs in `.md` files unless
 
 ## Environment setup
 
-Follow `docs/contributing/dev_install.qmd`.
-
-The default Python environment for this repo uses the repository name as the environment name. For this repo, activate it with `mamba activate dascore`. If that environment is unavailable, stop and report it clearly instead of guessing another environment.
+First check if existing environment contains dascore. If not, create a new one with mamba or uv named the same as the current worktree.
 
 Typical setup:
 
@@ -33,7 +30,6 @@ pre-commit install -f
 ## Linting and formatting
 
 - Run pre-commit hooks before finalizing changes.
-- Project lint/format is driven by pre-commit and Ruff config in `pyproject.toml`.
 
 ```bash
 pre-commit run --all
@@ -42,8 +38,6 @@ pre-commit run --all
 Tip: running twice can apply auto-fixes on first pass.
 
 ## Testing requirements
-
-Follow `docs/contributing/testing.qmd`.
 
 Run targeted tests for changed behavior, then broader tests as needed:
 
@@ -63,7 +57,6 @@ For doctests:
 ```bash
 pytest dascore --doctest-modules
 ```
-
 ## Test authoring conventions
 
 - Put tests under `tests/` mirroring package structure.
@@ -75,15 +68,11 @@ pytest dascore --doctest-modules
 
 ## Code conventions
 
-
-- Prefer `pathlib.Path` over raw path strings (except performance-sensitive bulk file workflows).
-- Use snake_case dataframe column names when possible.
-- Use `df["col"]` (getitem), not `df.col` (getattr).
+- For dataframes, use snake_case column names and access via getitem, not getattr.
 - Prefer non-inplace dataframe operations unless inplace is explicitly required.
 - Add type hints for public functions/methods.
-- Use NumPy-style docstrings for public APIs.
-- Add a short explanatory comment for private helpers when intent is not obvious.
-- Keep comments meaningful; do not restate obvious code.
+- Use NumPy-style docstrings for public APIs. Strive for short, informative example sections.
+- Add a short explanatory docstring for private objects.
 
 ## Documentation changes
 
@@ -91,7 +80,8 @@ If behavior or API changes, update docs in the same PR.
 
 - Documentation source lives in `docs/` (`.qmd` files).
 - API docs are generated from docstrings.
-- Build docs workflow (see `docs/contributing/documentation.qmd`):
+- Build docs workflow:
+- Dont add newlines to markdown prose; let editors wrap.
 
 ```bash
 python scripts/build_api_docs.py

--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -17,7 +17,7 @@ This file gives AI/code agents a practical checklist for contributing safely to 
 
 ## Environment setup
 
-First check if existing environment contains dascore. If not, create a new one with mamba or uv named the same as the current worktree.
+Use an environment named after the current worktree slug. If it is unavailable, create it with mamba or uv before running checks. This keeps editable installs isolated between worktrees.
 
 Typical setup:
 
@@ -81,7 +81,7 @@ If behavior or API changes, update docs in the same PR.
 - Documentation source lives in `docs/` (`.qmd` files).
 - API docs are generated from docstrings.
 - Build docs workflow:
-- Dont add newlines to markdown prose; let editors wrap.
+- Don't add newlines to markdown prose; let editors wrap.
 
 ```bash
 python scripts/build_api_docs.py

--- a/.agents/skills/start_task/SKILL.md
+++ b/.agents/skills/start_task/SKILL.md
@@ -22,10 +22,10 @@ Instructions for starting work on a task in this repo in an isolated git worktre
    - Collapse repeated `-`.
    - Trim leading/trailing `-`.
 4. Use branch name `{slug}` unless the user explicitly requested another branch naming convention.
-5. Create the worktree at `.agents/worktrees/{slug}`.
+5. Create the worktree at `worktrees/{slug}`.
 6. Preflight checks before creating anything:
    - Confirm the repo root exists and is a git repository.
-   - If `.agents/worktrees/{slug}` already exists, reuse it if it is attached to the intended branch; otherwise stop and report the conflict.
+   - If `worktrees/{slug}` already exists, reuse it if it is attached to the intended branch; otherwise stop and report the conflict.
    - If branch `{slug}` already exists, create the worktree from that branch instead of failing.
 7. Create the worktree:
    - If the branch does not exist: create it from the current default working branch.
@@ -43,6 +43,6 @@ Instructions for starting work on a task in this repo in an isolated git worktre
 
 ## Notes
 
-- Use `.agents/worktrees/` consistently. 
+- Use `worktrees/` consistently. 
 - Do not modify or delete existing worktrees unless the user explicitly asks.
 - If the repo already has unrelated uncommitted changes in the main worktree, leave them alone; creating a separate worktree is the isolation mechanism.

--- a/.agents/skills/start_task/SKILL.md
+++ b/.agents/skills/start_task/SKILL.md
@@ -31,7 +31,7 @@ Instructions for starting work on a task in this repo in an isolated git worktre
    - If the branch does not exist: create it from the current default working branch.
    - If the branch exists: attach the worktree to that branch.
 8. Change into the new worktree directory.
-9. Activate the matching mamba environment with `mamba activate {repo_name}`.
+9. Activate or create the matching mamba environment named `{slug}`, then use `mamba activate {slug}`.
 10. Run one lightweight sanity check before starting work:
    - `python -c "import {repo_name}"`
    - If the package import name differs from the repo name, use the package name used by the repo.

--- a/.gitignore
+++ b/.gitignore
@@ -92,8 +92,9 @@ docs/index.quarto_ipynb
 
 # Agent stuff
 .claude
+.codex.bak
 CLAUDE.md
-.agents/worktrees/
+worktrees/
 
 # profile stuff
 prof/


### PR DESCRIPTION

## Description

  - Simplifies DASCore agent guidance for environment setup, linting, testing,
  code style, and docs workflow.
  - Updates the start-task skill to create isolated worktrees under `worktrees/
  {slug}` instead of `.agents/worktrees/{slug}`.
  - Updates `.gitignore`

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised agent guidance: streamlined prose rules, updated environment setup to prefer per-worktree environments and explicit creation steps, and clarified code conventions and docstring/typing guidance.
* **Chores**
  * Aligned workflow instructions and worktree path conventions and updated environment activation naming.
  * Updated ignore patterns to include new backup and worktree-related files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->