### PR TITLE
Cover the CoordRange fast paths missed on dev

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1392,10 +1392,10 @@ class CoordRange(BaseCoord):
 
         def _round_ratio(numerator, denominator, digits):
             """Round numerator/denominator, cheaply for scalars."""
+            # Inputs are always scalar-like (multi-element arrays are rejected
+            # by the pd.isnull check above) and rounding python floats is
+            # ~10x faster than numpy scalars, hence the float conversion.
             ratio = _maybe_unbox_scalar(numerator / denominator)
-            if isinstance(ratio, np.ndarray):  # multi-element array inputs
-                return np.round(ratio, digits)
-            # rounding python floats is ~10x faster than numpy scalars.
             return round(float(ratio), digits)
 
         zero = _TD64_ZERO if is_timedelta64(step) else 0
@@ -1529,8 +1529,16 @@ class CoordRange(BaseCoord):
             # Scalar fast path; avoids several small-array allocations.
             # Due to float weirdness we need a little bit of a fudge factor.
             # (float() first since rounding numpy scalars is ~10x slower)
-            fraction = round(float((value - start) / step), 10)
-            if not math.isfinite(fraction):  # e.g. a step of 0
+            # A step of 0 (a len 1 CoordRange) has no index to compute, so
+            # None is returned, meaning the value doesn't constrain the
+            # selection. It is caught after the division (python scalars
+            # raise, numpy scalars give inf/nan) since testing a numpy step
+            # for truthiness up front costs ~10x more on this hot path.
+            try:
+                fraction = round(float((value - start) / step), 10)
+            except ZeroDivisionError:
+                return None
+            if not math.isfinite(fraction):
                 return None
             out = math.ceil(fraction) if forward else math.floor(fraction)
             if forward and out < 0:

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1520,6 +1520,19 @@ class CoordRange(BaseCoord):
         out = self._new_grid(new_start, new_step, len(self))
         return out, slice(None, None, -1)
 
+    def _get_zero_step_index(self, value, forward):
+        """
+        Get the index of a value for a coord with a step of 0.
+
+        Every sample of such a coord equals start, so the index is either the
+        first sample or one just outside the coord, which makes the
+        selection degenerate.
+        """
+        start = self.start
+        if forward:  # index of the first sample >= value
+            return 0 if value <= start else len(self)
+        return 0 if value >= start else -1
+
     def _get_index(self, value, forward=True):
         """Get the index corresponding to a value."""
         if (value := self._get_compatible_value(value)) is None:
@@ -1529,17 +1542,15 @@ class CoordRange(BaseCoord):
             # Scalar fast path; avoids several small-array allocations.
             # Due to float weirdness we need a little bit of a fudge factor.
             # (float() first since rounding numpy scalars is ~10x slower)
-            # A step of 0 (a len 1 CoordRange) has no index to compute, so
-            # None is returned, meaning the value doesn't constrain the
-            # selection. It is caught after the division (python scalars
-            # raise, numpy scalars give inf/nan) since testing a numpy step
-            # for truthiness up front costs ~10x more on this hot path.
+            # A step of 0 is handled after the division (python scalars raise,
+            # numpy scalars give inf/nan) since testing a numpy step for
+            # truthiness up front costs ~10x more on this hot path.
             try:
                 fraction = round(float((value - start) / step), 10)
             except ZeroDivisionError:
-                return None
+                return self._get_zero_step_index(value, forward)
             if not math.isfinite(fraction):
-                return None
+                return self._get_zero_step_index(value, forward)
             out = math.ceil(fraction) if forward else math.floor(fraction)
             if forward and out < 0:
                 return None

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1369,6 +1369,29 @@ class TestCoordRange:
         assert len(new) == 1
         assert np.all(new.values == np.zeros(0))
 
+    @pytest.mark.parametrize(
+        "start,step",
+        [
+            (0, 0),
+            (np.float64(0), np.float64(0)),
+            (np.datetime64("2020-01-01", "ns"), np.timedelta64(0, "ns")),
+        ],
+    )
+    def test_select_step_of_0(self, start, step):
+        """A step of 0 has no index to select on, so all values are kept."""
+        coord = CoordRange(start=start, stop=start, step=step)
+        # numpy scalars warn (rather than raise) on the zero division.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            new, index = coord.select((start, start + 10 * (step + 1)))
+        assert new == coord
+        assert index == slice(None, None, None)
+
+    def test_zero_dim_array_inputs(self):
+        """Ensure 0d arrays (which aren't unboxed) can init a CoordRange."""
+        coord = CoordRange(start=np.array(0.0), stop=np.array(10.0), step=np.array(1.0))
+        assert len(coord) == 10
+        assert coord.step == 1.0
+
     def test_reversed_coord(self, evenly_sampled_reversed_coord):
         """Ensure reverse sampling works for evenly sampled coord."""
         coord = evenly_sampled_reversed_coord

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1370,21 +1370,27 @@ class TestCoordRange:
         assert np.all(new.values == np.zeros(0))
 
     @pytest.mark.parametrize(
-        "start,step",
+        "start,unit",
         [
-            (0, 0),
-            (np.float64(0), np.float64(0)),
-            (np.datetime64("2020-01-01", "ns"), np.timedelta64(0, "ns")),
+            (0, 1),
+            (np.float64(0), np.float64(1)),
+            (np.datetime64("2020-01-01", "ns"), np.timedelta64(1, "s")),
         ],
     )
