### PR TITLE
Streamline exact rolling output construction

### DIFF
--- a/benchmarks/test_patch_benchmarks.py
+++ b/benchmarks/test_patch_benchmarks.py
@@ -353,6 +353,11 @@ class TestRollingBenchmarks:
         """Time rolling mean calculation."""
         big_roller.mean()
 
+    @pytest.mark.benchmark
+    def test_rolling_mean_full_call(self, example_patch):
+        """Time a complete rolling mean, including roller construction."""
+        example_patch.rolling(time=5, samples=True, center=True).mean()
+
 
 class TestAlignBenchmarks:
     """Benchmarks for align_to_coord operation."""

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Literal
 
 import numpy as np
@@ -11,7 +12,6 @@ import dascore as dc
 from dascore.constants import samples_arg_description
 from dascore.exceptions import ParameterError
 from dascore.utils.docs import compose_docstring
-from dascore.utils.models import DascoreBaseModel
 from dascore.utils.patch import get_dim_axis_value, get_window_axis_step
 from dascore.utils.pd import rolling_df
 
@@ -37,11 +37,14 @@ Examples
 """
 
 
-class _PatchRollerInfo(DascoreBaseModel):
+@dataclass(frozen=True, slots=True)
+class _PatchRollerInfo:
     """
     A dataclass for storing info on rolling operation.
 
-    Should be subclassed to implement rolling methods.
+    Should be subclassed to implement rolling methods. This is an ephemeral
+    internal object created on every rolling call, so it is a plain dataclass
+    rather than a validated model.
     """
 
     patch: Any  # cant set to patch due to circular import
@@ -59,9 +62,10 @@ class _PatchRollerInfo(DascoreBaseModel):
         Accounts for centered or non-centered coordinates. If the window
         length is even, the first half value is used.
         """
-        coord = self.patch.get_coord(self.dim)
-        if self.step > 1:
-            coord = coord[:: self.step]
+        # Without a step the dimension is unchanged; reuse the coord manager.
+        if self.step == 1:
+            return self.patch.coords
+        coord = self.patch.get_coord(self.dim)[:: self.step]
         return self.patch.coords.update(**{self.dim: coord})
 
     def _get_attrs_with_apply_history(self, func_or_str):
@@ -75,6 +79,16 @@ class _PatchRollerInfo(DascoreBaseModel):
         new_history.append(hist_str)
         attrs = self.patch.attrs.update(history=new_history, coords={})
         return attrs
+
+    def _new_patch(self, data, attrs):
+        """
+        Create the output patch from rolled data.
+
+        The coordinates and attrs are both built here, so the Patch is
+        created directly rather than through `Patch.update`, which would
+        reconcile the attrs against the coords a second time.
+        """
+        return self.patch.__class__(data=data, coords=self.get_coords(), attrs=attrs)
 
 
 class _NumpyPatchRoller(_PatchRollerInfo):
@@ -91,17 +105,26 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         return int(out)
 
     def _pad_roll_array(self, data):
-        """Pad."""
+        """
+        Pad the reduced array with NaNs and align it to the output coordinate.
+
+        The NaNs go at the start of the axis, except when centering, which
+        moves `num_nans // 2` of them to the end. This is done with a single
+        allocation rather than a pad followed by a roll.
+        """
         num_nans = 1 + (self.window - 2) // self.step
-        pad_width = [(0, 0)] * len(data.shape)
-        pad_width[self.axis] = (num_nans, 0)
-        padded = np.pad(data, pad_width, constant_values=np.nan)
+        if not num_nans:  # window of one sample; nothing to pad.
+            return data
+        shape = list(data.shape)
+        shape[self.axis] += num_nans
+        out = np.full(shape, np.nan, dtype=data.dtype)
+        start = num_nans - num_nans // 2 if self.center else num_nans
+        slicer = [slice(None, None)] * len(shape)
+        slicer[self.axis] = slice(start, start + data.shape[self.axis])
+        out[tuple(slicer)] = data
         if self.step == 1:
