### PR TITLE
Add ty type checking to pre-commit

### DIFF
--- a/.github/actions/mamba-install-dascore/action.yml
+++ b/.github/actions/mamba-install-dascore/action.yml
@@ -47,8 +47,11 @@ runs:
         cache-environment: true
         cache-environment-key: environment-${{ env.CURRENT_DATE }}-${{ inputs.environment-file }}
         post-cleanup: "shell-init"
+        # python-gil pins the regular (GIL) build; without it the solver can
+        # pick the free-threaded cp314t build, which many wheels don't support.
         create-args: >-
           python=${{ inputs.python-version }}
+          python-gil
 
     # Not sure why this is needed but it appears to be the case
     - name: fix env

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - dev
   pull_request:
     branches:
       - master
+      - dev
 
 jobs:
   lint_code:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,15 @@ repos:
     hooks:
     -   id: fix-future-annotations
 
+    # Type check with ty. It always checks the whole project (not just changed
+    # files); scoping and rule selection live in pyproject.toml under [tool.ty].
+-   repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.65
+    hooks:
+    -   id: ty
+        # Isolated mode keeps uv from creating a uv.lock or .venv in the repo.
+        args: [--isolated]
+
     # strips out all outputs from notebooks.
 -   repo: https://github.com/kynan/nbstripout
     rev: 0.6.1

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping
 from functools import partial
 from pathlib import Path
 from types import MappingProxyType
-from typing import Literal, Protocol, TypeVar, runtime_checkable
+from typing import Literal, Protocol, TypeVar, get_args, runtime_checkable
 
 import numpy as np
 import pandas as pd
@@ -64,7 +64,7 @@ ONE_BILLION = 1_000_000_000
 ONE_SECOND_IN_NS = np.timedelta64(ONE_BILLION, "ns")
 
 # Valid strings for "datatype" attribute
