### PR TITLE
CI: test free-threaded Python build

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -55,11 +55,13 @@ jobs:
         # Defined in .github/actions/load-shared-vars/action.yml
         python-version: ${{ fromJson(needs.setup.outputs.python-matrix) }}
         free_thread: [false]
+        test_shell: ["bash -el {0}"]
         include:
           - os: ubuntu-latest
             python-version: "3.14t"
             free_thread: true
             name: free_thread
+            test_shell: "env PYTHON_GIL=0 bash --noprofile --norc -e -o pipefail {0}"
 
     # only run if CI isn't turned off
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')
@@ -134,21 +136,21 @@ jobs:
 
       - name: generate qmd docs tests
         id: generate_qmd_tests
-        shell: bash -el {0}
+        shell: ${{ matrix.test_shell }}
         run: python scripts/generate_doc_code_tests.py
 
       # Runs test suite and calculates coverage
       - name: run test suite
         id: run_test_suite
         continue-on-error: ${{ env.debug_enabled == 'true' }}
-        shell: bash -el {0}
+        shell: ${{ matrix.test_shell }}
         run: ./.github/test_code.sh
 
       # Runs examples in docstrings
       - name: test docstrings
         id: run_docstrings
         continue-on-error: ${{ env.debug_enabled == 'true' }}
-        shell: bash -el {0}
+        shell: ${{ matrix.test_shell }}
         run: ./.github/test_code.sh doctest
 
       - name: note SSH key requirement for debug access

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -55,13 +55,11 @@ jobs:
         # Defined in .github/actions/load-shared-vars/action.yml
         python-version: ${{ fromJson(needs.setup.outputs.python-matrix) }}
         free_thread: [false]
-        test_shell: ["bash -el {0}"]
         include:
           - os: ubuntu-latest
             python-version: "3.14t"
             free_thread: true
             name: free_thread
-            test_shell: "env PYTHON_GIL=0 bash --noprofile --norc -e -o pipefail {0}"
 
     # only run if CI isn't turned off
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')
@@ -136,22 +134,37 @@ jobs:
 
       - name: generate qmd docs tests
         id: generate_qmd_tests
-        shell: ${{ matrix.test_shell }}
-        run: python scripts/generate_doc_code_tests.py
+        shell: bash -el {0}
+        run: |
+          if [[ "${{ matrix.free_thread }}" == "true" ]]; then
+            export PATH="${pythonLocation}/bin:${PATH}"
+            export PYTHON_GIL=0
+          fi
+          python scripts/generate_doc_code_tests.py
 
       # Runs test suite and calculates coverage
       - name: run test suite
         id: run_test_suite
         continue-on-error: ${{ env.debug_enabled == 'true' }}
-        shell: ${{ matrix.test_shell }}
-        run: ./.github/test_code.sh
+        shell: bash -el {0}
+        run: |
+          if [[ "${{ matrix.free_thread }}" == "true" ]]; then
+            export PATH="${pythonLocation}/bin:${PATH}"
+            export PYTHON_GIL=0
+          fi
+          ./.github/test_code.sh
 
       # Runs examples in docstrings
       - name: test docstrings
         id: run_docstrings
         continue-on-error: ${{ env.debug_enabled == 'true' }}
-        shell: ${{ matrix.test_shell }}
-        run: ./.github/test_code.sh doctest
+        shell: bash -el {0}
+        run: |
+          if [[ "${{ matrix.free_thread }}" == "true" ]]; then
+            export PATH="${pythonLocation}/bin:${PATH}"
+            export PYTHON_GIL=0
+          fi
+          ./.github/test_code.sh doctest
 
       - name: note SSH key requirement for debug access
         if: env.debug_enabled == 'true' && (steps.run_test_suite.outcome == 'failure' || steps.run_docstrings.outcome == 'failure')

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -43,15 +43,23 @@ jobs:
         id: load-vars
 
   test_code:
+    name: ${{ matrix.name || format('test_code ({0}, Python {1})', matrix.os, matrix.python-version) }}
     needs: setup
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # Defined in .github/actions/load-shared-vars/action.yml
         os: ${{ fromJson(needs.setup.outputs.os-matrix) }}
         # Defined in .github/actions/load-shared-vars/action.yml
         python-version: ${{ fromJson(needs.setup.outputs.python-matrix) }}
+        free_thread: [false]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.14t"
+            free_thread: true
+            name: free_thread
 
     # only run if CI isn't turned off
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')
@@ -69,10 +77,60 @@ jobs:
           fetch-depth: '0'
 
       - uses: ./.github/actions/mamba-install-dascore
+        if: ${{ !matrix.free_thread }}
         with:
           python-version: ${{ matrix.python-version }}
           cache-number: ${{ env.CACHE_NUMBER }}
           prepare-test-data: "true"
+
+      - name: set up free-threaded Python
+        if: matrix.free_thread
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: install free-threaded test dependencies
+        if: matrix.free_thread
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test,docs]" findiff
+
+      - name: verify free-threaded runtime
+        if: matrix.free_thread
+        shell: bash
+        run: |
+          python -c 'import dascore, sys, sysconfig; assert sysconfig.get_config_var("Py_GIL_DISABLED") == 1; assert not sys._is_gil_enabled()'
+
+      - name: export free-threaded test data cache env
+        if: matrix.free_thread
+        shell: bash
+        env:
+          INPUT_CACHE_NUMBER: ${{ env.CACHE_NUMBER }}
+          RUNNER_OS: ${{ runner.os }}
+        run: python .github/scripts/export_test_data_cache_env.py >> "$GITHUB_ENV"
+
+      - name: restore free-threaded test data cache
+        if: matrix.free_thread
+        id: restore-free-thread-test-data
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.DATA_CACHE_PATH }}
+          key: ${{ env.DATA_CACHE_KEY }}
+
+      - name: prime free-threaded test data cache
+        if: matrix.free_thread && steps.restore-free-thread-test-data.outputs.cache-hit != 'true'
+        shell: bash
+        run: python .github/scripts/cache_test_data.py
+
+      - name: save free-threaded test data cache
+        if: matrix.free_thread && steps.restore-free-thread-test-data.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.DATA_CACHE_PATH }}
+          key: ${{ env.DATA_CACHE_KEY }}
 
       - name: generate qmd docs tests
         id: generate_qmd_tests


### PR DESCRIPTION
## Description

Add a gating Ubuntu CPython 3.14 free-threaded build to the main test matrix under the display name `free_thread`.

- Select the official `3.14t` interpreter with `actions/setup-python`.
- Install DASCore's core, test, and documentation dependencies from free-threaded wheels.
- Assert after importing DASCore that the interpreter was built with `Py_GIL_DISABLED=1` and the GIL remains disabled.
- Reuse the existing test-data cache and the normal qmd, test-suite, doctest, and coverage steps.
- Disable matrix fail-fast so a failure in this newer runtime does not cancel conventional Python coverage.

The free-threaded row intentionally does not install `dascore[extras]`: the current `pymseed -> orjson` dependency chain rejects free-threaded Python. Optional integration tests therefore skip normally while the supported DASCore core runs as a required job.

## Testing

- Python 3.14.6 free-threading runtime assertion: passed.
- Full non-network suite with generated qmd tests: 7,724 passed, 232 skipped, 100 deselected, 2 xfailed.
- Module doctests: 142 passed.
- `pre-commit run --all` twice: passed, including actionlint.
- Claude CLI ultrareview: one finding addressed by disabling matrix fail-fast.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded the automated test matrix to include free-threaded Python 3.14.
  * Added runtime checks to verify the free-threaded runs are executing with the GIL disabled.
  * Adjusted dependency installation and introduced free-threaded-specific test-data caching to improve reliability and speed.
  * Ensured documentation-related tests, unit tests, and doctests run under the appropriate shell/environment for each configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->