### PR TITLE
Burn down the mechanical invalid-argument-type diagnostics

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -126,8 +126,15 @@ PATCH_MERGE_ATTRS = ("network", "station", "dims", "data_type", "data_category")
 # Level of progress bar
 PROGRESS_LEVELS = Literal["standard", "basic", None]
 
-# Options for handling specific warnings
-WARN_LEVELS = Literal["warn", "raise", None]
+# Options for handling specific warnings. "ignore" and None both mean
+# "do nothing"; warn_or_raise has always accepted either.
+WARN_LEVELS = Literal["warn", "raise", "ignore", None]
+
+# The actions warnings.simplefilter and warnings.filterwarnings accept.
+# Spelled out because the standard library's alias for them is stub-only.
+WARNING_ACTIONS = Literal[
+    "default", "error", "ignore", "always", "all", "module", "once"
+]
 
 # A map from the unit name to the code used in numpy.timedelta64. The codes
 # are spelled out in the annotation because numpy's unit parameter accepts

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -50,7 +50,7 @@ from dascore.utils.array import (
     hash_array,
 )
 from dascore.utils.display import get_nice_text
-from dascore.utils.docs import compose_docstring
+from dascore.utils.docs import compose_docstring, get_docstring
 from dascore.utils.misc import (
     _get_nullish,
     _maybe_array_to_slice,
@@ -1290,7 +1290,7 @@ class CoordPartial(BaseCoord):
             return self._select_by_array(args, relative=relative, samples=samples)
         return self._select_by_samples(args)
 
-    @compose_docstring(doc=BaseCoord.order.__doc__)
+    @compose_docstring(doc=get_docstring(BaseCoord.order))
     def order(
         self, array, relative=False, samples=False
     ) -> tuple[Self, slice | ArrayLike]:
@@ -1300,7 +1300,7 @@ class CoordPartial(BaseCoord):
         self._check_order_and_select(relative, samples)
         return super().order(array, relative=relative, samples=samples)
 
-    @compose_docstring(doc=BaseCoord.change_length.__doc__)
+    @compose_docstring(doc=get_docstring(BaseCoord.change_length))
     def change_length(self, length: int) -> Self:
         """
         {doc}
@@ -1601,7 +1601,7 @@ class CoordRange(BaseCoord):
         fraction = func(np.round((array - start) / step, decimals=10))
         return fraction.astype(np.int64)
 
-    @compose_docstring(doc=BaseCoord.update_limits.__doc__)
+    @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
     def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
         """{doc}."""
         if all(x is not None for x in [min, max, step]):
@@ -1661,7 +1661,7 @@ class CoordRange(BaseCoord):
         # the min/max are needed for reverse sorted coord.
         return np.max([self.stop - self.step, self.start])
 
-    @compose_docstring(doc=BaseCoord.change_length.__doc__)
+    @compose_docstring(doc=get_docstring(BaseCoord.change_length))
     def change_length(self, length: int) -> Self:
         """
         {doc}
@@ -1784,7 +1784,7 @@ class CoordArray(BaseCoord):
         out = CoordRange(start=start, stop=stop, step=step, units=self.units)
         return out.change_length(len(self))
 
-    @compose_docstring(doc=BaseCoord.update_limits.__doc__)
+    @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
     def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
         """{doc}."""
         if sum(x is not None for x in [min, max, step]) > 1:
@@ -2317,7 +2317,7 @@ class CoordSegmented(BaseCoord):
         )
         return self.new(segments=segments), slice(None, None, -1)
 
-    @compose_docstring(doc=BaseCoord.update_limits.__doc__)
+    @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
     def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
         """{doc}."""
         if step is not None:
@@ -2438,7 +2438,7 @@ class CoordSegmented(BaseCoord):
             return None
         return candidate
 
