### PR TITLE
Scan one-shot iterables instead of silently returning nothing

### DIFF
--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import inspect
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Collection, Generator, Mapping
+from collections.abc import Callable, Generator, Iterable, Iterator, Mapping
 from functools import cached_property, wraps
 from numbers import Integral
 from pathlib import Path
@@ -63,17 +63,18 @@ from dascore.utils.plugins import get_entry_point_loaders
 from dascore.utils.progress import track
 from dascore.utils.remote_io import get_remote_cache_scope, remote_cache_scope
 
-# What the scan dispatchers accept: one resource or patch, or a
-# collection of them (`_iterate_scan_inputs` flattens its input with
-# `iterate` before resolving each element). A one-shot iterator is
-# excluded on purpose: the dispatcher walks its input twice, once to
-# size the progress bar, so a generator would silently scan nothing.
+# What the scan dispatchers accept: one resource or patch, or an
+# iterable of them (`_iterate_scan_inputs` flattens its input with
+# `iterate` before resolving each element). The dispatcher walks its
+# input twice, once to size the progress bar, so one-shot iterators
+# (e.g. generators) are materialized up front rather than silently
+# scanning nothing (see #818).
 ScanInput = (
     path_types
     | dc.Patch
     | dc.BaseSpool
     | IOResourceManager
-    | Collection[path_types | dc.Patch | IOResourceManager]
+    | Iterable[path_types | dc.Patch | IOResourceManager]
 )
 
 
@@ -1293,6 +1294,11 @@ def _iter_scan_results(
     fiber_io_hint: dict[str, FiberIO] = {}
     # A dict for keeping track of missing optional dependencies.
     missing_optional_deps = defaultdict(lambda: 0)
+    # A one-shot iterator (e.g. a generator) can't survive both walks
+    # below, so materialize it once up front (see #818). The cast just
+    # keeps the element type ty loses when narrowing the union.
+    if isinstance(path, Iterator):
+        path = list(cast("Iterable[path_types | dc.Patch | IOResourceManager]", path))
     # Unfortunately, we have to iterate the scan candidates twice to get
     # an estimate for the progress bar length. Maybe there is a better way...
     _generator = _iterate_scan_inputs(

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -829,6 +829,22 @@ class TestScan:
         """Patches can be scanned directly, one summary each."""
         assert len(dc.scan([random_patch, random_patch])) == 2
 
+    @pytest.mark.parametrize("func", [dc.scan, dc.scan_to_df, dc.scan_payloads])
+    def test_scan_accepts_a_one_shot_iterable(self, func, tmp_path, random_patch):
+        """A generator input scans every element, not silently nothing (#818)."""
+        path_1 = tmp_path / "patch_1.h5"
+        path_2 = tmp_path / "patch_2.h5"
+        random_patch.io.write(path_1, "dasdae")
+        random_patch.io.write(path_2, "dasdae")
+        expected = len(func([path_1, path_2]))
+        assert expected == 2
+        assert len(func(p for p in [path_1, path_2])) == expected
+        assert len(func(iter([path_1, path_2]))) == expected
+
+    def test_scan_accepts_a_generator_of_patches(self, random_patch):
+        """A generator of patches yields one summary each (#818)."""
+        assert len(dc.scan(p for p in [random_patch, random_patch])) == 2
+
     def test_scan_no_good_files(self, tmp_path):
         """Scan with no fiber files should return []."""
         dummy_file = tmp_path / "data.txt"


### PR DESCRIPTION
## Description

Fixes #818: `dc.scan` (and `dc.scan_to_df` / `dc.scan_payloads`) silently returned an empty result when given a one-shot iterable such as a generator. `_iter_scan_results` walks its input twice — once through `_count_generator` to size the progress bar and once to actually scan — so the counting pass drained the iterator and the scan pass saw nothing.

Changes:

- `_iter_scan_results` now materializes `Iterator` inputs to a list before the two walks, so generators (and `iter(...)`, `map`, `zip`, etc.) scan every element. Since all three public scan dispatchers funnel through this function, one fix covers them all. Re-iterable inputs (lists, sets, spools) are untouched, so a lazy spool is never materialized.
- The `ScanInput` alias is widened from `Collection[...]` to `Iterable[...]`, as anticipated in #816/#818, since generators are now handled correctly.
- Tests cover generator and `iter()` inputs for all three dispatchers plus a generator of patches; all four fail on the unfixed code.

The pre-existing double directory traversal noted in the `TODO` above `_count_generator` is unchanged and out of scope here.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
- fixed: `dc.scan`, `dc.scan_to_df`, and `dc.scan_payloads` scan one-shot iterables such as generators ([#818](https://github.com/DASDAE/dascore/issues/818)), which previously returned an empty result because the progress-bar count drained the iterator.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
