### PR TITLE
Raise CoordError instead of assert for non-1D coord operations

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -347,7 +347,9 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             msg = "Using an array input for select with samples requires integer dtype."
             raise CoordError(msg)
         # Filter out bad indices
-        assert self.ndim <= 1, "Select only works on 1D coords."
+        if self.ndim > 1:
+            msg = "Select only works on 1D coords."
+            raise CoordError(msg)
         inds = np.arange(len(self))
         valid_values = np.isin(inds, array)
         return self[valid_values], valid_values
@@ -430,7 +432,9 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
         if self == other:
             return self, other, slice(None), slice(None)
-        assert self.ndim == 1, "can only align 1D arrays."
+        if self.ndim != 1:
+            msg = "can only align 1D coords."
+            raise CoordError(msg)
         if isinstance(self, CoordPartial) or isinstance(other, CoordPartial):
             valid_non_coord(self, other)
             return self, other, slice(None), slice(None)
@@ -821,7 +825,9 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             If True, raise an error if the number of samples obtained exceeds
             the length of the coordinate.
         """
-        assert self.ndim == 1, "get sample count only works for 1D coords."
+        if self.ndim != 1:
+            msg = "get sample count only works for 1D coords."
+            raise CoordError(msg)
         if not self.evenly_sampled:
             msg = "Coordinate is not evenly sampled, can't get sample count."
             raise CoordError(msg)
@@ -1100,7 +1106,9 @@ class CoordPartial(BaseCoord):
         """
         {doc}
         """
-        assert self.ndim == 1, "change_length only works on 1D coords."
+        if self.ndim != 1:
+            msg = "change_length only works on 1D coords."
+            raise CoordError(msg)
         return get_coord(shape=(length,))
 
     def to_summary(self, dims=()) -> CoordSummary:
@@ -1162,7 +1170,9 @@ class CoordRange(BaseCoord):
         start, stop, step, shape = _attrs
         if not pd.isnull(shape):
             shape = tuple(iterate(shape))
-            assert len(shape) == 1, "Coord range only works for 1D coords."
+            if len(shape) != 1:
+                msg = "Coord range only works for 1D coords."
+                raise CoordError(msg)
             length = shape[0]
             if pd.isnull(start):
                 start = stop - step * length
@@ -1361,6 +1371,7 @@ class CoordRange(BaseCoord):
         """
         {doc}
         """
+        # CoordRange is always 1D by construction; keep as an internal invariant.
         assert self.ndim == 1, "Can only change length for 1D coords."
         if (current := len(self)) == length:
             return self

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy.io.wavfile import write
 
 from dascore.constants import ONE_SECOND, SpoolType
+from dascore.exceptions import ParameterError
 from dascore.io.core import FiberIO
 from dascore.utils.patch import check_patch_coords
 
@@ -54,7 +55,9 @@ class WavIO(FiberIO):
             see if this fixes the issue.
         """
         resource = Path(resource)
-        assert len(spool) == 1, "Only single patch spools can be written to wav"
+        if len(spool) != 1:
+            msg = "Only single patch spools can be written to wav"
+            raise ParameterError(msg)
         patch = spool[0]
         # write a single wav file, maybe multi-channeled.
         data, sr = self._get_wav_data(patch, resample_frequency)

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import dascore as dc
 from dascore.constants import PatchType
