### PR TITLE
implemented gap-sensistive waterfall plot

### DIFF
--- a/dascore/utils/gaps.py
+++ b/dascore/utils/gaps.py
@@ -1,0 +1,104 @@
+"""Utilities for detecting coordinate gaps and constructing cell edges."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+from dascore.utils.time import is_datetime64, is_timedelta64, to_float
+
+
+def _to_numeric(values):
+    """Convert timedeltas to seconds while retaining other numeric values."""
+    values = np.asarray(values)
+    return to_float(values) if is_timedelta64(values) else values
+
+
+def _normalize_coord_values(values):
+    """Normalize coordinate values for gap and edge calculations."""
+    values = np.asarray(values)
+    if is_datetime64(values):
+        return values.astype("datetime64[ns]")
+    return _to_numeric(values)
+
+
+def is_monotonic_and_finite(values) -> bool:
+    """Return True when values are finite and strictly monotonic."""
+    values = _normalize_coord_values(values)
+    if not np.all(np.isfinite(values)):
+        return False
+    diffs = _to_numeric(np.diff(values))
+    return bool(not len(diffs) or np.all(diffs > 0) or np.all(diffs < 0))
+
+
+def get_gap_edges(values, gap_factor: float | None = None):
+    """
+    Return cell edges and coordinate gap locations.
+
+    Timedelta coordinates are converted to seconds. Datetime coordinates are
+    retained so plotting libraries with datetime support can convert them.
+    When ``gap_factor`` is None, adjacent cell edges meet halfway between
+    coordinate centers. Otherwise, intervals larger than ``gap_factor`` times
+    the median interval are expanded into a gap.
+
+    Parameters
+    ----------
+    values
+        One-dimensional, monotonic coordinate centers.
+    gap_factor
+        Factor of the median interval above which an interval is a gap. If
+        None, no intervals are considered gaps.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Cell edges and a Boolean array marking gaps after each input value.
+    """
+    values = _normalize_coord_values(values)
+    if len(values) == 1:
+        msg = "Singleton coordinate has no inferred cell width; using a default width."
+        warnings.warn(msg, UserWarning, stacklevel=2)
+        if is_datetime64(values):
+            step = np.asarray(np.timedelta64(1, "D")).astype("timedelta64[ns]")[()]
+        else:
+            step = 1
+        return np.asarray([values[0] - step / 2, values[0] + step / 2]), np.zeros(
+            0, dtype=bool
+        )
+
+    diffs = np.diff(values)
+    numeric_diffs = _to_numeric(diffs)
+    gap_mask = np.zeros(len(diffs), dtype=bool)
+    if gap_factor is not None:
+        representative_interval = np.median(np.abs(numeric_diffs))
+        gap_mask = np.abs(numeric_diffs) > representative_interval * gap_factor
+
+    if not np.any(gap_mask):
+        edges = np.concatenate(
+            (
+                [values[0] - diffs[0] / 2],
+                values[:-1] + diffs / 2,
+                [values[-1] + diffs[-1] / 2],
+            )
+        )
+        return edges, gap_mask
+
+    representative_step = np.median(np.abs(diffs))
+    direction = 1 if numeric_diffs[0] > 0 else -1
+    signed_step = direction * representative_step
+    first_step = signed_step if gap_mask[0] else diffs[0]
+    last_step = signed_step if gap_mask[-1] else diffs[-1]
+    edges = [values[0] - first_step / 2]
+    for index, diff in enumerate(diffs):
+        if gap_mask[index]:
+            edges.extend(
+                [
+                    values[index] + signed_step / 2,
+                    values[index + 1] - signed_step / 2,
+                ]
+            )
+        else:
+            edges.append(values[index] + diff / 2)
+    edges.append(values[-1] + last_step / 2)
+    return np.asarray(edges), gap_mask

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -329,6 +329,9 @@ def waterfall(
         'auto' (default) selects a suitable interpolation stage automatically.
         See matplotlib's imshow documentation for more details. This option
         does not apply when ``pcolormesh`` is used.
+    gap_factor
+        Coordinate intervals larger than this factor times the median interval
+        are treated as gaps. Must be greater than 1.
     gap_color
         Matplotlib color used to display gaps in irregular dimension
         coordinates. When a color is provided, a masked row or column is
@@ -337,9 +340,6 @@ def waterfall(
         without expanding the data matrix. This option only applies when
         ``pcolormesh`` is used. Existing masked or NaN data receive the same
         color as coordinate gaps.
-    gap_factor
-        Coordinate intervals larger than this factor times the median interval
-        are treated as gaps. Must be greater than 1.
     log
         If True, visualize the common logarithm of the absolute values of patch data.
         To avoid log(0), the abs(array) is cast to float64 and a small value

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from typing import Literal
 
 import matplotlib as mpl
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -28,7 +29,14 @@ def _validate_scale_type(scale_type):
     """Validate that scale_type is either 'relative' or 'absolute'."""
     valid_types = {"absolute", "relative"}
     if scale_type not in valid_types:
-        msg = f"scale_type must be one of {valid_types}, " f"but got '{scale_type}'"
+        msg = f"scale_type must be one of {valid_types}, but got '{scale_type}'"
+        raise ParameterError(msg)
+
+
+def _validate_gap_factor(gap_factor):
+    """Validate the factor used to identify coordinate gaps."""
+    if not np.isfinite(gap_factor) or gap_factor <= 1:
+        msg = "gap_factor must be a finite number greater than 1"
         raise ParameterError(msg)
 
 
@@ -157,6 +165,111 @@ def _get_waterfall_colormap(patch, cmap=None):
     return _get_cmap(cmap)
 
 
+def _get_plot_coord(coord):
+    """Return coordinate values in units understood by matplotlib meshes."""
+    values = np.asarray(coord)
+    if np.issubdtype(values.dtype, np.datetime64):
+        return mdates.date2num(values)
+    if np.issubdtype(values.dtype, np.timedelta64):
+        return values / np.timedelta64(1, "s")
+    return values
+
+
+def _get_gap_edges(values, gap_factor):
+    """Return cell edges and locations of gaps in monotonic center values."""
+    values = np.asarray(values)
+    if len(values) == 1:
+        return np.asarray([values[0] - 0.5, values[0] + 0.5]), np.array([])
+    diffs = np.diff(values)
+    abs_diffs = np.abs(diffs)
+    representative_step = np.median(abs_diffs)
+    gap_mask = abs_diffs > (representative_step * gap_factor)
+    signed_step = np.sign(diffs[0]) * representative_step
+
+    first_step = signed_step if gap_mask[0] else diffs[0]
+    last_step = signed_step if gap_mask[-1] else diffs[-1]
+    edges = [values[0] - first_step / 2]
+    for index, diff in enumerate(diffs):
+        if gap_mask[index]:
+            edges.extend(
+                [
+                    values[index] + signed_step / 2,
+                    values[index + 1] - signed_step / 2,
+                ]
+            )
+        else:
+            edges.append(values[index] + diff / 2)
+    edges.append(values[-1] + last_step / 2)
+    return np.asarray(edges), gap_mask
+
+
+def _insert_gap_bands(data, gap_mask, axis):
+    """Insert masked bands into an array at each coordinate gap."""
+    if not np.any(gap_mask):
+        return data
+    old_size = data.shape[axis]
+    new_size = old_size + np.count_nonzero(gap_mask)
+    new_shape = list(data.shape)
+    new_shape[axis] = new_size
+    out = np.ma.masked_all(new_shape, dtype=data.dtype)
+    new_indices = np.arange(old_size) + np.cumsum(
+        np.concatenate(([0], gap_mask.astype(int)))
+    )
+    indexer = [slice(None)] * data.ndim
+    indexer[axis] = new_indices
+    out[tuple(indexer)] = data
+    return out
+
+
+def _coordinates_support_mesh(coords):
+    """Return True when coordinates define finite monotonic mesh centers."""
+    for values in coords.values():
+        values = _get_plot_coord(values)
+        if not np.all(np.isfinite(values)):
+            return False
+        diffs = np.diff(values)
+        if len(diffs) and not (np.all(diffs > 0) or np.all(diffs < 0)):
+            return False
+    return True
+
+
+def _plot_with_mesh(ax, data, dims, coords, cmap, gap_color, gap_factor):
+    """Plot irregularly sampled data using a quadrilateral mesh."""
+    mesh_data = np.ma.asarray(data)
+    edges = {}
+    for axis, dim in enumerate(dims):
+        values = _get_plot_coord(coords[dim])
+        dim_edges, gap_mask = _get_gap_edges(values, gap_factor)
+        if gap_color is None:
+            dim_edges = (
+                np.concatenate(
+                    (
+                        [values[0] - (values[1] - values[0]) / 2],
+                        values[:-1] + np.diff(values) / 2,
+                        [values[-1] + (values[-1] - values[-2]) / 2],
+                    )
+                )
+                if len(values) > 1
+                else dim_edges
+            )
+        else:
+            mesh_data = _insert_gap_bands(mesh_data, gap_mask, axis)
+        edges[dim] = dim_edges
+
+    if gap_color is not None:
+        cmap = cmap.with_extremes(bad=gap_color)
+    return ax.pcolormesh(
+        edges[dims[1]],
+        edges[dims[0]],
+        mesh_data,
+        cmap=cmap,
+        shading="flat",
+        edgecolors="none",
+        linewidth=0,
+        antialiased=False,
+    )
+
+
 @patch_function()
 def waterfall(
     patch: PatchType,
@@ -166,12 +279,20 @@ def waterfall(
     scale_type: Literal["relative", "absolute"] = "relative",
     interpolation: str | None = "antialiased",
     interpolation_stage: str = "auto",
+    gap_color: str | Sequence[float] | None = None,
+    gap_factor: float = 1.5,
     log: bool = False,
     cbar: bool = True,
     show: bool = False,
 ) -> plt.Axes:
     """
     Create a waterfall plot of the Patch data.