-VALID_DATA_TYPES = (
+DataType = Literal[
     "",  # unspecified
     "velocity",
     "strain_rate",
@@ -88,10 +88,12 @@ VALID_DATA_TYPES = (
     "dispersion",
     "phase_weighted_stack",
     "otdr",
-)
+]
+VALID_DATA_TYPES = get_args(DataType)
 
 # Valid categories (of instruments)
-VALID_DATA_CATEGORIES = ("", "DAS", "DTS", "DSS")
+DataCategory = Literal["", "DAS", "DTS", "DSS"]
+VALID_DATA_CATEGORIES = get_args(DataCategory)
 
 max_lens = {
     "path": 120,

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from pydantic import ConfigDict, Field, PlainValidator, model_validator
 from typing_extensions import Self
 
 from dascore.constants import (
-    VALID_DATA_CATEGORIES,
-    VALID_DATA_TYPES,
+    DataCategory,
+    DataType,
     max_lens,
 )
 from dascore.utils.misc import (
@@ -52,10 +52,10 @@ class PatchAttrs(DascoreBaseModel):
         arbitrary_types_allowed=True,
     )
 
-    data_type: Annotated[Literal[VALID_DATA_TYPES], str_validator] = Field(
+    data_type: Annotated[DataType, str_validator] = Field(
         description="Describes the quantity being measured.", default=""
     )
-    data_category: Annotated[Literal[VALID_DATA_CATEGORIES], str_validator] = Field(
+    data_category: Annotated[DataCategory, str_validator] = Field(
         description="Describes the type of data.",
         default="",
     )

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -44,7 +44,8 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from itertools import zip_longest
-from typing import Annotated, TypeVar
+from types import EllipsisType
+from typing import Annotated
 
 import numpy as np
 from pydantic import field_validator, model_validator
@@ -81,7 +82,7 @@ from dascore.utils.models import (
     frozen_dict_validator,
 )
 
-MaybeArray = TypeVar("MaybeArray", ArrayLike, np.ndarray, None)
+MaybeArray = ArrayLike | np.ndarray | None
 CoordManagerInput = Mapping[
     str,
     BaseCoord | np.ndarray | tuple[str | tuple[str, ...], BaseCoord | np.ndarray],
@@ -802,7 +803,7 @@ class CoordManager(DascoreBaseModel):
 
     def _get_dim_array_dict(
         self, keep_coord=False
-    ) -> dict[tuple[str], ArrayLike | BaseCoord]:
+    ) -> dict[str, tuple[tuple[str, ...], ArrayLike | BaseCoord]]:
         """
         Get the coord map in the form:
         {coord_name = ((dims,), array)}.
@@ -839,7 +840,7 @@ class CoordManager(DascoreBaseModel):
             new_coords[name] = coord.simplify_units()
         return self.new(coord_map=new_coords)
 
-    def transpose(self, *dims: str | type(Ellipsis)) -> Self:
+    def transpose(self, *dims: str | EllipsisType) -> Self:
         """Transpose the coordinates."""
 
         def _get_transpose_dims(new, old):

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -17,7 +17,8 @@ from collections.abc import Sized
 from contextlib import suppress
 from functools import cache
 from operator import gt, lt
-from typing import Any, Literal, TypeVar
+from types import EllipsisType
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -74,10 +75,10 @@ from dascore.utils.time import (
     to_int,
 )
 
-# Valid values for min/max
-min_max_type = TypeVar("min_max_type")
-
-step_type = TypeVar("step_type")
+# Values for min/max/step. The CoordSummary validator coerces these to match
+# the summary dtype (datetime64, float, etc.) so they are open-ended here.
+min_max_type = Any
+step_type = Any
 
 CoordKind = Literal["string", "empty", "single", "array", "range"]
 
@@ -841,7 +842,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
     def get_slice_tuple(
         self,
-        select: slice | None | type(Ellipsis) | tuple[Any, Any],
+        select: slice | None | EllipsisType | tuple[Any, Any],
         relative=False,
     ) -> tuple[Any, Any]:
         """
@@ -2779,7 +2780,7 @@ def get_coord(
     step=None,
     units: None | Unit | Quantity | str = None,
     shape: None | int | tuple[int, ...] = None,
-    dtype: str | np.dtype = None,
+    dtype: str | np.dtype | None = None,
     segments: tuple[BaseCoord, ...] | list[BaseCoord] | None = None,
 ) -> BaseCoord:
     """

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -19,7 +19,12 @@ from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.coords import BaseCoord
 from dascore.core.summary import PatchSummary
-from dascore.utils.array import PatchUFunc, patch_array_function, patch_array_ufunc
+from dascore.utils.array import (
+    PatchUFunc,
+    apply_ufunc,
+    patch_array_function,
+    patch_array_ufunc,
+)
 from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
 from dascore.utils.models import ArrayLike
 from dascore.utils.namespace import NamespaceOwner
@@ -109,37 +114,37 @@ class Patch(NamespaceOwner):
         return dascore.proc.equals(self, other)
 
     def __add__(self, other):
-        return dascore.utils.array.apply_ufunc(np.add, self, other)
+        return apply_ufunc(np.add, self, other)
 
     def __sub__(self, other):
-        return dascore.utils.array.apply_ufunc(np.subtract, self, other)
+        return apply_ufunc(np.subtract, self, other)
 
     def __floordiv__(self, other):
-        return dascore.utils.array.apply_ufunc(np.floor_divide, self, other)
+        return apply_ufunc(np.floor_divide, self, other)
 
     def __truediv__(self, other):
-        return dascore.utils.array.apply_ufunc(np.divide, self, other)
+        return apply_ufunc(np.divide, self, other)
 
     def __mul__(self, other):
-        return dascore.utils.array.apply_ufunc(np.multiply, self, other)
+        return apply_ufunc(np.multiply, self, other)
 
     def __pow__(self, other):
-        return dascore.utils.array.apply_ufunc(np.power, self, other)
+        return apply_ufunc(np.power, self, other)
 
     def __mod__(self, other):
-        return dascore.utils.array.apply_ufunc(np.mod, self, other)
+        return apply_ufunc(np.mod, self, other)
 
     def __gt__(self, other):
-        return dascore.utils.array.apply_ufunc(np.greater, self, other)
+        return apply_ufunc(np.greater, self, other)
 
     def __ge__(self, other):
-        return dascore.utils.array.apply_ufunc(np.greater_equal, self, other)
+        return apply_ufunc(np.greater_equal, self, other)
 
     def __lt__(self, other):
-        return dascore.utils.array.apply_ufunc(np.less, self, other)
+        return apply_ufunc(np.less, self, other)
 
     def __le__(self, other):
-        return dascore.utils.array.apply_ufunc(np.less_equal, self, other)
+        return apply_ufunc(np.less_equal, self, other)
 
     def __bool__(self):
         return dascore.proc.basic.bool_patch(self)
@@ -150,25 +155,25 @@ class Patch(NamespaceOwner):
 
     def __rsub__(self, other):
         """Reverse subtraction: other - self."""
-        return dascore.utils.array.apply_ufunc(np.subtract, other, self)
+        return apply_ufunc(np.subtract, other, self)
 
     __rmul__ = __mul__
 
     def __rpow__(self, other):
         """Reverse power: other ** self."""
-        return dascore.utils.array.apply_ufunc(np.power, other, self)
+        return apply_ufunc(np.power, other, self)
 
     def __rtruediv__(self, other):
         """Reverse true division: other / self."""
-        return dascore.utils.array.apply_ufunc(np.divide, other, self)
+        return apply_ufunc(np.divide, other, self)
 
     def __rfloordiv__(self, other):
         """Reverse floor division: other // self."""
-        return dascore.utils.array.apply_ufunc(np.floor_divide, other, self)
+        return apply_ufunc(np.floor_divide, other, self)
 
     def __rmod__(self, other):
         """Reverse modulo: other % self."""
-        return dascore.utils.array.apply_ufunc(np.mod, other, self)
+        return apply_ufunc(np.mod, other, self)
 
     def __neg__(self):
         return self.update(data=-self.data)
@@ -377,7 +382,7 @@ class Patch(NamespaceOwner):
     drop_private_coords = dascore.proc.drop_private_coords
     coords_from_df = dascore.proc.coords_from_df
     make_broadcastable_to = dascore.proc.make_broadcastable_to
-    apply_ufunc = dascore.utils.array.apply_ufunc
+    apply_ufunc = apply_ufunc
     get_patch_names = get_patch_names
     get_axis = dascore.proc.get_axis
     full = dascore.proc.full

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -321,7 +321,7 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         self,
         size: int | None = None,
         count: int | None = None,
-    ) -> Generator[Self, None, None]:
+    ) -> Generator[BaseSpool, None, None]:
         """
         Yield sub-patches based on specified parameters.
 
@@ -369,7 +369,7 @@ class BaseSpool(NamespaceOwner, abc.ABC):
 
     def map(
         self,
-        func: Callable[[dc.Patch, ...], T],
+        func: Callable[..., T],
         *,
         client: ExecutorType | None = None,
         size: int | None = None,
@@ -575,7 +575,7 @@ class Spool(BaseSpool):
         self,
         size: int | None = None,
         count: int | None = None,
-    ) -> Generator[Self, None, None]:
+    ) -> Generator[BaseSpool, None, None]:
         """{doc}."""
         if not ((count is not None) ^ (size is not None)):
             msg = "Spool.split requires either spool_count or spool_size."

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -13,10 +13,13 @@ from functools import cached_property, wraps
 from numbers import Integral
 from pathlib import Path
 from threading import RLock
-from typing import Any, Literal, NotRequired, TypedDict, get_type_hints
+from typing import Any, Literal, TypedDict, get_type_hints
 
 import numpy as np
 import pandas as pd
+
+# NotRequired is only in typing from python 3.11; dascore supports 3.10.
+from typing_extensions import NotRequired
 
 import dascore as dc
 from dascore.compat import Progress, UPath
@@ -819,7 +822,7 @@ class FiberIO:
 
     name: str = ""
     version: str = ""
-    preferred_extensions: tuple[str] = ()
+    preferred_extensions: tuple[str, ...] = ()
     # Specifies if this fiber IO expects a directory or single file
     input_type: Literal["file", "directory"] = "file"
     # True when a single resource can hold more than one patch.

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -22,13 +22,13 @@ from dascore.utils.misc import (
 # --- Getting format/version
 
 _FebusSlice = namedtuple(
-    "FebusSlice",
+    "_FebusSlice",
     ["group", "group_name", "source", "source_name", "zone", "zone_name", "data_name"],
 )
 
 
 _FebusTime = namedtuple(
-    "FebusTime",
+    "_FebusTime",
     ["block_time", "time_step", "idx_start", "idx_stop"],
 )
 

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -54,9 +54,7 @@ def set_dims(self: PatchType, **kwargs: str) -> PatchType:
     return self.new(coords=cm)
 
 
-def pipe(
-    self: PatchType, func: Callable[[PatchType, ...], PatchType], *args, **kwargs
-) -> PatchType:
+def pipe(self: PatchType, func: Callable[..., PatchType], *args, **kwargs) -> PatchType:
     """
     Pipe the patch to a function.
 

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -11,7 +11,7 @@ from collections.abc import Sequence
 from functools import partial
 from math import prod
 from operator import mul, truediv
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import numpy.fft as nft
@@ -37,7 +37,10 @@ from dascore.utils.patch import (
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.transformatter import FourierTransformatter
 
-ShortTimeFFT = lazy_import("scipy.signal", "ShortTimeFFT")
+if TYPE_CHECKING:
+    from scipy.signal import ShortTimeFFT
+else:
+    ShortTimeFFT = lazy_import("scipy.signal", "ShortTimeFFT")
 get_window = lazy_import("scipy.signal.windows", "get_window")
 
 DFT_OUTPUT_DATA_TYPE_MAP = {

--- a/dascore/transform/taup.py
+++ b/dascore/transform/taup.py
@@ -25,7 +25,7 @@ def _jit_taup_uniform(data, dx, dt, p_vals):
     two_sided_p_vals = np.concatenate((-np.flip(p_vals), p_vals))
     taup = np.zeros(shape=(2 * n_slo, nt))
 
-    for ip in numba.prange(n_slo):  # noqa
+    for ip in numba.prange(n_slo):  # noqa  # ty: ignore[unresolved-reference]
         pdx = p_vals[ip] * dx
         for tau in range(nt):
             for ix in range(nx):
@@ -54,7 +54,7 @@ def _jit_taup_general(data, distance, dt, p_vals):
     taup = np.zeros(shape=(2 * n_slo, nt))
     mod_distance = distance - distance[0]
 
-    for ip in numba.prange(n_slo):  # noqa
+    for ip in numba.prange(n_slo):  # noqa  # ty: ignore[unresolved-reference]
         p = p_vals[ip]
         for tau in range(nt):
             for ix in range(nx):

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -613,8 +613,8 @@ def _maybe_unpack(maybe_array):
 
 @cache
 def _get_compiled_suffix_prefix_regex(
-    suffixes: str | tuple[str],
-    prefixes: str | tuple[str] | None,
+    suffixes: str | tuple[str, ...],
+    prefixes: str | tuple[str, ...] | None,
 ):
     """Get a compiled regex which matches the form prefixes_suffixes."""
     suffixes = iterate(suffixes)

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -52,7 +52,7 @@ from dascore.utils.time import to_float
 
 attr_type = dict[str, Any] | str | Sequence[str] | None
 
-_DimAxisValue = namedtuple("DimAxisValue", ["dim", "axis", "value"])
+_DimAxisValue = namedtuple("_DimAxisValue", ["dim", "axis", "value"])
 
 
 def _format_values(val):
@@ -78,7 +78,11 @@ def _format_values(val):
 
 def _func_and_kwargs_str(func: Callable, patch, *args, **kwargs) -> str:
     """Get a str rep of the function and input args."""
-    callargs = inspect.getcallargs(func, patch, *args, **kwargs)
+    # getcallargs is deprecated, but Signature.bind is not a drop-in
+    # replacement (different handling of self and defaults); keep it for now.
+    callargs = inspect.getcallargs(  # ty: ignore[deprecated]
+        func, patch, *args, **kwargs
+    )
     callargs.pop("patch", None)
     callargs.pop("self", None)
     kwargs_ = callargs.pop("kwargs", {})
@@ -289,7 +293,7 @@ def patch_function(
                 coords=required_coords,
             )
             check_patch_attrs(patch, required_attrs)
-            out: PatchType = func(patch, *args, **kwargs)
+            out = func(patch, *args, **kwargs)
             attr_updates = {}
             if data_type is not None:
                 attr_updates["data_type"] = data_type
@@ -648,8 +652,8 @@ def get_dim_axis_value(
     patch: PatchType,
     *,
     args: tuple = tuple(),
-    kwargs: dict = FrozenDict(),
-    arg_keys: tuple[str] = ("dim", "coord", "dims", "coords"),
+    kwargs: Mapping = FrozenDict(),
+    arg_keys: tuple[str, ...] = ("dim", "coord", "dims", "coords"),
     allow_multiple: bool = False,
     allow_extra: bool = False,
 ) -> tuple[_DimAxisValue, ...]:

--- a/docs/contributing/style_and_linting.qmd
+++ b/docs/contributing/style_and_linting.qmd
@@ -22,3 +22,5 @@ will automatically fix the issue they raise on the first run.
 DASCore makes extensive use of Python 3's [type hints](https://docs.python.org/3/library/typing.html).
 Use them to annotate any public functions/methods. See the docstring section of the [documentation page](documentation.qmd)
 for more information and some examples.
+
+The hints are checked by [ty](https://github.com/astral-sh/ty) as part of the pre-commit hooks. ty always checks the whole `dascore` package (not just changed files); its configuration lives in `pyproject.toml` under `[tool.ty]`. Several rules with large pre-existing error counts are temporarily ignored there and will be re-enabled incrementally — please don't add new type errors in the categories that are already enforced.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,34 @@ markers = [
 # Use `\n` line endings for all files
 line-ending = "lf"
 
+[tool.ty.src]
+include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
+
+# Rules with large pre-existing error counts, ignored until incrementally
+# burned down. Counts at time of adoption: invalid-argument-type 210,
+# unresolved-attribute 163, invalid-return-type 76, no-matching-overload 42,
+# not-subscriptable 36, invalid-method-override 35, invalid-assignment 21,
+# unsupported-operator 17, call-non-callable 11, not-iterable 10.
+[tool.ty.rules]
+invalid-argument-type = "ignore"
+unresolved-attribute = "ignore"
+invalid-return-type = "ignore"
+no-matching-overload = "ignore"
+not-subscriptable = "ignore"
+invalid-method-override = "ignore"
+invalid-assignment = "ignore"
+unsupported-operator = "ignore"
+call-non-callable = "ignore"
+not-iterable = "ignore"
+
+# These files lazily import optional or untyped modules (xarray, numba,
+# h5py.h5r) that are not installed in the pre-commit hook's environment.
+[[tool.ty.overrides]]
+include = ["dascore/compat.py", "dascore/utils/jit.py", "dascore/io/dasvader/utils.py"]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+
 [tool.typos.files]
 extend-exclude = ["docs/_static/logo.svg"]
 


### PR DESCRIPTION
## Description

Adds [ty](https://github.com/astral-sh/ty) as a pre-commit hook so type hints are checked on every commit (and in the lint CI job via `pre-commit run --all`).

Running ty 0.0.65 on `dev` reports 735 diagnostics in `dascore/`, so full enforcement isn't realistic in one PR. The approach here:

- The hook (`astral-sh/ty-pre-commit`, `--isolated` so uv never creates a `uv.lock`/`.venv` in the repo) always checks the whole `dascore` package; scoping and rule selection live in `pyproject.toml` under `[tool.ty]`.
- Ten rules with large pre-existing error counts (~640 diagnostics total, counts noted in `pyproject.toml`) are set to `ignore` for incremental burn-down in follow-up PRs. Everything else is enforced now.
- The remaining ~44 diagnostics were genuine hint mistakes and are fixed here, deliberately without introducing any complicated typing constructs. Highlights:
  - `NotRequired` was imported from `typing` (a 3.11+ symbol; we support 3.10) — this alone caused 69 diagnostics via the `ScanPayload` TypedDict.
  - `tuple[str]` used where `tuple[str, ...]` was meant, `type(Ellipsis)` in annotations, TypeVars used outside generic contexts, a lazy-import object used as a return annotation, etc.
  - `VALID_DATA_TYPES`/`VALID_DATA_CATEGORIES` are now derived from explicit `Literal` aliases (`DataType`, `DataCategory`) via `get_args`, so the pydantic validation values are identical.
  - Three files that lazily import optional modules (`xarray`, `numba`, `h5py.h5r`) get a per-file `unresolved-import` override since those extras aren't installed in the hook's environment.

No runtime behavior changes intended; pydantic validation for `PatchAttrs` and `CoordSummary` is value-equivalent. Full test suite passes locally (8082 passed, 187 skipped, 2 xfailed).

Also adds a short note about ty to the style/linting contributor docs.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive static type checking for the package.
  * Improved type annotations across coordinates, patches, spools, processing, and utility APIs.

* **Documentation**
  * Added guidance for type checking and linting workflows.

* **Chores**
  * Updated automated checks to run for both primary development branches and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## CI fixes bundled here

- `lint.yml` now also triggers on `dev` pushes/PRs — otherwise the ty hook would never run in CI for dev-targeted PRs.
- The mamba install action now passes `python-gil`: conda-forge's new python 3.14.6 build let the solver pick the free-threaded `cp314t` variant, which broke env setup for all PRs (orjson, via `pymseed`, has no cp314t wheels and refuses free-threaded source builds). The free-threaded workflow has its own setup and is unaffected.
