### PR TITLE
Fix CI security issues found by zizmor

### DIFF
--- a/.github/actions/load-shared-vars/action.yml
+++ b/.github/actions/load-shared-vars/action.yml
@@ -1,9 +1,12 @@
 # This is where global configurations are added.
 
 name: "Load Shared Variables"
-description: "Loads shared variables and sets them as environment variables and outputs"
+description: "Loads shared variables and sets them as step outputs"
 
 outputs:
+  python-default:
+    description: "Default python version"
+    value: ${{ steps.load.outputs.python-default }}
   python-test-matrix:
     description: "Python version matrix for full tests"
     value: ${{ steps.load.outputs.python-test-matrix }}
@@ -22,6 +25,6 @@ runs:
         python_test_matrix='["3.11","3.12","3.13","3.14"]'
         python_min_deps_matrix='["3.13","3.14"]'
 
-        echo "PYTHON_DEFAULT=$python_default" >> "$GITHUB_ENV"
+        echo "python-default=$python_default" >> "$GITHUB_OUTPUT"
         echo "python-test-matrix=$python_test_matrix" >> "$GITHUB_OUTPUT"
         echo "python-min-deps-matrix=$python_min_deps_matrix" >> "$GITHUB_OUTPUT"

--- a/.github/actions/mamba-install-dascore/action.yml
+++ b/.github/actions/mamba-install-dascore/action.yml
@@ -33,11 +33,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up environment variable with date
-      shell: bash -l {0}
-      run: echo "CURRENT_DATE=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+    - name: Get current date for cache key
+      id: date
+      shell: bash
+      run: echo "current-date=$(date '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
-    - uses: mamba-org/setup-micromamba@v3
+    - uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39  # v3.2.1
       with:
         micromamba-version: '2.0.5-0' # versions: https://github.com/mamba-org/micromamba-releases
         environment-file: ${{ inputs.environment-file }}
@@ -45,7 +46,7 @@ runs:
           bash
           powershell
         cache-environment: true
-        cache-environment-key: environment-${{ env.CURRENT_DATE }}-${{ inputs.environment-file }}
+        cache-environment-key: environment-${{ steps.date.outputs.current-date }}-${{ inputs.environment-file }}
         post-cleanup: "shell-init"
         create-args: >-
           python=${{ inputs.python-version }}
@@ -71,24 +72,27 @@ runs:
     - name: install dascore
       if: "${{ inputs.install-package == 'true' }}"
       shell: bash -l {0}
+      env:
+        INSTALL_GROUP_STR: ${{ inputs.install-group-str }}
       run: |
-        pip install -e .${{ inputs.install-group-str }}
+        pip install -e ".${INSTALL_GROUP_STR}"
 
-    - name: export test data cache env
+    - name: export test data cache info
+      id: data-cache
       shell: bash -el {0}
       env:
         INPUT_CACHE_NUMBER: ${{ inputs.cache-number }}
         RUNNER_OS: ${{ runner.os }}
       run: |
-        python .github/scripts/export_test_data_cache_env.py >> "$GITHUB_ENV"
+        python .github/scripts/export_test_data_cache_env.py >> "$GITHUB_OUTPUT"
 
     - name: restore test data cache
       if: "${{ inputs.prepare-test-data == 'true' }}"
       id: restore-test-data
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
-        path: ${{ env.DATA_CACHE_PATH }}
-        key: ${{ env.DATA_CACHE_KEY }}
+        path: ${{ steps.data-cache.outputs.DATA_CACHE_PATH }}
+        key: ${{ steps.data-cache.outputs.DATA_CACHE_KEY }}
 
     - name: prime test data cache
       if: "${{ inputs.prepare-test-data == 'true' && steps.restore-test-data.outputs.cache-hit != 'true' }}"
@@ -97,10 +101,10 @@ runs:
 
     - name: save test data cache
       if: "${{ inputs.prepare-test-data == 'true' && steps.restore-test-data.outputs.cache-hit != 'true' }}"
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
-        path: ${{ env.DATA_CACHE_PATH }}
-        key: ${{ env.DATA_CACHE_KEY }}
+        path: ${{ steps.data-cache.outputs.DATA_CACHE_PATH }}
+        key: ${{ steps.data-cache.outputs.DATA_CACHE_KEY }}
 
     # Print out the package info for current environment
     - name: print package info

