### PR TITLE
Bring the CI cache back under budget

### DIFF
--- a/.github/actions/load-shared-vars/action.yml
+++ b/.github/actions/load-shared-vars/action.yml
@@ -25,8 +25,11 @@ runs:
       shell: bash
       run: |
         python_default="3.13"
-        python_min_deps_matrix='["3.13","3.14"]'
-        python_test_matrix='["3.11","3.12","3.13","3.14"]'
+        # Min-deps covers the oldest supported version, so every version
+        # pyproject claims is tested somewhere without widening the full
+        # matrix (each entry there costs one environment cache per OS).
+        python_min_deps_matrix='["3.11","3.14"]'
+        python_test_matrix='["3.12","3.13","3.14"]'
         test_os_matrix='["ubuntu-latest","macos-latest","windows-latest"]'
         echo "PYTHON_DEFAULT=$python_default" >> "$GITHUB_ENV"
         echo "python-default=$python_default" >> "$GITHUB_OUTPUT"

--- a/.github/actions/mamba-install-dascore/action.yml
+++ b/.github/actions/mamba-install-dascore/action.yml
@@ -33,9 +33,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up environment variable with date
+    # Weekly, not daily. The env file's content hash is already part of the
+    # key setup-micromamba builds, so this only exists to pick up upstream
+    # package updates for unpinned deps. A daily key minted ~35 fresh
+    # environment caches every day (platform x python x env file), which is
+    # more than the repo's 10 GB cache budget on its own and evicted the
+    # test-data caches.
+    - name: Set up environment variable with cache week
       shell: bash -l {0}
-      run: echo "CURRENT_DATE=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+      # %G, not %Y: ISO week numbers pair with the ISO year, so %Y-W%V
+      # collides across a new year boundary.
+      run: echo "CACHE_WEEK=$(date '+%G-W%V')" >> $GITHUB_ENV
 
     - uses: mamba-org/setup-micromamba@v3
       with:
@@ -45,7 +53,7 @@ runs:
           bash
           powershell
         cache-environment: true
-        cache-environment-key: environment-${{ env.CURRENT_DATE }}-${{ inputs.environment-file }}
+        cache-environment-key: environment-${{ env.CACHE_WEEK }}-${{ inputs.environment-file }}
         post-cleanup: "shell-init"
         create-args: >-
           python=${{ inputs.python-version }}
@@ -82,6 +90,10 @@ runs:
       run: |
         python .github/scripts/export_test_data_cache_env.py >> "$GITHUB_ENV"
 
+    # restore-keys lets a changed registry reuse the previous cache: pooch
+    # then fetches only the added files instead of re-downloading all of them.
+    # A prefix-only match reports cache-hit false, so the prime and save steps
+    # below still run and publish the cache under the new exact key.
     - name: restore test data cache
       if: "${{ inputs.prepare-test-data == 'true' }}"
       id: restore-test-data
@@ -89,6 +101,7 @@ runs:
       with:
         path: ${{ env.DATA_CACHE_PATH }}
         key: ${{ env.DATA_CACHE_KEY }}
+        restore-keys: ${{ env.DATA_CACHE_RESTORE_PREFIX }}
 
     - name: prime test data cache
       if: "${{ inputs.prepare-test-data == 'true' && steps.restore-test-data.outputs.cache-hit != 'true' }}"

--- a/.github/actions/mamba-install-dascore/action.yml
+++ b/.github/actions/mamba-install-dascore/action.yml
@@ -55,8 +55,13 @@ runs:
         cache-environment: true
         cache-environment-key: environment-${{ env.CACHE_WEEK }}-${{ inputs.environment-file }}
         post-cleanup: "shell-init"
+        # python-gil pins the GIL-enabled build. Without it the solver can
+        # pick the free-threaded (cp3XXt) build of python, which is not what
+        # this job means to test and which lacks wheels for some deps.
+        # Free-threading is covered separately by test_free_threaded.yml.
         create-args: >-
           python=${{ inputs.python-version }}
