### PR TITLE
Burn down the coord, protobuf and forwarding-mismatch diagnostics

### DIFF
--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -138,9 +138,11 @@ class PatchAttrs(DascoreBaseModel):
             out = model_dump()
         else:
             out = attr_map
-        if isinstance(out, Mapping):
-            out = dict(out)
-            out.pop("dims", None)
+        # Anything not already a mapping came from model_dump, which
+        # returns one, so this only restates the contract for the checker.
+        assert isinstance(out, Mapping), "attr_map must resolve to a mapping"
+        out = dict(out)
+        out.pop("dims", None)
         return cls(**out)
 
     def update(self, **kwargs) -> Self:

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from pydantic import ConfigDict, Field, PlainValidator, model_validator
 from typing_extensions import Self
@@ -138,12 +138,12 @@ class PatchAttrs(DascoreBaseModel):
             out = model_dump()
         else:
             out = attr_map
-        # Anything not already a mapping came from model_dump, which
-        # returns one, so this only restates the contract for the checker.
-        assert isinstance(out, Mapping), "attr_map must resolve to a mapping"
-        out = dict(out)
-        out.pop("dims", None)
-        return cls(**out)
+        if isinstance(out, Mapping):
+            out = dict(out)
+            out.pop("dims", None)
+        # Anything else may still be unpackable -- a pandas Series, say --
+        # and the constructor has always been what rejects the rest.
+        return cls(**cast("Mapping[str, Any]", out))
 
     def update(self, **kwargs) -> Self:
         """Update an attribute in the model, return new model."""

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -1133,7 +1133,7 @@ class CoordManager(DascoreBaseModel):
 
 def get_coord_manager(
     coords: CoordManagerInput | CoordManager | None = None,
-    dims: tuple[str, ...] | None = None,
+    dims: Sequence[str] | None = None,
     shape=None,
 ) -> CoordManager:
     """
@@ -1175,6 +1175,8 @@ def get_coord_manager(
     >>> cm = get_coord_manager(coords=coords, dims=dims)
     """
     # return coords if we already have a coord manager.
+    # A list of dims would never compare equal to a CoordManager's tuple.
+    dims = None if dims is None else tuple(dims)
     if isinstance(coords, CoordManager):
         # maybe try to rename dims.
         if dims is not None and dims != coords.dims:

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -42,7 +42,7 @@ print(new_cm)
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from itertools import zip_longest
 from types import EllipsisType
 from typing import Annotated, Any
@@ -447,7 +447,7 @@ class CoordManager(DascoreBaseModel):
 
     def drop_coords(
         self,
-        *coords: str | Collection[str],
+        *coords: str,
         array: MaybeArray = None,
     ) -> tuple[Self, MaybeArray]:
         """

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -42,7 +42,7 @@ print(new_cm)
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from itertools import zip_longest
 from types import EllipsisType
 from typing import Annotated, Any
@@ -447,7 +447,7 @@ class CoordManager(DascoreBaseModel):
 
     def drop_coords(
         self,
-        *coords: str | Sequence[str],
+        *coords: str | Collection[str],
         array: MaybeArray = None,
     ) -> tuple[Self, MaybeArray]:
         """

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -425,7 +425,7 @@ class CoordManager(DascoreBaseModel):
         assert out.shape == self.shape
         return out, array
 
-    def new(self, dims=None, coord_map=None, dim_map=None) -> Self:
+    def new(self, dims=None, coord_map=None, dim_map=None, **kwargs) -> Self:
         """
         Return a new coordmanager with specified attributes replaced.
 
@@ -442,6 +442,7 @@ class CoordManager(DascoreBaseModel):
             dims=dims if dims is not None else self.dims,
             coord_map=coord_map if coord_map is not None else self.coord_map,
             dim_map=dim_map if dim_map is not None else self.dim_map,
+            **kwargs,
         )
         return out
 

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -347,7 +347,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         return tuple(iterate(value))
 
     @abc.abstractmethod
-    def convert_units(self, unit) -> Self:
+    def convert_units(self, units) -> Self:
         """Convert from one unit to another. Set units if None are set."""
 
     def _get_value_index(self, coord_array, values_to_find):
@@ -433,8 +433,8 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
     @abc.abstractmethod
     def select(
-        self, arg, relative=False, samples=False
-    ) -> tuple[Self, slice | ArrayLike]:
+        self, args, relative=False, samples=False
+    ) -> tuple[BaseCoord, slice | ArrayLike]:
         """
         Returns an entity that can be used in a list for numpy indexing
         and selected coord.
@@ -442,7 +442,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
     def order(
         self, array, relative=False, samples=False
-    ) -> tuple[Self, slice | ArrayLike]:
+    ) -> tuple[BaseCoord, slice | ArrayLike]:
         """
         Order coordinate according to array values or samples.
 
@@ -700,7 +700,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
     def sort(self, reverse=False) -> tuple[BaseCoord, slice | ArrayLike]:
         """Sort the contents of the coord. Return new coord and slice for sorting."""
 
-    def snap(self) -> CoordRange:
+    def snap(self) -> BaseCoord:
         """
         Snap the coordinates to evenly sampled grid points.
 
@@ -766,7 +766,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         return pd.DataFrame(columns=columns)
 
     @abc.abstractmethod
-    def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
+    def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
         """
         Update the limits or sampling of the coordinates.
 
@@ -796,7 +796,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         data: ArrayLike | np.ndarray | None = None,
         values: ArrayLike | np.ndarray | None = None,
         **kwargs,
-    ) -> Self:
+    ) -> BaseCoord:
         """
         Update the data of the coordinate.
 
@@ -903,7 +903,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             out = self.min() + value if pos else self.max() + value
         return out
 
