### PR TITLE
Forward specplot kwargs to waterfall

### DIFF
--- a/dascore/viz/specplot.py
+++ b/dascore/viz/specplot.py
@@ -104,6 +104,7 @@ def specplot(
         log=False,
         cbar=cbar,
         show=False,
+        **kwargs,
     )
 
     # Format axis labels.

--- a/tests/test_viz/test_specplot.py
+++ b/tests/test_viz/test_specplot.py
@@ -31,6 +31,15 @@ def test_specplot_uses_existing_axes(random_patch):
     assert out is ax
 
 
+def test_specplot_forwards_waterfall_kwargs(random_patch):
+    """Specplot forwards extra keyword arguments to waterfall."""
+    patch = random_patch.dft("time").abs()
+
+    ax = patch.viz.specplot(interpolation_stage="rgba")
+
+    assert ax.images[0].get_interpolation_stage() == "rgba"
+
+
 def test_specplot_relabels_frequency_axis(random_patch):
     """The ft_time axis label is rewritten as Frequency."""
     patch = random_patch.dft("time").abs()


### PR DESCRIPTION
## Summary
- forward extra specplot keyword arguments to the underlying waterfall call
- add a regression test for interpolation_stage passthrough

Fixes #722

## Tests
- pytest tests/test_viz/test_specplot.py::test_specplot_forwards_waterfall_kwargs
- pytest tests/test_viz/test_specplot.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `specplot` now passes keyword arguments through to the underlying waterfall rendering, so display options like interpolation settings are applied as expected.
  * Added coverage to ensure forwarded rendering options are preserved in the plotted output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->