### PR TITLE
Add benchmark for importing dascore

### DIFF
--- a/benchmarks/readme.md
+++ b/benchmarks/readme.md
@@ -17,6 +17,7 @@ pytest benchmarks/ --codspeed
 pytest benchmarks/test_patch_benchmarks.py --codspeed
 pytest benchmarks/test_io_benchmarks.py --codspeed
 pytest benchmarks/test_spool_benchmarks.py --codspeed
+pytest benchmarks/test_import_benchmarks.py --codspeed
 ```
 
 ## Benchmark Structure
@@ -26,6 +27,7 @@ Benchmarks are now organized as pytest tests in the `benchmarks/` directory:
 - `test_patch_benchmarks.py` - Core Patch processing, transform, and visualization benchmarks
 - `test_io_benchmarks.py` - File I/O operations benchmarks
 - `test_spool_benchmarks.py` - Spool chunking and selection benchmarks
+- `test_import_benchmarks.py` - Import time benchmarks
 
 Each benchmark uses the `@pytest.mark.benchmark` decorator to automatically measure performance.
 

--- a/benchmarks/readme.md
+++ b/benchmarks/readme.md
@@ -27,7 +27,7 @@ Benchmarks are now organized as pytest tests in the `benchmarks/` directory:
 - `test_patch_benchmarks.py` - Core Patch processing, transform, and visualization benchmarks
 - `test_io_benchmarks.py` - File I/O operations benchmarks
 - `test_spool_benchmarks.py` - Spool chunking and selection benchmarks
-- `test_import_benchmarks.py` - Import time benchmarks
+- `test_import_benchmarks.py` - Import benchmarks (dascore's own modules; third party dependencies stay warm)
 
 Each benchmark uses the `@pytest.mark.benchmark` decorator to automatically measure performance.
 

--- a/benchmarks/test_import_benchmarks.py
+++ b/benchmarks/test_import_benchmarks.py
@@ -17,13 +17,15 @@ def _dascore_module_names():
 
 class TestImportBenchmarks:
     """
-    Benchmarks for importing dascore.
+    Benchmarks for re-executing dascore's modules.
 
     Only dascore's own modules are removed from the module cache, so these
-    measure the cost of executing dascore's module bodies rather than the
-    cost of importing third party dependencies (which python only pays once
-    per interpreter). See tests/test_imports.py for the guards which keep
-    slow optional dependencies out of the import chain entirely.
+    measure the cost of executing dascore's module bodies, not the one-time
+    cost of importing third party dependencies. A fresh interpreter (eg a
+    CLI call) also pays the latter, but it cannot be measured here; a
+    subprocess falls outside the region CodSpeed instruments. Instead, see
+    tests/test_imports.py for the guards which keep slow dependencies out of
+    the import chain entirely.
     """
 
     @pytest.fixture()
@@ -44,8 +46,8 @@ class TestImportBenchmarks:
         pint.set_application_registry(registry)
 
     @pytest.mark.benchmark
-    def test_import_dascore(self, restore_dascore_modules):
-        """Time importing the top-level dascore module."""
+    def test_reimport_dascore(self, restore_dascore_modules):
+        """Time re-importing the top-level dascore module."""
         for name in _dascore_module_names():
             del sys.modules[name]
         importlib.import_module("dascore")

--- a/benchmarks/test_import_benchmarks.py
+++ b/benchmarks/test_import_benchmarks.py
@@ -1,0 +1,44 @@
+"""Benchmarks for importing dascore using pytest-codspeed."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+
+import pytest
+
+
+def _dascore_module_names():
+    """Get the names of all currently imported dascore modules."""
+    return [x for x in sys.modules if x == "dascore" or x.startswith("dascore.")]
+
+
+class TestImportBenchmarks:
+    """
+    Benchmarks for importing dascore.
+
+    Only dascore's own modules are removed from the module cache, so these
+    measure the cost of executing dascore's module bodies rather than the
+    cost of importing third party dependencies (which python only pays once
+    per interpreter). See tests/test_imports.py for the guards which keep
+    slow optional dependencies out of the import chain entirely.
+    """
+
+    @pytest.fixture()
+    def restore_dascore_modules(self):
+        """Put the original dascore modules back after re-importing them."""
+        saved = {x: sys.modules[x] for x in _dascore_module_names()}
+        # dascore adds a warning filter on import; catch_warnings undoes that.
+        with warnings.catch_warnings():
+            yield
+        for name in _dascore_module_names():
+            del sys.modules[name]
+        sys.modules.update(saved)
+
+    @pytest.mark.benchmark
+    def test_import_dascore(self, restore_dascore_modules):
+        """Time importing the top-level dascore module."""
+        for name in _dascore_module_names():
+            del sys.modules[name]
+        importlib.import_module("dascore")

--- a/benchmarks/test_import_benchmarks.py
+++ b/benchmarks/test_import_benchmarks.py
@@ -6,6 +6,7 @@ import importlib
 import sys
 import warnings
 
+import pint
 import pytest
 
 
@@ -28,13 +29,19 @@ class TestImportBenchmarks:
     @pytest.fixture()
     def restore_dascore_modules(self):
         """Put the original dascore modules back after re-importing them."""
+        # Import here so third party dependencies are warm before timing,
+        # even when this file is the only one collected.
+        importlib.import_module("dascore")
         saved = {x: sys.modules[x] for x in _dascore_module_names()}
+        # Re-importing dascore makes (and installs) a new pint registry.
+        registry = pint.get_application_registry().get()
         # dascore adds a warning filter on import; catch_warnings undoes that.
         with warnings.catch_warnings():
             yield
         for name in _dascore_module_names():
             del sys.modules[name]
         sys.modules.update(saved)
+        pint.set_application_registry(registry)
 
     @pytest.mark.benchmark
     def test_import_dascore(self, restore_dascore_modules):


### PR DESCRIPTION
## Description

DASCore had benchmarks for patches, IO, and spools, but nothing tracking how long `import dascore` takes. Import time matters for CLI/script startup, and it is easy to regress by adding an eager import or expensive module-level work.

This adds `benchmarks/test_import_benchmarks.py`, which purges dascore's own modules from `sys.modules` and re-imports the package inside the measured region, so CodSpeed tracks the cost of executing dascore's module bodies (~40 ms locally). Third party dependencies are left in the module cache (and warmed in fixture setup) since python only pays for those once per interpreter; `tests/test_imports.py` already guards against slow optional dependencies (matplotlib, scipy.signal) entering the import chain at all.

The fixture restores the original dascore modules, the pint application registry, and the warning filters on teardown so the rest of the benchmark session is unaffected.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an import-performance benchmark to measure reloading the package while minimizing third-party dependency overhead.

* **Documentation**
  * Added instructions for running the new import benchmark with CodSpeed.
  * Documented import benchmarks in the benchmark structure overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->