### PR TITLE
Rolling apply args

### DIFF
--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -6,7 +6,6 @@ from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
-from pydantic import Field
 
 import dascore as dc
 from dascore.constants import samples_arg_description
@@ -31,7 +30,6 @@ class _PatchRollerInfo(DascoreBaseModel):
     axis: int
     center: bool
     roll_hist: str = ""
-    func_kwargs: dict = Field(default_factory=dict)
 
     def get_coords(self):
         """
@@ -84,7 +82,7 @@ class _NumpyPatchRoller(_PatchRollerInfo):
             padded = np.roll(padded, -(num_nans // 2), axis=self.axis)
         return padded
 
-    def apply(self, function):
+    def apply(self, function, *args, **kwargs):
         """
         Apply a function over the specified moving window.
 
@@ -92,6 +90,10 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         ----------
         function
             The function which is applied. Must accept an axis argument.
+        *args
+            Positional arguments passed to function.
+        **kwargs
+            Keyword arguments passed to function.
         """
         # TODO look at replacing this with a call to `as_strided` that
         # accounts for strides.
@@ -107,9 +109,8 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         start = self.get_start_index()
         step_slice[self.axis] = slice(start, None, self.step)
         # apply function, then pad with NaNs and roll
-        kwargs = self.func_kwargs
         trimmed_slide_view = slide_view[tuple(step_slice)]
-        raw = function(trimmed_slide_view, axis=-1, **kwargs).astype(np.float64)
+        raw = function(trimmed_slide_view, *args, axis=-1, **kwargs).astype(np.float64)
         out = self._pad_roll_array(raw)
         new_coords = self.get_coords()
         attrs = self._get_attrs_with_apply_history(function)
@@ -179,8 +180,8 @@ class _PandasPatchRoller(_PatchRollerInfo):
         attrs = self._get_attrs_with_apply_history(name)
         return self._repack_patch(df, attrs=attrs)
 
-    def apply(self, func):
-        df = self._get_rolling().apply(func, **self.func_kwargs)
+    def apply(self, func, *args, **kwargs):
+        df = self._get_rolling().apply(func, args=args, kwargs=kwargs)
         attrs = self._get_attrs_with_apply_history(func)
         return self._repack_patch(df, attrs=attrs)
 
@@ -312,6 +313,16 @@ def rolling(
 
     patch = dc.get_example_patch()
     zcr_patch = patch.rolling(time=100, step=2, samples=True).apply(zcr_std)
+
+    # Additional arguments can be passed directly to apply.
+    def percentile(frame, q, axis=-1):
+        '''Compute a rolling percentile.'''
+        return np.percentile(frame, q, axis=axis)
+
+
+    percentile_patch = patch.rolling(time=100, step=2, samples=True).apply(
+        percentile, 80
+    )
     ```
 
     Examples

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -15,6 +15,27 @@ from dascore.utils.models import DascoreBaseModel
 from dascore.utils.patch import get_dim_axis_value
 from dascore.utils.pd import rolling_df
 
+rolling_apply_description = """
+Apply a function over the specified moving window.
+
+Parameters
+----------
+function
+    The function which is applied.
+*args
+    Positional arguments passed to function.
+**kwargs
+    Keyword arguments passed to function.
+
+Examples
+--------
+>>> import numpy as np
+>>> import dascore as dc
+>>>
+>>> patch = dc.get_example_patch()
+>>> out = patch.rolling(time=100, samples=True).apply(np.percentile, 80)
+"""
+
 
 class _PatchRollerInfo(DascoreBaseModel):
     """
