### PR TITLE
Add CoordSegmented: compositional segmented coordinates

### DIFF
--- a/.github/actions/prep_doc_build/action.yml
+++ b/.github/actions/prep_doc_build/action.yml
@@ -7,7 +7,10 @@ runs:
     - name: Install quarto
       uses: quarto-dev/quarto-actions/setup@v2
       with:
-        version: 1.3.450
+        # 1.3.x dies with "RangeError: Invalid string length" once the
+        # generated _quarto.yml API sidebar gets large enough; see
+        # quarto-dev/quarto-cli#10504.
+        version: 1.8.27
 
     - name: print quarto version
       shell: bash -l {0}

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -191,6 +191,7 @@ dascore_styles = dict(
     default_coord="bold",
     coord_range="bold green",
     coord_monotonic="bold grey",
+    coord_segmented="bold cyan",
     coord_array="bold orange",
     coord_degenerate="bold red",
     coord_non="bold red",

--- a/dascore/core/__init__.py
+++ b/dascore/core/__init__.py
@@ -4,5 +4,5 @@ Core routines and functionality for processing distributed fiber data.
 from __future__ import annotations
 from .patch import Patch  # noqa
 from .summary import PatchSummary  # noqa
-from .coords import CoordSummary, get_coord
+from .coords import CoordSegmented, CoordSummary, concat_coords, get_coord
 from .coordmanager import get_coord_manager, CoordManager

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -2021,9 +2021,14 @@ class CoordSegmented(BaseCoord):
         out = np.concatenate([x.values for x in self.segments])
         return array(out.astype(self.dtype, copy=False))
 
-    @cached_method
     def _as_monotonic(self) -> CoordMonotonicArray:
-        """Return an equivalent (materialized) monotonic array coord."""
+        """
+        Return an equivalent (materialized) monotonic array coord.
+
+        Deliberately not cached: transient materialization for rare
+        operations (snap, get_next_index) must not permanently defeat the
+        O(segments) memory model.
+        """
         return CoordMonotonicArray(values=self.values, units=self.units)
 
     def _min(self):
@@ -2129,14 +2134,35 @@ class CoordSegmented(BaseCoord):
             return self._select_by_array(args, relative=relative, samples=samples)
         if samples:
             return self._select_by_samples(args)
-        # Index math is delegated to an equivalent monotonic array (the values
-        # are identical by construction); the resulting slice is re-applied
-        # segment-wise so structure is preserved. Array args were handled
-        # above, so monotonic select always returns a slice here.
-        _, indexer = self._as_monotonic().select(args, relative=relative)
-        assert isinstance(indexer, slice)
-        start_i, stop_i, _ = indexer.indices(len(self))
-        return self._slice_segments(start_i, stop_i), indexer
+        # Delegate to each segment and compose the global slice from segment
+        # offsets. The window over a monotonic coordinate keeps a contiguous
+        # run of samples, and range segments answer in O(1), so selection
+        # stays O(segments) and never materializes the concatenated values.
+        v1, v2 = self.get_slice_tuple(args, relative=relative)
+        kept, lo, hi = [], None, None
+        for seg, off in zip(self.segments, self._segment_offsets()):
+            seg_min, seg_max = seg.min(), seg.max()
+            if (v2 is not None and seg_min > v2) or (v1 is not None and seg_max < v1):
+                continue  # entirely outside the window
+            inside_lo = v1 is None or v1 <= seg_min
+            inside_hi = v2 is None or v2 >= seg_max
+            if inside_lo and inside_hi:  # entirely inside; keep untouched
+                sub, seg_lo, seg_hi = seg, 0, len(seg)
+            else:  # boundary segment; delegate the exact trim
+                sub, indexer = seg.select((v1, v2))
+                seg_lo, seg_hi, _ = indexer.indices(len(seg))
+                if seg_hi <= seg_lo:
+                    continue
+            if lo is None:
+                lo = int(off) + seg_lo
+            hi = int(off) + seg_hi
+            kept.append(sub)
+        if not kept:
+            return self.empty(), slice(0, 0)
+        new = self._rebuild(kept)
+        start = None if lo == 0 else lo
+        stop = None if hi >= len(self) else hi
+        return new, slice(start, stop)
 
     def _get_index(self, value, forward=True):
         """Get the index corresponding to a value."""

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -2049,10 +2049,8 @@ class CoordSegmented(BaseCoord):
         return self.__class__(segments=segments)
 
     def _rebuild(self, segments) -> BaseCoord:
-        """Build the simplest coordinate from a list of segments."""
+        """Build the simplest coordinate from a (non-empty) list of segments."""
         segments = tuple(segments)
-        if not segments:
-            return self.empty()
         if len(segments) == 1:
             return segments[0]
         try:
@@ -2108,12 +2106,12 @@ class CoordSegmented(BaseCoord):
             return self._select_by_samples(args)
         # Index math is delegated to an equivalent monotonic array (the values
         # are identical by construction); the resulting slice is re-applied
-        # segment-wise so structure is preserved.
+        # segment-wise so structure is preserved. Array args were handled
+        # above, so monotonic select always returns a slice here.
         _, indexer = self._as_monotonic().select(args, relative=relative)
-        if isinstance(indexer, slice):
-            start_i, stop_i, _ = indexer.indices(len(self))
-            return self._slice_segments(start_i, stop_i), indexer
-        return get_coord(data=self.values[indexer], units=self.units), indexer
+        assert isinstance(indexer, slice)
+        start_i, stop_i, _ = indexer.indices(len(self))
+        return self._slice_segments(start_i, stop_i), indexer
 
     def _get_index(self, value, forward=True):
         """Get the index corresponding to a value."""
@@ -2236,8 +2234,9 @@ class CoordSegmented(BaseCoord):
         else:
             step = span / (n - 1)
             zero = 0
-        if (step > zero) != ascending or step == zero:
-            return None
+        # Strictly monotonic segments guarantee a nonzero step matching the
+        # sort direction.
+        assert step != zero and (step > zero) == ascending
         candidate = CoordRange(
             start=first, stop=last + step, step=step, units=self.units
         ).change_length(n)
@@ -2349,7 +2348,8 @@ def concat_coords(*coords, units=None) -> BaseCoord:
     _validate_segment_compat(tuple(flat))
     multi = [x for x in flat if len(x) > 1]
     ascending = multi[0].sorted if multi else True
-    flat.sort(key=lambda x: to_float(x.min()), reverse=not ascending)
+    # Sort on native values; float conversion would collapse ns datetimes.
+    flat.sort(key=lambda x: x.min(), reverse=not ascending)
     if len(flat) == 1:
         return _maybe_promote_segment(flat[0])
     _validate_segment_chain(tuple(flat))

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import abc
 import fnmatch
 import hashlib
+import itertools
 import json
 import re
 from collections.abc import Sized
@@ -21,6 +22,7 @@ import numpy as np
 import pandas as pd
 from pydantic import (
     ValidationError,
+    field_serializer,
     field_validator,
     model_validator,
 )
@@ -654,6 +656,62 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         easier to work with.
         """
         return self
+
+    def simplify(self, tolerance=None) -> BaseCoord:
+        """
+        Return the simplest coordinate representing the same values.
+
+        Unlike [`snap`](`dascore.core.coords.BaseCoord.snap`), which forces a
+        uniform coordinate with unbounded interior error, simplify never moves
+        any value by more than `tolerance`.
+
+        Parameters
+        ----------
+        tolerance
+            The maximum amount any coordinate value may change. For time-like
+            coordinates this is a timedelta (numeric values interpreted as
+            seconds). None or 0 permit only exact (lossless) simplifications.
+
+        Notes
+        -----
+        Most coordinates are already in their simplest form and return
+        themselves. [`CoordSegmented`](`dascore.core.coords.CoordSegmented`)
+        re-fits its segments as evenly sampled ranges wherever the fit error
+        stays within tolerance, possibly collapsing to a single
+        [`CoordRange`](`dascore.core.coords.CoordRange`).
+        """
+        return self
+
+    def get_discontinuities(self, kind="all", tolerance=None) -> pd.DataFrame:
+        """
+        Return a dataframe describing discontinuities in the coordinate.
+
+        Parameters
+        ----------
+        kind
+            Either "all" (every segment boundary) or "gaps" (boundaries whose
+            spacing exceeds the local sampling interval by more than
+            `tolerance`).
+        tolerance
+            For kind="gaps", the excess spacing (beyond the expected sampling
+            interval) required to report a boundary. For time-like
+            coordinates numeric values are interpreted as seconds. Default 0.
+
+        Notes
+        -----
+        The returned dataframe has columns: `index` (position of the first
+        sample after the boundary), `before`, `after` (values on either side),
+        `delta` (after - before) and `excess` (delta minus the expected local
+        sampling interval, NaN when no sampling interval is defined).
+
+        Coordinates without internal segment structure return an empty
+        dataframe.
+        """
+        if kind not in ("all", "gaps"):
+            msg = f"kind must be 'all' or 'gaps', got {kind!r}"
+            raise ParameterError(msg)
+        columns = ["index", "before", "after", "delta", "excess"]
+        return pd.DataFrame(columns=columns)
 
     @abc.abstractmethod
     def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
@@ -1714,6 +1772,593 @@ class CoordMonotonicArray(CoordArray):
         return self._step_meets_requirement(lt)
 
 
+def _coerce_segment(seg) -> BaseCoord:
+    """Coerce a segment input (coord or dumped dict) to a coordinate."""
+    if isinstance(seg, BaseCoord):
+        return seg
+    if isinstance(seg, dict):
+        # Round-trip support: rebuild segments from model_dump payloads.
+        if seg.get("values") is not None:
+            return CoordMonotonicArray(**seg)
+        return CoordRange(**seg)
+    msg = f"Segments must be coordinates, got {type(seg)}."
+    raise CoordError(msg)
+
+
+def _maybe_promote_segment(seg: BaseCoord) -> BaseCoord:
+    """Promote an exactly evenly sampled array segment to a CoordRange."""
+    if not isinstance(seg, CoordMonotonicArray) or len(seg) < 2:
+        return seg
+    values = seg.values
+    diffs = np.diff(values)
+    if len(np.unique(diffs)) != 1:
+        return seg
+    step = diffs[0]
+    candidate = CoordRange(
+        start=values[0], stop=values[-1] + step, step=step, units=seg.units
+    )
+    # Only promote when the range reproduces the values bit-exactly; unlike
+    # get_coord inference, segments must never change any value.
+    if len(candidate) == len(seg) and np.array_equal(candidate.values, values):
+        return candidate
+    return seg
+
+
+def _fuse_segments(segments: tuple[BaseCoord, ...]) -> tuple[BaseCoord, ...]:
+    """Fuse adjacent segments that continue exactly (normal form)."""
+    out = [segments[0]]
+    for seg in segments[1:]:
+        prev = out[-1]
+        both_ranges = isinstance(prev, CoordRange) and isinstance(seg, CoordRange)
+        if both_ranges and prev.step == seg.step and prev.stop == seg.start:
+            out[-1] = CoordRange(
+                start=prev.start, stop=seg.stop, step=prev.step, units=prev.units
+            )
+            continue
+        both_arrays = isinstance(prev, CoordMonotonicArray) and isinstance(
+            seg, CoordMonotonicArray
+        )
+        if both_arrays:
+            # Adjacent irregular arrays carry no sampling expectation, so the
+            # boundary between them has no meaning; fuse for canonical form.
+            values = np.concatenate([prev.values, seg.values])
+            out[-1] = CoordMonotonicArray(values=values, units=prev.units)
+            continue
+        out.append(seg)
+    return tuple(out)
+
+
+def _validate_segment_compat(segments: tuple[BaseCoord, ...]) -> None:
+    """Validate segment types, dtypes, and units are compatible."""
+    for seg in segments:
+        if not isinstance(seg, CoordRange | CoordMonotonicArray):
+            msg = (
+                "Segments must be CoordRange or CoordMonotonicArray, "
+                f"got {type(seg)}."
+            )
+            raise CoordError(msg)
+        if not len(seg):
+            msg = "Segments must not be empty."
+            raise CoordError(msg)
+    dtypes = {np.dtype(s.dtype) for s in segments}
+    time_like = {dtype_time_like(x) for x in dtypes}
+    kinds = {x.kind for x in dtypes}
+    if len(time_like) > 1 or (True in time_like and len(kinds) > 1):
+        msg = f"Segments must share compatible dtypes, got {dtypes}."
+        raise CoordError(msg)
+    units = {get_quantity(s.units) for s in segments}
+    if len(units) > 1:
+        msg = "All segments must have the same units."
+        raise CoordError(msg)
+
+
+def _validate_segment_chain(segments: tuple[BaseCoord, ...]) -> None:
+    """Validate direction consistency and strict non-overlap of segments."""
+    multi = [s for s in segments if len(s) > 1]
+    ascending = multi[0].sorted if multi else segments[0].min() < segments[-1].min()
+    for seg in multi:
+        ok = seg.sorted if ascending else seg.reverse_sorted
+        if not ok:
+            msg = "All segments must be sorted in a consistent direction."
+            raise CoordError(msg)
+    for prev, nxt in itertools.pairwise(segments):
+        if ascending:
+            good = nxt.min() > prev.max()
+        else:
+            good = nxt.max() < prev.min()
+        if not good:
+            msg = (
+                "Segments must be monotonic and non-overlapping; segment "
+                f"({nxt.min()}, {nxt.max()}) overlaps or precedes "
+                f"({prev.min()}, {prev.max()})."
+            )
+            raise CoordError(msg)
+
+
+class CoordSegmented(BaseCoord):
+    """
+    A coordinate composed of an ordered sequence of monotonic segments.
+
+    Segments are normal coordinates ([`CoordRange`](`dascore.core.coords.CoordRange`)
+    or [`CoordMonotonicArray`](`dascore.core.coords.CoordMonotonicArray`)); the
+    values of the segmented coordinate are exactly the concatenation of the
+    segment values. Segment boundaries record discontinuities (e.g. data gaps)
+    without altering any value, which makes this the natural coordinate for
+    data merged across nearly-contiguous blocks.
+
+    Notes
+    -----
+    - Direct construction requires at least two segments after normalization;
+      use [`concat_coords`](`dascore.core.coords.concat_coords`) (or
+      `get_coord(segments=...)`) which returns a plain coordinate when the
+      inputs fuse into one segment.
+    - Normalization promotes exactly evenly sampled array segments to ranges
+      and fuses segments that continue exactly, so equal-valued segmented
+      coordinates compare and fingerprint equal regardless of how they
+      were assembled.
+    - `step` is always None; use
+      [`simplify`](`dascore.core.coords.BaseCoord.simplify`) to obtain an
+      evenly sampled coordinate with bounded error, or
+      [`snap`](`dascore.core.coords.BaseCoord.snap`) to force one.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> from dascore.core.coords import concat_coords, get_coord
+    >>>
+    >>> # Two evenly sampled blocks separated by a gap.
+    >>> c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+    >>> c2 = get_coord(start=15.0, stop=25.0, step=1.0)
+    >>> coord = concat_coords(c1, c2)
+    >>> assert coord.segment_count == 2
+    >>> assert coord.min() == 0.0 and coord.max() == 24.0
+    >>>
+    >>> # Exactly contiguous blocks fuse back to a single range.
+    >>> c3 = get_coord(start=10.0, stop=20.0, step=1.0)
+    >>> fused = concat_coords(c1, c3)
+    >>> assert fused == get_coord(start=0.0, stop=20.0, step=1.0)
+    """
+
+    # Note: typed as BaseCoord (not a union) because pydantic union dispatch
+    # runs member before-validators on foreign instances; the model validator
+    # below enforces the concrete segment types.
+    segments: tuple[BaseCoord, ...]
+    _rich_style = dascore_styles["coord_segmented"]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_segments(cls, data: Any) -> Any:
+        """Coerce, normalize, and validate segments; derive model fields."""
+        if not isinstance(data, dict):
+            return data
+        segments = data.get("segments")
+        if isinstance(segments, BaseCoord):
+            segments = (segments,)
+        segments = tuple(_coerce_segment(x) for x in iterate(segments))
+        if not segments:
+            msg = "CoordSegmented requires at least one segment."
+            raise CoordError(msg)
+        _validate_segment_compat(segments)
+        _validate_segment_chain(segments)
+        segments = _fuse_segments(tuple(_maybe_promote_segment(x) for x in segments))
+        if len(segments) < 2:
+            msg = (
+                "Segments fuse into a single coordinate; use concat_coords "
+                "or get_coord(segments=...) which return it directly."
+            )
+            raise CoordError(msg)
+        seg_units = segments[0].units
+        if (given := data.get("units")) is not None:
+            if get_quantity(given) != get_quantity(seg_units):
+                msg = (
+                    f"units {given} do not match segment units {seg_units}. "
+                    "Use set_units or convert_units instead."
+                )
+                raise CoordError(msg)
+        data["segments"] = segments
+        data["units"] = seg_units
+        data["shape"] = (sum(len(x) for x in segments),)
+        data["dtype"] = np.result_type(*[s.dtype for s in segments])
+        data["step"] = None
+        return data
+
+    @field_serializer("segments")
+    def _serialize_segments(self, segments, _info):
+        """Serialize each segment with its own (subclass) schema."""
+        return [x.model_dump() for x in segments]
+
+    def __eq__(self, other) -> bool:
+        """Compare segment-wise (nested arrays break generic dump equality)."""
+        if not isinstance(other, CoordSegmented):
+            return False
+        if len(self.segments) != len(other.segments):
+            return False
+        pairs = zip(self.segments, other.segments)
+        return all(s1 == s2 for s1, s2 in pairs)
+
+    __hash__ = BaseCoord.__hash__
+
+    @property
+    def segment_count(self) -> int:
+        """Return the number of segments."""
+        return len(self.segments)
+
+    @cached_method
+    def _segment_offsets(self) -> np.ndarray:
+        """Return the starting sample index of each segment."""
+        lens = [len(x) for x in self.segments]
+        return np.cumsum([0, *lens[:-1]])
+
+    @property
+    @cached_method
+    def values(self) -> ArrayLike:
+        """Return the values of the coordinate as an array."""
+        out = np.concatenate([x.values for x in self.segments])
+        return array(out.astype(self.dtype, copy=False))
+
+    @cached_method
+    def _as_monotonic(self) -> CoordMonotonicArray:
+        """Return an equivalent (materialized) monotonic array coord."""
+        return CoordMonotonicArray(values=self.values, units=self.units)
+
+    def _min(self):
+        """Return min value (exact, no materialization)."""
+        first, last = self.segments[0], self.segments[-1]
+        return first.min() if self.sorted else last.min()
+
+    def _max(self):
+        """Return max value (exact, no materialization)."""
+        first, last = self.segments[0], self.segments[-1]
+        return last.max() if self.sorted else first.max()
+
+    @property
+    @cached_method
+    def sorted(self) -> bool:
+        """Return True if sorted in ascending order."""
+        return bool(self.segments[0].min() < self.segments[-1].min())
+
+    @property
+    @cached_method
+    def reverse_sorted(self) -> bool:
+        """Return True if sorted in descending order."""
+        return not self.sorted
+
+    def _fingerprint_components(self) -> tuple[Any, ...]:
+        """Return the payload needed to fingerprint segmented coords."""
+        return (("segments", tuple(x.fingerprint() for x in self.segments)),)
+
+    def new(self, **kwargs):
+        """Update coordinate."""
+        if "data" in kwargs or "values" in kwargs:
+            data = kwargs.get("data", kwargs.get("values"))
+            return get_coord(data=data, units=kwargs.get("units", self.units))
+        segments = kwargs.pop("segments", self.segments)
+        units = kwargs.pop("units", self.units)
+        return self.__class__(segments=segments, units=units)
+
+    def set_units(self, units) -> Self:
+        """Set new units on the coordinate and all segments."""
+        segments = tuple(x.set_units(units) for x in self.segments)
+        return self.__class__(segments=segments)
+
+    def convert_units(self, units) -> Self:
+        """Convert units, or set units if none exist."""
+        if dtype_time_like(self.dtype):
+            return self
+        segments = tuple(x.convert_units(units) for x in self.segments)
+        return self.__class__(segments=segments)
+
+    def _rebuild(self, segments) -> BaseCoord:
+        """Build the simplest coordinate from a list of segments."""
+        segments = tuple(segments)
+        if not segments:
+            return self.empty()
+        if len(segments) == 1:
+            return segments[0]
+        try:
+            return self.__class__(segments=segments)
+        except (ValidationError, CoordError):
+            fused = _fuse_segments(tuple(_maybe_promote_segment(x) for x in segments))
+            if len(fused) == 1:  # Segments fused to a single coordinate.
+                return fused[0]
+            raise
+
+    def _slice_segments(self, start: int, stop: int) -> BaseCoord:
+        """Return the coordinate for a contiguous sample range."""
+        if stop <= start:
+            return self.empty()
+        out = []
+        for seg, off in zip(self.segments, self._segment_offsets()):
+            lo, hi = max(start - off, 0), min(stop - off, len(seg))
+            if hi <= lo:
+                continue
+            sub = seg if (lo == 0 and hi == len(seg)) else seg[slice(lo, hi)]
+            out.append(sub)
+        return self._rebuild(out)
+
+    def __getitem__(self, item):
+        if isinstance(item, int | np.integer):
+            length = len(self)
+            index = int(item) + length if item < 0 else int(item)
+            if not 0 <= index < length:
+                msg = f"{item} exceeds coord length of {self}"
+                raise IndexError(msg)
+            offsets = self._segment_offsets()
+            seg_ind = int(np.searchsorted(offsets, index, side="right")) - 1
+            return self.segments[seg_ind][index - int(offsets[seg_ind])]
+        if isinstance(item, slice):
+            start = None if item.start is ... else item.start
+            stop = None if item.stop is ... else item.stop
+            item = slice(start, stop, item.step)
+            start_i, stop_i, step_i = item.indices(len(self))
+            if step_i == 1:
+                return self._slice_segments(start_i, stop_i)
+        out = self.values[item]
+        if not np.ndim(out):
+            return out
+        return get_coord(data=out, units=self.units)
+
+    def select(
+        self, args, relative=False, samples=False
+    ) -> tuple[BaseCoord, slice | ArrayLike]:
+        """Apply select, return selected coords and index for selecting data."""
+        if is_array(args):
+            return self._select_by_array(args, relative=relative, samples=samples)
+        if samples:
+            return self._select_by_samples(args)
+        # Index math is delegated to an equivalent monotonic array (the values
+        # are identical by construction); the resulting slice is re-applied
+        # segment-wise so structure is preserved.
+        _, indexer = self._as_monotonic().select(args, relative=relative)
+        if isinstance(indexer, slice):
+            start_i, stop_i, _ = indexer.indices(len(self))
+            return self._slice_segments(start_i, stop_i), indexer
+        return get_coord(data=self.values[indexer], units=self.units), indexer
+
+    def _get_index(self, value, forward=True):
+        """Get the index corresponding to a value."""
+        return self._as_monotonic()._get_index(value, forward=forward)
+
+    def sort(self, reverse=False) -> tuple[BaseCoord, slice | ArrayLike]:
+        """Sort the contents of the coord. Return new coord and slice for sorting."""
+        forward_forward = not reverse and self.sorted
+        reverse_reverse = reverse and self.reverse_sorted
+        if forward_forward or reverse_reverse:
+            return self, slice(None)
+        segments = tuple(
+            seg.sort(reverse=reverse)[0] for seg in reversed(self.segments)
+        )
+        return self.new(segments=segments), slice(None, None, -1)
+
+    @compose_docstring(doc=BaseCoord.update_limits.__doc__)
+    def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
+        """{doc}."""
+        if step is not None:
+            msg = (
+                "Segmented coordinates have no single step; use simplify or "
+                "snap to get an evenly sampled coordinate first."
+            )
+            raise ParameterError(msg)
+        if min is not None and max is not None:
+            msg = "Cannot specify both min and max in update_limits."
+            raise ParameterError(msg)
+        out = self
+        if min is not None:
+            delta = get_compatible_values(min, self.dtype) - self.min()
+            out = out._shift(delta)
+        elif max is not None:
+            delta = get_compatible_values(max, self.dtype) - self.max()
+            out = out._shift(delta)
+        return out.new(**kwargs) if kwargs else out
+
+    def _shift(self, delta) -> Self:
+        """Return a copy of the coordinate with all values shifted by delta."""
+        segments = []
+        for seg in self.segments:
+            if isinstance(seg, CoordRange):
+                new = seg.new(start=seg.start + delta, stop=seg.stop + delta)
+            else:
+                new = seg.new(values=seg.values + delta)
+            segments.append(new)
+        return self.new(segments=tuple(segments))
+
+    def snap(self) -> CoordRange:
+        """
+        Snap the coordinates to evenly sampled grid points.
+
+        The min/max of the coordinate remain unchanged; every interior value
+        may move without bound. Use
+        [`simplify`](`dascore.core.coords.BaseCoord.simplify`) for a
+        tolerance-bounded alternative.
+        """
+        return self._as_monotonic().snap()
+
+    def simplify(self, tolerance=None) -> BaseCoord:
+        """
+        Return the simplest coordinate representing the same values.
+
+        Segments are greedily re-fit as evenly sampled ranges; a fit is
+        accepted only when no value moves by more than `tolerance`. With a
+        sufficient tolerance a fully contiguous segmented coordinate collapses
+        to a single [`CoordRange`](`dascore.core.coords.CoordRange`).
+
+        Parameters
+        ----------
+        tolerance
+            The maximum amount any coordinate value may change. For time-like
+            coordinates this is a timedelta (numeric values interpreted as
+            seconds). None or 0 permit only exact simplifications.
+        """
+        tol = self._get_tolerance(tolerance)
+        result = []
+        run = [self.segments[0]]
+        run_fit = self._fit_run(run, tol)
+        for seg in self.segments[1:]:
+            trial = [*run, seg]
+            fit = self._fit_run(trial, tol)
+            if fit is not None:
+                run, run_fit = trial, fit
+            else:
+                result.append(run_fit if run_fit is not None else run[0])
+                run, run_fit = [seg], self._fit_run([seg], tol)
+        result.append(run_fit if run_fit is not None else run[0])
+        return self._rebuild(result)
+
+    def _get_tolerance(self, tolerance):
+        """Coerce the tolerance to the dtype expected for value deviations."""
+        if tolerance is None:
+            tolerance = 0
+        if dtype_time_like(self.dtype):
+            tolerance = dc.to_timedelta64(tolerance)
+            zero = dc.to_timedelta64(0)
+        else:
+            zero = 0
+        if tolerance < zero:
+            msg = "simplify tolerance must not be negative."
+            raise ParameterError(msg)
+        return tolerance
+
+    def _fit_run(self, run, tol) -> CoordRange | None:
+        """Fit a run of segments to a single range within tol, or None."""
+        if len(run) == 1 and isinstance(run[0], CoordRange):
+            return run[0]
+        n = sum(len(x) for x in run)
+        if n < 2:
+            return None
+        ascending = self.sorted
+        first = run[0].min() if ascending else run[0].max()
+        last = run[-1].max() if ascending else run[-1].min()
+        span = last - first
+        if is_timedelta64(span) or is_datetime64(first):
+            span_ns = dc.to_timedelta64(span).astype(np.int64)
+            step = np.timedelta64(int(np.round(span_ns / (n - 1))), "ns")
+            zero = dc.to_timedelta64(0)
+        else:
+            step = span / (n - 1)
+            zero = 0
+        if (step > zero) != ascending or step == zero:
+            return None
+        candidate = CoordRange(
+            start=first, stop=last + step, step=step, units=self.units
+        ).change_length(n)
+        actual = np.concatenate([x.values for x in run])
+        deviation = np.max(np.abs(candidate.values - actual))
+        if deviation > tol:
+            return None
+        return candidate
+
+    @compose_docstring(doc=BaseCoord.get_discontinuities.__doc__)
+    def get_discontinuities(self, kind="all", tolerance=None) -> pd.DataFrame:
+        """{doc}."""
+        if kind not in ("all", "gaps"):
+            msg = f"kind must be 'all' or 'gaps', got {kind!r}"
+            raise ParameterError(msg)
+        offsets = self._segment_offsets()
+        ascending = self.sorted
+        rows = []
+        for num in range(1, len(self.segments)):
+            prev, nxt = self.segments[num - 1], self.segments[num]
+            before = prev.max() if ascending else prev.min()
+            after = nxt.min() if ascending else nxt.max()
+            delta = after - before
+            expected = self._expected_step(prev)
+            excess = np.abs(delta) - np.abs(expected) if expected is not None else None
+            rows.append(
+                dict(
+                    index=int(offsets[num]),
+                    before=before,
+                    after=after,
+                    delta=delta,
+                    excess=excess,
+                )
+            )
+        df = pd.DataFrame(rows, columns=["index", "before", "after", "delta", "excess"])
+        if kind == "gaps":
+            tol = self._get_tolerance(tolerance)
+            excess = df["excess"]
+            df = df[~pd.isnull(excess) & (excess > tol)]
+        return df.reset_index(drop=True)
+
+    @staticmethod
+    def _expected_step(seg) -> Any:
+        """Return the expected next-sample spacing after a segment, or None."""
+        if isinstance(seg, CoordRange):
+            return seg.step
+        if len(seg) > 1:
+            values = seg.values
+            return values[-1] - values[-2]
+        return None
+
+
+def concat_coords(*coords, units=None) -> BaseCoord:
+    """
+    Concatenate monotonic coordinates into a single coordinate.
+
+    This operation is truth-preserving: no value is ever altered, and every
+    boundary between inputs that does not continue exactly is recorded as a
+    segment boundary. The result is a
+    [`CoordSegmented`](`dascore.core.coords.CoordSegmented`) unless the inputs
+    fuse into a single segment, in which case that coordinate is returned
+    directly. Use [`simplify`](`dascore.core.coords.BaseCoord.simplify`) on
+    the result for tolerance-bounded gap absorption.
+
+    Parameters
+    ----------
+    *coords
+        Coordinates to concatenate. Each must be evenly sampled
+        ([`CoordRange`](`dascore.core.coords.CoordRange`)), monotonic
+        ([`CoordMonotonicArray`](`dascore.core.coords.CoordMonotonicArray`)),
+        or already segmented. Inputs are ordered by their envelopes; they
+        must share dtype kind, units, and sort direction, and must not
+        overlap.
+    units
+        If provided, set (not convert) these units on the output.
+
+    Examples
+    --------
+    >>> from dascore.core.coords import concat_coords, get_coord
+    >>>
+    >>> c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+    >>> c2 = get_coord(start=15.0, stop=25.0, step=1.0)
+    >>> coord = concat_coords(c1, c2)
+    >>> assert len(coord) == len(c1) + len(c2)
+    """
+    flat = []
+    for coord in coords:
+        if isinstance(coord, CoordSegmented):
+            flat.extend(coord.segments)
+        elif isinstance(coord, CoordRange | CoordMonotonicArray):
+            if len(coord):
+                flat.append(coord)
+        elif isinstance(coord, BaseCoord):
+            if coord.degenerate:
+                continue
+            msg = (
+                "concat_coords only supports evenly sampled, monotonic, or "
+                f"segmented coordinates, got {type(coord)}."
+            )
+            raise CoordError(msg)
+        else:
+            msg = f"concat_coords requires coordinates, got {type(coord)}."
+            raise CoordError(msg)
+    if units is not None:
+        flat = [x.set_units(units) for x in flat]
+    if not flat:
+        msg = "concat_coords requires at least one non-empty coordinate."
+        raise CoordError(msg)
+    _validate_segment_compat(tuple(flat))
+    multi = [x for x in flat if len(x) > 1]
+    ascending = multi[0].sorted if multi else True
+    flat.sort(key=lambda x: to_float(x.min()), reverse=not ascending)
+    if len(flat) == 1:
+        return _maybe_promote_segment(flat[0])
+    _validate_segment_chain(tuple(flat))
+    segments = _fuse_segments(tuple(_maybe_promote_segment(x) for x in flat))
+    if len(segments) == 1:
+        return segments[0]
+    return CoordSegmented(segments=segments)
+
+
 def _get_coord_kind(
     data: ArrayLike | None = None,
     *,
@@ -1916,6 +2561,7 @@ def get_coord(
     units: None | Unit | Quantity | str = None,
     shape: None | int | tuple[int, ...] = None,
     dtype: str | np.dtype = None,
+    segments: tuple[BaseCoord, ...] | list[BaseCoord] | None = None,
 ) -> BaseCoord:
     """
     Return a coordinate from provided inputs.
@@ -1945,6 +2591,10 @@ def get_coord(
         this shape. Otherwise, leave unset.
     dtype
         Data type for coord. Often can be inferred from other arguments.
+    segments
+        A sequence of monotonic coordinates to concatenate into one
+        coordinate (see [`concat_coords`](`dascore.core.coords.concat_coords`)).
+        Cannot be combined with other value inputs.
 
     Notes
     -----
@@ -2043,6 +2693,13 @@ def get_coord(
                 _max = _get_new_max(data, _min, _step)
                 return _min, _max + _step, _step, is_monotonic
         return None, None, None, is_monotonic
+
+    if segments is not None:
+        others = (data, values, start, min, stop, max, step, shape, dtype)
+        if any(x is not None for x in others):
+            msg = "segments cannot be combined with other get_coord inputs."
+            raise CoordError(msg)
+        return concat_coords(*segments, units=units)
 
     data = _get_array(data, values)
     shape = _get_shape(shape)

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -65,7 +65,13 @@ from dascore.utils.models import (
     DascoreBaseModel,
     UnitQuantity,
 )
-from dascore.utils.time import dtype_time_like, is_datetime64, is_timedelta64, to_float
+from dascore.utils.time import (
+    dtype_time_like,
+    is_datetime64,
+    is_timedelta64,
+    to_float,
+    to_int,
+)
 
 # Valid values for min/max
 min_max_type = TypeVar("min_max_type")
@@ -1681,6 +1687,23 @@ class CoordArray(BaseCoord):
         return (("array", hash_array(self.values)),)
 
 
+def _negate_for_search(values):
+    """
+    Negate values so descending arrays can use ascending searchsorted.
+
+    Exactness matters: converting ns-precision datetimes (or large ints) to
+    float collapses nearby values, so time-like values negate on their int
+    ns representation and signed numerics negate natively. Only unsigned
+    ints (which would wrap) fall back to float.
+    """
+    array = np.atleast_1d(np.asarray(values))
+    if dtype_time_like(array.dtype):
+        return -to_int(array)
+    if array.dtype.kind == "u":
+        return -to_float(array)
+    return -array
+
+
 class CoordMonotonicArray(CoordArray):
     """A coordinate with strictly increasing or decreasing values."""
 
@@ -1727,8 +1750,8 @@ class CoordMonotonicArray(CoordArray):
         # since search sorted only works on ascending monotonic arrays we
         # negative descending arrays to get the same effect.
         if self.reverse_sorted:
-            values = to_float(values) * -1
-            new_value = to_float(new_value) * -1
+            values = _negate_for_search(values)
+            new_value = _negate_for_search(new_value)
         # side = "right" if forward else "left"
         # out = np.atleast_1d(np.searchsorted(values, new_value, side=side))
         # Search values. Ensure the returned index is in bounds (eg values GT
@@ -1840,10 +1863,12 @@ def _validate_segment_compat(segments: tuple[BaseCoord, ...]) -> None:
         if not len(seg):
             msg = "Segments must not be empty."
             raise CoordError(msg)
-    dtypes = {np.dtype(s.dtype) for s in segments}
-    time_like = {dtype_time_like(x) for x in dtypes}
-    kinds = {x.kind for x in dtypes}
-    if len(time_like) > 1 or (True in time_like and len(kinds) > 1):
+    # Width promotion within one dtype kind is lossless (i4+i8, f4+f8,
+    # M8[s]+M8[ns]); mixing kinds (e.g. int64 + float64) can silently alter
+    # values (ints above 2**53), so it is rejected outright.
+    kinds = {np.dtype(s.dtype).kind for s in segments}
+    if len(kinds) > 1:
+        dtypes = {np.dtype(s.dtype) for s in segments}
         msg = f"Segments must share compatible dtypes, got {dtypes}."
         raise CoordError(msg)
     units = {get_quantity(s.units) for s in segments}
@@ -2206,6 +2231,9 @@ class CoordSegmented(BaseCoord):
         """Coerce the tolerance to the dtype expected for value deviations."""
         if tolerance is None:
             tolerance = 0
+        if hasattr(tolerance, "units"):  # pint quantity tolerances
+            target = "s" if dtype_time_like(self.dtype) else self.units
+            tolerance = convert_units(tolerance.magnitude, target, tolerance.units)
         if dtype_time_like(self.dtype):
             tolerance = dc.to_timedelta64(tolerance)
             zero = dc.to_timedelta64(0)
@@ -2288,6 +2316,71 @@ class CoordSegmented(BaseCoord):
             return values[-1] - values[-2]
         return None
 
+    @classmethod
+    def from_array(cls, array, tolerance=None, units=None) -> BaseCoord:
+        """
+        Build a coordinate from a monotonic array, detecting uniform runs.
+
+        Values are preserved exactly; each maximal evenly sampled run becomes
+        an evenly sampled segment and each internal sampling break becomes a
+        segment boundary, so gaps inside the array are queryable via
+        [`get_discontinuities`](`dascore.core.coords.BaseCoord.get_discontinuities`).
+        Fully uniform arrays come back as a plain
+        [`CoordRange`](`dascore.core.coords.CoordRange`) and arrays with no
+        detectable runs as a plain monotonic coordinate.
+
+        Parameters
+        ----------
+        array
+            A strictly monotonic 1D array (numeric, datetime64, or
+            timedelta64) with no missing values.
+        tolerance
+            If not None, apply
+            [`simplify`](`dascore.core.coords.BaseCoord.simplify`) with this
+            tolerance to the result, re-fitting jittery runs and absorbing
+            small gaps with bounded error.
+        units
+            Units for the coordinate.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from dascore.core.coords import CoordSegmented
+        >>>
+        >>> values = np.array([0.0, 1, 2, 3, 10, 11, 12, 13])
+        >>> coord = CoordSegmented.from_array(values)
+        >>> assert coord.segment_count == 2
+        >>> assert len(coord.get_discontinuities("gaps")) == 1
+        """
+        values = np.asarray(array)
+        if values.ndim != 1:
+            msg = "from_array requires a 1D array."
+            raise CoordError(msg)
+        if pd.isnull(values).any():
+            msg = "from_array does not support missing values."
+            raise CoordError(msg)
+        if len(values) < 3:
+            out = get_coord(data=values, units=units)
+        else:
+            diffs = np.diff(values)
+            zero = diffs[0] - diffs[0]
+            if not (np.all(diffs > zero) or np.all(diffs < zero)):
+                msg = "from_array requires strictly monotonic values."
+                raise CoordError(msg)
+            # A diff belongs to a uniform run when it matches a neighboring
+            # diff; isolated diffs are seams (gaps or sampling changes).
+            eq_next = diffs[:-1] == diffs[1:]
+            in_run = np.zeros(len(diffs), dtype=bool)
+            in_run[1:] |= eq_next
+            in_run[:-1] |= eq_next
+            splits = np.flatnonzero(~in_run) + 1
+            blocks = np.split(values, splits)
+            segments = [CoordMonotonicArray(values=x, units=units) for x in blocks]
+            out = concat_coords(*segments)
+        if tolerance is not None:
+            out = out.simplify(tolerance)
+        return out
+
 
 def concat_coords(*coords, units=None) -> BaseCoord:
     """
@@ -2324,6 +2417,8 @@ def concat_coords(*coords, units=None) -> BaseCoord:
     """
     flat = []
     for coord in coords:
+        if isinstance(coord, dict):  # model_dump round-trip payloads
+            coord = _coerce_segment(coord)
         if isinstance(coord, CoordSegmented):
             flat.extend(coord.segments)
         elif isinstance(coord, CoordRange | CoordMonotonicArray):
@@ -2695,9 +2790,12 @@ def get_coord(
         return None, None, None, is_monotonic
 
     if segments is not None:
-        others = (data, values, start, min, stop, max, step, shape, dtype)
-        if any(x is not None for x in others):
-            msg = "segments cannot be combined with other get_coord inputs."
+        # shape/dtype/step are derived fields on CoordSegmented, so they
+        # legitimately appear alongside segments when round-tripping a
+        # model_dump (e.g. through CoordManager); ignore them here.
+        others = (data, values, start, min, stop, max)
+        if any(x is not None for x in others) or not pd.isnull(step):
+            msg = "segments cannot be combined with other coordinate value inputs."
             raise CoordError(msg)
         return concat_coords(*segments, units=units)
 

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -361,6 +361,7 @@ class Patch(NamespaceOwner):
     set_dims = dascore.proc.set_dims
     squeeze = dascore.proc.coords.squeeze
     append_dims = dascore.proc.coords.append_dims
+    split_gaps = dascore.proc.coords.split_gaps
     transpose = dascore.proc.coords.transpose
     add_distance_to = dascore.proc.coords.add_distance_to
     snap_coords = dascore.proc.snap_coords

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -1311,7 +1311,10 @@ def _maybe_split_gapped_patches(spool, fiber_io, split):
         coords = (patch.get_coord(x) for x in patch.dims)
         return any(isinstance(x, CoordSegmented) for x in coords)
 
-    gapped = [_has_gaps(x) for x in spool]
+    # Materialize once (cheap; patches are in memory) so gap detection and
+    # splitting see the same patch sequence.
+    contents = list(spool)
+    gapped = [_has_gaps(x) for x in contents]
     if not any(gapped):
         return spool
     if not split:
@@ -1323,7 +1326,7 @@ def _maybe_split_gapped_patches(spool, fiber_io, split):
         )
         raise ParameterError(msg)
     patches = []
-    for patch, has_gaps in zip(spool, gapped):
+    for patch, has_gaps in zip(contents, gapped, strict=True):
         patches.extend(patch.split_gaps() if has_gaps else [patch])
     if len(patches) > 1 and not fiber_io.multi_patch_write:
         msg = (

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -38,6 +38,7 @@ from dascore.exceptions import (
     InvalidFiberFileError,
     InvalidFiberIOError,
     MissingOptionalDependencyError,
+    ParameterError,
     PatchAttributeError,
     RemoteCacheError,
     UnknownFiberFormatError,
@@ -713,6 +714,8 @@ class FiberIO:
     preferred_extensions: tuple[str] = ()
     # Specifies if this fiber IO expects a directory or single file
     input_type: Literal["file", "directory"] = "file"
+    # True when a single resource can hold more than one patch.
+    multi_patch_write: bool = False
 
     manager = _FiberIOManager("dascore.fiber_io")
 
@@ -1294,11 +1297,50 @@ def get_format(
     return out
 
 
+def _maybe_split_gapped_patches(spool, fiber_io, split):
+    """Handle patches whose dimensional coords contain gaps before writing."""
+    from dascore.core.coords import CoordSegmented
+    from dascore.core.spool import MemorySpool
+
+    # Only in-memory patches are inspected; file-backed patches always have
+    # contiguous coordinates (gapped patches are never persisted).
+    if not isinstance(spool, MemorySpool):
+        return spool
+
+    def _has_gaps(patch):
+        coords = (patch.get_coord(x) for x in patch.dims)
+        return any(isinstance(x, CoordSegmented) for x in coords)
+
+    gapped = [_has_gaps(x) for x in spool]
+    if not any(gapped):
+        return spool
+    if not split:
+        msg = (
+            "Cannot write patches whose dimensional coordinates contain "
+            "gaps (segmented coordinates); a written patch must be "
+            "contiguous. Pass split=True to write each contiguous section "
+            "as its own patch, or split explicitly with patch.split_gaps()."
+        )
+        raise ParameterError(msg)
+    patches = []
+    for patch, has_gaps in zip(spool, gapped):
+        patches.extend(patch.split_gaps() if has_gaps else [patch])
+    if len(patches) > 1 and not fiber_io.multi_patch_write:
+        msg = (
+            f"Format {fiber_io.name} writes a single patch per file, so "
+            "gapped patches cannot be split into it. Use patch.split_gaps() "
+            "and write each patch to its own file."
+        )
+        raise ParameterError(msg)
+    return dc.spool(patches)
+
+
 def write(
     patch_or_spool,
     path: path_types,
     file_format: str,
     file_version: str | None = None,
+    split: bool = False,
     **kwargs,
 ) -> Path:
     """
@@ -1313,6 +1355,14 @@ def write(
     file_version
         Optionally specify the version of the file, else use the latest
         version for the format.
+    split
+        A written patch must have contiguous (non-gapped) coordinates.
+        If True, patches whose dimensional coordinates contain gaps
+        (segmented coordinates, e.g. from merging nearly-contiguous data)
+        are split into contiguous patches before writing; this requires a
+        format which supports multiple patches per file. If False (default)
+        such patches raise a
+        [`ParameterError`](`dascore.exceptions.ParameterError`).
 
     Raises
     ------
@@ -1334,6 +1384,7 @@ def write(
     fiber_io = FiberIO.manager.get_fiberio(format=file_format, version=file_version)
     if not isinstance(patch_or_spool, dc.BaseSpool):
         patch_or_spool = dc.spool([patch_or_spool])
+    patch_or_spool = _maybe_split_gapped_patches(patch_or_spool, fiber_io, split)
     with IOResourceManager(path) as man:
         func = fiber_io.write
         required_type = func._required_type

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -49,6 +49,7 @@ class DASDAEV1(FiberIO):
     name = "DASDAE"
     preferred_extensions = ("h5", "hdf5")
     version = "1"
+    multi_patch_write = True
 
     def write(
         self,
@@ -73,10 +74,16 @@ class DASDAEV1(FiberIO):
         with contextlib.suppress(ValueError):
             resource.create_group("waveforms")
         waveforms = resource["waveforms"]
-        # write new patches to file
+        # write new patches to file, ensuring unique group names within this
+        # batch so same-named patches (e.g. gap-split siblings that differ
+        # only along a non-named dimension) don't overwrite each other.
         patch_names = get_patch_names(patches).values
+        counts: dict[str, int] = {}
         for patch, name in zip(patches, patch_names):
-            _save_patch(patch, waveforms, name)
+            num = counts.get(name, 0)
+            counts[name] = num + 1
+            unique_name = name if num == 0 else f"{name}__{num}"
+            _save_patch(patch, waveforms, unique_name)
 
     def _get_patch_summary(self, patches) -> pd.DataFrame:
         """Get a patch summary to put into index."""

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -77,9 +77,11 @@ class DASDAEV1(FiberIO):
         # write new patches to file, ensuring unique group names within this
         # batch so same-named patches (e.g. gap-split siblings that differ
         # only along a non-named dimension) don't overwrite each other.
+        # strict zip keeps streaming (no spool materialization) while failing
+        # loudly if the name pass and patch pass ever disagree in length.
         patch_names = get_patch_names(patches).values
         counts: dict[str, int] = {}
-        for patch, name in zip(patches, patch_names):
+        for patch, name in zip(patches, patch_names, strict=True):
             num = counts.get(name, 0)
             counts[name] = num + 1
             unique_name = name if num == 0 else f"{name}__{num}"

--- a/dascore/io/pickle/core.py
+++ b/dascore/io/pickle/core.py
@@ -20,6 +20,7 @@ class PickleIO(FiberIO):
 
     name = "PICKLE"
     preferred_extensions = ("pkl", "pickle")
+    multi_patch_write = True
 
     def _header_is_dascore(self, byte_stream):
         """Return True if the first few bytes mention dascore classes."""

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
 
-from dascore.constants import PatchType, select_values_description
+from dascore.constants import PatchType, SpoolType, select_values_description
 from dascore.core.coords import BaseCoord
 from dascore.exceptions import (
     CoordError,
@@ -810,3 +810,65 @@ def get_axis(self: PatchType, dim: str) -> int:
     >>> assert axis == patch.get_axis("time")
     """
     return self.coords.get_axis(dim)
+
+
+def split_gaps(self: PatchType, dim: str | None = None) -> SpoolType:
+    """
+    Split the patch into contiguous patches at coordinate gaps.
+
+    Dimensional coordinates that are segmented
+    ([`CoordSegmented`](`dascore.core.coords.CoordSegmented`), e.g. produced
+    by concatenating nearly-contiguous data) mark where the patch is not
+    contiguous. This splits the patch at every segment boundary so each
+    output patch has a plain, contiguous coordinate.
+
+    Parameters
+    ----------
+    self
+        The Patch object.
+    dim
+        The dimension to split along. If None (default), split along every
+        dimension with a segmented coordinate. Patches without segmented
+        coordinates come back unchanged (as a length 1 spool).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import dascore as dc
+    >>> from dascore.core.coords import concat_coords, get_coord
+    >>>
+    >>> # A patch whose distance coordinate has a gap.
+    >>> dist = concat_coords(
+    ...     get_coord(start=0.0, stop=10.0, step=1.0),
+    ...     get_coord(start=15.0, stop=25.0, step=1.0),
+    ... )
+    >>> patch = dc.Patch(
+    ...     data=np.zeros((len(dist), 5)),
+    ...     coords={"distance": dist, "time": dc.to_datetime64(np.arange(5))},
+    ...     dims=("distance", "time"),
+    ... )
+    >>> spool = patch.split_gaps()
+    >>> assert len(spool) == 2
+    """
+    import dascore as dc
+    from dascore.core.coords import CoordSegmented
+
+    if dim is not None and dim not in self.dims:
+        msg = f"split_gaps dim must be one of {self.dims}, got {dim!r}."
+        raise ParameterError(msg)
+    dims = (dim,) if dim is not None else self.dims
+    patches = [self]
+    for dname in dims:
+        out = []
+        for patch in patches:
+            coord = patch.get_coord(dname)
+            if not isinstance(coord, CoordSegmented):
+                out.append(patch)
+                continue
+            offset = 0
+            for seg in coord.segments:
+                stop = offset + len(seg)
+                out.append(patch.select(**{dname: (offset, stop)}, samples=True))
+                offset = stop
+        patches = out
+    return dc.spool(patches)

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -944,6 +944,80 @@ class TestReviewFindings:
         assert patch == patch2
 
 
+class TestSplitGapsAndWrite:
+    """Tests for patch.split_gaps and the write-path split behavior."""
+
+    @pytest.fixture()
+    def gapped_patch(self, float_gap_coord):
+        """A patch whose distance coordinate has one gap."""
+        rng = np.random.default_rng(31)
+        time = dc.to_datetime64(np.arange(10))
+        return dc.Patch(
+            data=rng.random((len(float_gap_coord), 10)),
+            coords={"distance": float_gap_coord, "time": time},
+            dims=("distance", "time"),
+        )
+
+    def test_split_gaps(self, gapped_patch):
+        """Splitting yields contiguous patches partitioning the data."""
+        spool = gapped_patch.split_gaps()
+        assert len(spool) == 2
+        p1, p2 = spool
+        assert isinstance(p1.get_coord("distance"), CoordRange)
+        assert isinstance(p2.get_coord("distance"), CoordRange)
+        assert np.array_equal(p1.data, gapped_patch.data[:10])
+        assert np.array_equal(p2.data, gapped_patch.data[10:])
+        combined = np.concatenate(
+            [p1.get_coord("distance").values, p2.get_coord("distance").values]
+        )
+        assert np.array_equal(combined, gapped_patch.get_coord("distance").values)
+
+    def test_split_gaps_no_gaps(self):
+        """Contiguous patches come back unchanged in a length 1 spool."""
+        patch = dc.get_example_patch()
+        spool = patch.split_gaps()
+        assert len(spool) == 1
+        assert spool[0] == patch
+
+    def test_split_gaps_explicit_dim(self, gapped_patch):
+        """A specific dimension can be requested."""
+        assert len(gapped_patch.split_gaps(dim="distance")) == 2
+        assert len(gapped_patch.split_gaps(dim="time")) == 1
+
+    def test_split_gaps_bad_dim(self, gapped_patch):
+        """Unknown dimensions raise."""
+        with pytest.raises(ParameterError, match="dim must be one of"):
+            gapped_patch.split_gaps(dim="bob")
+
+    def test_write_gapped_raises_by_default(self, gapped_patch, tmp_path):
+        """Writing a gapped patch without split=True raises."""
+        with pytest.raises(ParameterError, match="split=True"):
+            dc.write(gapped_patch, tmp_path / "gapped.h5", "dasdae")
+
+    def test_write_split_round_trip(self, gapped_patch, tmp_path):
+        """split=True writes contiguous patches that round trip exactly."""
+        path = tmp_path / "gapped.h5"
+        dc.write(gapped_patch, path, "dasdae", split=True)
+        spool = dc.spool(path)
+        assert len(spool) == 2
+        patches = sorted(spool, key=lambda p: p.get_coord("distance").min())
+        combined = np.concatenate([p.data for p in patches])
+        assert np.array_equal(combined, gapped_patch.data)
+        coords = np.concatenate([p.get_coord("distance").values for p in patches])
+        assert np.array_equal(coords, gapped_patch.get_coord("distance").values)
+
+    def test_write_split_single_patch_format_raises(self, gapped_patch, tmp_path):
+        """Formats that hold one patch per file raise cleanly."""
+        with pytest.raises(ParameterError, match="single patch per file"):
+            dc.write(gapped_patch, tmp_path / "gapped.wav", "wav", split=True)
+
+    def test_write_contiguous_unaffected(self, tmp_path):
+        """Normal patches write exactly as before, split flag or not."""
+        patch = dc.get_example_patch()
+        path = dc.write(patch, tmp_path / "normal.h5", "dasdae", split=True)
+        assert path.exists()
+
+
 class TestFromArray:
     """Tests for CoordSegmented.from_array."""
 

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -1017,6 +1017,14 @@ class TestSplitGapsAndWrite:
         path = dc.write(patch, tmp_path / "normal.h5", "dasdae", split=True)
         assert path.exists()
 
+    def test_write_file_backed_spool_unaffected(self, tmp_path):
+        """Non-memory spools skip the gap inspection (never gapped)."""
+        path1 = dc.write(dc.get_example_patch(), tmp_path / "a.h5", "dasdae")
+        file_spool = dc.spool(path1)
+        assert not isinstance(file_spool, dc.core.spool.MemorySpool)
+        path2 = dc.write(file_spool, tmp_path / "b.h5", "dasdae")
+        assert path2.exists()
+
 
 class TestFromArray:
     """Tests for CoordSegmented.from_array."""

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -312,7 +312,9 @@ class TestEquivalenceWithMonotonic:
             c1, i1 = seg.select(args)
             c2, i2 = mono.select(args)
             assert np.array_equal(np.atleast_1d(c1.values), np.atleast_1d(c2.values))
-            assert i1 == i2
+            # Slices must resolve identically (literal form may differ, e.g.
+            # slice(None, None) vs slice(None, len)).
+            assert i1.indices(len(seg)) == i2.indices(len(mono))
 
     def test_getitem_parity(self, coord_pair):
         """Integer and slice indexing agree with the materialized coord."""
@@ -382,6 +384,15 @@ class TestSelect:
         """Value-array selection keeps only matching values."""
         out, _ = float_gap_coord.select(np.array([1.0, 15.0, 99.0]))
         assert np.array_equal(out.values, np.array([1.0, 15.0]))
+
+    def test_select_between_samples_of_segment(self):
+        """A window inside a segment's envelope but between samples is empty."""
+        coarse = CoordMonotonicArray(values=np.array([0.0, 10.0]))
+        fine = get_coord(start=20.0, stop=25.0, step=1.0)
+        coord = concat_coords(coarse, fine)
+        out, indexer = coord.select((3.0, 7.0))
+        assert len(out) == 0
+        assert indexer == slice(0, 0)
 
     def test_select_none_returns_all(self, float_gap_coord):
         """A null select keeps everything."""
@@ -879,6 +890,32 @@ class TestReviewFindings:
         """Dimensionality mismatches raise."""
         with pytest.raises(Exception, match=r"(?i)cannot convert|dimensionality"):
             time_gap_coord.simplify(get_quantity("1 m"))
+
+    def test_select_never_materializes(self, monkeypatch):
+        """Value selection must stay O(segments): no full-array pass.
+
+        Locks in the second-review performance finding: range selects on a
+        20M-sample segmented coord must not touch the concatenated values.
+        """
+        c1 = get_coord(start=0.0, stop=1e7, step=1.0)
+        c2 = get_coord(start=2e7, stop=3e7, step=1.0)
+        coord = concat_coords(c1, c2)
+
+        def _boom(self):
+            msg = "select must not materialize concatenated values"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(CoordSegmented, "values", property(_boom))
+        out, indexer = coord.select((5.0, 2.5e7))
+        assert isinstance(indexer, slice)
+        assert out.min() == 5.0 and out.max() == 2.5e7
+        # empty, full, and relative selects also stay off the values path.
+        empty, _ = coord.select((1.2e7, 1.8e7))
+        assert len(empty) == 0
+        full, _ = coord.select(None)
+        assert len(full) == len(coord)
+        sub, _ = coord.select((10.0, -10.0), relative=True)
+        assert len(sub)
 
     def test_patch_round_trip(self, float_gap_coord):
         """Segmented coords survive attachment to a Patch (CoordManager)."""

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 from pydantic import ValidationError
 
+import dascore as dc
 from dascore.core.coords import (
     CoordMonotonicArray,
     CoordPartial,
@@ -798,3 +799,200 @@ class TestEdgeCases:
         bad = [float_gap_coord.segments[0], time_seg]
         with pytest.raises(ValidationError, match="compatible dtypes"):
             float_gap_coord._rebuild(bad)
+
+
+class TestReviewFindings:
+    """Regression tests for review findings on PR #749."""
+
+    def test_mixed_int_float_segments_raise(self):
+        """Mixing int and float segments could corrupt large ints; reject."""
+        floats = get_coord(data=np.array([0.0, 1.0]))
+        big = 2**53 + 1
+        ints = get_coord(data=np.array([big, big + 2], dtype=np.int64))
+        with pytest.raises(CoordError, match="compatible dtypes"):
+            concat_coords(floats, ints)
+
+    def test_int_width_promotion_lossless(self):
+        """Different int widths share a kind and concatenate exactly."""
+        # Non-uniform diffs keep these as array segments; a float pass
+        # would corrupt values above 2**53.
+        small = CoordMonotonicArray(values=np.array([0, 1, 3], dtype=np.int32))
+        big_val = 2**53 + 1
+        big = CoordMonotonicArray(
+            values=np.array([big_val, big_val + 2, big_val + 3], dtype=np.int64)
+        )
+        coord = concat_coords(small, big)
+        assert coord.values[-3] == big_val
+        assert coord.values[-1] == big_val + 3
+
+    def test_reverse_ns_select_monotonic(self):
+        """Reverse ns-datetime lookup must not go through floats."""
+        ns = np.timedelta64(1, "ns")
+        t0 = np.datetime64("2024-01-01T00:00:00", "ns")
+        values = t0 + np.array([95, 85, 75]) * ns
+        coord = get_coord(data=values)
+        assert coord.reverse_sorted
+        probe = t0 + 75 * ns
+        out, _ = coord.select((probe, probe))
+        assert len(out) == 1
+        assert out.values[0] == probe
+
+    def test_reverse_ns_select_segmented(self):
+        """The exact reverse-segmented scenario from review."""
+        ns = np.timedelta64(1, "ns")
+        t0 = np.datetime64("2024-01-01T00:00:00", "ns")
+        c1 = get_coord(data=t0 + np.array([95, 85, 75]) * ns)
+        c2 = get_coord(data=t0 + np.array([60, 50, 40]) * ns)
+        coord = concat_coords(c1, c2)
+        assert coord.reverse_sorted
+        probe = t0 + 75 * ns
+        out, _ = coord.select((probe, probe))
+        assert len(out) == 1
+        assert out.values[0] == probe
+
+    def test_reverse_unsigned_select(self):
+        """Unsigned reverse coords negate via float (would wrap natively)."""
+        # Direct construction; get_coord inference wraps on descending uints.
+        coord = CoordMonotonicArray(values=np.array([30, 20, 5], dtype=np.uint64))
+        assert coord.reverse_sorted
+        out, _ = coord.select((20, 20))
+        assert len(out) == 1
+        assert out.values[0] == 20
+
+    def test_quantity_tolerance_numeric(self, float_gap_coord):
+        """Unit-bearing tolerances convert to coordinate units."""
+        coord = float_gap_coord.set_units("m")
+        out = coord.simplify(get_quantity("3 m"))
+        assert isinstance(out, CoordRange)
+        # 300 cm is the same tolerance in other units.
+        out2 = coord.simplify(get_quantity("300 cm"))
+        assert out2 == out
+
+    def test_quantity_tolerance_time(self, time_gap_coord):
+        """Time coords accept time-dimensional quantity tolerances."""
+        out = time_gap_coord.simplify(get_quantity("2000 ms"))
+        assert isinstance(out, CoordRange)
+        df = time_gap_coord.get_discontinuities("gaps", tolerance=get_quantity("10 s"))
+        assert df.empty
+
+    def test_quantity_tolerance_bad_dimensionality(self, time_gap_coord):
+        """Dimensionality mismatches raise."""
+        with pytest.raises(Exception, match=r"(?i)cannot convert|dimensionality"):
+            time_gap_coord.simplify(get_quantity("1 m"))
+
+    def test_patch_round_trip(self, float_gap_coord):
+        """Segmented coords survive attachment to a Patch (CoordManager)."""
+        time = dc.to_datetime64(np.arange(10))
+        rng = np.random.default_rng(42)
+        patch = dc.Patch(
+            data=rng.random((len(float_gap_coord), 10)),
+            coords={"distance": float_gap_coord, "time": time},
+            dims=("distance", "time"),
+        )
+        attached = patch.get_coord("distance")
+        assert isinstance(attached, CoordSegmented)
+        assert np.array_equal(attached.values, float_gap_coord.values)
+        # update_coords goes through the model_dump round trip.
+        updated = patch.update_coords(distance=float_gap_coord)
+        assert isinstance(updated.get_coord("distance"), CoordSegmented)
+        # selection across the gap trims data consistently.
+        sub = patch.select(distance=(5.0, 18.0))
+        assert sub.shape == (9, 10)
+        assert np.array_equal(
+            sub.get_coord("distance").values,
+            np.array([5.0, 6, 7, 8, 9, 15, 16, 17, 18]),
+        )
+        # equality of identically constructed patches works.
+        patch2 = patch.new()
+        assert patch == patch2
+
+
+class TestFromArray:
+    """Tests for CoordSegmented.from_array."""
+
+    def test_gapped_uniform_array(self):
+        """Uniform runs separated by a gap become two range segments."""
+        values = np.array([0.0, 1, 2, 3, 10, 11, 12, 13])
+        coord = CoordSegmented.from_array(values)
+        assert isinstance(coord, CoordSegmented)
+        assert coord.segment_count == 2
+        assert all(isinstance(x, CoordRange) for x in coord.segments)
+        assert np.array_equal(coord.values, values)
+        gaps = coord.get_discontinuities("gaps")
+        assert len(gaps) == 1
+        assert gaps.iloc[0]["index"] == 4
+
+    def test_fully_uniform_returns_range(self):
+        """A gapless uniform array degrades to a plain range."""
+        coord = CoordSegmented.from_array(np.arange(10.0))
+        assert isinstance(coord, CoordRange)
+
+    def test_irregular_returns_monotonic(self):
+        """Arrays with no uniform runs come back as one monotonic coord."""
+        values = np.array([0.0, 1.0, 2.1, 3.3, 4.0])
+        coord = CoordSegmented.from_array(values)
+        assert isinstance(coord, CoordMonotonicArray)
+        assert np.array_equal(coord.values, values)
+
+    def test_isolated_sample_between_gaps(self):
+        """A lone sample between gaps becomes its own segment."""
+        values = np.array([0.0, 1, 2, 10, 20, 21, 22])
+        coord = CoordSegmented.from_array(values)
+        assert coord.segment_count == 3
+        assert np.array_equal(coord.values, values)
+        assert len(coord.get_discontinuities()) == 2
+
+    def test_datetime_gap(self):
+        """Datetime arrays with internal gaps segment exactly."""
+        one_s = np.timedelta64(1, "s")
+        t0 = np.datetime64("2020-01-01", "ns")
+        values = np.concatenate(
+            [t0 + np.arange(5) * one_s, t0 + (np.arange(5) + 8) * one_s]
+        )
+        coord = CoordSegmented.from_array(values)
+        assert coord.segment_count == 2
+        assert np.array_equal(coord.values, values)
+        assert len(coord.get_discontinuities("gaps")) == 1
+
+    def test_tolerance_absorbs_gap(self):
+        """A tolerance re-fits the result with bounded error."""
+        values = np.array([0.0, 1, 2, 3, 6, 7, 8, 9])
+        coord = CoordSegmented.from_array(values, tolerance=2.0)
+        assert isinstance(coord, CoordRange)
+        assert np.max(np.abs(coord.values - values)) <= 2.0
+
+    def test_reverse_array(self):
+        """Reverse-sorted arrays segment correctly."""
+        values = np.array([13.0, 12, 11, 10, 3, 2, 1, 0])
+        coord = CoordSegmented.from_array(values)
+        assert coord.segment_count == 2
+        assert coord.reverse_sorted
+        assert np.array_equal(coord.values, values)
+
+    def test_short_arrays_pass_through(self):
+        """Arrays too short to segment build plain coords."""
+        assert len(CoordSegmented.from_array(np.array([1.0, 2.0]))) == 2
+        assert len(CoordSegmented.from_array(np.array([1.0]))) == 1
+
+    def test_non_monotonic_raises(self):
+        """Unsorted or duplicated values are rejected."""
+        with pytest.raises(CoordError, match="monotonic"):
+            CoordSegmented.from_array(np.array([0.0, 2.0, 1.0, 3.0]))
+        with pytest.raises(CoordError, match="monotonic"):
+            CoordSegmented.from_array(np.array([0.0, 1.0, 1.0, 2.0]))
+
+    def test_nan_raises(self):
+        """Missing values are rejected."""
+        with pytest.raises(CoordError, match="missing"):
+            CoordSegmented.from_array(np.array([0.0, np.nan, 2.0]))
+
+    def test_2d_raises(self):
+        """Only 1D arrays are supported."""
+        with pytest.raises(CoordError, match="1D"):
+            CoordSegmented.from_array(np.zeros((3, 3)))
+
+    def test_units(self):
+        """Units land on the result."""
+        values = np.array([0.0, 1, 2, 10, 11, 12])
+        coord = CoordSegmented.from_array(values, units="m")
+        assert get_quantity(coord.units) == get_quantity("m")

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -361,7 +361,7 @@ class TestSelect:
 
     def test_select_samples(self, float_gap_coord):
         """Samples-based selection works via base machinery (stop exclusive)."""
-        out, indexer = float_gap_coord.select((2, 12), samples=True)
+        out, _ = float_gap_coord.select((2, 12), samples=True)
         assert len(out) == 10
         assert np.array_equal(out.values, float_gap_coord.values[2:12])
 
@@ -374,7 +374,7 @@ class TestSelect:
     def test_select_bool_array(self, float_gap_coord):
         """Boolean mask selection materializes correctly."""
         mask = float_gap_coord.values > 8.0
-        out, indexer = float_gap_coord.select(mask)
+        out, _ = float_gap_coord.select(mask)
         assert np.array_equal(out.values, float_gap_coord.values[mask])
 
     def test_select_value_array(self, float_gap_coord):
@@ -384,7 +384,7 @@ class TestSelect:
 
     def test_select_none_returns_all(self, float_gap_coord):
         """A null select keeps everything."""
-        out, indexer = float_gap_coord.select(None)
+        out, _ = float_gap_coord.select(None)
         assert out == float_gap_coord
 
 
@@ -639,6 +639,20 @@ class TestRoundTrips:
         coord = concat_coords(get_coord(data=v1), get_coord(data=v2))
         assert np.array_equal(coord.values, np.concatenate([v1, v2]))
 
+    def test_ns_precision_sort_order(self):
+        """Segments closer than float epoch resolution still sort correctly.
+
+        Casting ns datetimes to float collapses differences below ~128 ns
+        at modern epochs, so the envelope sort must use native values.
+        """
+        ns = np.timedelta64(1, "ns")
+        t0 = np.datetime64("2024-01-01T00:00:00", "ns")
+        v1 = t0 + np.arange(3) * 10 * ns
+        v2 = t0 + (np.arange(3) * 10 + 35) * ns
+        assert float(v1[0]) == float(v2[0])  # the collapse this guards against
+        coord = concat_coords(get_coord(data=v2), get_coord(data=v1))
+        assert np.array_equal(coord.values, np.concatenate([v1, v2]))
+
     def test_empty_from_coord(self, float_gap_coord):
         """Emptying a segmented coord gives a zero-length coordinate."""
         out = float_gap_coord.empty()
@@ -657,3 +671,130 @@ class TestRoundTrips:
         """new(data=...) falls back to plain coord creation."""
         out = float_gap_coord.new(data=np.arange(10.0))
         assert isinstance(out, CoordRange)
+
+
+class TestEdgeCases:
+    """Edge and guard-path behaviors."""
+
+    def test_promotion_requires_bit_exact_round_trip(self):
+        """Equal float diffs alone don't promote; values must round-trip."""
+        # [0, 0.1, 0.2] has bit-equal diffs but a range cannot reproduce
+        # the values exactly, so it must stay an array segment.
+        values = np.array([0.0, 0.1, 0.2])
+        assert len(np.unique(np.diff(values))) == 1
+        out = concat_coords(CoordMonotonicArray(values=values))
+        assert isinstance(out, CoordMonotonicArray)
+
+    def test_slice_can_promote_and_fuse(self):
+        """Slicing an array segment uniform lets it fuse with a range."""
+        a = get_coord(start=0.0, stop=10.0, step=1.0)
+        b = CoordMonotonicArray(values=np.array([10.0, 11.0, 12.0, 13.5]))
+        coord = concat_coords(a, b)
+        assert coord.segment_count == 2
+        out = coord[0:13]
+        assert isinstance(out, CoordRange)
+        assert np.array_equal(out.values, np.arange(13.0))
+
+    def test_segments_must_be_coords(self):
+        """Raw arrays passed as segments raise."""
+        with pytest.raises(ValidationError, match="must be coordinates"):
+            CoordSegmented(segments=(np.arange(3),))
+
+    def test_unsupported_segment_class_raises(self):
+        """Coord classes other than range/monotonic are rejected."""
+        from dascore.core.coords import CoordArray
+
+        bad = CoordArray(values=np.array([3.0, 1.0, 2.0]))
+        good = get_coord(start=10.0, stop=20.0, step=1.0)
+        with pytest.raises(ValidationError, match="CoordRange or CoordMonotonic"):
+            CoordSegmented(segments=(bad, good))
+
+    def test_empty_segment_raises(self):
+        """Zero-length segments are rejected."""
+        empty = CoordMonotonicArray(values=np.array([], dtype=np.float64))
+        good = get_coord(start=10.0, stop=20.0, step=1.0)
+        with pytest.raises(ValidationError, match="must not be empty"):
+            CoordSegmented(segments=(empty, good))
+
+    def test_no_segments_raises(self):
+        """An empty segment tuple is rejected."""
+        with pytest.raises(ValidationError, match="at least one segment"):
+            CoordSegmented(segments=())
+
+    def test_single_coord_instance_as_segments(self):
+        """A bare coordinate as segments is wrapped, then fails the 2+ rule."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        with pytest.raises(ValidationError, match="fuse"):
+            CoordSegmented(segments=c1)
+
+    def test_validator_passes_non_dict_through(self, float_gap_coord):
+        """The before-validator leaves non-dict payloads alone."""
+        out = CoordSegmented._validate_segments(float_gap_coord)
+        assert out is float_gap_coord
+
+    def test_eq_other_types(self, float_gap_coord):
+        """Equality is False for other coord types and segment counts."""
+        mono = get_coord(data=float_gap_coord.values)
+        assert float_gap_coord != mono
+        three = concat_coords(
+            float_gap_coord, get_coord(start=30.0, stop=40.0, step=1.0)
+        )
+        assert float_gap_coord != three
+
+    def test_zero_dim_index_returns_scalar(self, float_gap_coord):
+        """A 0-d array index returns a scalar value."""
+        out = float_gap_coord[np.array(10)]
+        assert out == 15.0
+
+    def test_shift_mixed_segments(self, mixed_segment_coord):
+        """Shifting moves array segments as well as ranges."""
+        out = mixed_segment_coord.update_limits(min=100.0)
+        assert np.allclose(out.values, mixed_segment_coord.values + 100.0)
+
+    def test_simplify_single_sample_segment(self):
+        """Length-one segments cannot be fit and pass through simplify."""
+        coord = concat_coords(
+            get_coord(start=0.0, stop=10.0, step=1.0),
+            CoordMonotonicArray(values=np.array([99.0])),
+        )
+        out = coord.simplify(0.5)
+        assert out == coord
+
+    def test_discontinuities_after_array_segment(self):
+        """The expected step after an array segment comes from its diffs."""
+        coord = concat_coords(
+            CoordMonotonicArray(values=np.array([0.0, 1.0, 2.5])),
+            get_coord(start=10.0, stop=20.0, step=1.0),
+        )
+        df = coord.get_discontinuities()
+        assert len(df) == 1
+        # expected local spacing is 2.5 - 1.0 = 1.5; delta is 10 - 2.5 = 7.5.
+        assert df.iloc[0]["excess"] == 6.0
+
+    def test_discontinuities_after_single_sample_segment(self):
+        """No expected step after a length-one segment (excess is null)."""
+        coord = concat_coords(
+            CoordMonotonicArray(values=np.array([0.0])),
+            get_coord(start=10.0, stop=20.0, step=1.0),
+        )
+        df = coord.get_discontinuities()
+        assert len(df) == 1
+        assert pd.isnull(df.iloc[0]["excess"])
+        # boundaries with unknown spacing are never reported as gaps.
+        assert coord.get_discontinuities("gaps").empty
+
+    def test_base_get_discontinuities_bad_kind(self):
+        """The BaseCoord implementation validates kind too."""
+        coord = get_coord(start=0.0, stop=10.0, step=1.0)
+        with pytest.raises(ParameterError, match="kind"):
+            coord.get_discontinuities("overlaps")
+
+    def test_rebuild_reraises_real_errors(self, float_gap_coord):
+        """_rebuild only swallows errors caused by segments fusing to one."""
+        t0 = np.datetime64("2020-01-01", "ns")
+        time_seg = get_coord(
+            start=t0, stop=t0 + np.timedelta64(10, "s"), step=np.timedelta64(1, "s")
+        )
+        bad = [float_gap_coord.segments[0], time_seg]
+        with pytest.raises(ValidationError, match="compatible dtypes"):
+            float_gap_coord._rebuild(bad)

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -1,0 +1,659 @@
+"""Tests for segmented (piecewise) coordinates."""
+
+from __future__ import annotations
+
+import pickle
+
+import numpy as np
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from dascore.core.coords import (
+    CoordMonotonicArray,
+    CoordPartial,
+    CoordRange,
+    CoordSegmented,
+    concat_coords,
+    get_coord,
+)
+from dascore.exceptions import CoordError, ParameterError
+from dascore.units import get_quantity
+
+
+@pytest.fixture(scope="session")
+def float_gap_coord() -> CoordSegmented:
+    """Two evenly sampled float blocks (0..9, 15..24) separated by a gap."""
+    c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+    c2 = get_coord(start=15.0, stop=25.0, step=1.0)
+    return concat_coords(c1, c2)
+
+
+@pytest.fixture(scope="session")
+def time_gap_coord() -> CoordSegmented:
+    """Two evenly sampled time blocks separated by a 3 second gap."""
+    one_s = np.timedelta64(1, "s")
+    t0 = np.datetime64("2020-01-01T00:00:00", "ns")
+    c1 = get_coord(start=t0, stop=t0 + 10 * one_s, step=one_s)
+    c2 = get_coord(start=t0 + 12 * one_s, stop=t0 + 22 * one_s, step=one_s)
+    return concat_coords(c1, c2)
+
+
+@pytest.fixture(scope="session")
+def mixed_segment_coord() -> CoordSegmented:
+    """A range segment followed by an irregular array segment."""
+    c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+    c2 = get_coord(data=np.array([12.0, 12.1, 13.7, 20.0]))
+    assert isinstance(c2, CoordMonotonicArray)
+    return concat_coords(c1, c2)
+
+
+@pytest.fixture(scope="session")
+def reverse_gap_coord() -> CoordSegmented:
+    """A reverse-sorted segmented coordinate."""
+    c1 = get_coord(start=24.0, stop=14.0, step=-1.0)
+    c2 = get_coord(start=9.0, stop=-1.0, step=-1.0)
+    return concat_coords(c1, c2)
+
+
+class TestConstruction:
+    """Tests for building segmented coords and their normal form."""
+
+    def test_concat_returns_segmented(self, float_gap_coord):
+        """Two non-contiguous blocks make a segmented coord."""
+        assert isinstance(float_gap_coord, CoordSegmented)
+        assert float_gap_coord.segment_count == 2
+        assert len(float_gap_coord) == 20
+
+    def test_exactly_contiguous_fuse(self):
+        """Blocks that continue exactly fuse back into one range."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        c2 = get_coord(start=10.0, stop=20.0, step=1.0)
+        out = concat_coords(c1, c2)
+        assert isinstance(out, CoordRange)
+        assert out == get_coord(start=0.0, stop=20.0, step=1.0)
+
+    def test_uniform_array_segments_promoted(self):
+        """Exactly evenly sampled array segments become ranges."""
+        c1 = get_coord(data=np.arange(5.0))
+        c2 = get_coord(start=8.0, stop=12.0, step=1.0)
+        out = concat_coords(c1, c2)
+        assert all(isinstance(x, CoordRange) for x in out.segments)
+
+    def test_canonical_across_construction_orders(self):
+        """Equal values give equal coords regardless of how assembled."""
+        a = concat_coords(
+            get_coord(start=0.0, stop=5.0, step=1.0),
+            get_coord(start=8.0, stop=12.0, step=1.0),
+        )
+        b = concat_coords(
+            get_coord(data=np.array([8.0, 9.0, 10.0, 11.0])),
+            get_coord(data=np.array([0.0, 1.0, 2.0, 3.0, 4.0])),
+        )
+        assert a == b
+        assert a.fingerprint() == b.fingerprint()
+
+    def test_out_of_order_inputs_sorted(self):
+        """concat_coords orders inputs by their envelopes."""
+        c1 = get_coord(start=15.0, stop=25.0, step=1.0)
+        c2 = get_coord(start=0.0, stop=10.0, step=1.0)
+        out = concat_coords(c1, c2)
+        assert out.min() == 0.0 and out.max() == 24.0
+        assert np.all(np.diff(out.values) > 0)
+
+    def test_adjacent_arrays_fuse(self):
+        """Adjacent irregular arrays fuse (their boundary has no meaning)."""
+        c1 = get_coord(data=np.array([0.0, 0.1, 1.7]))
+        c2 = get_coord(data=np.array([2.0, 3.3, 3.4]))
+        out = concat_coords(c1, c2)
+        assert isinstance(out, CoordMonotonicArray)
+
+    def test_direct_construction_needs_two_segments(self):
+        """The class itself requires >= 2 segments post normalization."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        with pytest.raises(ValidationError, match="fuse"):
+            CoordSegmented(segments=(c1,))
+
+    def test_fusing_inputs_rejected_by_class(self):
+        """Directly constructing with fusable segments raises (use concat)."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        c2 = get_coord(start=10.0, stop=20.0, step=1.0)
+        with pytest.raises(ValidationError, match="fuse"):
+            CoordSegmented(segments=(c1, c2))
+
+    def test_overlap_raises(self):
+        """Overlapping segments are rejected."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        c2 = get_coord(start=5.0, stop=15.0, step=1.0)
+        with pytest.raises(CoordError, match="overlap"):
+            concat_coords(c1, c2)
+
+    def test_shared_value_raises(self):
+        """Segments sharing a boundary value are rejected (not strict)."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)  # max 9
+        c2 = get_coord(data=np.array([9.0, 11.0, 12.0]))
+        with pytest.raises(CoordError, match="overlap"):
+            concat_coords(c1, c2)
+
+    def test_mixed_direction_raises(self):
+        """Segments sorted in different directions are rejected."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        c2 = get_coord(start=25.0, stop=15.0, step=-1.0)
+        with pytest.raises(CoordError):
+            concat_coords(c1, c2)
+
+    def test_mixed_dtype_kind_raises(self):
+        """Time and numeric segments cannot mix."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        t0 = np.datetime64("2020-01-01", "ns")
+        c2 = get_coord(
+            start=t0, stop=t0 + np.timedelta64(10, "s"), step=np.timedelta64(1, "s")
+        )
+        with pytest.raises(CoordError):
+            concat_coords(c1, c2)
+
+    def test_mixed_units_raise(self):
+        """Segments with different units are rejected."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0, units="m")
+        c2 = get_coord(start=15.0, stop=25.0, step=1.0, units="ft")
+        with pytest.raises(CoordError, match="units"):
+            concat_coords(c1, c2)
+
+    def test_unsupported_coord_type_raises(self):
+        """String and other unsupported coords are rejected."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        c2 = get_coord(data=np.array(["a", "b", "c"]))
+        with pytest.raises(CoordError, match="only supports"):
+            concat_coords(c1, c2)
+
+    def test_non_coord_raises(self):
+        """Raw arrays are not silently coerced."""
+        with pytest.raises(CoordError, match="requires coordinates"):
+            concat_coords(np.arange(10))
+
+    def test_empty_input_raises(self):
+        """At least one non-empty coordinate is required."""
+        with pytest.raises(CoordError, match="at least one"):
+            concat_coords()
+
+    def test_degenerate_inputs_skipped(self):
+        """Empty coordinates contribute nothing."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        empty = c1.empty()
+        out = concat_coords(c1, empty)
+        assert out == c1
+
+    def test_single_input_returns_input(self):
+        """A single coordinate comes back as itself."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        assert concat_coords(c1) == c1
+
+    def test_segmented_inputs_flatten(self, float_gap_coord):
+        """Segmented inputs contribute their segments."""
+        c3 = get_coord(start=30.0, stop=40.0, step=1.0)
+        out = concat_coords(float_gap_coord, c3)
+        assert out.segment_count == 3
+
+    def test_units_param_sets_units(self):
+        """The units argument sets units on the result."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        c2 = get_coord(start=15.0, stop=25.0, step=1.0)
+        out = concat_coords(c1, c2, units="m")
+        assert get_quantity(out.units) == get_quantity("m")
+
+    def test_get_coord_segments_kwarg(self, float_gap_coord):
+        """get_coord(segments=...) dispatches to concat_coords."""
+        out = get_coord(segments=float_gap_coord.segments)
+        assert out == float_gap_coord
+
+    def test_get_coord_segments_conflicts(self):
+        """Segments cannot combine with other value inputs."""
+        c1 = get_coord(start=0.0, stop=10.0, step=1.0)
+        with pytest.raises(CoordError, match="cannot be combined"):
+            get_coord(segments=(c1,), start=0, stop=1, step=0.1)
+
+    def test_container_units_mismatch_raises(self, float_gap_coord):
+        """Explicit units that contradict segment units raise."""
+        with pytest.raises(ValidationError, match="units"):
+            CoordSegmented(segments=float_gap_coord.segments, units="m")
+
+
+class TestProperties:
+    """Tests for basic properties of segmented coords."""
+
+    def test_step_is_none(self, float_gap_coord):
+        """Segmented coords report no single step."""
+        assert float_gap_coord.step is None
+
+    def test_not_evenly_sampled(self, float_gap_coord):
+        """Segmented coords are never evenly sampled."""
+        assert not float_gap_coord.evenly_sampled
+
+    def test_sorted_flags(self, float_gap_coord, reverse_gap_coord):
+        """Sort direction is reported correctly."""
+        assert float_gap_coord.sorted
+        assert not float_gap_coord.reverse_sorted
+        assert reverse_gap_coord.reverse_sorted
+        assert not reverse_gap_coord.sorted
+
+    def test_min_max_exact(self, float_gap_coord, reverse_gap_coord):
+        """Min/max come from segment envelopes exactly."""
+        assert float_gap_coord.min() == 0.0
+        assert float_gap_coord.max() == 24.0
+        assert reverse_gap_coord.min() == 0.0
+        assert reverse_gap_coord.max() == 24.0
+
+    def test_values_are_concatenation(self, float_gap_coord):
+        """Values are exactly the concatenated segment values."""
+        expected = np.concatenate([x.values for x in float_gap_coord.segments])
+        assert np.array_equal(float_gap_coord.values, expected)
+
+    def test_dtype_and_shape(self, time_gap_coord):
+        """Dtype and shape derive from segments."""
+        assert np.issubdtype(time_gap_coord.dtype, np.datetime64)
+        assert time_gap_coord.shape == (20,)
+
+    def test_not_degenerate(self, float_gap_coord):
+        """A populated segmented coord is not degenerate."""
+        assert not float_gap_coord.degenerate
+
+    def test_str_and_rich(self, float_gap_coord):
+        """String representations render."""
+        assert str(float_gap_coord)
+        assert float_gap_coord.__rich__() is not None
+
+    def test_time_units_forced_to_seconds(self, time_gap_coord):
+        """Time coords keep the standard second units."""
+        assert get_quantity(time_gap_coord.units) == get_quantity("s")
+
+    def test_coord_range_no_extend(self, float_gap_coord):
+        """coord_range works without extension; extension needs a step."""
+        assert float_gap_coord.coord_range(extend=False) == 24.0
+        with pytest.raises(CoordError):
+            float_gap_coord.coord_range(extend=True)
+
+    def test_get_sample_count_raises(self, float_gap_coord):
+        """No single sampling interval means no sample counts."""
+        with pytest.raises(CoordError):
+            float_gap_coord.get_sample_count(1.0)
+
+
+class TestEquivalenceWithMonotonic:
+    """Segmented coords must behave exactly like their materialized values."""
+
+    def get_pair(self, coord):
+        """Return (segmented, equivalent monotonic array coord)."""
+        return coord, get_coord(data=coord.values, units=coord.units)
+
+    @pytest.fixture(
+        params=[
+            "float_gap_coord",
+            "time_gap_coord",
+            "mixed_segment_coord",
+            "reverse_gap_coord",
+        ]
+    )
+    def coord_pair(self, request):
+        """A segmented coord and its materialized twin."""
+        return self.get_pair(request.getfixturevalue(request.param))
+
+    def test_select_range_parity(self, coord_pair):
+        """Range selects agree with the materialized coordinate."""
+        seg, mono = coord_pair
+        values = seg.values
+        probes = [
+            (values[2], values[-3]),
+            (values[0], values[-1]),
+            (None, values[5]),
+            (values[5], None),
+        ]
+        for args in probes:
+            c1, i1 = seg.select(args)
+            c2, i2 = mono.select(args)
+            assert np.array_equal(np.atleast_1d(c1.values), np.atleast_1d(c2.values))
+            assert i1 == i2
+
+    def test_getitem_parity(self, coord_pair):
+        """Integer and slice indexing agree with the materialized coord."""
+        seg, mono = coord_pair
+        for ind in [0, 5, len(seg) - 1, -1]:
+            assert seg[ind] == mono.values[ind]
+        for slc in [slice(2, 15), slice(None), slice(None, None, 2), slice(15, 2, -1)]:
+            assert np.array_equal(
+                np.atleast_1d(seg[slc].values), np.atleast_1d(mono[slc].values)
+            )
+
+    def test_get_next_index_parity(self, coord_pair):
+        """get_next_index matches the materialized coordinate."""
+        seg, mono = coord_pair
+        if seg.reverse_sorted:  # get_next_index requires sorted coords.
+            return
+        probe = seg.values[3]
+        assert seg.get_next_index(probe) == mono.get_next_index(probe)
+
+    def test_approx_equal(self, coord_pair):
+        """A segmented coord approx-equals its materialized twin."""
+        seg, mono = coord_pair
+        assert seg.approx_equal(mono)
+
+
+class TestSelect:
+    """Tests for value-based selection."""
+
+    def test_select_within_gap_is_empty(self, float_gap_coord):
+        """A window entirely inside a gap selects nothing (no ghosts)."""
+        out, indexer = float_gap_coord.select((11.0, 14.0))
+        assert len(out) == 0
+        assert indexer == slice(0, 0)
+
+    def test_select_across_seam_keeps_structure(self, float_gap_coord):
+        """A window spanning the seam returns a segmented coord."""
+        out, indexer = float_gap_coord.select((5.0, 18.0))
+        assert isinstance(out, CoordSegmented)
+        assert out.segment_count == 2
+        assert np.array_equal(out.values, np.array([5.0, 6, 7, 8, 9, 15, 16, 17, 18]))
+        assert indexer == slice(5, 14)
+
+    def test_select_single_segment_degrades(self, float_gap_coord):
+        """A window inside one block returns a plain range."""
+        out, _ = float_gap_coord.select((16.0, 20.0))
+        assert isinstance(out, CoordRange)
+
+    def test_select_samples(self, float_gap_coord):
+        """Samples-based selection works via base machinery (stop exclusive)."""
+        out, indexer = float_gap_coord.select((2, 12), samples=True)
+        assert len(out) == 10
+        assert np.array_equal(out.values, float_gap_coord.values[2:12])
+
+    def test_select_relative(self, float_gap_coord):
+        """Relative selection resolves against min/max."""
+        out, _ = float_gap_coord.select((1.0, -1.0), relative=True)
+        assert out.min() == 1.0
+        assert out.max() == 23.0
+
+    def test_select_bool_array(self, float_gap_coord):
+        """Boolean mask selection materializes correctly."""
+        mask = float_gap_coord.values > 8.0
+        out, indexer = float_gap_coord.select(mask)
+        assert np.array_equal(out.values, float_gap_coord.values[mask])
+
+    def test_select_value_array(self, float_gap_coord):
+        """Value-array selection keeps only matching values."""
+        out, _ = float_gap_coord.select(np.array([1.0, 15.0, 99.0]))
+        assert np.array_equal(out.values, np.array([1.0, 15.0]))
+
+    def test_select_none_returns_all(self, float_gap_coord):
+        """A null select keeps everything."""
+        out, indexer = float_gap_coord.select(None)
+        assert out == float_gap_coord
+
+
+class TestGetItem:
+    """Tests for indexing behavior."""
+
+    def test_int_indexing(self, float_gap_coord):
+        """Integer indexing crosses segments correctly."""
+        assert float_gap_coord[0] == 0.0
+        assert float_gap_coord[9] == 9.0
+        assert float_gap_coord[10] == 15.0
+        assert float_gap_coord[-1] == 24.0
+
+    def test_out_of_bounds_raises(self, float_gap_coord):
+        """Bad indices raise IndexError."""
+        with pytest.raises(IndexError):
+            _ = float_gap_coord[len(float_gap_coord)]
+
+    def test_slice_across_seam(self, float_gap_coord):
+        """Slices spanning the seam preserve structure."""
+        out = float_gap_coord[8:12]
+        assert isinstance(out, CoordSegmented)
+        assert np.array_equal(out.values, np.array([8.0, 9.0, 15.0, 16.0]))
+
+    def test_slice_single_segment(self, float_gap_coord):
+        """Slices within one block degrade to that block's type."""
+        out = float_gap_coord[2:5]
+        assert isinstance(out, CoordRange)
+
+    def test_empty_slice(self, float_gap_coord):
+        """Empty slices produce an empty coordinate."""
+        out = float_gap_coord[5:5]
+        assert isinstance(out, CoordPartial)
+        assert len(out) == 0
+
+    def test_fancy_indexing_materializes(self, float_gap_coord):
+        """Fancy indexing falls back to materialized values."""
+        out = float_gap_coord[np.array([0, 10, 19])]
+        assert np.array_equal(out.values, np.array([0.0, 15.0, 24.0]))
+
+
+class TestSortAndShift:
+    """Tests for sort, update_limits, and unit operations."""
+
+    def test_sort_noop(self, float_gap_coord):
+        """Sorting a sorted coord is a no-op."""
+        out, indexer = float_gap_coord.sort()
+        assert out is float_gap_coord
+        assert indexer == slice(None)
+
+    def test_reverse_round_trip(self, float_gap_coord):
+        """Reversing twice returns the original."""
+        rev, indexer = float_gap_coord.sort(reverse=True)
+        assert rev.reverse_sorted
+        assert indexer == slice(None, None, -1)
+        back, _ = rev.sort()
+        assert back == float_gap_coord
+
+    def test_update_limits_min_shifts(self, float_gap_coord):
+        """Setting min translates all segments."""
+        out = float_gap_coord.update_limits(min=100.0)
+        assert out.min() == 100.0
+        assert np.array_equal(out.values, float_gap_coord.values + 100.0)
+        assert isinstance(out, CoordSegmented)
+
+    def test_update_limits_max_shifts(self, float_gap_coord):
+        """Setting max translates all segments."""
+        out = float_gap_coord.update_limits(max=0.0)
+        assert out.max() == 0.0
+        assert np.array_equal(out.values, float_gap_coord.values - 24.0)
+
+    def test_update_limits_step_raises(self, float_gap_coord):
+        """Setting a step on a segmented coord is an error."""
+        with pytest.raises(ParameterError, match="no single step"):
+            float_gap_coord.update_limits(step=2.0)
+
+    def test_update_limits_min_and_max_raises(self, float_gap_coord):
+        """Min and max cannot both be given."""
+        with pytest.raises(ParameterError):
+            float_gap_coord.update_limits(min=0.0, max=100.0)
+
+    def test_time_shift(self, time_gap_coord):
+        """Time coords shift with datetime min values."""
+        new_min = time_gap_coord.min() + np.timedelta64(1, "D")
+        out = time_gap_coord.update_limits(min=new_min)
+        assert out.min() == new_min
+
+    def test_set_units(self, float_gap_coord):
+        """set_units applies to container and segments."""
+        out = float_gap_coord.set_units("m")
+        assert get_quantity(out.units) == get_quantity("m")
+        assert all(get_quantity(x.units) == get_quantity("m") for x in out.segments)
+
+    def test_convert_units(self, float_gap_coord):
+        """convert_units scales all values consistently."""
+        out = float_gap_coord.set_units("m").convert_units("ft")
+        expected = float_gap_coord.values / 0.3048
+        assert np.allclose(out.values, expected)
+        assert isinstance(out, CoordSegmented)
+
+    def test_convert_units_time_noop(self, time_gap_coord):
+        """Time coords do not convert units."""
+        assert time_gap_coord.convert_units("ft") is time_gap_coord
+
+
+class TestSimplifyAndSnap:
+    """Tests for tolerance-bounded simplification and snapping."""
+
+    def test_simplify_zero_keeps_structure(self, float_gap_coord):
+        """Zero tolerance cannot absorb a real gap."""
+        out = float_gap_coord.simplify(0)
+        assert out == float_gap_coord
+
+    def test_simplify_absorbs_gap_within_tolerance(self, float_gap_coord):
+        """A large enough tolerance collapses to a single range."""
+        out = float_gap_coord.simplify(3.0)
+        assert isinstance(out, CoordRange)
+        assert len(out) == len(float_gap_coord)
+        assert out.min() == float_gap_coord.min()
+        assert out.max() == float_gap_coord.max()
+
+    def test_simplify_error_bounded(self, float_gap_coord):
+        """No value moves by more than the tolerance."""
+        tol = 3.0
+        out = float_gap_coord.simplify(tol)
+        deviation = np.max(np.abs(out.values - float_gap_coord.values))
+        assert deviation <= tol
+
+    def test_simplify_insufficient_tolerance_noop(self, float_gap_coord):
+        """A too-small tolerance leaves the coord unchanged."""
+        out = float_gap_coord.simplify(0.5)
+        assert out == float_gap_coord
+
+    def test_simplify_idempotent(self, float_gap_coord):
+        """Simplifying twice equals simplifying once."""
+        once = float_gap_coord.simplify(3.0)
+        assert once.simplify(3.0) == once
+
+    def test_simplify_time_tolerance_seconds(self, time_gap_coord):
+        """Numeric tolerances on time coords mean seconds."""
+        out = time_gap_coord.simplify(2)
+        assert isinstance(out, CoordRange)
+        deviation = np.max(np.abs(out.values - time_gap_coord.values))
+        assert deviation <= np.timedelta64(2, "s")
+
+    def test_simplify_promotes_close_array_segment(self):
+        """Nearly uniform array segments become ranges within tolerance."""
+        values = np.array([0.0, 1.05, 2.0, 2.95, 4.0])
+        coord = concat_coords(
+            get_coord(data=values), get_coord(start=10.0, stop=14.0, step=1.0)
+        )
+        out = coord.simplify(0.1)
+        assert all(isinstance(x, CoordRange) for x in out.segments)
+
+    def test_negative_tolerance_raises(self, float_gap_coord):
+        """Negative tolerances make no sense."""
+        with pytest.raises(ParameterError):
+            float_gap_coord.simplify(-1.0)
+
+    def test_simplify_base_coord_noop(self):
+        """Other coords return themselves from simplify."""
+        coord = get_coord(start=0.0, stop=10.0, step=1.0)
+        assert coord.simplify(10) is coord
+
+    def test_snap_forces_range(self, float_gap_coord):
+        """Snap always produces a range preserving min/max and length."""
+        out = float_gap_coord.snap()
+        assert isinstance(out, CoordRange)
+        assert len(out) == len(float_gap_coord)
+        assert out.min() == float_gap_coord.min()
+        assert out.max() == float_gap_coord.max()
+
+    def test_reverse_simplify(self, reverse_gap_coord):
+        """Simplify works on reverse-sorted coords."""
+        out = reverse_gap_coord.simplify(3.0)
+        assert isinstance(out, CoordRange)
+        assert out.reverse_sorted
+
+
+class TestDiscontinuities:
+    """Tests for gap/boundary introspection."""
+
+    def test_all_boundaries(self, float_gap_coord):
+        """Every segment boundary is reported."""
+        df = float_gap_coord.get_discontinuities()
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["index"] == 10
+        assert row["before"] == 9.0
+        assert row["after"] == 15.0
+        assert row["delta"] == 6.0
+        assert row["excess"] == 5.0
+
+    def test_gaps_with_tolerance(self, time_gap_coord):
+        """Gap filtering respects the tolerance."""
+        assert len(time_gap_coord.get_discontinuities("gaps")) == 1
+        assert len(time_gap_coord.get_discontinuities("gaps", tolerance=10)) == 0
+
+    def test_bad_kind_raises(self, float_gap_coord):
+        """Unknown kinds raise ParameterError."""
+        with pytest.raises(ParameterError, match="kind"):
+            float_gap_coord.get_discontinuities("overlaps")
+
+    def test_base_coord_empty(self):
+        """Coordinates without structure report no discontinuities."""
+        coord = get_coord(start=0.0, stop=10.0, step=1.0)
+        df = coord.get_discontinuities()
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+    def test_reverse_gaps(self, reverse_gap_coord):
+        """Gap detection works on reverse-sorted coords."""
+        df = reverse_gap_coord.get_discontinuities("gaps")
+        assert len(df) == 1
+
+
+class TestRoundTrips:
+    """Serialization and summary round trips."""
+
+    def test_model_dump_round_trip(self, mixed_segment_coord):
+        """model_dump payloads rebuild the same coordinate."""
+        out = CoordSegmented(**mixed_segment_coord.model_dump())
+        assert out == mixed_segment_coord
+
+    def test_pickle_round_trip(self, time_gap_coord):
+        """Pickling preserves the coordinate."""
+        out = pickle.loads(pickle.dumps(time_gap_coord))
+        assert out == time_gap_coord
+
+    def test_to_summary(self, float_gap_coord):
+        """Summaries carry exact min/max and a null step."""
+        summary = float_gap_coord.to_summary()
+        assert summary.min == 0.0
+        assert summary.max == 24.0
+        assert summary.step is None
+        assert summary.len == 20
+        assert summary.fingerprint == float_gap_coord.fingerprint()
+
+    def test_get_attrs_dict_no_step(self, float_gap_coord):
+        """The attrs dict omits the (null) step."""
+        out = float_gap_coord.get_attrs_dict("time")
+        assert "time_step" not in out
+        assert out["time_min"] == 0.0
+        assert out["time_max"] == 24.0
+
+    def test_ns_precision_exact(self):
+        """Nanosecond datetimes survive bit-exactly (no float pass)."""
+        ns = np.timedelta64(1, "ns")
+        t0 = np.datetime64("2020-01-01T00:00:00.123456789", "ns")
+        v1 = t0 + np.arange(10) * 1000 * ns
+        v2 = t0 + (np.arange(10) * 1000 + 10_501) * ns
+        coord = concat_coords(get_coord(data=v1), get_coord(data=v2))
+        assert np.array_equal(coord.values, np.concatenate([v1, v2]))
+
+    def test_empty_from_coord(self, float_gap_coord):
+        """Emptying a segmented coord gives a zero-length coordinate."""
+        out = float_gap_coord.empty()
+        assert len(out) == 0
+        assert np.dtype(out.dtype) == np.dtype(float_gap_coord.dtype)
+
+    def test_new_with_segments(self, float_gap_coord):
+        """new(segments=...) builds an updated coordinate."""
+        segments = tuple(
+            x.update_limits(min=x.min() + 100) for x in float_gap_coord.segments
+        )
+        out = float_gap_coord.new(segments=segments)
+        assert out.min() == 100.0
+
+    def test_new_with_data(self, float_gap_coord):
+        """new(data=...) falls back to plain coord creation."""
+        out = float_gap_coord.new(data=np.arange(10.0))
+        assert isinstance(out, CoordRange)


### PR DESCRIPTION
## Description

Adds `CoordSegmented`, a coordinate composed of an ordered sequence of monotonic segments (`CoordRange` or `CoordMonotonicArray`), plus a `concat_coords` function and two new `BaseCoord` methods (`simplify`, `get_discontinuities`). This PR only adds the class — nothing constructs it in production code yet; wiring patch merge/chunk to produce it is a follow-up PR.

### Motivation

Merging nearly-contiguous patches currently forces a binary coordinate choice: snap to a uniform `CoordRange` (endpoints exact, but interior values can be arbitrarily wrong when a tolerated gap is absorbed) or materialize a full `CoordArray` (exact but heavy, structure lost). `CoordSegmented` is the middle ground: it holds the original segments, its values are exactly their concatenation, and segment boundaries record data gaps without altering any value. Memory is O(segments), min/max are exact without materialization, and gap introspection becomes a coordinate primitive.

### What's included

- **`CoordSegmented`**: full `BaseCoord` contract. Select/getitem preserve segment structure and match `CoordMonotonicArray` semantics exactly (tested by parity); a window inside a gap selects nothing; a window inside one block degrades to that block's plain coordinate. `step` is None; reverse-sorted coords supported; ns-precision datetimes never pass through floats.
- **`concat_coords(*coords, units=None)`**: truth-preserving concatenation. Inputs are ordered by envelope; overlapping, mixed-dtype, mixed-units, or mixed-direction inputs raise. Returns a plain coordinate when inputs fuse to a single segment.
- **Normal form**: exactly uniform array segments promote to ranges (bit-exact check only), exactly continuing ranges fuse, adjacent irregular arrays fuse, single segments degrade to the bare coordinate — so equal values compare and fingerprint equal regardless of assembly order.
- **`BaseCoord.simplify(tolerance)`**: bounded-error alternative to `snap()` — re-fits segments as evenly sampled ranges, never moving any value more than `tolerance`. Other coords return self.
- **`BaseCoord.get_discontinuities(kind, tolerance)`**: dataframe of segment boundaries and gaps; the primitive behind a future `spool.get_gaps()`.
- **`CoordSegmented.from_array(array, tolerance=None)`**: segment a monotonic array into uniform runs so gaps *inside* an array coordinate become queryable boundaries; optional tolerance re-fits with bounded error.
- **`patch.split_gaps(dim=None)`** and a `split=` kwarg on `dc.write`: a written patch must be contiguous, so saving a patch with gapped dimensional coords raises by default; `split=True` writes each contiguous section as its own patch (multi-patch formats only — the check lives once in the generic write dispatcher, individual FiberIOs are untouched apart from a declarative `multi_patch_write` attribute). This removes any need for native segment serialization: split pieces are plain patches, and gaps persist *between* patches where spools and indices already see them. Includes a DASDAE fix uniquifying group names within a write batch (pre-existing silent overwrite of same-named patches).
- **`get_coord(segments=...)`** dispatches to `concat_coords`; `CoordSegmented` and `concat_coords` are exported from `dascore.core`.

### Notes for review

- Direct `CoordSegmented(...)` construction with segments that fuse to one coordinate raises (a pydantic constructor cannot return a different class); `concat_coords` is the intended API.
- The `segments` field is typed `tuple[BaseCoord, ...]` instead of a concrete union: pydantic union dispatch runs member before-validators against foreign instances. Concrete types are enforced in the model validator, and a `field_serializer` keeps round-trips lossless.
- 98 new tests, including parity against equivalent monotonic coords, error-bound checks for `simplify`, and an ns bit-exactness regression test.

## Changelog

<!-- Retrofitted after #864; recovered from docs/changelog.qmd history. -->
- added: `CoordSegmented` and `concat_coords(...)` for exact piecewise-monotonic coordinates with queryable sampling changes and gaps.
- added: `patch.split_gaps()` and `dc.write(..., split=True)` split segmented dimensions into contiguous patches; `split=True` needs a format that can hold multiple patches and raises `ParameterError` otherwise.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added segmented (piecewise) coordinate support with normalization and `concat_coords`, plus `CoordSegmented` and `get_coord(segments=...)`.
  * Exposed additional coordinate-related symbols and added a new display style for segmented coordinates.
  * Added `Patch.split_gaps` and updated `write(..., split=...)` to split gapped dimensional coordinates when supported (enabled for DASDAE and Pickle output).
* **Bug Fixes**
  * Fixed descending monotonic indexing/selection to preserve exactness for time-like and large integer values.
  * Made `simplify` and discontinuity reporting consistently return concrete results.
* **Tests**
  * Added extensive segmented-coordinate and gap-handling coverage, including serialization and indexing/simplify/snap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

