### PR TITLE
Fix assorted regression edge cases

### DIFF
--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -366,7 +366,7 @@ def normalize(
         order = int(norm[-1])
         norm_values = np.linalg.norm(self.data, axis=axis, ord=order)
     elif norm == "max":
-        norm_values = np.max(data, axis=axis)
+        norm_values = np.max(np.abs(data), axis=axis)
     elif norm == "bit":
         pass
     else:
@@ -865,7 +865,8 @@ def demedian(patch, dim: str = "time"):
     >>> ax2 = (patch0-patch1).viz.waterfall(ax = axs[2], show=False)
     >>> _ = ax2.set_title('Difference');
     >>>
-    >>> plt.show()
+    >>> plt.show()  # doctest: +SKIP
+    >>> plt.close(fig)
     """
     axis = patch.get_axis(dim)
     data = patch.data
@@ -923,7 +924,8 @@ def demean(patch, dim: str = "time"):
     >>> ax2 = (patch0-patch1).viz.waterfall(ax = axs[2], show=False)
     >>> _ = ax2.set_title('Difference');
     >>>
-    >>> plt.show()
+    >>> plt.show()  # doctest: +SKIP
+    >>> plt.close(fig)
     """
     axis = patch.get_axis(dim)
     data = patch.data

--- a/dascore/proc/mute.py
+++ b/dascore/proc/mute.py
@@ -73,6 +73,7 @@ class _MuteGeometry(ABC, DascoreBaseModel):
             if not isinstance(smooth, Mapping):
                 vals = [smooth] * len(dims)
                 axes = self.axes
+                smooth_dims = dims
             else:
                 # Otherwise, the smooth dict must be a subset of the dimensions.
                 if not set(smooth).issubset(set(dims)):
@@ -82,10 +83,12 @@ class _MuteGeometry(ABC, DascoreBaseModel):
                         f"smooth keys are {list(smooth)}."
                     )
                     raise ParameterError(msg)
-                vals = [smooth[dim] for dim in dims if dim in smooth]
-                axes = [self.dims.index(x) for x in smooth]
+                dim_axis_map = dict(zip(self.dims, self.axes, strict=True))
+                smooth_dims = [dim for dim in dims if dim in smooth]
+                vals = [smooth[dim] for dim in smooth_dims]
+                axes = [dim_axis_map[dim] for dim in smooth_dims]
 
-            return vals, axes
+            return vals, axes, smooth_dims
 
         def _convert_to_samples(smooth, dims, patch):
             """Convert the smooth parameter to number of samples."""
@@ -108,8 +111,8 @@ class _MuteGeometry(ABC, DascoreBaseModel):
                     out.append(coord.get_sample_count(val))
             return out
 
