### PR TITLE
Fix incorrect code and prose in tutorial docs

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -59,7 +59,7 @@ spool = (
     # Index the directory contents
     .update()
     # Sub-select a specific time range
-    .select(time_min=('2020-01-01', ...))
+    .select(time=('2020-01-01', ...))
     # Specify chunk of the output patches
     .chunk(time=60, overlap=10)
 )

--- a/docs/recipes/smoothing.qmd
+++ b/docs/recipes/smoothing.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Patch Smoothing"
 execute:
-  warn: false
+  warning: false
 ---
 
 This recipe compares several smoothing strategies.

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -120,21 +120,27 @@ sorted_data = data[indexer, :]
 ```
 
 ### Snap
-['snap'](`dascore.core.coords.BaseCoord.snap`) is used to calculate an average spacing between samples and "snap" all values to that spacing. If the coordinate is not sorted, it will be sorted in the process. This method should be used with care since it causes some loss in precision and can introduce inaccuracies in down-stream calculations. The min and max of the coordinate remain unchanged. 
+[`snap`](`dascore.core.coords.BaseCoord.snap`) is used to calculate an average spacing between samples and "snap" all values to that spacing. If the coordinate is not sorted, it will be sorted in the process. This method should be used with care since it causes some loss in precision and can introduce inaccuracies in down-stream calculations. The min and max of the coordinate remain unchanged.
+
+Unlike [`sort`](`dascore.core.coords.BaseCoord.sort`), `snap` returns only a new coordinate; no indexer is needed since the values, not their order, are what change.
 
 ```{python}
 import numpy as np
 
 from dascore.core import get_coord
 
-random_array = np.random.rand(10) 
+random_array = np.random.rand(10)
 random_coord = get_coord(data=random_array)
 
-sorted_coord, indexer = random_coord.sort()
+# Snap returns a single, evenly sampled coordinate.
+snapped_coord = random_coord.snap()
 
-# The data array can be updated like so:
-data = np.random.rand(10, 20)
-sorted_data = data[indexer, :] 
+print(f"before snapping, evenly sampled: {random_coord.evenly_sampled}")
+print(f"after snapping, evenly sampled: {snapped_coord.evenly_sampled}")
+
+# The min and max are unchanged (up to floating point precision).
+assert np.isclose(random_coord.min(), snapped_coord.min())
+assert np.isclose(random_coord.max(), snapped_coord.max())
 ```
 
 
@@ -254,7 +260,7 @@ coord_dict = {
 }
 
 cm_many_coords = get_coord_manager(coords=coord_dict, dims=("dim1", "dim2"))
-print(cm)
+print(cm_many_coords)
 ```
 
 ### Update

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -122,7 +122,7 @@ sorted_data = data[indexer, :]
 ### Snap
 [`snap`](`dascore.core.coords.BaseCoord.snap`) is used to calculate an average spacing between samples and "snap" all values to that spacing. If the coordinate is not sorted, it will be sorted in the process. This method should be used with care since it causes some loss in precision and can introduce inaccuracies in down-stream calculations. The min and max of the coordinate remain unchanged.
 
-Unlike [`sort`](`dascore.core.coords.BaseCoord.sort`), `snap` returns only a new coordinate; no indexer is needed since the values, not their order, are what change.
+Unlike [`sort`](`dascore.core.coords.BaseCoord.sort`), `snap` returns only a new coordinate, not an indexer. Since snapping an unsorted coordinate also reorders it, use [`CoordManager.snap`](`dascore.core.coordmanager.CoordManager.snap`) instead when an associated data array needs to stay aligned.
 
 ```{python}
 import numpy as np
@@ -132,7 +132,7 @@ from dascore.core import get_coord
 random_array = np.random.rand(10)
 random_coord = get_coord(data=random_array)
 
-# Snap returns a single, evenly sampled coordinate.
+# Snap returns a single, evenly sampled (and sorted) coordinate.
 snapped_coord = random_coord.snap()
 
 print(f"before snapping, evenly sampled: {random_coord.evenly_sampled}")
@@ -304,8 +304,10 @@ and drop or disassociate coordinates.
 # Disassociate "new_coord" from dimension distance.
 new_cm_3 = new_cm_1.update(new_coord=(None, new_coord))
 
-# Drop coordinate "new_coord".
-new_cm_4 = cm.update(new_coord=None)
+# Drop coordinate "new_coord". Note this must be done on a coord manager
+# which actually has "new_coord"; dropping a missing coord is a no-op.
+new_cm_4 = new_cm_1.update(new_coord=None)
+assert "new_coord" not in new_cm_4.coord_map
 
 # Drop dimension "time".
 new_cm_5 = cm.update(time=None)

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -784,9 +784,9 @@ patch_reduced = patch.add.reduce("distance")
 ```
 
 
