### PR TITLE
Add guard test: NETCDF_CF rejects Silixa Carina netCDF-flavored HDF5

### DIFF
--- a/dascore/data_registry.txt
+++ b/dascore/data_registry.txt
@@ -48,3 +48,4 @@ ofl100_1.sor 2af23609ac952f588d97ee195338f44227f61322422756e54a5c4a18b6704749 ht
 ofl100_2.sor d8787d6171e2a2b3c6443c28b724440274694d525da617202c6b7a7bb2e13a8c https://github.com/dasdae/test_data/raw/master/otdr/ofl100_2.sor
 ofl100_3.sor d9167fffc91565eaa48b65fd55e5f0600b7a96ebac549f1b2344ffb7bacf2336 https://github.com/dasdae/test_data/raw/master/otdr/ofl100_3.sor
 sintela_protobuf_1.pb cafa038c033cb5e4cf4aa90bab203eb1e10dc05a6052c0576dc80d6a5b3b42dc https://github.com/dasdae/test_data/raw/master/das/sintela_protobuf_1.pb
+silixa_h5_ingv_1.h5 738a359fb0f7848fc352f6d2879967dd15bd5c3f04b4c3e12c553825b9df861d https://github.com/dasdae/test_data/raw/master/das/silixa_h5_ingv_1.h5

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -111,7 +111,13 @@ COMMON_IO_WRITE_TESTS = (
 # Specifies data registry entries which should not be tested.
 # DASVader is covered in its own test module to isolate its compatibility-path
 # testing from the shared common-IO matrix.
-SKIP_DATA_FILES = {"brady_hs_DAS_DTS_coords.csv", "das_vader_1.jld2"}
+SKIP_DATA_FILES = {
+    "brady_hs_DAS_DTS_coords.csv",
+    "das_vader_1.jld2",
+    # No reader claims this file yet; the Silixa Carina variant reader
+    # (which will claim it) should remove this entry when it lands.
+    "silixa_h5_ingv_1.h5",
+}
 
 
 def _scan_summary(scan_result):

--- a/tests/test_io/test_netcdf/test_netcdf.py
+++ b/tests/test_io/test_netcdf/test_netcdf.py
@@ -16,6 +16,7 @@ from dascore.io.netcdf.utils import (
     get_cf_version,
     is_netcdf4_file,
 )
+from dascore.utils.downloader import fetch
 
 pytest.importorskip("xarray")
 
@@ -573,6 +574,23 @@ class TestNetCDFIO:
         monkeypatch.setattr(importlib, "import_module", _import_module)
 
         assert dc.get_format(minimal_cf_netcdf_path) == ("NETCDF_CF", "1.8")
+
+    def test_get_format_rejects_silixa_carina_hdf5(self):
+        """
+        NETCDF_CF must not claim Silixa Carina/iDAS HDF5 files.
+
+        These files (e.g. the INGV Mt Etna deployment) are written through a
+        netCDF library, so they carry _NCProperties and dimension scales, but
+        their netCDF coordinate variables are empty or zeroed; the usable
+        metadata lives in Silixa attrs on the root. They have no Conventions
+        attr, so the version requirement in get_format must reject them.
+        """
+        path = fetch("silixa_h5_ingv_1.h5")
+        formatter = netcdf_core.NetCDFCFV18()
+        with h5py.File(path, "r") as h5file:
+            assert is_netcdf4_file(h5file)
+            assert get_cf_version(h5file) is None
+            assert formatter.get_format(h5file) is False
 
     def test_round_trip(self, example_patch, tmp_path):
         """Test round-trip: patch -> NetCDF -> patch."""


### PR DESCRIPTION
## Description

First PR of the format-reader series from the 2026-08 format-gap survey (new readers for PubDAS Global-DAS-Month formats will follow, each as its own PR against dev).

Silixa Carina deployments (e.g. INGV Mt Etna, whose trimmed sample this PR registers as `silixa_h5_ingv_1.h5`) write HDF5 through a netCDF library: the files carry `_NCProperties` and dimension-scale machinery, but have no `Conventions` attr and their netCDF coordinate variables (`t`, `x`, `cm`) are empty or zeroed — the usable metadata lives in Silixa attrs on the root. This adds a test pinning that `NETCDF_CF.get_format` keeps rejecting these files (via the CF-version requirement), so the upcoming Silixa-variant reader can claim them without contention, and so future loosening of NetCDF detection can't silently mis-claim them.

- `is_netcdf4_file` correctly reports True (the file genuinely is netCDF-written); the rejection happens on the missing CF version — the test asserts each step so a failure localizes.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes. (n/a — part of the format-reader series)
- [x] documented the new feature with docstrings and/or appropriate doc page. (n/a — test only)
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.