### PR TITLE
Add WebAssembly packaging and tests

### DIFF
--- a/.github/workflows/test_wasm.yml
+++ b/.github/workflows/test_wasm.yml
@@ -1,0 +1,50 @@
+# Build the PyPI wheel and exercise it in a real Pyodide WebAssembly runtime.
+name: TestWasm
+on:
+  push:
+    branches:
+      - master
+      - dev
+      - wasm
+  pull_request:
+    branches:
+      - master
+      - dev
+    paths:
+      - 'dascore/**'
+      - 'scripts/test_wasm.mjs'
+      - 'pyproject.toml'
+      - '.github/workflows/test_wasm.yml'
+
+concurrency:
+  group: TestWasm-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test_wasm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: 'true'
+          fetch-depth: '0'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Build universal wheel
+        run: |
+          python -m pip install build
+          python -m build --wheel
+
+      - name: Install Pyodide
+        run: npm install --no-save pyodide@314.0.2
+
+      - name: Test wheel in WebAssembly
+        run: node scripts/test_wasm.mjs dist/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ license = { file="docs/LICENSE" }
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
+    "Environment :: WebAssembly",
+    "Environment :: WebAssembly :: Emscripten",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python :: 3.10",

--- a/readme.md
+++ b/readme.md
@@ -20,3 +20,20 @@ Documentation [[stable](https://dascore.org), [development](https://dascore.netl
 > Chambers, D., Jin, G., Tourei, A., Issah, A. H. S., Lellouch, A., Martin, E., Zhu, D., Girard, A., Yuan, S., Cullison, T., Snyder, T., Kim, S., Danes, N., Pnithan, N., Boltz, M. S. & Mendoza, M. M. (2024). DASCore: a Python Library for Distributed Fiber Optic Sensing. Seismica, 3(2).
 
 [![Contributors](https://contrib.rocks/image?repo=DASDAE/dascore)](https://github.com/DASDAE/dascore/graphs/contributors)
+
+## WebAssembly
+
+DASCore's universal wheel runs in browsers and Node.js through [Pyodide](https://pyodide.org/). Install it from PyPI with `micropip`:
+
+```python
+import micropip
+
+await micropip.install("dascore")
+
+import dascore as dc
+
+patch = dc.get_example_patch(shape=(10, 100))
+processed = patch.detrend("time")
+```
+
+Core patch processing, h5py-backed formats, and SQLite-backed directory spools work under Pyodide. Browser file access uses Pyodide's virtual filesystem and is subject to browser security rules. Optional extras with native extensions are available only when Pyodide provides compatible builds.

--- a/scripts/test_wasm.mjs
+++ b/scripts/test_wasm.mjs
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { loadPyodide } from "pyodide";
+
+async function main() {
+  const wheelArg = process.argv[2];
+  if (!wheelArg) {
+    throw new Error("Usage: node scripts/test_wasm.mjs path/to/dascore.whl");
+  }
+
+  const wheelPath = path.resolve(wheelArg);
+  const emscriptenPath = `/tmp/${path.basename(wheelPath)}`;
+  const pyodide = await loadPyodide();
+  pyodide.FS.writeFile(emscriptenPath, fs.readFileSync(wheelPath));
+
+  await pyodide.loadPackage("micropip");
+  const micropip = pyodide.pyimport("micropip");
+  await micropip.install(`emfs:${emscriptenPath}`);
+  micropip.destroy();
+
+  await pyodide.runPythonAsync(`
+import platform
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+import dascore as dc
+from dascore.io import H5Reader
+
+assert platform.system() == "Emscripten"
+
+patch = dc.get_example_patch(shape=(2, 8))
+detrended = patch.detrend("time")
+assert detrended.shape == (2, 8)
+assert np.isfinite(detrended.data).all()
+
+assert H5Reader.constructor is h5py.File
+h5_path = "/tmp/dascore-wasm-smoke.h5"
+with h5py.File(h5_path, "w") as handle:
+    handle["data"] = patch.data
+with H5Reader.get_handle(h5_path) as handle:
+    assert np.array_equal(handle["data"][:], patch.data)
+
+spool_path = Path("/tmp/dascore-wasm-spool")
+spool_path.mkdir(exist_ok=True)
+dc.write(patch, spool_path / "patch.h5", "DASDAE")
+spool = dc.spool(spool_path).update()
+assert len(spool) == 1
+assert spool[0].shape == patch.shape
+assert (spool_path / ".dascore_index.sqlite3").exists()
+`);
+
+  console.log("DASCore WebAssembly smoke test passed.");
+}
+
+main().catch((error) => {
+  console.error(error.message ?? error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Description

Add first-class WebAssembly support and validation for DASCore's existing universal wheel.

- Advertise WebAssembly and Emscripten support in the package metadata.
- Document installation with `micropip` under Pyodide.
- Build and install the release wheel in a real Pyodide runtime in CI.
- Exercise patch processing, h5py-backed HDF5 access, and the SQLite-backed directory spool index under Emscripten.

The implementation is based on the current `dev` branch after the PyTables removal, so it does not add platform-specific dependency markers or compatibility shims.

Testing performed:

- Pyodide 314.0.2 smoke test: passed.
- Focused native import, HDF5, directory-spool, and index tests: 417 passed.
- Full native suite: all non-socket tests passed; the remote-I/O subset passed separately with localhost sockets enabled (116 passed, 6 skipped).
- Pre-commit hooks for all changed files: passed.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
- added: WebAssembly/Emscripten support is advertised in the package metadata, documented for `micropip` under Pyodide, and exercised in CI.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebAssembly support for running DASCore in browsers and Node.js through Pyodide.
  * Added documentation with installation instructions, usage examples, and supported capabilities.

* **Bug Fixes**
  * Added automated WebAssembly smoke testing for processing, HDF5 read/write operations, and spool workflows.

* **Documentation**
  * Added WebAssembly platform classifications to project metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->