### PR TITLE
Local agents

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -2,6 +2,8 @@
 
 This file gives AI/code agents a practical checklist for contributing safely to DASCore.
 
+## User local specific instructions
+Also load .agents/agents.local.md if present.
 
 ## Scope and priorities
 

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ docs/index.quarto_ipynb
 CLAUDE.md
 worktrees/
 .scratch
+.agents/agents.local.md
 
 # profile stuff
 prof/


### PR DESCRIPTION
## Description
Users can have a variety of setups and permissions on the machine they are working on. Also available tools may differ from user to user.

This PR adds the option to add a user-specific `.agents/agents.local.md` file to the instructions. 
This file is not committed to git, but kept available for local development

Basically simply this instruction is added to agents.md:

```
## User local specific instructions
Also load .agents/agents.local.md if present.
```


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation and configuration files to support local-specific agent instructions and improved repository maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->