### PR TITLE
Fix/fbe decibel

### DIFF
--- a/dascore/transform/fbe.py
+++ b/dascore/transform/fbe.py
@@ -41,7 +41,8 @@ def fbe(
         can be used for downsampling of the resulting patch.
         See also [rolling](`dascore.Patch.rolling`)
     db
-        Return patch data in decibel [dB] instead of orginal units
+        Return patch data in decibel [dB] instead of orginal units.
+        Decibel is calculated as 20 * log10( sqrt(mean(x^2))) ).
     **kwargs
         Used to specify the dimension and asociated frequency, wavelength, or
         equivalent limits. For example time=(1, 100) applies a time-dimension bandpass
@@ -92,7 +93,7 @@ def fbe(
     )
 
     if db:
-        fbe = (10 * fbe.log10()).update(
+        fbe = (20 * fbe.log10()).update(
             attrs={"data_type": "frequency_band_energy", "data_units": "dB"}
         )
 

--- a/tests/test_transform/test_fbe.py
+++ b/tests/test_transform/test_fbe.py
@@ -45,7 +45,7 @@ class TestFBE:
 
         filtered = random_patch.pass_filter(**kwargs)
         rms = (filtered**2).rolling(time=0.01, step=0.01).mean() ** 0.5
-        expected = 10 * rms.log10()
+        expected = 20 * rms.log10()
 
         assert np.allclose(out.data, expected.data, equal_nan=True)
 


### PR DESCRIPTION
fixed fbe scaling when converting to decibel. See (https://github.com/DASDAE/dascore/discussions/739)



## Checklist

I have (if applicable):

- [X] referenced the GitHub issue this PR closes.
- [X] documented the new feature with docstrings and/or appropriate doc page.
- [X] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected decibel conversion in the FBE transform to use standard RMS-based scaling.
  * Updated resulting dB values and validation to reflect the corrected calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->