### PR TITLE
Support chunking spools with timedelta64 coordinates (fixes #553)

### DIFF
--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -75,6 +75,12 @@ def get_intervals(
         # need to ensure we have numpy datetimes, not pandas
         start, stop = to_datetime64(start), to_datetime64(stop)
         length = to_timedelta64(length)
+    elif is_timedelta64(start):
+        # a span of a timedelta64 coordinate is itself a duration, so a
+        # numeric chunk length must be coerced to timedelta64 (otherwise the
+        # duration < length comparison mixes Timedelta and float).
+        start, stop = to_timedelta64(start), to_timedelta64(stop)
+        length = to_timedelta64(length)
     # get variable and perform checks
     overlap = length * 0 if not overlap else overlap
     step = length * 0 if pd.isnull(step) else step
@@ -236,8 +242,9 @@ class ChunkManager:
     def _get_duration_overlap(self, duration, start, step, overlap=None):
         """Get duration and overlap from kwargs."""
         overlap = overlap if overlap is not None else self._overlap
-        # cast step to time delta if start is datetime
-        if is_datetime64(start):
+        # cast step/overlap to timedelta if start is datetime or timedelta;
+        # a span of either dtype is a duration.
+        if is_datetime64(start) or is_timedelta64(start):
             step = to_timedelta64(step)
             overlap = to_timedelta64(overlap)
         if pd.isnull(overlap):

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -632,6 +632,24 @@ class TestSpoolBehaviorOptionalImports:
 class TestMisc:
     """Tests for misc. spool cases."""
 
+    def test_chunk_timedelta_coord(self):
+        """
+        Chunking a spool whose time coordinate is timedelta64 (rather than
+        datetime64) should work with a numeric chunk size (see #553).
+        """
+        from dascore.examples import ricker_moveout
+
+        patch = ricker_moveout()
+        assert np.issubdtype(patch.get_coord("time").dtype, np.timedelta64)
+        spool = dc.spool(patch)
+        # Previously raised a TypeError comparing Timedelta with float.
+        chunked = spool.chunk(time=0.02)
+        assert len(chunked) > 1
+        # The chunked patches retain the timedelta64 time coordinate.
+        assert np.issubdtype(chunked[0].get_coord("time").dtype, np.timedelta64)
+        # Overlap (also numeric) must work too.
+        assert len(spool.chunk(time=0.02, overlap=0.005)) > 1
+
     def test_changed_memory_spool(self, random_patch):
         """
         Calling spool on a patch that was returned from None results in

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -88,6 +88,22 @@ class TestGetIntervals:
         assert out[-1, 1] == stop
         assert out[0, 0] == start
 
+    def test_timedelta_start_numeric_length(self):
+        """
+        A numeric length for a timedelta64 start should be coerced to a
+        duration, just like for datetime64 starts (see #553). Previously this
+        raised a type error comparing a timedelta64 with a float.
+        """
+        start = np.timedelta64(0, "s")
+        stop = start + np.timedelta64(20, "s")
+        # A numeric (float) length previously raised here for timedelta starts.
+        out = get_intervals(start, stop, length=2.0)
+        # Output stays timedelta64 and each interval spans the requested length.
+        assert np.issubdtype(out.dtype, np.timedelta64)
+        assert np.all(out[:, 1] - out[:, 0] == np.timedelta64(2, "s"))
+        assert out[0, 0] == start
+        assert out[-1, 1] == stop
+
 
 class TestBasicChunkDF:
     """Test basic DF chunking."""


### PR DESCRIPTION
Fixes #553.

## Problem

Chunking a spool whose time coordinate is `timedelta64` (rather than `datetime64`) raised a `TypeError` when a numeric chunk size was given:

```python
import dascore as dc
from dascore.examples import ricker_moveout

patch = ricker_moveout()  # time coord is timedelta64, not datetime64
dc.spool(patch).chunk(time=0.02)
# TypeError: '<' not supported between instances of 'Timedelta' and 'float'
```

## Root cause

A span of a `timedelta64` coordinate is itself a duration, so a numeric chunk length/overlap must be coerced to `timedelta64` before it is compared/combined with the coordinate values. Two spots only handled the `datetime64` case:

- `get_intervals` coerced the chunk **length** to `timedelta64` only for `datetime64` starts, so `duration < length` mixed a `timedelta64` with a `float`.
- `ChunkManager._get_duration_overlap` coerced **step** and **overlap** only for `datetime64` starts, so the overlap path (`overlap > length`) hit the same mismatch.

## Fix

Extend both spots to also handle `timedelta64` starts (coerce length/step/overlap to `timedelta64`). The `datetime64` path is unchanged.

## Verification

- `dc.spool(ricker_moveout()).chunk(time=0.02)` now returns 75 chunked patches; `chunk(time=0.02, overlap=0.005)` returns 99; merging (`chunk(time=None)`) works; chunked patches retain the `timedelta64` time coordinate.
- `datetime64` chunking is unchanged (regression-checked, with and without overlap).
- Two regression tests added (both **fail on `master`** with the type error, pass with this change):
  - `tests/test_utils/test_chunk.py::TestGetIntervals::test_timedelta_start_numeric_length` (root cause, `get_intervals` level)
  - `tests/test_core/test_spool.py::TestMisc::test_chunk_timedelta_coord` (end-to-end spool scenario from the issue)
- Full suite: **5936 passed, 80 skipped, 4 xfailed**. `pre-commit run --files ...` (ruff, ruff-format, typos) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of time coordinates expressed as durations during chunking operations
  * Fixed duration casting logic to ensure consistent behavior in overlap calculations

* **Tests**
  * Added comprehensive test coverage for chunking spools with duration-based time coordinates
  * Expanded test coverage for interval generation when using duration values as start points

<!-- end of auto-generated comment: release notes by coderabbit.ai -->