### PR TITLE
Bump ruff to v0.16.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,9 @@ repos:
     # Ruff is a replacement for flake8 and many other linters (much faster too)
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.8
+    rev: v0.16.1
     hooks:
-    -   id: ruff
+    -   id: ruff-check
         args: ["--fix"]
         # Run the formatter.
     -   id: ruff-format

--- a/benchmarks/notebooks/patch_v_xarray.ipynb
+++ b/benchmarks/notebooks/patch_v_xarray.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "patch = dc.get_example_patch(\"random_das\")\n",
     "dar = patch.to_xarray()\n",
-    "t1, t2 = patch.attrs['time_min'], patch.attrs['time_max']\n",
+    "t1, t2 = patch.attrs[\"time_min\"], patch.attrs[\"time_max\"]\n",
     "duration = t2 - t1"
    ]
   },
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "%%timeit\n",
-    "patch.select(time=(t1 + duration/2, t2))"
+    "patch.select(time=(t1 + duration / 2, t2))"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "%%timeit\n",
-    "patch.select(time=(t1, t2-duration/2))"
+    "patch.select(time=(t1, t2 - duration / 2))"
    ]
   },
   {
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "%%timeit \n",
-    "dar.sel(time=slice(t1+ duration/2, t2))"
+    "dar.sel(time=slice(t1 + duration / 2, t2))"
    ]
   },
   {
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "%%timeit \n",
-    "dar.sel(time=slice(t1, t2 - duration/2))"
+    "dar.sel(time=slice(t1, t2 - duration / 2))"
    ]
   },
   {

--- a/benchmarks/notebooks/rolling.ipynb
+++ b/benchmarks/notebooks/rolling.ipynb
@@ -15,9 +15,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import dascore as dc\n",
     "import numba\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "\n",
+    "import dascore as dc"
    ]
   },
   {
@@ -26,19 +27,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def rolling_mean(data, window_size,step_size, axis = 0):\n",
+    "def rolling_mean(data, window_size, step_size, axis=0):\n",
     "    total_samples = data.shape[axis]\n",
-    "    mean_values = np.empty((int(total_samples/step_size),data.shape[1]))\n",
+    "    mean_values = np.empty((int(total_samples / step_size), data.shape[1]))\n",
     "\n",
     "    for j, k in enumerate(range(0, total_samples, step_size)):\n",
-    "\n",
-    "        if k+window_size>total_samples:\n",
+    "        if k + window_size > total_samples:\n",
     "            mean_values[j, :] = np.full((data.shape[1]), np.nan)\n",
     "        else:\n",
-    "            mean_values[j, :] = np.mean(\n",
-    "                data[k : k + window_size, :], axis=axis\n",
-    "            )\n",
-    "\n",
+    "            mean_values[j, :] = np.mean(data[k : k + window_size, :], axis=axis)\n",
     "\n",
     "    return mean_values"
    ]
@@ -70,9 +67,9 @@
    "outputs": [],
    "source": [
     "@numba.jit\n",
-    "def rolling_mean_numba(data, window_size,step_size, axis = 0):\n",
+    "def rolling_mean_numba(data, window_size, step_size, axis=0):\n",
     "    total_samples = data.shape[axis]\n",
-    "    mean_values = np.empty((int(total_samples/step_size),data.shape[1]))\n",
+    "    mean_values = np.empty((int(total_samples / step_size), data.shape[1]))\n",
     "\n",
     "    for j, k in enumerate(range(0, total_samples, step_size)):\n",
     "        mean_values[j, :] = np.mean(\n",
@@ -96,9 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import dascore as dc\n",
-    "from dascore.units import s\n"
+    "import dascore as dc"
    ]
   },
   {
@@ -134,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%timeit patch_mean = patch.rolling(time=1*s, step=0.5*s).mean()\n"
+    "%timeit patch_mean = patch.rolling(time=1*s, step=0.5*s).mean()"
    ]
   },
   {
@@ -152,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%timeit patch_mean = patch.rolling(time=3*s, step=1*s).mean()\n"
+    "%timeit patch_mean = patch.rolling(time=3*s, step=1*s).mean()"
    ]
   }
  ],

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -94,9 +94,7 @@ class PatchAttrs(DascoreBaseModel):
             return data
         data = dict(data)
         if "coords" in data and not isinstance(data["coords"], str):
-            msg = (
-                "PatchAttrs no longer accepts coordinate metadata. " "Received: coords."
-            )
+            msg = "PatchAttrs no longer accepts coordinate metadata. Received: coords."
             raise ValueError(msg)
         data.pop("dims", None)
         return data

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -529,10 +529,7 @@ class CoordManager(DascoreBaseModel):
         dim_map = dict(self.dim_map)
         for old_dim, new_dim in kwargs.items():
             if new_dim not in coord_map or old_dim not in dims:
-                msg = (
-                    f"{old_dim} is not a dimension or {new_dim} is not a "
-                    f"coordinate."
-                )
+                msg = f"{old_dim} is not a dimension or {new_dim} is not a coordinate."
                 raise CoordError(msg)
             # ensure coords have the same shape
             old_coord, new_coord = coord_map[old_dim], coord_map[new_dim]
