### PR TITLE
Fix/waterfall imshow bug

### DIFF
--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -202,8 +202,9 @@ def waterfall(
     interpolation_stage
         If 'data', interpolation is carried out on the data provided by the user.
         If 'rgba', the interpolation is carried out after the colormapping has
-        been applied (visual interpolation). See matplotlib's imshow
-        documentation for more details.
+        been applied (visual interpolation).
+        'auto' selects a suitable interpolation stage automatically.
+        See matplotlib's imshow documentation for more details.
     log
         If True, visualize the common logarithm of the absolute values of patch data.
         To avoid log(0), the abs(array) is cast to float64 and a small value

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -165,7 +165,7 @@ def waterfall(
     scale: float | Sequence[float] | None = None,
     scale_type: Literal["relative", "absolute"] = "relative",
     interpolation: str | None = "antialiased",
-    interpolation_stage: str | None = "auto",
+    interpolation_stage: str = "auto",
     log: bool = False,
     cbar: bool = True,
     show: bool = False,
@@ -203,7 +203,7 @@ def waterfall(
         If 'data', interpolation is carried out on the data provided by the user.
         If 'rgba', the interpolation is carried out after the colormapping has
         been applied (visual interpolation).
-        'auto' selects a suitable interpolation stage automatically.
+        'auto' (default) selects a suitable interpolation stage automatically.
         See matplotlib's imshow documentation for more details.
     log
         If True, visualize the common logarithm of the absolute values of patch data.
@@ -292,10 +292,6 @@ def waterfall(
             aspect="auto",
             cmap=cmap,
             origin="lower",
-            # Note: these parameters are so that matplotlib versions > 3.10 behave
-            # like matplotlib < 3.9, which tends to work better for visualizing big
-            # DAS data. See #512. We might consider making these parameters of the
-            # waterfall function in the future.
             interpolation=interpolation,
             interpolation_stage=interpolation_stage,
         )

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -165,6 +165,7 @@ def waterfall(
     scale: float | Sequence[float] | None = None,
     scale_type: Literal["relative", "absolute"] = "relative",
     interpolation: str | None = "antialiased",
+    interpolation_stage: str | None = "auto",
     log: bool = False,
     cbar: bool = True,
     show: bool = False,
@@ -198,6 +199,11 @@ def waterfall(
         which is relevant for DAS. Usually, "antialiased" works well, but if the
         data look smeared disabling interpolation with None might help. Other
         options are available, see matplotlib's documentation for more details.
+    interpolation_stage
+        If 'data', interpolation is carried out on the data provided by the user.
+        If 'rgba', the interpolation is carried out after the colormapping has
+        been applied (visual interpolation). See matplotlib's imshow
+        documentation for more details.
     log
         If True, visualize the common logarithm of the absolute values of patch data.
         To avoid log(0), the abs(array) is cast to float64 and a small value
@@ -290,7 +296,7 @@ def waterfall(
             # DAS data. See #512. We might consider making these parameters of the
             # waterfall function in the future.
             interpolation=interpolation,
-            interpolation_stage="data",
+            interpolation_stage=interpolation_stage,
         )
     if scale is not None and len(scale) == 2 and np.all(np.isfinite(scale)):
         im.set_clim(np.asarray(scale))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ keywords = ["geophysics", "distributed-acoustic-sensing"]
 
 dependencies = [
      "h5py",
-     "matplotlib>=3.8",
+     "matplotlib>=3.10",
      "numpy>=1.24",
      "packaging",
      "pandas>=2.0",


### PR DESCRIPTION
## Description
Long time-windows with high sampling rate and low dynamic range have a tendiecy to show up as white panels when plotting with viz.waterfall()
As noted in the source:
```
            # Note: these parameters are so that matplotlib versions > 3.10 behave
            # like matplotlib < 3.9, which tends to work better for visualizing big
            # DAS data. See #512. We might consider making these parameters of the
            # waterfall function in the future.
```

The solution seems to be to set `interpolation_stage='auto'`, as the matplotlib documentation states:

```
interpolation_stage{'auto', 'data', 'rgba'}, default: 'auto'
Supported values:

'data': Interpolation is carried out on the data provided by the user This is useful if interpolating between pixels during upsampling.

'rgba': The interpolation is carried out in RGBA-space after the color-mapping has been applied. This is useful if downsampling and combining pixels visually.

'auto': Select a suitable interpolation stage automatically. This uses 'rgba' when downsampling, or upsampling at a rate less than 3, and 'data' when upsampling at a higher rate.
```
Option "auto" is new in version 3.10

This PR adds the option for the user to set the value, while defaulting to "auto"




## Checklist

I have (if applicable):

- [X] referenced the GitHub issue this PR closes.
- [X] documented the new feature with docstrings and/or appropriate doc page.
- [] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waterfall visualization adds a new interpolation-stage option to control when interpolation happens relative to color mapping (choices: auto, data, rgba) for finer rendering control.
* **Chores**
  * Minimum required matplotlib version raised to ensure compatibility with the new rendering option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->