-    def empty(self, axes=None) -> Self:
+    def empty(self, axes=None) -> BaseCoord:
         """
         Empty out the coordinate.
 
@@ -922,7 +922,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         data = np.empty(tuple(new_shape), dtype=self.dtype)
         return get_coord(data=data)
 
-    def index(self, indexer, axis: int | None = None) -> Self:
+    def index(self, indexer, axis: int | None = None) -> BaseCoord:
         """
         Index the coordinate and return new coordinate.
 
@@ -1145,7 +1145,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
                 return True
         return all_close(self.values, other.values)
 
-    def change_length(self, length: int) -> Self:
+    def change_length(self, length: int) -> BaseCoord:
         """
         Adjust the length of the coordinate by changing the end value.
 
@@ -1240,9 +1240,16 @@ class CoordPartial(BaseCoord):
         """No values to change so update can just call new."""
         return self.new(**kwargs)
 
-    # Other operations that normally modify data do not in this case.
-    update_limits = update
-    set_units = update
+    # Other operations that normally modify data do not in this case;
+    # they are spelled out rather than aliased so each keeps the
+    # signature its base declares.
+    def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
+        """No values to change, so only the metadata in kwargs is applied."""
+        return self.update(min=min, max=max, step=step, **kwargs)
+
+    def set_units(self, units) -> Self:
+        """No values to change, so this only records the new units."""
+        return self.update(units=units)
 
     def convert_units(self, units) -> Self:
         """Convert scalar metadata units, or set units if none exist."""
@@ -1307,7 +1314,7 @@ class CoordPartial(BaseCoord):
     @compose_docstring(doc=get_docstring(BaseCoord.order))
     def order(
         self, array, relative=False, samples=False
-    ) -> tuple[Self, slice | ArrayLike]:
+    ) -> tuple[BaseCoord, slice | ArrayLike]:
         """
         {doc}.
         """
@@ -1315,7 +1322,7 @@ class CoordPartial(BaseCoord):
         return super().order(array, relative=relative, samples=samples)
 
     @compose_docstring(doc=get_docstring(BaseCoord.change_length))
-    def change_length(self, length: int) -> Self:
+    def change_length(self, length: int) -> BaseCoord:
         """
         {doc}
         """
@@ -1616,7 +1623,7 @@ class CoordRange(BaseCoord):
         return fraction.astype(np.int64)
 
     @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
-    def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
+    def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
         """{doc}."""
         if all(x is not None for x in [min, max, step]):
             msg = "At most two parameters can be specified in update_limits."
@@ -1676,7 +1683,7 @@ class CoordRange(BaseCoord):
         return np.max([self.stop - self.step, self.start])
 
     @compose_docstring(doc=get_docstring(BaseCoord.change_length))
-    def change_length(self, length: int) -> Self:
+    def change_length(self, length: int) -> BaseCoord:
         """
         {doc}
         """
@@ -1730,7 +1737,7 @@ class CoordArray(BaseCoord):
 
     def select(
         self, args, relative=False, samples=False
-    ) -> tuple[Self, slice | ArrayLike]:
+    ) -> tuple[BaseCoord, slice | ArrayLike]:
         """Apply select, return selected coords and index for selecting data."""
         if is_array(args):
             return self._select_by_array(args, relative=relative, samples=samples)
@@ -1800,7 +1807,7 @@ class CoordArray(BaseCoord):
         return out.change_length(len(self))
 
     @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
-    def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
+    def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
         """{doc}."""
         if sum(x is not None for x in [min, max, step]) > 1:
             msg = "At most one parameter can be specified in update_limits."
@@ -1863,7 +1870,7 @@ class CoordMonotonicArray(CoordArray):
 
     def select(
         self, args, relative=False, samples=False
-    ) -> tuple[Self, slice | ArrayLike]:
+    ) -> tuple[BaseCoord, slice | ArrayLike]:
         """Apply select, return selected coords and index for selecting data."""
         if is_array(args):
             return self._select_by_array(args, relative=relative, samples=samples)
@@ -2332,7 +2339,7 @@ class CoordSegmented(BaseCoord):
         return self.new(segments=segments), slice(None, None, -1)
 
     @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
-    def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
+    def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
         """{doc}."""
         if step is not None:
             msg = (
@@ -2363,7 +2370,7 @@ class CoordSegmented(BaseCoord):
             segments.append(new)
         return self.new(segments=tuple(segments))
 
-    def snap(self) -> CoordRange:
+    def snap(self) -> BaseCoord:
         """
         Snap the coordinates to evenly sampled grid points.
 
@@ -2708,9 +2715,9 @@ class CoordString(BaseCoord):
         values["step"] = None
         return values
 
-    def convert_units(self, unit) -> Self:
+    def convert_units(self, units) -> Self:
         """String coordinates cannot be converted between units."""
-        if unit not in (None, ""):
+        if units not in (None, ""):
             _raise_string_coord_error("unit conversion")
         return self
 
@@ -2730,7 +2737,7 @@ class CoordString(BaseCoord):
 
     def select(
         self, args, relative=False, samples=False
-    ) -> tuple[Self, slice | ArrayLike]:
+    ) -> tuple[BaseCoord, slice | ArrayLike]:
         """Select by exact values, wildcard patterns, regexes, samples, or masks."""
         if relative:
             _raise_string_coord_error("relative selection")
@@ -2779,7 +2786,7 @@ class CoordString(BaseCoord):
             return False
         return bool(np.all(values[:-1] >= values[1:]))
 
-    def update_limits(self, min=None, max=None, step=None, **kwargs) -> Self:
+    def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
         """Reject numeric limit updates on string coords."""
         # Deliberately match BaseCoord/CoordRange parameter names for API parity.
         unsupported_kwargs = set(kwargs) - {"data"}

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1145,7 +1145,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
                 return True
         return all_close(self.values, other.values)
 
