### PR TITLE
PERF: skip CoordRange re-validation when the sample count is known

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -86,6 +86,12 @@ CoordKind = Literal["string", "empty", "single", "array", "range"]
 _TD64_ZERO = np.timedelta64(0, "ns")
 
 
+@cache
+def _second_quantity():
+    """Cache the 'second' quantity time-like coords are normalized to."""
+    return get_quantity("s")
+
+
 def ensure_consistent_dtype(value, name, dtype):
     """Ensure the values are consistent with dtype."""
     # For some reason all ints are getting converted to floats using default
@@ -1313,6 +1319,39 @@ class CoordRange(BaseCoord):
     _evenly_sampled = True
     _rich_style = dascore_styles["coord_range"]
 
+    def _new_grid(self, start, step, length: int) -> Self:
+        """
+        Return a CoordRange on an exactly known grid, skipping re-validation.
+
+        `validate_start_stop_step_len` exists to *derive* shape and a
+        normalized stop (always `start + step * length`) from loosely
+        specified inputs. Callers below already know the sample count exactly
+        -- it comes from index arithmetic on an existing, validated coord --
+        so re-deriving it costs ~60us per call and can only reproduce what is
+        passed in here.
+
+        Only use this where start/step come from an already-validated
+        CoordRange and length is computed from indices; anything taking user
+        input must go through the validating constructor.
+        """
+        units = self.units
+        # Mirror check_time_units, which forces time-like coords to seconds.
+        # Note it tests `start` for truthiness, so a coord starting at exactly
+        # zero is left alone; that quirk is reproduced here deliberately.
+        if start and (is_timedelta64(start) or is_datetime64(start)):
+            units = _second_quantity()
+        return self.model_construct(
+            # copy; model_construct stores the set by reference.
+            _fields_set=set(self.model_fields_set),
+            units=units,
+            step=step,
+            shape=(length,),
+            # matches what the validator stores for dtype.
+            dtype=np.asarray(start + step).dtype,
+            start=start,
+            stop=start + step * length,
+        )
+
     @model_validator(mode="before")
     @classmethod
     def validate_start_stop_step_len(cls, values):
@@ -1415,8 +1454,7 @@ class CoordRange(BaseCoord):
             if len(indices):
                 new_step = self.step * indices.step
                 new_start = self.start + indices.start * self.step
-                new_stop = new_start + new_step * len(indices)
-                return self.new(start=new_start, stop=new_stop, step=new_step)
+                return self._new_grid(new_start, new_step, len(indices))
         out = self.values[item]
         return get_coord(data=out, units=self.units)
 
@@ -1458,9 +1496,12 @@ class CoordRange(BaseCoord):
         data = slice(start, (stop + 1) if stop is not None else stop)
         if self._slice_degenerate(data):
             return self.empty(), slice(0, 0)
+        # The sample count is known exactly from the indices, so build the
+        # new grid directly rather than making the validator re-derive it.
+        first = 0 if start is None else start
+        last = (len(self) - 1) if stop is None else stop
         new_start = self[start] if start is not None else self.start
-        new_end = self[stop] + self.step if stop is not None else self.stop
-        new_coords = self.new(start=new_start, stop=new_end)
+        new_coords = self._new_grid(new_start, self.step, last + 1 - first)
         return new_coords, data
 
     def sort(self, reverse=False) -> tuple[BaseCoord, slice | ArrayLike]:
@@ -1472,10 +1513,11 @@ class CoordRange(BaseCoord):
             return self, slice(None)
         new_step = -self.step
         if reverse:  # reversing a forward sorted Coordrange
-            new_start, new_stop = self.max(), self.min() + new_step
+            new_start = self.max()
         else:  # order a reverse sorted one
-            new_start, new_stop = self.min(), self.max() + new_step
-        out = self.new(start=new_start, stop=new_stop, step=new_step)
+            new_start = self.min()
+        # reversing preserves the sample count.
+        out = self._new_grid(new_start, new_step, len(self))
         return out, slice(None, None, -1)
 
     def _get_index(self, value, forward=True):