+from dascore.exceptions import ParameterError
 from dascore.utils.patch import (
     get_dim_axis_value,
     patch_function,
@@ -196,7 +197,9 @@ def correlate(
             "(e.g., select(lag_time=(...)))"
         )
         warnings.warn(msg, DeprecationWarning)
-    assert len(patch.dims) == 2, "must be a 2D patch."
+    if len(patch.dims) != 2:
+        msg = "must be a 2D patch."
+        raise ParameterError(msg)
     dim, source_axis, source = get_dim_axis_value(patch, kwargs=kwargs)[0]
     # Get the axis and coord over which fft should be calculated.
     fft_axis = next(iter(set(range(len(patch.dims))) - {source_axis}))

--- a/dascore/proc/detrend.py
+++ b/dascore/proc/detrend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Literal
 
 from dascore.constants import PatchType
+from dascore.exceptions import ParameterError
 from dascore.utils.imports import lazy_import
 from dascore.utils.patch import patch_function
 
@@ -36,7 +37,9 @@ def detrend(
     >>> pa = dascore.get_example_patch() # generate example patch
     >>> out = pa.detrend("time") # detrend along the time dimension
     """
-    assert dim in patch.dims
+    if dim not in patch.dims:
+        msg = f"dim '{dim}' is not in patch dimensions {patch.dims}"
+        raise ParameterError(msg)
     axis = patch.get_axis(dim)
     out = scipy_detrend(patch.data, axis=axis, type=type)
     return patch.new(data=out)

--- a/dascore/proc/taper.py
+++ b/dascore/proc/taper.py
@@ -23,7 +23,9 @@ def _get_taper_slices(patch, kwargs):
     dim, axis, value = get_dim_axis_value(patch, kwargs=kwargs)[0]
     coord = patch.coords.coord_map[dim]
     if isinstance(value, Sequence | np.ndarray):
-        assert len(value) == 2, "Length 2 sequence required."
+        if len(value) != 2:
+            msg = "Length 2 sequence required."
+            raise ParameterError(msg)
         start, stop = value[0], value[1]
     else:
         start, stop = value, value

--- a/dascore/viz/map_fiber.py
+++ b/dascore/viz/map_fiber.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from dascore.constants import PatchType
+from dascore.exceptions import ParameterError
 from dascore.utils.patch import patch_function
 from dascore.utils.plotting import (
     _get_ax,
@@ -20,8 +21,12 @@ from dascore.utils.plotting import (
 def _set_scale(im, scale, scale_type, color_coords):
     """Set the scale of the color bar based on scale and scale_type."""
     # check scale parameters
-    assert scale_type in {"absolute", "relative"}
-    assert isinstance(scale, float | int) or len(scale) == 2
+    if scale_type not in {"absolute", "relative"}:
+        msg = f"scale_type must be 'absolute' or 'relative', got {scale_type!r}"
+        raise ParameterError(msg)
+    if not (isinstance(scale, float | int) or len(scale) == 2):
+        msg = "scale must be a number or a length-2 sequence"
+        raise ParameterError(msg)
     # make sure we have a len two array
     modifier = 1
     if scale_type == "relative":
@@ -88,15 +93,21 @@ def map_fiber(
     """
     dims = []
     if isinstance(x, str):
-        assert x in patch.coords, f"{x} not found in patch coordinates"
+        if x not in patch.coords:
+            msg = f"{x} not found in patch coordinates"
+            raise ParameterError(msg)
         dims.append(x)
         x = patch.coords.get_array(x)
     if isinstance(y, str):
-        assert y in patch.coords, f"{y} not found in patch coordinates"
+        if y not in patch.coords:
+            msg = f"{y} not found in patch coordinates"
+            raise ParameterError(msg)
         dims.append(y)
         y = patch.coords.get_array(y)
     if isinstance(color, str):
-        assert color in patch.coords, f"{color} not found in patch coordinates"
+        if color not in patch.coords:
+            msg = f"{color} not found in patch coordinates"
+            raise ParameterError(msg)
         data_type = color
         data_units = patch.attrs.coords[color].units
         color = patch.coords.get_array(color)

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -2078,3 +2078,49 @@ class TestIssues:
         data = np.stack([dates, dates], axis=-1)
         coord = get_coord(data=data)
         assert isinstance(coord, CoordArray)
+
+
+class TestDimensionalityErrors:
+    """
+    Operations that only support 1D coordinates should raise CoordError on
+    multi-dim input rather than a bare AssertionError (which is also stripped
+    under `python -O`).
+    """
+
+    @pytest.fixture(scope="class")
+    def coord_2d(self):
+        """A simple 2D (non-dimensional) coordinate."""
+        return get_coord(values=np.arange(12).reshape(3, 4))
+
+    @pytest.fixture(scope="class")
+    def partial_2d(self):
+        """A 2D partial coordinate."""
+        coord = get_coord(start=0, step=1, shape=(2, 3))
+        assert isinstance(coord, CoordPartial) and coord.ndim == 2
+        return coord
+
+    def test_select_sample_array_2d_raises(self, coord_2d):
+        """Selecting with a sample array requires a 1D coord."""
+        with pytest.raises(CoordError, match="1D coords"):
+            coord_2d.select(np.array([0, 1]), samples=True)
+
+    def test_get_sample_count_2d_raises(self, coord_2d):
+        """get_sample_count requires a 1D coord."""
+        with pytest.raises(CoordError, match="1D coords"):
+            coord_2d.get_sample_count(2)
+
+    def test_align_to_2d_raises(self, coord_2d):
+        """align_to requires 1D coords."""
+        other = get_coord(values=np.arange(6).reshape(2, 3))
+        with pytest.raises(CoordError, match="1D coords"):
+            coord_2d.align_to(other)
+
+    def test_change_length_2d_partial_raises(self, partial_2d):
+        """change_length requires a 1D coord."""
+        with pytest.raises(CoordError, match="1D coords"):
+            partial_2d.change_length(5)
+
+    def test_coord_range_requires_1d_shape(self):
+        """Constructing a CoordRange with a 2D shape must be rejected."""
+        with pytest.raises(ValidationError, match="only works for 1D coords"):
+            CoordRange(start=0, step=1, shape=(2, 3))

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -9,6 +9,7 @@ from scipy.io.wavfile import read as read_wav
 
 import dascore as dc
 from dascore.constants import ONE_SECOND
+from dascore.exceptions import ParameterError
 
 
 class TestWriteWav:
@@ -68,3 +69,10 @@ class TestWriteWav:
             # Verify content of first file
             sr, data = read_wav(str(wavs[0]))
         assert sr == int(ONE_SECOND / patch.get_coord("time").step)
+
+    def test_multi_patch_spool_raises(self, audio_patch, tmp_path_factory):
+        """Writing a spool with more than one patch to wav should raise."""
+        path = tmp_path_factory.mktemp("wave_multi") / "temp.wav"
+        spool = dc.spool([audio_patch, audio_patch])
+        with pytest.raises(ParameterError, match="single patch spools"):
+            dc.write(spool, path, "wav")

--- a/tests/test_proc/test_correlate.py
+++ b/tests/test_proc/test_correlate.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
-from dascore.exceptions import UnitError
+from dascore.exceptions import ParameterError, UnitError
 from dascore.units import m
 from dascore.utils.time import to_float
 
@@ -186,3 +186,14 @@ class TestCorrelateInternal:
         """Ensure the lag parameter is deprecated."""
         with pytest.warns(DeprecationWarning):
             corr_patch.correlate(time=1, lag=10, samples=True)
+
+
+class TestCorrelateErrors:
+    """Tests for correlate input validation."""
+
+    def test_non_2d_patch_raises(self):
+        """Correlate requires a 2D patch."""
+        coord = dc.get_coord(start=0, step=1, stop=10)
+        patch_1d = dc.Patch(np.arange(10.0), coords={"time": coord}, dims=("time",))
+        with pytest.raises(ParameterError, match="2D patch"):
+            patch_1d.correlate(time=0, samples=True)

--- a/tests/test_proc/test_detrend.py
+++ b/tests/test_proc/test_detrend.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
+
+from dascore.exceptions import ParameterError
 
 
 class TestDetrend:
@@ -15,3 +18,8 @@ class TestDetrend:
         det = new.detrend(dim="time", type="linear")
         means = np.mean(det.data, axis=det.get_axis("time"))
         assert np.allclose(means, 0)
+
+    def test_bad_dim_raises(self, random_patch):
+        """A dim not in the patch should raise ParameterError."""
+        with pytest.raises(ParameterError, match="not in patch dim"):
+            random_patch.detrend(dim="not_a_dim")

--- a/tests/test_proc/test_taper.py
+++ b/tests/test_proc/test_taper.py
@@ -314,3 +314,12 @@ class TestTaperRange:
         # Values from start_idx to end should be 0 (muted)
         assert np.allclose(out.data[start_idx, :], 1)
         assert np.allclose(out.data[end_idx - 1, :], 1)
+
+
+class TestTaperErrors:
+    """Tests for taper input validation."""
+
+    def test_non_length_2_sequence_raises(self, random_patch):
+        """A sequence taper value must have exactly two entries."""
+        with pytest.raises(ParameterError, match="Length 2 sequence"):
+            random_patch.taper(time=(0.1, 0.2, 0.3))

--- a/tests/test_viz/test_map_fiber.py
+++ b/tests/test_viz/test_map_fiber.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import pytest
 
 import dascore as dc
+from dascore.exceptions import ParameterError
 from dascore.utils.time import is_datetime64
 
 
@@ -116,3 +117,32 @@ class TestPlotMap:
         """Ensure show path is callable."""
         monkeypatch.setattr(plt, "show", lambda: None)
         random_patch.viz.map_fiber(show=True)
+
+
+class TestMapFiberErrors:
+    """Tests for map_fiber input validation."""
+
+    def test_bad_x_coord(self, random_patch):
+        """A non-existent x coordinate name should raise."""
+        with pytest.raises(ParameterError, match="not found in patch"):
+            random_patch.viz.map_fiber("not_a_coord", "time")
+
+    def test_bad_y_coord(self, random_patch):
+        """A non-existent y coordinate name should raise."""
+        with pytest.raises(ParameterError, match="not found in patch"):
+            random_patch.viz.map_fiber("distance", "not_a_coord")
+
+    def test_bad_color_coord(self, random_patch):
+        """A non-existent color coordinate name should raise."""
+        with pytest.raises(ParameterError, match="not found in patch"):
+            random_patch.viz.map_fiber("distance", "time", "not_a_coord")
+
+    def test_bad_scale_type(self, random_patch):
+        """An unknown scale_type should raise."""
+        with pytest.raises(ParameterError, match="scale_type"):
+            random_patch.viz.map_fiber(scale_type="nope", scale=10)
+
+    def test_bad_scale_length(self, random_patch):
+        """A scale that is neither a number nor a length-2 sequence should raise."""
+        with pytest.raises(ParameterError, match="scale must be"):
+            random_patch.viz.map_fiber(scale=(1, 2, 3))


### PR DESCRIPTION
## Description

Several operations guarded caller input with `assert`, which produces a bare `AssertionError` and — more importantly — is stripped entirely under `python -O`, so in optimized runs the check silently vanishes and bad input proceeds into a confusing downstream failure. This converts the **user-reachable** validation asserts across the codebase to raise proper exceptions, while leaving genuine internal invariants (impossible-by-construction shape/postcondition checks, binary-format parser consistency) as asserts.

**Coordinates (`core/coords.py`)** → `CoordError`:

- `_select_by_sample_array`, `align_to`, `get_sample_count`, `CoordPartial.change_length`, and `CoordRange` construction (rejecting a 2D `shape`).
- `CoordRange.change_length`'s ndim check is impossible to violate (a `CoordRange` is always 1D), so it stays an `assert`.

**proc / viz / io** → `ParameterError`:

- `proc/taper`: taper window must be a length-2 sequence.
- `proc/detrend`: `dim` must be in the patch.
- `proc/correlate`: patch must be 2D.
- `viz/map_fiber`: `x`/`y`/`color` must be existing coords; `scale_type` and `scale` are validated.
- `io/wav`: only single-patch spools can be written to wav.

No behavior change on the happy path — this only makes the failure modes explicit and `-O`-safe. Every new error path has a test, and the changed modules keep 100% line coverage.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes. _(none — robustness cleanup)_
- [ ] documented the new feature with docstrings and/or appropriate doc page. _(n/a — no new feature; error messages are self-describing)_
- [x] included tests. New error-path tests in `test_coords.py`, `test_taper.py`, `test_detrend.py`, `test_correlate.py`, `test_map_fiber.py`, and `test_wav.py`.
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
