### PR TITLE
Validate stalta window order

### DIFF
--- a/dascore/transform/stalta.py
+++ b/dascore/transform/stalta.py
@@ -5,6 +5,7 @@ Patch function for 'short-term average' to 'long-term average' ratio transform
 from __future__ import annotations
 
 from dascore.constants import PatchType
+from dascore.exceptions import ParameterError
 from dascore.utils.misc import check_filter_kwargs
 from dascore.utils.patch import patch_function
 
@@ -52,6 +53,9 @@ def stalta(
     ... );
     """
     dim, (sta, lta) = check_filter_kwargs(kwargs)
+    if lta <= sta:
+        msg = f"The long-term window must exceed the short-term window, got {lta}."
+        raise ParameterError(msg)
 
     sta_data = patch.rolling(**{dim: sta}, samples=samples).mean()
     lta_data = patch.rolling(**{dim: lta}, samples=samples).mean()

--- a/tests/test_transform/test_stalta.py
+++ b/tests/test_transform/test_stalta.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from dascore.exceptions import ParameterError
+
 
 class TestStaLta:
     """Tests for short-term average / long-term average ratio."""
@@ -78,3 +80,8 @@ class TestStaLta:
         """Ensure invalid window kwargs are rejected."""
         with pytest.raises(ValueError):
             random_patch.stalta(time=(0.01, 0.05, 0.1))
+
+    def test_lta_must_exceed_sta(self, random_patch):
+        """Ensure the long-term window must exceed the short-term window."""
+        with pytest.raises(ParameterError, match="long-term window"):
+            random_patch.stalta(time=(0.05, 0.01))


### PR DESCRIPTION
## Summary
- reject STA/LTA window tuples where the long-term window is not larger than the short-term window
- add a regression for reversed STA/LTA windows

Fixes #726

## Tests
- pytest tests/test_transform/test_stalta.py::TestStaLta::test_lta_must_exceed_sta
- pytest tests/test_transform/test_stalta.py