### PR TITLE
Tighten the FiberIO contract its plugins were already keeping

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,9 @@ repos:
     # Ruff is a replacement for flake8 and many other linters (much faster too)
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.8
+    rev: v0.16.1
     hooks:
-    -   id: ruff
+    -   id: ruff-check
         args: ["--fix"]
         # Run the formatter.
     -   id: ruff-format

--- a/benchmarks/notebooks/patch_v_xarray.ipynb
+++ b/benchmarks/notebooks/patch_v_xarray.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "patch = dc.get_example_patch(\"random_das\")\n",
     "dar = patch.to_xarray()\n",
-    "t1, t2 = patch.attrs['time_min'], patch.attrs['time_max']\n",
+    "t1, t2 = patch.attrs[\"time_min\"], patch.attrs[\"time_max\"]\n",
     "duration = t2 - t1"
    ]
   },
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "%%timeit\n",
-    "patch.select(time=(t1 + duration/2, t2))"
+    "patch.select(time=(t1 + duration / 2, t2))"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "%%timeit\n",
-    "patch.select(time=(t1, t2-duration/2))"
+    "patch.select(time=(t1, t2 - duration / 2))"
    ]
   },
   {
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "%%timeit \n",
-    "dar.sel(time=slice(t1+ duration/2, t2))"
+    "dar.sel(time=slice(t1 + duration / 2, t2))"
    ]
   },
   {
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "%%timeit \n",
-    "dar.sel(time=slice(t1, t2 - duration/2))"
+    "dar.sel(time=slice(t1, t2 - duration / 2))"
    ]
   },
   {

--- a/benchmarks/notebooks/rolling.ipynb
+++ b/benchmarks/notebooks/rolling.ipynb
@@ -15,9 +15,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import dascore as dc\n",
     "import numba\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "\n",
+    "import dascore as dc"
    ]
   },
   {
@@ -26,19 +27,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def rolling_mean(data, window_size,step_size, axis = 0):\n",
+    "def rolling_mean(data, window_size, step_size, axis=0):\n",
     "    total_samples = data.shape[axis]\n",
-    "    mean_values = np.empty((int(total_samples/step_size),data.shape[1]))\n",
+    "    mean_values = np.empty((int(total_samples / step_size), data.shape[1]))\n",
     "\n",
     "    for j, k in enumerate(range(0, total_samples, step_size)):\n",
-    "\n",
-    "        if k+window_size>total_samples:\n",
+    "        if k + window_size > total_samples:\n",
     "            mean_values[j, :] = np.full((data.shape[1]), np.nan)\n",
     "        else:\n",
-    "            mean_values[j, :] = np.mean(\n",
-    "                data[k : k + window_size, :], axis=axis\n",
-    "            )\n",
-    "\n",
+    "            mean_values[j, :] = np.mean(data[k : k + window_size, :], axis=axis)\n",
     "\n",
     "    return mean_values"
    ]
@@ -70,9 +67,9 @@
    "outputs": [],
    "source": [
     "@numba.jit\n",
-    "def rolling_mean_numba(data, window_size,step_size, axis = 0):\n",
+    "def rolling_mean_numba(data, window_size, step_size, axis=0):\n",
     "    total_samples = data.shape[axis]\n",
-    "    mean_values = np.empty((int(total_samples/step_size),data.shape[1]))\n",
+    "    mean_values = np.empty((int(total_samples / step_size), data.shape[1]))\n",
     "\n",
     "    for j, k in enumerate(range(0, total_samples, step_size)):\n",
     "        mean_values[j, :] = np.mean(\n",
@@ -96,9 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import dascore as dc\n",
-    "from dascore.units import s\n"
+    "import dascore as dc"
    ]
   },
   {
@@ -134,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%timeit patch_mean = patch.rolling(time=1*s, step=0.5*s).mean()\n"
+    "%timeit patch_mean = patch.rolling(time=1*s, step=0.5*s).mean()"
    ]
   },
   {
@@ -152,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%timeit patch_mean = patch.rolling(time=3*s, step=1*s).mean()\n"
+    "%timeit patch_mean = patch.rolling(time=3*s, step=1*s).mean()"
    ]
   }
  ],

--- a/benchmarks/notebooks/rolling.ipynb
+++ b/benchmarks/notebooks/rolling.ipynb
@@ -93,7 +93,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import dascore as dc"
+    "import dascore as dc\n",
+    "from dascore.units import s"
    ]
   },
   {

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -94,9 +94,7 @@ class PatchAttrs(DascoreBaseModel):
             return data
         data = dict(data)
         if "coords" in data and not isinstance(data["coords"], str):
-            msg = (
-                "PatchAttrs no longer accepts coordinate metadata. " "Received: coords."
-            )
+            msg = "PatchAttrs no longer accepts coordinate metadata. Received: coords."
             raise ValueError(msg)
         data.pop("dims", None)
         return data

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -529,10 +529,7 @@ class CoordManager(DascoreBaseModel):
         dim_map = dict(self.dim_map)
         for old_dim, new_dim in kwargs.items():
             if new_dim not in coord_map or old_dim not in dims:
-                msg = (
-                    f"{old_dim} is not a dimension or {new_dim} is not a "
-                    f"coordinate."
-                )
+                msg = f"{old_dim} is not a dimension or {new_dim} is not a coordinate."
                 raise CoordError(msg)
             # ensure coords have the same shape
             old_coord, new_coord = coord_map[old_dim], coord_map[new_dim]
@@ -696,7 +693,7 @@ class CoordManager(DascoreBaseModel):
         """
         used_dims = [self.dim_map[x] for x in kwargs if x in self.coord_map]
         if len(set(used_dims)) < len(used_dims):
-            msg = f"Cannot use {kwargs} for query; some coords " f"share a dimension."
+            msg = f"Cannot use {kwargs} for query; some coords share a dimension."
             raise CoordError(msg)
 
     def __rich__(self) -> str:

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -377,10 +377,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
     def _order_by_sample_array(self, array):
         """Select based on index values."""
         if not np.issubdtype(array.dtype, np.integer):
-            msg = (
-                "Using an array input for select "
-                "with samples requires integer dtype."
-            )
+            msg = "Using an array input for select with samples requires integer dtype."
             raise CoordError(msg)
         # Filter out bad indices
         array = array[np.abs(array) < len(self)]
@@ -863,7 +860,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
     def get_slice_tuple(
         self,
-        select: slice | None | EllipsisType | tuple[Any, Any],
+        select: slice | EllipsisType | tuple[Any, Any] | None,
         relative=False,
     ) -> tuple[Any, Any]:
         """
@@ -1005,7 +1002,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             samples = int(np.ceil(ratio))
         if enforce_lt_coord and samples > len(self):
             msg = (
-                f"value of {value} with samples={samples } results in a window "
+                f"value of {value} with samples={samples} results in a window "
                 f"larger than coordinate length of {len(self)}."
             )
             raise ParameterError(msg)
@@ -1991,8 +1988,7 @@ def _validate_segment_compat(segments: tuple[BaseCoord, ...]) -> None:
     for seg in segments:
         if not isinstance(seg, CoordRange | CoordMonotonicArray):
             msg = (
-                "Segments must be CoordRange or CoordMonotonicArray, "
-                f"got {type(seg)}."
+                f"Segments must be CoordRange or CoordMonotonicArray, got {type(seg)}."
             )
             raise CoordError(msg)
         if not len(seg):
@@ -2810,15 +2806,15 @@ class CoordString(BaseCoord):
 
 def get_coord(
     *,
-    data: ArrayLike | None | np.ndarray | BaseCoord = None,
-    values: ArrayLike | None | np.ndarray = None,
+    data: ArrayLike | np.ndarray | BaseCoord | None = None,
+    values: ArrayLike | np.ndarray | None = None,
     start=None,
     min=None,
     stop=None,
     max=None,
     step=None,
-    units: None | Unit | Quantity | str = None,
-    shape: None | int | tuple[int, ...] = None,
+    units: Unit | Quantity | str | None = None,
+    shape: int | tuple[int, ...] | None = None,
     dtype: str | np.dtype | None = None,
     segments: tuple[BaseCoord, ...] | list[BaseCoord] | None = None,
 ) -> BaseCoord:

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -536,10 +536,7 @@ class Spool(BaseSpool):
                 np.issubdtype(array.dtype, np.bool_)
                 or np.issubdtype(array.dtype, np.integer)
             ):
-                msg = (
-                    "Only bool or int dtypes are supported for spool "
-                    "array selection."
-                )
+                msg = "Only bool or int dtypes are supported for spool array selection."
                 raise ValueError(msg)
             return self._new_from_catalog(self._catalog.restrict(array))
         try:

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -6,7 +6,7 @@ import abc
 from collections.abc import Callable, Generator, Iterator, Sequence
 from functools import singledispatch
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar
+from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar, overload
 
 import numpy as np
 import pandas as pd
@@ -82,9 +82,16 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         )
     }
 
+    # An int selects one patch; a slice or array selects a sub-spool.
+    @overload
+    def __getitem__(self, item: int) -> dc.Patch: ...
+
+    @overload
+    def __getitem__(self, item: slice | np.ndarray) -> BaseSpool: ...
+
     @abc.abstractmethod
-    def __getitem__(self, item: int | slice | np.ndarray) -> dc.Patch:
-        """Returns a patch from the spool."""
+    def __getitem__(self, item: int | slice | np.ndarray) -> dc.Patch | BaseSpool:
+        """Return a patch, or a spool for a slice or array of indices."""
 
     @abc.abstractmethod
     def __iter__(self) -> Iterator[dc.Patch]:
@@ -512,7 +519,13 @@ class Spool(BaseSpool):
         # relation is never realized just for a length
         return len(self._catalog)
 
-    def __getitem__(self, item) -> PatchType | BaseSpool:
+    @overload
+    def __getitem__(self, item: int) -> dc.Patch: ...
+
+    @overload
+    def __getitem__(self, item: slice | np.ndarray) -> BaseSpool: ...
+
+    def __getitem__(self, item) -> dc.Patch | BaseSpool:
         if isinstance(item, slice):
             # a lazy id-membership window (D2); never realizes the flat
             # relation, and keeps split()/map() parts cheap

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Callable, Generator, Sequence
+from collections.abc import Callable, Generator, Iterator, Sequence
 from functools import singledispatch
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar
@@ -83,11 +83,11 @@ class BaseSpool(NamespaceOwner, abc.ABC):
     }
 
     @abc.abstractmethod
-    def __getitem__(self, item: int | slice | np.ndarray) -> PatchType:
+    def __getitem__(self, item: int | slice | np.ndarray) -> dc.Patch:
         """Returns a patch from the spool."""
 
     @abc.abstractmethod
-    def __iter__(self) -> PatchType:
+    def __iter__(self) -> Iterator[dc.Patch]:
         """
         Iterate through the Patches in the spool.
 

--- a/dascore/io/ap_sensing/core.py
+++ b/dascore/io/ap_sensing/core.py
@@ -40,6 +40,7 @@ class APSensingV10(FiberIO):
         version_str = _get_version_string(resource)
         if version_str:
             return self.name, version_str
+        return False
 
     def scan(self, resource: H5Reader, **kwargs) -> list[ScanPayload]:
         """Scan an AP sensing file, return summary info about the contents."""

--- a/dascore/io/ap_sensing/core.py
+++ b/dascore/io/ap_sensing/core.py
@@ -4,6 +4,8 @@ Core modules for AP sensing support.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -28,7 +30,11 @@ class APSensingV10(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "10"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return format name and version string if AP sensing, else False.
 

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import inspect
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Generator, Mapping
+from collections.abc import Callable, Generator, Mapping, Sequence
 from functools import cached_property, wraps
 from numbers import Integral
 from pathlib import Path
@@ -30,8 +30,6 @@ import dascore as dc
 from dascore.compat import Progress, UPath
 from dascore.constants import (
     PROGRESS_LEVELS,
-    PatchType,
-    SpoolType,
     path_types,
     timeable_types,
 )
@@ -64,6 +62,17 @@ from dascore.utils.paths import coerce_to_local_path, coerce_to_upath, is_local_
 from dascore.utils.plugins import get_entry_point_loaders
 from dascore.utils.progress import track
 from dascore.utils.remote_io import get_remote_cache_scope, remote_cache_scope
+
+# What the scan dispatchers accept: one resource or patch, or any
+# iterable of them (`_iterate_scan_inputs` flattens its input with
+# `iterate` before resolving each element).
+ScanInput = (
+    path_types
+    | dc.Patch
+    | dc.BaseSpool
+    | IOResourceManager
+    | Sequence[path_types | dc.Patch]
+)
 
 
 class ScanPayload(TypedDict):
@@ -874,7 +883,7 @@ class FiberIO:
         }
     )
 
-    def read(self, resource, /, **kwargs) -> SpoolType:
+    def read(self, resource, /, **kwargs) -> dc.BaseSpool:
         """
         Load data from a path.
 
