### PR TITLE
Preserve NaT in saturating time arithmetic

### DIFF
--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -27,24 +27,35 @@ def _float_array_to_ns(array):
 
 
 def _saturate_time(value, amount, sign: int = 1):
-    """Add/subtract a timedelta to a time-like value, saturating at int64 bounds.
-
-    Numpy silently wraps datetime64/timedelta64 overflow rather than raising,
-    so the arithmetic is performed with Python ints (via object arrays) and
-    clipped back into the valid int64 range.
-    """
+    """Add or subtract a timedelta, clamping time-like overflows."""
     is_dt = is_datetime64(value)
     is_td = is_timedelta64(value)
     if not (is_dt or is_td):
         msg = f"type {type(value)} is not supported"
         raise NotImplementedError(msg)
+
     value = to_datetime64(value) if is_dt else to_timedelta64(value)
+    amount = to_timedelta64(amount)
     dtype = "datetime64[ns]" if is_dt else "timedelta64[ns]"
     limits = np.iinfo(np.int64)
-    lower, upper = int(limits.min) + 1, int(limits.max)
-    value_ns = np.asarray(to_int(value)).astype(object)
-    amount_ns = np.asarray(sign * to_int(to_timedelta64(amount))).astype(object)
-    out = np.clip(value_ns + amount_ns, lower, upper)
+    nat, lower, upper = limits.min, limits.min + 1, limits.max
+    value_ns = np.asarray(to_int(value))
+    amount_ns = np.asarray(to_int(amount))
+    nat_mask = (value_ns == nat) | (amount_ns == nat)
+
+    left = np.where(nat_mask, 0, value_ns)
+    right = np.where(nat_mask, 0, amount_ns)
+    right = -right if sign < 0 else right
+    with np.errstate(over="ignore"):
+        out = left + right
+
+    upper_mask = (right > 0) & (out < left)
+    lower_mask = (right < 0) & (out > left)
+    nat_out = out == nat
+    if np.any(upper_mask | lower_mask | nat_out | nat_mask):
+        out = np.where(upper_mask, upper, out)
+        out = np.where(lower_mask | (nat_out & ~upper_mask), lower, out)
+        out = np.where(nat_mask, nat, out)
     return np.asarray(out).astype(np.int64).astype(dtype)[()]
 
 

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -525,6 +525,32 @@ class TestSaturateTime:
         expected = np.array([int(limits.max), 5]).astype("datetime64[ns]")
         assert np.all(out == expected)
 
+    def test_datetime_nat_stays_nat(self):
+        """NaT datetime operands should stay missing."""
+        nat = np.datetime64("NaT")
+
+        assert pd.isnull(saturate_add(nat, np.timedelta64(1, "s")))
+        assert pd.isnull(saturate_subtract(nat, np.timedelta64(1, "s")))
+
+    def test_amount_nat_stays_nat(self):
+        """NaT timedelta operands should make the result missing."""
+        out = saturate_add(np.datetime64("2020-01-01"), np.timedelta64("NaT"))
+
+        assert pd.isnull(out)
+
+    def test_array_nat_entries_stay_nat(self):
+        """Array entries with NaT operands should stay missing elementwise."""
+        dt = np.array(["2020-01-01", "NaT", "2020-01-03"], dtype="datetime64[ns]")
+        delta = np.array([1, 1, "NaT"], dtype="timedelta64[ns]")
+
+        added = saturate_add(dt, delta)
+        subtracted = saturate_subtract(dt, delta)
+
+        assert added[0] == dt[0] + delta[0]
+        assert subtracted[0] == dt[0] - delta[0]
+        assert pd.isnull(added[1]) and pd.isnull(subtracted[1])
+        assert pd.isnull(added[2]) and pd.isnull(subtracted[2])
+
     def test_unsupported_type_raises_after_overflow(self):
         """Unsupported values should still raise from the fallback path."""
         with pytest.raises(NotImplementedError):

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -477,15 +477,6 @@ class TestToInt:
 class TestSaturateTime:
     """Tests for saturating datetime and timedelta operations."""
 
-    class _OverflowingAdd:
-        """Object which forces the saturating fallback path."""
-
-        def __add__(self, other):
-            raise OverflowError
-
-        def __sub__(self, other):
-            raise OverflowError
-
     def test_datetime_add_saturates_upper_bound(self):
         """Adding past datetime64 max should clamp to max."""
         limits = np.iinfo(np.int64)
@@ -551,10 +542,10 @@ class TestSaturateTime:
         assert pd.isnull(added[1]) and pd.isnull(subtracted[1])
         assert pd.isnull(added[2]) and pd.isnull(subtracted[2])
 
-    def test_unsupported_type_raises_after_overflow(self):
-        """Unsupported values should still raise from the fallback path."""
+    def test_unsupported_type_raises(self):
+        """Non time-like values should raise NotImplementedError."""
         with pytest.raises(NotImplementedError):
-            saturate_add(self._OverflowingAdd(), np.timedelta64(5, "ns"))
+            saturate_add("not a time", np.timedelta64(5, "ns"))
 
 
 class TestIsDateTime:


### PR DESCRIPTION
## Summary
- preserve NaT values in saturate_add and saturate_subtract
- add scalar and array regressions for NaT operands

Fixes #724

## Tests
- pytest tests/test_utils/test_time.py::TestSaturateTime::test_datetime_nat_stays_nat tests/test_utils/test_time.py::TestSaturateTime::test_amount_nat_stays_nat tests/test_utils/test_time.py::TestSaturateTime::test_array_nat_entries_stay_nat
- pytest tests/test_utils/test_time.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time arithmetic to handle overflow and underflow more reliably.
  * Missing time values are now preserved consistently during addition and subtraction.
  * Array-based time operations now return expected results element by element, including missing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->