### PR TITLE
TST: cover the paths excluded by coverage pragmas

### DIFF
--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -720,7 +720,7 @@ class _FiberIOManager:
                     # raise, in which case the format doesn't belong.
                     func_input = man.get_resource(required_type)
                     format_version = func(func_input, _pre_cast=True)
-                except RemoteCacheError:  # pragma: no cover -- remote fetch only
+                except RemoteCacheError:
                     # A remote fetch failure is a real error, not a "wrong
                     # format" signal, so it must propagate rather than be
                     # swallowed by the robustness handler below.

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -425,7 +425,7 @@ def _build_members(sub: pd.DataFrame, outputs: pd.DataFrame, name) -> pd.DataFra
                 continue
             lo = max(src1[src_num], chu1[out_num])
             hi = min(src2[src_num], chu2[out_num])
-            if lo > hi:
+            if lo > hi:  # pragma: no cover -- searchsorted boundary guard
                 # Sources within a partition are continuous (partitioning
                 # splits on gaps) and start-corrected, so searchsorted does
                 # not offer a non-overlapping source in practice; this guards

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -425,7 +425,7 @@ def _build_members(sub: pd.DataFrame, outputs: pd.DataFrame, name) -> pd.DataFra
                 continue
             lo = max(src1[src_num], chu1[out_num])
             hi = min(src2[src_num], chu2[out_num])
-            if lo > hi:  # pragma: no cover -- searchsorted boundary guard
+            if lo > hi:
                 # Sources within a partition are continuous (partitioning
                 # splits on gaps) and start-corrected, so searchsorted does
                 # not offer a non-overlapping source in practice; this guards

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -425,12 +425,12 @@ def _build_members(sub: pd.DataFrame, outputs: pd.DataFrame, name) -> pd.DataFra
                 continue
             lo = max(src1[src_num], chu1[out_num])
             hi = min(src2[src_num], chu2[out_num])
-            if lo > hi:  # pragma: no cover -- searchsorted boundary guard
-                # Sources within a partition are continuous (partitioning
-                # splits on gaps) and start-corrected, so searchsorted does
-                # not offer a non-overlapping source in practice; this guards
-                # against a boundary off-by-one rather than a reachable state.
-                continue
+            # Sources within a partition are continuous (partitioning
+            # splits on gaps) and start-corrected, so searchsorted never
+            # offers a source which does not overlap the output. Assert it
+            # rather than skipping: silently dropping a source would lose
+            # data, and the state cannot be reached from the public API.
+            assert lo <= hi, f"source {src_num} does not overlap output {out_num}"
             unchanged = (
                 lo == orig_min[src_num]
                 and hi == orig_max[src_num]

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -240,7 +240,7 @@ class H5Writer(H5Reader):
     class _RemoteH5Writer:
         """Wrap a local h5py file and upload it back to the remote resource."""
 
-        def __init__(self, resource: UPath, mode: str):  # pragma: no cover
+        def __init__(self, resource: UPath, mode: str):
             self._resource = resource
             suffix = resource.suffix or ".h5"
             fd, temp_name = tempfile.mkstemp(suffix=suffix)
@@ -264,10 +264,10 @@ class H5Writer(H5Reader):
         def __getitem__(self, item):
             return self._handle[item]
 
-        def __setitem__(self, key, value):  # pragma: no cover
+        def __setitem__(self, key, value):
             self._handle[key] = value
 
-        def __contains__(self, item):  # pragma: no cover
+        def __contains__(self, item):
             return item in self._handle
 
         def commit(self):
@@ -299,10 +299,10 @@ class H5Writer(H5Reader):
             """Backward-compatible alias for abort()."""
             self.abort()
 
-        def __enter__(self):  # pragma: no cover
+        def __enter__(self):
             return self
 
-        def __exit__(self, exc_type, exc, tb):  # pragma: no cover
+        def __exit__(self, exc_type, exc, tb):
             if exc_type is None:
                 self.commit()
             else:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -514,6 +514,27 @@ class TestBrokenEntryPoint:
         assert len(list(broken_ep_manager.yield_fiberio()))
 
 
+class TestGetFormatErrors:
+    """Errors which must not be mistaken for a format mismatch."""
+
+    def test_remote_cache_error_propagates(self, monkeypatch, tmp_path):
+        """A remote fetch failure is a real error, not a wrong-format signal.
+
+        The loop over FiberIOs swallows exceptions so a reader which does
+        not recognize a file can be skipped; a cache failure has to escape
+        that handler instead of being reported as an unknown format.
+        """
+        path = tmp_path / "unfetchable.h5"
+        path.write_bytes(b"not really an h5 file")
+
+        def _raise(*args, **kwargs):
+            raise RemoteCacheError("cannot fetch this resource")
+
+        monkeypatch.setattr(IOResourceManager, "get_resource", _raise)
+        with pytest.raises(RemoteCacheError, match="cannot fetch this resource"):
+            dc.get_format(path)
+
+
 class TestFormatManagerConcurrency:
     """Concurrent plugin loading must never expose a partial registry."""
 

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -11,7 +11,7 @@ import pytest
 import dascore as dc
 from dascore.exceptions import ChunkError
 from dascore.utils.chunk import get_intervals
-from dascore.utils.chunk_plan import build_chunk_plan
+from dascore.utils.chunk_plan import _build_members, build_chunk_plan
 from dascore.utils.time import to_timedelta64
 
 STARTTIME = np.datetime64("2020-01-03")
@@ -345,3 +345,30 @@ class TestPlanMembers:
         )
         assert len(plan.outputs) == len(df)
         assert not plan.members["_modified"].any()
