### PR TITLE
fix numpy 2.5 and overflow issue

### DIFF
--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -295,7 +295,7 @@ class PatchAttrs(DascoreBaseModel):
             if step is None:
                 is_time = isinstance(start, np.datetime64 | np.timedelta64)
                 if is_time:
-                    out[step_name] = np.timedelta64("NaT")
+                    out[step_name] = np.timedelta64("NaT", "ns")
                 elif isinstance(start, float | np.floating):
                     out[step_name] = np.nan
         return out

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -80,6 +80,32 @@ def ensure_consistent_dtype(value, name, dtype):
     return value
 
 
+def _reduce_time_like(func, data):
+    """Reduce datetime/timedelta data relative to a reference value."""
+    data = np.asarray(data)
+    valid = data[~pd.isnull(data)]
+    try:
+        out = np.atleast_1d(func(data))
+        if not (valid.size and np.all(pd.isnull(out))):
+            return out
+    except (TypeError, ValueError, OverflowError):
+        pass
+
+    if valid.size:
+        ref = valid[0]
+    else:
+        ref = (
+            np.datetime64("NaT", "ns")
+            if is_datetime64(data)
+            else np.timedelta64("NaT", "ns")
+        )
+    deltas = data - ref
+    # Reducers like std over absolute times are not semantically time points,
+    # but this preserves the previous dim_reduce behavior.
+    out = ref + dc.to_timedelta64(func(dc.to_float(deltas)))
+    return np.atleast_1d(out)
+
+
 def _get_dtype(value, dtype):
     """Get the data type based on the first argument."""
     if dtype is not None and dtype != "":
