### PR TITLE
Stop persisting GITHUB_TOKEN in CI checkouts

### DIFF
--- a/.github/workflows/build_deploy_master_docs.yaml
+++ b/.github/workflows/build_deploy_master_docs.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           fetch-tags: "true"
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: ./.github/actions/load-shared-vars
 

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           fetch-tags: "true"
           fetch-depth: '0'
+          persist-credentials: false
 
       - name: Set manual stable docs version
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/get_coverage.yml
+++ b/.github/workflows/get_coverage.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           fetch-tags: "true"
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: ./.github/actions/load-shared-vars
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-tags: "true"
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: ./.github/actions/load-shared-vars
 

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           fetch-tags: "true"
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: ./.github/actions/load-shared-vars
 

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -35,6 +35,8 @@ jobs:
       os-matrix: ${{ steps.load-vars.outputs.test-os-matrix }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/load-shared-vars
         id: load-vars
 
@@ -62,6 +64,7 @@ jobs:
         with:
           fetch-tags: "true"
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: ./.github/actions/mamba-install-dascore
         with:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -39,6 +39,8 @@ jobs:
       os-matrix: ${{ steps.load-vars.outputs.test-os-matrix }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/load-shared-vars
         id: load-vars
 
@@ -67,6 +69,7 @@ jobs:
         with:
           fetch-tags: 'true'
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: ./.github/actions/mamba-install-dascore
         with:

--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-tags: "true"
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: ./.github/actions/load-shared-vars
 

--- a/.github/workflows/test_wasm.yml
+++ b/.github/workflows/test_wasm.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           fetch-tags: 'true'
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           fetch-tags: "true"
           fetch-depth: '0'
+          persist-credentials: false
 
       - uses: ./.github/actions/load-shared-vars
 


### PR DESCRIPTION
## Description

`actions/checkout` defaults to `persist-credentials: true`, which writes the job's `GITHUB_TOKEN` into `.git/config` as an `http.extraheader`. It then stays readable by every subsequent step in the job, including the third-party tooling our workflows run (mamba/conda, npm, quarto, pyodide-build, codspeed). `runtests.yml` already set `persist-credentials: false` on the network job; this applies the same setting to the remaining 11 checkout steps.

Nothing in CI needs the persisted credentials — no workflow pushes with git:

- docs deploy via `quarto publish` (Netlify token) and `actions/deploy-pages` (OIDC)
- release assets via `softprops/action-gh-release`
- PyPI via `pypa/gh-action-pypi-publish`
- `build_deploy_stable_docs.yaml` only runs local `git tag --list` / `git restore`

The one remote git call is `git fetch --tags --force` in `.github/actions/mamba-install-dascore`, which works anonymously against this public repo and already runs credential-free today in the network test job.

This clears all `artipacked` findings from zizmor (`uvx zizmor@1.26.1 .github/workflows/` goes from 12 to 0; the remaining `unpinned-uses` findings are pre-existing and out of scope).

Raised by CodeRabbit on #783, which flagged the new WASM job's checkout. Rather than fix that one step in isolation, all of them are handled here. #783 keeps only the Pyodide version alignment.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
