### PR TITLE
Pass kwargs through Patch.viz.spectrogram for 2D patches (fixes #661)

### DIFF
--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -87,9 +87,9 @@ def spectrogram(
     if other_dim is not None:
         if aggr_domain == "time":
             patch_aggr = patch.aggregate(other_dim, method="mean", dim_reduce="squeeze")
-            spec = patch_aggr.spectrogram(dim)
+            spec = patch_aggr.spectrogram(dim, **kwargs)
         elif aggr_domain == "frequency":
-            _spec = patch.spectrogram(dim).squeeze()
+            _spec = patch.spectrogram(dim, **kwargs).squeeze()
             spec = _spec.aggregate(other_dim, method="mean").squeeze()
         else:
             raise ValueError(

--- a/tests/test_viz/test_spectrogram.py
+++ b/tests/test_viz/test_spectrogram.py
@@ -83,3 +83,27 @@ class TestPlotSpectrogram:
         monkeypatch.setattr(plt, "show", lambda: None)
         axis = random_patch.viz.spectrogram(dim="time", show=True)
         assert isinstance(axis, plt.Axes)
+
+    @staticmethod
+    def _image_shape(axis):
+        """Return the shape of the data backing the spectrogram image."""
+        images = axis.get_images()
+        if images:
+            return images[0].get_array().shape
+        return axis.collections[0].get_array().shape
+
+    @pytest.mark.parametrize("aggr_domain", ["frequency", "time"])
+    def test_kwargs_passed_to_spectrogram_2d(self, random_patch, aggr_domain):
+        """Ensure kwargs (e.g. nperseg) reach scipy for 2D patches. See #661."""
+        default = random_patch.viz.spectrogram(dim="time", aggr_domain=aggr_domain)
+        windowed = random_patch.viz.spectrogram(
+            dim="time", aggr_domain=aggr_domain, nperseg=64
+        )
+        assert self._image_shape(default) != self._image_shape(windowed)
+
+    def test_kwargs_passed_to_spectrogram_1d(self, random_patch):
+        """Ensure kwargs reach scipy for 1D patches as well. See #661."""
+        patch = random_patch.select(distance=0, samples=True).squeeze()
+        default = patch.viz.spectrogram(dim="time")
+        windowed = patch.viz.spectrogram(dim="time", nperseg=64)
+        assert self._image_shape(default) != self._image_shape(windowed)


### PR DESCRIPTION
## Description

Closes #661.

`Patch.viz.spectrogram` accepts `**kwargs` documented as *"Passed to scipy.signal.spectrogram to control spectrogram options"*, but for 2D patches they were silently swallowed. For example:

```python
import dascore as dc
eve1 = dc.get_example_patch("example_event_1")  # 2D (distance, time)
ax = eve1.viz.spectrogram(dim="time", nperseg=64)
```

produced exactly the same plot as without `nperseg=64` — only 4 time samples instead of the higher resolution the shorter window should give.

## Root cause

`dascore/viz/spectrogram.py` only forwarded `**kwargs` to `patch.spectrogram(dim, **kwargs)` in the 1D `else` branch. The 2D path (when `other_dim is not None`) called `patch.spectrogram(dim)` in both the `aggr_domain="time"` and `aggr_domain="frequency"` branches without passing the kwargs along.

## Fix

Forward `**kwargs` to `patch.spectrogram(dim, **kwargs)` in both aggregation branches. The underlying transform already relays them to `scipy.signal.spectrogram`.

## Verification

- New parametrized regression tests assert that passing `nperseg=64` changes the rendered image shape for both `aggr_domain` values on a 2D patch (plus a 1D guard). The 2D tests fail on master / pass with the fix.
- Full `tests/test_viz/test_spectrogram.py` suite passes.
- pre-commit clean.

## Note

As the reporter asked, `Patch.viz.spectrogram` still routes through the deprecated `dascore.transform.spectro.spectrogram`. That deprecation is a separate concern (the transform is slated for removal in 0.2.0 in favor of `Patch.stft()`); this PR focuses on the kwargs-passthrough bug. Happy to follow up on migrating the viz to `stft` if desired.