### PR TITLE
Fix error handling and kurtosis API ergonomics

### DIFF
--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -110,6 +110,7 @@ class _FiberIOManager:
     def __init__(self, entry_point: str):
         self._entry_point = entry_point
         self._loaded_eps: set[str] = set()
+        self._failed_formats: set[str] = set()
         self._format_version = defaultdict(dict)
         self._extension_list = defaultdict(list)
         # This is a dict of {input_type: (fiberio_name, version)}
@@ -133,7 +134,8 @@ class _FiberIOManager:
     @property
     def unloaded_formats(self):
         """Return names of known formats."""
-        return sorted(self.known_formats - set(self._format_version))
+        loaded_or_failed = set(self._format_version) | self._failed_formats
+        return sorted(self.known_formats - loaded_or_failed)
 
     @cached_method
     def _get_fiber_io_by_input_type(self, input_type) -> set[FiberIO]:
@@ -156,6 +158,9 @@ class _FiberIOManager:
         for format_name in self.known_formats:
             unsorted = self._format_version[format_name]
             keys = sorted(unsorted, reverse=True)
+            # formats whose plugins failed to load have no fiber_ios.
+            if not keys:
+                continue
             fiber_ios = [unsorted[key] for key in keys]
             priority_fiber_ios.append(fiber_ios[0])
             if len(fiber_ios) > 1:
@@ -178,8 +183,20 @@ class _FiberIOManager:
         # Load one, or all, formats
         for form in formats:
             entries = [name for name in self._eps.index if name.startswith(form)]
-            for eps in self._eps.loc[entries]:
-                self.register_fiberio(eps()())
+            for name, eps in self._eps.loc[entries].items():
+                try:
+                    self.register_fiberio(eps()())
+                except Exception as e:
+                    msg = (
+                        f"Failed to load FiberIO plugin '{name}' "
+                        f"({e.__class__.__name__}: {e}); skipping it. "
+                        "This can happen when an entry point from a previous "
+                        "install is stale; reinstalling dascore (or the "
+                        "package providing the plugin) may fix it."
+                    )
+                    warnings.warn(msg, UserWarning, stacklevel=2)
+            if form not in self._format_version:
+                self._failed_formats.add(form)
         # The selected format(s) should now be loaded
         assert set(formats).isdisjoint(self.unloaded_formats)
 

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -304,7 +304,7 @@ class _FiberIOManager:
         # no format found
         if not fiber_ios:
             format_list = list(self.known_formats)
-            msg = f"Unknown format {format}, " f"known formats are {format_list}"
+            msg = f"Unknown format {format}, known formats are {format_list}"
             raise UnknownFiberFormatError(msg)
         # a version is specified
         if version:

