### PR TITLE
Use fsspec for remote cache downloads

### DIFF
--- a/dascore/config.py
+++ b/dascore/config.py
@@ -128,10 +128,6 @@ class DascoreConfig(BaseModel):
         default=1_048_576,
         description="Block size in bytes for general remote file downloads.",
     )
-    remote_download_timeout: float = Field(
-        default=60.0,
-        description="Timeout in seconds for blocking remote file downloads.",
-    )
     remote_hdf5_block_size: int = Field(
         default=5_242_880,
         description="Block size in bytes for remote HDF5 access on tuned protocols.",

--- a/dascore/utils/remote_io.py
+++ b/dascore/utils/remote_io.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import os
 import shutil
 import tempfile
 import warnings
-from collections.abc import Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import lru_cache
 from hashlib import sha256
 from pathlib import Path
-from urllib.request import Request, urlopen
 
 from dascore.compat import UPath
 from dascore.config import get_config
@@ -124,67 +121,11 @@ def clear_remote_file_cache():
     _REMOTE_RESOURCE_CACHE.clear()
 
 
-def _basic_auth_header(auth) -> str | None:
-    """
-    Build an HTTP Basic ``Authorization`` header value from an fsspec auth spec.
-
-    Handles the two shapes fsspec/aiohttp use for basic auth:
-    - a ``(login, password)`` sequence (fsspec ``auth=(user, pass)``), and
-    - an object exposing ``login``/``password`` (``aiohttp.BasicAuth``).
-
-    Returns ``None`` for anything else (e.g. token objects, SSL contexts) since
-    those cannot be expressed as a blocking ``urllib`` request header.
-    """
-    login = password = None
-    if isinstance(auth, str | bytes):
-        return None
-    if isinstance(auth, Sequence) and len(auth) == 2:
-        login, password = auth
-    else:
-        login = getattr(auth, "login", None)
-        password = getattr(auth, "password", None)
-    if login is None or password is None:
-        return None
-    token = base64.b64encode(f"{login}:{password}".encode()).decode("ascii")
-    return f"Basic {token}"
-
-
-def _http_headers_from_storage_options(resource) -> dict[str, str]:
-    """
-    Extract HTTP request headers from an fsspec/UPath resource.
-
-    fsspec stores HTTP headers nested under a ``headers`` key in
-    ``storage_options`` (e.g. ``{"headers": {"Authorization": "Bearer ..."}}``),
-    not as top-level entries. Only string-valued headers are forwarded because
-    ``urllib`` rejects non-string header values.
-
-    Basic-auth credentials passed as ``auth=(user, pass)`` or via
-    ``client_kwargs={"auth": aiohttp.BasicAuth(...)}`` are translated into an
-    ``Authorization`` header so credentials survive the blocking ``urllib``
-    download fallback. An explicit ``Authorization`` header always wins. Other
-    ``client_kwargs`` (SSL contexts, cookies, timeouts) cannot be mapped onto a
-    ``urllib`` request and are not forwarded.
-    """
-    storage_options = getattr(resource, "storage_options", None) or {}
-    headers = storage_options.get("headers", {}) or {}
-    out = {
-        str(key): str(value)
-        for key, value in headers.items()
-        if isinstance(value, str | bytes | int | float)
-    }
-    # Derive an Authorization header from basic-auth options unless one is set.
-    if not any(key.lower() == "authorization" for key in out):
-        client_kwargs = storage_options.get("client_kwargs") or {}
-        auth = storage_options.get("auth", client_kwargs.get("auth"))
-        if auth is not None and (auth_header := _basic_auth_header(auth)):
-            out["Authorization"] = auth_header
-    return out
-
-
 def _download_remote_file(path, local_path: Path):
     """Download a remote path into its cache location."""
     resource = coerce_to_upath(path)
     protocol = getattr(resource, "protocol", None)
+    open_kwargs = {"block_size": 0} if protocol in _HTTP_PROTOCOLS else {}
     local_path.parent.mkdir(parents=True, exist_ok=True)
     fd, temp_name = tempfile.mkstemp(
         dir=local_path.parent,
@@ -194,27 +135,12 @@ def _download_remote_file(path, local_path: Path):
     os.close(fd)
     tmp_path = Path(temp_name)
     try:
-        if protocol in _HTTP_PROTOCOLS:
-            # Use a direct blocking HTTP download here rather than
-            # ``resource.open(...)``. The fallback path can be entered while an
-            # active fsspec HTTP read is already in progress, and re-entering
-            # that stack from inside the fallback can deadlock.
-            headers = _http_headers_from_storage_options(resource)
-            # Supported public inputs are normalized to a real UPath first, so
-            # `protocol` and `str(resource)` come from the same object and do
-            # not need separate scheme validation here.
-            request = Request(str(resource), headers=headers)
-            timeout = get_config().remote_download_timeout
-            with (
-                urlopen(request, timeout=timeout) as remote_fi,
-                tmp_path.open("wb") as local_fi,
-            ):
-                while chunk := remote_fi.read(get_config().remote_download_block_size):
-                    local_fi.write(chunk)
-        else:
-            with resource.open("rb") as remote_fi, tmp_path.open("wb") as local_fi:
-                while chunk := remote_fi.read(get_config().remote_download_block_size):
-                    local_fi.write(chunk)
+        with (
+            resource.open("rb", **open_kwargs) as remote_fi,
+            tmp_path.open("wb") as local_fi,
+        ):
+            while chunk := remote_fi.read(get_config().remote_download_block_size):
+                local_fi.write(chunk)
         tmp_path.replace(local_path)
     finally:
         tmp_path.unlink(missing_ok=True)
@@ -358,12 +284,12 @@ class _FallbackFileObj:
         if self._using_local:
             return
         old_handle = self._handle
+        old_handle.close()
         # Reopen against the stable local artifact and continue from the same
         # logical file position the caller was already using.
         self._handle = self._local_opener()
         self._handle.seek(self._pos)
         self._using_local = True
-        old_handle.close()
 
     def _with_fallback(self, func, fallback_pos=None):
         """Run an operation and retry against the cached local file if needed."""

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -34,7 +34,6 @@ from dascore.utils.misc import suppress_warnings
 from dascore.utils.remote_io import (
     _FallbackFileObj,
     _get_cached_local_file,
-    _http_headers_from_storage_options,
     clear_remote_file_cache,
     get_remote_cache_path,
     get_remote_cache_scope,
@@ -691,28 +690,21 @@ class TestIOResourceManager:
         assert local_path.read_bytes() == b"a"
         assert handle.read_sizes == [321, 321]
 
-    def test_http_remote_download_uses_urlopen_not_upath_open(
-        self, monkeypatch, tmp_path
-    ):
-        """HTTP cache downloads should bypass fsspec open re-entry."""
+    def test_http_remote_download_uses_upath_open(self, monkeypatch, tmp_path):
+        """HTTP cache downloads should preserve the fsspec transport."""
 
         class _HTTPResource:
             def __init__(self):
                 self.protocol = "http"
-                # fsspec/UPath nests HTTP headers under a "headers" key rather
-                # than as top-level storage_options entries.
                 self.storage_options = {
                     "headers": {"User-Agent": "dascore-test"},
                     "client_kwargs": {"trust_env": True},
                 }
+                self.open_args = None
 
-            def __str__(self):
-                return "http://example.com/data.bin"
-
-            def open(self, *_args, **_kwargs):
-                raise AssertionError(
-                    "HTTP fallback download should not call resource.open"
-                )
+            def open(self, *args, **kwargs):
+                self.open_args = (args, kwargs)
+                return response
 
         class _HTTPResponse:
             def __init__(self):
@@ -729,64 +721,17 @@ class TestIOResourceManager:
             def __exit__(self, *_args):
                 return False
 
-        seen = {}
         response = _HTTPResponse()
-
-        def _fake_urlopen(request, timeout=None):
-            seen["url"] = request.full_url
-            seen["headers"] = dict(request.header_items())
-            seen["timeout"] = timeout
-            return response
+        resource = _HTTPResource()
 
         monkeypatch.setattr(remote_io, "coerce_to_upath", lambda resource: resource)
-        monkeypatch.setattr(remote_io, "urlopen", _fake_urlopen)
         with set_config(remote_download_block_size=2):
             local_path = tmp_path / "downloaded.bin"
-            remote_io._download_remote_file(_HTTPResource(), local_path)
+            remote_io._download_remote_file(resource, local_path)
 
         assert local_path.read_bytes() == b"abc"
-        assert seen["url"] == "http://example.com/data.bin"
-        # Nested headers are forwarded; non-header storage options are not.
-        assert seen["headers"] == {"User-agent": "dascore-test"}
-        assert seen["timeout"] == 60.0
+        assert resource.open_args == (("rb",), {"block_size": 0})
         assert response.read_sizes == [2, 2, 2]
-
-    def test_http_remote_download_uses_configured_timeout(self, monkeypatch, tmp_path):
-        """HTTP cache downloads should pass through the configured timeout."""
-
-        class _HTTPResource:
-            def __init__(self):
-                self.protocol = "http"
-                self.storage_options = {}
-
-            def __str__(self):
-                return "http://example.com/data.bin"
-
-        class _HTTPResponse:
-            def read(self, _size=-1):
-                return b""
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_args):
-                return False
-
-        seen = {}
-
-        def _fake_urlopen(request, timeout=None):
-            seen["url"] = request.full_url
-            seen["timeout"] = timeout
-            return _HTTPResponse()
-
-        monkeypatch.setattr(remote_io, "coerce_to_upath", lambda resource: resource)
-        monkeypatch.setattr(remote_io, "urlopen", _fake_urlopen)
-        with set_config(remote_download_timeout=12.5):
-            local_path = tmp_path / "downloaded.bin"
-            remote_io._download_remote_file(_HTTPResource(), local_path)
-
-        assert seen == {"url": "http://example.com/data.bin", "timeout": 12.5}
-        assert local_path.read_bytes() == b""
 
     def test_ensure_local_file_can_unwrap_io_resource_manager(self):
         """ensure_local_file should accept IOResourceManager instances."""
@@ -919,73 +864,8 @@ class TestRemoteIOFallback:
         assert not is_no_range_http_error(RuntimeError("range requests"))
 
 
-class TestHttpHeadersFromStorageOptions:
-    """Tests for translating fsspec storage options into urllib headers."""
-
-    class _Resource:
-        def __init__(self, storage_options):
-            self.storage_options = storage_options
-
-    def _expected_basic(self):
-        """Return the expected basic-auth header for user/pass 'u'/'p'."""
-        import base64
-
-        return "Basic " + base64.b64encode(b"u:p").decode()
-
-    def test_nested_headers_forwarded(self):
-        """Headers nested under the 'headers' key should be forwarded."""
-        resource = self._Resource({"headers": {"X-Tok": "abc", "X-Num": 5}})
-        out = _http_headers_from_storage_options(resource)
-        assert out == {"X-Tok": "abc", "X-Num": "5"}
-
-    def test_top_level_auth_tuple_becomes_authorization(self):
-        """A (user, pass) auth tuple should become a Basic auth header."""
-        resource = self._Resource({"auth": ("u", "p")})
-        out = _http_headers_from_storage_options(resource)
-        assert out["Authorization"] == self._expected_basic()
-
-    def test_client_kwargs_auth_becomes_authorization(self):
-        """Basic-auth-like objects in client_kwargs should be translated."""
-
-        class _BasicAuth:
-            login = "u"
-            password = "p"
-
-        resource = self._Resource({"client_kwargs": {"auth": _BasicAuth()}})
-        out = _http_headers_from_storage_options(resource)
-        assert out["Authorization"] == self._expected_basic()
-
-    def test_explicit_authorization_header_wins(self):
-        """An explicit Authorization header should not be overwritten by auth."""
-        resource = self._Resource(
-            {"headers": {"Authorization": "Bearer TOK"}, "auth": ("u", "p")}
-        )
-        out = _http_headers_from_storage_options(resource)
-        assert out["Authorization"] == "Bearer TOK"
-
-    def test_untranslatable_client_kwargs_ignored(self):
-        """Non-auth client_kwargs cannot map to urllib and are dropped."""
-        resource = self._Resource({"client_kwargs": {"trust_env": True}})
-        assert _http_headers_from_storage_options(resource) == {}
-
-    def test_string_auth_not_translated(self):
-        """A bare string auth value is not basic auth and yields no header."""
-        resource = self._Resource({"auth": "some-token"})
-        assert _http_headers_from_storage_options(resource) == {}
-
-    def test_partial_auth_object_ignored(self):
-        """An auth object missing a password yields no Authorization header."""
-
-        class _PartialAuth:
-            login = "u"
-            password = None
-
-        resource = self._Resource({"auth": _PartialAuth()})
-        assert _http_headers_from_storage_options(resource) == {}
-
-    def test_empty_storage_options(self):
-        """A resource with no storage options yields no headers."""
-        assert _http_headers_from_storage_options(self._Resource({})) == {}
+class TestFallbackFileObj:
+    """Tests for switching failed remote handles to local cache files."""
 
     def test_fallback_file_obj_switches_once_and_preserves_position(self):
         """_FallbackFileObj should retry on the local file and preserve cursor."""
@@ -999,6 +879,7 @@ class TestHttpHeadersFromStorageOptions:
         local_handles = []
 
         def _open_local():
+            assert remote.closed
             handle = BytesIO(b"abcdef")
             local_handles.append(handle)
             return handle


### PR DESCRIPTION
## Description

Use fsspec/universal-pathlib as the single transport for remote cache materialization.

The HTTP cache fallback previously opened a second `urllib` connection because materialization could begin while the failed fsspec handle was still open. This duplicated HTTP behavior and required manually translating only a subset of fsspec storage options.

This change closes the failed remote handle before materialization, then streams HTTP resources through `UPath.open(..., block_size=0)`. It removes the urllib-specific header/auth translation and the blocking-download timeout setting that only applied to that alternate stack. The existing atomic cache write and configured download chunk size remain unchanged.

Regression tests verify that HTTP materialization uses the UPath/fsspec transport and that the failed remote handle is closed before the local cache opener runs.

Validation:
- `pytest tests -m "not network" -q` — 7,735 passed
- `pytest tests -m network -q` — 100 passed
- `pytest dascore --doctest-modules -q` — 142 passed
- `pre-commit run --all-files` — passed

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote file downloading across supported HTTP and S3-compatible storage backends.
  * Enhanced fallback handling so remote connections close cleanly when switching to cached local files.
  * Removed the remote download timeout option from runtime configuration; downloads now use the underlying storage connection’s behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->