### PR TITLE
Validate the requested length in BaseCoord.change_length

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -131,7 +131,8 @@ def _reduce_time_like(func, data):
 
 def _validate_new_length(length) -> int:
     """Ensure a requested coordinate length is a non-negative integer."""
-    if not isinstance(length, int | np.integer):
+    # bool is an int subclass; True/False are never a sensible length.
+    if isinstance(length, bool) or not isinstance(length, int | np.integer):
         msg = f"change_length requires an integer length, not {length!r}."
         raise ParameterError(msg)
     if length < 0:

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1395,7 +1395,8 @@ class CoordRange(BaseCoord):
         # A CoordRange always has at least one sample (start == stop has a
         # length of 1) so an empty coord is the only way to represent 0.
         if length == 0:
-            return self.empty()
+            data = np.empty(0, dtype=self.dtype)
+            return get_coord(data=data, step=self.step, units=self.units)
         diff = length - current
         stop, step = self.stop, self.step
         out = self.update(stop=stop + step * diff)

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -129,6 +129,17 @@ def _reduce_time_like(func, data):
     return np.atleast_1d(out)
 
 
+def _validate_new_length(length) -> int:
+    """Ensure a requested coordinate length is a non-negative integer."""
+    if not isinstance(length, int | np.integer):
+        msg = f"change_length requires an integer length, not {length!r}."
+        raise ParameterError(msg)
+    if length < 0:
+        msg = f"change_length requires a non-negative length, not {length}."
+        raise ParameterError(msg)
+    return int(length)
+
+
 def _get_dtype(value, dtype):
     """Get the data type based on the first argument."""
     if dtype is not None and dtype != "":
@@ -967,7 +978,12 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         Parameters
         ----------
         length
-            The output length.
+            The output length. Must be a non-negative integer.
+
+        Raises
+        ------
+        ParameterError
+            If length is not a non-negative integer.
         """
         msg = f"Coordinate type {self.__class__} does not implement change_length"
         raise NotImplementedError(msg)
@@ -1109,7 +1125,7 @@ class CoordPartial(BaseCoord):
         if self.ndim != 1:
             msg = "change_length only works on 1D coords."
             raise CoordError(msg)
-        return get_coord(shape=(length,))
+        return get_coord(shape=(_validate_new_length(length),))
 
     def to_summary(self, dims=()) -> CoordSummary:
         """Get the summary info about the coord."""
@@ -1373,8 +1389,13 @@ class CoordRange(BaseCoord):
         """
         # CoordRange is always 1D by construction; keep as an internal invariant.
         assert self.ndim == 1, "Can only change length for 1D coords."
+        length = _validate_new_length(length)
         if (current := len(self)) == length:
             return self
+        # A CoordRange always has at least one sample (start == stop has a
+        # length of 1) so an empty coord is the only way to represent 0.
+        if length == 0:
+            return self.empty()
         diff = length - current
         stop, step = self.stop, self.step
         out = self.update(stop=stop + step * diff)

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -2028,6 +2028,15 @@ class TestChangeLength:
         for coord in (evenly_sampled_coord, basic_non_coord):
             assert len(coord.change_length(0)) == 0
 
+    def test_zero_length_keeps_metadata(self, evenly_sampled_float_coord_with_units):
+        """Ensure an emptied coord keeps its units, step and dtype."""
+        coord = evenly_sampled_float_coord_with_units
+        out = coord.change_length(0)
+        assert len(out) == 0
+        assert out.units == coord.units
+        assert out.step == coord.step
+        assert out.dtype == coord.dtype
+
 
 class TestIssues:
     """Tests for special issues related to coords."""

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -2014,7 +2014,7 @@ class TestChangeLength:
             with pytest.raises(ParameterError, match="non-negative"):
                 coord.change_length(length)
 
-    @pytest.mark.parametrize("length", [2.5, 3.0, "3", None])
+    @pytest.mark.parametrize("length", [2.5, 3.0, "3", None, True, False])
     def test_non_integer_length_raises(
         self, evenly_sampled_coord, basic_non_coord, length
     ):

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -2005,6 +2005,29 @@ class TestChangeLength:
         with pytest.raises(NotImplementedError):
             BaseCoord.change_length(coord, 10)
 
+    @pytest.mark.parametrize("length", [-1, -10])
+    def test_negative_length_raises(
+        self, evenly_sampled_coord, basic_non_coord, length
+    ):
+        """Ensure a negative length is rejected rather than making a bad coord."""
+        for coord in (evenly_sampled_coord, basic_non_coord):
+            with pytest.raises(ParameterError, match="non-negative"):
+                coord.change_length(length)
+
+    @pytest.mark.parametrize("length", [2.5, 3.0, "3", None])
+    def test_non_integer_length_raises(
+        self, evenly_sampled_coord, basic_non_coord, length
+    ):
+        """Ensure non integer lengths are rejected."""
+        for coord in (evenly_sampled_coord, basic_non_coord):
+            with pytest.raises(ParameterError, match="integer length"):
+                coord.change_length(length)
+
+    def test_zero_length(self, evenly_sampled_coord, basic_non_coord):
+        """Ensure a length of zero produces an empty coord."""
+        for coord in (evenly_sampled_coord, basic_non_coord):
+            assert len(coord.change_length(0)) == 0
+
 
 class TestIssues:
     """Tests for special issues related to coords."""


### PR DESCRIPTION
## Description

`BaseCoord.change_length` is a public method, but the two implementations did not validate the requested length:

- `CoordPartial.change_length` passed the value straight to `get_coord(shape=(length,))`, so `change_length(-1)` happily returned a `CoordPartial` with `shape=(-1,)` (and therefore a negative `len`).
- `CoordRange.change_length` did not produce a bad coord, but it signalled invalid input with a bare, message-less `AssertionError` from the trailing `assert len(out) == length` invariant, including for a zero length (a `CoordRange` always has at least one sample, since `start == stop` has a length of 1).

This adds a small `_validate_new_length` helper used by both: non-integer and negative lengths now raise `ParameterError`, and a requested length of zero returns an empty coord that keeps the original units, step and dtype. All existing callers (`dascore/io/*`, `dascore/proc/*`) pass `len(...)` results, so they are unaffected.

Noticed while reviewing an (invalid) CodeRabbit comment on #778; unrelated to that PR, so it is split out here.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
- fixed: `BaseCoord.change_length` validates its argument — a negative length previously produced a `CoordPartial` with a negative `len`, or a message-less `AssertionError`.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
