### PR TITLE
Fallback on stale Pint cache

### DIFF
--- a/dascore/units.py
+++ b/dascore/units.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from collections.abc import Sequence
 from functools import cache
 from typing import Any, TypeVar
@@ -10,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pint
 from pint import DimensionalityError, Quantity, UndefinedUnitError, Unit
+from platformdirs import user_cache_path
 
 import dascore as dc
 from dascore.compat import is_array
@@ -21,10 +23,20 @@ str_or_none = TypeVar("str_or_none", None, str)
 numeric = TypeVar("numeric", np.ndarray, int, float)
 
 
+def _get_unit_registry():
+    """Create a Pint registry, clearing stale automatic cache if needed."""
+    try:
+        return pint.UnitRegistry(cache_folder=":auto:")
+    except FileNotFoundError:
+        path = user_cache_path(appname="pint", appauthor=False)
+        shutil.rmtree(path, ignore_errors=True)
+        return pint.UnitRegistry(cache_folder=":auto:")
+
+
 @cache
 def get_registry():
     """Get the pint unit registry."""
-    ureg = pint.UnitRegistry(cache_folder=":auto:")
+    ureg = _get_unit_registry()
     # a few custom defs, we may need our own unit registry if this
     # gets too long.
     ureg.define("PI=pi")

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -25,6 +25,41 @@ from dascore.units import (
 class TestUnitInit:
     """Ensure units can be initialized."""
 
+    def test_stale_pint_cache_falls_back(self, monkeypatch):
+        """Stale Pint disk cache should not prevent registry creation."""
+        from dascore import units
+
+        class FakeRegistry:
+            pass
+
+        cache_folders = []
+        removed_paths = []
+        cache_path = "pint-cache"
+        fake_registry = FakeRegistry()
+
+        def unit_registry(*args, **kwargs):
+            cache_folders.append(kwargs.get("cache_folder"))
+            if len(cache_folders) == 1 and kwargs.get("cache_folder") == ":auto:":
+                raise FileNotFoundError("stale pint cache")
+            return fake_registry
+
+        def rmtree(path, ignore_errors):
+            removed_paths.append((path, ignore_errors))
+
+        monkeypatch.setattr(units.pint, "UnitRegistry", unit_registry)
+        monkeypatch.setattr(
+            units,
+            "user_cache_path",
+            lambda appname, appauthor: cache_path,
+        )
+        monkeypatch.setattr(units.shutil, "rmtree", rmtree)
+
+        registry = units._get_unit_registry()
+
+        assert cache_folders == [":auto:", ":auto:"]
+        assert removed_paths == [(cache_path, True)]
+        assert registry is fake_registry
+
     def test_time(self):
         """Tests for time units."""
         sec = dc.get_unit("s")


### PR DESCRIPTION
## Description

DASCore currently creates the Pint registry with `cache_folder=":auto:"`. If Pint/flexcache has stale cache metadata pointing to files from a removed environment or worktree, registry creation can raise `FileNotFoundError` during import-time unit parsing.

This PR keeps Pint disk caching enabled. If registry creation hits a stale-cache `FileNotFoundError`, DASCore removes the automatic Pint cache directory and retries registry creation with `cache_folder=":auto:"`, allowing Pint to regenerate a fresh cache. It also adds a regression test for that cache cleanup and retry path.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.

## Tests

- `XDG_CACHE_HOME=/tmp/dascore-cache uv run pytest tests/test_units.py`
- `uvx prek run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unit registry initialization so the app can recover automatically if a stale cache prevents loading units.
  * Added fallback handling that clears the affected cache and retries, reducing startup issues caused by cached unit data.
  * Expanded test coverage for the cache-recovery path to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->