### PR TITLE
Speed up reading and merging many files

### DIFF
--- a/benchmarks/test_spool_benchmarks.py
+++ b/benchmarks/test_spool_benchmarks.py
@@ -2,15 +2,43 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.utils.time import to_timedelta64
 
 
 @pytest.fixture
 def spool_no_gap():
     """Get test spool with no gaps."""
     return dc.get_example_spool("random_das", length=10)
+
+
+def _make_contiguous_patches(count, shape=(50, 100), time_step=0.004):
+    """Make small patches contiguous in time."""
+    base = dc.get_example_patch(
+        "random_das",
+        time_min="2023-01-01",
+        shape=shape,
+        time_step=time_step,
+        distance_step=1.0,
+    ).update_attrs(history=[])
+    duration = to_timedelta64(shape[1] * time_step)
+    start = np.datetime64("2023-01-01")
+    return [
+        base.update_coords(time_min=start + i * duration).update_attrs(history=[])
+        for i in range(count)
+    ]
+
+
+@pytest.fixture(scope="module")
+def many_file_directory(tmp_path_factory):
+    """Create a directory of many small contiguous DASDAE files."""
+    path = tmp_path_factory.mktemp("many_file_benchmark")
+    for i, patch in enumerate(_make_contiguous_patches(25)):
+        patch.io.write(path / f"file_{i:03d}.h5", "dasdae")
+    return path
 
 
 @pytest.fixture
@@ -105,3 +133,61 @@ class TestSelectionBenchmarks:
         spool = diverse_spool
         spool.select(tag="some_*")
         spool.select(station="wayou?")
+
+
+class TestManyFileDirectoryBenchmarks:
+    """Benchmarks for working with a directory of many files."""
+
+    @pytest.fixture
+    def indexed_spool(self, many_file_directory):
+        """Get an indexed spool of the directory."""
+        return dc.spool(many_file_directory).update(progress=None)
+
+    @pytest.mark.benchmark
+    def test_index_directory(self, many_file_directory):
+        """Time indexing a directory of many files."""
+        for index_path in many_file_directory.glob(".dascore*"):
+            index_path.unlink()
+        spool = dc.spool(many_file_directory).update(progress=None)
+        assert len(spool)
+
+    @pytest.mark.benchmark
+    def test_merge_many_files(self, indexed_spool):
+        """Time merging many files into a single patch."""
+        merged = indexed_spool.chunk(time=None)
+        patches = list(merged)
+        assert len(patches) == 1
+
+    @pytest.mark.benchmark
+    def test_iterate_chunked(self, indexed_spool):
+        """Time loading chunks which each span several files."""
+        # each file spans 0.4s, so each chunk merges 4 files.
+        chunked = indexed_spool.chunk(time=1.6)
+        for patch in chunked:
+            assert isinstance(patch, dc.Patch)
+
+
+class TestMemorySpoolBenchmarks:
+    """Benchmarks for in-memory spool creation and access."""
+
+    @pytest.fixture(scope="class")
+    def many_patches(self):
+        """Get a list of many small contiguous patches."""
+        return _make_contiguous_patches(100)
+
+    @pytest.mark.benchmark
+    def test_spool_from_patches_access(self, many_patches):
+        """Time creating a spool from patches and accessing its contents."""
+        spool = dc.spool(many_patches)
+        assert len(spool) == len(many_patches)
+        assert isinstance(spool[0], dc.Patch)
+        assert isinstance(spool[-1], dc.Patch)
+        for patch in spool:
+            assert isinstance(patch, dc.Patch)
+
+    @pytest.mark.benchmark
+    def test_merge_many_patches(self, many_patches):
+        """Time merging many in-memory patches into one."""
+        merged = dc.spool(many_patches).chunk(time=None)
+        assert len(merged) == 1
+        assert isinstance(merged[0], dc.Patch)

--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -15,12 +15,7 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.constants import PROGRESS_LEVELS
-from dascore.core.spool import (
-    BaseSpool,
-    DataFrameSpool,
-    MemorySpool,
-    _patches_from_read,
-)
+from dascore.core.spool import BaseSpool, DataFrameSpool, MemorySpool
 from dascore.exceptions import MissingPatchError
 from dascore.io.indexer import AbstractIndexer, DirectoryIndexer
 from dascore.utils.docs import compose_docstring
@@ -134,7 +129,7 @@ class DirectorySpool(DataFrameSpool):
         final_kwargs.update(self._select_kwargs)
         patches = self._read_patches(final_kwargs)
         if patches is None:  # fast path doesn't apply, use generic read.
