### PR TITLE
Fix DASDAE FileSpool patch attribute loading

### DIFF
--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -20,8 +20,10 @@ from dascore.utils.misc import unbyte
 from dascore.utils.patch import get_patch_names
 
 from .utils import (
+    _get_attrs,
     _get_contents_from_patch_groups,
     _kwargs_empty,
+    _matches_attr_filters,
     _read_patch,
     _save_patch,
     _write_meta,
@@ -118,7 +120,10 @@ class DASDAEV1(FiberIO):
         except (KeyError, IndexError):
             return dc.spool([])
         for patch_group in waveform_group:
-            patch = _read_patch(patch_group, **kwargs)
+            attrs = _get_attrs(patch_group)
+            if not _matches_attr_filters(attrs, kwargs):
+                continue
+            patch = _read_patch(patch_group, attrs=attrs, **kwargs)
             if not patch.data.size and not _kwargs_empty(kwargs):
                 continue
             patches.append(patch)

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -173,10 +173,16 @@ def _get_dims(patch_group):
 
 def _matches_attr_filters(attrs, kwargs):
     """Return True if attrs match any applicable attr filters in kwargs."""
+
+    def is_nullish(value):
+        """Return True if value is a scalar nullish query value."""
+        is_null = pd.isnull(value)
+        return bool(is_null) if not hasattr(is_null, "__len__") else False
+
     query = {
         x: y
         for x, y in kwargs.items()
-        if x not in _KWARG_NON_KEYS and not x.startswith("_") and y is not None
+        if x not in _KWARG_NON_KEYS and not x.startswith("_") and not is_nullish(y)
     }
     if not query:
         return True

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 from tables import NodeError
 
 import dascore as dc
@@ -10,10 +11,11 @@ from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
 from dascore.utils.misc import suppress_warnings
+from dascore.utils.pd import filter_df
 from dascore.utils.time import to_int
 
 # Keys not counted as true kwargs for determining if patch is filtered/selected.
-_KWARG_NON_KEYS = {"file_version", "file_format", "path"}
+_KWARG_NON_KEYS = {"file_version", "file_format", "path", "_modified"}
 
 
 # --- Functions for writing DASDAE format
@@ -156,9 +158,22 @@ def _get_dims(patch_group):
     return out
 
 
-def _read_patch(patch_group, **kwargs):
+def _matches_attr_filters(attrs, kwargs):
+    """Return True if attrs match any applicable attr filters in kwargs."""
+    query = {
+        x: y
+        for x, y in kwargs.items()
+        if x not in _KWARG_NON_KEYS and not x.startswith("_") and y is not None
+    }
+    if not query:
+        return True
+    attr_df = pd.DataFrame([attrs.model_dump(exclude={"coords"})])
+    return bool(filter_df(attr_df, ignore_bad_kwargs=True, **query)[0])
+
+
+def _read_patch(patch_group, attrs=None, **kwargs):
     """Read a patch group, return Patch."""
-    attrs = _get_attrs(patch_group)
+    attrs = _get_attrs(patch_group) if attrs is None else attrs
     dims = _get_dims(patch_group)
     coords = _get_coords(patch_group, dims, attrs)
     # Note, previously this was wrapped with try, except (Index, KeyError)

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -159,6 +159,21 @@ class TestReadDASDAE:
         spool = parser.read(generic_hdf5)
         assert not len(spool)
 
+    def test_file_spool_loads_distinct_attrs(self, tmp_path, random_patch):
+        """Lazy loading should materialize the patch for each DASDAE row."""
+        path = tmp_path / "multi_patch.h5"
+        patches = [
+            random_patch.update_attrs(tag="S100", label="L100"),
+            random_patch.update_attrs(tag="S120", label="L120"),
+        ]
+
+        dc.write(dc.spool(patches), path, "DASDAE")
+        spool = dc.spool(path)
+
+        assert spool.get_contents()["tag"].to_list() == ["S100", "S120"]
+        assert [x.attrs.tag for x in spool] == ["S100", "S120"]
+        assert [x.attrs.label for x in spool] == ["L100", "L120"]
+
 
 class TestScanDASDAE:
     """Tests for scanning the dasdae format."""


### PR DESCRIPTION
## Description

Fixes #735.

DASDAE `FileSpool` lazy loading could materialize the wrong patch when multiple patch groups in one file shared coordinate extents but differed in attrs such as `tag` or custom identity fields. The reader now checks patch-group attrs against applicable lazy-load kwargs before materializing the patch, while preserving coordinate selection behavior.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

## Verification

- `pre-commit run --all-files`
- `python -m coverage run -m pytest tests/test_io/test_dasdae/test_dasdae.py tests/test_clients/test_filespool.py`
- `python -m coverage report --show-missing dascore/io/dasdae/core.py dascore/io/dasdae/utils.py`
- Confirmed changed production lines have no missing coverage in coverage JSON.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DASDAE spool loading to preserve per-patch metadata accurately across multiple patches (including tag/label) in both contents and iteration order.
  * Enhanced DASDAE reads to apply attribute-based filter criteria more reliably, only returning patch groups that match the requested attributes.
* **Tests**
  * Added test coverage for spooled DASDAE files containing patches with distinct per-patch attributes, verifying correct load and sequential iteration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->