-    def change_length(self, length: int) -> BaseCoord:
+    def change_length(self, length: int) -> Self:
         """
         Adjust the length of the coordinate by changing the end value.
 
@@ -1240,16 +1240,15 @@ class CoordPartial(BaseCoord):
         """No values to change so update can just call new."""
         return self.new(**kwargs)
 
-    # Other operations that normally modify data do not in this case;
-    # they are spelled out rather than aliased so each keeps the
-    # signature its base declares.
+    # update_limits is spelled out rather than aliased to update so it keeps
+    # the signature its base declares. It must forward only what the caller
+    # supplied: a None reaching _validate_nullish_to_nan would overwrite the
+    # stored start, stop or step with nan.
     def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
-        """No values to change, so only the metadata in kwargs is applied."""
-        return self.update(min=min, max=max, step=step, **kwargs)
-
-    def set_units(self, units) -> Self:
-        """No values to change, so this only records the new units."""
-        return self.update(units=units)
+        """No values to limit, so only what was passed is applied."""
+        limits = {"min": min, "max": max, "step": step}
+        passed = {i: v for i, v in limits.items() if v is not None}
+        return self.update(**passed, **kwargs)
 
     def convert_units(self, units) -> Self:
         """Convert scalar metadata units, or set units if none exist."""
@@ -1322,7 +1321,7 @@ class CoordPartial(BaseCoord):
         return super().order(array, relative=relative, samples=samples)
 
     @compose_docstring(doc=get_docstring(BaseCoord.change_length))
-    def change_length(self, length: int) -> BaseCoord:
+    def change_length(self, length: int) -> Self:
         """
         {doc}
         """
@@ -1683,7 +1682,7 @@ class CoordRange(BaseCoord):
         return np.max([self.stop - self.step, self.start])
 
     @compose_docstring(doc=get_docstring(BaseCoord.change_length))
-    def change_length(self, length: int) -> BaseCoord:
+    def change_length(self, length: int) -> Self:
         """
         {doc}
         """
@@ -2370,7 +2369,7 @@ class CoordSegmented(BaseCoord):
             segments.append(new)
         return self.new(segments=tuple(segments))
 
-    def snap(self) -> BaseCoord:
+    def snap(self) -> CoordRange:
         """
         Snap the coordinates to evenly sampled grid points.
 

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -341,7 +341,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
 
     @field_validator("shape", mode="before")
     @classmethod
-    def _validate_nullish_to_nan(cls, value):
+    def _validate_shape_to_tuple(cls, value):
         """Ensure shape is a tuple."""
         # This also allows shape to be an int.
         return tuple(iterate(value))

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -21,7 +21,6 @@ from dascore.core.coordmanager import (
     CoordManagerInput,
     get_coord_manager,
 )