-```{.note}
-PatchUFunc.reduce/accumulate accept dim (mapped internally to axis), while numpy ufuncs accept axis.
-```
+:::{.callout-note}
+`PatchUFunc.reduce`/`accumulate` accept `dim` (mapped internally to `axis`), while numpy ufuncs accept `axis`.
+:::
 
 For more advanced usage, you can create patch ufuncs.
 

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -161,7 +161,7 @@ Here is an example of using a rolling mean to smooth along the time axis:
 import dascore as dc
 
 patch = dc.get_example_patch("example_event_1")
-# Apply moving mean window over every 10 samples
+# Apply moving mean window over every 50 samples
 dt = patch.get_coord('time').step
 
 smoothed = patch.rolling(time=50*dt).mean()

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -126,10 +126,10 @@ import numpy as np
 spool = dc.get_example_spool()
 
 # Get an array of integers which indicate the index of included patches
-bool_array = np.array([2, 0])
+index_array = np.array([2, 0])
 
 # create a new spool with patch 2 and patch 0.
-new = spool[bool_array]
+new = spool[index_array]
 ```
 
 # get_contents
@@ -223,7 +223,7 @@ print(merged[0].coords)
 
 The [`map`](`dascore.core.spool.BaseSpool.map`) method applies a function to all patches in the spool. It provides an efficient way to process large datasets, especially when combined with clients (aka executors).
 
-For example, calculating the maximum value for each channel (distance) for 4 second increments with 1 second overlap can be done like so:
+For example, calculating the maximum value for each channel (distance) for 5 second increments with 1 second overlap can be done like so:
 
 ```{python}
 import dascore as dc


### PR DESCRIPTION
## Description

A review of the tutorial docs turned up several examples that are wrong in ways that are invisible at render time — the cells execute without error, they just don't do what the surrounding prose says. This PR fixes the factual errors only; clarity and structure suggestions from the same review are being split into follow-up PRs.

**`docs/index.qmd`** — the front page's first chained spool example used `.select(time_min=('2020-01-01', ...))`, which silently returns an **empty spool**. Verified against the file the cell actually fetches:

| call | patches |
|---|---|
| `sp.select(time_min=('2020-01-01', ...))` | 0 |
| `sp.select(time=('2020-01-01', ...))` | 1 |

The cell is `#| output: false`, so nothing surfaced. Changed to `time=`.

`time_min` is a real contents column, so the tuple never reaches the range-query machinery — it becomes `df["time_min"].isin(("2020-01-01", Ellipsis))`, a membership test that matches nothing. #810 makes this raise instead of returning empty.

**`docs/tutorial/coords.qmd`**

- The "Snap" section's code block was a verbatim copy of the "Sort" example above it and never called `snap`. Worse, the copied shape doesn't transfer: `sort()` returns `(coord, indexer)` but `snap()` returns a single coord, so a reader patterning off the neighboring example gets a `TypeError`. Rewritten to actually call `snap` and demonstrate the documented behavior (becomes evenly sampled, min/max preserved), with a note that snapping an unsorted coord also reorders it and that `CoordManager.snap` is what you want when an array must stay aligned.
- The non-dimensional coordinate example built `cm_many_coords` and then printed `cm` — the two-coord manager from the previous cell. The rendered output never showed the dim-associated and non-dim coords the section exists to teach. Now prints `cm_many_coords`.
- The "drop a coordinate" example called `cm.update(new_coord=None)`, but `cm` never had `new_coord` — so it demonstrated nothing (`cm.update(new_coord=None) == cm`). Now uses `new_cm_1` and asserts the coord is actually gone.

**`docs/tutorial/spool.qmd`**

- The integer-array indexing example named its integer array `bool_array` (copy-paste from the boolean section above).
- Prose said "4 second increments" over `spool.chunk(time=5, overlap=1)`.

**`docs/tutorial/processing.qmd`** — comment said "moving mean window over every 10 samples" over `patch.rolling(time=50*dt)` (confirmed: 49 leading NaNs, i.e. a 50-sample window).

**`docs/tutorial/patch.qmd`** — the `PatchUFunc` note used a ` ```{.note} ` fence. That's a code block with class `note`, not a Quarto callout, so it rendered as a grey code box. Changed to `:::{.callout-note}`.

**`docs/recipes/smoothing.qmd`** — front matter set `warn: false` instead of `warning: false`, so warnings were never actually suppressed on that page.

## Testing

No test suite covers tutorial `.qmd` code, so I executed every `{python}` cell of each changed file in a shared namespace (as Quarto does) — all pass:

```
OK   index.qmd (5 cells)
OK   tutorial/patch.qmd (39 cells)
OK   tutorial/spool.qmd (13 cells)
OK   tutorial/processing.qmd (20 cells)
OK   tutorial/coords.qmd (16 cells)
OK   recipes/smoothing.qmd (9 cells)
```

The new `snap` example's `np.isclose` assertions were stress-tested over 300 random trials to make sure they aren't flaky (exact float equality on `max` is *not* safe here — `CoordRange` recomputes it from `start + n*step`). The callout change was checked through pandoc to confirm it produces a `<div class="callout-note">` rather than a `<pre>`. All new cross-reference targets resolve in `docs/.cross_ref.json`.

`pre-commit run --files <changed>` passes.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
