### PR TITLE
fix manual doc relase

### DIFF
--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -39,6 +39,7 @@ jobs:
             echo "::error::No release tag matching v[0-9]* exists."
             exit 1
           fi
+          git checkout --detach "$tag"
           echo "DASCORE_DOC_VERSION=${tag#v}" >> "$GITHUB_ENV"
 
       - uses: ./.github/actions/load-shared-vars

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -34,13 +34,22 @@ jobs:
       - name: Set manual stable docs version
         if: github.event_name == 'workflow_dispatch'
         run: |
+          # Manually set DASCore version based on last tag. 
           tag="$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)"
           if [ -z "$tag" ]; then
             echo "::error::No release tag matching v[0-9]* exists."
             exit 1
           fi
-          git checkout --detach "$tag"
           echo "DASCORE_DOC_VERSION=${tag#v}" >> "$GITHUB_ENV"
+
+          # Keep workflow actions and docs build scripts from this checkout,
+          # but build/import DASCore package code exactly as the release tag.
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ] && [ "${GITHUB_REF_NAME:-}" = "$tag" ]; then
+            echo "Already running from latest release tag $tag; leaving dascore/ unchanged."
+          else
+            git restore --source "$tag" -- dascore
+          fi
+
 
       - uses: ./.github/actions/load-shared-vars
 
@@ -51,10 +60,8 @@ jobs:
           environment-file: './.github/doc_environment.yml'
           prepare-test-data: "true"
 
-      - uses: ./.github/actions/build-docs
 
-      #      - name: Setup Pages
-      #        uses: actions/configure-pages@v5
+      - uses: ./.github/actions/build-docs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -31,6 +31,16 @@ jobs:
           fetch-tags: "true"
           fetch-depth: '0'
 
+      - name: Set manual stable docs version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          tag="$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)"
+          if [ -z "$tag" ]; then
+            echo "::error::No release tag matching v[0-9]* exists."
+            exit 1
+          fi
+          echo "DASCORE_DOC_VERSION=${tag#v}" >> "$GITHUB_ENV"
+
       - uses: ./.github/actions/load-shared-vars
 
       - uses: ./.github/actions/mamba-install-dascore

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -113,11 +113,12 @@ def _reduce_time_like(func, data):
     # Some reducers cannot operate directly on time-like dtypes. If direct
     # reduction fails, or returns only nulls despite valid input, fall back to
     # reducing offsets from a valid reference value.
-    with suppress(TypeError, ValueError, OverflowError):
-        out = np.atleast_1d(func(data))
-        # Return direct reductions that produce at least one non-null value.
-        if not np.all(pd.isnull(out)):
-            return out
+    if func not in {np.mean, np.nanmean}:
+        with suppress(TypeError, ValueError, OverflowError):
+            out = np.atleast_1d(func(data))
+            # Return direct reductions that produce at least one non-null value.
+            if not np.all(pd.isnull(out)):
+                return out
 
     ref = valid[0]
     # Reducers like std over absolute times are not semantically time points,