-            patches = _patches_from_read(dc.read(**final_kwargs))
+            patches = list(dc.read(**final_kwargs))
         if not patches:
             # Iteration skips these with a warning, see #583.
             msg = (
@@ -172,7 +167,7 @@ class DirectorySpool(DataFrameSpool):
         spool = fiber_io.read(kwargs["path"], **select)
         if not isinstance(spool, MemorySpool):
             return None
-        patches = spool._unprocessed_patches()
+        patches = list(spool)
         # Without selection, a multi-patch file is ambiguous: the row refers
         # to one specific patch. Let the generic path pick the right one.
         if len(patches) > 1 and not select:

--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -15,7 +15,7 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.constants import PROGRESS_LEVELS
-from dascore.core.spool import BaseSpool, DataFrameSpool
+from dascore.core.spool import BaseSpool, DataFrameSpool, MemorySpool
 from dascore.io.indexer import AbstractIndexer, DirectoryIndexer
 from dascore.utils.docs import compose_docstring
 from dascore.utils.pd import adjust_segments
@@ -126,5 +126,46 @@ class DirectorySpool(DataFrameSpool):
         """Given a row from the managed dataframe, return a patch."""
         final_kwargs = dict(kwargs)
         final_kwargs.update(self._select_kwargs)
-        patch = dc.read(**final_kwargs)[0]
-        return patch
+        patches = self._read_patches(final_kwargs)
+        if patches is None:  # fast path doesn't apply, use generic read.
+            patches = [dc.read(**final_kwargs)[0]]
+        if not len(patches):
+            # Note: DataFrameSpool.__iter__ matches on "out of bounds" to
+            # skip patches trimmed to nothing (see #583).
+            msg = "index of [0] is out of bounds for spool."
+            raise IndexError(msg)
+        return patches[0]
+
+    def _read_patches(self, kwargs) -> list | None:
+        """
+        Read patches directly through the file's FiberIO.
+
+        This skips the format detection of dc.read and the spool indexing
+        machinery applied to its output, which add up when loading many
+        files. Returns None when the fast path can't be safely used.
+        """
+        fmt, version = kwargs.get("file_format"), kwargs.get("file_version")
+        if not fmt:
+            return None
+        fiber_io = dc.io.FiberIO.manager.get_fiberio(format=fmt, version=version)
+        # Only apply select kwargs when the source patch is trimmed by the
+        # instruction df or the spool itself; otherwise the whole file is
+        # wanted and selection is wasted work.
+        if kwargs.get("_modified") or self._select_kwargs:
+            select = {
+                k: v
+                for k, v in kwargs.items()
+                if k not in ("path", "file_format", "file_version")
+                and not k.startswith("_")
+            }
+        else:
+            select = {}
+        spool = fiber_io.read(kwargs["path"], **select)
+        if not isinstance(spool, MemorySpool):
+            return None
+        patches = spool._unprocessed_patches()
+        # Without selection, a multi-patch file is ambiguous: the row refers
+        # to one specific patch. Let the generic path pick the right one.
+        if len(patches) > 1 and not select:
+            return None
+        return patches

--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -129,14 +129,14 @@ class DirectorySpool(DataFrameSpool):
         patches = self._read_patches(final_kwargs)
         if patches is None:  # fast path doesn't apply, use generic read.
             patches = [dc.read(**final_kwargs)[0]]
-        if not len(patches):
+        if not patches:
             # Note: DataFrameSpool.__iter__ matches on "out of bounds" to
             # skip patches trimmed to nothing (see #583).
             msg = "index of [0] is out of bounds for spool."
             raise IndexError(msg)
         return patches[0]
 
-    def _read_patches(self, kwargs) -> list | None:
+    def _read_patches(self, kwargs) -> list[dc.Patch] | None:
         """
         Read patches directly through the file's FiberIO.
 
@@ -155,8 +155,7 @@ class DirectorySpool(DataFrameSpool):
             select = {
                 k: v
                 for k, v in kwargs.items()
-                if k not in ("path", "file_format", "file_version")
-                and not k.startswith("_")
+                if k not in self._drop_columns and not k.startswith("_")
             }
         else:
             select = {}

--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -16,6 +16,7 @@ from typing_extensions import Self
 import dascore as dc
 from dascore.constants import PROGRESS_LEVELS
 from dascore.core.spool import BaseSpool, DataFrameSpool, MemorySpool
+from dascore.exceptions import MissingPatchError
 from dascore.io.indexer import AbstractIndexer, DirectoryIndexer
 from dascore.utils.docs import compose_docstring
 from dascore.utils.pd import adjust_segments
@@ -128,12 +129,18 @@ class DirectorySpool(DataFrameSpool):
         final_kwargs.update(self._select_kwargs)
         patches = self._read_patches(final_kwargs)
         if patches is None:  # fast path doesn't apply, use generic read.
-            patches = [dc.read(**final_kwargs)[0]]
+            spool = dc.read(**final_kwargs)
+            if isinstance(spool, MemorySpool):
+                patches = spool._unprocessed_patches()
+            else:  # a FiberIO returned an unusual spool type.
+                patches = list(spool)
         if not patches:
-            # Note: DataFrameSpool.__iter__ matches on "out of bounds" to
-            # skip patches trimmed to nothing (see #583).
-            msg = "index of [0] is out of bounds for spool."
-            raise IndexError(msg)
+            # Iteration skips these with a warning, see #583.
+            msg = (
+                f"No patch in {final_kwargs.get('path')} matches the "
+                f"requested range; it may have been trimmed to nothing."
+            )
+            raise MissingPatchError(msg)
         return patches[0]
 
     def _read_patches(self, kwargs) -> list[dc.Patch] | None:

--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -15,7 +15,12 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.constants import PROGRESS_LEVELS
-from dascore.core.spool import BaseSpool, DataFrameSpool, MemorySpool
+from dascore.core.spool import (
+    BaseSpool,
+    DataFrameSpool,
+    MemorySpool,
+    _patches_from_read,
+)
 from dascore.exceptions import MissingPatchError
 from dascore.io.indexer import AbstractIndexer, DirectoryIndexer
 from dascore.utils.docs import compose_docstring
@@ -129,11 +134,7 @@ class DirectorySpool(DataFrameSpool):
         final_kwargs.update(self._select_kwargs)
         patches = self._read_patches(final_kwargs)
         if patches is None:  # fast path doesn't apply, use generic read.
-            spool = dc.read(**final_kwargs)
-            if isinstance(spool, MemorySpool):
-                patches = spool._unprocessed_patches()
-            else:  # a FiberIO returned an unusual spool type.
-                patches = list(spool)
+            patches = _patches_from_read(dc.read(**final_kwargs))
         if not patches:
             # Iteration skips these with a warning, see #583.
             msg = (

--- a/dascore/clients/dirspool.py
+++ b/dascore/clients/dirspool.py
@@ -145,7 +145,9 @@ class DirectorySpool(DataFrameSpool):
         files. Returns None when the fast path can't be safely used.
         """
         fmt, version = kwargs.get("file_format"), kwargs.get("file_version")
-        if not fmt:
+        if not fmt or not version:
+            # Without a concrete version get_fiberio would return the newest
+            # reader; let dc.read detect the file's actual version instead.
             return None
         fiber_io = dc.io.FiberIO.manager.get_fiberio(format=fmt, version=version)
         # Only apply select kwargs when the source patch is trimmed by the

--- a/dascore/clients/filespool.py
+++ b/dascore/clients/filespool.py
@@ -10,7 +10,8 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.constants import PROGRESS_LEVELS, SpoolType
-from dascore.core.spool import BaseSpool, DataFrameSpool
+from dascore.core.spool import BaseSpool, DataFrameSpool, MemorySpool
+from dascore.exceptions import MissingPatchError
 from dascore.io.core import FiberIO
 from dascore.utils.docs import compose_docstring
 
@@ -65,7 +66,19 @@ class FileSpool(DataFrameSpool):
 
     def _load_patch(self, kwargs) -> Self:
         """Given a row from the managed dataframe, return a patch."""
-        return dc.read(**kwargs)[0]
+        spool = dc.read(**kwargs)
+        if isinstance(spool, MemorySpool):
+            patches = spool._unprocessed_patches()
+        else:  # a FiberIO returned an unusual spool type.
+            patches = list(spool)
+        if not patches:
+            # Iteration skips these with a warning, see #583.
+            msg = (
+                f"No patch in {self._path} matches the requested range; "
+                f"it may have been trimmed to nothing."
+            )
+            raise MissingPatchError(msg)
+        return patches[0]
 
     @compose_docstring(doc=BaseSpool.update.__doc__)
     def update(self: SpoolType, progress: PROGRESS_LEVELS = "standard") -> Self:

--- a/dascore/clients/filespool.py
+++ b/dascore/clients/filespool.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.constants import PROGRESS_LEVELS, SpoolType
-from dascore.core.spool import BaseSpool, DataFrameSpool, MemorySpool
+from dascore.core.spool import BaseSpool, DataFrameSpool, _patches_from_read
 from dascore.exceptions import MissingPatchError
 from dascore.io.core import FiberIO
 from dascore.utils.docs import compose_docstring
@@ -66,11 +66,7 @@ class FileSpool(DataFrameSpool):
 
     def _load_patch(self, kwargs) -> Self:
         """Given a row from the managed dataframe, return a patch."""
-        spool = dc.read(**kwargs)
-        if isinstance(spool, MemorySpool):
-            patches = spool._unprocessed_patches()
-        else:  # a FiberIO returned an unusual spool type.
-            patches = list(spool)
+        patches = _patches_from_read(dc.read(**kwargs))
         if not patches:
             # Iteration skips these with a warning, see #583.
             msg = (

--- a/dascore/clients/filespool.py
+++ b/dascore/clients/filespool.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.constants import PROGRESS_LEVELS, SpoolType
-from dascore.core.spool import BaseSpool, DataFrameSpool, _patches_from_read
+from dascore.core.spool import BaseSpool, DataFrameSpool
 from dascore.exceptions import MissingPatchError
 from dascore.io.core import FiberIO
 from dascore.utils.docs import compose_docstring
@@ -66,7 +66,7 @@ class FileSpool(DataFrameSpool):
 
     def _load_patch(self, kwargs) -> Self:
         """Given a row from the managed dataframe, return a patch."""
-        patches = _patches_from_read(dc.read(**kwargs))
+        patches = list(dc.read(**kwargs))
         if not patches:
             # Iteration skips these with a warning, see #583.
             msg = (

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -1049,6 +1049,29 @@ class CoordManager(DascoreBaseModel):
             out[name] = coord.to_summary(dims=dim_map[name])
         return out
 
+    def _get_dim_summary(self) -> dict:
+        """
+        Get a flat dict with the dims string and each dimension's range.
+
+        The output has {dim}_min, {dim}_max and {dim}_step keys for each
+        dimension; much cheaper than dumping the full summary models.
+        """
+        info = {"dims": ",".join(self.dims)}
+        for dim in self.dims:
+            coord = self.coord_map[dim]
+            start, step = coord.min(), coord.step
+            if step is None:
+                # Use a typed null, as PatchAttrs.flat_dump does, so column
+                # comparisons on the resulting dataframe behave.
+                if isinstance(start, np.datetime64 | np.timedelta64):
+                    step = np.timedelta64("NaT", "ns")
+                elif isinstance(start, float | np.floating):
+                    step = np.nan
+            info[f"{dim}_min"] = start
+            info[f"{dim}_max"] = coord.max()
+            info[f"{dim}_step"] = step
+        return info
+
     def get_coord(self, coord_name: str) -> BaseCoord:
         """
         Retrieve a single coordinate from the coordinate manager.

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -674,17 +674,17 @@ class MemorySpool(DataFrameSpool):
         # (len, integer access, iteration) are served straight from the
         # patch list. This makes creating a spool from patches nearly free,
         # which matters when reading many files.
-        self._patches: list[PatchType] | None = None
+        self._patches: tuple[PatchType, ...] | None = None
         self._data = None
         if data is not None:
             if isinstance(data, dc.Patch):
-                self._patches = [data]
+                self._patches = (data,)
             elif isinstance(data, Sequence) and all(
                 isinstance(x, dc.Patch) for x in data
             ):
-                # Copy the sequence so mutating it afterwards doesn't
-                # change the spool contents.
-                self._patches = list(data)
+                # Copy to an immutable tuple so neither mutating the input
+                # sequence nor the stored one can change the spool contents.
+                self._patches = tuple(data)
             else:  # eg a spool or dataframe; needs the dataframe machinery.
                 self._data = data
 

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -88,8 +88,6 @@ def _get_varying_dim(df) -> str | None:
     varying = []
     for dim in dims:
         mins, maxs = df.get(f"{dim}_min"), df.get(f"{dim}_max")
-        if mins is None or maxs is None:
-            continue
         if mins.nunique(dropna=False) > 1 or maxs.nunique(dropna=False) > 1:
             varying.append(dim)
     return varying[0] if len(varying) == 1 else None

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -25,7 +25,13 @@ from dascore.constants import (
     numeric_types,
     timeable_types,
 )
-from dascore.exceptions import InvalidSpoolError, ParameterError
+from dascore.exceptions import (
+    CoordMergeError,
+    InvalidSpoolError,
+    MissingPatchError,
+    ParameterError,
+)
+from dascore.utils.attrs import combine_patch_attrs
 from dascore.utils.chunk import ChunkManager
 from dascore.utils.display import get_dascore_text, get_nice_text
 from dascore.utils.docs import compose_docstring
@@ -34,6 +40,8 @@ from dascore.utils.misc import CacheDescriptor, _spool_map, deep_equality_check
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import (
     _force_patch_merge,
+    _get_merge_dim,
+    _get_merged_coord,
     _patch_dim_summary,
     _spool_up,
     concatenate_patches,
@@ -52,6 +60,53 @@ from dascore.utils.pd import (
 )
 
 T = TypeVar("T")
+
+
+def _dim_slice(ndim: int, axis: int, start: int, stop: int) -> tuple:
+    """Get an nd slice tuple selecting start:stop along axis."""
+    out = [slice(None)] * ndim
+    out[axis] = slice(start, stop)
+    return tuple(out)
+
+
+def _get_varying_dim(df) -> str | None:
+    """
+    Get the single dimension whose range varies across rows of df.
+
+    Returns None when no dimension varies, several do, or the dataframe
+    doesn't carry range columns for the varying dimension; those cases
+    need the fully materialized merge to sort out.
+    """
+    dims = get_dim_names_from_columns(df)
+    varying = []
+    for dim in dims:
+        mins, maxs = df.get(f"{dim}_min"), df.get(f"{dim}_max")
+        if mins is None or maxs is None:
+            continue
+        if mins.nunique(dropna=False) > 1 or maxs.nunique(dropna=False) > 1:
+            varying.append(dim)
+    return varying[0] if len(varying) == 1 else None
+
+
+def _estimate_merge_samples(df, dim) -> int | None:
+    """
+    Estimate the total number of samples along dim of the merged rows.
+
+    Returns None if the estimate cannot be made (eg unknown steps), in
+    which case streaming the merge isn't possible.
+    """
+    if dim is None:
+        return None
+    cols = [f"{dim}_min", f"{dim}_max", f"{dim}_step"]
+    if not set(cols).issubset(df.columns):
+        return None
+    mins, maxs, steps = (df[x] for x in cols)
+    if mins.isnull().any() or maxs.isnull().any() or steps.isnull().any():
+        return None
+    counts = np.round((maxs - mins) / steps).astype(np.int64) + 1
+    if (counts < 0).any():
+        return None
+    return int(counts.sum())
 
 
 class BaseSpool(NamespaceOwner, abc.ABC):
@@ -356,6 +411,10 @@ class DataFrameSpool(BaseSpool):
     _source_df: pd.DataFrame = CacheDescriptor("_cache", "_get_source_df")
     # A dataframe of instructions for going from source_df to df
     _instruction_df: pd.DataFrame = CacheDescriptor("_cache", "_get_instruction_df")
+    # A mapping of current_index to positional rows of the instruction df
+    _instruction_indices: Mapping = CacheDescriptor(
+        "_cache", "_get_instruction_indices"
+    )
     # kwargs for filtering contents
     _select_kwargs: Mapping | None = FrozenDict()
     # kwargs for merging patches
@@ -372,6 +431,15 @@ class DataFrameSpool(BaseSpool):
 
     def _get_instruction_df(self):
         """Function to get the current df."""
+
+    def _get_instruction_indices(self):
+        """
+        Get a mapping of {current_index: positional rows} of the instruction df.
+
+        Using this avoids a full scan of the instruction df for each patch
+        request, which matters when many patches are loaded.
+        """
+        return self._instruction_df.groupby("current_index").indices
 
     def __init__(
         self, select_kwargs: dict | None = None, merge_kwargs: dict | None = None
@@ -425,19 +493,11 @@ class DataFrameSpool(BaseSpool):
         for ind in range(len(self._df)):
             try:
                 yield self._unbox_patch(self._get_patches_from_index(ind))
-            except IndexError as e:
-                # Check if this is the known #583 pattern (coordinate mismatch)
-                msg_str = str(e)
-                if "out of bounds" in msg_str:
-                    # This is the expected #583 case where patch coordinates don't align
-                    msg = (
-                        f"Skipping patch at index {ind} due to coordinate mismatch "
-                        f"(#583): {msg_str}"
-                    )
-                    warnings.warn(msg, UserWarning, stacklevel=2)
-                else:
-                    # Some other IndexError - re-raise it as it's a real bug
-                    raise
+            except MissingPatchError as e:
+                # The patch couldn't be produced, usually because a
+                # coordinate mismatch trimmed it to nothing (see #583).
+                msg = f"Skipping patch at index {ind} (see #583): {e}"
+                warnings.warn(msg, UserWarning, stacklevel=2)
 
     def _unbox_patch(self, patch_list):
         """Unbox a single patch from a patch list, check len."""
@@ -454,9 +514,10 @@ class DataFrameSpool(BaseSpool):
             inds = self._df.index[df_ind]
         except IndexError:
             msg = f"index of [{df_ind}] is out of bounds for spool."
-            raise IndexError(msg)
-        df1 = instruction[instruction["current_index"] == inds]
-        assert not df1.empty
+            raise IndexError(msg) from None
+        positions = self._instruction_indices.get(inds)
+        assert positions is not None and len(positions), "no instructions found"
+        df1 = instruction.iloc[positions]
         joined = df1.join(source.drop(columns=df1.columns, errors="ignore"))
         # Occasionally, duplicates can creep into the source_df,
         # but it costs a bit to check for duplicates, so only check and drop
@@ -469,26 +530,23 @@ class DataFrameSpool(BaseSpool):
 
     def _patch_from_instruction_df(self, joined):
         """Get the patches joined columns of instruction df."""
-        out = []
         df_dict_list = self._df_to_dict_list(joined)
         expected_len = len(joined["current_index"].unique())
+        if len(df_dict_list) > expected_len:
+            # Several sources merge into one patch. When the output size can
+            # be determined from the instructions, stream the sources into a
+            # pre-allocated array so they don't all need to be in memory with
+            # the merged output at once.
+            merge_dim = _get_varying_dim(joined)
+            samples = _estimate_merge_samples(joined, merge_dim)
+            if samples is not None:
+                patch = self._merge_patches_streaming(
+                    joined, df_dict_list, merge_dim, samples
+                )
+                return [patch]
+        out = []
         for patch_kwargs in df_dict_list:
-            # convert kwargs to format understood by parser/patch.select
-            kwargs = _convert_min_max_in_kwargs(patch_kwargs, joined)
-            patch = self._load_patch(kwargs)
-            # If the limits of the source patch were not modified, we can just
-            # use the select kwargs. This is important for missing coordinates
-            # (NaN values) to not get trimmed out.
-            if kwargs.get("_modified"):
-                select_kwargs = {
-                    i: v
-                    for i, v in kwargs.items()
-                    if i in patch.dims or i in patch.coords.coord_map
-                }
-            else:
-                select_kwargs = self._select_kwargs
-            if select_kwargs:
-                patch: dc.Patch = patch.select(**select_kwargs)
+            patch = self._load_trimmed_patch(patch_kwargs, joined)
             # The index doesn't carry all the dimensional info, so get what
             # merging needs from the patch coords (cheaper than attr dumps).
             info = _patch_dim_summary(patch)
@@ -497,6 +555,90 @@ class DataFrameSpool(BaseSpool):
         if len(out) > expected_len:
             out = _force_patch_merge(out, merge_kwargs=self._merge_kwargs)
         return [x["patch"] for x in out]
+
+    def _load_trimmed_patch(self, patch_kwargs, joined) -> dc.Patch:
+        """Load a single patch and trim it to its instruction range."""
+        # convert kwargs to format understood by parser/patch.select
+        kwargs = _convert_min_max_in_kwargs(patch_kwargs, joined)
+        patch = self._load_patch(kwargs)
+        # If the limits of the source patch were not modified, we can just
+        # use the select kwargs. This is important for missing coordinates
+        # (NaN values) to not get trimmed out.
+        if kwargs.get("_modified"):
+            select_kwargs = {
+                i: v
+                for i, v in kwargs.items()
+                if i in patch.dims or i in patch.coords.coord_map
+            }
+        else:
+            select_kwargs = self._select_kwargs
+        if select_kwargs:
+            patch = patch.select(**select_kwargs)
+        return patch
+
+    def _merge_patches_streaming(self, joined, df_dict_list, merge_dim, samples):
+        """
+        Merge the patches described by the instructions along merge_dim.
+
+        Each patch is copied into a pre-allocated output array as it is
+        loaded, then released; this avoids holding all source patches and
+        the merged output in memory at the same time, as concatenating
+        would.
+        """
+        buffer, offset, axis, dims = None, 0, None, None
+        coords, attrs, summaries = [], [], []
+        for patch_kwargs in df_dict_list:
+            patch = self._load_trimmed_patch(patch_kwargs, joined)
+            if dims is None:
+                dims = patch.dims
+                axis = patch.get_axis(merge_dim)
+            elif patch.dims != dims:
+                patch = patch.transpose(*dims)
+            data = patch.data
+            if buffer is None:
+                shape = list(data.shape)
+                shape[axis] = samples
+                buffer = np.empty(shape, dtype=data.dtype)
+            # Mixed dtypes upcast, mirroring np.concatenate behavior.
+            dtype = np.result_type(buffer.dtype, data.dtype)
+            if dtype != buffer.dtype:
+                buffer = buffer.astype(dtype)
+            end = offset + data.shape[axis]
+            if end > buffer.shape[axis]:
+                # The estimate came up short (eg from slightly uneven
+                # sampling); grow the buffer to fit.
+                shape = list(buffer.shape)
+                shape[axis] = end
+                new_buffer = np.empty(shape, dtype=buffer.dtype)
+                new_buffer[_dim_slice(buffer.ndim, axis, 0, offset)] = buffer[
+                    _dim_slice(buffer.ndim, axis, 0, offset)
+                ]
+                buffer = new_buffer
+            buffer[_dim_slice(buffer.ndim, axis, offset, end)] = data
+            offset = end
+            coords.append(patch.coords)
+            attrs.append(patch.attrs)
+            summaries.append(_patch_dim_summary(patch))
+        if offset != buffer.shape[axis]:  # over-estimated; trim excess.
+            buffer = buffer[_dim_slice(buffer.ndim, axis, 0, offset)]
+        # Ensure the loaded patches only vary along the expected dimension,
+        # the same requirement _force_patch_merge enforces.
+        summary_df = pd.DataFrame(summaries)
+        found_dim = _get_merge_dim(summary_df)
+        if found_dim != merge_dim:
+            msg = (
+                f"Cannot merge patches; expected them to vary along "
+                f"{merge_dim} but found {found_dim}."
+            )
+            raise CoordMergeError(msg)
+        conf = self._merge_kwargs.get("conflicts", None)
+        drop_conflicting = conf in {"drop", "keep_first"}
+        new_coord = _get_merged_coord(summary_df, merge_dim, coords, drop_conflicting)
+        coord = new_coord.coord_map[merge_dim]
+        new_attrs = combine_patch_attrs(
+            attrs, merge_dim, coord=coord, **self._merge_kwargs
+        )
+        return dc.Patch(data=buffer, coords=new_coord, attrs=new_attrs, dims=list(dims))
 
     def _get_dummy_dataframes(self, current):
         """
@@ -582,6 +724,8 @@ class DataFrameSpool(BaseSpool):
         new._df = df
         new._source_df = source_df
         new._instruction_df = instruction_df
+        # Discard stale instruction indices (eg from copied caches).
+        new._cache.pop("_instruction_indices", None)
         new._select_kwargs = dict(self._select_kwargs)
         new._select_kwargs.update(select_kwargs or {})
         new._merge_kwargs = dict(self._merge_kwargs)

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -34,6 +34,7 @@ from dascore.utils.misc import CacheDescriptor, _spool_map, deep_equality_check
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import (
     _force_patch_merge,
+    _patch_dim_summary,
     _spool_up,
     concatenate_patches,
     get_patch_names,
@@ -486,10 +487,11 @@ class DataFrameSpool(BaseSpool):
                 }
             else:
                 select_kwargs = self._select_kwargs
-            patch: dc.Patch = patch.select(**select_kwargs)
-            # its unfortunate, but currently we need to regenerate the patch
-            # dict because the index doesn't carry all the dimensional info
-            info = patch.attrs.flat_dump(exclude=["history"])
+            if select_kwargs:
+                patch: dc.Patch = patch.select(**select_kwargs)
+            # The index doesn't carry all the dimensional info, so get what
+            # merging needs from the patch coords (cheaper than attr dumps).
+            info = _patch_dim_summary(patch)
             info["patch"] = patch
             out.append(info)
         if len(out) > expected_len:
@@ -691,6 +693,15 @@ class MemorySpool(DataFrameSpool):
     def _load_patch(self, kwargs) -> Self:
         """Load the patch into memory."""
         return kwargs["patch"]
+
+    def _unprocessed_patches(self) -> list[PatchType]:
+        """
+        Return the patches as loaded, bypassing the instruction machinery.
+
+        Unlike indexing/iterating the spool, this applies no selection or
+        merging; it simply returns the patches the spool was created with.
+        """
+        return list(self._df["patch"])
 
     # Add specific implementation of concatenate patches.
     concatenate = _spool_up(concatenate_patches)

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -36,13 +36,17 @@ from dascore.utils.chunk import ChunkManager
 from dascore.utils.display import get_dascore_text, get_nice_text
 from dascore.utils.docs import compose_docstring
 from dascore.utils.mapping import FrozenDict
-from dascore.utils.misc import CacheDescriptor, _spool_map, deep_equality_check
+from dascore.utils.misc import (
+    CacheDescriptor,
+    _spool_map,
+    broadcast_for_index,
+    deep_equality_check,
+)
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import (
     _force_patch_merge,
     _get_merge_dim,
     _get_merged_coord,
-    _patch_dim_summary,
     _spool_up,
     concatenate_patches,
     get_patch_names,
@@ -60,20 +64,6 @@ from dascore.utils.pd import (
 )
 
 T = TypeVar("T")
-
-
-def _dim_slice(ndim: int, axis: int, start: int, stop: int) -> tuple:
-    """Get an nd slice tuple selecting start:stop along axis."""
-    out = [slice(None)] * ndim
-    out[axis] = slice(start, stop)
-    return tuple(out)
-
-
-def _patches_from_read(spool: BaseSpool) -> list[PatchType]:
-    """Get the raw patch list from a spool returned by dc.read."""
-    if isinstance(spool, MemorySpool):
-        return spool._unprocessed_patches()
-    return list(spool)  # a FiberIO returned an unusual spool type.
 
 
 def _get_varying_dim(df) -> str | None:
@@ -420,10 +410,6 @@ class DataFrameSpool(BaseSpool):
     _source_df: pd.DataFrame = CacheDescriptor("_cache", "_get_source_df")
     # A dataframe of instructions for going from source_df to df
     _instruction_df: pd.DataFrame = CacheDescriptor("_cache", "_get_instruction_df")
-    # A mapping of current_index to positional rows of the instruction df
-    _instruction_indices: Mapping = CacheDescriptor(
-        "_cache", "_get_instruction_indices"
-    )
     # kwargs for filtering contents
     _select_kwargs: Mapping | None = FrozenDict()
     # kwargs for merging patches
@@ -440,15 +426,6 @@ class DataFrameSpool(BaseSpool):
 
     def _get_instruction_df(self):
         """Function to get the current df."""
-
-    def _get_instruction_indices(self):
-        """
-        Get a mapping of {current_index: positional rows} of the instruction df.
-
-        Using this avoids a full scan of the instruction df for each patch
-        request, which matters when many patches are loaded.
-        """
-        return self._instruction_df.groupby("current_index").indices
 
     def __init__(
         self, select_kwargs: dict | None = None, merge_kwargs: dict | None = None
@@ -524,7 +501,13 @@ class DataFrameSpool(BaseSpool):
         except IndexError:
             msg = f"index of [{df_ind}] is out of bounds for spool."
             raise IndexError(msg) from None
-        positions = self._instruction_indices.get(inds)
+        # Group positional instruction rows by current index (and cache) to
+        # avoid a full instruction df scan for each requested patch.
+        indices = self._cache.get("_instruction_indices")
+        if indices is None:
+            indices = instruction.groupby("current_index").indices
+            self._cache["_instruction_indices"] = indices
+        positions = indices.get(inds)
         assert positions is not None and len(positions), "no instructions found"
         df1 = instruction.iloc[positions]
         joined = df1.join(source.drop(columns=df1.columns, errors="ignore"))
@@ -558,7 +541,7 @@ class DataFrameSpool(BaseSpool):
             patch = self._load_trimmed_patch(patch_kwargs, joined)
             # The index doesn't carry all the dimensional info, so get what
             # merging needs from the patch coords (cheaper than attr dumps).
-            info = _patch_dim_summary(patch)
+            info = patch.coords._get_dim_summary()
             info["patch"] = patch
             out.append(info)
         if len(out) > expected_len:
@@ -619,11 +602,12 @@ class DataFrameSpool(BaseSpool):
                 shape = list(buffer.shape)
                 shape[axis] = end
                 new_buffer = np.empty(shape, dtype=buffer.dtype)
-                head = _dim_slice(buffer.ndim, axis, 0, offset)
+                head = broadcast_for_index(buffer.ndim, axis, slice(0, offset))
                 new_buffer[head] = buffer[head]
                 buffer = new_buffer
             try:
-                buffer[_dim_slice(buffer.ndim, axis, offset, end)] = data
+                index = broadcast_for_index(buffer.ndim, axis, slice(offset, end))
+                buffer[index] = data
             except ValueError as e:
                 msg = (
                     f"Cannot merge patches; their shapes are incompatible "
@@ -633,9 +617,9 @@ class DataFrameSpool(BaseSpool):
             offset = end
             coords.append(patch.coords)
             attrs.append(patch.attrs)
-            summaries.append(_patch_dim_summary(patch))
+            summaries.append(patch.coords._get_dim_summary())
         if offset != buffer.shape[axis]:  # over-estimated; trim excess.
-            buffer = buffer[_dim_slice(buffer.ndim, axis, 0, offset)]
+            buffer = buffer[broadcast_for_index(buffer.ndim, axis, slice(0, offset))]
         # Ensure the loaded patches only vary along the expected dimension,
         # the same requirement _force_patch_merge enforces.
         summary_df = pd.DataFrame(summaries)
@@ -845,8 +829,6 @@ class MemorySpool(DataFrameSpool):
             elif isinstance(data, Sequence) and all(
                 isinstance(x, dc.Patch) for x in data
             ):
-                # Copy to an immutable tuple so neither mutating the input
-                # sequence nor the stored one can change the spool contents.
                 self._patches = tuple(data)
             else:  # eg a spool or dataframe; needs the dataframe machinery.
                 self._data = data
@@ -944,17 +926,6 @@ class MemorySpool(DataFrameSpool):
     def _load_patch(self, kwargs) -> Self:
         """Load the patch into memory."""
         return kwargs["patch"]
-
-    def _unprocessed_patches(self) -> list[PatchType]:
-        """
-        Return the patches as loaded, bypassing the instruction machinery.
-
-        Unlike indexing/iterating the spool, this applies no selection or
-        merging; it simply returns the patches the spool was created with.
-        """
-        if self._patches is not None:
-            return list(self._patches)
-        return list(self._df["patch"])
 
     @compose_docstring(doc=DataFrameSpool.new_from_df.__doc__)
     def new_from_df(self, *args, **kwargs):

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -667,13 +667,101 @@ class DataFrameSpool(BaseSpool):
 class MemorySpool(DataFrameSpool):
     """A Spool for storing patches in memory."""
 
-    # tuple of attributes to remove from table
-
     def __init__(self, data: PatchType | Sequence[PatchType] | None = None):
         super().__init__()
+        # When a patch, or sequence of patches, is given the managing
+        # dataframes are built lazily (on first access); simple operations
+        # (len, integer access, iteration) are served straight from the
+        # patch list. This makes creating a spool from patches nearly free,
+        # which matters when reading many files.
+        self._patches: list[PatchType] | None = None
+        self._data = None
         if data is not None:
-            dfs = self._get_dummy_dataframes(patches_to_df(data))
-            self._df, self._source_df, self._instruction_df = dfs
+            if isinstance(data, dc.Patch):
+                self._patches = [data]
+            elif isinstance(data, Sequence) and all(
+                isinstance(x, dc.Patch) for x in data
+            ):
+                # Copy the sequence so mutating it afterwards doesn't
+                # change the spool contents.
+                self._patches = list(data)
+            else:  # eg a spool or dataframe; needs the dataframe machinery.
+                self._data = data
+
+    def _get_df(self):
+        """Build the managing dataframes from the input patches."""
+        data = self._patches if self._patches is not None else self._data
+        if data is None:
+            return None
+        df, source, instruction = self._get_dummy_dataframes(patches_to_df(data))
+        self._source_df = source
+        self._instruction_df = instruction
+        return df
+
+    def _get_source_df(self):
+        """Build the source df (happens as part of building current df)."""
+        _ = self._df
+        return self._cache.get("_source_df")
+
+    def _get_instruction_df(self):
+        """Build the instruction df (happens as part of building current df)."""
+        _ = self._df
+        return self._cache.get("_instruction_df")
+
+    def __len__(self) -> int:
+        if self._patches is not None:
+            return len(self._patches)
+        return super().__len__()
+
+    def __getitem__(self, item) -> PatchType | BaseSpool:
+        # Fast path: a spool created directly from patches (which never has
+        # select kwargs) can serve integer requests from the patch list.
+        patches = self._patches
+        if (
+            patches is not None
+            and not self._select_kwargs
+            and isinstance(item, int | np.integer)
+        ):
+            try:
+                return patches[item]
+            except IndexError:
+                msg = f"index of [{item}] is out of bounds for spool."
+                raise IndexError(msg)
+        return super().__getitem__(item)
+
+    def __iter__(self) -> PatchType:
+        patches = self._patches
+        if patches is not None and not self._select_kwargs:
+            yield from patches
+        else:
+            yield from super().__iter__()
+
+    def __eq__(self, other) -> bool:
+        """
+        Equality check which ignores the state of the lazy dataframes.
+
+        The managed dataframes are built and compared directly so that
+        equality does not depend on whether they were constructed yet.
+        """
+        if self is other:
+            return True
+        if not isinstance(other, MemorySpool):
+            return super().__eq__(other)
+        return deep_equality_check(self._eq_dict(), other._eq_dict())
+
+    def _eq_dict(self) -> dict:
+        """Get a dict for equality checks, normalizing lazy state."""
+        out = dict(self.__dict__)
+        # Build (if needed) and compare the dataframes; drop the inputs
+        # they were built from, whose form can differ for equal contents.
+        out["_cache"] = {
+            "_df": self._df,
+            "_source_df": self._source_df,
+            "_instruction_df": self._instruction_df,
+        }
+        out.pop("_patches", None)
+        out.pop("_data", None)
+        return out
 
     def __rich__(self):
         base = super().__rich__()
@@ -701,6 +789,8 @@ class MemorySpool(DataFrameSpool):
         Unlike indexing/iterating the spool, this applies no selection or
         merging; it simply returns the patches the spool was created with.
         """
+        if self._patches is not None:
+            return list(self._patches)
         return list(self._df["patch"])
 
     # Add specific implementation of concatenate patches.

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -729,7 +729,7 @@ class MemorySpool(DataFrameSpool):
                 return patches[item]
             except IndexError:
                 msg = f"index of [{item}] is out of bounds for spool."
-                raise IndexError(msg)
+                raise IndexError(msg) from None
         return super().__getitem__(item)
 
     def __iter__(self) -> PatchType:

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -782,9 +782,7 @@ class DataFrameSpool(BaseSpool):
             if f"{attribute}_min" in attrs:
                 attribute = f"{attribute}_min"
             else:
-                msg = (
-                    "Invalid attribute. " "Please use a valid attribute such as: 'time'"
-                )
+                msg = "Invalid attribute. Please use a valid attribute such as: 'time'"
                 raise IndexError(msg)
 
         # get a mapping from the old current index to the sorted ones

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -575,10 +575,13 @@ class DataFrameSpool(BaseSpool):
     ):
         """Create a new instance from dataframes."""
         new = self.__class__(self)
-        df_, source_, inst_ = self._get_dummy_dataframes(df)
+        if source_df is None or instruction_df is None:
+            _, source_, inst_ = self._get_dummy_dataframes(df)
+            source_df = source_df if source_df is not None else source_
+            instruction_df = instruction_df if instruction_df is not None else inst_
         new._df = df
-        new._source_df = source_df if source_df is not None else source_
-        new._instruction_df = instruction_df if instruction_df is not None else inst_
+        new._source_df = source_df
+        new._instruction_df = instruction_df
         new._select_kwargs = dict(self._select_kwargs)
         new._select_kwargs.update(select_kwargs or {})
         new._merge_kwargs = dict(self._merge_kwargs)
@@ -795,6 +798,15 @@ class MemorySpool(DataFrameSpool):
         if self._patches is not None:
             return list(self._patches)
         return list(self._df["patch"])
+
+    @compose_docstring(doc=DataFrameSpool.new_from_df.__doc__)
+    def new_from_df(self, *args, **kwargs):
+        """{doc}."""
+        new = super().new_from_df(*args, **kwargs)
+        # The provided dataframes fully define the new spool; drop the
+        # construction input so derived spools don't retain their parents.
+        new._data = None
+        return new
 
     # Add specific implementation of concatenate patches.
     concatenate = _spool_up(concatenate_patches)

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -665,15 +665,18 @@ class DataFrameSpool(BaseSpool):
 
 
 class MemorySpool(DataFrameSpool):
-    """A Spool for storing patches in memory."""
+    """
+    A Spool for storing patches in memory.
+
+    When created from patches, the managing dataframes are built lazily
+    (on first access by an operation which needs them, such as chunk or
+    select) and simple operations (len, integer access, iteration) are
+    served straight from the patch tuple. This makes creating a spool
+    from patches nearly free, which matters when reading many files.
+    """
 
     def __init__(self, data: PatchType | Sequence[PatchType] | None = None):
         super().__init__()
-        # When a patch, or sequence of patches, is given the managing
-        # dataframes are built lazily (on first access); simple operations
-        # (len, integer access, iteration) are served straight from the
-        # patch list. This makes creating a spool from patches nearly free,
-        # which matters when reading many files.
         self._patches: tuple[PatchType, ...] | None = None
         self._data = None
         if data is not None:

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -69,6 +69,13 @@ def _dim_slice(ndim: int, axis: int, start: int, stop: int) -> tuple:
     return tuple(out)
 
 
+def _patches_from_read(spool: BaseSpool) -> list[PatchType]:
+    """Get the raw patch list from a spool returned by dc.read."""
+    if isinstance(spool, MemorySpool):
+        return spool._unprocessed_patches()
+    return list(spool)  # a FiberIO returned an unusual spool type.
+
+
 def _get_varying_dim(df) -> str | None:
     """
     Get the single dimension whose range varies across rows of df.
@@ -103,7 +110,11 @@ def _estimate_merge_samples(df, dim) -> int | None:
     mins, maxs, steps = (df[x] for x in cols)
     if mins.isnull().any() or maxs.isnull().any() or steps.isnull().any():
         return None
-    counts = np.round((maxs - mins) / steps).astype(np.int64) + 1
+    ratios = (maxs - mins) / steps
+    # Degenerate steps (eg 0) make the sample counts meaningless.
+    if not np.isfinite(ratios.astype(np.float64)).all():
+        return None
+    counts = np.round(ratios).astype(np.int64) + 1
     if (counts < 0).any():
         return None
     return int(counts.sum())
@@ -610,11 +621,17 @@ class DataFrameSpool(BaseSpool):
                 shape = list(buffer.shape)
                 shape[axis] = end
                 new_buffer = np.empty(shape, dtype=buffer.dtype)
-                new_buffer[_dim_slice(buffer.ndim, axis, 0, offset)] = buffer[
-                    _dim_slice(buffer.ndim, axis, 0, offset)
-                ]
+                head = _dim_slice(buffer.ndim, axis, 0, offset)
+                new_buffer[head] = buffer[head]
                 buffer = new_buffer
-            buffer[_dim_slice(buffer.ndim, axis, offset, end)] = data
+            try:
+                buffer[_dim_slice(buffer.ndim, axis, offset, end)] = data
+            except ValueError as e:
+                msg = (
+                    f"Cannot merge patches; their shapes are incompatible "
+                    f"along the dimensions not being merged ({merge_dim})."
+                )
+                raise CoordMergeError(msg) from e
             offset = end
             coords.append(patch.coords)
             attrs.append(patch.attrs)

--- a/dascore/exceptions.py
+++ b/dascore/exceptions.py
@@ -39,6 +39,16 @@ class IncompatiblePatchError(PatchError):
     """Raised when an operator cannot be performed on a patch."""
 
 
+class MissingPatchError(IndexError, PatchError):
+    """
+    Raised when no patch can be produced for a spool entry.
+
+    This typically happens when a patch is trimmed to nothing by
+    a coordinate selection (see #583). Subclasses IndexError for
+    backwards compatibility.
+    """
+
+
 class CoordError(ValueError, PatchError):
     """Raised when something is wrong with a Coordinate."""
 

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -209,6 +209,17 @@ def invert_quantity(unit: pint.Unit | str) -> pint.Unit | None:
     return 1 / quant
 
 
+@cache
+def _unit_to_str(unit: Unit) -> str:
+    """
+    Get the string representation of a unit; cache the result.
+
+    Unit equality/hashing is exact (e.g. m != cm) so, unlike Quantity,
+    Unit is safe to use as a cache key.
+    """
+    return str(unit)
+
+
 def get_quantity_str(quant_value: str | Quantity | None) -> str | None:
     """
     Ensure a unit/quantity is valid and return its string representation.
@@ -220,20 +231,32 @@ def get_quantity_str(quant_value: str | Quantity | None) -> str | None:
     quant_value
         A input specifying a quantity.
     """
+    # Note: this is called by the pydantic serializers of attrs and coord
+    # models, so it runs many times when working with many patches; the
+    # common paths need to stay cheap (hence _validate_quantity_str and
+    # _unit_to_str caches).
     quant_value = unbyte(quant_value)
     if quant_value is None or quant_value == "":
         return None
-    try:
-        quant = get_quantity(quant_value)
-    except UndefinedUnitError:
-        msg = f"DASCore failed to parse the following unit/quantity: {quant_value}"
-        raise UnitError(msg)
+    if isinstance(quant_value, str):
+        _validate_quantity_str(quant_value)
+        return quant_value
+    quant = get_quantity(quant_value)
     if isinstance(quant_value, Quantity):
         if quant.magnitude == 1.0:
-            quant_value = str(quant.units)
-        else:
-            quant_value = str(quant)
+            return _unit_to_str(quant.units)
+        return str(quant)
     return str(quant_value)
+
+
+@cache
+def _validate_quantity_str(quant_str: str) -> None:
+    """Raise a UnitError if the string doesn't specify a valid quantity."""
+    try:
+        get_quantity(quant_str)
+    except UndefinedUnitError:
+        msg = f"DASCore failed to parse the following unit/quantity: {quant_str}"
+        raise UnitError(msg)
 
 
 def get_inverted_quant(quant, data_units):

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -256,9 +256,9 @@ def _validate_quantity_str(quant_str: str) -> None:
     """Raise a UnitError if the string doesn't specify a valid quantity."""
     try:
         get_quantity(quant_str)
-    except UndefinedUnitError:
+    except UndefinedUnitError as e:
         msg = f"DASCore failed to parse the following unit/quantity: {quant_str}"
-        raise UnitError(msg)
+        raise UnitError(msg) from e
 
 
 def get_inverted_quant(quant, data_units):

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -241,11 +241,13 @@ def get_quantity_str(quant_value: str | Quantity | None) -> str | None:
     if isinstance(quant_value, str):
         _validate_quantity_str(quant_value)
         return quant_value
-    quant = get_quantity(quant_value)
     if isinstance(quant_value, Quantity):
-        if quant.magnitude == 1.0:
-            return _unit_to_str(quant.units)
-        return str(quant)
+        if quant_value.magnitude == 1.0:
+            return _unit_to_str(quant_value.units)
+        return str(quant_value)
+    # Any other type (eg a pint Unit): validate by conversion, then use
+    # the string of the original input.
+    get_quantity(quant_value)
     return str(quant_value)
 
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -384,6 +384,51 @@ def merge_patches(
     return dc.spool(patches).chunk(**{dim: None}, tolerance=tolerance)
 
 
+def _get_merge_dim(df) -> str | None:
+    """
+    Get the merge dimension from a dataframe of patch dim summaries.
+
+    The merge dimension is the single dimension whose range varies between
+    rows; None means complete overlap (nothing to merge).
+    """
+    dims = df["dims"].unique()
+    assert len(dims) == 1
+    dims = dims[0].split(",")
+    dims_vary = pd.Series({x: False for x in dims})
+    for dim in dims:
+        cols = [f"{dim}_min", f"{dim}_max", f"{dim}_step"]
+        vals = df[cols].values
+        vals_eq = vals == vals[[0], :]
+        vals_null = pd.isnull(vals)
+        columns_equal = (vals_eq | vals_null).all(axis=1)
+        dims_vary[dim] = not np.all(columns_equal)
+    assert dims_vary.sum() <= 1, "Only one dimension can vary for forced merge"
+    if not dims_vary.any():  # the case of complete overlap.
+        return None
+    return dims_vary[dims_vary].index[0]
+
+
+def _maybe_expected_step(df, dim):
+    """Get the expected step if all steps are close, else None."""
+    col = df[f"{dim}_step"].values
+    if all_diffs_close_enough(col):
+        return get_middle_value(col)
+    return None
+
+
+def _get_merged_coord(df, merge_dim, coords, drop_conflicting=False):
+    """Get merged coordinates, also validate anticipated sampling."""
+    new_coord = merge_coord_managers(
+        coords, dim=merge_dim, drop_conflicting=drop_conflicting
+    )
+    expected_step = _maybe_expected_step(df, merge_dim)
+    if not pd.isnull(expected_step):
+        new_coord = new_coord.snap(merge_dim)[0]
+        # TODO slightly different dt can be produced, let pass for now
+        # need to think more about how the merging should work.
+    return new_coord
+
+
 def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
     """
     Force a merge of the patches along a dimension.
@@ -391,45 +436,8 @@ def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
     This function is used in conjunction with `spool.chunk`, which
     does all the compatibility checks beforehand.
     """
-
-    def _get_merge_col(df):
-        dims = df["dims"].unique()
-        assert len(dims) == 1
-        dims = dims[0].split(",")
-        dims_vary = pd.Series({x: False for x in dims})
-        for dim in dims:
-            cols = [f"{dim}_min", f"{dim}_max", f"{dim}_step"]
-            vals = df[cols].values
-            vals_eq = vals == vals[[0], :]
-            vals_null = pd.isnull(vals)
-            columns_equal = (vals_eq | vals_null).all(axis=1)
-            dims_vary[dim] = not np.all(columns_equal)
-        assert dims_vary.sum() <= 1, "Only one dimension can vary for forced merge"
-        if not dims_vary.any():  # the case of complete overlap.
-            return None
-        return dims_vary[dims_vary].index[0]
-
-    def _maybe_step(df, dim):
-        """Get the expected step if all steps are close, else None."""
-        col = df[f"{dim}_step"].values
-        if all_diffs_close_enough(col):
-            return get_middle_value(col)
-        return None
-
-    def _get_new_coord(df, merge_dim, coords, drop_conflicting=False):
-        """Get new coordinates, also validate anticipated sampling."""
-        new_coord = merge_coord_managers(
-            coords, dim=merge_dim, drop_conflicting=drop_conflicting
-        )
-        expected_step = _maybe_step(df, merge_dim)
-        if not pd.isnull(expected_step):
-            new_coord = new_coord.snap(merge_dim)[0]
-            # TODO slightly different dt can be produced, let pass for now
-            # need to think more about how the merging should work.
-        return new_coord
-
     df = pd.DataFrame(patch_dict_list)
-    merge_dim = _get_merge_col(df)
+    merge_dim = _get_merge_dim(df)
     merge_kwargs = merge_kwargs if merge_kwargs is not None else {}
     if merge_dim is None:  # nothing to merge, complete overlap
         return [patch_dict_list[0]]
@@ -446,7 +454,7 @@ def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
     # Determine if conflicting non-dimensional coords should be dropped.
     conf = merge_kwargs.get("conflicts", None)
     drop_conf_coords = True if conf in {"drop", "keep_first"} else False
-    new_coord = _get_new_coord(df, merge_dim, coords, drop_conf_coords)
+    new_coord = _get_merged_coord(df, merge_dim, coords, drop_conf_coords)
     coord = new_coord.coord_map[merge_dim] if merge_dim in dims else None
     new_attrs = combine_patch_attrs(attrs, merge_dim, coord=coord, **merge_kwargs)
     patch = dc.Patch(data=new_data, coords=new_coord, attrs=new_attrs, dims=dims)

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -435,7 +435,8 @@ def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
         return [patch_dict_list[0]]
     dims = df["dims"].iloc[0].split(",")
     # get patches, ensure they are oriented the same.
-    patches = [x.transpose(*dims) for x in df["patch"]]
+    dims_tuple = tuple(dims)
+    patches = [x if x.dims == dims_tuple else x.transpose(*dims) for x in df["patch"]]
     axis = patches[0].get_axis(merge_dim)
     # get data, coords, attrs for merging patch together.
     data = [x.data for x in patches]
@@ -451,6 +452,32 @@ def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
     patch = dc.Patch(data=new_data, coords=new_coord, attrs=new_attrs, dims=dims)
     new_dict = {"patch": patch}
     return [new_dict]
+
+
+def _patch_dim_summary(patch: PatchType) -> dict:
+    """
+    Get a dict summarizing the patch's dimensional coordinates.
+
+    The output has the dims string and {dim}_min, {dim}_max, {dim}_step
+    for each dimension: the columns [`_force_patch_merge`](
+    `dascore.utils.patch._force_patch_merge`) needs to determine the merge
+    dimension. It is much cheaper than dumping the full attrs model.
+    """
+    info = {"dims": ",".join(patch.dims)}
+    for dim in patch.dims:
+        coord = patch.get_coord(dim)
+        start, step = coord.min(), coord.step
+        if step is None:
+            # Use a typed null, as PatchAttrs.flat_dump does, so column
+            # comparisons on the resulting dataframe behave.
+            if isinstance(start, np.datetime64 | np.timedelta64):
+                step = np.timedelta64("NaT", "ns")
+            elif isinstance(start, float | np.floating):
+                step = np.nan
+        info[f"{dim}_min"] = start
+        info[f"{dim}_max"] = coord.max()
+        info[f"{dim}_step"] = step
+    return info
 
 
 def get_start_stop_step(patch: PatchType, dim):

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -462,32 +462,6 @@ def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
     return [new_dict]
 
 
-def _patch_dim_summary(patch: PatchType) -> dict:
-    """
-    Get a dict summarizing the patch's dimensional coordinates.
-
-    The output has the dims string and {dim}_min, {dim}_max, {dim}_step
-    for each dimension: the columns [`_force_patch_merge`](
-    `dascore.utils.patch._force_patch_merge`) needs to determine the merge
-    dimension. It is much cheaper than dumping the full attrs model.
-    """
-    info = {"dims": ",".join(patch.dims)}
-    for dim in patch.dims:
-        coord = patch.get_coord(dim)
-        start, step = coord.min(), coord.step
-        if step is None:
-            # Use a typed null, as PatchAttrs.flat_dump does, so column
-            # comparisons on the resulting dataframe behave.
-            if isinstance(start, np.datetime64 | np.timedelta64):
-                step = np.timedelta64("NaT", "ns")
-            elif isinstance(start, float | np.floating):
-                step = np.nan
-        info[f"{dim}_min"] = start
-        info[f"{dim}_max"] = coord.max()
-        info[f"{dim}_step"] = step
-    return info
-
-
 def get_start_stop_step(patch: PatchType, dim):
     """Convenience method for getting start, stop, step for a given coord."""
     assert dim in patch.dims, f"{dim} is not in Patch dimensions of {patch.dims}"

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -345,7 +345,7 @@ def patches_to_df(
     if "history" not in df.columns:
         df = df.assign(history="")
     if "patch" not in df.columns:
-        df["patch"] = to_object_array(patches)
+        df["patch"] = None
     return df
 
 

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -157,6 +157,27 @@ class TestLoadPatchFastPath:
         assert spool._read_patches({"file_format": "DASDAE"}) is None
         assert spool._read_patches({"file_version": "1"}) is None
 
+    def test_unusual_fiberio_spool_defers_to_generic_read(
+        self, one_directory_spool, monkeypatch
+    ):
+        """Fast path should defer if the reader returns a non-memory spool."""
+
+        class _Reader:
+            def read(self, *args, **kwargs):
+                return ()
+
+        monkeypatch.setattr(
+            dc.io.FiberIO.manager,
+            "get_fiberio",
+            lambda format, version: _Reader(),
+        )
+        kwargs = {
+            "path": one_directory_spool.get_contents()["path"].iloc[0],
+            "file_format": "DASDAE",
+            "file_version": "1",
+        }
+        assert one_directory_spool._read_patches(kwargs) is None
+
 
 class TestDirectoryIndex:
     """Tests for returning summaries of all files in managed directory."""

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -13,7 +13,7 @@ import dascore as dc
 import dascore.examples
 from dascore.clients.dirspool import DirectorySpool
 from dascore.constants import ONE_SECOND
-from dascore.exceptions import ParameterError
+from dascore.exceptions import MissingPatchError, ParameterError
 from dascore.io.core import PatchFileSummary
 from dascore.utils.hdf5 import HDFPatchIndexManager
 from dascore.utils.misc import register_func, suppress_warnings
@@ -565,6 +565,19 @@ class TestFileSpoolIntegrations:
         with pytest.warns(UserWarning, match="Skipping patch at index.*#583"):
             for patch in dist_differ_spool:
                 assert isinstance(patch, dc.Patch)
+
+    def test_missing_patch_error_catchable_as_index_error(self, dist_differ_spool):
+        """
+        For backwards compatibility, MissingPatchError must remain
+        catchable as an IndexError, which spool indexing used to raise.
+        """
+        assert issubclass(MissingPatchError, IndexError)
+        with suppress_warnings(UserWarning):
+            for ind in range(len(dist_differ_spool)):
+                try:
+                    dist_differ_spool[ind]
+                except IndexError:
+                    pass
 
     @pytest.mark.xfail()
     def test_selected_out_distance_shortens_spool(self, dist_differ_spool):

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -143,6 +143,21 @@ class TestMultiPatchFile:
         assert patch.attrs.time_max == contents["time_max"].max()
 
 
+class TestLoadPatchFastPath:
+    """Tests for the direct FiberIO read path used by _load_patch."""
+
+    def test_requires_concrete_format_and_version(self, one_directory_spool):
+        """
+        Without a concrete format and version the fast path must defer to
+        dc.read, which detects them from the file; get_fiberio with a None
+        version would return the newest reader, not the file's version.
+        """
+        spool = one_directory_spool
+        assert spool._read_patches({"file_format": "", "file_version": ""}) is None
+        assert spool._read_patches({"file_format": "DASDAE"}) is None
+        assert spool._read_patches({"file_version": "1"}) is None
+
+
 class TestDirectoryIndex:
     """Tests for returning summaries of all files in managed directory."""
 

--- a/tests/test_clients/test_dirspool.py
+++ b/tests/test_clients/test_dirspool.py
@@ -69,6 +69,21 @@ def non_distance_dir_spool(tmp_path_factory):
     return dc.spool(path).update()
 
 
+@pytest.fixture(scope="class")
+@register_func(DIRECTORY_SPOOLS)
+def multi_patch_file_spool(tmp_path_factory):
+    """Create a directory whose single file contains multiple patches."""
+    path = tmp_path_factory.mktemp("multi_patch_file_spool")
+    patch_1 = dascore.examples.get_example_patch("random_das")
+    # Create a second patch contiguous with the first. Clear the history
+    # so the two patches remain mergeable.
+    time = patch_1.get_coord("time")
+    patch_2 = patch_1.update_coords(time_min=time.max() + time.step)
+    patch_1, patch_2 = (x.update_attrs(history=[]) for x in (patch_1, patch_2))
+    dc.write(dc.spool([patch_1, patch_2]), path / "multi_patch.h5", "dasdae")
+    return dc.spool(path).update()
+
+
 @pytest.fixture
 def directory_spool_redundant_index(random_spool, tmp_path_factory):
     """Force a spool to be indexed many times with same files."""
@@ -102,6 +117,30 @@ class TestDirectorySpoolBasics:
         new = diverse_directory_spool.select(station="big_gaps")
         contents = new.get_contents()
         assert (contents["station"] == "big_gaps").all()
+
+
+class TestMultiPatchFile:
+    """Tests for directories with files that contain multiple patches."""
+
+    def test_iteration_returns_distinct_patches(self, multi_patch_file_spool):
+        """Each row must map to its own patch, not just the file's first."""
+        spool = multi_patch_file_spool
+        contents = spool.get_contents()
+        assert len(spool) == 2
+        patches = list(spool)
+        expected = set(contents["time_min"])
+        returned = {x.attrs.time_min for x in patches}
+        assert returned == expected
+
+    def test_merge(self, multi_patch_file_spool):
+        """Ensure patches from a single file can be merged."""
+        spool = multi_patch_file_spool
+        contents = spool.get_contents()
+        merged = spool.chunk(time=None)
+        assert len(merged) == 1
+        patch = merged[0]
+        assert patch.attrs.time_min == contents["time_min"].min()
+        assert patch.attrs.time_max == contents["time_max"].max()
 
 
 class TestDirectoryIndex:

--- a/tests/test_clients/test_filespool.py
+++ b/tests/test_clients/test_filespool.py
@@ -6,6 +6,7 @@ import pytest
 
 import dascore as dc
 from dascore.clients.filespool import FileSpool
+from dascore.exceptions import MissingPatchError
 from dascore.utils.hdf5 import HDFPatchIndexManager
 
 
@@ -60,3 +61,12 @@ class TestBasic:
         assert len(spool) == 3
         for patch in spool:
             assert isinstance(patch, dc.Patch)
+
+    def test_empty_read_raises_missing_patch(self, terra15_file_spool, monkeypatch):
+        """An empty read result should raise the skip-aware missing patch error."""
+        monkeypatch.setattr(
+            "dascore.clients.filespool.dc.read", lambda **kwargs: dc.spool([])
+        )
+        msg = "No patch in .* matches the requested range"
+        with pytest.raises(MissingPatchError, match=msg):
+            terra15_file_spool._load_patch({"path": terra15_file_spool._path})

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -665,3 +665,54 @@ class TestStreamingMerge:
             p2 = p2.update(data=p2.data.astype(np.float32))
         merged = dc.spool([p1, p2]).chunk(time=None)[0]
         assert merged.data.dtype == np.float64
+
+    def test_transposes_patch_to_first_patch_dims(self, random_patch, monkeypatch):
+        """Streaming merge should tolerate patches with the same dims reordered."""
+        spool = dc.spool([])
+        p1 = random_patch.update_attrs(history=[])
+        time = p1.get_coord("time")
+        p2 = p1.update_coords(time_min=time.max() + time.step).update_attrs(history=[])
+        p2 = p2.transpose(*reversed(p2.dims))
+        patches = iter([p1, p2])
+        monkeypatch.setattr(
+            spool, "_load_trimmed_patch", lambda patch_kwargs, joined: next(patches)
+        )
+        time_axis = p1.get_axis("time")
+        samples = p1.data.shape[time_axis] * 2
+        out = spool._merge_patches_streaming(None, [{}, {}], "time", samples)
+        assert out.dims == p1.dims
+        assert out.data.shape[time_axis] == samples
+
+    def test_incompatible_shapes_raise_merge_error(self, random_patch, monkeypatch):
+        """Streaming merge should wrap non-merge-dimension shape mismatches."""
+        spool = dc.spool([])
+        p1 = random_patch.update_attrs(history=[])
+        time = p1.get_coord("time")
+        p2 = p1.update_coords(time_min=time.max() + time.step).update_attrs(history=[])
+        distance = p2.get_coord("distance")
+        p2 = p2.select(distance=(None, distance.max() - distance.step))
+        patches = iter([p1, p2])
+        monkeypatch.setattr(
+            spool, "_load_trimmed_patch", lambda patch_kwargs, joined: next(patches)
+        )
+        msg = "their shapes are incompatible"
+        with pytest.raises(CoordMergeError, match=msg):
+            samples = p1.data.shape[p1.get_axis("time")] * 2
+            spool._merge_patches_streaming(None, [{}, {}], "time", samples)
+
+    def test_unexpected_merge_dimension_raises(self, random_patch, monkeypatch):
+        """Streaming merge should validate the actual varying dimension."""
+        spool = dc.spool([])
+        p1 = random_patch.update_attrs(history=[])
+        dist = p1.get_coord("distance")
+        p2 = p1.update_coords(distance_min=dist.max() + dist.step).update_attrs(
+            history=[]
+        )
+        patches = iter([p1, p2])
+        monkeypatch.setattr(
+            spool, "_load_trimmed_patch", lambda patch_kwargs, joined: next(patches)
+        )
+        msg = "expected them to vary along time"
+        with pytest.raises(CoordMergeError, match=msg):
+            samples = p1.data.shape[p1.get_axis("time")] * 2
+            spool._merge_patches_streaming(None, [{}, {}], "time", samples)

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -616,3 +616,52 @@ class TestChunkMerge:
         assert match in str(caught_warnings[0].message)
         assert caught_warnings[0].filename == __file__
         assert len(out) == 1
+
+
+class TestStreamingMerge:
+    """
+    Tests for the streaming merge path, which copies each patch into a
+    pre-allocated array rather than concatenating all loaded patches.
+    """
+
+    def test_streaming_path_used(self, adjacent_spool_no_overlap, monkeypatch):
+        """Ensure simple merges take the streaming path."""
+        from dascore.core.spool import DataFrameSpool
+
+        called = []
+        original = DataFrameSpool._merge_patches_streaming
+
+        def wrapper(self, *args, **kwargs):
+            called.append(True)
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(DataFrameSpool, "_merge_patches_streaming", wrapper)
+        merged = adjacent_spool_no_overlap.chunk(time=None)
+        assert isinstance(merged[0], dc.Patch)
+        assert called
+
+    def test_matches_materialized_merge(self, adjacent_spool_no_overlap, monkeypatch):
+        """Streaming and concatenating merges must produce identical patches."""
+        import dascore.core.spool as spool_module
+
+        streamed = adjacent_spool_no_overlap.chunk(time=None)[0]
+        # Disabling the sample estimate forces the materialized path.
+        monkeypatch.setattr(
+            spool_module, "_estimate_merge_samples", lambda df, dim: None
+        )
+        materialized = adjacent_spool_no_overlap.chunk(time=None)[0]
+        assert np.array_equal(streamed.data, materialized.data)
+        assert streamed.coords == materialized.coords
+
+    @pytest.mark.parametrize("small_first", [True, False])
+    def test_mixed_dtype_upcast(self, random_patch, small_first):
+        """Merging mixed dtypes must upcast like np.concatenate."""
+        p1 = random_patch.update_attrs(history=[])
+        time = p1.get_coord("time")
+        p2 = p1.update_coords(time_min=time.max() + time.step).update_attrs(history=[])
+        if small_first:
+            p1 = p1.update(data=p1.data.astype(np.float32))
+        else:
+            p2 = p2.update(data=p2.data.astype(np.float32))
+        merged = dc.spool([p1, p2]).chunk(time=None)[0]
+        assert merged.data.dtype == np.float64

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -17,7 +17,6 @@ from dascore.core.spool import (
     MemorySpool,
     _estimate_merge_samples,
     _get_varying_dim,
-    _patches_from_read,
 )
 from dascore.exceptions import (
     InvalidSpoolError,
@@ -177,20 +176,9 @@ class TestMemorySpoolLazy:
         spool = dc.spool(patch_list)
         assert len(spool._get_instruction_df()) == len(patch_list)
 
-    def test_unprocessed_patches_after_dataframe_build(self, patch_list):
-        """Raw patch extraction should work for dataframe-backed memory spools."""
-        spool = MemorySpool()
-        spool._df = pd.DataFrame({"patch": patch_list})
-        assert spool._patches is None
-        assert spool._unprocessed_patches() == patch_list
-
 
 class TestSpoolHelpers:
     """Tests for helper functions used by spool implementations."""
-
-    def test_patches_from_unusual_spool(self, random_patch):
-        """Non-memory spool results should be materialized by iteration."""
-        assert _patches_from_read((random_patch,)) == [random_patch]
 
     def test_get_varying_dim_ignores_missing_ranges(self):
         """Columns without min/max pairs should not count as varying dims."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -206,16 +206,12 @@ class TestSpoolHelpers:
 
     def test_estimate_merge_samples_degenerate_step(self):
         """Non-finite sample counts should disable streaming estimates."""
-        df = pd.DataFrame(
-            {"time_min": [0.0], "time_max": [1.0], "time_step": [0.0]}
-        )
+        df = pd.DataFrame({"time_min": [0.0], "time_max": [1.0], "time_step": [0.0]})
         assert _estimate_merge_samples(df, "time") is None
 
     def test_estimate_merge_samples_negative_count(self):
         """Ranges with negative sample counts should disable streaming estimates."""
-        df = pd.DataFrame(
-            {"time_min": [2.0], "time_max": [0.0], "time_step": [1.0]}
-        )
+        df = pd.DataFrame({"time_min": [2.0], "time_max": [0.0], "time_step": [1.0]})
         assert _estimate_merge_samples(df, "time") is None
 
 

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -84,6 +84,69 @@ class TestSpoolBasics:
             random_spool.viz.waterfall(random_spool)
 
 
+class TestMemorySpoolLazy:
+    """
+    Tests for lazy behavior of in-memory spools.
+
+    Spools created directly from patches shouldn't build their managing
+    dataframes until an operation requires them.
+    """
+
+    @pytest.fixture()
+    def patch_list(self):
+        """Get a list of contiguous patches."""
+        return list(dc.examples.get_example_spool(length=3))
+
+    def test_simple_access_builds_no_dataframes(self, patch_list):
+        """len, integer access, and iteration should not build dataframes."""
+        spool = dc.spool(patch_list)
+        assert len(spool) == len(patch_list)
+        assert spool[0] == patch_list[0]
+        assert spool[-1] == patch_list[-1]
+        assert list(spool) == patch_list
+        assert "_df" not in spool._cache
+
+    def test_out_of_bounds_raises(self, patch_list):
+        """The fast path must raise the same IndexError as the df path."""
+        spool = dc.spool(patch_list)
+        match = "out of bounds for spool"
+        with pytest.raises(IndexError, match=match):
+            _ = spool[len(patch_list)]
+        assert "_df" not in spool._cache
+
+    def test_access_unchanged_after_df_built(self, patch_list):
+        """Patch access must return the same thing before/after df built."""
+        spool = dc.spool(patch_list)
+        lazy_patches = list(spool)
+        _ = spool.get_contents()  # forces the dataframes to build
+        assert "_df" in spool._cache
+        assert list(spool) == lazy_patches
+        assert spool[0] == lazy_patches[0]
+
+    def test_equality_independent_of_access(self, patch_list):
+        """Equal spools must stay equal regardless of what was accessed."""
+        spool1, spool2 = dc.spool(patch_list), dc.spool(patch_list)
+        _ = spool1.get_contents()  # build one spool's dataframes only.
+        assert spool1 == spool2
+        assert spool2 == spool1
+
+    def test_input_mutation_does_not_change_spool(self, patch_list):
+        """The spool contents are snapshotted at creation."""
+        data = list(patch_list)
+        spool = dc.spool(data)
+        data.pop()
+        assert len(spool) == len(patch_list)
+
+    def test_derived_spools_use_df_machinery(self, patch_list):
+        """Chunked/selected spools must go through the instruction dfs."""
+        spool = dc.spool(patch_list)
+        merged = spool.chunk(time=None)
+        assert len(merged) == 1
+        time_coord = merged[0].get_coord("time")
+        expected_min = min(x.attrs.time_min for x in patch_list)
+        assert time_coord.min() == expected_min
+
+
 class TestSpoolEquals:
     """Tests for spool equality."""
 

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -148,6 +148,13 @@ class TestMemorySpoolLazy:
         expected_min = min(x.attrs.time_min for x in patch_list)
         assert time_coord.min() == expected_min
 
+    def test_derived_spool_does_not_retain_parent(self, patch_list):
+        """Derived spools must not hold a reference to their parent."""
+        spool = dc.spool(patch_list)
+        chunked = spool.chunk(time=1)
+        assert chunked._data is None
+        assert chunked._patches is None
+
 
 class TestSpoolEquals:
     """Tests for spool equality."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -136,6 +136,8 @@ class TestMemorySpoolLazy:
         spool = dc.spool(data)
         data.pop()
         assert len(spool) == len(patch_list)
+        # The snapshot itself is immutable.
+        assert isinstance(spool._patches, tuple)
 
     def test_derived_spools_use_df_machinery(self, patch_list):
         """Chunked/selected spools must go through the instruction dfs."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -12,7 +12,13 @@ import pytest
 
 import dascore as dc
 from dascore.clients.filespool import FileSpool
-from dascore.core.spool import BaseSpool, MemorySpool
+from dascore.core.spool import (
+    BaseSpool,
+    MemorySpool,
+    _estimate_merge_samples,
+    _get_varying_dim,
+    _patches_from_read,
+)
 from dascore.exceptions import (
     InvalidSpoolError,
     MissingOptionalDependencyError,
@@ -154,6 +160,63 @@ class TestMemorySpoolLazy:
         chunked = spool.chunk(time=1)
         assert chunked._data is None
         assert chunked._patches is None
+
+    def test_single_patch_input_uses_lazy_storage(self, random_patch):
+        """A single patch should be stored lazily just like a patch sequence."""
+        spool = MemorySpool(random_patch)
+        assert spool._patches == (random_patch,)
+        assert len(spool) == 1
+
+    def test_empty_memory_spool_has_no_dataframe(self):
+        """An empty MemorySpool should report no managing dataframe."""
+        spool = MemorySpool()
+        assert spool._get_df() is None
+
+    def test_instruction_df_builds_from_lazy_patches(self, patch_list):
+        """Lazy patch input should still build instruction dataframes on demand."""
+        spool = dc.spool(patch_list)
+        assert len(spool._get_instruction_df()) == len(patch_list)
+
+    def test_unprocessed_patches_after_dataframe_build(self, patch_list):
+        """Raw patch extraction should work for dataframe-backed memory spools."""
+        spool = MemorySpool()
+        spool._df = pd.DataFrame({"patch": patch_list})
+        assert spool._patches is None
+        assert spool._unprocessed_patches() == patch_list
+
+
+class TestSpoolHelpers:
+    """Tests for helper functions used by spool implementations."""
+
+    def test_patches_from_unusual_spool(self, random_patch):
+        """Non-memory spool results should be materialized by iteration."""
+        assert _patches_from_read((random_patch,)) == [random_patch]
+
+    def test_get_varying_dim_ignores_missing_ranges(self):
+        """Columns without min/max pairs should not count as varying dims."""
+        df = pd.DataFrame(
+            {"time_min": [0, 0], "time_max": [1, 1], "distance_min": [0, 1]}
+        )
+        assert _get_varying_dim(df) is None
+
+    def test_estimate_merge_samples_missing_columns(self):
+        """Missing range columns should disable streaming estimates."""
+        df = pd.DataFrame({"time_min": [0], "time_max": [1]})
+        assert _estimate_merge_samples(df, "time") is None
+
+    def test_estimate_merge_samples_degenerate_step(self):
+        """Non-finite sample counts should disable streaming estimates."""
+        df = pd.DataFrame(
+            {"time_min": [0.0], "time_max": [1.0], "time_step": [0.0]}
+        )
+        assert _estimate_merge_samples(df, "time") is None
+
+    def test_estimate_merge_samples_negative_count(self):
+        """Ranges with negative sample counts should disable streaming estimates."""
+        df = pd.DataFrame(
+            {"time_min": [2.0], "time_max": [0.0], "time_step": [1.0]}
+        )
+        assert _estimate_merge_samples(df, "time") is None
 
 
 class TestSpoolEquals:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -107,6 +107,19 @@ class TestGetQuantStr:
         out = get_quantity_str(quant)
         assert "10.0" in out
 
+    def test_equal_quantities_keep_distinct_strings(self):
+        """
+        Quantities that compare equal (e.g. 1 m and 100 cm) must still
+        return their own string representations. This guards against
+        caching results keyed on quantity equality.
+        """
+        quant_m, quant_cm = get_quantity("1 m"), get_quantity("100 cm")
+        assert quant_m == quant_cm  # sanity check: pint treats these as equal
+        str_m, str_cm = get_quantity_str(quant_m), get_quantity_str(quant_cm)
+        assert str_m != str_cm
+        assert "m" in str_m
+        assert "c" in str_cm  # cm or centimeter
+
     def test_timedelta_to_quantity(self):
         """Ensure a timedelta can be converted to a quantity."""
         dt = dc.to_timedelta64(20)

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -373,6 +373,14 @@ class TestPatchesToDF:
         out = patches_to_df(df)
         assert "history" in out.columns
 
+    def test_patch_column_added(self, random_spool):
+        """Ensure the patch column gets added when dataframe input lacks it."""
+        df = random_spool.get_contents().drop(columns="patch", errors="ignore")
+        out = patches_to_df(df)
+        assert "patch" in out.columns
+        assert len(out["patch"]) == len(df)
+        assert out["patch"].isnull().all()
+
 
 class TestAlignPatches:
     """Tests for aligning patches."""

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -88,6 +88,11 @@ class TestToDateTime64:
         out = to_datetime64(None)
         assert pd.isnull(out)
 
+    def test_pandas_nat(self):
+        """Pandas NaT should return numpy NaT."""
+        out = to_datetime64(pd.NaT)
+        assert pd.isnull(out)
+
     def test_pandas_timestamp(self):
         """Ensure a timestamp returns the datetime64."""
         ts = pd.Timestamp("2020-01-03")


### PR DESCRIPTION
## Description

Reading and merging spools with many (hundreds of) files was much slower than the underlying file IO: profiling a 300-file merge showed only ~30% of the time going to actual HDF5 reads, the rest being fixed per-file python overhead (~12 ms/file). Merging also held every source patch plus the concatenated copy in memory at once. This PR removes the biggest overheads in the load path and streams merges:

- `DirectorySpool._load_patch` reads directly through the file's `FiberIO`, skipping `dc.read` format detection and the spool indexing machinery applied to its throwaway output. Range selection is only applied when the patch is actually trimmed (tracked by the instruction dataframe's `_modified` flag). The fast path requires a concrete format/version and falls back to `dc.read` otherwise (including for multi-patch files without selection, so each row still maps to its own patch).
- `MemorySpool` is lazy: the managing dataframes are only built when an operation needs them, and `len`, integer access, and iteration are served directly from an immutable patch tuple for spools created from patches. This makes the spool created (and immediately unwrapped) by every `FiberIO.read` call nearly free. Equality is normalized so it doesn't depend on whether the lazy dataframes were built, derived spools don't retain their parents, and `new_from_df` no longer builds dummy dataframes it discards.
- **Merges stream into a pre-allocated array** sized from the instruction dataframe instead of loading all sources and concatenating: peak memory for a merge drops ~45% (to output + one file) and a full-data copy is removed. Mixed dtypes upcast as `np.concatenate` would; inexact estimates grow or trim the buffer; inestimable cases (unknown steps, no varying indexed dim) use the previous materialized merge. Both paths produce identical results, and gap/continuity checks are unchanged (they happen on the dataframes at chunk time, before any data is read).
- `_get_patches_from_index` looks up instruction rows via a cached `groupby` mapping instead of scanning the whole instruction dataframe per patch, removing O(sources × outputs) scaling when iterating chunked spools.
- Patches trimmed to nothing (see #583) raise a dedicated `MissingPatchError` (an `IndexError` subclass for backwards compatibility) which iteration catches by type; the previous "out of bounds" message matching is gone and unexpected `IndexError`s always propagate. `FileSpool` had the same latent crash and gets the same treatment.
- `get_quantity_str` (called by the pydantic serializers of attrs/coord models on every dump) caches string validation and unit stringification. Caches are only keyed on types with exact equality (`str` and `pint.Unit`); a `Quantity` cannot key a cache because equal quantities with different units (`1 m == 100 cm`) would collide. A test guards this.
- New CodSpeed benchmarks cover indexing, merging, and chunked iteration over a many-file directory, plus in-memory spool creation/access and many-patch merges (~1 s total wall time).

Benchmarks (DASDAE format, warm cache, local disk):

| Scenario | Before | After |
|---|---|---|
| 300 files (1.4 GB), `chunk(time=None)` merge | ~4.6 s | ~1.9 s |
| — peak memory for the above | ~3.0 GB | ~1.6 GB |
| 1000 small files, merge all | ~12 s | ~3.4 s |
| 1000 small files, chunk into 250 patches | ~15 s | ~4.7 s |

For reference, raw pytables reads + `np.concatenate` of the same 300-file dataset take ~1.5 s. A likely follow-up (separate PR) is optional executor-parallel patch loading for cold/network storage.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster patch loading for directory-based workflows with improved handling of multi-patch files.
  * Enhanced lazy in-memory spooling for more efficient access patterns.
* **Bug Fixes**
  * Missing/trimmed entries now raise `MissingPatchError` (still catchable as `IndexError`), improving patch disambiguation.
  * Chunk/merge behavior is more consistent: dimension order and coordinate metadata are preserved; streaming merge matches materialized output.
  * Quantity-to-string formatting avoids over-normalizing equal quantities.
* **Tests**
  * Added coverage for multi-patch directory behavior, lazy spool semantics, streaming merge edge cases, and unit formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
