### PR TITLE
  Fix descending coordinate value-bound selection

### DIFF
--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -592,7 +592,7 @@ def sanitize_range_param(select) -> tuple:
     return select
 
 
-def _order_range_tuple(range_tuple):
+def order_range_tuple(range_tuple):
     """Ensure finite range bounds are in increasing order."""
     val_min, val_max = range_tuple
     if val_min is not None and val_max is not None and val_max < val_min:

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -592,6 +592,14 @@ def sanitize_range_param(select) -> tuple:
     return select
 
 
+def _order_range_tuple(range_tuple):
+    """Ensure finite range bounds are in increasing order."""
+    val_min, val_max = range_tuple
+    if val_min is not None and val_max is not None and val_max < val_min:
+        return val_max, val_min
+    return val_min, val_max
+
+
 def check_filter_sequence(filt_range):
     """Ensure the filter sequence is the right shape."""
     # strip out units if used.

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -271,6 +271,8 @@ def adjust_segments(df, ignore_bad_kwargs=False, **kwargs):
     not_modified = ~_column_or_value(out, "_modified", False)
     # find slice kwargs, get series corresponding to interval columns
     for name, (val_min, val_max) in yield_range_tuple_from_kwargs(out, kwargs):
+        if val_min is not None and val_max is not None and val_max < val_min:
+            val_min, val_max = val_max, val_min
         start, stop, step = get_interval_columns(out, name)
         min_val = val_min if val_min is not None else start.min()
         max_val = val_max if val_max is not None else stop.max()

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -16,7 +16,7 @@ import dascore as dc
 from dascore.constants import PatchType
 from dascore.core.attrs import PatchAttrs
 from dascore.exceptions import ParameterError
-from dascore.utils.misc import sanitize_range_param
+from dascore.utils.misc import _order_range_tuple, sanitize_range_param
 from dascore.utils.time import to_datetime64, to_timedelta64
 
 
@@ -168,14 +168,6 @@ def _filter_multicolumn_range(query_dict, df, bool_index):
         bool_index = np.logical_and(bool_index, not_null)
 
     return bool_index
-
-
-def _order_range_tuple(range_tuple):
-    """Ensure finite range bounds are in increasing order."""
-    val_min, val_max = range_tuple
-    if val_min is not None and val_max is not None and val_max < val_min:
-        return val_max, val_min
-    return val_min, val_max
 
 
 def _convert_times(df, some_dict):

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -16,7 +16,7 @@ import dascore as dc
 from dascore.constants import PatchType
 from dascore.core.attrs import PatchAttrs
 from dascore.exceptions import ParameterError
-from dascore.utils.misc import _order_range_tuple, sanitize_range_param
+from dascore.utils.misc import order_range_tuple, sanitize_range_param
 from dascore.utils.time import to_datetime64, to_timedelta64
 
 
@@ -271,7 +271,7 @@ def adjust_segments(df, ignore_bad_kwargs=False, **kwargs):
     not_modified = ~_column_or_value(out, "_modified", False)
     # find slice kwargs, get series corresponding to interval columns
     for name, range_tuple in yield_range_tuple_from_kwargs(out, kwargs):
-        val_min, val_max = _order_range_tuple(range_tuple)
+        val_min, val_max = order_range_tuple(range_tuple)
         start, stop, _ = get_interval_columns(out, name)
         min_val = val_min if val_min is not None else start.min()
         max_val = val_max if val_max is not None else stop.max()
@@ -312,7 +312,7 @@ def filter_df(df: pd.DataFrame, ignore_bad_kwargs=False, **kwargs) -> np.ndarray
     kwargs, range_query, _ = split_df_query(kwargs, df, ignore_bad_kwargs)
     multicolumn_range_query = _convert_times(df, range_query)
     multicolumn_range_query = {
-        key: _order_range_tuple(val) for key, val in multicolumn_range_query.items()
+        key: order_range_tuple(val) for key, val in multicolumn_range_query.items()
     }
     equality_query, collection_query = _get_flat_and_collection_queries(kwargs)
     # get a blank index of True for filters

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -170,6 +170,14 @@ def _filter_multicolumn_range(query_dict, df, bool_index):
     return bool_index
 
 
