### PR TITLE
Add hive-style path attributes to directory spools

### DIFF
--- a/benchmarks/test_spool_benchmarks.py
+++ b/benchmarks/test_spool_benchmarks.py
@@ -167,6 +167,36 @@ class TestManyFileDirectoryBenchmarks:
             assert isinstance(patch, dc.Patch)
 
 
+class TestHivePathAttrBenchmarks:
+    """Benchmarks for hive-style path attribute extraction and loading."""
+
+    @pytest.fixture(scope="class")
+    def hive_directory(self, tmp_path_factory):
+        """A hive-partitioned directory: 5 stations x 5 files."""
+        path = tmp_path_factory.mktemp("hive_benchmark")
+        patches = _make_contiguous_patches(25)
+        for i, patch in enumerate(patches):
+            sub = path / "network=XX" / f"station=S{i % 5}"
+            sub.mkdir(parents=True, exist_ok=True)
+            patch.io.write(sub / f"tag=raw__num={i:03d}.h5", "dasdae")
+        return path
+
+    @pytest.mark.benchmark
+    def test_index_hive_directory(self, hive_directory):
+        """Time indexing a hive tree (includes path-attr extraction)."""
+        for index_path in hive_directory.glob(".dascore*"):
+            index_path.unlink()
+        spool = dc.spool(hive_directory).update(progress=None)
+        assert len(spool.select(station="S0")) == 5
+
+    @pytest.mark.benchmark
+    def test_load_patches_with_path_attrs(self, hive_directory):
+        """Time loading patches that get path attrs stamped on."""
+        spool = dc.spool(hive_directory).update(progress=None)
+        for patch in spool:
+            assert patch.attrs.network == "XX"
+
+
 class TestMemorySpoolBenchmarks:
     """Benchmarks for in-memory spool creation and access."""
 

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -25,7 +25,12 @@ from dascore.exceptions import (
     UnitError,
 )
 from dascore.io.index.dialect import SQLiteDialect
