### PR TITLE
Coerce numeric relative offsets for timedelta64 coordinates (fixes #604)

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -625,9 +625,13 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         # if null or ... just return None
         if not is_array(value) and (pd.isnull(value) or value is Ellipsis):
             return None
-        # special case for datetime and relative
+        # special case for datetime/timedelta and relative
         if relative:
-            if np.issubdtype(self.dtype, np.datetime64):
+            # A relative offset into a time-like coordinate is a duration, so
+            # coerce it to timedelta64 for both datetime64 and timedelta64
+            # coords (previously only datetime64 was handled, so a numeric
+            # offset into a timedelta64 coord raised a ufunc type error).
+            if dtype_time_like(self.dtype):
                 value = dc.to_timedelta64(value)
             value = self._get_relative_values(value)
         # apply validators. These can, eg, coerce to correct dtype.

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -627,10 +627,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             return None
         # special case for datetime/timedelta and relative
         if relative:
-            # A relative offset into a time-like coordinate is a duration, so
-            # coerce it to timedelta64 for both datetime64 and timedelta64
-            # coords (previously only datetime64 was handled, so a numeric
-            # offset into a timedelta64 coord raised a ufunc type error).
+            # A relative offset into any time-like coord is a duration.
             if dtype_time_like(self.dtype):
                 value = dc.to_timedelta64(value)
             value = self._get_relative_values(value)

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -633,6 +633,24 @@ class TestSelect:
         else:
             assert ind_1 == ind_2
 
+    def test_select_relative_numeric_offset_timedelta(self):
+        """
+        A numeric relative offset into a timedelta64 coordinate should be
+        coerced to a duration, just like for datetime64 coords (see #604).
+        """
+        coord = dc.get_coord(data=dc.to_timedelta64(np.arange(0, 10)))
+        # A numeric offset previously raised a ufunc type error for
+        # timedelta64 coords; it should behave like the explicit duration.
+        out_num, ind_num = coord.select((2, -2), relative=True)
+        out_td, ind_td = coord.select(
+            (dc.to_timedelta64(2), dc.to_timedelta64(-2)), relative=True
+        )
+        assert np.all(out_num == out_td)
+        if isinstance(ind_num, np.ndarray):
+            assert np.all(ind_num == ind_td)
+        else:
+            assert ind_num == ind_td
+
     def test_select_changes_len(self, long_coord):
         """Ensure select changes the length of the coordinate."""
         data = long_coord.data

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -283,6 +283,21 @@ class TestInverseDiscreteFourierTransform:
 class TestSTFT:
     """Tests for the short-time Fourier transform."""
 
+    def test_numeric_window_with_timedelta_coord(self):
+        """
+        stft with a numeric window length should work when the time
+        coordinate is timedelta64 (not just datetime64); see #604.
+        """
+        patch = dc.get_example_patch()
+        time = patch.get_coord("time")
+        # Convert the time coordinate to timedelta64 (relative to the end).
+        new = patch.update_coords(time=time.values - time.values[-1])
+        # A numeric window length previously raised a ufunc type error here.
+        out_numeric = new.stft(time=0.1)
+        out_timedelta = new.stft(time=dc.to_timedelta64(0.1))
+        # The numeric form must match the explicit-duration form exactly.
+        assert out_numeric.equals(out_timedelta)
+
     def test_type(self, chirp_stft_patch, chirp_patch):
         """Simply ensure the correct type was returned."""
         patch = chirp_stft_patch


### PR DESCRIPTION
Fixes #604.

## Problem

With a `timedelta64` time coordinate, passing a numeric window length to `stft` raised a numpy ufunc type error, even though the equivalent explicit-duration call worked:

```python
import dascore as dc

patch = dc.get_example_patch()
time = patch.get_coord("time")
new = patch.update_coords(time=time.values - time.values[-1])  # timedelta64 coord

new.stft(time=0.1)                      # numpy._core._exceptions._UFuncBinaryResolutionError
new.stft(time=dc.to_timedelta64(0.1))   # works
```

## Root cause

`BaseCoord._get_compatible_value` (`dascore/core/coords.py`) only coerced a *relative* offset to `timedelta64` when the coordinate was `datetime64`:

```python
if relative:
    if np.issubdtype(self.dtype, np.datetime64):
        value = dc.to_timedelta64(value)
    value = self._get_relative_values(value)
```

For a `timedelta64` coordinate the numeric offset stayed a `float`, so `_get_relative_values` evaluated `coord.min() + value` as `timedelta64 + float` and raised. A relative offset into a time-like coordinate is a duration in both cases.

## Fix

Use the existing `dtype_time_like` helper (already imported) so a numeric relative offset is coerced to `timedelta64` for both `datetime64` and `timedelta64` coordinates.

## Verification

- `new.stft(time=0.1)` now succeeds and its output is **identical** (`Patch.equals`) to `new.stft(time=dc.to_timedelta64(0.1))`, which also resolves the reporter's secondary note that "the time coordinate seems to be wrong on the transform in this case".
- The `datetime64` path is unchanged; relative `select` on a `timedelta64` coordinate with a numeric offset now works too.
- Two regression tests added (both **fail on `master`** with the ufunc error, pass with this change):
  - `tests/test_core/test_coords.py::TestSelect::test_select_relative_numeric_offset_timedelta` (root cause, coord level)
  - `tests/test_transform/test_fourier.py::TestSTFT::test_numeric_window_with_timedelta_coord` (end-to-end stft)
- Full suite: **5936 passed, 80 skipped, 4 xfailed**. `pre-commit run --files ...` (ruff, ruff-format, typos) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relative time-based coordinate selection now behaves consistently for all time-like coordinate types when using numeric or duration offsets.

* **Tests**
  * Added tests verifying relative selection with numeric offsets on duration-style time coordinates and a regression test for spectral transforms using alternative time coordinate formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->