### PR TITLE
fix doc deploy

### DIFF
--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -70,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
  ## Summary

  - Update the stable docs workflow from `actions/deploy-pages@v4` to `actions/
  deploy-pages@v5`.

  ## Motivation

  The latest stable docs release workflow built the docs successfully, but the
  GitHub Pages deployment failed while creating the Pages deployment:

  ```text
  Failed to create deployment (status: 500) with build version
  5df73075cc7eaf8283dd73e26b6f3d75729c3f9e

  Rerunning the failed deploy job produced the same failure. The job also warned
  that actions/deploy-pages@v4 targets Node 20 and is being forced onto Node 24.
  actions/deploy-pages@v5 is the Node 24-compatible release.
```

This PR will hopefully fix it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation tooling to use the latest version of the GitHub Pages deployment action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->