### PR TITLE
Remove dead version/build config from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,8 @@
 # --- Build system configuration
 
 [build-system]
-requires = [ "setuptools>=41", "setuptools-scm", "scikit-build"]
+requires = [ "setuptools>=41", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools-git-versioning]
-enabled = true
 
 [tool.setuptools]
 include-package-data = true
@@ -18,7 +15,7 @@ packages = ["dascore"]
 
 [project]
 name = "dascore"
-dynamic = ["version"]  # version is fetched by setuptools-git-versioning
+dynamic = ["version"]  # version is derived from git tags by setuptools_scm
 
 authors = [
   { name="Derrick Chambers", email="chambers.ja.derrick@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # --- Build system configuration
 
 [build-system]
-requires = [ "setuptools>=41", "setuptools-scm"]
+requires = [ "setuptools>=61", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
## Description

Removes dead build configuration from `pyproject.toml` and fixes a comment that named the wrong tool.

`setuptools-git-versioning` is not in `[build-system] requires`, so under PEP 517 build isolation it was never installed and its `[tool.setuptools-git-versioning]` section was never read. The actual version provider is `setuptools_scm`, enabled by the empty `[tool.setuptools_scm]` section. The comment on `dynamic = ["version"]` credited the tool that isn't running, which sends anyone debugging a version problem to the wrong place.

`scikit-build` was likewise unused: DASCore is pure python with no `CMakeLists.txt`, no `setup.py`, and no C extensions, so it was downloaded on every build for nothing.

While editing that line, `setuptools>=41` is bumped to `>=61`. The `[project]` table requires setuptools 61+, as does modern `setuptools_scm`, so the old floor was never actually satisfiable for this project.

No behavior change. Verified by building sdists from the commit before and after the change under an identical throwaway tag: both produce `dascore-9.9.9.tar.gz` with byte-identical `PKG-INFO` and identical file lists. The post-change wheel installs into a clean venv and imports with the expected version.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package build configuration for more reliable releases.
  * Release versions are now derived consistently from project tags, helping ensure published packages accurately reflect their source version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->