-            assert padded.shape == self.patch.data.shape
-        if self.center:
-            # roll array along axis to center
-            padded = np.roll(padded, -(num_nans // 2), axis=self.axis)
-        return padded
+            assert out.shape == self.patch.data.shape
+        return out
 
     @compose_docstring(apply_description=rolling_apply_description)
     def apply(self, function, *args, **kwargs):
@@ -127,11 +150,10 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         step_slice[self.axis] = slice(start, None, self.step)
         # apply function, then pad with NaNs and roll
         trimmed_slide_view = slide_view[tuple(step_slice)]
-        raw = function(trimmed_slide_view, *args, axis=-1, **kwargs).astype(np.float64)
-        out = self._pad_roll_array(raw)
-        new_coords = self.get_coords()
+        raw = function(trimmed_slide_view, *args, axis=-1, **kwargs)
+        out = self._pad_roll_array(np.asarray(raw, dtype=np.float64))
         attrs = self._get_attrs_with_apply_history(function)
-        return self.patch.update(data=out, coords=new_coords, attrs=attrs)
+        return self._new_patch(out, attrs)
 
     def mean(self):
         """Apply mean to moving window."""
@@ -181,14 +203,13 @@ class _PandasPatchRoller(_PatchRollerInfo):
         )
         return roll
 
-    def _repack_patch(self, df, attrs=None):
+    def _repack_patch(self, df, attrs):
         """Repack patch into dataframe."""
         data = df.values if not self.axis else df.T.values
         # get rid of extra dims if original data doesn't have them.
         if len(data.shape) != len(self.patch.data.shape):
             data = np.squeeze(data)
-        coords = self.get_coords()
-        return self.patch.update(data=data, coords=coords, attrs=attrs)
+        return self._new_patch(data, attrs)
 
     def _call_rolling_func(self, name, *args, **kwargs):
         """Helper function for calling a rolling function."""

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -243,6 +243,58 @@ class TestRolling:
         assert all_close(out, expected)
 
 
+class TestRollingMetadata:
+    """Ensure rolling output carries over the input patch's metadata."""
+
+    @pytest.fixture(scope="class")
+    def unit_patch(self, random_patch):
+        """A patch with units set on its coords and data."""
+        return random_patch.set_units("strain", distance="m", time="s")
+
+    @pytest.mark.parametrize("engine", ("numpy", "pandas"))
+    def test_coords_unchanged_without_step(self, random_patch, engine):
+        """Without a step the rolling dim is unchanged, so are the coords."""
+        out = random_patch.rolling(time=10, samples=True, engine=engine).mean()
+        assert out.coords == random_patch.coords
+
+    @pytest.mark.parametrize("engine", ("numpy", "pandas"))
+    def test_units_preserved(self, unit_patch, engine):
+        """Coord and data units should survive a rolling operation."""
+        out = unit_patch.rolling(time=10, samples=True, engine=engine).mean()
+        assert out.attrs.data_units == unit_patch.attrs.data_units
+        for dim in unit_patch.dims:
+            assert out.get_coord(dim).units == unit_patch.get_coord(dim).units
+
+    @pytest.mark.parametrize("engine", ("numpy", "pandas"))
+    def test_attrs_preserved(self, random_patch, engine):
+        """Non-coordinate attrs should be unaffected by rolling."""
+        patch = random_patch.update_attrs(tag="bob", station="wat")
+        out = patch.rolling(time=10, samples=True, engine=engine).mean()
+        assert out.attrs.tag == "bob"
+        assert out.attrs.station == "wat"
+
+    @pytest.mark.parametrize("engine", ("numpy", "pandas"))
+    def test_history_appended(self, random_patch, engine):
+        """A single history entry naming the operation should be added."""
+        out = random_patch.rolling(time=10, samples=True, engine=engine).mean()
+        history = list(out.attrs.history)
+        assert len(history) == len(random_patch.attrs.history) + 1
+        assert history[-1].startswith("rolling(") and "mean" in history[-1]
+
+    def test_non_dim_coords_preserved(self, random_patch_with_lat_lon):
+        """Coords which don't change shape should be kept."""
+        patch = random_patch_with_lat_lon
+        out = patch.rolling(time=10, samples=True).mean()
+        assert set(out.coords.coord_map) == set(patch.coords.coord_map)
+        assert out.get_array("latitude") is not None
+
+    def test_attrs_conform_to_coords(self, random_patch):
+        """The attrs coord summaries should match the output coords."""
+        out = random_patch.rolling(time=10, samples=True, step=3).mean()
+        assert out.attrs.coords == out.coords.to_summary_dict()
+        assert out.attrs.dim_tuple == out.dims
+
+
 class TestNumpyVsPandasRolling:
     """Ensure numpy rolling return the same results as pandas rolling."""
 

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -247,9 +247,10 @@ class TestRollingMetadata:
     """Ensure rolling output carries over the input patch's metadata."""
 
     @pytest.fixture(scope="class")
-    def unit_patch(self, random_patch):
-        """A patch with units set on its coords and data."""
-        return random_patch.set_units("strain", distance="m", time="s")
+    def unit_patch(self, random_patch_with_lat_lon):
+        """A patch with units set on its data and all of its coords."""
+        patch = random_patch_with_lat_lon
+        return patch.set_units("strain", distance="m", time="s", latitude="deg")
 
     @pytest.mark.parametrize("engine", ("numpy", "pandas"))
     def test_coords_unchanged_without_step(self, random_patch, engine):
@@ -259,11 +260,11 @@ class TestRollingMetadata:
 
     @pytest.mark.parametrize("engine", ("numpy", "pandas"))
     def test_units_preserved(self, unit_patch, engine):
-        """Coord and data units should survive a rolling operation."""
+        """Data units and units of every coord should survive rolling."""
         out = unit_patch.rolling(time=10, samples=True, engine=engine).mean()
         assert out.attrs.data_units == unit_patch.attrs.data_units
-        for dim in unit_patch.dims:
-            assert out.get_coord(dim).units == unit_patch.get_coord(dim).units
+        for name in unit_patch.coords.coord_map:
+            assert out.get_coord(name).units == unit_patch.get_coord(name).units
 
     @pytest.mark.parametrize("engine", ("numpy", "pandas"))
     def test_attrs_preserved(self, random_patch, engine):
@@ -273,24 +274,35 @@ class TestRollingMetadata:
         assert out.attrs.tag == "bob"
         assert out.attrs.station == "wat"
 
-    @pytest.mark.parametrize("engine", ("numpy", "pandas"))
-    def test_history_appended(self, random_patch, engine):
+    # The numpy engine routes its reductions through apply, pandas does not.
+    @pytest.mark.parametrize(
+        "engine,suffix", (("numpy", ".apply(mean)"), ("pandas", ".mean()"))
+    )
+    def test_history_appended(self, random_patch, engine, suffix):
         """A single history entry naming the operation should be added."""
         out = random_patch.rolling(time=10, samples=True, engine=engine).mean()
         history = list(out.attrs.history)
         assert len(history) == len(random_patch.attrs.history) + 1
-        assert history[-1].startswith("rolling(") and "mean" in history[-1]
+        expected = (
+            f"rolling(time=10, step=1, overlap=None, "
+            f"center=False, engine={engine}){suffix}"
+        )
+        assert history[-1] == expected
 
-    def test_non_dim_coords_preserved(self, random_patch_with_lat_lon):
-        """Coords which don't change shape should be kept."""
+    @pytest.mark.parametrize("engine", ("numpy", "pandas"))
+    def test_non_dim_coords_preserved(self, random_patch_with_lat_lon, engine):
+        """Coords which don't change shape should be kept as they were."""
         patch = random_patch_with_lat_lon
-        out = patch.rolling(time=10, samples=True).mean()
+        out = patch.rolling(time=10, samples=True, engine=engine).mean()
         assert set(out.coords.coord_map) == set(patch.coords.coord_map)
-        assert out.get_array("latitude") is not None
+        for name in set(patch.coords.coord_map) - {"time"}:
+            assert out.get_coord(name) == patch.get_coord(name)
+            assert np.array_equal(out.get_array(name), patch.get_array(name))
 
-    def test_attrs_conform_to_coords(self, random_patch):
+    @pytest.mark.parametrize("engine", ("numpy", "pandas"))
+    def test_attrs_conform_to_coords(self, random_patch, engine):
         """The attrs coord summaries should match the output coords."""
-        out = random_patch.rolling(time=10, samples=True, step=3).mean()
+        out = random_patch.rolling(time=10, samples=True, step=3, engine=engine).mean()
         assert out.attrs.coords == out.coords.to_summary_dict()
         assert out.attrs.dim_tuple == out.dims
 


### PR DESCRIPTION
## Description

Follow-up to #765 and #768, covering the "additional exact rolling cleanup" items: reduce the per-call overhead of `patch.rolling(...)` without changing any numerics.

Profiling a representative localized DAS patch (`(28, 600)` float32, 10-sample centered distance window) showed that ~90% of a rolling mean was metadata and array bookkeeping rather than the reduction itself. Three things stood out:

- `_PatchRollerInfo` inherits from a pydantic model, so every `patch.rolling(...)` call paid validation for an ephemeral, internal object.
- `_pad_roll_array` allocated three arrays: `astype` then `np.pad` then `np.roll`. Because the padding is all NaN, the roll is equivalent to writing the data at an offset, so one allocation suffices.
- Both engines built the output through `Patch.update(data=..., coords=..., attrs=...)`. That calls `CoordManager.update_from_attrs`, and then `Patch.__init__` reconciles attrs against coords again, so the coord summaries were rebuilt twice per call even though the roller had already produced a valid `CoordManager` and `PatchAttrs`.

Changes:

- `_PatchRollerInfo` is now a frozen dataclass.
- `_pad_roll_array` pads and centers in a single allocation.
- `get_coords` returns the patch's coord manager unchanged when there is no step (the rolling dimension is unchanged in that case).
- A shared `_new_patch` helper constructs the output Patch directly from the coords and attrs the roller already built. Both engines use it.

No public API or behavior change; `engine`, `step`, `center`, `overlap` and all reductions behave exactly as before.

### Verification

Output was compared against `master` over a sweep of 3,536 combinations: both engines, all six reductions plus `apply`, 1D/2D/3D patches, int64/float32/float64 data, data containing NaN and ±inf, patches with units and with non-dimensional coords, windows of 1/2/3/11, with and without step and centering. Data bytes, dtype, shape, coords and serialized attrs are identical in every case, and the 182 combinations that raise produce the same exception and message.

### Timings

Wall clock per call, mean of 200 runs:

| Case | master | this PR |
|---|---:|---:|
| `(28, 600)` distance window 10, centered | 0.634 ms | 0.319 ms |
| `(28, 600)` time window 10 | 0.874 ms | 0.582 ms |
| `(28, 600)` window 11, step 3, centered | 0.687 ms | 0.423 ms |
| `(300, 2000)` time window 10 | 16.23 ms | 13.60 ms |
| pandas engine, 1D, window 5 | 1.375 ms | 1.115 ms |

The large-patch case gains less because it is dominated by the reduction itself rather than by overhead.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rolling mean correctness, including proper step handling, padding/alignment, and centering behavior.
  * Preserved rolling metadata: coordinates, units, non-coordinate attributes, dimension info, and consistent history entries.
* **Performance**
  * Optimized rolling execution by reducing redundant patch/coordinate reconciliation and improving array padding/alignment.
* **Tests**
  * Added a benchmark covering the full rolling-mean call path.
  * Added tests validating rolling metadata preservation and accurate metadata updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->