--- a/dascore/utils/coordmanager.py
+++ b/dascore/utils/coordmanager.py
@@ -95,8 +95,9 @@ def merge_coord_managers(
             tolerance = snap_tolerance * c_coord.step
             assumed_start = c_coord.max() + c_coord.step
             diff = np.abs(assumed_start - n_coord.min())
+            zero = np.asarray([0], dtype=np.asarray(diff).dtype)[0]
             # snap is close enough, update coord.
-            if diff > 0 and diff <= tolerance:
+            if diff > zero and diff <= tolerance:
                 coord_list[ind] = n_coord.update_limits(min=assumed_start)
             # snap is too far off, bail out.
             elif diff > tolerance:

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -218,19 +218,16 @@ def _array_to_timedelta64(array: np.ndarray) -> np.datetime64:
         return np.array(int_array).astype("timedelta64[ns]")
 
     assert np.isreal(array[0])
-    nans = pd.isnull(array)
+    invalid = pd.isnull(array) | ~np.isfinite(array)
     # Need to make copy to 1) not change original array and 2) handle
     # immutable arrays. See #575.
-    if np.any(nans):
+    if np.any(invalid):
         array = np.array(array)
-        array[nans] = 0
+        array[invalid] = 0
     # inf/NaN complain, salience these types of warnings for this block.
     with np.errstate(divide="ignore", invalid="ignore"):
-        nans = nans | ~np.isfinite(array)
-        array = np.array(array)
-        array[nans] = 0
         out = _float_array_to_ns(array).astype("timedelta64[ns]")
-        out[nans] = _NAT_TIMEDELTA64
+        out[invalid] = _NAT_TIMEDELTA64
     return out
 
 

--- a/scripts/_qmd_builder.py
+++ b/scripts/_qmd_builder.py
@@ -74,20 +74,24 @@ def build_amp_toc_tree(api_path=API_PATH):
     return out
 
 
-def create_quarto_qmd():
-    """Create the _quarto.yml file."""
-
-    def _get_nice_version_string():
-        """Just get a simplified version string."""
+def _get_dascore_title():
+    """Get the DASCore title with the docs version."""
+    doc_version = os.environ.get("DASCORE_DOC_VERSION")
+    if doc_version is not None:
+        vstr = doc_version
+    else:
         version_str = str(dc.__version__)
         if "dev" not in version_str:
             vstr = version_str
         else:
             vstr = version_str.split("+")[0]
-        return f"DASCore ({vstr})"
+    return f"DASCore ({vstr})"
 
+
+def create_quarto_qmd():
+    """Create the _quarto.yml file."""
     temp = get_template("_quarto.yml")
-    version_str = _get_nice_version_string()
+    version_str = _get_dascore_title()
     api_toc_tree = build_amp_toc_tree()
     out = temp.render(dascore_version_str=version_str, api_toc_tree=api_toc_tree)
     path = Path(__file__).parent.parent / "docs" / "_quarto.yml"

--- a/scripts/test_qmd_builder.py
+++ b/scripts/test_qmd_builder.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("jinja2")
-
-import _qmd_builder
+_qmd_builder = pytest.importorskip("_qmd_builder")
 
 
 class TestGetDascoreTitle:

--- a/scripts/test_qmd_builder.py
+++ b/scripts/test_qmd_builder.py
@@ -1,0 +1,34 @@
+"""Tests for building Quarto config values."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("jinja2")
+
+import _qmd_builder
+
+
+class TestGetDascoreTitle:
+    """Tests for DASCore title version formatting."""
+
+    def test_release_version(self, monkeypatch):
+        """Release versions are shown as-is."""
+        monkeypatch.delenv("DASCORE_DOC_VERSION", raising=False)
+        monkeypatch.setattr(_qmd_builder.dc, "__version__", "0.1.16")
+
+        assert _qmd_builder._get_dascore_title() == "DASCore (0.1.16)"
+
+    def test_dev_version(self, monkeypatch):
+        """Dev versions strip local version metadata."""
+        monkeypatch.delenv("DASCORE_DOC_VERSION", raising=False)
+        monkeypatch.setattr(_qmd_builder.dc, "__version__", "0.1.16.dev19+gabc123")
+
+        assert _qmd_builder._get_dascore_title() == "DASCore (0.1.16.dev19)"
+
+    def test_doc_version_override(self, monkeypatch):
+        """The docs version override controls the rendered site title."""
+        monkeypatch.setenv("DASCORE_DOC_VERSION", "0.1.16")
+        monkeypatch.setattr(_qmd_builder.dc, "__version__", "0.1.16.dev19+gabc123")
+
+        assert _qmd_builder._get_dascore_title() == "DASCore (0.1.16)"

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -959,6 +959,19 @@ class TestApproxEqual:
         assert out.approx_equal(coord)
 
 
+class TestReduceCoord:
+    """Tests for reducing coordinates."""
+
+    def test_mean_large_timedelta_doesnt_overflow(self):
+        """Mean reduction of large timedeltas should not overflow."""
+        value = np.timedelta64(np.iinfo(np.int64).max, "ns")
+        coord = get_coord(data=np.array([value, value]))
+
+        out = coord.reduce_coord("mean")
+
+        assert out.values[0] == value
+
+
 class TestCoordRange:
     """Tests for coords from array."""
 

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -373,6 +373,14 @@ class TestToTimeDelta64:
         assert pd.isnull(out[0])
         assert out[1] == np.timedelta64(1, "s")
 
+    def test_non_finite_values_are_nat(self):
+        """Infinite and NaN values should not overflow during conversion."""
+        out = to_timedelta64([np.inf, -np.inf, np.nan, 1.0])
+
+        assert out.dtype == np.dtype("timedelta64[ns]")
+        assert np.all(pd.isnull(out[:3]))
+        assert out[3] == np.timedelta64(1, "s")
+
     def test_array_of_datetimes(self, random_patch):
         """Ensure datetime64 array can be converted to timedelta array."""
         dt_array = random_patch.get_coord("time").values

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -359,6 +359,20 @@ class TestToTimeDelta64:
         out = to_timedelta64(ar)
         assert np.all(pd.isnull(out))
 
+    @pytest.mark.filterwarnings(
+        "error:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning"
+    )
+    def test_null_values_use_explicit_timedelta_unit(self):
+        """Null-like values should not create generic-unit timedeltas."""
+        assert pd.isnull(to_timedelta64(None))
+        assert pd.isnull(to_timedelta64("NaT"))
+
+        out = to_timedelta64([None, 1.0])
+
+        assert out.dtype == np.dtype("timedelta64[ns]")
+        assert pd.isnull(out[0])
+        assert out[1] == np.timedelta64(1, "s")
+
     def test_array_of_datetimes(self, random_patch):
         """Ensure datetime64 array can be converted to timedelta array."""
         dt_array = random_patch.get_coord("time").values


### PR DESCRIPTION
  ## Summary

  Fix manual stable-docs builds so the Quarto site title shows the latest released DASCore version instead of a dev version when the workflow is manually triggered from a non-tag branch.

  ## Changes

  - Added a `workflow_dispatch`-only step in `BuildDeployStableDocs` that finds the latest `v*` release tag and exports it as `DASCORE_DOC_VERSION`.
  - Updated Quarto config generation to prefer `DASCORE_DOC_VERSION` when present, while preserving existing package-version behavior otherwise.
  - Added focused tests for release, dev, and env-override title generation.

  ## Motivation

  When `BuildDeployStableDocs` is triggered manually from a branch such as `master`, editable package versioning can produce a dev version like `0.1.16.dev19`. For stable docs, we only need the Quarto page title to show
  the latest released version, e.g. `DASCore (0.1.16)`.

  This keeps release-triggered stable docs and dev-doc behavior unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved manual documentation builds to automatically select the latest stable documentation version from matching Git tags, failing if none are found.
  * Standardized the generated documentation title/version, with an environment-variable override to control the displayed version.

* **Bug Fixes**
  * Fixed mean reduction for large datetime/timedelta values to avoid overflow and ensure accurate results.
  * Improved tolerance-based coordinate snapping to use dtype-consistent “zero” comparisons.

* **Tests**
  * Added regression coverage for mean reduction with large timedeltas and for documentation title/version formatting and overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->