### PR TITLE
Make the stable docs workflow pre-release safe

### DIFF
--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -16,11 +16,14 @@ permissions:
   deployments: write
   id-token: write
 
-# Allow one concurrent deployment. A pre-release build never deploys, so it
-# gets its own group rather than cancelling (or being cancelled by) a real
-# Pages deployment, which shares the "pages" group with the master docs.
+# Allow one concurrent deployment. Only runs which can deploy need to
+# serialize, so they share the "pages" group with the master docs workflow.
+# A pre-release never deploys; it is grouped per tag so that publishing one
+# pre-release cannot cancel another's build before it attaches docs.zip.
 concurrency:
-  group: ${{ github.event.release.prerelease && 'pages-prerelease' || 'pages' }}
+  group: >-
+    ${{ github.event.release.prerelease
+    && format('pages-prerelease-{0}', github.ref) || 'pages' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -16,9 +16,11 @@ permissions:
   deployments: write
   id-token: write
 
-# Allow one concurrent deployment
+# Allow one concurrent deployment. A pre-release build never deploys, so it
+# gets its own group rather than cancelling (or being cancelled by) a real
+# Pages deployment, which shares the "pages" group with the master docs.
 concurrency:
-  group: "pages"
+  group: ${{ github.event.release.prerelease && 'pages-prerelease' || 'pages' }}
   cancel-in-progress: true
 
 jobs:
@@ -34,10 +36,14 @@ jobs:
       - name: Set manual stable docs version
         if: github.event_name == 'workflow_dispatch'
         run: |
-          # Manually set DASCore version based on last tag. 
-          tag="$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)"
+          # Manually set DASCore version based on the last stable tag.
+          # Match only final releases: git's version sort places a
+          # pre-release (v0.2.0b1) above its final (v0.2.0), so an
+          # unfiltered list would publish beta docs as stable.
+          tag="$(git tag --list 'v[0-9]*' --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)"
           if [ -z "$tag" ]; then
-            echo "::error::No release tag matching v[0-9]* exists."
+            echo "::error::No stable release tag matching vX.Y.Z exists."
             exit 1
           fi
           echo "DASCORE_DOC_VERSION=${tag#v}" >> "$GITHUB_ENV"
@@ -79,6 +85,10 @@ jobs:
           files: docs.zip
 
   deploy:
+    # Stable docs describe the latest stable release, so a pre-release (eg a
+    # beta cut from dev) must not replace them. github.event.release is absent
+    # for workflow_dispatch, so manual runs still deploy.
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     needs: build
     environment:

--- a/docs/contributing/publish_a_new_release.qmd
+++ b/docs/contributing/publish_a_new_release.qmd
@@ -27,7 +27,7 @@ Then click 'Publish Release'. This will kick off the doc-build and publishing ta
 A pre-release (alpha, beta, or release candidate) lets users try in-progress work without affecting anyone who installs DASCore normally. Publishing one differs from a stable release in four ways:
 
 1. **Set the release Target to the branch the code lives on**, usually `dev`. The Target defaults to `master`, and workflows run from the tagged commit, so tagging the wrong branch publishes the wrong code.
-2. **Use a [PEP 440](https://peps.python.org/pep-0440/) pre-release tag**, appending `bN` or `rcN` to the version being worked toward: `v0.2.0b1` for the first beta of `0.2.0`. Do not use the plain `v0.2.0` tag, which belongs to the final release. `pip install dascore` ignores pre-releases, so only users who ask for one with `pip install --pre dascore` will get it.
+2. **Use a [PEP 440](https://peps.python.org/pep-0440/) pre-release tag**, appending `aN`, `bN`, or `rcN` to the version being worked toward for an alpha, beta, or release candidate: `v0.2.0a1`, `v0.2.0b1`, `v0.2.0rc1`. Do not use the plain `v0.2.0` tag, which belongs to the final release. `pip install dascore` ignores pre-releases, so only users who ask for one with `pip install --pre dascore` will get it.
 3. **Tick the "Set as a pre-release" checkbox.** This is load-bearing, not cosmetic: `BuildDeployStableDocs` keys on it to skip deploying, so an unticked pre-release replaces the stable documentation site with pre-release docs.
 4. **Skip the conda-forge section entirely.** conda has no equivalent of `--pre` and orders `0.2.0b1` above `0.1.20`, so publishing a pre-release to the main channel would serve it to every conda user. conda-forge handles pre-releases through a separate `rc` branch and label.
 
@@ -44,7 +44,12 @@ After publishing, open [GitHub Actions](https://github.com/DASDAE/dascore/action
 
 Once the workflows finish, check that PyPI shows the new version and that the stable documentation site reflects the release. For a pre-release the documentation site is expected to be unchanged; check the `docs.zip` asset on the release instead.
 
-If a workflow fails, fix the underlying issue on the branch the release came from and publish a new release if the tag has already been distributed, bumping the patch version (`v0.1.21`) or the pre-release number (`v0.2.0b2`). Never move or replace a public release tag, and do not re-run `PublishPackage` after new commits land on the branch: the version is derived from the tag, and a re-run against a moved branch produces a version PyPI will reject.
+If a workflow fails, first check whether PyPI already has the files, since the recovery differs:
+
+- **Transient failure, nothing uploaded.** Re-run the job. Release workflows check out the release tag rather than the branch it was cut from, so a re-run builds the same commit and produces the same version even if the branch has moved on. Note PyPI refuses to replace a file it already has, so a re-run after a partial upload fails on the files that did land.
+- **A source change is needed.** Publish a new release with a new tag, bumping the patch version (`v0.1.21`) or the pre-release number (`v0.2.0b2`). Fix the underlying issue on the branch the release came from.
+
+Never move or replace a public release tag, and never delete a version from PyPI expecting to re-upload it: PyPI does not allow a filename to be reused, even after deletion.
 
 ## Conda-forge
 

--- a/docs/contributing/publish_a_new_release.qmd
+++ b/docs/contributing/publish_a_new_release.qmd
@@ -22,6 +22,19 @@ The GitHub releases page can generate release notes automatically, but maintaine
 
 Then click 'Publish Release'. This will kick off the doc-build and publishing task automatically, as well as publish the tagged source code to PyPI.
 
+## Pre-releases
+
+A pre-release (alpha, beta, or release candidate) lets users try in-progress work without affecting anyone who installs DASCore normally. Publishing one differs from a stable release in four ways:
+
+1. **Set the release Target to the branch the code lives on**, usually `dev`. The Target defaults to `master`, and workflows run from the tagged commit, so tagging the wrong branch publishes the wrong code.
+2. **Use a [PEP 440](https://peps.python.org/pep-0440/) pre-release tag**, appending `bN` or `rcN` to the version being worked toward: `v0.2.0b1` for the first beta of `0.2.0`. Do not use the plain `v0.2.0` tag, which belongs to the final release. `pip install dascore` ignores pre-releases, so only users who ask for one with `pip install --pre dascore` will get it.
+3. **Tick the "Set as a pre-release" checkbox.** This is load-bearing, not cosmetic: `BuildDeployStableDocs` keys on it to skip deploying, so an unticked pre-release replaces the stable documentation site with pre-release docs.
+4. **Skip the conda-forge section entirely.** conda has no equivalent of `--pre` and orders `0.2.0b1` above `0.1.20`, so publishing a pre-release to the main channel would serve it to every conda user. conda-forge handles pre-releases through a separate `rc` branch and label.
+
+`BuildDeployStableDocs` still runs for a pre-release and still takes ~30 minutes. It builds the docs and attaches `docs.zip` to the release, but the deploy step is skipped by design, so the stable documentation site is expected to stay unchanged. Do not re-dispatch the workflow to "fix" this.
+
+Because pre-releases exist to gather feedback, say plainly in the notes that it is a pre-release, how to install it (`pip install --pre dascore==0.2.0b1`), that it is not available on conda-forge, and where to report problems. Call out breaking changes against the last stable release explicitly, including any public API that has been removed.
+
 ## Verify package and docs publishing
 
 After publishing, open [GitHub Actions](https://github.com/DASDAE/dascore/actions) and confirm the release workflows complete successfully.
@@ -29,7 +42,9 @@ After publishing, open [GitHub Actions](https://github.com/DASDAE/dascore/action
 - `PublishPackage` builds the distributions and uploads DASCore to [PyPI](https://pypi.org/project/dascore/).
 - `BuildDeployStableDocs` builds the stable documentation, deploys it to GitHub Pages, and uploads `docs.zip` to the GitHub release. This may take 30 minutes or more.
 
-Once the workflows finish, check that PyPI shows the new version and that the stable documentation site reflects the release. If a workflow fails, fix the underlying issue on `master`, publish a new patch release if the tag has already been distributed, and avoid moving or replacing a public release tag.
+Once the workflows finish, check that PyPI shows the new version and that the stable documentation site reflects the release. For a pre-release the documentation site is expected to be unchanged; check the `docs.zip` asset on the release instead.
+
+If a workflow fails, fix the underlying issue on the branch the release came from and publish a new release if the tag has already been distributed, bumping the patch version (`v0.1.21`) or the pre-release number (`v0.2.0b2`). Never move or replace a public release tag, and do not re-run `PublishPackage` after new commits land on the branch: the version is derived from the tag, and a re-run against a moved branch produces a version PyPI will reject.
 
 ## Conda-forge
 


### PR DESCRIPTION
## Description

Found while reviewing whether a beta can safely be published from `dev`. Both issues are latent today and only bite once a pre-release tag exists, so this should land **before** any beta is tagged. Targeting `master` so it reaches `dev` through the normal master → dev merge rather than needing two PRs.

### 1. A pre-release tag hijacks the stable docs version

The `workflow_dispatch` path resolves "the latest release tag" with:

```bash
git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1
```

Git's version sort places a pre-release **above** its own final release. Reproduced in a scratch repo:

```
tags: v0.2.0rc1 v0.2.0b1 v0.2.0 v0.1.20 v0.1.19
picks: v0.2.0rc1
```

And in the state we would be in immediately after tagging a beta:

```
tags: v0.2.0b1 v0.1.20 v0.1.19
OLD picks: v0.2.0b1   <- builds beta docs, deploys as stable
NEW picks: v0.1.20    <- correct
```

So once `v0.2.0b1` exists, any manual re-run of BuildDeployStableDocs builds docs from pre-release code and publishes them as the stable site — and keeps doing so even after `v0.2.0` ships. The deploy guard does not prevent this, because `github.event.release` is null for `workflow_dispatch`. Fixed by matching only final `vX.Y.Z` tags.

### 2. master never got the pre-release deploy guard

#811 added the guard to `dev` only. The release-drafting UI defaults its Target to `master`, so a pre-release published without changing that would run **master's** unguarded copy and replace the stable docs site. This ports the deploy `if:` and the pre-release concurrency group.

The ported text is identical to dev's, so those hunks merge with no conflict; the only remaining difference in this file is dev's `persist-credentials: false`, which master does not touch.

### 3. Release guide had no pre-release instructions

The guide is written for a stable release from `master` and misleads on every step that matters for a beta: it says to type `v0.2.0` (burning the final version number), never mentions setting the release **Target** to `dev`, never mentions the **"Set as a pre-release"** checkbox the guard keys on, sends the maintainer to conda-forge (which has no equivalent of `--pre` and orders `0.2.0b1` above `0.1.20`), and tells them to verify a stable docs deploy that will not happen by design — where the natural "fix" of re-dispatching the workflow is exactly issue 1.

Also warns against re-running `PublishPackage` after the branch moves, since the version derives from the tag and a re-run then produces a local version segment PyPI rejects.

## Verification

`Check Yaml` and actionlint pass, the edited shell block parses under `bash -n`, and both tag-selection scenarios above were reproduced before and after the change.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes. (No issue; found during beta release review.)
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html). (Workflow shell logic; verified by reproducing both tag-selection scenarios.)
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for managing pre-releases, including versioning, GitHub release settings, package availability, documentation behavior, release notes, and installation.
  - Expanded post-release verification and recovery instructions for failed publishing workflows.

- **Bug Fixes**
  - Improved documentation deployment handling so pre-release deployments do not overwrite stable documentation.
  - Manual stable documentation deployments now recognize only final releases and provide clearer feedback when none are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->