--- a/dascore/transform/kurtosis.py
+++ b/dascore/transform/kurtosis.py
@@ -134,8 +134,9 @@ def kurtosis(
     statistical moment — becomes strongly positive during such impulsive
     arrivals.
 
-    Here, kurtosis is determined in a window of lenght "winlen". We
-    then determine kurtosis of the amplitude distribution in that window.
+    Here, kurtosis is determined in a window whose length is given as a
+    dimension keyword argument (e.g. ``time=0.5``). We then determine
+    kurtosis of the amplitude distribution in that window.
     Higher kurtosis thus indicates high amplitude outliers. This in turn
     can be interpreted as a signal arrival.
 

--- a/dascore/transform/kurtosis.py
+++ b/dascore/transform/kurtosis.py
@@ -6,19 +6,26 @@ from __future__ import annotations
 
 import numpy as np
 
-from dascore.constants import PatchType
+from dascore.constants import PatchType, samples_arg_description
+from dascore.exceptions import ParameterError
+from dascore.utils.docs import compose_docstring
 from dascore.utils.jit import maybe_numba_jit
-from dascore.utils.patch import patch_function
+from dascore.utils.patch import get_dim_axis_value, patch_function
 from dascore.utils.time import to_float
 
 
-def _validate_window(winlen: float, step: float) -> int:
-    """Convert window length in seconds to samples and validate."""
-    if winlen <= 0:
-        raise ValueError("winlen must be positive.")
-    nwin = round(winlen / step)
+def _get_window_samples(coord, dim, value, samples: bool) -> int:
+    """Convert a window length along a coordinate to a validated sample count."""
+    if coord.reverse_sorted:
+        coord, _ = coord.sort()
+    nwin = coord.get_sample_count(value, samples=samples)
     if nwin < 2:
-        raise ValueError("winlen is too small for the sampling interval.")
+        msg = (
+            f"kurtosis window of {value} along dimension '{dim}' spans "
+            f"{nwin} sample(s) but must span at least 2. The coordinate "
+            f"step is {coord.step}."
+        )
+        raise ParameterError(msg)
     return nwin
 
 
@@ -112,11 +119,12 @@ def _recursive_kurtosis(
 
 
 @patch_function()
+@compose_docstring(sample_explanation=samples_arg_description)
 def kurtosis(
     patch: PatchType,
-    winlen: float,
-    dim: str = "time",
+    samples: bool = False,
     recursive: bool = True,
+    **kwargs,
 ) -> PatchType:
     """
     Compute kurtosis along a patch dimension.
@@ -136,10 +144,8 @@ def kurtosis(
     ----------
     patch
         Input DASCore patch.
-    winlen
-        Window length used to calculate the kurtosis in.
-    dim
-        Dimension along which to compute kurtosis. Defaults to ``"time"``.
+    samples
+        {sample_explanation}
     recursive
         If True, use recursive pseudo-kurtosis: Instead of computing kurtosis
         in a sliding window (computationally expensive for continuous data),
@@ -147,6 +153,10 @@ def kurtosis(
         exponentially weighted moving estimator, so the algorithm updates continuously
         without storing long windows of data.
         If False, the common kurtosis calculation is used
+    **kwargs
+        Used to specify the dimension and window length, e.g. ``time=0.5``
+        computes kurtosis in 0.5 second windows along the time dimension.
+        Units are also supported, e.g. ``distance=10 * dascore.units.get_unit('m')``.
 
     Returns
     -------
@@ -160,7 +170,7 @@ def kurtosis(
     >>>
     >>> p = dc.examples.get_example_patch('example_event_2')
     >>>
-    >>> k = p.kurtosis(winlen = 0.002,dim = 'time')
+    >>> k = p.kurtosis(time=0.002)
     >>> ax = k.viz.waterfall(cmap = 'inferno')
 
     2) To better understand how kutosis works, we replace the data with
@@ -184,7 +194,7 @@ def kurtosis(
     >>> modi = p.update(data=data)
     >>>
     >>> # calculate kurtosis on modified data
-    >>> k = modi.kurtosis(winlen = 0.002, dim = 'time')
+    >>> k = modi.kurtosis(time=0.002)
     >>>
     >>> fix, axs = plt.subplots(2,2, figsize=(10,6), layout='constrained')
     >>> ax = orig.viz.waterfall(cmap = 'RdBu', ax=axs[0,0])
@@ -205,6 +215,7 @@ def kurtosis(
     >>> _ = axs[1,0].set_xlabel('Amplitude')
     >>> _ = axs[1,0].set_ylabel('Probability of occurrence')
     """
+    dim, _, winlen = get_dim_axis_value(patch, kwargs=kwargs)[0]
     orig_dims = patch.dims
     patch_t = patch.transpose(dim, ...)
 
@@ -213,13 +224,13 @@ def kurtosis(
 
     data_2d = data.reshape(orig_shape[0], -1)
 
-    step = abs(to_float(patch_t.get_coord(dim, require_evenly_sampled=True).step))
-
-    nwin = _validate_window(winlen, step)
+    coord = patch_t.get_coord(dim, require_evenly_sampled=True)
+    step = abs(to_float(coord.step))
+    nwin = _get_window_samples(coord, dim, winlen, samples)
 
     if recursive:
         varx = np.var(data_2d, axis=0)
-        out = _recursive_kurtosis(data_2d, step=step, winlen=winlen, varx=varx)
+        out = _recursive_kurtosis(data_2d, step=step, winlen=nwin * step, varx=varx)
     else:
         out = _windowed_kurtosis(data_2d, nwin=nwin)
 

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -612,10 +612,7 @@ def check_filter_sequence(filt_range):
     # strip out units if used.
     mags = tuple([getattr(x, "magnitude", x) for x in filt_range])
     if all([pd.isnull(x) for x in mags]):
-        msg = (
-            f"pass filter requires at least one filter limit, "
-            f"you passed {filt_range}"
-        )
+        msg = f"pass filter requires at least one filter limit, you passed {filt_range}"
         raise FilterValueError(msg)
     return filt_range
 

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -602,11 +602,15 @@ def order_range_tuple(range_tuple):
 
 def check_filter_sequence(filt_range):
     """Ensure the filter sequence is the right shape."""
+    if not isinstance(filt_range, Sequence) or len(filt_range) != 2:
+        msg = (
+            f"filter range must be a length two sequence of (low, high), "
+            f"not {filt_range}. Use None or ... for an open end, "
+            f"e.g. time=(None, 10) for a 10 Hz lowpass."
+        )
+        raise FilterValueError(msg)
     # strip out units if used.
     mags = tuple([getattr(x, "magnitude", x) for x in filt_range])
-    if not isinstance(filt_range, Sequence) or len(filt_range) != 2:
-        msg = f"filter range must be a length two sequence not {filt_range}"
-        raise FilterValueError(msg)
     if all([pd.isnull(x) for x in mags]):
         msg = (
             f"pass filter requires at least one filter limit, "

--- a/dascore/viz/specplot.py
+++ b/dascore/viz/specplot.py
@@ -6,10 +6,11 @@ from collections.abc import Sequence
 from typing import Literal
 
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib import ticker
 
 from dascore.constants import PatchType
-from dascore.exceptions import CoordError
+from dascore.exceptions import CoordError, PatchError
 from dascore.utils.patch import patch_function
 from dascore.utils.plotting import _get_dim_label
 
@@ -99,6 +100,13 @@ def specplot(
             f"but got {patch.ndim}D Patch with dims {patch.dims}"
         )
         raise CoordError(msg)
+    if np.iscomplexobj(patch.data):
+        msg = (
+            "specplot requires real-valued data but the patch data are "
+            "complex. Convert to amplitude first, e.g. "
+            "patch.abs().viz.specplot()."
+        )
+        raise PatchError(msg)
 
     # Make the plot
     ax = patch.viz.waterfall(

--- a/scripts/_index_api.py
+++ b/scripts/_index_api.py
@@ -28,6 +28,17 @@ def _get_file_path(obj):
     return Path(path)
 
 
+def _is_environment_path(path) -> bool:
+    """
+    Return True if the path belongs to an environment nested in the project.
+
+    Virtual environments (e.g. .venv) created inside the repository would
+    otherwise be traversed as if their contents were part of the project.
+    """
+    excluded = {"site-packages", ".venv", "venv", ".pixi", ".tox", ".nox"}
+    return bool(excluded.intersection(Path(path).parts))
+
+
 def _get_base_address(path, base_path):
     """
     Get the base address inherent in the path.
@@ -36,6 +47,8 @@ def _get_base_address(path, base_path):
 
     dascore.core.patch
     """
+    if _is_environment_path(path):
+        return ""
     try:
         out = Path(path).relative_to(Path(base_path))
     except ValueError:
@@ -164,6 +177,9 @@ def parse_project(obj, key=None):
         # this is something outside of dascore or we have already seen it.
         if str(base_path) not in str(path) or obj_id in data_dict:
             return
+        # skip contents of environments (e.g. .venv) nested in the project.
+        if _is_environment_path(path):
+            return
         # load all the modules first
         if isinstance(obj, ModuleType):
             key = _get_address(obj, path.relative_to(base_path))
@@ -193,6 +209,8 @@ def parse_project(obj, key=None):
                         continue
                     sub_path = _get_file_path(sub_obj)
                     if str(base_path) not in str(sub_path):
+                        continue
+                    if _is_environment_path(sub_path):
                         continue
                     sub_key = f"{key}.{sub_name}"
                     # make sure this is where the method is defined else skip

--- a/scripts/test_index_api.py
+++ b/scripts/test_index_api.py
@@ -1,0 +1,35 @@
+"""Tests for the api indexing helpers."""
+
+from __future__ import annotations
+
+from _index_api import _get_base_address, _is_environment_path
+
+
+class TestIsEnvironmentPath:
+    """Tests for detecting environment paths nested in the project."""
+
+    def test_venv_path(self):
+        """A .venv created in the repo should be excluded."""
+        assert _is_environment_path("/repo/.venv/lib/python3.12/foo.py")
+
+    def test_site_packages_path(self):
+        """Any site-packages path should be excluded."""
+        assert _is_environment_path("/repo/env/lib/site-packages/scipy/x.py")
+
+    def test_project_path(self):
+        """Regular project paths should not be excluded."""
+        assert not _is_environment_path("/repo/dascore/core/patch.py")
+
+
+class TestGetBaseAddress:
+    """Tests for converting paths to addresses."""
+
+    def test_environment_path_returns_empty(self):
+        """Environment paths should not get a base address."""
+        path = "/repo/.venv/lib/python3.12/site-packages/scipy/signal.py"
+        assert _get_base_address(path, "/repo") == ""
+
+    def test_project_path_returns_address(self):
+        """Project paths should convert to dotted addresses."""
+        path = "/repo/dascore/core/patch.py"
+        assert _get_base_address(path, "/repo") == "dascore.core.patch"

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -238,6 +238,8 @@ class TestBrokenEntryPoint:
         eps["NOT_REAL_FORMAT__V1"] = bad_loader
         manager.__dict__["_eps"] = eps
         manager.__dict__.pop("known_formats", None)
+        # clear the method cache so load_plugins runs again for this instance.
+        manager.__dict__.pop("_cache", None)
         return manager
 
     def test_load_plugins_warns_and_skips(self, broken_ep_manager):

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -223,6 +223,39 @@ class TestFormatManager:
         format_manager.load_plugins()
 
 
+class TestBrokenEntryPoint:
+    """Tests for graceful handling of unloadable FiberIO entry points."""
+
+    @pytest.fixture()
+    def broken_ep_manager(self):
+        """Return a manager with an entry point that cannot be loaded."""
+        manager = copy.deepcopy(FiberIO.manager)
+
+        def bad_loader():
+            raise ModuleNotFoundError("No module named 'dascore.io.not_real'")
+
+        eps = manager._eps.copy()
+        eps["NOT_REAL_FORMAT__V1"] = bad_loader
+        manager.__dict__["_eps"] = eps
+        manager.__dict__.pop("known_formats", None)
+        return manager
+
+    def test_load_plugins_warns_and_skips(self, broken_ep_manager):
+        """A stale/broken entry point should warn, not raise."""
+        with pytest.warns(UserWarning, match="Failed to load FiberIO"):
+            broken_ep_manager.load_plugins()
+        assert "NOT_REAL_FORMAT" not in broken_ep_manager.unloaded_formats
+
+    def test_other_formats_still_usable(self, broken_ep_manager):
+        """Remaining FiberIOs should work after a plugin fails to load."""
+        with pytest.warns(UserWarning, match="Failed to load FiberIO"):
+            broken_ep_manager.load_plugins()
+        out = list(broken_ep_manager.yield_fiberio("DASDAE", "1"))
+        assert len(out) == 1
+        # The prioritized list (used by scan/read) must also not choke.
+        assert len(list(broken_ep_manager.yield_fiberio()))
+
+
 class TestFormatter:
     """Tests for adding file supports through Formatter."""
 

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -35,6 +35,11 @@ class TestPassFilterChecks:
         with pytest.raises(FilterValueError, match="length two sequence"):
             _ = random_patch.pass_filter(time=[1, 3, 3])
 
+    def test_scalar_kwarg_raises(self, random_patch):
+        """A non-sequence filter value should get the same clear error."""
+        with pytest.raises(FilterValueError, match="length two sequence"):
+            _ = random_patch.pass_filter(time=10)
+
     def test_all_null_kwarg_raises(self, random_patch):
         """There must be one Non-null kwarg."""
         with pytest.raises(FilterValueError, match="at least one filter"):

--- a/tests/test_transform/test_kurtosis.py
+++ b/tests/test_transform/test_kurtosis.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from dascore.exceptions import CoordError
+import dascore as dc
+from dascore.exceptions import CoordError, ParameterError
 from dascore.transform.kurtosis import (
+    _get_window_samples,
     _moving_sum,
     _recursive_kurtosis,
-    _validate_window,
     _windowed_kurtosis,
 )
 
@@ -17,19 +18,24 @@ from dascore.transform.kurtosis import (
 class TestKurtosisHelpers:
     """Tests for kurtosis helper functions."""
 
-    def test_validate_window_returns_sample_count(self):
+    @pytest.fixture(scope="class")
+    def distance_coord(self):
+        """An evenly sampled coordinate with a step of 1."""
+        return dc.get_example_patch().get_coord("distance")
+
+    def test_window_samples_returns_sample_count(self, distance_coord):
         """Ensure window length converts to sample count."""
-        assert _validate_window(winlen=0.02, step=0.01) == 2
+        assert _get_window_samples(distance_coord, "distance", 2, False) == 2
 
-    def test_validate_window_rejects_non_positive_winlen(self):
+    def test_window_samples_rejects_non_positive_window(self, distance_coord):
         """Ensure non-positive window lengths raise."""
-        with pytest.raises(ValueError, match="winlen must be positive"):
-            _validate_window(winlen=0, step=0.01)
+        with pytest.raises(ParameterError, match="at least 2"):
+            _get_window_samples(distance_coord, "distance", 0, False)
 
-    def test_validate_window_rejects_too_short_window(self):
+    def test_window_samples_rejects_too_short_window(self, distance_coord):
         """Ensure windows shorter than two samples raise."""
-        with pytest.raises(ValueError, match="too small"):
-            _validate_window(winlen=0.005, step=0.01)
+        with pytest.raises(ParameterError, match="at least 2"):
+            _get_window_samples(distance_coord, "distance", 1, False)
 
     def test_moving_sum_values(self):
         """Ensure moving sum uses clipped centered windows."""
@@ -87,7 +93,7 @@ class TestKurtosis:
 
     def test_windowed_runs(self, random_patch):
         """Ensure windowed kurtosis runs."""
-        out = random_patch.kurtosis(winlen=0.01, recursive=False)
+        out = random_patch.kurtosis(time=0.01, recursive=False)
 
         assert out.dims == random_patch.dims
         assert out.data.shape == random_patch.data.shape
@@ -96,7 +102,7 @@ class TestKurtosis:
 
     def test_recursive_runs(self, random_patch):
         """Ensure recursive kurtosis runs."""
-        out = random_patch.kurtosis(winlen=0.01, recursive=True)
+        out = random_patch.kurtosis(time=0.01, recursive=True)
 
         assert out.dims == random_patch.dims
         assert out.data.shape == random_patch.data.shape
@@ -107,7 +113,7 @@ class TestKurtosis:
         """Ensure internal transpose does not affect output dims."""
         patch = random_patch.transpose("distance", "time")
 
-        out = patch.kurtosis(winlen=0.01, dim="time", recursive=False)
+        out = patch.kurtosis(time=0.01, recursive=False)
 
         assert out.dims == patch.dims
         assert out.data.shape == patch.data.shape
@@ -116,11 +122,7 @@ class TestKurtosis:
         """Ensure kurtosis can operate along distance."""
         step = random_patch.get_coord("distance").step
 
-        out = random_patch.kurtosis(
-            winlen=3 * step,
-            dim="distance",
-            recursive=False,
-        )
+        out = random_patch.kurtosis(distance=3 * step, recursive=False)
 
         assert out.dims == random_patch.dims
         assert out.data.shape == random_patch.data.shape
@@ -130,7 +132,7 @@ class TestKurtosis:
         time = random_patch.get_coord("time").data[::-1]
         patch = random_patch.update_coords(time=time)
 
-        out = patch.kurtosis(winlen=0.01, dim="time")
+        out = patch.kurtosis(time=0.01)
 
         assert out.dims == patch.dims
         assert out.data.shape == patch.data.shape
@@ -142,28 +144,39 @@ class TestKurtosis:
         patch = random_patch.update_coords(time=time)
 
         with pytest.raises(CoordError, match="not evenly sampled"):
-            patch.kurtosis(winlen=0.01, dim="time")
+            patch.kurtosis(time=0.01)
 
-    def test_invalid_winlen_raises(self, random_patch):
-        """Ensure invalid winlen raises."""
-        with pytest.raises(ValueError, match="winlen must be positive"):
-            random_patch.kurtosis(winlen=0)
+    def test_samples_keyword(self, random_patch):
+        """Window lengths can be given directly in samples."""
+        out = random_patch.kurtosis(time=5, samples=True, recursive=False)
 
-    def test_too_short_winlen_raises(self, random_patch):
-        """Ensure too-short winlen raises."""
+        assert out.data.shape == random_patch.data.shape
+
+    def test_no_dimension_raises(self, random_patch):
+        """Omitting the dimension kwarg should raise a helpful error."""
+        with pytest.raises(ParameterError, match="dimension"):
+            random_patch.kurtosis(recursive=False)
+
+    def test_invalid_window_raises(self, random_patch):
+        """Ensure a non-positive window raises."""
+        with pytest.raises(ParameterError, match="at least 2"):
+            random_patch.kurtosis(time=0)
+
+    def test_too_short_window_raises(self, random_patch):
+        """Ensure a window shorter than two samples raises."""
         step = random_patch.get_coord("time").step
 
         if isinstance(step, np.timedelta64):
             step = step / np.timedelta64(1, "s")
 
-        with pytest.raises(ValueError, match="too small"):
-            random_patch.kurtosis(winlen=step / 2)
+        with pytest.raises(ParameterError, match="at least 2"):
+            random_patch.kurtosis(time=step / 2)
 
     def test_constant_data_windowed_returns_nan(self, random_patch):
         """Ensure windowed kurtosis handles constant data."""
         patch = random_patch.update(data=np.ones_like(random_patch.data, dtype=float))
 
-        out = patch.kurtosis(winlen=0.01, recursive=False)
+        out = patch.kurtosis(time=0.01, recursive=False)
 
         assert np.isnan(out.data).all()
 
@@ -171,6 +184,6 @@ class TestKurtosis:
         """Ensure recursive kurtosis handles constant data."""
         patch = random_patch.update(data=np.ones_like(random_patch.data, dtype=float))
 
-        out = patch.kurtosis(winlen=0.01, recursive=True)
+        out = patch.kurtosis(time=0.01, recursive=True)
 
         assert not np.isinf(out.data).any()

--- a/tests/test_viz/test_specplot.py
+++ b/tests/test_viz/test_specplot.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
-from dascore.exceptions import CoordError
+from dascore.exceptions import CoordError, PatchError
 
 
 def test_specplot_requires_fourier_dimension(random_patch):
@@ -24,6 +24,14 @@ def test_specplot_requires_2d_patch():
     ).dft("time")
 
     with pytest.raises(CoordError, match="2D Patch"):
+        patch.viz.specplot()
+
+
+def test_specplot_complex_data_raises(random_patch):
+    """Specplot on complex data raises with a hint to use abs() first."""
+    patch = random_patch.dft("time")
+
+    with pytest.raises(PatchError, match=r"abs\(\)"):
         patch.viz.specplot()
 
 


### PR DESCRIPTION
## Summary
- warn and skip unloadable FiberIO entry points instead of failing IO discovery
- raise clearer errors for scalar pass_filter values and complex specplot data
- update kurtosis to the standard dim keyword signature and refresh related tests/docs
- ignore in-repo environments when indexing API docs

## Tests
- pytest tests/test_io/test_io_core.py tests/test_proc/test_filter.py tests/test_transform/test_kurtosis.py tests/test_viz/test_specplot.py scripts/test_index_api.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kurtosis now accepts window settings by dimension name and supports interpreting the window in samples.
  * API indexing now ignores paths inside local Python environments, reducing noise in generated indexes.

* **Bug Fixes**
  * Plugin loading now skips broken entries more gracefully and warns instead of failing outright.
  * Spectral plots now reject complex data with a clear message to convert to amplitude first.
  * Filter validation now gives clearer guidance for invalid range inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->