+
+    Evenly sampled dimension coordinates are rendered with ``imshow`` for
+    efficient display and image interpolation. Finite, monotonic irregular
+    coordinates are rendered with ``pcolormesh`` so cell geometry follows the
+    coordinate values. Incomplete or nonmonotonic coordinates fall back to
+    ``imshow`` with index-based or minimum/maximum extents.
 
     Parameters
     ----------
@@ -199,12 +320,26 @@ def waterfall(
         which is relevant for DAS. Usually, "antialiased" works well, but if the
         data look smeared disabling interpolation with None might help. Other
         options are available, see matplotlib's documentation for more details.
+        This option does not apply when irregular coordinates select the
+        ``pcolormesh`` renderer.
     interpolation_stage
         If 'data', interpolation is carried out on the data provided by the user.
         If 'rgba', the interpolation is carried out after the colormapping has
         been applied (visual interpolation).
         'auto' (default) selects a suitable interpolation stage automatically.
-        See matplotlib's imshow documentation for more details.
+        See matplotlib's imshow documentation for more details. This option
+        does not apply when ``pcolormesh`` is used.
+    gap_color
+        Matplotlib color used to display gaps in irregular dimension
+        coordinates. When a color is provided, a masked row or column is
+        inserted for each detected gap and displayed with this color. The
+        default of None bridges gaps by extending adjacent cells across them
+        without expanding the data matrix. This option only applies when
+        ``pcolormesh`` is used. Existing masked or NaN data receive the same
+        color as coordinate gaps.
+    gap_factor
+        Coordinate intervals larger than this factor times the median interval
+        are treated as gaps. Must be greater than 1.
     log
         If True, visualize the common logarithm of the absolute values of patch data.
         To avoid log(0), the abs(array) is cast to float64 and a small value
@@ -272,6 +407,7 @@ def waterfall(
     """
     # Validate inputs
     patch = _validate_patch_dims(patch)
+    _validate_gap_factor(gap_factor)
     # Setup axes and data
     ax = _get_ax(ax)
     if log:
@@ -280,20 +416,32 @@ def waterfall(
         data = patch.data
     dims = patch.dims
     dims_r = tuple(reversed(dims))
-    coords = {dim: patch.coords.get_array(dim) for dim in dims}
-    # Plot using imshow and set colorbar limits
-    extents = _get_extents(dims_r, coords)
+    dim_coords = {dim: patch.get_coord(dim) for dim in dims}
+    coords = {dim: np.asarray(coord) for dim, coord in dim_coords.items()}
     cmap = _get_waterfall_colormap(patch, cmap)
     scale = _get_scale(scale, scale_type, data)
-    with mpl.rc_context({"image.resample": True}):
-        im = ax.imshow(
+    use_image = all(coord.evenly_sampled for coord in dim_coords.values())
+    if use_image or not _coordinates_support_mesh(coords):
+        extents = _get_extents(dims_r, coords)
+        with mpl.rc_context({"image.resample": True}):
+            im = ax.imshow(
+                data,
+                extent=extents,
+                aspect="auto",
+                cmap=cmap,
+                origin="lower",
+                interpolation=interpolation,
+                interpolation_stage=interpolation_stage,
+            )
+    else:
+        im = _plot_with_mesh(
+            ax,
             data,
-            extent=extents,
-            aspect="auto",
-            cmap=cmap,
-            origin="lower",
-            interpolation=interpolation,
-            interpolation_stage=interpolation_stage,
+            dims,
+            coords,
+            cmap,
+            gap_color=gap_color,
+            gap_factor=gap_factor,
         )
     if scale is not None and len(scale) == 2 and np.all(np.isfinite(scale)):
         im.set_clim(np.asarray(scale))

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -6,13 +6,13 @@ from collections.abc import Sequence
 from typing import Literal
 
 import matplotlib as mpl
-import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 
 from dascore.constants import DEFAULT_COLORMAPS, PatchType
 from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, maybe_convert_percent_to_fraction
+from dascore.utils.gaps import get_gap_edges, is_monotonic_and_finite
 from dascore.utils.misc import tukey_fence
 from dascore.utils.patch import patch_function
 from dascore.utils.plotting import (
@@ -165,44 +165,6 @@ def _get_waterfall_colormap(patch, cmap=None):
     return _get_cmap(cmap)
 
 
-def _get_plot_coord(coord):
-    """Return coordinate values in units understood by matplotlib meshes."""
-    values = np.asarray(coord)
-    if np.issubdtype(values.dtype, np.datetime64):
-        return mdates.date2num(values)
-    if np.issubdtype(values.dtype, np.timedelta64):
-        return values / np.timedelta64(1, "s")
-    return values
-
-
-def _get_gap_edges(values, gap_factor):
-    """Return cell edges and locations of gaps in monotonic center values."""
-    values = np.asarray(values)
-    if len(values) == 1:
-        return np.asarray([values[0] - 0.5, values[0] + 0.5]), np.array([])
-    diffs = np.diff(values)
-    abs_diffs = np.abs(diffs)
-    representative_step = np.median(abs_diffs)
-    gap_mask = abs_diffs > (representative_step * gap_factor)
-    signed_step = np.sign(diffs[0]) * representative_step
-
-    first_step = signed_step if gap_mask[0] else diffs[0]
-    last_step = signed_step if gap_mask[-1] else diffs[-1]
-    edges = [values[0] - first_step / 2]
-    for index, diff in enumerate(diffs):
-        if gap_mask[index]:
-            edges.extend(
-                [
-                    values[index] + signed_step / 2,
-                    values[index + 1] - signed_step / 2,
-                ]
-            )
-        else:
-            edges.append(values[index] + diff / 2)
-    edges.append(values[-1] + last_step / 2)
-    return np.asarray(edges), gap_mask
-
-
 def _insert_gap_bands(data, gap_mask, axis):
     """Insert masked bands into an array at each coordinate gap."""
     if not np.any(gap_mask):
@@ -221,38 +183,14 @@ def _insert_gap_bands(data, gap_mask, axis):
     return out
 
 
-def _coordinates_support_mesh(coords):
-    """Return True when coordinates define finite monotonic mesh centers."""
-    for values in coords.values():
-        values = _get_plot_coord(values)
-        if not np.all(np.isfinite(values)):
-            return False
-        diffs = np.diff(values)
-        if len(diffs) and not (np.all(diffs > 0) or np.all(diffs < 0)):
-            return False
-    return True
-
-
 def _plot_with_mesh(ax, data, dims, coords, cmap, gap_color, gap_factor):
     """Plot irregularly sampled data using a quadrilateral mesh."""
     mesh_data = np.ma.asarray(data)
     edges = {}
+    mesh_gap_factor = gap_factor if gap_color is not None else None
     for axis, dim in enumerate(dims):
-        values = _get_plot_coord(coords[dim])
-        dim_edges, gap_mask = _get_gap_edges(values, gap_factor)
-        if gap_color is None:
-            dim_edges = (
-                np.concatenate(
-                    (
-                        [values[0] - (values[1] - values[0]) / 2],
-                        values[:-1] + np.diff(values) / 2,
-                        [values[-1] + (values[-1] - values[-2]) / 2],
-                    )
-                )
-                if len(values) > 1
-                else dim_edges
-            )
-        else:
+        dim_edges, gap_mask = get_gap_edges(coords[dim], mesh_gap_factor)
+        if gap_color is not None:
             mesh_data = _insert_gap_bands(mesh_data, gap_mask, axis)
         edges[dim] = dim_edges
 
@@ -329,9 +267,6 @@ def waterfall(
         'auto' (default) selects a suitable interpolation stage automatically.
         See matplotlib's imshow documentation for more details. This option
         does not apply when ``pcolormesh`` is used.
-    gap_factor
-        Coordinate intervals larger than this factor times the median interval
-        are treated as gaps. Must be greater than 1.
     gap_color
         Matplotlib color used to display gaps in irregular dimension
         coordinates. When a color is provided, a masked row or column is
@@ -340,6 +275,16 @@ def waterfall(
         without expanding the data matrix. This option only applies when
         ``pcolormesh`` is used. Existing masked or NaN data receive the same
         color as coordinate gaps.
+    gap_factor
+        When ``gap_color`` is provided, coordinate intervals larger than this
+        factor times the median interval are displayed as gaps. With the
+        default ``gap_color=None``, cells bridge intervals and this parameter
+        has no visual effect. Gap detection assumes the median interval
+        represents the sampling interval, so coordinates containing contiguous
+        regions with different sampling rates may classify the more coarsely
+        sampled region as gaps. For such data, use the default
+        ``gap_color=None``, increase ``gap_factor``, or plot/resample the
+        regions separately. Must be greater than 1.
     log
         If True, visualize the common logarithm of the absolute values of patch data.
         To avoid log(0), the abs(array) is cast to float64 and a small value
@@ -421,7 +366,7 @@ def waterfall(
     cmap = _get_waterfall_colormap(patch, cmap)
     scale = _get_scale(scale, scale_type, data)
     use_image = all(coord.evenly_sampled for coord in dim_coords.values())
-    if use_image or not _coordinates_support_mesh(coords):
+    if use_image or not all(is_monotonic_and_finite(x) for x in coords.values()):
         extents = _get_extents(dims_r, coords)
         with mpl.rc_context({"image.resample": True}):
             im = ax.imshow(

--- a/tests/test_utils/test_gaps.py
+++ b/tests/test_utils/test_gaps.py
@@ -1,0 +1,83 @@
+"""Tests for coordinate gap utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dascore.utils.gaps import get_gap_edges, is_monotonic_and_finite
+
+
+class TestGetGapEdges:
+    """Tests for constructing coordinate cell edges."""
+
+    def test_numeric_without_gaps(self):
+        """Numeric coordinates produce midpoint cell edges."""
+        edges, gaps = get_gap_edges([0, 1, 2])
+        np.testing.assert_allclose(edges, [-0.5, 0.5, 1.5, 2.5])
+        assert not np.any(gaps)
+
+    def test_numeric_with_gap(self):
+        """Large numeric intervals are expanded into a gap."""
+        edges, gaps = get_gap_edges([0, 1, 5, 6], gap_factor=1.5)
+        np.testing.assert_allclose(edges, [-0.5, 0.5, 1.5, 4.5, 5.5, 6.5])
+        np.testing.assert_array_equal(gaps, [False, True, False])
+
+    def test_timedelta(self):
+        """Timedeltas are converted to seconds before constructing edges."""
+        values = np.array([0, 1, 2], dtype="timedelta64[s]")
+        edges, gaps = get_gap_edges(values)
+        np.testing.assert_allclose(edges, [-0.5, 0.5, 1.5, 2.5])
+        assert not np.any(gaps)
+
+    def test_datetime(self):
+        """Datetime edges retain datetime dtype and support gaps."""
+        values = np.array(
+            ["2020-01-01", "2020-01-02", "2020-01-06"],
+            dtype="datetime64[D]",
+        )
+        edges, gaps = get_gap_edges(values, gap_factor=1.5)
+        expected = np.array(
+            [
+                "2019-12-31T12:00:00",
+                "2020-01-01T12:00:00",
+                "2020-01-03T06:00:00",
+                "2020-01-04T18:00:00",
+                "2020-01-07T06:00:00",
+            ],
+            dtype="datetime64[ns]",
+        )
+        assert np.issubdtype(edges.dtype, np.datetime64)
+        np.testing.assert_array_equal(edges, expected)
+        np.testing.assert_array_equal(gaps, [False, True])
+
+    def test_singleton_datetime(self):
+        """Singleton datetimes warn and receive a one-day default cell width."""
+        with pytest.warns(UserWarning, match="Singleton coordinate"):
+            edges, gaps = get_gap_edges(np.array(["2020-01-01"], dtype="datetime64[D]"))
+        expected = np.array(
+            ["2019-12-31T12:00:00", "2020-01-01T12:00:00"], dtype="datetime64[ns]"
+        )
+        np.testing.assert_array_equal(edges, expected)
+        assert not len(gaps)
+
+    def test_singleton_numeric(self):
+        """Singleton numeric coordinates warn and receive a unit cell width."""
+        with pytest.warns(UserWarning, match="Singleton coordinate"):
+            edges, gaps = get_gap_edges([10])
+        np.testing.assert_allclose(edges, [9.5, 10.5])
+        assert not len(gaps)
+
+
+class TestIsMonotonicAndFinite:
+    """Tests for validating mesh coordinate centers."""
+
+    @pytest.mark.parametrize("values", [[0, 1, 2], [2, 1, 0]])
+    def test_valid(self, values):
+        """Ascending and descending finite values are valid."""
+        assert is_monotonic_and_finite(values)
+
+    @pytest.mark.parametrize("values", [[0, 2, 1], [0, np.nan, 2]])
+    def test_invalid(self, values):
+        """Nonmonotonic and nonfinite values are invalid."""
+        assert not is_monotonic_and_finite(values)

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from matplotlib.collections import QuadMesh
+from matplotlib.image import AxesImage
 
 import dascore as dc
 from dascore.exceptions import ParameterError
@@ -64,6 +66,109 @@ class TestWaterfall:
         old_coord = random_patch.get_coord("time")
         new_time = to_timedelta64(np.arange(len(old_coord)))
         return random_patch.update_coords(time=new_time)
+
+    @pytest.fixture()
+    def distance_gap_patch(self, random_patch):
+        """Create a patch with one large gap in its distance coordinate."""
+        coord = random_patch.get_coord("distance")
+        values = np.asarray(coord).copy()
+        split = len(values) // 2
+        values[split:] += coord.step * 10
+        return random_patch.update_coords(distance=values), split
+
+    @pytest.fixture()
+    def time_gap_patch(self, random_patch):
+        """Create a patch with one large gap in its time coordinate."""
+        coord = random_patch.get_coord("time")
+        values = np.asarray(coord).copy()
+        split = len(values) // 2
+        values[split:] += coord.step * 10
+        return random_patch.update_coords(time=values), split
+
+    def test_even_coordinates_use_image(self, random_patch):
+        """Evenly sampled coordinates retain the fast image renderer."""
+        ax = random_patch.viz.waterfall(cbar=False)
+        assert isinstance(ax.images[0], AxesImage)
+        assert not any(isinstance(x, QuadMesh) for x in ax.collections)
+
+    def test_gap_uses_masked_mesh(self, distance_gap_patch):
+        """A gap color adds one masked mesh band."""
+        patch, split = distance_gap_patch
+        ax = patch.viz.waterfall(gap_color="white", cbar=False)
+        mesh = ax.collections[0]
+        array = mesh.get_array()
+        mask = np.ma.getmaskarray(array)
+        assert isinstance(mesh, QuadMesh)
+        assert not ax.images
+        assert array.shape == (patch.shape[0] + 1, patch.shape[1])
+        assert np.all(mask[split, :])
+        assert mesh.get_coordinates().shape[:2] == (
+            patch.shape[0] + 2,
+            patch.shape[1] + 1,
+        )
+        assert np.allclose(mesh.cmap.get_bad(), [1, 1, 1, 1])
+
+    def test_gap_mesh_colorbar_and_scale(self, distance_gap_patch):
+        """Mesh plots retain waterfall colorbar and scaling behavior."""
+        patch, _ = distance_gap_patch
+        ax = patch.viz.waterfall(
+            scale=(-1, 1), scale_type="absolute", gap_color="white"
+        )
+        mesh = ax.collections[0]
+        assert mesh.colorbar is not None
+        assert mesh.get_clim() == (-1, 1)
+
+    def test_bridge_gap_doesnt_expand_data(self, distance_gap_patch):
+        """The default extends cells across a gap without adding a band."""
+        patch, _ = distance_gap_patch
+        ax = patch.viz.waterfall(cbar=False)
+        mesh = ax.collections[0]
+        assert mesh.get_array().shape == patch.shape
+        assert mesh.get_coordinates().shape[:2] == tuple(x + 1 for x in patch.shape)
+
+    def test_gap_color(self, distance_gap_patch):
+        """A specified gap color is assigned to masked mesh cells."""
+        patch, _ = distance_gap_patch
+        ax = patch.viz.waterfall(gap_color="white", cbar=False)
+        assert np.allclose(ax.collections[0].cmap.get_bad(), [1, 1, 1, 1])
+
+    def test_gaps_in_both_axes(self, distance_gap_patch):
+        """Gap bands can be inserted along both dimensions."""
+        patch, distance_split = distance_gap_patch
+        time = patch.get_coord("time")
+        values = np.asarray(time).copy()
+        time_split = len(values) // 2
+        values[time_split:] += time.step * 10
+        patch = patch.update_coords(time=values)
+        ax = patch.viz.waterfall(gap_color="white", cbar=False)
+        mesh_array = ax.collections[0].get_array()
+        mask = np.ma.getmaskarray(mesh_array)
+        assert mesh_array.shape == tuple(x + 1 for x in patch.shape)
+        assert np.all(mask[distance_split, :])
+        assert np.all(mask[:, time_split])
+
+    def test_time_gap_keeps_regular_ticks(self, time_gap_patch):
+        """Time-axis ticks remain monotonic and evenly spaced across gaps."""
+        patch, split = time_gap_patch
+        ax = patch.viz.waterfall(gap_color="white", cbar=False)
+        mask = np.ma.getmaskarray(ax.collections[0].get_array())
+        ax.get_figure().canvas.draw()
+        tick_diffs = np.diff(ax.get_xticks())
+        assert np.all(mask[:, split])
+        assert np.all(tick_diffs > 0)
+        assert np.allclose(tick_diffs, tick_diffs[0])
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"gap_factor": 1}, "gap_factor"),
+            ({"gap_factor": np.inf}, "gap_factor"),
+        ],
+    )
+    def test_bad_gap_options_raise(self, random_patch, kwargs, match):
+        """Invalid gap display options raise an informative error."""
+        with pytest.raises(ParameterError, match=match):
+            random_patch.viz.waterfall(**kwargs)
 
     def test_returns_axes(self, random_patch):
         """Call waterfall plot, return."""

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -108,7 +108,8 @@ class TestWaterfall:
         distance = np.asarray(patch.get_coord("distance"))
         patch = patch.update_coords(distance=distance)
         assert not patch.get_coord("distance").evenly_sampled
