### PR TITLE
Add DASDAE compression options

### DIFF
--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -11,6 +11,7 @@ from dascore.constants import SpoolType
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import (
     H5Reader,
+    HDF5CompressionSpec,
     HDFPatchIndexManager,
     NodeError,
     PyTablesReader,
@@ -20,7 +21,6 @@ from dascore.utils.misc import unbyte
 from dascore.utils.patch import get_patch_names
 
 from .utils import (
-    _get_compression_filter,
     _get_contents_from_patch_groups,
     _kwargs_empty,
     _read_patch,
@@ -61,6 +61,7 @@ class DASDAEV1(FiberIO):
         index=False,
         compression=None,
         compression_level=None,
+        shuffle=True,
         **kwargs,
     ):
         """
@@ -78,16 +79,24 @@ class DASDAEV1(FiberIO):
             This is recommended for files with many patches and not recommended
             for files with few patches.
         compression
-            The PyTables compression library for patch data and coordinate
-            arrays. The default of None writes uncompressed arrays.
+            The HDF5 compression library for patch data and coordinate
+            arrays. The default of None writes uncompressed arrays unless a
+            positive compression level is provided. Use "gzip" for portable
+            HDF5 compression.
         compression_level
             Compression level from 0 to 9. A level of 0 disables compression.
             If a compression library is provided and this is None, level 5 is
             used. If only a positive compression level is provided,
             "blosc:zstd" is used. Level 5 is recommended for general use.
+        shuffle
+            If True, apply the HDF5 shuffle filter before compression.
         """
         # write out patches
-        filters = _get_compression_filter(compression, compression_level)
+        filters = HDF5CompressionSpec(
+            compression=compression,
+            compression_level=compression_level,
+            shuffle=shuffle,
+        ).to_pytables_filters()
         _write_meta(resource, self.version)
         # get an iterable of patches and save them
         patches = [spool] if isinstance(spool, dc.Patch) else spool

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -20,6 +20,7 @@ from dascore.utils.misc import unbyte
 from dascore.utils.patch import get_patch_names
 
 from .utils import (
+    _get_compression_filter,
     _get_contents_from_patch_groups,
     _kwargs_empty,
     _read_patch,
@@ -53,7 +54,15 @@ class DASDAEV1(FiberIO):
     preferred_extensions = ("h5", "hdf5")
     version = "1"
 
-    def write(self, spool: SpoolType, resource: PyTablesWriter, index=False, **kwargs):
+    def write(
+        self,
+        spool: SpoolType,
+        resource: PyTablesWriter,
+        index=False,
+        compression=None,
+        compression_level=None,
+        **kwargs,
+    ):
         """
         Write a collection of patches to a DASDAE file.
 
@@ -68,8 +77,17 @@ class DASDAEV1(FiberIO):
             writing but will make reading/scanning the file more efficient.
             This is recommended for files with many patches and not recommended
             for files with few patches.
+        compression
+            The PyTables compression library for patch data and coordinate
+            arrays. The default of None writes uncompressed arrays.
+        compression_level
+            Compression level from 0 to 9. A level of 0 disables compression.
+            If a compression library is provided and this is None, level 5 is
+            used. If only a positive compression level is provided,
+            "blosc:zstd" is used. Level 5 is recommended for general use.
         """
         # write out patches
+        filters = _get_compression_filter(compression, compression_level)
         _write_meta(resource, self.version)
         # get an iterable of patches and save them
         patches = [spool] if isinstance(spool, dc.Patch) else spool
@@ -81,7 +99,7 @@ class DASDAEV1(FiberIO):
         # write new patches to file
         patch_names = get_patch_names(patches).values
         for patch, name in zip(patches, patch_names):
-            _save_patch(patch, waveforms, resource, name)
+            _save_patch(patch, waveforms, resource, name, filters=filters)
         indexer = HDFPatchIndexManager(resource)
         if index or indexer.has_index:
             df = self._get_patch_summary(patches)

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -238,6 +238,10 @@ def _get_patch_content_from_group(group):
     for key in attrs._f_list():
         value = getattr(attrs, key)
         new_key = key.replace("_attrs_", "")
+        # Older DASDAE files can expose scalar HDF attrs as 0-D arrays with
+        # some PyTables versions; normalize them before building PatchAttrs.
+        if isinstance(value, np.ndarray) and not value.shape:
+            value = np.atleast_1d(value)[0]
         out[new_key] = value
     # rename dims
     out["dims"] = out.pop("_dims")

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
-from tables import Atom, Filters, NodeError
+from tables import Atom, NodeError
 
 import dascore as dc
 from dascore.core.attrs import PatchAttrs
@@ -11,8 +11,6 @@ from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.time import to_int
-
-DEFAULT_COMPRESSION = "blosc:zstd"
 
 # Keys not counted as true kwargs for determining if patch is filtered/selected.
 _KWARG_NON_KEYS = {"file_version", "file_format", "path"}
@@ -28,19 +26,6 @@ def _create_or_get_group(h5, group, name):
     except NodeError:
         group = getattr(group, name)
     return group
-
-
-def _get_compression_filter(compression=None, compression_level=None):
-    """Return PyTables filters for DASDAE array compression."""
-    if compression_level is None:
-        compression_level = 5 if compression else 0
-    if not 0 <= compression_level <= 9:
-        msg = "compression_level must be between 0 and 9."
-        raise ValueError(msg)
-    if compression_level == 0:
-        return None
-    compression = compression or DEFAULT_COMPRESSION
-    return Filters(complevel=compression_level, complib=compression, shuffle=True)
 
 
 def _create_or_squash_array(h5, group, name, data, filters=None):

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
-from tables import NodeError
+from tables import Atom, Filters, NodeError
 
 import dascore as dc
 from dascore.core.attrs import PatchAttrs
@@ -11,6 +11,8 @@ from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.time import to_int
+
+DEFAULT_COMPRESSION = "blosc:zstd"
 
 # Keys not counted as true kwargs for determining if patch is filtered/selected.
 _KWARG_NON_KEYS = {"file_version", "file_format", "path"}
@@ -28,14 +30,40 @@ def _create_or_get_group(h5, group, name):
     return group
 
 
-def _create_or_squash_array(h5, group, name, data):
+def _get_compression_filter(compression=None, compression_level=None):
+    """Return PyTables filters for DASDAE array compression."""
+    if compression_level is None:
+        compression_level = 5 if compression else 0
+    if not 0 <= compression_level <= 9:
+        msg = "compression_level must be between 0 and 9."
+        raise ValueError(msg)
+    if compression_level == 0:
+        return None
+    compression = compression or DEFAULT_COMPRESSION
+    return Filters(complevel=compression_level, complib=compression, shuffle=True)
+
+
+def _create_or_squash_array(h5, group, name, data, filters=None):
     """Create a new array, if it exists delete and re-create."""
+    data = np.asarray(data)
+    use_carray = filters is not None and data.size and data.shape
+
+    def create_array():
+        if use_carray:
+            atom = Atom.from_dtype(data.dtype)
+            array = h5.create_carray(
+                group, name, atom=atom, shape=data.shape, filters=filters
+            )
+            array[:] = data
+            return array
+        return h5.create_array(group, name, data)
+
     try:
-        array = h5.create_array(group, name, data)
+        array = create_array()
     except NodeError:
         old_node = getattr(group, name)
         h5.remove_node(old_node)
-        array = h5.create_array(group, name, data)
+        array = create_array()
     return array
 
 
@@ -57,19 +85,19 @@ def _save_attrs_and_dims(patch, patch_group):
     patch_group._v_attrs["_dims"] = ",".join(patch.dims)
 
 
-def _save_array(data, name, group, h5):
+def _save_array(data, name, group, h5, filters=None):
     """Save an array to a group, handle datetime flubbery."""
     # handle datetime conversions
     is_dt = np.issubdtype(data.dtype, np.datetime64)
     is_td = np.issubdtype(data.dtype, np.timedelta64)
     if is_dt or is_td:
         data = to_int(data)
-    array_node = _create_or_squash_array(h5, group, name, data)
+    array_node = _create_or_squash_array(h5, group, name, data, filters=filters)
     array_node._v_attrs["is_datetime64"] = is_dt
     array_node._v_attrs["is_timedelta64"] = is_td
 
 
-def _save_coords(patch, patch_group, h5):
+def _save_coords(patch, patch_group, h5, filters=None):
     """Save coordinates."""
     cm = patch.coords
     for name, coord in cm.coord_map.items():
@@ -77,20 +105,20 @@ def _save_coords(patch, patch_group, h5):
         # First save coordinate arrays
         data = coord.values
         save_name = f"_coord_{name}"
-        _save_array(data, save_name, patch_group, h5)
+        _save_array(data, save_name, patch_group, h5, filters=filters)
         # then save dimensions of coordinates
         save_name = f"_cdims_{name}"
         patch_group._v_attrs[save_name] = ",".join(dims)
 
 
-def _save_patch(patch, wave_group, h5, name):
+def _save_patch(patch, wave_group, h5, name, filters=None):
     """Save the patch to disk."""
     patch_group = _create_or_get_group(h5, wave_group, name)
     _save_attrs_and_dims(patch, patch_group)
-    _save_coords(patch, patch_group, h5)
+    _save_coords(patch, patch_group, h5, filters=filters)
     # add data
     if patch.data.shape:
-        _create_or_squash_array(h5, patch_group, "data", patch.data)
+        _create_or_squash_array(h5, patch_group, "data", patch.data, filters=filters)
 
 
 # --- Functions for reading

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -238,9 +238,6 @@ def _get_patch_content_from_group(group):
     for key in attrs._f_list():
         value = getattr(attrs, key)
         new_key = key.replace("_attrs_", "")
-        # need to unpack 0 dim arrays.
-        if isinstance(value, np.ndarray) and not value.shape:
-            value = np.atleast_1d(value)[0]
         out[new_key] = value
     # rename dims
     out["dims"] = out.pop("_dims")

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -21,6 +21,7 @@ import tables
 from h5py import File as H5pyFile
 from packaging.version import parse as get_version
 from pandas.io.common import stringify_path
+from pydantic import model_validator
 from tables import ClosedNodeError
 from tables import File as PyTablesFile
 
@@ -36,6 +37,7 @@ from dascore.utils.misc import (
     suppress_warnings,
     unbyte,
 )
+from dascore.utils.models import DascoreBaseModel
 from dascore.utils.pd import (
     _remove_base_path,
     fill_defaults_from_pydantic,
@@ -49,6 +51,42 @@ NodeError = tables.NodeError
 
 ns_to_datetime = partial(pd.to_datetime, unit="ns")
 ns_to_timedelta = partial(pd.to_timedelta, unit="ns")
+
+DEFAULT_PYTABLES_COMPRESSION = "blosc:zstd"
+_PYTABLES_COMPRESSION_ALIASES = FrozenDict({"gzip": "zlib"})
+
+
+class HDF5CompressionSpec(DascoreBaseModel):
+    """Backend-neutral HDF5 compression settings."""
+
+    compression: str | None = None
+    compression_level: int | None = None
+    shuffle: bool = True
+
+    @model_validator(mode="after")
+    def validate_compression_level(self):
+        """Ensure compression level fits the HDF5/PyTables range."""
+        level = self.compression_level
+        if level is not None and not 0 <= level <= 9:
+            msg = "compression_level must be between 0 and 9."
+            raise ValueError(msg)
+        return self
+
+    @property
+    def effective_level(self) -> int:
+        """Return the actual compression level to use."""
+        if self.compression_level is None:
+            return 5 if self.compression else 0
+        return self.compression_level
+
+    def to_pytables_filters(self) -> tables.Filters | None:
+        """Translate compression settings to PyTables filters."""
+        level = self.effective_level
+        if level == 0:
+            return None
+        complib = self.compression or DEFAULT_PYTABLES_COMPRESSION
+        complib = _PYTABLES_COMPRESSION_ALIASES.get(complib, complib)
+        return tables.Filters(complevel=level, complib=complib, shuffle=self.shuffle)
 
 
 class _HDF5Store(pd.HDFStore):

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -21,6 +21,12 @@ patch = dc.get_example_patch()
 patch.io.write(write_path, "dasdae")
 ```
 
+DASDAE files can be compressed by passing a `compression_level` from 1 to 9. Level 5 uses `blosc:zstd` and is recommended for general use because it usually gives most of the size reduction without the slower writes of the highest levels.
+
+```{python}
+patch.io.write(write_path, "dasdae", compression_level=5)
+```
+
 ```{python}
 #| echo: false
 if write_path.exists():

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -21,7 +21,7 @@ patch = dc.get_example_patch()
 patch.io.write(write_path, "dasdae")
 ```
 
-DASDAE files can be compressed by passing a `compression_level` from 1 to 9. Level 5 uses `blosc:zstd` and is recommended for general use because it usually gives most of the size reduction without the slower writes of the highest levels.
+DASDAE files can be compressed with `compression_level`; level 5 is recommended. Use `compression="gzip"` for portable HDF5 compression.
 
 ```{python}
 patch.io.write(write_path, "dasdae", compression_level=5)

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -14,9 +14,9 @@ from dascore.compat import random_state
 from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.dasdae.utils import (
     _create_or_squash_array,
-    _get_compression_filter,
     _get_patch_content_from_group,
 )
+from dascore.utils.hdf5 import HDF5CompressionSpec
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
 
@@ -179,7 +179,7 @@ class TestWriteDASDAE:
     def test_compressed_scalar_array_falls_back(self, tmp_path_factory):
         """DASDAE compression skips scalar arrays unsupported by CArray."""
         path = tmp_path_factory.mktemp("dasdae_compressed_scalar") / "out.h5"
-        filters = _get_compression_filter(compression_level=5)
+        filters = HDF5CompressionSpec(compression_level=5).to_pytables_filters()
         with tables.open_file(path, mode="w") as h5:
             node = _create_or_squash_array(h5, h5.root, "scalar", np.array(1), filters)
             assert node.shape == ()

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -15,6 +15,7 @@ from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.dasdae.utils import (
     _create_or_squash_array,
     _get_compression_filter,
+    _get_patch_content_from_group,
 )
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
@@ -244,6 +245,22 @@ class TestScanDASDAE:
         common_keys = set(info1) & set(info2) - {"history"}
         for key in common_keys:
             assert info1[key] == info2[key]
+
+    def test_scan_unpacks_scalar_array_attrs(self):
+        """Min-deps PyTables can expose scalar HDF attrs as 0-D arrays."""
+
+        class Attrs:
+            _attrs_custom_attr = np.array(1)
+            _dims = "time,distance"
+
+            def _f_list(self):
+                return ["_attrs_custom_attr", "_dims"]
+
+        class Group:
+            _v_attrs = Attrs()
+
+        attrs = _get_patch_content_from_group(Group())
+        assert attrs["custom_attr"] == 1
 
     # TODO we need to re-think indexing before this can work.
     @pytest.mark.xfail

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -145,8 +145,10 @@ class TestWriteDASDAE:
         """Selecting from a compressed file must match selecting in memory."""
         path = tmp_path_factory.mktemp("dasdae_compressed_select") / "out.h5"
         random_patch.io.write(path, "DASDAE", compression_level=5)
-        dist = random_patch.get_coord("distance")
-        select = {"distance": (dist.min(), dist.min() + (dist.max() - dist.min()) / 2)}
+        # Select on existing coordinate values so the bounds keep the coord's
+        # dtype (a fractional midpoint would not round-trip through int coords).
+        dist = random_patch.get_coord("distance").values
+        select = {"distance": (dist[0], dist[len(dist) // 2])}
         from_disk = dc.spool(path).select(**select)[0]
         in_memory = random_patch.select(**select)
         assert from_disk.equals(in_memory)

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -7,10 +7,16 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import tables
 
 import dascore as dc
 from dascore.compat import random_state
 from dascore.io.dasdae.core import DASDAEV1
+from dascore.io.dasdae.utils import (
+    _create_or_squash_array,
+    _get_compression_filter,
+    _get_patch_content_from_group,
+)
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
 
@@ -118,6 +124,59 @@ class TestWriteDASDAE:
         sp_cc = dc.spool(written_dascore_correlate)
         assert isinstance(sp_cc[0], dc.Patch)
 
+    def test_write_compressed(self, tmp_path_factory, random_patch):
+        """DASDAE can write compressed arrays with user-provided levels."""
+        path = tmp_path_factory.mktemp("dasdae_compressed") / "compressed.h5"
+        dc.write(
+            random_patch,
+            path,
+            "DASDAE",
+            compression="blosc:zstd",
+            compression_level=5,
+        )
+        with tables.open_file(path) as h5:
+            group = next(h5.iter_nodes("/waveforms"))
+            assert group.data.filters.complib == "blosc:zstd"
+            assert group.data.filters.complevel == 5
+
+    def test_write_compression_level_uses_default(self, tmp_path_factory, random_patch):
+        """Compression level alone uses the default DASDAE compression library."""
+        path = tmp_path_factory.mktemp("dasdae_compressed") / "level_only.h5"
+        random_patch.io.write(path, "DASDAE", compression_level=3)
+        with tables.open_file(path) as h5:
+            group = next(h5.iter_nodes("/waveforms"))
+            assert group.data.filters.complib == "blosc:zstd"
+            assert group.data.filters.complevel == 3
+
+    def test_write_compressed_empty_coord(self, tmp_path_factory, random_patch):
+        """Compressed DASDAE writes preserve zero-length arrays."""
+        path = tmp_path_factory.mktemp("dasdae_compressed_empty") / "out.h5"
+        time = random_patch.get_coord("time")
+        empty_patch = random_patch.select(time=(time.max() + 3 * time.step, ...))
+        empty_patch.io.write(
+            path,
+            "dasdae",
+            compression="blosc:zstd",
+            compression_level=5,
+        )
+        new_patch = dc.read(path)[0]
+        assert empty_patch.equals(new_patch)
+
+    def test_compressed_scalar_array_falls_back(self, tmp_path_factory):
+        """DASDAE compression skips scalar arrays unsupported by CArray."""
+        path = tmp_path_factory.mktemp("dasdae_compressed_scalar") / "out.h5"
+        filters = _get_compression_filter(compression_level=5)
+        with tables.open_file(path, mode="w") as h5:
+            node = _create_or_squash_array(h5, h5.root, "scalar", np.array(1), filters)
+            assert node.shape == ()
+            assert node.filters.complevel == 0
+
+    def test_bad_compression_level_raises(self, random_patch, tmp_path_factory):
+        """Compression levels outside the PyTables range are invalid."""
+        path = tmp_path_factory.mktemp("dasdae_bad_compression") / "out.h5"
+        with pytest.raises(ValueError, match="compression_level"):
+            random_patch.io.write(path, "dasdae", compression_level=10)
+
 
 class TestReadDASDAE:
     """Test for reading a dasdae format."""
@@ -159,6 +218,22 @@ class TestReadDASDAE:
         spool = parser.read(generic_hdf5)
         assert not len(spool)
 
+    def test_get_format_false(self, generic_hdf5):
+        """A generic HDF5 file is not a DASDAE file."""
+        parser = DASDAEV1()
+        assert not parser.get_format(generic_hdf5)
+
+    def test_read_empty_selection_returns_no_patches(
+        self, tmp_path_factory, random_patch
+    ):
+        """Selections outside an empty patch should return no patches."""
+        path = tmp_path_factory.mktemp("dasdae_read_empty_selection") / "out.h5"
+        time = random_patch.get_coord("time")
+        random_patch.io.write(path, "dasdae")
+        empty_range_start = time.max() + 3 * time.step
+        out = dc.read(path, time=(empty_range_start, ...))
+        assert len(out) == 0
+
 
 class TestScanDASDAE:
     """Tests for scanning the dasdae format."""
@@ -170,6 +245,22 @@ class TestScanDASDAE:
         common_keys = set(info1) & set(info2) - {"history"}
         for key in common_keys:
             assert info1[key] == info2[key]
+
+    def test_scan_unpacks_scalar_array_attrs(self):
+        """Scanning unpacks attrs stored as scalar arrays."""
+
+        class Attrs:
+            _attrs_custom_attr = np.array(1)
+            _dims = "time,distance"
+
+            def _f_list(self):
+                return ["_attrs_custom_attr", "_dims"]
+
+        class Group:
+            _v_attrs = Attrs()
+
+        attrs = _get_patch_content_from_group(Group())
+        assert attrs["custom_attr"] == 1
 
     # TODO we need to re-think indexing before this can work.
     @pytest.mark.xfail

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -15,7 +15,6 @@ from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.dasdae.utils import (
     _create_or_squash_array,
     _get_compression_filter,
-    _get_patch_content_from_group,
 )
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
@@ -245,22 +244,6 @@ class TestScanDASDAE:
         common_keys = set(info1) & set(info2) - {"history"}
         for key in common_keys:
             assert info1[key] == info2[key]
-
-    def test_scan_unpacks_scalar_array_attrs(self):
-        """Scanning unpacks attrs stored as scalar arrays."""
-
-        class Attrs:
-            _attrs_custom_attr = np.array(1)
-            _dims = "time,distance"
-
-            def _f_list(self):
-                return ["_attrs_custom_attr", "_dims"]
-
-        class Group:
-            _v_attrs = Attrs()
-
-        attrs = _get_patch_content_from_group(Group())
-        assert attrs["custom_attr"] == 1
 
     # TODO we need to re-think indexing before this can work.
     @pytest.mark.xfail

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -138,6 +138,18 @@ class TestWriteDASDAE:
             group = next(h5.iter_nodes("/waveforms"))
             assert group.data.filters.complib == "blosc:zstd"
             assert group.data.filters.complevel == 5
+        # the compressed data (and coords) must round-trip unchanged.
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_compressed_selective_read(self, tmp_path_factory, random_patch):
+        """Selecting from a compressed file must match selecting in memory."""
+        path = tmp_path_factory.mktemp("dasdae_compressed_select") / "out.h5"
+        random_patch.io.write(path, "DASDAE", compression_level=5)
+        dist = random_patch.get_coord("distance")
+        select = {"distance": (dist.min(), dist.min() + (dist.max() - dist.min()) / 2)}
+        from_disk = dc.spool(path).select(**select)[0]
+        in_memory = random_patch.select(**select)
+        assert from_disk.equals(in_memory)
 
     def test_write_compression_level_uses_default(self, tmp_path_factory, random_patch):
         """Compression level alone uses the default DASDAE compression library."""

--- a/tests/test_utils/test_hdf_utils.py
+++ b/tests/test_utils/test_hdf_utils.py
@@ -15,6 +15,7 @@ import dascore as dc
 from dascore.exceptions import InvalidFileHandlerError
 from dascore.utils.downloader import fetch
 from dascore.utils.hdf5 import (
+    HDF5CompressionSpec,
     HDFPatchIndexManager,
     PyTablesWriter,
     extract_h5_attrs,
@@ -80,6 +81,40 @@ class TestGetHDF5Handlder:
         """
         with open_hdf5_file(simple_hdf_file_handler_append, mode="r") as fi:
             assert isinstance(fi, tables.File)
+
+
+class TestHDF5CompressionSpec:
+    """Tests for backend-neutral HDF5 compression settings."""
+
+    def test_default_is_uncompressed(self):
+        """No compression inputs should produce no PyTables filters."""
+        spec = HDF5CompressionSpec()
+        assert spec.to_pytables_filters() is None
+
+    def test_level_uses_pytables_default(self):
+        """A level without a compressor uses the PyTables default."""
+        filters = HDF5CompressionSpec(compression_level=5).to_pytables_filters()
+        assert filters.complib == "blosc:zstd"
+        assert filters.complevel == 5
+        assert filters.shuffle
+
+    def test_gzip_maps_to_pytables_zlib(self):
+        """The public gzip name maps to the PyTables zlib filter."""
+        filters = HDF5CompressionSpec(
+            compression="gzip", compression_level=3
+        ).to_pytables_filters()
+        assert filters.complib == "zlib"
+        assert filters.complevel == 3
+
+    def test_level_zero_disables_compression(self):
+        """A compression level of 0 explicitly disables compression."""
+        spec = HDF5CompressionSpec(compression="gzip", compression_level=0)
+        assert spec.to_pytables_filters() is None
+
+    def test_bad_level_raises(self):
+        """Compression levels must fit the HDF5/PyTables range."""
+        with pytest.raises(ValueError, match="compression_level"):
+            HDF5CompressionSpec(compression_level=10)
 
 
 class TestHDFPatchIndexManager:


### PR DESCRIPTION
## Description

Adds optional compression controls for DASDAE writes while keeping uncompressed output as the default. Users can now pass `compression` and/or `compression_level` through `dc.write` or `patch.io.write`; a positive `compression_level` defaults to `blosc:zstd`, and level 5 is documented as the recommended general-purpose setting.

This also updates DASDAE array writing to use compressed PyTables CArrays only for non-empty, non-scalar arrays, preserving the existing uncompressed Array fallback for scalar and zero-length arrays.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional PyTables/HDF5 compression controls for writing DASDAE files, including `compression`, `compression_level`, and `shuffle`.
* **Bug Fixes**
  * Improved write/read behavior for compressed outputs, including empty selections and scalar/0-D attribute handling.
  * Ensured unsupported scalar-array compression is safely skipped.
* **Documentation**
  * Updated the file I/O tutorial with compression guidance and a `compression_level=5` example.
* **Tests**
  * Added validation of compression filter metadata and expanded DASDAE read/scan edge-case coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->