+def _order_range_tuple(range_tuple):
+    """Ensure finite range bounds are in increasing order."""
+    val_min, val_max = range_tuple
+    if val_min is not None and val_max is not None and val_max < val_min:
+        return val_max, val_min
+    return val_min, val_max
+
+
 def _convert_times(df, some_dict):
     """Convert query values to datetime/timedelta values."""
     if not some_dict:
@@ -270,10 +278,9 @@ def adjust_segments(df, ignore_bad_kwargs=False, **kwargs):
     # Track which rows have been modified
     not_modified = ~_column_or_value(out, "_modified", False)
     # find slice kwargs, get series corresponding to interval columns
-    for name, (val_min, val_max) in yield_range_tuple_from_kwargs(out, kwargs):
-        if val_min is not None and val_max is not None and val_max < val_min:
-            val_min, val_max = val_max, val_min
-        start, stop, step = get_interval_columns(out, name)
+    for name, range_tuple in yield_range_tuple_from_kwargs(out, kwargs):
+        val_min, val_max = _order_range_tuple(range_tuple)
+        start, stop, _ = get_interval_columns(out, name)
         min_val = val_min if val_min is not None else start.min()
         max_val = val_max if val_max is not None else stop.max()
         too_small = start < min_val
@@ -312,6 +319,9 @@ def filter_df(df: pd.DataFrame, ignore_bad_kwargs=False, **kwargs) -> np.ndarray
     min_max_query = _convert_times(df, _get_min_max_query(kwargs, df))
     kwargs, range_query, _ = split_df_query(kwargs, df, ignore_bad_kwargs)
     multicolumn_range_query = _convert_times(df, range_query)
+    multicolumn_range_query = {
+        key: _order_range_tuple(val) for key, val in multicolumn_range_query.items()
+    }
     equality_query, collection_query = _get_flat_and_collection_queries(kwargs)
     # get a blank index of True for filters
     bool_index = np.ones(len(df), dtype=bool)

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1271,6 +1271,30 @@ class TestMonotonicCoord:
         assert new[0] <= val1
         assert new[-1] >= val2
 
+    def test_reverse_monotonic_value_bounds_are_order_independent(self):
+        """Finite bounds should be treated as a value interval."""
+        ar = np.cumsum(np.abs(random_state.rand(100)))[::-1]
+        coord = get_coord(data=ar)
+        eps = 0.000000001
+        low, high = ar[60] + eps, ar[50] - eps
+        expected = coord.values[(coord.values >= low) & (coord.values <= high)]
+        low_first, low_first_slice = coord.select((low, high))
+        high_first, high_first_slice = coord.select((high, low))
+        assert np.allclose(low_first.values, expected)
+        assert np.allclose(high_first.values, expected)
+        assert low_first_slice == high_first_slice
+        assert low_first.min() >= low
+        assert low_first.max() <= high
+
+    def test_reverse_range_value_bounds_are_order_independent(self):
+        """Evenly sampled descending coords should honor value bounds."""
+        coord = get_coord(data=np.arange(10, 0, -1), units="Hz")
+        low_first, low_slice = coord.select((3.1, 6.9))
+        high_first, high_slice = coord.select((6.9, 3.1))
+        assert np.all(low_first.values == np.array([6, 5, 4]))
+        assert np.all(high_first.values == low_first.values)
+        assert high_slice == low_slice
+
     def test_index_with_string(self, monotonic_datetime_coord):
         """Ensure indexing works with date string."""
         coord = monotonic_datetime_coord

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -245,6 +245,26 @@ class TestInit:
         assert time_shape == len(patch.coords.get_array("time"))
         assert time_shape == len(patch.coords.get_array("time"))
 
+    def test_select_descending_frequency_value_bounds(self):
+        """Value selection should not depend on descending coord order."""
+        frequency = np.cumsum(np.abs(random_state.rand(100)))[::-1]
+        coord = dc.get_coord(data=frequency, units="Hz")
+        patch = dc.Patch(
+            data=np.arange(len(frequency)),
+            coords={"frequency": coord},
+            dims=("frequency",),
+        )
+        eps = 0.000000001
+        low, high = frequency[60] + eps, frequency[50] - eps
+        low_first = patch.select(frequency=(low, high))
+        high_first = patch.select(frequency=(high, low))
+        expected = frequency[(frequency >= low) & (frequency <= high)]
+        out_freq = low_first.get_coord("frequency")
+        assert np.allclose(out_freq.values, expected)
+        assert np.allclose(high_first.get_coord("frequency").values, expected)
+        assert out_freq.min() >= low
+        assert out_freq.max() <= high
+
     def test_init_no_coords(self, random_patch):
         """Ensure a new patch can be inited from only attrs."""
         attrs = random_patch.attrs

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -258,10 +258,14 @@ class TestInit:
         low, high = frequency[60] + eps, frequency[50] - eps
         low_first = patch.select(frequency=(low, high))
         high_first = patch.select(frequency=(high, low))
