### PR TITLE
Wire Spool.chunk's snap_coords argument to the merge path

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -694,6 +694,7 @@ class DataFrameSpool(BaseSpool):
         chunker = ChunkManager(
             overlap=overlap,
             keep_partial=keep_partial,
+            snap_coords=snap_coords,
             group_columns=self._group_columns,
             tolerance=tolerance,
             conflict=conflict,

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -187,7 +187,9 @@ class BaseSpool(NamespaceOwner, abc.ABC):
             This often occurs because of data gaps or at end of chunks.
         snap_coords
             If True, snap the coords on joined patches such that the spacing
-            remains constant.
+            remains constant. If False, keep the original coordinate values
+            of the joined patches, which can result in unevenly sampled
+            patches.
         tolerance
             The maximum number of samples a block of data can be spaced (gap) and
             still be considered contiguous.
@@ -630,13 +632,17 @@ class DataFrameSpool(BaseSpool):
                 f"{merge_dim} but found {found_dim}."
             )
             raise CoordMergeError(msg)
-        conf = self._merge_kwargs.get("conflicts", None)
+        merge_kwargs = dict(self._merge_kwargs)
+        # snap_coords controls coordinate merging, not attr merging, so it
+        # must not be passed on to combine_patch_attrs.
+        snap = merge_kwargs.pop("snap_coords", True)
+        conf = merge_kwargs.get("conflicts", None)
         drop_conflicting = conf in {"drop", "keep_first"}