+
+
+class TestBuildMembers:
+    """Direct tests for binding outputs to source slices."""
+
+    def test_source_disjoint_from_output_is_skipped(self):
+        """A source which ends before its output starts contributes no row.
+
+        Partitioning splits on gaps, so the search for candidate sources
+        does not offer one in practice; this pins the guard which keeps a
+        boundary off-by-one from emitting an inverted interval.
+        """
+        sub = pd.DataFrame(
+            {
+                "time_min": [0.0, 5.0],
+                "time_max": [1.0, 6.0],
+                "time_step": [1.0, 1.0],
+                "_patch_id": [1, 2],
+            }
+        )
+        outputs = pd.DataFrame({"output_id": [0], "time_min": [3.0], "time_max": [6.0]})
+
+        members = _build_members(sub, outputs, "time")
+
+        # the 0-1 source cannot serve a 3-6 output; only the 5-6 one can
+        assert list(members["_patch_id"]) == [2]
+        assert (members["time_min"] <= members["time_max"]).all()

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -11,7 +11,7 @@ import pytest
 import dascore as dc
 from dascore.exceptions import ChunkError
 from dascore.utils.chunk import get_intervals
-from dascore.utils.chunk_plan import _build_members, build_chunk_plan
+from dascore.utils.chunk_plan import build_chunk_plan
 from dascore.utils.time import to_timedelta64
 
 STARTTIME = np.datetime64("2020-01-03")
@@ -345,30 +345,3 @@ class TestPlanMembers:
         )
         assert len(plan.outputs) == len(df)
         assert not plan.members["_modified"].any()
-
-
-class TestBuildMembers:
-    """Direct tests for binding outputs to source slices."""
-
-    def test_source_disjoint_from_output_is_skipped(self):
-        """A source which ends before its output starts contributes no row.
-
-        Partitioning splits on gaps, so the search for candidate sources
-        does not offer one in practice; this pins the guard which keeps a
-        boundary off-by-one from emitting an inverted interval.
-        """
-        sub = pd.DataFrame(
-            {
-                "time_min": [0.0, 5.0],
-                "time_max": [1.0, 6.0],
-                "time_step": [1.0, 1.0],
-                "_patch_id": [1, 2],
-            }
-        )
-        outputs = pd.DataFrame({"output_id": [0], "time_min": [3.0], "time_max": [6.0]})
-
-        members = _build_members(sub, outputs, "time")
-
-        # the 0-1 source cannot serve a 3-6 output; only the 5-6 one can
-        assert list(members["_patch_id"]) == [2]
-        assert (members["time_min"] <= members["time_max"]).all()

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -11,6 +11,7 @@ import pytest
 from upath import UPath
 
 import dascore as dc
+import dascore.utils.hdf5 as hdf5_module
 import dascore.utils.remote_io as remote_io
 from dascore.config import config_context
 from dascore.exceptions import PatchConversionError, RemoteCacheError
@@ -426,6 +427,54 @@ class TestGetHandleFromResource:
                 handle.create_dataset("data", data=[1, 2, 3])
                 raise RuntimeError("boom")
         assert not path.exists()
