### PR TITLE
Validate the conflict argument of Spool.chunk

### DIFF
--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -27,7 +27,7 @@ from dascore.utils.misc import (
 _VALID_CONFLICT_VALUES = ("drop", "raise", "keep_first")
 
 
-def validate_conflict(conflict):
+def validate_conflict(conflict: str) -> Literal["drop", "raise", "keep_first"]:
     """Ensure a conflict(s) argument is a supported value."""
     if conflict not in _VALID_CONFLICT_VALUES:
         msg = f"conflict must be one of {_VALID_CONFLICT_VALUES}, got {conflict!r}."

--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 import dascore as dc
 from dascore.constants import attr_conflict_description
-from dascore.exceptions import AttributeMergeError
+from dascore.exceptions import AttributeMergeError, ParameterError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import (
     _dict_list_diffs,
@@ -23,6 +23,16 @@ from dascore.utils.misc import (
     is_valid_coord_str,
     iterate,
 )
+
+_VALID_CONFLICT_VALUES = ("drop", "raise", "keep_first")
+
+
+def validate_conflict(conflict):
+    """Ensure a conflict(s) argument is a supported value."""
+    if conflict not in _VALID_CONFLICT_VALUES:
+        msg = f"conflict must be one of {_VALID_CONFLICT_VALUES}, got {conflict!r}."
+        raise ParameterError(msg)
+    return conflict
 
 
 @compose_docstring(conflict_desc=attr_conflict_description)
@@ -51,6 +61,7 @@ def combine_patch_attrs(
         shortcut if it has already been computed.
     """
     # TODO this is a monstrosity! need to refactor.
+    validate_conflict(conflicts)
     model_fields = dc.core.CoordSummary.model_fields
     eq_coord_fields = set(model_fields) - {"min", "max", "step"}
 

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -31,6 +31,8 @@ from dascore.utils.time import (
 
 _DEFAULT_TOLERANCE = 1.5
 
+_VALID_CONFLICT_VALUES = ("drop", "raise", "keep_first")
+
 
 def get_intervals(
     start,
@@ -168,8 +170,18 @@ class ChunkManager:
         self._snap_coords = snap_coords
         self._tolerance = tolerance
         self._name, self._value = self._validate_kwargs(kwargs)
-        self._attr_conflict = conflict
+        self._attr_conflict = self._validate_conflict(conflict)
         self._validate_chunker()
+
+    def _validate_conflict(self, conflict):
+        """Ensure conflict is a supported value."""
+        if conflict not in _VALID_CONFLICT_VALUES:
+            msg = (
+                f"conflict must be one of {_VALID_CONFLICT_VALUES}, "
+                f"got {conflict!r}."
+            )
+            raise ParameterError(msg)
+        return conflict
 
     def _validate_kwargs(self, kwargs):
         """Ensure kwargs is len one and has a valid."""

--- a/dascore/utils/chunk.py
+++ b/dascore/utils/chunk.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from dascore.constants import attr_conflict_description, numeric_types, timeable_types
 from dascore.exceptions import ChunkError, CoordMergeError, ParameterError
+from dascore.utils.attrs import validate_conflict
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import get_middle_value
 from dascore.utils.pd import (
@@ -30,8 +31,6 @@ from dascore.utils.time import (
 )
 
 _DEFAULT_TOLERANCE = 1.5
-
-_VALID_CONFLICT_VALUES = ("drop", "raise", "keep_first")
 
 
 def get_intervals(
@@ -170,18 +169,8 @@ class ChunkManager:
         self._snap_coords = snap_coords
         self._tolerance = tolerance
         self._name, self._value = self._validate_kwargs(kwargs)
-        self._attr_conflict = self._validate_conflict(conflict)
+        self._attr_conflict = validate_conflict(conflict)
         self._validate_chunker()
-
-    def _validate_conflict(self, conflict):
-        """Ensure conflict is a supported value."""
-        if conflict not in _VALID_CONFLICT_VALUES:
-            msg = (
-                f"conflict must be one of {_VALID_CONFLICT_VALUES}, "
-                f"got {conflict!r}."
-            )
-            raise ParameterError(msg)
-        return conflict
 
     def _validate_kwargs(self, kwargs):
         """Ensure kwargs is len one and has a valid."""

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -473,6 +473,16 @@ class TestChunkMerge:
         patch = out[0]
         assert isinstance(patch, dc.Patch)
 
+    def test_invalid_conflict_raises(self, adjacent_spool_different_attrs):
+        """
+        An unrecognized conflict value should raise rather than silently
+        selecting undocumented behavior. See #804.
+        """
+        spool = adjacent_spool_different_attrs
+        for bad_value in ("banana", "", None):
+            with pytest.raises(ParameterError, match="conflict must be one of"):
+                spool.chunk(time=..., conflict=bad_value)
+
     def test_chunk_patches_with_non_coord(self, random_patch):
         """Tests for chunking when some patches have non coordinate dimensions."""
         patches = [random_patch.mean("time") for _ in range(3)]

--- a/tests/test_utils/test_attrs_utils.py
+++ b/tests/test_utils/test_attrs_utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import pytest
 
 from dascore import PatchAttrs
-from dascore.exceptions import AttributeMergeError
+from dascore.exceptions import AttributeMergeError, ParameterError
 from dascore.utils.attrs import combine_patch_attrs, separate_coord_info
 
 
@@ -49,6 +49,12 @@ class TestMergeAttrs:
             combine_patch_attrs([pa1, pa2])
         out = combine_patch_attrs([pa1, pa2], drop_attrs="history")
         assert isinstance(out, PatchAttrs)
+
+    def test_invalid_conflicts_raises(self):
+        """An unsupported conflicts value should raise. See #804."""
+        pa1, pa2 = PatchAttrs(tag="bob"), PatchAttrs(tag="bill")
+        with pytest.raises(ParameterError, match="conflict must be one of"):
+            combine_patch_attrs([pa1, pa2], conflicts="banana")
 
     def test_conflicts(self):
         """Ensure when non-dim fields aren't equal merge raises."""

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -259,6 +259,11 @@ class TestChunkExceptions:
         with pytest.raises(ParameterError, match="must be greater than 0"):
             ChunkManager(time=0)
 
+    def test_raises_invalid_conflict(self):
+        """An unsupported conflict value should raise. See #804."""
+        with pytest.raises(ParameterError, match="conflict must be one of"):
+            ChunkManager(time=None, conflict="banana")
+
     def test_raises_invalid_key_in_kwargs(self, contiguous_df):
         """Ensure an invalid key in kwargs raises an error."""
         chunk_manager = ChunkManager(Time=10)


### PR DESCRIPTION
## Description

Closes #804.

`Spool.chunk`'s `conflict` argument is typed as `Literal["drop", "raise", "keep_first"]` but was never validated at runtime. An unrecognized value (eg a typo like `conflict="ignore"`) was silently accepted and selected a fourth behavior none of the valid options provide: conflicting non-dimensional coordinates were neither dropped nor reported, and no error was raised.

`ChunkManager.__init__` now validates the value and raises a `ParameterError` (a `ValueError` subclass) naming the accepted values:

```
ParameterError: conflict must be one of ('drop', 'raise', 'keep_first'), got 'banana'.
```

Since `DataFrameSpool.chunk` constructs the `ChunkManager` eagerly, the error surfaces at the `chunk` call rather than later when patches are loaded. The three documented values behave exactly as before.

The check lives in `dascore.utils.attrs.validate_conflict` and is shared with `combine_patch_attrs`, which had the same problem: an unrecognized `conflicts` value silently behaved like `"drop"`.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
- fixed: `Spool.chunk` raises `ParameterError` for an unrecognized `conflict` value ([#804](https://github.com/DASDAE/dascore/issues/804)), which previously selected a fourth behavior none of the valid options provide.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page. (No API change; existing docs already describe the valid values.)
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid conflict-handling options now raise a clear `ParameterError` instead of being silently accepted.
  * Conflict modes are consistently validated when combining attributes and managing chunks.

* **Tests**
  * Added coverage to verify errors are raised for unsupported conflict values across chunking and attribute-combination workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->