-from dascore.core.coords import BaseCoord
 from dascore.core.summary import PatchSummary
 from dascore.utils.array import (
     PatchUFunc,

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from functools import cached_property
-from typing import Final
+from typing import Any, Final
 from uuid import uuid4
 
 import numpy as np
@@ -16,11 +16,7 @@ import dascore.utils.io
 from dascore import transform
 from dascore.compat import DataArray, array
 from dascore.core.attrs import PatchAttrs
-from dascore.core.coordmanager import (
-    CoordManager,
-    CoordManagerInput,
-    get_coord_manager,
-)
+from dascore.core.coordmanager import CoordManager, get_coord_manager
 from dascore.core.summary import PatchSummary
 from dascore.utils.array import (
     PatchUFunc,
@@ -80,7 +76,7 @@ class Patch(NamespaceOwner):
     def __init__(
         self,
         data: ArrayLike | DataArray | None = None,
-        coords: CoordManagerInput | CoordManager | None = None,
+        coords: Mapping[str, Any] | CoordManager | None = None,
         dims: Sequence[str] | None = None,
         attrs: Mapping | PatchAttrs | None = None,
     ):

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -16,7 +16,11 @@ import dascore.utils.io
 from dascore import transform
 from dascore.compat import DataArray, array
 from dascore.core.attrs import PatchAttrs
-from dascore.core.coordmanager import CoordManager, get_coord_manager
+from dascore.core.coordmanager import (
+    CoordManager,
+    CoordManagerInput,
+    get_coord_manager,
+)
 from dascore.core.coords import BaseCoord
 from dascore.core.summary import PatchSummary
 from dascore.utils.array import (
@@ -77,7 +81,7 @@ class Patch(NamespaceOwner):
     def __init__(
         self,
         data: ArrayLike | DataArray | None = None,
-        coords: Mapping[str, ArrayLike | BaseCoord] | CoordManager | None = None,
+        coords: CoordManagerInput | CoordManager | None = None,
         dims: Sequence[str] | None = None,
         attrs: Mapping | PatchAttrs | None = None,
     ):

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -84,7 +84,7 @@ def _flatten_coord_summary(
     exclude: set[str] | None = None,
 ) -> dict[str, Any]:
     """Flatten a single coord summary into scan/index-style fields."""
-    exclude = set() if exclude is None else exclude
+    exclude = set[str]() if exclude is None else exclude
     summary_dict = _coord_summary_to_dict(summary)
     out = {}
     if dim_tuple and coord_name not in exclude:

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -261,7 +261,7 @@ class PatchSummary(DascoreBaseModel):
 
     def flat_dump(self, dim_tuple: bool = False, exclude=None) -> dict[str, Any]:
         """Return a flat dict suitable for indexing/dataframes."""
-        exclude = set(() if exclude is None else exclude)
+        exclude = set[str](() if exclude is None else exclude)
         # Build flattened attrs first, then overlay coord summaries so coord-
         # derived fields win over any attr using the same simplified key.
         out = self.attrs.flat_dump(exclude=exclude)

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -234,8 +234,8 @@ def _scan_payload_to_summary(
         shape=tuple(payload.get("shape", ())),
         dtype=str(payload["dtype"]),
         source_path=source_path,
-        source_format=source_format,
-        source_version=source_version,
+        source_format=source_format or "",
+        source_version=source_version or "",
         source_patch_id=(
             normalize_source_patch_id(source_patch_id)
             or normalize_source_patch_id(payload.get("source_patch_id"))
@@ -694,7 +694,7 @@ class _FiberIOManager:
 
     def _get_format(
         self,
-        path: str | Path | IOResourceManager,
+        path: path_types | IOResourceManager,
         file_format: str | None = None,
         file_version: str | None = None,
         fiber_io_hint: dict[str, FiberIO] | None = None,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -234,8 +234,8 @@ def _scan_payload_to_summary(
         shape=tuple(payload.get("shape", ())),
         dtype=str(payload["dtype"]),
         source_path=source_path,
-        source_format=source_format or "",
-        source_version=source_version or "",
+        source_format=source_format,
+        source_version=source_version,
         source_patch_id=(
             normalize_source_patch_id(source_patch_id)
             or normalize_source_patch_id(payload.get("source_patch_id"))

--- a/dascore/io/index/indexer.py
+++ b/dascore/io/index/indexer.py
@@ -136,7 +136,7 @@ class DBDirectoryIndexer:
     ):
         path = UPath(path).absolute() if isinstance(path, UPath) else Path(path)
         requires_local_directory(path, label="DBDirectoryIndexer")
-        self.path = coerce_to_local_path(path).absolute()
+        self.path = Path(coerce_to_local_path(path)).absolute()
         self.index_path = Path(self._find_index_path(index_path))
         try:
             self._backend = get_backend(self.index_path)
@@ -288,7 +288,7 @@ class DBDirectoryIndexer:
             signal = None
             if candidate is None:  # the reply to a "skip" send
                 continue
-            path = coerce_to_local_path(candidate)
+            path = Path(candidate)
             if path.is_dir():
                 if self._directory_format(path):
                     signal = "skip"

--- a/dascore/io/index/indexer.py
+++ b/dascore/io/index/indexer.py
@@ -33,7 +33,11 @@ from dascore.io.index.ingest import (
 )
 from dascore.io.index.schema import SPOOL_HIDDEN_COLUMNS
 from dascore.utils.misc import _iter_filesystem
-from dascore.utils.paths import directory_writable, requires_local_directory
+from dascore.utils.paths import (
+    coerce_to_local_path,
+    directory_writable,
+    requires_local_directory,
+)
 
 
 def _path_digest(path) -> str:
@@ -132,7 +136,7 @@ class DBDirectoryIndexer:
     ):
         path = UPath(path).absolute() if isinstance(path, UPath) else Path(path)
         requires_local_directory(path, label="DBDirectoryIndexer")
-        self.path = Path(path).absolute()
+        self.path = coerce_to_local_path(path).absolute()
         self.index_path = Path(self._find_index_path(index_path))
         try:
             self._backend = get_backend(self.index_path)
@@ -284,7 +288,7 @@ class DBDirectoryIndexer:
             signal = None
             if candidate is None:  # the reply to a "skip" send
                 continue
-            path = Path(candidate)
+            path = coerce_to_local_path(candidate)
             if path.is_dir():
                 if self._directory_format(path):
                     signal = "skip"

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -330,7 +330,7 @@ class PlanResolver(PatchResolver):
         # informational only: the directory/file the plan derived from
         self.origin_path = origin_path
 
-    def live_entries(self) -> Mapping[str, dc.Patch]:
+    def live_entries(self) -> dict[str, dc.Patch]:
         """Expose the loader's live registry (for absorption/transfer)."""
         return self.loader.live_entries()
 

--- a/dascore/io/sintela/protobuf_utils.py
+++ b/dascore/io/sintela/protobuf_utils.py
@@ -43,7 +43,7 @@ Building descriptors at runtime through the lower-level, more stable
 from __future__ import annotations
 
 import struct
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from functools import cache
 from typing import Any
 
@@ -464,7 +464,7 @@ def _common_header_time(common_header) -> np.datetime64 | None:
 
 
 def _parse_records(
-    records: list[EnvelopeRecord], *, scan_mode: bool = False
+    records: Iterable[EnvelopeRecord], *, scan_mode: bool = False
 ) -> tuple[list[Any], ParsedMeta]:
     """Decode protobuf payloads and return messages plus selected META."""
     messages = _get_proto_messages(include_sample_fields=not scan_mode)
@@ -530,8 +530,12 @@ def _get_distance_coord(start_channel: int, spacing: float, count: int, step: in
     )
 
 
-def _get_times(times: list[np.datetime64]):
-    """Build a time coordinate from packet timestamps."""
+def _get_times(times: list[np.datetime64 | None]):
+    """
+    Build a time coordinate from packet timestamps.
+
+    A packet whose common header carries no time contributes NaT.
+    """
     return get_coord(data=np.asarray(times, dtype="datetime64[ns]"))
 
 
@@ -557,7 +561,7 @@ def _base_attrs(
     Each packet family supplies its own ``data_type``/``data_units`` via
     ``extra``; the fields below are shared across all families.
     """
-    attrs = dict(
+    attrs = SintelaProtobufAttrs(
         data_category="DAS",
         packet_type=packet_type,
         recorder_namespace=meta.recorder_namespace,
@@ -572,9 +576,7 @@ def _base_attrs(
         start_channel=int(getattr(common_header, "start_channel", 0)),
         channel_step=None,
     )
-    if extra:
-        attrs.update(extra)
-    return SintelaProtobufAttrs(**attrs)
+    return attrs.new(**extra) if extra else attrs
 
 
 def _get_band_attr_data_type(band_def: tuple[tuple[Any, ...], ...]) -> tuple[str, str]:

--- a/dascore/io/sintela/protobuf_utils.py
+++ b/dascore/io/sintela/protobuf_utils.py
@@ -534,7 +534,9 @@ def _get_times(times: list[np.datetime64 | None]):
     """
     Build a time coordinate from packet timestamps.
 
-    A packet whose common header carries no time contributes NaT.
+    Callers reject a packet with no header time before getting here; the
+    None in the signature is what the list comprehension produces, not a
+    supported input.
     """
     return get_coord(data=np.asarray(times, dtype="datetime64[ns]"))
 

--- a/dascore/io/terra15/utils.py
+++ b/dascore/io/terra15/utils.py
@@ -179,8 +179,9 @@ def _get_time_coord(data_node, snap_dims=True):
     """Get the time coordinate."""
     t_min, t_max, _time_len, d_time = _get_scanned_time_info(data_node)
     if snap_dims:
-        kwargs = dict(start=t_min, stop=t_max + d_time, step=d_time, units="s")
-        time_coord = get_coord(**kwargs)
+        time_coord = get_coord(
+            start=t_min, stop=t_max + d_time, step=d_time, units="s"
+        )
     else:
         time_coord = _get_raw_time_coord(data_node)
     return time_coord

--- a/dascore/io/terra15/utils.py
+++ b/dascore/io/terra15/utils.py
@@ -179,9 +179,7 @@ def _get_time_coord(data_node, snap_dims=True):
     """Get the time coordinate."""
     t_min, t_max, _time_len, d_time = _get_scanned_time_info(data_node)
     if snap_dims:
-        time_coord = get_coord(
-            start=t_min, stop=t_max + d_time, step=d_time, units="s"
-        )
+        time_coord = get_coord(start=t_min, stop=t_max + d_time, step=d_time, units="s")
     else:
         time_coord = _get_raw_time_coord(data_node)
     return time_coord

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -6,6 +6,7 @@ import shutil
 from collections.abc import Sequence
 from functools import cache
 from threading import RLock
+from types import EllipsisType
 from typing import Any, TypeVar
 
 import numpy as np
@@ -116,17 +117,19 @@ def _str_to_quant(qunat_str):
 
 # Anything get_quantity can resolve: a unit or quantity, a string naming
 # one, a numpy time value, or a bare number (which is dimensionless).
-# PlainUnit is the base pint builds its registry Unit from, and is what
-# a quantity's .units is statically.
+# PlainUnit is the base pint builds its registry Unit from (so it covers
+# Unit too), and is what a quantity's .units is statically. bytes and
+# Ellipsis are the two cases get_quantity opens by handling.
 quantity_like = (
     str
+    | bytes
     | Quantity
-    | Unit
     | PlainUnit
     | np.datetime64
     | np.timedelta64
     | int
     | float
+    | EllipsisType
     | None
 )
 
@@ -272,7 +275,12 @@ def _unit_to_str(unit: Unit) -> str:
         return str(unit)
 
 
-def get_quantity_str(quant_value: quantity_like) -> str | None:
+# The subset of quantity_like which names a unit; a numpy time value
+# would come back stringified as a date rather than a unit.
+unit_like = str | bytes | Quantity | PlainUnit | None
+
+
+def get_quantity_str(quant_value: unit_like) -> str | None:
     """
     Ensure a unit/quantity is valid and return its string representation.
 
@@ -342,7 +350,7 @@ def get_inverted_quant(quant: Quantity | None, data_units):
 def get_filter_units(
     arg1: Quantity | float,
     arg2: Quantity | float,
-    to_unit: quantity_like,
+    to_unit: unit_like,
     dim: str | None = None,
 ) -> tuple[float, float]:
     """

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import pint
 from pint import DimensionalityError, Quantity, UndefinedUnitError, Unit
+from pint.facets.plain import PlainUnit
 from platformdirs import user_cache_path
 
 import dascore as dc
@@ -115,8 +116,18 @@ def _str_to_quant(qunat_str):
 
 # Anything get_quantity can resolve: a unit or quantity, a string naming
 # one, a numpy time value, or a bare number (which is dimensionless).
+# PlainUnit is the base pint builds its registry Unit from, and is what
+# a quantity's .units is statically.
 quantity_like = (
-    str | Quantity | Unit | np.datetime64 | np.timedelta64 | int | float | None
+    str
+    | Quantity
+    | Unit
+    | PlainUnit
+    | np.datetime64
+    | np.timedelta64
+    | int
+    | float
+    | None
 )
 
 
@@ -236,7 +247,7 @@ def assert_dtype_compatible_with_units(dtype, quantity) -> Quantity:
     return quant
 
 
-def invert_quantity(unit: pint.Unit | str | Quantity | None) -> Quantity | None:
+def invert_quantity(unit: quantity_like) -> Quantity | None:
     """Invert a unit."""
     # just get magnitude for isnull test to avoid warning of casting
     # quantity to array.
@@ -331,7 +342,7 @@ def get_inverted_quant(quant: Quantity | None, data_units):
 def get_filter_units(
     arg1: Quantity | float,
     arg2: Quantity | float,
-    to_unit: str | Quantity,
+    to_unit: quantity_like,
     dim: str | None = None,
 ) -> tuple[float, float]:
     """

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -113,8 +113,15 @@ def _str_to_quant(qunat_str):
         return ureg.Quantity(qunat_str)
 
 
+# Anything get_quantity can resolve: a unit or quantity, a string naming
+# one, a numpy time value, or a bare number (which is dimensionless).
+quantity_like = (
+    str | Quantity | Unit | np.datetime64 | np.timedelta64 | int | float | None
+)
+
+
 def get_quantity(
-    value: str | Quantity | Unit | np.datetime64 | np.timedelta64 | None,
+    value: quantity_like,
 ) -> Quantity | None:
     """
     Convert a value to a pint quantity.
@@ -174,8 +181,8 @@ def _get_conversion_factors(from_quant, to_quant) -> tuple[float, float, float]:
 
 def convert_units(
     data: numeric | Quantity,
-    to_units: str | Quantity | None,
-    from_units: str | Quantity | None = None,
+    to_units: quantity_like,
+    from_units: quantity_like = None,
 ) -> numeric:
     """
     Convert units in array from one type of units to another.
@@ -254,7 +261,7 @@ def _unit_to_str(unit: Unit) -> str:
         return str(unit)
 
 
-def get_quantity_str(quant_value: str | Quantity | None) -> str | None:
+def get_quantity_str(quant_value: quantity_like) -> str | None:
     """
     Ensure a unit/quantity is valid and return its string representation.
 

--- a/dascore/utils/downloader.py
+++ b/dascore/utils/downloader.py
@@ -12,7 +12,7 @@ import pooch
 from dascore.config import get_config
 from dascore.constants import DATA_VERSION
 
-REGISTRY_PATH = Path(files("dascore").joinpath("data_registry.txt"))
+REGISTRY_PATH = Path(str(files("dascore").joinpath("data_registry.txt")))
 LARGE_REGISTRY_FILES = frozenset({"whale_1.hdf5"})
 
 

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -534,7 +534,15 @@ def all_diffs_close_enough(diffs):
     return np.allclose(diffs, med, rtol=0.001)
 
 
-def unbyte(byte_or_str: _T | bytes) -> _T | str:
+@overload
+def unbyte(byte_or_str: bytes) -> str: ...
+
+
+@overload
+def unbyte(byte_or_str: _T) -> _T: ...
+
+
+def unbyte(byte_or_str):
     """
     Decode a bytes value, passing anything else through unchanged.
 

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -16,7 +16,7 @@ from functools import cache
 from io import IOBase
 from pathlib import Path
 from types import ModuleType
-from typing import Literal, overload
+from typing import Literal, TypeVar, overload
 
 import numpy as np
 import pandas as pd
@@ -33,6 +33,8 @@ from dascore.exceptions import (
 )
 from dascore.utils.paths import coerce_to_upath, is_local_path, is_pathlike
 from dascore.utils.progress import track
+
+_T = TypeVar("_T")
 
 
 def register_func(list_or_dict: list | dict, key=None):
@@ -527,10 +529,15 @@ def all_diffs_close_enough(diffs):
     return np.allclose(diffs, med, rtol=0.001)
 
 
-def unbyte(byte_or_str: bytes | str) -> str:
-    """Ensure a string is given by str or possibly bytes."""
+def unbyte(byte_or_str: _T | bytes) -> _T | str:
+    """
+    Decode a bytes value, passing anything else through unchanged.
+
+    Callers use this to normalize values which may or may not have come
+    from a binary file, so the non-bytes case is the common one.
+    """
     if isinstance(byte_or_str, bytes | np.bytes_):
-        byte_or_str = byte_or_str.decode("utf8")
+        return byte_or_str.decode("utf8")
     return byte_or_str
 
 

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -31,7 +31,12 @@ from dascore.exceptions import (
     MissingOptionalDependencyError,
     ParameterError,
 )
-from dascore.utils.paths import coerce_to_upath, is_local_path, is_pathlike
+from dascore.utils.paths import (
+    coerce_to_local_path,
+    coerce_to_upath,
+    is_local_path,
+    is_pathlike,
+)
 from dascore.utils.progress import track
 
 _T = TypeVar("_T")
@@ -224,7 +229,7 @@ def _iter_filesystem(
     if is_pathlike(paths):
         if is_local_path(paths):
             yield from _iter_local_filesystem(
-                Path(paths),
+                coerce_to_local_path(paths),
                 ext=ext,
                 timestamp=timestamp,
                 skip_hidden=skip_hidden,

--- a/dascore/utils/models.py
+++ b/dascore/utils/models.py
@@ -74,12 +74,15 @@ PositiveInt = Annotated[int, Field(gt=0)]
 PositiveFiniteFloat = Annotated[float, Field(gt=0, allow_inf_nan=False)]
 
 
-def sensible_model_equals(
-    self: BaseModel | Mapping, other: BaseModel | Mapping
-) -> bool:
+def sensible_model_equals(self: BaseModel | Mapping, other: object) -> bool:
     """Custom equality to not compare private attrs and handle numpy arrays."""
     d1 = self.model_dump() if isinstance(self, BaseModel) else self
-    d2 = other.model_dump() if isinstance(other, BaseModel) else other
+    if isinstance(other, BaseModel):
+        d2 = other.model_dump()
+    elif isinstance(other, Mapping):
+        d2 = other
+    else:  # nothing else can carry the same fields
+        return NotImplemented
     if not set(d1) == set(d2):  # different keys, not equal
         return False
     for name in set(x for x in d1 if not x.startswith("_")):

--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.signal import spectrogram as scipy_spectrogram
 
+import dascore as dc
 from dascore.constants import PatchType
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
@@ -40,7 +41,7 @@ def _get_new_original_coord(old_coord, array):
 
 def _get_transformed_coord(coord, freqs):
     """Get the transformed coordinates."""
-    units = 1 / coord.units if coord.units is not None else None
+    units = dc.get_quantity(1 / coord.units) if coord.units is not None else None
     return get_coord(data=freqs, units=units)
 
 

--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.signal import spectrogram as scipy_spectrogram
 
-import dascore as dc
 from dascore.constants import PatchType
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
@@ -41,7 +40,7 @@ def _get_new_original_coord(old_coord, array):
 
 def _get_transformed_coord(coord, freqs):
     """Get the transformed coordinates."""
-    units = dc.get_quantity(1 / coord.units) if coord.units is not None else None
+    units = 1 / coord.units if coord.units is not None else None
     return get_coord(data=freqs, units=units)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,8 +267,8 @@ line-ending = "lf"
 include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
-# burned down. Counts as of 2026-08-04: invalid-argument-type 86,
-# invalid-return-type 31, invalid-method-override 4.
+# burned down. Counts as of 2026-08-05: invalid-argument-type 31,
+# invalid-return-type 30, invalid-method-override 4.
 [tool.ty.rules]
 invalid-argument-type = "ignore"
 invalid-return-type = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,7 @@ include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
 # burned down. Counts as of 2026-08-04: invalid-argument-type 86,
-# invalid-return-type 36, invalid-method-override 15.
+# invalid-return-type 31, invalid-method-override 4.
 [tool.ty.rules]
 invalid-argument-type = "ignore"
 invalid-return-type = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,8 +267,8 @@ line-ending = "lf"
 include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
-# burned down. Counts as of 2026-08-05: invalid-argument-type 31,
-# invalid-return-type 30, invalid-method-override 4.
+# burned down. Counts as of 2026-08-05: invalid-argument-type 36,
+# invalid-return-type 31, invalid-method-override 4.
 [tool.ty.rules]
 invalid-argument-type = "ignore"
 invalid-return-type = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,12 +267,11 @@ line-ending = "lf"
 include = ["dascore"]  # tests/ still has many diagnostics; expand scope later.
 
 # Rules with large pre-existing error counts, ignored until incrementally
-# burned down. Counts as of 2026-08-05: invalid-argument-type 36,
-# invalid-return-type 31, invalid-method-override 4.
+# burned down. Counts as of 2026-08-05: invalid-argument-type 34,
+# invalid-return-type 31. invalid-method-override reached zero and is on.
 [tool.ty.rules]
 invalid-argument-type = "ignore"
 invalid-return-type = "ignore"
-invalid-method-override = "ignore"
 
 # These files lazily import optional or untyped modules (xarray, numba,
 # h5py.h5r) that are not installed in the pre-commit hook's environment.

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@ A python library for distributed fiber optic sensing.
 
 [![coverage](https://codecov.io/gh/dasdae/dascore/branch/master/graph/badge.svg)](https://codecov.io/gh/dasdae/dascore)
 [![CodSpeed Badge](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/DASDAE/dascore)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Checked with ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 [![PyPI Version](https://img.shields.io/pypi/v/dascore.svg)](https://pypi.python.org/pypi/dascore)
 [![supported versions](https://img.shields.io/pypi/pyversions/dascore.svg?label=python_versions)](https://pypi.python.org/pypi/dascore)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/dascore.svg?label=pypi)](https://pypi.org/project/dascore/)

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -1334,6 +1334,16 @@ class TestSetUnits:
         out = cm.set_units(time="s")
         assert out.coord_map["time"].units == get_quantity("s")
 
+    def test_patch_set_units_on_valueless_coord(self):
+        """The same holds through the patch, which is how users reach it."""
+        cm = get_coord_manager(
+            {"time": get_coord(shape=(10,)), "distance": np.arange(4) * 1.0},
+            dims=("time", "distance"),
+        )
+        patch = dc.Patch(data=np.zeros((10, 4)), coords=cm, dims=cm.dims)
+        out = patch.set_units(time="s")
+        assert out.get_coord("time").units == get_quantity("s")
+
 
 class TestConvertUnits:
     """Tests for converting coordinate units."""

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -1321,6 +1321,20 @@ class TestSnap:
         assert snapped.coord_map["time"].step == expected_dt
 
 
+class TestSetUnits:
+    """Tests for setting coordinate units."""
+
+    def test_set_units_on_valueless_coord(self):
+        """A dim coord with no values takes units like any other."""
+        cm = get_coord_manager(
+            {"time": get_coord(shape=(10,)), "distance": np.arange(4) * 1.0},
+            dims=("time", "distance"),
+        )
+        assert isinstance(cm.coord_map["time"], CoordPartial)
+        out = cm.set_units(time="s")
+        assert out.coord_map["time"].units == get_quantity("s")
+
+
 class TestConvertUnits:
     """Tests for converting coordinate units."""
 

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1687,6 +1687,18 @@ class TestPartialCoord:
         """Ensure non coords are equal to themselves."""
         assert basic_non_coord == basic_non_coord
 
+    def test_set_units_positionally(self, basic_non_coord):
+        """Units are set the same way as on any other coord."""
+        out = basic_non_coord.set_units("m")
+        assert out.units == dc.get_quantity("m")
+        assert isinstance(out, CoordPartial)
+
+    def test_update_limits_only_touches_metadata(self, basic_non_coord):
+        """There are no values to limit, so only the metadata changes."""
+        out = basic_non_coord.update_limits(units="m")
+        assert out.units == dc.get_quantity("m")
+        assert isinstance(out, CoordPartial)
+
     def test_dimensionless_shape_survives_dump(self):
         """A partial coord keeps its shape when defaults are excluded."""
         coord = get_coord(shape=())

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1693,10 +1693,12 @@ class TestPartialCoord:
         assert out.units == dc.get_quantity("m")
         assert isinstance(out, CoordPartial)
 
-    def test_update_limits_only_touches_metadata(self, basic_non_coord):
-        """There are no values to limit, so only the metadata changes."""
-        out = basic_non_coord.update_limits(units="m")
+    def test_update_limits_only_touches_metadata(self):
+        """There are no values to limit, so the stored scalars survive."""
+        coord = get_coord(shape=(4,), step=1.0, dtype="float64")
+        out = coord.update_limits(units="m")
         assert out.units == dc.get_quantity("m")
+        assert out.step == coord.step
         assert isinstance(out, CoordPartial)
 
     def test_dimensionless_shape_survives_dump(self):

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1687,6 +1687,10 @@ class TestPartialCoord:
         """Ensure non coords are equal to themselves."""
         assert basic_non_coord == basic_non_coord
 
+    def test_shape_accepts_an_int(self):
+        """A partial coord coerces an int shape like every other coord."""
+        assert CoordPartial(shape=5, dtype="float64").shape == (5,)
+
     def test_set_units_positionally(self, basic_non_coord):
         """Units are set the same way as on any other coord."""
         out = basic_non_coord.set_units("m")

--- a/tests/test_io/test_indexer.py
+++ b/tests/test_io/test_indexer.py
@@ -134,7 +134,9 @@ class TestFindIndex:
     def test_local_upath_normalized_to_path(self, tmp_path):
         """Local UPath inputs should normalize to pathlib.Path internally."""
         out = DBDirectoryIndexer(UPath(tmp_path))
-        assert isinstance(out.path, Path)
+        # A local UPath is itself a Path subclass, so isinstance is not
+        # enough to show it was normalized.
+        assert type(out.path) is type(Path(tmp_path))
         assert out.path == Path(tmp_path).absolute()
 
     def test_index_map_dir_comes_from_config(self, tmp_path):

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -152,6 +152,11 @@ class TestIterFS:
         }
         assert out == expected
 
+    def test_local_file_uri(self, simple_dir):
+        """A local path carrying a file:// scheme walks like a plain one."""
+        out = set(_iter_filesystem(simple_dir.as_uri()))
+        assert out == set(_iter_filesystem(simple_dir))
+
     def test_extension(self, simple_dir):
         """Test filtering based on extension."""
         out = set(_iter_filesystem(simple_dir, ext=".txt"))


### PR DESCRIPTION
## Description

Continues the ty burn-down after #816, combining the four remaining planned pieces. Across the three still-ignored rules the count goes **156 → 65**:

| rule | before | after |
|---|---|---|
| `invalid-argument-type` | 86 | **31** |
| `invalid-return-type` | 40 | **30** |
| `invalid-method-override` | 30 | **4** |

### Coords say what they actually return

The coord methods which canonicalize declared `-> Self`, but a coord routinely comes back as a different class — `empty()` always gives a `CoordPartial`, `index()`/`snap()`/`sort()` give a `CoordRange` from an array coord, and `select()` does too once the selection turns out to be evenly sampled. Those six say `BaseCoord` now; the type variable stays where the class really is preserved, such as `convert_units`.

The base also disagreed with every one of its own implementations about two parameter names — `arg` against `args`, `unit` against `units` — so the base moved, which is the side nothing calls (all 70 in-repo `convert_units` calls are positional).

**A bug fell out of that.** `CoordPartial` aliased `update_limits` and `set_units` to `update`, whose only parameter is `**kwargs`, which made `set_units` unusable:

```python
patch.set_units(time="s")   # where that dim's coord holds no values
# TypeError: CoordPartial.update() takes 1 positional argument but 2 were given
```

Both are spelled out now, each keeping the signature its base declares. Two tests cover it and fail on the old code.

### The sintela protobuf block

23 diagnostics on a single line, and the same root cause as #807 and #812: attrs collected in a plain `dict` and splatted into the model, so every field was offered the dict's value union. Building the model directly and applying the family's extras with `new()` leaves each field its own type. Two helpers there also under-declared — a packet with no header time contributes `None`, and the record parser only iterates.

### Things that were narrower than what they forward to

`Patch.__init__`'s `coords` was narrower than the `CoordManagerInput` it hands to `get_coord_manager`, and `get_coord_manager` took only a `tuple` of dims while its callers have a `Sequence` — which also meant **a list of dims never compared equal to a `CoordManager`'s tuple**, so a rename was silently skipped. `get_quantity` has always accepted a bare number as dimensionless and a pint `Unit` as itself, but three of its neighbours declared narrower subsets of the same idea; they share one `quantity_like` alias now. `unbyte` only decodes bytes and hands everything else back untouched, which `bytes | str` could not say.

Three `Path(...)` calls on a value that may be a `UPath` now go through the existing `coerce_to_local_path`, which is also **more correct**: bare `Path("file:///tmp/x")` keeps the scheme as a literal path segment, and that helper exists precisely to strip it.

### Capstone

Ruff and ty badges in the readme.

## What is not done

The rules stay ignored: **31 / 30 / 4** remain. They are one-offs now, not clusters — no two share a root cause — and several turn on whether a value can really be `None` at that point, which is a question about behaviour rather than annotation. I stopped rather than guess at those; the review of #816 was a good reminder of what rushing one produces.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Expanded support for path-like inputs, iterable records, coordinate collections, and quantity values.
  * Improved coordinate operations, including unit assignment and limit updates for valueless coordinates.
  * Improved handling of missing metadata and timestamps during data import.
  * Preserved non-byte values when decoding utility inputs.
  * Improved unit handling in spectrogram visualizations.

* **Documentation**
  * Added Ruff and ty status badges to the README.

* **Tests**
  * Added coverage for coordinate units and updates without coordinate values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->