-        smooth_by_dims, axes = _broadcast_smooth_to_dims(self.dims, smooth)
-        smooth_ints = _convert_to_samples(smooth_by_dims, self.dims, patch)
+        smooth_by_dims, axes, smooth_dims = _broadcast_smooth_to_dims(self.dims, smooth)
+        smooth_ints = _convert_to_samples(smooth_by_dims, smooth_dims, patch)
         # Now convert to input format for scipy's gaussian filter.
         return smooth_ints, axes
 

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -83,7 +83,7 @@ def decimate(
     coords, slices = patch.coords.decimate(**{dim: int(factor)})
     # Apply scipy.signal.decimate and get new coords
     if filter_type:
-        data = _apply_scipy_decimation(patch.data, factor, ftype=filter_type, axis=axis)
+        data = _apply_scipy_decimation(patch, factor, ftype=filter_type, axis=axis)
     else:  # No filter, simply slice along specified dimension.
         data = patch.data[slices]
         # Need to copy so array isn't a slice and holds onto reference of parent

--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -63,9 +63,9 @@ def _get_indefinite_integral(patch, dxs_or_vals, axes):
     We need to calculate the distance weighted average for the areas between
     samples for the integration dimension.
     """
-    out = np.zeros_like(patch.data)
     array = patch.data
     for dx_or_val, ax in zip(dxs_or_vals, axes):
+        out = np.zeros_like(array)
         # if coordinate values are provided need to get diffs.
         if is_array(dx_or_val):
             dx_or_val = dx_or_val[1:] - dx_or_val[:-1]
@@ -77,7 +77,8 @@ def _get_indefinite_integral(patch, dxs_or_vals, axes):
         # get average values of trapezoid between points
         avs = (array[stop_indexer] + array[start_indexer]) * (dx_or_val / 2)
         out[stop_indexer] = np.cumsum(avs, axis=ax)
-    return out, patch.coords  # coords shouldn't change
+        array = out
+    return array, patch.coords  # coords shouldn't change
 
 
 @patch_function(data_type="")

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -297,8 +297,12 @@ def _apply_aggregator(patch, dim, func, dim_reduce="empty"):
     data = patch.data
     dims = tuple(iterate(patch.dims if dim is None else dim))
     dfo = get_dim_axis_value(patch, args=dims, allow_multiple=True)
+    if dim_reduce == "squeeze" and {dim for dim, _, _ in dfo} == set(patch.dims):
+        msg = "Cannot squeeze all dimensions; at least one dimension must remain."
+        raise ParameterError(msg)
     # Iter all specified dimensions.
-    for dim, axis, _ in dfo:
+    for dim, _, _ in dfo:
+        axis = patch.get_axis(dim)
         new_coord = patch.get_coord(dim).reduce_coord(dim_reduce=dim_reduce)
         if new_coord is None:
             coords = patch.coords.drop_coords(dim)[0]
@@ -306,7 +310,10 @@ def _apply_aggregator(patch, dim, func, dim_reduce="empty"):
         else:
             coords = patch.coords.update(**{dim: new_coord})
             data = np.expand_dims(func(data, axis=axis), axis)
-        patch = patch.new(data=data, coords=coords)
+        attrs = patch.attrs.model_dump(exclude={"coords", "dims"}, exclude_unset=True)
+        attrs["coords"] = coords.to_summary_dict()
+        attrs["dims"] = coords.dims
+        patch = patch.new(data=data, coords=coords, attrs=attrs)
     return patch
 
 

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -459,7 +459,7 @@ class ChunkManager:
                     g_stop,
                     dur,
                     overlap=overlap,
-                    step=step.iloc[0],
+                    step=step.loc[current_df.index].iloc[0],
                     keep_partials=self._keep_partials,
                 )
             except ChunkError:  # this chunk is too short, skip.

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -177,7 +177,7 @@ def _iter_filesystem(
     ----------
     paths
         The path to the base directory to traverse. Can also use a collection
-        of paths.
+        of paths when ``include_directories`` is False.
     ext : str or None
         The extensions of files to return.
     timestamp : int or float
@@ -420,7 +420,7 @@ def maybe_get_items(
     unpack_names = set() if unpack_names is None else unpack_names
     out = {}
     for old_name, new_name in attr_map.items():
-        if not (value := obj.get(old_name, None)):
+        if (value := obj.get(old_name, None)) is None:
             continue
         val = unbyte(value)
         out[new_name] = _maybe_unpack(val) if old_name in unpack_names else val

--- a/dascore/utils/moving.py
+++ b/dascore/utils/moving.py
@@ -3,8 +3,10 @@ Unified interface for moving window operations with automatic engine selection.
 
 This module provides a generic interface for 1D moving window operations
 that can use either scipy or bottleneck backends, with automatic fallback
-when optional dependencies are missing. Bottleneck median windows are aligned
-with centered scipy semantics away from edges.
+when optional dependencies are missing. Bottleneck trailing windows are shifted
+toward centered-window alignment. Odd non-median bottleneck windows match scipy
+away from edges; even non-median windows keep the requested bottleneck engine for
+performance and may differ from scipy's even-window convention.
 """
 
 from __future__ import annotations
@@ -63,7 +65,7 @@ def _apply_scipy_operation(
     ddof: int = 0,
 ) -> np.ndarray:
     """Apply scipy operation with proper handling."""
-    module_name, func_name = OPERATION_REGISTRY[operation]["scipy"]
+    _, func_name = OPERATION_REGISTRY[operation]["scipy"]
     func = _get_engine_function("scipy", operation)
     scipy_kwargs = {"mode": mode, "cval": cval, "origin": origin}
 
@@ -116,10 +118,15 @@ def _apply_bottleneck_median(
 
     func = _get_engine_function("bottleneck", "median")
     result = func(data, window=window, axis=axis, min_count=min_count)
+    return _shift_bottleneck_result(result, window, axis)
+
+
+def _shift_bottleneck_result(result: np.ndarray, window: int, axis: int) -> np.ndarray:
+    """Shift trailing bottleneck windows to centered window alignment."""
     shift = window // 2
     if shift:
-        destination = [slice(None)] * data.ndim
-        source = [slice(None)] * data.ndim
+        destination = [slice(None)] * result.ndim
+        source = [slice(None)] * result.ndim
         destination[axis] = slice(0, -shift)
         source[axis] = slice(shift, None)
         result[tuple(destination)] = result[tuple(source)]
@@ -171,7 +178,7 @@ def _apply_bottleneck_operation(
 
     extra_kwargs = {"ddof": ddof} if operation == "std" else {}
     result = func(data, window=window, axis=axis, min_count=min_count, **extra_kwargs)
-    return result
+    return _shift_bottleneck_result(result, window, axis)
 
 
 # Engine function wrappers (defined after functions)
@@ -252,6 +259,9 @@ def moving_window(
         Axis along which to operate
     engine : {"auto", "scipy", "bottleneck"}, default "auto"
         Engine to use
+        Bottleneck non-median windows keep the bottleneck engine for even
+        windows. These are shifted toward centered alignment but can differ
+        from scipy's even-window convention.
     mode
         Boundary mode. Non-default values use scipy for operations where
         bottleneck cannot preserve scipy boundary semantics.

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -170,7 +170,7 @@ def to_timedelta64(obj: float | np.ndarray | str | timedelta):
     >>> td_1 = dc.to_timedelta64(10.1232)
     >>>
     >>> # This also works on negative numbers.
-    >>> td_2 = dc.to_datetime64(-10.5)
+    >>> td_2 = dc.to_timedelta64(-10.5)
     >>>
     >>> # Convert a string to timedelta64
     >>> td_str = "1000000000 nanoseconds"

--- a/tests/test_proc/test_aggregate.py
+++ b/tests/test_proc/test_aggregate.py
@@ -121,6 +121,33 @@ class TestBasicAggregations:
         assert "time" not in out.dims
         assert out.ndim == 1
 
+    def test_multi_dim_reduce_squeeze_3d(self):
+        """Squeezing multiple dims should not use stale axis numbers."""
+        data = np.arange(27, dtype=float).reshape(3, 3, 3)
+        coords = {
+            "distance": np.arange(3),
+            "time": np.arange(3),
+            "face": np.arange(3),
+        }
+        patch = dc.Patch(data=data, coords=coords, dims=("distance", "time", "face"))
+        out = patch.aggregate(
+            dim=("distance", "time"), method="mean", dim_reduce="squeeze"
+        )
+        expected = np.mean(
+            patch.data,
+            axis=(patch.get_axis("distance"), patch.get_axis("time")),
+        )
+        assert out.dims == ("face",)
+        npt.assert_allclose(out.data, expected)
+
+    def test_dim_reduce_squeeze_all_dims_raises(self, random_patch):
+        """Squeeze should not create an unsupported scalar patch."""
+        msg = "at least one dimension"
+        with pytest.raises(ParameterError, match=msg):
+            random_patch.aggregate(
+                dim=("distance", "time"), method="mean", dim_reduce="squeeze"
+            )
+
     def test_dim_reduce_mean(self, random_patch):
         """Ensure the mean value can be left on the coord."""
         out = random_patch.aggregate(dim="time", method="mean", dim_reduce="mean")

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -171,6 +171,18 @@ class TestNormalize:
         bit_norm = patch.normalize("time", norm="bit")
         assert np.all(np.unique(bit_norm.data) == np.array([-1.0, 0, 1.0]))
 
+    def test_max_uses_absolute_values(self, random_patch):
+        """Max normalization should divide by maximum absolute value."""
+        data = -np.abs(random_patch.data) - 1
+        patch = random_patch.new(data=data)
+
+        out = patch.normalize("time", norm="max")
+
+        axis = patch.get_axis("time")
+        assert np.all(out.data <= 0)
+        assert np.all(np.abs(out.data) <= 1)
+        assert np.allclose(np.max(np.abs(out.data), axis=axis), 1)
+
     def test_zero_channels(self, random_patch):
         """Ensure after operation each zero row or vector remains so."""
         zeroed_data = np.copy(random_patch.data)

--- a/tests/test_proc/test_mute.py
+++ b/tests/test_proc/test_mute.py
@@ -186,6 +186,16 @@ class Test1DLineMute:
         sub = muted1.select(time=(v1, v2), relative=True)
         assert not np.allclose(sub.data, 1)
 
+    def test_single_dict_smooth_matches_scalar(self, patch_ones):
+        """A smooth dict should smooth the selected patch axis."""
+        coord = patch_ones.get_coord("time")
+        v1, v2 = _get_testable_coord_values(coord, relative=True)
+        muted_scalar = patch_ones.line_mute(time=(v1, v2), relative=True, smooth=5)
+        muted_dict = patch_ones.line_mute(
+            time=(v1, v2), relative=True, smooth={"time": 5}
+        )
+        np.testing.assert_allclose(muted_dict.data, muted_scalar.data)
+
     def test_single_quantity(self, patch_ones):
         """A single quantity should work with a specified dimension."""
         coord = patch_ones.get_coord("time")
@@ -258,13 +268,24 @@ class TestMuteLines:
             distance=distance,
         )
         inverted = patch_ones.line_mute(time=time, distance=distance, invert=True)
-
         points = [(110, 3), (271, 7), (23, 1), (50, 6), (250, 1), (170, 3)]
         expected = np.array([0, 0, 0, 1, 1, 1])
         _assert_point_values(muted, self._dims, points=points, expected_values=expected)
         _assert_point_values(
             inverted, self._dims, points=points, expected_values=-expected + 1
         )
+
+    def test_dict_smooth_is_independent_of_key_order(self, patch_ones):
+        """Dict smooth values should stay paired with their dimensions."""
+        time = ([0, 2], [0, 4])
+        distance = ([0, 100], [0, 100])
+        smooth1 = {"time": 5, "distance": 3}
+        smooth2 = {"distance": 3, "time": 5}
+
+        muted1 = patch_ones.line_mute(time=time, distance=distance, smooth=smooth1)
+        muted2 = patch_ones.line_mute(time=time, distance=distance, smooth=smooth2)
+
+        np.testing.assert_allclose(muted1.data, muted2.data)
 
     def test_implicit_with_positive_line(self, patch_ones):
         """

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,6 +13,8 @@ from dascore.compat import random_state
 from dascore.exceptions import FilterValueError
 from dascore.units import Hz, m, s
 from dascore.utils.patch import get_start_stop_step
+
+resample_mod = importlib.import_module("dascore.proc.resample")
 
 
 class TestInterpolate:
@@ -132,13 +136,32 @@ class TestDecimate:
         with pytest.raises(FilterValueError, match=match):
             small_patch.decimate(distance=2)
 
+    def test_scipy_decimation_gets_patch(self, random_patch, monkeypatch):
+        """The scipy decimation helper should receive the patch, not its data."""
+        calls = []
+
+        def decimate_spy(patch, factor, ftype, axis):
+            assert isinstance(patch, dc.Patch)
+            calls.append((patch, factor, ftype, axis))
+            slicer = [slice(None)] * patch.ndim
+            slicer[axis] = slice(None, None, int(factor))
+            return patch.data[tuple(slicer)]
+
+        monkeypatch.setattr(resample_mod, "_apply_scipy_decimation", decimate_spy)
+
+        out = random_patch.decimate(time=2, filter_type="iir")
+
+        patch, factor, _, axis = calls[0]
+        assert patch is random_patch
+        assert out.shape[axis] == random_patch.shape[axis] // factor
+
 
 class TestResample:
     """Tests for resampling along a given dimension."""
 
     def test_downsample_time(self, random_patch):
         """Test decreasing the temporal sampling rate."""
-        start, stop, step = get_start_stop_step(random_patch, "time")
+        _, _, step = get_start_stop_step(random_patch, "time")
         patch = random_patch
         axis = patch.get_axis("time")
         new_dt = 2 * step
@@ -207,7 +230,7 @@ class TestResample:
 
     def test_slightly_above_current_rate(self, random_patch):
         """Tests for resampling slightly above current rate."""
-        start, stop, step = get_start_stop_step(random_patch, "distance")
+        _, _, step = get_start_stop_step(random_patch, "distance")
         new_step = step + 0.0000001
         out = random_patch.resample(distance=new_step)
         assert out.attrs["distance_max"] <= random_patch.attrs["distance_max"]
@@ -215,7 +238,7 @@ class TestResample:
 
     def test_slightly_under_current_rate(self, random_patch):
         """Tests for resampling slightly under current rate."""
-        start, stop, step = get_start_stop_step(random_patch, "distance")
+        _, _, step = get_start_stop_step(random_patch, "distance")
         new_step = step - 0.0000001
         out = random_patch.resample(distance=new_step)
         assert out.attrs["distance_max"] <= random_patch.attrs["distance_max"]

--- a/tests/test_transform/test_integrate.py
+++ b/tests/test_transform/test_integrate.py
@@ -79,6 +79,19 @@ class TestIndefiniteIntegrals:
         data_out = out.data.flatten()
         assert np.allclose(expected, data_out)
 
+    def test_integrate_multiple_dims_matches_sequential(self):
+        """Indefinite multi-dim integration should compose axis integrals."""
+        data = np.arange(12, dtype=float).reshape(3, 4)
+        coords = {"distance": np.arange(3), "time": np.arange(4)}
+        patch = dc.Patch(data=data, coords=coords, dims=("distance", "time"))
+
+        out = patch.integrate(dim=("distance", "time"), definite=False)
+        expected = patch.integrate(dim="distance", definite=False).integrate(
+            dim="time", definite=False
+        )
+
+        np.testing.assert_allclose(out.data, expected.data)
+
 
 class TestDefiniteIntegration:
     """Test case for definite path integration."""

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -155,6 +155,28 @@ class TestBasicChunkDF:
         time_min = df2.iloc[0]["time_min"]
         assert time_min.minute == 1
 
+    def test_chunk_uses_step_from_each_group(self):
+        """Each sampling group should use its own step for interval ends."""
+        df = pd.DataFrame(
+            {
+                "time_min": [
+                    np.datetime64("2020-01-01T00:00:00"),
+                    np.datetime64("2020-02-01T00:00:00"),
+                ],
+                "time_max": [
+                    np.datetime64("2020-01-01T00:01:39"),
+                    np.datetime64("2020-02-01T00:16:30"),
+                ],
+                "time_step": [np.timedelta64(1, "s"), np.timedelta64(10, "s")],
+            }
+        )
+
+        _, chunked = ChunkManager(time=50).chunk(df)
+
+        ten_second_group = chunked[chunked["time_step"] == np.timedelta64(10, "s")]
+        first = ten_second_group.iloc[0]
+        assert first["time_max"] - first["time_min"] == np.timedelta64(40, "s")
+
     def test_keep_leftovers(self, contiguous_df):
         """Ensure leftovers show up in df."""
         chunker = ChunkManager(overlap=None, keep_partial=True, time=28)

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -305,6 +305,28 @@ class TestMaybeGetItems:
         assert "sue" in out
         assert "who" not in out
 
+    def test_falsy_values_are_preserved(self):
+        """Falsy values are legitimate attributes and should not be dropped."""
+        data = {"zero": 0, "zero_float": 0.0, "empty": "", "missing": None}
+        attr_map = {
+            "zero": "zero",
+            "zero_float": "zero_float",
+            "empty": "empty",
+            "missing": "missing",
+        }
+
+        out = maybe_get_items(data, attr_map=attr_map)
+
+        assert out == {"zero": 0, "zero_float": 0.0, "empty": ""}
+
+    def test_multi_element_array_values_are_preserved(self):
+        """Array values should not be truth-tested while being copied."""
+        array = np.array([1, 2])
+
+        out = maybe_get_items({"array": array}, attr_map={"array": "array"})
+
+        np.testing.assert_array_equal(out["array"], array)
+
 
 class TestWarnOrRaise:
     """Ensure warn or raise works."""

--- a/tests/test_utils/test_moving.py
+++ b/tests/test_utils/test_moving.py
@@ -286,6 +286,32 @@ class TestMovingWindow:
                 result_bn[tuple(indexer)], result_scipy[tuple(indexer)]
             )
 
+    @pytest.mark.parametrize("operation", ["mean", "sum", "min", "max"])
+    def test_bottleneck_operations_are_centered(self, operation):
+        """Bottleneck operations should match scipy away from edge regions."""
+        pytest.importorskip("bottleneck")
+        data = np.array(
+            [
+                [0.0, 3.0, 1.0, 8.0, 4.0, 2.0, 6.0],
+                [5.0, 4.0, 9.0, 1.0, 7.0, 3.0, 2.0],
+                [2.0, 8.0, 4.0, 6.0, 0.0, 5.0, 1.0],
+                [7.0, 1.0, 5.0, 2.0, 9.0, 6.0, 3.0],
+                [4.0, 6.0, 2.0, 5.0, 3.0, 1.0, 8.0],
+            ]
+        )
+
+        for axis, window in ((0, 3), (1, 5)):
+            result_scipy = moving_window(data, window, operation, axis, engine="scipy")
+            result_bn = moving_window(
+                data, window, operation, axis, engine="bottleneck"
+            )
+            half_window = window // 2
+            indexer = [slice(None)] * data.ndim
+            indexer[axis] = slice(half_window, -half_window)
+            np.testing.assert_allclose(
+                result_bn[tuple(indexer)], result_scipy[tuple(indexer)]
+            )
+
     def test_bottleneck_median_boundary_options(self):
         """Non-default scipy boundary options should not be ignored."""
         pytest.importorskip("bottleneck")

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -295,6 +295,10 @@ class TestToTimeDelta64:
             expected = -to_timedelta64(abs(val))
             assert out == expected or (pd.isnull(out) and pd.isnull(expected))
 
+    def test_negative_example_uses_timedelta_function(self):
+        """The negative-number example should demonstrate to_timedelta64."""
+        assert "dc.to_timedelta64(-10.5)" in to_timedelta64.__doc__
+
     def test_negative_int(self):
         """Negative ints should be a symmetric operation."""
         floats_to_test = [1, 10, 100]


### PR DESCRIPTION
context: I took Fable for a spin and it found these bugs.

## Summary
- Fix axis and metadata handling for multi-dimensional aggregation and unsupported all-dimension squeeze.
- Fix regression edge cases in normalize, mute smoothing, decimation, integration, chunking, misc attr extraction, moving windows, and time docs.
- Add focused regression tests for each corrected behavior.

## Test Plan
- pytest tests/test_proc/test_aggregate.py tests/test_proc/test_basic.py tests/test_proc/test_mute.py tests/test_proc/test_resample.py tests/test_transform/test_integrate.py tests/test_utils/test_chunk.py tests/test_utils/test_misc.py tests/test_utils/test_moving.py tests/test_utils/test_time.py
- pytest tests
- pre-commit run --all