+          python-gil
 
     # Not sure why this is needed but it appears to be the case
     - name: fix env

--- a/.github/doc_environment.yml
+++ b/.github/doc_environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pydantic>2.0
   - pip
   - pandas
-  - pooch>=1.2
+  - pooch>=1.3
   - xarray
   - pre-commit
   - pytables

--- a/.github/scripts/cache_test_data.py
+++ b/.github/scripts/cache_test_data.py
@@ -9,7 +9,32 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from dascore.utils.downloader import fetch, get_registry_df  # noqa: E402
+from dascore.utils.downloader import (  # noqa: E402
+    fetch,
+    get_fetcher,
+    get_registry_df,
+)
+
+
+def _prune_unregistered(registered: set[str]) -> None:
+    """
+    Delete cached files no longer in the registry.
+
+    The cache is restored from an older key when the registry changes, so a
+    file dropped from the registry would otherwise ride along into every
+    later cache. Compares against the full registry, not the primed subset,
+    so a large file that was legitimately fetched is kept.
+    """
+    root = Path(get_fetcher().path)
+    if not root.is_dir():
+        return
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.relative_to(root).as_posix() in registered:
+            continue
+        print(f"Pruning unregistered cache file: {path}")  # noqa
+        path.unlink()
 
 
 def main() -> None:
@@ -20,6 +45,7 @@ def main() -> None:
     for index, name in enumerate(registry["name"], start=1):
         path = Path(fetch(name))
         print(f"[{index}/{total}] {name} -> {path}")  # noqa
+    _prune_unregistered(set(get_registry_df()["name"]))
     print("Finished priming DASCore test-data cache")  # noqa
 
 

--- a/.github/scripts/export_test_data_cache_env.py
+++ b/.github/scripts/export_test_data_cache_env.py
@@ -4,31 +4,51 @@ from __future__ import annotations
 
 import os
 import sys
+from hashlib import sha256
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from dascore.utils.downloader import get_test_data_cache_info  # noqa: E402
+from dascore.constants import DATA_VERSION  # noqa: E402
+from dascore.utils.downloader import REGISTRY_PATH, get_fetcher  # noqa: E402
+
+
+def get_restore_prefix(runner_os: str, cache_number: str) -> str:
+    """
+    Return the cache-key prefix used to fall back to an older cache.
+
+    A registry change makes the exact key miss. Restoring the previous cache
+    under this prefix leaves pooch fetching only the added files rather than
+    the whole registry again.
+
+    ``cache_number`` is part of the prefix, not just the full key, so bumping
+    it still resets the cache; a prefix which stopped at the data version
+    would fall back onto the cache the bump meant to drop.
+    """
+    return f"data-{runner_os}-{DATA_VERSION}-{cache_number}-"
+
+
+def get_key(runner_os: str, cache_number: str, registry_hash: str) -> str:
+    """Return the cache key for the given OS, cache number, and registry."""
+    return f"{get_restore_prefix(runner_os, cache_number)}{registry_hash}"
 
 
 def main() -> None:
     """Print cache metadata as KEY=VALUE lines for GitHub Actions env files."""
     runner_os = os.environ["RUNNER_OS"]
     cache_number = os.environ["INPUT_CACHE_NUMBER"]
-    info = get_test_data_cache_info()
+    registry_hash = sha256(REGISTRY_PATH.read_bytes()).hexdigest()
+    # pooch stores files in <root>/<DATA_VERSION>; cache the whole root, since
+    # DATA_VERSION is already part of the key.
+    cache_path = Path(get_fetcher().path).parent
 
