### PR TITLE
Add Patch.from_parts and stop reconciling attrs twice

### DIFF
--- a/benchmarks/test_patch_benchmarks.py
+++ b/benchmarks/test_patch_benchmarks.py
@@ -190,6 +190,54 @@ class TestProcessingBenchmarks:
         patch.slope_mute(slopes=(1000, 3000))
 
 
+class TestPatchConstructionBenchmarks:
+    """Benchmarks for the patch construction paths."""
+
+    @pytest.fixture(scope="module")
+    def new_data(self, example_patch):
+        """Data for constructing new patches; built outside the timed call."""
+        return np.asarray(example_patch.data) * 2
+
+    @pytest.fixture(scope="module")
+    def decimated(self, example_patch):
+        """A coord manager with one dimension shortened."""
+        coord = example_patch.get_coord("time")[::2]
+        return example_patch.coords.update(time=coord)
+
+    @pytest.mark.benchmark
+    def test_new_data_only(self, example_patch, new_data):
+        """Time new when only data changes; coords and attrs are reused."""
+        example_patch.new(data=new_data)
+
+    @pytest.mark.benchmark
+    def test_new_with_coords(self, example_patch, decimated):
+        """Time new when the coords change, so attrs must be rebuilt."""
+        example_patch.new(data=example_patch.data[:, ::2], coords=decimated)
+
+    @pytest.mark.benchmark
+    def test_new_with_coords_and_attrs(self, example_patch, new_data):
+        """Time new when both coords and attrs are passed."""
+        patch = example_patch
+        patch.new(data=new_data, coords=patch.coords, attrs=patch.attrs)
+
+    @pytest.mark.benchmark
+    def test_from_parts(self, example_patch, new_data):
+        """Time the fast constructor for already conforming parts."""
+        patch = example_patch
+        dc.Patch.from_parts(new_data, patch.coords, patch.attrs)
+
+    @pytest.mark.benchmark
+    def test_patch_init(self, example_patch, new_data):
+        """
+        Time the normal constructor.
+
+        This is a control; it should not move, since the strict path is
+        deliberately left alone.
+        """
+        patch = example_patch
+        dc.Patch(data=new_data, coords=patch.coords, dims=patch.dims, attrs=patch.attrs)
+
+
 class TestTransformBenchmarks:
     """Benchmarks for patch transform operations."""
 

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -254,6 +254,22 @@ class PatchAttrs(DascoreBaseModel):
             out["coords"] = {}
         return self.__class__(**out)
 
+    def _conform_to(self, coords: dc.CoordManager) -> Self:
+        """
+        Return attrs whose coord summaries and dims come from coords.
+
+        Equivalent to `self.update(coords=coords)` but skips a full model
+        dump and re-validation. This uses model_copy, which does no type
+        coercion, so the values assigned here must already be in their
+        final form.
+        """
+        return self.model_copy(
+            update={
+                "coords": FrozenDict(coords.to_summary_dict()),
+                "dims": ",".join(coords.dims),
+            }
+        )
+
     def drop(self, *args):
         """Drop specific keys if they exist."""
         contents = dict(self)

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -16,6 +16,7 @@ from dascore.compat import DataArray, array
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.coords import BaseCoord
+from dascore.exceptions import PatchCoordinateError
 from dascore.utils.array import PatchUFunc, patch_array_function, patch_array_ufunc
 from dascore.utils.deprecate import deprecate
 from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
@@ -23,6 +24,16 @@ from dascore.utils.models import ArrayLike
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import check_patch_attrs, check_patch_coords, get_patch_names
 from dascore.utils.time import to_float
+
+
+def _check_dims_match(coords: CoordManager, attrs: PatchAttrs) -> None:
+    """Raise if the coord manager and attrs disagree about dimensions."""
+    if coords.dims != attrs.dim_tuple:
+        msg = (
+            f"Dimension mismatch between coords ({coords.dims}) and "
+            f"attrs ({attrs.dim_tuple})."
+        )
+        raise PatchCoordinateError(msg)
 
 
 class Patch(NamespaceOwner):