@@ -1568,13 +1610,10 @@ class CoordRange(BaseCoord):
         """
         # CoordRange is always 1D by construction; keep as an internal invariant.
         assert self.ndim == 1, "Can only change length for 1D coords."
-        if (current := len(self)) == length:
+        if len(self) == length:
             return self
-        diff = length - current
-        stop, step = self.stop, self.step
-        out = self.update(stop=stop + step * diff)
-        assert len(out) == length
-        return out
+        # Only the sample count changes; start/step are already valid.
+        return self._new_grid(self.start, self.step, length)
 
     @property
     def sorted(self) -> bool:

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -2178,6 +2178,14 @@ class TestChangeLength:
         new = coord.change_length(current - 1)
         assert len(new) == current - 1
 
+    def test_change_length_tiny_step(self):
+        """Length should be exact even when step is small enough to lose precision."""
+        # Deriving the new stop from float arithmetic used to round back to
+        # the original length (and trip an assert) for tiny steps.
+        coord = get_coord(start=0.0, stop=1e-6, step=1e-9)
+        for length in (len(coord) - 1, len(coord) + 5):
+            assert len(coord.change_length(length)) == length
+
     def test_non_coord_change_length(self, basic_non_coord):
         """Ensure non coord can change length."""
         out = basic_non_coord.change_length(2 * len(basic_non_coord))


### PR DESCRIPTION
## Description

Follow-up to #778 (stacked on it — please merge that first; this diff is only the second commit).

`CoordRange.validate_start_stop_step_len` exists to *derive* `shape` and a normalized `stop` (always `start + step * length`) from loosely specified inputs. But the internal callers that build a derived coord — `select`, `sort`, `__getitem__`, `change_length` — already know the sample count exactly, because it comes from index arithmetic on an existing, already-validated coord. Re-deriving it through `self.new()` costs a `model_dump` plus a full validating construction (~60 µs) that can only reproduce what was passed in.

This adds a private `CoordRange._new_grid(start, step, length)` which builds the model with `model_construct` and does the two lines of arithmetic the validator would have done, and routes those four call sites through it. The public/validating path is untouched — anything taking user input still goes through the normal constructor.

Measured (min of 5 timeit repeats, same venv, vs #778):

| operation | #778 | this PR | speedup |
|---|---|---|---|
| `coord.select(time tuple)` | 109 µs | 45 µs | 2.4x |
| `coord.sort(reverse=True)` | 93 µs | 18 µs | 5.1x |
| `coord[2:1000]` | 86 µs | 18 µs | 4.8x |
| `coord.change_length(1500)` | 111 µs | 18 µs | 6.3x |
| `patch.select(time=tuple)` | 204 µs | 135 µs | 1.5x |
| `patch.select` no-op | 157 µs | 91 µs | 1.7x |

Cumulative against dev before #778: `coord.select` 238 → 45 µs (5.3x), `patch.select` 368 → 135 µs (2.7x), no-op select 354 → 91 µs (3.9x).

### Verification

Because this bypasses validation, correctness was checked by differential testing rather than by inspection: a harness runs `select` (over many index pairs), `sort` (both directions), `__getitem__` (four slice forms) and `change_length` (six lengths) across 11 coord flavours — int, float, tiny-step float, datetime, timedelta, all three reversed, and one with units — and dumps `start`/`stop`/`step`/`shape`/`dtype`/`units`, the first/last/summed values, `model_fields_set`, and the `model_fields_set` after a `.new()` round trip. Output is byte-identical to the base branch except for the one case noted below.

The harness caught two things that would otherwise have shipped:

- `check_time_units` force-sets `units` to seconds for time-like coords, so skipping validation dropped units on derived time coords. `_new_grid` now mirrors that rule (including its `if start := ...` truthiness test, which leaves a coord starting at exactly zero alone — reproduced deliberately, and flagged below).
- `model_construct` stores the passed `_fields_set` **by reference**; it is now copied so derived coords don't share one mutable set.

### Two pre-existing issues surfaced (not fixed here, except as noted)

1. **`change_length` could return the wrong length.** It derived the new stop as `stop + step * diff` and let the validator recount, which for small steps rounds back to the original length — `get_coord(start=0.0, stop=1e-6, step=1e-9).change_length(999)` returned length 1000 and tripped the `assert len(out) == length` guard. Setting the count directly fixes this; added `test_change_length_tiny_step` to pin it. This is the only behavioral difference from the base branch.
2. **`check_time_units` tests `start` for truthiness**, so a timedelta coord starting at exactly zero keeps `units=None` while any derived coord from it gains `units='s'`. Left as-is here to keep this PR performance-only; worth a separate look.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
