### PR TITLE
Fix doc-build workflow for fork PRs

### DIFF
--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -63,7 +63,7 @@ jobs:
 
       # Determine if the automated documentation comment exists.
       - name: Find Comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/find-comment@v3
         id: fc
         with:
@@ -73,7 +73,7 @@ jobs:
 
       # Create a comment with a download link to build docs
       - name: Create or update comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
## Description

  - Fixes the failure that cropped up in PR #682, where the docs rendered successfully but the workflow failed while trying to post the artifact link as a PR comment.
  - Skips the doc-build comment lookup/write steps for fork PRs, where GITHUB_TOKEN does not have permission to write issue comments.
  - Keeps the docs build and artifact upload unchanged, so fork PRs still roduce a downloadable documentation artifact in the Actions run.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