@@ -60,6 +71,11 @@ class Patch(NamespaceOwner):
     - If coords and attrs are provided, attrs will have priority. This means
     if there is a conflict between information contained in both, the coords
     will be recalculated.
+
+    - Because the constructor always reconciles the two, every Patch has attrs
+    whose coordinate summaries match its coords. Code which already holds a
+    conforming pair can skip that work with
+    [`Patch.from_parts`](`dascore.core.patch.Patch.from_parts`).
     """
 
     data: ArrayLike
@@ -98,10 +114,76 @@ class Patch(NamespaceOwner):
         else:
             # ensure attrs conforms to coords
             attrs = dc.PatchAttrs.from_dict(attrs).update(coords=coords)
-        assert coords.dims == attrs.dim_tuple, "dim mismatch on coords and attrs"
+        _check_dims_match(coords, attrs)
         self._coords = coords
         self._attrs = attrs
         self._data = array(self.coords.validate_data(data))
+
+    @classmethod
+    def from_parts(
+        cls,
+        data: ArrayLike,
+        coords: CoordManager,
+        attrs: PatchAttrs,
+    ) -> Self:
+        """
+        Create a patch from parts which already conform to each other.
+
+        This is a fast alternative to the normal constructor for code which
+        has already built a coordinate manager and matching attributes. It
+        skips recomputing the coordinate summaries stored on attrs, which
+        the constructor does unconditionally.
+
+        Parameters
+        ----------
+        data
+            The array data. Its shape must match coords.
+        coords
+            A CoordManager describing the data's dimensions.
+        attrs
+            A PatchAttrs whose coordinate summaries were derived from coords.
+
+        Raises
+        ------
+        PatchCoordinateError
+            If coords and attrs disagree about dimension names.
+        CoordDataError
+            If the data shape does not match coords.
+
+        Notes
+        -----
+        The data shape and dimension names are validated, but the coordinate
+        summaries on attrs are trusted. Passing attrs whose summaries came
+        from a different coordinate manager creates a Patch whose attrs
+        disagree with its coords.
+
+        Every Patch conforms by construction, so `patch.attrs` is always safe
+        to pass alongside `patch.coords`. If the coords have changed, rebuild
+        the attrs first with `patch.attrs.update(coords=new_coords)`. Note
+        that attrs built with an empty `coords` (a common way to let the
+        constructor repopulate them) do *not* conform, and the dimension
+        check will not catch it, since clearing coords leaves dims in place.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> patch = dc.get_example_patch()
+        >>>
+        >>> # Data of the same shape reuses the existing coords and attrs.
+        >>> out = dc.Patch.from_parts(patch.data * 2, patch.coords, patch.attrs)
+        >>>
+        >>> # If the coords change, the attrs must be rebuilt from them.
+        >>> coords = patch.coords.update(time=patch.get_coord("time")[::2])
+        >>> out = dc.Patch.from_parts(
+        ...     patch.data[..., ::2], coords, patch.attrs.update(coords=coords)
+        ... )
+        """
+        _check_dims_match(coords, attrs)
+        new = cls.__new__(cls)
+        new._coords = coords
+        new._attrs = attrs
+        new._data = array(coords.validate_data(data))
+        return new
 
     _namespace_entry_point_group = "dascore.patch_namespace"
 

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -10,7 +10,7 @@ import pandas as pd
 from scipy.fft import next_fast_len
 
 import dascore as dc
-from dascore.compat import array
+from dascore.compat import DataArray, array
 from dascore.constants import PatchType
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import CoordManager, get_coord_manager
@@ -239,6 +239,16 @@ def update(
     -----
     - If both coords and attrs are defined, attrs will have priority.
     """
+    # A Patch or DataArray passed as data brings its own coords and attrs,
+    # which the constructor unpacks, so it can't use the fast paths here.
+    data_has_meta = isinstance(data, DataArray | dc.Patch)
+    # When nothing that can affect coords or attrs changed, the reconciling
+    # done when self was created still holds and needn't be repeated.
+    if not data_has_meta and attrs is None and dims is None:
+        # Identity, not equality; CoordManager equality compares arrays.
+        if coords is None or coords is self.coords:
+            new_data = self.data if data is None else data
+            return self.from_parts(new_data, self.coords, self.attrs)
     data = data if data is not None else self.data
     coords = coords if coords is not None else self.coords
     if dims is None:
