### PR TITLE
Waterfall with default colormaps per datatype

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -147,12 +147,12 @@ for each attribute.
 
 select_values_description = """
 Any dimension name can be passed as key, and the values can be:
-    - a Slice or a tuple of (min, max) for that dimension. 
+    - a Slice or a tuple of (min, max) for that dimension.
       `None` and ... both indicate open intervals.
-    - an array of values to select, which must be a subset of the 
+    - an array of values to select, which must be a subset of the
       coordinate array.
     - an array of booleans of the same length as the coordinate where
-      `True` indicates values to keep. 
+      `True` indicates values to keep.
 """
 
 check_behavior_description = """
@@ -204,11 +204,30 @@ _AGG_FUNCS: Mapping[str, Callable] = MappingProxyType(
 
 DIM_REDUCE_DOCS = """
 dim_reduce
-    How to reduce the dimensional coordinate associated with the 
+    How to reduce the dimensional coordinate associated with the
     aggregated axis. Can be the name of any valid aggregator, a callable,
-    "empty" (the default) which returns a length 1 partial coord, or 
-    "squeeze" which drops the coordinate. For dimensions with datetime 
-    or timedelta datatypes, if the operation fails it will automatically 
-    be applied to the coordinates converted to floats then the output 
-    converted back to the appropriate time type. 
+    "empty" (the default) which returns a length 1 partial coord, or
+    "squeeze" which drops the coordinate. For dimensions with datetime
+    or timedelta datatypes, if the operation fails it will automatically
+    be applied to the coordinates converted to floats then the output
+    converted back to the appropriate time type.
 """
+
+
+DEFAULT_COLORMAPS = {
+    "frequency-band energy": "Spectral_r",
+    "stalta": "RdGy_r",
+    "kurtosis": "gnuplot2",
+    "fourier transform": "magma",
+    "power spectral density": "turbo",
+    "power spectrum": "turbo",
+    "amplitude spectrum": "turbo",
+    "strain_rate": "RdBu_r",
+    "strain": "seismic",
+    "velocity": "viridis",
+    "phase": "twilight_shifted",
+    "phase_difference": "bone",
+    "phase_rate": "seismic",
+    "temperature": "coolwarm",
+    "temperature_gradient": "RdYlBu_r",
+}

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -25,7 +25,9 @@ def _get_dim_label(patch, dim):
 def _get_cmap(cmap):
     """Return a color map from a colormap or string."""
     if isinstance(cmap, str):  # get color map if a string was passed
-        cmap = plt.get_cmap(cmap)
+        cmap = plt.get_cmap(cmap).copy()
+        cmap.set_over(cmap(1.0))
+        cmap.set_under(cmap(0.0))
     return cmap
 
 

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -178,8 +178,8 @@ def waterfall(
     ax
         A matplotlib object, if None create one.
     cmap
-        A matplotlib colormap string or instance. If None, a colorbar will be
-        chosen automatically, depending on the data_type of the patch.
+        A matplotlib colormap string or instance. If None, a colormap will be
+        chosen automatically, depending on the data_type of the patch. Defaults to 'bwr'
     scale
         If not None, controls the saturation level of the colorbar.
         Values can either be a float, to set upper and lower limit to the same

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -160,12 +160,11 @@ def _default_colormap_per_datatype(patch):
 def waterfall(
     patch: PatchType,
     ax: plt.Axes | None = None,
-    cmap: str | None = None,
+    cmap: str | None = "default",
     scale: float | Sequence[float] | None = None,
     scale_type: Literal["relative", "absolute"] = "relative",
     interpolation: str | None = "antialiased",
     log: bool = False,
-    cbar: bool = True,
     show: bool = False,
 ) -> plt.Axes:
     """
