### PR TITLE
Retain step when slicing an evenly sampled coordinate (fixes #567)

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1169,8 +1169,16 @@ class CoordRange(BaseCoord):
         if isinstance(item, slice):
             start = None if item.start is ... else item.start
             end = None if item.stop is ... else item.stop
-            # Todo we can probably add more intelligent logic for slices.
             item = slice(start, end, item.step)
+            # A (possibly strided) slice of an evenly sampled range is still
+            # evenly sampled, so preserve the step rather than collapsing to a
+            # CoordMonotonicArray (which loses step for len==1). See #567.
+            indices = range(len(self))[item]
+            if len(indices):
+                new_step = self.step * indices.step
+                new_start = self.start + indices.start * self.step
+                new_stop = new_start + new_step * len(indices)
+                return self.new(start=new_start, stop=new_stop, step=new_step)
         out = self.values[item]
         return get_coord(data=out, units=self.units)
 

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -692,6 +692,21 @@ class TestSelect:
         out = monotonic_float_coord.select((i1, i2), samples=True)[0]
         assert np.all(values[i1:i2] == out.values)
 
+    def test_single_sample_retains_step(self, evenly_sampled_coord):
+        """A length-1 selection of an evenly sampled coord keeps its step. See #567."""
+        out, _ = evenly_sampled_coord.select(1, samples=True)
+        assert len(out) == 1
+        assert out.step is not None
+        assert out.step == evenly_sampled_coord.step
+        assert out.values[0] == evenly_sampled_coord.values[1]
+
+    def test_single_sample_retains_step_datetime(self, evenly_sampled_date_coord):
+        """Same as above but for a datetime coord (step is a timedelta64)."""
+        out, _ = evenly_sampled_date_coord.select(3, samples=True)
+        assert len(out) == 1
+        assert out.step == evenly_sampled_date_coord.step
+        assert out.values[0] == evenly_sampled_date_coord.values[3]
+
     def test_values_not_in_coord(self, long_coord):
         """Ensure using values not in coord results in an empty coordinate."""
         values1 = long_coord.values[: len(long_coord) // 2]

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -554,6 +554,14 @@ class TestSelect:
         sub2 = random_patch.select(time=np.int64(10), samples=True)
         assert sub1 == sub2
 
+    def test_single_sample_retains_step(self, random_patch):
+        """Single-sample select of an evenly sampled coord keeps step. See #567."""
+        orig = random_patch.get_coord("time")
+        sub_patch = random_patch.select(time=1, samples=1)
+        time = sub_patch.get_coord("time")
+        assert time.step is not None
+        assert time.step == orig.step
+
 
 class TestOrder:
     """Tests for ordering Patches."""


### PR DESCRIPTION
## Description

Closes #567.

Evenly sampled coordinates should keep their `step` even when reduced to length 1, e.g. via `patch.select(time=1, samples=1)`. Currently the step is lost:

```python
import dascore as dc

patch = dc.get_example_patch()
sub_patch = patch.select(time=1, samples=1)
time = sub_patch.get_coord("time")
assert time.step is not None  # fails on master
```

## Root cause

`CoordRange.__getitem__` handled slice indexers by materializing the values (`self.values[item]`) and rebuilding via `get_coord(data=...)`. For a length-1 result that produces a `CoordMonotonicArray`, which has no `step` — so an evenly sampled coordinate silently becomes non-evenly-sampled.

## Fix

A (possibly strided) slice of an evenly sampled range is still evenly sampled, so `CoordRange.__getitem__` now computes the resulting `start`/`stop`/`step` directly for slice indexers and returns a `CoordRange`. Non-slice indexers (boolean / fancy arrays) are unchanged. Strided, reverse, and empty slices were verified to behave as before.

## Verification

- New regression tests at the coord level (`TestSelect::test_single_sample_retains_step`, plus a datetime variant) and at the patch level (the issue's exact example). All fail on master / pass with the fix.
- Full test suite: 5937 passed, 80 skipped, 4 xfailed.
- pre-commit clean.