### PR TITLE
added output type to dft; data_type is now 'fourier transform'

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@
 name: LintCode
 on:
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -277,7 +277,7 @@ def dft(
     """
     output = output.upper()
     if output not in DFT_OUTPUT_TYPES:
-        msg = f"Unknown kind={output!r}. Expected one of: {DFT_OUTPUT_TYPES}."
+        msg = f"Unknown output={output!r}. Expected one of: {DFT_OUTPUT_TYPES}."
         raise ValueError(msg)
     if output == "FFT" and db:
         msg = "db=True is only supported for output='AS', 'PS', or 'PSD'."

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -160,46 +160,22 @@ def _get_transformed_domain_extent(patch, dims):
     return extent
 
 
-def _get_one_sided_spectral_factor(patch, real):
-    """Get the factor for converting rfft spectra to one-sided spectra."""
-    if real is None:
-        return 1
-
-    # rfft drops negative frequencies only along the real axis. The returned
-    # factor is shaped for broadcasting over the full transformed array.
-    ft_dim = f"ft_{real}"
-    axis = patch.get_axis(ft_dim)
-    factor = np.ones(patch.coord_shapes[ft_dim])
-    n_samples = len(patch.get_coord(real))
-
-    # Even-length real inputs include a Nyquist bin; odd-length inputs don't.
-    stop = -1 if n_samples % 2 == 0 else None
-    factor[slice(1, stop)] = 2
-
-    shape = [1] * patch.ndim
-    shape[axis] = len(factor)
-    return factor.reshape(shape)
-
-
 def _convert_dft_spectral_amplitudes(patch, output, dims, real, db):
     """Convert the FFT output to spectral amplitude representations."""
     amp = patch.abs()
     extent = _get_transformed_domain_extent(amp, dims)
-    one_sided_factor = _get_one_sided_spectral_factor(patch, real)
     data_units = _get_dft_data_units(patch, dims, output)
     if output == "AS":
         # Convert DASCore's dx-scaled Fourier coefficients to harmonic
-        # amplitude. One-sided spectra collect the dropped negative-frequency
-        # amplitude into the corresponding positive-frequency bins.
-        out = (amp / extent) * one_sided_factor
+        # amplitude.
+        out = amp / extent
     elif output == "PS":
-        # PS bins sum to mean square. For one-sided spectra, power from the
-        # dropped negative-frequency bins is added to positive-frequency bins.
-        out = (amp * amp / (extent * extent)) * one_sided_factor
+        # PS bins sum to mean square.
+        out = amp * amp / (extent * extent)
     elif output == "PSD":
         # PSD bins integrate to mean square when multiplied by frequency-bin
         # volume, which is the reciprocal of the transformed-domain extent.
-        out = (amp * amp / extent) * one_sided_factor
+        out = amp * amp / extent
     if db:
         out = out + np.finfo(out.data.dtype).eps
         db_scale = 20 if output == "AS" else 10
@@ -270,7 +246,8 @@ def dft(
       types are normalized as described in the ``output`` parameter.
 
     - For ``output='AS'``, ``'PS'``, or ``'PSD'`` with ``real=True``, the
-      non-DC and non-Nyquist bins are converted to one-sided spectra.
+      non-DC and non-Nyquist bins have not been converted to one-sided spectra.
+      Depending on your use case, you may need to multiply non-zero bins by 2.
 
     - If all requested dimensions are already transformed, ``dft`` returns
       the input patch unchanged, regardless of the requested ``output``.

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from functools import partial
 from operator import mul, truediv
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import numpy.fft as nft
@@ -18,6 +18,7 @@ from scipy.signal import ShortTimeFFT
 from scipy.signal.windows import get_window
 
 import dascore as dc
+from dascore import units
 from dascore.compat import ndarray
 from dascore.constants import PatchType
 from dascore.core.attrs import PatchAttrs
@@ -91,9 +92,8 @@ def _get_dft_attrs(patch, dims, new_coords, pad=False):
     new = dict(patch.attrs)
     new["dims"] = new_coords.dims
     new["data_units"] = _get_data_units_from_dims(patch, dims, mul)
-    # As per #390, we also want to remove data_type (eg the patch is no
-    # longer in strain rate after the dft)
-    new["_pre_dft_data_type"] = new.pop("data_type", None)
+    new["_pre_dft_data_type"] = new.get("data_type")
+    new["data_type"] = "fourier transform"
     new["_dft_padded"] = pad
     return PatchAttrs(**new)
 
@@ -110,6 +110,37 @@ def _get_untransformed_dims(patch, dims):
     return out
 
 
+def _convert_dft_spectral_amplitudes(patch, output, dim, db):
+    """Convert the FFT output to spectral ampitude representations"""
+    data_types = {
+        "AS": "Amplitude Spectrum",
+        "PS": "Power Spectrum",
+        "PSD": "Power Spectral Density",
+    }
+    patch = patch.abs()
+    # Scale spectral quantity from dft.
+    if output == "AS":
+        out = patch
+    elif output == "PS":
+        out = patch * patch
+    elif output == "PSD":
+        n = len(patch.get_coord(dim))
+        ft_coord = patch.get_coord("ft_" + dim)
+        fsamp = 1 / (ft_coord.step * ft_coord.units)
+        out = patch * patch / (n * fsamp)
+    else:
+        msg = f"Unknown kind={output!r}. Expected one of: {tuple(data_types)}."
+        raise ValueError(msg)
+
+    if db:
+        out = out + np.finfo(out.data.dtype).eps if db else out
+        db_scale = 20 if output == "AS" else 10
+        out = db_scale * out.log10()
+        out = out.set_units(units.dB)
+
+    return out.update_attrs(data_type=data_types[output])
+
+
 @patch_function()
 def dft(
     patch: PatchType,
@@ -117,6 +148,8 @@ def dft(
     *,
     real: str | bool | None = None,
     pad: bool = True,
+    output: Literal["FFT", "PSD", "PS", "AS"] = "FFT",
+    db: bool = False,
 ) -> PatchType:
     """
     Perform the discrete Fourier transform (dft) on specified dimension(s).
@@ -136,6 +169,17 @@ def dft(
         If True, pad patch before performing dft along desired dimensions to
         the next fast length. This can avoid major slow-downs when dimension
         lengths are prime numbers.
+    output
+        Spectral representation to return for each frequency bin
+        - ``'FFT'``: Complex Fourier coefficients (FFT output).
+        - ``'AS'``:  Amplitude spectrum, i.e., the magnitude of the FFT.
+        - ``'PS'``:  Power spectrum, proportional to the squared magnitude
+                     of the FFT.
+        - ``'PSD'``: Power spectral density, i.e., power spectrum normalized
+                     by frequency bandwidth, with units of power per Hz.
+    db
+        If True, converts the output into decibel units, if output is not FFT.
+
 
     Notes
     -----
@@ -172,6 +216,12 @@ def dft(
     >>> # dft on specified dimensions, specify real dimension
     >>> dft_some_real = patch.dft(dim=("time", "distance"), real="time")
     """
+    output = output.upper()
+    valid_types = ["FFT", "PSD", "PS", "AS"]
+    if output not in valid_types:
+        msg = f"Unknown kind={output!r}. Expected one of: {tuple(valid_types)}."
+        raise ValueError(msg)
+
     dims = list(iterate(dim if dim is not None else patch.dims))
     patch.check_coords(coords=dims)
     real = dims[-1] if real is True else real  # if true grab last dim
@@ -201,7 +251,12 @@ def dft(
     data = nft.fftshift(fft_data, axes=axes[shift_slice])
     # get attributes
     attrs = _get_dft_attrs(patch, dims, new_coords, pad=pad)
-    return patch.new(data=data, coords=new_coords, attrs=attrs)
+    patch_out = patch.new(data=data, coords=new_coords, attrs=attrs)
+
+    if output != "FFT":
+        patch_out = _convert_dft_spectral_amplitudes(patch_out, output, dim, db)
+
+    return patch_out
 
 
 def _get_idft_dims_steps_axis(patch, dim):

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from functools import partial
+from math import prod
 from operator import mul, truediv
 from typing import Any, Literal
 
@@ -37,48 +38,49 @@ from dascore.utils.patch import (
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.transformatter import FourierTransformatter
 
-DFT_OUTPUT_DATA_TYPES = {
+DFT_OUTPUT_DATA_TYPE_MAP = {
     "AS": "Amplitude Spectrum",
     "PS": "Power Spectrum",
     "PSD": "Spectral Density",
 }
-DFT_OUTPUT_TYPES = ("FFT", *DFT_OUTPUT_DATA_TYPES)
+DFT_OUTPUT_TYPES = ("FFT", *DFT_OUTPUT_DATA_TYPE_MAP)
 
 
 def _get_dft_coord_units(units):
     """Get units for DFT coordinates."""
     new_units = invert_quantity(units)
-    if new_units == dc.get_quantity("Hz"):
+    # This purposefully converts 1/s to Hz to be more conventional. See #693.
+    if new_units == dc.get_quantity("1/s"):
         new_units = dc.get_quantity("Hz")
     return new_units
 
 
-def _get_dft_spectral_data_units(patch, dims, output, db):
-    """Get conventional data units for DFT spectral outputs."""
-    if db:
-        return units.dB
+def _get_dft_coord_unit_product(patch, dims, transformed=False):
+    """Get the product of original or transformed coordinate units."""
+    names = [f"ft_{dim}" if transformed else dim for dim in iterate(dims)]
+    return prod(
+        unit
+        for name in names
+        if (unit := dc.get_quantity(patch.get_coord(name).units)) is not None
+    )
+
+
+def _get_dft_data_units(patch, dims, output="FFT"):
+    """Get data units for DFT outputs."""
     data_units = dc.get_quantity(patch.attrs.data_units)
     if data_units is None:
         return None
-    domain_units = None
-    spectral_units = None
-    for dim in iterate(dims):
-        dim_units = dc.get_quantity(patch.get_coord(dim).units)
-        ft_units = dc.get_quantity(patch.get_coord(f"ft_{dim}").units)
-        domain_units = dim_units if domain_units is None else domain_units * dim_units
-        spectral_units = (
-            ft_units if spectral_units is None else spectral_units * ft_units
-        )
-    original_units = (
-        data_units / domain_units if domain_units is not None else data_units
-    )
-    if output == "AS":
-        return original_units
-    if output == "PS":
-        return original_units * original_units
-    if output == "PSD" and spectral_units is not None:
-        return original_units * original_units / spectral_units
-    return original_units * original_units
+    domain_units = _get_dft_coord_unit_product(patch, dims)
+    if output == "FFT":
+        return data_units * domain_units
+    original_units = data_units / domain_units
+    spectral_units = _get_dft_coord_unit_product(patch, dims, transformed=True)
+    output_units = {
+        "AS": original_units,
+        "PS": original_units**2,
+        "PSD": original_units**2 / spectral_units,
+    }
+    return output_units[output]
 
 
 def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
@@ -90,19 +92,11 @@ def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
     # Note: We need original_cm and patch because patch may have undergone
     # padding.
 
-    def _get_fft_coord(x_len, dx, units):
-        """Get coord for normal fft coord."""
+    def _get_fft_coord(x_len, dx, units, is_real=False):
+        """Get coord for fft frequency bins."""
         new_dx = 1.0 / (x_len * dx)
-        stop = ((x_len - 1) // 2 + 1) * new_dx
-        start = -(x_len // 2) * new_dx
-        units = _get_dft_coord_units(units)
-        return get_coord(start=start, stop=stop, step=new_dx, units=units)
-
-    def _get_rfft_coord(x_len, dx, units):
-        """Get coord from real fft coord."""
-        new_dx = 1.0 / (x_len * dx)
-        start = 0
-        stop = (x_len // 2 + 1) * new_dx
+        start = 0 if is_real else -(x_len // 2) * new_dx
+        stop = (x_len // 2 + 1) * new_dx if is_real else ((x_len - 1) // 2 + 1) * new_dx
         units = _get_dft_coord_units(units)
         return get_coord(start=start, stop=stop, step=new_dx, units=units)
 
@@ -117,10 +111,7 @@ def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
         size = old_coord.shape[0]
         dx = dxs[i]
         new_name = ft.rename_dims(dim)[0]
-        if dim == real:
-            coord = _get_rfft_coord(size, dx, units)
-        else:
-            coord = _get_fft_coord(size, dx, units)
+        coord = _get_fft_coord(size, dx, units, is_real=dim == real)
         new_coords[new_name] = (new_name, coord)
         # Add padded coordinates
         if original_cm is not None:
@@ -134,7 +125,7 @@ def _get_dft_attrs(patch, dims, new_coords, pad=False, output="FFT"):
     """Get new attributes for transformed patch."""
     new = dict(patch.attrs)
     new["dims"] = new_coords.dims
-    new["data_units"] = _get_data_units_from_dims(patch, dims, mul)
+    new["data_units"] = _get_dft_data_units(patch, dims)
     new["_pre_dft_data_type"] = new.get("data_type")
     new["data_type"] = "fourier transform"
     new["_dft_output"] = output
@@ -195,7 +186,7 @@ def _convert_dft_spectral_amplitudes(patch, output, dims, real, db):
     amp = patch.abs()
     extent = _get_transformed_domain_extent(amp, dims)
     one_sided_factor = _get_one_sided_spectral_factor(patch, real)
-    data_units = _get_dft_spectral_data_units(patch, dims, output, db)
+    data_units = _get_dft_data_units(patch, dims, output)
     if output == "AS":
         # Convert DASCore's dx-scaled Fourier coefficients to harmonic
         # amplitude. One-sided spectra collect the dropped negative-frequency
@@ -214,9 +205,10 @@ def _convert_dft_spectral_amplitudes(patch, output, dims, real, db):
         db_scale = 20 if output == "AS" else 10
         out = db_scale * out.log10()
         out = out.set_units(units.dB)
+        data_units = out.attrs.data_units
 
     return out.update_attrs(
-        data_type=DFT_OUTPUT_DATA_TYPES[output],
+        data_type=DFT_OUTPUT_DATA_TYPE_MAP[output],
         data_units=data_units,
     )
 

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -110,7 +110,7 @@ def _get_untransformed_dims(patch, dims):
     return out
 
 
-def _convert_dft_spectral_amplitudes(patch, output, dim, db):
+def _convert_dft_spectral_amplitudes(patch, output, dims, db):
     """Convert the FFT output to spectral ampitude representations"""
     data_types = {
         "AS": "Amplitude Spectrum",
@@ -124,14 +124,12 @@ def _convert_dft_spectral_amplitudes(patch, output, dim, db):
     elif output == "PS":
         out = patch * patch
     elif output == "PSD":
-        n = len(patch.get_coord(dim))
-        ft_coord = patch.get_coord("ft_" + dim)
-        fsamp = 1 / (ft_coord.step * ft_coord.units)
-        out = patch * patch / (n * fsamp)
-    else:
-        msg = f"Unknown kind={output!r}. Expected one of: {tuple(data_types)}."
-        raise ValueError(msg)
-
+        out = patch * patch
+        for dim in iterate(dims):
+            n = len(patch.get_coord(dim))
+            ft_coord = patch.get_coord(f"ft_{dim}")
+            fsamp = 1 / (ft_coord.step * ft_coord.units)
+            out = out / (n * fsamp)
     if db:
         out = out + np.finfo(out.data.dtype).eps if db else out
         db_scale = 20 if output == "AS" else 10
@@ -254,7 +252,7 @@ def dft(
     patch_out = patch.new(data=data, coords=new_coords, attrs=attrs)
 
     if output != "FFT":
-        patch_out = _convert_dft_spectral_amplitudes(patch_out, output, dim, db)
+        patch_out = _convert_dft_spectral_amplitudes(patch_out, output, dims, db)
 
     return patch_out
 

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -24,7 +24,7 @@ from dascore.constants import PatchType
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
-from dascore.exceptions import PatchError
+from dascore.exceptions import ParameterError, PatchError
 from dascore.units import Quantity, invert_quantity, percent
 from dascore.utils.misc import broadcast_for_index, iterate
 from dascore.utils.patch import (
@@ -36,6 +36,13 @@ from dascore.utils.patch import (
 )
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.transformatter import FourierTransformatter
+
+DFT_OUTPUT_DATA_TYPES = {
+    "AS": "Amplitude Spectrum",
+    "PS": "Power Spectrum",
+    "PSD": "Spectral Density",
+}
+DFT_OUTPUT_TYPES = ("FFT", *DFT_OUTPUT_DATA_TYPES)
 
 
 def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
@@ -87,13 +94,14 @@ def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
     return cm
 
 
-def _get_dft_attrs(patch, dims, new_coords, pad=False):
+def _get_dft_attrs(patch, dims, new_coords, pad=False, output="FFT"):
     """Get new attributes for transformed patch."""
     new = dict(patch.attrs)
     new["dims"] = new_coords.dims
     new["data_units"] = _get_data_units_from_dims(patch, dims, mul)
     new["_pre_dft_data_type"] = new.get("data_type")
     new["data_type"] = "fourier transform"
+    new["_dft_output"] = output
     new["_dft_padded"] = pad
     return PatchAttrs(**new)
 
@@ -110,33 +118,67 @@ def _get_untransformed_dims(patch, dims):
     return out
 
 
-def _convert_dft_spectral_amplitudes(patch, output, dims, db):
-    """Convert the FFT output to spectral ampitude representations"""
-    data_types = {
-        "AS": "Amplitude Spectrum",
-        "PS": "Power Spectrum",
-        "PSD": "Power Spectral Density",
-    }
-    patch = patch.abs()
-    # Scale spectral quantity from dft.
+def _get_transformed_domain_extent(patch, dims):
+    """Get the transformed-domain extent from the DFT bin spacing."""
+    extent = 1
+    preserve_units = patch.attrs.data_units is not None
+    for dim in iterate(dims):
+        ft_coord = patch.get_coord(f"ft_{dim}")
+        # df = 1 / (n * dx), so 1 / df is the original-domain extent.
+        # For multi-axis DFTs, the total extent is the product over axes.
+        step = abs(ft_coord.step)
+        if preserve_units and ft_coord.units is not None:
+            step = step * ft_coord.units
+        extent = extent / step
+    return extent
+
+
+def _get_one_sided_spectral_factor(patch, real):
+    """Get the factor for converting rfft spectra to one-sided spectra."""
+    if real is None:
+        return 1
+
+    # rfft drops negative frequencies only along the real axis. The returned
+    # factor is shaped for broadcasting over the full transformed array.
+    ft_dim = f"ft_{real}"
+    axis = patch.get_axis(ft_dim)
+    factor = np.ones(patch.coord_shapes[ft_dim])
+    n_samples = len(patch.get_coord(real))
+
+    # Even-length real inputs include a Nyquist bin; odd-length inputs don't.
+    stop = -1 if n_samples % 2 == 0 else None
+    factor[slice(1, stop)] = 2
+
+    shape = [1] * patch.ndim
+    shape[axis] = len(factor)
+    return factor.reshape(shape)
+
+
+def _convert_dft_spectral_amplitudes(patch, output, dims, real, db):
+    """Convert the FFT output to spectral amplitude representations."""
+    amp = patch.abs()
+    extent = _get_transformed_domain_extent(amp, dims)
+    one_sided_factor = _get_one_sided_spectral_factor(patch, real)
     if output == "AS":
-        out = patch
+        # Convert DASCore's dx-scaled Fourier coefficients to harmonic
+        # amplitude. One-sided spectra collect the dropped negative-frequency
+        # amplitude into the corresponding positive-frequency bins.
+        out = (amp / extent) * one_sided_factor
     elif output == "PS":
-        out = patch * patch
+        # PS bins sum to mean square. For one-sided spectra, power from the
+        # dropped negative-frequency bins is added to positive-frequency bins.
+        out = (amp * amp / (extent * extent)) * one_sided_factor
     elif output == "PSD":
-        out = patch * patch
-        for dim in iterate(dims):
-            n = len(patch.get_coord(dim))
-            ft_coord = patch.get_coord(f"ft_{dim}")
-            fsamp = 1 / (ft_coord.step * ft_coord.units)
-            out = out / (n * fsamp)
+        # PSD bins integrate to mean square when multiplied by frequency-bin
+        # volume, which is the reciprocal of the transformed-domain extent.
+        out = (amp * amp / extent) * one_sided_factor
     if db:
-        out = out + np.finfo(out.data.dtype).eps if db else out
+        out = out + np.finfo(out.data.dtype).eps
         db_scale = 20 if output == "AS" else 10
         out = db_scale * out.log10()
         out = out.set_units(units.dB)
 
-    return out.update_attrs(data_type=data_types[output])
+    return out.update_attrs(data_type=DFT_OUTPUT_DATA_TYPES[output])
 
 
 @patch_function()
@@ -169,14 +211,15 @@ def dft(
         lengths are prime numbers.
     output
         Spectral representation to return for each frequency bin
-        - ``'FFT'``: Complex Fourier coefficients (FFT output).
-        - ``'AS'``:  Amplitude spectrum, i.e., the magnitude of the FFT.
-        - ``'PS'``:  Power spectrum, proportional to the squared magnitude
-                     of the FFT.
-        - ``'PSD'``: Power spectral density, i.e., power spectrum normalized
-                     by frequency bandwidth, with units of power per Hz.
+        - ``'FFT'``: Complex Fourier coefficients scaled by sample spacing.
+        - ``'AS'``: Amplitude spectrum in the original data units.
+        - ``'PS'``: Power spectrum whose bin sum gives mean square.
+        - ``'PSD'``: Spectral density whose bin-width-weighted sum gives
+                     mean square.
     db
         If True, converts the output into decibel units, if output is not FFT.
+        This applies ``20 * log10`` to ``'AS'`` and ``10 * log10`` to ``'PS'``
+        or ``'PSD'`` without a reference value.
 
 
     Notes
@@ -190,8 +233,15 @@ def dft(
 
     - Each transformed dimension has units of 1/original units.
 
-    - Output data units are the original data units multiplied by the units
-      of each transformed dimension.
+    - For ``output='FFT'``, output data units are the original data units
+      multiplied by the units of each transformed dimension. Other output
+      types are normalized as described in the ``output`` parameter.
+
+    - For ``output='AS'``, ``'PS'``, or ``'PSD'`` with ``real=True``, the
+      non-DC and non-Nyquist bins are converted to one-sided spectra.
+
+    - If all requested dimensions are already transformed, ``dft`` returns
+      the input patch unchanged, regardless of the requested ``output``.
 
     - Non-dimensional coordinates associated with transformed coordinates
       will be dropped in the output.
@@ -215,10 +265,12 @@ def dft(
     >>> dft_some_real = patch.dft(dim=("time", "distance"), real="time")
     """
     output = output.upper()
-    valid_types = ["FFT", "PSD", "PS", "AS"]
-    if output not in valid_types:
-        msg = f"Unknown kind={output!r}. Expected one of: {tuple(valid_types)}."
+    if output not in DFT_OUTPUT_TYPES:
+        msg = f"Unknown kind={output!r}. Expected one of: {DFT_OUTPUT_TYPES}."
         raise ValueError(msg)
+    if output == "FFT" and db:
+        msg = "db=True is only supported for output='AS', 'PS', or 'PSD'."
+        raise ParameterError(msg)
 
     dims = list(iterate(dim if dim is not None else patch.dims))
     patch.check_coords(coords=dims)
@@ -248,11 +300,13 @@ def dft(
     shift_slice = slice(None) if real is None else slice(None, -1)
     data = nft.fftshift(fft_data, axes=axes[shift_slice])
     # get attributes
-    attrs = _get_dft_attrs(patch, dims, new_coords, pad=pad)
+    attrs = _get_dft_attrs(patch, dims, new_coords, pad=pad, output=output)
     patch_out = patch.new(data=data, coords=new_coords, attrs=attrs)
 
     if output != "FFT":
-        patch_out = _convert_dft_spectral_amplitudes(patch_out, output, dims, db)
+        patch_out = _convert_dft_spectral_amplitudes(
+            patch_out, output, dims, real, db
+        )
 
     return patch_out
 
@@ -326,8 +380,17 @@ def _get_idft_attrs(patch, dims, new_coords):
     # Restore the pre-dft datatype.
     if "_pre_dft_data_type" in new:
         new["data_type"] = new.pop("_pre_dft_data_type", None)
+    new.pop("_dft_output", None)
     new.pop("_dft_padded", None)
     return PatchAttrs(**new)
+
+
+def _check_dft_output_invertible(patch):
+    """Raise if patch DFT data are not invertible Fourier coefficients."""
+    output = patch.attrs.get("_dft_output", "FFT")
+    if output != "FFT":
+        msg = f"Only dft(output='FFT') can be inverted with idft, not {output!r}."
+        raise ValueError(msg)
 
 
 @patch_function()
@@ -373,6 +436,7 @@ def idft(patch: PatchType, dim: str | None | Sequence[str] = None) -> PatchType:
     >>> # get inverse dft, transformed axis are ascertained automatically
     >>> idft = dft_time.idft()
     """
+    _check_dft_output_invertible(patch)
     dims, _steps, axes, real = _get_idft_dims_steps_axis(patch, dim)
     new_dims = FourierTransformatter().rename_dims(dims, forward=False)
     func = nft.irfftn if real else nft.ifftn

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -45,6 +45,42 @@ DFT_OUTPUT_DATA_TYPES = {
 DFT_OUTPUT_TYPES = ("FFT", *DFT_OUTPUT_DATA_TYPES)
 
 
+def _get_dft_coord_units(units):
+    """Get units for DFT coordinates."""
+    new_units = invert_quantity(units)
+    if new_units == dc.get_quantity("Hz"):
+        new_units = dc.get_quantity("Hz")
+    return new_units
+
+
+def _get_dft_spectral_data_units(patch, dims, output, db):
+    """Get conventional data units for DFT spectral outputs."""
+    if db:
+        return units.dB
+    data_units = dc.get_quantity(patch.attrs.data_units)
+    if data_units is None:
+        return None
+    domain_units = None
+    spectral_units = None
+    for dim in iterate(dims):
+        dim_units = dc.get_quantity(patch.get_coord(dim).units)
+        ft_units = dc.get_quantity(patch.get_coord(f"ft_{dim}").units)
+        domain_units = dim_units if domain_units is None else domain_units * dim_units
+        spectral_units = (
+            ft_units if spectral_units is None else spectral_units * ft_units
+        )
+    original_units = (
+        data_units / domain_units if domain_units is not None else data_units
+    )
+    if output == "AS":
+        return original_units
+    if output == "PS":
+        return original_units * original_units
+    if output == "PSD" and spectral_units is not None:
+        return original_units * original_units / spectral_units
+    return original_units * original_units
+
+
 def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
     """
     Create coordinates based on dxs and patch shape.
@@ -59,7 +95,7 @@ def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
         new_dx = 1.0 / (x_len * dx)
         stop = ((x_len - 1) // 2 + 1) * new_dx
         start = -(x_len // 2) * new_dx
-        units = invert_quantity(units)
+        units = _get_dft_coord_units(units)
         return get_coord(start=start, stop=stop, step=new_dx, units=units)
 
     def _get_rfft_coord(x_len, dx, units):
@@ -67,7 +103,7 @@ def _get_dft_new_coords(patch, dxs, dims, axes, real, original_cm=None):
         new_dx = 1.0 / (x_len * dx)
         start = 0
         stop = (x_len // 2 + 1) * new_dx
-        units = invert_quantity(units)
+        units = _get_dft_coord_units(units)
         return get_coord(start=start, stop=stop, step=new_dx, units=units)
 
     # first disassociate old coordinates. We do this rather than drop them
@@ -159,6 +195,7 @@ def _convert_dft_spectral_amplitudes(patch, output, dims, real, db):
     amp = patch.abs()
     extent = _get_transformed_domain_extent(amp, dims)
     one_sided_factor = _get_one_sided_spectral_factor(patch, real)
+    data_units = _get_dft_spectral_data_units(patch, dims, output, db)
     if output == "AS":
         # Convert DASCore's dx-scaled Fourier coefficients to harmonic
         # amplitude. One-sided spectra collect the dropped negative-frequency
@@ -178,7 +215,10 @@ def _convert_dft_spectral_amplitudes(patch, output, dims, real, db):
         out = db_scale * out.log10()
         out = out.set_units(units.dB)
 
-    return out.update_attrs(data_type=DFT_OUTPUT_DATA_TYPES[output])
+    return out.update_attrs(
+        data_type=DFT_OUTPUT_DATA_TYPES[output],
+        data_units=data_units,
+    )
 
 
 @patch_function()
@@ -263,6 +303,8 @@ def dft(
     >>> dft_time_real = patch.dft(dim="time", real=True)
     >>> # dft on specified dimensions, specify real dimension
     >>> dft_some_real = patch.dft(dim=("time", "distance"), real="time")
+    >>> # calculate a power spectral density along time
+    >>> psd = patch.dft(dim="time", real=True, output="PSD")
     """
     output = output.upper()
     if output not in DFT_OUTPUT_TYPES:
@@ -304,9 +346,7 @@ def dft(
     patch_out = patch.new(data=data, coords=new_coords, attrs=attrs)
 
     if output != "FFT":
-        patch_out = _convert_dft_spectral_amplitudes(
-            patch_out, output, dims, real, db
-        )
+        patch_out = _convert_dft_spectral_amplitudes(patch_out, output, dims, real, db)
 
     return patch_out
 

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -15,8 +15,7 @@ from dascore.utils.misc import suppress_warnings
 
 def _get_dim_label(patch, dim):
     """Create a label for the given dimension, including units if defined."""
-    attrs = patch.attrs
-    maybe_units = attrs.get(f"{dim}_units")
+    maybe_units = patch.get_coord(dim).units
     dim_str = string.capwords(str(dim))
     unit_str = f" [{get_quantity_str(maybe_units)}]" if maybe_units else ""
     return dim_str + unit_str

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -182,10 +182,10 @@ class TestDiscreteFourierTransform:
         assert not out.equals(fft_sin_patch_time)
         assert np.allclose(out.data, fft_sin_patch_all.data)
 
-    def test_datatype_removed(self, fft_sin_patch_time, sin_patch):
-        """Ensure the data_type attr is removed after transform."""
+    def test_datatype_changed(self, fft_sin_patch_time, sin_patch):
+        """Ensure the data_type attr is changed after transform."""
         assert sin_patch.attrs.data_type == "strain_rate"
-        assert fft_sin_patch_time.attrs.data_type == ""
+        assert fft_sin_patch_time.attrs.data_type == "fourier transform"
 
     def test_pad(self, sin_patch_trimmed):
         """Ensure patch is padded when requested and not otherwise."""
@@ -202,6 +202,61 @@ class TestDiscreteFourierTransform:
         out = str(fft_sin_patch_time)
         assert isinstance(out, str)
         assert out
+
+    @pytest.mark.parametrize(
+        ("output", "data_type"),
+        [
+            ("FFT", "fourier transform"),
+            # ("AS", "Amplitude Spectrum"),
+            # ("PS", "Power Spectrum"),
+            # ("PSD", "Power Spectral Density"),
+        ],
+    )
+    def test_output_spectral_representations(self, sin_patch, output, data_type):
+        """Ensure supported spectral outputs are converted from FFT output."""
+        fft = sin_patch.dft("time", output="FFT")
+        amp = fft.abs() + np.finfo(sin_patch.data.dtype).eps
+        out = sin_patch.dft("time", output=output)
+
+        if output == "FFT":
+            expected = fft.data
+        elif output == "AS":
+            expected = amp.data
+        elif output == "PS":
+            expected = amp.data * amp.data
+        else:
+            ps = sin_patch.dft("time", output="PS")
+            n = len(out.get_coord("time"))
+            ft_coord = out.get_coord("ft_time")
+            fsamp = 1 / (ft_coord.step * ft_coord.units)
+            expected = (ps / (n * fsamp)).data
+
+        assert out.attrs.data_type == data_type
+        assert out.data.shape == fft.data.shape
+        assert np.allclose(out.data, expected)
+
+    def test_output_is_case_insensitive(self, sin_patch):
+        """Ensure output names are normalized before conversion."""
+        lower = sin_patch.dft("time", output="as")
+        upper = sin_patch.dft("time", output="AS")
+        assert lower.equals(upper)
+
+    def test_invalid_output_raises(self, sin_patch):
+        """Ensure invalid output types raise."""
+        with pytest.raises(ValueError, match="Unknown kind"):
+            sin_patch.dft("time", output="bad")
+
+    @pytest.mark.parametrize(("output", "scale"), [("AS", 20), ("PS", 10), ("PSD", 10)])
+    def test_db_output(self, sin_patch, output, scale):
+        """Ensure spectral outputs can be converted to decibels."""
+        linear = sin_patch.dft("time", output=output)
+        out = sin_patch.dft("time", output=output, db=True)
+        eps = np.finfo(linear.data.dtype).eps
+        expected = scale * np.log10(linear.data + eps)
+
+        assert get_quantity(out.attrs.data_units) == get_quantity("dB")
+        assert out.attrs.data_type == linear.attrs.data_type
+        assert np.allclose(out.data, expected)
 
 
 class TestInverseDiscreteFourierTransform:

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -10,7 +10,7 @@ import dascore as dc
 import dascore.proc.coords
 from dascore.exceptions import ParameterError, PatchError
 from dascore.transform.fourier import dft, idft
-from dascore.units import get_quantity, second
+from dascore.units import get_quantity, get_quantity_str, second
 from dascore.utils.misc import iterate
 
 F_0 = 2
@@ -89,9 +89,7 @@ class TestDiscreteFourierTransform:
         expected = np.mean(patch.data**2, axis=old_axes)
         spectral_power = np.sum(out.data, axis=ft_axes)
         if output == "PSD":
-            bin_volume = np.prod(
-                [abs(out.get_coord(f"ft_{dim}").step) for dim in dims]
-            )
+            bin_volume = np.prod([abs(out.get_coord(f"ft_{dim}").step) for dim in dims])
             spectral_power = spectral_power * bin_volume
 
         assert np.allclose(spectral_power, expected)
@@ -278,9 +276,7 @@ class TestDiscreteFourierTransform:
         ],
     )
     @pytest.mark.parametrize("output", ["PS", "PSD"])
-    def test_spectral_power_scaling_multiple_dims(
-        self, sin_patch, dims, real, output
-    ):
+    def test_spectral_power_scaling_multiple_dims(self, sin_patch, dims, real, output):
         """Ensure multi-axis spectral outputs recover mean square."""
         out = sin_patch.dft(dim=dims, real=real, pad=False, output=output)
 
@@ -322,6 +318,22 @@ class TestDiscreteFourierTransform:
         assert get_quantity(ps.attrs.data_units) == data_units * data_units
         expected_psd_units = data_units * data_units * time_units
         assert get_quantity(psd.attrs.data_units) == expected_psd_units
+
+    def test_time_dft_coord_uses_hz(self, sin_patch):
+        """Ensure transformed time coords use Hz rather than reduced 1/s."""
+        out = sin_patch.dft("time", pad=False)
+
+        assert get_quantity(out.get_coord("ft_time").units) == get_quantity("Hz")
+        assert get_quantity_str(out.get_coord("ft_time").units) == "Hz"
+
+    def test_strain_rate_psd_units_use_hz(self, sin_patch):
+        """Ensure strain-rate PSD units use conventional per-Hz units."""
+        patch = sin_patch.set_units("strain/s")
+
+        out = patch.dft("time", real=True, pad=False, output="PSD")
+
+        assert get_quantity(out.attrs.data_units) == get_quantity("(strain/s)**2/Hz")
+        assert "Hz" in get_quantity_str(out.attrs.data_units)
 
     @pytest.mark.parametrize("output", ["AS", "PS", "PSD"])
     def test_spectral_output_without_data_units(self, sin_patch, output):

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -368,7 +368,7 @@ class TestDiscreteFourierTransform:
 
     def test_invalid_output_raises(self, sin_patch):
         """Ensure invalid output types raise."""
-        with pytest.raises(ValueError, match="Unknown kind"):
+        with pytest.raises(ValueError, match="Unknown output"):
             sin_patch.dft("time", output="bad")
 
     def test_db_true_with_fft_raises(self, sin_patch):

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -8,9 +8,10 @@ from scipy.fft import next_fast_len
 
 import dascore as dc
 import dascore.proc.coords
-from dascore.exceptions import PatchError
+from dascore.exceptions import ParameterError, PatchError
 from dascore.transform.fourier import dft, idft
 from dascore.units import get_quantity, second
+from dascore.utils.misc import iterate
 
 F_0 = 2
 seconds = get_quantity("seconds")
@@ -79,6 +80,21 @@ def chirp_stft_detrend_patch(chirp_patch):
 
 class TestDiscreteFourierTransform:
     """Forward DFT suite."""
+
+    def _assert_spectral_power_matches_patch(self, patch, out, dims, output):
+        """Ensure spectral outputs recover the time-domain mean square."""
+        dims = patch.dims if dims is None else tuple(iterate(dims))
+        old_axes = tuple(patch.get_axis(dim) for dim in dims)
+        ft_axes = tuple(out.get_axis(f"ft_{dim}") for dim in dims)
+        expected = np.mean(patch.data**2, axis=old_axes)
+        spectral_power = np.sum(out.data, axis=ft_axes)
+        if output == "PSD":
+            bin_volume = np.prod(
+                [abs(out.get_coord(f"ft_{dim}").step) for dim in dims]
+            )
+            spectral_power = spectral_power * bin_volume
+
+        assert np.allclose(spectral_power, expected)
 
     def test_max_frequency(self, fft_sin_patch_time):
         """Ensure when sin wave is input max freq is correct."""
@@ -164,6 +180,13 @@ class TestDiscreteFourierTransform:
         out = fft_sin_patch_time.dft("time")
         assert out.equals(fft_sin_patch_time)
 
+    def test_idempotent_does_not_convert_output(self, fft_sin_patch_time):
+        """Ensure output is ignored when no new dimensions are transformed."""
+        out = fft_sin_patch_time.dft("time", output="AS")
+
+        assert out.equals(fft_sin_patch_time)
+        assert out.attrs["_dft_output"] == "FFT"
+
     def test_idempotent_all_dims(self, fft_sin_patch_all):
         """
         Ensure dft is idempotent for transforms applied to all dims.
@@ -187,6 +210,10 @@ class TestDiscreteFourierTransform:
         assert sin_patch.attrs.data_type == "strain_rate"
         assert fft_sin_patch_time.attrs.data_type == "fourier transform"
 
+    def test_dft_output_attr_set(self, fft_sin_patch_time):
+        """Ensure the DFT output type is tracked."""
+        assert fft_sin_patch_time.attrs["_dft_output"] == "FFT"
+
     def test_pad(self, sin_patch_trimmed):
         """Ensure patch is padded when requested and not otherwise."""
         trimmed = sin_patch_trimmed
@@ -207,33 +234,103 @@ class TestDiscreteFourierTransform:
         ("output", "data_type"),
         [
             ("FFT", "fourier transform"),
-            # ("AS", "Amplitude Spectrum"),
-            # ("PS", "Power Spectrum"),
-            # ("PSD", "Power Spectral Density"),
+            ("AS", "Amplitude Spectrum"),
+            ("PS", "Power Spectrum"),
+            ("PSD", "Spectral Density"),
         ],
     )
     def test_output_spectral_representations(self, sin_patch, output, data_type):
-        """Ensure supported spectral outputs are converted from FFT output."""
+        """Ensure supported spectral outputs are returned."""
         fft = sin_patch.dft("time", output="FFT")
-        amp = fft.abs() + np.finfo(sin_patch.data.dtype).eps
         out = sin_patch.dft("time", output=output)
 
-        if output == "FFT":
-            expected = fft.data
-        elif output == "AS":
-            expected = amp.data
-        elif output == "PS":
-            expected = amp.data * amp.data
-        else:
-            ps = sin_patch.dft("time", output="PS")
-            n = len(out.get_coord("time"))
-            ft_coord = out.get_coord("ft_time")
-            fsamp = 1 / (ft_coord.step * ft_coord.units)
-            expected = (ps / (n * fsamp)).data
-
         assert out.attrs.data_type == data_type
+        assert out.attrs["_dft_output"] == output
         assert out.data.shape == fft.data.shape
-        assert np.allclose(out.data, expected)
+
+    @pytest.mark.parametrize("real", [False, True])
+    def test_amplitude_spectrum_scaling(self, sin_patch, real):
+        """Ensure AS recovers harmonic amplitudes."""
+        out = sin_patch.dft("time", real=real, pad=False, output="AS")
+        time_axis = sin_patch.get_axis("time")
+        ft_axis = out.get_axis("ft_time")
+        sine_amp = np.ptp(sin_patch.data, axis=time_axis) / 2
+        expected = sine_amp if real else sine_amp / 2
+
+        assert np.allclose(np.max(out.data, axis=ft_axis), expected, rtol=0.005)
+
+    @pytest.mark.parametrize("output", ["PS", "PSD"])
+    @pytest.mark.parametrize("real", [False, True])
+    def test_spectral_power_scaling(self, sin_patch, real, output):
+        """Ensure PS and PSD integrate/sum to time-domain mean square."""
+        dims = ("time",)
+        out = sin_patch.dft("time", real=real, pad=False, output=output)
+
+        self._assert_spectral_power_matches_patch(sin_patch, out, dims, output)
+
+    @pytest.mark.parametrize(
+        ("dims", "real"),
+        [
+            (None, None),
+            (("time", "distance"), None),
+            (("time", "distance"), "time"),
+            (("distance", "time"), "distance"),
+        ],
+    )
+    @pytest.mark.parametrize("output", ["PS", "PSD"])
+    def test_spectral_power_scaling_multiple_dims(
+        self, sin_patch, dims, real, output
+    ):
+        """Ensure multi-axis spectral outputs recover mean square."""
+        out = sin_patch.dft(dim=dims, real=real, pad=False, output=output)
+
+        self._assert_spectral_power_matches_patch(sin_patch, out, dims, output)
+
+    @pytest.mark.parametrize("output", ["PS", "PSD"])
+    def test_spectral_power_scaling_padded(self, sin_patch_trimmed, output):
+        """Ensure default padded spectral outputs use the padded extent."""
+        padded = sin_patch_trimmed.pad(time="fft")
+        out = sin_patch_trimmed.dft("time", output=output)
+
+        self._assert_spectral_power_matches_patch(padded, out, ("time",), output)
+
+    def test_real_spectral_output_does_not_double_edges(self, sin_patch):
+        """Ensure one-sided spectral outputs don't double DC or Nyquist."""
+        time_axis = sin_patch.get_axis("time")
+        time_shape = [1] * sin_patch.ndim
+        time_shape[time_axis] = sin_patch.shape[time_axis]
+        nyquist = (-1) ** np.arange(sin_patch.shape[time_axis])
+        data = np.broadcast_to(nyquist.reshape(time_shape), sin_patch.shape)
+        patch = sin_patch.new(data=data)
+
+        out = patch.dft("time", real=True, pad=False, output="AS")
+        ft_axis = out.get_axis("ft_time")
+        nyquist_amp = np.take(out.data, -1, axis=ft_axis)
+
+        assert np.allclose(nyquist_amp, 1)
+
+    def test_spectral_output_units(self, sin_patch):
+        """Ensure spectral output units are scaled according to output type."""
+        data_units = get_quantity(sin_patch.attrs.data_units)
+        time_units = get_quantity(sin_patch.get_coord("time").units)
+
+        as_ = sin_patch.dft("time", pad=False, output="AS")
+        ps = sin_patch.dft("time", pad=False, output="PS")
+        psd = sin_patch.dft("time", pad=False, output="PSD")
+
+        assert get_quantity(as_.attrs.data_units) == data_units
+        assert get_quantity(ps.attrs.data_units) == data_units * data_units
+        expected_psd_units = data_units * data_units * time_units
+        assert get_quantity(psd.attrs.data_units) == expected_psd_units
+
+    @pytest.mark.parametrize("output", ["AS", "PS", "PSD"])
+    def test_spectral_output_without_data_units(self, sin_patch, output):
+        """Ensure spectral outputs don't invent units without data units."""
+        patch = sin_patch.update_attrs(data_units=None)
+
+        out = patch.dft("time", pad=False, output=output)
+
+        assert out.attrs.data_units is None
 
     def test_output_is_case_insensitive(self, sin_patch):
         """Ensure output names are normalized before conversion."""
@@ -246,9 +343,14 @@ class TestDiscreteFourierTransform:
         with pytest.raises(ValueError, match="Unknown kind"):
             sin_patch.dft("time", output="bad")
 
+    def test_db_true_with_fft_raises(self, sin_patch):
+        """Ensure dB conversion is only accepted for spectral outputs."""
+        with pytest.raises(ParameterError, match="db=True is only supported"):
+            sin_patch.dft("time", output="FFT", db=True)
+
     @pytest.mark.parametrize(("output", "scale"), [("AS", 20), ("PS", 10), ("PSD", 10)])
     def test_db_output(self, sin_patch, output, scale):
-        """Ensure spectral outputs can be converted to decibels."""
+        """Ensure spectral outputs use DASCore's no-reference dB scaling."""
         linear = sin_patch.dft("time", output=output)
         out = sin_patch.dft("time", output=output, db=True)
         eps = np.finfo(linear.data.dtype).eps
@@ -307,6 +409,20 @@ class TestInverseDiscreteFourierTransform:
         """Ensure data_type attr is restored."""
         out = fft_sin_patch_time.idft("time")
         assert out.attrs.data_type == sin_patch.attrs.data_type
+
+    def test_dft_output_attr_removed_after_idft(self, fft_sin_patch_time):
+        """Ensure inverse DFT removes private DFT output metadata."""
+        out = fft_sin_patch_time.idft("time")
+
+        assert "_dft_output" not in out.attrs
+
+    @pytest.mark.parametrize("output", ["AS", "PS", "PSD"])
+    def test_non_fft_output_cannot_be_inverted(self, sin_patch, output):
+        """Ensure non-FFT spectral representations cannot be inverted."""
+        out = sin_patch.dft("time", output=output)
+
+        with pytest.raises(ValueError, match="Only dft\\(output='FFT'\\)"):
+            out.idft("time")
 
     def test_undo_padding(self, sin_patch_trimmed):
         """Ensure the padding is undone in idft."""

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -94,6 +94,23 @@ class TestDiscreteFourierTransform:
 
         assert np.allclose(spectral_power, expected)
 
+    def _assert_real_output_matches_full_dft(self, patch, out, dims, output, real):
+        """Ensure real spectral outputs are not converted to one-sided spectra."""
+        dims = patch.dims if dims is None else tuple(iterate(dims))
+        real = dims[-1] if real is True else real
+        full = patch.dft(dim=dims, real=False, pad=False, output=output)
+        real_axis = full.get_axis(f"ft_{real}")
+        nonnegative = full.get_coord(f"ft_{real}").data >= 0
+        full_ft_axes = tuple(full.get_axis(f"ft_{dim}") for dim in dims)
+        out_ft_axes = tuple(out.get_axis(f"ft_{dim}") for dim in dims)
+        expected = np.sum(
+            np.compress(nonnegative, full.data, axis=real_axis),
+            axis=full_ft_axes,
+        )
+        spectral_power = np.sum(out.data, axis=out_ft_axes)
+
+        assert np.allclose(spectral_power, expected)
+
     def test_max_frequency(self, fft_sin_patch_time):
         """Ensure when sin wave is input max freq is correct."""
         assert "ft_time" in fft_sin_patch_time.dims
@@ -253,34 +270,48 @@ class TestDiscreteFourierTransform:
         time_axis = sin_patch.get_axis("time")
         ft_axis = out.get_axis("ft_time")
         sine_amp = np.ptp(sin_patch.data, axis=time_axis) / 2
-        expected = sine_amp if real else sine_amp / 2
+        expected = sine_amp / 2
 
         assert np.allclose(np.max(out.data, axis=ft_axis), expected, rtol=0.005)
 
     @pytest.mark.parametrize("output", ["PS", "PSD"])
-    @pytest.mark.parametrize("real", [False, True])
-    def test_spectral_power_scaling(self, sin_patch, real, output):
+    def test_spectral_power_scaling(self, sin_patch, output):
         """Ensure PS and PSD integrate/sum to time-domain mean square."""
         dims = ("time",)
-        out = sin_patch.dft("time", real=real, pad=False, output=output)
+        out = sin_patch.dft("time", pad=False, output=output)
+
+        self._assert_spectral_power_matches_patch(sin_patch, out, dims, output)
+
+    @pytest.mark.parametrize(
+        "dims",
+        [
+            None,
+            ("time", "distance"),
+        ],
+    )
+    @pytest.mark.parametrize("output", ["PS", "PSD"])
+    def test_spectral_power_scaling_multiple_dims(self, sin_patch, dims, output):
+        """Ensure multi-axis spectral outputs recover mean square."""
+        out = sin_patch.dft(dim=dims, pad=False, output=output)
 
         self._assert_spectral_power_matches_patch(sin_patch, out, dims, output)
 
     @pytest.mark.parametrize(
         ("dims", "real"),
         [
-            (None, None),
-            (("time", "distance"), None),
+            (("time",), True),
             (("time", "distance"), "time"),
             (("distance", "time"), "distance"),
         ],
     )
     @pytest.mark.parametrize("output", ["PS", "PSD"])
-    def test_spectral_power_scaling_multiple_dims(self, sin_patch, dims, real, output):
-        """Ensure multi-axis spectral outputs recover mean square."""
+    def test_real_spectral_outputs_match_full_dft_bins(
+        self, sin_patch, dims, real, output
+    ):
+        """Ensure real spectral outputs keep raw nonnegative-frequency bins."""
         out = sin_patch.dft(dim=dims, real=real, pad=False, output=output)
 
-        self._assert_spectral_power_matches_patch(sin_patch, out, dims, output)
+        self._assert_real_output_matches_full_dft(sin_patch, out, dims, output, real)
 
     @pytest.mark.parametrize("output", ["PS", "PSD"])
     def test_spectral_power_scaling_padded(self, sin_patch_trimmed, output):
@@ -289,21 +320,6 @@ class TestDiscreteFourierTransform:
         out = sin_patch_trimmed.dft("time", output=output)
 
         self._assert_spectral_power_matches_patch(padded, out, ("time",), output)
-
-    def test_real_spectral_output_does_not_double_edges(self, sin_patch):
-        """Ensure one-sided spectral outputs don't double DC or Nyquist."""
-        time_axis = sin_patch.get_axis("time")
-        time_shape = [1] * sin_patch.ndim
-        time_shape[time_axis] = sin_patch.shape[time_axis]
-        nyquist = (-1) ** np.arange(sin_patch.shape[time_axis])
-        data = np.broadcast_to(nyquist.reshape(time_shape), sin_patch.shape)
-        patch = sin_patch.new(data=data)
-
-        out = patch.dft("time", real=True, pad=False, output="AS")
-        ft_axis = out.get_axis("ft_time")
-        nyquist_amp = np.take(out.data, -1, axis=ft_axis)
-
-        assert np.allclose(nyquist_amp, 1)
 
     def test_spectral_output_units(self, sin_patch):
         """Ensure spectral output units are scaled according to output type."""


### PR DESCRIPTION
## Description
This PR adds option to output various amplitude outputs types to DFT (amplitude spectra, power spectra, or power spectral density). Optionally data can be converted to decibel
The default output is "FFT", so that it remains backward compatible


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [X] documented the new feature with docstrings and/or appropriate doc page.
- [X] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * dft adds selectable outputs: FFT, amplitude spectrum (AS), power spectrum (PS), and power spectral density (PSD); case-insensitive selection and optional dB conversion for spectral outputs.

* **Bug Fixes**
  * DFT preserves prior data-type metadata, sets transformed data type to "fourier transform", rejects invalid output or dB-for-FFT, and prevents inversion for non-FFT spectral outputs.

* **Style/UX**
  * Dimension labels now read units from coordinate metadata for plotting.

* **Tests**
  * Expanded tests cover all output kinds, scaling, dB behavior, validation, and inversion rules.

* **Chores**
  * Lint workflow push trigger restricted to master branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->