-    print(f"DATA_REGISTRY_HASH={info.registry_hash}")  # noqa: T201
-    print(f"DATA_CACHE_PATH={info.cache_path}")  # noqa: T201
-    print(f"DATA_VERSION={info.data_version}")  # noqa: T201
-    print(  # noqa: T201
-        f"DATA_CACHE_KEY={info.get_key(runner_os=runner_os, cache_number=cache_number)}"
-    )
-    restore_prefix = info.get_restore_prefix(
-        runner_os=runner_os, cache_number=cache_number
-    )
-    print(f"DATA_CACHE_RESTORE_PREFIX={restore_prefix}")  # noqa: T201
+    print(f"DATA_REGISTRY_HASH={registry_hash}")  # noqa: T201
+    print(f"DATA_CACHE_PATH={cache_path}")  # noqa: T201
+    print(f"DATA_VERSION={DATA_VERSION}")  # noqa: T201
+    print(f"DATA_CACHE_KEY={get_key(runner_os, cache_number, registry_hash)}")  # noqa: T201
+    print(f"DATA_CACHE_RESTORE_PREFIX={get_restore_prefix(runner_os, cache_number)}")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/.github/scripts/export_test_data_cache_env.py
+++ b/.github/scripts/export_test_data_cache_env.py
@@ -25,6 +25,10 @@ def main() -> None:
     print(  # noqa: T201
         f"DATA_CACHE_KEY={info.get_key(runner_os=runner_os, cache_number=cache_number)}"
     )
+    restore_prefix = info.get_restore_prefix(
+        runner_os=runner_os, cache_number=cache_number
+    )
+    print(f"DATA_CACHE_RESTORE_PREFIX={restore_prefix}")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -45,6 +45,8 @@ jobs:
     timeout-minutes: 35
     runs-on: ${{ matrix.os }}
     strategy:
+      # See the note in runtests.yml: a cancelled job never saves its cache.
+      fail-fast: false
       matrix:
         # Defined in .github/actions/load-shared-vars/action.yml
         os: ${{ fromJson(needs.setup.outputs.os-matrix) }}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -49,6 +49,10 @@ jobs:
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
+      # One job failing used to cancel the rest, and a cancelled job never
+      # reaches its cache-save step - so a single unrelated failure both hid
+      # the other results and forced every other job to re-prime next run.
+      fail-fast: false
       matrix:
         # Defined in .github/actions/load-shared-vars/action.yml
         os: ${{ fromJson(needs.setup.outputs.os-matrix) }}

--- a/dascore/utils/downloader.py
+++ b/dascore/utils/downloader.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from functools import cache
-from hashlib import sha256
 from importlib.resources import files
 from pathlib import Path
 
@@ -27,8 +25,8 @@ def _get_fetcher(cache_dir: str) -> pooch.Pooch:
         version=DATA_VERSION,
         version_dev="master",
         env="DFS_DATA_DIR",
-        # Priming the CI cache pulls every registry file in one pass, so a
-        # single read timeout from the host used to fail the whole job.
+        # Retry transient network failures; without this a single read
+        # timeout aborts a bulk fetch of the registry.
         retry_if_failed=3,
     )
     fetcher.load_registry(REGISTRY_PATH)
@@ -49,53 +47,6 @@ class _FetcherProxy:
 
 
 fetcher = _FetcherProxy()
-
-
-@dataclass(frozen=True)
-class TestDataCacheInfo:
-    """Metadata needed to restore or prime the CI test-data cache."""
-
-    registry_path: Path
-    cache_path: Path
-    data_version: str
-    registry_hash: str
-
-    def get_restore_prefix(self, runner_os: str, cache_number: str | int) -> str:
-        """
-        Return the cache-key prefix used to fall back to an older cache.
-
-        A registry change makes the exact key miss. Restoring the previous
-        cache under this prefix leaves pooch fetching only the added files
-        rather than the whole registry again.
-
-        ``cache_number`` is part of the prefix, not just the full key, so
-        bumping it still resets the cache; a prefix which stopped at the
-        data version would fall back onto the cache the bump meant to drop.
-        """
-        return f"data-{runner_os}-{self.data_version}-{cache_number}-"
-
-    def get_key(self, runner_os: str, cache_number: str | int) -> str:
-        """Return the GitHub Actions cache key for the given OS and cache number."""
-        prefix = self.get_restore_prefix(runner_os, cache_number)
-        return f"{prefix}{self.registry_hash}"
-
-
-@cache
-def _get_test_data_cache_info(cache_dir: str) -> TestDataCacheInfo:
-    """Return the metadata needed to populate the CI test-data cache."""
-    registry_path = Path(REGISTRY_PATH)
-    fetcher = _get_fetcher(cache_dir)
-    return TestDataCacheInfo(
-        registry_path=registry_path,
-        cache_path=Path(fetcher.path).parent,
-        data_version=DATA_VERSION,
-        registry_hash=sha256(registry_path.read_bytes()).hexdigest(),
-    )
-
-
-def get_test_data_cache_info() -> TestDataCacheInfo:
-    """Return the metadata needed to populate the CI test-data cache."""
-    return _get_test_data_cache_info(str(get_config().downloader_cache_dir))
 
 
 @cache

