### PR TITLE
Skip reparsing canonical CoordRange coords in CoordManager update/select

### DIFF
--- a/benchmarks/test_patch_benchmarks.py
+++ b/benchmarks/test_patch_benchmarks.py
@@ -89,6 +89,16 @@ class TestProcessingBenchmarks:
         patch.select(time=(t1, t2))
 
     @pytest.mark.benchmark
+    def test_update_existing_coords(self, example_patch):
+        """Time update_coords re-passing already-validated BaseCoords."""
+        patch = example_patch
+        coords = patch.coords
+        patch.update_coords(
+            time=coords.coord_map["time"],
+            distance=coords.coord_map["distance"],
+        )
+
+    @pytest.mark.benchmark
     def test_sobel_filter(self, example_patch):
         """Time the Sobel filter."""
         patch = example_patch

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -54,7 +54,12 @@ from typing_extensions import Self
 
 import dascore as dc
 from dascore.constants import dascore_styles, select_values_description
-from dascore.core.coords import BaseCoord, CoordSummary, get_coord
+from dascore.core.coords import (
+    BaseCoord,
+    CoordRange,
+    CoordSummary,
+    get_coord,
+)
 from dascore.exceptions import (
     CoordDataError,
     CoordError,
@@ -1272,6 +1277,15 @@ def _get_coord_dim_map(coords, dims):
 
     def _get_coord(coord):
         """Get a coordinate from various inputs."""
+        # A CoordRange is already canonical (it is the evenly-sampled
+        # representation), so re-parsing it via model_dump -> get_coord is pure
+        # overhead; return it directly. Other coord types are NOT short-circuited:
+        # array coords (CoordArray/CoordMonotonicArray) can be left non-canonical
+        # by slicing (e.g. an evenly spaced subset that should collapse to a
+        # CoordRange), and a fully-specified CoordPartial should canonicalize to a
+        # CoordRange -- get_coord performs that inference.
+        if isinstance(coord, CoordRange):
+            return coord
         if hasattr(coord, "model_dump"):
             coord = coord.model_dump(exclude_defaults=True)
         if isinstance(coord, Mapping):  # input is a dict

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -17,6 +17,8 @@ from dascore.core.coordmanager import (
 )
 from dascore.core.coords import (
     BaseCoord,
+    CoordPartial,
+    CoordRange,
     get_coord,
 )
 from dascore.exceptions import (
@@ -1082,6 +1084,80 @@ class TestUpdate:
         new = coord_manager.update(distance=(dist * 2) * ft)
         new_coord = new.coord_map["distance"]
         assert dc.get_quantity(new_coord.units) == ft
+
+
+class TestPreserveBaseCoord:
+    """Canonical coords should not be reparsed when passed through update/select.
+
+    Only CoordRange (the canonical evenly-sampled representation) is returned
+    unchanged. Other coord types (CoordPartial, CoordArray, CoordMonotonicArray)
+    are still re-inferred so a fully-specified partial, or slicing that yields an
+    even/empty subset, is canonicalized.
+    """
+
+    def test_update_preserves_range_coord_identity(self, cm_basic):
+        """Updating a CoordRange dim with its own coord keeps the same object."""
+        for name in cm_basic.dims:
+            coord = cm_basic.coord_map[name]
+            assert isinstance(coord, CoordRange)
+            out = cm_basic.update(**{name: coord})
+            assert out.coord_map[name] is coord
+
+    def test_full_partial_canonicalizes_to_range(self, cm_non_coord_dim):
+        """A fully-specified CoordPartial must still become a CoordRange.
+
+        Regression guard: only CoordRange is short-circuited, so a CoordPartial
+        that carries complete start/stop/step is re-inferred into a CoordRange
+        (otherwise value-based selection on it would wrongly raise).
+        """
+        cm = cm_non_coord_dim
+        assert isinstance(cm.coord_map["time"], CoordPartial)
+        size = cm.shape[cm.get_axis("time")]
+        full_partial = CoordPartial(shape=(size,), start=0, stop=size, step=1)
+        out = cm.update(time=full_partial)
+        assert isinstance(out.coord_map["time"], CoordRange)
+        # value-based selection must work on the canonicalized coord.
+        selected, _ = out.select(time=(0, size - 1))
+        assert selected.shape[selected.get_axis("time")] <= size
+
+    def test_update_array_coord_is_equivalent(self, cm_wacky_dims):
+        """Irregular array coords may be re-parsed but stay value-equal."""
+        for name in cm_wacky_dims.dims:
+            coord = cm_wacky_dims.coord_map[name]
+            out = cm_wacky_dims.update(**{name: coord})
+            assert out.coord_map[name] == coord
+            assert np.array_equal(out.get_array(name), cm_wacky_dims.get_array(name))
+
+    def test_select_preserves_untouched_range_coord(self, cm_multidim):
+        """Selecting distance leaves the independent CoordRange time unchanged."""
+        original_time = cm_multidim.coord_map["time"]
+        assert isinstance(original_time, CoordRange)
+        new, _ = cm_multidim.select(distance=(100, 400))
+        assert new.coord_map["time"] is original_time
+        # latitude is tied to distance, so it must be re-sliced (new object).
+        assert new.coord_map["latitude"] is not cm_multidim.coord_map["latitude"]
+
+    def test_select_result_still_correct(self, cm_basic):
+        """The fast path must not change select results."""
+        new, _ = cm_basic.select(distance=(100, 400))
+        dist = new.get_array("distance")
+        full = cm_basic.get_array("distance")
+        expected = full[(full >= 100) & (full <= 400)]
+        assert np.array_equal(dist, expected)
+
+    def test_even_subset_of_irregular_coord_canonicalizes(self):
+        """A sample-selected even subset of an irregular coord becomes a CoordRange.
+
+        Regression guard: array coords must still be re-inferred so slicing that
+        happens to be evenly sampled is canonicalized rather than left as an
+        irregular array coordinate.
+        """
+        coord = dc.get_coord(data=np.array([0.0, 1.0, 3.0]))
+        patch = dc.Patch(data=np.arange(3.0), coords={"x": coord}, dims=("x",))
+        out = patch.select(x=(0, 2), samples=True)  # indices 0..2 -> [0, 1]
+        new_coord = out.coords.coord_map["x"]
+        assert isinstance(new_coord, CoordRange)
+        assert new_coord.evenly_sampled
 
 
 class TestSqueeze:


### PR DESCRIPTION
## What

`CoordManager.update` / `update_coords` / `select` funnel every coordinate
through `_get_coord` (nested in `_get_coord_dim_map`), which dumps each coord via
`model_dump()` and rebuilds it with `get_coord(**dict)` — re-running full
validation and, for array coords, the monotonic / even-sampling scan — **even
when the coordinate was already a valid, canonical object**. Because `BaseCoord`
is a pydantic model, this bypassed `get_coord`'s own
`if isinstance(data, BaseCoord): return data` fast path.

This adds a single short-circuit for the one type where returning the coord
unchanged is provably a no-op:

```python
if isinstance(coord, CoordRange):
    return coord
```

A `CoordRange` is the canonical evenly-sampled representation and round-trips
identically through `model_dump()` → `get_coord()`.

## Why only CoordRange (not all BaseCoords)

The reparse also *canonicalizes* non-canonical coordinates, so it cannot be
blanket-skipped:

- **Array coords** (`CoordArray` / `CoordMonotonicArray`) can be left
  non-canonical by slicing — e.g. an evenly spaced subset produced by
  `__getitem__` during sample selection should collapse to a `CoordRange`.
- A **fully-specified `CoordPartial`** should canonicalize to a `CoordRange`
  (otherwise value-based selection on it wrongly raises).

Both cases are covered by regression tests. `CoordRange` was verified (and
independently confirmed in review) to round-trip identically for forward,
reversed, singleton, datetime, unit-bearing, and dtype-bearing variants.

## Performance (micro-benchmark on master-equivalent code)

| Operation | Before | After |
|---|---:|---:|
| `update_coords`, CoordRange dims | ~393 µs | ~22 µs (**~17×**) |
| value-based `select`, CoordRange | ~596 µs | ~180 µs (**~3.3×**) |

Array-coord paths are intentionally unchanged (they still reparse for
canonicalization). Output is bit-for-bit identical: coordinate arrays, dim maps,
dtypes, data, attrs, and history are unchanged.

## Tests / benchmarks

- Identity preservation for `CoordRange` update/select; value-equivalence for
  array coords; the select result is unchanged.
- Regression guards: even sample-select subset of an irregular coord →
  `CoordRange`; fully-specified `CoordPartial` → `CoordRange` with working
  value-select.
- New `test_update_existing_coords` CodSpeed benchmark.

## Verification

- `pytest tests` → 6318 passed, 84 skipped, 4 xfailed.
- Doctests for `coordmanager.py` pass; `pre-commit` clean.
- Reviewed via Codex CLI across three iterations; two real edge cases it found
  (array-slice and fully-specified-CoordPartial canonicalization) were fixed and
  now have regression tests.

Follow-up to #765 / #757; see `.scratch/optimization_ideas.md` (PR 3).
