### PR TITLE
CI: isolate network tests from required suite

### DIFF
--- a/.github/actions/load-shared-vars/action.yml
+++ b/.github/actions/load-shared-vars/action.yml
@@ -4,6 +4,9 @@ name: "Load Shared Variables"
 description: "Loads shared variables and sets them as environment variables and outputs"
 
 outputs:
+  python-default:
+    description: "Default Python version for single-version jobs"
+    value: ${{ steps.load.outputs.python-default }}
   python-test-matrix:
     description: "Python version matrix for full tests"
     value: ${{ steps.load.outputs.python-test-matrix }}
@@ -26,6 +29,7 @@ runs:
         python_test_matrix='["3.11","3.12","3.13","3.14"]'
         test_os_matrix='["ubuntu-latest","macos-latest","windows-latest"]'
         echo "PYTHON_DEFAULT=$python_default" >> "$GITHUB_ENV"
+        echo "python-default=$python_default" >> "$GITHUB_OUTPUT"
         echo "python-test-matrix=$python_test_matrix" >> "$GITHUB_OUTPUT"
         echo "python-min-deps-matrix=$python_min_deps_matrix" >> "$GITHUB_OUTPUT"
         echo "test-os-matrix=$test_os_matrix" >> "$GITHUB_OUTPUT"

--- a/.github/test_code.sh
+++ b/.github/test_code.sh
@@ -3,7 +3,7 @@
 # Script to run tests to account for wonkiness of periodic mac failures.
 args=(tests -m "not network" -s --cov dascore --cov-append --cov-report=xml)
 if [[ "$1" == "network" ]]; then
-  args=(tests -m network -s)
+  args=(tests -m network -s --cov dascore --cov-append --cov-report=xml)
 fi
 if [[ "$1" == "doctest" ]]; then
   args=(dascore --doctest-modules)

--- a/.github/test_code.sh
+++ b/.github/test_code.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 
 # Script to run tests to account for wonkiness of periodic mac failures.
-args="tests -s --cov dascore --cov-append --cov-report=xml"
+args=(tests -m "not network" -s --cov dascore --cov-append --cov-report=xml)
+if [[ "$1" == "network" ]]; then
+  args=(tests -m network -s)
+fi
 if [[ "$1" == "doctest" ]]; then
-  args="dascore --doctest-modules"
+  args=(dascore --doctest-modules)
 fi
 if [[ "$1" == "profile" ]]; then
-  args="benchmarks --codspeed"
+  args=(benchmarks --codspeed)
 fi
 
 exit_code=0
 
-python -m pytest $args || exit_code=$?
+python -m pytest "${args[@]}" || exit_code=$?
 
 # Check the exit code is related to sporadic failures on mac, see #312
 if [ $exit_code -ne 132 ] && [ $exit_code -ne 0 ]; then

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Shared values live in .github/actions/load-shared-vars/action.yml
+      python-default: ${{ steps.load-vars.outputs.python-default }}
       python-matrix: ${{ steps.load-vars.outputs.python-test-matrix }}
       os-matrix: ${{ steps.load-vars.outputs.test-os-matrix }}
     steps:
@@ -120,3 +121,40 @@ jobs:
         if: steps.generate_qmd_tests.outcome == 'failure' || steps.run_test_suite.outcome == 'failure' || steps.run_docstrings.outcome == 'failure'
         shell: bash
         run: exit 1
+
+  network_tests:
+    needs: setup
+    timeout-minutes: 60
+    continue-on-error: true
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    # Keep remote-IO coverage visible without blocking unrelated changes.
+    if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')
+
+    env:
+      env_file: 'environment.yml'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: 'true'
+          fetch-depth: '0'
+
+      - uses: ./.github/actions/mamba-install-dascore
+        with:
+          python-version: ${{ needs.setup.outputs.python-default }}
+          cache-number: ${{ env.CACHE_NUMBER }}
+          prepare-test-data: "true"
+
+      - name: run network tests
+        shell: bash -el {0}
+        run: ./.github/test_code.sh network
+
+      - name: summarize non-gating failure
+        if: failure()
+        shell: bash
+        run: echo "Network tests failed, but this report-only job does not block the workflow." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -143,6 +143,7 @@ jobs:
         with:
           fetch-tags: 'true'
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: ./.github/actions/mamba-install-dascore
         with:
@@ -153,6 +154,14 @@ jobs:
       - name: run network tests
         shell: bash -el {0}
         run: ./.github/test_code.sh network
+
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: false
+          files: ./coverage.xml
+          flags: network
+          name: PR_network_tests_${{ matrix.os }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: summarize non-gating failure
         if: failure()

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+flags:
+  unittests:
+    carryforward: false
+  network:
+    carryforward: true


### PR DESCRIPTION
## Description

The localhost HTTP/fsspec tests are marked `network` and can intermittently hang while h5py probes remote HDF5 metadata. Because they currently run inside the required test matrix, those transport-level flakes can block unrelated changes.

This PR separates that coverage from the required suite:

- the default test runner now selects `-m "not network"` and retains coverage reporting;
- an explicit `network` runner mode selects all tests carrying the marker;
- a report-only Linux/macOS job runs the network tests on the shared default Python version; and
- the network matrix has fail-fast disabled and is allowed to fail, so both platforms report without blocking the workflow;
- successful network jobs upload a separate Codecov flag; and
- the network flag carries coverage forward when a report-only run flakes, preserving project coverage without making that run gating.

This is a CI-policy change only. The remote-HDF5 implementation and its existing tests are unchanged.

Validation:

- `./.github/test_code.sh network`: 100 passed initially; coverage-enabled revalidation passed 99 with 1 timeout skip.
- `./.github/test_code.sh`: 7229 passed, 87 skipped, 100 deselected, 3 xfailed.
- targeted pre-commit hooks: YAML and GitHub Actions lint passed.
- Codecov configuration validation: valid.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added network test coverage on Ubuntu and macOS (non-blocking / report-only).
  * Improved test argument handling to preserve command-line options reliably.
  * Network test failures now appear in the workflow summary without blocking overall validation (when applicable).

* **Chores**
  * Exposed the configured default Python version as a reusable workflow output.
  * Updated code coverage carryforward rules to apply separately by flag group (unit vs network).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->