--- a/.github/actions/prep_doc_build/action.yml
+++ b/.github/actions/prep_doc_build/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install quarto
-      uses: quarto-dev/quarto-actions/setup@v2
+      uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b  # v2.2.0
       with:
         version: 1.3.450
         tinytex: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     # Wait a week before adopting a new release in case it gets yanked.
     cooldown:
       default-days: 7
+    # Bundle all action bumps into a single monthly PR instead of one PR
+    # per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep SHA-pinned GitHub Actions up to date.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      # Covers .github/workflows plus the local composite actions.
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      interval: "monthly"
+    # Wait a week before adopting a new release in case it gets yanked.
+    cooldown:
+      default-days: 7

--- a/.github/scripts/export_test_data_cache_env.py
+++ b/.github/scripts/export_test_data_cache_env.py
@@ -14,7 +14,7 @@ from dascore.utils.downloader import get_test_data_cache_info  # noqa: E402
 
 
 def main() -> None:
-    """Print cache metadata as KEY=VALUE lines for GitHub Actions env files."""
+    """Print cache metadata as KEY=VALUE lines for GitHub Actions output files."""
     runner_os = os.environ["RUNNER_OS"]
     cache_number = os.environ["INPUT_CACHE_NUMBER"]
     info = get_test_data_cache_info()

--- a/.github/workflows/build_deploy_master_docs.yaml
+++ b/.github/workflows/build_deploy_master_docs.yaml
@@ -11,12 +11,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# The docs publish to netlify with its own token, so the GITHUB_TOKEN only
+# needs to read the repo.
 permissions:
   contents: read
-  pages: write
-  deployments: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -31,17 +29,19 @@ jobs:
       name: github-pages
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
+          persist-credentials: false
           fetch-tags: "true"
           fetch-depth: '0'
 
       - uses: ./.github/actions/load-shared-vars
+        id: shared-vars
 
       - uses: ./.github/actions/mamba-install-dascore
         with:
           # Defined in .github/actions/load-shared-vars/action.yml
-          python-version: ${{ env.PYTHON_DEFAULT }}
+          python-version: ${{ steps.shared-vars.outputs.python-default }}
           environment-file: './.github/doc_environment.yml'
           prepare-test-data: "true"
 

--- a/.github/workflows/build_deploy_stable_docs.yaml
+++ b/.github/workflows/build_deploy_stable_docs.yaml
@@ -9,12 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Write permissions are granted per job below; the default is read-only.
 permissions:
-  contents: write
-  pages: write
-  deployments: write
-  id-token: write
+  contents: read
 
 # Allow one concurrent deployment. Only runs which can deploy need to
 # serialize, so they share the "pages" group with the master docs workflow.
@@ -30,9 +27,13 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload docs.zip to the release.
+      contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
+          persist-credentials: false
           fetch-tags: "true"
           fetch-depth: '0'
 
@@ -61,11 +62,12 @@ jobs:
 
 
       - uses: ./.github/actions/load-shared-vars
+        id: shared-vars
 
       - uses: ./.github/actions/mamba-install-dascore
         with:
           # Defined in .github/actions/load-shared-vars/action.yml
-          python-version: ${{ env.PYTHON_DEFAULT }}
+          python-version: ${{ steps.shared-vars.outputs.python-default }}
           environment-file: './.github/doc_environment.yml'
           prepare-test-data: "true"
 
@@ -73,7 +75,7 @@ jobs:
       - uses: ./.github/actions/build-docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: 'docs/_site'
 
@@ -82,10 +84,10 @@ jobs:
         run: zip docs.zip docs/_site -r
 
       - name: Upload release docs
-        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: docs.zip
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$GITHUB_REF_NAME" docs.zip --clobber
 
   deploy:
     # Stable docs describe the latest stable release, so a pre-release (eg a