-from dascore.io.index.ingest import SourceRecord, attr_column_name
+from dascore.io.index.ingest import (
+    SourceRecord,
+    attr_column_name,
+    dump_path_attrs,
+    hive_typed_attrs,
+)
 from dascore.io.index.query import (
     Query,
     _as_query_list,
@@ -279,6 +284,13 @@ class SQLIndexBackend(abc.ABC):
     def _ensure_attr_columns(
         self, records: list[SourceRecord]
     ) -> tuple[dict[tuple[str, str], str], set[tuple[str, str, str]]]:
+        """Lazily add typed attr columns for the records' patch attrs."""
+        attr_dicts = [p.attrs for record in records for p in record.patches]
+        return self._ensure_attr_columns_for(attr_dicts)
+
+    def _ensure_attr_columns_for(
+        self, attr_dicts
+    ) -> tuple[dict[tuple[str, str], str], set[tuple[str, str, str]]]:
         """
         Lazily add typed attr columns; return the (name, kind) -> column
         map and a set of (name, kind, units) values to skip.
@@ -306,11 +318,10 @@ class SQLIndexBackend(abc.ABC):
         }
         taken = set(mapping.values())
         observed: dict[tuple[str, str], set[str | None]] = {}
-        for record in records:
-            for patch in record.patches:
-                for name, typed in patch.attrs.items():
-                    key = (name, typed.kind)
-                    observed.setdefault(key, set()).add(typed.units)
+        for attrs in attr_dicts:
+            for name, typed in attrs.items():
+                key = (name, typed.kind)
+                observed.setdefault(key, set()).add(typed.units)
         needed: dict[tuple[str, str], str | None] = {}
         skip_units: set[tuple[str, str, str]] = set()
         for key, units_seen in observed.items():
@@ -462,6 +473,7 @@ class SQLIndexBackend(abc.ABC):
                         record.format_version,
                         record.mtime_ns,
                         record.size_bytes,
+                        dump_path_attrs(record.path_attrs),
                         now,
                         ordinal,
                     )
@@ -608,6 +620,94 @@ class SQLIndexBackend(abc.ABC):
         """Remove sources (identified by base_uri + path) and dependents."""
         with self._transaction():
             self._delete_by_paths(source_paths, base_uri=base_uri)
+
+    def move_sources(
+        self,
+        moves: dict[str, str],
+        new_path_attrs: dict[str, dict[str, str]] | None = None,
+        base_uri: str = "",
+    ) -> None:
+        """
+        Rewrite source paths in place (filesystem renames), atomically.
+
+        Updates each source's stored path and its hive path attrs without
+        touching patch/coord rows, so a directory rename never re-reads
+        file contents. ``moves`` maps old -> new source_path;
+        ``new_path_attrs`` maps old source_path -> the new path's hive
+        attrs. The caller (the directory syncer) guarantees the new hive
+        keys are a superset of the old ones — a removed key would need
+        the file's own attr value back, which only a rescan can supply.
+        """
+        if not moves:
+            return
+        path_attrs = new_path_attrs or {}
+        attrs_by_old = {
+            old: hive_typed_attrs(attrs) for old, attrs in path_attrs.items() if attrs
+        }
+        with self._transaction():
+            column_map, _ = self._ensure_attr_columns_for(attrs_by_old.values())
+            # attr name -> [(kind, column)] once; per-move dataframe
+            # filtering dominated large renames.
+            kinds_by_name: dict[str, list[tuple[str, str]]] = {}
+            for row in self._attr_meta().itertuples():
+                kinds_by_name.setdefault(row.attr_name, []).append(
+                    (row.value_kind, row.column_name)
+                )
+            now = time.time_ns()
+            ids: dict[str, int] = {}
+            for chunk, marks in self._iter_in_batches(list(moves)):
+                df = self._fetch_df(
+                    f"SELECT source_id, source_path FROM sources "
+                    f"WHERE source_path IN ({marks}) AND base_uri = ?",
+                    [*chunk, base_uri],
+                )
+                ids.update(zip(df["source_path"], (int(x) for x in df["source_id"])))
+            source_rows = [
+                (
+                    new,
+                    dump_path_attrs(path_attrs.get(old)),
+                    now,
+                    ids[old],
+                )
+                for old, new in moves.items()
+                if old in ids
+            ]
+            self._executemany(
+                "UPDATE sources SET source_path = ?, path_attrs = ?, "
+                "last_indexed_ns = ? WHERE source_id = ?",
+                source_rows,
+            )
+            # hive wins: set the str column and clear any other-kind columns
+            # of the same attr name, matching what a fresh ingest of the
+            # merged attrs would have produced. A directory rename gives
+            # every moved source the same assignments, so group by the
+            # assignment signature and update each group's patches at once.
+            groups: dict[tuple, list[int]] = {}
+            for old in moves:
+                attrs = attrs_by_old.get(old)
+                if not attrs or old not in ids:
+                    continue
+                sig = []
+                for name, typed in attrs.items():
+                    sig.append((column_map[(name, typed.kind)], typed.value))
+                    sig.extend(
+                        (column, None)
+                        for kind, column in kinds_by_name.get(name, ())
+                        if kind != typed.kind
+                    )
+                groups.setdefault(tuple(sorted(sig)), []).append(ids[old])
+            for sig, source_ids in groups.items():
+                assignments = ", ".join(
+                    f"{self.dialect.quote(col)} = ?" for col, _ in sig
+                )
+                values = [value for _, value in sig]
+                for chunk, marks in self._iter_in_batches(source_ids):
+                    self._execute(
+                        f"UPDATE attrs SET {assignments} WHERE patch_id IN "
+                        f"(SELECT patch_id FROM patches "
+                        f"WHERE source_id IN ({marks}))",
+                        (*values, *chunk),
+                    )
 
     # --- queries -----------------------------------------------------
 
@@ -791,11 +891,13 @@ class SQLIndexBackend(abc.ABC):
                 new_columns[name] = series
         if cols_to_drop:
             out = out.drop(columns=cols_to_drop)
-        # flat-contract names for source columns
+        # flat-contract names for source columns; path_attrs goes private
+        # so chunk merge-compat grouping (non-private columns) ignores it
         renames = {
             "source_path": "path",
             "source_format": "file_format",
             "format_version": "file_version",
+            "path_attrs": "_path_attrs",
         }
         out = out.rename(columns=renames)
         if "base_uri" in out:

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -638,8 +638,6 @@ class SQLIndexBackend(abc.ABC):
         keys are a superset of the old ones — a removed key would need
         the file's own attr value back, which only a rescan can supply.
         """
-        if not moves:
-            return
         path_attrs = new_path_attrs or {}
         attrs_by_old = {
             old: hive_typed_attrs(attrs) for old, attrs in path_attrs.items() if attrs

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -17,6 +17,7 @@ Selection composes Query predicates without running SQL; realization
 from __future__ import annotations
 
 import abc
+import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -279,7 +280,14 @@ class FileResolver(PatchResolver):
             # one, so these rows read the whole source.
             trim = {}
         spool = self._read(path, row, trim, source_patch_id)
-        return _resolve_read_spool(spool, source_patch_id)
+        patch = _resolve_read_spool(spool, source_patch_id)
+        # Hive-style path attrs override what the file recorded (renaming
+        # a path is the user's way of correcting metadata), so loaded
+        # patches agree with the index contents.
+        raw_path_attrs = row.get("_path_attrs")
+        if isinstance(raw_path_attrs, str) and raw_path_attrs:
+            patch = patch.update_attrs(**json.loads(raw_path_attrs))
+        return patch
 
 
 class CompositeResolver(PatchResolver):

--- a/dascore/io/index/indexer.py
+++ b/dascore/io/index/indexer.py
@@ -26,7 +26,11 @@ from dascore.config import config_attr
 from dascore.constants import PROGRESS_LEVELS
 from dascore.exceptions import InvalidIndexVersionError
 from dascore.io.index.backend import get_backend, resolve_query
-from dascore.io.index.ingest import SourceRecord, summaries_to_records
+from dascore.io.index.ingest import (
+    SourceRecord,
+    hive_path_attrs,
+    summaries_to_records,
+)
 from dascore.io.index.schema import SPOOL_HIDDEN_COLUMNS
 from dascore.utils.misc import _iter_filesystem
 from dascore.utils.paths import directory_writable, requires_local_directory
@@ -297,6 +301,48 @@ class DBDirectoryIndexer:
             files[self._rel(path)] = (stat.st_mtime_ns, stat.st_size, path)
         return files
 
+    def _detect_moves(
+        self,
+        stale: list[str],
+        stored: dict[str, tuple[int, int] | None],
+        files: dict[str, tuple[int, int, Path]],
+    ) -> dict[str, str]:
+        """
+        Map old -> new relative path for unambiguous renames/moves.
+
+        A moved source keeps its exact (mtime_ns, size_bytes) — for
+        directory-format units, the rename-invariant manifest signature —
+        so a stale path and a brand-new path with identical stats, each
+        unique on its side, are the same bytes at a new location and the
+        index can rewrite the path instead of re-reading contents. This
+        makes attaching metadata by renaming hive-style directories (or
+        files) cheap on large archives. Renames that *remove* a hive key
+        are excluded: restoring the file's own value for the dropped
+        attr requires a rescan.
+        """
+        old_by_stats: dict[tuple[int, int], list[str]] = {}
+        for rel in stale:
+            stats = stored.get(rel)
+            if stats is None or rel == ".":
+                continue
+            old_by_stats.setdefault(stats, []).append(rel)
+        new_by_stats: dict[tuple[int, int], list[str]] = {}
+        for rel, (mtime, size, _) in files.items():
+            if rel in stored:
+                continue
+            new_by_stats.setdefault((mtime, size), []).append(rel)
+        moves: dict[str, str] = {}
+        for stats, olds in old_by_stats.items():
+            news = new_by_stats.get(stats, ())
+            if len(olds) != 1 or len(news) != 1:
+                continue  # ambiguous match: fall back to rescan
+            old, new = olds[0], news[0]
+            old_keys = set(hive_path_attrs(old, warn=False))
+            if old_keys - set(hive_path_attrs(new, warn=False)):
+                continue
+            moves[old] = new
+        return moves
+
     def update(self, paths=None, progress: PROGRESS_LEVELS = "standard") -> Self:
         """
         Update the index: scan new/changed sources, drop removed ones.
@@ -306,7 +352,8 @@ class DBDirectoryIndexer:
         and stale-source removal is folded in (the walk is the dominant
         cost; removal afterwards is nearly free). Directory-format scan
         units (e.g. XMLBinary) are rescanned whole when any member file
-        changes.
+        changes. Renamed/moved sources are detected by their unchanged
+        stats and rewritten in place, never rescanned (see _detect_moves).
         """
         files = self._walk()
         stored = {
@@ -323,6 +370,16 @@ class DBDirectoryIndexer:
             for rel, (mtime, size, _) in files.items()
             if stored.get(rel) != (mtime, size)
         ]
+        # Moves apply to the unrestricted sets, like stale removal below:
+        # the rows must track the filesystem even when a `paths` argument
+        # narrows which sources get rescanned.
+        moves = self._detect_moves(stale, stored, files)
+        if moves:
+            new_attrs = {old: hive_path_attrs(new) for old, new in moves.items()}
+            self._backend.move_sources(moves, new_attrs)
+            moved_targets = set(moves.values())
+            stale = [rel for rel in stale if rel not in moves]
+            changed = [rel for rel in changed if rel not in moved_targets]
         if paths is not None:
             # restrict the rescan (not stale removal) to the given paths
             keep = set()
@@ -366,11 +423,12 @@ class DBDirectoryIndexer:
                         format_version="",
                         mtime_ns=mtime,
                         size_bytes=size,
+                        path_attrs=hive_path_attrs(rel, warn=False) or None,
                     )
                 )
             if records:
                 self._backend.write_sources(records)
