### PR TITLE
Keep relative time bounds out of the canonical numeric range

### DIFF
--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -114,6 +114,11 @@ def _canonical_range(value) -> _CanonicalRange | None:
             units = str(base.units)
         elif isinstance(bound, bool | np.bool_):
             return None
+        elif isinstance(bound, np.datetime64 | np.timedelta64):
+            # Time bounds are never a canonical-SI numeric range. timedelta64
+            # needs naming here because numpy makes it an np.integer subclass,
+            # so it would otherwise reach float() below and raise.
+            return None
         elif isinstance(bound, int | float | np.integer | np.floating):
             magnitudes.append(float(bound))
         else:  # datetimes, strings: not a numeric range

--- a/tests/test_io/test_index/test_catalog.py
+++ b/tests/test_io/test_index/test_catalog.py
@@ -9,6 +9,7 @@ import pytest
 
 import dascore as dc
 from dascore.io.index import PatchCatalog
+from dascore.io.index.catalog import _canonical_range
 from dascore.io.index.query import InvalidSpoolQueryError
 
 
@@ -142,6 +143,50 @@ class TestResidualSelects:
             patch.get_coord("time").max() - patch.get_coord("time").min()
         ) / np.timedelta64(1, "s")
         assert got_span <= span - 1
+
+
+class TestRelativeTimeCoords:
+    """Patches whose time axis is an offset rather than a date (#798)."""
+
+    @pytest.fixture()
+    def relative_time_catalog(self, patches):
+        """A catalog over patches with a timedelta64 time coordinate."""
+        out = []
+        for patch in patches:
+            coord = patch.get_coord("time")
+            out.append(patch.update_coords(time=coord.values - coord.min()))
+        return PatchCatalog.from_patches(tuple(out))
+
+    def test_select_then_load(self, relative_time_catalog):
+        """A selected relative range loads, trimmed to the requested bounds."""
+        start, stop = np.timedelta64(1, "s"), np.timedelta64(3, "s")
+        view = relative_time_catalog.select(time=(start, stop))
+        assert len(view)
+        coord = view.get_patch(0).get_coord("time")
+        assert coord.min() >= start
+        assert coord.max() <= stop
+
+    def test_select_open_ended(self, relative_time_catalog):
+        """One-sided relative ranges load as well."""
+        stop = np.timedelta64(2, "s")
+        coord = relative_time_catalog.select(time=(None, stop)).get_patch(0)
+        assert coord.get_coord("time").max() <= stop
+
+    @pytest.mark.parametrize(
+        "bounds",
+        [
+            (np.timedelta64(1, "s"), np.timedelta64(3, "s")),
+            (np.datetime64("2020-01-01"), np.datetime64("2020-01-02")),
+            (None, np.timedelta64(3, "s")),
+        ],
+    )
+    def test_time_ranges_are_not_canonical(self, bounds):
+        """Time bounds keep their native form for the residual select."""
+        assert _canonical_range(bounds) is None
+
+    def test_numeric_ranges_still_canonical(self):
+        """Numeric bounds are still resolved to SI magnitudes."""
+        assert _canonical_range((1, 10)).magnitudes == (1.0, 10.0)
 
 
 class TestDirectoryCatalog:


### PR DESCRIPTION
## Description

Fixes #798: selecting a range on a relative (timedelta64) time coordinate returned the correct rows, but materializing a patch from the result raised `TypeError: float() argument must be a string or a real number, not 'datetime.timedelta'`.

`_canonical_range` (`dascore/io/index/catalog.py`) resolves numeric bounds to canonical SI magnitudes and means to pass everything else through — its fallback is commented "datetimes, strings: not a numeric range". But numpy makes `np.timedelta64` a subclass of `np.signedinteger`:

```python
np.timedelta64.__mro__
# (timedelta64, signedinteger, integer, number, generic, object)
```

so a relative bound satisfied `isinstance(bound, int | float | np.integer | np.floating)`, took the numeric branch, and hit `float(bound)` — itself a `TypeError` for timedelta64. Absolute times are `np.datetime64`, which is *not* an integer subclass, so they took the intended fallback and were never affected.

The fix checks both time types before the numeric branch, which is the ordering `typed_value` already uses in `io/index/ingest.py` when classifying attrs into `time`/`dur` versus `num`.

Everything else about relative-time patches already worked (`len`, `get_contents()`, `spool[0]`, iteration, `chunk(time=...)`), so this only restores the select-then-load path.

## Example

Before, this raised on the last line; now it loads, trimmed to the requested bounds:

```python
import numpy as np
import dascore as dc

patch = dc.get_example_patch()
coord = patch.get_coord("time")
rel = patch.update_coords(time=coord.values - coord.min())  # relative time axis

spool = dc.spool([rel]).select(time=(np.timedelta64(1, "s"), np.timedelta64(3, "s")))
spool[0]
```

## Tests

`TestRelativeTimeCoords` in `tests/test_io/test_index/test_catalog.py` covers the reported crash (select then load, with the trimmed bounds asserted), a one-sided range, and `_canonical_range` directly for `datetime64`/`timedelta64`/open bounds so the residual-select path is pinned as well as the envelope path. Both new select tests fail on `dev` without the fix.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of time-based catalog selections using `datetime64` and `timedelta64` values.
  * Bounded and open-ended time selections now load and trim data correctly.
  * Numeric ranges continue to be interpreted consistently using standard SI magnitudes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->