### PR TITLE
Fix rank-0 coord select guard and fbe doc typo

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -347,7 +347,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             msg = "Using an array input for select with samples requires integer dtype."
             raise CoordError(msg)
         # Filter out bad indices
-        if self.ndim > 1:
+        if self.ndim != 1:
             msg = "Select only works on 1D coords."
             raise CoordError(msg)
         inds = np.arange(len(self))

--- a/dascore/transform/fbe.py
+++ b/dascore/transform/fbe.py
@@ -41,8 +41,8 @@ def fbe(
         can be used for downsampling of the resulting patch.
         See also [rolling](`dascore.Patch.rolling`)
     db
-        Return patch data in decibel [dB] instead of orginal units.
-        Decibel is calculated as 20 * log10( sqrt(mean(x^2))) ).
+        Return patch data in decibel [dB] instead of original units.
+        Decibel is calculated as 20 * log10( sqrt(mean(x^2)) ).
     **kwargs
         Used to specify the dimension and asociated frequency, wavelength, or
         equivalent limits. For example time=(1, 100) applies a time-dimension bandpass

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -2104,6 +2104,13 @@ class TestDimensionalityErrors:
         with pytest.raises(CoordError, match="1D coords"):
             coord_2d.select(np.array([0, 1]), samples=True)
 
+    def test_select_sample_array_0d_raises(self):
+        """A rank-0 coord must also be rejected, not just >1D."""
+        coord_0d = CoordPartial(shape=())
+        assert coord_0d.ndim == 0
+        with pytest.raises(CoordError, match="1D coords"):
+            coord_0d.select(np.array([0, 1]), samples=True)
+
     def test_get_sample_count_2d_raises(self, coord_2d):
         """get_sample_count requires a 1D coord."""
         with pytest.raises(CoordError, match="1D coords"):


### PR DESCRIPTION
## Description

Two small fixes surfaced by a CodeRabbit review while integrating `master` into `dev` (#769). Split out here so the integration merge stays a pure merge.

- **`dascore/core/coords.py`** — `_select_by_sample_array` guarded on `ndim > 1`, so a rank-0 coord (e.g. `CoordPartial(shape=())`) slipped past and then crashed on `np.arange(len(self))` with an opaque `TypeError`. Changed to `ndim != 1`, matching the sibling guards already used in `align_to`, `get_sample_count`, and `change_length`. Added a regression test.
- **`dascore/transform/fbe.py`** — fixed the "orginal" typo and the unbalanced parenthesis in the dB docstring formula (`20 * log10( sqrt(mean(x^2)) )`).

A third finding (map_fiber `_set_scale` scale validation) was intentionally left alone — it's a private helper in an obscure plotting path where bad input already errors, and hardening it wasn't worth the added code.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page. (docstring corrected)
- [x] included tests. (rank-0 select regression test)
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

### Verification

- `pytest tests/test_core/test_coords.py::TestDimensionalityErrors tests/test_transform/test_fbe.py` — passed.
- `pre-commit run --files <changed>` — passed.