-    @compose_docstring(doc=BaseCoord.get_discontinuities.__doc__)
+    @compose_docstring(doc=get_docstring(BaseCoord.get_discontinuities))
     def get_discontinuities(self, kind="all", tolerance=None) -> pd.DataFrame:
         """{doc}."""
         if kind not in ("all", "gaps"):

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -31,7 +31,7 @@ from dascore.exceptions import (
     ParameterError,
 )
 from dascore.utils.display import get_dascore_text, get_nice_text
-from dascore.utils.docs import compose_docstring
+from dascore.utils.docs import compose_docstring, get_docstring
 from dascore.utils.misc import (
     _spool_map,
     deep_equality_check,
@@ -364,7 +364,7 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         """
         return self
 
-    @compose_docstring(desc=concatenate_patches.__doc__)
+    @compose_docstring(desc=get_docstring(concatenate_patches))
     def concatenate(self, check_behavior: WARN_LEVELS = "warn", **kwargs):
         """{desc}"""
         msg = f"spool of type {self.__class__} has no concatenate implementation"
@@ -502,7 +502,7 @@ class Spool(BaseSpool):
         """The realized flat relation (cached by the catalog)."""
         return self._catalog.to_df()
 
-    @compose_docstring(doc=BaseSpool.get_contents.__doc__)
+    @compose_docstring(doc=get_docstring(BaseSpool.get_contents))
     def get_contents(self) -> pd.DataFrame:
         """{doc}."""
         return _copy_public_dataframe(self._df)
@@ -546,7 +546,7 @@ class Spool(BaseSpool):
 
     # --- selection and presentation specs -------------------------------
 
-    @compose_docstring(doc=BaseSpool.select.__doc__)
+    @compose_docstring(doc=get_docstring(BaseSpool.select))
     def select(
         self,
         *,
@@ -566,14 +566,14 @@ class Spool(BaseSpool):
         )
         return self._new_from_catalog(catalog)
 
-    @compose_docstring(doc=BaseSpool.sort.__doc__)
+    @compose_docstring(doc=get_docstring(BaseSpool.sort))
     def sort(self, attribute) -> Self:
         """{doc}."""
         # a lazy ORDER BY spec (D2): no copy, no realization; the
         # ordinal contract supplies the deterministic tiebreak
         return self._new_from_catalog(self._catalog.order_by(attribute))
 
-    @compose_docstring(doc=BaseSpool.split.__doc__)
+    @compose_docstring(doc=get_docstring(BaseSpool.split))
     def split(
         self,
         size: int | None = None,
@@ -761,7 +761,7 @@ class Spool(BaseSpool):
             **kwargs,
         )
 
-    @compose_docstring(doc=BaseSpool.chunk.__doc__)
+    @compose_docstring(doc=get_docstring(BaseSpool.chunk))
     def chunk(
         self,
         overlap: numeric_types | timeable_types | None = None,
@@ -804,7 +804,7 @@ class Spool(BaseSpool):
         )
         return self._new_from_catalog(catalog)
 
-    @compose_docstring(desc=concatenate_patches.__doc__)
+    @compose_docstring(desc=get_docstring(concatenate_patches))
     def concatenate(self, check_behavior: WARN_LEVELS = "warn", **kwargs) -> Self:
         """{desc}"""
         from dascore.io.index.planned import derived_catalog
@@ -944,7 +944,7 @@ class Spool(BaseSpool):
         """True when any of this spool's patches live in memory."""
         return bool(self._catalog.resolver.live_entries())
 
-    @compose_docstring(doc=BaseSpool.update.__doc__)
+    @compose_docstring(doc=get_docstring(BaseSpool.update))
     def update(self, progress: PROGRESS_LEVELS = "standard") -> Self:
         """
         {doc}

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -102,9 +102,7 @@ def random_patch(
         )
     coords = dict(distance=dist_array, time=time_array)
     # assemble and output.
-    out = dict(data=array, coords=coords, attrs=attrs, dims=("distance", "time"))
-    patch = dc.Patch(**out)
-    return patch
+    return dc.Patch(data=array, coords=coords, attrs=attrs, dims=("distance", "time"))
 
 
 @register_func(EXAMPLE_PATCHES, key="patch_with_null")

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -23,6 +23,7 @@ import numpy as np
 import pandas as pd
 
 import dascore as dc
+from dascore.constants import WARN_LEVELS
 from dascore.io.index.backend import get_backend
 from dascore.io.index.catalog import (
     CompositeResolver,
@@ -311,7 +312,7 @@ class PlanResolver(PatchResolver):
         merge_kwargs: Mapping,
         parent_residuals: tuple = (),
         mode: str = "chunk",
-        check_behavior: str = "warn",
+        check_behavior: WARN_LEVELS = "warn",
         origin_path=None,
     ):
         if "output_id" not in member_rows.columns:
@@ -410,7 +411,7 @@ def derived_catalog(
     parent: PatchCatalog | None,
     merge_kwargs: Mapping,
     mode: str = "chunk",
-    check_behavior: str = "warn",
+    check_behavior: WARN_LEVELS = "warn",
     origin_path=None,
 ) -> PatchCatalog:
     """

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -114,8 +114,9 @@ def update_attrs(self: PatchType, **attrs) -> PatchType:
     new_attrs = self.attrs.model_dump(exclude_unset=True)
     new_attrs.update(attrs)
     validated = PatchAttrs.from_dict(new_attrs)
-    out = dict(coords=self.coords, attrs=validated, dims=self.dims)
-    return self.__class__(self._data, **out)
+    return self.__class__(
+        self._data, coords=self.coords, attrs=validated, dims=self.dims
+    )
 
 
 def equals(self: PatchType, other: Any, only_required_attrs=True, close=False) -> bool:

--- a/dascore/utils/docs.py
+++ b/dascore/utils/docs.py
@@ -42,6 +42,19 @@ def format_dtypes(dtype_dict: dict[str, Any]) -> str:
     return out
 
 
+def get_docstring(obj) -> str:
+    """
+    Return an object's docstring.
+
+    `__doc__` is `str | None` on anything, but the callers here compose a
+    documented function's docstring into their own, so a missing one means
+    the docstring was deleted, not that there is nothing to compose.
+    """
+    docstring = obj.__doc__
+    assert docstring is not None, f"{obj} has no docstring to compose."
+    return docstring
+
+
 def compose_docstring(**kwargs: str | Sequence[str]):
     """
     Decorator for composing docstrings.

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -302,13 +302,12 @@ def xarray_to_patch(data_array) -> PatchType:
     # this cant work if xarray isn't installed. This ensures it is.
     _ = optional_import("xarray")
 
-    params = dict(
+    return dc.Patch(
         coords={i: (x.dims, x.values) for i, x in data_array.coords.items()},
         attrs=dict(data_array.attrs.items()),
         dims=data_array.dims,
         data=data_array.data,
     )
-    return dc.Patch(**params)
 
 
 def patch_to_obspy(patch: PatchType):

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -25,7 +25,7 @@ from scipy.special import factorial
 
 from dascore.compat import UPath, is_array
 from dascore.config import config_context, get_config
-from dascore.constants import WARN_LEVELS
+from dascore.constants import WARN_LEVELS, WARNING_ACTIONS
 from dascore.exceptions import (
     FilterValueError,
     MissingOptionalDependencyError,
@@ -65,7 +65,7 @@ def register_func(list_or_dict: list | dict, key=None):
 def suppress_warnings(
     category=Warning,
     message: str | None = None,
-    action: str = "ignore",
+    action: WARNING_ACTIONS = "ignore",
     record: bool = False,
 ):
     """
@@ -109,7 +109,8 @@ def warn_or_raise(
     warning
         The type of warning to use. Must be a subclass of Warning.
     behavior
-        If None, do nothing. If
+        "warn" to issue the warning, "raise" to raise the exception, and
+        "ignore" (or None) to do nothing.
     """
     if not behavior or behavior == "ignore":
         return

--- a/dascore/utils/moving.py
+++ b/dascore/utils/moving.py
@@ -24,6 +24,10 @@ from dascore.utils.misc import optional_import
 
 bn = optional_import("bottleneck", on_missing="ignore")
 
+# The engines which can back a moving window operation. "auto" prefers
+# bottleneck and falls back to whichever of the two is installed.
+MOVING_ENGINE = Literal["auto", "scipy", "bottleneck"]
+
 # Operation registry mapping operations to engine implementations
 OPERATION_REGISTRY = {
     "median": {
@@ -241,7 +245,7 @@ def moving_window(
     window: int,
     operation: str,
     axis: int = 0,
-    engine: Literal["auto", "scipy", "bottleneck"] = "auto",
+    engine: MOVING_ENGINE = "auto",
     mode: str = "reflect",
     cval: float = 0.0,
     origin: int = 0,
@@ -319,7 +323,7 @@ def move_median(
     data: np.ndarray,
     window: int,
     axis: int = 0,
-    engine: str = "auto",
+    engine: MOVING_ENGINE = "auto",
     mode: str = "reflect",
     cval: float = 0.0,
     origin: int = 0,
@@ -343,7 +347,7 @@ def move_mean(
     data: np.ndarray,
     window: int,
     axis: int = 0,
-    engine: str = "auto",
+    engine: MOVING_ENGINE = "auto",
     mode: str = "reflect",
     cval: float = 0.0,
     origin: int = 0,
@@ -367,7 +371,7 @@ def move_std(
     data: np.ndarray,
     window: int,
     axis: int = 0,
-    engine: str = "auto",
+    engine: MOVING_ENGINE = "auto",
     min_count: int = 1,
     ddof: int = 0,
 ) -> np.ndarray:
@@ -381,7 +385,7 @@ def move_sum(
     data: np.ndarray,
     window: int,
     axis: int = 0,
-    engine: str = "auto",
+    engine: MOVING_ENGINE = "auto",
     mode: str = "reflect",
     cval: float = 0.0,
     origin: int = 0,
@@ -405,7 +409,7 @@ def move_min(
     data: np.ndarray,
     window: int,
     axis: int = 0,
-    engine: str = "auto",
+    engine: MOVING_ENGINE = "auto",
     mode: str = "reflect",
     cval: float = 0.0,
     origin: int = 0,
@@ -429,7 +433,7 @@ def move_max(
     data: np.ndarray,
     window: int,
     axis: int = 0,
-    engine: str = "auto",
+    engine: MOVING_ENGINE = "auto",
     mode: str = "reflect",
     cval: float = 0.0,
     origin: int = 0,

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -38,6 +38,23 @@ def get_progress_instance(progress: PROGRESS_LEVELS | Progress = "standard"):
     return Progress(*progress_list)
 
 
+def get_track_length(sequence: Iterable, length: int | None, min_length: int) -> int:
+    """
+    Return the total to report to the progress bar.
+
+    A length of 0 means no bar: either the sequence is too short to be
+    worth one, or it is an iterable whose length cannot be known.
+    """
+    # A generator has no length, so only measure when none was passed in.
+    if not length and isinstance(sequence, Sized):
+        # Being Sized is not a promise: len() of a 0-d array still raises.
+        with suppress(TypeError, ValueError):
+            length = len(sequence)
+    if length is None or length < min_length:
+        return 0
+    return length
+
+
 def track(
     sequence: Iterable,
     description: str,
@@ -60,23 +77,18 @@ def track(
             "basic" reduced refresh rate,
             "standard" - the normal progress bar
         can also accept a subclass of rich.progress.Progress.
+    length
+        The number of items, for sequences which cannot report their own.
     min_length
         The minimum length to emmit a progress bar.
     """
-    # A generator has no length, so only measure when none was passed in.
-    if not length and isinstance(sequence, Sized):
-        # Being Sized is not a promise: len() of a 0-d array still raises.
-        with suppress(TypeError, ValueError):
-            length = len(sequence)
-    # An unsized iterable with no length given gets no progress bar.
-    if length is None or length < min_length:
-        length = 0
+    total = get_track_length(sequence, length, min_length)
     # This is a dirty hack to allow debugging while running tests.
     # Otherwise, pdb doesn't work in any tracking scope.
     # See: https://github.com/Textualize/rich/issues/1053
     # Rich progress requires a refresh thread, which WebAssembly can't start.
     no_threads = sys.platform in ("emscripten", "wasi")
-    if get_config().debug or not length or progress is None or no_threads:
+    if get_config().debug or not total or progress is None or no_threads:
         yield from sequence
         return
     update = 1.0 if isinstance(progress, str) and progress == "standard" else 5.0
@@ -84,7 +96,7 @@ def track(
     with progress:
         yield from progress.track(
             sequence,
-            total=length,
+            total=total,
             description=description,
             update_period=update,
         )

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, Sized
 from contextlib import suppress
 
 import rich.progress as prog
@@ -20,7 +20,6 @@ def get_progress_instance(progress: PROGRESS_LEVELS | Progress = "standard"):
     # If a progress class is passed in, just use it.
     if isinstance(progress, Progress):
         return progress
-    kwargs = {}
     progress_list = [
         prog.SpinnerColumn(),
         prog.TextColumn("[progress.description]{task.description}"),
@@ -32,9 +31,11 @@ def get_progress_instance(progress: PROGRESS_LEVELS | Progress = "standard"):
     ]
     if progress == "basic":
         # set the refresh rate very low and eliminate the spinner
-        kwargs["refresh_per_second"] = get_config().progress_basic_refresh_per_second
-        progress_list = progress_list[1:]
-    return Progress(*progress_list, **kwargs)
+        return Progress(
+            *progress_list[1:],
+            refresh_per_second=get_config().progress_basic_refresh_per_second,
+        )
+    return Progress(*progress_list)
 
 
 def track(
@@ -62,13 +63,13 @@ def track(
     min_length
         The minimum length to emmit a progress bar.
     """
-    # In the case of a generator we need to make sure this just exists
-    guess_len = length if length is not None else 0
-    with suppress(TypeError, ValueError):
-        length = len(sequence) if not guess_len else guess_len
-    if length is None:  # unsized iterable with no length given; no progress bar
-        length = 0
-    if length < min_length:
+    # A generator has no length, so only measure when none was passed in.
+    if not length and isinstance(sequence, Sized):
+        # Being Sized is not a promise: len() of a 0-d array still raises.
+        with suppress(TypeError, ValueError):
+            length = len(sequence)
+    # An unsized iterable with no length given gets no progress bar.
+    if length is None or length < min_length:
         length = 0
     # This is a dirty hack to allow debugging while running tests.
     # Otherwise, pdb doesn't work in any tracking scope.
@@ -83,7 +84,7 @@ def track(
     with progress:
         yield from progress.track(
             sequence,
-            total=length or len(sequence),
+            total=length,
             description=description,
             update_period=update,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,7 +260,7 @@ line-ending = "lf"
 include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
-# burned down. Counts as of 2026-08-04: invalid-argument-type 129,
+# burned down. Counts as of 2026-08-04: invalid-argument-type 90,
 # invalid-return-type 67, invalid-method-override 36.
 [tool.ty.rules]
 invalid-argument-type = "ignore"

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -12,6 +12,7 @@ from dascore.examples import EXAMPLE_PATCHES
 from dascore.utils.docs import (
     compose_docstring,
     format_dtypes,
+    get_docstring,
     get_plugin_table,
     objs_to_doc_df,
 )
@@ -98,6 +99,26 @@ class TestDocsting:
 
                 {params}
                 """
+
+
+class TestGetDocstring:
+    """Tests for pulling a docstring out of an object."""
+
+    def test_returns_docstring(self):
+        """The docstring of a documented object is returned unchanged."""
+
+        def documented():
+            """Some words."""
+
+        assert get_docstring(documented) == documented.__doc__
+
+    def test_raises_when_undocumented(self):
+        """An object with no docstring is a source error, not a None value."""
+
+        def undocumented(): ...
+
+        with pytest.raises(AssertionError, match="has no docstring"):
+            get_docstring(undocumented)
 
 
 class TestGetPluginTable:

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 from rich.progress import Progress
 
@@ -48,6 +50,9 @@ class TestProgressBar:
         monkeypatch.setattr(
             "dascore.utils.progress.get_progress_instance", lambda _: DummyProgress()
         )
+        # WebAssembly cannot start rich's refresh thread, so track skips the
+        # bar there entirely; the stand-in above needs no thread.
+        monkeypatch.setattr(sys, "platform", "linux")
         with config_context(debug=False):
             sequence = Unmeasurable([1, 2, 3])
             assert list(track(sequence, "length_tracker", length=10)) == [1, 2, 3]

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -2,13 +2,43 @@
 
 from __future__ import annotations
 
-import sys
-
+import numpy as np
 import pytest
 from rich.progress import Progress
 
 from dascore.config import config_context
-from dascore.utils.progress import get_progress_instance, track
+from dascore.utils.progress import get_progress_instance, get_track_length, track
+
+
+class TestGetTrackLength:
+    """Tests for deciding the total a progress bar reports."""
+
+    def test_sized_sequence_is_measured(self):
+        """A sequence with no length given is measured."""
+        assert get_track_length([1, 2, 3], None, 1) == 3
+
+    def test_given_length_is_not_remeasured(self):
+        """A length passed in is used as-is; the sequence is left alone."""
+
+        class Unmeasurable(list):
+            """A sequence which fails if anything asks for its length."""
+
+            def __len__(self):
+                raise AssertionError("the sequence should not be measured")
+
+        assert get_track_length(Unmeasurable([1, 2, 3]), 10, 1) == 10
+
+    def test_unsized_sequence_gets_no_bar(self):
+        """A generator has no length to report."""
+        assert get_track_length(iter([1, 2, 3]), None, 1) == 0
+
+    def test_sized_but_unmeasurable_gets_no_bar(self):
+        """A 0-d array is Sized but len() still raises on it."""
+        assert get_track_length(np.array(5), None, 1) == 0
+
+    def test_shorter_than_min_length_gets_no_bar(self):
+        """A sequence below the minimum is not worth a bar."""
+        assert get_track_length([1, 2], None, 5) == 0
 
 
 class TestProgressBar:
@@ -25,38 +55,6 @@ class TestProgressBar:
         """Unsized iterables without a length just skip the progress bar."""
         with config_context(debug=False):
             assert list(track(iter([1, 2, 3]), "unsized_tracker")) == [1, 2, 3]
-
-    def test_given_length_is_the_reported_total(self, monkeypatch):
-        """A length passed in is the bar's total; the sequence is not measured."""
-        seen = {}
-
-        class Unmeasurable(list):
-            """A sequence which fails if anything asks for its length."""
-
-            def __len__(self):
-                raise AssertionError("the sequence should not be measured")
-
-        class DummyProgress:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_):
-                return False
-
-            def track(self, sequence, total=None, **_):
-                seen["total"] = total
-                yield from sequence
-
-        monkeypatch.setattr(
-            "dascore.utils.progress.get_progress_instance", lambda _: DummyProgress()
-        )
-        # WebAssembly cannot start rich's refresh thread, so track skips the
-        # bar there entirely; the stand-in above needs no thread.
-        monkeypatch.setattr(sys, "platform", "linux")
-        with config_context(debug=False):
-            sequence = Unmeasurable([1, 2, 3])
-            assert list(track(sequence, "length_tracker", length=10)) == [1, 2, 3]
-        assert seen["total"] == 10
 
     def test_get_basic_progress(self):
         """Ensure we can return a basic progress bar."""

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -24,9 +24,15 @@ class TestProgressBar:
         with config_context(debug=False):
             assert list(track(iter([1, 2, 3]), "unsized_tracker")) == [1, 2, 3]
 
-    def test_given_length_wins_over_the_sequence(self, monkeypatch):
-        """A length passed in is reported as the total, not the sequence's own."""
+    def test_given_length_is_the_reported_total(self, monkeypatch):
+        """A length passed in is the bar's total; the sequence is not measured."""
         seen = {}
+
+        class Unmeasurable(list):
+            """A sequence which fails if anything asks for its length."""
+
+            def __len__(self):
+                raise AssertionError("the sequence should not be measured")
 
         class DummyProgress:
             def __enter__(self):
@@ -43,7 +49,8 @@ class TestProgressBar:
             "dascore.utils.progress.get_progress_instance", lambda _: DummyProgress()
         )
         with config_context(debug=False):
-            assert list(track([1, 2, 3], "length_tracker", length=10)) == [1, 2, 3]
+            sequence = Unmeasurable([1, 2, 3])
+            assert list(track(sequence, "length_tracker", length=10)) == [1, 2, 3]
         assert seen["total"] == 10
 
     def test_get_basic_progress(self):

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -24,6 +24,28 @@ class TestProgressBar:
         with config_context(debug=False):
             assert list(track(iter([1, 2, 3]), "unsized_tracker")) == [1, 2, 3]
 
+    def test_given_length_wins_over_the_sequence(self, monkeypatch):
+        """A length passed in is reported as the total, not the sequence's own."""
+        seen = {}
+
+        class DummyProgress:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+            def track(self, sequence, total=None, **_):
+                seen["total"] = total
+                yield from sequence
+
+        monkeypatch.setattr(
+            "dascore.utils.progress.get_progress_instance", lambda _: DummyProgress()
+        )
+        with config_context(debug=False):
+            assert list(track([1, 2, 3], "length_tracker", length=10)) == [1, 2, 3]
+        assert seen["total"] == 10
+
     def test_get_basic_progress(self):
         """Ensure we can return a basic progress bar."""
         pbar = get_progress_instance("basic")


### PR DESCRIPTION
## Description

Next step in the ty burn-down, following #807: the mechanical part of the `invalid-argument-type` backlog, which drops from 129 to 90. No suppressions, four root causes:

**A docstring composed from another object.** `__doc__` is `str | None` on anything, so the fifteen places that compose an overridden method's docstring into their own were handing `compose_docstring` a value it does not accept. A `get_docstring` helper asserts what those call sites already mean — the docstring exists, and its absence is a source error, not a runtime condition.

**Literal string options that lost their narrowing at a wrapper.** The six moving-window convenience functions declare `engine: str` and pass it to `moving_window`, which declares the three engines it accepts; `suppress_warnings` declares `action: str` and passes it to `warnings.simplefilter`; the planned-catalog constructors declare `check_behavior: str` and receive a `WARN_LEVELS`. Each now declares the set it actually takes. `WARN_LEVELS` also gains `"ignore"`, which `warn_or_raise` has always handled alongside `None` but never advertised.

**Untyped dicts splatted into a constructor.** The same shape #807 fixed in the index: keyword arguments collected in a plain `dict` and immediately unpacked, so every parameter was offered the dict's value union instead of its own type. In `get_progress_instance` the one keyword is now passed directly; in `examples.py`, `proc/basic.py` and `xarray_to_patch` the dicts were built and unpacked on the next line with nothing else reading them.

### What that turned up

`track` computed the progress bar total as `length or len(sequence)`, but the function returns early when `length` is falsy, so the fallback could never run — and it would have called `len` on the possibly-unsized sequence the surrounding code goes out of its way to guard. Measuring the sequence now asks whether it is `Sized` instead of calling `len` and catching the failure, and the total is the length.

### Not included

Four `isinstance(resource, cls | SomeType)` calls in `utils/io.py` and `utils/hdf5.py` are rejected by ty but cannot use the tuple form ty accepts, because ruff's UP038 (pinned here at ruff v0.4.8, and deprecated in ruff since) requires the `|` form. That one needs a ruff decision, not a typing one.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
