### PR TITLE
Don't deploy stable docs for a pre-release

### DIFF
--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -80,6 +80,10 @@ jobs:
           files: docs.zip
 
   deploy:
+    # Stable docs describe the latest stable release, so a pre-release (eg a
+    # beta cut from dev) must not replace them. github.event.release is absent
+    # for workflow_dispatch, so manual runs still deploy.
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     needs: build
     environment:

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -16,9 +16,11 @@ permissions:
   deployments: write
   id-token: write
 
-# Allow one concurrent deployment
+# Allow one concurrent deployment. A pre-release build never deploys, so it
+# gets its own group rather than cancelling (or being cancelled by) a real
+# Pages deployment, which shares the "pages" group with the master docs.
 concurrency:
-  group: "pages"
+  group: ${{ github.event.release.prerelease && 'pages-prerelease' || 'pages' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

Prep for cutting a beta from `dev`.

`BuildDeployStableDocs` triggers on `release: published` with no filter, so publishing a pre-release would run the full build **and deploy it to GitHub Pages** — replacing the published stable docs (currently v0.1.20) with docs built from `dev`. That is the wrong outcome for a beta: stable docs should keep describing the latest stable release.

This guards the `deploy` job on the pre-release flag:

```yaml
if: ${{ !github.event.release.prerelease }}
```

Deliberately guarding `deploy` rather than the whole workflow, so for a pre-release the `build` job still runs and:

- attaches `docs.zip` to the pre-release, same as a normal release, and
- verifies the docs actually build at the tagged commit.

Only the Pages deployment is skipped.

`workflow_dispatch` runs are unaffected — `github.event.release` doesn't exist for that event, so the expression evaluates to `!null` → `true` and the manual "set stable docs version" path still deploys as before.

Targeting `dev` because release-triggered workflows run from the tagged commit, and the beta will be tagged from `dev`. `dev`'s copy of this workflow has also already diverged from `master` (it carries `persist-credentials: false`), so this avoids adding a conflict to the pending `master` → `dev` sync.

Verified with `pre-commit run` — `Check Yaml` and `Lint GitHub Actions workflow files` (actionlint) both pass. The behavior itself is only observable when a release is published, so it can't be exercised in CI ahead of time.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes. (No issue; found while checking release readiness of `dev`.)
- [ ] documented the new feature with docstrings and/or appropriate doc page. (No user-facing API change; `publish_a_new_release.qmd` describes stable releases and stays accurate.)
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html). (Not testable — CI cannot publish a release to assert on.)
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation to only publish documentation for stable releases, excluding prerelease versions. Manual workflow triggers remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->