--- a/dascore/utils/downloader.py
+++ b/dascore/utils/downloader.py
@@ -27,6 +27,9 @@ def _get_fetcher(cache_dir: str) -> pooch.Pooch:
         version=DATA_VERSION,
         version_dev="master",
         env="DFS_DATA_DIR",
+        # Priming the CI cache pulls every registry file in one pass, so a
+        # single read timeout from the host used to fail the whole job.
+        retry_if_failed=3,
     )
     fetcher.load_registry(REGISTRY_PATH)
     return fetcher
@@ -57,11 +60,24 @@ class TestDataCacheInfo:
     data_version: str
     registry_hash: str
 
+    def get_restore_prefix(self, runner_os: str, cache_number: str | int) -> str:
+        """
+        Return the cache-key prefix used to fall back to an older cache.
+
+        A registry change makes the exact key miss. Restoring the previous
+        cache under this prefix leaves pooch fetching only the added files
+        rather than the whole registry again.
+
+        ``cache_number`` is part of the prefix, not just the full key, so
+        bumping it still resets the cache; a prefix which stopped at the
+        data version would fall back onto the cache the bump meant to drop.
+        """
+        return f"data-{runner_os}-{self.data_version}-{cache_number}-"
+
     def get_key(self, runner_os: str, cache_number: str | int) -> str:
         """Return the GitHub Actions cache key for the given OS and cache number."""