-        if stale or changed or not self._initial_update_done:
+        if stale or changed or moves or not self._initial_update_done:
             # Directory archives present in time order; ingest assigns
             # walk-order ordinals, so each sync renumbers to keep the
             # contract (iterate by ordinal) aligned with time. The

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -10,6 +10,7 @@ units here, so cross-patch comparisons in the index are always valid.
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 import warnings
 from dataclasses import dataclass, field, fields, replace
@@ -20,6 +21,7 @@ import pandas as pd
 from dascore.core.summary import PatchSummary, normalize_source_patch_id
 from dascore.io.index.schema import KINDS, RESERVED_ATTR_COLUMNS
 from dascore.units import get_quantity
+from dascore.utils.paths import parse_hive_path_attrs
 from dascore.utils.time import to_datetime64, to_int, to_timedelta64
 
 _SANITIZE_RE = re.compile(r"[^a-z0-9_]+")
@@ -126,6 +128,7 @@ class SourceRecord:
     base_uri: str | None = None
     mtime_ns: int | None = None
     size_bytes: int | None = None
+    path_attrs: dict[str, str] | None = None
     patches: tuple[PatchRecord, ...] = ()
 
 
@@ -198,29 +201,74 @@ def typed_value(value) -> TypedValue | None:
     return None  # complex attrs (sequences, dicts, ...) are skipped
 
 
+def _attr_name_status(name: str) -> str:
+    """
+    Classify an attr name for indexing: "ok", "skip", or "reserved".
+
+    Structural/underscore names skip silently; names that sanitize to a
+    structural storage/contract column are reserved (callers warn).
+    Coordinate-envelope-shaped names (e.g. "channel_step") are ordinary
+    attrs; a genuine collision with a coord envelope column is handled
+    (warn, coord wins) when the flat view is built.
+    """
+    if name in _SKIPPED_ATTRS or name.startswith("_"):
+        return "skip"
+    if sanitize_attr_name(name) in RESERVED_ATTR_COLUMNS:
+        return "reserved"
+    return "ok"
+
+
 def _extract_attrs(summary: PatchSummary) -> dict[str, TypedValue]:
     """Get indexable typed attrs from a patch summary."""
     raw = summary.attrs.model_dump()
     out = {}
     for name, value in raw.items():
-        if name in _SKIPPED_ATTRS or name.startswith("_"):
-            continue
-        # Structural storage/contract column names cannot double as attr
-        # columns. Coordinate-envelope-shaped names (e.g. "channel_step")
-        # are ordinary attrs; a genuine collision with a coord envelope
-        # column is handled (warn, coord wins) when the flat view is built.
-        if sanitize_attr_name(name) in RESERVED_ATTR_COLUMNS:
+        status = _attr_name_status(name)
+        if status == "reserved":
             msg = (
                 f"Skipping reserved attr name {name!r}; it collides with a "
                 "structural index column. The attr stays on the patch but "
                 "is not queryable through the spool."
             )
             warnings.warn(msg, UserWarning)
+        if status != "ok":
             continue
         typed = typed_value(value)
         if typed is not None:
             out[name] = typed
     return out
+
+
+def hive_path_attrs(rel_posix: str, warn: bool = True) -> dict[str, str]:
+    """
+    Return the indexable hive-style path attrs for a stored relative path.
+
+    Applies the same name rules as file attrs: structural/underscore
+    names are dropped silently, reserved column collisions warn and drop.
+    """
+    out = {}
+    for name, value in parse_hive_path_attrs(rel_posix).items():
+        status = _attr_name_status(name)
+        if status == "reserved" and warn:
+            msg = (
+                f"Skipping hive-style path key {name!r} in {rel_posix!r}; "
+                "it collides with a structural index column."
+            )
+            warnings.warn(msg, UserWarning)
+        if status != "ok":
+            continue
+        out[name] = value
+    return out
+
+
+def hive_typed_attrs(path_attrs: dict[str, str]) -> dict[str, TypedValue]:
+    """Wrap hive path attrs as string TypedValues (no type inference)."""
+    return {name: TypedValue("str", value) for name, value in path_attrs.items()}
+
+
+def dump_path_attrs(path_attrs: dict[str, str] | None) -> str | None:
+    """Serialize a path-attrs dict for the sources table (None when empty)."""
+    return json.dumps(path_attrs, sort_keys=True) if path_attrs else None
 
 
 def _coord_record(name: str, summary) -> CoordRecord | None:
@@ -372,11 +420,19 @@ def summaries_to_records(
             patches.append(record)
         posix_path = path.replace("\\", "/")
         store_path = posix_path
+        path_attrs = None
         if root_prefix is not None and (
             posix_path == root_prefix or posix_path.startswith(f"{root_prefix}/")
         ):
             # "." (not "") marks a source that IS the root (directory units)
             store_path = posix_path[len(root_prefix) :].lstrip("/") or "."
+            # Hive-style key=value directory segments become string attrs
+            # that override same-named file attrs (renaming a directory is
+            # the user's way of correcting metadata).
+            path_attrs = hive_path_attrs(store_path) or None
+            if path_attrs:
+                typed = hive_typed_attrs(path_attrs)
+                patches = [replace(p, attrs={**p.attrs, **typed}) for p in patches]
         out.append(
             SourceRecord(
                 source_path=store_path,
@@ -385,6 +441,7 @@ def summaries_to_records(
                 format_version=first.source_version,
                 mtime_ns=(mtimes_ns or {}).get(path),
                 size_bytes=(sizes_bytes or {}).get(path),
+                path_attrs=path_attrs,
                 patches=tuple(patches),
             )
         )
@@ -501,6 +558,7 @@ def assemble_source_records(
                     **{f: _py_scalar(getattr(patch, f)) for f in _PATCH_ROW_FIELDS},
                 )
             )
+        raw_path_attrs = _py_scalar(getattr(src, "path_attrs", None))
         out.append(
             SourceRecord(
                 source_path=_py_scalar(src.source_path) or "",
@@ -509,6 +567,7 @@ def assemble_source_records(
                 format_version=_py_scalar(src.format_version) or "",
                 mtime_ns=_py_scalar(src.mtime_ns),
                 size_bytes=_py_scalar(src.size_bytes),
+                path_attrs=json.loads(raw_path_attrs) if raw_path_attrs else None,
                 patches=tuple(patch_records),
             )
         )

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -230,7 +230,7 @@ def _extract_attrs(summary: PatchSummary) -> dict[str, TypedValue]:
                 "structural index column. The attr stays on the patch but "
                 "is not queryable through the spool."
             )
-            warnings.warn(msg, UserWarning)
+            warnings.warn(msg, UserWarning, stacklevel=2)
         if status != "ok":
             continue
         typed = typed_value(value)
@@ -254,7 +254,7 @@ def hive_path_attrs(rel_posix: str, warn: bool = True) -> dict[str, str]:
                 f"Skipping hive-style path key {name!r} in {rel_posix!r}; "
                 "it collides with a structural index column."
             )