@@ -928,18 +954,6 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         ----------
         {dim_reduce}
         """
-
-        def _maybe_handle_datatypes(func, data):
-            """Maybe handle the complexity of date times here."""
-            try:  # First try function directly
-                out = func(data)
-            # Fall back to floats and re-packing.
-            except (TypeError, ValueError, np.core._exceptions.UFuncTypeError):
-                float_data = dc.to_float(data)
-                dfunc = dc.to_datetime64 if is_datetime64(data) else dc.to_timedelta64
-                out = dfunc(func(float_data))
-            return np.atleast_1d(out)
-
         if dim_reduce == "empty":
             # Preserve concrete single-sample coords; only synthesize a partial
             # coord when reduction actually collapses a longer coordinate.
@@ -952,7 +966,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             func = dim_reduce if callable(dim_reduce) else func
             coord_data = self.data
             if dtype_time_like(coord_data):
-                result = _maybe_handle_datatypes(func, coord_data)
+                result = _reduce_time_like(func, coord_data)
             else:
                 result = func(self.data)
             new_coord = self.update(data=result)
@@ -1136,7 +1150,8 @@ class CoordRange(BaseCoord):
                 # handle conversion to integer if other values are ints.
                 if isinstance(start, int) and isinstance(stop, int):
                     step = int(step) if np.isclose(np.round(step), step) else step
-        if step != 0:
+        zero = dc.to_timedelta64(0) if is_timedelta64(step) else 0
+        if step != zero:
             span = _maybe_unbox_scalar(np.round((stop - start) / step, 1))
             int_val = int(_maybe_unbox_scalar(np.ceil(span)))
             stop = start + step * int_val
@@ -1335,12 +1350,14 @@ class CoordRange(BaseCoord):
     @property
     def sorted(self) -> bool:
         """Returns true if sorted in ascending order."""
-        return self.step >= 0
+        zero = dc.to_timedelta64(0) if is_timedelta64(self.step) else 0
+        return self.step >= zero
 
     @property
     def reverse_sorted(self) -> bool:
         """Returns true if sorted in ascending order."""
-        return self.step < 0
+        zero = dc.to_timedelta64(0) if is_timedelta64(self.step) else 0
+        return self.step < zero
 
 
 class CoordArray(BaseCoord):
@@ -1430,7 +1447,8 @@ class CoordArray(BaseCoord):
                 step = np.timedelta64(int(np.round(_step)), "ns")
             else:
                 step = dur / (len(self) - 1)
-            assert step > 0
+            zero = dc.to_timedelta64(0) if is_timedelta64(step) else 0
+            assert step > zero
         if self.reverse_sorted:
             step = -step
             start, stop = max_v, min_v + step

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -87,6 +87,7 @@ def _is_translation_equivariant(func, data):
     valid = data[~pd.isnull(data)]
     if not len(valid):
         return True
+    valid = valid[:32]
     shift = 1.0
     with np.errstate(all="ignore"):
         try:

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Sized
+from contextlib import suppress
 from functools import cache
 from operator import gt, lt
 from typing import Any, TypeVar
@@ -80,29 +81,49 @@ def ensure_consistent_dtype(value, name, dtype):
     return value
 
 
+def _is_translation_equivariant(func, data):
+    """Return True if shifting inputs shifts the reduced output equally."""
+    # This is a bit heavy/magic, but needed for generic support.
+    valid = data[~pd.isnull(data)]
+    if not len(valid):
+        return True
+    shift = 1.0
+    with np.errstate(all="ignore"):
+        try:
+            base = np.asarray(func(valid))
+            shifted = np.asarray(func(valid + shift))
+        except Exception:
+            return True
+    expected = base + shift
+    try:
+        return bool(np.allclose(shifted, expected, equal_nan=True))
+    except TypeError:
+        return True
+
+
 def _reduce_time_like(func, data):
     """Reduce datetime/timedelta data relative to a reference value."""
     data = np.asarray(data)
     valid = data[~pd.isnull(data)]
-    try:
-        out = np.atleast_1d(func(data))
-        if not (valid.size and np.all(pd.isnull(out))):
-            return out
-    except (TypeError, ValueError, OverflowError):
-        pass
+    if not valid.size:
+        nfunc = np.datetime64 if is_datetime64(data) else np.timedelta64
+        return np.atleast_1d(nfunc("NaT", "ns"))
 
-    if valid.size:
-        ref = valid[0]
-    else:
-        ref = (
-            np.datetime64("NaT", "ns")
-            if is_datetime64(data)
-            else np.timedelta64("NaT", "ns")
-        )
-    deltas = data - ref
+    # Some reducers cannot operate directly on time-like dtypes. If direct
+    # reduction fails, or returns only nulls despite valid input, fall back to
+    # reducing offsets from a valid reference value.
+    with suppress(TypeError, ValueError, OverflowError):
+        out = np.atleast_1d(func(data))
+        # Return direct reductions that produce at least one non-null value.
+        if not np.all(pd.isnull(out)):
+            return out
+
+    ref = valid[0]
     # Reducers like std over absolute times are not semantically time points,
-    # but this preserves the previous dim_reduce behavior.
-    out = ref + dc.to_timedelta64(func(dc.to_float(deltas)))
+    # but this preserves the previous dim_reduce behavior for equivariant reducers.
+    delta_float = dc.to_float(data - ref)
+    reduced = dc.to_timedelta64(func(delta_float))
+    out = ref + reduced if _is_translation_equivariant(func, delta_float) else reduced
     return np.atleast_1d(out)
 
 

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -71,9 +71,9 @@ class PatchFileSummary(DascoreBaseModel):
     station: str = Field("", max_length=max_lens["station"])
     network: str = Field("", max_length=max_lens["network"])
     dims: CommaSeparatedStr = Field("", max_length=max_lens["dims"])
-    time_min: DateTime64 = np.datetime64("NaT")
-    time_max: DateTime64 = np.datetime64("NaT")
-    time_step: TimeDelta64 = np.timedelta64("NaT")
+    time_min: DateTime64 = np.datetime64("NaT", "ns")
+    time_max: DateTime64 = np.datetime64("NaT", "ns")
+    time_step: TimeDelta64 = np.timedelta64("NaT", "ns")
     # the attributes to index on
     file_version: str = ""
     file_format: str = ""

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -155,9 +155,9 @@ def _all_null(maybe_ar):
 def _get_nullish(dtype=np.floating):
     """Get nullish values for a given dtype."""
     if np.issubdtype(dtype, np.datetime64):
-        return np.datetime64("NaT")
+        return np.datetime64("NaT", "ns")
     elif np.issubdtype(dtype, np.timedelta64):
-        return np.timedelta64("NaT")
+        return np.timedelta64("NaT", "ns")
     return np.nan
 
 

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -17,6 +17,9 @@ from dascore.constants import (
 )
 from dascore.exceptions import TimeError
 
+_NAT_DATETIME64 = np.datetime64("NaT", "ns")
+_NAT_TIMEDELTA64 = np.timedelta64("NaT", "ns")
+
 
 @singledispatch
 def to_datetime64(obj: timeable_types | np.ndarray):
@@ -50,7 +53,7 @@ def to_datetime64(obj: timeable_types | np.ndarray):
     >>> dt_array = dc.to_datetime64(timestamp_array)
     """
     if pd.isnull(obj):