@@ -925,7 +934,7 @@ class FiberIO:
             raise NotImplementedError(msg)
         return [_patch_to_scan_payload(pa) for pa in spool]
 
-    def write(self, spool: SpoolType, resource, /, **kwargs):
+    def write(self, spool: dc.BaseSpool, resource, /, **kwargs):
         """Write the spool to a resource (eg path, stream, etc.)."""
         msg = f"FiberIO: {self.name} has no write method"
         raise NotImplementedError(msg)
@@ -1041,7 +1050,7 @@ def read(
     time: tuple[timeable_types | None, timeable_types | None] | None = None,
     distance: tuple[float | None, float | None] | None = None,
     **kwargs,
-) -> SpoolType:
+) -> dc.BaseSpool:
     """
     Read a fiber file.
 
@@ -1112,7 +1121,7 @@ def read(
 
 
 def scan_to_df(
-    path: path_types | PatchType | SpoolType | IOResourceManager | pd.DataFrame,
+    path: ScanInput | pd.DataFrame,
     file_format: str | None = None,
     file_version: str | None = None,
     ext: str | None = None,
@@ -1263,7 +1272,7 @@ def _handle_missing_optionals(output_count, optional_dep_dict):
 
 
 def _iter_scan_results(
-    path: path_types | PatchType | SpoolType | IOResourceManager,
+    path: ScanInput,
     file_format: str | None = None,
     file_version: str | None = None,
     ext: str | None = None,
@@ -1393,7 +1402,7 @@ def _iter_scan_results(
 
 
 def scan_payloads(
-    path: path_types | PatchType | SpoolType | IOResourceManager,
+    path: ScanInput,
     file_format: str | None = None,
     file_version: str | None = None,
     ext: str | None = None,
@@ -1463,7 +1472,7 @@ def scan_payloads(
 
 
 def scan(
-    path: path_types | PatchType | SpoolType | IOResourceManager,
+    path: ScanInput,
     file_format: str | None = None,
     file_version: str | None = None,
     ext: str | None = None,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -751,7 +751,9 @@ class _FiberIOManager:
                 finally:
                     # If file handle-like seek back to 0 so it can be reused.
                     getattr(func_input, "seek", lambda x: None)(0)
-                if format_version:
+                # get_format returns (name, version) or a falsy value;
+                # a bare True would carry no version to report.
+                if isinstance(format_version, tuple):
                     return format_version
             else:
                 msg = f"Could not determine file format of {man.source}"

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import inspect
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Generator, Mapping, Sequence
+from collections.abc import Callable, Collection, Generator, Mapping
 from functools import cached_property, wraps
 from numbers import Integral
 from pathlib import Path
@@ -63,15 +63,17 @@ from dascore.utils.plugins import get_entry_point_loaders
 from dascore.utils.progress import track
 from dascore.utils.remote_io import get_remote_cache_scope, remote_cache_scope
 
-# What the scan dispatchers accept: one resource or patch, or any
-# iterable of them (`_iterate_scan_inputs` flattens its input with
-# `iterate` before resolving each element).
+# What the scan dispatchers accept: one resource or patch, or a
+# collection of them (`_iterate_scan_inputs` flattens its input with
+# `iterate` before resolving each element). A one-shot iterator is
+# excluded on purpose: the dispatcher walks its input twice, once to
+# size the progress bar, so a generator would silently scan nothing.
 ScanInput = (
     path_types
     | dc.Patch
     | dc.BaseSpool
     | IOResourceManager
-    | Sequence[path_types | dc.Patch]
+    | Collection[path_types | dc.Patch | IOResourceManager]
 )
 
 
@@ -588,8 +590,9 @@ class _FiberIOManager:
             extension=extension,
         )
         fiber_io = next(iterator, None)
-        # yield_fiberio raises UnknownFiberFormatError for every input which
-        # names nothing, and at least one FiberIO is always registered.
+        # yield_fiberio raises rather than yield nothing for a format or
+        # version it does not know, and with nothing named at all it yields
+        # the whole registry, which is never empty.
         assert fiber_io is not None, "no fiber_io for the requested inputs"
         return fiber_io
 
@@ -751,9 +754,7 @@ class _FiberIOManager:
                 finally:
                     # If file handle-like seek back to 0 so it can be reused.
                     getattr(func_input, "seek", lambda x: None)(0)
-                # get_format returns (name, version) or a falsy value;
-                # a bare True would carry no version to report.
-                if isinstance(format_version, tuple):
+                if format_version:
                     return format_version
             else:
                 msg = f"Could not determine file format of {man.source}"
@@ -888,7 +889,7 @@ class FiberIO:
         }
     )
 
-    def read(self, resource, /, **kwargs) -> dc.BaseSpool:
+    def read(self, resource, **kwargs) -> dc.BaseSpool:
         """
         Load data from a path.
 
@@ -900,7 +901,7 @@ class FiberIO:
         msg = f"FiberIO: {self.name} has no read method"
         raise NotImplementedError(msg)
 
-    def scan(self, resource, /, *, snap: bool = True, **kwargs) -> list[ScanPayload]:
+    def scan(self, resource, *, snap: bool = True, **kwargs) -> list[ScanPayload]:
         """
         Return patch-local metadata and exact coords for a resource.
 
@@ -939,12 +940,12 @@ class FiberIO:
             raise NotImplementedError(msg)
         return [_patch_to_scan_payload(pa) for pa in spool]
 
-    def write(self, spool: dc.BaseSpool, resource, /, **kwargs):
+    def write(self, spool: dc.Patch | dc.BaseSpool, resource, **kwargs):
         """Write the spool to a resource (eg path, stream, etc.)."""
         msg = f"FiberIO: {self.name} has no write method"
         raise NotImplementedError(msg)
 
-    def get_format(self, resource, /, **kwargs) -> tuple[str, str] | bool:
+    def get_format(self, resource, **kwargs) -> tuple[str, str] | Literal[False]:
         """
         Return a tuple of (format_name, version_numbers).
 

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -587,8 +587,11 @@ class _FiberIOManager:
             version=version,
             extension=extension,
         )
-        for fiber_io in iterator:
-            return fiber_io
+        fiber_io = next(iterator, None)
+        # yield_fiberio raises UnknownFiberFormatError for every input which
+        # names nothing, and at least one FiberIO is always registered.
+        assert fiber_io is not None, "no fiber_io for the requested inputs"
+        return fiber_io
 
     def yield_fiberio(
         self,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -874,7 +874,7 @@ class FiberIO:
         }
     )
 
-    def read(self, resource, **kwargs) -> SpoolType:
+    def read(self, resource, /, **kwargs) -> SpoolType:
         """
         Load data from a path.
 
@@ -886,7 +886,7 @@ class FiberIO:
         msg = f"FiberIO: {self.name} has no read method"
         raise NotImplementedError(msg)
 
-    def scan(self, resource, snap: bool = True, **kwargs) -> list[ScanPayload]:
+    def scan(self, resource, /, *, snap: bool = True, **kwargs) -> list[ScanPayload]:
         """
         Return patch-local metadata and exact coords for a resource.
 
@@ -925,12 +925,12 @@ class FiberIO:
             raise NotImplementedError(msg)
         return [_patch_to_scan_payload(pa) for pa in spool]
 
-    def write(self, spool: SpoolType, resource, **kwargs):
+    def write(self, spool: SpoolType, resource, /, **kwargs):
         """Write the spool to a resource (eg path, stream, etc.)."""
         msg = f"FiberIO: {self.name} has no write method"
         raise NotImplementedError(msg)
 
