### PR TITLE
Fix DASVader anonymous reference handling

### DIFF
--- a/dascore/io/dasvader/core.py
+++ b/dascore/io/dasvader/core.py
@@ -24,8 +24,9 @@ class DASVaderV1(FiberIO):
     Notes
     -----
     Legacy DASVader files may contain anonymous JLD2 object references. DASCore
-    detects those files and raises `DASVaderCompatibilityError` with compatibility
-    instructions instead of failing inside `h5py`. A known working stack for
+    reads these references when supported by HDF5 and raises
+    `DASVaderCompatibilityError` with compatibility instructions when
+    dereferencing fails. A known working stack for
     such legacy files is `h5py<3.16` with `HDF5 1.14.x`.
     """
 

--- a/dascore/io/dasvader/utils.py
+++ b/dascore/io/dasvader/utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import h5py
 import numpy as np
-from h5py import h5r
 from h5py.h5r import Reference
 
 import dascore as dc
@@ -77,12 +76,13 @@ def _raise_legacy_ref_error(h5, field_name: str) -> None:
 
 
 def _dereference(h5, value, field_name: str):
-    """Resolve an HDF5 reference, rejecting legacy anonymous DASVader refs."""
+    """Resolve an HDF5 reference or raise a clear compatibility error."""
     if not isinstance(value, Reference):
         return value
-    if h5r.get_name(value, h5.id) is None:
+    try:
+        return h5[value]
+    except KeyError:
         _raise_legacy_ref_error(h5, field_name)
-    return h5[value]
 
 
 # --- Metadata parsing

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -13,7 +13,7 @@ import pytest
 from h5py.h5r import Reference
 
 import dascore as dc
-from dascore.exceptions import DependencyError
+from dascore.exceptions import DASVaderCompatibilityError, DependencyError
 from dascore.io.dasvader.utils import _dereference, _julia_ms_to_datetime64
 from dascore.utils.downloader import fetch
 
@@ -253,3 +253,18 @@ class TestDASVader:
             resolved = _dereference(resource, reference, "htime")
 
             assert resolved[0] == 1
+
+    def test_dereference_failure(self):
+        """Failed references should raise a clear compatibility error."""
+
+        class BrokenResource:
+            """Minimal HDF5 resource whose references cannot be resolved."""
+
+            filename = "legacy.jld2"
+
+            def __getitem__(self, value):
+                raise KeyError(value)
+
+        match = r"legacy\.jld2.*'htime'.*h5py<3\.16"
+        with pytest.raises(DASVaderCompatibilityError, match=match):
+            _dereference(BrokenResource(), Reference(), "htime")

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -239,3 +239,17 @@ class TestDASVader:
         """Non-reference values should be returned unchanged."""
         value = np.float64(5_000.0)
         assert _dereference(None, value, "PulseRateFreq") == value
+
+    def test_dereference_anonymous_reference(self, tmp_path):
+        """Anonymous references should be read when supported by HDF5."""
+        path = tmp_path / "anonymous_reference.h5"
+        with h5py.File(path, "w") as resource:
+            target = resource.create_dataset("target", data=np.array([1]))
+            resource.create_dataset("reference", data=target.ref, dtype=h5py.ref_dtype)
+            del resource["target"]
+            reference = resource["reference"][()]
+
+            assert h5py.h5r.get_name(reference, resource.id) is None
+            resolved = _dereference(resource, reference, "htime")
+
+            assert resolved[0] == 1


### PR DESCRIPTION
## Description

Legacy DASVader JLD2 files can contain readable HDF5 object references without linked object names. The compatibility guard introduced in #647 treated `h5r.get_name(...) is None` as proof that a reference could not be read, so DASCore raised `DASVaderCompatibilityError` on compatible h5py/HDF5 stacks before attempting dereferencing.

This change attempts `h5[value]` first and translates an actual `KeyError` into the existing compatibility error. It restores legacy-file reads with h5py 3.15/HDF5 1.14 while retaining the clear error under h5py 3.16/HDF5 2.0. The reader note now describes that behavior, and a self-contained regression test covers an anonymous but readable reference.

## Validation

- `pytest -q tests/test_io/test_dasvader/test_dasvader.py` with h5py 3.15.1/HDF5 1.14.6: 8 passed.
- Same focused suite with h5py 3.16.0/HDF5 2.0.0: 7 passed, 1 compatibility skip.
- Bounded read of the reported legacy file with h5py 3.15.1: one `(235000, 2)` `float32` patch.
- `pytest -q tests`: 6320 passed, 83 skipped, 4 xfailed.
- `pre-commit run --all`: passed.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when reading legacy DASVader files that include anonymous HDF5 references.
  * Reference resolution now uses direct dereferencing behavior when supported, with clearer fallback when resolution fails.
  * Compatibility guidance is provided when anonymous references cannot be dereferenced.
* **Tests**
  * Added coverage for anonymous HDF5 reference dereferencing and confirmed expected behavior on dereference failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->