### PR TITLE
Enable ty's not-subscriptable and no-matching-overload rules

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -129,8 +129,13 @@ PROGRESS_LEVELS = Literal["standard", "basic", None]
 # Options for handling specific warnings
 WARN_LEVELS = Literal["warn", "raise", None]
 
-# A map from the unit name to the code used in numpy.timedelta64
-NUMPY_TIME_UNIT_MAPPING = {
+# A map from the unit name to the code used in numpy.timedelta64. The codes
+# are spelled out in the annotation because numpy's unit parameter accepts
+# only those literals, not str.
+NUMPY_TIME_UNIT_MAPPING: Mapping[
+    str,
+    Literal["h", "m", "s", "ms", "us", "ns", "ps", "fs", "as", "Y", "M", "W", "D"],
+] = {
     "hour": "h",
     "minute": "m",
     "second": "s",

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -212,6 +212,7 @@ class CoordSummary(DascoreBaseModel):
             msg = "Cannot convert summary which is not evenly sampled to coord."
             raise CoordError(msg)
         step = self.step
+        assert step is not None  # is_range_like above rules out a null step
         # this is a reverse coord
         if np.sign(step) == -1:
             start, stop = self.max, self.min + step
@@ -288,7 +289,11 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
     units: UnitQuantity = None
     step: Any = None
-    shape: tuple[int, ...] | None = None
+    # Every coord has a shape; each subclass derives it in a before-validator
+    # from the values or range it was built with. The default exists only
+    # because those validators are invisible to type checkers, which would
+    # otherwise want shape passed at every construction site.
+    shape: tuple[int, ...] = ()
     dtype: Any = None
 
     if TYPE_CHECKING:

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1191,6 +1191,10 @@ class CoordPartial(BaseCoord):
     A coordinate which only contains partial information.
     """
 
+    # Redeclared without a default: a partial coord is nothing but its
+    # shape, and it is the one coord which cannot re-derive it on the way
+    # back from a model_dump(exclude_defaults=True).
+    shape: tuple[int, ...]
     start: Any = np.nan
     stop: Any = np.nan
     step: Any = np.nan

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -584,7 +584,11 @@ class Spool(BaseSpool):
             msg = "Spool.split requires either spool_count or spool_size."
             raise ParameterError(msg)
         start = 0
-        step = int(np.ceil(len(self) / count if count else size))
+        if count is not None:
+            step = int(np.ceil(len(self) / count))
+        else:
+            assert size is not None  # the check above sets exactly one of them
+            step = size
         while start < len(self):
             yield self[start : start + step]
             start += step

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -588,7 +588,7 @@ class Spool(BaseSpool):
             step = int(np.ceil(len(self) / count))
         else:
             assert size is not None  # the check above sets exactly one of them
-            step = size
+            step = int(np.ceil(size))  # tolerate a non-integral size
         while start < len(self):
             yield self[start : start + step]
             start += step

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -777,8 +777,14 @@ class _TypeCasterMethod(Protocol):
 
 
 def _required_resource_type(method) -> type | None:
-    """Return the resource type a FiberIO method's caster coerces its input to."""
-    return cast(_TypeCasterMethod, method)._required_type
+    """
+    Return the resource type a FiberIO method's caster coerces its input to.
+
+    None when the method's resource parameter carries no type hint, or
+    when the method was never wrapped at all (only the base FiberIO's
+    own methods, which __init_subclass__ does not visit).
+    """
+    return getattr(method, "_required_type", None)
 
 
 def _type_caster(func, sig, required_type, arg_name):
@@ -1218,7 +1224,7 @@ def _get_fiber_io_and_req_type(
     fiber_io_hint = FiberIO.manager.get_fiberio(
         format=file_format_, version=file_version_
     )
-    req_type = getattr(fiber_io_hint.scan, "_required_type", None)
+    req_type = _required_resource_type(fiber_io_hint.scan)
     resource = manager.get_resource(req_type)
     # this will get the required resource type to pass to scan.
     return fiber_io_hint, resource

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -77,7 +77,7 @@ def _coerce_scalar(value, target_kinds: set[str]):
         raise InvalidSpoolQueryError(msg)
     if typed.kind == "str" and "time" in target_kinds:
         try:
-            retyped = typed_value(np.datetime64(pd.Timestamp(value), "ns"))
+            retyped = typed_value(pd.Timestamp(value).to_datetime64())
             return retyped
         except (ValueError, TypeError):
             pass

--- a/dascore/io/sintela/protobuf_utils.py
+++ b/dascore/io/sintela/protobuf_utils.py
@@ -580,12 +580,12 @@ def _base_attrs(
 def _get_band_attr_data_type(band_def: tuple[tuple[Any, ...], ...]) -> tuple[str, str]:
     """Return patch-level BAND data type/units."""
     mapped = [_BAND_DATA_TYPE_MAP.get(int(item[0])) for item in band_def]
-    if any(item is None for item in mapped):
-        return "frequency_band_energy", ""
+    # Only bands which all map to the same known data type carry its units;
+    # an unmapped band is None, which no mapped band compares equal to.
     first = mapped[0]
-    if all(item == first for item in mapped):
-        return "frequency_band_energy", first[1]
-    return "frequency_band_energy", ""
+    if first is None or any(item != first for item in mapped):
+        return "frequency_band_energy", ""
+    return "frequency_band_energy", first[1]
 
 
 def _assert_equal(name: str, values: list[Any]):

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -7,6 +7,7 @@ import functools
 import importlib
 import inspect
 import itertools
+import math
 import os
 import re
 import warnings
@@ -770,7 +771,8 @@ def _spool_map(spool, func, size=None, client=None, progress=True, **kwargs):
     # Now things get interesting. We need to split the spool here
     # so that patches don't get serialized.
     if size is None:
-        size = len(spool) / (os.cpu_count() or 1)
+        # split takes a patch count, so round up rather than hand it a float.
+        size = math.ceil(len(spool) / (os.cpu_count() or 1))
     spools = list(spool.split(size=size))
     # this is a hack to get the progress bar to work. Essentially, we just
     # add a secret flag to all but one spool so that progress bar is only
@@ -1010,15 +1012,18 @@ def maybe_mem_map(fid: IOBase, dtype="<u1") -> np.ndarray | np.memmap:
     fid
         A buffered reader, e.g. from open(file) as fid.
     """
-    try:
-        # File objects backed by memory (BytesIO and friends) have no
-        # usable name; those fall through to the in-memory read below.
-        raw = np.memmap(getattr(fid, "name", None), dtype=dtype, mode="r")
-    except (AttributeError, TypeError, ValueError):
-        # Fallback: read into memory
-        fid.seek(0)
-        raw = np.frombuffer(fid.read(), dtype=dtype)
-    return raw
+    # File objects backed by memory (BytesIO and friends) have no usable
+    # name, so there is nothing to map; they read into memory below.
+    name = getattr(fid, "name", None)
+    if name is not None:
+        try:
+            return np.memmap(name, dtype=dtype, mode="r")
+        except (AttributeError, TypeError, ValueError):
+            # A name which is not a mappable path (an fd number, an empty
+            # file) also falls back rather than failing the read.
+            pass
+    fid.seek(0)
+    return np.frombuffer(fid.read(), dtype=dtype)
 
 
 def deep_equality_check(obj1, obj2, visited=None):

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -1018,9 +1018,10 @@ def maybe_mem_map(fid: IOBase, dtype="<u1") -> np.ndarray | np.memmap:
     if name is not None:
         try:
             return np.memmap(name, dtype=dtype, mode="r")
-        except (AttributeError, TypeError, ValueError):
-            # A name which is not a mappable path (an fd number, an empty
-            # file) also falls back rather than failing the read.
+        except (AttributeError, OSError, TypeError, ValueError):
+            # A name which is not a mappable path -- an fd number, an empty
+            # file, a path already unlinked, a filesystem which cannot map --
+            # falls back rather than failing a read the handle can still do.
             pass
     fid.seek(0)
     return np.frombuffer(fid.read(), dtype=dtype)

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from collections import namedtuple
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Literal, Protocol, cast
+from typing import Any, Literal, Protocol, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -303,7 +303,7 @@ def patch_function(
     def _wrapper(func):
         if validate_call:
             config = dict(arbitrary_types_allowed=True)
-            func = pydantic.validate_call(func, config=config)
+            func = pydantic.validate_call(config=config)(func)
 
         @functools.wraps(func)
         def _func(patch, *args, **kwargs):
@@ -975,6 +975,25 @@ def _get_data_units_from_dims(patch, dims, operator):
     return data_units
 
 
+@overload
+def _get_dx_or_spacing_and_axes(
+    patch,
+    dim,
+    require_sorted: bool = ...,
+    *,
+    require_evenly_spaced: Literal[True],
+) -> tuple[tuple[float, ...], tuple[int, ...]]: ...
+
+
+@overload
+def _get_dx_or_spacing_and_axes(
+    patch,
+    dim,
+    require_sorted: bool = ...,
+    require_evenly_spaced: bool = ...,
+) -> tuple[tuple[float | np.ndarray, ...], tuple[int, ...]]: ...
+
+
 def _get_dx_or_spacing_and_axes(
     patch,
     dim,
@@ -994,6 +1013,8 @@ def _get_dx_or_spacing_and_axes(
         If True, raise an error if all requested dimensions are not sorted.
     require_evenly_spaced
         If True, raise an error if all requested dimensions are not evenly sampled.
+        Every returned value is then a scalar spacing rather than an array of
+        values, which the overloads above make visible to callers.
     """
     dims = iterate(dim if dim is not None else patch.dims)
     out = []

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -135,10 +135,9 @@ def _array_to_datetime64(array: np.ndarray) -> np.datetime64 | np.ndarray:
         array = array.astype("datetime64[ns]")
     # dealing with an array of datetime64 or empty array
     if np.issubdtype(array.dtype, np.datetime64) or len(array) == 0:
-        if not array.shape:  # dealing with degenerate (0-D( array
-            out = np.datetime64(array, "ns")
-        else:
-            out = array.astype("datetime64[ns]")
+        out = array.astype("datetime64[ns]")
+        if not array.shape:  # unpack degenerate (0-D) array to a scalar
+            out = out[()]
     # dealing with numerical data
     elif np.issubdtype(array.dtype, np.timedelta64) or np.isreal(array[0]):
         with np.errstate(divide="ignore", invalid="ignore"):
@@ -243,17 +242,16 @@ def _pass_time_delta(time_delta):
 @to_timedelta64.register(np.ndarray)
 @to_timedelta64.register(list)
 @to_timedelta64.register(tuple)
-def _array_to_timedelta64(array: np.ndarray) -> np.datetime64:
-    """Convert an array of floating point timestamps to an array of np.datatime64."""
+def _array_to_timedelta64(array: np.ndarray) -> np.timedelta64 | np.ndarray:
+    """Convert an array of floating point durations to np.timedelta64."""
     array = np.asarray(array)
     # convert pure object arrays into float so sign casting works.
     if np.issubdtype(array.dtype, np.dtype(object)):
         array = array.astype(np.float64)
     if np.issubdtype(array.dtype, np.timedelta64) or len(array) == 0:
-        if not array.shape:  # unpack degenerate array
-            return np.timedelta64(array, "ns")
-        else:
-            return array.astype("timedelta64[ns]")
+        out = array.astype("timedelta64[ns]")
+        # unpack degenerate (0-D) array to a scalar
+        return out[()] if not array.shape else out
     # Need to just get the ns form datetime64
     elif np.issubdtype(array.dtype, np.datetime64):
         int_array = array.view(np.int64)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,14 +260,11 @@ line-ending = "lf"
 include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
-# burned down. Counts as of 2026-08-03: invalid-argument-type 171,
-# invalid-return-type 69, invalid-method-override 36, no-matching-overload 13,
-# not-subscriptable 5.
+# burned down. Counts as of 2026-08-04: invalid-argument-type 166,
+# invalid-return-type 67, invalid-method-override 36.
 [tool.ty.rules]
 invalid-argument-type = "ignore"
 invalid-return-type = "ignore"
-no-matching-overload = "ignore"
-not-subscriptable = "ignore"
 invalid-method-override = "ignore"
 
 # These files lazily import optional or untyped modules (xarray, numba,

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1687,6 +1687,13 @@ class TestPartialCoord:
         """Ensure non coords are equal to themselves."""
         assert basic_non_coord == basic_non_coord
 
+    def test_dimensionless_shape_survives_dump(self):
+        """A partial coord keeps its shape when defaults are excluded."""
+        coord = get_coord(shape=())
+        dumped = coord.model_dump(exclude_defaults=True)
+        assert dumped["shape"] == ()
+        assert CoordPartial(**dumped) == coord
+
     def test_empty_update_equal(self, basic_non_coord):
         """Empty update should produce an equal coord."""
         out = basic_non_coord.update()

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -610,6 +610,11 @@ class TestSplit:
         assert len(split[0]) == 2
         assert len(split[1]) == 1
 
+    def test_non_integral_size(self, random_spool_len_10):
+        """A size which isn't a whole number rounds up rather than raising."""
+        split = list(random_spool_len_10.split(size=2.5))
+        assert [len(x) for x in split] == [3, 3, 3, 1]
+
     def test_spool_count(self, random_spool_len_10):
         """Ensure we can split based on the desired number of spools."""
         split = list(random_spool_len_10.split(count=3))

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -603,12 +603,18 @@ class TestSplit:
             patch = spool[0]
             assert isinstance(patch, dc.Patch)
 
-    def test_spool_count(self, random_spool):
-        """Ensure we can split based on desired size of spool."""
+    def test_uneven_size(self, random_spool):
+        """Ensure a size which doesn't divide evenly leaves a short last spool."""
         split = list(random_spool.split(size=2))
         assert len(split) == 2
         assert len(split[0]) == 2
         assert len(split[1]) == 1
+
+    def test_spool_count(self, random_spool_len_10):
+        """Ensure we can split based on the desired number of spools."""
+        split = list(random_spool_len_10.split(count=3))
+        assert len(split) == 3
+        assert sum(len(x) for x in split) == 10
 
     def test_base_split_raises(self, random_spool):
         """Ensure BaseSpool split raises NoteImplementedError."""

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -766,6 +766,16 @@ class TestMaybeMemMap:
         assert not isinstance(array, np.memmap)
         assert array.size == 0
 
+    def test_name_no_longer_on_disk(self, tmp_path):
+        """An open handle whose path is gone still reads through the handle."""
+        path = tmp_path / "unlinked.bin"
+        path.write_bytes(b"1234")
+        with open(path, "rb") as fid:
+            path.unlink()
+            array = maybe_mem_map(fid)
+        assert not isinstance(array, np.memmap)
+        assert array.size == 4
+
     def test_bytes_io_nonzero_position(self):
         """Fallback should read entire buffer even if pointer is not at 0."""
         bio = BytesIO()

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -766,13 +766,13 @@ class TestMaybeMemMap:
         assert not isinstance(array, np.memmap)
         assert array.size == 0
 
-    def test_name_no_longer_on_disk(self, tmp_path):
-        """An open handle whose path is gone still reads through the handle."""
-        path = tmp_path / "unlinked.bin"
-        path.write_bytes(b"1234")
-        with open(path, "rb") as fid:
-            path.unlink()
-            array = maybe_mem_map(fid)
+    def test_name_not_on_disk(self):
+        """A handle whose name is not a real path still reads through it."""
+
+        class _NamedBytesIO(BytesIO):
+            name = "not-a-real-path"
+
+        array = maybe_mem_map(_NamedBytesIO(b"1234"))
         assert not isinstance(array, np.memmap)
         assert array.size == 4
 

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -756,6 +756,16 @@ class TestMaybeMemMap:
         assert isinstance(array, np.ndarray)
         assert array.size == 4
 
+    def test_unmappable_file(self, tmp_path):
+        """A named file numpy cannot map still reads into memory."""
+        path = tmp_path / "empty.bin"
+        path.touch()
+        with open(path, "rb") as fid:
+            array = maybe_mem_map(fid)
+        assert isinstance(array, np.ndarray)
+        assert not isinstance(array, np.memmap)
+        assert array.size == 0
+
     def test_bytes_io_nonzero_position(self):
         """Fallback should read entire buffer even if pointer is not at 0."""
         bio = BytesIO()


### PR DESCRIPTION
## Description

Third step of the ty burn-down (#795, #796, #797). `not-subscriptable` and `no-matching-overload` both go to zero and come off the ignore list, leaving three ignored rules instead of five.

**The one API question**

`BaseCoord.shape` was typed `tuple[int, ...] | None` but every coord has a shape: each subclass derives it in a before-validator, and the field validator already normalized a missing value to `()`. The `None` was a placeholder that no constructed coord ever carried, which is why the four `self.shape[0]` sites read as subscripting `None`.

Making it required instead traded those four errors for 21 `missing-argument` reports, since the before-validators that supply it are invisible to type checkers, so the annotation keeps a default. `CoordPartial` does declare it required: it is the one coord which cannot re-derive its shape on the way back from `model_dump(exclude_defaults=True)` — the array coords rebuild it from `values`, `CoordRange` from start/stop/step, `CoordSegmented` from its segments — so with `()` as the base default a dimensionless partial coord would lose its only defining field on the round trip through `CoordManager`. That has a regression test.

**Root-cause fixes**

- `_get_dx_or_spacing_and_axes` is overloaded on `require_evenly_spaced`. With it set, `get_coord` requires an evenly sampled coord, so every returned value is a scalar spacing rather than an array of values; the two callers that pass it no longer see the union.
- `NUMPY_TIME_UNIT_MAPPING` declares its literal unit codes, which is what numpy's unit parameter accepts — not `str`.
- The degenerate-array branches in `_array_to_datetime64` and `_array_to_timedelta64` unpack with `[()]` instead of rebuilding the scalar through `np.datetime64`/`np.timedelta64`, which drops the duplicated `astype` in each. `_array_to_timedelta64` was also annotated `-> np.datetime64`; it returns timedeltas, and fixing that removed three `invalid-return-type` reports as well.
- `maybe_mem_map` checks for a name before mapping instead of handing `np.memmap` a `None` it is guaranteed to reject. The fallback now also covers a name that exists but cannot be mapped (an empty file, an fd number), which gets a test.
- `Spool.split` branches on `count` rather than relying on `np.ceil` to absorb a `None`. `_spool_map` was passing it a float size, so it rounds up itself and `split`'s `int` annotation is now true.
- `patch_function` calls `pydantic.validate_call` as the decorator factory it is rather than passing `func` and `config` together.
- `_get_band_attr_data_type` compares against the first mapped band once instead of scanning for `None` separately.
- The spool query coerces with `pd.Timestamp.to_datetime64`.

**Carried over from #797**

`_required_resource_type` read the `_required_type` marker through an unconditional `cast`, which had no runtime behavior and turned an unwrapped method into an `AttributeError` rather than `None`, while `_get_fiber_io_and_req_type` did the same lookup a second way with `getattr`. One concept, one idiom, on its own commit.

**Tests**

The split-by-count path had no test — the one named for it split by size. That is now two tests, and the empty-shape round trip and unmappable-file fallback are covered.

The counts comment in `pyproject.toml` is refreshed: `invalid-argument-type` 166, `invalid-return-type` 67, `invalid-method-override` 36. Bringing `tests/` into scope stays for a later step.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datetime and timedelta conversions, including reliable scalar handling.
  * Fixed file loading for unnamed, empty, or non-memory-mappable files.
  * Improved spool splitting for uneven sizes and requested part counts.
  * Strengthened coordinate shape handling and serialization reliability.
  * Improved resource detection during scan operations.

* **Refactor**
  * Enhanced type checking and clarified public typing behavior.
  * Improved handling of supported time units and band data types.

* **Tests**
  * Added regression coverage for coordinate serialization, spool splitting, and file loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->