-    def get_format(self, resource, **kwargs) -> tuple[str, str] | bool:
+    def get_format(self, resource, /, **kwargs) -> tuple[str, str] | bool:
         """
         Return a tuple of (format_name, version_numbers).
 

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -7,7 +7,6 @@ import contextlib
 import pandas as pd
 
 import dascore as dc
-from dascore.constants import SpoolType
 from dascore.io import FiberIO
 from dascore.utils.hdf5 import H5Reader, H5Writer
 from dascore.utils.io import _normalize_source_patch_ids
@@ -55,7 +54,7 @@ class DASDAEV1(FiberIO):
 
     def write(
         self,
-        spool: SpoolType,
+        spool: dc.Patch | dc.BaseSpool,
         resource: H5Writer,
         **kwargs,
     ):
@@ -112,7 +111,7 @@ class DASDAEV1(FiberIO):
         version = unbyte(attrs.get("__DASDAE_version__", ""))
         return file_format, version
 
-    def read(self, resource: H5Reader, source_patch_id=(), **kwargs) -> SpoolType:
+    def read(self, resource: H5Reader, source_patch_id=(), **kwargs) -> dc.BaseSpool:
         """Read a dascore file."""
         patches = []
         source_patch_ids = _normalize_source_patch_ids(source_patch_id)

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+from typing import Literal
 
 import pandas as pd
 
@@ -101,7 +102,11 @@ class DASDAEV1(FiberIO):
         )
         return df
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Return the format from a dasdae file."""
         is_dasdae, version = False, ""  # NOQA
         attrs = resource.attrs

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -30,7 +32,11 @@ class DASHDF5(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "1.0"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return True if file contains terra15 version 2 data else False.
 

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -42,6 +42,7 @@ class DASHDF5(FiberIO):
         version_str = _get_cf_version_str(resource)
         if version_str:
             return self.name, version_str
+        return False
 
     def scan(
         self, resource: H5Reader, snap: bool = True, **kwargs

--- a/dascore/io/dashdf5/utils.py
+++ b/dascore/io/dashdf5/utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -20,7 +22,7 @@ _DAS_ATTR_MAPPING = {"long_name": "data_type"}
 _CRS_MAPPING = {"epsg_code": "epsg_code"}
 
 
-def _get_cf_version_str(hdf_fi) -> str | bool:
+def _get_cf_version_str(hdf_fi) -> str | Literal[False]:
     """Return the version string for dashdf5 files."""
     conventions = hdf_fi.attrs.get("Conventions", [])
     cf_str = [x for x in conventions if x.startswith("CF-")]

--- a/dascore/io/dasvader/core.py
+++ b/dascore/io/dasvader/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload
@@ -34,7 +36,11 @@ class DASVaderV1(FiberIO):
     preferred_extensions = ("jld2",)
     version = "1"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return format if file contains DASVader JLD2 data else False.
 

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -96,7 +96,7 @@ def _get_zone_time(feb):
     assert block_pad > 1
     overlaps_removed = extents[2] != 0
     if overlaps_removed:
-        block_no_pad = int(round(block_time / dt))
+        block_no_pad = round(block_time / dt)
     else:
         block_no_pad = int(round(block_pad / (1 + (overlap / 100)), 0))
     # Perform checks to make sure this is DAS data. If not, you need to use
@@ -131,9 +131,9 @@ def _get_block_time(feb):
     # n for others. The first might imply different times for different
     # zones? We aren't set up to handle that, but we don't know if it can happen
     # so just assert here.
-    assert np.max(time_shape) == np.prod(
-        time_shape
-    ), "Non flat 2d time vector is not supported by DASCore Febus reader."
+    assert np.max(time_shape) == np.prod(time_shape), (
+        "Non flat 2d time vector is not supported by DASCore Febus reader."
+    )
     # Get the average time spacing in each block. These can vary a bit so
     # account for outliers.
     time = np.squeeze(feb.source["time"][:])

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import warnings
 from types import EllipsisType
+from typing import Literal
 
 import numpy as np
 
@@ -87,7 +88,11 @@ class Febus2(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "2"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return True if file contains febus version 8 data else False.
 
@@ -157,7 +162,11 @@ class FebusG1CSV1(FiberIO):
     preferred_extensions = ("bsl", "mtx")
     version = "1"
 
-    def get_format(self, resource: TextReader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: TextReader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Get the name/version of a G1 file else return False."""
         is_g1_file = _is_g1_file(resource)
         resource.seek(0)  # proactively set resource back to position 0.
@@ -196,7 +205,11 @@ class FebusMTXH5V1(FiberIO):
     preferred_extensions = ("h5", "hdf5")
     version = "1"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Get the name/version of an MTX HDF5 file else return False."""
         version = _mtx_version(resource)
         return (self.name, self.version) if version == self.version else False
@@ -254,7 +267,11 @@ class FebusBSLH5V1(FiberIO):
     preferred_extensions = ("h5", "hdf5")
     version = "1"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Get the name/version of a BSL HDF5 file else return False."""
         version = _bsl_version(resource)
         return (self.name, self.version) if version == self.version else False
@@ -321,9 +338,11 @@ class FebusT1V1(FiberIO):
 
     preferred_extensions = ("hdf5", "h5")
 
-    def get_format(self, fi: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self, resource: H5Reader, **kwargs
+    ) -> tuple[str, str] | Literal[False]:
         """Return (name, version) if this is a FEBUS T1 file, else False."""
-        return (self.name, self.version) if _is_t1_file(fi) else False
+        return (self.name, self.version) if _is_t1_file(resource) else False
 
     def scan(
         self, resource: H5Reader, snap: bool = True, **kwargs

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -39,7 +39,7 @@ from .g1utils import (
 )
 from .t1utils import _get_t1_patch, _is_t1_file, _scan_t1
 
-_float_select_type = tuple[float | None | EllipsisType, float | None | EllipsisType]
+_float_select_type = tuple[float | EllipsisType | None, float | EllipsisType | None]
 _time_select_type = tuple[
     opt_timeable_types | EllipsisType,
     opt_timeable_types | EllipsisType,

--- a/dascore/io/gdr/core.py
+++ b/dascore/io/gdr/core.py
@@ -9,7 +9,6 @@ overview attributes MetadataStandard and RawDataStandard.
 from __future__ import annotations
 
 import dascore as dc
-from dascore.constants import SpoolType
 from dascore.io import FiberIO, ScanPayload
 from dascore.io.gdr.utils_das import (
     _get_attrs_coords_and_data,
@@ -40,7 +39,7 @@ class GDR_V1(FiberIO):  # noqa
         """Determine if the resource belongs to this format."""
         return _get_version(resource)
 
-    def read(self, resource: H5Reader, snap=True, **kwargs) -> SpoolType:
+    def read(self, resource: H5Reader, snap=True, **kwargs) -> dc.BaseSpool:
         """
         Read a resource belonging to this format.
 

--- a/dascore/io/gdr/core.py
+++ b/dascore/io/gdr/core.py
@@ -8,6 +8,8 @@ overview attributes MetadataStandard and RawDataStandard.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import dascore as dc
 from dascore.io import FiberIO, ScanPayload
 from dascore.io.gdr.utils_das import (
@@ -35,7 +37,11 @@ class GDR_V1(FiberIO):  # noqa
     preferred_extensions = ("hdf5", "h5")
     version = "1"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Determine if the resource belongs to this format."""
         return _get_version(resource)
 

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import dascore as dc
 from dascore.io import FiberIO, ScanPayload
 from dascore.utils.hdf5 import H5Reader
@@ -16,7 +18,11 @@ class H5Simple(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "1"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Determine if is simple h5 format."""
         if _is_h5simple(resource):
             return self.name, self.version

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import dascore as dc
-from dascore.constants import SpoolType
 from dascore.io import FiberIO, ScanPayload
 from dascore.utils.hdf5 import H5Reader
 
@@ -23,7 +22,7 @@ class H5Simple(FiberIO):
             return self.name, self.version
         return False
 
-    def read(self, resource: H5Reader, snap=True, **kwargs) -> SpoolType:
+    def read(self, resource: H5Reader, snap=True, **kwargs) -> dc.BaseSpool:
         """
         Read a simple h5 file.
 

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -201,7 +201,7 @@ class SQLIndexBackend(abc.ABC):
                 )
             for index_name, table, column in INDEXES:
                 self._execute(
-                    f"CREATE INDEX IF NOT EXISTS {index_name} " f"ON {table} ({column})"
+                    f"CREATE INDEX IF NOT EXISTS {index_name} ON {table} ({column})"
                 )
             self._execute(
                 "INSERT INTO meta_data VALUES (?, ?, ?, ?)",

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -359,7 +359,7 @@ def _coord_record(name: str, summary) -> CoordRecord | None:
             step_num=step_num,
             **common,
         )
-    if dtype.kind in "US" or dtype == object:
+    if dtype.kind in "USO":
         return CoordRecord(
             value_kind="str",
             min_str=str(summary.min),

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -129,7 +129,7 @@ def _coord_record_from_row(
     if step is not None:
         # lo, hi, and step always share a time kind (or are all floats), but
         # ty unions the branch types and rejects the mixed combinations.
-        length = int(round((hi - lo) / step)) + 1  # ty: ignore[unsupported-operator]
+        length = round((hi - lo) / step) + 1  # ty: ignore[unsupported-operator]
     key = row.get(f"_{name}_def_key")
     fingerprint = None
     if isinstance(key, str) and key.startswith("fp:"):

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -102,7 +102,7 @@ def _to_target_unit(typed, target_units: str | None, name: str):
 def _range_bounds(
     value,
     target_kinds: set[str],
-    target_units: str | None | object = _UNSET,
+    target_units: str | object | None = _UNSET,
     name: str = "value",
 ):
     """

--- a/dascore/io/mseed/core.py
+++ b/dascore/io/mseed/core.py
@@ -30,6 +30,8 @@ https://geofon.gfz.de/redmine/projects/redmine/wiki/DAS.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload
@@ -46,7 +48,11 @@ class MSeedV2(FiberIO):
     preferred_extensions = ("mseed", "msd", "miniseed")
     version = "2"
 
-    def get_format(self, resource: LocalPath, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: LocalPath,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Determine if path is a MiniSEED file."""
         return _detect_format(resource)
 

--- a/dascore/io/mseed/utils.py
+++ b/dascore/io/mseed/utils.py
@@ -9,7 +9,7 @@ from fractions import Fraction
 from itertools import groupby
 from math import ceil, floor
 from struct import unpack
-from typing import Generic, TypeVar
+from typing import Generic, Literal, TypeVar
 
 import numpy as np
 
@@ -668,7 +668,7 @@ def _detect_mseed_v2_header(header: bytes) -> bool:
     return valid_time and valid_offsets and sample_count > 0
 
 
-def _detect_format(path: LocalPath) -> tuple[str, str] | bool:
+def _detect_format(path: LocalPath) -> tuple[str, str] | Literal[False]:
     """Return the MiniSEED version for a path or False."""
     header = _read_file_header(path, 48)
     if header.startswith(b"MS\x03"):

--- a/dascore/io/netcdf/core.py
+++ b/dascore/io/netcdf/core.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import numpy as np
 
 import dascore as dc
-from dascore.constants import SpoolType
 from dascore.io import FiberIO
 from dascore.io.core import ScanPayload, _make_scan_payload
 from dascore.io.utils import get_exact_coord
@@ -68,7 +67,7 @@ class NetCDFCFV18(FiberIO):
             pass
         return False
 
-    def read(self, resource: H5Reader, **kwargs) -> SpoolType:
+    def read(self, resource: H5Reader, **kwargs) -> dc.BaseSpool:
         """Read a NetCDF-4 file into a Spool, streaming remote resources."""
         with _open_xarray_dataset(resource) as dataset:
             data_var_name = get_xarray_data_var_name(dataset)
@@ -95,7 +94,7 @@ class NetCDFCFV18(FiberIO):
             encoding["shuffle"] = True
         return encoding
 
-    def write(self, spool: SpoolType, resource: Path, **kwargs) -> None:
+    def write(self, spool: dc.BaseSpool, resource: Path, **kwargs) -> None:
         """
         Write a Spool to NetCDF-4 through xarray.
 
@@ -200,7 +199,7 @@ class NetCDFCFV18(FiberIO):
         coord_kwargs = {k: v for k, v in kwargs.items() if k in patch.coords.coord_map}
         return patch.select(**coord_kwargs) if coord_kwargs else patch
 
-    def _validate_and_extract_patch(self, spool: SpoolType) -> dc.Patch:
+    def _validate_and_extract_patch(self, spool: dc.BaseSpool) -> dc.Patch:
         """Validate write input and return the single supported patch."""
         patches = [spool] if isinstance(spool, dc.Patch) else list(spool)
         if len(patches) == 0:

--- a/dascore/io/netcdf/core.py
+++ b/dascore/io/netcdf/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 
@@ -53,7 +54,11 @@ class NetCDFCFV18(FiberIO):
     version = "1.8"
     preferred_extensions = ("nc", "nc4", "netcdf")
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Return format tuple if file is a CF-convention NetCDF-4, else False."""
         if not is_netcdf4_file(resource):
             return False
@@ -94,7 +99,7 @@ class NetCDFCFV18(FiberIO):
             encoding["shuffle"] = True
         return encoding
 
-    def write(self, spool: dc.BaseSpool, resource: Path, **kwargs) -> None:
+    def write(self, spool: dc.Patch | dc.BaseSpool, resource: Path, **kwargs) -> None:
         """
         Write a Spool to NetCDF-4 through xarray.
 
@@ -199,7 +204,7 @@ class NetCDFCFV18(FiberIO):
         coord_kwargs = {k: v for k, v in kwargs.items() if k in patch.coords.coord_map}
         return patch.select(**coord_kwargs) if coord_kwargs else patch
 
-    def _validate_and_extract_patch(self, spool: dc.BaseSpool) -> dc.Patch:
+    def _validate_and_extract_patch(self, spool: dc.Patch | dc.BaseSpool) -> dc.Patch:
         """Validate write input and return the single supported patch."""
         patches = [spool] if isinstance(spool, dc.Patch) else list(spool)
         if len(patches) == 0:

--- a/dascore/io/neubrex/core.py
+++ b/dascore/io/neubrex/core.py
@@ -9,7 +9,6 @@ import numpy as np
 import dascore as dc
 import dascore.io.neubrex.utils_das as das_utils
 import dascore.io.neubrex.utils_rfs as rfs_utils
-from dascore.constants import SpoolType
 from dascore.io import FiberIO, ScanPayload
 from dascore.utils.hdf5 import H5Reader
 
@@ -55,7 +54,7 @@ class NeubrexRFSV1(FiberIO):
             return self.name, self.version
         return False
 
-    def read(self, resource: H5Reader, snap=True, **kwargs) -> SpoolType:
+    def read(self, resource: H5Reader, snap=True, **kwargs) -> dc.BaseSpool:
         """
         Read a resource belonging to this format.
 
@@ -107,7 +106,7 @@ class NeubrexDASV1(FiberIO):
             return self.name, self.version
         return False
 
-    def read(self, resource: H5Reader, **kwargs) -> SpoolType:
+    def read(self, resource: H5Reader, **kwargs) -> dc.BaseSpool:
         """
         Read a resource of this format.
 

--- a/dascore/io/neubrex/core.py
+++ b/dascore/io/neubrex/core.py
@@ -4,6 +4,8 @@ Core modules for reading Neubrex data.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -48,7 +50,11 @@ class NeubrexRFSV1(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "1"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Determine if the resource belongs to this format."""
         if rfs_utils._is_neubrex(resource):
             return self.name, self.version
@@ -100,7 +106,11 @@ class NeubrexDASV1(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "1"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Determine if resource belongs to this format."""
         if das_utils._is_neubrex(resource):
             return self.name, self.version

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -40,6 +40,7 @@ class OptoDASV8(FiberIO):
         version_str = _get_opto_das_version_str(resource)
         if version_str:
             return self.name, version_str
+        return False
 
     def scan(
         self, resource: H5Reader, snap: bool = True, **kwargs

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -28,7 +30,11 @@ class OptoDASV8(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "8"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return True if file contains OptoDAS version 8 data else False.
 

--- a/dascore/io/pickle/core.py
+++ b/dascore/io/pickle/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pickle
+from typing import Literal
 
 import dascore
 from dascore.io import BinaryReader, BinaryWriter, FiberIO
@@ -28,7 +29,11 @@ class PickleIO(FiberIO):
         spool_or_patch = b"Spool" in byte_stream or b"Patch" in byte_stream
         return has_dascore and spool_or_patch
 
-    def get_format(self, resource: BinaryReader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: BinaryReader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return True if file contains a pickled Patch or Spool.
 
@@ -53,6 +58,6 @@ class PickleIO(FiberIO):
         out = pickle.load(resource)
         return dascore.spool(out)
 
-    def write(self, patch, resource: BinaryWriter, **kwargs):
+    def write(self, spool, resource: BinaryWriter, **kwargs):
         """Write a Patch/Spool to disk."""
-        pickle.dump(patch, resource)
+        pickle.dump(spool, resource)

--- a/dascore/io/pickle/core.py
+++ b/dascore/io/pickle/core.py
@@ -35,12 +35,13 @@ class PickleIO(FiberIO):
         **kwargs,
     ) -> tuple[str, str] | Literal[False]:
         """
-        Return True if file contains a pickled Patch or Spool.
+        Return (name, version) if the file holds a pickled Patch or
+        Spool, else False.
 
         Parameters
         ----------
         resource
-            A path to the file which may contain terra15 data.
+            A binary resource which may contain a pickled patch.
         """
         try:
             start = resource.read(100)  # read first 100 bytes, look for class names

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 
 import dascore as dc
-from dascore.constants import SpoolType, opt_timeable_types
+from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload
 from dascore.utils.models import UnitQuantity, UTF8Str
 
@@ -92,6 +92,6 @@ class ProdMLV2_1(ProdMLV2_0):  # noqa
 
     version = "2.1"
 
-    def write(self, spool: SpoolType, resource: H5Writer, **kwargs) -> None:
+    def write(self, spool: dc.BaseSpool, resource: H5Writer, **kwargs) -> None:
         """Write one raw Patch to a standalone ProdML HDF5 file."""
         _write_prodml(spool, resource)

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -35,7 +37,11 @@ class ProdMLV2_0(FiberIO):  # noqa
     preferred_extensions = ("hdf5", "h5")
     version = "2.0"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return True if file contains prodML version 2 data else False.
 
@@ -93,6 +99,8 @@ class ProdMLV2_1(ProdMLV2_0):  # noqa
 
     version = "2.1"
 
-    def write(self, spool: dc.BaseSpool, resource: H5Writer, **kwargs) -> None:
+    def write(
+        self, spool: dc.Patch | dc.BaseSpool, resource: H5Writer, **kwargs
+    ) -> None:
         """Write one raw Patch to a standalone ProdML HDF5 file."""
         _write_prodml(spool, resource)

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -47,6 +47,7 @@ class ProdMLV2_0(FiberIO):  # noqa
         version_str = _get_prodml_version_str(resource)
         if version_str:
             return (self.name, version_str)
+        return False
 
     def scan(
         self, resource: H5Reader, snap: bool = True, **kwargs

--- a/dascore/io/rsf/core.py
+++ b/dascore/io/rsf/core.py
@@ -28,7 +28,7 @@ class RSFV1(FiberIO):
     # just make another class in the same module named rsfV2.
     version = "1"
 
-    def write(self, spool, path, data_path=None, **kwargs):
+    def write(self, spool, resource, data_path=None, **kwargs):
         """
         Write a patch to RSF format.
 
@@ -37,7 +37,7 @@ class RSFV1(FiberIO):
         data_path needs to be bindata_file.rsf or /location/of/bindata_file.rsf
         (NO '@')
 
-        path needs to be hdr_file.rsf or /location/of/hdr_file.rsf
+        resource needs to be hdr_file.rsf or /location/of/hdr_file.rsf
 
         spool needs to have a single patch in it
 
@@ -48,7 +48,7 @@ class RSFV1(FiberIO):
         ----------
         spool
             The input spool to convert to rsf, must have exactly one patch.
-        path
+        resource
             Path to create the rsf file
         data_path
             If data and rsf header information are to be separate, the
@@ -104,7 +104,7 @@ class RSFV1(FiberIO):
             with outdatapath.open("wb") as fi:
                 fi.write(data_bytes)
             out = "\n".join(hdr_info)
-            outpath = _coerce_output_path(path)
+            outpath = _coerce_output_path(resource)
             outpath.parent.mkdir(exist_ok=True, parents=True)
             with outpath.open("w") as fi:
                 fi.write(out)
@@ -112,7 +112,7 @@ class RSFV1(FiberIO):
             # outputs header and binary combined (.rsf with both hdr and bin)
             hdr_info.append('in="stdin"\n\n')
             out = "\n".join(hdr_info).encode()
-            outpath = _coerce_output_path(path)
+            outpath = _coerce_output_path(resource)
             outpath.parent.mkdir(exist_ok=True, parents=True)
             with outpath.open("wb") as fi:
                 fi.write(out)

--- a/dascore/io/rsf/core.py
+++ b/dascore/io/rsf/core.py
@@ -86,15 +86,15 @@ class RSFV1(FiberIO):
         length = len(axis_lengs)
         hdr_info = [hdr_str, file_format, f"esize={file_esize}"]
         for i in range(length):
-            hdr_info.append(f"n{i+1}={axis_lengs[i]}")
+            hdr_info.append(f"n{i + 1}={axis_lengs[i]}")
             if axis_names[i] == "time":
-                hdr_info.append(f"o{i+1}=0.0")
+                hdr_info.append(f"o{i + 1}=0.0")
                 hdr_info.append(f"starttime={axis_origs[i]}")
             else:
-                hdr_info.append(f"o{i+1}={axis_origs[i]}")
-            hdr_info.append(f"d{i+1}={axis_steps[i]}")
-            hdr_info.append(f'label{i+1}="{axis_names[i]}"')
-            hdr_info.append(f'unit{i+1}="{axis_units[i]}"')
+                hdr_info.append(f"o{i + 1}={axis_origs[i]}")
+            hdr_info.append(f"d{i + 1}={axis_steps[i]}")
+            hdr_info.append(f'label{i + 1}="{axis_names[i]}"')
+            hdr_info.append(f'unit{i + 1}="{axis_units[i]}"')
 
         if data_path is not None:
             # outputs header and binary separately (.rsf and .rsf@)

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import dascore as dc
 from dascore.io.core import FiberIO, ScanPayload
 from dascore.utils.io import LocalBinaryReader, LocalPath
@@ -28,11 +30,15 @@ class SegyV1_0(FiberIO):  # noqa
     # subclassed and this changed for debugging reasons.
     _package_name = "segyio"
 
-    def get_format(self, fp: LocalBinaryReader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: LocalBinaryReader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Make sure input is segy."""
-        return _get_segy_version(fp)
+        return _get_segy_version(resource)
 
-    def read(self, path: LocalPath, time=None, channel=None, **kwargs):
+    def read(self, resource: LocalPath, time=None, channel=None, **kwargs):
         """
         Read should take a path and return a patch or sequence of patches.
 
@@ -41,7 +47,7 @@ class SegyV1_0(FiberIO):  # noqa
         be implemented as well.
         """
         segyio = optional_import(self._package_name)
-        path_str = str(path)
+        path_str = str(resource)
         with segyio.open(path_str, ignore_geometry=True) as fi:
             coords = _get_coords(fi)
             attrs = _get_attrs(fi, coords, path_str, self, include_source=True)
@@ -54,14 +60,14 @@ class SegyV1_0(FiberIO):  # noqa
         patch = dc.Patch(coords=coords, data=data, attrs=attrs)
         return dc.spool([patch])
 
-    def scan(self, path: LocalPath, **kwargs) -> list[ScanPayload]:
+    def scan(self, resource: LocalPath, **kwargs) -> list[ScanPayload]:
         """
         Used to get metadata about a file without reading the whole file.
 
         Returns lightweight scan metadata without loading the data array.
         """
         segyio = optional_import(self._package_name)
-        path_str = str(path)
+        path_str = str(resource)
         with segyio.open(path_str, ignore_geometry=True) as fi:
             coords = _get_coords(fi)
             attrs = _get_attrs(fi, coords, path_str, self)

--- a/dascore/io/sentek/core.py
+++ b/dascore/io/sentek/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -37,7 +39,11 @@ class SentekV5(FiberIO):
         # tend to be quite small.
         return dc.spool(patch).select(time=time, distance=distance)
 
-    def get_format(self, resource: BinaryReader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: BinaryReader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Auto detect sentek format."""
         return _get_version(resource)
 

--- a/dascore/io/silixah5/core.py
+++ b/dascore/io/silixah5/core.py
@@ -4,6 +4,8 @@ Core modules for Silixa H5 support.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -30,7 +32,11 @@ class SilixaH5V1(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "1"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return name and version string if Silixa hdf5 else False.
 

--- a/dascore/io/silixah5/core.py
+++ b/dascore/io/silixah5/core.py
@@ -42,6 +42,7 @@ class SilixaH5V1(FiberIO):
         version_str = _get_version_string(resource, self.version)
         if version_str:
             return self.name, version_str
+        return False
 
     def scan(self, resource: H5Reader, **kwargs) -> list[ScanPayload]:
         """Scan a Silixa HDF5 file, return summary information on the contents."""

--- a/dascore/io/sintela/core.py
+++ b/dascore/io/sintela/core.py
@@ -4,6 +4,8 @@ Core module for reading Sintela binary format.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -35,7 +37,11 @@ class SintelaBinaryV3(FiberIO):
     preferred_extensions = ("raw",)
     version = "3"
 
-    def get_format(self, resource: BinaryReader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: BinaryReader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return name and version string or False.
 
@@ -89,7 +95,11 @@ class SintelaProtobufV1(FiberIO):
     preferred_extensions = ("pb",)
     version = "1"
 
-    def get_format(self, resource: BinaryReader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: BinaryReader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Return the format/version tuple if the file is Sintela protobuf."""
         position = resource.tell()
         try:

--- a/dascore/io/sr4731/core.py
+++ b/dascore/io/sr4731/core.py
@@ -4,6 +4,8 @@ Core module for reading SR-4731 OTDR SOR files.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import BinaryReader, FiberIO, ScanPayload
@@ -26,7 +28,11 @@ class SR4731V200(FiberIO):
             "file_version": self.version,
         }
 
-    def get_format(self, resource: BinaryReader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: BinaryReader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """Return format and version if the file is a supported SR-4731 file."""
         return _get_format(resource, self.name, self.version)
 

--- a/dascore/io/sr4731/core.py
+++ b/dascore/io/sr4731/core.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import dascore as dc
 from dascore.constants import opt_timeable_types
-from dascore.io import BinaryReader, FiberIO
+from dascore.io import BinaryReader, FiberIO, ScanPayload
 
 from .utils import SR4731PatchAttrs, _get_format, _get_patch_attrs, _get_patches
 
@@ -30,7 +30,7 @@ class SR4731V200(FiberIO):
         """Return format and version if the file is a supported SR-4731 file."""
         return _get_format(resource, self.name, self.version)
 
-    def scan(self, resource: BinaryReader, **kwargs) -> list[dc.PatchAttrs]:
+    def scan(self, resource: BinaryReader, **kwargs) -> list[ScanPayload]:
         """Scan an SR-4731 SOR file."""
         attrs = _get_patch_attrs(
             resource,

--- a/dascore/io/sr4731/utils.py
+++ b/dascore/io/sr4731/utils.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import struct
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 
@@ -34,7 +34,7 @@ from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.coords import BaseCoord, get_coord
 from dascore.exceptions import InvalidFiberFileError
-from dascore.io.core import _make_scan_payload
+from dascore.io.core import ScanPayload, _make_scan_payload
 
 DIMS = ("time", "distance")
 REQUIRED_BLOCKS = frozenset(
@@ -308,7 +308,7 @@ def _get_patch_attrs(
     resource,
     attr_class: type[PatchAttrs] = SR4731PatchAttrs,
     extras: dict | None = None,
-) -> dict:
+) -> ScanPayload:
     """Return patch attrs for an SR-4731 SOR file."""
     parsed = _parse_sor(resource, load_samples=False)
     coords = _get_coords(parsed)
@@ -341,7 +341,7 @@ def _get_patches(
     return [patch]
 
 
-def _get_format(resource, name: str, version: str) -> tuple[str, str] | bool:
+def _get_format(resource, name: str, version: str) -> tuple[str, str] | Literal[False]:
     """Return SR-4731 format/version if the resource is supported."""
     try:
         parsed = _parse_sor(resource, load_samples=False)

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 import dascore as dc
@@ -21,17 +23,21 @@ class TDMSFormatterV4713(FiberIO):
     preferred_extensions = ("tdms",)
     lead_in_length = 28
 
-    def get_format(self, stream: BinaryReader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: BinaryReader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return a tuple of (TDMS, version) if TDMS else False.
 
         Parameters
         ----------
-        stream
+        resource
             A path to the file which may contain silixa data.
         """
         try:
-            version_str = _get_version_str(stream)
+            version_str = _get_version_str(resource)
             if version_str:
                 return "TDMS", version_str
             else:

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -6,7 +6,7 @@ import datetime
 import mmap
 import struct
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 
@@ -102,8 +102,8 @@ def parse_time_stamp(fractions, seconds):
         return None
 
 
-def _get_version_str(tdms_file, lead_in_length=28) -> str:
-    """Return True if we have the right file type."""
+def _get_version_str(tdms_file, lead_in_length=28) -> str | Literal[False]:
+    """Return the version string for a TDMS file, else False."""
     lead_in = tdms_file.read(lead_in_length)
     # lead_in is 28 bytes:
     # [string of length 4][int32][int32][int64][int64]

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import dascore as dc
 from dascore.constants import timeable_types
 from dascore.io import FiberIO, ScanPayload
@@ -22,7 +24,11 @@ class Terra15FormatterV4(FiberIO):
     preferred_extensions = ("hdf5", "h5")
     version = "4"
 
-    def get_format(self, resource: H5Reader, **kwargs) -> tuple[str, str] | bool:
+    def get_format(
+        self,
+        resource: H5Reader,
+        **kwargs,
+    ) -> tuple[str, str] | Literal[False]:
         """
         Return True if file contains terra15 version 2 data else False.
 

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -34,6 +34,7 @@ class Terra15FormatterV4(FiberIO):
         version_str = _get_terra15_version_str(resource)
         if version_str:
             return (self.name, version_str)
+        return False
 
     def scan(
         self, resource: H5Reader, snap: bool = True, **kwargs

--- a/dascore/io/terra15/utils.py
+++ b/dascore/io/terra15/utils.py
@@ -177,7 +177,7 @@ def _get_default_attrs(root_node_attrs):
 
 def _get_time_coord(data_node, snap_dims=True):
     """Get the time coordinate."""
-    t_min, t_max, time_len, d_time = _get_scanned_time_info(data_node)
+    t_min, t_max, _time_len, d_time = _get_scanned_time_info(data_node)
     if snap_dims:
         kwargs = dict(start=t_min, stop=t_max + d_time, step=d_time, units="s")
         time_coord = get_coord(**kwargs)

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import numpy as np
 from scipy.io.wavfile import write
 
+import dascore as dc
 from dascore.compat import UPath
-from dascore.constants import ONE_SECOND, SpoolType
+from dascore.constants import ONE_SECOND
 from dascore.exceptions import ParameterError
 from dascore.io.core import FiberIO
 from dascore.utils.patch import check_patch_coords
@@ -22,7 +23,7 @@ class WavIO(FiberIO):
 
     def write(
         self,
-        spool: SpoolType,
+        spool: dc.BaseSpool,
         resource: str | Path | UPath,
         resample_frequency=None,
         **kwargs,

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -23,7 +23,7 @@ class WavIO(FiberIO):
 
     def write(
         self,
-        spool: dc.BaseSpool,
+        spool: dc.Patch | dc.BaseSpool,
         resource: str | Path | UPath,
         resample_frequency=None,
         **kwargs,
@@ -66,6 +66,9 @@ class WavIO(FiberIO):
             if is_local_path(resource)
             else coerce_to_upath(resource)
         )
+        # dc.write always hands over a spool, but a direct call may pass a
+        # bare patch; dc.spool leaves a spool alone.
+        spool = dc.spool(spool)
         if len(spool) != 1:
             msg = "Only single patch spools can be written to wav"
             raise ParameterError(msg)

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Literal
 from xml.etree.ElementTree import ParseError
 
 import numpy as np
@@ -84,7 +85,7 @@ class XMLBinaryV1(FiberIO):
         )
         return dc.spool(patches)
 
-    def get_format(self, resource, **kwargs) -> tuple[str, str] | bool:
+    def get_format(self, resource, **kwargs) -> tuple[str, str] | Literal[False]:
         """Determine if directory is an XML Binary type."""
         path = self._get_base_path(resource)
         index_path = path / self._metadata_name

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -200,7 +200,7 @@ def bool_patch(self: PatchType):
 def update(
     self: PatchType,
     data: ArrayLike | np.ndarray | None = None,
-    coords: None | dict[str | Sequence[str], ArrayLike] | CoordManager = None,
+    coords: dict[str | Sequence[str], ArrayLike] | CoordManager | None = None,
     dims: Sequence[str] | None = None,
     attrs: Mapping | PatchAttrs | None = None,
 ) -> PatchType:

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -8,7 +8,8 @@ import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
 
-from dascore.constants import PatchType, SpoolType, select_values_description
+import dascore as dc
+from dascore.constants import PatchType, select_values_description
 from dascore.core.coords import BaseCoord
 from dascore.exceptions import (
     CoordError,
@@ -825,7 +826,7 @@ def get_axis(self: PatchType, dim: str) -> int:
     return self.coords.get_axis(dim)
 
 
-def split_gaps(self: PatchType, dim: str | None = None) -> SpoolType:
+def split_gaps(self: PatchType, dim: str | None = None) -> dc.BaseSpool:
     """
     Split the patch into contiguous patches at coordinate gaps.
 

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -864,7 +864,6 @@ def split_gaps(self: PatchType, dim: str | None = None) -> dc.BaseSpool:
     >>> spool = patch.split_gaps()
     >>> assert len(spool) == 2
     """
-    import dascore as dc
     from dascore.core.coords import CoordSegmented
 
     if dim is not None and dim not in self.dims:

--- a/dascore/proc/whiten.py
+++ b/dascore/proc/whiten.py
@@ -81,8 +81,8 @@ def _check_freq_range(fft_coord, freq_range):
 @patch_function()
 def whiten(
     patch: PatchType,
-    smooth_size: None | float = None,
-    water_level: None | float = None,
+    smooth_size: float | None = None,
+    water_level: float | None = None,
     **kwargs,
 ) -> PatchType:
     """

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -16,8 +16,8 @@ from dascore.utils.patch import patch_function
 def dispersion_phase_shift(
     patch: PatchType,
     phase_velocities: Sequence[float],
-    approx_resolution: None | float = None,
-    approx_freq: None | tuple[float, float] = None,
+    approx_resolution: float | None = None,
+    approx_freq: tuple[float, float] | None = None,
 ) -> PatchType:
     """
     Compute dispersion images using the phase-shift method.

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -669,7 +669,7 @@ def _get_short_time_fft(patch) -> ShortTimeFFT:
 
 
 @patch_function()
-def istft(patch) -> PatchType:
+def istft(patch) -> dc.Patch:
     """
     Invert a short-time fourier transform.
 

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -199,7 +199,7 @@ def _convert_dft_spectral_amplitudes(patch, output, dims, real, db):
 @patch_function()
 def dft(
     patch: PatchType,
-    dim: str | None | Sequence[str],
+    dim: str | Sequence[str] | None,
     *,
     real: str | bool | None = None,
     pad: bool = True,
@@ -411,7 +411,7 @@ def _check_dft_output_invertible(patch):
 
 
 @patch_function()
-def idft(patch: PatchType, dim: str | None | Sequence[str] = None) -> PatchType:
+def idft(patch: PatchType, dim: str | Sequence[str] | None = None) -> PatchType:
     """
     Perform the inverse discrete Fourier transform (idft) on specified dimension(s).
 

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -174,8 +174,8 @@ def _get_conversion_factors(from_quant, to_quant) -> tuple[float, float, float]:
 
 def convert_units(
     data: numeric | Quantity,
-    to_units: None | str | Quantity,
-    from_units: None | str | Quantity = None,
+    to_units: str | Quantity | None,
+    from_units: str | Quantity | None = None,
 ) -> numeric:
     """
     Convert units in array from one type of units to another.
@@ -325,7 +325,7 @@ def get_filter_units(
     arg1: Quantity | float,
     arg2: Quantity | float,
     to_unit: str | Quantity,
-    dim: None | str = None,
+    dim: str | None = None,
 ) -> tuple[float, float]:
     """
     Get a tuple for applying filter based on dimension coordinates.

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -86,8 +86,7 @@ def _resolve_group_attrs(group, columns) -> tuple[str, ...]:
         group = (group,) if isinstance(group, str) else tuple(group)
         if missing := [x for x in group if x not in columns]:
             msg = (
-                f"group attribute(s) {missing} do not exist on any patch "
-                "in the spool."
+                f"group attribute(s) {missing} do not exist on any patch in the spool."
             )
             raise InvalidSpoolQueryError(msg)
         return group
@@ -252,7 +251,7 @@ def _partition(
     tolerance merged patches the default would have kept apart (#662);
     the caller owns warning about it.
     """
-    start, stop, step = get_interval_columns(df, name)
+    _start, _stop, step = get_interval_columns(df, name)
     cols = [x for x in group_attrs if x in df.columns]
     if "dims" in df.columns:
         cols.append("dims")
@@ -470,8 +469,7 @@ def build_chunk_plan(
     """
     if len(kwargs) != 1:
         msg = (
-            "Chunking only supported along one dimension. You passed "
-            f"kwargs: {kwargs}"
+            f"Chunking only supported along one dimension. You passed kwargs: {kwargs}"
         )
         raise ParameterError(msg)
     ((name, value),) = kwargs.items()
@@ -493,7 +491,7 @@ def build_chunk_plan(
         msg = f"missing_dim must be 'raise' or 'drop', got {missing_dim!r}"
         raise ParameterError(msg)
     if conflict not in ("drop", "raise", "keep_first"):
-        msg = "conflict must be 'drop', 'raise', or 'keep_first', " f"got {conflict!r}"
+        msg = f"conflict must be 'drop', 'raise', or 'keep_first', got {conflict!r}"
         raise ParameterError(msg)
 
     min_name, max_name = f"{name}_min", f"{name}_max"

--- a/dascore/utils/coordmanager.py
+++ b/dascore/utils/coordmanager.py
@@ -50,10 +50,7 @@ def merge_coord_managers(
         """Ensure all managers have same dimensions."""
         dims = {x.dims for x in managers}
         if len(dims) != 1:
-            msg = (
-                "Can't merge coord managers, they don't all have the "
-                "same dimensions!"
-            )
+            msg = "Can't merge coord managers, they don't all have the same dimensions!"
             raise CoordMergeError(msg)
         return managers[0].dims
 
@@ -108,8 +105,7 @@ def merge_coord_managers(
             # snap is too far off, bail out.
             elif diff > tolerance:
                 msg = (
-                    f"Cannot merge. Snap tolerance: {get_nice_text(tolerance)}"
-                    f" not met"
+                    f"Cannot merge. Snap tolerance: {get_nice_text(tolerance)} not met"
                 )
                 raise CoordMergeError(msg)
         return coord_list

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -223,7 +223,7 @@ class H5Reader(_H5CasterBase):
         h5py can consume a binary file object via the
         ``fileobj`` driver, so remote UPath inputs stay streaming-based here.
         """
-        if isinstance(resource, cls | _ManagedH5pyFile):
+        if isinstance(resource, (cls, _ManagedH5pyFile)):
             return resource
         return open_h5_resource(
             resource,

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -108,7 +108,7 @@ class BinaryReader(io.BytesIO):
     @classmethod
     def get_handle(cls, resource):
         """Get the handle object from various sources."""
-        if isinstance(resource, cls | io.BufferedIOBase):
+        if isinstance(resource, (cls, io.BufferedIOBase)):
             if cls.reset_offset:
                 resource.seek(0)  # reset byte offset
             return resource
@@ -128,7 +128,7 @@ class LocalBinaryReader(BinaryReader):
     @classmethod
     def get_handle(cls, resource):
         """Get the binary handle, materializing remote resources if needed."""
-        if isinstance(resource, cls | io.BufferedIOBase):
+        if isinstance(resource, (cls, io.BufferedIOBase)):
             if cls.reset_offset:
                 resource.seek(0)
             return resource
@@ -150,7 +150,7 @@ class TextReader(BinaryReader):
     @classmethod
     def get_handle(cls, resource):
         """Get a text handle from a resource."""
-        if isinstance(resource, cls | io.TextIOBase):
+        if isinstance(resource, (cls, io.TextIOBase)):
             if cls.reset_offset:
                 resource.seek(0)
             return resource

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -297,7 +297,7 @@ def patch_to_xarray(patch: PatchType):
     return xr.DataArray(patch.data, attrs=attrs, dims=patch_dims, coords=coords)
 
 
-def xarray_to_patch(data_array) -> PatchType:
+def xarray_to_patch(data_array) -> dc.Patch:
     """Convert an xarray dataarray to a patch."""
     # this cant work if xarray isn't installed. This ensures it is.
     _ = optional_import("xarray")
@@ -362,7 +362,7 @@ def patch_to_obspy(patch: PatchType):
     return obspy.Stream(traces)
 
 
-def obspy_to_patch(stream, dim="distance") -> PatchType:
+def obspy_to_patch(stream, dim="distance") -> dc.Patch:
     """
     Convert an obspy stream to a patch.
 

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -598,7 +598,7 @@ def yield_sub_sequences(sequence, length=None):
 
 
 def maybe_get_items(
-    obj, attr_map: Mapping[str, str], unpack_names: None | set[str] = None
+    obj, attr_map: Mapping[str, str], unpack_names: set[str] | None = None
 ):
     """
     Maybe get items from a mapping (if they exist).

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -402,7 +402,7 @@ def merge_patches(
     dim: str = "time",
     check_history: bool = True,
     tolerance: float = 1.5,
-) -> Sequence[PatchType]:
+) -> dc.BaseSpool:
     """
     Merge all compatible patches in spool or patch list together.
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -21,7 +21,6 @@ from dascore.constants import (
     DEFAULT_ATTRS_TO_IGNORE,
     WARN_LEVELS,
     PatchType,
-    SpoolType,
     check_behavior_description,
 )
 from dascore.exceptions import (
@@ -346,7 +345,7 @@ def patch_function(
 
 
 def patches_to_df(
-    patches: Sequence[PatchType] | SpoolType | pd.DataFrame,
+    patches: Sequence[dc.Patch] | dc.BaseSpool | pd.DataFrame,
 ) -> pd.DataFrame:
     """
     Return a dataframe.
@@ -399,7 +398,7 @@ def patches_to_df(
     removed_in="0.2.0",
 )
 def merge_patches(
-    patches: Sequence[PatchType] | pd.DataFrame | SpoolType,
+    patches: Sequence[dc.Patch] | pd.DataFrame | dc.BaseSpool,
     dim: str = "time",
     check_history: bool = True,
     tolerance: float = 1.5,
@@ -1434,7 +1433,7 @@ def concatenate_patches(
 @compose_docstring(check_desc=check_behavior_description)
 def stack_patches(
     patches, dim_vary=None, check_behavior: WARN_LEVELS = "warn"
-) -> PatchType:
+) -> dc.Patch:
     """
     Stack (add) all patches compatible with first patch together.
 

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -637,9 +637,9 @@ def patch_to_dataframe(patch: PatchType) -> pd.DataFrame:
     """
     dims = patch.dims
     # ensure a 2D patch is passed
-    assert (
-        len(dims) == 2
-    ), "Patch must have exactly 2 dimensions to convert to dataframe"
+    assert len(dims) == 2, (
+        "Patch must have exactly 2 dimensions to convert to dataframe"
+    )
     # get arrays with dimensional values
     index_values = patch.get_coord(dims[0]).values
     col_values = patch.get_coord(dims[1]).values

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -654,7 +654,7 @@ def patch_to_dataframe(patch: PatchType) -> pd.DataFrame:
 
 def dataframe_to_patch(
     df: pd.DataFrame, attrs: PatchAttrs | Mapping | None = None
-) -> PatchType:
+) -> dc.Patch:
     """
     Convert a dataframe to a patch.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,11 @@ max-complexity = 10
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
+# Notebooks are exploratory; ruff started linting them in v0.16 and the
+# docstring rules make little sense for a scratch cell.
+[tool.ruff.lint.per-file-ignores]
+"*.ipynb" = ["D103"]
+
 [tool.pytest.ini_options]
 norecursedirs = [
     "*.egg",
@@ -260,7 +265,7 @@ line-ending = "lf"
 include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
-# burned down. Counts as of 2026-08-04: invalid-argument-type 90,
+# burned down. Counts as of 2026-08-04: invalid-argument-type 86,
 # invalid-return-type 37, invalid-method-override 15.
 [tool.ty.rules]
 invalid-argument-type = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,7 @@ include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
 # burned down. Counts as of 2026-08-04: invalid-argument-type 90,
-# invalid-return-type 40, invalid-method-override 16.
+# invalid-return-type 37, invalid-method-override 15.
 [tool.ty.rules]
 invalid-argument-type = "ignore"
 invalid-return-type = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,7 @@ include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
 # burned down. Counts as of 2026-08-04: invalid-argument-type 90,
-# invalid-return-type 67, invalid-method-override 36.
+# invalid-return-type 40, invalid-method-override 16.
 [tool.ty.rules]
 invalid-argument-type = "ignore"
 invalid-return-type = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,7 +232,9 @@ convention = "numpy"
 # Notebooks are exploratory; ruff started linting them in v0.16 and the
 # docstring rules make little sense for a scratch cell.
 [tool.ruff.lint.per-file-ignores]
-"*.ipynb" = ["D103"]
+# F401: a notebook often imports a name only used inside an IPython magic,
+# which ruff cannot see, and its autofix would delete the import.
+"*.ipynb" = ["D103", "F401"]
 
 [tool.pytest.ini_options]
 norecursedirs = [

--- a/scripts/_index_api.py
+++ b/scripts/_index_api.py
@@ -101,7 +101,7 @@ def parse_project(obj, key=None):
 
     def get_type(
         obj, parent_is_class=False
-    ) -> None | Literal["module", "function", "method", "class"]:
+    ) -> Literal["module", "function", "method", "class"] | None:
         """Return a string of the type of object."""
         obj = _unwrap_obj(obj)
         if isinstance(obj, ModuleType):

--- a/scripts/test_render_api.py
+++ b/scripts/test_render_api.py
@@ -10,7 +10,7 @@ import pytest
 # These tests only work if doc deps are installed.
 pytest.importorskip("jinja2")
 
-from _render_api import build_signature, get_type_hints, to_quarto_code  # noqa
+from _render_api import build_signature, get_type_hints, to_quarto_code
 
 
 class TestGetTypeHints:

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -343,7 +343,7 @@ class TestDrop:
         """Trying to drop a dim that doesnt exist should just return."""
         array = np.ones(cm_multidim.shape)
         axis = cm_multidim.get_axis("time")
-        cm, new_array = cm_multidim.drop_coords("time", array=array)
+        _cm, new_array = cm_multidim.drop_coords("time", array=array)
         assert new_array.shape[axis] == 0
 
     def test_drop_non_dim_coord(self, cm_multidim):
@@ -412,7 +412,7 @@ class TestSelect:
     def test_filter_array(self, cm_basic):
         """Ensure an array can be filtered."""
         data = np.ones(cm_basic.shape)
-        new, trim = cm_basic.select(distance=(100, 400), array=data)
+        _new, trim = cm_basic.select(distance=(100, 400), array=data)
         assert trim.shape == trim.shape
 
     def test_select_emptying_dim(self, cm_basic):
@@ -501,7 +501,7 @@ class TestSelect:
         """Ensure trim also trims related dimensions."""
         cm = cm_multidim
         data = np.empty(cm.shape)
-        out, new_data = cm.select(array=data, time=slice(2, 4), samples=True)
+        out, _new_data = cm.select(array=data, time=slice(2, 4), samples=True)
         for name, coord in out.coord_map.items():
             dims = cm.dim_map[name]
             if "time" not in dims:

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -838,7 +838,7 @@ class TestSelect:
         """A sub-array should allow indexing."""
         values = long_coord.values
         sub = values[1:-1]
-        out, reduction = long_coord.select(sub)
+        _out, reduction = long_coord.select(sub)
         assert reduction.sum() == len(sub)
 
     def test_overlapping_array(self, long_coord):
@@ -855,7 +855,7 @@ class TestSelect:
     def test_duplicate_array_samples(self, long_coord):
         """Ensure duplicate do nothing."""
         inds = np.array([0, 0, 0])
-        coord, reduction = long_coord.select(inds, samples=True)
+        coord, _reduction = long_coord.select(inds, samples=True)
         assert len(coord) == len(np.unique(inds))
         assert np.all(coord.values == coord.values[0])
 
@@ -870,7 +870,7 @@ class TestSelect:
         """Ensure duplicate values don't cause duplicates in array."""
         second_value = long_coord.values[1]
         array = np.array([second_value, second_value])
-        coord, reduction = long_coord.select(array)
+        coord, _reduction = long_coord.select(array)
         assert len(coord) == len(np.unique(array))
         assert np.all(array == second_value)
 
@@ -957,7 +957,7 @@ class TestSelect:
 
     def test_percentage(self, coord):
         """Ensure selecting by percentage works."""
-        out, indexer = coord.select((10 * percent, -20 * percent))
+        out, _indexer = coord.select((10 * percent, -20 * percent))
         if coord.evenly_sampled:
             assert abs((len(out) / len(coord)) - 0.70) < len(coord) / 100.0
 
@@ -992,7 +992,7 @@ class TestOrder:
     def test_duplicate_array_samples(self, long_coord):
         """Ensure duplicate indices cause duplicates in array."""
         inds = np.array([0, 0, 0])
-        coord, reduction = long_coord.order(inds, samples=True)
+        coord, _reduction = long_coord.order(inds, samples=True)
         assert len(coord) == len(inds)
         assert np.all(coord.values == coord.values[0])
 
@@ -1007,14 +1007,14 @@ class TestOrder:
         """Ensure duplicate values cause duplicates in array."""
         second_value = long_coord.values[1]
         array = np.array([second_value, second_value])
-        coord, reduction = long_coord.order(array)
+        coord, _reduction = long_coord.order(array)
         assert len(coord) == len(array)
         assert np.all(array == second_value)
 
     def test_sorted_by_values(self, long_coord):
         """Ensure the output is sorted by values given to select."""
         vals = long_coord.values[np.array([4, 2, 1, 3])]
-        coord, reduction = long_coord.order(vals)
+        coord, _reduction = long_coord.order(vals)
         assert vals.shape == coord.shape
         assert np.all(vals == coord.values)
 
@@ -1065,7 +1065,7 @@ class TestOrder:
         old_values = coord_with_duplicates.values
         to_find = [0, 1, 1]
         expected_len = sum((old_values == x).sum() for x in to_find)
-        out, inds = coord_with_duplicates.order(to_find)
+        out, _inds = coord_with_duplicates.order(to_find)
         assert len(out) == expected_len
 
     def test_order_samples_non_int_aray(self, evenly_sampled_coord):
@@ -1193,13 +1193,13 @@ class TestCoordRange:
     def test_identity_slice_ints(self, evenly_sampled_coord):
         """Ensure slice with exact start/end gives same coord."""
         coord = evenly_sampled_coord
-        new, sliced = coord.select((coord.start, coord.stop))
+        new, _sliced = coord.select((coord.start, coord.stop))
         assert new == coord
 
     def test_identity_slice_floats(self, evenly_sampled_float_coord_with_units):
         """Ensure slice with exact start/end gives same coord."""
         coord = evenly_sampled_float_coord_with_units
-        new, sliced = coord.select((coord.start, coord.stop))
+        new, _sliced = coord.select((coord.start, coord.stop))
         assert new == coord
 
     def test_float_basics(self):
@@ -1214,7 +1214,7 @@ class TestCoordRange:
         coord = evenly_sampled_float_coord_with_units
         value_ft = 100
         value_m = value_ft * 0.3048
-        new, sliced = coord.select((value_ft * dc.get_unit("ft"), ...))
+        new, _sliced = coord.select((value_ft * dc.get_unit("ft"), ...))
         # ensure value is surrounded.
         assert new.start + new.step >= value_m
         assert new.start - new.step <= value_m
@@ -1249,7 +1249,7 @@ class TestCoordRange:
         """Ensure string selection works with datetime objects."""
         coord = evenly_sampled_date_coord
         date_str = "1970-01-01T12"
-        new, sliced = coord.select((date_str, ...))
+        new, _sliced = coord.select((date_str, ...))
         datetime = dc.to_datetime64(date_str)
         assert new.start + new.step >= datetime
         assert new.start - new.step <= datetime
@@ -1314,7 +1314,7 @@ class TestCoordRange:
     def test_test_select_end_floats(self, evenly_sampled_float_coord_with_units):
         """Ensure we can select right up to the end of the array."""
         coord = evenly_sampled_float_coord_with_units
-        new_coord, out = coord.select((coord.min(), coord.max()))
+        new_coord, _out = coord.select((coord.min(), coord.max()))
         assert len(new_coord) == len(coord)
         assert np.allclose(new_coord.values, coord.values)
 
@@ -1580,13 +1580,13 @@ class TestMonotonicCoord:
         lims = coord.limits
         dur = lims[1] - lims[0]
         select_range = (lims[0] - 2 * dur, lims[1] + dur)
-        wide_coord, inds = coord.select(select_range)
+        wide_coord, _inds = coord.select(select_range)
         # coord should be unchanged
         assert len(wide_coord) == len(coord)
         assert wide_coord == coord
-        wide_coord, inds = coord.select((select_range[0], None))
+        wide_coord, _inds = coord.select((select_range[0], None))
         assert wide_coord == coord
-        wide_coord, inds = coord.select((None, select_range[1]))
+        wide_coord, _inds = coord.select((None, select_range[1]))
         assert wide_coord == coord
 
     def test_properties_mono(self, monotonic_float_coord):
@@ -1625,13 +1625,13 @@ class TestNonOrderedArrayCoords:
         min_v, max_v = np.min(random_coord.values), np.max(random_coord.values)
         dist = max_v - min_v
         val1, val2 = min_v + 0.2 * dist, max_v - 0.2 * dist
-        new, ind_array = random_coord.select((val1, val2))
+        new, _ind_array = random_coord.select((val1, val2))
         assert np.all(new.values >= val1)
         assert np.all(new.values <= val2)
 
     def test_sort(self, random_coord):
         """Ensure the coord can be ordered."""
-        new, ordering = random_coord.sort()
+        new, _ordering = random_coord.sort()
         assert isinstance(new, CoordMonotonicArray)
 
     def test_snap(self, random_coord):
@@ -1747,7 +1747,7 @@ class TestPartialCoord:
     def test_order_by_samples(self, basic_non_coord):
         """Ensure coord can be ordered by samples."""
         order = [0, 1]
-        out, ind = basic_non_coord.order(order, samples=True)
+        out, _ind = basic_non_coord.order(order, samples=True)
         assert len(order) == len(out)
 
     def test_to_summary(self, basic_non_coord):
@@ -1886,7 +1886,7 @@ class TestCoercion:
     def test_date_str(self, evenly_sampled_date_coord):
         """Ensure date strings get coerced."""
         drange = ("1970-01-01T00:00:01", 10)
-        out, indexer = evenly_sampled_date_coord.select(drange)
+        out, _indexer = evenly_sampled_date_coord.select(drange)
         assert isinstance(out, evenly_sampled_date_coord.__class__)
         assert out.dtype == evenly_sampled_date_coord.dtype
 
@@ -1894,7 +1894,7 @@ class TestCoercion:
         """Ensure date strings get coerced."""
         coord = evenly_sampled_time_delta_coord
         drange = (10, 2_000)
-        out, indexer = coord.select(drange)
+        out, _indexer = coord.select(drange)
         assert isinstance(out, coord.__class__)
         assert out.dtype == coord.dtype
 
@@ -2191,9 +2191,9 @@ class TestAlignTo:
         """Ensure when non_coords are compatible original coords returned."""
         coord = evenly_sampled_coord
         non_coord = get_coord(data=1)
-        c1, c2, s1, s2 = coord.align_to(non_coord)
+        c1, _c2, _s1, _s2 = coord.align_to(non_coord)
         assert c1 == coord
-        c1, c2, s1, s2 = non_coord.align_to(coord)
+        c1, _c2, _s1, _s2 = non_coord.align_to(coord)
         assert c1 == non_coord
 
     def test_incompatible_non_coords(self, basic_non_coord):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -135,9 +135,9 @@ class TestDeltaPatch:
         assert isinstance(patch, dc.Patch), "delta_patch should return a Patch instance"
 
         dims = patch.dims
-        assert (
-            "time" in dims and "distance" in dims
-        ), "Patch must have 'time' and 'distance' dimensions"
+        assert "time" in dims and "distance" in dims, (
+            "Patch must have 'time' and 'distance' dimensions"
+        )
 
     @pytest.mark.parametrize("dim", ["time", "distance"])
     def test_delta_patch_delta_location(self, dim):
@@ -158,9 +158,9 @@ class TestDeltaPatch:
         # Replace the center value with zero and ensure all zeros remain
         test_data = np.copy(data)
         test_data[mid_idx] = 0
-        assert np.allclose(
-            test_data, 0
-        ), "All other samples should be zero except the center"
+        assert np.allclose(test_data, 0), (
+            "All other samples should be zero except the center"
+        )
 
     @pytest.mark.parametrize("dim", ["time", "distance"])
     def test_delta_patch_with_patch(self, dim):
@@ -180,9 +180,9 @@ class TestDeltaPatch:
         assert data[mid_idx] == 1.0, "Center sample should be 1.0"
         test_data = np.copy(data)
         test_data[mid_idx] = 0
-        assert np.allclose(
-            test_data, 0
-        ), "All other samples should be zero except the center"
+        assert np.allclose(test_data, 0), (
+            "All other samples should be zero except the center"
+        )
 
     @pytest.mark.parametrize("dim", ["lag_time", "distance"])
     def test_delta_patch_with_3d_patch(self, dim):
@@ -201,6 +201,6 @@ class TestDeltaPatch:
         assert data[mid_idx] == 1.0, "Center sample should be 1.0"
         test_data = np.copy(data)
         test_data[mid_idx] = 0
-        assert np.allclose(
-            test_data, 0
-        ), "All other samples should be zero except the center"
+        assert np.allclose(test_data, 0), (
+            "All other samples should be zero except the center"
+        )

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -260,11 +260,12 @@ class TestGetFormat:
 
     def test_random_textfile_isnt_format(self, io_instance, dummy_text_file):
         """Ensure a dummy text file the format (it isn't any fiber format)."""
-        assert not io_instance.get_format(dummy_text_file)
+        # The contract is False, not merely something falsy.
+        assert io_instance.get_format(dummy_text_file) is False
 
     def test_random_h5_isnt_format(self, io_instance, generic_hdf5):
         """Ensure a dummy h5 file the format (it isn't any fiber format)."""
-        assert not io_instance.get_format(generic_hdf5)
+        assert io_instance.get_format(generic_hdf5) is False
 
     def test_all_other_files_arent_format(self, io_instance):
         """All other data files should not show up as this format."""

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -528,6 +528,16 @@ class TestWrite:
         """Ensure the random patch can be written."""
         assert written_fiber_path.exists()
 
+    def test_accepts_patch_or_spool(self, random_patch, fiber_io_writer, tmp_path):
+        """A writer takes a bare patch or a spool; dc.write only sends spools."""
+        pre_ext = list(iterate(fiber_io_writer.preferred_extensions))
+        ext = "" if not len(pre_ext) else pre_ext[0]
+        from_patch = tmp_path / f"patch.{ext}"
+        from_spool = tmp_path / f"spool.{ext}"
+        fiber_io_writer.write(random_patch, from_patch)
+        fiber_io_writer.write(dc.spool([random_patch]), from_spool)
+        assert from_patch.exists() and from_spool.exists()
+
     def test_roundtrip(self, random_patch, written_fiber_path, fiber_io_writer):
         """If the writer can read, ensure round-tripping patch is equal."""
         if not fiber_io_writer.implements_read:

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -481,9 +481,9 @@ class TestScan:
         for summary in scanned_summaries:
             for coord_name, coord in summary.coords.items():
                 with suppress(TypeError):  # incomparable types (e.g. NaT/NaN)
-                    assert (
-                        coord.min <= coord.max
-                    ), f"{coord_name}: min ({coord.min}) > max ({coord.max})"
+                    assert coord.min <= coord.max, (
+                        f"{coord_name}: min ({coord.min}) > max ({coord.max})"
+                    )
 
     def test_no_bytes(self, scanned_summaries):
         """Sometimes bytes are returned from scanning, we need str."""

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -849,5 +849,5 @@ class TestStringArrayHelpers:
         )
         with h5py.File(path, mode="w") as h5:
             group = h5.create_group("waveforms")
-            with pytest.raises(TypeError, match="Object dtype|object arrays"):
+            with pytest.raises(TypeError, match=r"Object dtype|object arrays"):
                 _save_array(data, "obj", group=group)

--- a/tests/test_io/test_index/test_db_dirspool.py
+++ b/tests/test_io/test_index/test_db_dirspool.py
@@ -109,7 +109,7 @@ class TestUpdateLifecycle:
 
     def test_no_change_update_uses_narrow_projection(self, fresh, monkeypatch):
         """A no-op update reads only the stat columns, not the wide table."""
-        path, spool = fresh
+        _path, spool = fresh
         backend = spool.indexer._backend
 
         def _boom(self):

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -6,7 +6,7 @@ import copy
 import io
 import threading
 from pathlib import Path
-from typing import TypeVar
+from typing import ClassVar, TypeVar
 
 import h5py
 import numpy as np
@@ -98,6 +98,19 @@ class _FiberCaster(FiberIO):
     def scan(self, not_path: BinaryReader):
         """Ensure an off-name still works for type casting."""
         assert isinstance(not_path, io.BufferedReader)
+
+
+class _FiberInheritsScan(FiberIO):
+    """A FiberIO which implements only read, as the docs allow."""
+
+    name = "_InheritsScan"
+    version = "1"
+    seen_snap: ClassVar[list] = []
+
+    def read(self, resource, snap=True, **kwargs):
+        """Record what the inherited scan forwarded."""
+        self.seen_snap.append(snap)
+        return dc.spool([dc.get_example_patch()])
 
 
 class _FiberUnsupportedTypeHints(FiberIO):
@@ -351,6 +364,21 @@ class TestFormatManager:
         """Deep copy manager to avoid changing state used by other objects."""
         manager = copy.deepcopy(FiberIO.manager)
         return manager
+
+    def test_inherited_scan_delegates_to_read(self):
+        """A FiberIO which implements only read still scans, snap and all."""
+        fiber_io = _FiberInheritsScan()
+        fiber_io.seen_snap.clear()
+        assert len(fiber_io.scan("ignored")) == 1
+        assert len(fiber_io.scan(resource="ignored", snap=False)) == 1
+        assert fiber_io.seen_snap == [True, False]
+
+    def test_get_fiberio_needs_a_registry(self):
+        """get_fiberio promises a FiberIO; an empty registry cannot supply one."""
+        manager = _FiberIOManager("dascore.fiber_io")
+        manager.__dict__["_eps"] = pd.Series({}, dtype=object)
+        with pytest.raises(AssertionError, match="no fiber_io"):
+            manager.get_fiberio()
 
     def test_specific_format_and_version(self, format_manager):
         """
@@ -784,6 +812,22 @@ class TestScan:
         random_patch.io.write(path_2, "dasdae")
         random_patch.io.write(path_3, "dasdae")
         return out
+
+    @pytest.mark.parametrize("func", [dc.scan, dc.scan_to_df, dc.scan_payloads])
+    def test_scan_accepts_a_collection(self, func, tmp_path, random_patch):
+        """A collection of resources scans as the sum of its members."""
+        path_1 = tmp_path / "patch_1.h5"
+        path_2 = tmp_path / "patch_2.h5"
+        random_patch.io.write(path_1, "dasdae")
+        random_patch.io.write(path_2, "dasdae")
+        expected = len(func(path_1)) + len(func(path_2))
+        assert len(func([path_1, path_2])) == expected
+        # A set is a collection too, and the dispatcher does not index.
+        assert len(func({path_1, path_2})) == expected
+
+    def test_scan_accepts_a_collection_of_patches(self, random_patch):
+        """Patches can be scanned directly, one summary each."""
+        assert len(dc.scan([random_patch, random_patch])) == 2
 
     def test_scan_no_good_files(self, tmp_path):
         """Scan with no fiber files should return []."""

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -62,7 +62,7 @@ class TestWriteWav:
         """Ensure resampling changes sampling rate in file."""
         path = tmp_path_factory.mktemp("wav_resample") / "resampled.wav"
         dc.write(audio_patch, path, "wav", resample_frequency=1000)
-        (sr, ar) = read_wav(str(path))
+        (sr, _ar) = read_wav(str(path))
         assert sr == 1000
 
     def test_write_non_distance_dims(
@@ -80,7 +80,7 @@ class TestWriteWav:
         for mic_val in patch.coords.get_array("microphone"):
             assert path / f"microphone_{mic_val}.wav" in wavs
             # Verify content of first file
-            sr, data = read_wav(str(wavs[0]))
+            sr, _data = read_wav(str(wavs[0]))
         assert sr == int(ONE_SECOND / patch.get_coord("time").step)
 
     def test_write_remote_directory(self, audio_patch_non_distance_dim):

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -195,12 +195,12 @@ class TestHampelFilter:
                 approximate_spike = abs(result_approximate.data[time_idx, dist_idx])
 
                 # Both methods should reduce the spike magnitude
-                assert (
-                    standard_spike < original_spike
-                ), f"Standard method didn't reduce spike at ({time_idx}, {dist_idx})"
-                assert (
-                    approximate_spike < original_spike
-                ), f"Approximate method didn't reduce spike at ({time_idx}, {dist_idx})"
+                assert standard_spike < original_spike, (
+                    f"Standard method didn't reduce spike at ({time_idx}, {dist_idx})"
+                )
+                assert approximate_spike < original_spike, (
+                    f"Approximate did not reduce spike at ({time_idx}, {dist_idx})"
+                )
 
                 # Both should achieve similar spike reduction (within 50% of each other)
                 reduction_ratio = min(standard_spike, approximate_spike) / max(

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -305,9 +305,9 @@ class TestNumpyVsPandasRolling:
         ).sum()
         numpy_isnan = np.isnan(numpy_out.data)
         pandas_isnan = np.isnan(pandas_out.data)
-        assert np.all(
-            np.equal(numpy_isnan, pandas_isnan)
-        ), "The NaN indices do not match"
+        assert np.all(np.equal(numpy_isnan, pandas_isnan)), (
+            "The NaN indices do not match"
+        )
 
     def test_center_same_stepped(self, range_patch):
         """Ensure center values are handled the same."""
@@ -320,9 +320,9 @@ class TestNumpyVsPandasRolling:
         ).sum()
         numpy_isnan = np.isnan(numpy_out.data)
         pandas_isnan = np.isnan(pandas_out.data)
-        assert np.all(
-            np.equal(numpy_isnan, pandas_isnan)
-        ), "The NaN indices do not match"
+        assert np.all(np.equal(numpy_isnan, pandas_isnan)), (
+            "The NaN indices do not match"
+        )
 
     def test_dimension_order(self, range_patch):
         """Ensure the dimension order doesn't matter."""

--- a/tests/test_proc/test_taper.py
+++ b/tests/test_proc/test_taper.py
@@ -247,7 +247,7 @@ class TestTaperRange:
 
     def test_bad_use_of_none(self, random_patch):
         """Ensure bad use of None raises."""
-        with pytest.raises(ParameterError, match="Cannot use ... or None"):
+        with pytest.raises(ParameterError, match=r"Cannot use ... or None"):
             random_patch.taper_range(time=(1, None), relative=True)
 
     def test_use_none(self, random_patch):

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -199,9 +199,9 @@ class TestWhiten:
         whitened_patch_freq_domain = dft.whiten(smooth_size=5, time=None)
 
         # check if the returned data is in the frequency domain
-        assert np.iscomplexobj(
-            whitened_patch_freq_domain.data
-        ), "Expected the output to be complex, indicating freq. domain patch."
+        assert np.iscomplexobj(whitened_patch_freq_domain.data), (
+            "Expected the output to be complex, indicating freq. domain patch."
+        )
 
         assert "ft_time" in dft.coords.coord_map
 

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -339,7 +339,7 @@ class TestPlanMembers:
     def test_modified_flag_no_chunk(self, contiguous_df):
         """Rows whose limits don't change aren't modified."""
         time_diff = contiguous_df["time_max"] - contiguous_df["time_min"]
-        df = contiguous_df.assign(time_max=lambda x: (x["time_max"] - x["time_step"]))
+        df = contiguous_df.assign(time_max=lambda x: x["time_max"] - x["time_step"])
         plan = build_chunk_plan(
             df, overlap=0, time=time_diff.iloc[0], keep_partial=True
         )

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -90,7 +90,7 @@ class TestDocsting:
 
     def test_raises_when_some_placeholders_are_unused(self):
         """Providing extra substitution keys should fail loudly."""
-        with pytest.raises(ValueError, match="unused keys.*extra"):
+        with pytest.raises(ValueError, match=r"unused keys.*extra"):
 
             @compose_docstring(params="value", extra="not-used")
             def dummy_func():

--- a/tests/test_viz/test_spectrogram.py
+++ b/tests/test_viz/test_spectrogram.py
@@ -61,7 +61,7 @@ class TestPlotSpectrogram:
 
     def test_invalid_aggr_domain(self, random_patch):
         """Ensure ValueError is raised for invalid aggr_domain."""
-        with pytest.raises(ValueError, match="should be 'time' or 'frequency'."):
+        with pytest.raises(ValueError, match=r"should be 'time' or 'frequency'."):
             random_patch.viz.spectrogram(aggr_domain="invalid")
 
     def test_invalid_patch_dims(self, random_patch):

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -311,9 +311,9 @@ class TestWaterfall:
         expected_label = f"{data_type}{expected_dunits} - log_10"
 
         # Check if the colorbar label matches the expected label
-        assert (
-            cb_label == expected_label
-        ), f"Expected '{expected_label}', but got '{cb_label}'"
+        assert cb_label == expected_label, (
+            f"Expected '{expected_label}', but got '{cb_label}'"
+        )
 
     def test_incomplete_time_coord(self):
         """Test waterfall plot with incomplete time coordinates (issue #534)."""


### PR DESCRIPTION
## Description

Phase two of the ty burn-down, following #812: the FiberIO plugin contract. `invalid-method-override` drops 36 → 16 and `invalid-return-type` 67 → 40, 47 diagnostics in all. No suppressions.

Almost every plugin was an incompatible override of its own base class, and the fixes are all in `FiberIO` itself rather than in the 25 plugins.

**A FiberIO is handed its resource positionally.** Every plugin renames the first parameter to say what it takes — `fp`, `stream`, `path`, `patch` — but the base declared it as an ordinary parameter, so each rename was a Liskov violation: a caller could have passed `resource=` by keyword and missed. Nothing does, and nothing can — the type-casting wrapper finds the resource by *position* (`_automatic_type_casters` maps a method to a parameter index). Declaring that in the base fixes 19 of the 20. `scan`'s `snap` becomes keyword-only for the same reason; the plugins that do not name it absorb it through `**kwargs`.

**`SpoolType` and `PatchType` said nothing in sixteen places.** A type variable only means something when it appears more than once in a signature, tying an argument to the return. These sixteen used one in the return alone, or as a lone union member, where it binds to nothing and says no more than the class it is bound to — while hiding what the annotation got wrong. Two things fell out once they were gone: `FiberIO.write` always receives a spool, because `dc.write` wraps a bare patch before dispatching; and the scan dispatchers accept an *iterable* of resources, which nothing said (`dascore/io/index/indexer.py` passes a `list[Path]`). The latter gets a named `ScanInput`.

**Three return contracts the code did not keep.** `get_format` promises a `(name, version)` tuple or `False`, and six formats fell off the end returning `None` for a file that is not theirs — falsy, so the dispatcher never noticed. `sr4731`'s `scan` still claimed `list[PatchAttrs]`, a shape `FiberIO.scan` stopped accepting; the helper it returns has produced `ScanPayload`s all along. And `get_fiberio` promises a `FiberIO` or the error `yield_fiberio` raises, but returned `None` if its iterator was somehow empty.

The dispatcher now looks for the tuple it is about to return rather than merely a truthy value, so a plugin returning a bare `True` — a detection with no version to unpack — falls through to the next candidate instead. The contract test for "not my format" tightens from falsy to `is False`; it fails on three of its 54 parametrizations without the fix.

### Not included

The `| bool` half of `get_format`'s return type still promises `True` is meaningful across 30 signatures. Spelling it `Literal[False]` everywhere would state the contract exactly but needs a `typing` import in twenty files for two diagnostics, so I left it.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spool indexing clearly supports individual patches, slices, and array selections.
  * Scanning accepts individual inputs and collections of paths or patches.
  * File writers accept either a single patch or a single-patch spool.
  * Scan utilities support broader input types, including data frames.

* **Bug Fixes**
  * Unsupported file formats now report a consistent `False` result.
  * Improved consistency when handling patch and spool inputs across I/O operations.
  * Improved validation of scan and format-detection results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->