### PR TITLE
Tidy prose and examples in the tutorials

### DIFF
--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -8,7 +8,7 @@ execute:
 This page covers advanced DASCore features. Most users will be fine with only the coordinate material presented in the [patch tutorial](patch.qmd#coords).
 :::
 
-In order to manage coordinate labels and array manipulations, DASCore implements two classes, [BaseCoordinate](`dascore.core.coords.BaseCoord`), which has several associated subclasses corresponding to different types of coordinates, and [CoordManager](`dascore.core.coordmanager.CoordManager`) which manages a group of coordinates. Much like the [`Patch`](`dascore.core.patch.Patch`), instances of both of these classes are immutable (to the extent possible), so they cannot be modified in place but have methods which return new instances.  
+In order to manage coordinate labels and array manipulations, DASCore implements two classes, [`BaseCoord`](`dascore.core.coords.BaseCoord`), which has several associated subclasses corresponding to different types of coordinates, and [CoordManager](`dascore.core.coordmanager.CoordManager`) which manages a group of coordinates. Much like the [`Patch`](`dascore.core.patch.Patch`), instances of both of these classes are immutable (to the extent possible), so they cannot be modified in place but have methods which return new instances.  
 
 # Coordinates
 
@@ -114,7 +114,7 @@ coord = get_coord(start=start, stop=stop, step=step)
 new_data = coord.values + np.timedelta64(10, "s")
 coord_new_data = coord.update(data=new_data)
 
-# Update step, keeping length and start but shorting end time.
+# Update step, keeping length and start but shortening end time.
 coord_new_step = coord.update(step=np.timedelta64(1800, 's'))
 
 # Change maximum value, keeping length the same and changing step.

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -117,7 +117,7 @@ print(f"Data contents are\n{patch.data}")
 ```
 
 :::{.callout-note}
-The data arrays should be read-only. This means you can't modify them, but must first make a copy.
+The data arrays are read-only. This means you can't modify them in place; you must make a copy first.
 
 ```python
 import numpy as np
@@ -511,7 +511,7 @@ pa = dc.get_example_patch()
 new_data_patch = pa.update(data=pa.data * 10)
 
 # Completely replace the attributes.
-new_data_patch = pa.update(attrs=dict(station="TMU"))
+new_attrs_patch = pa.update(attrs=dict(station="TMU"))
 ```
 
 ## Update attrs
@@ -562,6 +562,7 @@ Or by specifying new min, max, or step values for a coordinate.
 import dascore as dc
 
 pa = dc.get_example_patch()
+one_second = dc.to_timedelta64(1)
 
 # Change the starting time of the array.
 new_time = pa.coords.min('time') + one_second
@@ -622,7 +623,7 @@ patch_detached_lat = patch.update_coords(latitude=(None, lat))
 
 ## Dropping coordinates
 
-Non-dimensional coordinates can be dropped using [`Patch.drop_coords`](`dascore.proc.coords.drop_coords`). Dimensional coordinates, however, cannot be dropped doing so would force the patch data to become degenerate.
+Non-dimensional coordinates can be dropped using [`Patch.drop_coords`](`dascore.proc.coords.drop_coords`). Dimensional coordinates, however, cannot be dropped since doing so would force the patch data to become degenerate.
 
 ```{python}
 import dascore as dc

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -36,10 +36,10 @@ patch = dc.get_example_patch()
 # Select first distance value to make distance dim flat.
 
 flat_patch = patch.select(distance=0, samples=True)
-print(f"Pre-squeeze dims: {flat_patch.shape}")
+print(f"Pre-squeeze shape: {flat_patch.shape}")
 
 squeezed = flat_patch.squeeze()
-print(f"Post-squeeze dims: {squeezed.shape}")
+print(f"Post-squeeze shape: {squeezed.shape}")
 ```
 
 ## Dropna

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -73,7 +73,7 @@ index_path = Path(tempfile.mkdtemp()) / "index.h5"
 spool = dc.spool(directory_path, index_path=index_path).update()
 ```
 
-New spools created using the same directory will know where to find the index file, **unless** there is a valid index file already in the directory.
+A new spool created for the same directory will find this index file automatically. The exception is when a valid index file already exists inside the data directory itself, which takes precedence.
 
 :::{.callout-warning}
 If you remove files from a directory that has already been indexed, you should delete the index file and then call `update` again on the spool like this:
@@ -204,7 +204,6 @@ spool = dc.get_example_spool()
 
 # Return dataframe with contents of spool (each row has metadata of a patch)
 contents = spool.get_contents()
-print(contents)
 ```
 
 ```{python}

--- a/docs/tutorial/transformations.qmd
+++ b/docs/tutorial/transformations.qmd
@@ -4,7 +4,7 @@ execute:
   warning: false
 ---
 
-In DASCore, transformations are operations which change the units of a patch. Transforms can be found in the [transform module](`dascore.transform`) or accessed as `Patch` methods.
+In DASCore, transformations are operations which change the domain of a patch, and usually its units and dimension names along with it. Transforms can be found in the [transform module](`dascore.transform`) or accessed as `Patch` methods.
 
 # Discrete Fourier Transforms
 
@@ -41,6 +41,16 @@ print(real_transform.get_coord("ft_distance"))
 ```
 
 The Inverse Discrete Fourier Transform [idft](`dascore.transform.fourier.idft`) undoes the transformation.
+
+```{python}
+import numpy as np
+
+# A round trip recovers the original patch.
+round_trip = patch.dft(dim="time").idft()
+
+print(f"dims after round trip: {round_trip.dims}")
+assert np.allclose(round_trip.data.real, patch.data)
+```
 
 # Short Time Fourier Transform
 

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -17,7 +17,7 @@ import dascore as dc
 patch = dc.get_example_patch('example_event_2')
 
 # Default scaling uses IQR-based fence to handle outliers
-patch.viz.waterfall(show=True)
+patch.viz.waterfall(show=True);
 ```
 
 ### Controlling color scaling


### PR DESCRIPTION
## Description

The last batch from the tutorial review that produced #808 and #822 — small corrections, no behavior changes. Grouped here rather than scattered so the substantive PRs stayed readable.

**`coords.qmd`**
- "shorting end time" → "shortening"
- Link text read `BaseCoordinate`; the target is `BaseCoord`

**`patch.qmd`**
- "The data arrays should be read-only" — they *are*; it's enforced. Reworded so readers don't treat it as advice.
- "Dimensional coordinates, however, cannot be dropped doing so would force the patch data to become degenerate" — missing "since", making it a run-on.
- The update example bound `new_data_patch` twice, the second time for an `attrs` replacement. Renamed the second to `new_attrs_patch`, which is the whole point of the contrast with `update_attrs` below it.
- One cell used `one_second` from a previous cell while every other cell stands alone. Defined it locally so the cell is copy-pasteable.

**`processing.qmd`** — the squeeze example printed `"Pre-squeeze dims: (1, 2000)"` while showing `.shape`. Labels now say shape.

**`spool.qmd`**
- "New spools created using the same directory will know where to find the index file, **unless** there is a valid index file already in the directory" — a double negative that takes a few passes to parse. Rewritten affirmatively.
- Dropped a `print(contents)` inside a cell marked `output: false`, where it could never render.

**`transformations.qmd`**
- "transformations are operations which change the units of a patch" is too narrow — `dft` changes the domain and the dimension names too, which is the part that surprises people.
- `idft` got one sentence and no example. Added a round trip showing `dft(dim="time").idft()` recovers the original.

**`visualization.qmd`** — a missing trailing `;` leaked the matplotlib Axes repr into the rendered page; every other viz call in the docs has one.

## Testing

- All 8 tutorial pages execute end to end: `coords` 20 cells, `patch` 44, `spool` 15, `file_io` 10, `transformations` 5, `visualization` 4, `processing` 20, `concepts` 4
- `pytest tests` — 8362 passed, 88 skipped, 2 xfailed
- `pre-commit` passes

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.