@@ -178,8 +177,9 @@ def waterfall(
     ax
         A matplotlib object, if None create one.
     cmap
-        A matplotlib colormap string or instance. If None, a colormap will be
-        chosen automatically, depending on the data_type of the patch. Defaults to 'bwr'
+        A matplotlib colormap string or instance. If "default", a colormap will be
+        chosen automatically, depending on the data_type of the patch. Set to
+        None to not plot the colorbar.
     scale
         If not None, controls the saturation level of the colorbar.
         Values can either be a float, to set upper and lower limit to the same
@@ -199,8 +199,8 @@ def waterfall(
         options are available, see matplotlib's documentation for more details.
     log
         If True, visualize the common logarithm of the absolute values of patch data.
-    cbar
-        If True, colorbar is added.
+        To avoid log(0), the abs(array) is cast to float64 and a small value
+        added.
     show
         If True, show the plot, else just return axis.
 
@@ -263,23 +263,21 @@ def waterfall(
     patch = _validate_patch_dims(patch)
     # Setup axes and data
     ax = _get_ax(ax)
-    # cmap = _get_cmap(cmap)
-    # data = np.log10(np.absolute(patch.data)) if log else patch.data
-    float_dtype = np.result_type(np.abs(patch.data).dtype, np.float64)
-    eps = np.finfo(float_dtype).eps
-    data = (
-        np.log10(np.abs(patch.data).astype(float_dtype, copy=False) + eps)
-        if log
-        else patch.data
-    )
+    if log:
+        data = np.log10(np.abs(patch.data) + np.finfo(np.float64).eps)
+    else:
+        data = patch.data
     dims = patch.dims
     dims_r = tuple(reversed(dims))
     coords = {dim: patch.coords.get_array(dim) for dim in dims}
     # Plot using imshow and set colorbar limits
     extents = _get_extents(dims_r, coords)
 
-    if cmap is None:
+    add_colorbar = cmap is not None
+    if cmap == "default":
         cmap = _default_colormap_per_datatype(patch)
+    else:
+        cmap = _get_cmap(cmap)
 
     scale = _get_scale(scale, scale_type, data)
     with mpl.rc_context({"image.resample": True}):
@@ -301,7 +299,7 @@ def waterfall(
     # Format axis labels and handle time-like dimensions
     _format_axis_labels(ax, patch, dims_r)
     # Add colorbar if requested
-    if cbar:
+    if add_colorbar:
         _add_colorbar(ax, im, data, patch, log, scale)
     if show:
         plt.show()

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -9,7 +9,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
-from dascore.constants import PatchType
+from dascore.constants import DEFAULT_COLORMAPS, PatchType
 from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, maybe_convert_percent_to_fraction
 from dascore.utils.misc import tukey_fence
@@ -117,11 +117,27 @@ def _format_axis_labels(ax, patch, dims_r):
             ax.invert_yaxis()
 
 
-def _add_colorbar(ax, im, patch, log):
+def _add_colorbar(ax, im, data, patch, log, scale):
     """
     Add a colorbar with appropriate labels to the plot.
+    When auto-scaling, extend-triangles are added if data above or below limits exist
     """
-    cb = ax.get_figure().colorbar(im, ax=ax, fraction=0.05, pad=0.025)
+    mi = np.nanmin(data)
+    mx = np.nanmax(data)
+
+    above, below = False, False
+    if scale is not None and len(scale) == 2:
+        above = (mx > scale[1]) and not np.isclose(scale[1], mx)
+        below = (mi < scale[0]) and not np.isclose(scale[0], mi)
+    extend_map = {
+        (True, True): "both",
+        (True, False): "max",
+        (False, True): "min",
+    }
+    extend = extend_map.get((above, below), "neither")
+    cb = ax.get_figure().colorbar(
+        im, ax=ax, fraction=0.05, pad=0.025, extend=extend, extendfrac=0.025
+    )
     data_type = str(patch.attrs.get("data_type", ""))
     data_units = get_quantity_str(patch.attrs.data_units) or ""
     dunits = f" [{data_units}]" if (data_type and data_units) else f"{data_units}"
@@ -131,15 +147,25 @@ def _add_colorbar(ax, im, patch, log):
     cb.set_label(label)
 
 
+def _default_colormap_per_datatype(patch):
+    """
+    Select a default colormap based on datatype
+    """
+    this_type = str(patch.attrs.get("data_type", "")).lower()
+    cmap = DEFAULT_COLORMAPS.get(this_type, "bwr")  # defaults to "bwr"
+    return _get_cmap(cmap)
+
+
 @patch_function()
 def waterfall(
     patch: PatchType,
     ax: plt.Axes | None = None,
-    cmap: str = "bwr",
+    cmap: str | None = None,
     scale: float | Sequence[float] | None = None,
     scale_type: Literal["relative", "absolute"] = "relative",
     interpolation: str | None = "antialiased",
     log: bool = False,
+    cbar: bool = True,
     show: bool = False,
 ) -> plt.Axes:
     """
@@ -152,8 +178,8 @@ def waterfall(
     ax
         A matplotlib object, if None create one.
     cmap
-        A matplotlib colormap string or instance. Set to None to not plot the
-        colorbar.
+        A matplotlib colormap string or instance. If None, a colorbar will be
+        chosen automatically, depending on the data_type of the patch.
     scale
         If not None, controls the saturation level of the colorbar.
         Values can either be a float, to set upper and lower limit to the same
@@ -173,6 +199,8 @@ def waterfall(
         options are available, see matplotlib's documentation for more details.
     log
         If True, visualize the common logarithm of the absolute values of patch data.
+    cbar
+        If True, colorbar is added.
     show
         If True, show the plot, else just return axis.
 
@@ -235,13 +263,24 @@ def waterfall(
     patch = _validate_patch_dims(patch)
     # Setup axes and data
     ax = _get_ax(ax)
-    cmap = _get_cmap(cmap)
-    data = np.log10(np.absolute(patch.data)) if log else patch.data
+    # cmap = _get_cmap(cmap)
+    # data = np.log10(np.absolute(patch.data)) if log else patch.data
+    float_dtype = np.result_type(np.abs(patch.data).dtype, np.float64)
+    eps = np.finfo(float_dtype).eps
+    data = (
+        np.log10(np.abs(patch.data).astype(float_dtype, copy=False) + eps)
+        if log
+        else patch.data
+    )
     dims = patch.dims
     dims_r = tuple(reversed(dims))
     coords = {dim: patch.coords.get_array(dim) for dim in dims}
     # Plot using imshow and set colorbar limits
     extents = _get_extents(dims_r, coords)
+
+    if cmap is None:
+        cmap = _default_colormap_per_datatype(patch)
+
     scale = _get_scale(scale, scale_type, data)
     with mpl.rc_context({"image.resample": True}):
         im = ax.imshow(
@@ -262,8 +301,8 @@ def waterfall(
     # Format axis labels and handle time-like dimensions
     _format_axis_labels(ax, patch, dims_r)
     # Add colorbar if requested
-    if cmap is not None:
-        _add_colorbar(ax, im, patch, log)
+    if cbar:
+        _add_colorbar(ax, im, data, patch, log, scale)
     if show:
         plt.show()
     return ax

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -114,7 +114,7 @@ class TestWaterfall:
 
     def test_no_colorbar(self, random_patch):
         """Ensure the colorbar can be disabled."""
-        ax = random_patch.viz.waterfall(cmap=None)
+        ax = random_patch.viz.waterfall(cbar=False)
         # ensure no colorbar was created.
         assert ax.images[-1].colorbar is None
 
@@ -171,7 +171,7 @@ class TestWaterfall:
         # Retrieve the expected data type and data units
         data_type = str(random_patch.attrs["data_type"])
         data_units = get_quantity_str(random_patch.attrs.data_units) or ""
-        expected_dunits = f" ({data_units})" if data_units else ""
+        expected_dunits = f" [{data_units}]" if data_units else ""
 
         # Construct the expected label
         expected_label = f"{data_type}{expected_dunits} - log_10"
@@ -258,3 +258,25 @@ class TestWaterfall:
 
     def test_percent_scale(self, random_patch):
         """Ensure the percent unit works with scale."""
+        from dascore.units import percent
+
+        ax = random_patch.viz.waterfall(scale=10 * percent, scale_type="absolute")
+        assert ax is not None
+
+    def test_invalid_scale_disables_colorbar_extend(self, random_patch):
+        """Ensure invalid scales fall back to extend='neither'."""
+        ax = random_patch.viz.waterfall(scale=(np.nan, 1), show=False)
+        cbar = ax.images[-1].colorbar
+        assert cbar.extend == "neither"
+
+    def test_log_with_zero_data_has_finite_clim(self, random_patch):
+        """Ensure that color limits work with in log-scale with zeros"""
+        patch = random_patch.update(data=np.zeros(random_patch.shape))
+        ax = patch.viz.waterfall(log=True)
+        assert np.all(np.isfinite(ax.images[0].get_clim()))
+
+    def test_default_colormap_uses_data_type(self, random_patch):
+        """Ensure colormap is chosen automatically."""
+        patch = random_patch.update_attrs(data_type="velocity")
+        ax = patch.viz.waterfall()
+        assert ax.images[0].cmap is not None

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -114,8 +114,7 @@ class TestWaterfall:
 
     def test_no_colorbar(self, random_patch):
         """Ensure the colorbar can be disabled."""
-        ax = random_patch.viz.waterfall(cbar=False)
-        # ensure no colorbar was created.
+        ax = random_patch.viz.waterfall(cmap=None)
         assert ax.images[-1].colorbar is None
 
     def test_units(self, random_patch):


### PR DESCRIPTION
## Description
Waterfall had the default colormap "bwr". This PR makes use of the data_type attribute to set defaul colormaps depending on patch.datatype. Maps are defined in constants.py
Also, added a boolean option "cbar" to indicate if a colorbar is to be shown or not (earlier behavior was to toggle with cmap=None)

Fixed with adding eps number to data to avoid division-by-zero warning when taking the log

Colorbar now automatically shows "extend" triangles if the color limits do not encompass the full data range


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [X] documented the new feature with docstrings and/or appropriate doc page.
- [X] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic default colormap selection for waterfall plots based on data type.
  * Option to omit the colorbar by passing no colormap (cmap=None).

* **Bug Fixes**
  * Safer log scaling that avoids -inf on zeros and handles all-zero data.
  * Improved colorbar extension behavior to reflect actual data limits.

* **Tests**
  * Added tests for colorbar visibility, log handling, scaling modes, and default colormap selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->