-        ax = patch.viz.waterfall(cbar=False)
+        with pytest.warns(UserWarning, match="Singleton coordinate"):
+            ax = patch.viz.waterfall(cbar=False)
         mesh = ax.collections[0]
         assert isinstance(mesh, QuadMesh)
         assert mesh.get_coordinates().shape[:2] == tuple(x + 1 for x in patch.shape)

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -91,6 +91,37 @@ class TestWaterfall:
         assert isinstance(ax.images[0], AxesImage)
         assert not any(isinstance(x, QuadMesh) for x in ax.collections)
 
+    def test_irregular_timedelta_coordinates_use_mesh(self, timedelta_patch):
+        """Irregular timedelta coordinates are converted to seconds for meshes."""
+        values = np.asarray(timedelta_patch.get_coord("time")).copy()
+        split = len(values) // 2
+        values[split:] += np.timedelta64(10, "s")
+        patch = timedelta_patch.update_coords(time=values)
+        ax = patch.viz.waterfall(cbar=False)
+        mesh = ax.collections[0]
+        assert isinstance(mesh, QuadMesh)
+        assert np.all(np.isfinite(mesh.get_coordinates()))
+
+    def test_singleton_irregular_coordinate_uses_mesh(self, random_patch):
+        """A singleton irregular coordinate receives finite cell edges."""
+        patch = random_patch.select(distance=0, samples=True)
+        distance = np.asarray(patch.get_coord("distance"))
+        patch = patch.update_coords(distance=distance)
+        assert not patch.get_coord("distance").evenly_sampled
+        ax = patch.viz.waterfall(cbar=False)
+        mesh = ax.collections[0]
+        assert isinstance(mesh, QuadMesh)
+        assert mesh.get_coordinates().shape[:2] == tuple(x + 1 for x in patch.shape)
+
+    def test_nonmonotonic_coordinate_uses_image(self, random_patch):
+        """Nonmonotonic coordinates retain the image-rendering fallback."""
+        distance = np.asarray(random_patch.get_coord("distance")).copy()
+        distance[[1, 2]] = distance[[2, 1]]
+        patch = random_patch.update_coords(distance=distance)
+        ax = patch.viz.waterfall(cbar=False)
+        assert isinstance(ax.images[0], AxesImage)
+        assert not any(isinstance(x, QuadMesh) for x in ax.collections)
+
     def test_gap_uses_masked_mesh(self, distance_gap_patch):
         """A gap color adds one masked mesh band."""
         patch, split = distance_gap_patch


### PR DESCRIPTION
The waterfall plot is very fast by using the imshow functionality. This however assumes evenly sampled axis. DAScore however also support monotonic, but uneven, axis. 

One example of such data is when files of a spool are processed as continuous data and a transformed data-product is amalgamated into a compressed axis. A simple example would be the absolute maximum of each channel within each file. Data gaps due to missing files would not plot properly, as imhow stretches dataover the gaps. this also results in the axis ticks not aligning correctly with the cell position.

This PR fixes the issue. Imshow is still used for regular arrays. However, if one or more axis have gaps, pcolormesh is used. The user can choose to fill gaps with a selectable color, or to correctly stretch the last sample before the gap.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x ] documented the new feature with docstrings and/or appropriate doc page.
- [ x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waterfall plots now render irregular, monotonic coordinate grids using mesh-based rendering.
  * Added gap-aware visualization with optional `gap_color` and tunable `gap_factor`.
* **Bug Fixes**
  * Preserved colorbars, scaling, and axis formatting when gaps are present.
  * Improved behavior for datetime/duration axes, including consistent time tick placement across gaps.
* **Tests**
  * Added coverage for gap detection, gap band masking, renderer selection, and invalid `gap_factor` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->