-            warnings.warn(msg, UserWarning)
+            warnings.warn(msg, UserWarning, stacklevel=2)
         if status != "ok":
             continue
         out[name] = value

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -486,7 +486,7 @@ def build_sql(
     )
     sql = (
         "SELECT s.source_path, s.base_uri, s.source_format, s.format_version, "
-        f"p.*{attr_cols} "
+        f"s.path_attrs, p.*{attr_cols} "
         f"{_FROM}"
         f"WHERE {where.sql} "
         f"{order}"

--- a/dascore/io/index/schema.py
+++ b/dascore/io/index/schema.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from types import MappingProxyType
 
 # Version of the index schema, independent of dascore's version.
-INDEX_VERSION = 3
+INDEX_VERSION = 4
 # Identity string so any tool can sanity-check what it opened.
 WHAT_IS_THIS = "dascore_spool_index"
 
@@ -46,6 +46,12 @@ SOURCES = MappingProxyType(
         "format_version": "str",
         "mtime_ns": "int64",
         "size_bytes": "int64",
+        # JSON dict of hive-style key=value attrs parsed from the stored
+        # path's directory segments; NULL when the path carries none.
+        # Records which attr values are path-derived so moves can rewrite
+        # them and patch loading can stamp them without re-parsing paths
+        # (derived/union catalogs absolutize paths, losing the segments).
+        "path_attrs": "str",
         "last_indexed_ns": "int64",
         # The catalog's explicit ordering contract: patch rows present in
         # (ordinal, patch_id) order. Assigned at ingest (insertion
@@ -200,6 +206,7 @@ RESERVED_ATTR_COLUMNS = frozenset(
         "base_uri",
         "mtime_ns",
         "size_bytes",
+        "path_attrs",
         "n_dims",
         "dims",
         "shape",

--- a/dascore/utils/paths.py
+++ b/dascore/utils/paths.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import re
 import tempfile
 from pathlib import Path
+from urllib.parse import unquote
 
 from dascore.compat import UPath
 from dascore.exceptions import InvalidSpoolError
+
+# Hive's sentinel for a NULL partition value; means "no value", so the
+# key is treated as absent rather than set to the sentinel string.
+_HIVE_NULL = "__HIVE_DEFAULT_PARTITION__"
+# A trailing file extension: dot then a letter-led alphanumeric run, so
+# numeric values like "depth=1.5" keep their fractional part.
+_EXTENSION_RE = re.compile(r"\.[A-Za-z][A-Za-z0-9]*$")
 
 # Synthetic URI schemes for in-memory patch identities (see
 # dascore.io.index.catalog); such paths dispatch to in-memory registries
@@ -80,6 +89,47 @@ def coerce_to_local_path(resource) -> Path:
     if isinstance(resource, str) and "://" not in resource:
         return Path(resource)
     return Path(coerce_to_upath(resource).path)
+
+
+def parse_hive_path_attrs(rel_posix: str) -> dict[str, str]:
+    """
+    Parse hive-style ``key=value`` pairs from a relative path.
+
+    Every path segment participates, including the file name, whose
+    extension is first stripped. A segment holds one pair (Hive layout,
+    ``network=XX/``) or several separated by ``__`` — the same separator
+    DASCore's default patch names use — as in ``station=A__tag=raw.h5``.
+    Keys and values are percent-decoded after splitting, so encoded
+    ``=`` (``%3D``), ``__`` (``%5F%5F``), and ``.`` survive inside either
+    part. When a key repeats, the deepest (then rightmost) one wins.
+    Pairs with an empty key or value, or with Hive's NULL sentinel as
+    the value, are skipped, as are segments/parts without ``=``.
+
+    Parameters
+    ----------
+    rel_posix
+        A POSIX-style path relative to the spool root (as stored in the
+        index), e.g. ``"network=XX/station=A/file.h5"``.
+
+    Examples
+    --------
+    >>> from dascore.utils.paths import parse_hive_path_attrs
+    >>> parse_hive_path_attrs("network=XX/station=A/cable=n__tag=raw.h5")
+    {'network': 'XX', 'station': 'A', 'cable': 'n', 'tag': 'raw'}
+    """
+    out: dict[str, str] = {}
+    segments = rel_posix.split("/")
+    segments[-1] = _EXTENSION_RE.sub("", segments[-1])
+    for segment in segments:
+        for part in segment.split("__"):
+            key, sep, value = part.partition("=")
+            if not sep:
+                continue
+            key, value = unquote(key), unquote(value)
+            if not key or not value or value == _HIVE_NULL:
+                continue
+            out[key] = value
+    return out
 
 
 def requires_local_directory(resource, *, label: str):

--- a/docs/notes/spool_index.qmd
+++ b/docs/notes/spool_index.qmd
@@ -11,7 +11,7 @@ The schema separates records with different lifetimes and cardinalities. This av
 | Table | One row per | Purpose |
 |---|---|---|
 | `meta_data` | index | Identifies the file and its schema version |
-| `sources` | file or directory-format source | Tracks the source path, format, size, modification time, and presentation ordinal |
+| `sources` | file or directory-format source | Tracks the source path, format, size, modification time, hive-style path attrs (JSON), and presentation ordinal |
 | `patches` | patch within a source | Stores patch identity and common time/distance envelopes |
 | `attrs` | patch | Stores typed attribute values in dynamically added columns |
 | `attr_meta` | attribute name and value kind | Maps original attribute names to typed storage columns and canonical units |
@@ -27,6 +27,32 @@ The last two tables are deliberately separate. Many patches can share a distance
 The index is an incrementally updated cache. A directory update scans new or changed sources, transactionally replaces their patch rows, and removes rows for deleted sources. Foreign keys cascade source deletion through patches, attributes, and patch-coordinate links. Unreferenced coordinate definitions may remain available for reuse.
 
 The current schema version is validated before any mutation. An unrelated or incomplete database raises an error with instructions to delete and rebuild it; DASCore does not silently repair or migrate it. A file that identifies itself as a DASCore spool index of a different schema version is rebuilt automatically by the directory indexer — the index is a disposable cache whose truth is the files.
+
+## Hive-style path attributes
+
+Stored source paths are parsed for `key=value` pairs (each directory segment, and `__`-separated pairs in any segment including the extension-stripped file name). The pairs are merged into every patch's attrs at ingest as plain string values — the path wins over a same-named file attr, since renaming a path is the user's way of correcting metadata. The applied dict is also persisted on the source row (`sources.path_attrs`, JSON) and surfaced privately as `_path_attrs` in the flat relation: derived and union catalogs absolutize paths, so provenance must ride with the row for patch loading to stamp the attrs and for moves to rewrite them. Reserved/underscore key names follow the same skip rules as file attrs; values are never type-inferred.
+
+Renames are detected during a directory update by exact `(mtime_ns, size_bytes)` stat identity (the rename-invariant manifest signature for directory-format units) between a disappeared and a brand-new path, each unique on its side. A detected move rewrites the source path and its path-derived attr values in SQL without re-reading file contents, so renaming a partition directory over a large archive is cheap. A rename that *removes* a hive key falls back to a rescan — the file's own value for that attr is only recoverable by reading it — and ambiguous stat matches also rescan rather than guess.
+
+```{python}
+import tempfile
+from pathlib import Path
+
+import dascore as dc
+
+root = Path(tempfile.mkdtemp())
+(root / "network=XX" / "station=A").mkdir(parents=True)
+dc.get_example_patch().io.write(root / "network=XX" / "station=A" / "tag=raw.h5", "DASDAE")
+
+spool = dc.spool(root).update()
+row = spool.get_contents().iloc[0]
+assert (row["network"], row["station"], row["tag"]) == ("XX", "A", "raw")
+assert spool[0].attrs.station == "A"
+
+# a directory rename is a pure metadata rewrite
+(root / "network=XX" / "station=A").rename(root / "network=XX" / "station=B")
+assert dc.spool(root).update().get_contents()["station"].iloc[0] == "B"
+```
 
 ## Ordering
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -86,6 +86,49 @@ spool.update()
 It is best not to delete files once added to a directory managed by DASCore.
 :::
 
+### Path attributes (hive-style directories)
+
+Directory spools parse `key=value` pairs out of the paths inside the spool, in the style of [Hive partitioning](https://hive.apache.org/). Each directory segment can hold one pair (`network=XX/`), and any segment — including the file name, whose extension is ignored — can hold several separated by `__` (the same separator DASCore's default patch names use). The parsed values become string attributes: they show up in `get_contents()`, work with `select`, and are set on loaded patches. When a path attribute and an attribute stored inside the file share a name, the path wins — renaming a directory (or file) is how you attach or correct metadata without rewriting data.
+
+```{python}
+import shutil
+import tempfile
+from pathlib import Path
+
+import dascore as dc
+
+# Build a small hive-partitioned directory of DAS files.
+data_path = Path(tempfile.mkdtemp()) / "experiment=demo" / "cable=north"
+data_path.mkdir(parents=True)
+dc.get_example_patch().io.write(data_path / "tag=raw.h5", "DASDAE")
+
+spool = dc.spool(data_path.parent.parent).update()
+df = spool.get_contents()
+assert df["experiment"].iloc[0] == "demo"
+assert len(spool.select(cable="north")) == 1
+
+# The loaded patch carries the path attributes too.
+patch = spool[0]
+assert patch.attrs["experiment"] == "demo"
+assert patch.attrs.tag == "raw"
+```
+
+Renaming a partition directory and calling `update()` refreshes the affected attributes by rewriting index rows — file contents are not re-read, so this stays fast even for very large directories.
+
+```{python}
+root = data_path.parent.parent
+(root / "experiment=demo").rename(root / "experiment=final")
+spool = spool.update()
+assert spool.get_contents()["experiment"].iloc[0] == "final"
+shutil.rmtree(root)
+```
+
+A few details worth knowing:
+
+- Values are always strings; `select` supports equality, collections, unix-style globs, and regular expressions on them.
+- Removing a `key=value` pair from a path triggers a rescan of the affected files (the file's own value has to be recovered), while adding or changing pairs does not.
+- A path key that matches a coordinate name (e.g. `distance=...`) resolves attrs-first in bare `select` kwargs; use the `_coords` argument to target the coordinate explicitly.
+
 Despite some implementation differences, all spools have common behavior/methods.
 
 :::{.callout-note}

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -91,7 +91,6 @@ It is best not to delete files once added to a directory managed by DASCore.
 Directory spools parse `key=value` pairs out of the paths inside the spool, in the style of [Hive partitioning](https://hive.apache.org/). Each directory segment can hold one pair (`network=XX/`), and any segment — including the file name, whose extension is ignored — can hold several separated by `__` (the same separator DASCore's default patch names use). The parsed values become string attributes: they show up in `get_contents()`, work with `select`, and are set on loaded patches. When a path attribute and an attribute stored inside the file share a name, the path wins — renaming a directory (or file) is how you attach or correct metadata without rewriting data.
 
 ```{python}
-import shutil
 import tempfile
 from pathlib import Path
 
@@ -120,7 +119,6 @@ root = data_path.parent.parent
 (root / "experiment=demo").rename(root / "experiment=final")
 spool = spool.update()
 assert spool.get_contents()["experiment"].iloc[0] == "final"
-shutil.rmtree(root)
 ```
 
 A few details worth knowing:

--- a/tests/test_io/test_index/test_hive_attrs.py
+++ b/tests/test_io/test_index/test_hive_attrs.py
@@ -295,8 +295,15 @@ class TestEdgeCases:
         spool = Spool.from_directory(hive_dir).update(progress=None)
         spool.indexer.close()
         index_path = hive_dir / ".dascore_index.sqlite3"
-        with sqlite3.connect(index_path) as con:
+        # close explicitly: sqlite3's context manager only wraps the
+        # transaction, and a lingering handle blocks the rebuild's
+        # unlink on Windows.
+        con = sqlite3.connect(index_path)
+        try:
             con.execute("UPDATE meta_data SET index_version = 3")
+            con.commit()
+        finally:
+            con.close()
         reopened = Spool.from_directory(hive_dir).update(progress=None)
         try:
             assert reopened.get_contents()["station"].iloc[0] == "A"

--- a/tests/test_io/test_index/test_hive_attrs.py
+++ b/tests/test_io/test_index/test_hive_attrs.py
@@ -1,0 +1,304 @@
+"""
+Tests for hive-style path attributes on directory spools.
+
+key=value path segments (directories and file names) become string
+attrs in the index, override file-declared attrs, stamp onto loaded
+patches, and survive directory renames without content rescans.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+
+import pytest
+
+import dascore as dc
+from dascore.core.spool import Spool
+from dascore.utils.paths import parse_hive_path_attrs
+
+
+@pytest.fixture()
+def scan_calls(monkeypatch):
+    """Count dc.scan invocations (the content-rescan choke point)."""
+    calls = []
+    real = dc.scan
+
+    def wrapper(*args, **kwargs):
+        calls.append(args)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(dc, "scan", wrapper)
+    return calls
+
+
+@pytest.fixture()
+def hive_dir(tmp_path):
+    """One patch under network=XX/station=A with filename attrs."""
+    sub = tmp_path / "network=XX" / "station=A"
+    sub.mkdir(parents=True)
+    patch = dc.get_example_patch()
+    patch.io.write(sub / "cable=north__tag=raw.h5", "dasdae")
+    return tmp_path
+
+
+@pytest.fixture()
+def hive_spool(hive_dir):
+    """An updated directory spool over the hive tree."""
+    spool = Spool.from_directory(hive_dir).update(progress=None)
+    yield spool
+    spool.indexer.close()
+
+
+class TestParseHivePathAttrs:
+    """The pure path parser."""
+
+    def test_directory_segments(self):
+        """Plain hive layout parses each directory."""
+        out = parse_hive_path_attrs("network=XX/station=A/file.h5")
+        assert out == {"network": "XX", "station": "A"}
+
+    def test_filename_pairs(self):
+        """The file name participates, extension stripped, __ separated."""
+        out = parse_hive_path_attrs("cable=north__tag=raw.h5")
+        assert out == {"cable": "north", "tag": "raw"}
+
+    def test_percent_decoding(self):
+        """Keys/values decode after splitting so %3D survives."""
+        out = parse_hive_path_attrs("a%20b=c%3Dd/file.h5")
+        assert out == {"a b": "c=d"}
+
+    def test_deepest_wins(self):
+        """A repeated key takes the deepest value."""
+        out = parse_hive_path_attrs("station=A/station=B/file.h5")
+        assert out == {"station": "B"}
+
+    def test_empty_key_or_value_skipped(self):
+        """'=x' and 'x=' segments contribute nothing."""
+        assert parse_hive_path_attrs("=x/y=/file.h5") == {}
+
+    def test_hive_null_sentinel_skipped(self):
+        """Hive's NULL partition sentinel means missing."""
+        out = parse_hive_path_attrs("station=__HIVE_DEFAULT_PARTITION__/f.h5")
+        assert out == {}
+
+    def test_no_pairs(self):
+        """Paths without = parse to nothing."""
+        assert parse_hive_path_attrs("plain/dir/file.h5") == {}
+        assert parse_hive_path_attrs(".") == {}
+        assert parse_hive_path_attrs("file.h5") == {}
+
+    def test_value_keeps_second_equals(self):
+        """Only the first = splits; the rest stays in the value."""
+        assert parse_hive_path_attrs("a=b=c/f.h5") == {"a": "b=c"}
+
+    def test_numeric_value_keeps_fraction(self):
+        """A trailing .5 is a value fragment, not an extension."""
+        assert parse_hive_path_attrs("depth=1.5/f.h5") == {"depth": "1.5"}
+        assert parse_hive_path_attrs("depth=1.5") == {"depth": "1.5"}
+
+
+class TestHiveIndexing:
+    """Hive attrs land in the index and drive selection."""
+
+    def test_contents_columns(self, hive_spool):
+        """Directory and filename attrs appear as string columns."""
+        df = hive_spool.get_contents()
+        row = df.iloc[0]
+        assert row["network"] == "XX"
+        assert row["station"] == "A"
+        assert row["cable"] == "north"
+        assert row["tag"] == "raw"
+
+    def test_select_equality_and_glob(self, hive_spool):
+        """Select supports equality and glob on hive attrs."""
+        assert len(hive_spool.select(station="A")) == 1
+        assert len(hive_spool.select(station="nope")) == 0
+        assert len(hive_spool.select(cable="nor*")) == 1
+
+    def test_non_hive_spool_unaffected(self, tmp_path):
+        """A plain directory spool gains no hive columns."""
+        patch = dc.get_example_patch()
+        patch.io.write(tmp_path / "plain_file.h5", "dasdae")
+        spool = Spool.from_directory(tmp_path).update(progress=None)
+        try:
+            df = spool.indexer.get_contents()
+            assert df["_path_attrs"].isnull().all()
+            assert "cable" not in df.columns
+        finally:
+            spool.indexer.close()
+
+
+class TestHiveWins:
+    """Path attrs override file-declared attrs."""
+
+    @pytest.fixture()
+    def conflict_spool(self, tmp_path):
+        """File says station=B but lives under station=A."""
+        sub = tmp_path / "station=A"
+        sub.mkdir()
+        patch = dc.get_example_patch().update_attrs(station="B")
+        patch.io.write(sub / "conflict.h5", "dasdae")
+        spool = Spool.from_directory(tmp_path).update(progress=None)
+        yield spool
+        spool.indexer.close()
+
+    def test_index_shows_path_value(self, conflict_spool):
+        """The contents show the path's value."""
+        assert conflict_spool.get_contents()["station"].iloc[0] == "A"
+
+    def test_loaded_patch_shows_path_value(self, conflict_spool):
+        """The loaded patch also shows the path's value."""
+        assert conflict_spool[0].attrs.station == "A"
+
+
+class TestPatchStamping:
+    """Hive attrs reach loaded patches in every load path."""
+
+    def test_getitem(self, hive_spool):
+        """spool[i] carries the hive attrs."""
+        patch = hive_spool[0]
+        assert patch.attrs.network == "XX"
+        assert patch.attrs.station == "A"
+        assert patch.attrs["cable"] == "north"
+
+    def test_chunked(self, tmp_path):
+        """Patches from a chunked spool keep hive attrs."""
+        from dascore.examples import spool_to_directory
+
+        sub = tmp_path / "network=XX"
+        sub.mkdir()
+        spool_to_directory(dc.get_example_spool("random_das"), path=sub)
+        spool = Spool.from_directory(tmp_path).update(progress=None)
+        try:
+            merged = spool.chunk(time=None)
+            assert merged[0].attrs.network == "XX"
+        finally:
+            spool.indexer.close()
+
+    def test_union(self, hive_spool, tmp_path_factory):
+        """Union spools keep hive attrs in contents and patches."""
+        other_dir = tmp_path_factory.mktemp("other") / "station=Z"
+        other_dir.mkdir()
+        dc.get_example_patch().io.write(other_dir / "other.h5", "dasdae")
+        other = Spool.from_directory(other_dir.parent).update(progress=None)
+        try:
+            union = hive_spool + other
+            stations = set(union.get_contents()["station"])
+            assert stations == {"A", "Z"}
+            assert {p.attrs.station for p in union} == {"A", "Z"}
+        finally:
+            other.indexer.close()
+
+    def test_pickle_roundtrip(self, hive_spool):
+        """Pickled spools keep hive attrs on loaded patches."""
+        loaded = pickle.loads(pickle.dumps(hive_spool))
+        assert loaded[0].attrs.station == "A"
+
+
+class TestMoveDetection:
+    """Renames rewrite the index without content rescans."""
+
+    def test_directory_rename_no_rescan(self, hive_spool, hive_dir, scan_calls):
+        """Renaming a partition directory never re-reads file contents."""
+        df_before = hive_spool.indexer.get_contents()
+        (hive_dir / "network=XX" / "station=A").rename(
+            hive_dir / "network=XX" / "station=Q"
+        )
+        updated = hive_spool.update(progress=None)
+        assert not scan_calls
+        df = updated.indexer.get_contents()
+        assert df["station"].iloc[0] == "Q"
+        assert df["path"].iloc[0].startswith("network=XX/station=Q/")
+        # patch/coord rows survived: same patch identity
+        assert list(df["_patch_id"]) == list(df_before["_patch_id"])
+        assert updated[0].attrs.station == "Q"
+
+    def test_file_rename_adds_attr_no_rescan(self, hive_spool, hive_dir, scan_calls):
+        """Adding a key via the file name is also a pure move."""
+        old = hive_dir / "network=XX" / "station=A" / "cable=north__tag=raw.h5"
+        old.rename(old.with_name("cable=north__tag=raw__phase=2.h5"))
+        updated = hive_spool.update(progress=None)
+        assert not scan_calls
+        assert updated.get_contents()["phase"].iloc[0] == "2"
+
+    def test_removed_key_triggers_rescan(self, hive_spool, hive_dir, scan_calls):
+        """Dropping a hive key needs the file's own value back: rescan."""
+        old = hive_dir / "network=XX" / "station=A" / "cable=north__tag=raw.h5"
+        old.rename(old.with_name("cable=north.h5"))
+        updated = hive_spool.update(progress=None)
+        assert len(scan_calls) == 1
+        df = updated.get_contents()
+        # the file itself declares a tag; with the path key gone it returns
+        assert df["tag"].iloc[0] == dc.get_example_patch().attrs.tag
+
+    def test_ambiguous_stats_fall_back_to_rescan(self, tmp_path, scan_calls):
+        """Twin files with identical stats are rescanned, not guessed."""
+        patch = dc.get_example_patch()
+        patch.io.write(tmp_path / "twin_a.h5", "dasdae")
+        patch.io.write(tmp_path / "twin_b.h5", "dasdae")
+        stat = (tmp_path / "twin_a.h5").stat()
+        os.utime(tmp_path / "twin_b.h5", ns=(stat.st_atime_ns, stat.st_mtime_ns))
+        if (tmp_path / "twin_a.h5").stat().st_size != (
+            tmp_path / "twin_b.h5"
+        ).stat().st_size:
+            pytest.skip("twin files did not serialize to equal sizes")
+        spool = Spool.from_directory(tmp_path).update(progress=None)
+        try:
+            scan_calls.clear()
+            sub = tmp_path / "tag=x"
+            sub.mkdir()
+            (tmp_path / "twin_a.h5").rename(sub / "twin_a.h5")
+            (tmp_path / "twin_b.h5").rename(sub / "twin_b.h5")
+            updated = spool.update(progress=None)
+            assert len(scan_calls) == 1  # one scan covering both twins
+            assert set(updated.get_contents()["tag"]) == {"x"}
+        finally:
+            spool.indexer.close()
+
+    def test_non_fiber_file_rename(self, hive_spool, hive_dir, scan_calls):
+        """A moved non-fiber file stays quietly tracked."""
+        (hive_dir / "notes.txt").write_text("hello")
+        spool = hive_spool.update(progress=None)
+        scan_calls.clear()
+        (hive_dir / "notes.txt").rename(hive_dir / "network=XX" / "notes.txt")
+        spool = spool.update(progress=None)
+        assert not scan_calls
+        assert len(spool) == 1
+
+
+class TestEdgeCases:
+    """Reserved names, coord collisions, and version rebuilds."""
+
+    def test_reserved_key_warns_and_skips(self, tmp_path):
+        """A hive key colliding with a structural column warns."""
+        sub = tmp_path / "time_min=5"
+        sub.mkdir()
+        dc.get_example_patch().io.write(sub / "file.h5", "dasdae")
+        with pytest.warns(UserWarning, match="hive-style path key"):
+            spool = Spool.from_directory(tmp_path).update(progress=None)
+        spool.indexer.close()
+
+    def test_restricted_update_still_moves(self, hive_spool, hive_dir, scan_calls):
+        """update(paths=...) applies moves outside the restriction."""
+        (hive_dir / "network=XX" / "station=A").rename(
+            hive_dir / "network=XX" / "station=R"
+        )
+        hive_spool.indexer.update(paths=[hive_dir / "does_not_exist"], progress=None)
+        assert not scan_calls
+        assert hive_spool.indexer.get_contents()["station"].iloc[0] == "R"
+
+    def test_old_index_version_rebuilds(self, hive_dir):
+        """An index stamped with an older version rebuilds transparently."""
+        import sqlite3
+
+        spool = Spool.from_directory(hive_dir).update(progress=None)
+        spool.indexer.close()
+        index_path = hive_dir / ".dascore_index.sqlite3"
+        with sqlite3.connect(index_path) as con:
+            con.execute("UPDATE meta_data SET index_version = 3")
+        reopened = Spool.from_directory(hive_dir).update(progress=None)
+        try:
+            assert reopened.get_contents()["station"].iloc[0] == "A"
+        finally:
+            reopened.indexer.close()

--- a/tests/test_io/test_index/test_hive_attrs.py
+++ b/tests/test_io/test_index/test_hive_attrs.py
@@ -256,6 +256,26 @@ class TestMoveDetection:
         finally:
             spool.indexer.close()
 
+    def test_plain_rename_without_hive_keys(self, tmp_path, scan_calls):
+        """A rename with no hive keys anywhere is still a cheap move."""
+        dc.get_example_patch().io.write(tmp_path / "plain_a.h5", "dasdae")
+        spool = Spool.from_directory(tmp_path).update(progress=None)
+        try:
+            scan_calls.clear()
+            (tmp_path / "plain_a.h5").rename(tmp_path / "plain_b.h5")
+            updated = spool.update(progress=None)
+            assert not scan_calls
+            assert updated.get_contents()["path"].iloc[0] == "plain_b.h5"
+        finally:
+            spool.indexer.close()
+
+    def test_detect_moves_skips_unstatted_and_root(self, hive_spool, hive_dir):
+        """Sources without stored stats and the root unit never match."""
+        files = {"new.h5": (1, 2, hive_dir / "new.h5")}
+        stored = {"gone.h5": None, ".": (1, 2)}
+        moves = hive_spool.indexer._detect_moves(["gone.h5", "."], stored, files)
+        assert moves == {}
+
     def test_non_fiber_file_rename(self, hive_spool, hive_dir, scan_calls):
         """A moved non-fiber file stays quietly tracked."""
         (hive_dir / "notes.txt").write_text("hello")


### PR DESCRIPTION
## Description

Directory spools now parse `key=value` pairs out of the paths inside the spool, Hive-style. Each directory segment can hold one pair (`network=XX/`), and any segment — including the file name, with its extension stripped — can hold several separated by `__` (the same separator `get_patch_names` uses), e.g. `station=A__tag=raw.h5`. Parsed values become string attrs: they appear in `get_contents()`, work with `select` (equality, collections, glob, regex), participate in chunk grouping, survive unions/pickling, and are stamped onto loaded patches. When a path attr and a file-declared attr share a name, the path wins — renaming a directory (or file) attaches or corrects metadata without rewriting data.

Details:

- Parser: `dascore.utils.paths.parse_hive_path_attrs` (percent-decoding, deepest-key-wins, Hive NULL sentinel skipped, letter-led extension stripping so `depth=1.5` survives). Reserved/underscore key names follow the same skip/warn rules as file attrs.
- Provenance: the applied dict is persisted per source (`sources.path_attrs`, JSON) and surfaced privately as `_path_attrs`, since derived/union catalogs absolutize paths. `INDEX_VERSION` 3 → 4; existing indexes rebuild automatically.
- Move detection: updates match a disappeared path to a brand-new one by exact `(mtime_ns, size_bytes)` identity (unique 1:1 on both sides; the rename-invariant manifest signature for directory-format units) and rewrite paths + path-derived attrs in batched SQL, never re-reading contents. Renames that *remove* a hive key, or ambiguous stat matches, fall back to a rescan.
- Values stay strings (no type inference); numeric inference could be a follow-up if range selects on path keys turn out to matter.

Benchmarks vs `dev` (600 files / 12 partition dirs): cold index build, no-op update, time select, and patch loading unchanged within noise; renaming one partition dir + update went 457 ms → 72 ms, renaming all 12 dirs 4.13 s → 0.12 s (~34×, and the gap grows with archive size since dev rescans contents). Path parsing costs ~1.5 µs/path. Two codspeed benchmarks added (`TestHivePathAttrBenchmarks`: hive indexing, patch loading with stamped attrs).

Behavior note for release: directories whose names happen to contain `=` now silently produce attrs, and the version bump forces a one-time index rebuild.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
- added: directory spools parse Hive-style `key=value` path segments into string attrs, usable in `get_contents()`, `select`, and chunk grouping; a path attr wins over a file-declared attr of the same name, so renaming a directory attaches metadata without rewriting data. Any path segment containing `=` is parsed this way, so a directory named for something else that happens to contain one now yields an attr.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Hive-style `key=value` path attributes in directory-based spools.
  * Path attributes are now stored and surfaced in spool contents, enabling filtering and appearing on loaded patches.
  * Includes correct parsing (encoded values, `__`-separated pairs, repeated-key precedence) and efficient rename/move handling that updates attributes without rescanning when safe.
* **Bug Fixes**
  * Path-derived attributes correctly override conflicting file-defined attributes.
* **Documentation**
  * Expanded spool index and tutorial docs with examples and rename edge cases.
* **Tests**
  * Added end-to-end coverage for parsing, selection, patch stamping, and move detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->