### PR TITLE
Make demean, demedian, standardize, and normalize NaN aware

### DIFF
--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -346,6 +346,9 @@ def normalize(
     """
     Normalize a patch along a specified dimension.
 
+    NaN values are ignored when computing the norm. They remain NaN in the
+    output but do not affect any other sample.
+
     Parameters
     ----------
     dim
@@ -376,9 +379,11 @@ def normalize(
     data = self.data
     if norm in {"l1", "l2"}:
         order = int(norm[-1])
-        norm_values = np.linalg.norm(self.data, axis=axis, ord=order)
+        # Equivalent to np.linalg.norm, but skips NaN rather than letting a
+        # single null blank every sample sharing its slice.
+        norm_values = np.nansum(np.abs(data) ** order, axis=axis) ** (1 / order)
     elif norm == "max":
-        norm_values = np.max(np.abs(data), axis=axis)
+        norm_values = np.nanmax(np.abs(data), axis=axis)
     elif norm == "bit":
         pass
     else:
@@ -413,6 +418,9 @@ def standardize(
     where u is the mean of the training samples or zero if with_mean=False,
     and s is the standard deviation of the training samples or one if with_std=False.
 
+    NaN values are ignored when computing the mean and standard deviation. They
+    remain NaN in the output but do not affect any other sample.
+
     Parameters
     ----------
     dim
@@ -434,8 +442,8 @@ def standardize(
     """
     axis = self.get_axis(dim)
     data = self.data
-    mean = np.mean(data, axis=axis, keepdims=True)
-    std = np.std(data, axis=axis, keepdims=True)
+    mean = np.nanmean(data, axis=axis, keepdims=True)
+    std = np.nanstd(data, axis=axis, keepdims=True)
     new_data = (data - mean) / std
     return self.new(data=new_data)
 
@@ -838,6 +846,10 @@ def demedian(patch, dim: str = "time"):
     """
     Remove the median along a given dimension of a DASCore patch.
 
+    NaN values are ignored when computing the median, consistent with
+    [Patch.median](`dascore.proc.aggregate.median`). They remain NaN in the
+    output but do not affect any other sample.
+
     Parameters
     ----------
     patch :
@@ -884,7 +896,7 @@ def demedian(patch, dim: str = "time"):
     data = patch.data
 
     # Compute median along axis, keep dims for broadcasting
-    med = np.median(data, axis=axis, keepdims=True)
+    med = np.nanmedian(data, axis=axis, keepdims=True)
 
     new_data = data - med
 
@@ -896,6 +908,10 @@ def demedian(patch, dim: str = "time"):
 def demean(patch, dim: str = "time"):
     """
     Remove the mean along a given dimension of a DASCore patch.
+
+    NaN values are ignored when computing the mean, consistent with
+    [Patch.mean](`dascore.proc.aggregate.mean`). They remain NaN in the output
+    but do not affect any other sample.
 
     Parameters
     ----------
@@ -943,7 +959,7 @@ def demean(patch, dim: str = "time"):
     data = patch.data
 
     # Compute mean along axis, keep dims for broadcasting
-    mea = np.mean(data, axis=axis, keepdims=True)
+    mea = np.nanmean(data, axis=axis, keepdims=True)
 
     new_data = data - mea
 

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -347,7 +347,8 @@ def normalize(
     Normalize a patch along a specified dimension.
 
     NaN values are ignored when computing the norm. They remain NaN in the
-    output but do not affect any other sample.
+    output but do not affect any other sample. Slices with a norm of zero,
+    meaning they contain nothing but zeros and NaN, are returned unscaled.
 
     Parameters
     ----------
@@ -380,27 +381,23 @@ def normalize(
     if norm in {"l1", "l2"}:
         order = int(norm[-1])
         # Equivalent to np.linalg.norm, but skips NaN rather than letting a
-        # single null blank every sample sharing its slice.
-        norm_values = np.nansum(np.abs(data) ** order, axis=axis) ** (1 / order)
+        # single null blank every sample sharing its slice. The float exponent
+        # promotes ints so the powers cannot overflow a narrow dtype.
+        norm_values = np.nansum(np.abs(data) ** float(order), axis=axis) ** (1 / order)
+        divisor = np.expand_dims(norm_values, axis=axis)
     elif norm == "max":
-        norm_values = np.nanmax(np.abs(data), axis=axis)
+        divisor = np.expand_dims(np.nanmax(np.abs(data), axis=axis), axis=axis)
     elif norm == "bit":
-        pass
+        divisor = np.abs(data)
     else:
         msg = (
             f"Norm value of {norm} is not supported. "
             f"Supported values are {('l1', 'l2', 'max', 'bit')}"
         )
         raise ValueError(msg)
-    if norm == "bit":
-        new_data = np.divide(
-            data, np.abs(data), out=np.zeros_like(data), where=np.abs(data) != 0
-        )
-    else:
-        expanded_norm = np.expand_dims(norm_values, axis=axis)
-        new_data = np.divide(
-            data, expanded_norm, out=np.zeros_like(data), where=expanded_norm != 0
-        )
+    # A zero divisor means there is nothing but zeros and nulls to scale, so
+    # divide those by one; the zeros stay zero and the nulls stay null.
+    new_data = data / np.where(divisor == 0, 1, divisor)
     return self.new(data=new_data)
 
 

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -213,6 +213,48 @@ class TestNormalize:
         out = patch.normalize(dim, norm=norm)
         assert np.isnan(out.data).sum() == 1
 
+    @pytest.mark.filterwarnings("ignore:All-NaN slice encountered")
+    @pytest.mark.parametrize("norm", ["l1", "l2", "max"])
+    @pytest.mark.parametrize("dim", ["time", "distance"])
+    def test_all_nan_slice_stays_null(self, random_patch, dim, norm):
+        """A completely null slice should stay null rather than become zeros."""
+        data = np.asarray(random_patch.data, dtype=np.float64).copy()
+        # Null the first slice reduced by norm (patch is 2D, so the other axis).
+        other_axis = 1 - random_patch.get_axis(dim)
+        null_slice = tuple(0 if i == other_axis else slice(None) for i in range(2))
+        data[null_slice] = np.nan
+        patch = random_patch.new(data=data)
+
+        out = patch.normalize(dim, norm=norm)
+
+        assert np.all(np.isnan(out.data[null_slice]))
+        assert not np.any(np.isnan(np.delete(out.data, 0, axis=other_axis)))
+
+    @pytest.mark.parametrize("norm", ["l1", "l2", "max", "bit"])
+    def test_null_in_zero_slice_stays_null(self, random_patch, norm):
+        """A null in an otherwise zero slice should stay null, not become zero."""
+        data = np.zeros(random_patch.shape, dtype=np.float64)
+        data[0, 0] = np.nan
+        patch = random_patch.new(data=data)
+
+        out = patch.normalize("time", norm=norm)
+
+        assert np.isnan(out.data[0, 0])
+        assert np.all(out.data[0, 1:] == 0)
+
+    @pytest.mark.parametrize("norm", ["l1", "l2", "max", "bit"])
+    def test_int_data(self, random_patch, norm):
+        """Integer data should normalize to floats without overflowing."""
+        # 100 is large enough that squaring it overflows int8.
+        data = np.full(random_patch.shape, 100, dtype=np.int8)
+        samples = data.shape[random_patch.get_axis("time")]
+        expected = {"l1": 1 / samples, "l2": 1 / np.sqrt(samples), "max": 1, "bit": 1}
+
+        out = random_patch.new(data=data).normalize("time", norm=norm)
+
+        assert np.issubdtype(out.data.dtype, np.floating)
+        assert np.allclose(out.data, expected[norm])
+
 
 class TestStandardize:
     """Tests for standardization."""

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -18,6 +18,13 @@ OP_NAMES = ("add", "sub", "pow", "truediv", "floordiv", "mul", "mod")
 TEST_OPS = tuple(getattr(operator, x) for x in OP_NAMES)
 
 
+def _patch_with_nan(patch, index=(0, 0)):
+    """Return a float patch with a single NaN so slice contamination shows."""
+    data = np.asarray(patch.data, dtype=np.float64).copy()
+    data[index] = np.nan
+    return patch.new(data=data)
+
+
 @pytest.fixture(scope="session")
 def random_complex_patch(random_patch):
     """Swap out data for complex data."""
@@ -198,6 +205,14 @@ class TestNormalize:
             assert np.all(norm.data[0, :] == 0.0)
             assert np.all(norm.data[:, 0] == 0.0)
 
+    @pytest.mark.parametrize("norm", ["l1", "l2", "max"])
+    @pytest.mark.parametrize("dim", ["time", "distance"])
+    def test_nan_does_not_contaminate_slice(self, random_patch, dim, norm):
+        """A single NaN should not blank every value sharing its slice."""
+        patch = _patch_with_nan(random_patch)
+        out = patch.normalize(dim, norm=norm)
+        assert np.isnan(out.data).sum() == 1
+
 
 class TestStandardize:
     """Tests for standardization."""
@@ -210,6 +225,16 @@ class TestStandardize:
         # test along the time axis
         out = random_patch.standardize("time")
         assert not np.any(pd.isnull(out.data))
+
+    @pytest.mark.parametrize("dim", ["time", "distance"])
+    def test_nan_does_not_contaminate_slice(self, random_patch, dim):
+        """A single NaN should not blank every value sharing its slice."""
+        patch = _patch_with_nan(random_patch)
+        out = patch.standardize(dim)
+        axis = out.get_axis(dim)
+        assert np.isnan(out.data).sum() == 1
+        assert np.allclose(np.nanmean(out.data, axis=axis), 0)
+        assert np.allclose(np.nanstd(out.data, axis=axis), 1)
 
     def test_std(self, random_patch):
         """Ensure after operation standard deviations are 1."""
@@ -860,6 +885,15 @@ class TestDemedian:
         medians = np.median(dem.data, axis=dem.get_axis(dim))
         assert np.allclose(medians, 0)
 
+    @pytest.mark.parametrize("dim", ["time", "distance"])
+    def test_nan_does_not_contaminate_slice(self, random_patch, dim):
+        """A single NaN should not blank every value sharing its slice."""
+        patch = _patch_with_nan(random_patch)
+        out = patch.demedian(dim=dim)
+        assert np.isnan(out.data).sum() == 1
+        medians = np.nanmedian(out.data, axis=out.get_axis(dim))
+        assert np.allclose(medians, 0)
+
 
 class TestDemean:
     """Tests for demean of data."""
@@ -871,4 +905,13 @@ class TestDemean:
         # perform detrend, ensure all mean values are close to zero
         dem = new.demean(dim=dim)
         means = np.mean(dem.data, axis=dem.get_axis(dim))
+        assert np.allclose(means, 0)
+
+    @pytest.mark.parametrize("dim", ["time", "distance"])
+    def test_nan_does_not_contaminate_slice(self, random_patch, dim):
+        """A single NaN should not blank every value sharing its slice."""
+        patch = _patch_with_nan(random_patch)
+        out = patch.demean(dim=dim)
+        assert np.isnan(out.data).sum() == 1
+        means = np.nanmean(out.data, axis=out.get_axis(dim))
         assert np.allclose(means, 0)


### PR DESCRIPTION
## Description

`dascore.proc.aggregate` is uniformly NaN-aware — `min`, `max`, `mean`, `median`, `std`, and `sum` all dispatch to the `np.nan*` variants. The axis-wise reductions in `dascore.proc.basic` were not, so the same patch and dimension disagreed about what a reduction means:

```python
patch.median(dim="distance")    # [[35.0]]      np.nanmedian
patch.demedian(dim="distance")  # [[nan] * 5]   np.median
```

Because these operations broadcast the reduction back over the axis, one null blanked **every** sample sharing its slice. The failure was silent and total: a single bad channel erased the patch instead of degrading it. That is easy to miss, since the output is still a well-formed patch of the right shape.

This affected `demean`, `demedian`, `standardize`, and `normalize` (`l1`, `l2`, `max`). `normalize(norm="bit")` was already elementwise and is unchanged.

The fix uses the nan-aware reductions, so a NaN stays NaN at its own position and leaves the rest of the slice alone — matching what `Patch.mean`/`Patch.median` already do.

### Notes for review

- **This changes behavior only in the presence of NaN.** For NaN-free input the results are unchanged.
- For `l1`/`l2`, `np.linalg.norm` has no nan-aware counterpart, so it is replaced with an equivalent `np.nansum(np.abs(data) ** order, axis=axis) ** (1 / order)`. I verified this matches `np.linalg.norm` elementwise for real, complex, and integer data, for both orders and both axes.
- **The zero-norm guard in `normalize` changed** (second commit, after review). `np.divide(..., out=np.zeros_like(data), where=norm != 0)` dropped every zero-norm slice into the pre-zeroed output, so an all-NaN slice — and a null sharing a slice with zeros, e.g. `[nan, 0, 0]`, for `max` too — came out as valid-looking zeros. The division now divides by a safe divisor, `data / np.where(divisor == 0, 1, divisor)`: a zero divisor means the slice holds nothing but zeros and nulls, so dividing it by one leaves the zeros zero and the nulls null. `bit` now shares that path. One side effect: integer patches normalize to floats instead of raising `UFuncTypeError`, since the output array is no longer `zeros_like(data)`.
- **`nanmedian`/`nanmean` are slower** than their plain counterparts (they copy and mask). `aggregate.py` already pays that cost library-wide, so this seemed like the consistent trade, but flagging it since `normalize`/`standardize` sit on hot paths for some users. Measured on a 2000x5000 patch, `normalize` along time: `l1` 91 -> 181 ms and `l2` 90 -> 149 ms (`nansum` masks, `linalg.norm` did not have to), while `max` 93 -> 84 ms and `bit` 142 -> 130 ms. Say the word if the `l1`/`l2` cost is not worth it and I will add a nan-free fast path.
- All-NaN slices yield NaN. Where numpy's own nan-aware reduction is used (`nanmean`, `nanmedian`, `nanstd`, `nanmax`) that comes with `RuntimeWarning: All-NaN slice encountered`, the same thing `Patch.median` does today. `l1`/`l2` return NaN without a warning, since `nansum` does not warn.
- **`detrend` is deliberately left alone.** It raises `ValueError: array must not contain infs or NaNs` from SciPy rather than silently returning NaN. That is at least loud, and fixing it properly means masked least-squares per trace, not a function swap. Happy to open a separate issue for it.

I did not find any indication in #678 or the surrounding history that `np.median`/`np.mean` were chosen deliberately here, but I may have missed context — please say so if this was intentional.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
- fixed: `demean`, `demedian`, `standardize`, and `normalize` are NaN-aware, so one null no longer poisons the whole axis; `demean` and `demedian` now agree with the aggregations of the same name.
- fixed: `normalize` works on an integer-dtype patch, which previously raised `UFuncTypeError` for any `order`.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patch normalization, standardization, mean removal, and median removal to correctly ignore `NaN` values when computing statistics.
  * Preserved `NaN` values so they remain localized instead of contaminating entire reduced slices.
  * Updated computations to use NaN-aware mean/std/max and L1/L2 norm behavior for more reliable results.

* **Tests**
  * Added regression coverage to verify `NaN` handling for normalization, standardization, demedian, and demean along both time and distance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