-        return np.datetime64("NaT")
+        return _NAT_DATETIME64
     msg = f"type {type(obj)} is not supported"
     raise NotImplementedError(msg)
 
@@ -93,7 +96,7 @@ def _array_to_datetime64(array: np.ndarray) -> np.datetime64 | np.ndarray:
         else:
             out = array.astype("datetime64[ns]")
     # dealing with numerical data
-    elif not np.issubdtype(array.dtype, np.datetime64) and np.isreal(array[0]):
+    elif np.issubdtype(array.dtype, np.timedelta64) or np.isreal(array[0]):
         with np.errstate(divide="ignore", invalid="ignore"):
             array = to_float(np.array(array))  # need to make copy to write
             array[nans] = 0  # temporary replace NaNs
@@ -105,7 +108,7 @@ def _array_to_datetime64(array: np.ndarray) -> np.datetime64 | np.ndarray:
             ns = (frac_sec * 1_000_000_000).astype(np.int64)
             out = (sign * (int_sec * 1_000_000_000 + ns)).astype("datetime64[ns]")
         # fill NaN Back in
-        out[nans] = np.datetime64("NaT")
+        out[nans] = _NAT_DATETIME64
     return out
 
 
@@ -135,7 +138,7 @@ def _datetime_to_datetime64(dt: datetime):
     # because pandas NaT has datetime in its MRO we need to check
     # if this is nullish and return NaT if so.
     if pd.isnull(dt):
-        return np.datetime64("NaT")
+        return _NAT_DATETIME64
     return to_datetime64(np.datetime64(dt))
 
 
@@ -175,7 +178,7 @@ def to_timedelta64(obj: float | np.ndarray | str | timedelta):
 
     """
     if pd.isnull(obj):
-        return np.timedelta64("NaT")
+        return _NAT_TIMEDELTA64
     msg = f"type {type(obj)} is not supported"
     raise NotImplementedError(msg)
 
@@ -231,7 +234,7 @@ def _array_to_timedelta64(array: np.ndarray) -> np.datetime64:
         frac_sec = abs_array % 1.0
         ns = (frac_sec * 1_000_000_000).astype(np.int64).astype("timedelta64[ns]")
         out = sign * (seconds + ns)
-        out[nans] = np.timedelta64("NaT")
+        out[nans] = _NAT_TIMEDELTA64
     return out
 
 
@@ -272,7 +275,7 @@ def _time_delta_from_str(time_delta_str: str):
             new_unit = NUMPY_TIME_UNIT_MAPPING[units]
             return np.timedelta64(int(val), new_unit)
         case [val] if val.lower() == "nat" or val.lower() == "":
-            return np.timedelta64("NaT")
+            return _NAT_TIMEDELTA64
         case _:
             msg = f"Could not convert {time_delta_str} to timedelta64"
             raise TimeError(msg)

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -21,6 +21,11 @@ _NAT_DATETIME64 = np.datetime64("NaT", "ns")
 _NAT_TIMEDELTA64 = np.timedelta64("NaT", "ns")
 
 
+def _float_array_to_ns(array):
+    """Convert seconds as floats to signed integer nanoseconds."""
+    return np.rint(array * 1_000_000_000).astype(np.int64)
+
+
 @singledispatch
 def to_datetime64(obj: timeable_types | np.ndarray):
     """
@@ -99,14 +104,9 @@ def _array_to_datetime64(array: np.ndarray) -> np.datetime64 | np.ndarray:
     elif np.issubdtype(array.dtype, np.timedelta64) or np.isreal(array[0]):
         with np.errstate(divide="ignore", invalid="ignore"):
             array = to_float(np.array(array))  # need to make copy to write