+
+    def test_h5_writer_remote_context_commits(self):
+        """Leaving the context without an error uploads the file."""
+        path = UPath("memory://dascore/upath-write-commit.h5")
+        with H5Writer.get_handle(path) as handle:
+            handle.create_dataset("data", data=[1, 2, 3])
+        assert path.exists()
+        with path.open("rb") as raw, h5py.File(raw, "r", driver="fileobj") as reopened:
+            assert list(reopened["data"][:]) == [1, 2, 3]
+
+    def test_h5_writer_remote_append_keeps_existing(self):
+        """Reopening an existing remote file downloads it before writing."""
+        path = UPath("memory://dascore/upath-write-append.h5")
+        with H5Writer.get_handle(path) as handle:
+            handle.create_dataset("first", data=[1, 2, 3])
+        with H5Writer.get_handle(path) as handle:
+            handle.create_dataset("second", data=[4, 5, 6])
+        with path.open("rb") as raw, h5py.File(raw, "r", driver="fileobj") as reopened:
+            assert list(reopened["first"][:]) == [1, 2, 3]
+            assert list(reopened["second"][:]) == [4, 5, 6]
+
+    def test_h5_writer_remote_setitem_and_contains(self):
+        """The remote writer proxies item assignment and membership."""
+        path = UPath("memory://dascore/upath-write-setitem.h5")
+        with H5Writer.get_handle(path) as handle:
+            handle["data"] = [1, 2, 3]
+            assert "data" in handle
+            assert "missing" not in handle
+
+    def test_h5_writer_remote_cleans_up_after_open_failure(self, monkeypatch):
+        """A failed local open removes the temp file and raises."""
+        created = []
+        real_mkstemp = hdf5_module.tempfile.mkstemp
+
+        def _tracking_mkstemp(*args, **kwargs):
+            file_descriptor, name = real_mkstemp(*args, **kwargs)
+            created.append(Path(name))
+            return file_descriptor, name
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(hdf5_module.tempfile, "mkstemp", _tracking_mkstemp)
+        monkeypatch.setattr(hdf5_module, "H5pyFile", _raise)
+        path = UPath("memory://dascore/upath-write-open-failure.h5")
+        with pytest.raises(RuntimeError, match="boom"):
+            H5Writer.get_handle(path)
+        assert created and not created[0].exists()
 
     def test_h5_writer_remote_abort_is_idempotent(self):
         """Remote writer aborts should be safe to call more than once."""


### PR DESCRIPTION
## Description

Removes every `# pragma: no cover` from these files: six are replaced by tests, the last by an assertion.

The markers were hiding code from the coverage *report*, not from the test suite's reach. That has a cost: a pragma on dead code means coverage cannot tell you it is dead (one such function, `_get_remote_cache_dir`, is deleted in #781 after exactly that happened), and a pragma on a `def` line excludes the whole method even when most of it is exercised.

### What is now tested

**The remote HDF5 writer** (`_RemoteH5Writer`, five markers). All five sat on `def` lines, so they excluded entire methods, though coverage showed most of `__init__` and `__exit__` were already being run. New tests cover what was genuinely unreached:

- committing when the context exits without an error (the upload path),
- reopening an existing remote file, which downloads it before writing,
- item assignment and membership on the wrapper,
- removing the temp file and re-raising when the local `h5py` open fails.

**`get_format` re-raising `RemoteCacheError`.** The loop over FiberIOs swallows exceptions so a reader which does not recognize a file can be skipped; a failed remote fetch has to escape that handler rather than be reported as an unknown format. The test monkeypatches `IOResourceManager.get_resource` so it does not depend on which plugins happen to be installed.

**The chunk-plan boundary guard becomes an assertion.** This one is genuinely unreachable through the public API — sources within a partition are continuous (partitioning splits on gaps) and start-corrected, so the source `searchsorted` selects always overlaps its output. A test could only reach it by handing `_build_members` a state the partitioner cannot produce, which is an implementation detail rather than a boundary (thanks @codex for pushing back on the first attempt).

`assert lo <= hi` is the better shape for that: it states the invariant, runs on every iteration so it needs no exclusion, and fails loudly if the invariant ever breaks. Skipping was the wrong response in any case — dropping a source silently loses data, where an inverted interval would at least be visible. The assertion holds across the whole suite.

### Result

No `# pragma: no cover` remains in `dascore/utils/hdf5.py`, `dascore/utils/chunk_plan.py` or `dascore/io/core.py`, and every line in them is covered. The three markers in `dascore/utils/io.py` and `dascore/utils/remote_io.py` are removed by #781, after which the package has none.

## Validation

- Full suite: 8229 passed, 89 skipped, 2 xfailed.
- Non-network suite (what the coverage flag uploads): 8129 passed, with the only uncovered lines in the whole package being the two pre-existing ones in `examples.py` that CI covers through the generated doc-code tests.
- `pre-commit run --all`: passed.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote cache errors encountered during format detection are now propagated correctly instead of being reported as unknown formats.
  * Remote HDF5 writing is more reliable, including proper commit behavior on context-manager exit, safe append behavior, and correct `in`/item access.
  * Inconsistent chunk interval mapping now fails fast instead of being silently skipped.

* **Tests**
  * Added regression coverage for remote cache error propagation.
  * Added remote HDF5 writer tests for commit, append preservation, item access/membership, and cleanup after open failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->