### PR TITLE
Add PRODML write support

### DIFF
--- a/dascore/io/prodml/__init__.py
+++ b/dascore/io/prodml/__init__.py
@@ -1,5 +1,8 @@
-"""
-Support for prodML format.
+"""Support for the PRODML format.
+
+``dc.write`` supports one raw time-by-distance patch as a standalone PRODML
+2.1-compatible HDF5 file. Full PRODML 2.3 conformance requires EPC/XML, which
+DASCore does not write.
 
 More info about ProdML can be found here:
 https://www.energistics.org/prodml-developers-users

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -92,6 +92,6 @@ class ProdMLV2_1(ProdMLV2_0):  # noqa
 
     version = "2.1"
 
-    def write(self, spool: SpoolType, resource: H5Writer) -> None:
+    def write(self, spool: SpoolType, resource: H5Writer, **kwargs) -> None:
         """Write one raw Patch to a standalone ProdML HDF5 file."""
         _write_prodml(spool, resource)

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import numpy as np
 
 import dascore as dc
-from dascore.constants import opt_timeable_types
+from dascore.constants import SpoolType, opt_timeable_types
 from dascore.io import FiberIO, ScanPayload
 from dascore.utils.models import UnitQuantity, UTF8Str
 
-from ...utils.hdf5 import H5Reader
-from .utils import _get_prodml_version_str, _read_prodml, _yield_prodml_attrs_coords
+from ...utils.hdf5 import H5Reader, H5Writer
+from .utils import (
+    _get_prodml_version_str,
+    _read_prodml,
+    _write_prodml,
+    _yield_prodml_attrs_coords,
+)
 
 
 class ProdMLPatchAttrs(dc.PatchAttrs):
@@ -86,3 +91,7 @@ class ProdMLV2_1(ProdMLV2_0):  # noqa
     """Support for ProdML V 2.1."""
 
     version = "2.1"
+
+    def write(self, spool: SpoolType, resource: H5Writer) -> None:
+        """Write one raw Patch to a standalone ProdML HDF5 file."""
+        _write_prodml(spool, resource)

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterator
 from dataclasses import dataclass
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import h5py
 import numpy as np
@@ -44,6 +44,8 @@ _ROOT_ATTRS = {
     "GaugeLengthUnits": "gauge_length_units",
     "GaugeLength.uom": "gauge_length_units",
     "AcquisitionId": "acquisition_id",
+    "FacilityId": "facility_id",
+    "ServiceCompanyName": "service_company_name",
     "schemaVersion": "schema_version",
 }
 
@@ -115,6 +117,15 @@ def _get_prodml_version_str(hdf_fi) -> str:
     # in some prodml schemaVersion is str, in other float; this handles both.
     version_str = str(unbyte(attrs["schemaVersion"]))
     return version_str
+
+
+def _get_root_attrs(attrs):
+    """Return normalized attributes from an Acquisition group."""
+    out = maybe_get_items(attrs, _ROOT_ATTRS)
+    if "facility_id" in out:
+        values = tuple(unbyte(x) for x in np.atleast_1d(out["facility_id"]))
+        out["facility_id"] = values[0] if len(values) == 1 else values
+    return out
 
 
 def _get_distance_coord(acq):
@@ -357,23 +368,22 @@ def _prepare_prodml_write(spool):
     )
     attrs = patch.attrs
     acquisition_id = str(attrs.acquisition_id or uuid4())
-    try:
-        acquisition_id = str(UUID(acquisition_id))
-    except (ValueError, TypeError, AttributeError) as exc:
-        raise PatchError("ProdML acquisition_id must be a valid UUID.") from exc
 
     facility = attrs.get("facility_id") or attrs.station or "UNKNOWN"
     service_company = attrs.get("service_company_name") or "UNKNOWN"
     data_units = get_quantity_str(attrs.data_units) or "UNKNOWN"
-    string_values = (facility, service_company, data_units)
-    if not all(isinstance(x, str) and 0 < len(x) <= 64 for x in string_values):
-        msg = "ProdML facility, service company, and data unit must be String64 values."
-        raise PatchError(msg)
+    string_values = {
+        "FacilityId": facility,
+        "ServiceCompanyName": service_company,
+        "RawDataUnit": data_units,
+    }
+    for name, value in string_values.items():
+        if not isinstance(value, str) or not 0 < len(value.encode("utf-8")) <= 64:
+            msg = f"ProdML {name} must contain 1 to 64 UTF-8 bytes (String64)."
+            raise PatchError(msg)
 
     start_time, end_time = _iso_time(times[0]), _iso_time(times[-1])
     output_rate = 1_000_000.0 / time_step_us
-    pulse_rate = _get_measure(attrs, "pulse_rate", "pulse_rate_units", "Hz")
-    pulse_rate = pulse_rate or (output_rate, "Hz")
     num_loci = len(patch.get_coord("distance"))
     file_uuid, acquisition_uuid, raw_uuid = (str(uuid4()) for _ in range(3))
     acquisition_attrs = {
@@ -385,8 +395,6 @@ def _prepare_prodml_write(spool):
         "MinimumFrequency": 0.0,
         "MinimumFrequency.uom": _fixed_string("Hz"),
         "NumberOfLoci": num_loci,
-        "PulseRate": pulse_rate[0],
-        "PulseRate.uom": _fixed_string(pulse_rate[1]),
         "ServiceCompanyName": _fixed_string(service_company),
         "SpatialSamplingInterval": distance_step,
         "SpatialSamplingInterval.uom": _fixed_string(distance_units),
@@ -396,6 +404,7 @@ def _prepare_prodml_write(spool):
         "uuid": _fixed_string(acquisition_uuid),
     }
     for name, units_name, target, hdf_name in (
+        ("pulse_rate", "pulse_rate_units", "Hz", "PulseRate"),
         ("pulse_width", "pulse_width_units", "s", "PulseWidth"),
         ("gauge_length", "gauge_length_units", "m", "GaugeLength"),
     ):
@@ -525,7 +534,7 @@ def _yield_prodml_attrs_coords(
     """Scan a prodML file, return metadata."""
     acq = fi["Acquisition"]
     # Get the information common to all from root attributes.
-    base_info = maybe_get_items(acq.attrs, _ROOT_ATTRS)
+    base_info = _get_root_attrs(acq.attrs)
     base_info.update(extras if extras is not None else {})
     d_coord = _get_distance_coord(acq)
     # Iterate the raw and processed data and return results in a list.
@@ -558,7 +567,7 @@ def _read_prodml(fi, distance=None, time=None, source_patch_id=None):
     """Read the prodml values into a patch."""
     out = []
     acq = fi["Acquisition"]
-    base_info = maybe_get_items(acq.attrs, _ROOT_ATTRS)
+    base_info = _get_root_attrs(acq.attrs)
     d_coord = _get_distance_coord(acq)
     source_patch_ids = _normalize_source_patch_ids(source_patch_id)
     for info in _yield_data_nodes(fi):

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterator
 from dataclasses import dataclass
+from uuid import UUID, uuid4
 
 import h5py
 import numpy as np
@@ -11,7 +13,9 @@ import numpy as np
 import dascore as dc
 from dascore.constants import VALID_DATA_TYPES
 from dascore.core.coords import get_coord
+from dascore.exceptions import InvalidSpoolError, PatchError, UnitError
 from dascore.io.utils import get_exact_coord
+from dascore.units import convert_units, get_quantity_str
 from dascore.utils.io import _normalize_source_patch_ids
 from dascore.utils.misc import iterate, maybe_get_items, register_func, unbyte
 from dascore.utils.models import UnitQuantity, UTF8Str
@@ -19,9 +23,9 @@ from dascore.utils.models import UnitQuantity, UTF8Str
 # --- Getting format/version
 
 _EXPECTED_ATTRS = (
-    "PulseRate",
-    "PulseWidth",
     "NumberOfLoci",
+    "SpatialSamplingInterval",
+    "StartLocusIndex",
     "schemaVersion",
     "uuid",
 )
@@ -39,6 +43,7 @@ _ROOT_ATTRS = {
     "GaugeLengthUnit": "gauge_length_units",
     "GaugeLengthUnits": "gauge_length_units",
     "GaugeLength.uom": "gauge_length_units",
+    "AcquisitionId": "acquisition_id",
     "schemaVersion": "schema_version",
 }
 
@@ -105,9 +110,11 @@ def _get_prodml_version_str(hdf_fi) -> str:
         return ""
     attrs = acquisition.attrs
     is_prodml = set(_EXPECTED_ATTRS).issubset(set(attrs))
+    if not is_prodml:
+        return ""
     # in some prodml schemaVersion is str, in other float; this handles both.
     version_str = str(unbyte(attrs["schemaVersion"]))
-    return version_str if is_prodml else ""
+    return version_str
 
 
 def _get_distance_coord(acq):
@@ -216,10 +223,242 @@ def _get_data_unit_and_type(node):
         "FbeDataUnit": "data_units",
     }
     out = maybe_get_items(attrs, attr_map)
+    if str(out.get("data_units", "")).upper() == "UNKNOWN":
+        out.pop("data_units")
     if (data_type := out.get("data_type")) is not None:
         clean = data_type.lower().replace(" ", "_")
         out["data_type"] = clean if clean in VALID_DATA_TYPES else ""
     return out
