### PR TITLE
Restore review fixes dropped from #808 and #810

### DIFF
--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -148,7 +148,9 @@ def _check_misdirected_range_query(key, val, df):
     base = key[:-4] if key.endswith(("_min", "_max")) else None
     if base is None or not {f"{base}_min", f"{base}_max"}.issubset(set(df.columns)):
         return
-    if not any(x is ... or x is None for x in val):
+    # Only a two element sequence can be a range. Anything else is a
+    # membership check, where None may be a legitimate value to match.
+    if len(val) != 2 or not any(x is ... or x is None for x in val):
         return
     msg = (
         f"An open bound (... or None) is not valid in the query for column "

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -122,7 +122,7 @@ sorted_data = data[indexer, :]
 ### Snap
 [`snap`](`dascore.core.coords.BaseCoord.snap`) is used to calculate an average spacing between samples and "snap" all values to that spacing. If the coordinate is not sorted, it will be sorted in the process. This method should be used with care since it causes some loss in precision and can introduce inaccuracies in down-stream calculations. The min and max of the coordinate remain unchanged.
 
-Unlike [`sort`](`dascore.core.coords.BaseCoord.sort`), `snap` returns only a new coordinate, not an indexer. Since snapping an unsorted coordinate also reorders it, use [`CoordManager.snap`](`dascore.core.coordmanager.CoordManager.snap`) instead when an associated data array needs to stay aligned.
+Unlike [`sort`](`dascore.core.coords.BaseCoord.sort`), `snap` returns only a new coordinate and no indexer, because it replaces the coordinate values rather than permuting them. This means that for an unsorted coordinate the snapped values no longer label the samples they used to. Use [`CoordManager.snap`](`dascore.core.coordmanager.CoordManager.snap`), which sorts the coordinate and its associated array together before snapping, when data alignment matters.
 
 ```{python}
 import numpy as np

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -272,6 +272,15 @@ class TestFilterDfAdvanced:
         out = filter_df(example_df_2, bp_min=tuple(vals))
         assert np.all(out == example_df_2["bp_min"].isin(vals))
 
+    @pytest.mark.parametrize("val", [[None], [100, None, 125]])
+    def test_non_range_shaped_collection_still_isin(self, example_df_2, val):
+        """
+        Only a two element sequence can be a range, so other collections stay
+        membership checks even when they contain None.
+        """
+        out = filter_df(example_df_2, bp_min=val)
+        assert np.all(out == example_df_2["bp_min"].isin(val))
+
     def test_ellipsis_kept_for_non_interval_column(self, example_df_2):
         """
         Columns with no min/max pair are plain isin checks; an ellipsis there


### PR DESCRIPTION
## Description

#808 and #810 were both squash merged a few minutes before the commits addressing their review feedback were pushed, so master has the pre-review state of both.

| Event | Time |
|---|---|
| #808 merged (`f5419611`) | 14:03:43 |
| #810 merged (`26008f10`) | 15:01:34 |
| `a83b8010` — #810 review fix pushed | 15:03:29 |
| `3b0dbdb2` — #808 review fix pushed | 15:03:55 |

Nobody did anything wrong; the pushes just lost the race. This restores the three dropped pieces.

### 1. Regression on master (the reason this isn't just cleanup)

#810 added a check that raises when an open bound (`...` or `None`) appears in a membership query on an interval column. Review caught that it was too broad — only a **two element** sequence can be a range, so collections of any other length are ordinary `isin` queries where `None` may be a legitimate value to match.

That fix didn't land, so on master today:

```python
filter_df(df, bp_min=[None])            # ParameterError  (should be an isin check)
filter_df(df, bp_min=[100, None, 125])  # ParameterError  (should be an isin check)
```

Reproduced against `origin/master` before writing this. Restores the `len(val) != 2` guard and the parametrized test covering both shapes.

### 2. Corrected `snap` wording in the coordinate tutorial

The merged text says snapping an unsorted coordinate "reorders" it. It doesn't — `snap` builds an ascending `CoordRange` over the same min/max, so values are *replaced*, not permuted:

```
orig : [0. 5. 1. 4.]
snap : [0.  1.667  3.333  5. ]
```

Sample 1 was labeled `5.0` and is now labeled `1.67`. "Reorders" implies a permutation, which would have preserved the label-to-sample pairing — the opposite of what actually happens. The corrected text says it replaces values rather than permuting them, and points at `CoordManager.snap` (which sorts the coordinate and its array together first) for when alignment matters.

### 3. The missing test

`test_non_range_shaped_collection_still_isin`, which guards item 1.

## Verification

Rather than trusting the cherry-picks, I diffed each restored file against the corresponding branch's final reviewed state — `docs/tutorial/coords.qmd`, `dascore/utils/pd.py`, `tests/test_utils/test_pd.py` and `docs/index.qmd` all match exactly. Nothing else from either branch is missing from master.

- `pytest tests` — 6459 passed, 83 skipped, 4 xfailed
- `dascore/utils/pd.py` — 100% coverage, 0 missed
- `pytest dascore --doctest-modules` — 138 passed
- `tutorial/coords.qmd` (16 cells) and `index.qmd` (5 cells) execute
- `pre-commit run --files <changed>` — passes

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of range queries to correctly handle edge cases with special values.

* **Documentation**
  * Clarified behavior of coordinate snapping operations and best practices for maintaining data alignment.

* **Tests**
  * Enhanced test coverage for query type detection with various input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->