-        expected = frequency[(frequency >= low) & (frequency <= high)]
+        mask = (frequency >= low) & (frequency <= high)
+        expected = frequency[mask]
+        expected_data = patch.data[mask]
         out_freq = low_first.get_coord("frequency")
         assert np.allclose(out_freq.values, expected)
         assert np.allclose(high_first.get_coord("frequency").values, expected)
+        assert np.array_equal(low_first.data, expected_data)
+        assert np.array_equal(high_first.data, expected_data)
         assert out_freq.min() >= low
         assert out_freq.max() <= high
 

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -327,7 +327,7 @@ class TestSelect:
         time_min = to_datetime64(contents["time_min"].min() + to_timedelta64(4))
         time_max = to_datetime64(contents["time_max"].max() - to_timedelta64(4))
         distance_min = contents["distance_min"].min() + 50
-        distance_max = contents["distance_min"].max() - 50
+        distance_max = contents["distance_max"].max() - 50
         new_spool = spool.select(
             time=(time_min, time_max), distance=(distance_min, distance_max)
         )

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -283,6 +283,21 @@ class TestAdjustSegments:
         assert (out["distance_min"] >= distance[0]).all()
         assert (out["distance_max"] <= distance[1]).all()
 
+    def test_reversed_bounds_keep_adjusted_limits_ordered(self):
+        """Reversed finite bounds should trim metadata by value interval."""
+        df = pd.DataFrame(
+            {
+                "frequency_min": [100.0],
+                "frequency_max": [200.0],
+                "frequency_step": [-1.0],
+            }
+        )
+        out = adjust_segments(df, frequency=(130.0, 120.0))
+        row = out.iloc[0]
+        assert row["frequency_min"] == 120.0
+        assert row["frequency_max"] == 130.0
+        assert row["_modified"]
+
     def test_missing_interval_col_raises_keyerro(self, adjacent_df):
         """Ensure if an interval column is missing a KeyError is raised."""
         df = adjacent_df.drop(columns=["distance_min"])

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -298,6 +298,22 @@ class TestAdjustSegments:
         assert row["frequency_max"] == 130.0
         assert row["_modified"]
 
+    def test_reversed_bounds_keep_contained_segments(self):
+        """Reversed finite bounds should filter by the ordered value interval."""
+        df = pd.DataFrame(
+            {
+                "frequency_min": [121.0],
+                "frequency_max": [125.0],
+                "frequency_step": [-1.0],
+            }
+        )
+        out = adjust_segments(df, frequency=(130.0, 120.0))
+        assert len(out) == 1
+        row = out.iloc[0]
+        assert row["frequency_min"] == 121.0
+        assert row["frequency_max"] == 125.0
+        assert not row["_modified"]
+
     def test_missing_interval_col_raises_keyerro(self, adjacent_df):
         """Ensure if an interval column is missing a KeyError is raised."""
         df = adjacent_df.drop(columns=["distance_min"])


### PR DESCRIPTION

## Description

Fixes #718.
Value-based selections on descending monotonic coordinates should be interpreted by coordinate value, not storage order. This PR adds regressions for descending coordinate and patch selections, and normalizes reversed finite bounds when trimming dataframe-backed segment metadata so adjusted `*_min`/`*_max` values remain ordered.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection behavior for descending or reverse-ordered coordinate ranges (including frequency).
  * Reversed `(low, high)` bounds are now handled consistently, producing the same selected values/data regardless of argument order.
  * Range trimming now preserves correctly ordered bounds and clamps within the intended inclusive interval.
  * Corrected a test range calculation for multi-range spool selection.
* **Tests**
  * Added unit tests covering order-independent value-bounds selection and segment adjustment for descending frequency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->