@@ -696,7 +693,7 @@ class CoordManager(DascoreBaseModel):
         """
         used_dims = [self.dim_map[x] for x in kwargs if x in self.coord_map]
         if len(set(used_dims)) < len(used_dims):
-            msg = f"Cannot use {kwargs} for query; some coords " f"share a dimension."
+            msg = f"Cannot use {kwargs} for query; some coords share a dimension."
             raise CoordError(msg)
 
     def __rich__(self) -> str:

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -377,10 +377,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
     def _order_by_sample_array(self, array):
         """Select based on index values."""
         if not np.issubdtype(array.dtype, np.integer):
-            msg = (
-                "Using an array input for select "
-                "with samples requires integer dtype."
-            )
+            msg = "Using an array input for select with samples requires integer dtype."
             raise CoordError(msg)
         # Filter out bad indices
         array = array[np.abs(array) < len(self)]
@@ -863,7 +860,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
     def get_slice_tuple(
         self,
-        select: slice | None | EllipsisType | tuple[Any, Any],
+        select: slice | EllipsisType | tuple[Any, Any] | None,
         relative=False,
     ) -> tuple[Any, Any]:
         """
@@ -1005,7 +1002,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             samples = int(np.ceil(ratio))
         if enforce_lt_coord and samples > len(self):
             msg = (
-                f"value of {value} with samples={samples } results in a window "
+                f"value of {value} with samples={samples} results in a window "
                 f"larger than coordinate length of {len(self)}."
             )
             raise ParameterError(msg)
@@ -1991,8 +1988,7 @@ def _validate_segment_compat(segments: tuple[BaseCoord, ...]) -> None:
     for seg in segments:
         if not isinstance(seg, CoordRange | CoordMonotonicArray):
             msg = (
-                "Segments must be CoordRange or CoordMonotonicArray, "
-                f"got {type(seg)}."
+                f"Segments must be CoordRange or CoordMonotonicArray, got {type(seg)}."
             )
             raise CoordError(msg)
         if not len(seg):
@@ -2810,15 +2806,15 @@ class CoordString(BaseCoord):
 
 def get_coord(
     *,
-    data: ArrayLike | None | np.ndarray | BaseCoord = None,
-    values: ArrayLike | None | np.ndarray = None,
+    data: ArrayLike | np.ndarray | BaseCoord | None = None,
+    values: ArrayLike | np.ndarray | None = None,
     start=None,
     min=None,
     stop=None,
     max=None,
     step=None,
-    units: None | Unit | Quantity | str = None,
-    shape: None | int | tuple[int, ...] = None,
+    units: Unit | Quantity | str | None = None,
+    shape: int | tuple[int, ...] | None = None,
     dtype: str | np.dtype | None = None,
     segments: tuple[BaseCoord, ...] | list[BaseCoord] | None = None,
 ) -> BaseCoord:

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -536,10 +536,7 @@ class Spool(BaseSpool):
                 np.issubdtype(array.dtype, np.bool_)
                 or np.issubdtype(array.dtype, np.integer)
             ):
-                msg = (
-                    "Only bool or int dtypes are supported for spool "
-                    "array selection."
-                )
+                msg = "Only bool or int dtypes are supported for spool array selection."
                 raise ValueError(msg)
             return self._new_from_catalog(self._catalog.restrict(array))
         try:

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -96,7 +96,7 @@ def _get_zone_time(feb):
     assert block_pad > 1
     overlaps_removed = extents[2] != 0
     if overlaps_removed:
-        block_no_pad = int(round(block_time / dt))
+        block_no_pad = round(block_time / dt)
     else:
         block_no_pad = int(round(block_pad / (1 + (overlap / 100)), 0))
     # Perform checks to make sure this is DAS data. If not, you need to use
@@ -131,9 +131,9 @@ def _get_block_time(feb):
     # n for others. The first might imply different times for different
     # zones? We aren't set up to handle that, but we don't know if it can happen
     # so just assert here.
-    assert np.max(time_shape) == np.prod(
-        time_shape
-    ), "Non flat 2d time vector is not supported by DASCore Febus reader."
+    assert np.max(time_shape) == np.prod(time_shape), (
+        "Non flat 2d time vector is not supported by DASCore Febus reader."
+    )
     # Get the average time spacing in each block. These can vary a bit so
     # account for outliers.
     time = np.squeeze(feb.source["time"][:])

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -39,7 +39,7 @@ from .g1utils import (
 )
 from .t1utils import _get_t1_patch, _is_t1_file, _scan_t1
 
-_float_select_type = tuple[float | None | EllipsisType, float | None | EllipsisType]
+_float_select_type = tuple[float | EllipsisType | None, float | EllipsisType | None]
 _time_select_type = tuple[
     opt_timeable_types | EllipsisType,
     opt_timeable_types | EllipsisType,

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -201,7 +201,7 @@ class SQLIndexBackend(abc.ABC):
                 )
             for index_name, table, column in INDEXES:
                 self._execute(
-                    f"CREATE INDEX IF NOT EXISTS {index_name} " f"ON {table} ({column})"
+                    f"CREATE INDEX IF NOT EXISTS {index_name} ON {table} ({column})"
                 )
             self._execute(
                 "INSERT INTO meta_data VALUES (?, ?, ?, ?)",

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -359,7 +359,7 @@ def _coord_record(name: str, summary) -> CoordRecord | None:
             step_num=step_num,
             **common,
         )