-    def test_select_step_of_0(self, start, step):
-        """A step of 0 has no index to select on, so all values are kept."""
+    def test_select_step_of_0(self, start, unit):
+        """All samples of a step of 0 coord equal start; select on that."""
+        step = start - start  # a zero step of the right type.
         coord = CoordRange(start=start, stop=start, step=step)
         # numpy scalars warn (rather than raise) on the zero division.
         with np.errstate(divide="ignore", invalid="ignore"):
-            new, index = coord.select((start, start + 10 * (step + 1)))
-        assert new == coord
-        assert index == slice(None, None, None)
+            # a range which contains start keeps the sample.
+            kept, index = coord.select((start - unit, start + unit))
+            # ranges which don't are degenerate.
+            after, _ = coord.select((start + unit, start + 2 * unit))
+            before, _ = coord.select((start - 2 * unit, start - unit))
+        assert kept == coord
+        assert index == slice(None, 1, None)
+        assert after.degenerate and before.degenerate
 
     def test_zero_dim_array_inputs(self):
         """Ensure 0d arrays (which aren't unboxed) can init a CoordRange."""

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -1240,6 +1240,7 @@ class TestRemoteCacheConcurrency:
             fi.write(b"dascore" * 64)
         return path
 
+    @pytest.mark.concurrency
     def test_racing_callers_download_once(self, monkeypatch, run_in_threads):
         """Callers wanting one resource agree on the path and download it once."""
         resource = self._memory_file("shared.bin")
@@ -1256,6 +1257,7 @@ class TestRemoteCacheConcurrency:
         assert len(downloads) == 1
         assert results[0].exists()
 
+    @pytest.mark.concurrency
     def test_distinct_resources_are_not_serialized(self, monkeypatch, run_in_threads):
         """Unrelated downloads run at once; one global lock would time out here."""
         resources = [self._memory_file(f"file_{i}.bin") for i in range(4)]
@@ -1311,6 +1313,7 @@ class TestRemoteCacheConcurrency:
 class TestIOResourceManagerConcurrency:
     """One manager hands every caller the same handle per type."""
 
+    @pytest.mark.concurrency
     def test_racing_callers_share_one_handle(self, tmp_path, run_in_threads):
         """get_resource opens each required type exactly once."""
         path = tmp_path / "concurrent_resource.bin"


### PR DESCRIPTION
## Description

Restores 100% coverage on `dev`. The perf work in #778 left two uncovered lines in `dascore/core/coords.py`, which every branch cut since then inherits (#784 and #786 both report the same two misses).

**`_round_ratio` ndarray branch (validator)** — dead code. Multi-element arrays never reach it: `validate_start_stop_step_len` calls `pd.isnull` on start/stop/step/shape first, which raises on any array with more than one element. Only scalars, 0d arrays, and 1-element arrays (unboxed by `_maybe_unbox_scalar`) get that far, and `float()` handles all of them. Removed, with a test for the 0d-array input that used to take that branch.

**Non-finite fraction guard in `CoordRange._get_index`** — only reachable for a `CoordRange` with a step of 0 (`test_coord_range_len_1` covers building one), and nothing selected on one. Doing so turned up two problems:

- The scalar fast path added in #778 divides python scalars directly, so `CoordRange(start=0, stop=0, step=0).select((0, 10))` raised `ZeroDivisionError`. Numpy scalars instead give `inf`/`nan` and hit the guard. Both are now handled.
- The old behavior was not worth restoring. Every sample of a zero-step coord equals `start` (`.values` is `[start]`), but on `dev`/`master` `select((0, 0))` returned an empty coord while `select((1, None))` kept the sample — an artifact of `inf`/`nan` casting to `INT64_MIN`, not a contract. `_get_zero_step_index` now gives these coords real single-value semantics: bounds containing `start` keep the sample, bounds that don't select nothing.

The zero step is detected after the division rather than up front because testing a numpy step for truthiness costs ~130 ns for `timedelta64` vs ~12 ns for `math.isfinite`, and this is a hot path for time-coordinate selection.


Also marks the three thread-spawning tests added in #781 (`TestRemoteCacheConcurrency` and `TestIOResourceManagerConcurrency` in `tests/test_utils/test_io_utils.py`) with `concurrency`, which they were missing. They fail with `RuntimeError: can't start new thread` in the WebAssembly suite added by #783, which deselects `not network and not concurrency`. An AST sweep over `tests/` confirms these were the only thread-using tests without the mark.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
