### PR TITLE
Validate specplot dimensionality

### DIFF
--- a/dascore/viz/specplot.py
+++ b/dascore/viz/specplot.py
@@ -93,6 +93,12 @@ def specplot(
     is_fft_dim = [d.startswith("ft_") for d in dims]
     if not any(is_fft_dim):
         raise CoordError("Patch does not contain a Fourier-transformed coordinate")
+    if patch.ndim != 2:
+        msg = (
+            f"Can only make specplot of 2D Patch, "
+            f"but got {patch.ndim}D Patch with dims {patch.dims}"
+        )
+        raise CoordError(msg)
 
     # Make the plot
     ax = patch.viz.waterfall(

--- a/tests/test_viz/test_specplot.py
+++ b/tests/test_viz/test_specplot.py
@@ -1,8 +1,10 @@
 """Tests for spectrum plotting."""
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
+import dascore as dc
 from dascore.exceptions import CoordError
 
 
@@ -10,6 +12,19 @@ def test_specplot_requires_fourier_dimension(random_patch):
     """Specplot raises if the patch has no Fourier-transformed coordinate."""
     with pytest.raises(CoordError, match="Fourier-transformed coordinate"):
         random_patch.viz.specplot()
+
+
+def test_specplot_requires_2d_patch():
+    """Specplot raises a clear CoordError for non-2D patches."""
+    time = dc.to_datetime64(0) + np.arange(100) * np.timedelta64(10, "ms")
+    patch = dc.Patch(
+        data=np.ones(100),
+        coords={"time": time},
+        dims=("time",),
+    ).dft("time")
+
+    with pytest.raises(CoordError, match="2D Patch"):
+        patch.viz.specplot()
 
 
 def test_specplot_returns_axes(random_patch):


### PR DESCRIPTION
## Summary
- raise a clear CoordError when specplot is called on a non-2D spectral patch
- add a regression test for 1D Fourier-transformed patches

Fixes #723

## Tests
- pytest tests/test_viz/test_specplot.py::test_specplot_requires_2d_patch
- pytest tests/test_viz/test_specplot.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `specplot` now checks that the input data is 2D before creating a spectrum plot.
  * If a non-2D input is provided, it now raises a clear error message showing the received dimensions.
* **Tests**
  * Added coverage to verify that spectrum plotting fails as expected for 1D inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->