+            nans = nans | ~np.isfinite(array)
             array[nans] = 0  # temporary replace NaNs
-            abs_array = np.abs(array)
-            sign = np.sign(array)
-            # separate seconds and factions, assume ns precision
-            int_sec = abs_array.astype(np.int64)
-            frac_sec = abs_array % 1.0
-            ns = (frac_sec * 1_000_000_000).astype(np.int64)
-            out = (sign * (int_sec * 1_000_000_000 + ns)).astype("datetime64[ns]")
+            out = _float_array_to_ns(array).astype("datetime64[ns]")
         # fill NaN Back in
         out[nans] = _NAT_DATETIME64
     return out
@@ -226,14 +226,10 @@ def _array_to_timedelta64(array: np.ndarray) -> np.datetime64:
         array[nans] = 0
     # inf/NaN complain, salience these types of warnings for this block.
     with np.errstate(divide="ignore", invalid="ignore"):
-        # separate seconds and factions, convert fractions to ns precision,
-        # sub in array. Track sign and use abs to ensure sign comes out.
-        sign = np.sign(array)
-        abs_array = np.abs(array)
-        seconds = abs_array.astype(np.int64).astype("timedelta64[s]")
-        frac_sec = abs_array % 1.0
-        ns = (frac_sec * 1_000_000_000).astype(np.int64).astype("timedelta64[ns]")
-        out = sign * (seconds + ns)
+        nans = nans | ~np.isfinite(array)
+        array = np.array(array)
+        array[nans] = 0
+        out = _float_array_to_ns(array).astype("timedelta64[ns]")
         out[nans] = _NAT_TIMEDELTA64
     return out
 

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1618,7 +1618,7 @@ class TestPartialCoord:
         out = coord.reduce_coord(func)
 
         assert len(out) == 1
-        assert np.issubdtype(out.dtype, np.datetime64)
+        assert out.dtype == np.dtype("datetime64[ns]")
         assert pd.isnull(out.data[0])
         assert dtypes == []
 

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1603,6 +1603,25 @@ class TestPartialCoord:
         )
         assert isinstance(out, CoordRange)
 
+    def test_all_null_datetime_reduce_returns_nat(self):
+        """All-null time reductions return NaT before calling reducer."""
+        coord = get_coord(shape=(2,), dtype="datetime64[ns]")
+        dtypes = []
+
+        def func(data):
+            data = np.asarray(data)
+            dtypes.append(data.dtype)
+            if np.issubdtype(data.dtype, np.datetime64):
+                raise TypeError("datetime reduction unsupported")
+            return 1.0
+
+        out = coord.reduce_coord(func)
+
+        assert len(out) == 1
+        assert np.issubdtype(out.dtype, np.datetime64)
+        assert pd.isnull(out.data[0])
+        assert dtypes == []
+
 
 class TestCoercion:
     """Some data types should support coercion in selecting (eg dates)."""

--- a/tests/test_proc/test_aggregate.py
+++ b/tests/test_proc/test_aggregate.py
@@ -10,7 +10,7 @@ import pytest
 
 import dascore
 import dascore as dc
-from dascore.core.coords import _reduce_time_like
+from dascore.core.coords import _is_translation_equivariant, _reduce_time_like
 from dascore.exceptions import ParameterError
 from dascore.proc.aggregate import _AGG_FUNCS
 from dascore.utils.misc import broadcast_for_index
@@ -18,6 +18,28 @@ from dascore.utils.misc import broadcast_for_index
 
 class TestReduceTimeLike:
     """Tests for time-like coordinate reductions."""
+
+    def test_translation_equivariant_with_no_valid_data(self):
+        """Empty or all-null data cannot disprove translation equivariance."""
+        data = np.array([np.nan, np.nan])
+        assert _is_translation_equivariant(np.nanmean, data)
+
+    def test_translation_equivariant_when_reducer_raises(self):
+        """Reducers which cannot be checked are treated as equivariant."""
+
+        def reducer(_array):
+            raise ValueError
+
+        assert _is_translation_equivariant(reducer, np.array([1.0, 2.0]))
+
+    def test_translation_equivariant_when_comparison_raises(self, monkeypatch):
+        """Comparison failures default to treating reducers as equivariant."""
+
+        def raise_type_error(*_args, **_kwargs):
+            raise TypeError
+
+        monkeypatch.setattr(np, "allclose", raise_type_error)
+        assert _is_translation_equivariant(np.nanmean, np.array([1.0, 2.0]))
 
     def test_all_nat_datetime_reduction_returns_typed_nat(self):
         """All-null datetime reductions use the datetime NaT fallback."""