-        return (
-            f"data-{runner_os}-{self.data_version}-{self.registry_hash}-{cache_number}"
-        )
+        prefix = self.get_restore_prefix(runner_os, cache_number)
+        return f"{prefix}{self.registry_hash}"
 
 
 @cache

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -49,3 +49,4 @@ The [releases page](https://github.com/DASDAE/dascore/releases) tracks changes f
 - Removed `dascore.transform.spectrogram` and `Patch.spectrogram`; use [`Patch.stft`](`dascore.Patch.stft`) for transforms. `Patch.viz.spectrogram` remains available for plotting.
 - Removed `dascore.utils.patch.merge_patches`; use `dc.spool(...).chunk(...)`.
 - Removed deprecated compatibility parameters `gauge_multiple`, `lag`, and `notch`; use `step_multiple`, select on lag coordinates after correlation, and `invert`, respectively.
+- DASCore now requires Python 3.11 or later (was 3.10, which was never covered by CI and reaches end of life in October 2026).

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pydantic>=2.1
   - pip
   - pandas>=2.0
-  - pooch>=1.2
+  - pooch>=1.3
   - xarray
   - pre-commit
   - h5py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,13 @@ authors = [
 description = "A python library for distributed fiber optic sensing"
 readme = "readme.md"
 license = { file="docs/LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: WebAssembly",
     "Environment :: WebAssembly :: Emscripten",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Topic :: Scientific/Engineering",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -52,7 +51,7 @@ dependencies = [
      "numpy>=1.24",
      "packaging",
      "pandas>=2.0",
-     "pooch>=1.2",
+     "pooch>=1.3",  # retry_if_failed was added in 1.3
      "pydantic>2.1",
      "rich",
       "typing_extensions>=4.12",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,8 +141,8 @@ def run_in_threads():
             assert not thread.is_alive(), "thread never finished; possible deadlock"
         if errors:
             # The first failure is re-raised as-is rather than aggregated:
-            # ExceptionGroup is 3.11+ while the package supports 3.10, and it
-            # rejects BaseException members such as pytest's own skip/fail.
+            # ExceptionGroup rejects BaseException members such as pytest's
+            # own skip/fail.
             raise errors[0]
         return results
 

--- a/tests/test_utils/test_downloader.py
+++ b/tests/test_utils/test_downloader.py
@@ -100,7 +100,40 @@ class TestTestDataCacheInfo:
 
         out = info.get_key(runner_os="Linux", cache_number=7)
 
-        assert out == f"data-Linux-{DATA_VERSION}-{info.registry_hash}-7"
+        # cache_number precedes the registry hash so it can be part of the
+        # restore-keys prefix; see test_restore_prefix_respects_the_cache_
+        # number_reset.
+        assert out == f"data-Linux-{DATA_VERSION}-7-{info.registry_hash}"
+
+    def test_restore_prefix_is_a_prefix_of_the_key(self):
+        """The restore fallback must match keys from other registry hashes.
+
+        CI passes this as ``restore-keys``; if it stopped being a prefix of
+        the exact key, a registry change would silently re-download every
+        file rather than reusing the previous cache.
+        """
+        info = get_test_data_cache_info()
+
+        prefix = info.get_restore_prefix(runner_os="Linux", cache_number=7)
+
+        assert prefix == f"data-Linux-{DATA_VERSION}-7-"
+        assert info.get_key(runner_os="Linux", cache_number=7).startswith(prefix)
+        # Must not match another OS, whose cache holds different paths.
+        assert not info.get_key(runner_os="Windows", cache_number=7).startswith(prefix)
+
+    def test_restore_prefix_respects_the_cache_number_reset(self):
+        """Bumping cache_number must not fall back onto the dropped cache.
+
+        cache_number is the documented manual reset. If it were absent from
+        the prefix, restore-keys would hand back the very cache the bump was
+        meant to discard.
+        """
+        info = get_test_data_cache_info()
+
+        old_key = info.get_key(runner_os="Linux", cache_number=1)
+        new_prefix = info.get_restore_prefix(runner_os="Linux", cache_number=2)
+
+        assert not old_key.startswith(new_prefix)
 
     def test_cache_info_respects_configured_cache_dir(self, tmp_path):
         """Cache info should reflect the configured downloader cache root."""

--- a/tests/test_utils/test_downloader.py
+++ b/tests/test_utils/test_downloader.py
@@ -6,16 +6,13 @@ import pandas as pd
 import pytest
 
 from dascore.config import config_context
-from dascore.constants import DATA_VERSION
 from dascore.utils.downloader import (
     LARGE_REGISTRY_FILES,
-    REGISTRY_PATH,
     _fetch_cached,
     fetch,
     fetcher,
     get_fetcher,
     get_registry_df,
-    get_test_data_cache_info,
 )
 
 
@@ -80,64 +77,3 @@ class TestFetch:
         out = _fetch_cached(name="example.dat", cache_dir=str(tmp_path))
 
         assert out == tmp_path / "example.dat"
-
-
-class TestTestDataCacheInfo:
-    """Tests for CI cache metadata derived from downloader state."""
-
-    def test_cache_info_matches_downloader_configuration(self):
-        """Ensure cache metadata stays aligned with downloader config."""
-        info = get_test_data_cache_info()
-
-        assert info.registry_path == REGISTRY_PATH
-        assert info.cache_path == fetcher.path.parent
-        assert info.data_version == DATA_VERSION
-        assert len(info.registry_hash) == 64
-
-    def test_cache_key_includes_expected_parts(self):
-        """Ensure the generated cache key matches the CI convention."""
-        info = get_test_data_cache_info()
-
-        out = info.get_key(runner_os="Linux", cache_number=7)
-
-        # cache_number precedes the registry hash so it can be part of the
-        # restore-keys prefix; see test_restore_prefix_respects_the_cache_
-        # number_reset.
-        assert out == f"data-Linux-{DATA_VERSION}-7-{info.registry_hash}"
-
-    def test_restore_prefix_is_a_prefix_of_the_key(self):
-        """The restore fallback must match keys from other registry hashes.
-
-        CI passes this as ``restore-keys``; if it stopped being a prefix of
-        the exact key, a registry change would silently re-download every
-        file rather than reusing the previous cache.
-        """
-        info = get_test_data_cache_info()
-
-        prefix = info.get_restore_prefix(runner_os="Linux", cache_number=7)
-
-        assert prefix == f"data-Linux-{DATA_VERSION}-7-"
-        assert info.get_key(runner_os="Linux", cache_number=7).startswith(prefix)
-        # Must not match another OS, whose cache holds different paths.
-        assert not info.get_key(runner_os="Windows", cache_number=7).startswith(prefix)
-
-    def test_restore_prefix_respects_the_cache_number_reset(self):
-        """Bumping cache_number must not fall back onto the dropped cache.
-
-        cache_number is the documented manual reset. If it were absent from
-        the prefix, restore-keys would hand back the very cache the bump was
-        meant to discard.
-        """
-        info = get_test_data_cache_info()
-
-        old_key = info.get_key(runner_os="Linux", cache_number=1)
-        new_prefix = info.get_restore_prefix(runner_os="Linux", cache_number=2)
-
-        assert not old_key.startswith(new_prefix)
-
-    def test_cache_info_respects_configured_cache_dir(self, tmp_path):
-        """Cache info should reflect the configured downloader cache root."""
-        cache_dir = tmp_path / "downloads"
-        with config_context(downloader_cache_dir=cache_dir):
-            info = get_test_data_cache_info()
-        assert info.cache_path == cache_dir


### PR DESCRIPTION
## Description

The repo's GitHub Actions cache sits at **14.04 GB against a 10 GB limit**, so LRU eviction runs continuously and the test-data caches are the collateral. Every eviction forces a re-download of the whole registry from `raw.githubusercontent.com`, one file at a time with no retry, which is where the intermittent CI failures come from — a single 30 s read timeout fails the whole job before any test runs.

Measured breakdown of the 41 live caches:

| prefix | caches | size |
|---|---|---|
| `environment-*` | 35 | **10.37 GB** |
| `data-*` | 6 | 3.67 GB |

The environment caches are 74% of the budget on their own.

### Why the environment caches explode

`cache-environment-key` embedded `$(date '+%Y-%m-%d')`, minting a brand-new key every day. `setup-micromamba` then appends platform, python-args, and an env-file content hash, so the real multiplier is 3 platforms × 4 python versions × 2 env files ≈ **35 fresh caches per day** at 240–560 MB each.

The date isn't pointless — with unpinned deps it's what picks up upstream package updates — so it's now **ISO week** (`%G-W%V`) rather than deleted. Same intent, ~7× less churn. `%G` rather than `%Y` because ISO week numbers pair with the ISO year and `%Y-W%V` collides across a new-year boundary.

Evidence this was eviction rather than a key-design problem: at registry hash `6f304af6` the Windows and macOS data caches survived while the **Linux one was gone**, so a run had to re-prime and re-save it. Same key, same day, one OS evicted and two kept is the LRU signature. The data cache key itself — `data-{OS}-{DATA_VERSION}-{sha256(registry)}-{bust}` — is content-addressed and correct, and is unchanged here.

### Changes

- **Weekly environment cache key** instead of daily (above).
- **`restore-keys` fallback for the data cache.** A registry change previously missed the exact key and re-downloaded all 47 files. It now falls back to `data-{OS}-{DATA_VERSION}-{cache_number}-`, and pooch fetches only the added files. A prefix-only match reports `cache-hit != 'true'`, so the prime and save steps still run and publish under the new exact key. `get_key` builds on `get_restore_prefix` so the two cannot drift.

  The key is reordered to put `cache_number` *before* the registry hash, so it can live in the prefix. Without that, bumping `cache_number` — the documented manual reset — would fall back onto the very cache the bump was meant to discard, silently doing nothing. The reorder costs one re-prime per OS on first run; a working reset knob is worth it.
- **The cache key now lives in the CI script, not the library.** `TestDataCacheInfo` / `get_test_data_cache_info` were removed from `dascore.utils.downloader` and the key/prefix construction moved into `.github/scripts/export_test_data_cache_env.py`, its only consumer. A GitHub Actions cache key is not library API, and its tests do not belong in the test suite; DASCore stays agnostic about the CI backend. `retry_if_failed` stays — retrying a transient read timeout is useful to anyone fetching the registry, not just CI.
- **Unregistered files are pruned before saving.** Restoring an older cache carries along files since dropped from the registry, which would otherwise ride into every later cache forever. Priming now deletes anything not in the *full* registry — the full one, not the primed subset, so a large file that was legitimately fetched is kept.
- **`retry_if_failed=3` on the pooch fetcher**, with the `pooch` floor raised `>=1.2` → `>=1.3` (the option landed in 1.3, so on 1.2 this would have been a `TypeError` at import). Priming pulls the whole registry in one pass, so one transient read timeout used to fail the job.
- **`fail-fast: false` on the `test_code` and min-deps matrices.** This is a caching fix as much as a reporting one: a cancelled job never reaches its cache-save step, so one unrelated failure both hid the other results and forced every other job to re-prime on the next run. (`network_tests` already set this.)
- **Python matrix trimmed** from `3.11–3.14` to `3.12–3.14`. Each entry costs one environment cache per OS.
- **Min-deps moved from `3.13/3.14` to `3.11/3.14`.** Same job count and same cache count, but it now covers the *oldest* supported version, which is the more useful thing for a minimum-dependency run — and it keeps 3.11 verified despite leaving the full matrix.
- **`requires-python` raised to `>=3.11`** and the 3.10 classifier dropped. 3.10 was never in any CI matrix, so the package claimed support it did not verify; it also reaches end of life in October 2026. Every version `pyproject` now claims is tested somewhere.
- **`python-gil` added to the micromamba `create-args`.** This is the fallout of the key change, and worth spelling out: `python=3.14` alone lets the solver pick the *free-threaded* `cp314t` build on linux-64 (`scipy` is what tips it — `python=3.14 scipy>=1.15.0` reproduces it locally, `python=3.14` alone does not). `dev` only passed because its ubuntu 3.14 job kept restoring a pre-`cp314t` environment cache; the first fresh solve — this PR's, or `dev`'s own next week — hits it. The job then has no `orjson` wheel (a `pymseed` dependency), tries to build it from source, and `orjson` refuses to build against free-threaded CPython. `python-gil` pins the GIL-enabled build; it resolves cleanly for 3.11–3.14, and free-threading keeps its own coverage in `test_free_threaded.yml`.

Expected steady state: ~5 environment caches per week plus data, comfortably inside the budget. A further ~2.3 GB returns on its own when `dev` reaches `master`, since dev's `downloader.py` rework already cut the data cache from 1014 MB to 237 MB per OS.

### Not included

Pruning the now-unreachable dated `environment-*` caches will speed this up, but is an operational step rather than a repo change.

## Changelog

<!-- Retrofitted after #864; recovered from docs/changelog.qmd history. -->
- changed **breaking**: DASCore requires Python 3.11 or later (was 3.10, which was never covered by CI and reaches end of life in October 2026).

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html). CI-only change; the cache-key tests were removed along with the library helper they covered.
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Python 3.10 is no longer supported. DASCore now requires Python 3.11+ (up to Python 3.14).

* **Bug Fixes**
  * Improved download reliability with enhanced transient network retries.
  * Improved test-data cache keying, fallback restoration, and automated cleanup to reduce stale or incomplete caches.

* **Chores**
  * Updated CI caching behavior (including more flexible restore fallbacks) and micromamba cache keying.
  * Adjusted CI Python/test matrices and disabled fail-fast for matrix jobs to preserve other results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