@@ -247,9 +257,11 @@ def update(
     if attrs is not None:
         coords, attrs = coords.update_from_attrs(attrs)
     else:
-        _attrs = dc.PatchAttrs.from_dict(attrs or self.attrs)
-        attrs = _attrs.update(coords=coords)
-    return self.__class__(data=data, coords=coords, attrs=attrs)
+        attrs = dc.PatchAttrs.from_dict(self.attrs)._conform_to(coords)
+    if data_has_meta:  # let the constructor unpack the patch/DataArray.
+        return self.__class__(data=data, coords=coords, attrs=attrs)
+    # coords and attrs were just reconciled; the constructor would redo it.
+    return self.from_parts(data, coords, attrs)
 
 
 @patch_function()

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -190,7 +190,7 @@ def sobel_filter(
     dim, mode, cval = _check_sobel_args(dim, mode, cval)
     axis = patch.get_axis(dim)
     out = ndimage.sobel(patch.data, axis=axis, mode=mode, cval=cval)
-    return dc.Patch(data=out, coords=patch.coords, attrs=patch.attrs, dims=patch.dims)
+    return dc.Patch.from_parts(out, patch.coords, patch.attrs)
 
 
 def _create_size_and_axes(patch, kwargs, samples):
@@ -331,7 +331,7 @@ def notch_filter(patch: PatchType, q: float, **kwargs) -> PatchType:
             raise FilterValueError(msg)
         b, a = iirnotch(w0, Q=q, fs=sr)
         data = filtfilt(b, a, data, axis=axis)
-    return dc.Patch(data=data, coords=patch.coords, attrs=patch.attrs, dims=patch.dims)
+    return dc.Patch.from_parts(data, patch.coords, patch.attrs)
 
 
 @patch_function()

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -68,27 +68,31 @@ class _PatchRollerInfo:
         coord = self.patch.get_coord(self.dim)[:: self.step]
         return self.patch.coords.update(**{self.dim: coord})
 
-    def _get_attrs_with_apply_history(self, func_or_str):
-        """Get new attrs that has history from apply attached."""
-        new_history = list(self.patch.attrs.history)
+    def _get_attrs(self, func_or_str, coords):
+        """Get attrs, with the apply history attached, conforming to coords."""
         if callable(func_or_str):
             func_name = getattr(func_or_str, "__name__", "")
             hist_str = f"{self.roll_hist}.apply({func_name})"
         else:
             hist_str = f"{self.roll_hist}.{func_or_str}()"
-        new_history.append(hist_str)
-        attrs = self.patch.attrs.update(history=new_history, coords={})
-        return attrs
+        # Must be a tuple; model_copy below does no type coercion.
+        history = (*self.patch.attrs.history, hist_str)
+        if coords is self.patch.coords:
+            # The coords didn't change, so their summaries still hold.
+            return self.patch.attrs.model_copy(update={"history": history})
+        return self.patch.attrs.update(history=history, coords=coords)
 
-    def _new_patch(self, data, attrs):
+    def _new_patch(self, data, func_or_str):
         """
         Create the output patch from rolled data.
 
-        The coordinates and attrs are both built here, so the Patch is
-        created directly rather than through `Patch.update`, which would
-        reconcile the attrs against the coords a second time.
+        The coords and matching attrs are both built here, so the patch is
+        made with `Patch.from_parts` rather than the normal constructor,
+        which would reconcile the two a second time.
         """
-        return self.patch.__class__(data=data, coords=self.get_coords(), attrs=attrs)
+        coords = self.get_coords()
+        attrs = self._get_attrs(func_or_str, coords)
+        return self.patch.from_parts(data, coords, attrs)
 
 
 class _NumpyPatchRoller(_PatchRollerInfo):
@@ -152,8 +156,7 @@ class _NumpyPatchRoller(_PatchRollerInfo):
         trimmed_slide_view = slide_view[tuple(step_slice)]
         raw = function(trimmed_slide_view, *args, axis=-1, **kwargs)
         out = self._pad_roll_array(np.asarray(raw, dtype=np.float64))
-        attrs = self._get_attrs_with_apply_history(function)
-        return self._new_patch(out, attrs)
+        return self._new_patch(out, function)
 
     def mean(self):
         """Apply mean to moving window."""
@@ -203,20 +206,19 @@ class _PandasPatchRoller(_PatchRollerInfo):
         )
         return roll
 
-    def _repack_patch(self, df, attrs):
+    def _repack_patch(self, df, func_or_str):
         """Repack patch into dataframe."""
         data = df.values if not self.axis else df.T.values
         # get rid of extra dims if original data doesn't have them.
         if len(data.shape) != len(self.patch.data.shape):
             data = np.squeeze(data)
-        return self._new_patch(data, attrs)
+        return self._new_patch(data, func_or_str)
 
     def _call_rolling_func(self, name, *args, **kwargs):
         """Helper function for calling a rolling function."""
         rolling = self._get_rolling()
         df = getattr(rolling, name)(*args, **kwargs)
-        attrs = self._get_attrs_with_apply_history(name)
-        return self._repack_patch(df, attrs=attrs)
+        return self._repack_patch(df, name)
 
     @compose_docstring(apply_description=rolling_apply_description)
     def apply(self, function, *args, **kwargs):
@@ -224,8 +226,7 @@ class _PandasPatchRoller(_PatchRollerInfo):
         {apply_description}
         """
         df = self._get_rolling().apply(function, args=args, kwargs=kwargs)
-        attrs = self._get_attrs_with_apply_history(function)
-        return self._repack_patch(df, attrs=attrs)
+        return self._repack_patch(df, function)
 
     def mean(self):
         """Apply mean."""

--- a/dascore/transform/differentiate.py
+++ b/dascore/transform/differentiate.py
@@ -145,4 +145,5 @@ def differentiate(
     # update units
     data_units = _get_data_units_from_dims(patch, dims, truediv)
     attrs = patch.attrs.update(data_units=data_units)
-    return patch.new(data=new_data, attrs=attrs)
+    # Coords are unchanged, so attrs still conform to them.
+    return patch.from_parts(new_data, patch.coords, attrs)

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -118,7 +118,8 @@ def velocity_to_strain_rate(
     new_attrs = patch.attrs.update(
         data_type="strain_rate", gauge_length=step * step_multiple
     )
-    return patch.update(attrs=new_attrs)
+    # Coords are unchanged, so attrs still conform to them.
+    return patch.from_parts(patch.data, patch.coords, new_attrs)
 
 
 @patch_function(
@@ -273,4 +274,5 @@ def radians_to_strain(
     # Build output patch
     new_attrs = patch.attrs.update(data_units=new_units)
     new_data = patch.data * const * d_factor
-    return patch.update(data=new_data, attrs=new_attrs)
+    # Coords are unchanged, so attrs still conform to them.
+    return patch.from_parts(new_data, patch.coords, new_attrs)

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -310,10 +310,8 @@ def _apply_aggregator(patch, dim, func, dim_reduce="empty"):
         else:
             coords = patch.coords.update(**{dim: new_coord})
             data = np.expand_dims(func(data, axis=axis), axis)
-        attrs = patch.attrs.model_dump(exclude={"coords", "dims"}, exclude_unset=True)
-        attrs["coords"] = coords.to_summary_dict()
-        attrs["dims"] = coords.dims
-        patch = patch.new(data=data, coords=coords, attrs=attrs)
+        # Attrs are rebuilt from the new coords, so they conform to them.
+        patch = patch.from_parts(data, coords, patch.attrs._conform_to(coords))
     return patch
 
 

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import operator
 import weakref
+from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -14,7 +15,12 @@ import dascore as dc
 from dascore.compat import random_state
 from dascore.core import Patch
 from dascore.core.coords import BaseCoord, CoordRange
-from dascore.exceptions import CoordError, ParameterError
+from dascore.exceptions import (
+    CoordDataError,
+    CoordError,
+    ParameterError,
+    PatchCoordinateError,
+)
 from dascore.proc.basic import apply_operator
 from dascore.utils.misc import suppress_warnings
 
@@ -91,9 +97,8 @@ class TestInit:
         out = dict(data=array, coords=coords, attrs=attrs, dims=dims)
         return Patch(**out)
 
-    @pytest.fixture(scope="class")
     def test_conflicting_attrs_coords_raises(self):
-        """Patch for testing conflicting coordinates/attributes."""
+        """Conflicting coordinate info in attrs and coords should raise."""
         array = random_state.random((10, 10))
         # create attrs, these should all get overwritten by coords.
         attrs = dict(
@@ -112,7 +117,7 @@ class TestInit:
         # assemble and output.
         dims = ("distance", "time")
         out = dict(data=array, coords=coords, attrs=attrs, dims=dims)
-        msg = "Coords and attrs are incompatible."
+        msg = "At most one parameter can be specified in update_limits"
         with pytest.raises(ValueError, match=msg):
             dc.Patch(**out)
 
@@ -345,6 +350,182 @@ class TestNew:
         dims = ("tom", "jerry")
         out = random_patch.new(dims=dims)
         assert out.dims == dims
+
+    def test_new_data_only_validates_shape(self, random_patch):
+        """New should still reject data which doesn't match the coords."""
+        data = random_patch.data[:-1]
+        with pytest.raises(CoordDataError):
+            random_patch.new(data=data)
+
+    def test_new_coords_validates_shape(self, random_patch):
+        """New should reject data which doesn't match passed coords."""
+        coords = random_patch.coords
+        with pytest.raises(CoordDataError):
+            random_patch.new(data=random_patch.data[:, :-1], coords=coords)
+
+    def test_new_same_coords_matches_default(self, random_patch):
+        """Passing the patch's own coords should match passing nothing."""
+        data = random_patch.data * 2
+        out1 = random_patch.new(data=data)
+        out2 = random_patch.new(data=data, coords=random_patch.coords)
+        assert out1.equals(out2, only_required_attrs=False)
+
+    def test_new_no_args_equals_input(self, random_patch):
+        """New with no arguments should reproduce the patch."""
+        assert random_patch.new().equals(random_patch, only_required_attrs=False)
+
+    def test_new_from_patch_takes_over_metadata(self, random_patch):
+        """Passing a patch as data should adopt its coords and attrs."""
+        other = random_patch.decimate(time=2)
+        out = random_patch.new(data=other)
+        assert out.coords == other.coords
+        assert out.shape == other.shape
+
+
+class TestFromParts:
+    """Tests for the `Patch.from_parts` fast constructor."""
+
+    def test_round_trip(self, patch):
+        """Rebuilding a patch from its own parts should reproduce it."""
+        out = dc.Patch.from_parts(patch.data, patch.coords, patch.attrs)
+        assert out.equals(patch, only_required_attrs=False)
+
+    def test_matches_normal_constructor(self, patch):
+        """from_parts should match what the constructor produces."""
+        data = patch.data * 2
+        fast = dc.Patch.from_parts(data, patch.coords, patch.attrs)
+        slow = dc.Patch(
+            data=data, coords=patch.coords, dims=patch.dims, attrs=patch.attrs
+        )
+        assert fast.equals(slow, only_required_attrs=False)
+        assert fast.coords == slow.coords
+        assert fast.attrs == slow.attrs
+
+    def test_data_not_writeable(self, random_patch):
+        """Data should be read-only, just as with the normal constructor."""
+        out = dc.Patch.from_parts(
+            np.array(random_patch.data), random_patch.coords, random_patch.attrs
+        )
+        assert not out.data.flags.writeable
+
+    def test_changed_coords_need_rebuilt_attrs(self, random_patch):
+        """The documented recipe for changed coords should conform."""
+        patch = random_patch
+        coords = patch.coords.update(time=patch.get_coord("time")[::2])
+        attrs = patch.attrs.update(coords=coords)
+        out = dc.Patch.from_parts(patch.data[:, ::2], coords, attrs)
+        assert dict(out.attrs.coords) == out.coords.to_summary_dict()
+
+    def test_bad_shape_raises(self, random_patch):
+        """Data which doesn't match the coords should raise."""
+        with pytest.raises(CoordDataError):
+            dc.Patch.from_parts(
+                random_patch.data[:-1], random_patch.coords, random_patch.attrs
+            )
+
+    def test_dim_mismatch_raises(self, random_patch):
+        """Attrs which disagree with coords about dims should raise."""
+        attrs = random_patch.attrs.update(dims="jazz,hands")
+        with pytest.raises(PatchCoordinateError, match="Dimension mismatch"):
+            dc.Patch.from_parts(random_patch.data, random_patch.coords, attrs)
+
+    def test_subclass_preserved(self, random_patch):
+        """from_parts should honor the class it is called on."""
+
+        class SubPatch(dc.Patch):
+            """A patch subclass."""
+
+        out = SubPatch.from_parts(
+            random_patch.data, random_patch.coords, random_patch.attrs
+        )
+        assert isinstance(out, SubPatch)
+
+
+class TestAttrsConformTo:
+    """Tests for the cheap `PatchAttrs._conform_to` rebuild."""
+
+    @pytest.fixture(scope="class")
+    def coord_managers(self, random_patch_with_lat_lon):
+        """Coord managers covering the interesting kinds of change."""
+        patch = random_patch_with_lat_lon
+        coords = patch.coords
+        return {
+            "same": coords,
+            "decimated": coords.update(time=patch.get_coord("time")[::2]),
+            "dropped": coords.drop_coords("latitude")[0],
+            "transposed": coords.transpose(),
+        }
+
+    def test_matches_update(self, random_patch_with_lat_lon, coord_managers):
+        """_conform_to should match the slower attrs.update(coords=...)."""
+        attrs = random_patch_with_lat_lon.attrs
+        for name, cm in coord_managers.items():
+            fast, slow = attrs._conform_to(cm), attrs.update(coords=cm)
+            assert fast == slow, f"mismatch for {name}"
+            assert fast.model_dump() == slow.model_dump(), f"dump differs for {name}"
+
+    def test_result_conforms(self, random_patch_with_lat_lon, coord_managers):
+        """The rebuilt attrs should agree with the coords they came from."""
+        attrs = random_patch_with_lat_lon.attrs
+        for name, cm in coord_managers.items():
+            out = attrs._conform_to(cm)
+            assert dict(out.coords) == cm.to_summary_dict(), name
+            assert out.dim_tuple == cm.dims, name
+
+    def test_model_copy_does_not_coerce(self, random_patch):
+        """
+        Document why _conform_to must pass final types.
+
+        model_copy skips validation, so a list where a tuple is expected
+        produces an object which is not equal to the validated one.
+        """
+        attrs = random_patch.attrs
+        history = ["a", "b"]
+        coerced = attrs.model_copy(update={"history": tuple(history)})
+        uncoerced = attrs.model_copy(update={"history": history})
+        assert coerced == attrs.update(history=history)
+        assert uncoerced != attrs.update(history=history)
+
+
+class TestAttrsCoordsInvariant:
+    """
+    Every Patch should have attrs whose coord summaries match its coords.
+
+    This is what makes `Patch.from_parts` safe; the constructor establishes
+    it unconditionally. If this breaks, the fast paths built on it are wrong.
+    """
+
+    ops: ClassVar = {
+        "abs": lambda p: p.abs(),
+        "add": lambda p: p + 1,
+        # Differing history makes _merge_models drop the coord summaries,
+        # so this is the binary-op case most likely to break the invariant.
+        "add_patch": lambda p: p + p.update_attrs(history=["boo"]),
+        "select": lambda p: p.select(time=(1, 20), samples=True),
+        "decimate": lambda p: p.decimate(time=2),
+        "transpose": lambda p: p.transpose(),
+        "squeeze": lambda p: p.select(distance=0, samples=True).squeeze(),
+        "pad": lambda p: p.pad(time=2),
+        "dropna": lambda p: p.dropna("time"),
+        "sobel": lambda p: p.sobel_filter("time"),
+        "differentiate": lambda p: p.differentiate("time"),
+        "integrate": lambda p: p.integrate("time"),
+        "aggregate": lambda p: p.mean("time"),
+        "aggregate_squeeze": lambda p: p.mean("time", dim_reduce="squeeze"),
+        "rolling": lambda p: p.rolling(time=5, samples=True).mean(),
+        "rolling_step": lambda p: p.rolling(time=5, samples=True, step=3).mean(),
+        "dft": lambda p: p.dft("time"),
+        "idft": lambda p: p.dft("time").idft(),
+        "set_units": lambda p: p.set_units("strain", time="s"),
+        "update_attrs": lambda p: p.update_attrs(tag="bob"),
+    }
+
+    @pytest.mark.parametrize("name", list(ops))
+    def test_invariant_holds(self, random_patch_with_lat_lon, name):
+        """Output attrs should always agree with output coords."""
+        out = self.ops[name](random_patch_with_lat_lon)
+        assert dict(out.attrs.coords) == out.coords.to_summary_dict()
+        assert out.attrs.dim_tuple == out.coords.dims
 
 
 class TestDisplay:

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -299,12 +299,32 @@ class TestRollingMetadata:
             assert out.get_coord(name) == patch.get_coord(name)
             assert np.array_equal(out.get_array(name), patch.get_array(name))
 
+    # step=1 reuses the patch's coords; step>1 rebuilds them. The attrs are
+    # built differently in each case, so both need covering.
     @pytest.mark.parametrize("engine", ("numpy", "pandas"))
-    def test_attrs_conform_to_coords(self, random_patch, engine):
+    @pytest.mark.parametrize("step", (1, 3))
+    def test_attrs_conform_to_coords(self, random_patch, engine, step):
         """The attrs coord summaries should match the output coords."""
-        out = random_patch.rolling(time=10, samples=True, step=3, engine=engine).mean()
+        out = random_patch.rolling(
+            time=10, samples=True, step=step, engine=engine
+        ).mean()
         assert out.attrs.coords == out.coords.to_summary_dict()
         assert out.attrs.dim_tuple == out.dims
+
+    @pytest.mark.parametrize("engine", ("numpy", "pandas"))
+    @pytest.mark.parametrize("step", (1, 3))
+    def test_history_is_tuple(self, random_patch, engine, step):
+        """
+        History must stay a tuple.
+
+        The step==1 path uses model_copy, which does no type coercion, so a
+        list would silently produce attrs unequal to the validated form.
+        """
+        out = random_patch.rolling(
+            time=10, samples=True, step=step, engine=engine
+        ).mean()
+        assert isinstance(out.attrs.history, tuple)
+        assert out.attrs == out.attrs.update(history=out.attrs.history)
 
 
 class TestNumpyVsPandasRolling:


### PR DESCRIPTION
## Description

Follow-up to #775, which sped up rolling partly by adding a local `_new_patch` helper that bypassed `Patch.update`. That helper was a symptom; the redundancy is in `update` itself. This removes it, and generalizes the fix.

`Patch.__init__` reconciles attrs against coords unconditionally, which establishes an invariant every Patch satisfies:

```python
dict(patch.attrs.coords) == patch.coords.to_summary_dict()
patch.attrs.dim_tuple == patch.coords.dims
```

`Patch.update` also reconciles, then hands the result to the constructor, which does the same work again. And `patch.new(data=arr)` — the single most common shape of call in the library — reconciles twice even though nothing that could affect coords or attrs has changed.

The cost here is not pydantic validation, which is worth stating since it is the intuitive suspect. `PatchAttrs.model_construct` (pydantic's own validation bypass) measures *slower* than validating, 99 µs against 34.5 µs, because it is pure Python where validation is Rust in pydantic-core. The cost is dascore's own reconciliation: `separate_coord_info`, `model_dump`, `to_summary_dict`, and one `CoordSummary` per coord.

### Changes

**`Patch.from_parts(data, coords, attrs)`** — a public classmethod for code which already holds a conforming pair. It validates the data shape and the dimension names, but trusts the coordinate summaries, so it costs a few microseconds rather than 130–250. The docstring documents the contract and the failure mode, including the trap that attrs built with an empty `coords` do *not* conform and the dimension check will not catch it.

**`PatchAttrs._conform_to(coords)`** — rebuilds attrs from a coord manager using `model_copy` instead of a dump and re-validate. Verified equal to `attrs.update(coords=coords)`, with identical `model_dump()`, across unchanged / decimated / dropped-coord / transposed coord managers. 132 µs → 38 µs.

**`proc.basic.update`** — returns `from_parts` directly when `attrs`, `dims` and a differing `coords` are all absent, and otherwise reconciles once and constructs without letting `__init__` repeat it.

**Call-site conversions** — only where there is a real win, meaning sites that pass `attrs=` (and so hit the more expensive `update_from_attrs`) or that bypass `update` entirely: rolling (retiring `_new_patch` from #775), `sobel_filter`, `notch_filter`, `differentiate`, `velocity_to_strain_rate`, `radians_to_strain`, and `_apply_aggregator`, which backs every aggregation.

`Patch.__init__` is unchanged apart from turning its dim-mismatch `assert` into a raise, so both construction paths behave the same under `python -O`.

### What is deliberately not converted

- **The ~24 sites passing `coords=` but no attrs** (`select`, `decimate`, `resample`, `pad`, `transpose`, …) gain nothing from an explicit call, since they would have to build `attrs.update(coords=cm)` themselves. They speed up for free from `_conform_to`.
- **The ~25 `data=`-only sites** (`abs`, `taper`, `detrend`, …) likewise need no source change.
- **`utils/array.py:197`, backing every binary operator** — the most tempting target, and currently unsafe. When two patches with differing history are combined, `_merge_models` pops `coords` from both, returning attrs with `coords == {}` while `dims` still matches, so the dimension check would pass and we would silently emit patches violating the invariant. Needs `_merge_models` fixed first.
- **Sites which rely on reconciliation to repair stale attrs** — `dropna`, `convert_units`, `rename_coords`, `dft`/`idft`/`stft`/`istft`, `integrate`, `spectrogram`, `velocity_to_strain_rate_edgeless`, `concatenate_patches`, `stack_patches`. They still get the double→single reconcile win with no source change. Worth a separate issue; several are latent bugs the moment anyone bypasses reconciliation.
- **IO readers and other direct-constructor sites** — they parse untrusted files, where validation earns its keep and 139 µs is noise against disk I/O.

### Verification

Output is unchanged. A sweep of 648 combinations — 8 patch kinds (including int64, float32, NaN, units, non-dimensional coords, custom attrs) × 81 operations — compared data bytes, shape, dtype, coords repr, serialized attrs, dims and the read-only flag against `master`. All 648 identical, and the 72 that raise produce the same exception and message. The sweep covers every converted site, every excluded site, the full rolling matrix from #775, and binary ops between patches with differing attrs.

A new `TestAttrsCoordsInvariant` asserts the invariant across 20 operations. It is what makes `from_parts` legal, so if a future change breaks it, the test names the reason. Writing it caught that `p + p.update_attrs(tag="x")` raises `IncompatiblePatchError` outright — only `history` and `dims` differences are tolerated between operands — so the test uses the case that actually exercises the coord-dropping path.

Also repairs `test_conflicting_attrs_coords_raises`, which was decorated `@pytest.fixture` and so had never been collected, and asserted a message that does not exist in the codebase.

### Timings

Default example patch, mean per call:

| call | master | this PR |
|---|---:|---:|
| `patch.new(data=arr)` | 515 µs | **6 µs** |
| `patch.new(data, coords=cm)` | 503 µs | **76 µs** |
| `patch.new(data, coords, attrs)` | 689 µs | 448 µs |
| `patch.abs()` | 957 µs | 407 µs |
| `patch.select(time=...)` | 824 µs | 359 µs |
| `patch.mean("time")` | 1854 µs | 1351 µs |
| `patch + 1` | 1800 µs | 986 µs |
| `patch.differentiate("time")` | 5.85 ms | 4.64 ms |
| `patch.rolling(time=5).mean()` | 11.24 ms | 9.44 ms |
| `dc.Patch(...)` direct — **control** | 252 µs | 251 µs |

The control is deliberately unmoved; the strict constructor was left alone. Ops on the large example patch gain proportionally less because they are compute-dominated.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
