### PR TITLE
Type the index ingest module and stabilize coord summary keys

### DIFF
--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -13,7 +13,9 @@ import hashlib
 import json
 import re
 import warnings
+from collections.abc import Hashable
 from dataclasses import dataclass, field, fields, replace
+from typing import SupportsInt, TypedDict, cast
 
 import numpy as np
 import pandas as pd
@@ -48,6 +50,17 @@ class TypedValue:
 
     def __post_init__(self):
         assert self.kind in KINDS
+
+
+class _CommonCoordFields(TypedDict):
+    """The CoordRecord fields every value kind carries."""
+
+    coord_name: str
+    dtype: str
+    coord_dims: str
+    length: int | None
+    units: str | None
+    coord_hash: str | None
 
 
 @dataclass(frozen=True)
@@ -162,6 +175,18 @@ def _base_unit_info(value, unit_str: str | None = None) -> tuple[float, str]:
     return float(quant.magnitude), str(quant.units)
 
 
+def _to_ns(value) -> int:
+    """
+    Return a time or duration as a plain int of nanoseconds.
+
+    `to_int` hands back a numpy scalar. Records hold plain python
+    scalars, and CoordRecord.def_key hashes their reprs, so a numpy
+    scalar here would give a coord one summary key on a fresh scan and
+    another when the same coord is read back out of an index.
+    """
+    return int(to_int(value))
+
+
 def _is_missing(value) -> bool:
     """Return True for values that mean 'not present'."""
     if value is None or (isinstance(value, str) and value == ""):
@@ -189,9 +214,9 @@ def typed_value(value) -> TypedValue | None:
     if isinstance(value, bool | np.bool_):
         return TypedValue("bool", bool(value))
     if isinstance(value, np.datetime64):
-        return TypedValue("time", to_int(value))
+        return TypedValue("time", _to_ns(value))
     if isinstance(value, np.timedelta64):
-        return TypedValue("dur", to_int(value))
+        return TypedValue("dur", _to_ns(value))
     # pint scalar quantity or unit.
     if hasattr(value, "units"):
         magnitude = getattr(value, "magnitude", 1)
@@ -205,7 +230,7 @@ def typed_value(value) -> TypedValue | None:
         return TypedValue("str", value)
     # datetime/timedelta and anything datetime-like numpy missed.
     try:
-        return TypedValue("time", to_int(to_datetime64(value)))
+        return TypedValue("time", _to_ns(to_datetime64(value)))
     except Exception:
         pass
     return None  # complex attrs (sequences, dicts, ...) are skipped
@@ -292,7 +317,7 @@ def _coord_record(name: str, summary) -> CoordRecord | None:
     # reuse it below (a Quantity-keyed cache is unsafe — 1 m == 100 cm with
     # equal hashes but different strings).
     units_str = str(summary.units) if summary.units is not None else None
