### PR TITLE
Revert DASDAE compression options

### DIFF
--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -11,7 +11,6 @@ from dascore.constants import SpoolType
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import (
     H5Reader,
-    HDF5CompressionSpec,
     HDFPatchIndexManager,
     NodeError,
     PyTablesReader,
@@ -61,9 +60,6 @@ class DASDAEV1(FiberIO):
         spool: SpoolType,
         resource: PyTablesWriter,
         index=False,
-        compression=None,
-        compression_level=None,
-        shuffle=True,
         **kwargs,
     ):
         """
@@ -80,25 +76,8 @@ class DASDAEV1(FiberIO):
             writing but will make reading/scanning the file more efficient.
             This is recommended for files with many patches and not recommended
             for files with few patches.
-        compression
-            The HDF5 compression library for patch data and coordinate
-            arrays. The default of None writes uncompressed arrays unless a
-            positive compression level is provided. Use "gzip" for portable
-            HDF5 compression.
-        compression_level
-            Compression level from 0 to 9. A level of 0 disables compression.
-            If a compression library is provided and this is None, level 5 is
-            used. If only a positive compression level is provided,
-            "blosc:zstd" is used. Level 5 is recommended for general use.
-        shuffle
-            If True, apply the HDF5 shuffle filter before compression.
         """
         # write out patches
-        filters = HDF5CompressionSpec(
-            compression=compression,
-            compression_level=compression_level,
-            shuffle=shuffle,
-        ).to_pytables_filters()
         _write_meta(resource, self.version)
         # get an iterable of patches and save them
         patches = [spool] if isinstance(spool, dc.Patch) else spool
@@ -110,7 +89,7 @@ class DASDAEV1(FiberIO):
         # write new patches to file
         patch_names = get_patch_names(patches).values
         for patch, name in zip(patches, patch_names):
-            _save_patch(patch, waveforms, resource, name, filters=filters)
+            _save_patch(patch, waveforms, resource, name)
         indexer = HDFPatchIndexManager(resource)
         if index or indexer.has_index:
             df = self._get_patch_summary(patches)

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
-from tables import Atom, NodeError
+from tables import NodeError
 
 import dascore as dc
 from dascore.core.attrs import PatchAttrs
@@ -30,27 +30,14 @@ def _create_or_get_group(h5, group, name):
     return group
 
 
-def _create_or_squash_array(h5, group, name, data, filters=None):
+def _create_or_squash_array(h5, group, name, data):
     """Create a new array, if it exists delete and re-create."""
-    data = np.asarray(data)
-    use_carray = filters is not None and data.size and data.shape
-
-    def create_array():
-        if use_carray:
-            atom = Atom.from_dtype(data.dtype)
-            array = h5.create_carray(
-                group, name, atom=atom, shape=data.shape, filters=filters
-            )
-            array[:] = data
-            return array
-        return h5.create_array(group, name, data)
-
     try:
-        array = create_array()
+        array = h5.create_array(group, name, data)
     except NodeError:
         old_node = getattr(group, name)
         h5.remove_node(old_node)
-        array = create_array()
+        array = h5.create_array(group, name, data)
     return array
 
 
@@ -72,19 +59,19 @@ def _save_attrs_and_dims(patch, patch_group):
     patch_group._v_attrs["_dims"] = ",".join(patch.dims)
 
 
-def _save_array(data, name, group, h5, filters=None):
+def _save_array(data, name, group, h5):
     """Save an array to a group, handle datetime flubbery."""
     # handle datetime conversions
     is_dt = np.issubdtype(data.dtype, np.datetime64)
     is_td = np.issubdtype(data.dtype, np.timedelta64)
     if is_dt or is_td:
         data = to_int(data)
-    array_node = _create_or_squash_array(h5, group, name, data, filters=filters)
+    array_node = _create_or_squash_array(h5, group, name, data)
     array_node._v_attrs["is_datetime64"] = is_dt
     array_node._v_attrs["is_timedelta64"] = is_td
 
 
-def _save_coords(patch, patch_group, h5, filters=None):
+def _save_coords(patch, patch_group, h5):
     """Save coordinates."""
     cm = patch.coords
     for name, coord in cm.coord_map.items():
@@ -92,20 +79,20 @@ def _save_coords(patch, patch_group, h5, filters=None):
         # First save coordinate arrays
         data = coord.values
         save_name = f"_coord_{name}"
