### PR TITLE
waterfall cbar param and cmap=None

### DIFF
--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -69,7 +69,7 @@ def dispersion_phase_shift(
 
     disp_patch = patch.dispersion_phase_shift(np.arange(100,1500,1),
                 approx_resolution=0.1,approx_freq=[5,70])
-    ax = disp_patch.viz.waterfall(show=False,cmap=None)
+    ax = disp_patch.viz.waterfall(show=False, cbar=False)
     ax.set_xlim(5, 70)
     ax.set_ylim(1500, 100)
     disp_patch.viz.waterfall(show=True, ax=ax)

--- a/dascore/transform/taup.py
+++ b/dascore/transform/taup.py
@@ -114,7 +114,7 @@ def tau_p(
     ...     .tau_p(np.arange(1000,6000,10))
     ...     .transpose('time','slowness')
     ... )
-    >>> ax = taup_patch.viz.waterfall(show=False, cmap=None)
+    >>> ax = taup_patch.viz.waterfall(show=False, cbar=False)
     >>> _ = taup_patch.viz.waterfall(ax=ax)
     """
     patch_cop = patch.convert_units(distance="m", time="s").transpose(

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -180,8 +180,7 @@ def waterfall(
         A matplotlib object, if None create one.
     cmap
         A matplotlib colormap string or instance. If `None`, a colormap will be
-        chosen automatically, depending on the data_type of the patch. Set to
-        None to not plot the colorbar.
+        chosen automatically, depending on the data_type of the patch.
     scale
         If not None, controls the saturation level of the colorbar.
         Values can either be a float, to set upper and lower limit to the same
@@ -204,7 +203,8 @@ def waterfall(
         To avoid log(0), the abs(array) is cast to float64 and a small value
         added.
     cbar
-        If True, plot the colorbar, else do not.
+        If True, plot the colorbar, else do not. This controls only colorbar
+        display; use `cmap` to control colormap selection.
     show
         If True, show the plot, else just return axis.
 

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -147,12 +147,13 @@ def _add_colorbar(ax, im, data, patch, log, scale):
     cb.set_label(label)
 
 
-def _default_colormap_per_datatype(patch):
+def _get_waterfall_colormap(patch, cmap=None):
     """
     Select a default colormap based on datatype
     """
-    this_type = str(patch.attrs.get("data_type", "")).lower()
-    cmap = DEFAULT_COLORMAPS.get(this_type, "bwr")  # defaults to "bwr"
+    if cmap is None:
+        this_type = str(patch.attrs.get("data_type", "")).lower()
+        cmap = DEFAULT_COLORMAPS.get(this_type, "bwr")  # defaults to "bwr"
     return _get_cmap(cmap)
 
 
@@ -160,11 +161,12 @@ def _default_colormap_per_datatype(patch):
 def waterfall(
     patch: PatchType,
     ax: plt.Axes | None = None,
-    cmap: str | None = "default",
+    cmap: str | None = None,
     scale: float | Sequence[float] | None = None,
     scale_type: Literal["relative", "absolute"] = "relative",
     interpolation: str | None = "antialiased",
     log: bool = False,
+    cbar: bool = True,
     show: bool = False,
 ) -> plt.Axes:
     """
@@ -177,7 +179,7 @@ def waterfall(
     ax
         A matplotlib object, if None create one.
     cmap
-        A matplotlib colormap string or instance. If "default", a colormap will be
+        A matplotlib colormap string or instance. If `None`, a colormap will be
         chosen automatically, depending on the data_type of the patch. Set to
         None to not plot the colorbar.
     scale
@@ -201,6 +203,8 @@ def waterfall(
         If True, visualize the common logarithm of the absolute values of patch data.
         To avoid log(0), the abs(array) is cast to float64 and a small value
         added.
+    cbar
+        If True, plot the colorbar, else do not.
     show
         If True, show the plot, else just return axis.
 
@@ -272,13 +276,7 @@ def waterfall(
     coords = {dim: patch.coords.get_array(dim) for dim in dims}
     # Plot using imshow and set colorbar limits
     extents = _get_extents(dims_r, coords)
-
-    add_colorbar = cmap is not None
-    if cmap == "default":
-        cmap = _default_colormap_per_datatype(patch)
-    else:
-        cmap = _get_cmap(cmap)
-
+    cmap = _get_waterfall_colormap(patch, cmap)
     scale = _get_scale(scale, scale_type, data)
     with mpl.rc_context({"image.resample": True}):
         im = ax.imshow(
@@ -299,7 +297,7 @@ def waterfall(
     # Format axis labels and handle time-like dimensions
     _format_axis_labels(ax, patch, dims_r)
     # Add colorbar if requested
-    if add_colorbar:
+    if cbar:
         _add_colorbar(ax, im, data, patch, log, scale)
     if show:
         plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,7 @@ max-complexity = 10
 convention = "numpy"
 
 [tool.pytest.ini_options]
+norecursedirs = ["worktrees"]
 filterwarnings = [
     # Ignore hdf5 warnings from pytables, See pytables #1035
     'ignore::Warning:tables:'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,18 @@ max-complexity = 10
 convention = "numpy"
 
 [tool.pytest.ini_options]
-norecursedirs = ["worktrees"]
+norecursedirs = [
+    "*.egg",
+    ".*",
+    "_darcs",
+    "build",
+    "CVS",
+    "dist",
+    "node_modules",
+    "venv",
+    "{arch}",
+    "worktrees",
+]
 filterwarnings = [
     # Ignore hdf5 warnings from pytables, See pytables #1035
     'ignore::Warning:tables:'

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -114,7 +114,7 @@ class TestWaterfall:
 
     def test_no_colorbar(self, random_patch):
         """Ensure the colorbar can be disabled."""
-        ax = random_patch.viz.waterfall(cmap=None)
+        ax = random_patch.viz.waterfall(cmap=None, cbar=False)
         assert ax.images[-1].colorbar is None
 
     def test_units(self, random_patch):

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -114,7 +114,7 @@ class TestWaterfall:
 
     def test_no_colorbar(self, random_patch):
         """Ensure the colorbar can be disabled."""
-        ax = random_patch.viz.waterfall(cmap=None, cbar=False)
+        ax = random_patch.viz.waterfall(cbar=False)
         assert ax.images[-1].colorbar is None
 
     def test_units(self, random_patch):


### PR DESCRIPTION
## Description

This follows up on [this comment](https://github.com/DASDAE/dascore/pull/695#issuecomment-4593431925)  PR #695. 

@andreas-wuestefeld rightly pointed out that the old API in `Patch.viz.waterfall` did not allow hiding the colorbar without using the default colormap (since `cmap=None` both hid the colorbar and set the colormap). This PR adds his `cbar` back to waterfall (an original part of #694) . 

It also makes `cmap`'s default value `None` rather than 'auto' or 'default'. Alternatives are:

1. Require `cmap` be a string (which is a hard break in backwards compatibility) or
2. Let None and 'auto' both do the same thing, which is also a poor design.  

So, now that `cbar` exclusively controls if the color bar shows up, it's probably best to just have `cmap`s default value set to `None`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waterfall plotting gains an explicit cbar parameter (defaults to True) and defaults cmap to None.
* **Behavior Changes**
  * Colormap selection is now resolved automatically when cmap is unset; colorbar display is driven solely by cbar.
* **Documentation**
  * Examples updated to reflect new cbar usage.
* **Tests**
  * Tests updated to explicitly disable the colorbar.
* **Chores**
  * Test discovery configuration improved to exclude additional directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->