### PR TITLE
Feature/dominant frequency

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -2,7 +2,6 @@
 
 This file gives AI/code agents a practical checklist for contributing safely to DASCore.
 
-Keep Markdown prose unwrapped. Do not hard-wrap paragraphs in `.md` files unless a specific format requires it.
 
 ## Scope and priorities
 
@@ -18,9 +17,7 @@ Keep Markdown prose unwrapped. Do not hard-wrap paragraphs in `.md` files unless
 
 ## Environment setup
 
-Follow `docs/contributing/dev_install.qmd`.
-
-The default Python environment for this repo uses the repository name as the environment name. For this repo, activate it with `mamba activate dascore`. If that environment is unavailable, stop and report it clearly instead of guessing another environment.
+Use an environment named after the current worktree slug. If it is unavailable, create it with mamba or uv before running checks. This keeps editable installs isolated between worktrees.
 
 Typical setup:
 
@@ -33,7 +30,6 @@ pre-commit install -f
 ## Linting and formatting
 
 - Run pre-commit hooks before finalizing changes.
-- Project lint/format is driven by pre-commit and Ruff config in `pyproject.toml`.
 
 ```bash
 pre-commit run --all
@@ -42,8 +38,6 @@ pre-commit run --all
 Tip: running twice can apply auto-fixes on first pass.
 
 ## Testing requirements
-
-Follow `docs/contributing/testing.qmd`.
 
 Run targeted tests for changed behavior, then broader tests as needed:
 
@@ -63,7 +57,6 @@ For doctests:
 ```bash
 pytest dascore --doctest-modules
 ```
-
 ## Test authoring conventions
 
 - Put tests under `tests/` mirroring package structure.
@@ -75,15 +68,11 @@ pytest dascore --doctest-modules
 
 ## Code conventions
 
-
-- Prefer `pathlib.Path` over raw path strings (except performance-sensitive bulk file workflows).
-- Use snake_case dataframe column names when possible.
-- Use `df["col"]` (getitem), not `df.col` (getattr).
+- For dataframes, use snake_case column names and access via getitem, not getattr.
 - Prefer non-inplace dataframe operations unless inplace is explicitly required.
 - Add type hints for public functions/methods.
-- Use NumPy-style docstrings for public APIs.
-- Add a short explanatory comment for private helpers when intent is not obvious.
-- Keep comments meaningful; do not restate obvious code.
+- Use NumPy-style docstrings for public APIs. Strive for short, informative example sections.
+- Add a short explanatory docstring for private objects.
 
 ## Documentation changes
 
@@ -91,7 +80,8 @@ If behavior or API changes, update docs in the same PR.
 
 - Documentation source lives in `docs/` (`.qmd` files).
 - API docs are generated from docstrings.
-- Build docs workflow (see `docs/contributing/documentation.qmd`):
+- Build docs workflow:
+- Don't add newlines to markdown prose; let editors wrap.
 
 ```bash
 python scripts/build_api_docs.py

--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -12,8 +12,9 @@ This file gives AI/code agents a practical checklist for contributing safely to 
 ## Development workflow
 
 1. Work on a feature/fix branch, not `master`.
-2. Keep commits focused (one logical change per commit where possible).
-3. Use pull requests to merge to `master`.
+2. Create task worktrees under the repository root at `worktrees/{slug}`. Do not create task worktrees under `.agents/worktrees`, even if the current shell starts there.
+3. Keep commits focused (one logical change per commit where possible).
+4. Use pull requests to merge to `master`.
 
 ## Environment setup
 

--- a/.agents/skills/start_task/SKILL.md
+++ b/.agents/skills/start_task/SKILL.md
@@ -22,10 +22,13 @@ Instructions for starting work on a task in this repo in an isolated git worktre
    - Collapse repeated `-`.
    - Trim leading/trailing `-`.
 4. Use branch name `{slug}` unless the user explicitly requested another branch naming convention.
-5. Create the worktree at `worktrees/{slug}`.
+5. Create the worktree at `{repo_root}/worktrees/{slug}`.
+   - This path is relative to the repository root discovered in step 2, not relative to the current working directory.
+   - Do not create task worktrees under `{repo_root}/.agents/worktrees`.
 6. Preflight checks before creating anything:
    - Confirm the repo root exists and is a git repository.
-   - If `worktrees/{slug}` already exists, reuse it if it is attached to the intended branch; otherwise stop and report the conflict.
+   - Print or otherwise verify the resolved target path is exactly `{repo_root}/worktrees/{slug}` before running `git worktree add`.
+   - If `{repo_root}/worktrees/{slug}` already exists, reuse it if it is attached to the intended branch; otherwise stop and report the conflict.
    - If branch `{slug}` already exists, create the worktree from that branch instead of failing.
 7. Create the worktree:
    - If the branch does not exist: create it from the current default working branch.
@@ -43,6 +46,6 @@ Instructions for starting work on a task in this repo in an isolated git worktre
 
 ## Notes
 
-- Use `worktrees/` consistently. 
+- Use `{repo_root}/worktrees/` consistently.
 - Do not modify or delete existing worktrees unless the user explicitly asks.
 - If the repo already has unrelated uncommitted changes in the main worktree, leave them alone; creating a separate worktree is the isolation mechanism.

--- a/.agents/skills/start_task/SKILL.md
+++ b/.agents/skills/start_task/SKILL.md
@@ -22,16 +22,16 @@ Instructions for starting work on a task in this repo in an isolated git worktre
    - Collapse repeated `-`.
    - Trim leading/trailing `-`.
 4. Use branch name `{slug}` unless the user explicitly requested another branch naming convention.
-5. Create the worktree at `.agents/worktrees/{slug}`.
+5. Create the worktree at `worktrees/{slug}`.
 6. Preflight checks before creating anything:
    - Confirm the repo root exists and is a git repository.
-   - If `.agents/worktrees/{slug}` already exists, reuse it if it is attached to the intended branch; otherwise stop and report the conflict.
+   - If `worktrees/{slug}` already exists, reuse it if it is attached to the intended branch; otherwise stop and report the conflict.
    - If branch `{slug}` already exists, create the worktree from that branch instead of failing.
 7. Create the worktree:
    - If the branch does not exist: create it from the current default working branch.
    - If the branch exists: attach the worktree to that branch.
 8. Change into the new worktree directory.
-9. Activate the matching mamba environment with `mamba activate {repo_name}`.
+9. Activate or create the matching mamba environment named `{slug}`, then use `mamba activate {slug}`.
 10. Run one lightweight sanity check before starting work:
    - `python -c "import {repo_name}"`
    - If the package import name differs from the repo name, use the package name used by the repo.
@@ -43,6 +43,6 @@ Instructions for starting work on a task in this repo in an isolated git worktre
 
 ## Notes
 
-- Use `.agents/worktrees/` consistently. 
+- Use `worktrees/` consistently. 
 - Do not modify or delete existing worktrees unless the user explicitly asks.
 - If the repo already has unrelated uncommitted changes in the main worktree, leave them alone; creating a separate worktree is the isolation mechanism.

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -2,9 +2,9 @@
 name: BuildDeployStableDocs
 
 on:
-  # Runs when creating a new release
+  # Runs when publishing a new release
   release:
-    types: [ created ]
+    types: [ published ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -92,8 +92,9 @@ docs/index.quarto_ipynb
 
 # Agent stuff
 .claude
+.codex.bak
 CLAUDE.md
-.agents/worktrees/
+worktrees/
 
 # profile stuff
 prof/

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -795,7 +795,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             samples = int(np.ceil(ratio))
         if enforce_lt_coord and samples > len(self):
             msg = (
-                f"value of {value} with samples={samples }results in a window "
+                f"value of {value} with samples={samples } results in a window "
                 f"larger than coordinate length of {len(self)}."
             )
             raise ParameterError(msg)

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -490,6 +490,8 @@ class Patch(NamespaceOwner):
     dispersion_phase_shift = transform.dispersion_phase_shift
     tau_p = transform.tau_p
     hilbert = transform.hilbert
+    mean_frequency = transform.mean_frequency
+    median_frequency = transform.median_frequency
     envelope = transform.envelope
     phase_weighted_stack = transform.phase_weighted_stack
 

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -6,7 +6,6 @@ from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
-from pydantic import Field
 
 import dascore as dc
 from dascore.constants import samples_arg_description
@@ -15,6 +14,27 @@ from dascore.utils.docs import compose_docstring
 from dascore.utils.models import DascoreBaseModel
 from dascore.utils.patch import get_dim_axis_value, get_window_axis_step
 from dascore.utils.pd import rolling_df
+
+rolling_apply_description = """
+Apply a function over the specified moving window.
+
+Parameters
+----------
+function
+    The function which is applied.
+*args
+    Positional arguments passed to function.
+**kwargs
+    Keyword arguments passed to function.
+
+Examples
+--------
+>>> import numpy as np
+>>> import dascore as dc
+>>>
+>>> patch = dc.get_example_patch()
+>>> out = patch.rolling(time=100, samples=True).apply(np.percentile, 80)
+"""
 
 
 class _PatchRollerInfo(DascoreBaseModel):
@@ -31,7 +51,6 @@ class _PatchRollerInfo(DascoreBaseModel):
     axis: int
     center: bool
     roll_hist: str = ""
-    func_kwargs: dict = Field(default_factory=dict)
 
     def get_coords(self):
         """
@@ -84,14 +103,14 @@ class _NumpyPatchRoller(_PatchRollerInfo):
             padded = np.roll(padded, -(num_nans // 2), axis=self.axis)
         return padded
 
-    def apply(self, function):
+    @compose_docstring(apply_description=rolling_apply_description)
+    def apply(self, function, *args, **kwargs):
         """
-        Apply a function over the specified moving window.
+        {apply_description}
 
-        Parameters
-        ----------
-        function
-            The function which is applied. Must accept an axis argument.
+        Notes
+        -----
+        The provided function must accept an ``axis`` argument.
         """
         # TODO look at replacing this with a call to `as_strided` that
         # accounts for strides.
@@ -107,9 +126,8 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         start = self.get_start_index()
         step_slice[self.axis] = slice(start, None, self.step)
         # apply function, then pad with NaNs and roll
-        kwargs = self.func_kwargs
         trimmed_slide_view = slide_view[tuple(step_slice)]
-        raw = function(trimmed_slide_view, axis=-1, **kwargs).astype(np.float64)
+        raw = function(trimmed_slide_view, *args, axis=-1, **kwargs).astype(np.float64)
         out = self._pad_roll_array(raw)
         new_coords = self.get_coords()
         attrs = self._get_attrs_with_apply_history(function)
@@ -179,9 +197,13 @@ class _PandasPatchRoller(_PatchRollerInfo):
         attrs = self._get_attrs_with_apply_history(name)
         return self._repack_patch(df, attrs=attrs)
 
-    def apply(self, func):
-        df = self._get_rolling().apply(func, **self.func_kwargs)
-        attrs = self._get_attrs_with_apply_history(func)
+    @compose_docstring(apply_description=rolling_apply_description)
+    def apply(self, function, *args, **kwargs):
+        """
+        {apply_description}
+        """
+        df = self._get_rolling().apply(function, args=args, kwargs=kwargs)
+        attrs = self._get_attrs_with_apply_history(function)
         return self._repack_patch(df, attrs=attrs)
 
     def mean(self):
@@ -319,6 +341,16 @@ def rolling(
 
     patch = dc.get_example_patch()
     zcr_patch = patch.rolling(time=100, step=2, samples=True).apply(zcr_std)
+
+    # Additional arguments can be passed directly to apply.
+    def percentile(frame, q, axis=-1):
+        '''Compute a rolling percentile.'''
+        return np.percentile(frame, q, axis=axis)
+
+
+    percentile_patch = patch.rolling(time=100, step=2, samples=True).apply(
+        percentile, 80
+    )
     ```
 
     Examples

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -13,7 +13,7 @@ from dascore.constants import samples_arg_description
 from dascore.exceptions import ParameterError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.models import DascoreBaseModel
-from dascore.utils.patch import get_dim_axis_value
+from dascore.utils.patch import get_dim_axis_value, get_window_axis_step
 from dascore.utils.pd import rolling_df
 
 
@@ -213,6 +213,7 @@ class _PandasPatchRoller(_PatchRollerInfo):
 def rolling(
     patch: dc.Patch,
     step=None,
+    overlap=None,
     center=False,
     engine: Literal["numpy", "pandas", None] = None,
     samples=False,
@@ -230,7 +231,13 @@ def rolling(
     step
         The window is evaluated at every step result, equivalent to slicing
         at every step. If the step argument is not None, the result will
-        have a different shape than the input. Default None.
+        have a different shape than the input. Mutually exclusive with
+        overlap. Default None.
+    overlap
+        The overlap between windows. Can be a number (assumed to be in units of
+        the rolling dimension if `samples`==False), a percent, or None. If
+        provided, step is calculated as `window - overlap`. Percent overlap is
+        always interpreted relative to the window length.
     center
         If False, set the window labels as the right edge of the window index.
         If True, set the window labels as the center of the window index. Default False.
@@ -337,20 +344,18 @@ def rolling(
             return _PandasPatchRoller
         return _NumpyPatchRoller
 
-    # get window sizes in samples
     dim, axis, value = get_dim_axis_value(patch, kwargs=kwargs)[0]
-    roll_hist = f"rolling({dim}={value}, step={step}, center={center}, engine={engine})"
-    coord = patch.get_coord(dim)
-    window = coord.get_sample_count(value, samples=samples, enforce_lt_coord=True)
-    step = (
-        1
-        if step is None
-        else coord.get_sample_count(step, samples=samples, enforce_lt_coord=True)
-    )
+    window, _, step = get_window_axis_step(patch, overlap, step, samples, **kwargs)
+    # Handle default when no overlap/step specified and ensure window size
+    step = 1 if step is None else step
     if window == 0 or step == 0:
         msg = "Window or step size can't be zero. Use any positive values."
         raise ParameterError(msg)
     cls = _get_engine(step, engine, patch)
+    roll_hist = (
+        f"rolling({dim}={value}, step={step}, overlap={overlap}, "
+        f"center={center}, engine={engine})"
+    )
     out = cls(
         patch=patch,
         window=window,

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -213,10 +213,10 @@ class _PandasPatchRoller(_PatchRollerInfo):
 def rolling(
     patch: dc.Patch,
     step=None,
-    overlap=None,
     center=False,
     engine: Literal["numpy", "pandas", None] = None,
     samples=False,
+    overlap=None,
     **kwargs,
 ) -> _NumpyPatchRoller | _PandasPatchRoller:
     """
@@ -233,11 +233,6 @@ def rolling(
         at every step. If the step argument is not None, the result will
         have a different shape than the input. Mutually exclusive with
         overlap. Default None.
-    overlap
-        The overlap between windows. Can be a number (assumed to be in units of
-        the rolling dimension if `samples`==False), a percent, or None. If
-        provided, step is calculated as `window - overlap`. Percent overlap is
-        always interpreted relative to the window length.
     center
         If False, set the window labels as the right edge of the window index.
         If True, set the window labels as the center of the window index. Default False.
@@ -251,6 +246,11 @@ def rolling(
         is probably better.
     samples
         {sample_explination}
+    overlap
+        The overlap between windows. Can be a number (assumed to be in units of
+        the rolling dimension if `samples`==False), a percent, or None. If
+        provided, step is calculated as `window - overlap`. Percent overlap is
+        always interpreted relative to the window length.
     **kwargs
         Used to pass dimension and window size.
         For example `time=10` represents window size of

--- a/dascore/transform/__init__.py
+++ b/dascore/transform/__init__.py
@@ -14,3 +14,4 @@ from .spectro import spectrogram
 from .strain import velocity_to_strain_rate, velocity_to_strain_rate_edgeless, radians_to_strain
 from .dispersion import dispersion_phase_shift
 from .taup import tau_p
+from .mean_median_frequency import mean_frequency, median_frequency

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -30,6 +30,7 @@ from dascore.utils.patch import (
     _get_data_units_from_dims,
     _get_dx_or_spacing_and_axes,
     get_dim_axis_value,
+    get_window_axis_step,
     patch_function,
 )
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
@@ -319,7 +320,7 @@ def idft(patch: PatchType, dim: str | None | Sequence[str] = None) -> PatchType:
     >>> # get inverse dft, transformed axis are ascertained automatically
     >>> idft = dft_time.idft()
     """
-    dims, steps, axes, real = _get_idft_dims_steps_axis(patch, dim)
+    dims, _steps, axes, real = _get_idft_dims_steps_axis(patch, dim)
     new_dims = FourierTransformatter().rename_dims(dims, forward=False)
     func = nft.irfftn if real else nft.ifftn
     # Get new coords, fft sizes, and padding to remove.
@@ -374,7 +375,7 @@ def _get_stft_coords(patch, dim, axis, coord, stft, window):
 @patch_function()
 def stft(
     patch: PatchType,
-    taper_window: str | ndarray | tuple[str, Any, ...] = "hann",
+    taper_window: str | ndarray | tuple[str | Any, ...] = "hann",
     overlap: Quantity | int | None = 50 * percent,
     samples: bool = False,
     detrend: bool = False,
@@ -440,26 +441,20 @@ def stft(
     [Patch.dft](`dascore.Patch.dft`), [Patch.istft](`dascore.Patch.istft`)
     """
     # Get coordinate information.
-    (dim, axis, val) = get_dim_axis_value(patch, kwargs=kwargs)[0]
+    (dim, axis, _) = get_dim_axis_value(patch, kwargs=kwargs)[0]
     coord = patch.get_coord(dim, require_evenly_sampled=True)
-    window_samples = coord.get_sample_count(val, samples=samples, enforce_lt_coord=True)
-    step = dc.to_float(coord.step)
-    sampling_rate = 1 / abs(step)
-    # Create window and calculate hop.
+    # Get window count/step in samples
+    window_samples, _, hop = get_window_axis_step(
+        patch, step=None, overlap=overlap, samples=samples, **kwargs
+    )
+    # Default step here is the same size as window (no overlap).
+    hop = hop if hop is not None else window_samples
+    sampling_rate = 1 / abs(dc.to_float(coord.step))
+    # Create window.
     if isinstance(taper_window, ndarray):
         window = taper_window
     else:
         window = get_window(taper_window, window_samples, fftbins=False)
-    # By using a coord and enforce_lt_coord, we guarantee the overlap is lt window.
-    if overlap is not None:
-        overlap = coord[:window_samples].get_sample_count(
-            overlap,
-            samples=samples,
-            enforce_lt_coord=True,
-        )
-    else:
-        overlap = 0
-    hop = window_samples - overlap
     # Perform stft
     fft_mode = "onesided" if np.isrealobj(patch.data) else "centered"
     stft = ShortTimeFFT(
@@ -471,7 +466,8 @@ def stft(
     )
     func = stft.stft if not detrend else partial(stft.stft_detrend, detr="linear")
     # For compatibility with dft, we scale by step. See the DFT note for why.
-    new_data = func(patch.data, axis=axis) * step
+    coord_step = dc.to_float(coord.step)
+    new_data = func(patch.data, axis=axis) * coord_step
     # Get new coordinate manager
     cm = _get_stft_coords(patch, dim, axis, coord, stft, window)
     # Update attrs with metadata needed to invert stft

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -257,7 +257,7 @@ def mean_frequency(
     >>>
     >>> patch = dc.get_example_patch('example_event_2')
     >>>
-    >>> fig, axs = plt.subplots(2,1, layout='constrained', figsize=(8,10))
+    >>> fig, axs = plt.subplots(1,2, layout='constrained', figsize=(12,4))
     >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
     >>>
     >>> para = {'cmap':'turbo', 'scale':(50,300), 'scale_type':'absolute' }
@@ -285,9 +285,15 @@ def mean_frequency(
         frq, pxx = _get_psd_in_window(
             data, dt=dt, method=method, fmin=fmin, fmax=fmax, nperseg=nperseg
         )
-
         # calculate mean frequency
+        """
         mfr = np.sum(frq * pxx, axis=-1) / np.sum(pxx, axis=-1)
+        """
+        numerator = np.sum(frq * pxx, axis=-1)
+        denominator = np.nansum(pxx, axis=-1)
+        mfr = np.divide(
+            numerator, denominator, out=np.zeros_like(numerator), where=denominator != 0
+        )
 
         return mfr
 
@@ -377,7 +383,7 @@ def median_frequency(
     >>>
     >>> patch = dc.get_example_patch('example_event_2')
     >>>
-    >>> fig, axs = plt.subplots(2,1, layout='constrained', figsize=(8,10))
+    >>> fig, axs = plt.subplots(1,2, layout='constrained', figsize=(12,4))
     >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
     >>>
     >>> para = {'cmap':'turbo', 'scale':(50,300), 'scale_type':'absolute' }

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -374,7 +374,7 @@ def median_frequency(
     >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
     >>>
     >>> para = {'cmap':'turbo', 'scale':(50,300), 'scale_type':'absolute' }
-    >>> med = patch.mean_frequency(winlen=.01, step=.001, fmin=50, fmax=300)
+    >>> med = patch.median_frequency(winlen=.01, step=.001, fmin=50, fmax=300)
     >>> ax = med.viz.waterfall(**para, ax=axs[1] )
     """
     dt = patch.get_coord("time").step

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -14,6 +14,7 @@ from scipy.signal import get_window
 
 import dascore as dc
 from dascore.constants import PatchType
+from dascore.utils.patch import patch_function
 
 
 def _welch(xx, win, fs=1.0, nperseg=256):
@@ -204,7 +205,7 @@ def _get_psd_in_window(data, method="WELCH", dt=1, fmin=None, fmax=None, nperseg
 
 
 # %%
-@dc.patch_function(required_dims=("time",), history="full")
+@patch_function(required_dims=("time",), history="full")
 def mean_frequency(
     patch: PatchType,
     winlen: float | None = None,
@@ -244,11 +245,16 @@ def mean_frequency(
     method
         Method for calculating spectrum.
         Can be any of "welch" (default), "fft", or "dft"
-    Returns
 
+    Returns
+    -------
+        The Patch instance with the mean-frequency as data.
 
     Example
-    ----------
+    -------
+    >>> import dascore as dc
+    >>> import matplotlib.pyplot as plt
+    >>>
     >>> patch = dc.get_example_patch('example_event_2')
     >>>
     >>> fig, axs = plt.subplots(2,1, layout='constrained', figsize=(8,10))
@@ -256,7 +262,7 @@ def mean_frequency(
     >>>
     >>> para = {'cmap':'turbo', 'scale':(50,300), 'scale_type':'absolute' }
     >>> mea = patch.mean_frequency(winlen=.010, step=.001, fmin=50, fmax=300)
-    >>> ax = mea.viz.waterfall(ax=axs[1], para)
+    >>> ax = mea.viz.waterfall(**para, ax=axs[1])
 
     """
     do_collapse = False
@@ -318,7 +324,7 @@ def mean_frequency(
 
 
 # %%
-@dc.patch_function(required_dims=("time",), history="full")
+@patch_function(required_dims=("time",), history="full")
 def median_frequency(
     patch: PatchType,
     winlen: float | None = None,
@@ -343,7 +349,6 @@ def median_frequency(
     timestamps.
 
 
-
     Parameters
     ----------
     patch
@@ -360,18 +365,24 @@ def median_frequency(
         Method for calculating spectrum.
         Can be any of "welch" (default), "fft", or "dft"
 
+    Returns
+    -------
+        The Patch instance with the median-frequency as data.
+
 
     Example
-    ----------
+    -------
+    >>> import dascore as dc
+    >>> import matplotlib.pyplot as plt
+    >>>
     >>> patch = dc.get_example_patch('example_event_2')
     >>>
     >>> fig, axs = plt.subplots(2,1, layout='constrained', figsize=(8,10))
     >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
     >>>
-    >>>
     >>> para = {'cmap':'turbo', 'scale':(50,300), 'scale_type':'absolute' }
     >>> med = patch.mean_frequency(winlen=.010, step=.001, fmin=50, fmax=300)
-    >>> ax = med.viz.waterfall(ax=axs[1], para)
+    >>> ax = med.viz.waterfall(**para, ax=axs[1] )
     """
     do_collapse = False
     if winlen is None:

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -12,7 +12,6 @@ import numpy as np
 from scipy import fftpack
 from scipy.signal import get_window
 
-import dascore as dc
 from dascore.constants import PatchType
 from dascore.utils.patch import patch_function
 
@@ -208,7 +207,7 @@ def _get_psd_in_window(data, method="WELCH", dt=1, fmin=None, fmax=None, nperseg
 @patch_function(required_dims=("time",), history="full")
 def mean_frequency(
     patch: PatchType,
-    winlen: float | None = None,
+    winlen: float,
     step: float | None = None,
     fmin: float | None = None,
     fmax: float | None = None,
@@ -265,13 +264,6 @@ def mean_frequency(
     >>> ax = mea.viz.waterfall(**para, ax=axs[1])
 
     """
-    do_collapse = False
-    if winlen is None:
-        do_collapse = True
-        winlen = (
-            patch.get_coord("time").max() - patch.get_coord("time").min()
-        ) / np.timedelta64(1, "s")
-
     if step is None:
         step = winlen
 
@@ -328,14 +320,6 @@ def mean_frequency(
     if patch.get_axis("distance") != mfr_patch.get_axis("distance"):
         mfr_patch = mfr_patch.transpose()
 
-    if do_collapse:
-        # remove first sample, which is only NaNs
-        mfr_patch = mfr_patch.select(time=(-1, 2), samples=True)
-
-        # now set timestamp to the center of the time-window
-        t_middle = patch.get_coord("time").min() + dc.to_timedelta64(winlen / 2)
-        mfr_patch = mfr_patch.update_coords(time=t_middle)
-
     return mfr_patch.update(attrs={"data_type": "Mean Frequency", "data_units": "Hz"})
 
 
@@ -343,7 +327,7 @@ def mean_frequency(
 @patch_function(required_dims=("time",), history="full")
 def median_frequency(
     patch: PatchType,
-    winlen: float | None = None,
+    winlen: float,
     step: float | None = None,
     fmin: float | None = None,
     fmax: float | None = None,
@@ -400,13 +384,6 @@ def median_frequency(
     >>> med = patch.mean_frequency(winlen=.010, step=.001, fmin=50, fmax=300)
     >>> ax = med.viz.waterfall(**para, ax=axs[1] )
     """
-    do_collapse = False
-    if winlen is None:
-        do_collapse = True
-        winlen = (
-            patch.get_coord("time").max() - patch.get_coord("time").min()
-        ) / np.timedelta64(1, "s")
-
     if step is None:
         step = winlen
 
@@ -459,13 +436,5 @@ def median_frequency(
     )
     if patch.get_axis("distance") != med_patch.get_axis("distance"):
         med_patch = med_patch.transpose()
-
-    if do_collapse:
-        # remove first sample, which is only NaNs
-        med_patch = med_patch.select(time=(-1, 2), samples=True)
-
-        # now set timestamp to the center of the time-window
-        t_middle = patch.get_coord("time").min() + dc.to_timedelta64(winlen / 2)
-        med_patch = med_patch.update_coords(time=t_middle)
 
     return med_patch.update(attrs={"data_type": "Median Frequency", "data_units": "Hz"})

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -275,6 +275,16 @@ def mean_frequency(
     if step is None:
         step = winlen
 
+    if fmin is not None:
+        min_cycles = 3
+        min_winlen = min_cycles / fmin
+
+        if winlen < min_winlen:
+            raise ValueError(
+                f"winlen={winlen} s is too short for fmin={fmin} Hz. "
+                f"Need at least 3 cycles, i.e. {min_winlen:.4f} s."
+            )
+
     dt = patch.get_coord("time").step
     if isinstance(dt, np.timedelta64):
         dt = dt / np.timedelta64(1, "s")
@@ -399,6 +409,16 @@ def median_frequency(
 
     if step is None:
         step = winlen
+
+    if fmin is not None:
+        min_cycles = 3
+        min_winlen = min_cycles / fmin
+
+        if winlen < min_winlen:
+            raise ValueError(
+                f"winlen={winlen} s is too short for fmin={fmin} Hz. "
+                f"Need at least 3 cycles, i.e. {min_winlen:.4f} s."
+            )
 
     dt = patch.get_coord("time").step
     if isinstance(dt, np.timedelta64):

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -114,8 +114,14 @@ def _welch(xx, win, fs=1.0, nperseg=256):
                 pxx[:, 0] += xft[:, 0] ** 2 / (k + 1)
                 pxx[:, 1:] += (xft[:, 1::2] ** 2 + xft[:, 2::2] ** 2) / (k + 1.0)
 
-        pxx[:, 1:-1] *= 2 * scale
-        pxx[:, (0, -1)] *= scale
+        if nfft % 2 == 0:
+            # even: DC and Nyquist not doubled
+            pxx[:, 1:-1] *= 2 * scale
+            pxx[:, (0, -1)] *= scale
+        else:
+            # odd: only DC excluded from doubling
+            pxx[:, 1:] *= 2 * scale
+            pxx[:, 0] *= scale
 
         psd[:, i, :] = pxx
     f = np.arange(pxx.shape[-1]) * (fs / nfft)
@@ -169,7 +175,7 @@ def _fft_psd(xx, fs=1.0):
 
 # %% define a wrapper function to call
 def _get_psd_in_window(data, method="WELCH", dt=1, fmin=None, fmax=None, nperseg=None):
-    allowed_methods = ["WELCH", "FFT", "DFT"]
+    allowed_methods = ["WELCH", "FFT"]
     assert (
         method.upper() in allowed_methods
     ), f"Invalid method: '{method}'. Must be one of {allowed_methods}"
@@ -187,9 +193,6 @@ def _get_psd_in_window(data, method="WELCH", dt=1, fmin=None, fmax=None, nperseg
 
     elif method.upper() == "FFT":
         frq, pxx = _fft_psd(data, fs=(1 / dt))
-
-    else:
-        raise ValueError(f"{method} method not implemented yet")
 
     # use only desired part of spectrum
     inf1 = 0 if fmin is None else np.searchsorted(frq, fmin)
@@ -243,7 +246,7 @@ def mean_frequency(
         Optional upper frequency bound in Hz, applied on calculated spectra
     method
         Method for calculating spectrum.
-        Can be any of "welch" (default), "fft", or "dft"
+        Can be any of "welch" (default), or "fft"
 
     Returns
     -------
@@ -353,7 +356,7 @@ def median_frequency(
         Optional upper frequency bound in Hz, applied on calculated spectra
     method
         Method for calculating spectrum.
-        Can be any of "welch" (default), "fft", or "dft"
+        Can be any of "welch" (default), or "fft"
 
     Returns
     -------

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -238,9 +238,9 @@ def mean_frequency(
     step
         Step between windows in seconds. Defaults to `winlen`.
     fmin
-        Optional lower frequency bound in Hz.
+        Optional lower frequency bound in Hz, applied on calculated spectra
     fmax
-        Optional upper frequency bound in Hz.
+        Optional upper frequency bound in Hz, applied on calculated spectra
     method
         Method for calculating spectrum.
         Can be any of "welch" (default), "fft", or "dft"
@@ -264,22 +264,12 @@ def mean_frequency(
     >>> ax = mea.viz.waterfall(**para, ax=axs[1])
 
     """
-    if step is None:
-        step = winlen
-
-    if fmin is not None:
-        min_cycles = 3
-        min_winlen = min_cycles / fmin
-
-        if winlen < min_winlen:
-            raise ValueError(
-                f"winlen={winlen} s is too short for fmin={fmin} Hz. "
-                f"Need at least 3 cycles, i.e. {min_winlen:.4f} s."
-            )
-
     dt = patch.get_coord("time").step
     if isinstance(dt, np.timedelta64):
         dt = dt / np.timedelta64(1, "s")
+
+    if step is None:
+        step = dt
 
     def _get_mean_freq_in_window(
         data, axis=None, dt=dt, method=method, fmin=fmin, fmax=fmax, nperseg=nperseg
@@ -358,9 +348,9 @@ def median_frequency(
     step
         Step between windows in seconds. Defaults to `winlen`.
     fmin
-        Optional lower frequency bound in Hz.
+        Optional lower frequency bound in Hz, applied on calculated spectra
     fmax
-        Optional upper frequency bound in Hz.
+        Optional upper frequency bound in Hz, applied on calculated spectra
     method
         Method for calculating spectrum.
         Can be any of "welch" (default), "fft", or "dft"
@@ -381,25 +371,15 @@ def median_frequency(
     >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
     >>>
     >>> para = {'cmap':'turbo', 'scale':(50,300), 'scale_type':'absolute' }
-    >>> med = patch.mean_frequency(winlen=.010, step=.001, fmin=50, fmax=300)
+    >>> med = patch.mean_frequency(winlen=.01, step=.001, fmin=50, fmax=300)
     >>> ax = med.viz.waterfall(**para, ax=axs[1] )
     """
-    if step is None:
-        step = winlen
-
-    if fmin is not None:
-        min_cycles = 3
-        min_winlen = min_cycles / fmin
-
-        if winlen < min_winlen:
-            raise ValueError(
-                f"winlen={winlen} s is too short for fmin={fmin} Hz. "
-                f"Need at least 3 cycles, i.e. {min_winlen:.4f} s."
-            )
-
     dt = patch.get_coord("time").step
     if isinstance(dt, np.timedelta64):
         dt = dt / np.timedelta64(1, "s")
+
+    if step is None:
+        step = winlen
 
     def _get_median_freq_in_window(
         data, axis=None, dt=dt, method=method, fmin=fmin, fmax=fmax, nperseg=nperseg

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -239,7 +239,7 @@ def mean_frequency(
     winlen
         Window length in seconds.
     step
-        Step between windows in seconds. Defaults to `winlen`.
+        Step between windows in seconds. Defaults to original sampling rate.
     fmin
         Optional lower frequency bound in Hz, applied on calculated spectra
     fmax
@@ -349,7 +349,7 @@ def median_frequency(
     winlen
         Window length in seconds.
     step
-        Step between windows in seconds. Defaults to `winlen`.
+        Step between windows in seconds. Defaults to original sampling rate.
     fmin
         Optional lower frequency bound in Hz, applied on calculated spectra
     fmax

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -1,0 +1,434 @@
+"""
+Spyder Editor
+
+This is a temporary script file.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+import numpy as np
+from scipy import fftpack
+from scipy.signal import get_window
+
+import dascore as dc
+from dascore.constants import PatchType
+
+
+def _welch(xx, win, fs=1.0, nperseg=256):
+    """
+    Estimate power spectral density using Welch's method.
+    Specialized WELCH function to speed up processing in mean-frequency
+
+    Welch's method computes an estimate of the power spectral density by
+    dividing the data into overlapping segments, computing a modified
+    periodogram for each segment and averaging the periodograms.
+
+    This welch method is from the scipy library, to cut down on processing
+    cost this is a reduced algorithm.
+
+    Assumed_values:
+        nfft: None
+        detrend: 'constant'
+        returns_onsided: True
+        scaling: 'density'
+        noverlap: None
+        axis: -1
+
+    Args:
+        x: Time series of measurement data
+        win: Desired window to use in the type of an array
+        fs: Sampling frequency of the time series
+        nperseg: Length of each segment
+
+    Returns
+    -------
+        f (array of sampling frequencies), pxx (Power spectral density)
+    """
+    if xx.shape[-1] < nperseg:
+        nperseg = xx.shape[-1]
+        win = get_window("hann", nperseg)
+
+    # if scaling == 'density':
+    scale = 1.0 / (fs * (win * win).sum())
+
+    # if noverlap is None:
+    noverlap = nperseg // 2
+
+    # if nfft is None:
+    nfft = nperseg
+
+    step = nperseg - noverlap
+    indices = np.arange(0, xx.shape[2] - nperseg + 1, step)
+    psd = np.zeros((xx.shape[0], xx.shape[1], nfft // 2 + 1), float)
+
+    # Although this seems inefficient, tests show that a loop is the fastest solution
+    for i in range(xx.shape[1]):
+        x = xx[:, i, :]
+        outshape = list(x.shape)
+        if nfft % 2 == 0:  # even
+            outshape[-1] = nfft // 2 + 1
+            pxx = np.empty(outshape, x.dtype)
+
+            ind = indices[0]
+            x_dt = x[:, ind : ind + nperseg] - np.mean(
+                x[:, ind : ind + nperseg], 1, keepdims=True
+            )
+            xft = fftpack.rfft(x_dt * win, nfft)
+            pxx[:, (0, -1)] = xft[:, (0, -1)] ** 2
+            pxx[:, 1:-1] = xft[:, 1:-1:2] ** 2 + xft[:, 2::2] ** 2
+            for k_i, ind in enumerate(indices[1:]):
+                x_dt = x[:, ind : ind + nperseg] - np.mean(
+                    x[:, ind : ind + nperseg], 1, keepdims=True
+                )
+                xft = fftpack.rfft(x_dt * win, nfft)
+                # fftpack.rfft returns the positive frequency part of the fft
+                # as real values, packed r r i r i r i ...
+                # this indexing is to extract the matching real and imaginary
+                # parts, while also handling the pure real zero and nyquist
+                # frequencies.
+                k = k_i + 1
+                pxx *= k / (k + 1.0)
+                pxx[:, (0, -1)] += xft[:, (0, -1)] ** 2 / (k + 1.0)
+                pxx[:, 1:-1] += (xft[:, 1:-1:2] ** 2 + xft[:, 2::2] ** 2) / (k + 1.0)
+
+        else:  # odd
+            outshape[-1] = (nfft + 1) // 2
+            pxx = np.empty(outshape, x.dtype)
+
+            ind = indices[0]
+            x_dt = x[:, ind : ind + nperseg] - np.mean(
+                x[:, ind : ind + nperseg], 1, keepdims=True
+            )
+            xft = fftpack.rfft(x_dt * win, nfft)
+            pxx[:, 0] = xft[:, 0] ** 2
+            pxx[:, 1:] = xft[:, 1::2] ** 2 + xft[:, 2::2] ** 2
+            for k_i, ind in enumerate(indices[1:]):
+                x_dt = x[:, ind : ind + nperseg] - np.mean(
+                    x[:, ind : ind + nperseg], 1, keepdims=True
+                )
+                xft = fftpack.rfft(x_dt * win, nfft)
+                k = k_i + 1
+                pxx *= k / (k + 1.0)
+                pxx[:, 0] += xft[:, 0] ** 2 / (k + 1)
+                pxx[:, 1:] += (xft[:, 1::2] ** 2 + xft[:, 2::2] ** 2) / (k + 1.0)
+
+        pxx[:, 1:-1] *= 2 * scale
+        pxx[:, (0, -1)] *= scale
+
+        psd[:, i, :] = pxx
+    f = np.arange(pxx.shape[-1]) * (fs / nfft)
+
+    return f, psd
+
+
+# %%
+def _fft_psd(xx, fs=1.0):
+    """
+    Simple one-sided PSD from FFT.
+
+    Parameters
+    ----------
+    xx : ndarray
+        Input array with shape (..., time)
+    fs : float
+        Sampling frequency
+
+    Returns
+    -------
+    f : ndarray
+        Frequency axis
+    pxx : ndarray
+        One-sided power spectral density
+    """
+    import numpy as np
+
+    n = xx.shape[-1]
+
+    # remove mean along time axis (like detrend='constant')
+    x = xx - np.mean(xx, axis=-1, keepdims=True)
+
+    # FFT
+    xft = np.fft.rfft(x, axis=-1)
+
+    # Power spectral density
+    pxx = (np.abs(xft) ** 2) / (fs * n)
+
+    # One-sided correction
+    if n % 2 == 0:
+        if pxx.shape[-1] > 2:
+            pxx[..., 1:-1] *= 2.0
+    else:
+        if pxx.shape[-1] > 1:
+            pxx[..., 1:] *= 2.0
+
+    f = np.fft.rfftfreq(n, d=1.0 / fs)
+    return f, pxx
+
+
+# %% define a wrapper function to call
+def _get_psd_in_window(data, method="WELCH", dt=1, fmin=None, fmax=None, nperseg=None):
+    allowed_methods = ["WELCH", "FFT", "DFT"]
+    assert (
+        method.upper() in allowed_methods
+    ), f"Invalid method: '{method}'. Must be one of {allowed_methods}"
+
+    if fmin is not None and fmax is not None:
+        assert fmin < fmax, f"fmin ({fmin}) must be smaller than fmax ({fmax})"
+
+    # if data.shape[-1] < nperseg:
+    #    nperseg = data.shape[1]
+    nperseg = data.shape[-1]
+    win = get_window("hann", nperseg)
+
+    if method.upper() == "WELCH":
+        frq, pxx = _welch(data, win, (1 / dt), nperseg=nperseg)
+
+    elif method.upper() == "FFT":
+        frq, pxx = _fft_psd(data, fs=(1 / dt))
+
+    else:
+        raise ValueError(f"{method} method not implemented yet")
+
+    # use only desired part of spectrum
+    inf1 = 0 if fmin is None else np.searchsorted(frq, fmin)
+    inf2 = -1 if fmax is None else np.searchsorted(frq, fmax)
+
+    pxx = pxx[:, :, inf1:inf2]
+    frq = frq[inf1:inf2]
+    return (
+        frq,
+        pxx,
+    )
+
+
+# %%
+@dc.patch_function(required_dims=("time",), history="full")
+def mean_frequency(
+    patch: PatchType,
+    winlen: float | None = None,
+    step: float | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    method: str = "welch",
+    nperseg: float = 256,
+) -> PatchType:
+    """
+    Compute rolling mean-frequency along a time axis. This represents "center of
+    gravity" of the signal's power spectrum.
+
+    See for more detail:
+        - @Phinyomark12
+        - [Online version of the Phinyomark publication](
+            https://www.intechopen.com/chapters/40123)
+        - [Matlab's meanfreq](https://se.mathworks.com/help/signal/ref/meanfreq.html)
+
+    Note: The output  replaces the original `time` coordinate with window-centered
+    timestamps.
+
+
+
+    Parameters
+    ----------
+    patch
+        Input DASCore patch.
+    winlen
+        Window length in seconds.
+    step
+        Step between windows in seconds. Defaults to `winlen`.
+    fmin
+        Optional lower frequency bound in Hz.
+    fmax
+        Optional upper frequency bound in Hz.
+    method
+        Method for calculating spectrum.
+        Can be any of "welch" (default), "fft", or "dft"
+    Returns
+
+
+    Example
+    ----------
+    >>> patch = dc.get_example_patch('example_event_2')
+    >>>
+    >>> fig, axs = plt.subplots(2,1, layout='constrained', figsize=(8,10))
+    >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
+    >>>
+    >>> para = {'cmap':'turbo', 'scale':(50,300), 'scale_type':'absolute' }
+    >>> mea = patch.mean_frequency(winlen=.010, step=.001, fmin=50, fmax=300)
+    >>> ax = mea.viz.waterfall(ax=axs[1], para)
+
+    """
+    do_collapse = False
+    if winlen is None:
+        do_collapse = True
+        winlen = (
+            patch.get_coord("time").max() - patch.get_coord("time").min()
+        ) / np.timedelta64(1, "s")
+
+    if step is None:
+        step = winlen
+
+    dt = patch.get_coord("time").step
+    if isinstance(dt, np.timedelta64):
+        dt = dt / np.timedelta64(1, "s")
+
+    def _get_mean_freq_in_window(
+        data, axis=None, dt=dt, method=method, fmin=fmin, fmax=fmax, nperseg=nperseg
+    ):
+        frq, pxx = _get_psd_in_window(
+            data, dt=dt, method=method, fmin=fmin, fmax=fmax, nperseg=nperseg
+        )
+
+        # calculate mean frequency
+        mfr = np.sum(frq * pxx, axis=-1) / np.sum(pxx, axis=-1)
+
+        return mfr
+
+    # create a "partial" function to allow arguments being parsed to the "apply"
+    # method of the rolling function
+    fun = partial(
+        _get_mean_freq_in_window,
+        dt=dt,
+        method=method,
+        fmin=fmin,
+        fmax=fmax,
+        nperseg=nperseg,
+    )
+
+    # now apply the rolling function; make sure time axis is last dimension
+    dim = "time"
+    mfr_patch = (
+        patch.transpose(..., dim)
+        .rolling(time=winlen, step=step, samples=False)
+        .apply(fun)
+    )
+    if patch.get_axis("distance") != mfr_patch.get_axis("distance"):
+        mfr_patch = mfr_patch.transpose()
+
+    if do_collapse:
+        # remove first sample, which is only NaNs
+        mfr_patch = mfr_patch.select(time=(-1, 2), samples=True)
+
+        # now set timestamp to the center of the time-window
+        t_middle = patch.get_coord("time").min() + dc.to_timedelta64(winlen / 2)
+        mfr_patch = mfr_patch.update_coords(time=t_middle)
+
+    return mfr_patch.update(attrs={"data_type": "Mean Frequency", "data_units": "Hz"})
+
+
+# %%
+@dc.patch_function(required_dims=("time",), history="full")
+def median_frequency(
+    patch: PatchType,
+    winlen: float | None = None,
+    step: float | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    nperseg: float = 256,
+    method: str = "welch",
+) -> PatchType:
+    """
+    Compute rolling median-frequency along a time axis. This measure divides a signal's
+    power spectrum into two regions of equal total power. It identifies the exact
+    frequency point where 50% of the signal's energy is above, and 50% is below.
+
+    See for more detail:
+        - @Phinyomark12
+        - [Online version of the Phinyomark publication](
+            https://www.intechopen.com/chapters/40123)
+        - [Matlab's medfreq](https://se.mathworks.com/help/signal/ref/medfreq.html)
+
+    Note: The output  replaces the original `time` coordinate with window-centered
+    timestamps.
+
+
+
+    Parameters
+    ----------
+    patch
+        Input DASCore patch.
+    winlen
+        Window length in seconds.
+    step
+        Step between windows in seconds. Defaults to `winlen`.
+    fmin
+        Optional lower frequency bound in Hz.
+    fmax
+        Optional upper frequency bound in Hz.
+    method
+        Method for calculating spectrum.
+        Can be any of "welch" (default), "fft", or "dft"
+
+
+    Example
+    ----------
+    >>> patch = dc.get_example_patch('example_event_2')
+    >>>
+    >>> fig, axs = plt.subplots(2,1, layout='constrained', figsize=(8,10))
+    >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
+    >>>
+    >>>
+    >>> para = {'cmap':'turbo', 'scale':(50,300), 'scale_type':'absolute' }
+    >>> med = patch.mean_frequency(winlen=.010, step=.001, fmin=50, fmax=300)
+    >>> ax = med.viz.waterfall(ax=axs[1], para)
+    """
+    do_collapse = False
+    if winlen is None:
+        do_collapse = True
+        winlen = (
+            patch.get_coord("time").max() - patch.get_coord("time").min()
+        ) / np.timedelta64(1, "s")
+
+    if step is None:
+        step = winlen
+
+    dt = patch.get_coord("time").step
+    if isinstance(dt, np.timedelta64):
+        dt = dt / np.timedelta64(1, "s")
+
+    def _get_median_freq_in_window(
+        data, axis=None, dt=dt, method=method, fmin=fmin, fmax=fmax, nperseg=nperseg
+    ):
+        frq, pxx = _get_psd_in_window(
+            data, dt=dt, method=method, fmin=fmin, fmax=fmax, nperseg=nperseg
+        )
+
+        # calculate median frequency
+        cumulative_psd = np.cumsum(pxx, axis=-1)
+        total_power = cumulative_psd[:, :, -1]
+        half = total_power[..., None] / 2
+        median_idx = np.argmax(cumulative_psd >= half, axis=-1)
+
+        return frq[median_idx]
+
+    # create a "partial" function to allow arguments being parsed to the "apply"
+    # method of the rolling function
+    fun = partial(
+        _get_median_freq_in_window,
+        dt=dt,
+        method=method,
+        fmin=fmin,
+        fmax=fmax,
+        nperseg=nperseg,
+    )
+
+    # now apply the rolling function
+    dim = "time"
+    med_patch = (
+        patch.transpose(..., dim)
+        .rolling(time=winlen, step=step, samples=False)
+        .apply(fun)
+    )
+    if patch.get_axis("distance") != med_patch.get_axis("distance"):
+        med_patch = med_patch.transpose()
+
+    if do_collapse:
+        # remove first sample, which is only NaNs
+        med_patch = med_patch.select(time=(-1, 2), samples=True)
+
+        # now set timestamp to the center of the time-window
+        t_middle = patch.get_coord("time").min() + dc.to_timedelta64(winlen / 2)
+        med_patch = med_patch.update_coords(time=t_middle)
+
+    return med_patch.update(attrs={"data_type": "Median Frequency", "data_units": "Hz"})

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -255,7 +255,7 @@ def mean_frequency(
     >>> import dascore as dc
     >>> import matplotlib.pyplot as plt
     >>>
-    >>> patch = dc.get_example_patch('example_event_2')
+    >>> patch = dc.examples.get_example_patch('example_event_2')
     >>>
     >>> fig, axs = plt.subplots(1,2, layout='constrained', figsize=(12,4))
     >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
@@ -381,7 +381,7 @@ def median_frequency(
     >>> import dascore as dc
     >>> import matplotlib.pyplot as plt
     >>>
-    >>> patch = dc.get_example_patch('example_event_2')
+    >>> patch = dc.examples.get_example_patch('example_event_2')
     >>>
     >>> fig, axs = plt.subplots(1,2, layout='constrained', figsize=(12,4))
     >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])

--- a/dascore/transform/mean_median_frequency.py
+++ b/dascore/transform/mean_median_frequency.py
@@ -1,8 +1,4 @@
-"""
-Spyder Editor
-
-This is a temporary script file.
-"""
+"""Rolling mean and median frequency transforms for DASCore patches"""
 
 from __future__ import annotations
 
@@ -148,8 +144,6 @@ def _fft_psd(xx, fs=1.0):
     pxx : ndarray
         One-sided power spectral density
     """
-    import numpy as np
-
     n = xx.shape[-1]
 
     # remove mean along time axis (like detrend='constant')
@@ -176,16 +170,17 @@ def _fft_psd(xx, fs=1.0):
 # %% define a wrapper function to call
 def _get_psd_in_window(data, method="WELCH", dt=1, fmin=None, fmax=None, nperseg=None):
     allowed_methods = ["WELCH", "FFT"]
-    assert (
-        method.upper() in allowed_methods
-    ), f"Invalid method: '{method}'. Must be one of {allowed_methods}"
+    if method.upper() not in allowed_methods:
+        raise ValueError(
+            f"Invalid method: '{method}'. Must be one of {allowed_methods}"
+        )
 
     if fmin is not None and fmax is not None:
-        assert fmin < fmax, f"fmin ({fmin}) must be smaller than fmax ({fmax})"
+        if fmin >= fmax:
+            raise ValueError(f"fmin ({fmin}) must be smaller than fmax ({fmax})")
 
-    # if data.shape[-1] < nperseg:
-    #    nperseg = data.shape[1]
-    nperseg = data.shape[-1]
+    if nperseg is None:
+        nperseg = data.shape[-1]
     win = get_window("hann", nperseg)
 
     if method.upper() == "WELCH":
@@ -215,7 +210,7 @@ def mean_frequency(
     fmin: float | None = None,
     fmax: float | None = None,
     method: str = "welch",
-    nperseg: float = 256,
+    nperseg: int = 256,
 ) -> PatchType:
     """
     Compute rolling mean-frequency along a time axis. This represents "center of
@@ -324,7 +319,7 @@ def median_frequency(
     step: float | None = None,
     fmin: float | None = None,
     fmax: float | None = None,
-    nperseg: float = 256,
+    nperseg: int = 256,
     method: str = "welch",
 ) -> PatchType:
     """
@@ -382,7 +377,7 @@ def median_frequency(
         dt = dt / np.timedelta64(1, "s")
 
     if step is None:
-        step = winlen
+        step = dt
 
     def _get_median_freq_in_window(
         data, axis=None, dt=dt, method=method, fmin=fmin, fmax=fmax, nperseg=nperseg

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from functools import cache
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -295,9 +295,7 @@ def get_filter_units(
         """Ensure to units are valid."""
         if to_unit is None:
             dim_str = "" if dim is None else dim
-            msg = (
-                f"Cannot use units on dimension {dim_str} because it has " f"no units."
-            )
+            msg = f"Cannot use units on dimension {dim_str} because it has no units."
             raise UnitError(msg)
 
     # fast-path for non-unit, non-quantity inputs.
@@ -357,6 +355,18 @@ def quant_sequence_to_quant_array(sequence: Sequence[Quantity]) -> Quantity:
     return array * next(iter(units))
 
 
+def is_percent(value: Any) -> bool:
+    """
+    Return True if value is a percent quantity.
+
+    Parameters
+    ----------
+    value
+        Any value of any type to be to test if it is a percent quantity.
+    """
+    return isinstance(value, Quantity) and value.units == get_unit("percent")
+
+
 def maybe_convert_percent_to_fraction(obj):
     """
     Iterate an object and convert any percentages to fractions.
@@ -399,14 +409,11 @@ def maybe_convert_percent_to_fraction(obj):
     >>> assert result[1] == 0.5
     >>> assert result[2] == get_quantity("2 Hz")
     """
-    percent = get_unit("percent")
     out = []
     obj = [obj] if isinstance(obj, Quantity) and obj.ndim == 0 else obj
     for val in iterate(obj):
-        if hasattr(val, "units"):
-            mag, unit = val.magnitude, val.units
-            if unit == percent:
-                val = mag / 100
+        if is_percent(val):
+            val = val.magnitude / 100
         out.append(val)
     return out
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -32,7 +32,7 @@ from dascore.exceptions import (
     PatchAttributeError,
     PatchCoordinateError,
 )
-from dascore.units import get_quantity
+from dascore.units import get_quantity, is_percent
 from dascore.utils.attrs import combine_patch_attrs
 from dascore.utils.coordmanager import merge_coord_managers
 from dascore.utils.deprecate import deprecate
@@ -763,6 +763,91 @@ def get_patch_window_size(
         size[axis] = samps
 
     return tuple(size)
+
+
+def get_window_axis_step(
+    patch,
+    overlap=None,
+    step=None,
+    samples=False,
+    **kwargs,
+) -> tuple[int, int, int | None]:
+    """
+    Get window size, axis, and step for a single patch dimension.
+
+    Parameters
+    ----------
+    patch
+        The patch with the dimension and coordinate.
+    overlap
+        Optional overlap between adjacent windows. Percent quantities are
+        interpreted relative to the window size.
+    step
+        Optional step between adjacent windows. Mutually exclusive with overlap.
+        Percent quantities are interpreted relative to the window size.
+    samples
+        If True, numeric window, overlap, and step values are interpreted as
+        sample counts. Quantities with explicit units keep their unit meaning.
+    **kwargs
+        Exactly one dimension name and window size.
+
+    Returns
+    -------
+    tuple
+        The window size in samples, the axis for the dimension, and the step in
+        samples. The step is None if neither step nor overlap was provided.
+    """
+
+    def _percent_to_window_samps(window, val):
+        """Convert any percentages to samples of the window."""
+        if is_per := is_percent(val):
+            mag = val.magnitude
+            if mag < 0 or mag > 100:
+                msg = f"Percentage must be between 0 and 100, not {val}"
+                raise ParameterError(msg)
+            val = int(np.round(val.magnitude / 100 * window))
+        return val, is_per
+
+    def _check_not_negative(val, name):
+        """Ensure a step or overlap value isn't negative."""
+        magnitude = val.magnitude if isinstance(val, dc.units.Quantity) else val
+        if magnitude is not None and magnitude < 0:
+            msg = f"{name} must be non-negative"
+            raise ParameterError(msg)
+
+    def quantity_to_samps(val, coord, samples=False):
+        """Convert quantity value to number of samples."""
+        # None just passes through
+        if val is None:
+            return None
+        # Specifying a quantity should overwrite samples parameter.
+        if isinstance(val, dc.units.Quantity):
+            samples = False
+        return coord.get_sample_count(val, samples=samples, enforce_lt_coord=True)
+
+    if overlap is not None and step is not None:
+        msg = "step and overlap are mutually exclusive."
+        raise ParameterError(msg)
+
+    dim, axis, win = get_dim_axis_value(patch, kwargs=kwargs, allow_multiple=False)[0]
+    coord = patch.get_coord(dim, require_evenly_sampled=True)
+    win_samp = coord.get_sample_count(win, samples=samples, enforce_lt_coord=True)
+    # Convert any percentages to win_samples
+    step, step_percent = _percent_to_window_samps(win_samp, step)
+    overlap, overlap_percent = _percent_to_window_samps(win_samp, overlap)
+    _check_not_negative(step, "step")
+    _check_not_negative(overlap, "overlap")
+    # Then convert to coordinate samples. This handles differing units and such.
+    step = quantity_to_samps(step, coord, samples=samples or step_percent)
+    overlap = quantity_to_samps(overlap, coord, samples=samples or overlap_percent)
+    # Convert overlap to step
+    if step is None and overlap is not None:
+        step = win_samp - overlap
+    if step is not None and step <= 0:
+        msg = "Window step must be greater than zero."
+        raise ParameterError(msg)
+    # Get window length/step in samples
+    return win_samp, axis, step
 
 
 def _get_data_units_from_dims(patch, dims, operator):

--- a/docs/contributing/publish_a_new_release.qmd
+++ b/docs/contributing/publish_a_new_release.qmd
@@ -2,16 +2,37 @@
 title: "Publish a new release"
 ---
 
-On this page, we provide step-by-step guidance on how to publish a new release for DASCore.
+This page describes the maintainer workflow for publishing a DASCore release. DASCore's package version is derived from git tags, so the release tag is the source of truth and no version file needs to be edited by hand.
 
-## Step 1: Draft a new release and publish
+## Before releasing
 
-On DASCore GitHub page, you should go to [Releases](https://github.com/DASDAE/dascore/releases), draft a new release. On the draft, choose a new tag and a release title (e.g. 0.0.14). Finally, generate release notes and publish the release.
+Make sure the docs build. Because the doc-build can take a bit of time, the doc-build is not automatically tested on each PR. You can test this using the `documentation` tag on a new PR, or run it locally following the [doc-build instructions](documentation.qmd#generating-documentation).
 
-## Step 2: Check the release status
+Next, from the github interface navigate to DASCore's [release page](https://github.com/DASDAE/dascore/releases) and click on [draft new release](https://github.com/DASDAE/dascore/releases/new). For the tag, note the latest release, then choose the next version tag using DASCore's versioning policy in the [general guidelines](general_guidelines.qmd) (eg if the latest version is `v0.1.20` then type `v0.1.21` for a patch/bug fix release and `v0.2.0` for a larger feature release).
 
-On [Actions](https://github.com/DASDAE/dascore/actions), check the release status for both "PublishPackage" and "BuildDeployStableDocs". Also, make sure [PyPI](https://pypi.org/project/dascore/) is updated.
+## Draft the release notes
 
-## Step 3: Commit required changes for Conda
+Compare the merged changes since the previous release and group user-facing changes into a short changelog. The changelog should usually include these sections:
 
-For [conda](https://github.com/conda-forge/dascore-feedstock), you need to wait a few hours to get a pull request, and then verify/edit the dependencies, extras, etc. on [meta.yaml](https://github.com/conda-forge/dascore-feedstock/blob/main/recipe/meta.yaml) at /dascore-feedstock/recipe directory based on [pyproject.toml](https://github.com/DASDAE/dascore/blob/master/pyproject.toml) at /dascore directory. Therefore, if they do not match, you need to clone the dascore-feedstock branch (the branch that the bot wants to merge into the master), add the bot's fork as a remote (`git remote add conda_bot git@github.com:regro-cf-autotick-bot/dascore-feedstock`), fetch the new branch (`git fetch conda_bot`), and then check the bot's created branch out. Then, you modify the branch and push it back. After merging the pull request, you can verify the latest DASCore version at [conda-forge](https://anaconda.org/conda-forge/dascore).
+- New Features
+- Bug Fixes
+- Breaking Changes
+
+The GitHub releases page can generate release notes automatically, but maintainers should review and edit the generated text so it is useful to users. Also note, DASCore includes an agent skill called "draft release" so a coding agent of your choice can help you do this. In the changelog, prefer concise descriptions of behavior and API changes over internal implementation details. Include pull request links when they help readers find more context.
+
+Then click 'Publish Release'. This will kick off the doc-build and publishing task automatically, as well as publish the tagged source code to PyPI.
+
+## Verify package and docs publishing
+
+After publishing, open [GitHub Actions](https://github.com/DASDAE/dascore/actions) and confirm the release workflows complete successfully.
+
+- `PublishPackage` builds the distributions and uploads DASCore to [PyPI](https://pypi.org/project/dascore/).
+- `BuildDeployStableDocs` builds the stable documentation, deploys it to GitHub Pages, and uploads `docs.zip` to the GitHub release. This may take 30 minutes or more.
+
+Once the workflows finish, check that PyPI shows the new version and that the stable documentation site reflects the release. If a workflow fails, fix the underlying issue on `master`, publish a new patch release if the tag has already been distributed, and avoid moving or replacing a public release tag.
+
+## Conda-forge
+
+Unfortunately, simply creating the tag will not publish to conda-forge automatically. To do this, first wait until the new package appears on [DASCore's PyPI page](https://pypi.org/project/dascore/). Next, navigate to [DASCore's feedstock](https://github.com/conda-forge/dascore-feedstock) and open a new issue. Click "bot commands" and create an issue with the title "@conda-forge-admin, please update version". The conda-forge bot will then see there is a new release on PyPI and open a PR. Alternatively, the bot will automatically see the new version and open a new PR within a day or so.
+
+When this PR opens, examine the requirements and dependencies listed, and make sure they have not gotten out of sync with DASCore's current pyproject.toml. In general, conda-forge should lean more towards including dependencies that are optional, although some have been abandoned if they are very slow at making conda releases. Once this is correct, merge the pull request. After the feedstock PR is merged, the new version should be published to conda-forge in an hour or so. Verify the new package appears on [conda-forge](https://anaconda.org/conda-forge/dascore).

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -210,6 +210,38 @@ class TestRolling:
         patch_2 = roll2.apply(np.sum)
         assert patch_2.shape == patch_1.shape
 
+    def test_numpy_apply_with_args_kwargs(self, random_patch):
+        """Ensure numpy rolling apply supports extra function arguments."""
+
+        def percentile_plus(frame, q, offset=0, axis=None):
+            """Get percentile with an offset."""
+            return np.percentile(frame, q, axis=axis) + offset
+
+        dt = random_patch.get_coord("time").step
+        out = random_patch.rolling(time=10 * dt, step=10 * dt, engine="numpy").apply(
+            percentile_plus, 80, offset=1
+        )
+        expected = random_patch.rolling(
+            time=10 * dt, step=10 * dt, engine="numpy"
+        ).apply(lambda frame, axis=None: np.percentile(frame, 80, axis=axis) + 1)
+        assert all_close(out, expected)
+
+    def test_pandas_apply_with_args_kwargs(self, random_patch):
+        """Ensure pandas rolling apply supports extra function arguments."""
+
+        def percentile_plus(frame, q, offset=0, axis=None):
+            """Get percentile with an offset."""
+            return np.percentile(frame, q, axis=axis) + offset
+
+        dt = random_patch.get_coord("time").step
+        out = random_patch.rolling(time=10 * dt, step=10 * dt, engine="pandas").apply(
+            percentile_plus, 80, offset=1
+        )
+        expected = random_patch.rolling(
+            time=10 * dt, step=10 * dt, engine="pandas"
+        ).apply(lambda frame: np.percentile(frame, 80) + 1)
+        assert all_close(out, expected)
+
 
 class TestNumpyVsPandasRolling:
     """Ensure numpy rolling return the same results as pandas rolling."""

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -80,6 +80,16 @@ class TestRolling:
         expected = vals[start :: self.step, None]
         assert np.allclose(out.data, expected)
 
+    def test_apply_with_overlap(self, range_patch):
+        """Ensure rolling supports overlap end-to-end."""
+        step = range_patch.get_coord("distance").step
+        window = self.window * step
+        overlap = (self.window - self.step) * step
+        overlap_out = range_patch.rolling(distance=window, overlap=overlap).mean()
+        step_out = range_patch.rolling(distance=window, step=self.step * step).mean()
+        assert overlap_out.shape == step_out.shape
+        assert all_close(overlap_out, step_out)
+
     def test_window_size_one(self, random_patch):
         """Ensure we can get a window size of one."""
         time_step = random_patch.get_coord("time").step

--- a/tests/test_transform/test_mean_median_frequency.py
+++ b/tests/test_transform/test_mean_median_frequency.py
@@ -1,0 +1,124 @@
+"""Tests for mean and median frequency transforms."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dascore import units
+
+
+class TestMeanFrequency:
+    """Tests for mean_frequency patch function."""
+
+    def test_runs(self, random_patch):
+        """Ensure mean_frequency runs as a patch method."""
+        out = random_patch.mean_frequency(winlen=0.01, step=0.01)
+
+        assert out.attrs.data_type == "Mean Frequency"
+        assert out.attrs.data_units == units.Hz
+        assert "time" in out.dims
+        assert "distance" in out.dims
+
+    def test_fft_method_runs(self, random_patch):
+        """Ensure FFT method runs."""
+        out = random_patch.mean_frequency(winlen=0.01, step=0.01, method="fft")
+
+        assert out.attrs.data_type == "Mean Frequency"
+        assert out.attrs.data_units == units.Hz
+        assert np.isfinite(out.data).any()
+
+    def test_step_defaults_to_winlen(self, random_patch):
+        """Ensure step defaults to winlen."""
+        out = random_patch.mean_frequency(winlen=0.01)
+        expected = random_patch.mean_frequency(winlen=0.01, step=0.01)
+
+        assert np.allclose(out.data, expected.data, equal_nan=True)
+
+    def test_frequency_bounds(self, random_patch):
+        """Ensure frequency bounds are accepted."""
+        out = random_patch.mean_frequency(
+            winlen=0.01,
+            step=0.01,
+            fmin=10,
+            fmax=100,
+        )
+
+        assert out.attrs.data_type == "Mean Frequency"
+        assert out.attrs.data_units == units.Hz
+
+    def test_invalid_frequency_bounds_raise(self, random_patch):
+        """Ensure invalid frequency bounds raise."""
+        with pytest.raises(AssertionError, match="must be smaller than fmax"):
+            random_patch.mean_frequency(
+                winlen=0.01,
+                step=0.01,
+                fmin=100,
+                fmax=10,
+            )
+
+    def test_collapse_mode_runs(self, random_patch):
+        """Ensure winlen=None collapses over the full time range."""
+        out = random_patch.mean_frequency()
+
+        assert out.attrs.data_type == "Mean Frequency"
+        assert out.attrs.data_units == units.Hz
+        assert out.data.shape != random_patch.data.shape
+
+
+class TestMedianFrequency:
+    """Tests for median_frequency patch function."""
+
+    def test_runs(self, random_patch):
+        """Ensure median_frequency runs as a patch method."""
+        out = random_patch.median_frequency(winlen=0.01, step=0.01)
+
+        assert out.attrs.data_type == "Median Frequency"
+        assert out.attrs.data_units == units.Hz
+        assert "time" in out.dims
+        assert "distance" in out.dims
+
+    def test_fft_method_runs(self, random_patch):
+        """Ensure FFT method runs."""
+        out = random_patch.median_frequency(winlen=0.01, step=0.01, method="fft")
+
+        assert out.attrs.data_type == "Median Frequency"
+        assert out.attrs.data_units == units.Hz
+        assert np.isfinite(out.data).any()
+
+    def test_step_defaults_to_winlen(self, random_patch):
+        """Ensure step defaults to winlen."""
+        out = random_patch.median_frequency(winlen=0.01)
+        expected = random_patch.median_frequency(winlen=0.01, step=0.01)
+
+        assert np.allclose(out.data, expected.data, equal_nan=True)
+
+    def test_frequency_bounds(self, random_patch):
+        """Ensure frequency bounds are accepted."""
+        out = random_patch.median_frequency(
+            winlen=0.01,
+            step=0.01,
+            fmin=10,
+            fmax=100,
+        )
+
+        assert out.attrs.data_type == "Median Frequency"
+        assert out.attrs.data_units == units.Hz
+
+    def test_invalid_frequency_bounds_raise(self, random_patch):
+        """Ensure invalid frequency bounds raise."""
+        with pytest.raises(AssertionError, match="must be smaller than fmax"):
+            random_patch.median_frequency(
+                winlen=0.01,
+                step=0.01,
+                fmin=100,
+                fmax=10,
+            )
+
+    def test_collapse_mode_runs(self, random_patch):
+        """Ensure winlen=None collapses over the full time range."""
+        out = random_patch.median_frequency()
+
+        assert out.attrs.data_type == "Median Frequency"
+        assert out.attrs.data_units == units.Hz
+        assert out.data.shape != random_patch.data.shape

--- a/tests/test_transform/test_mean_median_frequency.py
+++ b/tests/test_transform/test_mean_median_frequency.py
@@ -13,7 +13,7 @@ class TestMeanFrequency:
 
     def test_runs(self, random_patch):
         """Ensure mean_frequency runs as a patch method."""
-        out = random_patch.mean_frequency(winlen=0.01, step=0.01)
+        out = random_patch.mean_frequency(winlen=0.3, step=0.01)
 
         assert out.attrs.data_type == "Mean Frequency"
         assert out.attrs.data_units == units.Hz
@@ -22,23 +22,16 @@ class TestMeanFrequency:
 
     def test_fft_method_runs(self, random_patch):
         """Ensure FFT method runs."""
-        out = random_patch.mean_frequency(winlen=0.01, step=0.01, method="fft")
+        out = random_patch.mean_frequency(winlen=0.3, step=0.01, method="fft")
 
         assert out.attrs.data_type == "Mean Frequency"
         assert out.attrs.data_units == units.Hz
         assert np.isfinite(out.data).any()
 
-    def test_step_defaults_to_winlen(self, random_patch):
-        """Ensure step defaults to winlen."""
-        out = random_patch.mean_frequency(winlen=0.01)
-        expected = random_patch.mean_frequency(winlen=0.01, step=0.01)
-
-        assert np.allclose(out.data, expected.data, equal_nan=True)
-
     def test_frequency_bounds(self, random_patch):
         """Ensure frequency bounds are accepted."""
         out = random_patch.mean_frequency(
-            winlen=0.01,
+            winlen=0.3,
             step=0.01,
             fmin=10,
             fmax=100,
@@ -51,19 +44,11 @@ class TestMeanFrequency:
         """Ensure invalid frequency bounds raise."""
         with pytest.raises(AssertionError, match="must be smaller than fmax"):
             random_patch.mean_frequency(
-                winlen=0.01,
+                winlen=0.3,
                 step=0.01,
                 fmin=100,
                 fmax=10,
             )
-
-    def test_collapse_mode_runs(self, random_patch):
-        """Ensure winlen=None collapses over the full time range."""
-        out = random_patch.mean_frequency()
-
-        assert out.attrs.data_type == "Mean Frequency"
-        assert out.attrs.data_units == units.Hz
-        assert out.data.shape != random_patch.data.shape
 
     def test_winlen_too_short_for_fmin_raises(self, random_patch):
         """Ensure low frequencies require sufficiently long windows."""
@@ -79,7 +64,7 @@ class TestMedianFrequency:
 
     def test_runs(self, random_patch):
         """Ensure median_frequency runs as a patch method."""
-        out = random_patch.median_frequency(winlen=0.01, step=0.01)
+        out = random_patch.median_frequency(winlen=0.3, step=0.01)
 
         assert out.attrs.data_type == "Median Frequency"
         assert out.attrs.data_units == units.Hz
@@ -88,23 +73,16 @@ class TestMedianFrequency:
 
     def test_fft_method_runs(self, random_patch):
         """Ensure FFT method runs."""
-        out = random_patch.median_frequency(winlen=0.01, step=0.01, method="fft")
+        out = random_patch.median_frequency(winlen=0.3, step=0.01, method="fft")
 
         assert out.attrs.data_type == "Median Frequency"
         assert out.attrs.data_units == units.Hz
         assert np.isfinite(out.data).any()
 
-    def test_step_defaults_to_winlen(self, random_patch):
-        """Ensure step defaults to winlen."""
-        out = random_patch.median_frequency(winlen=0.01)
-        expected = random_patch.median_frequency(winlen=0.01, step=0.01)
-
-        assert np.allclose(out.data, expected.data, equal_nan=True)
-
     def test_frequency_bounds(self, random_patch):
         """Ensure frequency bounds are accepted."""
         out = random_patch.median_frequency(
-            winlen=0.01,
+            winlen=0.3,
             step=0.01,
             fmin=10,
             fmax=100,
@@ -117,19 +95,11 @@ class TestMedianFrequency:
         """Ensure invalid frequency bounds raise."""
         with pytest.raises(AssertionError, match="must be smaller than fmax"):
             random_patch.median_frequency(
-                winlen=0.01,
+                winlen=0.3,
                 step=0.01,
                 fmin=100,
                 fmax=10,
             )
-
-    def test_collapse_mode_runs(self, random_patch):
-        """Ensure winlen=None collapses over the full time range."""
-        out = random_patch.median_frequency()
-
-        assert out.attrs.data_type == "Median Frequency"
-        assert out.attrs.data_units == units.Hz
-        assert out.data.shape != random_patch.data.shape
 
     def test_winlen_too_short_for_fmin_raises(self, random_patch):
         """Ensure low frequencies require sufficiently long windows."""

--- a/tests/test_transform/test_mean_median_frequency.py
+++ b/tests/test_transform/test_mean_median_frequency.py
@@ -4,8 +4,107 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from scipy.signal import get_window, welch
 
 from dascore import units
+from dascore.transform.mean_median_frequency import _fft_psd, _welch
+
+
+class TestWelch:
+    """Tests for the specialized Welch PSD helper."""
+
+    def test_output_shapes(self):
+        """Ensure frequency and PSD arrays have expected shapes."""
+        rng = np.random.default_rng(42)
+        data = rng.normal(size=(4, 3, 128))
+        win = get_window("hann", 64)
+
+        freq, pxx = _welch(data, win=win, fs=100.0, nperseg=64)
+
+        assert freq.shape == (33,)
+        assert pxx.shape == (4, 3, 33)
+
+    def test_short_input_reduces_nperseg(self):
+        """Ensure nperseg is reduced when the signal is shorter."""
+        rng = np.random.default_rng(42)
+        data = rng.normal(size=(4, 3, 32))
+        win = get_window("hann", 64)
+
+        freq, pxx = _welch(data, win=win, fs=100.0, nperseg=64)
+
+        assert freq.shape == (17,)
+        assert pxx.shape == (4, 3, 17)
+
+    def test_matches_scipy_welch_even_nperseg(self):
+        """Ensure helper matches scipy.signal.welch for even nperseg."""
+        rng = np.random.default_rng(42)
+        data = rng.normal(size=(4, 3, 128))
+        nperseg = 64
+        fs = 100.0
+        win = get_window("hann", nperseg)
+
+        freq, pxx = _welch(data, win=win, fs=fs, nperseg=nperseg)
+        expected_freq, expected_pxx = welch(
+            data,
+            fs=fs,
+            window=win,
+            nperseg=nperseg,
+            noverlap=nperseg // 2,
+            detrend="constant",
+            scaling="density",
+            return_onesided=True,
+            axis=-1,
+        )
+
+        assert np.allclose(freq, expected_freq)
+        assert np.allclose(pxx, expected_pxx)
+
+    def test_matches_scipy_welch_odd_nperseg(self):
+        """Ensure helper matches scipy.signal.welch for odd nperseg."""
+        rng = np.random.default_rng(42)
+        data = rng.normal(size=(4, 3, 129))
+        nperseg = 63
+        fs = 100.0
+        win = get_window("hann", nperseg)
+
+        freq, pxx = _welch(data, win=win, fs=fs, nperseg=nperseg)
+        expected_freq, expected_pxx = welch(
+            data,
+            fs=fs,
+            window=win,
+            nperseg=nperseg,
+            noverlap=nperseg // 2,
+            detrend="constant",
+            scaling="density",
+            return_onesided=True,
+            axis=-1,
+        )
+
+        assert np.allclose(freq, expected_freq)
+        assert np.allclose(pxx, expected_pxx)
+
+    def test_constant_signal_has_zero_non_dc_power(self):
+        """Ensure detrending removes constant signal power."""
+        data = np.ones((2, 3, 128))
+        nperseg = 64
+        win = get_window("hann", nperseg)
+
+        _, pxx = _welch(data, win=win, fs=100.0, nperseg=nperseg)
+
+        assert np.allclose(pxx, 0.0)
+
+    def test_frequency_axis_uses_sampling_frequency(self):
+        """Ensure frequency spacing is fs / nperseg."""
+        data = np.ones((2, 3, 128))
+        nperseg = 64
+        fs = 200.0
+        win = get_window("hann", nperseg)
+
+        freq, _ = _welch(data, win=win, fs=fs, nperseg=nperseg)
+
+        assert np.allclose(np.diff(freq), fs / nperseg)
+        assert freq[0] == 0
+        assert freq[-1] == fs / 2
 
 
 class TestMeanFrequency:
@@ -50,6 +149,18 @@ class TestMeanFrequency:
                 fmax=10,
             )
 
+    def test_transposes_output_when_distance_axis_changes(self, random_patch):
+        """Ensure output is transposed back when rolling/apply changes axis order."""
+        patch = random_patch.transpose("time", "distance")
+
+        out = patch.mean_frequency(
+            winlen=0.01,
+            step=0.01,
+        )
+
+        assert out.get_axis("distance") == patch.get_axis("distance")
+        assert out.dims == patch.dims
+
 
 class TestMedianFrequency:
     """Tests for median_frequency patch function."""
@@ -92,3 +203,41 @@ class TestMedianFrequency:
                 fmin=100,
                 fmax=10,
             )
+
+    def test_transposes_output_when_distance_axis_changes(self, random_patch):
+        """Ensure output is transposed back when rolling/apply changes axis order."""
+        patch = random_patch.transpose("time", "distance")
+
+        out = patch.mean_frequency(
+            winlen=0.01,
+            step=0.01,
+        )
+
+        assert out.get_axis("distance") == patch.get_axis("distance")
+        assert out.dims == patch.dims
+
+
+class TestFFTPSD:
+    """Tests for simple FFT PSD helper."""
+
+    def test_even_length_doubles_only_interior_bins(self):
+        """Ensure even-length FFT excludes Nyquist from doubling."""
+        rng = np.random.default_rng(42)
+        data = rng.normal(size=(1, 1, 128))
+
+        _, pxx = _fft_psd(data, fs=100.0)
+
+        n = data.shape[-1]
+        x = data - np.mean(data, axis=-1, keepdims=True)
+        xft = np.fft.rfft(x, axis=-1)
+
+        raw = (np.abs(xft) ** 2) / (100.0 * n)
+
+        # DC unchanged
+        assert np.allclose(pxx[..., 0], raw[..., 0])
+
+        # Nyquist unchanged
+        assert np.allclose(pxx[..., -1], raw[..., -1])
+
+        # interior bins doubled
+        assert np.allclose(pxx[..., 1:-1], raw[..., 1:-1] * 2)

--- a/tests/test_transform/test_mean_median_frequency.py
+++ b/tests/test_transform/test_mean_median_frequency.py
@@ -7,7 +7,7 @@ import pytest
 from scipy.signal import get_window, welch
 
 from dascore import units
-from dascore.transform.mean_median_frequency import _fft_psd, _welch
+from dascore.transform.mean_median_frequency import _fft_psd, _get_psd_in_window, _welch
 
 
 class TestWelch:
@@ -161,6 +161,17 @@ class TestMeanFrequency:
         assert out.get_axis("distance") == patch.get_axis("distance")
         assert out.dims == patch.dims
 
+    def test_mean_frequency_step_defaults_to_time_step(self, random_patch):
+        """Cover step=None branch in mean_frequency."""
+        dt = random_patch.get_coord("time").step
+        if isinstance(dt, np.timedelta64):
+            dt = dt / np.timedelta64(1, "s")
+
+        out = random_patch.mean_frequency(winlen=0.01, step=None, method="fft")
+        expected = random_patch.mean_frequency(winlen=0.01, step=dt, method="fft")
+
+        assert np.allclose(out.data, expected.data, equal_nan=True)
+
 
 class TestMedianFrequency:
     """Tests for median_frequency patch function."""
@@ -216,6 +227,17 @@ class TestMedianFrequency:
         assert out.get_axis("distance") == patch.get_axis("distance")
         assert out.dims == patch.dims
 
+    def test_median_frequency_step_defaults_to_time_step(self, random_patch):
+        """Cover step=None branch in median_frequency."""
+        dt = random_patch.get_coord("time").step
+        if isinstance(dt, np.timedelta64):
+            dt = dt / np.timedelta64(1, "s")
+
+        out = random_patch.median_frequency(winlen=0.01, step=None, method="fft")
+        expected = random_patch.median_frequency(winlen=0.01, step=dt, method="fft")
+
+        assert np.allclose(out.data, expected.data, equal_nan=True)
+
 
 class TestFFTPSD:
     """Tests for simple FFT PSD helper."""
@@ -241,3 +263,25 @@ class TestFFTPSD:
 
         # interior bins doubled
         assert np.allclose(pxx[..., 1:-1], raw[..., 1:-1] * 2)
+
+    def test_fft_psd_odd_length_doubles_all_non_dc_bins(self):
+        """Cover the odd-length branch in _fft_psd."""
+        rng = np.random.default_rng(42)
+        data = rng.normal(size=(2, 3, 127))
+        fs = 100.0
+
+        _, pxx = _fft_psd(data, fs=fs)
+
+        n = data.shape[-1]
+        demeaned = data - np.mean(data, axis=-1, keepdims=True)
+        raw = np.abs(np.fft.rfft(demeaned, axis=-1)) ** 2 / (fs * n)
+
+        assert np.allclose(pxx[..., 0], raw[..., 0])
+        assert np.allclose(pxx[..., 1:], raw[..., 1:] * 2.0)
+
+    def test_invalid_frequency_bounds_raise(self):
+        """Cover fmin >= fmax validation in _get_psd_in_window."""
+        data = np.ones((2, 3, 128))
+
+        with pytest.raises(ValueError, match=r"must be smaller than fmax"):
+            _get_psd_in_window(data, method="fft", dt=0.01, fmin=20, fmax=10)

--- a/tests/test_transform/test_mean_median_frequency.py
+++ b/tests/test_transform/test_mean_median_frequency.py
@@ -50,14 +50,6 @@ class TestMeanFrequency:
                 fmax=10,
             )
 
-    def test_winlen_too_short_for_fmin_raises(self, random_patch):
-        """Ensure low frequencies require sufficiently long windows."""
-        with pytest.raises(ValueError, match="too short for fmin"):
-            random_patch.mean_frequency(
-                winlen=0.01,
-                fmin=200,
-            )
-
 
 class TestMedianFrequency:
     """Tests for median_frequency patch function."""
@@ -99,12 +91,4 @@ class TestMedianFrequency:
                 step=0.01,
                 fmin=100,
                 fmax=10,
-            )
-
-    def test_winlen_too_short_for_fmin_raises(self, random_patch):
-        """Ensure low frequencies require sufficiently long windows."""
-        with pytest.raises(ValueError, match="too short for fmin"):
-            random_patch.median_frequency(
-                winlen=0.01,
-                fmin=200,
             )

--- a/tests/test_transform/test_mean_median_frequency.py
+++ b/tests/test_transform/test_mean_median_frequency.py
@@ -65,6 +65,14 @@ class TestMeanFrequency:
         assert out.attrs.data_units == units.Hz
         assert out.data.shape != random_patch.data.shape
 
+    def test_winlen_too_short_for_fmin_raises(self, random_patch):
+        """Ensure low frequencies require sufficiently long windows."""
+        with pytest.raises(ValueError, match="too short for fmin"):
+            random_patch.mean_frequency(
+                winlen=0.01,
+                fmin=200,
+            )
+
 
 class TestMedianFrequency:
     """Tests for median_frequency patch function."""
@@ -122,3 +130,11 @@ class TestMedianFrequency:
         assert out.attrs.data_type == "Median Frequency"
         assert out.attrs.data_units == units.Hz
         assert out.data.shape != random_patch.data.shape
+
+    def test_winlen_too_short_for_fmin_raises(self, random_patch):
+        """Ensure low frequencies require sufficiently long windows."""
+        with pytest.raises(ValueError, match="too short for fmin"):
+            random_patch.median_frequency(
+                winlen=0.01,
+                fmin=200,
+            )

--- a/tests/test_transform/test_mean_median_frequency.py
+++ b/tests/test_transform/test_mean_median_frequency.py
@@ -208,7 +208,7 @@ class TestMedianFrequency:
         """Ensure output is transposed back when rolling/apply changes axis order."""
         patch = random_patch.transpose("time", "distance")
 
-        out = patch.mean_frequency(
+        out = patch.median_frequency(
             winlen=0.01,
             step=0.01,
         )

--- a/tests/test_transform/test_mean_median_frequency.py
+++ b/tests/test_transform/test_mean_median_frequency.py
@@ -141,7 +141,7 @@ class TestMeanFrequency:
 
     def test_invalid_frequency_bounds_raise(self, random_patch):
         """Ensure invalid frequency bounds raise."""
-        with pytest.raises(AssertionError, match="must be smaller than fmax"):
+        with pytest.raises(ValueError, match="must be smaller than fmax"):
             random_patch.mean_frequency(
                 winlen=0.3,
                 step=0.01,
@@ -196,7 +196,7 @@ class TestMedianFrequency:
 
     def test_invalid_frequency_bounds_raise(self, random_patch):
         """Ensure invalid frequency bounds raise."""
-        with pytest.raises(AssertionError, match="must be smaller than fmax"):
+        with pytest.raises(ValueError, match="must be smaller than fmax"):
             random_patch.median_frequency(
                 winlen=0.3,
                 step=0.01,

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -20,6 +20,7 @@ from dascore.exceptions import (
     PatchAttributeError,
     PatchCoordinateError,
 )
+from dascore.units import percent
 from dascore.utils.patch import (
     _spool_up,
     align_patch_coords,
@@ -27,6 +28,7 @@ from dascore.utils.patch import (
     get_dim_axis_value,
     get_patch_names,
     get_patch_window_size,
+    get_window_axis_step,
     merge_compatible_coords_attrs,
     patches_to_df,
     stack_patches,
@@ -395,16 +397,14 @@ class TestMergeCompatibleCoordsAttrs:
     def test_extra_attrs(self, random_patch):
         """Ensure extra attributes are added to patch."""
         patch = random_patch.update_attrs(new_attr=10)
-        coords, attrs = merge_compatible_coords_attrs(patch, random_patch)
+        _, attrs = merge_compatible_coords_attrs(patch, random_patch)
         assert attrs.get("new_attr") == 10
 
     def test_different_dims(self, random_patch):
         """Ensure we can merge patches which share some dims but not all."""
         patch1 = random_patch
         patch2 = random_patch.rename_coords(time="money")
-        coord, attrs = merge_compatible_coords_attrs(
-            patch1, patch2, dim_intersection=True
-        )
+        coord, _ = merge_compatible_coords_attrs(patch1, patch2, dim_intersection=True)
         assert set(coord.dims) == (set(patch1.dims) | set(patch2.dims))
 
 
@@ -850,3 +850,88 @@ class TestGetPatchWindowSize:
 
         with pytest.raises(CoordError):
             get_patch_window_size(irregular_patch, {"time": 0.5})
+
+
+class TestGetWindowAxisStep:
+    """Tests for getting window size, axis, and step."""
+
+    window = 16
+    step = 8
+
+    def test_apply_with_overlap(self, random_patch):
+        """Ensure overlap is converted to the correct step size."""
+        coord = random_patch.get_coord("distance")
+        window = self.window * coord.step
+        overlap = (self.window - self.step) * coord.step
+        out = get_window_axis_step(random_patch, distance=window, overlap=overlap)
+        assert out == (self.window, random_patch.get_axis("distance"), self.step)
+
+    def test_apply_with_percent_overlap(self, random_patch):
+        """Ensure percent overlap is supported."""
+        coord = random_patch.get_coord("distance")
+        window = self.window * coord.step
+        out = get_window_axis_step(random_patch, distance=window, overlap=50 * percent)
+        assert out == (self.window, random_patch.get_axis("distance"), self.step)
+
+    def test_apply_with_percent_overlap_and_samples(self, random_patch):
+        """Ensure percent overlap works when samples=True."""
+        out = get_window_axis_step(
+            random_patch, distance=self.window, overlap=50 * percent, samples=True
+        )
+        assert out == (self.window, random_patch.get_axis("distance"), self.step)
+
+    def test_negative_overlap_raises(self, random_patch):
+        """Ensure negative overlap is rejected."""
+        step = random_patch.get_coord("distance").step
+        msg = "overlap must be non-negative"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch, distance=self.window * step, overlap=-step
+            )
+
+    def test_invalid_percent_overlap_raises(self, random_patch):
+        """Ensure percent overlap must be between 0 and 100."""
+        msg = "Percentage must be between 0 and 100"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch, distance=self.window, overlap=101 * percent, samples=True
+            )
+
+    def test_complete_overlap_raises(self, random_patch):
+        """Ensure complete overlap is rejected."""
+        msg = "Window step must be greater than zero"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch, distance=self.window, overlap=100 * percent, samples=True
+            )
+
+    def test_overlap_larger_than_window_raises(self, random_patch):
+        """Ensure overlap larger than window is rejected."""
+        msg = "Window step must be greater than zero"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch,
+                distance=self.window,
+                overlap=self.window + 1,
+                samples=True,
+            )
+
+    def test_step_and_overlap_raises(self, random_patch):
+        """Ensure step and overlap are mutually exclusive."""
+        step = random_patch.get_coord("distance").step
+        msg = "step and overlap are mutually exclusive"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch,
+                distance=self.window * step,
+                step=self.step * step,
+                overlap=50 * percent,
+            )
+
+    def test_none_overlap_matches_default(self, random_patch):
+        """Ensure overlap=None preserves default window/step behavior."""
+        step = random_patch.get_coord("distance").step
+        out = get_window_axis_step(
+            random_patch, distance=self.window * step, overlap=None
+        )
+        assert out == (self.window, random_patch.get_axis("distance"), None)


### PR DESCRIPTION
Some more transformations that have been useful for me in the past:
mean_frequency and median_frequency apply a rolling window and calculate a measure of the "dominant frequency"

Sometimes mean_frequency shows better what you expect from your data, sometimes median_frequency. Here are options for both.

Note that these functions make use of the "partial" function on the rolling_function. 
this can be updated once the rolling_function allows for arguments directly

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [X] documented the new feature with docstrings and/or appropriate doc page.
- [X] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Patch objects gain mean_frequency and median_frequency transforms for rolling-window spectral analysis with configurable window/step, optional fmin/fmax, and selectable PSD method; outputs include updated data type and units (Hz).

* **Tests**
  * Added tests for PSD/FFT behavior, helper routines, frequency-bounds validation, output attributes, numerical stability, and axis/shape handling for the new transforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->