-        _save_array(data, save_name, patch_group, h5, filters=filters)
+        _save_array(data, save_name, patch_group, h5)
         # then save dimensions of coordinates
         save_name = f"_cdims_{name}"
         patch_group._v_attrs[save_name] = ",".join(dims)
 
 
-def _save_patch(patch, wave_group, h5, name, filters=None):
+def _save_patch(patch, wave_group, h5, name):
     """Save the patch to disk."""
     patch_group = _create_or_get_group(h5, wave_group, name)
     _save_attrs_and_dims(patch, patch_group)
-    _save_coords(patch, patch_group, h5, filters=filters)
+    _save_coords(patch, patch_group, h5)
     # add data
     if patch.data.shape:
-        _create_or_squash_array(h5, patch_group, "data", patch.data, filters=filters)
+        _create_or_squash_array(h5, patch_group, "data", patch.data)
 
 
 # --- Functions for reading
@@ -244,8 +231,7 @@ def _get_patch_content_from_group(group):
     for key in attrs._f_list():
         value = getattr(attrs, key)
         new_key = key.replace("_attrs_", "")
-        # Older DASDAE files can expose scalar HDF attrs as 0-D arrays with
-        # some PyTables versions; normalize them before building PatchAttrs.
+        # need to unpack 0 dim arrays.
         if isinstance(value, np.ndarray) and not value.shape:
             value = np.atleast_1d(value)[0]
         out[new_key] = value

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -21,7 +21,6 @@ import tables
 from h5py import File as H5pyFile
 from packaging.version import parse as get_version
 from pandas.io.common import stringify_path
-from pydantic import model_validator
 from tables import ClosedNodeError
 from tables import File as PyTablesFile
 
@@ -37,7 +36,6 @@ from dascore.utils.misc import (
     suppress_warnings,
     unbyte,
 )
