### PR TITLE
Don't let a pre-release tag become the stable docs version

### DIFF
--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -148,7 +148,9 @@ def _check_misdirected_range_query(key, val, df):
     base = key[:-4] if key.endswith(("_min", "_max")) else None
     if base is None or not {f"{base}_min", f"{base}_max"}.issubset(set(df.columns)):
         return
-    if not any(x is ... or x is None for x in val):
+    # Only a two element sequence can be a range. Anything else is a
+    # membership check, where None may be a legitimate value to match.
+    if len(val) != 2 or not any(x is ... or x is None for x in val):
         return
     msg = (
         f"An open bound (... or None) is not valid in the query for column "

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -122,7 +122,7 @@ sorted_data = data[indexer, :]
 ### Snap
 [`snap`](`dascore.core.coords.BaseCoord.snap`) is used to calculate an average spacing between samples and "snap" all values to that spacing. If the coordinate is not sorted, it will be sorted in the process. This method should be used with care since it causes some loss in precision and can introduce inaccuracies in down-stream calculations. The min and max of the coordinate remain unchanged.
 
-Unlike [`sort`](`dascore.core.coords.BaseCoord.sort`), `snap` returns only a new coordinate, not an indexer. Since snapping an unsorted coordinate also reorders it, use [`CoordManager.snap`](`dascore.core.coordmanager.CoordManager.snap`) instead when an associated data array needs to stay aligned.
+Unlike [`sort`](`dascore.core.coords.BaseCoord.sort`), `snap` returns only a new coordinate and no indexer, because it replaces the coordinate values rather than permuting them. This means that for an unsorted coordinate the snapped values no longer label the samples they used to. Use [`CoordManager.snap`](`dascore.core.coordmanager.CoordManager.snap`), which sorts the coordinate and its associated array together before snapping, when data alignment matters.
 
 ```{python}
 import numpy as np

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -272,6 +272,15 @@ class TestFilterDfAdvanced:
         out = filter_df(example_df_2, bp_min=tuple(vals))
         assert np.all(out == example_df_2["bp_min"].isin(vals))
 
+    @pytest.mark.parametrize("val", [[None], [100, None, 125]])
+    def test_non_range_shaped_collection_still_isin(self, example_df_2, val):
+        """
+        Only a two element sequence can be a range, so other collections stay
+        membership checks even when they contain None.
+        """
+        out = filter_df(example_df_2, bp_min=val)
+        assert np.all(out == example_df_2["bp_min"].isin(val))
+
     def test_ellipsis_kept_for_non_interval_column(self, example_df_2):
         """
         Columns with no min/max pair are plain isin checks; an ellipsis there


### PR DESCRIPTION
## Description

Found while reviewing whether a beta can safely be published from `dev`. This is a latent bug that publishing the beta would **activate**, so it should land before any pre-release tag exists.

`BuildDeployStableDocs` resolves "the latest release tag" for its manual `workflow_dispatch` path with:

```bash
git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1
```

Git's version sort places a pre-release **above** its own final release. Reproduced in a scratch repo:

```
tags: v0.2.0rc1 v0.2.0b1 v0.2.0 v0.1.20 v0.1.19
picks: v0.2.0rc1
```

And in the situation we would actually be in right after tagging a beta:

```
tags: v0.2.0b1 v0.1.20 v0.1.19
OLD picks: v0.2.0b1   <- builds beta docs, deploys as stable
NEW picks: v0.1.20    <- correct
```

So once `v0.2.0b1` exists, any manual re-run of BuildDeployStableDocs would build docs from beta code and publish them as the stable site — and keep doing so even after `v0.2.0` ships. The prerelease guard added in #811 does not prevent this, because `github.event.release` is null for `workflow_dispatch`. Fixed by matching only final `vX.Y.Z` tags.

The same bug exists on `master`, which matters because the dispatch UI defaults to `master`; that needs a companion PR.

### Docs

Also documents how to publish a pre-release. The current guide is written for a stable release from `master` and would mislead on every step that matters:

- tells the maintainer to type `v0.2.0`, which burns the final version number
- never mentions setting the release **Target** to `dev` (it defaults to `master`)
- never mentions the **"Set as a pre-release"** checkbox, which is what the docs guard keys on
- sends them to conda-forge, which has no equivalent of `--pre` and orders `0.2.0b1` above `0.1.20`, so a beta there would reach every conda user
- says to verify the stable docs site updated, which will not happen for a pre-release by design — and the natural "fix" (re-dispatching the workflow) is exactly the bug above

Also adds a warning against re-running `PublishPackage` after the branch moves, since the version comes from the tag and a re-run then produces a local version segment that PyPI rejects.

Verified: `Check Yaml` and actionlint pass; the edited shell block parses with `bash -n`; and both tag-selection scenarios above were reproduced before and after the change.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes. (No issue; found during beta release review.)
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html). (Workflow shell logic; verified by reproducing both scenarios in a scratch repo.)
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.