+
+
+# --- Writing ProdML files.
+
+
+def _fixed_string(value):
+    """Return a fixed-length HDF5 byte string."""
+    return np.bytes_(str(value).encode())
+
+
+def _fixed_strings(values):
+    """Return an array of fixed-length HDF5 byte strings."""
+    encoded = [str(value).encode() for value in values]
+    return np.asarray(encoded, dtype=f"S{max(map(len, encoded))}")
+
+
+def _get_single_patch(spool):
+    """Return the only Patch in a writable spool."""
+    patches = [spool] if isinstance(spool, dc.Patch) else list(spool)
+    if len(patches) != 1 or not isinstance(patches[0], dc.Patch):
+        msg = "ProdML writing requires exactly one Patch."
+        raise InvalidSpoolError(msg)
+    return patches[0]
+
+
+def _round_times_to_microseconds(coord):
+    """Round absolute timestamps to nearest microsecond using integer math."""
+    values = np.asarray(coord.values)
+    if not np.issubdtype(values.dtype, np.datetime64) or len(values) < 2:
+        msg = "ProdML writing requires at least two absolute time samples."
+        raise PatchError(msg)
+    if np.any(np.isnat(values)):
+        raise PatchError("ProdML time coordinates cannot contain NaT.")
+    nanoseconds = values.astype("datetime64[ns]").astype(np.int64)
+    quotient, remainder = np.divmod(nanoseconds, 1_000)
+    increment = np.where(nanoseconds >= 0, remainder >= 500, remainder > 500)
+    microseconds = quotient + increment
+    diffs = np.diff(microseconds)
+    if np.any(diffs <= 0) or not np.all(diffs == diffs[0]):
+        msg = (
+            "ProdML time coordinates must remain increasing and evenly sampled "
+            "after microsecond rounding."
+        )
+        raise PatchError(msg)
+    if np.any(remainder):
+        msg = "ProdML timestamps were rounded to microseconds; precision was lost."
+        warnings.warn(msg, UserWarning, stacklevel=3)
+    return microseconds.astype(np.int64), int(diffs[0])
+
+
+def _get_distance_info(coord):
+    """Validate a distance coordinate and return its ProdML sampling values."""
+    values = np.asarray(coord.values)
+    if not len(values) or values.dtype.kind not in "iuf":
+        msg = "ProdML writing requires a nonempty numeric distance coordinate."
+        raise PatchError(msg)
+    values = values.astype(np.float64)
+    if not np.all(np.isfinite(values)):
+        raise PatchError("ProdML distance coordinates must be finite.")
+    diffs = np.diff(values)
+    step = coord.step
+    if step is None:
+        step = diffs[0] if len(diffs) else np.nan
+    step = float(step)
+    tolerance = np.finfo(float).eps * max(1.0, float(np.max(np.abs(values)))) * 10
+    if (
+        not np.isfinite(step)
+        or step <= 0
+        or not np.allclose(diffs, step, rtol=1e-9, atol=tolerance)
+    ):
+        msg = "ProdML distance coordinates must be increasing and evenly sampled."
+        raise PatchError(msg)
+    units = coord.unit_str
+    if not units:
+        raise PatchError("ProdML distance coordinates require length units.")
+    try:
+        convert_units(1.0, to_units="m", from_units=units)
+    except UnitError as exc:
+        msg = "ProdML distance coordinate units must represent length."
+        raise PatchError(msg) from exc
+    ratio = float(values[0] / step)
+    start_locus = int(np.round(ratio))
+    integer_tolerance = max(1e-9, abs(float(np.spacing(ratio))) * 4)
+    if not np.isclose(ratio, start_locus, rtol=0, atol=integer_tolerance):
+        msg = "ProdML requires distance_start / distance_step to be an integer."
+        raise PatchError(msg)
+    return step, units, start_locus
+
+
+def _get_measure(attrs, name, units_name, target_units):
+    """Return a complete positive measure, or None when it is unusable."""
+    value = attrs.get(name)
+    units = get_quantity_str(attrs.get(units_name))
+    try:
+        value = float(value)
+        if not units or not np.isfinite(value) or value <= 0:
+            return None
+        convert_units(value, to_units=target_units, from_units=units)
+    except (TypeError, ValueError, UnitError):
+        return None
+    return value, units
+
+
+def _iso_time(microseconds):
+    """Return an ISO-8601 UTC timestamp with microsecond precision."""
+    value = np.datetime64(int(microseconds), "us")
+    return _fixed_string(f"{np.datetime_as_string(value, unit='us')}+00:00")
+
+
+def _prepare_prodml_write(spool):
+    """Validate input and prepare all values needed to write ProdML."""
+    patch = _get_single_patch(spool)
+    if patch.data.ndim != 2 or set(patch.dims) != {"time", "distance"}:
+        msg = "ProdML writing requires a 2D Patch with time and distance dimensions."
+        raise PatchError(msg)
+    data = np.asarray(patch.data)
+    valid_dtype = data.dtype.kind in "iuf" and data.dtype.itemsize in {1, 2, 4, 8}
+    valid_dtype &= data.dtype.kind != "f" or data.dtype.itemsize in {4, 8}
+    if not data.size or not valid_dtype:
+        msg = "ProdML writing supports nonempty standard integer or float dtypes."
+        raise PatchError(msg)
+
+    times, time_step_us = _round_times_to_microseconds(patch.get_coord("time"))
+    distance_step, distance_units, start_locus = _get_distance_info(
+        patch.get_coord("distance")
+    )
+    attrs = patch.attrs
+    acquisition_id = str(attrs.acquisition_id or uuid4())
+    try:
+        acquisition_id = str(UUID(acquisition_id))
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise PatchError("ProdML acquisition_id must be a valid UUID.") from exc
+
+    facility = attrs.get("facility_id") or attrs.station or "UNKNOWN"
+    service_company = attrs.get("service_company_name") or "UNKNOWN"
+    data_units = get_quantity_str(attrs.data_units) or "UNKNOWN"
+    string_values = (facility, service_company, data_units)
+    if not all(isinstance(x, str) and 0 < len(x) <= 64 for x in string_values):
+        msg = "ProdML facility, service company, and data unit must be String64 values."
+        raise PatchError(msg)
+
+    start_time, end_time = _iso_time(times[0]), _iso_time(times[-1])
+    output_rate = 1_000_000.0 / time_step_us
+    pulse_rate = _get_measure(attrs, "pulse_rate", "pulse_rate_units", "Hz")
+    pulse_rate = pulse_rate or (output_rate, "Hz")
+    num_loci = len(patch.get_coord("distance"))
+    file_uuid, acquisition_uuid, raw_uuid = (str(uuid4()) for _ in range(3))
+    acquisition_attrs = {
+        "AcquisitionId": _fixed_string(acquisition_id),
+        "FacilityId": _fixed_strings([facility]),
+        "MaximumFrequency": output_rate / 2,
+        "MaximumFrequency.uom": _fixed_string("Hz"),
+        "MeasurementStartTime": start_time,
+        "MinimumFrequency": 0.0,
+        "MinimumFrequency.uom": _fixed_string("Hz"),
+        "NumberOfLoci": num_loci,
+        "PulseRate": pulse_rate[0],
+        "PulseRate.uom": _fixed_string(pulse_rate[1]),
+        "ServiceCompanyName": _fixed_string(service_company),
+        "SpatialSamplingInterval": distance_step,
+        "SpatialSamplingInterval.uom": _fixed_string(distance_units),
+        "StartLocusIndex": start_locus,
+        "TriggeredMeasurement": False,
+        "schemaVersion": _fixed_string("2.1"),
+        "uuid": _fixed_string(acquisition_uuid),
+    }
+    for name, units_name, target, hdf_name in (
+        ("pulse_width", "pulse_width_units", "s", "PulseWidth"),
+        ("gauge_length", "gauge_length_units", "m", "GaugeLength"),
+    ):
+        if measure := _get_measure(attrs, name, units_name, target):
+            acquisition_attrs[hdf_name] = measure[0]
+            acquisition_attrs[f"{hdf_name}.uom"] = _fixed_string(measure[1])
+
+    raw_attrs = {
+        "NumberOfLoci": num_loci,
+        "OutputDataRate": output_rate,
+        "OutputDataRate.uom": _fixed_string("Hz"),
+        "RawDataUnit": _fixed_string(data_units),
+        "StartLocusIndex": start_locus,
+        "uuid": _fixed_string(raw_uuid),
+    }
+    if attrs.data_type:
+        raw_attrs["RawDescription"] = _fixed_string(attrs.data_type)
+    data_attrs = {
+        "Count": data.size,
+        "Dimensions": _fixed_strings(
+            ["locus" if dim == "distance" else dim for dim in patch.dims]
+        ),
+        "PartEndTime": end_time,
+        "PartStartTime": start_time,
+        "StartIndex": 0,
+    }
+    time_attrs = {
+        "Count": len(times),
+        "EndTime": end_time,
+        "PartEndTime": end_time,
+        "PartStartTime": start_time,
+        "StartIndex": 0,
+        "StartTime": start_time,
+        "Uom": _fixed_string("us"),
+    }
+    return (
+        data,
+        times,
+        _fixed_string(file_uuid),
+        acquisition_attrs,
+        raw_attrs,
+        data_attrs,
+        time_attrs,
+    )
+
+
+def _write_prodml(spool, resource):
+    """Write one raw Patch to a standalone ProdML 2.1 HDF5 file."""
+    prepared = _prepare_prodml_write(spool)
+    data, times, file_uuid, acq_attrs, raw_attrs, data_attrs, time_attrs = prepared
+    h5_file = getattr(resource, "_handle", resource)
+    for key in list(h5_file):
+        del h5_file[key]
+    h5_file.attrs.clear()
+    h5_file.attrs["uuid"] = file_uuid
+    acquisition = h5_file.create_group("Acquisition")
+    acquisition.attrs.update(acq_attrs)
+    raw = acquisition.create_group("Raw[0]")
+    raw.attrs.update(raw_attrs)
+    raw_data = raw.create_dataset("RawData", data=data)
+    raw_data.attrs.update(data_attrs)
+    raw_time = raw.create_dataset("RawDataTime", data=times)
+    raw_time.attrs.update(time_attrs)
 
 
 @register_func(_NODE_ATTRS_PROCESSORS, key="raw")

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -352,21 +352,21 @@ def _get_acquisition_attrs(
 ):
     """Return attributes for the Acquisition group."""
     out = {
-        "AcquisitionId": encode_h5_strings(strings["AcquisitionId"]),
-        "FacilityId": encode_h5_strings([strings["FacilityId"]]),
+        "AcquisitionId": encode_h5_strings(strings["AcquisitionId"])[0],
+        "FacilityId": encode_h5_strings(strings["FacilityId"]),
         "MaximumFrequency": output_rate / 2,
-        "MaximumFrequency.uom": encode_h5_strings("Hz"),
+        "MaximumFrequency.uom": encode_h5_strings("Hz")[0],
         "MeasurementStartTime": start_time,
         "MinimumFrequency": 0.0,
-        "MinimumFrequency.uom": encode_h5_strings("Hz"),
+        "MinimumFrequency.uom": encode_h5_strings("Hz")[0],
         "NumberOfLoci": num_loci,
-        "ServiceCompanyName": encode_h5_strings(strings["ServiceCompanyName"]),
+        "ServiceCompanyName": encode_h5_strings(strings["ServiceCompanyName"])[0],
         "SpatialSamplingInterval": distance_step,
-        "SpatialSamplingInterval.uom": encode_h5_strings("m"),
+        "SpatialSamplingInterval.uom": encode_h5_strings("m")[0],
         "StartLocusIndex": start_locus,
         "TriggeredMeasurement": False,
-        "schemaVersion": encode_h5_strings("2.1"),
-        "uuid": encode_h5_strings(str(uuid4())),
+        "schemaVersion": encode_h5_strings("2.1")[0],
+        "uuid": encode_h5_strings(str(uuid4()))[0],
     }
     for name, units_name, target, hdf_name in (
         ("pulse_rate", "pulse_rate_units", "Hz", "PulseRate"),
@@ -375,7 +375,7 @@ def _get_acquisition_attrs(
     ):
         if measure := _get_measure(attrs, name, units_name, target):
             out[hdf_name] = measure[0]
-            out[f"{hdf_name}.uom"] = encode_h5_strings(measure[1])
+            out[f"{hdf_name}.uom"] = encode_h5_strings(measure[1])[0]
     return out
 
 
@@ -387,13 +387,13 @@ def _get_array_attrs(
     raw_attrs = {
         "NumberOfLoci": num_loci,
         "OutputDataRate": output_rate,
-        "OutputDataRate.uom": encode_h5_strings("Hz"),
-        "RawDataUnit": encode_h5_strings(strings["RawDataUnit"]),
+        "OutputDataRate.uom": encode_h5_strings("Hz")[0],
+        "RawDataUnit": encode_h5_strings(strings["RawDataUnit"])[0],
         "StartLocusIndex": start_locus,
-        "uuid": encode_h5_strings(str(uuid4())),
+        "uuid": encode_h5_strings(str(uuid4()))[0],
     }
     if patch.attrs.data_type:
-        raw_attrs["RawDescription"] = encode_h5_strings(patch.attrs.data_type)
+        raw_attrs["RawDescription"] = encode_h5_strings(patch.attrs.data_type)[0]
     data_attrs = {
         "Count": patch.data.size,
         "Dimensions": encode_h5_strings(
@@ -410,7 +410,7 @@ def _get_array_attrs(
         "PartStartTime": start_time,
         "StartIndex": 0,
         "StartTime": start_time,
-        "Uom": encode_h5_strings("us"),
+        "Uom": encode_h5_strings("us")[0],
     }
     return raw_attrs, data_attrs, time_attrs
 
@@ -423,7 +423,7 @@ def _prepare_prodml_write(spool):
     distance_step, start_locus = _get_distance_info(patch.get_coord("distance"))
     strings = _get_write_metadata(patch.attrs)
     start_time, end_time = (
-        encode_h5_strings(f"{np.datetime64(int(value), 'us')}+00:00")
+        encode_h5_strings(f"{np.datetime64(int(value), 'us')}+00:00")[0]
         for value in (times[0], times[-1])
     )
     output_rate = 1_000_000.0 / time_step_us
@@ -443,7 +443,7 @@ def _prepare_prodml_write(spool):
     return (
         data,
         times,
-        encode_h5_strings(str(uuid4())),
+        encode_h5_strings(str(uuid4()))[0],
         acquisition_attrs,
         raw_attrs,
         data_attrs,

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -321,8 +321,8 @@ def _get_distance_info(coord):
 def _get_measure(attrs, name, units_name, target_units):
     """Return a complete positive measure, or None when it is unusable."""
     value = attrs.get(name)
-    units = get_quantity_str(attrs.get(units_name))
     try:
+        units = get_quantity_str(attrs.get(units_name))
         value = float(value)
         if not units or not np.isfinite(value) or value <= 0:
             return None

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -273,10 +273,22 @@ def _round_times_to_microseconds(coord):
         raise PatchError(msg)
     if np.any(np.isnat(values)):
         raise PatchError("ProdML time coordinates cannot contain NaT.")
-    nanoseconds = values.astype("datetime64[ns]").astype(np.int64)
-    quotient, remainder = np.divmod(nanoseconds, 1_000)
-    increment = np.where(nanoseconds >= 0, remainder >= 500, remainder > 500)
-    microseconds = quotient + increment
+    microsecond_values = values.astype("datetime64[us]")
+    if np.array_equal(microsecond_values.astype(values.dtype), values):
+        microseconds = microsecond_values.astype(np.int64)
+        remainder = np.zeros_like(microseconds)
+    else:
+        nanosecond_values = values.astype("datetime64[ns]")
+        if not np.array_equal(nanosecond_values.astype(values.dtype), values):
+            msg = (
+                "ProdML time coordinates must fit the microsecond range or have "
+                "nanosecond precision."
+            )
+            raise PatchError(msg)
+        nanoseconds = nanosecond_values.astype(np.int64)
+        quotient, remainder = np.divmod(nanoseconds, 1_000)
+        increment = np.where(nanoseconds >= 0, remainder >= 500, remainder > 500)
+        microseconds = quotient + increment
     diffs = np.diff(microseconds)
     if np.any(diffs <= 0) or not np.all(diffs == diffs[0]):
         msg = (

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -16,6 +16,7 @@ from dascore.core.coords import get_coord
 from dascore.exceptions import InvalidSpoolError, PatchError, UnitError
 from dascore.io.utils import get_exact_coord
 from dascore.units import convert_units, get_quantity_str
+from dascore.utils.hdf5 import encode_h5_strings
 from dascore.utils.io import _normalize_source_patch_ids
 from dascore.utils.misc import iterate, maybe_get_items, register_func, unbyte
 from dascore.utils.models import UnitQuantity, UTF8Str
@@ -245,24 +246,27 @@ def _get_data_unit_and_type(node):
 # --- Writing ProdML files.
 
 
-def _fixed_string(value):
-    """Return a fixed-length HDF5 byte string."""
-    return np.bytes_(str(value).encode())
-
-
-def _fixed_strings(values):
-    """Return an array of fixed-length HDF5 byte strings."""
-    encoded = [str(value).encode() for value in values]
-    return np.asarray(encoded, dtype=f"S{max(map(len, encoded))}")
-
-
 def _get_single_patch(spool):
-    """Return the only Patch in a writable spool."""
+    """Return the only Patch after validating its writable structure."""
     patches = [spool] if isinstance(spool, dc.Patch) else list(spool)
     if len(patches) != 1 or not isinstance(patches[0], dc.Patch):
         msg = "ProdML writing requires exactly one Patch."
         raise InvalidSpoolError(msg)
-    return patches[0]
+    patch = patches[0]
+    if patch.data.ndim != 2 or set(patch.dims) != {"time", "distance"}:
+        msg = "ProdML writing requires a 2D Patch with time and distance dimensions."
+        raise PatchError(msg)
+    data = np.asarray(patch.data)
+    valid_dtype = data.dtype.kind in "iuf" and data.dtype.itemsize in {1, 2, 4, 8}
+    valid_dtype &= data.dtype.kind != "f" or data.dtype.itemsize in {4, 8}
+    if not data.size or not valid_dtype:
+        msg = "ProdML writing supports nonempty standard integer or float dtypes."
+        raise PatchError(msg)
+    for name in ("time", "distance"):
+        coord = patch.get_coord(name, require_sorted=True, require_evenly_sampled=True)
+        if not coord.sorted:
+            raise PatchError(f"ProdML {name} coordinates must be increasing.")
+    return patch
 
 
 def _round_times_to_microseconds(coord):
@@ -303,42 +307,14 @@ def _round_times_to_microseconds(coord):
 
 
 def _get_distance_info(coord):
-    """Validate a distance coordinate and return its ProdML sampling values."""
-    values = np.asarray(coord.values)
-    if not len(values) or values.dtype.kind not in "iuf":
-        msg = "ProdML writing requires a nonempty numeric distance coordinate."
+    """Return metre sampling values after checking locus-grid alignment."""
+    coord = coord.convert_units("m")
+    start, step = float(coord.min()), float(coord.step)
+    start_locus = round(start / step)
+    if not np.isclose(start, start_locus * step, rtol=0, atol=1e-9):
+        msg = "ProdML distance start must align with its sampling grid."
         raise PatchError(msg)
-    values = values.astype(np.float64)
-    if not np.all(np.isfinite(values)):
-        raise PatchError("ProdML distance coordinates must be finite.")
-    diffs = np.diff(values)
-    step = coord.step
-    if step is None:
-        step = diffs[0] if len(diffs) else np.nan
-    step = float(step)
-    tolerance = np.finfo(float).eps * max(1.0, float(np.max(np.abs(values)))) * 10
-    if (
-        not np.isfinite(step)
-        or step <= 0
-        or not np.allclose(diffs, step, rtol=1e-9, atol=tolerance)
-    ):
-        msg = "ProdML distance coordinates must be increasing and evenly sampled."
-        raise PatchError(msg)
-    units = coord.unit_str
-    if not units:
-        raise PatchError("ProdML distance coordinates require length units.")
-    try:
-        convert_units(1.0, to_units="m", from_units=units)
-    except UnitError as exc:
-        msg = "ProdML distance coordinate units must represent length."
-        raise PatchError(msg) from exc
-    ratio = float(values[0] / step)
-    start_locus = int(np.round(ratio))
-    integer_tolerance = max(1e-9, abs(float(np.spacing(ratio))) * 4)
-    if not np.isclose(ratio, start_locus, rtol=0, atol=integer_tolerance):
-        msg = "ProdML requires distance_start / distance_step to be an integer."
-        raise PatchError(msg)
-    return step, units, start_locus
+    return step, start_locus
 
 
 def _get_measure(attrs, name, units_name, target_units):
@@ -355,65 +331,42 @@ def _get_measure(attrs, name, units_name, target_units):
     return value, units
 
 
-def _iso_time(microseconds):
-    """Return an ISO-8601 UTC timestamp with microsecond precision."""
-    value = np.datetime64(int(microseconds), "us")
-    return _fixed_string(f"{np.datetime_as_string(value, unit='us')}+00:00")
-
-
-def _prepare_prodml_write(spool):
-    """Validate input and prepare all values needed to write ProdML."""
-    patch = _get_single_patch(spool)
-    if patch.data.ndim != 2 or set(patch.dims) != {"time", "distance"}:
-        msg = "ProdML writing requires a 2D Patch with time and distance dimensions."
-        raise PatchError(msg)
-    data = np.asarray(patch.data)
-    valid_dtype = data.dtype.kind in "iuf" and data.dtype.itemsize in {1, 2, 4, 8}
-    valid_dtype &= data.dtype.kind != "f" or data.dtype.itemsize in {4, 8}
-    if not data.size or not valid_dtype:
-        msg = "ProdML writing supports nonempty standard integer or float dtypes."
-        raise PatchError(msg)
-
-    times, time_step_us = _round_times_to_microseconds(patch.get_coord("time"))
-    distance_step, distance_units, start_locus = _get_distance_info(
-        patch.get_coord("distance")
-    )
-    attrs = patch.attrs
-    acquisition_id = str(attrs.acquisition_id or uuid4())
-
-    facility = attrs.get("facility_id") or attrs.station or "UNKNOWN"
-    service_company = attrs.get("service_company_name") or "UNKNOWN"
-    data_units = get_quantity_str(attrs.data_units) or "UNKNOWN"
-    string_values = {
-        "FacilityId": facility,
-        "ServiceCompanyName": service_company,
-        "RawDataUnit": data_units,
+def _get_write_metadata(attrs):
+    """Return normalized and validated metadata strings for writing."""
+    out = {
+        "AcquisitionId": str(attrs.acquisition_id or uuid4()),
+        "FacilityId": attrs.get("facility_id") or attrs.station or "UNKNOWN",
+        "ServiceCompanyName": attrs.get("service_company_name") or "UNKNOWN",
+        "RawDataUnit": get_quantity_str(attrs.data_units) or "UNKNOWN",
     }
-    for name, value in string_values.items():
+    for name in ("FacilityId", "ServiceCompanyName", "RawDataUnit"):
+        value = out[name]
         if not isinstance(value, str) or not 0 < len(value.encode("utf-8")) <= 64:
             msg = f"ProdML {name} must contain 1 to 64 UTF-8 bytes (String64)."
             raise PatchError(msg)
+    return out
 
-    start_time, end_time = _iso_time(times[0]), _iso_time(times[-1])
-    output_rate = 1_000_000.0 / time_step_us
-    num_loci = len(patch.get_coord("distance"))
-    file_uuid, acquisition_uuid, raw_uuid = (str(uuid4()) for _ in range(3))
-    acquisition_attrs = {
-        "AcquisitionId": _fixed_string(acquisition_id),
-        "FacilityId": _fixed_strings([facility]),
+
+def _get_acquisition_attrs(
+    attrs, strings, start_time, output_rate, distance_step, start_locus, num_loci
+):
+    """Return attributes for the Acquisition group."""
+    out = {
+        "AcquisitionId": encode_h5_strings(strings["AcquisitionId"]),
+        "FacilityId": encode_h5_strings([strings["FacilityId"]]),
         "MaximumFrequency": output_rate / 2,
-        "MaximumFrequency.uom": _fixed_string("Hz"),
+        "MaximumFrequency.uom": encode_h5_strings("Hz"),
         "MeasurementStartTime": start_time,
         "MinimumFrequency": 0.0,
-        "MinimumFrequency.uom": _fixed_string("Hz"),
+        "MinimumFrequency.uom": encode_h5_strings("Hz"),
         "NumberOfLoci": num_loci,
-        "ServiceCompanyName": _fixed_string(service_company),
+        "ServiceCompanyName": encode_h5_strings(strings["ServiceCompanyName"]),
         "SpatialSamplingInterval": distance_step,
-        "SpatialSamplingInterval.uom": _fixed_string(distance_units),
+        "SpatialSamplingInterval.uom": encode_h5_strings("m"),
         "StartLocusIndex": start_locus,
         "TriggeredMeasurement": False,
-        "schemaVersion": _fixed_string("2.1"),
-        "uuid": _fixed_string(acquisition_uuid),
+        "schemaVersion": encode_h5_strings("2.1"),
+        "uuid": encode_h5_strings(str(uuid4())),
     }
     for name, units_name, target, hdf_name in (
         ("pulse_rate", "pulse_rate_units", "Hz", "PulseRate"),
@@ -421,22 +374,29 @@ def _prepare_prodml_write(spool):
         ("gauge_length", "gauge_length_units", "m", "GaugeLength"),
     ):
         if measure := _get_measure(attrs, name, units_name, target):
-            acquisition_attrs[hdf_name] = measure[0]
-            acquisition_attrs[f"{hdf_name}.uom"] = _fixed_string(measure[1])
+            out[hdf_name] = measure[0]
+            out[f"{hdf_name}.uom"] = encode_h5_strings(measure[1])
+    return out
 
+
+def _get_array_attrs(
+    patch, strings, times, output_rate, start_locus, start_time, end_time
+):
+    """Return attributes for the raw data and time arrays."""
+    num_loci = len(patch.get_coord("distance"))
     raw_attrs = {
         "NumberOfLoci": num_loci,
         "OutputDataRate": output_rate,
-        "OutputDataRate.uom": _fixed_string("Hz"),
-        "RawDataUnit": _fixed_string(data_units),
+        "OutputDataRate.uom": encode_h5_strings("Hz"),
+        "RawDataUnit": encode_h5_strings(strings["RawDataUnit"]),
         "StartLocusIndex": start_locus,
-        "uuid": _fixed_string(raw_uuid),
+        "uuid": encode_h5_strings(str(uuid4())),
     }
-    if attrs.data_type:
-        raw_attrs["RawDescription"] = _fixed_string(attrs.data_type)
+    if patch.attrs.data_type:
+        raw_attrs["RawDescription"] = encode_h5_strings(patch.attrs.data_type)
     data_attrs = {
-        "Count": data.size,
-        "Dimensions": _fixed_strings(
+        "Count": patch.data.size,
+        "Dimensions": encode_h5_strings(
             ["locus" if dim == "distance" else dim for dim in patch.dims]
         ),
         "PartEndTime": end_time,
@@ -450,12 +410,40 @@ def _prepare_prodml_write(spool):
         "PartStartTime": start_time,
         "StartIndex": 0,
         "StartTime": start_time,
-        "Uom": _fixed_string("us"),
+        "Uom": encode_h5_strings("us"),
     }
+    return raw_attrs, data_attrs, time_attrs
+
+
+def _prepare_prodml_write(spool):
+    """Validate input and prepare all values needed to write ProdML."""
+    patch = _get_single_patch(spool)
+    data = np.asarray(patch.data)
+    times, time_step_us = _round_times_to_microseconds(patch.get_coord("time"))
+    distance_step, start_locus = _get_distance_info(patch.get_coord("distance"))
+    strings = _get_write_metadata(patch.attrs)
+    start_time, end_time = (
+        encode_h5_strings(f"{np.datetime64(int(value), 'us')}+00:00")
+        for value in (times[0], times[-1])
+    )
+    output_rate = 1_000_000.0 / time_step_us
+    num_loci = len(patch.get_coord("distance"))
+    acquisition_attrs = _get_acquisition_attrs(
+        patch.attrs,
+        strings,
+        start_time,
+        output_rate,
+        distance_step,
+        start_locus,
+        num_loci,
+    )
+    raw_attrs, data_attrs, time_attrs = _get_array_attrs(
+        patch, strings, times, output_rate, start_locus, start_time, end_time
+    )
     return (
         data,
         times,
-        _fixed_string(file_uuid),
+        encode_h5_strings(str(uuid4())),
         acquisition_attrs,
         raw_attrs,
         data_attrs,

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -36,10 +36,9 @@ ns_to_datetime = partial(pd.to_datetime, unit="ns")
 ns_to_timedelta = partial(pd.to_timedelta, unit="ns")
 
 
-def encode_h5_strings(values: str | Sequence[str]) -> np.bytes_ | np.ndarray:
-    """Encode string(s) as fixed-length UTF-8 HDF5 byte values."""
-    out = np.asarray([value.encode() for value in iterate(values)], dtype="S")
-    return out[0] if isinstance(values, str) else out
+def encode_h5_strings(values: str | Sequence[str]) -> np.ndarray:
+    """Encode strings as a fixed-length UTF-8 HDF5 byte array."""
+    return np.asarray([value.encode() for value in iterate(values)], dtype="S")
 
 
 class _ManagedH5pyFile:

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -21,6 +21,7 @@ from dascore.constants import remote_hdf5_tuned_protocols
 from dascore.utils.misc import (
     _maybe_make_parent_directory,
     _maybe_unpack,
+    iterate,
     unbyte,
 )
 from dascore.utils.remote_io import (
@@ -33,6 +34,12 @@ from dascore.utils.remote_io import (
 
 ns_to_datetime = partial(pd.to_datetime, unit="ns")
 ns_to_timedelta = partial(pd.to_timedelta, unit="ns")
+
+
+def encode_h5_strings(values: str | Sequence[str]) -> np.bytes_ | np.ndarray:
+    """Encode string(s) as fixed-length UTF-8 HDF5 byte values."""
+    out = np.asarray([value.encode() for value in iterate(values)], dtype="S")
+    return out[0] if isinstance(values, str) else out
 
 
 class _ManagedH5pyFile:

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -4,6 +4,7 @@ The [releases page](https://github.com/DASDAE/dascore/releases) tracks changes f
 
 ## Unreleased API Changes
 
+- PRODML 2.1 now supports writing one raw time-by-distance patch with `dc.write` as a standalone HDF5 file. Full PRODML 2.3 conformance requires EPC/XML packaging, which DASCore does not write.
 - **The `dascore.io.sintela_binary` module is removed (no alias).** Both Sintela readers now live in `dascore.io.sintela`, which also provides the new protobuf reader; use `from dascore.io.sintela import SintelaBinaryV3`. Reading Sintela binary files through `dc.read`/`dc.spool`/`dc.scan` is unaffected — only the direct module import path changed.
 - **Removed the unused `PatchFileSummary` model** (`dascore.io.PatchFileSummary`), superseded by [`PatchSummary`](`dascore.PatchSummary`), along with the internal helpers `coord_summary_from_data` and `_normalize_coord_summary_dtype`. Build a coord first (`get_coord(...)`) and call `.to_summary()` to summarize raw array data. The unused `index_query_buffer` config option is also removed.
 - The index backend no longer exposes a separate `AbstractIndexBackend` interface class; `SQLIndexBackend` is the base every backend implements (it was the only implementation of that interface). The `dascore.io.indexer` module is merged into `dascore.io.index.indexer`, and the placeholder `AbstractIndexer` base class is removed — use `DBDirectoryIndexer` directly.

--- a/tests/test_io/test_prodml/test_prodml_write.py
+++ b/tests/test_io/test_prodml/test_prodml_write.py
@@ -1,0 +1,408 @@
+"""Tests for writing standalone PRODML HDF5 files."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import h5py
+import numpy as np
+import pytest
+
+import dascore as dc
+from dascore.exceptions import InvalidSpoolError, PatchError, UnitError
+from dascore.io.prodml.core import ProdMLV2_0, ProdMLV2_1
+from dascore.units import get_quantity_str
+from dascore.utils.misc import suppress_warnings, unbyte
+
+
+@pytest.fixture
+def prodml_patch():
+    """Return a small Patch which PRODML can represent without loss."""
+    patch = dc.get_example_patch(
+        shape=(4, 5),
+        distance_min=4,
+        distance_step=2,
+        time_min=np.datetime64("2020-01-01", "us"),
+        time_step=np.timedelta64(2_000, "us"),
+        station="station-a",
+    )
+    data = np.arange(np.prod(patch.shape), dtype=np.int16).reshape(patch.shape)
+    return patch.new(data=data).update_attrs(
+        acquisition_id="27addb2c-e435-4cd5-81f1-080ed7cc5fd1",
+        facility_id="facility-a",
+        data_type="strain_rate",
+        data_units="m/s",
+    )
+
+
+def _decode(value):
+    """Decode one HDF5 string attribute."""
+    return str(unbyte(value))
+
+
+def _with_time(patch, values):
+    """Replace the time coordinate, resizing data along time as needed."""
+    values = np.asarray(values)
+    axis = patch.dims.index("time")
+    slices = [slice(None)] * patch.data.ndim
+    slices[axis] = slice(0, len(values))
+    data = patch.data[tuple(slices)]
+    coord = dc.get_coord(data=values, units="s")
+    return patch.new(data=data, coords=patch.coords.update(time=coord))
+
+
+class TestProdMLWriteDispatch:
+    """Writing should be exposed only by PRODML 2.1."""
+
+    def test_supported_versions(self):
+        """Version 2.1 implements write while version 2.0 remains read-only."""
+        assert ProdMLV2_1().implements_write
+        assert not ProdMLV2_0().implements_write
+
+    @pytest.mark.parametrize(
+        "api", ("dc_default", "dc_v21", "patch_default", "patch_v21")
+    )
+    def test_write_dispatch(self, api, prodml_patch, tmp_path):
+        """Both write APIs should support default and explicit version 2.1."""
+        path = tmp_path / f"{api}.h5"
+        if api == "dc_default":
+            dc.write(prodml_patch, path, "PRODML")
+        elif api == "dc_v21":
+            dc.write(prodml_patch, path, "PRODML", file_version="2.1")
+        elif api == "patch_default":
+            prodml_patch.io.write(path, "PRODML")
+        else:
+            prodml_patch.io.write(path, "PRODML", file_version="2.1")
+        assert dc.get_format(path) == ("PRODML", "2.1")
+
+
+class TestProdMLWriteLayout:
+    """The writer should emit the documented standalone HDF5 layout."""
+
+    def test_hdf_layout_and_metadata(self, prodml_patch, tmp_path):
+        """Required groups, datasets, attributes, and UUIDs should be present."""
+        path = dc.write(prodml_patch, tmp_path / "layout.h5", "PRODML")
+        with h5py.File(path, "r") as file:
+            assert set(file) == {"Acquisition"}
+            acquisition = file["Acquisition"]
+            assert set(acquisition) == {"Raw[0]"}
+            raw = acquisition["Raw[0]"]
+            assert set(raw) == {"RawData", "RawDataTime"}
+
+            acquisition_attrs = {
+                "AcquisitionId",
+                "FacilityId",
+                "MaximumFrequency",
+                "MaximumFrequency.uom",
+                "MeasurementStartTime",
+                "MinimumFrequency",
+                "MinimumFrequency.uom",
+                "NumberOfLoci",
+                "ServiceCompanyName",
+                "SpatialSamplingInterval",
+                "SpatialSamplingInterval.uom",
+                "StartLocusIndex",
+                "TriggeredMeasurement",
+                "schemaVersion",
+                "uuid",
+            }
+            raw_attrs = {
+                "NumberOfLoci",
+                "OutputDataRate",
+                "OutputDataRate.uom",
+                "RawDataUnit",
+                "StartLocusIndex",
+                "uuid",
+            }
+            data_attrs = {
+                "Count",
+                "Dimensions",
+                "PartEndTime",
+                "PartStartTime",
+                "StartIndex",
+            }
+            time_attrs = {
+                "Count",
+                "EndTime",
+                "PartEndTime",
+                "PartStartTime",
+                "StartIndex",
+                "StartTime",
+                "Uom",
+            }
+            assert acquisition_attrs <= set(acquisition.attrs)
+            assert raw_attrs <= set(raw.attrs)
+            assert data_attrs <= set(raw["RawData"].attrs)
+            assert time_attrs <= set(raw["RawDataTime"].attrs)
+
+            facility = acquisition.attrs["FacilityId"]
+            assert isinstance(facility, np.ndarray)
+            assert facility.shape == (1,)
+            assert facility.dtype.kind == "S"
+            assert _decode(facility[0]) == prodml_patch.attrs.facility_id
+            assert _decode(acquisition.attrs["AcquisitionId"]) == (
+                prodml_patch.attrs.acquisition_id
+            )
+            assert _decode(raw.attrs["RawDataUnit"]) == get_quantity_str(
+                prodml_patch.attrs.data_units
+            )
+
+            raw_data = raw["RawData"]
+            raw_time = raw["RawDataTime"]
+            assert raw_data.shape == prodml_patch.shape
+            assert raw_data.dtype == prodml_patch.data.dtype
+            assert raw_data.attrs["Count"] == prodml_patch.data.size
+            assert [_decode(x) for x in raw_data.attrs["Dimensions"]] == [
+                "locus",
+                "time",
+            ]
+            assert raw_time.dtype == np.dtype("int64")
+            assert raw_time.attrs["Count"] == len(prodml_patch.get_coord("time"))
+            assert _decode(raw_time.attrs["Uom"]) == "us"
+            for attrs, names in (
+                (acquisition.attrs, ("NumberOfLoci", "StartLocusIndex")),
+                (raw.attrs, ("NumberOfLoci", "StartLocusIndex")),
+                (raw_data.attrs, ("Count", "StartIndex")),
+                (raw_time.attrs, ("Count", "StartIndex")),
+            ):
+                assert all(np.asarray(attrs[name]).dtype == np.dtype("int64") for name in names)
+
+            uuid_values = (
+                _decode(acquisition.attrs["AcquisitionId"]),
+                _decode(file.attrs["uuid"]),
+                _decode(acquisition.attrs["uuid"]),
+                _decode(raw.attrs["uuid"]),
+            )
+            assert len(set(uuid_values)) == 4
+            assert all(str(UUID(value)) == value for value in uuid_values)
+
+    def test_replaces_existing_contents(self, prodml_patch, tmp_path):
+        """Writing should replace rather than append to an existing HDF5 file."""
+        path = tmp_path / "replace.h5"
+        with h5py.File(path, "w") as file:
+            file.create_group("sentinel")
+            file.attrs["sentinel"] = "old"
+        dc.write(prodml_patch, path, "PRODML")
+        with h5py.File(path, "r") as file:
+            assert set(file) == {"Acquisition"}
+            assert "sentinel" not in file.attrs
+            assert set(file["Acquisition"]) == {"Raw[0]"}
+
+
+class TestProdMLWriteRoundTrip:
+    """Representable Patch content should survive a write/read cycle."""
+
+    @pytest.mark.parametrize("dims", (("distance", "time"), ("time", "distance")))
+    def test_round_trip(self, dims, prodml_patch, tmp_path):
+        """Data, dtype, coordinates, dimensions, and core attrs should round trip."""
+        patch = prodml_patch.transpose(*dims)
+        path = dc.write(patch, tmp_path / "round_trip.h5", "PRODML")
+        out = dc.read(path, "PRODML", file_version="2.1")[0]
+
+        with h5py.File(path, "r") as file:
+            stored_dims = file["Acquisition/Raw[0]/RawData"].attrs["Dimensions"]
+            assert [_decode(x) for x in stored_dims] == [
+                "locus" if dim == "distance" else dim for dim in dims
+            ]
+        assert out.dims == patch.dims
+        assert out.data.dtype == patch.data.dtype
+        np.testing.assert_array_equal(out.data, patch.data)
+        for name in patch.dims:
+            np.testing.assert_array_equal(
+                out.get_coord(name).values, patch.get_coord(name).values
+            )
+            assert out.get_coord(name).units == patch.get_coord(name).units
+        assert out.attrs.acquisition_id == patch.attrs.acquisition_id
+        assert out.attrs.data_units == patch.attrs.data_units
+
+    def test_station_is_facility_fallback(self, prodml_patch, tmp_path):
+        """Station should populate FacilityId when no explicit facility attr exists."""
+        attrs = prodml_patch.attrs.drop("facility_id")
+        patch = prodml_patch.new(attrs=attrs)
+        path = dc.write(patch, tmp_path / "station.h5", "PRODML")
+        with h5py.File(path, "r") as file:
+            facility = file["Acquisition"].attrs["FacilityId"]
+            assert _decode(facility[0]) == patch.attrs.station
+
+    def test_missing_metadata_uses_defaults(self, prodml_patch, tmp_path):
+        """Required metadata should receive deterministic compatibility defaults."""
+        attrs = prodml_patch.attrs.drop("facility_id").update(
+            acquisition_id="", station="", data_units=None
+        )
+        patch = prodml_patch.new(attrs=attrs)
+        path = dc.write(patch, tmp_path / "defaults.h5", "PRODML")
+        with h5py.File(path, "r") as file:
+            acquisition = file["Acquisition"]
+            assert _decode(acquisition.attrs["FacilityId"][0]) == "UNKNOWN"
+            assert _decode(acquisition.attrs["ServiceCompanyName"]) == "UNKNOWN"
+            assert _decode(acquisition["Raw[0]"].attrs["RawDataUnit"]) == "UNKNOWN"
+            assert str(UUID(_decode(acquisition.attrs["AcquisitionId"])))
+        assert dc.read(path)[0].attrs.data_units is None
+
+    def test_acquisition_id_is_canonicalized(self, prodml_patch, tmp_path):
+        """Compact UUID input should be stored in PRODML's canonical form."""
+        canonical = prodml_patch.attrs.acquisition_id
+        patch = prodml_patch.update_attrs(acquisition_id=canonical.replace("-", ""))
+        path = dc.write(patch, tmp_path / "uuid.h5", "PRODML")
+        with h5py.File(path, "r") as file:
+            assert _decode(file["Acquisition"].attrs["AcquisitionId"]) == canonical
+
+    def test_single_distance_sample(self, prodml_patch, tmp_path):
+        """A one-locus Patch remains representable when its step is defined."""
+        axis = prodml_patch.dims.index("distance")
+        data = np.take(prodml_patch.data, [0], axis=axis)
+        distance = dc.get_coord(start=4, stop=6, step=2, units="m")
+        coords = prodml_patch.coords.update(distance=distance)
+        patch = prodml_patch.new(data=data, coords=coords)
+        out = dc.read(dc.write(patch, tmp_path / "one_locus.h5", "PRODML"))[0]
+        np.testing.assert_array_equal(out.data, patch.data)
+        np.testing.assert_array_equal(
+            out.get_coord("distance").values, patch.get_coord("distance").values
+        )
+
+
+class TestProdMLWriteTimePrecision:
+    """PRODML timestamp conversion should be explicit and predictable."""
+
+    def test_exact_microseconds_do_not_warn(self, prodml_patch, tmp_path):
+        """Exactly representable timestamps should be written silently."""
+        with suppress_warnings(UserWarning, action="always", record=True) as record:
+            dc.write(prodml_patch, tmp_path / "exact.h5", "PRODML")
+        assert not record
+
+    def test_sub_microseconds_round_and_warn_once(self, prodml_patch, tmp_path):
+        """Sub-microsecond timestamps should round to nearest microsecond once."""
+        base = np.datetime64("2020-01-01", "ns")
+        time = (
+            base
+            + np.timedelta64(600, "ns")
+            + np.arange(5) * np.timedelta64(2_000, "us")
+        )
+        patch = _with_time(prodml_patch, time)
+        path = tmp_path / "rounded.h5"
+        with pytest.warns(UserWarning, match="microsecond") as record:
+            dc.write(patch, path, "PRODML")
+        assert len(record) == 1
+
+        expected = (time.astype("datetime64[ns]").astype(np.int64) + 500) // 1_000
+        with h5py.File(path, "r") as file:
+            stored = file["Acquisition/Raw[0]/RawDataTime"][:]
+        np.testing.assert_array_equal(stored, expected)
+        out_time = dc.read(path)[0].get_coord("time").values
+        np.testing.assert_array_equal(
+            out_time, expected.astype("datetime64[us]").astype("datetime64[ns]")
+        )
+
+    def test_pre_epoch_ties_round_away_from_epoch(self, prodml_patch, tmp_path):
+        """Negative half-microseconds should round away from the Unix epoch."""
+        base = np.datetime64("1969-12-31T23:59:59.000000500", "ns")
+        time = base + np.arange(5) * np.timedelta64(2_000, "us")
+        patch = _with_time(prodml_patch, time)
+        path = tmp_path / "pre_epoch.h5"
+        with pytest.warns(UserWarning, match="microsecond") as record:
+            dc.write(patch, path, "PRODML")
+        assert len(record) == 1
+
+        expected = -1_000_000 + np.arange(5, dtype=np.int64) * 2_000
+        with h5py.File(path, "r") as file:
+            raw = file["Acquisition/Raw[0]"]
+            np.testing.assert_array_equal(raw["RawDataTime"][:], expected)
+            assert _decode(raw["RawData"].attrs["PartStartTime"]) == (
+                "1969-12-31T23:59:59.000000+00:00"
+            )
+
+
+class TestProdMLWriteValidation:
+    """Unrepresentable input should fail with a clear DASCore error."""
+
+    def test_one_patch_spool_is_valid(self, prodml_patch, tmp_path):
+        """A one-Patch spool is the supported cardinality."""
+        path = dc.write(dc.spool([prodml_patch]), tmp_path / "one.h5", "PRODML")
+        assert dc.get_format(path) == ("PRODML", "2.1")
+
+    @pytest.mark.parametrize("count", (0, 2))
+    def test_bad_spool_cardinality(self, count, prodml_patch, tmp_path):
+        """Empty and multi-Patch spools cannot map to one Raw[0]."""
+        patches = [
+            prodml_patch,
+            prodml_patch.update_attrs(tag="distinct-second-patch"),
+        ][:count]
+        spool = dc.spool(patches)
+        with pytest.raises(InvalidSpoolError):
+            dc.write(spool, tmp_path / f"spool_{count}.h5", "PRODML")
+
+    @pytest.mark.parametrize("dtype", (bool, np.float16, np.complex64, "U4", object))
+    def test_unsupported_dtype(self, dtype, prodml_patch, tmp_path):
+        """Only standard integer and floating-point data types are supported."""
+        patch = prodml_patch.new(data=np.ones(prodml_patch.shape, dtype=dtype))
+        with pytest.raises(PatchError, match=r"dtype|data type"):
+            dc.write(patch, tmp_path / "dtype.h5", "PRODML")
+
+    def test_invalid_input_preserves_existing_file(self, prodml_patch, tmp_path):
+        """Validation must finish before replacement clears an existing target."""
+        path = tmp_path / "preserve.h5"
+        with h5py.File(path, "w") as file:
+            file.create_group("sentinel")
+            file.attrs["sentinel"] = "old"
+        patch = prodml_patch.new(data=np.ones(prodml_patch.shape, dtype=bool))
+        with pytest.raises(PatchError):
+            dc.write(patch, path, "PRODML")
+        with h5py.File(path, "r") as file:
+            assert set(file) == {"sentinel"}
+            assert _decode(file.attrs["sentinel"]) == "old"
+
+    def test_string64_metadata(self, prodml_patch, tmp_path):
+        """PRODML String64 attributes cannot exceed their schema limit."""
+        patch = prodml_patch.update_attrs(facility_id="x" * 65)
+        with pytest.raises(PatchError, match="String64"):
+            dc.write(patch, tmp_path / "long_string.h5", "PRODML")
+
+    def test_wrong_dimensions(self, prodml_patch, tmp_path):
+        """The dimensions must be exactly time and distance."""
+        patch = prodml_patch.rename_coords(distance="channel")
+        with pytest.raises(PatchError, match=r"time.*distance|dimensions"):
+            dc.write(patch, tmp_path / "dims.h5", "PRODML")
+
+    def test_one_time_sample(self, prodml_patch, tmp_path):
+        """At least two time samples are needed to encode a sampling rate."""
+        time = prodml_patch.get_coord("time").values[:1]
+        patch = _with_time(prodml_patch, time)
+        with pytest.raises(PatchError, match=r"two|time"):
+            dc.write(patch, tmp_path / "one_time.h5", "PRODML")
+
+    def test_nat_time(self, prodml_patch, tmp_path):
+        """NaT cannot be represented by PRODML's integer epoch time array."""
+        time = prodml_patch.get_coord("time").values.copy()
+        time[2] = np.datetime64("NaT")
+        patch = _with_time(prodml_patch, time)
+        with pytest.raises(PatchError, match=r"NaT|time"):
+            dc.write(patch, tmp_path / "nat.h5", "PRODML")
+
+    def test_time_irregular_after_rounding(self, prodml_patch, tmp_path):
+        """Uniform nanoseconds that round to irregular microseconds are invalid."""
+        base = np.datetime64("2020-01-01", "ns")
+        time = base + np.arange(5) * np.timedelta64(1_500, "ns")
+        patch = _with_time(prodml_patch, time)
+        with suppress_warnings(UserWarning):
+            with pytest.raises(PatchError, match=r"even|regular|microsecond|time"):
+                dc.write(patch, tmp_path / "irregular_time.h5", "PRODML")
+
+    def test_distance_units_must_be_length(self, prodml_patch, tmp_path):
+        """The implicit locus coordinate requires physical length units."""
+        patch = prodml_patch.set_units(distance="s")
+        with pytest.raises((PatchError, UnitError), match=r"length|distance|unit"):
+            dc.write(patch, tmp_path / "distance_units.h5", "PRODML")
+
+    def test_irregular_distance(self, prodml_patch, tmp_path):
+        """Irregular distance cannot be reconstructed from PRODML attributes."""
+        distance = dc.get_coord(data=[4.0, 6.0, 9.0, 10.0], units="m")
+        patch = prodml_patch.update_coords(distance=distance)
+        with pytest.raises(PatchError, match=r"even|regular|distance"):
+            dc.write(patch, tmp_path / "irregular_distance.h5", "PRODML")
+
+    def test_nonintegral_start_locus(self, prodml_patch, tmp_path):
+        """Distance origin must be an integer multiple of sample spacing."""
+        distance = dc.get_coord(data=0.5 + np.arange(4) * 2, units="m")
+        patch = prodml_patch.update_coords(distance=distance)
+        with pytest.raises(PatchError, match=r"locus|start|distance"):
+            dc.write(patch, tmp_path / "start_locus.h5", "PRODML")

--- a/tests/test_io/test_prodml/test_prodml_write.py
+++ b/tests/test_io/test_prodml/test_prodml_write.py
@@ -30,6 +30,7 @@ def prodml_patch():
     return patch.new(data=data).update_attrs(
         acquisition_id="27addb2c-e435-4cd5-81f1-080ed7cc5fd1",
         facility_id="facility-a",
+        service_company_name="service-a",
         data_type="strain_rate",
         data_units="m/s",
     )
@@ -73,6 +74,13 @@ class TestProdMLWriteDispatch:
             prodml_patch.io.write(path, "PRODML")
         else:
             prodml_patch.io.write(path, "PRODML", file_version="2.1")
+        assert dc.get_format(path) == ("PRODML", "2.1")
+
+    def test_write_accepts_forwarded_kwargs(self, prodml_patch, tmp_path):
+        """Format-specific keywords should follow the shared writer contract."""
+        path = dc.write(
+            prodml_patch, tmp_path / "kwargs.h5", "PRODML", unused_option=True
+        )
         assert dc.get_format(path) == ("PRODML", "2.1")
 
 
@@ -146,6 +154,9 @@ class TestProdMLWriteLayout:
             assert _decode(raw.attrs["RawDataUnit"]) == get_quantity_str(
                 prodml_patch.attrs.data_units
             )
+            assert "PulseRate" not in acquisition.attrs
+            assert "PulseRate.uom" not in acquisition.attrs
+            assert raw.attrs["OutputDataRate"] == 500
 
             raw_data = raw["RawData"]
             raw_time = raw["RawDataTime"]
@@ -170,13 +181,21 @@ class TestProdMLWriteLayout:
                 )
 
             uuid_values = (
-                _decode(acquisition.attrs["AcquisitionId"]),
                 _decode(file.attrs["uuid"]),
                 _decode(acquisition.attrs["uuid"]),
                 _decode(raw.attrs["uuid"]),
             )
-            assert len(set(uuid_values)) == 4
+            assert len(set(uuid_values)) == 3
             assert all(str(UUID(value)) == value for value in uuid_values)
+
+    def test_explicit_pulse_rate(self, prodml_patch, tmp_path):
+        """PulseRate should be written only when supplied by patch metadata."""
+        patch = prodml_patch.update_attrs(pulse_rate=50, pulse_rate_units="Hz")
+        path = dc.write(patch, tmp_path / "pulse_rate.h5", "PRODML")
+        with h5py.File(path, "r") as file:
+            attrs = file["Acquisition"].attrs
+            assert attrs["PulseRate"] == 50
+            assert _decode(attrs["PulseRate.uom"]) == "Hz"
 
     def test_replaces_existing_contents(self, prodml_patch, tmp_path):
         """Writing should replace rather than append to an existing HDF5 file."""
@@ -216,6 +235,8 @@ class TestProdMLWriteRoundTrip:
             assert out.get_coord(name).units == patch.get_coord(name).units
         assert out.attrs.acquisition_id == patch.attrs.acquisition_id
         assert out.attrs.data_units == patch.attrs.data_units
+        assert out.attrs.facility_id == patch.attrs.facility_id
+        assert out.attrs.service_company_name == patch.attrs.service_company_name
 
     def test_station_is_facility_fallback(self, prodml_patch, tmp_path):
         """Station should populate FacilityId when no explicit facility attr exists."""
@@ -225,10 +246,11 @@ class TestProdMLWriteRoundTrip:
         with h5py.File(path, "r") as file:
             facility = file["Acquisition"].attrs["FacilityId"]
             assert _decode(facility[0]) == patch.attrs.station
+        assert dc.read(path)[0].attrs.facility_id == patch.attrs.station
 
     def test_missing_metadata_uses_defaults(self, prodml_patch, tmp_path):
         """Required metadata should receive deterministic compatibility defaults."""
-        attrs = prodml_patch.attrs.drop("facility_id").update(
+        attrs = prodml_patch.attrs.drop("facility_id", "service_company_name").update(
             acquisition_id="", station="", data_units=None
         )
         patch = prodml_patch.new(attrs=attrs)
@@ -241,13 +263,13 @@ class TestProdMLWriteRoundTrip:
             assert str(UUID(_decode(acquisition.attrs["AcquisitionId"])))
         assert dc.read(path)[0].attrs.data_units is None
 
-    def test_acquisition_id_is_canonicalized(self, prodml_patch, tmp_path):
-        """Compact UUID input should be stored in PRODML's canonical form."""
-        canonical = prodml_patch.attrs.acquisition_id
-        patch = prodml_patch.update_attrs(acquisition_id=canonical.replace("-", ""))
-        path = dc.write(patch, tmp_path / "uuid.h5", "PRODML")
+    def test_acquisition_id_is_preserved(self, prodml_patch, tmp_path):
+        """Arbitrary experiment identifiers should be stored unchanged."""
+        patch = prodml_patch.update_attrs(acquisition_id="run-001")
+        path = dc.write(patch, tmp_path / "acquisition_id.h5", "PRODML")
         with h5py.File(path, "r") as file:
-            assert _decode(file["Acquisition"].attrs["AcquisitionId"]) == canonical
+            assert _decode(file["Acquisition"].attrs["AcquisitionId"]) == "run-001"
+        assert dc.read(path)[0].attrs.acquisition_id == "run-001"
 
     def test_single_distance_sample(self, prodml_patch, tmp_path):
         """A one-locus Patch remains representable when its step is defined."""
@@ -353,10 +375,11 @@ class TestProdMLWriteValidation:
             assert set(file) == {"sentinel"}
             assert _decode(file.attrs["sentinel"]) == "old"
 
-    def test_string64_metadata(self, prodml_patch, tmp_path):
+    @pytest.mark.parametrize("value", ("x" * 65, "é" * 33))
+    def test_string64_metadata(self, value, prodml_patch, tmp_path):
         """PRODML String64 attributes cannot exceed their schema limit."""
-        patch = prodml_patch.update_attrs(facility_id="x" * 65)
-        with pytest.raises(PatchError, match="String64"):
+        patch = prodml_patch.update_attrs(facility_id=value)
+        with pytest.raises(PatchError, match=r"FacilityId.*String64"):
             dc.write(patch, tmp_path / "long_string.h5", "PRODML")
 
     def test_invalid_optional_measure_units_are_ignored(self, prodml_patch, tmp_path):

--- a/tests/test_io/test_prodml/test_prodml_write.py
+++ b/tests/test_io/test_prodml/test_prodml_write.py
@@ -36,11 +36,6 @@ def prodml_patch():
     )
 
 
-def _decode(value):
-    """Decode one HDF5 string attribute."""
-    return str(unbyte(value))
-
-
 def _with_time(patch, values):
     """Replace the time coordinate, resizing data along time as needed."""
     values = np.asarray(values)
@@ -147,11 +142,11 @@ class TestProdMLWriteLayout:
             assert isinstance(facility, np.ndarray)
             assert facility.shape == (1,)
             assert facility.dtype.kind == "S"
-            assert _decode(facility[0]) == prodml_patch.attrs.facility_id
-            assert _decode(acquisition.attrs["AcquisitionId"]) == (
+            assert unbyte(facility[0]) == prodml_patch.attrs.facility_id
+            assert unbyte(acquisition.attrs["AcquisitionId"]) == (
                 prodml_patch.attrs.acquisition_id
             )
-            assert _decode(raw.attrs["RawDataUnit"]) == get_quantity_str(
+            assert unbyte(raw.attrs["RawDataUnit"]) == get_quantity_str(
                 prodml_patch.attrs.data_units
             )
             assert "PulseRate" not in acquisition.attrs
@@ -163,13 +158,13 @@ class TestProdMLWriteLayout:
             assert raw_data.shape == prodml_patch.shape
             assert raw_data.dtype == prodml_patch.data.dtype
             assert raw_data.attrs["Count"] == prodml_patch.data.size
-            assert [_decode(x) for x in raw_data.attrs["Dimensions"]] == [
+            assert [unbyte(x) for x in raw_data.attrs["Dimensions"]] == [
                 "locus",
                 "time",
             ]
             assert raw_time.dtype == np.dtype("int64")
             assert raw_time.attrs["Count"] == len(prodml_patch.get_coord("time"))
-            assert _decode(raw_time.attrs["Uom"]) == "us"
+            assert unbyte(raw_time.attrs["Uom"]) == "us"
             for attrs, names in (
                 (acquisition.attrs, ("NumberOfLoci", "StartLocusIndex")),
                 (raw.attrs, ("NumberOfLoci", "StartLocusIndex")),
@@ -181,9 +176,9 @@ class TestProdMLWriteLayout:
                 )
 
             uuid_values = (
-                _decode(file.attrs["uuid"]),
-                _decode(acquisition.attrs["uuid"]),
-                _decode(raw.attrs["uuid"]),
+                unbyte(file.attrs["uuid"]),
+                unbyte(acquisition.attrs["uuid"]),
+                unbyte(raw.attrs["uuid"]),
             )
             assert len(set(uuid_values)) == 3
             assert all(str(UUID(value)) == value for value in uuid_values)
@@ -195,7 +190,7 @@ class TestProdMLWriteLayout:
         with h5py.File(path, "r") as file:
             attrs = file["Acquisition"].attrs
             assert attrs["PulseRate"] == 50
-            assert _decode(attrs["PulseRate.uom"]) == "Hz"
+            assert unbyte(attrs["PulseRate.uom"]) == "Hz"
 
     def test_replaces_existing_contents(self, prodml_patch, tmp_path):
         """Writing should replace rather than append to an existing HDF5 file."""
@@ -222,19 +217,15 @@ class TestProdMLWriteRoundTrip:
 
         with h5py.File(path, "r") as file:
             stored_dims = file["Acquisition/Raw[0]/RawData"].attrs["Dimensions"]
-            assert [_decode(x) for x in stored_dims] == [
+            assert [unbyte(x) for x in stored_dims] == [
                 "locus" if dim == "distance" else dim for dim in dims
             ]
-        assert out.dims == patch.dims
+        expected = patch.update_attrs(tag="", station="")
+        assert out == expected
         assert out.data.dtype == patch.data.dtype
-        np.testing.assert_array_equal(out.data, patch.data)
-        for name in patch.dims:
-            np.testing.assert_array_equal(
-                out.get_coord(name).values, patch.get_coord(name).values
-            )
-            assert out.get_coord(name).units == patch.get_coord(name).units
-        assert out.attrs.acquisition_id == patch.attrs.acquisition_id
-        assert out.attrs.data_units == patch.attrs.data_units
+        assert all(
+            out.get_coord(name).units == patch.get_coord(name).units for name in dims
+        )
         assert out.attrs.facility_id == patch.attrs.facility_id
         assert out.attrs.service_company_name == patch.attrs.service_company_name
 
@@ -245,7 +236,7 @@ class TestProdMLWriteRoundTrip:
         path = dc.write(patch, tmp_path / "station.h5", "PRODML")
         with h5py.File(path, "r") as file:
             facility = file["Acquisition"].attrs["FacilityId"]
-            assert _decode(facility[0]) == patch.attrs.station
+            assert unbyte(facility[0]) == patch.attrs.station
         assert dc.read(path)[0].attrs.facility_id == patch.attrs.station
 
     def test_missing_metadata_uses_defaults(self, prodml_patch, tmp_path):
@@ -257,10 +248,10 @@ class TestProdMLWriteRoundTrip:
         path = dc.write(patch, tmp_path / "defaults.h5", "PRODML")
         with h5py.File(path, "r") as file:
             acquisition = file["Acquisition"]
-            assert _decode(acquisition.attrs["FacilityId"][0]) == "UNKNOWN"
-            assert _decode(acquisition.attrs["ServiceCompanyName"]) == "UNKNOWN"
-            assert _decode(acquisition["Raw[0]"].attrs["RawDataUnit"]) == "UNKNOWN"
-            assert str(UUID(_decode(acquisition.attrs["AcquisitionId"])))
+            assert unbyte(acquisition.attrs["FacilityId"][0]) == "UNKNOWN"
+            assert unbyte(acquisition.attrs["ServiceCompanyName"]) == "UNKNOWN"
+            assert unbyte(acquisition["Raw[0]"].attrs["RawDataUnit"]) == "UNKNOWN"
+            assert str(UUID(unbyte(acquisition.attrs["AcquisitionId"])))
         assert dc.read(path)[0].attrs.data_units is None
 
     def test_acquisition_id_is_preserved(self, prodml_patch, tmp_path):
@@ -268,7 +259,8 @@ class TestProdMLWriteRoundTrip:
         patch = prodml_patch.update_attrs(acquisition_id="run-001")
         path = dc.write(patch, tmp_path / "acquisition_id.h5", "PRODML")
         with h5py.File(path, "r") as file:
-            assert _decode(file["Acquisition"].attrs["AcquisitionId"]) == "run-001"
+            value = file["Acquisition"].attrs["AcquisitionId"]
+            assert unbyte(value) == "run-001"
         assert dc.read(path)[0].attrs.acquisition_id == "run-001"
 
     def test_single_distance_sample(self, prodml_patch, tmp_path):
@@ -350,7 +342,7 @@ class TestProdMLWriteTimePrecision:
         with h5py.File(path, "r") as file:
             raw = file["Acquisition/Raw[0]"]
             np.testing.assert_array_equal(raw["RawDataTime"][:], expected)
-            assert _decode(raw["RawData"].attrs["PartStartTime"]) == (
+            assert unbyte(raw["RawData"].attrs["PartStartTime"]) == (
                 "1969-12-31T23:59:59.000000+00:00"
             )
 
@@ -392,7 +384,7 @@ class TestProdMLWriteValidation:
             dc.write(patch, path, "PRODML")
         with h5py.File(path, "r") as file:
             assert set(file) == {"sentinel"}
-            assert _decode(file.attrs["sentinel"]) == "old"
+            assert unbyte(file.attrs["sentinel"]) == "old"
 
     @pytest.mark.parametrize("value", ("x" * 65, "é" * 33))
     def test_string64_metadata(self, value, prodml_patch, tmp_path):
@@ -446,15 +438,31 @@ class TestProdMLWriteValidation:
         with pytest.raises((PatchError, UnitError), match=r"length|distance|unit"):
             dc.write(patch, tmp_path / "distance_units.h5", "PRODML")
 
-    def test_irregular_distance(self, prodml_patch, tmp_path):
-        """Irregular distance cannot be reconstructed from PRODML attributes."""
-        distance = dc.get_coord(data=[4.0, 6.0, 9.0, 10.0], units="m")
+    def test_missing_distance_units_assume_meters(self, prodml_patch, tmp_path):
+        """Unitless distance coordinates should be interpreted as meters."""
+        patch = prodml_patch.set_units(distance=None)
+        out = dc.read(dc.write(patch, tmp_path / "unitless.h5", "PRODML"))[0]
+        distance = out.get_coord("distance")
+        assert distance.unit_str == "m"
+        assert np.array_equal(distance.values, patch.get_coord("distance").values)
+
+    @pytest.mark.parametrize("values", ([4.0, 6.0, 9.0, 10.0], [10.0, 8.0, 6.0, 4.0]))
+    def test_invalid_distance(self, values, prodml_patch, tmp_path):
+        """Distance coordinates must be evenly sampled and increasing."""
+        distance = dc.get_coord(data=values, units="m")
         patch = prodml_patch.update_coords(distance=distance)
-        with pytest.raises(PatchError, match=r"even|regular|distance"):
+        with pytest.raises(PatchError, match=r"even|regular|distance|increasing"):
             dc.write(patch, tmp_path / "irregular_distance.h5", "PRODML")
 
-    def test_nonintegral_start_locus(self, prodml_patch, tmp_path):
-        """Distance origin must be an integer multiple of sample spacing."""
+    def test_fractional_meter_loci(self, prodml_patch, tmp_path):
+        """Fractional meter coordinates are valid when aligned to the grid."""
+        distance = dc.get_coord(data=0.5 + np.arange(4) * 0.5, units="m")
+        patch = prodml_patch.update_coords(distance=distance)
+        out = dc.read(dc.write(patch, tmp_path / "fractional.h5", "PRODML"))[0]
+        assert out.get_coord("distance") == distance
+
+    def test_unaligned_start_locus(self, prodml_patch, tmp_path):
+        """Distance origin must align with the implicit locus sampling grid."""
         distance = dc.get_coord(data=0.5 + np.arange(4) * 2, units="m")
         patch = prodml_patch.update_coords(distance=distance)
         with pytest.raises(PatchError, match=r"locus|start|distance"):

--- a/tests/test_io/test_prodml/test_prodml_write.py
+++ b/tests/test_io/test_prodml/test_prodml_write.py
@@ -165,7 +165,9 @@ class TestProdMLWriteLayout:
                 (raw_data.attrs, ("Count", "StartIndex")),
                 (raw_time.attrs, ("Count", "StartIndex")),
             ):
-                assert all(np.asarray(attrs[name]).dtype == np.dtype("int64") for name in names)
+                assert all(
+                    np.asarray(attrs[name]).dtype == np.dtype("int64") for name in names
+                )
 
             uuid_values = (
                 _decode(acquisition.attrs["AcquisitionId"]),
@@ -356,6 +358,15 @@ class TestProdMLWriteValidation:
         patch = prodml_patch.update_attrs(facility_id="x" * 65)
         with pytest.raises(PatchError, match="String64"):
             dc.write(patch, tmp_path / "long_string.h5", "PRODML")
+
+    def test_invalid_optional_measure_units_are_ignored(self, prodml_patch, tmp_path):
+        """Bad units on optional measures should not prevent writing."""
+        patch = prodml_patch.update_attrs(
+            pulse_width=10, pulse_width_units="not-a-unit"
+        )
+        path = dc.write(patch, tmp_path / "optional_units.h5", "PRODML")
+        with h5py.File(path, "r") as file:
+            assert "PulseWidth" not in file["Acquisition"].attrs
 
     def test_wrong_dimensions(self, prodml_patch, tmp_path):
         """The dimensions must be exactly time and distance."""

--- a/tests/test_io/test_prodml/test_prodml_write.py
+++ b/tests/test_io/test_prodml/test_prodml_write.py
@@ -294,6 +294,25 @@ class TestProdMLWriteTimePrecision:
             dc.write(prodml_patch, tmp_path / "exact.h5", "PRODML")
         assert not record
 
+    @pytest.mark.parametrize("year", ("1600", "2500"))
+    def test_microseconds_outside_nanosecond_range(self, year, prodml_patch, tmp_path):
+        """Wide microsecond timestamps should not wrap through nanoseconds."""
+        time = np.datetime64(year, "us") + np.arange(5) * np.timedelta64(2_000, "us")
+        patch = _with_time(prodml_patch, time)
+        path = dc.write(patch, tmp_path / f"wide_{year}.h5", "PRODML")
+        with h5py.File(path, "r") as file:
+            stored = file["Acquisition/Raw[0]/RawDataTime"][:]
+        np.testing.assert_array_equal(stored, time.astype(np.int64))
+
+    def test_finer_than_nanosecond_precision_is_rejected(self, prodml_patch, tmp_path):
+        """Unsupported sub-nanosecond precision should not be truncated."""
+        time = np.datetime64(1, "ps") + np.arange(5) * np.timedelta64(
+            2_000_000_000, "ps"
+        )
+        patch = _with_time(prodml_patch, time)
+        with pytest.raises(PatchError, match="nanosecond precision"):
+            dc.write(patch, tmp_path / "picoseconds.h5", "PRODML")
+
     def test_sub_microseconds_round_and_warn_once(self, prodml_patch, tmp_path):
         """Sub-microsecond timestamps should round to nearest microsecond once."""
         base = np.datetime64("2020-01-01", "ns")

--- a/tests/test_utils/test_hdf_utils.py
+++ b/tests/test_utils/test_hdf_utils.py
@@ -5,16 +5,28 @@ from __future__ import annotations
 from contextlib import closing
 
 import h5py
+import numpy as np
 import pytest
 
 from dascore.utils.downloader import fetch
 from dascore.utils.hdf5 import (
     H5Reader,
     H5Writer,
+    encode_h5_strings,
     extract_h5_attrs,
     get_h5py_file,
     h5_matches_structure,
 )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"), (("one", [b"one"]), (["one", "two"], [b"one", b"two"]))
+)
+def test_encode_h5_strings(value, expected):
+    """String encoding should consistently return a byte array."""
+    out = encode_h5_strings(value)
+    assert isinstance(out, np.ndarray)
+    assert out.tolist() == expected
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
## Summary

- add standalone PRODML 2.1-compatible HDF5 writing for one raw time-by-distance Patch
- derive acquisition, facility, units, sampling, and optional measurement metadata from Patch attrs and coordinates
- validate representability, preserve dimension order and dtype, round timestamps safely to microseconds, and replace existing targets only after validation
- clarify that full PRODML 2.3 EPC/XML packaging is outside this writer's scope

## Review

Claude ultrareview checked the branch against `dev`. Its one verified finding—invalid optional-measure units escaping the graceful omission path—was fixed with regression coverage.

## Validation

- `pytest -q tests/test_io/test_prodml` — 42 passed
- `pytest -q tests/test_io/test_io_core.py tests/test_io/test_common_io.py` — 1006 passed, 149 skipped
- `pre-commit run --all-files` — passed
- all 23 applicable official PRODML 2.3 DAS HDF5 examples still detect as PRODML 2.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to write a single raw time-by-distance patch as a standalone PRODML 2.1-compatible HDF5 file via `dc.write`, with version-specific behavior and forwarded options support.
  * Added strict validation for patch shape, coordinates sampling/alignment, supported dtypes, units, timestamps, and required metadata (including UUIDs).
  * Implemented HDF5 string encoding utility for writing fixed-length UTF-8 strings.
* **Bug Fixes**
  * Improved PRODML metadata normalization/handling (including “UNKNOWN” units/type cleanup and safer version/fingerprint behavior).
* **Documentation**
  * Clarified current PRODML support level (write-only 2.1; no full 2.3 EPC/XML packaging).
* **Tests**
  * Expanded standalone PRODML write/read, precision rounding warnings, replacement semantics, and extensive negative/validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Changelog

<!-- Retrofitted after #864; recovered from docs/changelog.qmd history. -->
- added: PRODML 2.1 write support for one raw time-by-distance patch as a standalone HDF5 file. Full PRODML 2.3 conformance requires EPC/XML packaging, which DASCore does not write.
