### PR TITLE
Don't fail the doc build on TYPE_CHECKING-only annotations

### DIFF
--- a/scripts/_render_api.py
+++ b/scripts/_render_api.py
@@ -140,6 +140,20 @@ def unpact_annotation(obj, data_dict, address_dict) -> str:
     return out.strip()
 
 
+def get_type_hints(obj) -> dict:
+    """
+    Get an object's type hints, tolerating names missing at runtime.
+
+    Annotations only imported under `TYPE_CHECKING` cannot be resolved when
+    the docs are built, so fall back to the unevaluated annotations rather
+    than failing the entire build.
+    """
+    try:
+        return typing.get_type_hints(obj)
+    except NameError:
+        return dict(inspect.get_annotations(obj))
+
+
 def build_signature(data, data_dict, address_dict):
     """Return html of signature block."""
     sentinel = object()  # to know missing values
@@ -192,7 +206,7 @@ def build_signature(data, data_dict, address_dict):
     def get_sig_dict(data):
         """Create a dict of render-able signature stuff."""
         sig = data["signature"]
-        annotations = typing.get_type_hints(data["object"])
+        annotations = get_type_hints(data["object"])
         out = dict(
             params=get_params(sig, annotations),
             return_line=get_return_line(sig),

--- a/scripts/_render_api.py
+++ b/scripts/_render_api.py
@@ -147,6 +147,11 @@ def get_type_hints(obj) -> dict:
     Annotations only imported under `TYPE_CHECKING` cannot be resolved when
     the docs are built, so fall back to the unevaluated annotations rather
     than failing the entire build.
+
+    The fallback is all-or-nothing because `get_type_hints` resolves an
+    object's annotations together. Today only class-level annotations hit
+    it, and those are never matched against the parameters a signature is
+    built from, so nothing renders differently.
     """
     try:
         return typing.get_type_hints(obj)

--- a/scripts/test_render_api.py
+++ b/scripts/test_render_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import typing
 
 import pytest
@@ -9,7 +10,7 @@ import pytest
 # These tests only work if doc deps are installed.
 pytest.importorskip("jinja2")
 
-from _render_api import get_type_hints, to_quarto_code  # noqa
+from _render_api import build_signature, get_type_hints, to_quarto_code  # noqa
 
 
 class TestGetTypeHints:
@@ -40,6 +41,19 @@ class TestGetTypeHints:
         with pytest.raises(NameError):
             typing.get_type_hints(Klass)
         assert get_type_hints(Klass) == {"attr": "OnlyImportedWhileTypeChecking"}
+
+    def test_signature_of_type_checking_annotated_class(self):
+        """Spool annotates a TYPE_CHECKING-only import; it must still render."""
+        from dascore.core.spool import Spool
+
+        data = {
+            "signature": inspect.signature(Spool),
+            "object": Spool,
+            "name": "Spool",
+        }
+        out = build_signature(data, {}, {})
+        assert "<b>Spool</b>" in out
+        assert "data" in out
 
 
 class TestToQuartoCode:

--- a/scripts/test_render_api.py
+++ b/scripts/test_render_api.py
@@ -2,12 +2,44 @@
 
 from __future__ import annotations
 
+import typing
+
 import pytest
 
 # These tests only work if doc deps are installed.
 pytest.importorskip("jinja2")
 
-from _render_api import to_quarto_code  # noqa
+from _render_api import get_type_hints, to_quarto_code  # noqa
+
+
+class TestGetTypeHints:
+    """Tests for resolving the type hints of documented objects."""
+
+    def test_resolvable_hints(self):
+        """Annotations which resolve should still return their objects."""
+
+        def func(a: int) -> str:
+            """A documented function."""
+
+        hints = get_type_hints(func)
+        assert hints["a"] is int
+        assert hints["return"] is str
+
+    def test_type_checking_only_annotation(self):
+        """
+        Annotations imported only under TYPE_CHECKING can't be resolved when
+        the docs are built, but they shouldn't break the build.
+        """
+
+        class Klass:
+            """A class annotated with a name missing at runtime."""
+
+            attr: OnlyImportedWhileTypeChecking  # noqa: F821
+
+        # The un-guarded call is what used to kill the doc build.
+        with pytest.raises(NameError):
+            typing.get_type_hints(Klass)
+        assert get_type_hints(Klass) == {"attr": "OnlyImportedWhileTypeChecking"}
 
 
 class TestToQuartoCode:


### PR DESCRIPTION
## Description

`TestDocBuild` has been failing on every `dev` run today, which blocks any release cut from `dev` (`BuildDeployStableDocs` runs the same build).

`scripts/_render_api.py` resolved annotations with `typing.get_type_hints`, which evaluates every annotation in an object's MRO. `Spool` declares `_catalog: PatchCatalog` as a class-level annotation while importing `PatchCatalog` only under `TYPE_CHECKING` — it has to stay lazy to avoid a circular import with `dascore.io.index.catalog`. So the build died with:

```
File "scripts/_render_api.py", line 195, in get_sig_dict
    annotations = typing.get_type_hints(data["object"])
NameError: name 'PatchCatalog' is not defined
```

This fixes it in the renderer rather than by un-lazying the import: annotations that can't be resolved at runtime now fall back to their unevaluated form instead of failing the whole build. That matches what the renderer already does elsewhere — `unpact_annotation` has had a `typing.ForwardRef` branch for exactly this situation.

No rendered output changes. For a class, `get_type_hints` returns *class-attribute* hints, which are never matched against the constructor parameters the signature is built from, so `Spool` renders exactly as before (verified against the generated `docs/api/dascore/core/spool/Spool.qmd`).

Verified locally: `python scripts/build_api_docs.py` now completes (1029 files scanned, 3203 good links, 0 bad) where it previously raised, and the generated `Spool` page renders the same signature as before. `quarto render docs` is running locally as a second check; the `documentation` label makes CI run the full build here too.

Note: CI runs `pytest tests`, so the tests under `scripts/` don't execute in CI — the real CI coverage for this is `TestDocBuild`, hence the `documentation` label on this PR. Wiring `scripts/` into the CI test run is worth doing separately.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes. (No issue; found while checking release readiness of `dev`.)
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API documentation rendering for type annotations that are unavailable at runtime.
  * Documentation generation now preserves unresolved annotations instead of failing when referenced types cannot be resolved.
  * Added coverage for both resolvable annotations and annotations defined only for static type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->