-    if dtype.kind in "US" or dtype == object:
+    if dtype.kind in "USO":
         return CoordRecord(
             value_kind="str",
             min_str=str(summary.min),

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -129,7 +129,7 @@ def _coord_record_from_row(
     if step is not None:
         # lo, hi, and step always share a time kind (or are all floats), but
         # ty unions the branch types and rejects the mixed combinations.
-        length = int(round((hi - lo) / step)) + 1  # ty: ignore[unsupported-operator]
+        length = round((hi - lo) / step) + 1  # ty: ignore[unsupported-operator]
     key = row.get(f"_{name}_def_key")
     fingerprint = None
     if isinstance(key, str) and key.startswith("fp:"):

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -102,7 +102,7 @@ def _to_target_unit(typed, target_units: str | None, name: str):
 def _range_bounds(
     value,
     target_kinds: set[str],
-    target_units: str | None | object = _UNSET,
+    target_units: str | object | None = _UNSET,
     name: str = "value",
 ):
     """

--- a/dascore/io/rsf/core.py
+++ b/dascore/io/rsf/core.py
@@ -86,15 +86,15 @@ class RSFV1(FiberIO):
         length = len(axis_lengs)
         hdr_info = [hdr_str, file_format, f"esize={file_esize}"]
         for i in range(length):
-            hdr_info.append(f"n{i+1}={axis_lengs[i]}")
+            hdr_info.append(f"n{i + 1}={axis_lengs[i]}")
             if axis_names[i] == "time":
-                hdr_info.append(f"o{i+1}=0.0")
+                hdr_info.append(f"o{i + 1}=0.0")
                 hdr_info.append(f"starttime={axis_origs[i]}")
             else:
-                hdr_info.append(f"o{i+1}={axis_origs[i]}")
-            hdr_info.append(f"d{i+1}={axis_steps[i]}")
-            hdr_info.append(f'label{i+1}="{axis_names[i]}"')
-            hdr_info.append(f'unit{i+1}="{axis_units[i]}"')
+                hdr_info.append(f"o{i + 1}={axis_origs[i]}")
+            hdr_info.append(f"d{i + 1}={axis_steps[i]}")
+            hdr_info.append(f'label{i + 1}="{axis_names[i]}"')
+            hdr_info.append(f'unit{i + 1}="{axis_units[i]}"')
 
         if data_path is not None:
             # outputs header and binary separately (.rsf and .rsf@)

--- a/dascore/io/terra15/utils.py
+++ b/dascore/io/terra15/utils.py
@@ -177,7 +177,7 @@ def _get_default_attrs(root_node_attrs):
 
 def _get_time_coord(data_node, snap_dims=True):
     """Get the time coordinate."""
-    t_min, t_max, time_len, d_time = _get_scanned_time_info(data_node)
+    t_min, t_max, _time_len, d_time = _get_scanned_time_info(data_node)
     if snap_dims:
         kwargs = dict(start=t_min, stop=t_max + d_time, step=d_time, units="s")
         time_coord = get_coord(**kwargs)

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -200,7 +200,7 @@ def bool_patch(self: PatchType):
 def update(
     self: PatchType,
     data: ArrayLike | np.ndarray | None = None,
-    coords: None | dict[str | Sequence[str], ArrayLike] | CoordManager = None,
+    coords: dict[str | Sequence[str], ArrayLike] | CoordManager | None = None,
     dims: Sequence[str] | None = None,
     attrs: Mapping | PatchAttrs | None = None,
 ) -> PatchType:

--- a/dascore/proc/whiten.py
+++ b/dascore/proc/whiten.py
@@ -81,8 +81,8 @@ def _check_freq_range(fft_coord, freq_range):
 @patch_function()
 def whiten(
     patch: PatchType,
-    smooth_size: None | float = None,
-    water_level: None | float = None,
+    smooth_size: float | None = None,
+    water_level: float | None = None,
     **kwargs,
 ) -> PatchType:
     """

--- a/dascore/transform/dispersion.py
+++ b/dascore/transform/dispersion.py
@@ -16,8 +16,8 @@ from dascore.utils.patch import patch_function
 def dispersion_phase_shift(
     patch: PatchType,
     phase_velocities: Sequence[float],
-    approx_resolution: None | float = None,
-    approx_freq: None | tuple[float, float] = None,
+    approx_resolution: float | None = None,
+    approx_freq: tuple[float, float] | None = None,
 ) -> PatchType:
     """
     Compute dispersion images using the phase-shift method.

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -199,7 +199,7 @@ def _convert_dft_spectral_amplitudes(patch, output, dims, real, db):
 @patch_function()
 def dft(
     patch: PatchType,
-    dim: str | None | Sequence[str],
+    dim: str | Sequence[str] | None,
     *,
     real: str | bool | None = None,
     pad: bool = True,
@@ -411,7 +411,7 @@ def _check_dft_output_invertible(patch):
 
 
 @patch_function()
-def idft(patch: PatchType, dim: str | None | Sequence[str] = None) -> PatchType:
+def idft(patch: PatchType, dim: str | Sequence[str] | None = None) -> PatchType:
     """
     Perform the inverse discrete Fourier transform (idft) on specified dimension(s).
 

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -174,8 +174,8 @@ def _get_conversion_factors(from_quant, to_quant) -> tuple[float, float, float]:
 
 def convert_units(
     data: numeric | Quantity,
-    to_units: None | str | Quantity,
-    from_units: None | str | Quantity = None,
+    to_units: str | Quantity | None,
+    from_units: str | Quantity | None = None,
 ) -> numeric:
     """
     Convert units in array from one type of units to another.
@@ -325,7 +325,7 @@ def get_filter_units(
     arg1: Quantity | float,
     arg2: Quantity | float,
     to_unit: str | Quantity,
-    dim: None | str = None,
+    dim: str | None = None,
 ) -> tuple[float, float]:
     """
     Get a tuple for applying filter based on dimension coordinates.

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -86,8 +86,7 @@ def _resolve_group_attrs(group, columns) -> tuple[str, ...]:
         group = (group,) if isinstance(group, str) else tuple(group)
         if missing := [x for x in group if x not in columns]:
             msg = (
-                f"group attribute(s) {missing} do not exist on any patch "
-                "in the spool."
+                f"group attribute(s) {missing} do not exist on any patch in the spool."
             )
             raise InvalidSpoolQueryError(msg)
         return group
@@ -252,7 +251,7 @@ def _partition(
     tolerance merged patches the default would have kept apart (#662);
     the caller owns warning about it.
     """
-    start, stop, step = get_interval_columns(df, name)
+    _start, _stop, step = get_interval_columns(df, name)
     cols = [x for x in group_attrs if x in df.columns]
     if "dims" in df.columns:
         cols.append("dims")
@@ -470,8 +469,7 @@ def build_chunk_plan(
     """
     if len(kwargs) != 1:
         msg = (
-            "Chunking only supported along one dimension. You passed "
-            f"kwargs: {kwargs}"
+            f"Chunking only supported along one dimension. You passed kwargs: {kwargs}"
         )
         raise ParameterError(msg)
     ((name, value),) = kwargs.items()
@@ -493,7 +491,7 @@ def build_chunk_plan(
         msg = f"missing_dim must be 'raise' or 'drop', got {missing_dim!r}"
         raise ParameterError(msg)
     if conflict not in ("drop", "raise", "keep_first"):
-        msg = "conflict must be 'drop', 'raise', or 'keep_first', " f"got {conflict!r}"
+        msg = f"conflict must be 'drop', 'raise', or 'keep_first', got {conflict!r}"
         raise ParameterError(msg)
 
     min_name, max_name = f"{name}_min", f"{name}_max"

--- a/dascore/utils/coordmanager.py
+++ b/dascore/utils/coordmanager.py
@@ -50,10 +50,7 @@ def merge_coord_managers(
         """Ensure all managers have same dimensions."""
         dims = {x.dims for x in managers}
         if len(dims) != 1:
-            msg = (
-                "Can't merge coord managers, they don't all have the "
-                "same dimensions!"
-            )
+            msg = "Can't merge coord managers, they don't all have the same dimensions!"
             raise CoordMergeError(msg)
         return managers[0].dims
 
@@ -108,8 +105,7 @@ def merge_coord_managers(
             # snap is too far off, bail out.
             elif diff > tolerance:
                 msg = (
-                    f"Cannot merge. Snap tolerance: {get_nice_text(tolerance)}"
-                    f" not met"
+                    f"Cannot merge. Snap tolerance: {get_nice_text(tolerance)} not met"
                 )
                 raise CoordMergeError(msg)
         return coord_list

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -223,7 +223,7 @@ class H5Reader(_H5CasterBase):
         h5py can consume a binary file object via the
         ``fileobj`` driver, so remote UPath inputs stay streaming-based here.
         """
-        if isinstance(resource, cls | _ManagedH5pyFile):
+        if isinstance(resource, (cls, _ManagedH5pyFile)):
             return resource
         return open_h5_resource(
             resource,

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -108,7 +108,7 @@ class BinaryReader(io.BytesIO):
     @classmethod
     def get_handle(cls, resource):
         """Get the handle object from various sources."""
-        if isinstance(resource, cls | io.BufferedIOBase):
+        if isinstance(resource, (cls, io.BufferedIOBase)):
             if cls.reset_offset:
                 resource.seek(0)  # reset byte offset
             return resource
@@ -128,7 +128,7 @@ class LocalBinaryReader(BinaryReader):
     @classmethod
     def get_handle(cls, resource):
         """Get the binary handle, materializing remote resources if needed."""
-        if isinstance(resource, cls | io.BufferedIOBase):
+        if isinstance(resource, (cls, io.BufferedIOBase)):
             if cls.reset_offset:
                 resource.seek(0)
             return resource
@@ -150,7 +150,7 @@ class TextReader(BinaryReader):
     @classmethod
     def get_handle(cls, resource):
         """Get a text handle from a resource."""
-        if isinstance(resource, cls | io.TextIOBase):
+        if isinstance(resource, (cls, io.TextIOBase)):
             if cls.reset_offset:
                 resource.seek(0)
             return resource

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -598,7 +598,7 @@ def yield_sub_sequences(sequence, length=None):
 
 
 def maybe_get_items(
-    obj, attr_map: Mapping[str, str], unpack_names: None | set[str] = None
+    obj, attr_map: Mapping[str, str], unpack_names: set[str] | None = None
 ):
     """
     Maybe get items from a mapping (if they exist).

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -637,9 +637,9 @@ def patch_to_dataframe(patch: PatchType) -> pd.DataFrame:
     """
     dims = patch.dims
     # ensure a 2D patch is passed
-    assert (
-        len(dims) == 2
-    ), "Patch must have exactly 2 dimensions to convert to dataframe"
+    assert len(dims) == 2, (
+        "Patch must have exactly 2 dimensions to convert to dataframe"
+    )
     # get arrays with dimensional values
     index_values = patch.get_coord(dims[0]).values
     col_values = patch.get_coord(dims[1]).values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,7 +265,7 @@ line-ending = "lf"
 include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
-# burned down. Counts as of 2026-08-04: invalid-argument-type 90,
+# burned down. Counts as of 2026-08-04: invalid-argument-type 86,
 # invalid-return-type 37, invalid-method-override 15.
 [tool.ty.rules]
 invalid-argument-type = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,11 @@ max-complexity = 10
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
+# Notebooks are exploratory; ruff started linting them in v0.16 and the
+# docstring rules make little sense for a scratch cell.
+[tool.ruff.lint.per-file-ignores]
+"*.ipynb" = ["D103"]
+
 [tool.pytest.ini_options]
 norecursedirs = [
     "*.egg",

--- a/scripts/_index_api.py
+++ b/scripts/_index_api.py
@@ -101,7 +101,7 @@ def parse_project(obj, key=None):
 
     def get_type(
         obj, parent_is_class=False
-    ) -> None | Literal["module", "function", "method", "class"]:
+    ) -> Literal["module", "function", "method", "class"] | None:
         """Return a string of the type of object."""
         obj = _unwrap_obj(obj)
         if isinstance(obj, ModuleType):

--- a/scripts/test_render_api.py
+++ b/scripts/test_render_api.py
@@ -10,7 +10,7 @@ import pytest
 # These tests only work if doc deps are installed.
 pytest.importorskip("jinja2")
 
-from _render_api import build_signature, get_type_hints, to_quarto_code  # noqa
+from _render_api import build_signature, get_type_hints, to_quarto_code
 
 
 class TestGetTypeHints:

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -343,7 +343,7 @@ class TestDrop:
         """Trying to drop a dim that doesnt exist should just return."""
         array = np.ones(cm_multidim.shape)
         axis = cm_multidim.get_axis("time")
-        cm, new_array = cm_multidim.drop_coords("time", array=array)
+        _cm, new_array = cm_multidim.drop_coords("time", array=array)
         assert new_array.shape[axis] == 0
 
     def test_drop_non_dim_coord(self, cm_multidim):
@@ -412,7 +412,7 @@ class TestSelect:
     def test_filter_array(self, cm_basic):
         """Ensure an array can be filtered."""
         data = np.ones(cm_basic.shape)
-        new, trim = cm_basic.select(distance=(100, 400), array=data)
+        _new, trim = cm_basic.select(distance=(100, 400), array=data)
         assert trim.shape == trim.shape
 
     def test_select_emptying_dim(self, cm_basic):
@@ -501,7 +501,7 @@ class TestSelect:
         """Ensure trim also trims related dimensions."""
         cm = cm_multidim
         data = np.empty(cm.shape)
-        out, new_data = cm.select(array=data, time=slice(2, 4), samples=True)
+        out, _new_data = cm.select(array=data, time=slice(2, 4), samples=True)
         for name, coord in out.coord_map.items():
             dims = cm.dim_map[name]
             if "time" not in dims:

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -838,7 +838,7 @@ class TestSelect:
         """A sub-array should allow indexing."""
         values = long_coord.values
         sub = values[1:-1]
-        out, reduction = long_coord.select(sub)
+        _out, reduction = long_coord.select(sub)
         assert reduction.sum() == len(sub)
 
     def test_overlapping_array(self, long_coord):
@@ -855,7 +855,7 @@ class TestSelect:
     def test_duplicate_array_samples(self, long_coord):
         """Ensure duplicate do nothing."""
         inds = np.array([0, 0, 0])
-        coord, reduction = long_coord.select(inds, samples=True)
+        coord, _reduction = long_coord.select(inds, samples=True)
         assert len(coord) == len(np.unique(inds))
         assert np.all(coord.values == coord.values[0])
 
@@ -870,7 +870,7 @@ class TestSelect:
         """Ensure duplicate values don't cause duplicates in array."""
         second_value = long_coord.values[1]
         array = np.array([second_value, second_value])
-        coord, reduction = long_coord.select(array)
+        coord, _reduction = long_coord.select(array)
         assert len(coord) == len(np.unique(array))
         assert np.all(array == second_value)
 
@@ -957,7 +957,7 @@ class TestSelect:
 
     def test_percentage(self, coord):
         """Ensure selecting by percentage works."""
-        out, indexer = coord.select((10 * percent, -20 * percent))
+        out, _indexer = coord.select((10 * percent, -20 * percent))
         if coord.evenly_sampled:
             assert abs((len(out) / len(coord)) - 0.70) < len(coord) / 100.0
 
@@ -992,7 +992,7 @@ class TestOrder:
     def test_duplicate_array_samples(self, long_coord):
         """Ensure duplicate indices cause duplicates in array."""
         inds = np.array([0, 0, 0])
-        coord, reduction = long_coord.order(inds, samples=True)
+        coord, _reduction = long_coord.order(inds, samples=True)
         assert len(coord) == len(inds)
         assert np.all(coord.values == coord.values[0])
 
@@ -1007,14 +1007,14 @@ class TestOrder:
         """Ensure duplicate values cause duplicates in array."""
         second_value = long_coord.values[1]
         array = np.array([second_value, second_value])
-        coord, reduction = long_coord.order(array)
+        coord, _reduction = long_coord.order(array)
         assert len(coord) == len(array)
         assert np.all(array == second_value)
 
     def test_sorted_by_values(self, long_coord):
         """Ensure the output is sorted by values given to select."""
         vals = long_coord.values[np.array([4, 2, 1, 3])]
-        coord, reduction = long_coord.order(vals)
+        coord, _reduction = long_coord.order(vals)
         assert vals.shape == coord.shape
         assert np.all(vals == coord.values)
 
@@ -1065,7 +1065,7 @@ class TestOrder:
         old_values = coord_with_duplicates.values
         to_find = [0, 1, 1]
         expected_len = sum((old_values == x).sum() for x in to_find)
-        out, inds = coord_with_duplicates.order(to_find)
+        out, _inds = coord_with_duplicates.order(to_find)
         assert len(out) == expected_len
 
     def test_order_samples_non_int_aray(self, evenly_sampled_coord):
@@ -1193,13 +1193,13 @@ class TestCoordRange:
     def test_identity_slice_ints(self, evenly_sampled_coord):
         """Ensure slice with exact start/end gives same coord."""
         coord = evenly_sampled_coord
-        new, sliced = coord.select((coord.start, coord.stop))
+        new, _sliced = coord.select((coord.start, coord.stop))
         assert new == coord
 
     def test_identity_slice_floats(self, evenly_sampled_float_coord_with_units):
         """Ensure slice with exact start/end gives same coord."""
         coord = evenly_sampled_float_coord_with_units
-        new, sliced = coord.select((coord.start, coord.stop))
+        new, _sliced = coord.select((coord.start, coord.stop))
         assert new == coord
 
     def test_float_basics(self):
@@ -1214,7 +1214,7 @@ class TestCoordRange:
         coord = evenly_sampled_float_coord_with_units
         value_ft = 100
         value_m = value_ft * 0.3048
-        new, sliced = coord.select((value_ft * dc.get_unit("ft"), ...))
+        new, _sliced = coord.select((value_ft * dc.get_unit("ft"), ...))
         # ensure value is surrounded.
         assert new.start + new.step >= value_m
         assert new.start - new.step <= value_m
@@ -1249,7 +1249,7 @@ class TestCoordRange:
         """Ensure string selection works with datetime objects."""
         coord = evenly_sampled_date_coord
         date_str = "1970-01-01T12"
-        new, sliced = coord.select((date_str, ...))
+        new, _sliced = coord.select((date_str, ...))
         datetime = dc.to_datetime64(date_str)
         assert new.start + new.step >= datetime
         assert new.start - new.step <= datetime
@@ -1314,7 +1314,7 @@ class TestCoordRange:
     def test_test_select_end_floats(self, evenly_sampled_float_coord_with_units):
         """Ensure we can select right up to the end of the array."""
         coord = evenly_sampled_float_coord_with_units
-        new_coord, out = coord.select((coord.min(), coord.max()))
+        new_coord, _out = coord.select((coord.min(), coord.max()))
         assert len(new_coord) == len(coord)
         assert np.allclose(new_coord.values, coord.values)
 
@@ -1580,13 +1580,13 @@ class TestMonotonicCoord:
         lims = coord.limits
         dur = lims[1] - lims[0]
         select_range = (lims[0] - 2 * dur, lims[1] + dur)
-        wide_coord, inds = coord.select(select_range)
+        wide_coord, _inds = coord.select(select_range)
         # coord should be unchanged
         assert len(wide_coord) == len(coord)
         assert wide_coord == coord
-        wide_coord, inds = coord.select((select_range[0], None))
+        wide_coord, _inds = coord.select((select_range[0], None))
         assert wide_coord == coord
-        wide_coord, inds = coord.select((None, select_range[1]))
+        wide_coord, _inds = coord.select((None, select_range[1]))
         assert wide_coord == coord
 
     def test_properties_mono(self, monotonic_float_coord):
@@ -1625,13 +1625,13 @@ class TestNonOrderedArrayCoords:
         min_v, max_v = np.min(random_coord.values), np.max(random_coord.values)
         dist = max_v - min_v
         val1, val2 = min_v + 0.2 * dist, max_v - 0.2 * dist
-        new, ind_array = random_coord.select((val1, val2))
+        new, _ind_array = random_coord.select((val1, val2))
         assert np.all(new.values >= val1)
         assert np.all(new.values <= val2)
 
     def test_sort(self, random_coord):
         """Ensure the coord can be ordered."""
-        new, ordering = random_coord.sort()
+        new, _ordering = random_coord.sort()
         assert isinstance(new, CoordMonotonicArray)
 
     def test_snap(self, random_coord):
@@ -1747,7 +1747,7 @@ class TestPartialCoord:
     def test_order_by_samples(self, basic_non_coord):
         """Ensure coord can be ordered by samples."""
         order = [0, 1]
-        out, ind = basic_non_coord.order(order, samples=True)
+        out, _ind = basic_non_coord.order(order, samples=True)
         assert len(order) == len(out)
 
     def test_to_summary(self, basic_non_coord):
@@ -1886,7 +1886,7 @@ class TestCoercion:
     def test_date_str(self, evenly_sampled_date_coord):
         """Ensure date strings get coerced."""
         drange = ("1970-01-01T00:00:01", 10)
-        out, indexer = evenly_sampled_date_coord.select(drange)
+        out, _indexer = evenly_sampled_date_coord.select(drange)
         assert isinstance(out, evenly_sampled_date_coord.__class__)
         assert out.dtype == evenly_sampled_date_coord.dtype
 
@@ -1894,7 +1894,7 @@ class TestCoercion:
         """Ensure date strings get coerced."""
         coord = evenly_sampled_time_delta_coord
         drange = (10, 2_000)
-        out, indexer = coord.select(drange)
+        out, _indexer = coord.select(drange)
         assert isinstance(out, coord.__class__)
         assert out.dtype == coord.dtype
 
@@ -2191,9 +2191,9 @@ class TestAlignTo:
         """Ensure when non_coords are compatible original coords returned."""
         coord = evenly_sampled_coord
         non_coord = get_coord(data=1)
-        c1, c2, s1, s2 = coord.align_to(non_coord)
+        c1, _c2, _s1, _s2 = coord.align_to(non_coord)
         assert c1 == coord
-        c1, c2, s1, s2 = non_coord.align_to(coord)
+        c1, _c2, _s1, _s2 = non_coord.align_to(coord)
         assert c1 == non_coord
 
     def test_incompatible_non_coords(self, basic_non_coord):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -135,9 +135,9 @@ class TestDeltaPatch:
         assert isinstance(patch, dc.Patch), "delta_patch should return a Patch instance"
 
         dims = patch.dims
-        assert (
-            "time" in dims and "distance" in dims
-        ), "Patch must have 'time' and 'distance' dimensions"
+        assert "time" in dims and "distance" in dims, (
+            "Patch must have 'time' and 'distance' dimensions"
+        )
 
     @pytest.mark.parametrize("dim", ["time", "distance"])
     def test_delta_patch_delta_location(self, dim):
@@ -158,9 +158,9 @@ class TestDeltaPatch:
         # Replace the center value with zero and ensure all zeros remain
         test_data = np.copy(data)
         test_data[mid_idx] = 0
-        assert np.allclose(
-            test_data, 0
-        ), "All other samples should be zero except the center"
+        assert np.allclose(test_data, 0), (
+            "All other samples should be zero except the center"
+        )
 
     @pytest.mark.parametrize("dim", ["time", "distance"])
     def test_delta_patch_with_patch(self, dim):
@@ -180,9 +180,9 @@ class TestDeltaPatch:
         assert data[mid_idx] == 1.0, "Center sample should be 1.0"
         test_data = np.copy(data)
         test_data[mid_idx] = 0
-        assert np.allclose(
-            test_data, 0
-        ), "All other samples should be zero except the center"
+        assert np.allclose(test_data, 0), (
+            "All other samples should be zero except the center"
+        )
 
     @pytest.mark.parametrize("dim", ["lag_time", "distance"])
     def test_delta_patch_with_3d_patch(self, dim):
@@ -201,6 +201,6 @@ class TestDeltaPatch:
         assert data[mid_idx] == 1.0, "Center sample should be 1.0"
         test_data = np.copy(data)
         test_data[mid_idx] = 0
-        assert np.allclose(
-            test_data, 0
-        ), "All other samples should be zero except the center"
+        assert np.allclose(test_data, 0), (
+            "All other samples should be zero except the center"
+        )

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -481,9 +481,9 @@ class TestScan:
         for summary in scanned_summaries:
             for coord_name, coord in summary.coords.items():
                 with suppress(TypeError):  # incomparable types (e.g. NaT/NaN)
-                    assert (
-                        coord.min <= coord.max
-                    ), f"{coord_name}: min ({coord.min}) > max ({coord.max})"
+                    assert coord.min <= coord.max, (
+                        f"{coord_name}: min ({coord.min}) > max ({coord.max})"
+                    )
 
     def test_no_bytes(self, scanned_summaries):
         """Sometimes bytes are returned from scanning, we need str."""

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -849,5 +849,5 @@ class TestStringArrayHelpers:
         )
         with h5py.File(path, mode="w") as h5:
             group = h5.create_group("waveforms")
-            with pytest.raises(TypeError, match="Object dtype|object arrays"):
+            with pytest.raises(TypeError, match=r"Object dtype|object arrays"):
                 _save_array(data, "obj", group=group)

--- a/tests/test_io/test_index/test_db_dirspool.py
+++ b/tests/test_io/test_index/test_db_dirspool.py
@@ -109,7 +109,7 @@ class TestUpdateLifecycle:
 
     def test_no_change_update_uses_narrow_projection(self, fresh, monkeypatch):
         """A no-op update reads only the stat columns, not the wide table."""
-        path, spool = fresh
+        _path, spool = fresh
         backend = spool.indexer._backend
 
         def _boom(self):

--- a/tests/test_io/test_wav/test_wav.py
+++ b/tests/test_io/test_wav/test_wav.py
@@ -62,7 +62,7 @@ class TestWriteWav:
         """Ensure resampling changes sampling rate in file."""
         path = tmp_path_factory.mktemp("wav_resample") / "resampled.wav"
         dc.write(audio_patch, path, "wav", resample_frequency=1000)
-        (sr, ar) = read_wav(str(path))
+        (sr, _ar) = read_wav(str(path))
         assert sr == 1000
 
     def test_write_non_distance_dims(
@@ -80,7 +80,7 @@ class TestWriteWav:
         for mic_val in patch.coords.get_array("microphone"):
             assert path / f"microphone_{mic_val}.wav" in wavs
             # Verify content of first file
-            sr, data = read_wav(str(wavs[0]))
+            sr, _data = read_wav(str(wavs[0]))
         assert sr == int(ONE_SECOND / patch.get_coord("time").step)
 
     def test_write_remote_directory(self, audio_patch_non_distance_dim):

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -195,12 +195,12 @@ class TestHampelFilter:
                 approximate_spike = abs(result_approximate.data[time_idx, dist_idx])
 
                 # Both methods should reduce the spike magnitude
-                assert (
-                    standard_spike < original_spike
-                ), f"Standard method didn't reduce spike at ({time_idx}, {dist_idx})"
-                assert (
-                    approximate_spike < original_spike
-                ), f"Approximate method didn't reduce spike at ({time_idx}, {dist_idx})"
+                assert standard_spike < original_spike, (
+                    f"Standard method didn't reduce spike at ({time_idx}, {dist_idx})"
+                )
+                assert approximate_spike < original_spike, (
+                    f"Approximate did not reduce spike at ({time_idx}, {dist_idx})"
+                )
 
                 # Both should achieve similar spike reduction (within 50% of each other)
                 reduction_ratio = min(standard_spike, approximate_spike) / max(

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -305,9 +305,9 @@ class TestNumpyVsPandasRolling:
         ).sum()
         numpy_isnan = np.isnan(numpy_out.data)
         pandas_isnan = np.isnan(pandas_out.data)
-        assert np.all(
-            np.equal(numpy_isnan, pandas_isnan)
-        ), "The NaN indices do not match"
+        assert np.all(np.equal(numpy_isnan, pandas_isnan)), (
+            "The NaN indices do not match"
+        )
 
     def test_center_same_stepped(self, range_patch):
         """Ensure center values are handled the same."""
@@ -320,9 +320,9 @@ class TestNumpyVsPandasRolling:
         ).sum()
         numpy_isnan = np.isnan(numpy_out.data)
         pandas_isnan = np.isnan(pandas_out.data)
-        assert np.all(
-            np.equal(numpy_isnan, pandas_isnan)
-        ), "The NaN indices do not match"
+        assert np.all(np.equal(numpy_isnan, pandas_isnan)), (
+            "The NaN indices do not match"
+        )
 
     def test_dimension_order(self, range_patch):
         """Ensure the dimension order doesn't matter."""

--- a/tests/test_proc/test_taper.py
+++ b/tests/test_proc/test_taper.py
@@ -247,7 +247,7 @@ class TestTaperRange:
 
     def test_bad_use_of_none(self, random_patch):
         """Ensure bad use of None raises."""
-        with pytest.raises(ParameterError, match="Cannot use ... or None"):
+        with pytest.raises(ParameterError, match=r"Cannot use ... or None"):
             random_patch.taper_range(time=(1, None), relative=True)
 
     def test_use_none(self, random_patch):

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -199,9 +199,9 @@ class TestWhiten:
         whitened_patch_freq_domain = dft.whiten(smooth_size=5, time=None)
 
         # check if the returned data is in the frequency domain
-        assert np.iscomplexobj(
-            whitened_patch_freq_domain.data
-        ), "Expected the output to be complex, indicating freq. domain patch."
+        assert np.iscomplexobj(whitened_patch_freq_domain.data), (
+            "Expected the output to be complex, indicating freq. domain patch."
+        )
 
         assert "ft_time" in dft.coords.coord_map
 

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -339,7 +339,7 @@ class TestPlanMembers:
     def test_modified_flag_no_chunk(self, contiguous_df):
         """Rows whose limits don't change aren't modified."""
         time_diff = contiguous_df["time_max"] - contiguous_df["time_min"]
-        df = contiguous_df.assign(time_max=lambda x: (x["time_max"] - x["time_step"]))
+        df = contiguous_df.assign(time_max=lambda x: x["time_max"] - x["time_step"])
         plan = build_chunk_plan(
             df, overlap=0, time=time_diff.iloc[0], keep_partial=True
         )

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -90,7 +90,7 @@ class TestDocsting:
 
     def test_raises_when_some_placeholders_are_unused(self):
         """Providing extra substitution keys should fail loudly."""
-        with pytest.raises(ValueError, match="unused keys.*extra"):
+        with pytest.raises(ValueError, match=r"unused keys.*extra"):
 
             @compose_docstring(params="value", extra="not-used")
             def dummy_func():

--- a/tests/test_viz/test_spectrogram.py
+++ b/tests/test_viz/test_spectrogram.py
@@ -61,7 +61,7 @@ class TestPlotSpectrogram:
 
     def test_invalid_aggr_domain(self, random_patch):
         """Ensure ValueError is raised for invalid aggr_domain."""
-        with pytest.raises(ValueError, match="should be 'time' or 'frequency'."):
+        with pytest.raises(ValueError, match=r"should be 'time' or 'frequency'."):
             random_patch.viz.spectrogram(aggr_domain="invalid")
 
     def test_invalid_patch_dims(self, random_patch):

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -311,9 +311,9 @@ class TestWaterfall:
         expected_label = f"{data_type}{expected_dunits} - log_10"
 
         # Check if the colorbar label matches the expected label
-        assert (
-            cb_label == expected_label
-        ), f"Expected '{expected_label}', but got '{cb_label}'"
+        assert cb_label == expected_label, (
+            f"Expected '{expected_label}', but got '{cb_label}'"
+        )
 
     def test_incomplete_time_coord(self):
         """Test waterfall plot with incomplete time coordinates (issue #534)."""


### PR DESCRIPTION
## Description

Bumps ruff from **v0.4.8** to **v0.16.1**. The pin was about eighteen months and twelve minor versions behind.

Everything the new rules found is mechanical:

- **RUF059** (31) — a name bound by tuple unpacking and never read gets an underscore.
- **RUF043** (4) — a regex handed to `pytest.raises(match=...)` is a raw string, so its metacharacters are deliberate rather than accidental.
- **RUF036** (2) — `None` goes at the end of a union.
- **RUF046** (2) — a one-argument `round()` already returns an int, so the `int()` around it went. (The two-argument form still needs it and was not touched.)
- **E721** (1) — `dtype == object` becomes `dtype.kind in "USO"`, folding it into the string-kind check on the same line and saying the same thing more directly.
- **E501** (1) — one assertion message shortened.

ruff also formats and lints notebooks now, which reformatted the two benchmark notebooks and asked for docstrings on their cells. Those are exploratory, so `D103` is ignored for `*.ipynb`.

The hook id becomes `ruff-check`, which it has been since v0.8; `ruff` still resolves but is a legacy alias.

### What this unblocks

ty rejects a class union as `isinstance`'s second argument — `isinstance(resource, cls | io.BufferedIOBase)` — and the tuple form it accepts was forbidden by **UP038**, which ruff has since deprecated and removed. Four calls in `utils/io.py` and `utils/hdf5.py` sat out the ty burn-down waiting on this. They are taken here, in their own commit: `invalid-argument-type` drops from 90 to 86.

Stacked on #816; that PR should merge first.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
