### PR TITLE
follow up to restore non-breaking API for rolling

### DIFF
--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -213,10 +213,10 @@ class _PandasPatchRoller(_PatchRollerInfo):
 def rolling(
     patch: dc.Patch,
     step=None,
-    overlap=None,
     center=False,
     engine: Literal["numpy", "pandas", None] = None,
     samples=False,
+    overlap=None,
     **kwargs,
 ) -> _NumpyPatchRoller | _PandasPatchRoller:
     """
@@ -233,11 +233,6 @@ def rolling(
         at every step. If the step argument is not None, the result will
         have a different shape than the input. Mutually exclusive with
         overlap. Default None.
-    overlap
-        The overlap between windows. Can be a number (assumed to be in units of
-        the rolling dimension if `samples`==False), a percent, or None. If
-        provided, step is calculated as `window - overlap`. Percent overlap is
-        always interpreted relative to the window length.
     center
         If False, set the window labels as the right edge of the window index.
         If True, set the window labels as the center of the window index. Default False.
@@ -251,6 +246,11 @@ def rolling(
         is probably better.
     samples
         {sample_explination}
+    overlap
+        The overlap between windows. Can be a number (assumed to be in units of
+        the rolling dimension if `samples`==False), a percent, or None. If
+        provided, step is calculated as `window - overlap`. Percent overlap is
+        always interpreted relative to the window length.
     **kwargs
         Used to pass dimension and window size.
         For example `time=10` represents window size of


### PR DESCRIPTION
## Description
A quick follow up to #686, simply re-arranges the new `overlap` parameter of `patch.rolling` to preserve backwards compatibility.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The rolling function's parameter order has been reorganized for improved API consistency; code using positional arguments when calling this function should be reviewed for compatibility.

* **Documentation**
  * Updated function documentation to reflect the new parameter sequence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->