@@ -94,6 +96,10 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      # Needed by actions/deploy-pages.
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -101,4 +107,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/get_coverage.yml
+++ b/.github/workflows/get_coverage.yml
@@ -5,22 +5,27 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   calc_coverage:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
+          persist-credentials: false
           fetch-tags: "true"
           fetch-depth: '0'
 
       - uses: ./.github/actions/load-shared-vars
+        id: shared-vars
 
       - uses: ./.github/actions/mamba-install-dascore
         with:
           # Defined in .github/actions/load-shared-vars/action.yml
-          python-version: ${{ env.PYTHON_DEFAULT }}
+          python-version: ${{ steps.shared-vars.outputs.python-default }}
           cache-number: 1
           prepare-test-data: "true"
 
@@ -29,7 +34,7 @@ jobs:
         run: |
           pytest -s --cov dascore --cov-report=xml
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
           fail_ci_if_error: true
           files: ./coverage.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   lint_code:
     runs-on: ubuntu-latest
@@ -16,20 +19,22 @@ jobs:
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
+          persist-credentials: false
           fetch-tags: "true"
           fetch-depth: '0'
 
       - uses: ./.github/actions/load-shared-vars
+        id: shared-vars
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           # Defined in .github/actions/load-shared-vars/action.yml
-          python-version: ${{ env.PYTHON_DEFAULT }}
+          python-version: ${{ steps.shared-vars.outputs.python-default }}
 
       - name: install linting packages
         run: uv tool install pre-commit

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -27,23 +27,25 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'benchmark')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
+          persist-credentials: false
           fetch-tags: "true"
           fetch-depth: '0'
 
       - uses: ./.github/actions/load-shared-vars
+        id: shared-vars
 
       - uses: ./.github/actions/mamba-install-dascore
         with:
           # Defined in .github/actions/load-shared-vars/action.yml
-          python-version: ${{ env.PYTHON_DEFAULT }}
+          python-version: ${{ steps.shared-vars.outputs.python-default }}
           install-group-str: "[profile]"
           cache-number: 1
           prepare-test-data: "true"
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@f22792bfac16f3e14eb9fbea76f4a48e9cc22b93  # v4.19.1
         with:
           mode: simulation
           # CodSpeed does not inherit the shell activation done by the

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/run_min_dep_tests.yml'
       - '.github/actions/**/*.yml'
 
+permissions:
+  contents: read
+
 env:
   # Ensure matplotlib doesn't try to show figures in CI
   MPLBACKEND: Agg