@@ -42,6 +64,18 @@ class TestReduceTimeLike:
             out = _reduce_time_like(reducer, data)
         assert out.dtype == np.dtype("timedelta64[ns]")
         assert np.isnat(out[0])
+
+    def test_timedelta_sum_fallback_does_not_add_reference(self):
+        """Non-equivariant timedelta reducers should not add the reference value."""
+
+        def reducer(array):
+            if np.issubdtype(np.asarray(array).dtype, np.timedelta64):
+                raise TypeError
+            return np.nansum(array)
+
+        data = np.array([np.timedelta64(10, "ns"), np.timedelta64(11, "ns")])
+        out = _reduce_time_like(reducer, data)
+        assert out == np.array([np.timedelta64(1, "ns")])
 
 
 class TestBasicAggregations:

--- a/tests/test_proc/test_aggregate.py
+++ b/tests/test_proc/test_aggregate.py
@@ -2,15 +2,46 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 import pytest
 
 import dascore
 import dascore as dc
+from dascore.core.coords import _reduce_time_like
 from dascore.exceptions import ParameterError
 from dascore.proc.aggregate import _AGG_FUNCS
 from dascore.utils.misc import broadcast_for_index
+
+
+class TestReduceTimeLike:
+    """Tests for time-like coordinate reductions."""
+
+    def test_all_nat_datetime_reduction_returns_typed_nat(self):
+        """All-null datetime reductions use the datetime NaT fallback."""
+        data = np.array([np.datetime64("NaT", "ns")] * 3)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            out = _reduce_time_like(np.nanmean, data)
+        assert out.dtype == np.dtype("datetime64[ns]")
+        assert np.isnat(out[0])
+
+    def test_all_nat_timedelta_reduction_returns_typed_nat(self):
+        """All-null timedelta reductions use the timedelta NaT fallback."""
+
+        def reducer(array):
+            if np.issubdtype(np.asarray(array).dtype, np.timedelta64):
+                raise TypeError
+            return np.nanmean(array)
+
+        data = np.array([np.timedelta64("NaT", "ns")] * 3)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            out = _reduce_time_like(reducer, data)
+        assert out.dtype == np.dtype("timedelta64[ns]")
+        assert np.isnat(out[0])
 
 
 class TestBasicAggregations:
@@ -70,6 +101,35 @@ class TestBasicAggregations:
         out = patch.aggregate(dim="time", method="mean", dim_reduce="mean")
         new_time = out.get_coord("time")
         assert len(new_time) == 1
+
+    def test_dim_reduce_mean_preserves_nanosecond_offsets(self):
+        """Time-like coord reductions preserve ns offsets far from epoch."""
+        start = np.datetime64("2020-01-01T00:00:00.123456789", "ns")
+        offsets = np.arange(5).astype("timedelta64[ns]")
+        time = start + offsets
+        patch = dc.Patch(data=np.ones(5), coords={"time": time}, dims=("time",))
+
+        out = patch.aggregate(dim="time", method="mean", dim_reduce="mean")
+
+        new_time = out.get_coord("time")
+        assert len(new_time) == 1
+        assert new_time.values[0] == start + np.timedelta64(2, "ns")
+
+    @pytest.mark.parametrize(
+        ("method", "expected"),
+        [("mean", np.timedelta64(2, "ns")), ("sum", np.timedelta64(8, "ns"))],
+    )
+    def test_dim_reduce_timedelta_nat_skips_nulls(self, method, expected):
+        """Timedelta coord reductions skip NaT like numeric nan reducers."""
+        time = np.arange(5).astype("timedelta64[ns]")
+        time[2] = np.timedelta64("NaT", "ns")
+        patch = dc.Patch(data=np.ones(5), coords={"time": time}, dims=("time",))
+
+        out = patch.aggregate(dim="time", method="mean", dim_reduce=method)
+
+        new_time = out.get_coord("time")
+        assert len(new_time) == 1
+        assert new_time.values[0] == expected
 
     def test_invalid_dim_reduce(self, random_patch):
         """Ensure an invalid dim_reduce argument raises."""

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -224,7 +225,7 @@ class TestToTimeDelta64:
     def test_float_array(self):
         """Ensure an array of flaots can be converted to ns timedelta."""
         ar = [1.0, 0.000000001, 0.001]