-from dascore.utils.models import DascoreBaseModel
 from dascore.utils.pd import (
     _remove_base_path,
     fill_defaults_from_pydantic,
@@ -51,42 +49,6 @@ NodeError = tables.NodeError
 
 ns_to_datetime = partial(pd.to_datetime, unit="ns")
 ns_to_timedelta = partial(pd.to_timedelta, unit="ns")
-
-DEFAULT_PYTABLES_COMPRESSION = "blosc:zstd"
-_PYTABLES_COMPRESSION_ALIASES = FrozenDict({"gzip": "zlib"})
-
-
-class HDF5CompressionSpec(DascoreBaseModel):
-    """Backend-neutral HDF5 compression settings."""
-
-    compression: str | None = None
-    compression_level: int | None = None
-    shuffle: bool = True
-
-    @model_validator(mode="after")
-    def validate_compression_level(self):
-        """Ensure compression level fits the HDF5/PyTables range."""
-        level = self.compression_level
-        if level is not None and not 0 <= level <= 9:
-            msg = "compression_level must be between 0 and 9."
-            raise ValueError(msg)
-        return self
-
-    @property
-    def effective_level(self) -> int:
-        """Return the actual compression level to use."""
-        if self.compression_level is None:
-            return 5 if self.compression else 0
-        return self.compression_level
-
-    def to_pytables_filters(self) -> tables.Filters | None:
-        """Translate compression settings to PyTables filters."""
-        level = self.effective_level
-        if level == 0:
-            return None
-        complib = self.compression or DEFAULT_PYTABLES_COMPRESSION
-        complib = _PYTABLES_COMPRESSION_ALIASES.get(complib, complib)
-        return tables.Filters(complevel=level, complib=complib, shuffle=self.shuffle)
 
 
 class _HDF5Store(pd.HDFStore):

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -21,12 +21,6 @@ patch = dc.get_example_patch()
 patch.io.write(write_path, "dasdae")
 ```
 
-DASDAE files can be compressed with `compression_level`; level 5 is recommended. Use `compression="gzip"` for portable HDF5 compression.
-
-```{python}
-patch.io.write(write_path, "dasdae", compression_level=5)
-```
-
 ```{python}
 #| echo: false
 if write_path.exists():

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -7,16 +7,10 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import tables
 
 import dascore as dc
 from dascore.compat import random_state
 from dascore.io.dasdae.core import DASDAEV1
-from dascore.io.dasdae.utils import (
-    _create_or_squash_array,
-    _get_patch_content_from_group,
-)
-from dascore.utils.hdf5 import HDF5CompressionSpec
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
 
@@ -124,73 +118,6 @@ class TestWriteDASDAE:
         sp_cc = dc.spool(written_dascore_correlate)
         assert isinstance(sp_cc[0], dc.Patch)
 
-    def test_write_compressed(self, tmp_path_factory, random_patch):
-        """DASDAE can write compressed arrays with user-provided levels."""
-        path = tmp_path_factory.mktemp("dasdae_compressed") / "compressed.h5"
-        dc.write(
-            random_patch,
-            path,
-            "DASDAE",
-            compression="blosc:zstd",
-            compression_level=5,
-        )
-        with tables.open_file(path) as h5:
-            group = next(h5.iter_nodes("/waveforms"))
-            assert group.data.filters.complib == "blosc:zstd"
-            assert group.data.filters.complevel == 5
-        # the compressed data (and coords) must round-trip unchanged.
-        assert dc.read(path)[0].equals(random_patch)
-
-    def test_compressed_selective_read(self, tmp_path_factory, random_patch):
-        """Selecting from a compressed file must match selecting in memory."""
-        path = tmp_path_factory.mktemp("dasdae_compressed_select") / "out.h5"
-        random_patch.io.write(path, "DASDAE", compression_level=5)
-        # Select on existing coordinate values so the bounds keep the coord's
-        # dtype (a fractional midpoint would not round-trip through int coords).
-        dist = random_patch.get_coord("distance").values
-        select = {"distance": (dist[0], dist[len(dist) // 2])}
-        from_disk = dc.spool(path).select(**select)[0]
-        in_memory = random_patch.select(**select)
-        assert from_disk.equals(in_memory)
-
-    def test_write_compression_level_uses_default(self, tmp_path_factory, random_patch):
-        """Compression level alone uses the default DASDAE compression library."""
-        path = tmp_path_factory.mktemp("dasdae_compressed") / "level_only.h5"
-        random_patch.io.write(path, "DASDAE", compression_level=3)
-        with tables.open_file(path) as h5:
-            group = next(h5.iter_nodes("/waveforms"))
-            assert group.data.filters.complib == "blosc:zstd"
-            assert group.data.filters.complevel == 3
-
-    def test_write_compressed_empty_coord(self, tmp_path_factory, random_patch):
-        """Compressed DASDAE writes preserve zero-length arrays."""
-        path = tmp_path_factory.mktemp("dasdae_compressed_empty") / "out.h5"
-        time = random_patch.get_coord("time")
-        empty_patch = random_patch.select(time=(time.max() + 3 * time.step, ...))
-        empty_patch.io.write(
-            path,
-            "dasdae",
-            compression="blosc:zstd",
-            compression_level=5,
-        )
-        new_patch = dc.read(path)[0]
-        assert empty_patch.equals(new_patch)
-
-    def test_compressed_scalar_array_falls_back(self, tmp_path_factory):
-        """DASDAE compression skips scalar arrays unsupported by CArray."""
-        path = tmp_path_factory.mktemp("dasdae_compressed_scalar") / "out.h5"
-        filters = HDF5CompressionSpec(compression_level=5).to_pytables_filters()
-        with tables.open_file(path, mode="w") as h5:
-            node = _create_or_squash_array(h5, h5.root, "scalar", np.array(1), filters)
-            assert node.shape == ()
-            assert node.filters.complevel == 0
-
-    def test_bad_compression_level_raises(self, random_patch, tmp_path_factory):
-        """Compression levels outside the PyTables range are invalid."""
-        path = tmp_path_factory.mktemp("dasdae_bad_compression") / "out.h5"
-        with pytest.raises(ValueError, match="compression_level"):
-            random_patch.io.write(path, "dasdae", compression_level=10)
-
 
 class TestReadDASDAE:
     """Test for reading a dasdae format."""
@@ -247,22 +174,6 @@ class TestReadDASDAE:
         assert [x.attrs.tag for x in spool] == ["S100", "S120"]
         assert [x.attrs.label for x in spool] == ["L100", "L120"]
 
-    def test_get_format_false(self, generic_hdf5):
-        """A generic HDF5 file is not a DASDAE file."""
-        parser = DASDAEV1()
-        assert not parser.get_format(generic_hdf5)
-
-    def test_read_empty_selection_returns_no_patches(
-        self, tmp_path_factory, random_patch
-    ):
-        """Selections outside an empty patch should return no patches."""
-        path = tmp_path_factory.mktemp("dasdae_read_empty_selection") / "out.h5"
-        time = random_patch.get_coord("time")
-        random_patch.io.write(path, "dasdae")
-        empty_range_start = time.max() + 3 * time.step
-        out = dc.read(path, time=(empty_range_start, ...))
-        assert len(out) == 0
-
 
 class TestScanDASDAE:
     """Tests for scanning the dasdae format."""
@@ -274,22 +185,6 @@ class TestScanDASDAE:
         common_keys = set(info1) & set(info2) - {"history"}
         for key in common_keys:
             assert info1[key] == info2[key]
-
-    def test_scan_unpacks_scalar_array_attrs(self):
-        """Min-deps PyTables can expose scalar HDF attrs as 0-D arrays."""
-
-        class Attrs:
-            _attrs_custom_attr = np.array(1)
-            _dims = "time,distance"
-
-            def _f_list(self):
-                return ["_attrs_custom_attr", "_dims"]
-
-        class Group:
-            _v_attrs = Attrs()
-
-        attrs = _get_patch_content_from_group(Group())
-        assert attrs["custom_attr"] == 1
 
     # TODO we need to re-think indexing before this can work.
     @pytest.mark.xfail

--- a/tests/test_utils/test_hdf_utils.py
+++ b/tests/test_utils/test_hdf_utils.py
@@ -15,7 +15,6 @@ import dascore as dc
 from dascore.exceptions import InvalidFileHandlerError
 from dascore.utils.downloader import fetch
 from dascore.utils.hdf5 import (
-    HDF5CompressionSpec,
     HDFPatchIndexManager,
     PyTablesWriter,
     extract_h5_attrs,
@@ -81,40 +80,6 @@ class TestGetHDF5Handlder:
         """
         with open_hdf5_file(simple_hdf_file_handler_append, mode="r") as fi:
             assert isinstance(fi, tables.File)
-
-
-class TestHDF5CompressionSpec:
-    """Tests for backend-neutral HDF5 compression settings."""
-
-    def test_default_is_uncompressed(self):
-        """No compression inputs should produce no PyTables filters."""
-        spec = HDF5CompressionSpec()
-        assert spec.to_pytables_filters() is None
-
-    def test_level_uses_pytables_default(self):
-        """A level without a compressor uses the PyTables default."""
-        filters = HDF5CompressionSpec(compression_level=5).to_pytables_filters()
-        assert filters.complib == "blosc:zstd"
-        assert filters.complevel == 5
-        assert filters.shuffle
-
-    def test_gzip_maps_to_pytables_zlib(self):
-        """The public gzip name maps to the PyTables zlib filter."""
-        filters = HDF5CompressionSpec(
-            compression="gzip", compression_level=3
-        ).to_pytables_filters()
-        assert filters.complib == "zlib"
-        assert filters.complevel == 3
-
-    def test_level_zero_disables_compression(self):
-        """A compression level of 0 explicitly disables compression."""
-        spec = HDF5CompressionSpec(compression="gzip", compression_level=0)
-        assert spec.to_pytables_filters() is None
-
-    def test_bad_level_raises(self):
-        """Compression levels must fit the HDF5/PyTables range."""
-        with pytest.raises(ValueError, match="compression_level"):
-            HDF5CompressionSpec(compression_level=10)
 
 
 class TestHDFPatchIndexManager:


### PR DESCRIPTION
## Summary
- Reverts PR #733 / commit 1175247d, which added DASDAE compression kwargs and HDF5CompressionSpec.
- Removes the temporary compression-option docs and tests so the open storage API PR can provide the replacement API cleanly.
- Preserves later master changes outside that compression-options surface.
- #734 will replace this functionality when it lands. 

## Tests
- pytest tests/test_io/test_dasdae/test_dasdae.py tests/test_utils/test_hdf_utils.py
- uvx prek run --files dascore/io/dasdae/core.py dascore/io/dasdae/utils.py dascore/utils/hdf5.py docs/tutorial/file_io.qmd tests/test_io/test_dasdae/test_dasdae.py tests/test_utils/test_hdf_utils.py