@@ -33,7 +36,9 @@ jobs:
       # Shared values live in .github/actions/load-shared-vars/action.yml
       python-matrix: ${{ steps.load-vars.outputs.python-min-deps-matrix }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/load-shared-vars
         id: load-vars
 
@@ -51,8 +56,9 @@ jobs:
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
+          persist-credentials: false
           fetch-tags: "true"
           fetch-depth: '0'
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/*.yml'
       - '.github/actions/**/*.yml'
 
+permissions:
+  contents: read
+
 env:
   # used to manually trigger cache reset. Just increment if needed.
   CACHE_NUMBER: 1
@@ -35,7 +38,9 @@ jobs:
       # Shared values live in .github/actions/load-shared-vars/action.yml
       python-matrix: ${{ steps.load-vars.outputs.python-test-matrix }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/load-shared-vars
         id: load-vars
 
@@ -57,8 +62,9 @@ jobs:
       env_file: 'environment.yml'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
+          persist-credentials: false
           fetch-tags: 'true'
           fetch-depth: '0'
 
@@ -79,7 +85,7 @@ jobs:
         run: ./.github/test_code.sh doctest
 
       # Upload coverage files
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
           fail_ci_if_error: false
           files: ./coverage.xml

--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [labeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   test_build_docs:
     if: |
@@ -14,25 +17,33 @@ jobs:
       || (github.event.action == 'labeled' && github.event.label.name == 'documentation')
       || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'documentation'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed to look up the uploaded artifact's id.
+      actions: read
+      # Needed to create/update the doc link comment on the PR.
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
+          persist-credentials: false
           fetch-tags: "true"
           fetch-depth: '0'
 
       - uses: ./.github/actions/load-shared-vars
+        id: shared-vars
 
       - uses: ./.github/actions/mamba-install-dascore
         with:
           # Defined in .github/actions/load-shared-vars/action.yml
-          python-version: ${{ env.PYTHON_DEFAULT }}
+          python-version: ${{ steps.shared-vars.outputs.python-default }}
           environment-file: './.github/doc_environment.yml'
           cache-number: 1
           prepare-test-data: "true"
 
       - uses: ./.github/actions/build-docs
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: documentation_build_test
           path: ./docs/_site
@@ -64,7 +75,7 @@ jobs:
       # Determine if the automated documentation comment exists.
       - name: Find Comment
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e  # v3.1.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -74,7 +85,7 @@ jobs:
       # Create a comment with a download link to build docs
       - name: Create or update comment
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -5,26 +5,35 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed for PyPI trusted publishing (OIDC).
+      id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
+          persist-credentials: false
           fetch-tags: "true"
           fetch-depth: '0'
 
       - uses: ./.github/actions/load-shared-vars
+        id: shared-vars
 
       - name: setup conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167  # v3.3.0
         with:
           mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
           environment-file: environment.yml
           # Defined in .github/actions/load-shared-vars/action.yml
-          python-version: ${{ env.PYTHON_DEFAULT }}
+          python-version: ${{ steps.shared-vars.outputs.python-default }}
 
       - name: create dists
         shell: bash -l {0}
@@ -32,7 +41,6 @@ jobs:
           python -m pip install build
           python -m build
 
+      # Authenticates via PyPI trusted publishing (OIDC); no token needed.
       - name: publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,9 @@ repos:
     rev: v1.6.27
     hooks:
     -   id: actionlint
+
+    # Audits github actions for security issues.
+-   repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+    -   id: zizmor


### PR DESCRIPTION
## Description

Closes #828.

Audits the GitHub Actions CI with [zizmor](https://github.com/zizmorcore/zizmor) and fixes all 59 findings (template injection, excessive permissions, credential persistence, unpinned actions, `GITHUB_ENV` writes), then adds zizmor to pre-commit (next to actionlint) so regressions are caught in the lint job. `zizmor .github/` now reports zero findings.

Changes:

- **Template injection fix**: `mamba-install-dascore` interpolated `inputs.install-group-str` directly into a `run:` script; it now passes through an env var.
- **SHA-pinned actions**: every third-party action is pinned to a full commit SHA with a `# vX.Y.Z` comment. A new `.github/dependabot.yml` (monthly, 7-day cooldown) keeps the pins updated, covering workflows and the composite actions.
- **Least-privilege permissions**: every workflow now sets `permissions: contents: read` at the top level; write permissions (`pages`/`id-token` for the pages deploy, `contents: write` for the release docs upload, `pull-requests: write`/`actions: read` for the doc-build PR comment, `id-token: write` for PyPI) are scoped to the jobs that need them. The master docs workflow dropped its unused `pages`/`deployments`/`id-token` writes (it publishes to netlify with its own token).
- **`persist-credentials: false`** on all checkouts. No step uses the persisted git credential: the repo is public (anonymous fetches still work) and pushes/uploads use their own tokens.
- **Composite actions no longer write `GITHUB_ENV`**: `load-shared-vars` exposes `python-default` as an output, and `mamba-install-dascore` moves the cache date and test-data cache metadata to step outputs.
- **Replaced `softprops/action-gh-release`** with a plain `gh release upload … --clobber` step (zizmor `superfluous-actions`; one fewer third-party action).
- **PyPI trusted publishing**: `upload_pypi.yml` now authenticates via OIDC instead of `secrets.PYPI_TOKEN`.

> [!IMPORTANT]
> Before the next release, the trusted publisher must be configured on pypi.org (project `dascore` → Publishing → add GitHub publisher: owner `DASDAE`, repo `dascore`, workflow `upload_pypi.yml`). The `PYPI_TOKEN` secret can be deleted after the first successful OIDC publish.

Not exercisable on this PR: `build_deploy_master_docs.yaml` (watch the run after merge), `build_deploy_stable_docs.yaml` and `upload_pypi.yml` (verify at the next release).

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
