### PR TITLE
Add DASDAE storage/codec API with h5py-native compression

### DIFF
--- a/dascore/io/__init__.py
+++ b/dascore/io/__init__.py
@@ -4,8 +4,12 @@ Modules for reading and writing fiber data.
 from __future__ import annotations
 
 from dascore.io.core import (
+    BaseCodec,
+    BaseStorage,
     FiberIO,
     ScanPayload,
+    get_codecs,
+    get_storage,
     read,
     scan,
     scan_payloads,

--- a/dascore/io/codec.py
+++ b/dascore/io/codec.py
@@ -1,0 +1,90 @@
+"""
+Registry for storage codecs.
+
+Codecs are discovered the same way FiberIO formats are: from a Python
+entry-point group (``dascore.codec``). External packages can register a new
+codec by pointing an entry point at a :class:`~dascore.io.core.BaseCodec`
+subclass, e.g. in their ``pyproject.toml``::
+
+    [project.entry-points."dascore.codec"]
+    daspack = "dascore_daspack:Daspack"
+
+DASCore's built-in codecs are always available; plugins are merged on top.
+"""
+
+from __future__ import annotations
+
+import functools
+import warnings
+
+from dascore.exceptions import InvalidFiberIOError
+from dascore.io.core import BaseCodec
+from dascore.utils.plugins import get_entry_point_loaders
+
+_CODEC_ENTRY_POINT_GROUP = "dascore.codec"
+
+
+def _codec_name(codec_cls: type[BaseCodec]) -> str:
+    """Return a codec class's registered (discriminator) name."""
+    field = codec_cls.model_fields.get("name")
+    name = field.default if field is not None else None
+    # A required or missing name field leaves no usable discriminator (name is
+    # None or the pydantic-undefined sentinel), which would otherwise register
+    # the codec under a bogus shared key and silently shadow other codecs.
+    if not isinstance(name, str) or not name:
+        msg = (
+            f"Codec {codec_cls.__name__} must declare a non-empty 'name' field "
+            "with a default, e.g. name: Literal['my_codec'] = 'my_codec'."
+        )
+        raise InvalidFiberIOError(msg)
+    return name
+
+
+@functools.cache
+def get_codec_registry() -> dict[str, type[BaseCodec]]:
+    """
+    Return all known codecs keyed by their public name.
+
+    Built-in codecs are always included; codecs registered by plugins via the
+    ``dascore.codec`` entry-point group are merged on top (and may override a
+    built-in of the same name).
+    """
+    # Imported lazily to avoid an import cycle (hdf5 imports from io.core).
+    from dascore.io.hdf5 import Gzip  # noqa: PLC0415
+
+    registry: dict[str, type[BaseCodec]] = {}
+    for codec_cls in (Gzip,):
+        registry[_codec_name(codec_cls)] = codec_cls
+    for ep_name, loader in get_entry_point_loaders(_CODEC_ENTRY_POINT_GROUP).items():
+        # A broken third-party registration must not poison the registry for
+        # the built-in codecs; warn and skip like the FiberIO plugin loader.
+        try:
+            codec_cls = loader()
+            registry[_codec_name(codec_cls)] = codec_cls
+        except Exception as exc:
+            msg = (
+                f"Failed to load codec plugin {ep_name!r} "
+                f"({exc.__class__.__name__}: {exc}); skipping it. "
+                "This can happen when an entry point from a previous install "
+                "is stale; reinstalling dascore (or the package providing the "
+                "plugin) may fix it."
+            )
+            warnings.warn(msg, UserWarning, stacklevel=2)
+    return registry
+
+
+def get_codec(name: str) -> type[BaseCodec]:
+    """
+    Return a registered codec class from its public name.
+
+    Raises
+    ------
+    ValueError
+        If no codec is registered under ``name``.
+    """
+    registry = get_codec_registry()
+    if name not in registry:
+        valid = ", ".join(sorted(registry)) or "(none)"
+        msg = f"Unknown codec {name!r}. Registered codecs: {valid}."
+        raise ValueError(msg)
+    return registry[name]

--- a/dascore/io/codec.py
+++ b/dascore/io/codec.py
@@ -1,0 +1,77 @@
+"""
+Registry for storage codecs.
+
+Codecs are discovered the same way FiberIO formats are: from a Python
+entry-point group (``dascore.codec``). External packages can register a new
+codec by pointing an entry point at a :class:`~dascore.io.core.BaseCodec`
+subclass, e.g. in their ``pyproject.toml``::
+
+    [project.entry-points."dascore.codec"]
+    daspack = "dascore_daspack:Daspack"
+
+DASCore's built-in codecs are always available; plugins are merged on top.
+"""
+
+from __future__ import annotations
+
+import functools
+
+from dascore.exceptions import InvalidFiberIOError
+from dascore.io.core import BaseCodec
+from dascore.utils.plugins import get_entry_point_loaders
+
+_CODEC_ENTRY_POINT_GROUP = "dascore.codec"
+
+
+def _codec_name(codec_cls: type[BaseCodec]) -> str:
+    """Return a codec class's registered (discriminator) name."""
+    field = codec_cls.model_fields.get("name")
+    name = field.default if field is not None else None
+    # A required or missing name field leaves no usable discriminator (name is
+    # None or the pydantic-undefined sentinel), which would otherwise register
+    # the codec under a bogus shared key and silently shadow other codecs.
+    if not isinstance(name, str) or not name:
+        msg = (
+            f"Codec {codec_cls.__name__} must declare a non-empty 'name' field "
+            "with a default, e.g. name: Literal['my_codec'] = 'my_codec'."
+        )
+        raise InvalidFiberIOError(msg)
+    return name
+
+
+@functools.cache
+def get_codec_registry() -> dict[str, type[BaseCodec]]:
+    """
+    Return all known codecs keyed by their public name.
+
+    Built-in codecs are always included; codecs registered by plugins via the
+    ``dascore.codec`` entry-point group are merged on top (and may override a
+    built-in of the same name).
+    """
+    # Imported lazily to avoid an import cycle (hdf5 imports from io.core).
+    from dascore.io.hdf5 import Gzip
+
+    registry: dict[str, type[BaseCodec]] = {}
+    for codec_cls in (Gzip,):
+        registry[_codec_name(codec_cls)] = codec_cls
+    for loader in get_entry_point_loaders(_CODEC_ENTRY_POINT_GROUP).values():
+        codec_cls = loader()
+        registry[_codec_name(codec_cls)] = codec_cls
+    return registry
+
+
+def get_codec(name: str) -> type[BaseCodec]:
+    """
+    Return a registered codec class from its public name.
+
+    Raises
+    ------
+    ValueError
+        If no codec is registered under ``name``.
+    """
+    registry = get_codec_registry()
+    if name not in registry:
+        valid = ", ".join(sorted(registry)) or "(none)"
+        msg = f"Unknown codec {name!r}. Registered codecs: {valid}."
+        raise ValueError(msg)
+    return registry[name]

--- a/dascore/io/codec.py
+++ b/dascore/io/codec.py
@@ -15,6 +15,7 @@ DASCore's built-in codecs are always available; plugins are merged on top.
 from __future__ import annotations
 
 import functools
+import warnings
 
 from dascore.exceptions import InvalidFiberIOError
 from dascore.io.core import BaseCodec
@@ -54,9 +55,21 @@ def get_codec_registry() -> dict[str, type[BaseCodec]]:
     registry: dict[str, type[BaseCodec]] = {}
     for codec_cls in (Gzip,):
         registry[_codec_name(codec_cls)] = codec_cls
-    for loader in get_entry_point_loaders(_CODEC_ENTRY_POINT_GROUP).values():
-        codec_cls = loader()
-        registry[_codec_name(codec_cls)] = codec_cls
+    for ep_name, loader in get_entry_point_loaders(_CODEC_ENTRY_POINT_GROUP).items():
+        # A broken third-party registration must not poison the registry for
+        # the built-in codecs; warn and skip like the FiberIO plugin loader.
+        try:
+            codec_cls = loader()
+            registry[_codec_name(codec_cls)] = codec_cls
+        except Exception as exc:
+            msg = (
+                f"Failed to load codec plugin {ep_name!r} "
+                f"({exc.__class__.__name__}: {exc}); skipping it. "
+                "This can happen when an entry point from a previous install "
+                "is stale; reinstalling dascore (or the package providing the "
+                "plugin) may fix it."
+            )
+            warnings.warn(msg, UserWarning, stacklevel=2)
     return registry
 
 

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -1826,12 +1826,8 @@ def _validate_write_kwargs(fiber_io, kwargs) -> None:
     names = [x for x in params if x != "self"]
     # The first two parameters (the spool and resource) are filled by write();
     # everything else the writer names is a valid user option.
-    allowed = {
-        name
-        for name in names[2:]
-        if params[name].kind
-        in (params[name].POSITIONAL_OR_KEYWORD, params[name].KEYWORD_ONLY)
-    }
+    named = (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    allowed = {name for name in names[2:] if params[name].kind in named}
     unknown = set(kwargs) - allowed
     if unknown:
         unknown_str = ", ".join(sorted(unknown))

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -15,17 +15,20 @@ from pathlib import Path
 from threading import RLock
 from typing import (
     Any,
+    ClassVar,
     Literal,
     NotRequired,
     Protocol,
     TypedDict,
     TypeVar,
     cast,
+    get_args,
     get_type_hints,
 )
 
 import numpy as np
 import pandas as pd
+from pydantic import ConfigDict
 
 import dascore as dc
 from dascore.compat import Progress, UPath
@@ -61,6 +64,7 @@ from dascore.utils.misc import (
     iterate,
     warn_or_raise,
 )
+from dascore.utils.models import DascoreBaseModel
 from dascore.utils.paths import coerce_to_local_path, coerce_to_upath, is_local_path
 from dascore.utils.plugins import get_entry_point_loaders
 from dascore.utils.progress import track
@@ -401,6 +405,74 @@ def _get_reloadable_source_path(
         if isinstance(candidate, str | Path | UPath):
             return coerce_to_upath(candidate)
     return ""
+
+
+class BaseCodec(DascoreBaseModel):
+    """
+    Base class for array payload transform options (codecs).
+
+    Concrete codecs declare a unique ``name`` as a ``Literal`` field so they
+    can act as discriminated-union members on a storage model and round-trip
+    through ``model_dump``/``model_validate``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BaseStorage(DascoreBaseModel):
+    """Base class for format-specific storage options."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: ClassVar[str] = ""
+    # Named presets mapping a preset name to storage kwargs, e.g.
+    # {"compressed": {"codec": {"name": "gzip", "level": 5}}}.
+    presets: ClassVar[dict[str, dict]] = {}
+    # Codec base classes this storage can physically store. A registered codec
+    # is usable here only if it subclasses one of these.
+    supported_codec_bases: ClassVar[tuple[type[BaseCodec], ...]] = ()
+
+    def __init_subclass__(cls, **kwargs):
+        """Ensure storage subclasses declare their storage name."""
+        super().__init_subclass__(**kwargs)
+        if not cls.name:
+            msg = "You must specify the storage object with the name field."
+            raise InvalidFiberIOError(msg)
+
+    @classmethod
+    def from_preset(cls, name: str) -> BaseStorage:
+        """Build a storage instance from a named preset."""
+        if name not in cls.presets:
+            valid = ", ".join(sorted(cls.presets)) or "(none)"
+            msg = (
+                f"Unknown storage preset {name!r} for {cls.__name__}. "
+                f"Valid presets: {valid}."
+            )
+            # A common slip is passing a codec name as the preset string;
+            # point at the working spelling instead of a dead end.
+            from dascore.io.codec import get_codec_registry  # noqa: PLC0415
+
+            if name in get_codec_registry():
+                msg += (
+                    f" Note: {name!r} is a codec name, not a preset; pass it "
+                    f"as storage={{'codec': {name!r}}}."
+                )
+            raise InvalidFiberIOError(msg)
+        return cls.model_validate(cls.presets[name])
+
+    @classmethod
+    def get_codecs(cls) -> tuple[type[BaseCodec], ...]:
+        """Return the registered codec classes this storage can use."""
+        if not cls.supported_codec_bases:
+            return ()
+        # Imported lazily to avoid an import cycle (codec imports from io.core).
+        from dascore.io.codec import get_codec_registry  # noqa: PLC0415
+
+        return tuple(
+            codec
+            for codec in get_codec_registry().values()
+            if issubclass(codec, cls.supported_codec_bases)
+        )
 
 
 class _FiberIOManager:
@@ -872,6 +944,17 @@ def _is_wrapped_func(func1, func2):
     return func is func2
 
 
+def _extract_storage_type(annotation):
+    """Return the BaseStorage subclass named by a type annotation, if any.
+
+    Handles a bare type (``DASDAEStorage``) and unions (``DASDAEStorage | None``).
+    """
+    for candidate in get_args(annotation) or (annotation,):
+        if isinstance(candidate, type) and issubclass(candidate, BaseStorage):
+            return candidate
+    return None
+
+
 class FiberIO:
     """
     An interface which adds support for a given filer format.
@@ -886,6 +969,8 @@ class FiberIO:
     input_type: Literal["file", "directory"] = "file"
     # True when a single resource can hold more than one patch.
     multi_patch_write: bool = False
+    # The format-specific storage options model supported by this IO.
+    storage_cls: type[BaseStorage] | None = None
 
     manager = _FiberIOManager("dascore.fiber_io")
 
@@ -1003,6 +1088,7 @@ class FiberIO:
                     "get_format": fiberio.implements_get_format,
                     "read": fiberio.implements_read,
                     "write": fiberio.implements_write,
+                    "storage": fiberio.storage_cls is not None,
                 }
                 out.append(format_info)
         return pd.DataFrame(out)
@@ -1049,9 +1135,16 @@ class FiberIO:
             method = getattr(cls, name)
             sig = inspect.signature(method)
             arg_name = list(sig.parameters)[param_ind]
-            required_type = get_type_hints(method).get(arg_name)
+            hints = get_type_hints(method)
+            required_type = hints.get(arg_name)
             method_wrapped = _type_caster(method, sig, required_type, arg_name)
             setattr(cls, name, method_wrapped)
+            # Derive storage_cls from write()'s `storage` annotation so the
+            # storage type has a single source of truth (unless set explicitly).
+            if name == "write" and cls.__dict__.get("storage_cls") is None:
+                storage_type = _extract_storage_type(hints.get("storage"))
+                if storage_type is not None:
+                    cls.storage_cls = storage_type
 
 
 @_reinit_after_fork
@@ -1688,6 +1781,111 @@ def _maybe_split_gapped_patches(spool, fiber_io, split):
 _PathT = TypeVar("_PathT", bound=path_types)
 
 
+def get_storage(
+    file_format: str,
+    file_version: str | None = None,
+) -> type[BaseStorage] | None:
+    """
+    Return the storage options class supported by a format/version.
+
+    Unknown formats raise UnknownFiberFormatError; known formats without
+    storage support return None.
+
+    Parameters
+    ----------
+    file_format
+        The known file format.
+    file_version
+        The known file version. If not provided, the newest version of the
+        format is used.
+    """
+    fiber_io = FiberIO.manager.get_fiberio(format=file_format, version=file_version)
+    return fiber_io.storage_cls
+
+
+def get_codecs(
+    file_format: str,
+    file_version: str | None = None,
+) -> tuple[type[BaseCodec], ...]:
+    """
+    Return the codec classes supported by a format/version.
+
+    Unknown formats raise UnknownFiberFormatError; known formats without
+    codec support return an empty tuple.
+
+    Parameters
+    ----------
+    file_format
+        The known file format.
+    file_version
+        The known file version. If not provided, the newest version of the
+        format is used.
+    """
+    storage_cls = get_storage(file_format=file_format, file_version=file_version)
+    if storage_cls is None:
+        return ()
+    return storage_cls.get_codecs()
+
+
+def _validate_write_kwargs(fiber_io, kwargs) -> None:
+    """
+    Reject write kwargs the format's writer does not declare.
+
+    Writers accept ``**kwargs`` for interface tolerance, so a misspelled
+    option name (e.g. ``stroage=``) would otherwise be silently swallowed
+    and produce a file that ignores what the caller asked for.
+    """
+    if not kwargs:
+        return
+    params = inspect.signature(fiber_io.write).parameters
+    names = [x for x in params if x != "self"]
+    # The first two parameters (the spool and resource) are filled by write();
+    # everything else the writer names is a valid user option.
+    named = (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    allowed = {name for name in names[2:] if params[name].kind in named}
+    unknown = set(kwargs) - allowed
+    if unknown:
+        unknown_str = ", ".join(sorted(unknown))
+        valid = ", ".join(sorted(allowed)) or "(none)"
+        msg = (
+            f"Unknown write option(s) {unknown_str} for format "
+            f"{fiber_io.name} version {fiber_io.version}. "
+            f"Supported options: {valid}."
+        )
+        raise ParameterError(msg)
+
+
+def _coerce_storage(storage, fiber_io):
+    """
+    Coerce a user-supplied storage argument to the format's storage model.
+
+    Accepts a storage instance, a dict of storage kwargs, or a preset name
+    string. Raises if the format declares no storage support.
+    """
+    storage_cls = fiber_io.storage_cls
+    if storage is None:
+        # Materialize the format's default storage so the write path never has
+        # to special-case None. Formats without storage support keep None (a
+        # harmless, ignored kwarg).
+        return None if storage_cls is None else storage_cls()
+    if storage_cls is None:
+        msg = f"Format {fiber_io.name} does not support storage options."
+        raise InvalidFiberIOError(msg)
+    if isinstance(storage, BaseCodec):
+        msg = (
+            f"Got codec {type(storage).__name__} for the storage argument; "
+            f"wrap it in storage options, e.g. "
+            f"storage={storage_cls.__name__}(codec=...) or "
+            "storage={'codec': ...}."
+        )
+        raise InvalidFiberIOError(msg)
+    if isinstance(storage, storage_cls):
+        return storage
+    if isinstance(storage, str):
+        return storage_cls.from_preset(storage)
+    return storage_cls.model_validate(storage)
+
+
 def write(
     patch_or_spool,
     path: _PathT,
@@ -1716,6 +1914,17 @@ def write(
         format which supports multiple patches per file. If False (default)
         such patches raise a
         [`ParameterError`](`dascore.exceptions.ParameterError`).
+    **kwargs
+        Format-specific write options forwarded to the format's writer;
+        options the target writer does not declare raise a
+        [`ParameterError`](`dascore.exceptions.ParameterError`) rather than
+        being silently ignored. Most notably ``storage``: for formats that
+        support it (see [`get_storage`](`dascore.io.core.get_storage`)),
+        storage options controlling compression and on-disk layout. Accepts
+        a storage instance, a preset name string (e.g.
+        ``storage="compressed"``), or a dict of storage kwargs such as
+        ``storage={"codec": {"name": "gzip", "level": 5}, "chunks": {"time": 2000}}``.
+        Formats without storage support reject an explicit ``storage``.
 
     Raises
     ------
@@ -1735,6 +1944,11 @@ def write(
     >>> path.unlink()
     """
     fiber_io = FiberIO.manager.get_fiberio(format=file_format, version=file_version)
+    # Coerce storage first so unsupported-storage formats give the specific
+    # "does not support storage options" error rather than the generic one.
+    if "storage" in kwargs:
+        kwargs["storage"] = _coerce_storage(kwargs["storage"], fiber_io)
+    _validate_write_kwargs(fiber_io, kwargs)
     if not isinstance(patch_or_spool, dc.BaseSpool):
         patch_or_spool = dc.spool([patch_or_spool])
     patch_or_spool = _maybe_split_gapped_patches(patch_or_spool, fiber_io, split)

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -406,7 +406,7 @@ class BaseStorage(DascoreBaseModel):
 
     name: ClassVar[str] = ""
     # Named presets mapping a preset name to storage kwargs, e.g.
-    # {"compressed": {"codec": {"name": "blosc:zstd"}}}.
+    # {"compressed": {"codec": {"name": "gzip", "level": 5}}}.
     presets: ClassVar[dict[str, dict]] = {}
     # Codec base classes this storage can physically store. A registered codec
     # is usable here only if it subclasses one of these.
@@ -428,6 +428,15 @@ class BaseStorage(DascoreBaseModel):
                 f"Unknown storage preset {name!r} for {cls.__name__}. "
                 f"Valid presets: {valid}."
             )
+            # A common slip is passing a codec name as the preset string;
+            # point at the working spelling instead of a dead end.
+            from dascore.io.codec import get_codec_registry
+
+            if name in get_codec_registry():
+                msg += (
+                    f" Note: {name!r} is a codec name, not a preset; pass it "
+                    f"as storage={{'codec': {name!r}}}."
+                )
             raise InvalidFiberIOError(msg)
         return cls.model_validate(cls.presets[name])
 
@@ -1798,6 +1807,14 @@ def _coerce_storage(storage, fiber_io):
     if storage_cls is None:
         msg = f"Format {fiber_io.name} does not support storage options."
         raise InvalidFiberIOError(msg)
+    if isinstance(storage, BaseCodec):
+        msg = (
+            f"Got codec {type(storage).__name__} for the storage argument; "
+            f"wrap it in storage options, e.g. "
+            f"storage={storage_cls.__name__}(codec=...) or "
+            "storage={'codec': ...}."
+        )
+        raise InvalidFiberIOError(msg)
     if isinstance(storage, storage_cls):
         return storage
     if isinstance(storage, str):
@@ -1833,6 +1850,15 @@ def write(
         format which supports multiple patches per file. If False (default)
         such patches raise a
         [`ParameterError`](`dascore.exceptions.ParameterError`).
+    **kwargs
+        Format-specific write options forwarded to the format's writer.
+        Most notably ``storage``: for formats that support it (see
+        [`get_storage`](`dascore.io.core.get_storage`)), storage options
+        controlling compression and on-disk layout. Accepts a storage
+        instance, a preset name string (e.g. ``storage="compressed"``), or
+        a dict of storage kwargs such as
+        ``storage={"codec": {"name": "gzip", "level": 5}, "chunks": {"time": 2000}}``.
+        Formats without storage support reject an explicit ``storage``.
 
     Raises
     ------

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -1812,6 +1812,38 @@ def get_codecs(
     return storage_cls.get_codecs()
 
 
+def _validate_write_kwargs(fiber_io, kwargs) -> None:
+    """
+    Reject write kwargs the format's writer does not declare.
+
+    Writers accept ``**kwargs`` for interface tolerance, so a misspelled
+    option name (e.g. ``stroage=``) would otherwise be silently swallowed
+    and produce a file that ignores what the caller asked for.
+    """
+    if not kwargs:
+        return
+    params = inspect.signature(fiber_io.write).parameters
+    names = [x for x in params if x != "self"]
+    # The first two parameters (the spool and resource) are filled by write();
+    # everything else the writer names is a valid user option.
+    allowed = {
+        name
+        for name in names[2:]
+        if params[name].kind
+        in (params[name].POSITIONAL_OR_KEYWORD, params[name].KEYWORD_ONLY)
+    }
+    unknown = set(kwargs) - allowed
+    if unknown:
+        unknown_str = ", ".join(sorted(unknown))
+        valid = ", ".join(sorted(allowed)) or "(none)"
+        msg = (
+            f"Unknown write option(s) {unknown_str} for format "
+            f"{fiber_io.name} version {fiber_io.version}. "
+            f"Supported options: {valid}."
+        )
+        raise ParameterError(msg)
+
+
 def _coerce_storage(storage, fiber_io):
     """
     Coerce a user-supplied storage argument to the format's storage model.
@@ -1872,12 +1904,14 @@ def write(
         such patches raise a
         [`ParameterError`](`dascore.exceptions.ParameterError`).
     **kwargs
-        Format-specific write options forwarded to the format's writer.
-        Most notably ``storage``: for formats that support it (see
-        [`get_storage`](`dascore.io.core.get_storage`)), storage options
-        controlling compression and on-disk layout. Accepts a storage
-        instance, a preset name string (e.g. ``storage="compressed"``), or
-        a dict of storage kwargs such as
+        Format-specific write options forwarded to the format's writer;
+        options the target writer does not declare raise a
+        [`ParameterError`](`dascore.exceptions.ParameterError`) rather than
+        being silently ignored. Most notably ``storage``: for formats that
+        support it (see [`get_storage`](`dascore.io.core.get_storage`)),
+        storage options controlling compression and on-disk layout. Accepts
+        a storage instance, a preset name string (e.g.
+        ``storage="compressed"``), or a dict of storage kwargs such as
         ``storage={"codec": {"name": "gzip", "level": 5}, "chunks": {"time": 2000}}``.
         Formats without storage support reject an explicit ``storage``.
 
@@ -1899,8 +1933,11 @@ def write(
     >>> path.unlink()
     """
     fiber_io = FiberIO.manager.get_fiberio(format=file_format, version=file_version)
+    # Coerce storage first so unsupported-storage formats give the specific
+    # "does not support storage options" error rather than the generic one.
     if "storage" in kwargs:
         kwargs["storage"] = _coerce_storage(kwargs["storage"], fiber_io)
+    _validate_write_kwargs(fiber_io, kwargs)
     if not isinstance(patch_or_spool, dc.BaseSpool):
         patch_or_spool = dc.spool([patch_or_spool])
     patch_or_spool = _maybe_split_gapped_patches(patch_or_spool, fiber_io, split)

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -15,16 +15,19 @@ from pathlib import Path
 from threading import RLock
 from typing import (
     Any,
+    ClassVar,
     Literal,
     NotRequired,
     Protocol,
     TypedDict,
     cast,
+    get_args,
     get_type_hints,
 )
 
 import numpy as np
 import pandas as pd
+from pydantic import ConfigDict
 
 import dascore as dc
 from dascore.compat import Progress, UPath
@@ -60,6 +63,7 @@ from dascore.utils.misc import (
     iterate,
     warn_or_raise,
 )
+from dascore.utils.models import DascoreBaseModel
 from dascore.utils.paths import coerce_to_local_path, coerce_to_upath, is_local_path
 from dascore.utils.plugins import get_entry_point_loaders
 from dascore.utils.progress import track
@@ -381,6 +385,65 @@ def _get_reloadable_source_path(
         if isinstance(candidate, str | Path | UPath):
             return coerce_to_upath(candidate)
     return ""
+
+
+class BaseCodec(DascoreBaseModel):
+    """
+    Base class for array payload transform options (codecs).
+
+    Concrete codecs declare a unique ``name`` as a ``Literal`` field so they
+    can act as discriminated-union members on a storage model and round-trip
+    through ``model_dump``/``model_validate``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BaseStorage(DascoreBaseModel):
+    """Base class for format-specific storage options."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: ClassVar[str] = ""
+    # Named presets mapping a preset name to storage kwargs, e.g.
+    # {"compressed": {"codec": {"name": "blosc:zstd"}}}.
+    presets: ClassVar[dict[str, dict]] = {}
+    # Codec base classes this storage can physically store. A registered codec
+    # is usable here only if it subclasses one of these.
+    supported_codec_bases: ClassVar[tuple[type[BaseCodec], ...]] = ()
+
+    def __init_subclass__(cls, **kwargs):
+        """Ensure storage subclasses declare their storage name."""
+        super().__init_subclass__(**kwargs)
+        if not cls.name:
+            msg = "You must specify the storage object with the name field."
+            raise InvalidFiberIOError(msg)
+
+    @classmethod
+    def from_preset(cls, name: str) -> BaseStorage:
+        """Build a storage instance from a named preset."""
+        if name not in cls.presets:
+            valid = ", ".join(sorted(cls.presets)) or "(none)"
+            msg = (
+                f"Unknown storage preset {name!r} for {cls.__name__}. "
+                f"Valid presets: {valid}."
+            )
+            raise InvalidFiberIOError(msg)
+        return cls.model_validate(cls.presets[name])
+
+    @classmethod
+    def get_codecs(cls) -> tuple[type[BaseCodec], ...]:
+        """Return the registered codec classes this storage can use."""
+        if not cls.supported_codec_bases:
+            return ()
+        # Imported lazily to avoid an import cycle (codec imports from io.core).
+        from dascore.io.codec import get_codec_registry
+
+        return tuple(
+            codec
+            for codec in get_codec_registry().values()
+            if issubclass(codec, cls.supported_codec_bases)
+        )
 
 
 class _FiberIOManager:
@@ -846,6 +909,17 @@ def _is_wrapped_func(func1, func2):
     return func is func2
 
 
+def _extract_storage_type(annotation):
+    """Return the BaseStorage subclass named by a type annotation, if any.
+
+    Handles a bare type (``DASDAEStorage``) and unions (``DASDAEStorage | None``).
+    """
+    for candidate in get_args(annotation) or (annotation,):
+        if isinstance(candidate, type) and issubclass(candidate, BaseStorage):
+            return candidate
+    return None
+
+
 class FiberIO:
     """
     An interface which adds support for a given filer format.
@@ -860,6 +934,8 @@ class FiberIO:
     input_type: Literal["file", "directory"] = "file"
     # True when a single resource can hold more than one patch.
     multi_patch_write: bool = False
+    # The format-specific storage options model supported by this IO.
+    storage_cls: type[BaseStorage] | None = None
 
     manager = _FiberIOManager("dascore.fiber_io")
 
@@ -977,6 +1053,7 @@ class FiberIO:
                     "get_format": fiberio.implements_get_format,
                     "read": fiberio.implements_read,
                     "write": fiberio.implements_write,
+                    "storage": fiberio.storage_cls is not None,
                 }
                 out.append(format_info)
         return pd.DataFrame(out)
@@ -1023,9 +1100,16 @@ class FiberIO:
             method = getattr(cls, name)
             sig = inspect.signature(method)
             arg_name = list(sig.parameters)[param_ind]
-            required_type = get_type_hints(method).get(arg_name)
+            hints = get_type_hints(method)
+            required_type = hints.get(arg_name)
             method_wrapped = _type_caster(method, sig, required_type, arg_name)
             setattr(cls, name, method_wrapped)
+            # Derive storage_cls from write()'s `storage` annotation so the
+            # storage type has a single source of truth (unless set explicitly).
+            if name == "write" and cls.__dict__.get("storage_cls") is None:
+                storage_type = _extract_storage_type(hints.get("storage"))
+                if storage_type is not None:
+                    cls.storage_cls = storage_type
 
 
 @_reinit_after_fork
@@ -1652,6 +1736,75 @@ def _maybe_split_gapped_patches(spool, fiber_io, split):
     return dc.spool(patches)
 
 
+def get_storage(
+    file_format: str,
+    file_version: str | None = None,
+) -> type[BaseStorage] | None:
+    """
+    Return the storage options class supported by a format/version.
+
+    Unknown formats raise UnknownFiberFormatError; known formats without
+    storage support return None.
+
+    Parameters
+    ----------
+    file_format
+        The known file format.
+    file_version
+        The known file version. If not provided, the newest version of the
+        format is used.
+    """
+    fiber_io = FiberIO.manager.get_fiberio(format=file_format, version=file_version)
+    return fiber_io.storage_cls
+
+
+def get_codecs(
+    file_format: str,
+    file_version: str | None = None,
+) -> tuple[type[BaseCodec], ...]:
+    """
+    Return the codec classes supported by a format/version.
+
+    Unknown formats raise UnknownFiberFormatError; known formats without
+    codec support return an empty tuple.
+
+    Parameters
+    ----------
+    file_format
+        The known file format.
+    file_version
+        The known file version. If not provided, the newest version of the
+        format is used.
+    """
+    storage_cls = get_storage(file_format=file_format, file_version=file_version)
+    if storage_cls is None:
+        return ()
+    return storage_cls.get_codecs()
+
+
+def _coerce_storage(storage, fiber_io):
+    """
+    Coerce a user-supplied storage argument to the format's storage model.
+
+    Accepts a storage instance, a dict of storage kwargs, or a preset name
+    string. Raises if the format declares no storage support.
+    """
+    storage_cls = fiber_io.storage_cls
+    if storage is None:
+        # Materialize the format's default storage so the write path never has
+        # to special-case None. Formats without storage support keep None (a
+        # harmless, ignored kwarg).
+        return None if storage_cls is None else storage_cls()
+    if storage_cls is None:
+        msg = f"Format {fiber_io.name} does not support storage options."
+        raise InvalidFiberIOError(msg)
+    if isinstance(storage, storage_cls):
+        return storage
+    if isinstance(storage, str):
+        return storage_cls.from_preset(storage)
+    return storage_cls.model_validate(storage)
+
+
 def write(
     patch_or_spool,
     path: path_types,
@@ -1699,6 +1852,8 @@ def write(
     >>> path.unlink()
     """
     fiber_io = FiberIO.manager.get_fiberio(format=file_format, version=file_version)
+    if "storage" in kwargs:
+        kwargs["storage"] = _coerce_storage(kwargs["storage"], fiber_io)
     if not isinstance(patch_or_spool, dc.BaseSpool):
         patch_or_spool = dc.spool([patch_or_spool])
     patch_or_spool = _maybe_split_gapped_patches(patch_or_spool, fiber_io, split)

--- a/dascore/io/dasdae/__init__.py
+++ b/dascore/io/dasdae/__init__.py
@@ -7,3 +7,4 @@ This is an experimental format and is subject to change.
 """
 from __future__ import annotations
 from .core import DASDAEV1
+from .storage import DASDAEStorage

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -83,8 +83,12 @@ class DASDAEV1(FiberIO):
         patches = [spool] if isinstance(spool, dc.Patch) else spool
         # Validate chunk dims against the data up front so a typo raises before
         # anything is written rather than silently producing an un-chunked file.
+        # Dims come from scan metadata: iterating a lazy spool here would load
+        # every data array once for validation and again in the write loop.
         if storage.chunks:
-            all_dims = {dim for patch in patches for dim in patch.dims}
+            scan_df = dc.scan_to_df(patches)
+            dims_rows = scan_df["dims"] if "dims" in scan_df.columns else ()
+            all_dims = {dim for row in dims_rows for dim in str(row).split(",") if dim}
             storage._validate_chunk_dims(all_dims)
         with contextlib.suppress(ValueError):
             resource.create_group("waveforms")

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -78,18 +78,22 @@ class DASDAEV1(FiberIO):
         """
         # write out patches
         storage = _coerce_storage(storage, self)
-        _write_meta(resource, self.version)
         # get an iterable of patches and save them
         patches = [spool] if isinstance(spool, dc.Patch) else spool
-        # Validate chunk dims against the data up front so a typo raises before
-        # anything is written rather than silently producing an un-chunked file.
-        # Dims come from scan metadata: iterating a lazy spool here would load
-        # every data array once for validation and again in the write loop.
+        # Validate chunk dims before writing any content so a typo raises
+        # instead of silently producing an un-chunked file (or leaving a
+        # DASDAE-stamped stub behind). Dims come from scan metadata:
+        # iterating a lazy spool here would load every data array once for
+        # validation and again in the write loop.
         if storage.chunks:
             scan_df = dc.scan_to_df(patches)
             dims_rows = scan_df["dims"] if "dims" in scan_df.columns else ()
             all_dims = {dim for row in dims_rows for dim in str(row).split(",") if dim}
-            storage._validate_chunk_dims(all_dims)
+            # An empty spool has nothing to chunk; write it like any other
+            # empty write rather than rejecting every chunk dim.
+            if len(scan_df):
+                storage._validate_chunk_dims(all_dims)
+        _write_meta(resource, self.version)
         with contextlib.suppress(ValueError):
             resource.create_group("waveforms")
         waveforms = resource["waveforms"]

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -9,11 +9,13 @@ import pandas as pd
 import dascore as dc
 from dascore.constants import SpoolType
 from dascore.io import FiberIO
+from dascore.io.core import _coerce_storage
 from dascore.utils.hdf5 import H5Reader, H5Writer
 from dascore.utils.io import _normalize_source_patch_ids
 from dascore.utils.misc import unbyte
 from dascore.utils.patch import get_patch_names
 
+from .storage import DASDAEStorage
 from .utils import (
     _get_contents_from_patch_groups_generic,
     _get_patch_attrs,
@@ -57,6 +59,7 @@ class DASDAEV1(FiberIO):
         self,
         spool: SpoolType,
         resource: H5Writer,
+        storage: DASDAEStorage | dict | str | None = None,
         **kwargs,
     ):
         """
@@ -68,11 +71,21 @@ class DASDAEV1(FiberIO):
             A collection of patches or a spool (same thing).
         resource
             The path to the file.
+        storage
+            DASDAE storage options controlling compression and chunk layout.
+            May be a ``DASDAEStorage``, a preset name (e.g. ``"compressed"``),
+            or a dict of storage kwargs. The default writes uncompressed arrays.
         """
         # write out patches
+        storage = _coerce_storage(storage, self)
         _write_meta(resource, self.version)
         # get an iterable of patches and save them
         patches = [spool] if isinstance(spool, dc.Patch) else spool
+        # Validate chunk dims against the data up front so a typo raises before
+        # anything is written rather than silently producing an un-chunked file.
+        if storage.chunks:
+            all_dims = {dim for patch in patches for dim in patch.dims}
+            storage._validate_chunk_dims(all_dims)
         with contextlib.suppress(ValueError):
             resource.create_group("waveforms")
         waveforms = resource["waveforms"]
@@ -87,7 +100,7 @@ class DASDAEV1(FiberIO):
             num = counts.get(name, 0)
             counts[name] = num + 1
             unique_name = name if num == 0 else f"{name}__{num}"
-            _save_patch(patch, waveforms, unique_name)
+            _save_patch(patch, waveforms, unique_name, storage)
 
     def _get_patch_summary(self, patches) -> pd.DataFrame:
         """Get a patch summary to put into index."""

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -9,11 +9,13 @@ import pandas as pd
 
 import dascore as dc
 from dascore.io import FiberIO
+from dascore.io.core import _coerce_storage
 from dascore.utils.hdf5 import H5Reader, H5Writer
 from dascore.utils.io import _normalize_source_patch_ids
 from dascore.utils.misc import unbyte
 from dascore.utils.patch import get_patch_names
 
+from .storage import DASDAEStorage
 from .utils import (
     _get_contents_from_patch_groups_generic,
     _get_patch_attrs,
@@ -57,6 +59,7 @@ class DASDAEV1(FiberIO):
         self,
         spool: dc.Patch | dc.BaseSpool,
         resource: H5Writer,
+        storage: DASDAEStorage | dict | str | None = None,
         **kwargs,
     ):
         """
@@ -68,11 +71,29 @@ class DASDAEV1(FiberIO):
             A collection of patches or a spool (same thing).
         resource
             The path to the file.
+        storage
+            DASDAE storage options controlling compression and chunk layout.
+            May be a ``DASDAEStorage``, a preset name (e.g. ``"compressed"``),
+            or a dict of storage kwargs. The default writes uncompressed arrays.
         """
         # write out patches
-        _write_meta(resource, self.version)
+        storage = _coerce_storage(storage, self)
         # get an iterable of patches and save them
         patches = [spool] if isinstance(spool, dc.Patch) else spool
+        # Validate chunk dims before writing any content so a typo raises
+        # instead of silently producing an un-chunked file (or leaving a
+        # DASDAE-stamped stub behind). Dims come from scan metadata:
+        # iterating a lazy spool here would load every data array once for
+        # validation and again in the write loop.
+        if storage.chunks:
+            scan_df = dc.scan_to_df(patches)
+            dims_rows = scan_df["dims"] if "dims" in scan_df.columns else ()
+            all_dims = {dim for row in dims_rows for dim in str(row).split(",") if dim}
+            # An empty spool has nothing to chunk; write it like any other
+            # empty write rather than rejecting every chunk dim.
+            if len(scan_df):
+                storage._validate_chunk_dims(all_dims)
+        _write_meta(resource, self.version)
         with contextlib.suppress(ValueError):
             resource.create_group("waveforms")
         waveforms = resource["waveforms"]
@@ -87,7 +108,7 @@ class DASDAEV1(FiberIO):
             num = counts.get(name, 0)
             counts[name] = num + 1
             unique_name = name if num == 0 else f"{name}__{num}"
-            _save_patch(patch, waveforms, unique_name)
+            _save_patch(patch, waveforms, unique_name, storage)
 
     def _get_patch_summary(self, patches) -> pd.DataFrame:
         """Get a patch summary to put into index."""

--- a/dascore/io/dasdae/storage.py
+++ b/dascore/io/dasdae/storage.py
@@ -1,0 +1,145 @@
+"""Storage options for DASDAE files."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import SerializeAsAny, field_validator, model_validator
+
+from dascore.io.codec import _codec_name, get_codec
+from dascore.io.core import BaseCodec, BaseStorage
+from dascore.io.hdf5 import HDF5Codec
+
+
+class DASDAEStorage(BaseStorage):
+    """
+    Storage options for DASDAE HDF5 files.
+
+    Parameters
+    ----------
+    codec
+        The compression codec. May be a codec instance, a codec name string
+        (e.g. ``"gzip"``), or a dict such as ``{"name": "gzip", "level": 3}``.
+        ``None`` (default) writes uncompressed arrays. Codec names are resolved
+        against the codec registry, so codecs added by plugins are usable here
+        as long as DASDAE can store them (see ``supported_codec_bases``).
+    chunks
+        A mapping of dimension name to chunk length used for the on-disk array
+        layout, e.g. ``{"time": 2000, "distance": 64}``. Dimensions absent from
+        the mapping use the full array length. Required by HDF5 for compression
+        but also usable on its own for faster partial reads.
+
+    Notes
+    -----
+    The codec and chunk layout apply to the patch data arrays and to the
+    coordinate arrays (chunks match coordinate arrays by dimension name).
+    """
+
+    name: ClassVar[str] = "dasdae"
+    presets: ClassVar[dict[str, dict]] = {
+        "compressed": {"codec": {"name": "gzip", "level": 5}},
+    }
+    # DASDAE stores arrays via native HDF5 dataset filters, so it supports
+    # HDF5-filter codecs. Byte-transform codecs would need a blob storage path.
+    supported_codec_bases: ClassVar[tuple[type[BaseCodec], ...]] = (HDF5Codec,)
+
+    codec: SerializeAsAny[BaseCodec] | None = None
+    chunks: dict[str, int] | None = None
+
+    @field_validator("codec", mode="before")
+    @classmethod
+    def _resolve_codec(cls, value):
+        """Resolve a codec from an instance, a name string, or a dict."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = {"name": value}
+        if isinstance(value, BaseCodec):
+            codec = value
+        elif isinstance(value, dict):
+            if "name" not in value:
+                msg = "codec dict must include a 'name' key."
+                raise ValueError(msg)
+            codec_cls = get_codec(value["name"])
+            codec = codec_cls(**value)
+        else:
+            msg = f"Cannot interpret codec value {value!r}."
+            raise ValueError(msg)
+        if not isinstance(codec, cls.supported_codec_bases):
+            allowed = ", ".join(c.__name__ for c in cls.supported_codec_bases)
+            msg = (
+                f"{cls.__name__} cannot store codec of type "
+                f"{type(codec).__name__}; it supports codecs of type: {allowed}."
+            )
+            raise ValueError(msg)
+        # Reject codec instances with no registered discriminator (e.g. a bare
+        # HDF5Codec()) here rather than erroring opaquely mid-write, and mark
+        # the discriminator as explicitly set so exclude_unset dumps (used by
+        # DascoreBaseModel.new) still include it and can round-trip.
+        name = getattr(codec, "name", None) or _codec_name(type(codec))
+        if "name" not in codec.model_fields_set:
+            codec = codec.model_copy(update={"name": name})
+        return codec
+
+    @model_validator(mode="after")
+    def _validate_chunks(self):
+        """Ensure chunk sizes are positive."""
+        for dim, size in (self.chunks or {}).items():
+            if size <= 0:
+                msg = f"chunk sizes must be positive, got {size} for {dim!r}."
+                raise ValueError(msg)
+        return self
+
+    def _validate_chunk_dims(self, dims) -> None:
+        """
+        Ensure configured chunk dims correspond to real dimensions.
+
+        Chunk dim names are not known to be valid at construction time (the
+        patch is not available), so a typo (e.g. ``"tim"`` for ``"time"``)
+        would otherwise be silently ignored, leaving the array un-chunked.
+        """
+        if not self.chunks:
+            return
+        unknown = set(self.chunks) - set(dims)
+        if unknown:
+            unknown_str = ", ".join(repr(x) for x in sorted(unknown))
+            valid_str = ", ".join(repr(x) for x in dims) or "(none)"
+            msg = (
+                f"Unknown chunk dimension(s): {unknown_str}. "
+                f"Valid dimensions: {valid_str}."
+            )
+            raise ValueError(msg)
+
+    def _resolve_chunkshape(self, dims, shape) -> tuple[int, ...] | None:
+        """
+        Resolve the chunk shape for a single array given its dims and shape.
+
+        Returns None (stay contiguous, or let h5py decide when compressing)
+        when no chunks are configured, the array is scalar, or dims don't
+        match the array.
+        """
+        if self.chunks is None or not shape or len(dims) != len(shape):
+            return None
+        return tuple(
+            min(self.chunks.get(dim, size), size)
+            for dim, size in zip(dims, shape, strict=True)
+        )
+
+    def _dataset_options(self, dims, shape) -> dict:
+        """
+        Return h5py ``create_dataset`` options for one array.
+
+        Combines the codec's compression kwargs with the chunk shape resolved
+        for the array's dims. An empty dict means default contiguous storage.
+        """
+        codec = self.codec
+        if codec is None:
+            out = {}
+        else:
+            # _resolve_codec guarantees only HDF5-filter codecs get this far.
+            assert isinstance(codec, HDF5Codec)
+            out = codec._dataset_kwargs()
+        chunkshape = self._resolve_chunkshape(dims, shape)
+        if chunkshape is not None:
+            out["chunks"] = chunkshape
+        return out

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -93,7 +93,7 @@ def _save_attrs_and_dims(patch, patch_group):
     patch_group.attrs["_dims"] = ",".join(patch.dims)
 
 
-def _save_array(data, name, group):
+def _save_array(data, name, group, dataset_options=None):
     """Save an array to a group, handling datetime and string values."""
     data = np.asarray(data)
     is_dt = np.issubdtype(data.dtype, np.datetime64)
@@ -107,7 +107,11 @@ def _save_array(data, name, group):
     if name in group:
         # Overwrite the dataset in place when callers resave the same array node.
         del group[name]
-    array_node = group.create_dataset(name, data=data)
+    # Compression/chunking need a non-empty, non-scalar dataset; anything else
+    # stays contiguous (a chunk shape may not contain zeros).
+    if not (dataset_options and data.size and data.shape):
+        dataset_options = {}
+    array_node = group.create_dataset(name, data=data, **dataset_options)
     array_node.attrs["is_datetime64"] = is_dt
     array_node.attrs["is_timedelta64"] = is_td
     array_node.attrs["is_string"] = is_str
@@ -116,7 +120,7 @@ def _save_array(data, name, group):
     return array_node
 
 
-def _save_coords(patch, patch_group):
+def _save_coords(patch, patch_group, storage):
     """Save coordinates."""
     cm = patch.coords
     for name, coord in cm.coord_map.items():
@@ -124,7 +128,8 @@ def _save_coords(patch, patch_group):
         # First save coordinate arrays
         data = coord.values
         save_name = f"_coord_{name}"
-        array_node = _save_array(data, save_name, patch_group)
+        dataset_options = storage._dataset_options(dims, np.shape(data))
+        array_node = _save_array(data, save_name, patch_group, dataset_options)
         step = coord.step
         if step is not None:
             is_td = np.issubdtype(np.asarray(step).dtype, np.timedelta64)
@@ -137,7 +142,7 @@ def _save_coords(patch, patch_group):
         patch_group.attrs[save_name] = ",".join(dims)
 
 
-def _save_patch(patch, wave_group, name):
+def _save_patch(patch, wave_group, name, storage):
     """Save the patch to disk."""
     if name in wave_group:
         # Replace the entire patch group so stale datasets/attrs can't survive.
@@ -147,10 +152,11 @@ def _save_patch(patch, wave_group, name):
     # in the separated-attrs form and must not be legacy-stripped on read.
     patch_group.attrs[_SEPARATE_ATTRS_KEY] = True
     _save_attrs_and_dims(patch, patch_group)
-    _save_coords(patch, patch_group)
+    _save_coords(patch, patch_group, storage)
     # add data
     if patch.data.shape:
-        _save_array(patch.data, "data", patch_group)
+        dataset_options = storage._dataset_options(patch.dims, patch.data.shape)
+        _save_array(patch.data, "data", patch_group, dataset_options)
 
 
 # --- Functions for reading
@@ -170,10 +176,8 @@ def _get_attrs(patch_group):
     return out
 
 
-def _read_array(table_array):
-    """Read an array into numpy."""
-    data = table_array[:]
-    attrs = table_array.attrs
+def _decode_array_values(data, attrs):
+    """Restore datetime/string dtypes stripped by _save_array on write."""
     if attrs.get("is_datetime64"):
         data = data.view("datetime64[ns]")
     if attrs.get("is_timedelta64"):
@@ -182,6 +186,11 @@ def _read_array(table_array):
         original_dtype = unbyte(attrs.get("original_string_dtype", ""))
         data = convert_bytes_to_strings(data, original_dtype)
     return data
+
+
+def _read_array(table_array):
+    """Read an array into numpy."""
+    return _decode_array_values(table_array[:], table_array.attrs)
 
 
 def _read_array_sample(table_array, index):
@@ -299,6 +308,7 @@ def _read_patch(patch_group, legacy: bool = True, **kwargs):
         attr_info = attrs
     attr_info["_source_patch_id"] = patch_group.name.rsplit("/", maxsplit=1)[-1]
     attrs = PatchAttrs.from_dict(attr_info)
+    data_node = patch_group["data"]
     # Note, previously this was wrapped with try, except (Index, KeyError)
     # and the data = np.array(None) in except block. Not sure, why, removed
     # try except.
@@ -314,11 +324,12 @@ def _read_patch(patch_group, legacy: bool = True, **kwargs):
             and ((i not in cmap) or (len(cmap[i]) == 1))
         }
         if sub_kwargs:
-            coords, data = coords.select(array=patch_group["data"], **sub_kwargs)
+            coords, data = coords.select(array=data_node, **sub_kwargs)
+            data = _decode_array_values(np.asarray(data), data_node.attrs)
         else:
-            data = patch_group["data"][:]
+            data = _read_array(data_node)
     else:
-        data = patch_group["data"][:]
+        data = _read_array(data_node)
     return dc.Patch(data=data, coords=coords, dims=dims, attrs=attrs)
 
 

--- a/dascore/io/hdf5.py
+++ b/dascore/io/hdf5.py
@@ -1,0 +1,49 @@
+"""HDF5 IO storage codecs."""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import model_validator
+
+from dascore.io.core import BaseCodec
+
+
+class HDF5Codec(BaseCodec):
+    """
+    Base class for codecs which map to native HDF5 dataset filters.
+
+    Concrete subclasses set ``_compression`` (the h5py ``compression`` value)
+    and declare a unique ``name`` Literal field.
+    """
+
+    level: int = 5
+    shuffle: bool = True
+
+    # The h5py compression name; set by concrete subclasses.
+    _compression: ClassVar[str] = ""
+
+    @model_validator(mode="after")
+    def _validate_level(self):
+        """Ensure compression level fits the HDF5 range."""
+        if not 0 <= self.level <= 9:
+            msg = "level must be between 0 and 9."
+            raise ValueError(msg)
+        return self
+
+    def _dataset_kwargs(self) -> dict:
+        """Return h5py dataset creation kwargs, empty when disabled."""
+        if self.level == 0:
+            return {}
+        return {
+            "compression": self._compression,
+            "compression_opts": self.level,
+            "shuffle": self.shuffle,
+        }
+
+
+class Gzip(HDF5Codec):
+    """Portable gzip (zlib/deflate) HDF5 compression."""
+
+    name: Literal["gzip"] = "gzip"
+    _compression: ClassVar[str] = "gzip"

--- a/dascore/io/netcdf/core.py
+++ b/dascore/io/netcdf/core.py
@@ -83,39 +83,47 @@ class NetCDFCFV18(FiberIO):
             return dc.spool([])
         return dc.spool([patch])
 
-    def _get_write_encoding(self, **kwargs):
+    def _get_write_encoding(self, compression=None, compression_opts=None, chunks=None):
         """Translate explicit write options into xarray encoding hints."""
-        compression = kwargs.get("compression")
         if compression not in ("gzip", None, False):
             msg = "xarray netcdf4 writing currently supports only gzip compression."
             raise ValueError(msg)
-        chunks = kwargs.get("chunks")
         encoding: dict[str, object] = {}
         if chunks not in (None, False, True):
             encoding["chunksizes"] = tuple(chunks)
         if compression == "gzip":
             encoding["zlib"] = True
-            encoding["complevel"] = kwargs.get("compression_opts", 4)
+            encoding["complevel"] = 4 if compression_opts is None else compression_opts
             encoding["shuffle"] = True
         return encoding
 
-    def write(self, spool: dc.Patch | dc.BaseSpool, resource: Path, **kwargs) -> None:
+    def write(
+        self,
+        spool: dc.Patch | dc.BaseSpool,
+        resource: Path,
+        compression=None,
+        compression_opts=None,
+        chunks=None,
+        **kwargs,
+    ) -> None:
         """
         Write a Spool to NetCDF-4 through xarray.
 
         Parameters
         ----------
-        kwargs
-            compression: 'gzip', None, or False
-            compression_opts: gzip level 1-9 (default 4)
-            chunks: True to defer chunking to xarray/backend defaults, or an
-                explicit tuple of chunk sizes
+        compression
+            'gzip', None, or False.
+        compression_opts
+            gzip level 1-9 (default 4).
+        chunks
+            True to defer chunking to xarray/backend defaults, or an
+            explicit tuple of chunk sizes.
         """
         patch = self._validate_and_extract_patch(spool)
         optional_import("xarray")  # raises a helpful error if xarray is absent
         dataset = patch_to_xarray(patch).rename("data").to_dataset()
         dataset.attrs["Conventions"] = f"CF-{self.version}"
-        encoding = self._get_write_encoding(**kwargs)
+        encoding = self._get_write_encoding(compression, compression_opts, chunks)
         dataset.to_netcdf(
             resource,
             encoding={"data": encoding} if encoding else None,

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -48,6 +48,34 @@ patch = dc.get_example_patch()
 patch.io.write(write_path, "dasdae")
 ```
 
+DASDAE compression is configured via the `storage` argument. The simplest form is a preset name; `"compressed"` uses the recommended general-purpose compression.
+
+```{python}
+patch.io.write(write_path, "dasdae", storage="compressed")
+```
+
+For finer control, pass a dict (no imports needed) selecting a codec and, optionally, a per-dimension chunk layout. Use the `gzip` codec for portable HDF5 compression.
+
+```{python}
+#| eval: false
+patch.io.write(
+    write_path,
+    "dasdae",
+    storage={"codec": {"name": "gzip", "level": 5}, "chunks": {"time": 2000}},
+)
+```
+
+The equivalent typed form uses `DASDAEStorage` and the codec classes, which is handy for editor completion and type checking.
+
+```{python}
+#| eval: false
+from dascore.io.dasdae import DASDAEStorage
+from dascore.io.hdf5 import Gzip
+
+storage = DASDAEStorage(codec=Gzip(level=5), chunks={"time": 2000})
+patch.io.write(write_path, "dasdae", storage=storage)
+```
+
 ```{python}
 #| echo: false
 if write_path.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,11 @@ NETCDF_CF__V1_8 = "dascore.io.netcdf.core:NetCDFCFV18"
 MSEED__V2 = "dascore.io.mseed.core:MSeedV2"
 MSEED__V3 = "dascore.io.mseed.core:MSeedV3"
 
+[project.entry-points."dascore.codec"]
+# Storage codecs. External packages may register additional codecs by pointing
+# an entry point in this group at a dascore.io.core.BaseCodec subclass.
+GZIP = "dascore.io.hdf5:Gzip"
+
 [project.entry-points."dascore.patch_namespace"]
 io = "dascore.io:PatchIO"
 viz = "dascore.viz:VizPatchNameSpace"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,11 @@ NETCDF_CF__V1_8 = "dascore.io.netcdf.core:NetCDFCFV18"
 MSEED__V2 = "dascore.io.mseed.core:MSeedV2"
 MSEED__V3 = "dascore.io.mseed.core:MSeedV3"
 
+[project.entry-points."dascore.codec"]
+# Storage codecs. External packages may register additional codecs by pointing
+# an entry point in this group at a dascore.io.core.BaseCodec subclass.
+GZIP = "dascore.io.hdf5:Gzip"
+
 [project.entry-points."dascore.patch_namespace"]
 io = "dascore.io:PatchIO"
 viz = "dascore.viz:VizPatchNameSpace"

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pickle
 import shutil
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 import h5py
 import numpy as np
@@ -18,8 +18,10 @@ from dascore.config import config_context
 from dascore.core.coords import CoordString
 from dascore.exceptions import InvalidFiberFileError
 from dascore.io import dasdae as dasdae_mod
+from dascore.io.core import BaseCodec
 from dascore.io.dasdae._compat import translate_legacy_attrs
 from dascore.io.dasdae.core import DASDAEV1
+from dascore.io.dasdae.storage import DASDAEStorage
 from dascore.io.dasdae.utils import (
     _decode_attr_value,
     _decode_legacy_attr_value,
@@ -29,15 +31,23 @@ from dascore.io.dasdae.utils import (
     _get_coords,
     _get_file_version,
     _get_scan_payload_from_group,
+    _read_array,
     _save_array,
     _save_patch,
 )
+from dascore.io.hdf5 import Gzip
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
 
 # a list of fixture names for written DASDAE files
 WRITTEN_FILES = []
+
+
+class _UnsupportedCodec(BaseCodec):
+    """A non-HDF5 codec used to test DASDAE storage validation."""
+
+    name: Literal["unsupported"] = "unsupported"
 
 
 @pytest.fixture(scope="class")
@@ -89,6 +99,14 @@ def dasdae_v1_file_path(request):
 class TestWriteDASDAE:
     """Ensure the format can be written."""
 
+    def _assert_data_compression(self, path, *, compression, level=None):
+        """Assert the stored DASDAE data array has the expected compression."""
+        with h5py.File(path) as h5:
+            group = next(iter(h5["waveforms"].values()))
+            assert group["data"].compression == compression
+            if level is not None:
+                assert group["data"].compression_opts == level
+
     def test_file_exists(self, dasdae_v1_file_path):
         """The file should *of course* exist."""
         assert Path(dasdae_v1_file_path).exists()
@@ -137,6 +155,272 @@ class TestWriteDASDAE:
         """Ensure cross correlated patches can be written and read."""
         sp_cc = dc.spool(written_dascore_correlate)
         assert isinstance(sp_cc[0], dc.Patch)
+
+    def test_write_compressed_with_storage(self, tmp_path_factory, random_patch):
+        """DASDAE can write compressed arrays with a storage object."""
+        path = tmp_path_factory.mktemp("dasdae_compressed") / "compressed.h5"
+        storage = DASDAEStorage(codec=Gzip(level=5))
+        dc.write(random_patch, path, "DASDAE", storage=storage)
+        self._assert_data_compression(path, compression="gzip", level=5)
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_compressed_file_is_smaller(self, tmp_path_factory, random_patch):
+        """Compression must actually shrink a compressible file on disk."""
+        base = tmp_path_factory.mktemp("dasdae_size_check")
+        # Constant data compresses extremely well, so any real compression
+        # must produce a much smaller file than the uncompressed write.
+        patch = random_patch.new(data=np.ones_like(random_patch.data))
+        patch.io.write(base / "plain.h5", "DASDAE")
+        patch.io.write(base / "compressed.h5", "DASDAE", storage="compressed")
+        plain = (base / "plain.h5").stat().st_size
+        compressed = (base / "compressed.h5").stat().st_size
+        assert compressed < plain / 2
+
+    def test_direct_write_coerces_storage(self, tmp_path_factory, random_patch):
+        """Direct DASDAEV1 writes accept the same storage shorthand as dc.write."""
+        path = tmp_path_factory.mktemp("dasdae_direct_storage") / "compressed.h5"
+        with h5py.File(path, mode="w") as h5:
+            DASDAEV1().write(random_patch, h5, storage="compressed")
+        self._assert_data_compression(path, compression="gzip", level=5)
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_default_storage_skips_chunk_validation(
+        self, tmp_path_factory, random_patch, monkeypatch
+    ):
+        """Unchunked writes do not scan dims only to no-op validation."""
+        path = tmp_path_factory.mktemp("dasdae_no_chunk_validation") / "out.h5"
+
+        def raise_if_called(*args, **kwargs):
+            raise AssertionError("chunk validation should be skipped")
+
+        monkeypatch.setattr(DASDAEStorage, "_validate_chunk_dims", raise_if_called)
+        random_patch.io.write(path, "DASDAE")
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_compressed_selective_read(self, tmp_path_factory, random_patch):
+        """Selecting from a compressed file must match selecting in memory."""
+        path = tmp_path_factory.mktemp("dasdae_compressed_select") / "out.h5"
+        random_patch.io.write(path, "DASDAE", storage="compressed")
+        dist = random_patch.get_coord("distance").values
+        select = {"distance": (dist[0], dist[len(dist) // 2])}
+        from_disk = dc.spool(path).select(**select)[0]
+        in_memory = random_patch.select(**select)
+        assert from_disk.equals(in_memory)
+
+    def test_write_compressed_empty_coord(self, tmp_path_factory, random_patch):
+        """Compressed DASDAE writes preserve zero-length arrays."""
+        path = tmp_path_factory.mktemp("dasdae_compressed_empty") / "out.h5"
+        time = random_patch.get_coord("time")
+        empty_patch = random_patch.select(time=(time.max() + 3 * time.step, ...))
+        empty_patch.io.write(path, "dasdae", storage="compressed")
+        new_patch = dc.read(path)[0]
+        assert empty_patch.equals(new_patch)
+
+    def test_compressed_scalar_array_falls_back(self, tmp_path_factory):
+        """DASDAE compression skips scalar arrays HDF5 cannot chunk."""
+        path = tmp_path_factory.mktemp("dasdae_compressed_scalar") / "out.h5"
+        options = DASDAEStorage.from_preset("compressed")._dataset_options((), ())
+        with h5py.File(path, mode="w") as h5:
+            node = _save_array(np.array(1), "scalar", h5, options)
+            assert node.shape == ()
+            assert node.compression is None
+
+    def test_write_dict_codec_coercion(self, tmp_path_factory, random_patch):
+        """A dict/string codec shorthand is coerced by the write path."""
+        path = tmp_path_factory.mktemp("dasdae_gzip") / "gzip.h5"
+        random_patch.io.write(path, "DASDAE", storage={"codec": "gzip"})
+        self._assert_data_compression(path, compression="gzip")
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_write_compressed_with_gzip(self, tmp_path_factory, random_patch):
+        """DASDAE can use portable gzip HDF5 compression."""
+        path = tmp_path_factory.mktemp("dasdae_gzip") / "gzip.h5"
+        random_patch.io.write(path, "DASDAE", storage=DASDAEStorage(codec=Gzip()))
+        self._assert_data_compression(path, compression="gzip")
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_chunked_unicode_array_roundtrips(self, tmp_path_factory):
+        """Chunked/compressed string arrays preserve non-ASCII values."""
+        path = tmp_path_factory.mktemp("dasdae_unicode_array") / "out.h5"
+        data = np.array(["cafe", "café"], dtype="U8")
+        storage = DASDAEStorage.from_preset("compressed")
+        options = storage._dataset_options(("label",), data.shape) | {"chunks": (1,)}
+        with h5py.File(path, mode="w") as h5:
+            node = _save_array(data, "labels", h5, options)
+            assert node[:].dtype.kind == "S"
+            assert np.array_equal(_read_array(node), data)
+
+    def test_unicode_patch_data_roundtrips(self, tmp_path_factory):
+        """Compressed patches whose data is a unicode array round-trip exactly."""
+        path = tmp_path_factory.mktemp("dasdae_unicode_data") / "out.h5"
+        data = np.array([["café", "naïve"], ["日本", "ok"]], dtype="U8")
+        patch = dc.Patch(
+            data=data,
+            coords={"distance": [0.0, 1.0], "time": [0.0, 1.0]},
+            dims=("distance", "time"),
+        )
+        patch.io.write(path, "dasdae", storage="compressed")
+        loaded = dc.read(path)[0]
+        assert loaded.data.dtype.kind == "U"
+        assert np.array_equal(loaded.data, data)
+
+    def test_write_with_chunks(self, tmp_path_factory, random_patch):
+        """DASDAE storage can specify a per-dimension chunk layout."""
+        path = tmp_path_factory.mktemp("dasdae_chunkshape") / "chunked.h5"
+        storage = DASDAEStorage(codec=Gzip(), chunks={"distance": 10, "time": 10})
+        random_patch.io.write(path, "DASDAE", storage=storage)
+        with h5py.File(path) as h5:
+            group = next(iter(h5["waveforms"].values()))
+            assert group["data"].chunks == (10, 10)
+            # Coordinate arrays share the layout, chunked by their dim name.
+            assert group["_coord_distance"].chunks == (10,)
+            assert group["_coord_distance"].compression == "gzip"
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_explicit_storage_none_writes_default(self, tmp_path_factory, random_patch):
+        """An explicit storage=None is normalized to the default and round-trips."""
+        path = tmp_path_factory.mktemp("dasdae_storage_none") / "out.h5"
+        dc.write(random_patch, path, "DASDAE", storage=None)
+        with h5py.File(path) as h5:
+            group = next(iter(h5["waveforms"].values()))
+            # Default storage is uncompressed.
+            assert group["data"].compression is None
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_typoed_chunk_dim_raises_on_write(self, tmp_path_factory, random_patch):
+        """A chunk dim that isn't a real patch dim raises instead of no-op."""
+        path = tmp_path_factory.mktemp("dasdae_chunk_typo") / "out.h5"
+        with pytest.raises(ValueError, match="Unknown chunk dimension"):
+            random_patch.io.write(path, "DASDAE", storage={"chunks": {"tim": 500}})
+        # Validation happens before any patch data is written.
+        with h5py.File(path) as h5:
+            assert "waveforms" not in h5
+
+    def test_chunks_without_codec(self, tmp_path_factory, random_patch):
+        """Chunks apply even without a codec (chunked-uncompressed layout)."""
+        path = tmp_path_factory.mktemp("dasdae_chunks_only") / "chunked.h5"
+        random_patch.io.write(path, "DASDAE", storage={"chunks": {"time": 500}})
+        with h5py.File(path) as h5:
+            group = next(iter(h5["waveforms"].values()))
+            # time is the second dim; chunk length clamps to the request.
+            assert group["data"].chunks[1] == 500
+            assert group["data"].compression is None
+        assert dc.read(path)[0].equals(random_patch)
+
+
+class TestDASDAEStorage:
+    """Tests for DASDAE storage settings."""
+
+    def test_default_is_uncompressed(self):
+        """Default storage produces no dataset options and no chunking."""
+        storage = DASDAEStorage()
+        assert storage._dataset_options(("distance", "time"), (3, 4)) == {}
+        assert storage._resolve_chunkshape(("distance", "time"), (3, 4)) is None
+
+    def test_compressed_preset_uses_default_codec(self):
+        """The compressed preset uses the DASDAE default codec."""
+        storage = DASDAEStorage.from_preset("compressed")
+        assert storage.codec == Gzip(level=5)
+        options = storage._dataset_options(("time",), (10,))
+        assert options["compression"] == "gzip"
+        assert options["compression_opts"] == 5
+
+    def test_codec_string_shorthand(self):
+        """A bare codec name is coerced to the codec instance."""
+        assert DASDAEStorage(codec="gzip").codec == Gzip()
+
+    def test_codec_dict_shorthand(self):
+        """A codec dict is dispatched by its discriminator name."""
+        assert DASDAEStorage(codec={"name": "gzip", "level": 3}).codec == Gzip(level=3)
+
+    def test_codec_dict_requires_name(self):
+        """Codec dictionaries must include the registry discriminator."""
+        with pytest.raises(ValueError, match="name"):
+            DASDAEStorage(codec={"level": 3})
+
+    def test_bad_codec_input_raises(self):
+        """Unsupported codec input types raise a clear error."""
+        with pytest.raises(ValueError, match="Cannot interpret codec"):
+            DASDAEStorage(codec=object())
+
+    def test_unsupported_codec_base_raises(self):
+        """DASDAE rejects codecs it cannot store in HDF5 arrays."""
+        with pytest.raises(ValueError, match="cannot store codec"):
+            DASDAEStorage(codec=_UnsupportedCodec())
+
+    def test_unknown_codec_name_raises(self):
+        """An unknown codec name reports it is unregistered."""
+        with pytest.raises(ValueError, match="Unknown codec"):
+            DASDAEStorage(codec="lz4")
+
+    def test_gzip_codec_maps_to_h5py_kwargs(self):
+        """Gzip codec maps to the h5py gzip dataset kwargs."""
+        options = DASDAEStorage(codec=Gzip(level=3))._dataset_options(("time",), (10,))
+        assert options == {
+            "compression": "gzip",
+            "compression_opts": 3,
+            "shuffle": True,
+        }
+
+    def test_level_zero_codec_disables_compression(self):
+        """A level-0 codec writes uncompressed without erroring."""
+        storage = DASDAEStorage(codec=Gzip(level=0))
+        assert storage._dataset_options(("time",), (10,)) == {}
+
+    def test_bare_base_codec_rejected_at_construction(self):
+        """A codec base class with no registered name fails fast, not mid-write."""
+        from dascore.io.hdf5 import HDF5Codec
+
+        with pytest.raises(ValueError, match="name"):
+            DASDAEStorage(codec=HDF5Codec(level=5))
+
+    def test_new_preserves_codec(self):
+        """Deriving a modified storage with .new() keeps the codec (GH #734)."""
+        for storage in (
+            DASDAEStorage.from_preset("compressed"),
+            DASDAEStorage(codec="gzip"),
+            DASDAEStorage(codec=Gzip(level=3)),
+            DASDAEStorage(codec={"name": "gzip", "level": 4}),
+        ):
+            new = storage.new(chunks={"time": 100})
+            assert new.codec == storage.codec
+            assert new.chunks == {"time": 100}
+
+    def test_chunkshape_resolves_by_dim_name(self):
+        """Chunks map dim names to lengths, clamped to the array shape."""
+        storage = DASDAEStorage(chunks={"time": 5})
+        # time is the second dim here; distance uses its full length.
+        assert storage._resolve_chunkshape(("distance", "time"), (3, 20)) == (3, 5)
+        # request larger than the array is clamped down.
+        assert storage._resolve_chunkshape(("time",), (4,)) == (4,)
+        # scalar/mismatched arrays are left contiguous.
+        assert storage._resolve_chunkshape((), ()) is None
+
+    def test_negative_chunk_raises(self):
+        """Chunk sizes must be positive."""
+        with pytest.raises(ValueError, match="positive"):
+            DASDAEStorage(chunks={"time": 0})
+
+    def test_unknown_chunk_dim_raises(self):
+        """A chunk dim that matches no real dimension is rejected."""
+        storage = DASDAEStorage(chunks={"tim": 5})
+        with pytest.raises(ValueError, match="Unknown chunk dimension"):
+            storage._validate_chunk_dims(("distance", "time"))
+
+    def test_known_chunk_dims_pass(self):
+        """Valid chunk dims validate without error."""
+        storage = DASDAEStorage(chunks={"time": 5})
+        # Should not raise.
+        storage._validate_chunk_dims(("distance", "time"))
+
+    def test_validate_chunk_dims_no_chunks_returns(self):
+        """Default storage has no chunk dims to validate."""
+        storage = DASDAEStorage()
+        storage._validate_chunk_dims(())
+
+    def test_get_codecs(self):
+        """DASDAE reports the registered HDF5 codecs it can store."""
+        assert set(DASDAEStorage.get_codecs()) == {Gzip}
 
 
 class TestReadDASDAE:
@@ -470,8 +754,13 @@ class TestDASDAEInternalHelpers:
         path = tmp_path / "overwrite_patch.h5"
         with h5py.File(path, "w") as h5:
             waveforms = h5.create_group("waveforms")
-            _save_patch(random_patch, waveforms, "patch_0")
-            _save_patch(random_patch.update_attrs(tag="new"), waveforms, "patch_0")
+            _save_patch(random_patch, waveforms, "patch_0", DASDAEStorage())
+            _save_patch(
+                random_patch.update_attrs(tag="new"),
+                waveforms,
+                "patch_0",
+                DASDAEStorage(),
+            )
             attrs = _get_attrs(waveforms["patch_0"])
             assert attrs["tag"] == "new"
 

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -263,6 +263,24 @@ class TestWriteDASDAE:
         loaded = dc.read(path)[0]
         assert loaded.data.dtype.kind == "U"
         assert np.array_equal(loaded.data, data)
+        # The selective-read branch decodes through the same attr-aware path.
+        selected = dc.read(path, distance=(0.0, 0.0))[0]
+        assert selected.data.dtype.kind == "U"
+        assert np.array_equal(selected.data, data[:1])
+
+    def test_datetime_patch_data_selective_read(self, tmp_path_factory):
+        """Datetime data arrays keep their dtype through selective reads."""
+        path = tmp_path_factory.mktemp("dasdae_datetime_data") / "out.h5"
+        data = to_datetime64(["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"])
+        patch = dc.Patch(
+            data=data.reshape(2, 2),
+            coords={"distance": [0.0, 1.0], "time": [0.0, 1.0]},
+            dims=("distance", "time"),
+        )
+        patch.io.write(path, "dasdae", storage="compressed")
+        selected = dc.read(path, distance=(0.0, 0.0))[0]
+        assert np.issubdtype(selected.data.dtype, np.datetime64)
+        assert np.array_equal(selected.data, data.reshape(2, 2)[:1])
 
     def test_write_with_chunks(self, tmp_path_factory, random_patch):
         """DASDAE storage can specify a per-dimension chunk layout."""
@@ -286,6 +304,29 @@ class TestWriteDASDAE:
             # Default storage is uncompressed.
             assert group["data"].compression is None
         assert dc.read(path)[0].equals(random_patch)
+
+    def test_chunk_validation_does_not_load_patches(
+        self, tmp_path_factory, random_patch, monkeypatch
+    ):
+        """Chunk-dim validation must use scan metadata, not load patch data."""
+        src = tmp_path_factory.mktemp("dasdae_lazy_src") / "src.h5"
+        out = tmp_path_factory.mktemp("dasdae_lazy_out") / "out.h5"
+        dc.write(random_patch, src, "DASDAE")
+        lazy_spool = dc.spool(src)
+
+        calls = []
+        original = dasdae_mod.core._read_patch
+
+        def counting_read_patch(*args, **kwargs):
+            calls.append(1)
+            return original(*args, **kwargs)
+
+        # Patch the name bound in core, which both read paths call through.
+        monkeypatch.setattr(dasdae_mod.core, "_read_patch", counting_read_patch)
+        dc.write(lazy_spool, out, "DASDAE", storage={"chunks": {"time": 100}})
+        # One read per patch for the write itself; validation adds none.
+        assert len(calls) == 1
+        assert dc.read(out)[0].equals(random_patch)
 
     def test_typoed_chunk_dim_raises_on_write(self, tmp_path_factory, random_patch):
         """A chunk dim that isn't a real patch dim raises instead of no-op."""

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pickle
 import shutil
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 import h5py
 import numpy as np
@@ -17,9 +17,12 @@ from dascore.compat import random_state
 from dascore.config import config_context
 from dascore.core.coords import CoordString
 from dascore.exceptions import InvalidFiberFileError
+from dascore.io import dasdae as dasdae_mod
+from dascore.io.core import BaseCodec
 from dascore.io.dasdae import utils as dasdae_utils
 from dascore.io.dasdae._compat import translate_legacy_attrs
 from dascore.io.dasdae.core import DASDAEV1
+from dascore.io.dasdae.storage import DASDAEStorage
 from dascore.io.dasdae.utils import (
     _SEPARATE_ATTRS_KEY,
     _decode_attr_value,
@@ -30,15 +33,23 @@ from dascore.io.dasdae.utils import (
     _get_coords,
     _get_file_version,
     _get_scan_payload_from_group,
+    _read_array,
     _save_array,
     _save_patch,
 )
+from dascore.io.hdf5 import Gzip, HDF5Codec
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import register_func
 from dascore.utils.time import to_datetime64
 
 # a list of fixture names for written DASDAE files
 WRITTEN_FILES = []
+
+
+class _UnsupportedCodec(BaseCodec):
+    """A non-HDF5 codec used to test DASDAE storage validation."""
+
+    name: Literal["unsupported"] = "unsupported"
 
 
 @pytest.fixture(scope="class")
@@ -90,6 +101,14 @@ def dasdae_v1_file_path(request):
 class TestWriteDASDAE:
     """Ensure the format can be written."""
 
+    def _assert_data_compression(self, path, *, compression, level=None):
+        """Assert the stored DASDAE data array has the expected compression."""
+        with h5py.File(path) as h5:
+            group = next(iter(h5["waveforms"].values()))
+            assert group["data"].compression == compression
+            if level is not None:
+                assert group["data"].compression_opts == level
+
     def test_file_exists(self, dasdae_v1_file_path):
         """The file should *of course* exist."""
         assert Path(dasdae_v1_file_path).exists()
@@ -138,6 +157,324 @@ class TestWriteDASDAE:
         """Ensure cross correlated patches can be written and read."""
         sp_cc = dc.spool(written_dascore_correlate)
         assert isinstance(sp_cc[0], dc.Patch)
+
+    def test_write_compressed_with_storage(self, tmp_path_factory, random_patch):
+        """DASDAE can write compressed arrays with a storage object."""
+        path = tmp_path_factory.mktemp("dasdae_compressed") / "compressed.h5"
+        storage = DASDAEStorage(codec=Gzip(level=5))
+        dc.write(random_patch, path, "DASDAE", storage=storage)
+        self._assert_data_compression(path, compression="gzip", level=5)
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_compressed_file_is_smaller(self, tmp_path_factory, random_patch):
+        """Compression must actually shrink a compressible file on disk."""
+        base = tmp_path_factory.mktemp("dasdae_size_check")
+        # Constant data compresses extremely well, so any real compression
+        # must produce a much smaller file than the uncompressed write.
+        patch = random_patch.new(data=np.ones_like(random_patch.data))
+        patch.io.write(base / "plain.h5", "DASDAE")
+        patch.io.write(base / "compressed.h5", "DASDAE", storage="compressed")
+        plain = (base / "plain.h5").stat().st_size
+        compressed = (base / "compressed.h5").stat().st_size
+        assert compressed < plain / 2
+
+    def test_direct_write_coerces_storage(self, tmp_path_factory, random_patch):
+        """Direct DASDAEV1 writes accept the same storage shorthand as dc.write."""
+        path = tmp_path_factory.mktemp("dasdae_direct_storage") / "compressed.h5"
+        with h5py.File(path, mode="w") as h5:
+            DASDAEV1().write(random_patch, h5, storage="compressed")
+        self._assert_data_compression(path, compression="gzip", level=5)
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_default_storage_skips_chunk_validation(
+        self, tmp_path_factory, random_patch, monkeypatch
+    ):
+        """Unchunked writes do not scan dims only to no-op validation."""
+        path = tmp_path_factory.mktemp("dasdae_no_chunk_validation") / "out.h5"
+
+        def raise_if_called(*args, **kwargs):
+            raise AssertionError("chunk validation should be skipped")
+
+        monkeypatch.setattr(DASDAEStorage, "_validate_chunk_dims", raise_if_called)
+        random_patch.io.write(path, "DASDAE")
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_compressed_selective_read(self, tmp_path_factory, random_patch):
+        """Selecting from a compressed file must match selecting in memory."""
+        path = tmp_path_factory.mktemp("dasdae_compressed_select") / "out.h5"
+        random_patch.io.write(path, "DASDAE", storage="compressed")
+        dist = random_patch.get_coord("distance").values
+        select = {"distance": (dist[0], dist[len(dist) // 2])}
+        from_disk = dc.spool(path).select(**select)[0]
+        in_memory = random_patch.select(**select)
+        assert from_disk.equals(in_memory)
+
+    def test_write_compressed_empty_coord(self, tmp_path_factory, random_patch):
+        """Compressed DASDAE writes preserve zero-length arrays."""
+        path = tmp_path_factory.mktemp("dasdae_compressed_empty") / "out.h5"
+        time = random_patch.get_coord("time")
+        empty_patch = random_patch.select(time=(time.max() + 3 * time.step, ...))
+        empty_patch.io.write(path, "dasdae", storage="compressed")
+        new_patch = dc.read(path)[0]
+        assert empty_patch.equals(new_patch)
+
+    def test_compressed_scalar_array_falls_back(self, tmp_path_factory):
+        """DASDAE compression skips scalar arrays HDF5 cannot chunk."""
+        path = tmp_path_factory.mktemp("dasdae_compressed_scalar") / "out.h5"
+        options = DASDAEStorage.from_preset("compressed")._dataset_options((), ())
+        with h5py.File(path, mode="w") as h5:
+            node = _save_array(np.array(1), "scalar", h5, options)
+            assert node.shape == ()
+            assert node.compression is None
+
+    def test_write_dict_codec_coercion(self, tmp_path_factory, random_patch):
+        """A dict/string codec shorthand is coerced by the write path."""
+        path = tmp_path_factory.mktemp("dasdae_gzip") / "gzip.h5"
+        random_patch.io.write(path, "DASDAE", storage={"codec": "gzip"})
+        self._assert_data_compression(path, compression="gzip")
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_write_compressed_with_gzip(self, tmp_path_factory, random_patch):
+        """DASDAE can use portable gzip HDF5 compression."""
+        path = tmp_path_factory.mktemp("dasdae_gzip") / "gzip.h5"
+        random_patch.io.write(path, "DASDAE", storage=DASDAEStorage(codec=Gzip()))
+        self._assert_data_compression(path, compression="gzip")
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_chunked_unicode_array_roundtrips(self, tmp_path_factory):
+        """Chunked/compressed string arrays preserve non-ASCII values."""
+        path = tmp_path_factory.mktemp("dasdae_unicode_array") / "out.h5"
+        data = np.array(["cafe", "café"], dtype="U8")
+        storage = DASDAEStorage.from_preset("compressed")
+        options = storage._dataset_options(("label",), data.shape) | {"chunks": (1,)}
+        with h5py.File(path, mode="w") as h5:
+            node = _save_array(data, "labels", h5, options)
+            assert node[:].dtype.kind == "S"
+            assert np.array_equal(_read_array(node), data)
+
+    def test_unicode_patch_data_roundtrips(self, tmp_path_factory):
+        """Compressed patches whose data is a unicode array round-trip exactly."""
+        path = tmp_path_factory.mktemp("dasdae_unicode_data") / "out.h5"
+        data = np.array([["café", "naïve"], ["日本", "ok"]], dtype="U8")
+        patch = dc.Patch(
+            data=data,
+            coords={"distance": [0.0, 1.0], "time": [0.0, 1.0]},
+            dims=("distance", "time"),
+        )
+        patch.io.write(path, "dasdae", storage="compressed")
+        loaded = dc.read(path)[0]
+        assert loaded.data.dtype.kind == "U"
+        assert np.array_equal(loaded.data, data)
+        # The selective-read branch decodes through the same attr-aware path.
+        selected = dc.read(path, distance=(0.0, 0.0))[0]
+        assert selected.data.dtype.kind == "U"
+        assert np.array_equal(selected.data, data[:1])
+
+    def test_datetime_patch_data_selective_read(self, tmp_path_factory):
+        """Datetime data arrays keep their dtype through selective reads."""
+        path = tmp_path_factory.mktemp("dasdae_datetime_data") / "out.h5"
+        data = to_datetime64(["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"])
+        patch = dc.Patch(
+            data=data.reshape(2, 2),
+            coords={"distance": [0.0, 1.0], "time": [0.0, 1.0]},
+            dims=("distance", "time"),
+        )
+        patch.io.write(path, "dasdae", storage="compressed")
+        selected = dc.read(path, distance=(0.0, 0.0))[0]
+        assert np.issubdtype(selected.data.dtype, np.datetime64)
+        assert np.array_equal(selected.data, data.reshape(2, 2)[:1])
+
+    def test_write_with_chunks(self, tmp_path_factory, random_patch):
+        """DASDAE storage can specify a per-dimension chunk layout."""
+        path = tmp_path_factory.mktemp("dasdae_chunkshape") / "chunked.h5"
+        storage = DASDAEStorage(codec=Gzip(), chunks={"distance": 10, "time": 10})
+        random_patch.io.write(path, "DASDAE", storage=storage)
+        with h5py.File(path) as h5:
+            group = next(iter(h5["waveforms"].values()))
+            assert group["data"].chunks == (10, 10)
+            # Coordinate arrays share the layout, chunked by their dim name.
+            assert group["_coord_distance"].chunks == (10,)
+            assert group["_coord_distance"].compression == "gzip"
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_explicit_storage_none_writes_default(self, tmp_path_factory, random_patch):
+        """An explicit storage=None is normalized to the default and round-trips."""
+        path = tmp_path_factory.mktemp("dasdae_storage_none") / "out.h5"
+        dc.write(random_patch, path, "DASDAE", storage=None)
+        with h5py.File(path) as h5:
+            group = next(iter(h5["waveforms"].values()))
+            # Default storage is uncompressed.
+            assert group["data"].compression is None
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_chunk_validation_does_not_load_patches(
+        self, tmp_path_factory, random_patch, monkeypatch
+    ):
+        """Chunk-dim validation must use scan metadata, not load patch data."""
+        src = tmp_path_factory.mktemp("dasdae_lazy_src") / "src.h5"
+        out = tmp_path_factory.mktemp("dasdae_lazy_out") / "out.h5"
+        dc.write(random_patch, src, "DASDAE")
+        lazy_spool = dc.spool(src)
+
+        calls = []
+        original = dasdae_mod.core._read_patch
+
+        def counting_read_patch(*args, **kwargs):
+            calls.append(1)
+            return original(*args, **kwargs)
+
+        # Patch the name bound in core, which both read paths call through.
+        monkeypatch.setattr(dasdae_mod.core, "_read_patch", counting_read_patch)
+        dc.write(lazy_spool, out, "DASDAE", storage={"chunks": {"time": 100}})
+        # One read per patch for the write itself; validation adds none.
+        assert len(calls) == 1
+        assert dc.read(out)[0].equals(random_patch)
+
+    def test_typoed_chunk_dim_raises_on_write(self, tmp_path_factory, random_patch):
+        """A chunk dim that isn't a real patch dim raises instead of no-op."""
+        path = tmp_path_factory.mktemp("dasdae_chunk_typo") / "out.h5"
+        with pytest.raises(ValueError, match="Unknown chunk dimension"):
+            random_patch.io.write(path, "DASDAE", storage={"chunks": {"tim": 500}})
+        # Validation happens before any content, so no DASDAE-stamped stub
+        # is left behind for dc.get_format to misidentify.
+        with h5py.File(path) as h5:
+            assert "waveforms" not in h5
+            assert "__format__" not in h5.attrs
+
+    def test_empty_spool_with_chunks_writes(self, tmp_path_factory):
+        """An empty spool with chunk config writes like any empty write."""
+        path = tmp_path_factory.mktemp("dasdae_empty_chunks") / "out.h5"
+        dc.write(dc.spool([]), path, "DASDAE", storage={"chunks": {"time": 100}})
+        assert len(dc.spool(path).get_contents()) == 0
+
+    def test_chunks_without_codec(self, tmp_path_factory, random_patch):
+        """Chunks apply even without a codec (chunked-uncompressed layout)."""
+        path = tmp_path_factory.mktemp("dasdae_chunks_only") / "chunked.h5"
+        random_patch.io.write(path, "DASDAE", storage={"chunks": {"time": 500}})
+        with h5py.File(path) as h5:
+            group = next(iter(h5["waveforms"].values()))
+            # time is the second dim; chunk length clamps to the request.
+            assert group["data"].chunks[1] == 500
+            assert group["data"].compression is None
+        assert dc.read(path)[0].equals(random_patch)
+
+
+class TestDASDAEStorage:
+    """Tests for DASDAE storage settings."""
+
+    def test_default_is_uncompressed(self):
+        """Default storage produces no dataset options and no chunking."""
+        storage = DASDAEStorage()
+        assert storage._dataset_options(("distance", "time"), (3, 4)) == {}
+        assert storage._resolve_chunkshape(("distance", "time"), (3, 4)) is None
+
+    def test_compressed_preset_uses_default_codec(self):
+        """The compressed preset uses the DASDAE default codec."""
+        storage = DASDAEStorage.from_preset("compressed")
+        assert storage.codec == Gzip(level=5)
+        options = storage._dataset_options(("time",), (10,))
+        assert options["compression"] == "gzip"
+        assert options["compression_opts"] == 5
+
+    def test_codec_string_shorthand(self):
+        """A bare codec name is coerced to the codec instance."""
+        assert DASDAEStorage(codec="gzip").codec == Gzip()
+
+    def test_codec_dict_shorthand(self):
+        """A codec dict is dispatched by its discriminator name."""
+        assert DASDAEStorage(codec={"name": "gzip", "level": 3}).codec == Gzip(level=3)
+
+    def test_codec_dict_requires_name(self):
+        """Codec dictionaries must include the registry discriminator."""
+        with pytest.raises(ValueError, match="name"):
+            DASDAEStorage(codec={"level": 3})
+
+    def test_bad_codec_input_raises(self):
+        """Unsupported codec input types raise a clear error."""
+        with pytest.raises(ValueError, match="Cannot interpret codec"):
+            DASDAEStorage(codec=object())
+
+    def test_unsupported_codec_base_raises(self):
+        """DASDAE rejects codecs it cannot store in HDF5 arrays."""
+        with pytest.raises(ValueError, match="cannot store codec"):
+            DASDAEStorage(codec=_UnsupportedCodec())
+
+    def test_unknown_codec_name_raises(self):
+        """An unknown codec name reports it is unregistered."""
+        with pytest.raises(ValueError, match="Unknown codec"):
+            DASDAEStorage(codec="lz4")
+
+    def test_gzip_codec_maps_to_h5py_kwargs(self):
+        """Gzip codec maps to the h5py gzip dataset kwargs."""
+        options = DASDAEStorage(codec=Gzip(level=3))._dataset_options(("time",), (10,))
+        assert options == {
+            "compression": "gzip",
+            "compression_opts": 3,
+            "shuffle": True,
+        }
+
+    def test_level_zero_codec_disables_compression(self):
+        """A level-0 codec writes uncompressed without erroring."""
+        storage = DASDAEStorage(codec=Gzip(level=0))
+        assert storage._dataset_options(("time",), (10,)) == {}
+
+    def test_bare_base_codec_rejected_at_construction(self):
+        """A codec base class with no registered name fails fast, not mid-write."""
+        with pytest.raises(ValueError, match="name"):
+            DASDAEStorage(codec=HDF5Codec(level=5))
+
+    def test_new_preserves_codec(self):
+        """Deriving a modified storage with .new() keeps the codec (GH #734)."""
+        for storage in (
+            DASDAEStorage.from_preset("compressed"),
+            DASDAEStorage(codec="gzip"),
+            DASDAEStorage(codec=Gzip(level=3)),
+            DASDAEStorage(codec={"name": "gzip", "level": 4}),
+        ):
+            new = storage.new(chunks={"time": 100})
+            assert new.codec == storage.codec
+            assert new.chunks == {"time": 100}
+
+    def test_chunkshape_resolves_by_dim_name(self):
+        """Chunks map dim names to lengths, clamped to the array shape."""
+        storage = DASDAEStorage(chunks={"time": 5})
+        # time is the second dim here; distance uses its full length.
+        assert storage._resolve_chunkshape(("distance", "time"), (3, 20)) == (3, 5)
+        # request larger than the array is clamped down.
+        assert storage._resolve_chunkshape(("time",), (4,)) == (4,)
+        # scalar/mismatched arrays are left contiguous.
+        assert storage._resolve_chunkshape((), ()) is None
+
+    def test_negative_chunk_raises(self):
+        """Chunk sizes must be positive."""
+        with pytest.raises(ValueError, match="positive"):
+            DASDAEStorage(chunks={"time": 0})
+
+    def test_unknown_chunk_dim_raises(self):
+        """A chunk dim that matches no real dimension is rejected."""
+        storage = DASDAEStorage(chunks={"tim": 5})
+        with pytest.raises(ValueError, match="Unknown chunk dimension"):
+            storage._validate_chunk_dims(("distance", "time"))
+
+    def test_known_chunk_dims_pass(self):
+        """Valid chunk dims validate without error."""
+        storage = DASDAEStorage(chunks={"time": 5})
+        # Should not raise.
+        storage._validate_chunk_dims(("distance", "time"))
+
+    def test_validate_chunk_dims_no_chunks_returns(self):
+        """Default storage has no chunk dims to validate."""
+        storage = DASDAEStorage()
+        storage._validate_chunk_dims(())
+
+    def test_get_codecs(self):
+        """DASDAE reports the registered HDF5 codecs it can store."""
+        assert set(DASDAEStorage.get_codecs()) == {Gzip}
+
+    def test_codec_name_as_preset_gets_hint(self):
+        """Mistaking a codec name for a preset points at the codec spelling."""
+        with pytest.raises(ValueError, match="codec name, not a preset"):
+            DASDAEStorage.from_preset("gzip")
 
 
 class TestReadDASDAE:
@@ -469,8 +806,13 @@ class TestDASDAEInternalHelpers:
         path = tmp_path / "overwrite_patch.h5"
         with h5py.File(path, "w") as h5:
             waveforms = h5.create_group("waveforms")
-            _save_patch(random_patch, waveforms, "patch_0")
-            _save_patch(random_patch.update_attrs(tag="new"), waveforms, "patch_0")
+            _save_patch(random_patch, waveforms, "patch_0", DASDAEStorage())
+            _save_patch(
+                random_patch.update_attrs(tag="new"),
+                waveforms,
+                "patch_0",
+                DASDAEStorage(),
+            )
             attrs = _get_attrs(waveforms["patch_0"])
             assert attrs["tag"] == "new"
 

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -333,9 +333,17 @@ class TestWriteDASDAE:
         path = tmp_path_factory.mktemp("dasdae_chunk_typo") / "out.h5"
         with pytest.raises(ValueError, match="Unknown chunk dimension"):
             random_patch.io.write(path, "DASDAE", storage={"chunks": {"tim": 500}})
-        # Validation happens before any patch data is written.
+        # Validation happens before any content, so no DASDAE-stamped stub
+        # is left behind for dc.get_format to misidentify.
         with h5py.File(path) as h5:
             assert "waveforms" not in h5
+            assert "__format__" not in h5.attrs
+
+    def test_empty_spool_with_chunks_writes(self, tmp_path_factory):
+        """An empty spool with chunk config writes like any empty write."""
+        path = tmp_path_factory.mktemp("dasdae_empty_chunks") / "out.h5"
+        dc.write(dc.spool([]), path, "DASDAE", storage={"chunks": {"time": 100}})
+        assert len(dc.spool(path).get_contents()) == 0
 
     def test_chunks_without_codec(self, tmp_path_factory, random_patch):
         """Chunks apply even without a codec (chunked-uncompressed layout)."""
@@ -462,6 +470,11 @@ class TestDASDAEStorage:
     def test_get_codecs(self):
         """DASDAE reports the registered HDF5 codecs it can store."""
         assert set(DASDAEStorage.get_codecs()) == {Gzip}
+
+    def test_codec_name_as_preset_gets_hint(self):
+        """Mistaking a codec name for a preset points at the codec spelling."""
+        with pytest.raises(ValueError, match="codec name, not a preset"):
+            DASDAEStorage.from_preset("gzip")
 
 
 class TestReadDASDAE:

--- a/tests/test_io/test_hdf5.py
+++ b/tests/test_io/test_hdf5.py
@@ -1,0 +1,52 @@
+"""Tests for HDF5 IO storage codecs."""
+
+from __future__ import annotations
+
+import pytest
+
+from dascore.io.hdf5 import Gzip
+
+
+class TestHDF5Codecs:
+    """Tests for reusable HDF5 codec objects."""
+
+    def test_gzip_dataset_kwargs(self):
+        """Gzip maps to the native h5py gzip filter kwargs."""
+        kwargs = Gzip(level=3)._dataset_kwargs()
+        assert kwargs["compression"] == "gzip"
+        assert kwargs["compression_opts"] == 3
+        assert kwargs["shuffle"]
+
+    def test_shuffle_disabled(self):
+        """The shuffle filter can be turned off."""
+        assert not Gzip(shuffle=False)._dataset_kwargs()["shuffle"]
+
+    def test_level_zero_disables_compression(self):
+        """A level of 0 produces no dataset kwargs."""
+        assert Gzip(level=0)._dataset_kwargs() == {}
+
+    def test_bad_level_raises(self):
+        """HDF5 compression levels must fit the 0-9 range."""
+        with pytest.raises(ValueError, match="level"):
+            Gzip(level=10)
+        with pytest.raises(ValueError, match="level"):
+            Gzip(level=-1)
+
+
+class TestCodecSerialization:
+    """The Literal name lets codecs round-trip through pydantic."""
+
+    def test_name_included_in_dump(self):
+        """Dumping a codec includes its discriminator name."""
+        config = Gzip(level=2, shuffle=False).model_dump()
+        assert config == {"name": "gzip", "level": 2, "shuffle": False}
+
+    def test_roundtrip_through_validate(self):
+        """A dumped codec reconstructs the same instance."""
+        codec = Gzip(level=4)
+        assert Gzip.model_validate(codec.model_dump()) == codec
+
+    def test_extra_field_forbidden(self):
+        """Codecs reject unknown fields to catch typos."""
+        with pytest.raises(ValueError, match="Extra inputs"):
+            Gzip(not_a_field=3)

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -791,6 +791,11 @@ class TestCoerceStorage:
         """Storage dictionaries are validated into the format storage model."""
         assert _coerce_storage({}, _StorageImplementer()) == _TestStorage()
 
+    def test_codec_instance_as_storage_rejected_with_hint(self):
+        """Passing a codec where storage is expected points at the fix."""
+        with pytest.raises(InvalidFiberIOError, match="wrap it in storage"):
+            _coerce_storage(Gzip(level=5), _StorageImplementer())
+
 
 class TestBaseCodec:
     """Tests for the base IO codec model."""
@@ -825,8 +830,8 @@ class TestCodecRegistry:
         """A plugged-in HDF5 codec appears in DASDAE's supported codecs."""
         assert plugin_codec in get_codecs("DASDAE", "1")
 
-    def test_nameless_plugin_codec_raises(self, monkeypatch):
-        """A codec registered without a 'name' default fails loudly."""
+    def test_nameless_plugin_codec_warns_and_skips(self, monkeypatch):
+        """A codec registered without a 'name' default is skipped with a warning."""
         from dascore.io import codec as codec_mod
 
         class _NamelessCodec(HDF5Codec):
@@ -841,9 +846,33 @@ class TestCodecRegistry:
 
         monkeypatch.setattr(codec_mod, "get_entry_point_loaders", _fake_loaders)
         get_codec_registry.cache_clear()
-        with pytest.raises(InvalidFiberIOError, match="name"):
-            get_codec_registry()
+        try:
+            with pytest.warns(UserWarning, match="Failed to load codec plugin"):
+                registry = get_codec_registry()
+            # Built-in codecs survive the broken registration.
+            assert registry["gzip"] is Gzip
+        finally:
+            get_codec_registry.cache_clear()
+
+    def test_broken_plugin_entry_point_warns_and_skips(self, monkeypatch):
+        """A stale/broken codec entry point must not poison the registry."""
+        from dascore.io import codec as codec_mod
+
+        def _broken_loader():
+            raise ModuleNotFoundError("No module named 'dascore_daspack'")
+
+        def _fake_loaders(group):
+            if group == "dascore.codec":
+                return {"DASPACK": _broken_loader}
+            return {}
+
+        monkeypatch.setattr(codec_mod, "get_entry_point_loaders", _fake_loaders)
         get_codec_registry.cache_clear()
+        try:
+            with pytest.warns(UserWarning, match="Failed to load codec plugin"):
+                assert get_codec("gzip") is Gzip
+        finally:
+            get_codec_registry.cache_clear()
 
 
 class TestGetStorage:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -22,6 +22,7 @@ from dascore.exceptions import (
     InvalidFiberIOError,
     MissingOptionalDependencyError,
     MissingPatchError,
+    ParameterError,
     RemoteCacheError,
     UnknownFiberFormatError,
 )
@@ -823,6 +824,36 @@ class TestCoerceStorage:
         """Passing a codec where storage is expected points at the fix."""
         with pytest.raises(InvalidFiberIOError, match="wrap it in storage"):
             _coerce_storage(Gzip(level=5), _StorageImplementer())
+
+
+class TestWriteKwargValidation:
+    """dc.write must not silently swallow undeclared write options."""
+
+    def test_misspelled_storage_kwarg_raises(self, tmp_path, random_patch):
+        """A typo in the storage kwarg name raises instead of writing plain."""
+        with pytest.raises(ParameterError, match="stroage"):
+            random_patch.io.write(tmp_path / "out.h5", "dasdae", stroage="compressed")
+
+    def test_error_lists_supported_options(self, tmp_path, random_patch):
+        """The rejection names the writer's real options."""
+        with pytest.raises(ParameterError, match="storage"):
+            dc.write(random_patch, tmp_path / "out.h5", "dasdae", nope=1)
+
+    def test_format_without_options_rejects_any_kwarg(self, tmp_path, random_patch):
+        """Formats whose writers declare no options reject all extras."""
+        with pytest.raises(ParameterError, match=r"\(none\)"):
+            dc.write(random_patch, tmp_path / "out.pkl", "pickle", anything=1)
+
+    def test_declared_options_still_pass(self, tmp_path, random_patch):
+        """Declared writer options are unaffected by the validation."""
+        path = tmp_path / "out.h5"
+        dc.write(random_patch, path, "dasdae", storage="compressed")
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_storage_on_pickle_keeps_specific_error(self, tmp_path, random_patch):
+        """Storage on a storage-less format keeps its targeted message."""
+        with pytest.raises(InvalidFiberIOError, match="does not support storage"):
+            dc.write(random_patch, tmp_path / "out.pkl", "pickle", storage="compressed")
 
 
 class TestBaseCodec:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -6,7 +6,7 @@ import copy
 import io
 import threading
 from pathlib import Path
-from typing import TypeVar
+from typing import ClassVar, Literal, TypeVar
 
 import h5py
 import numpy as np
@@ -25,16 +25,23 @@ from dascore.exceptions import (
     RemoteCacheError,
     UnknownFiberFormatError,
 )
+from dascore.io.codec import get_codec, get_codec_registry
 from dascore.io.core import (
+    BaseStorage,
     FiberIO,
+    _coerce_storage,
     _FiberIOManager,
     _get_reloadable_source_path,
     _make_scan_payload,
     _reinit_manager_lock,
     _scan_result_to_summary,
     _validate_scan_payload,
+    get_codecs,
+    get_storage,
 )
 from dascore.io.dasdae.core import DASDAEV1
+from dascore.io.dasdae.storage import DASDAEStorage
+from dascore.io.hdf5 import Gzip, HDF5Codec
 from dascore.io.utils import get_exact_coord
 from dascore.utils.io import BinaryReader, BinaryWriter, IOResourceManager
 from dascore.utils.misc import suppress_warnings
@@ -74,6 +81,52 @@ class _FiberImplementer(FiberIO):
 
     def get_format(self, resource):
         """Dummy get_format."""
+
+
+class _TestStorage(BaseStorage):
+    """Storage object for testing FiberIO storage discovery."""
+
+    name: ClassVar[str] = "_implementer"
+
+
+class _StorageImplementer(FiberIO):
+    """A fiber io which declares storage support."""
+
+    name = "_StorageImplementer"
+    version = "1"
+    storage_cls = _TestStorage
+
+
+class _NoStorageImplementer(FiberIO):
+    """A fiber io with write support but no storage declaration."""
+
+    name = "_NoStorageImplementer"
+    version = "1"
+
+    def write(self, spool: SpoolType, resource):
+        """Dummy write."""
+
+
+@pytest.fixture
+def plugin_codec(monkeypatch):
+    """Register a dummy codec via the entry-point seam, then clean up."""
+    from dascore.io import codec as codec_mod
+
+    class _PluginCodec(HDF5Codec):
+        """A stand-in for an externally registered codec."""
+
+        name: Literal["_plugin_zlib"] = "_plugin_zlib"
+        _compression: ClassVar[str] = "gzip"
+
+    def _fake_loaders(group):
+        if group == "dascore.codec":
+            return {"_plugin_zlib": lambda: _PluginCodec}
+        return {}
+
+    monkeypatch.setattr(codec_mod, "get_entry_point_loaders", _fake_loaders)
+    get_codec_registry.cache_clear()
+    yield _PluginCodec
+    get_codec_registry.cache_clear()
 
 
 class _FiberCaster(FiberIO):
@@ -680,6 +733,154 @@ class TestFormatter:
         assert fio.implements_get_format
         assert fio.implements_read
         assert fio.implements_write
+
+
+class TestBaseStorage:
+    """Tests for the base IO storage model."""
+
+    def test_subclass_defines_name(self):
+        """Storage subclasses expose name metadata."""
+        assert _TestStorage.name == "_implementer"
+
+    def test_storage_models_are_frozen(self):
+        """Storage objects inherit DASCore's frozen model behavior."""
+        storage = _TestStorage()
+        with pytest.raises(Exception, match="frozen"):
+            storage.extra = "new"
+
+    def test_extra_field_forbidden(self):
+        """Storage models reject unknown kwargs to catch typos."""
+        with pytest.raises(ValueError, match="Extra inputs"):
+            _TestStorage(codc=None)
+
+    def test_missing_name_raises(self):
+        """Storage subclasses must define a name."""
+        with pytest.raises(InvalidFiberIOError, match="name"):
+
+            class _NamelessStorage(BaseStorage):
+                """Invalid storage object with no name."""
+
+    def test_unknown_preset_raises(self):
+        """Requesting an undefined preset raises a clear error."""
+        with pytest.raises(InvalidFiberIOError, match="preset"):
+            _TestStorage.from_preset("does_not_exist")
+
+    def test_get_codecs_empty_without_supported_bases(self):
+        """Storage without supported codec bases reports no codecs."""
+        assert _TestStorage.get_codecs() == ()
+
+
+class TestCoerceStorage:
+    """Tests for normalizing user storage inputs."""
+
+    def test_none_uses_default_storage(self):
+        """None becomes the format's default storage instance."""
+        out = _coerce_storage(None, _StorageImplementer())
+        assert out == _TestStorage()
+
+    def test_none_for_format_without_storage_stays_none(self):
+        """None is harmless for formats without storage support."""
+        assert _coerce_storage(None, _NoStorageImplementer()) is None
+
+    def test_format_without_storage_rejects_options(self):
+        """Formats without storage support reject explicit storage options."""
+        with pytest.raises(InvalidFiberIOError, match="storage options"):
+            _coerce_storage({}, _NoStorageImplementer())
+
+    def test_dict_validates_to_storage(self):
+        """Storage dictionaries are validated into the format storage model."""
+        assert _coerce_storage({}, _StorageImplementer()) == _TestStorage()
+
+
+class TestBaseCodec:
+    """Tests for the base IO codec model."""
+
+    def test_subclass_defines_name(self):
+        """Codec subclasses expose name metadata via the Literal field."""
+        assert Gzip().name == "gzip"
+
+
+class TestCodecRegistry:
+    """Tests for the plugin-style codec registry."""
+
+    def test_builtins_registered(self):
+        """Built-in codecs are always resolvable by name."""
+        assert get_codec("gzip") is Gzip
+
+    def test_unknown_codec_raises(self):
+        """Unknown codec names raise with a helpful message."""
+        with pytest.raises(ValueError, match="Unknown codec"):
+            get_codec("not_a_codec")
+
+    def test_plugin_codec_registered(self, plugin_codec):
+        """A codec registered via the entry-point seam is discoverable."""
+        assert get_codec("_plugin_zlib") is plugin_codec
+
+    def test_plugin_codec_usable_in_storage(self, plugin_codec):
+        """A plugged-in codec resolves through a storage model."""
+        storage = DASDAEStorage(codec="_plugin_zlib")
+        assert isinstance(storage.codec, plugin_codec)
+
+    def test_plugin_codec_in_get_codecs(self, plugin_codec):
+        """A plugged-in HDF5 codec appears in DASDAE's supported codecs."""
+        assert plugin_codec in get_codecs("DASDAE", "1")
+
+    def test_nameless_plugin_codec_raises(self, monkeypatch):
+        """A codec registered without a 'name' default fails loudly."""
+        from dascore.io import codec as codec_mod
+
+        class _NamelessCodec(HDF5Codec):
+            """A misdeclared codec missing its name discriminator."""
+
+            _compression: ClassVar[str] = "gzip"
+
+        def _fake_loaders(group):
+            if group == "dascore.codec":
+                return {"_nameless": lambda: _NamelessCodec}
+            return {}
+
+        monkeypatch.setattr(codec_mod, "get_entry_point_loaders", _fake_loaders)
+        get_codec_registry.cache_clear()
+        with pytest.raises(InvalidFiberIOError, match="name"):
+            get_codec_registry()
+        get_codec_registry.cache_clear()
+
+
+class TestGetStorage:
+    """Tests for discovering storage support by format/version."""
+
+    def test_gets_storage_for_format(self):
+        """Storage classes can be found from registered FiberIO metadata."""
+        assert get_storage("_StorageImplementer") is _TestStorage
+
+    def test_gets_storage_for_format_and_version(self):
+        """Storage lookup honors explicit format versions."""
+        assert get_storage("_StorageImplementer", "1") is _TestStorage
+
+    def test_returns_none_for_format_without_storage(self):
+        """Formats without storage metadata return None."""
+        assert get_storage("_TestFormatter", "1") is None
+
+    def test_gets_dasdae_storage(self):
+        """DASDAE declares its public storage object."""
+        assert get_storage("DASDAE", "1") is DASDAEStorage
+
+
+class TestGetCodecs:
+    """Tests for discovering codec support by format/version."""
+
+    def test_returns_empty_for_format_without_storage(self):
+        """Formats without storage metadata return no codecs."""
+        assert get_codecs("_TestFormatter", "1") == ()
+
+    def test_gets_dasdae_codecs(self):
+        """DASDAE reports the registered HDF5 codecs it can store."""
+        assert set(get_codecs("DASDAE", "1")) == {Gzip}
+
+    def test_unknown_format_raises(self):
+        """Unknown formats still raise instead of returning empty codecs."""
+        with pytest.raises(UnknownFiberFormatError):
+            get_codecs("not_a_format")
 
 
 class TestGetFormat:
@@ -1364,6 +1565,16 @@ class TestGetSupportedIOTable:
 
         # assert that the length of the DataFrame is not 0
         assert len(result_df) > 0
+
+    def test_get_supported_io_table_includes_storage(self):
+        """The supported IO table reports storage support."""
+        result_df = FiberIO.get_supported_io_table()
+        storage_row = result_df[result_df["name"] == "_STORAGEIMPLEMENTER"].iloc[0]
+        no_storage_row = result_df[
+            (result_df["name"] == "_TESTFORMATTER") & (result_df["version"] == "1")
+        ].iloc[0]
+        assert storage_row["storage"]
+        assert not no_storage_row["storage"]
 
 
 class TestIOCoreCoverageEdges:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -23,12 +23,17 @@ from dascore.exceptions import (
     InvalidFiberIOError,
     MissingOptionalDependencyError,
     MissingPatchError,
+    ParameterError,
     PatchAttributeError,
     RemoteCacheError,
     UnknownFiberFormatError,
 )
+from dascore.io import codec as codec_mod
+from dascore.io.codec import get_codec, get_codec_registry
 from dascore.io.core import (
+    BaseStorage,
     FiberIO,
+    _coerce_storage,
     _FiberIOManager,
     _get_reloadable_source_path,
     _make_scan_payload,
@@ -37,9 +42,13 @@ from dascore.io.core import (
     _scan_result_to_summary,
     _select_patch_from_spool,
     _validate_scan_payload,
+    get_codecs,
+    get_storage,
     is_directory_format,
 )
 from dascore.io.dasdae.core import DASDAEV1
+from dascore.io.dasdae.storage import DASDAEStorage
+from dascore.io.hdf5 import Gzip, HDF5Codec
 from dascore.io.utils import get_exact_coord
 from dascore.utils.io import BinaryReader, BinaryWriter, IOResourceManager
 from dascore.utils.misc import suppress_warnings
@@ -79,6 +88,51 @@ class _FiberImplementer(FiberIO):
 
     def get_format(self, resource, **kwargs):
         """Dummy get_format."""
+
+
+class _TestStorage(BaseStorage):
+    """Storage object for testing FiberIO storage discovery."""
+
+    name: ClassVar[str] = "_implementer"
+
+
+class _StorageImplementer(FiberIO):
+    """A fiber io which declares storage support."""
+
+    name = "_StorageImplementer"
+    version = "1"
+    storage_cls = _TestStorage
+
+
+class _NoStorageImplementer(FiberIO):
+    """A fiber io with write support but no storage declaration."""
+
+    name = "_NoStorageImplementer"
+    version = "1"
+
+    def write(self, spool, resource):
+        """Dummy write."""
+
+
+@pytest.fixture
+def plugin_codec(monkeypatch):
+    """Register a dummy codec via the entry-point seam, then clean up."""
+
+    class _PluginCodec(HDF5Codec):
+        """A stand-in for an externally registered codec."""
+
+        name: Literal["_plugin_zlib"] = "_plugin_zlib"
+        _compression: ClassVar[str] = "gzip"
+
+    def _fake_loaders(group):
+        if group == "dascore.codec":
+            return {"_plugin_zlib": lambda: _PluginCodec}
+        return {}
+
+    monkeypatch.setattr(codec_mod, "get_entry_point_loaders", _fake_loaders)
+    get_codec_registry.cache_clear()
+    yield _PluginCodec
+    get_codec_registry.cache_clear()
 
 
 class _FiberCaster(FiberIO):
@@ -728,6 +782,211 @@ class TestFormatter:
         assert fio.implements_get_format
         assert fio.implements_read
         assert fio.implements_write
+
+
+class TestBaseStorage:
+    """Tests for the base IO storage model."""
+
+    def test_subclass_defines_name(self):
+        """Storage subclasses expose name metadata."""
+        assert _TestStorage.name == "_implementer"
+
+    def test_storage_models_are_frozen(self):
+        """Storage objects inherit DASCore's frozen model behavior."""
+        storage = _TestStorage()
+        with pytest.raises(Exception, match="frozen"):
+            storage.extra = "new"
+
+    def test_extra_field_forbidden(self):
+        """Storage models reject unknown kwargs to catch typos."""
+        with pytest.raises(ValueError, match="Extra inputs"):
+            _TestStorage(codc=None)
+
+    def test_missing_name_raises(self):
+        """Storage subclasses must define a name."""
+        with pytest.raises(InvalidFiberIOError, match="name"):
+
+            class _NamelessStorage(BaseStorage):
+                """Invalid storage object with no name."""
+
+    def test_unknown_preset_raises(self):
+        """Requesting an undefined preset raises a clear error."""
+        with pytest.raises(InvalidFiberIOError, match="preset"):
+            _TestStorage.from_preset("does_not_exist")
+
+    def test_get_codecs_empty_without_supported_bases(self):
+        """Storage without supported codec bases reports no codecs."""
+        assert _TestStorage.get_codecs() == ()
+
+
+class TestCoerceStorage:
+    """Tests for normalizing user storage inputs."""
+
+    def test_none_uses_default_storage(self):
+        """None becomes the format's default storage instance."""
+        out = _coerce_storage(None, _StorageImplementer())
+        assert out == _TestStorage()
+
+    def test_none_for_format_without_storage_stays_none(self):
+        """None is harmless for formats without storage support."""
+        assert _coerce_storage(None, _NoStorageImplementer()) is None
+
+    def test_format_without_storage_rejects_options(self):
+        """Formats without storage support reject explicit storage options."""
+        with pytest.raises(InvalidFiberIOError, match="storage options"):
+            _coerce_storage({}, _NoStorageImplementer())
+
+    def test_dict_validates_to_storage(self):
+        """Storage dictionaries are validated into the format storage model."""
+        assert _coerce_storage({}, _StorageImplementer()) == _TestStorage()
+
+    def test_codec_instance_as_storage_rejected_with_hint(self):
+        """Passing a codec where storage is expected points at the fix."""
+        with pytest.raises(InvalidFiberIOError, match="wrap it in storage"):
+            _coerce_storage(Gzip(level=5), _StorageImplementer())
+
+
+class TestWriteKwargValidation:
+    """dc.write must not silently swallow undeclared write options."""
+
+    def test_misspelled_storage_kwarg_raises(self, tmp_path, random_patch):
+        """A typo in the storage kwarg name raises instead of writing plain."""
+        with pytest.raises(ParameterError, match="stroage"):
+            random_patch.io.write(tmp_path / "out.h5", "dasdae", stroage="compressed")
+
+    def test_error_lists_supported_options(self, tmp_path, random_patch):
+        """The rejection names the writer's real options."""
+        with pytest.raises(ParameterError, match="storage"):
+            dc.write(random_patch, tmp_path / "out.h5", "dasdae", nope=1)
+
+    def test_format_without_options_rejects_any_kwarg(self, tmp_path, random_patch):
+        """Formats whose writers declare no options reject all extras."""
+        with pytest.raises(ParameterError, match=r"\(none\)"):
+            dc.write(random_patch, tmp_path / "out.pkl", "pickle", anything=1)
+
+    def test_declared_options_still_pass(self, tmp_path, random_patch):
+        """Declared writer options are unaffected by the validation."""
+        path = tmp_path / "out.h5"
+        dc.write(random_patch, path, "dasdae", storage="compressed")
+        assert dc.read(path)[0].equals(random_patch)
+
+    def test_storage_on_pickle_keeps_specific_error(self, tmp_path, random_patch):
+        """Storage on a storage-less format keeps its targeted message."""
+        with pytest.raises(InvalidFiberIOError, match="does not support storage"):
+            dc.write(random_patch, tmp_path / "out.pkl", "pickle", storage="compressed")
+
+
+class TestBaseCodec:
+    """Tests for the base IO codec model."""
+
+    def test_subclass_defines_name(self):
+        """Codec subclasses expose name metadata via the Literal field."""
+        assert Gzip().name == "gzip"
+
+
+class TestCodecRegistry:
+    """Tests for the plugin-style codec registry."""
+
+    def test_builtins_registered(self):
+        """Built-in codecs are always resolvable by name."""
+        assert get_codec("gzip") is Gzip
+
+    def test_unknown_codec_raises(self):
+        """Unknown codec names raise with a helpful message."""
+        with pytest.raises(ValueError, match="Unknown codec"):
+            get_codec("not_a_codec")
+
+    def test_plugin_codec_registered(self, plugin_codec):
+        """A codec registered via the entry-point seam is discoverable."""
+        assert get_codec("_plugin_zlib") is plugin_codec
+
+    def test_plugin_codec_usable_in_storage(self, plugin_codec):
+        """A plugged-in codec resolves through a storage model."""
+        storage = DASDAEStorage(codec="_plugin_zlib")
+        assert isinstance(storage.codec, plugin_codec)
+
+    def test_plugin_codec_in_get_codecs(self, plugin_codec):
+        """A plugged-in HDF5 codec appears in DASDAE's supported codecs."""
+        assert plugin_codec in get_codecs("DASDAE", "1")
+
+    def test_nameless_plugin_codec_warns_and_skips(self, monkeypatch):
+        """A codec registered without a 'name' default is skipped with a warning."""
+
+        class _NamelessCodec(HDF5Codec):
+            """A misdeclared codec missing its name discriminator."""
+
+            _compression: ClassVar[str] = "gzip"
+
+        def _fake_loaders(group):
+            if group == "dascore.codec":
+                return {"_nameless": lambda: _NamelessCodec}
+            return {}
+
+        monkeypatch.setattr(codec_mod, "get_entry_point_loaders", _fake_loaders)
+        get_codec_registry.cache_clear()
+        try:
+            with pytest.warns(UserWarning, match="Failed to load codec plugin"):
+                registry = get_codec_registry()
+            # Built-in codecs survive the broken registration.
+            assert registry["gzip"] is Gzip
+        finally:
+            get_codec_registry.cache_clear()
+
+    def test_broken_plugin_entry_point_warns_and_skips(self, monkeypatch):
+        """A stale/broken codec entry point must not poison the registry."""
+
+        def _broken_loader():
+            raise ModuleNotFoundError("No module named 'dascore_daspack'")
+
+        def _fake_loaders(group):
+            if group == "dascore.codec":
+                return {"DASPACK": _broken_loader}
+            return {}
+
+        monkeypatch.setattr(codec_mod, "get_entry_point_loaders", _fake_loaders)
+        get_codec_registry.cache_clear()
+        try:
+            with pytest.warns(UserWarning, match="Failed to load codec plugin"):
+                assert get_codec("gzip") is Gzip
+        finally:
+            get_codec_registry.cache_clear()
+
+
+class TestGetStorage:
+    """Tests for discovering storage support by format/version."""
+
+    def test_gets_storage_for_format(self):
+        """Storage classes can be found from registered FiberIO metadata."""
+        assert get_storage("_StorageImplementer") is _TestStorage
+
+    def test_gets_storage_for_format_and_version(self):
+        """Storage lookup honors explicit format versions."""
+        assert get_storage("_StorageImplementer", "1") is _TestStorage
+
+    def test_returns_none_for_format_without_storage(self):
+        """Formats without storage metadata return None."""
+        assert get_storage("_TestFormatter", "1") is None
+
+    def test_gets_dasdae_storage(self):
+        """DASDAE declares its public storage object."""
+        assert get_storage("DASDAE", "1") is DASDAEStorage
+
+
+class TestGetCodecs:
+    """Tests for discovering codec support by format/version."""
+
+    def test_returns_empty_for_format_without_storage(self):
+        """Formats without storage metadata return no codecs."""
+        assert get_codecs("_TestFormatter", "1") == ()
+
+    def test_gets_dasdae_codecs(self):
+        """DASDAE reports the registered HDF5 codecs it can store."""
+        assert set(get_codecs("DASDAE", "1")) == {Gzip}
+
+    def test_unknown_format_raises(self):
+        """Unknown formats still raise instead of returning empty codecs."""
+        with pytest.raises(UnknownFiberFormatError):
+            get_codecs("not_a_format")
 
 
 class TestGetFormat:
@@ -1464,6 +1723,16 @@ class TestGetSupportedIOTable:
 
         # assert that the length of the DataFrame is not 0
         assert len(result_df) > 0
+
+    def test_get_supported_io_table_includes_storage(self):
+        """The supported IO table reports storage support."""
+        result_df = FiberIO.get_supported_io_table()
+        storage_row = result_df[result_df["name"] == "_STORAGEIMPLEMENTER"].iloc[0]
+        no_storage_row = result_df[
+            (result_df["name"] == "_TESTFORMATTER") & (result_df["version"] == "1")
+        ].iloc[0]
+        assert storage_row["storage"]
+        assert not no_storage_row["storage"]
 
 
 class TestIOCoreCoverageEdges:

--- a/tests/test_io/test_prodml/test_prodml_write.py
+++ b/tests/test_io/test_prodml/test_prodml_write.py
@@ -9,7 +9,12 @@ import numpy as np
 import pytest
 
 import dascore as dc
-from dascore.exceptions import InvalidSpoolError, PatchError, UnitError
+from dascore.exceptions import (
+    InvalidSpoolError,
+    ParameterError,
+    PatchError,
+    UnitError,
+)
 from dascore.io.prodml.core import ProdMLV2_0, ProdMLV2_1
 from dascore.units import get_quantity_str
 from dascore.utils.misc import suppress_warnings, unbyte
@@ -71,12 +76,10 @@ class TestProdMLWriteDispatch:
             prodml_patch.io.write(path, "PRODML", file_version="2.1")
         assert dc.get_format(path) == ("PRODML", "2.1")
 
-    def test_write_accepts_forwarded_kwargs(self, prodml_patch, tmp_path):
-        """Format-specific keywords should follow the shared writer contract."""
-        path = dc.write(
-            prodml_patch, tmp_path / "kwargs.h5", "PRODML", unused_option=True
-        )
-        assert dc.get_format(path) == ("PRODML", "2.1")
+    def test_write_rejects_undeclared_kwargs(self, prodml_patch, tmp_path):
+        """Options the writer does not declare raise instead of no-op."""
+        with pytest.raises(ParameterError, match="unused_option"):
+            dc.write(prodml_patch, tmp_path / "kwargs.h5", "PRODML", unused_option=True)
 
 
 class TestProdMLWriteLayout:

--- a/tests/test_io/test_prodml/test_prodml_write.py
+++ b/tests/test_io/test_prodml/test_prodml_write.py
@@ -71,12 +71,12 @@ class TestProdMLWriteDispatch:
             prodml_patch.io.write(path, "PRODML", file_version="2.1")
         assert dc.get_format(path) == ("PRODML", "2.1")
 
-    def test_write_accepts_forwarded_kwargs(self, prodml_patch, tmp_path):
-        """Format-specific keywords should follow the shared writer contract."""
-        path = dc.write(
-            prodml_patch, tmp_path / "kwargs.h5", "PRODML", unused_option=True
-        )
-        assert dc.get_format(path) == ("PRODML", "2.1")
+    def test_write_rejects_undeclared_kwargs(self, prodml_patch, tmp_path):
+        """Options the writer does not declare raise instead of no-op."""
+        from dascore.exceptions import ParameterError
+
+        with pytest.raises(ParameterError, match="unused_option"):
+            dc.write(prodml_patch, tmp_path / "kwargs.h5", "PRODML", unused_option=True)
 
 
 class TestProdMLWriteLayout:


### PR DESCRIPTION
## Description

Adds a storage/codec API for DASDAE writes, ported to dev's h5py-based IO stack. This supersedes #734, which was written against master's PyTables implementation.

Codecs describe how array payloads are compressed; storage objects describe how a writer applies those codecs plus layout options such as per-dimension chunking. Keeping the two separate means chunk layout stays a storage concern and codecs remain reusable by other HDF5-backed formats.

### User API

Simple preset compression:

```python
patch.io.write(path, "dasdae", storage="compressed")
```

Dict form with a codec and chunk layout (no imports needed):

```python
patch.io.write(
    path,
    "dasdae",
    storage={"codec": {"name": "gzip", "level": 5}, "chunks": {"time": 2000}},
)
```

Typed form:

```python
from dascore.io.dasdae import DASDAEStorage
from dascore.io.hdf5 import Gzip

storage = DASDAEStorage(codec=Gzip(level=5), chunks={"time": 2000})
patch.io.write(path, "dasdae", storage=storage)
```

Capability discovery:

```python
dc.io.get_storage("DASDAE")   # -> DASDAEStorage
dc.io.get_codecs("DASDAE")    # -> (Gzip,)
```

### Implementation

- `BaseCodec` and `BaseStorage` pydantic models in `dascore.io.core`, plus `get_storage()`/`get_codecs()` discovery. `FiberIO.storage_cls` is derived from the `storage` annotation on `write()` so the storage type has a single source of truth.
- A plugin-extensible codec registry (`dascore.codec` entry-point group) in `dascore.io.codec`; only `get_codecs` is exported on the `dascore.io` namespace to avoid a `get_codec`/`get_codecs` naming trap.
- An h5py-native `Gzip` codec in `dascore.io.hdf5`. Blosc/zstd is not included for now: h5py has no built-in blosc filter, so the `compressed` preset uses gzip level 5. A future `hdf5plugin`-backed codec can restore it through the registry without API changes.
- `DASDAEStorage` with `codec`/`chunks` options and fail-fast validation: unknown codec names, codec instances without a registered discriminator, non-positive chunk sizes, and typoed chunk dimension names all raise before any data is written. Chunk-dim validation uses scan metadata so lazy spools are not materialized twice.
- Codec and chunk layout apply to data arrays and coordinate arrays (chunks match coordinates by dim name); scalar and zero-length arrays fall back to contiguous storage.
- Patch data is now decoded through the same attribute-aware path as coordinates on read, so string and datetime data arrays round-trip exactly (previously they came back as raw bytes/int64), including through selective reads.

### Compatibility

Files written without a storage argument are byte-for-byte equivalent to before. Compressed files use native HDF5 filters, so any HDF5 reader (h5py, PyTables, external tools) can read them without DASCore.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable DASDAE storage options for compression and chunking.
  * Added built-in gzip compression with adjustable compression level and shuffle settings.
  * Added codec discovery and lookup, including support for registered extensions.
  * Added explicit NetCDF compression, compression-level, and chunking options.

* **Bug Fixes**
  * Improved validation for storage settings, codecs, and chunk dimensions.
  * Improved handling of scalar, empty, Unicode, date/time, and filtered data.

* **Documentation**
  * Added guidance and examples for configuring DASDAE compression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->