-        new_coord = _get_merged_coord(summary_df, merge_dim, coords, drop_conflicting)
-        coord = new_coord.coord_map[merge_dim]
-        new_attrs = combine_patch_attrs(
-            attrs, merge_dim, coord=coord, **self._merge_kwargs
+        new_coord = _get_merged_coord(
+            summary_df, merge_dim, coords, drop_conflicting, snap=snap
         )
+        coord = new_coord.coord_map[merge_dim]
+        new_attrs = combine_patch_attrs(attrs, merge_dim, coord=coord, **merge_kwargs)
         return dc.Patch(data=buffer, coords=new_coord, attrs=new_attrs, dims=list(dims))
 
     def _get_dummy_dataframes(self, current):
@@ -688,7 +694,6 @@ class DataFrameSpool(BaseSpool):
         chunker = ChunkManager(
             overlap=overlap,
             keep_partial=keep_partial,
-            snap_coords=snap_coords,
             group_columns=self._group_columns,
             tolerance=tolerance,
             conflict=conflict,
@@ -703,7 +708,7 @@ class DataFrameSpool(BaseSpool):
             out_df,
             source_df=self._source_df,
             instruction_df=instructions,
-            merge_kwargs={"conflicts": conflict},
+            merge_kwargs={"conflicts": conflict, "snap_coords": snap_coords},
         )
 
     def new_from_df(

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -157,7 +157,6 @@ class ChunkManager:
         overlap: timeable_types | numeric_types | None = None,
         group_columns: Collection[str] | None = None,
         keep_partial=False,
-        snap_coords=True,
         tolerance=_DEFAULT_TOLERANCE,
         conflict="raise",
         **kwargs,
@@ -165,7 +164,6 @@ class ChunkManager:
         self._overlap = overlap
         self._group_columns = group_columns
         self._keep_partials = keep_partial
-        self._snap_coords = snap_coords
         self._tolerance = tolerance
         self._name, self._value = self._validate_kwargs(kwargs)
         self._attr_conflict = conflict

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -278,7 +278,7 @@ class ChunkManager:
         if all_diffs_close_enough(np.concatenate([steps, boundary_diffs])):
             return step
         if np.issubdtype(np.asarray(steps).dtype, np.timedelta64):
-            return np.timedelta64("NaT")
+            return np.timedelta64("NaT", "ns")
         return np.nan
 
     def _create_df(self, df, name, start_stop, gnum):

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -13,7 +13,7 @@ import pandas as pd
 from dascore.constants import attr_conflict_description, numeric_types, timeable_types
 from dascore.exceptions import ChunkError, CoordMergeError, ParameterError
 from dascore.utils.docs import compose_docstring
-from dascore.utils.misc import get_middle_value
+from dascore.utils.misc import all_diffs_close_enough, get_middle_value
 from dascore.utils.pd import (
     _instructions_modified,
     _remove_overlaps,
@@ -135,6 +135,11 @@ class ChunkManager:
     keep_partial
         If True, keep segments which are shorter than chunk size (at end of
         contiguous blocks)
+    snap_coords
+        If True, joined coordinates are snapped to a constant step, so the
+        chunked segments advertise a single step. If False, segments whose
+        sources don't line up on a regular grid have no single step and
+        get a NaN step.
     tolerance
         The upper limit of a gap to tolerate in terms of the sampling
         along the desired dimension. E.G., the default value means entities
@@ -157,6 +162,7 @@ class ChunkManager:
         overlap: timeable_types | numeric_types | None = None,
         group_columns: Collection[str] | None = None,
         keep_partial=False,
+        snap_coords=True,
         tolerance=_DEFAULT_TOLERANCE,
         conflict="raise",
         **kwargs,
@@ -164,6 +170,7 @@ class ChunkManager:
         self._overlap = overlap
         self._group_columns = group_columns
         self._keep_partials = keep_partial
+        self._snap_coords = snap_coords
         self._tolerance = tolerance
         self._name, self._value = self._validate_kwargs(kwargs)
         self._attr_conflict = conflict
@@ -249,11 +256,36 @@ class ChunkManager:
             overlap = np.asarray([0], dtype=step.dtype)[0]
         return duration, overlap
 
+    def _get_group_step(self, df):
+        """
+        Get the sampling step to advertise for a group of source rows.
+
+        When snapping is disabled and the sources don't line up on a
+        regular grid, the merged coordinate keeps its uneven values, so no
+        single step describes the output; return NaN in that case.
+        """
+        steps = df[f"{self._name}_step"].values
+        step = get_middle_value(steps)
+        if self._snap_coords or len(df) < 2:
+            return step
+        mins = df[f"{self._name}_min"].values
+        maxs = df[f"{self._name}_max"].values
+        order = np.argsort(mins)
+        # The merged coord's diffs are each source's step plus the gaps
+        # between sources; apply the same evenly-sampled test get_coord
+        # uses on the concatenated values.
+        boundary_diffs = mins[order][1:] - maxs[order][:-1]
+        if all_diffs_close_enough(np.concatenate([steps, boundary_diffs])):
+            return step
+        if np.issubdtype(np.asarray(steps).dtype, np.timedelta64):
+            return np.timedelta64("NaT")
+        return np.nan
+
     def _create_df(self, df, name, start_stop, gnum):
         """Reconstruct the dataframe."""
         cols = f"{name}_min", f"{name}_max"
         out = pd.DataFrame(start_stop, columns=list(cols))
-        out[f"{name}_step"] = get_middle_value(df[f"{name}_step"].values)
+        out[f"{name}_step"] = self._get_group_step(df)
         merger = df.drop(columns=out.columns)
         # get dims to determine which columns are still compared. Some test
         # dfs don't have dims though, so it should still work without dims col.

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -416,13 +416,13 @@ def _maybe_expected_step(df, dim):
     return None
 
 
-def _get_merged_coord(df, merge_dim, coords, drop_conflicting=False):
+def _get_merged_coord(df, merge_dim, coords, drop_conflicting=False, snap=True):
     """Get merged coordinates, also validate anticipated sampling."""
     new_coord = merge_coord_managers(
         coords, dim=merge_dim, drop_conflicting=drop_conflicting
     )
     expected_step = _maybe_expected_step(df, merge_dim)
-    if not pd.isnull(expected_step):
+    if snap and not pd.isnull(expected_step):
         new_coord = new_coord.snap(merge_dim)[0]
         # TODO slightly different dt can be produced, let pass for now
         # need to think more about how the merging should work.
@@ -438,7 +438,10 @@ def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
     """
     df = pd.DataFrame(patch_dict_list)
     merge_dim = _get_merge_dim(df)
-    merge_kwargs = merge_kwargs if merge_kwargs is not None else {}
+    merge_kwargs = dict(merge_kwargs) if merge_kwargs is not None else {}
+    # snap_coords controls coordinate merging, not attr merging, so it
+    # must not be passed on to combine_patch_attrs.
+    snap = merge_kwargs.pop("snap_coords", True)
     if merge_dim is None:  # nothing to merge, complete overlap
         return [patch_dict_list[0]]
     dims = df["dims"].iloc[0].split(",")
@@ -454,7 +457,7 @@ def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
     # Determine if conflicting non-dimensional coords should be dropped.
     conf = merge_kwargs.get("conflicts", None)
     drop_conf_coords = True if conf in {"drop", "keep_first"} else False
-    new_coord = _get_merged_coord(df, merge_dim, coords, drop_conf_coords)
+    new_coord = _get_merged_coord(df, merge_dim, coords, drop_conf_coords, snap=snap)
     coord = new_coord.coord_map[merge_dim] if merge_dim in dims else None
     new_attrs = combine_patch_attrs(attrs, merge_dim, coord=coord, **merge_kwargs)
     patch = dc.Patch(data=new_data, coords=new_coord, attrs=new_attrs, dims=dims)

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -618,6 +618,55 @@ class TestChunkMerge:
         assert len(out) == 1
 
 
+class TestChunkSnapCoords:
+    """Tests for the snap_coords argument of chunk. See #803."""
+
+    @pytest.fixture(scope="class")
+    def spool_irregular_boundary(self, random_patch):
+        """
+        Two patches whose boundary is 1.4 samples apart: within the default
+        tolerance of 1.5, so chunk merges them.
+        """
+        p1 = random_patch
+        time = p1.get_coord("time")
+        p2 = p1.update_attrs(time_min=time.max() + time.step * 1.4)
+        return dc.spool([p1, p2])
+
+    def test_snap_false_preserves_values(self, spool_irregular_boundary):
+        """snap_coords=False must keep the original coordinate values."""
+        p1, p2 = spool_irregular_boundary[0], spool_irregular_boundary[1]
+        merged = spool_irregular_boundary.chunk(time=None, snap_coords=False)
+        assert len(merged) == 1
+        expected = np.concatenate([p1.get_array("time"), p2.get_array("time")])
+        assert np.array_equal(merged[0].get_array("time"), expected)
+
+    def test_snap_true_evenly_samples(self, spool_irregular_boundary):
+        """The default (snap_coords=True) still re-grids to a constant step."""
+        merged = spool_irregular_boundary.chunk(time=None)
+        assert len(merged) == 1
+        time = merged[0].get_array("time")
+        assert len(np.unique(np.diff(time))) == 1
+
+    def test_snap_false_materialized_merge(self, spool_irregular_boundary, monkeypatch):
+        """snap_coords=False must also work on the non-streaming merge path."""
+        import dascore.core.spool as spool_module
+
+        p1, p2 = spool_irregular_boundary[0], spool_irregular_boundary[1]
+        monkeypatch.setattr(
+            spool_module, "_estimate_merge_samples", lambda df, dim: None
+        )
+        merged = spool_irregular_boundary.chunk(time=None, snap_coords=False)
+        expected = np.concatenate([p1.get_array("time"), p2.get_array("time")])
+        assert np.array_equal(merged[0].get_array("time"), expected)
+
+    def test_snap_false_contiguous_unchanged(self, adjacent_spool_no_overlap):
+        """Truly contiguous patches merge identically with snapping disabled."""
+        merged = adjacent_spool_no_overlap.chunk(time=None, snap_coords=False)
+        snapped = adjacent_spool_no_overlap.chunk(time=None)
+        assert len(merged) == len(snapped) == 1
+        assert np.array_equal(merged[0].get_array("time"), snapped[0].get_array("time"))
+
+
 class TestStreamingMerge:
     """
     Tests for the streaming merge path, which copies each patch into a

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -659,6 +659,23 @@ class TestChunkSnapCoords:
         expected = np.concatenate([p1.get_array("time"), p2.get_array("time")])
         assert np.array_equal(merged[0].get_array("time"), expected)
 
+    def test_snap_false_contents_step(
+        self, spool_irregular_boundary, adjacent_spool_no_overlap
+    ):
+        """
+        The advertised step must be NaN when a no-snap merge leaves the
+        coordinate uneven, and stay concrete for contiguous or snapped merges.
+        """
+        merged = spool_irregular_boundary.chunk(time=None, snap_coords=False)
+        assert pd.isnull(merged.get_contents()["time_step"].iloc[0])
+        assert pd.isnull(merged[0].attrs["time_step"])
+        # Snapping produces an even coordinate, so the step remains.
+        snapped = spool_irregular_boundary.chunk(time=None)
+        assert not pd.isnull(snapped.get_contents()["time_step"].iloc[0])
+        # So does merging contiguous patches without snapping.
+        contiguous = adjacent_spool_no_overlap.chunk(time=None, snap_coords=False)
+        assert not pd.isnull(contiguous.get_contents()["time_step"].iloc[0])
+
     def test_snap_false_contiguous_unchanged(self, adjacent_spool_no_overlap):
         """Truly contiguous patches merge identically with snapping disabled."""
         merged = adjacent_spool_no_overlap.chunk(time=None, snap_coords=False)

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -676,6 +676,18 @@ class TestChunkSnapCoords:
         contiguous = adjacent_spool_no_overlap.chunk(time=None, snap_coords=False)
         assert not pd.isnull(contiguous.get_contents()["time_step"].iloc[0])
 
+    def test_snap_false_distance_merge(self, random_patch):
+        """Float-typed coords also keep values and get a NaN step. See #803."""
+        p1 = random_patch.update_coords(
+            distance=random_patch.get_array("distance").astype(np.float64)
+        )
+        dist = p1.get_coord("distance")
+        p2 = p1.update_attrs(distance_min=dist.max() + dist.step * 1.4)
+        spool = dc.spool([p1, p2]).chunk(distance=None, snap_coords=False)
+        assert np.isnan(spool.get_contents()["distance_step"].iloc[0])
+        expected = np.concatenate([p1.get_array("distance"), p2.get_array("distance")])
+        assert np.array_equal(spool[0].get_array("distance"), expected)
+
     def test_snap_false_contiguous_unchanged(self, adjacent_spool_no_overlap):
         """Truly contiguous patches merge identically with snapping disabled."""
         merged = adjacent_spool_no_overlap.chunk(time=None, snap_coords=False)


### PR DESCRIPTION
## Description

Closes #803.

`Spool.chunk`'s `snap_coords` argument was accepted, passed to `ChunkManager`, stored, and never read, so `snap_coords=False` behaved identically to the default: merged coordinates were always re-gridded to a constant step, silently moving samples away from the instants they actually carry (up to `tolerance` samples at each joined boundary).

This PR wires the argument through to the place the snapping actually happens:

- `DataFrameSpool.chunk` now records `snap_coords` in the spool's merge kwargs, next to `conflicts`.
- `_force_patch_merge` (materialized merge) and `_merge_patches_streaming` (streaming merge) pop it off before forwarding the remaining kwargs to `combine_patch_attrs`, and pass it to `_get_merged_coord`, which now skips `coords.snap(dim)` when it is `False`.
- The stored-but-unused `snap_coords` parameter on `ChunkManager` is removed (it was dead code; the chunk instructions don't depend on it).

With `snap_coords=False`, the merged coordinate is now the exact concatenation of the joined patches' coordinate values; the default behavior is unchanged. The example from #803 now produces different axes for the two settings, with `snap_coords=False` preserving the original 1 s sampling and the 1.4-sample boundary.

The `snap_coords` docstring entry now also states what `False` does.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
- fixed: `Spool.chunk(snap_coords=False)` is honored ([#803](https://github.com/DASDAE/dascore/issues/803)); the argument was stored and never read, so merged coordinates were always re-gridded to a constant step.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added control over coordinate snapping when combining data chunks.
  * Users can preserve original irregular boundaries by disabling coordinate snapping.

* **Bug Fixes**
  * Improved coordinate handling during streamed and materialized chunk merges.
  * Preserved existing behavior for evenly sampled and contiguous data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->