### PR TITLE
Add overlap support to rolling and unify window step handling

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -795,7 +795,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             samples = int(np.ceil(ratio))
         if enforce_lt_coord and samples > len(self):
             msg = (
-                f"value of {value} with samples={samples }results in a window "
+                f"value of {value} with samples={samples } results in a window "
                 f"larger than coordinate length of {len(self)}."
             )
             raise ParameterError(msg)

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -13,7 +13,7 @@ from dascore.constants import samples_arg_description
 from dascore.exceptions import ParameterError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.models import DascoreBaseModel
-from dascore.utils.patch import get_dim_axis_value
+from dascore.utils.patch import get_dim_axis_value, get_window_axis_step
 from dascore.utils.pd import rolling_df
 
 
@@ -213,6 +213,7 @@ class _PandasPatchRoller(_PatchRollerInfo):
 def rolling(
     patch: dc.Patch,
     step=None,
+    overlap=None,
     center=False,
     engine: Literal["numpy", "pandas", None] = None,
     samples=False,
@@ -230,7 +231,13 @@ def rolling(
     step
         The window is evaluated at every step result, equivalent to slicing
         at every step. If the step argument is not None, the result will
-        have a different shape than the input. Default None.
+        have a different shape than the input. Mutually exclusive with
+        overlap. Default None.
+    overlap
+        The overlap between windows. Can be a number (assumed to be in units of
+        the rolling dimension if `samples`==False), a percent, or None. If
+        provided, step is calculated as `window - overlap`. Percent overlap is
+        always interpreted relative to the window length.
     center
         If False, set the window labels as the right edge of the window index.
         If True, set the window labels as the center of the window index. Default False.
@@ -337,20 +344,18 @@ def rolling(
             return _PandasPatchRoller
         return _NumpyPatchRoller
 
-    # get window sizes in samples
     dim, axis, value = get_dim_axis_value(patch, kwargs=kwargs)[0]
-    roll_hist = f"rolling({dim}={value}, step={step}, center={center}, engine={engine})"
-    coord = patch.get_coord(dim)
-    window = coord.get_sample_count(value, samples=samples, enforce_lt_coord=True)
-    step = (
-        1
-        if step is None
-        else coord.get_sample_count(step, samples=samples, enforce_lt_coord=True)
-    )
+    window, _, step = get_window_axis_step(patch, overlap, step, samples, **kwargs)
+    # Handle default when no overlap/step specified and ensure window size
+    step = 1 if step is None else step
     if window == 0 or step == 0:
         msg = "Window or step size can't be zero. Use any positive values."
         raise ParameterError(msg)
     cls = _get_engine(step, engine, patch)
+    roll_hist = (
+        f"rolling({dim}={value}, step={step}, overlap={overlap}, "
+        f"center={center}, engine={engine})"
+    )
     out = cls(
         patch=patch,
         window=window,

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -30,6 +30,7 @@ from dascore.utils.patch import (
     _get_data_units_from_dims,
     _get_dx_or_spacing_and_axes,
     get_dim_axis_value,
+    get_window_axis_step,
     patch_function,
 )
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
@@ -319,7 +320,7 @@ def idft(patch: PatchType, dim: str | None | Sequence[str] = None) -> PatchType:
     >>> # get inverse dft, transformed axis are ascertained automatically
     >>> idft = dft_time.idft()
     """
-    dims, steps, axes, real = _get_idft_dims_steps_axis(patch, dim)
+    dims, _steps, axes, real = _get_idft_dims_steps_axis(patch, dim)
     new_dims = FourierTransformatter().rename_dims(dims, forward=False)
     func = nft.irfftn if real else nft.ifftn
     # Get new coords, fft sizes, and padding to remove.
@@ -374,7 +375,7 @@ def _get_stft_coords(patch, dim, axis, coord, stft, window):
 @patch_function()
 def stft(
     patch: PatchType,
-    taper_window: str | ndarray | tuple[str, Any, ...] = "hann",
+    taper_window: str | ndarray | tuple[str | Any, ...] = "hann",
     overlap: Quantity | int | None = 50 * percent,
     samples: bool = False,
     detrend: bool = False,
@@ -440,26 +441,20 @@ def stft(
     [Patch.dft](`dascore.Patch.dft`), [Patch.istft](`dascore.Patch.istft`)
     """
     # Get coordinate information.
-    (dim, axis, val) = get_dim_axis_value(patch, kwargs=kwargs)[0]
+    (dim, axis, _) = get_dim_axis_value(patch, kwargs=kwargs)[0]
     coord = patch.get_coord(dim, require_evenly_sampled=True)
-    window_samples = coord.get_sample_count(val, samples=samples, enforce_lt_coord=True)
-    step = dc.to_float(coord.step)
-    sampling_rate = 1 / abs(step)
-    # Create window and calculate hop.
+    # Get window count/step in samples
+    window_samples, _, hop = get_window_axis_step(
+        patch, step=None, overlap=overlap, samples=samples, **kwargs
+    )
+    # Default step here is the same size as window (no overlap).
+    hop = hop if hop is not None else window_samples
+    sampling_rate = 1 / abs(dc.to_float(coord.step))
+    # Create window.
     if isinstance(taper_window, ndarray):
         window = taper_window
     else:
         window = get_window(taper_window, window_samples, fftbins=False)
-    # By using a coord and enforce_lt_coord, we guarantee the overlap is lt window.
-    if overlap is not None:
-        overlap = coord[:window_samples].get_sample_count(
-            overlap,
-            samples=samples,
-            enforce_lt_coord=True,
-        )
-    else:
-        overlap = 0
-    hop = window_samples - overlap
     # Perform stft
     fft_mode = "onesided" if np.isrealobj(patch.data) else "centered"
     stft = ShortTimeFFT(
@@ -471,7 +466,8 @@ def stft(
     )
     func = stft.stft if not detrend else partial(stft.stft_detrend, detr="linear")
     # For compatibility with dft, we scale by step. See the DFT note for why.
-    new_data = func(patch.data, axis=axis) * step
+    coord_step = dc.to_float(coord.step)
+    new_data = func(patch.data, axis=axis) * coord_step
     # Get new coordinate manager
     cm = _get_stft_coords(patch, dim, axis, coord, stft, window)
     # Update attrs with metadata needed to invert stft

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from functools import cache
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -295,9 +295,7 @@ def get_filter_units(
         """Ensure to units are valid."""
         if to_unit is None:
             dim_str = "" if dim is None else dim
-            msg = (
-                f"Cannot use units on dimension {dim_str} because it has " f"no units."
-            )
+            msg = f"Cannot use units on dimension {dim_str} because it has no units."
             raise UnitError(msg)
 
     # fast-path for non-unit, non-quantity inputs.
@@ -357,6 +355,18 @@ def quant_sequence_to_quant_array(sequence: Sequence[Quantity]) -> Quantity:
     return array * next(iter(units))
 
 
+def is_percent(value: Any) -> bool:
+    """
+    Return True if value is a percent quantity.
+
+    Parameters
+    ----------
+    value
+        Any value of any type to be to test if it is a percent quantity.
+    """
+    return isinstance(value, Quantity) and value.units == get_unit("percent")
+
+
 def maybe_convert_percent_to_fraction(obj):
     """
     Iterate an object and convert any percentages to fractions.
@@ -399,14 +409,11 @@ def maybe_convert_percent_to_fraction(obj):
     >>> assert result[1] == 0.5
     >>> assert result[2] == get_quantity("2 Hz")
     """
-    percent = get_unit("percent")
     out = []
     obj = [obj] if isinstance(obj, Quantity) and obj.ndim == 0 else obj
     for val in iterate(obj):
-        if hasattr(val, "units"):
-            mag, unit = val.magnitude, val.units
-            if unit == percent:
-                val = mag / 100
+        if is_percent(val):
+            val = val.magnitude / 100
         out.append(val)
     return out
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -32,7 +32,7 @@ from dascore.exceptions import (
     PatchAttributeError,
     PatchCoordinateError,
 )
-from dascore.units import get_quantity
+from dascore.units import get_quantity, is_percent
 from dascore.utils.attrs import combine_patch_attrs
 from dascore.utils.coordmanager import merge_coord_managers
 from dascore.utils.deprecate import deprecate
@@ -763,6 +763,91 @@ def get_patch_window_size(
         size[axis] = samps
 
     return tuple(size)
+
+
+def get_window_axis_step(
+    patch,
+    overlap=None,
+    step=None,
+    samples=False,
+    **kwargs,
+) -> tuple[int, int, int | None]:
+    """
+    Get window size, axis, and step for a single patch dimension.
+
+    Parameters
+    ----------
+    patch
+        The patch with the dimension and coordinate.
+    overlap
+        Optional overlap between adjacent windows. Percent quantities are
+        interpreted relative to the window size.
+    step
+        Optional step between adjacent windows. Mutually exclusive with overlap.
+        Percent quantities are interpreted relative to the window size.
+    samples
+        If True, numeric window, overlap, and step values are interpreted as
+        sample counts. Quantities with explicit units keep their unit meaning.
+    **kwargs
+        Exactly one dimension name and window size.
+
+    Returns
+    -------
+    tuple
+        The window size in samples, the axis for the dimension, and the step in
+        samples. The step is None if neither step nor overlap was provided.
+    """
+
+    def _percent_to_window_samps(window, val):
+        """Convert any percentages to samples of the window."""
+        if is_per := is_percent(val):
+            mag = val.magnitude
+            if mag < 0 or mag > 100:
+                msg = f"Percentage must be between 0 and 100, not {val}"
+                raise ParameterError(msg)
+            val = int(np.round(val.magnitude / 100 * window))
+        return val, is_per
+
+    def _check_not_negative(val, name):
+        """Ensure a step or overlap value isn't negative."""
+        magnitude = val.magnitude if isinstance(val, dc.units.Quantity) else val
+        if magnitude is not None and magnitude < 0:
+            msg = f"{name} must be non-negative"
+            raise ParameterError(msg)
+
+    def quantity_to_samps(val, coord, samples=False):
+        """Convert quantity value to number of samples."""
+        # None just passes through
+        if val is None:
+            return None
+        # Specifying a quantity should overwrite samples parameter.
+        if isinstance(val, dc.units.Quantity):
+            samples = False
+        return coord.get_sample_count(val, samples=samples, enforce_lt_coord=True)
+
+    if overlap is not None and step is not None:
+        msg = "step and overlap are mutually exclusive."
+        raise ParameterError(msg)
+
+    dim, axis, win = get_dim_axis_value(patch, kwargs=kwargs, allow_multiple=False)[0]
+    coord = patch.get_coord(dim, require_evenly_sampled=True)
+    win_samp = coord.get_sample_count(win, samples=samples, enforce_lt_coord=True)
+    # Convert any percentages to win_samples
+    step, step_percent = _percent_to_window_samps(win_samp, step)
+    overlap, overlap_percent = _percent_to_window_samps(win_samp, overlap)
+    _check_not_negative(step, "step")
+    _check_not_negative(overlap, "overlap")
+    # Then convert to coordinate samples. This handles differing units and such.
+    step = quantity_to_samps(step, coord, samples=samples or step_percent)
+    overlap = quantity_to_samps(overlap, coord, samples=samples or overlap_percent)
+    # Convert overlap to step
+    if step is None and overlap is not None:
+        step = win_samp - overlap
+    if step is not None and step <= 0:
+        msg = "Window step must be greater than zero."
+        raise ParameterError(msg)
+    # Get window length/step in samples
+    return win_samp, axis, step
 
 
 def _get_data_units_from_dims(patch, dims, operator):

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -80,6 +80,16 @@ class TestRolling:
         expected = vals[start :: self.step, None]
         assert np.allclose(out.data, expected)
 
+    def test_apply_with_overlap(self, range_patch):
+        """Ensure rolling supports overlap end-to-end."""
+        step = range_patch.get_coord("distance").step
+        window = self.window * step
+        overlap = (self.window - self.step) * step
+        overlap_out = range_patch.rolling(distance=window, overlap=overlap).mean()
+        step_out = range_patch.rolling(distance=window, step=self.step * step).mean()
+        assert overlap_out.shape == step_out.shape
+        assert all_close(overlap_out, step_out)
+
     def test_window_size_one(self, random_patch):
         """Ensure we can get a window size of one."""
         time_step = random_patch.get_coord("time").step

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -20,6 +20,7 @@ from dascore.exceptions import (
     PatchAttributeError,
     PatchCoordinateError,
 )
+from dascore.units import percent
 from dascore.utils.patch import (
     _spool_up,
     align_patch_coords,
@@ -27,6 +28,7 @@ from dascore.utils.patch import (
     get_dim_axis_value,
     get_patch_names,
     get_patch_window_size,
+    get_window_axis_step,
     merge_compatible_coords_attrs,
     patches_to_df,
     stack_patches,
@@ -395,16 +397,14 @@ class TestMergeCompatibleCoordsAttrs:
     def test_extra_attrs(self, random_patch):
         """Ensure extra attributes are added to patch."""
         patch = random_patch.update_attrs(new_attr=10)
-        coords, attrs = merge_compatible_coords_attrs(patch, random_patch)
+        _, attrs = merge_compatible_coords_attrs(patch, random_patch)
         assert attrs.get("new_attr") == 10
 
     def test_different_dims(self, random_patch):
         """Ensure we can merge patches which share some dims but not all."""
         patch1 = random_patch
         patch2 = random_patch.rename_coords(time="money")
-        coord, attrs = merge_compatible_coords_attrs(
-            patch1, patch2, dim_intersection=True
-        )
+        coord, _ = merge_compatible_coords_attrs(patch1, patch2, dim_intersection=True)
         assert set(coord.dims) == (set(patch1.dims) | set(patch2.dims))
 
 
@@ -850,3 +850,88 @@ class TestGetPatchWindowSize:
 
         with pytest.raises(CoordError):
             get_patch_window_size(irregular_patch, {"time": 0.5})
+
+
+class TestGetWindowAxisStep:
+    """Tests for getting window size, axis, and step."""
+
+    window = 16
+    step = 8
+
+    def test_apply_with_overlap(self, random_patch):
+        """Ensure overlap is converted to the correct step size."""
+        coord = random_patch.get_coord("distance")
+        window = self.window * coord.step
+        overlap = (self.window - self.step) * coord.step
+        out = get_window_axis_step(random_patch, distance=window, overlap=overlap)
+        assert out == (self.window, random_patch.get_axis("distance"), self.step)
+
+    def test_apply_with_percent_overlap(self, random_patch):
+        """Ensure percent overlap is supported."""
+        coord = random_patch.get_coord("distance")
+        window = self.window * coord.step
+        out = get_window_axis_step(random_patch, distance=window, overlap=50 * percent)
+        assert out == (self.window, random_patch.get_axis("distance"), self.step)
+
+    def test_apply_with_percent_overlap_and_samples(self, random_patch):
+        """Ensure percent overlap works when samples=True."""
+        out = get_window_axis_step(
+            random_patch, distance=self.window, overlap=50 * percent, samples=True
+        )
+        assert out == (self.window, random_patch.get_axis("distance"), self.step)
+
+    def test_negative_overlap_raises(self, random_patch):
+        """Ensure negative overlap is rejected."""
+        step = random_patch.get_coord("distance").step
+        msg = "overlap must be non-negative"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch, distance=self.window * step, overlap=-step
+            )
+
+    def test_invalid_percent_overlap_raises(self, random_patch):
+        """Ensure percent overlap must be between 0 and 100."""
+        msg = "Percentage must be between 0 and 100"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch, distance=self.window, overlap=101 * percent, samples=True
+            )
+
+    def test_complete_overlap_raises(self, random_patch):
+        """Ensure complete overlap is rejected."""
+        msg = "Window step must be greater than zero"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch, distance=self.window, overlap=100 * percent, samples=True
+            )
+
+    def test_overlap_larger_than_window_raises(self, random_patch):
+        """Ensure overlap larger than window is rejected."""
+        msg = "Window step must be greater than zero"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch,
+                distance=self.window,
+                overlap=self.window + 1,
+                samples=True,
+            )
+
+    def test_step_and_overlap_raises(self, random_patch):
+        """Ensure step and overlap are mutually exclusive."""
+        step = random_patch.get_coord("distance").step
+        msg = "step and overlap are mutually exclusive"
+        with pytest.raises(ParameterError, match=msg):
+            get_window_axis_step(
+                random_patch,
+                distance=self.window * step,
+                step=self.step * step,
+                overlap=50 * percent,
+            )
+
+    def test_none_overlap_matches_default(self, random_patch):
+        """Ensure overlap=None preserves default window/step behavior."""
+        step = random_patch.get_coord("distance").step
+        out = get_window_axis_step(
+            random_patch, distance=self.window * step, overlap=None
+        )
+        assert out == (self.window, random_patch.get_axis("distance"), None)


### PR DESCRIPTION
 ## Description

  Adds overlap support to `Patch.rolling()` and centralizes window/step conversion logic for rolling and STFT.

  This PR introduces `get_window_axis_step()` to compute window size, axis, and step in samples from a single shared path. Percent overlap is interpreted relative to the window size, including when samples=True. The shared helper also validates invalid overlap/step combinations, negative values, and overlap values that would produce a zero or negative step.

  Rolling now accepts overlap as an alternative to step, and STFT uses the shared helper for overlap-to-hop calculation. The branch also adds is_percent() in dascore.units and fixes a small spacing typo in a coordinate error message.

  Tests added cover helper behavior for numeric overlap, percent overlap, samples=True, invalid percent overlap, complete overlap, overlap larger than the window, and step/overlap exclusivity.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `overlap` parameter to the `rolling()` function for flexible window overlap specification using sample counts or percentage values.

* **Bug Fixes**
  * Corrected spacing in error messages when computed sample counts exceed coordinate length.

* **Refactor**
  * Improved window and step calculation implementation across rolling and transform functions for better consistency.

* **Tests**
  * Added tests validating overlap functionality and window/step calculations with various input scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->