@@ -82,18 +103,14 @@ class _NumpyPatchRoller(_PatchRollerInfo):
             padded = np.roll(padded, -(num_nans // 2), axis=self.axis)
         return padded
 
+    @compose_docstring(apply_description=rolling_apply_description)
     def apply(self, function, *args, **kwargs):
         """
-        Apply a function over the specified moving window.
+        {apply_description}
 
-        Parameters
-        ----------
-        function
-            The function which is applied. Must accept an axis argument.
-        *args
-            Positional arguments passed to function.
-        **kwargs
-            Keyword arguments passed to function.
+        Notes
+        -----
+        The provided function must accept an ``axis`` argument.
         """
         # TODO look at replacing this with a call to `as_strided` that
         # accounts for strides.
@@ -180,9 +197,13 @@ class _PandasPatchRoller(_PatchRollerInfo):
         attrs = self._get_attrs_with_apply_history(name)
         return self._repack_patch(df, attrs=attrs)
 
-    def apply(self, func, *args, **kwargs):
-        df = self._get_rolling().apply(func, args=args, kwargs=kwargs)
-        attrs = self._get_attrs_with_apply_history(func)
+    @compose_docstring(apply_description=rolling_apply_description)
+    def apply(self, function, *args, **kwargs):
+        """
+        {apply_description}
+        """
+        df = self._get_rolling().apply(function, args=args, kwargs=kwargs)
+        attrs = self._get_attrs_with_apply_history(function)
         return self._repack_patch(df, attrs=attrs)
 
     def mean(self):

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -200,6 +200,38 @@ class TestRolling:
         patch_2 = roll2.apply(np.sum)
         assert patch_2.shape == patch_1.shape
 
+    def test_numpy_apply_with_args_kwargs(self, random_patch):
+        """Ensure numpy rolling apply supports extra function arguments."""
+
+        def percentile_plus(frame, q, offset=0, axis=None):
+            """Get percentile with an offset."""
+            return np.percentile(frame, q, axis=axis) + offset
+
+        dt = random_patch.get_coord("time").step
+        out = random_patch.rolling(time=10 * dt, step=10 * dt, engine="numpy").apply(
+            percentile_plus, 80, offset=1
+        )
+        expected = random_patch.rolling(
+            time=10 * dt, step=10 * dt, engine="numpy"
+        ).apply(lambda frame, axis=None: np.percentile(frame, 80, axis=axis) + 1)
+        assert all_close(out, expected)
+
+    def test_pandas_apply_with_args_kwargs(self, random_patch):
+        """Ensure pandas rolling apply supports extra function arguments."""
+
+        def percentile_plus(frame, q, offset=0, axis=None):
+            """Get percentile with an offset."""
+            return np.percentile(frame, q, axis=axis) + offset
+
+        dt = random_patch.get_coord("time").step
+        out = random_patch.rolling(time=10 * dt, step=10 * dt, engine="pandas").apply(
+            percentile_plus, 80, offset=1
+        )
+        expected = random_patch.rolling(
+            time=10 * dt, step=10 * dt, engine="pandas"
+        ).apply(lambda frame: np.percentile(frame, 80) + 1)
+        assert all_close(out, expected)
+
 
 class TestNumpyVsPandasRolling:
     """Ensure numpy rolling return the same results as pandas rolling."""


### PR DESCRIPTION
## Description

This PR updates rolling `apply` so custom functions can receive additional positional and keyword arguments directly from the `apply` call.

  For example:

  ```python
  patch.rolling(time=100, samples=True).apply(np.percentile, 80)
```
  The change supports both rolling engines:

  - numpy engine: forwards *args and **kwargs to the provided function
  - pandas engine: forwards *args and **kwargs through pandas rolling args/kwargs

  This also removes the unused internal func_kwargs field from _PatchRollerInfo, since function arguments are now supplied per apply call instead of stored on the roller object.

  The shared apply docstring now documents the arguments and includes an example. Tests were added for numpy and pandas rolling apply with extra positional and keyword arguments.

Superceeds #682.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rolling `apply` method now accepts extra positional and keyword arguments to pass to user-provided functions.

* **Documentation**
  * Enhanced rolling documentation with additional examples demonstrating parameter passing in rolling operations.

* **Tests**
  * Added test coverage for positional and keyword argument support across rolling engines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DASDAE/dascore/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->