### PR TITLE
Document sample range semantics and resolve unit ambiguity

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -184,10 +184,8 @@ Any dimension name can be passed as key, and the values can be:
     - an array of values to select, which must be a subset of the
       coordinate array.
     - an array of booleans of the same length as the coordinate where
-      `True` indicates values to keep.
-
-When `samples=True`, the values are indices along the coordinate rather
-than values in it.
+      `True` indicates values to keep. This form does not support
+      `samples=True`.
 """
 
 check_behavior_description = """

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -187,12 +187,7 @@ Any dimension name can be passed as key, and the values can be:
       `True` indicates values to keep.
 
 When `samples=True`, the values are indices along the coordinate rather
-than values in it. Note that `samples` means an index here and in
-[`order`](`dascore.Patch.order`), but a *count* of samples in most other
-patch functions, such as [`rolling`](`dascore.Patch.rolling`),
-[`pad`](`dascore.Patch.pad`), and [`roll`](`dascore.Patch.roll`). For
-instance, `distance=10, samples=True` selects channel number 10 here, but
-means ten channels wide in [`rolling`](`dascore.Patch.rolling`).
+than values in it.
 """
 
 check_behavior_description = """

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -178,12 +178,21 @@ for each attribute.
 
 select_values_description = """
 Any dimension name can be passed as key, and the values can be:
-    - a Slice or a tuple of (min, max) for that dimension.
+    - a tuple of (min, max) for that dimension, or an equivalent slice.
       `None` and ... both indicate open intervals.
+    - an integer, when `samples=True`, to select a single row or column.
     - an array of values to select, which must be a subset of the
       coordinate array.
     - an array of booleans of the same length as the coordinate where
       `True` indicates values to keep.
+
+When `samples=True`, the values are indices along the coordinate rather
+than values in it. Note that `samples` means an index here and in
+[`order`](`dascore.Patch.order`), but a *count* of samples in most other
+patch functions, such as [`rolling`](`dascore.Patch.rolling`),
+[`pad`](`dascore.Patch.pad`), and [`roll`](`dascore.Patch.roll`). For
+instance, `distance=10, samples=True` selects channel number 10 here, but
+means ten channels wide in [`rolling`](`dascore.Patch.rolling`).
 """
 
 check_behavior_description = """

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -528,6 +528,12 @@ def select(
       >>> len(patch.select(time=-1, samples=True).get_array("time"))
       1
 
+      A slice can be used in place of a tuple, and makes the half-open
+      behavior of sample ranges more obvious:
+
+      >>> len(patch.select(time=slice(0, -1), samples=True).get_array("time"))
+      1999
+
     """
     # Check for and raise on invalid kwargs.
     if invalid_coords := set(kwargs) - set(patch.coords.coord_map):

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -507,6 +507,27 @@ def select(
       multiple rows/columns need to be repeated,
       See [`Patch.order`](`dascore.Patch.order`).
 
+    - A range of values includes both of its endpoints, but a range of
+      samples excludes its upper bound, like python's slicing. This means
+      -1 at the end of a sample range excludes the last sample, even
+      though -1 on its own selects it.
+      For example, with 2000 time samples:
+
+      >>> import dascore as dc
+      >>> patch = dc.get_example_patch()
+      >>> # Both endpoints included; 11 channels.
+      >>> len(patch.select(distance=(0, 10)).get_array("distance"))
+      11
+      >>> # Upper bound excluded; 10 samples.
+      >>> len(patch.select(time=(0, 10), samples=True).get_array("time"))
+      10
+      >>> # -1 as a range end drops the last sample.
+      >>> len(patch.select(time=(0, -1), samples=True).get_array("time"))
+      1999
+      >>> # But -1 on its own selects it.
+      >>> len(patch.select(time=-1, samples=True).get_array("time"))
+      1
+
     """
     # Check for and raise on invalid kwargs.
     if invalid_coords := set(kwargs) - set(patch.coords.coord_map):

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -510,8 +510,8 @@ def select(
     - A range of values includes both of its endpoints, but a range of
       samples excludes its upper bound, like python's slicing. This means
       -1 at the end of a sample range excludes the last sample, even
-      though -1 on its own selects it.
-      For example, with 2000 time samples:
+      though -1 on its own selects it. Using the example patch, which has
+      300 distance channels and 2000 time samples:
 
       >>> import dascore as dc
       >>> patch = dc.get_example_patch()
@@ -575,7 +575,8 @@ def order(
     relative
         If True, order values are relative to the start/end of the coordinates.
     samples
-        If True, the
+        If True, the values are indices along the coordinate rather than
+        values in it.
     **kwargs
         Used to specify the coordinate and values on which the coordinates
         are ordered.

--- a/docs/tutorial/concepts.qmd
+++ b/docs/tutorial/concepts.qmd
@@ -68,7 +68,9 @@ filtered_time = patch.pass_filter(time=(1, 5))
 filtered_distance = patch.pass_filter(distance=(0.1, 0.2))
 ```
 
-However, the meaning of the values depends on the function, e.g. both frequency and period might make sense in the example above. For [pass_filter](`dascore.proc.filter.pass_filter`), bare numbers mean frequency (Hz) along `time` and wavenumber along `distance`. Note that the wavenumber is the inverse of the *distance coordinate's own units*, so it is 1/m only while that coordinate is in meters. The example patch's distance is in meters, so `distance=(0.1, 0.2)` above keeps spatial wavelengths of 5 m to 10 m.
+However, the meaning of the values depends on the function, e.g. both frequency and period might make sense in the example above. For [pass_filter](`dascore.proc.filter.pass_filter`), bare numbers mean frequency along `time` and wavenumber along `distance`. In both cases the number is the inverse of *that coordinate's own units*, so it is Hz and 1/m only while the coordinates are in seconds and meters. The example patch's distance is in meters, so `distance=(0.1, 0.2)` above keeps spatial wavelengths of 5 m to 10 m.
+
+Datetime and timedelta coordinates are always in seconds, so a `time` coordinate of that dtype always takes Hz. A numeric `time` coordinate does not: `example_event_2` stores time as float seconds, and converting it to milliseconds makes bare numbers mean 1/ms.
 
 Attaching units removes the guesswork, and lets the same band be stated as a wavelength instead:
 
@@ -91,6 +93,17 @@ assert np.allclose(by_wavenumber.data, by_wavelength.data)
 # units the coordinate happens to be in.
 in_feet = patch.convert_units(distance="ft")
 assert np.allclose(in_feet.pass_filter(distance=(10 * m, 100 * m)).data, by_wavelength.data)
+
+# The time axis behaves the same way when its coordinate is numeric.
+# example_event_2 stores time as float seconds, so bare numbers are Hz,
+# but in milliseconds the same band needs numbers 1000 times smaller.
+event = dc.get_example_patch("example_event_2")
+in_ms = event.convert_units(time="ms")
+
+assert np.allclose(
+    in_ms.pass_filter(time=(0.01, 0.05)).data,
+    event.pass_filter(time=(10, 50)).data,
+)
 ```
 
 When in doubt, be explicit with units and read the docs for the function in question!

--- a/docs/tutorial/concepts.qmd
+++ b/docs/tutorial/concepts.qmd
@@ -68,7 +68,26 @@ filtered_time = patch.pass_filter(time=(1, 5))
 filtered_distance = patch.pass_filter(distance=(0.1, 0.2))
 ```
 
-However, the meaning of the values depends on the function, e.g. both frequency and period might make sense in the example above. Being explicit with units helps, but be sure to read the docs!
+However, the meaning of the values depends on the function, e.g. both frequency and period might make sense in the example above. For [pass_filter](`dascore.proc.filter.pass_filter`), bare numbers mean frequency (Hz) along `time` and wavenumber (1/m) along `distance`, so `distance=(0.1, 0.2)` above keeps spatial wavelengths of 5 m to 10 m.
+
+Attaching units removes the guesswork, and lets the same band be stated as a wavelength instead:
+
+```{python}
+import dascore as dc
+import numpy as np
+from dascore.units import m
+
+patch = dc.get_example_patch()
+
+# Wavenumbers of 0.01 to 0.1 (1/m) and wavelengths of 10 m to 100 m
+# are two ways of describing the same band.
+by_wavenumber = patch.pass_filter(distance=(0.01, 0.1))
+by_wavelength = patch.pass_filter(distance=(10 * m, 100 * m))
+
+assert np.allclose(by_wavenumber.data, by_wavelength.data)
+```
+
+When in doubt, be explicit with units and read the docs for the function in question!
 
 # Units
 

--- a/docs/tutorial/concepts.qmd
+++ b/docs/tutorial/concepts.qmd
@@ -68,7 +68,7 @@ filtered_time = patch.pass_filter(time=(1, 5))
 filtered_distance = patch.pass_filter(distance=(0.1, 0.2))
 ```
 
-However, the meaning of the values depends on the function, e.g. both frequency and period might make sense in the example above. For [pass_filter](`dascore.proc.filter.pass_filter`), bare numbers mean frequency (Hz) along `time` and wavenumber (1/m) along `distance`, so `distance=(0.1, 0.2)` above keeps spatial wavelengths of 5 m to 10 m.
+However, the meaning of the values depends on the function, e.g. both frequency and period might make sense in the example above. For [pass_filter](`dascore.proc.filter.pass_filter`), bare numbers mean frequency (Hz) along `time` and wavenumber along `distance`. Note that the wavenumber is the inverse of the *distance coordinate's own units*, so it is 1/m only while that coordinate is in meters. The example patch's distance is in meters, so `distance=(0.1, 0.2)` above keeps spatial wavelengths of 5 m to 10 m.
 
 Attaching units removes the guesswork, and lets the same band be stated as a wavelength instead:
 
@@ -79,12 +79,18 @@ from dascore.units import m
 
 patch = dc.get_example_patch()
 
-# Wavenumbers of 0.01 to 0.1 (1/m) and wavelengths of 10 m to 100 m
-# are two ways of describing the same band.
+# This patch's distance is in meters, so bare numbers are 1/m.
+# Wavenumbers of 0.01 to 0.1 and wavelengths of 10 m to 100 m are two
+# ways of describing the same band.
 by_wavenumber = patch.pass_filter(distance=(0.01, 0.1))
 by_wavelength = patch.pass_filter(distance=(10 * m, 100 * m))
 
 assert np.allclose(by_wavenumber.data, by_wavelength.data)
+
+# With units attached the query means the same thing regardless of what
+# units the coordinate happens to be in.
+in_feet = patch.convert_units(distance="ft")
+assert np.allclose(in_feet.pass_filter(distance=(10 * m, 100 * m)).data, by_wavelength.data)
 ```
 
 When in doubt, be explicit with units and read the docs for the function in question!

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -133,7 +133,7 @@ path = ex.spool_to_directory(diverse_spool)
 spool = (
   dascore.spool(path)
   .select(network='das2')  # sub-select das2 network
-  .select(time=(None, '2022-01-01'))  # unselect anything after 2022
+  .select(time=(..., '2022-01-01'))  # unselect anything after 2022
   .chunk(time=2, overlap=0.5)  # change the chunking of the patches
 )
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -378,18 +378,39 @@ new = patch.select(time=(-2, -1), relative=True)
 new = patch.select(distance=(-100 * ft, ...), relative=True)
 ```
 
-The `samples` keyword tells `select` the meaning of the query is in samples rather than the units of the selected dimension. Unlike absolute selections, sample selections are **always** relative to the data contained in the patch. For example, 0 refers to the first sample along the dimension and -1 refers to the last.
+The `samples` keyword tells `select` the meaning of the query is in samples rather than the units of the selected dimension. Unlike absolute selections, sample selections are **always** relative to the data contained in the patch, so 0 refers to the first sample along the dimension and -1 refers to the last.
+
+:::{.callout-warning}
+Sample ranges and value ranges do not have the same end behavior. A value range includes both of its endpoints, but a sample range excludes its upper bound, like Python's slicing and `range`.
+
+A consequence worth remembering: `-1` used as the end of a range excludes the last sample, even though `-1` on its own selects it.
+
+| query | selects |
+|---|---|
+| `select(distance=(0, 10))` | values 0 through 10, **both included** (11 channels) |
+| `select(time=(0, 10), samples=True)` | samples 0 through 9 (10 samples) |
+| `select(time=(0, -1), samples=True)` | every sample **except** the last |
+| `select(time=-1, samples=True)` | only the last sample |
+
+: Range endpoints in values vs samples {.striped .hover}
+:::
 
 ```{python}
 import dascore as dc
 
 patch = dc.get_example_patch()
+sample_count = patch.shape[patch.dims.index("time")]
 
 # Trim patch to only include first 10 time rows (or columns).
 new = patch.select(time=(..., 10), samples=True)
+assert new.shape[new.dims.index("time")] == 10
 
 # Only include the last distance column or row.
 new = patch.select(distance=-1, samples=True)
+
+# But as the end of a range, -1 excludes the last sample.
+new = patch.select(time=(0, -1), samples=True)
+assert new.shape[new.dims.index("time")] == sample_count - 1
 ```
 
 Arrays can also be passed as values in which case they will be treated like sets, meaning only coordinate elements in the array will be selected.
@@ -489,7 +510,7 @@ import dascore as dc
 patch = (
     dc.get_example_patch('example_event_1')
     .taper(time=0.05)
-    .pass_filter(time=(None, 300))
+    .pass_filter(time=(..., 300))
 )
 
 patch.viz.waterfall(show=True);

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -393,6 +393,8 @@ A consequence worth remembering: `-1` used as the end of a range excludes the la
 | `select(time=-1, samples=True)` | only the last sample |
 
 : Range endpoints in values vs samples {.striped .hover}
+
+A slice can be used anywhere a `(min, max)` tuple can, and is worth preferring for sample ranges since `slice(0, -1)` reads exactly like `x[0:-1]`.
 :::
 
 ```{python}
@@ -411,7 +413,26 @@ new = patch.select(distance=-1, samples=True)
 # But as the end of a range, -1 excludes the last sample.
 new = patch.select(time=(0, -1), samples=True)
 assert len(new.get_array("time")) == sample_count - 1
+
+# A slice means the same thing, and makes that more obvious.
+assert len(patch.select(time=slice(0, -1), samples=True).get_array("time")) == sample_count - 1
 ```
+
+:::{.callout-important}
+`samples=True` means an *index* in `select` and [`order`](`dascore.Patch.order`), but a *count* of samples in most other patch functions. Compare:
+
+```{python}
+patch = dc.get_example_patch()
+
+# An index: channel number 10, so one channel.
+assert len(patch.select(distance=10, samples=True).get_array("distance")) == 1
+
+# A count: a window ten channels wide, so the patch keeps its shape.
+assert patch.rolling(distance=10, samples=True).mean().shape == patch.shape
+```
+
+The same is true of [`rolling`](`dascore.Patch.rolling`), [`pad`](`dascore.Patch.pad`), [`roll`](`dascore.Patch.roll`), [`resample`](`dascore.Patch.resample`), and the filter functions: the integer says *how many samples*, not *which sample*.
+:::
 
 Arrays can also be passed as values in which case they will be treated like sets, meaning only coordinate elements in the array will be selected.
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -378,7 +378,7 @@ new = patch.select(time=(-2, -1), relative=True)
 new = patch.select(distance=(-100 * ft, ...), relative=True)
 ```
 
-The `samples` keyword tells `select` the meaning of the query is in samples rather than the units of the selected dimension. Unlike absolute selections, sample selections are **always** relative to the data contained in the patch, so 0 refers to the first sample along the dimension and -1 refers to the last.
+The `samples` keyword tells `select` the meaning of the query is in samples rather than the units of the selected dimension. Unlike absolute selections, sample selections are **always** relative to the data contained in the patch: a single index of 0 is the first sample along the dimension and -1 is the last.
 
 :::{.callout-warning}
 Sample ranges and value ranges do not have the same end behavior. A value range includes both of its endpoints, but a sample range excludes its upper bound, like Python's slicing and `range`.

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -399,18 +399,18 @@ A consequence worth remembering: `-1` used as the end of a range excludes the la
 import dascore as dc
 
 patch = dc.get_example_patch()
-sample_count = patch.shape[patch.dims.index("time")]
+sample_count = len(patch.get_array("time"))
 
 # Trim patch to only include first 10 time rows (or columns).
 new = patch.select(time=(..., 10), samples=True)
-assert new.shape[new.dims.index("time")] == 10
+assert len(new.get_array("time")) == 10
 
 # Only include the last distance column or row.
 new = patch.select(distance=-1, samples=True)
 
 # But as the end of a range, -1 excludes the last sample.
 new = patch.select(time=(0, -1), samples=True)
-assert new.shape[new.dims.index("time")] == sample_count - 1
+assert len(new.get_array("time")) == sample_count - 1
 ```
 
 Arrays can also be passed as values in which case they will be treated like sets, meaning only coordinate elements in the array will be selected.

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -394,7 +394,7 @@ A consequence worth remembering: `-1` used as the end of a range excludes the la
 
 : Range endpoints in values vs samples {.striped .hover}
 
-A slice can be used anywhere a `(min, max)` tuple can, and is worth preferring for sample ranges since `slice(0, -1)` reads exactly like `x[0:-1]`.
+`select` also accepts a slice wherever it accepts a `(min, max)` tuple, which is worth preferring for sample ranges since `slice(0, -1)` reads exactly like `x[0:-1]`. Note this is specific to `select` and `order`; processing functions such as `pass_filter` and `taper` require a tuple. Note also that the slice is still only shorthand for a range, so it needs `samples=True` just as a tuple does — without it, `-1` is a coordinate value rather than an index.
 :::
 
 ```{python}

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -418,22 +418,6 @@ assert len(new.get_array("time")) == sample_count - 1
 assert len(patch.select(time=slice(0, -1), samples=True).get_array("time")) == sample_count - 1
 ```
 
-:::{.callout-important}
-`samples=True` means an *index* in `select` and [`order`](`dascore.Patch.order`), but a *count* of samples in most other patch functions. Compare:
-
-```{python}
-patch = dc.get_example_patch()
-
-# An index: channel number 10, so one channel.
-assert len(patch.select(distance=10, samples=True).get_array("distance")) == 1
-
-# A count: a window ten channels wide, so the patch keeps its shape.
-assert patch.rolling(distance=10, samples=True).mean().shape == patch.shape
-```
-
-The same is true of [`rolling`](`dascore.Patch.rolling`), [`pad`](`dascore.Patch.pad`), [`roll`](`dascore.Patch.roll`), [`resample`](`dascore.Patch.resample`), and the filter functions: the integer says *how many samples*, not *which sample*.
-:::
-
 Arrays can also be passed as values in which case they will be treated like sets, meaning only coordinate elements in the array will be selected.
 
 ```{python}

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -225,7 +225,7 @@ import dascore as dc
 spool = dc.get_example_spool()
 
 # Select a spool with data after Jan 3rd, 2020.
-subspool = spool.select(time=('2020-01-03T00:00:09', None))
+subspool = spool.select(time=('2020-01-03T00:00:09', ...))
 ```
 
 In addition to trimming the data along a specified dimension (as shown above), `select` can be used to filter patches that meet a specified criteria.

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -54,7 +54,7 @@ patch = (
     dc.get_example_patch('example_event_1')
     .set_units("mm/(m*s)", distance='m', time='s')
     .taper(time=0.05)
-    .pass_filter(time=(None, 300))
+    .pass_filter(time=(..., 300))
 )
 patch.viz.wiggle(scale = .5)
 ```


### PR DESCRIPTION
## Description

Follow-up to the tutorial review that produced #808. Those were outright errors; these are the places the docs are *correct but misleading*, which cost more reader time than the typos did.

### 1. Sample ranges are half-open and nothing said so

`docs/tutorial/patch.qmd` said "0 refers to the first sample along the dimension and -1 refers to the last." True for a scalar query, misleading for a range. Measured on this branch:

| query | selects |
|---|---|
| `select(distance=(0, 10))` | values 0 through 10, **both included** (11 channels) |
| `select(time=(0, 10), samples=True)` | samples 0 through 9 (10 samples) |
| `select(time=(0, -1), samples=True)` | 1999 of 2000 — every sample **except** the last |
| `select(time=-1, samples=True)` | only the last sample |

So value ranges are inclusive, sample ranges are half-open, and `-1` means opposite things depending on whether it is a scalar or a range endpoint. Added a callout with that table and extended the example with assertions that demonstrate it.

The `Patch.select` docstring had the same gap, so it gets the same note as a doctest.

These rules are not arbitrary — they are exactly xarray's, where `sel` is inclusive and `isel` is half-open. What DASCore loses relative to xarray is the *signal*: one method plus a keyword instead of two method names, and a `(a, b)` tuple that reads as a closed interval where a `slice` would not. Hence 4 below.

### 2. The concepts page asked a question and left it hanging

`docs/tutorial/concepts.qmd` says "the meaning of the values depends on the function, e.g. both frequency and period might make sense in the example above" — and then never answers it for its own example, `pass_filter(distance=(0.1, 0.2))`. Meanwhile `patch.qmd` uses `pass_filter(distance=(10*m, 100*m))` and calls it a wavelength, so a reader comparing the two pages gets contradictory signals.

Bare numbers on `distance` are wavenumber — specifically the inverse of whatever units that coordinate currently carries, not 1/m unconditionally. Verified:

```python
patch.pass_filter(distance=(0.01, 0.1)) == patch.pass_filter(distance=(10 * m, 100 * m))  # True
```

Now stated, with a runnable cell asserting the equivalence, plus a second assertion showing that a units-attached query survives `convert_units(distance="ft")` where a bare one does not.

### 3. One idiom for open intervals

The tutorials wrote open intervals three ways. Standardized `select`/`pass_filter` examples on `...`.

**Not** applied to `taper`: it requires `None` and raises `TypeError: unsupported operand type(s) for *: 'ellipsis' and 'int'` on `...`. That asymmetry is arguably worth fixing in the library, but not here.

### 4. Smaller `select` documentation gaps

`select_values_description` in `constants.py` listed "a Slice or a tuple of (min, max)" as though those were different things, when a slice is converted to a tuple on the first line of `sanitize_range_param`. It also omitted the plain-integer case entirely, despite that being the form the tutorial uses most. Both fixed. (That string composes into `Patch.select` and `CoordManager.select` only — not the `order` pair, which is just as well, since `order` reads a tuple as a sequence of values rather than a range.)

Also noted that `select` accepts a `slice` wherever it accepts a `(min, max)` tuple. This already worked; it is now stated as the preferred form for sample ranges, because `slice(0, -1)` makes the half-open behavior self-evident where `(0, -1)` does not — scoped to `select`/`order`, since `pass_filter` and `taper` reject slices, and with the caveat that a slice still needs `samples=True` to mean indices.

## Testing

- `pytest tests` — 8502 passed, 88 skipped, 2 xfailed
- `pytest dascore/proc/coords.py dascore/constants.py --doctest-modules` — 18 passed
- Every added/changed cell executed directly; all assertions hold
- `pre-commit` passes; new cross-references resolve

All 5 changed tutorial pages execute cleanly end to end (`patch.qmd` 44 cells, `concepts.qmd` 5, `spool.qmd` 15, `visualization.qmd` 4, `file_io.qmd` 10).

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified value- and sample-based selection, including ranges, slices, negative indexes, and open-ended bounds.
  * Added examples explaining inclusive value ranges versus half-open sample ranges.
  * Documented unit-aware frequency, wavenumber, wavelength, and distance filtering.
  * Updated tutorials to use ellipses for open-ended time and filter ranges.
  * Explained how sample-relative indexing differs from coordinate-value selection, including exclusive upper bounds and slice equivalence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

