### PR TITLE
add scratch dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ docs/index.quarto_ipynb
 .codex.bak
 CLAUDE.md
 worktrees/
+.scratch
 
 # profile stuff
 prof/


### PR DESCRIPTION
## Description
This simple PR adds a .scratch directory to the gitignore. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