-        expected = np.array([1 * 10**9, 1, 1 * 10**6], "timedelta64")
+        expected = np.array([1 * 10**9, 1, 1 * 10**6], "timedelta64[ns]")
         out = to_timedelta64(ar)
         assert np.all(out == expected)
 
@@ -307,7 +308,11 @@ class TestToTimeDelta64:
         arr = pd.array(["1s", "2s", None], dtype="string")
         out = to_timedelta64(arr)
         expected = np.array(
-            [np.timedelta64(1, "s"), np.timedelta64(2, "s"), np.timedelta64("NaT")]
+            [
+                np.timedelta64(1, "s"),
+                np.timedelta64(2, "s"),
+                np.timedelta64("NaT", "ns"),
+            ]
         ).astype("timedelta64[ns]")
         assert np.all(out[:2] == expected[:2])
         assert pd.isnull(out[2])
@@ -331,6 +336,14 @@ class TestToTimeDelta64:
         out2 = to_timedelta64("nat")
         assert pd.isnull(out1)
         assert pd.isnull(out2)
+
+    def test_none_nat_no_warnings(self):
+        """None should return a typed NaT without warnings."""
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            out = to_timedelta64(None)
+        assert pd.isnull(out)
+        assert not record
 
     def test_nat_array(self):
         """Ensure an array of NaT works."""

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -43,6 +43,13 @@ class TestToDateTime64:
         out = to_datetime64(float_array)
         assert np.all(input_datetime64 == out)
 
+    def test_float_array_preserves_ns_offsets(self):
+        """Float datetimes should preserve representable nanosecond offsets."""
+        expected = np.array(["2026-06-03T15:18:13.422442752"], dtype="datetime64[ns]")
+        float_array = expected.astype(np.float64) / 1_000_000_000
+        out = to_datetime64(float_array)
+        assert np.all(expected == out)
+
     def test_single_float(self):
         """Ensure a single float can be converted to datetime."""
         out = to_datetime64(1.0)

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -351,6 +351,7 @@ class TestToTimeDelta64:
             out = to_timedelta64(None)
         assert pd.isnull(out)
         assert not record
+        assert out.dtype == np.dtype("timedelta64[ns]")
 
     def test_nat_array(self):
         """Ensure an array of NaT works."""


### PR DESCRIPTION
## Description

  Fixes NumPy 2.5 / Python 3.14 failures in the min-deps CI around generic
  `datetime64` / `timedelta64` units and timedelta coordinate reductions.

  This PR:
  - uses explicit `ns` units when constructing `NaT` datetime/timedelta values
  - avoids comparing `timedelta64` values against bare Python integers
  - updates time-like coordinate reductions to reduce relative deltas from a
  valid reference value, preserving nanosecond precision far from epoch
  - handles `NaT` in timedelta reductions consistently with numeric `nan*`
  reducers
  - adds regression coverage for the original CI failures, nanosecond precision,
  `NaT`-skipping reductions, and typed all-`NaT` fallback behavior


  ## Checklist

  I have (if applicable):

  - [ ] referenced the GitHub issue this PR closes.
  - [ ] documented the new feature with docstrings and/or appropriate doc page.
  - [x] included tests. See [testing guidelines](https://dascore.org/
  contributing/testing.html).
  - [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized missing time values so both datetime and timedelta nulls consistently use nanosecond-resolution `NaT` representations.
  * Improved reduction of time-like coordinates (including all-null cases) to preserve correct `datetime64[ns]`/`timedelta64[ns]` results.
  * Updated timedelta-related step/sorting/snap “zero” handling to use typed zero comparisons for more reliable behavior.

* **Tests**
  * Added/expanded test coverage for time-like reductions and null handling, and updated time conversion expectations to match `*64[ns]` typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->