-    common = dict(
+    common = _CommonCoordFields(
         coord_name=name,
         dtype=summary.dtype,
         coord_dims=",".join(summary.dims),
@@ -310,9 +335,9 @@ def _coord_record(name: str, summary) -> CoordRecord | None:
         return CoordRecord(
             value_kind="time",
             is_relative=not is_datetime,
-            min_ns=to_int(convert(summary.min)),
-            max_ns=to_int(convert(summary.max)),
-            step_ns=None if pd.isnull(step) else to_int(to_timedelta64(step)),
+            min_ns=_to_ns(convert(summary.min)),
+            max_ns=_to_ns(convert(summary.max)),
+            step_ns=None if pd.isnull(step) else _to_ns(to_timedelta64(step)),
             **common,
         )
     if np.issubdtype(dtype, np.number):
@@ -475,6 +500,11 @@ _PATCH_ROW_FIELDS = tuple(
 )
 
 
+def _int_key(key: Hashable) -> int:
+    """Return a groupby key as an int; the id columns grouped on are integral."""
+    return int(cast("SupportsInt", key))
+
+
 def _py_scalar(value):
     """Convert a fetched cell to the plain python scalar records use."""
     if value is None or pd.isnull(value):
@@ -531,10 +561,12 @@ def assemble_source_records(
         else {}
     )
     link_groups = (
-        {int(k): v for k, v in links.groupby("patch_id")} if not links.empty else {}
+        {_int_key(k): v for k, v in links.groupby("patch_id")}
+        if not links.empty
+        else {}
     )
     patches_by_source = (
-        {int(k): v for k, v in patches.groupby("source_id")}
+        {_int_key(k): v for k, v in patches.groupby("source_id")}
         if not patches.empty
         else {}
     )

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -498,6 +498,11 @@ _PATCH_ROW_FIELDS = tuple(
     for f in fields(PatchRecord)
     if f.name not in ("source_patch_id", "dims", "shape", "attrs", "coords")
 )
+# Backends with no boolean type hand these columns back as 0/1, which
+# def_key would hash differently than the bool a scan produced.
+_COORD_DEF_BOOLS = frozenset(
+    f.name for f in fields(CoordRecord) if str(f.type).startswith("bool")
+)
 
 
 def _int_key(key: Hashable) -> int:
@@ -505,11 +510,11 @@ def _int_key(key: Hashable) -> int:
     return int(cast("SupportsInt", key))
 
 
-def _py_scalar(value):
+def _py_scalar(value, as_bool: bool = False):
     """Convert a fetched cell to the plain python scalar records use."""
     if value is None or pd.isnull(value):
         return None
-    if isinstance(value, np.bool_ | bool):
+    if as_bool or isinstance(value, np.bool_ | bool):
         return bool(value)
     if isinstance(value, np.integer | int):
         return int(value)
@@ -593,7 +598,10 @@ def assemble_source_records(
                         coord_name=link.coord_name,
                         coord_dims=link.coord_dims,
                         coord_hash=_py_scalar(cdef.fingerprint),
-                        **{f: _py_scalar(getattr(cdef, f)) for f in _COORD_DEF_FIELDS},
+                        **{
+                            f: _py_scalar(getattr(cdef, f), f in _COORD_DEF_BOOLS)
+                            for f in _COORD_DEF_FIELDS
+                        },
                     )
                 )
             patch_records.append(

--- a/dascore/io/index/schema.py
+++ b/dascore/io/index/schema.py
@@ -25,7 +25,7 @@ from types import MappingProxyType
 from typing import NamedTuple, get_args, get_type_hints
 
 # Version of the index schema, independent of dascore's version.
-INDEX_VERSION = 4
+INDEX_VERSION = 5
 # Identity string so any tool can sanity-check what it opened.
 WHAT_IS_THIS = "dascore_spool_index"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,7 +260,7 @@ line-ending = "lf"
 include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
-# burned down. Counts as of 2026-08-04: invalid-argument-type 166,
+# burned down. Counts as of 2026-08-04: invalid-argument-type 129,
 # invalid-return-type 67, invalid-method-override 36.
 [tool.ty.rules]
 invalid-argument-type = "ignore"

--- a/tests/test_io/test_index/test_index_edge_cases.py
+++ b/tests/test_io/test_index/test_index_edge_cases.py
@@ -15,7 +15,7 @@ import sqlite3
 import numpy as np
 import pandas as pd
 import pytest
-from test_index_contract import make_summaries
+from test_index_contract import _time_coord, make_summaries
 
 import dascore as dc
 from dascore.core.summary import PatchSummary
@@ -1065,6 +1065,29 @@ class TestCoordDeduplication:
         record = _coord_record("distance", summary.coords["distance"])
         assert record.coord_hash == patch.get_coord("distance").fingerprint()
         assert record.def_key.startswith("fp:")
+
+    def test_summary_key_stable_through_export(self, tmp_path):
+        """A summary-keyed coord dedups against its own exported records."""
+        # Without a step the coord is not range-like, so it has no
+        # fingerprint to key on and falls back to hashing its stored fields.
+        summary = PatchSummary(
+            attrs={"tag": "raw"},
+            coords={"time": {**_time_coord("2024-01-01T00:00:00", 60), "step": None}},
+            dims=("time",),
+            shape=(15000,),
+            dtype="float32",
+            source_path="sum/one.h5",
+            source_format="DASDAE",
+            source_version="1",
+        )
+        fresh = _coord_record("time", summary.coords["time"])
+        assert fresh.def_key.startswith("sum:")
+        back = get_backend(tmp_path / "sum.sqlite3")
+        back.write_sources(summaries_to_records([summary]))
+        exported = back.export_records()
+        back.close()
+        (coord,) = exported[0].patches[0].coords
+        assert coord.def_key == fresh.def_key
 
     def test_orphan_defs_tolerated(self, tmp_path):
         """Deleting sources leaves defs behind without breaking queries."""


### PR DESCRIPTION
## Description

Next step in the ty burn-down: `dascore/io/index/ingest.py` goes from 37 `invalid-argument-type` diagnostics to zero, the largest single-file cluster of the 166 the rule still reports. Project-wide the count drops to 129; the rule stays ignored until it reaches zero.

Three root causes, no suppressions:

- The `CoordRecord` fields every value kind carries were collected in a plain `dict`, so unpacking them into the constructor offered each field the dict's value union (`str | Unknown | None`) instead of its own type. They get a `TypedDict` instead, which also documents what "common" means.
- `assemble_source_records` groups by the integer id columns, but pandas types a groupby key as `Hashable`. A helper says what the frame cannot.
- `to_int` returns a numpy scalar, which is not the `int` the records are specified in. The nanosecond conversions go through `_to_ns`.

### The bug that last one uncovered

A coord with no fingerprint is deduplicated on a hash of its stored summary fields, so the same coord has to hash the same whether the record came from a fresh scan or was read back out of an index. It did not, from both ends:

- ingest produced `np.int64` for `min_ns`/`max_ns`/`step_ns`, whose `repr` is not an int's (and changed in numpy 2), while the read path produced plain ints;
- SQLite has no boolean type, so `is_monotonic` and `is_relative` came back as `0`/`1`, which `_py_scalar` has no way to tell from ints.

Either half is enough to make an exported record hash differently than the record it was exported from, so re-ingesting one created a second coord definition for a coord already in the index, and two patches with an identical coord could report different `_<name>_def_key` values. `_to_ns` fixes the first half, restoring the declared bool fixes the second, and a round-trip test covers the contract.

`INDEX_VERSION` goes to 5 because the def_key an existing index stores for those coords is now stale. Directory spools treat the index as a disposable cache and rebuild it on a version mismatch.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of date, time, duration, boolean, and integer coordinate values during indexing.
  * Preserved coordinate definition keys when indexed data is exported and reconstructed.
* **Maintenance**
  * Updated the index format version to reflect schema changes.
  * Corrected the documented type-checking diagnostic count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->