### PR TITLE
Enable PLC0415 so function-level imports need an explicit noqa

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -30,6 +30,14 @@ from dascore.exceptions import (
     MissingPatchError,
     ParameterError,
 )
+from dascore.utils.chunk_plan import (
+    _SOURCE_COLUMNS,
+    ChunkPlan,
+    _combined_dtype,
+    _ensure_patch_id,
+    build_chunk_plan,
+    samples_adjusted_envelopes,
+)
 from dascore.utils.display import get_dascore_text, get_nice_text
 from dascore.utils.docs import compose_docstring, get_docstring
 from dascore.utils.misc import (
@@ -674,11 +682,6 @@ class Spool(BaseSpool):
         themselves re-applied at load through the plan resolver.
         """
         from dascore.io.index.planned import derived_catalog  # noqa: PLC0415
-        from dascore.utils.chunk_plan import (  # noqa: PLC0415
-            _SOURCE_COLUMNS,
-            ChunkPlan,
-            samples_adjusted_envelopes,
-        )
 
         rows = self._df.reset_index(drop=True)
         working = samples_adjusted_envelopes(rows, self._catalog._residuals)
@@ -725,10 +728,6 @@ class Spool(BaseSpool):
             PlanResolver,
             collapse_working_df,
         )
-        from dascore.utils.chunk_plan import (  # noqa: PLC0415
-            _ensure_patch_id,
-            samples_adjusted_envelopes,
-        )
 
         resolver = self._catalog.resolver
         same_dim = isinstance(resolver, PlanResolver) and resolver.dim == dim
@@ -774,8 +773,6 @@ class Spool(BaseSpool):
         >>> members = plan.members
         >>> first = members[members["output_id"] == 0]
         """
-        from dascore.utils.chunk_plan import build_chunk_plan  # noqa: PLC0415
-
         _, working = self._plan_frames(next(iter(kwargs), None))
         return build_chunk_plan(
             working,
@@ -803,7 +800,6 @@ class Spool(BaseSpool):
     ) -> Self:
         """{doc}"""
         from dascore.io.index.planned import derived_catalog  # noqa: PLC0415
-        from dascore.utils.chunk_plan import build_chunk_plan  # noqa: PLC0415
 
         source_rows, working = self._plan_frames(next(iter(kwargs), None))
         plan = build_chunk_plan(
@@ -836,10 +832,6 @@ class Spool(BaseSpool):
     def concatenate(self, check_behavior: WARN_LEVELS = "warn", **kwargs) -> Self:
         """{desc}"""
         from dascore.io.index.planned import derived_catalog  # noqa: PLC0415
-        from dascore.utils.chunk_plan import (  # noqa: PLC0415
-            ChunkPlan,
-            _combined_dtype,
-        )
 
         if len(kwargs) != 1:
             msg = (
@@ -1088,8 +1080,6 @@ class Spool(BaseSpool):
             ]
             out = df.drop(columns=drop, errors="ignore")
             return out[sorted(out.columns)]
-
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         catalog = self._catalog
         rows = self._df

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -150,7 +150,7 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         """
         if not isinstance(other, BaseSpool):
             return NotImplemented
-        from dascore.io.index.catalog import PatchCatalog
+        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
         members = [self._as_catalog_member(), other._as_catalog_member()]
         union = PatchCatalog.union(members)
@@ -166,7 +166,7 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         means the whole catalog (or the catalog view itself carries the
         selection). The base implementation materializes the patches.
         """
-        from dascore.io.index.catalog import PatchCatalog
+        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
         return PatchCatalog.from_patches(list(self)), None
 
@@ -494,7 +494,7 @@ class Spool(BaseSpool):
         self,
         data: PatchType | Sequence[PatchType] | BaseSpool | None = None,
     ):
-        from dascore.io.index.catalog import PatchCatalog
+        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
         if isinstance(data, Spool):
             # copy-construction: share the catalog and provenance
@@ -673,8 +673,8 @@ class Spool(BaseSpool):
         with trimmed envelopes as the output envelopes and the trims
         themselves re-applied at load through the plan resolver.
         """
-        from dascore.io.index.planned import derived_catalog
-        from dascore.utils.chunk_plan import (
+        from dascore.io.index.planned import derived_catalog  # noqa: PLC0415
+        from dascore.utils.chunk_plan import (  # noqa: PLC0415
             _SOURCE_COLUMNS,
             ChunkPlan,
             samples_adjusted_envelopes,
@@ -721,8 +721,11 @@ class Spool(BaseSpool):
         residuals adjust the working envelopes so plans reflect the
         loading truth.
         """
-        from dascore.io.index.planned import PlanResolver, collapse_working_df
-        from dascore.utils.chunk_plan import (
+        from dascore.io.index.planned import (  # noqa: PLC0415
+            PlanResolver,
+            collapse_working_df,
+        )
+        from dascore.utils.chunk_plan import (  # noqa: PLC0415
             _ensure_patch_id,
             samples_adjusted_envelopes,
         )
@@ -771,7 +774,7 @@ class Spool(BaseSpool):
         >>> members = plan.members
         >>> first = members[members["output_id"] == 0]
         """
-        from dascore.utils.chunk_plan import build_chunk_plan
+        from dascore.utils.chunk_plan import build_chunk_plan  # noqa: PLC0415
 
         _, working = self._plan_frames(next(iter(kwargs), None))
         return build_chunk_plan(
@@ -799,8 +802,8 @@ class Spool(BaseSpool):
         **kwargs,
     ) -> Self:
         """{doc}"""
-        from dascore.io.index.planned import derived_catalog
-        from dascore.utils.chunk_plan import build_chunk_plan
+        from dascore.io.index.planned import derived_catalog  # noqa: PLC0415
+        from dascore.utils.chunk_plan import build_chunk_plan  # noqa: PLC0415
 
         source_rows, working = self._plan_frames(next(iter(kwargs), None))
         plan = build_chunk_plan(
@@ -832,8 +835,11 @@ class Spool(BaseSpool):
     @compose_docstring(desc=get_docstring(concatenate_patches))
     def concatenate(self, check_behavior: WARN_LEVELS = "warn", **kwargs) -> Self:
         """{desc}"""
-        from dascore.io.index.planned import derived_catalog
-        from dascore.utils.chunk_plan import ChunkPlan, _combined_dtype
+        from dascore.io.index.planned import derived_catalog  # noqa: PLC0415
+        from dascore.utils.chunk_plan import (  # noqa: PLC0415
+            ChunkPlan,
+            _combined_dtype,
+        )
 
         if len(kwargs) != 1:
             msg = (
@@ -907,12 +913,12 @@ class Spool(BaseSpool):
         The directory's index (created/updated via ``update()``) backs
         the catalog; ``path`` may also be an existing directory indexer.
         """
-        from dascore.io.index.catalog import FileResolver, PatchCatalog
-        from dascore.io.index.indexer import DBDirectoryIndexer
+        from dascore.io.index.catalog import FileResolver, PatchCatalog  # noqa: PLC0415
+        from dascore.io.index.indexer import DBDirectoryIndexer  # noqa: PLC0415
 
         out = cls()
         if isinstance(path, DBDirectoryIndexer):
-            from dascore.io.index.catalog import _DIRECTORY_ORDER
+            from dascore.io.index.catalog import _DIRECTORY_ORDER  # noqa: PLC0415
 
             out._catalog = PatchCatalog(
                 backend=path._backend,
@@ -940,7 +946,7 @@ class Spool(BaseSpool):
         if not path.exists() or path.is_dir():
             msg = f"{path} does not exist or is a directory"
             raise FileNotFoundError(msg)
-        from dascore.io.index.catalog import PatchCatalog
+        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
         _format, _version = dc.get_format(path, file_format, file_version)
         out = cls()
@@ -986,7 +992,7 @@ class Spool(BaseSpool):
         select, slicing, sort, chunk, concatenate, or combining spools)
         raises: update the root and re-apply the operations.
         """
-        from dascore.io.index.catalog import LiveResolver
+        from dascore.io.index.catalog import LiveResolver  # noqa: PLC0415
 
         catalog = self._catalog
         derived_msg = (
@@ -1001,7 +1007,7 @@ class Spool(BaseSpool):
             catalog.update(progress=progress)
             return self._new_from_catalog(catalog)
         if self._file_path is not None:
-            from dascore.io.core import FiberIO
+            from dascore.io.core import FiberIO  # noqa: PLC0415
 
             formatter = FiberIO.manager.get_fiberio(
                 format=self._file_format, version=self._file_version
@@ -1083,7 +1089,7 @@ class Spool(BaseSpool):
             out = df.drop(columns=drop, errors="ignore")
             return out[sorted(out.columns)]
 
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         catalog = self._catalog
         rows = self._df

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -37,6 +37,7 @@ from dascore.constants import (
 )
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import CoordManager
+from dascore.core.coords import CoordSegmented
 from dascore.core.spool import Spool
 from dascore.core.summary import PatchSummary, normalize_source_patch_id
 from dascore.exceptions import (
@@ -1645,8 +1646,6 @@ def _resolves_assembled_patches(spool) -> bool:
 
 def _maybe_split_gapped_patches(spool, fiber_io, split):
     """Handle patches whose dimensional coords contain gaps before writing."""
-    from dascore.core.coords import CoordSegmented  # noqa: PLC0415
-
     # Gap inspection depends on what the spool resolves, not on where
     # its ultimate members live: only literal file reads are always
     # contiguous (gapped patches are never persisted).

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -1645,7 +1645,7 @@ def _resolves_assembled_patches(spool) -> bool:
 
 def _maybe_split_gapped_patches(spool, fiber_io, split):
     """Handle patches whose dimensional coords contain gaps before writing."""
-    from dascore.core.coords import CoordSegmented
+    from dascore.core.coords import CoordSegmented  # noqa: PLC0415
 
     # Gap inspection depends on what the spool resolves, not on where
     # its ultimate members live: only literal file reads are always

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -801,7 +801,7 @@ class SQLIndexBackend(abc.ABC):
         fetched — O(selected membership), not O(total archive). The frames
         are assembled into the backend-independent transfer format.
         """
-        from dascore.io.index.ingest import assemble_source_records
+        from dascore.io.index.ingest import assemble_source_records  # noqa: PLC0415
 
         if patch_ids is None:
             sources = self._fetch_df("SELECT * FROM sources")
@@ -1100,7 +1100,7 @@ def resolve_query(
     Implements section 1 of the selector spec; raises on unknown names or
     names supplied in more than one namespace.
     """
-    from dascore.io.index.query import InvalidSpoolQueryError
+    from dascore.io.index.query import InvalidSpoolQueryError  # noqa: PLC0415
 
     def _drop_noops(mapping: dict) -> dict:
         """Bare None/... selectors are no-ops, matching Patch.select."""
@@ -1163,6 +1163,6 @@ def resolve_query(
 
 def get_backend(path: str | Path) -> SQLIndexBackend:
     """Create the SQLite spool-index backend at path."""
-    from dascore.io.index.lite import SQLiteBackend
+    from dascore.io.index.lite import SQLiteBackend  # noqa: PLC0415
 
     return SQLiteBackend(path)

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -27,11 +27,13 @@ from dascore.exceptions import (
 from dascore.io.index.dialect import SQLiteDialect
 from dascore.io.index.ingest import (
     SourceRecord,
+    assemble_source_records,
     attr_column_name,
     dump_path_attrs,
     hive_typed_attrs,
 )
 from dascore.io.index.query import (
+    InvalidSpoolQueryError,
     Query,
     _as_query_list,
     apply_residuals,
@@ -801,8 +803,6 @@ class SQLIndexBackend(abc.ABC):
         fetched — O(selected membership), not O(total archive). The frames
         are assembled into the backend-independent transfer format.
         """
-        from dascore.io.index.ingest import assemble_source_records  # noqa: PLC0415
-
         if patch_ids is None:
             sources = self._fetch_df("SELECT * FROM sources")
             patches = self._fetch_df("SELECT * FROM patches")
@@ -1100,7 +1100,6 @@ def resolve_query(
     Implements section 1 of the selector spec; raises on unknown names or
     names supplied in more than one namespace.
     """
-    from dascore.io.index.query import InvalidSpoolQueryError  # noqa: PLC0415
 
     def _drop_noops(mapping: dict) -> dict:
         """Bare None/... selectors are no-ops, matching Patch.select."""

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -83,7 +83,7 @@ class _CanonicalRange:
 
     def for_patch_coord(self, coord) -> tuple:
         """Return the range in the representation this coord needs."""
-        from dascore.units import get_quantity
+        from dascore.units import get_quantity  # noqa: PLC0415
 
         coord_units = getattr(coord, "units", None)
         if coord_units is None:
@@ -279,7 +279,7 @@ class FileResolver(PatchResolver):
 
     def resolve(self, row: Mapping, **trim) -> dc.Patch:
         """Read the patch, passing range trims down as read hints."""
-        from dascore.io.core import _resolve_read_spool
+        from dascore.io.core import _resolve_read_spool  # noqa: PLC0415
 
         path = row["path"]
         # relative paths resolve against the catalog root; URIs and
@@ -598,7 +598,7 @@ class PatchCatalog:
         in-memory backend; patches load through the file resolver on
         demand. There is no syncer — a changed file needs a new catalog.
         """
-        from dascore.io.index.ingest import summaries_to_records
+        from dascore.io.index.ingest import summaries_to_records  # noqa: PLC0415
 
         summaries = dc.scan(
             path, file_format=file_format, file_version=file_version, progress=None
@@ -616,7 +616,7 @@ class PatchCatalog:
         index_path: str | Path | None = None,
     ) -> PatchCatalog:
         """Catalog over a directory of fiber files."""
-        from dascore.io.index.indexer import DBDirectoryIndexer
+        from dascore.io.index.indexer import DBDirectoryIndexer  # noqa: PLC0415
 
         syncer = DBDirectoryIndexer(path, index_path=index_path)
         return cls(

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -32,13 +32,16 @@ import dascore as dc
 from dascore.constants import PROGRESS_LEVELS
 from dascore.core.summary import normalize_source_patch_id
 from dascore.exceptions import MissingPatchError
+from dascore.io.core import _resolve_read_spool
 from dascore.io.index.backend import get_backend, resolve_query
-from dascore.io.index.ingest import SourceRecord, patch_record
+from dascore.io.index.indexer import DBDirectoryIndexer
+from dascore.io.index.ingest import SourceRecord, patch_record, summaries_to_records
 from dascore.io.index.query import (
     InvalidSpoolQueryError,
     Query,
 )
 from dascore.io.index.schema import SPOOL_HIDDEN_COLUMNS, SPOOL_PRIVATE_RENAMES
+from dascore.units import get_quantity
 from dascore.utils.misc import is_range
 from dascore.utils.paths import is_memory_uri
 from dascore.utils.pd import adjust_segments, relative_ranges_to_absolute
@@ -83,8 +86,6 @@ class _CanonicalRange:
 
     def for_patch_coord(self, coord) -> tuple:
         """Return the range in the representation this coord needs."""
-        from dascore.units import get_quantity  # noqa: PLC0415
-
         coord_units = getattr(coord, "units", None)
         if coord_units is None:
             # unitless coords: bare canonical magnitudes (documented policy)
@@ -279,8 +280,6 @@ class FileResolver(PatchResolver):
 
     def resolve(self, row: Mapping, **trim) -> dc.Patch:
         """Read the patch, passing range trims down as read hints."""
-        from dascore.io.core import _resolve_read_spool  # noqa: PLC0415
-
         path = row["path"]
         # relative paths resolve against the catalog root; URIs and
         # absolute paths pass through untouched.
@@ -598,8 +597,6 @@ class PatchCatalog:
         in-memory backend; patches load through the file resolver on
         demand. There is no syncer — a changed file needs a new catalog.
         """
-        from dascore.io.index.ingest import summaries_to_records  # noqa: PLC0415
-
         summaries = dc.scan(
             path, file_format=file_format, file_version=file_version, progress=None
         )
@@ -616,8 +613,6 @@ class PatchCatalog:
         index_path: str | Path | None = None,
     ) -> PatchCatalog:
         """Catalog over a directory of fiber files."""
-        from dascore.io.index.indexer import DBDirectoryIndexer  # noqa: PLC0415
-
         syncer = DBDirectoryIndexer(path, index_path=index_path)
         return cls(
             backend=syncer._backend,

--- a/dascore/io/index/indexer.py
+++ b/dascore/io/index/indexer.py
@@ -235,7 +235,7 @@ class DBDirectoryIndexer:
 
     def _directory_format(self, path: Path) -> bool:
         """Return True when a directory is itself one FiberIO scan unit."""
-        from dascore.io.core import is_directory_format
+        from dascore.io.core import is_directory_format  # noqa: PLC0415
 
         return is_directory_format(path)
 

--- a/dascore/io/index/indexer.py
+++ b/dascore/io/index/indexer.py
@@ -25,6 +25,7 @@ from dascore.compat import UPath
 from dascore.config import config_attr
 from dascore.constants import PROGRESS_LEVELS
 from dascore.exceptions import InvalidIndexVersionError
+from dascore.io.core import is_directory_format
 from dascore.io.index.backend import get_backend, resolve_query
 from dascore.io.index.ingest import (
     SourceRecord,
@@ -235,8 +236,6 @@ class DBDirectoryIndexer:
 
     def _directory_format(self, path: Path) -> bool:
         """Return True when a directory is itself one FiberIO scan unit."""
-        from dascore.io.core import is_directory_format  # noqa: PLC0415
-
         return is_directory_format(path)
 
     @staticmethod

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -79,8 +79,8 @@ def _coord_record_from_row(
     planned dim's range fingerprint is reconstructed exactly. ``dims``
     names the dimensions the coordinate rides (itself by default).
     """
-    from dascore.core.coords import CoordSummary
-    from dascore.io.index.ingest import _coord_record
+    from dascore.core.coords import CoordSummary  # noqa: PLC0415
+    from dascore.io.index.ingest import _coord_record  # noqa: PLC0415
 
     dims = (name,) if dims is None else dims
     lo, hi = row.get(f"{name}_min"), row.get(f"{name}_max")
@@ -356,7 +356,7 @@ class PlanResolver(PatchResolver):
         return nested
 
     def _assembler(self):
-        from dascore.utils.patch_assembly import PatchAssembler
+        from dascore.utils.patch_assembly import PatchAssembler  # noqa: PLC0415
 
         return PatchAssembler(
             load_patch=self._load_member,
@@ -386,7 +386,7 @@ class PlanResolver(PatchResolver):
             assert len(members) == 1
             return self._load_member(members.iloc[0].to_dict())
         if self.mode == "concat":
-            from dascore.utils.patch import concatenate_patches
+            from dascore.utils.patch import concatenate_patches  # noqa: PLC0415
 
             patches = [
                 self._load_member(kwargs) for kwargs in members.to_dict("records")
@@ -444,7 +444,7 @@ def derived_catalog(
     trim_cols = [c for c in trims.columns if c not in ("_patch_id",)]
     sources = source_rows.copy(deep=False)
     if "_patch_id" not in sources.columns:
-        from dascore.utils.chunk_plan import _ensure_patch_id
+        from dascore.utils.chunk_plan import _ensure_patch_id  # noqa: PLC0415
 
         sources = _ensure_patch_id(sources)
     member_rows = trims[["_patch_id", *[c for c in trim_cols]]].merge(

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -24,6 +24,7 @@ import pandas as pd
 
 import dascore as dc
 from dascore.constants import WARN_LEVELS
+from dascore.core.coords import CoordSummary
 from dascore.io.index.backend import get_backend
 from dascore.io.index.catalog import (
     CompositeResolver,
@@ -36,9 +37,13 @@ from dascore.io.index.ingest import (
     CoordRecord,
     PatchRecord,
     SourceRecord,
+    _coord_record,
     typed_value,
 )
+from dascore.utils.chunk_plan import _ensure_patch_id
 from dascore.utils.misc import is_range
+from dascore.utils.patch import concatenate_patches
+from dascore.utils.patch_assembly import PatchAssembler
 from dascore.utils.pd import adjust_segments
 
 PLAN_SCHEME = "plan://"
@@ -79,9 +84,6 @@ def _coord_record_from_row(
     planned dim's range fingerprint is reconstructed exactly. ``dims``
     names the dimensions the coordinate rides (itself by default).
     """
-    from dascore.core.coords import CoordSummary  # noqa: PLC0415
-    from dascore.io.index.ingest import _coord_record  # noqa: PLC0415
-
     dims = (name,) if dims is None else dims
     lo, hi = row.get(f"{name}_min"), row.get(f"{name}_max")
     if lo is None or (pd.isnull(lo) and pd.isnull(hi)):
@@ -356,7 +358,6 @@ class PlanResolver(PatchResolver):
         return nested
 
     def _assembler(self):
-        from dascore.utils.patch_assembly import PatchAssembler  # noqa: PLC0415
 
         return PatchAssembler(
             load_patch=self._load_member,
@@ -386,8 +387,6 @@ class PlanResolver(PatchResolver):
             assert len(members) == 1
             return self._load_member(members.iloc[0].to_dict())
         if self.mode == "concat":
-            from dascore.utils.patch import concatenate_patches  # noqa: PLC0415
-
             patches = [
                 self._load_member(kwargs) for kwargs in members.to_dict("records")
             ]
@@ -444,8 +443,6 @@ def derived_catalog(
     trim_cols = [c for c in trims.columns if c not in ("_patch_id",)]
     sources = source_rows.copy(deep=False)
     if "_patch_id" not in sources.columns:
-        from dascore.utils.chunk_plan import _ensure_patch_id  # noqa: PLC0415
-
         sources = _ensure_patch_id(sources)
     member_rows = trims[["_patch_id", *[c for c in trim_cols]]].merge(
         sources.drop(columns=[c for c in trim_cols if c in sources], errors="ignore"),

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -10,6 +10,7 @@ exactly are applied as pandas residual filters.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -479,8 +480,6 @@ def build_sql(
     SQL-resolvable (regex must inspect rows) and the caller must fall
     back to a projected count.
     """
-    import json  # noqa: PLC0415
-
     queries = _as_query_list(query)
     where, residuals = _build_where(queries, dialect, attr_meta, coord_meta)
     if patch_ids is not None:

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -479,7 +479,7 @@ def build_sql(
     SQL-resolvable (regex must inspect rows) and the caller must fall
     back to a projected count.
     """
-    import json
+    import json  # noqa: PLC0415
 
     queries = _as_query_list(query)
     where, residuals = _build_where(queries, dialect, attr_meta, coord_meta)

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -896,7 +896,7 @@ def split_gaps(self: PatchType, dim: str | None = None) -> dc.BaseSpool:
     >>> spool = patch.split_gaps()
     >>> assert len(spool) == 2
     """
-    from dascore.core.coords import CoordSegmented
+    from dascore.core.coords import CoordSegmented  # noqa: PLC0415
 
     if dim is not None and dim not in self.dims:
         msg = f"split_gaps dim must be one of {self.dims}, got {dim!r}."

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -10,7 +10,7 @@ from scipy.interpolate import interp1d
 
 import dascore as dc
 from dascore.constants import PatchType, select_values_description
-from dascore.core.coords import BaseCoord
+from dascore.core.coords import BaseCoord, CoordSegmented
 from dascore.exceptions import (
     CoordError,
     ParameterError,
@@ -896,8 +896,6 @@ def split_gaps(self: PatchType, dim: str | None = None) -> dc.BaseSpool:
     >>> spool = patch.split_gaps()
     >>> assert len(spool) == 2
     """
-    from dascore.core.coords import CoordSegmented  # noqa: PLC0415
-
     if dim is not None and dim not in self.dims:
         msg = f"split_gaps dim must be one of {self.dims}, got {dim!r}."
         raise ParameterError(msg)

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -15,6 +15,7 @@ applied; `Spool.chunk` runs on these plans.
 
 from __future__ import annotations
 
+import inspect
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -296,8 +297,6 @@ def _user_stacklevel() -> int:
     build_chunk_plan directly), so a fixed stacklevel would blame library
     frames for some entries.
     """
-    import inspect  # noqa: PLC0415
-
     # The dascore package directory, resolved from the package itself so
     # this does not depend on this module's location within it.
     package_dir = str(Path(dc.__file__).resolve().parent)

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -296,7 +296,7 @@ def _user_stacklevel() -> int:
     build_chunk_plan directly), so a fixed stacklevel would blame library
     frames for some entries.
     """
-    import inspect
+    import inspect  # noqa: PLC0415
 
     # The dascore package directory, resolved from the package itself so
     # this does not depend on this module's location within it.

--- a/dascore/utils/coordmanager.py
+++ b/dascore/utils/coordmanager.py
@@ -135,7 +135,7 @@ def merge_coord_managers(
             # the (verified common) units so the merge stays unit-true
             common_units = next(iter(units))
             if common_units is not None:
-                from dascore.core.coords import get_coord
+                from dascore.core.coords import get_coord  # noqa: PLC0415
 
                 coord = get_coord(data=new_data, units=common_units)
                 out[coord_name] = (dims, coord)

--- a/dascore/utils/docs.py
+++ b/dascore/utils/docs.py
@@ -135,7 +135,7 @@ def get_plugin_table() -> pd.DataFrame:
     and sorts alphabetically. Columns are ``namespace``, ``package_name``,
     and ``package_url``.
     """
-    from dascore.utils.namespace import _PLUGIN_REGISTRY_DIR
+    from dascore.utils.namespace import _PLUGIN_REGISTRY_DIR  # noqa: PLC0415
 
     frames = [pd.read_csv(p) for p in sorted(_PLUGIN_REGISTRY_DIR.glob("*.csv"))]
     if not frames:

--- a/dascore/utils/jit.py
+++ b/dascore/utils/jit.py
@@ -67,7 +67,7 @@ def maybe_numba_jit(required=False, _missing_numba=False, **compiler_kwargs):
 
     has_numba = True
     try:
-        import numba
+        import numba  # noqa: PLC0415
 
         if _missing_numba:
             raise ImportError("Simulating missing numba.")

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -1521,8 +1521,6 @@ def swap_kwargs_dim_to_axis(patch, kwargs):
     if dim is not None:
         if isinstance(dim, str):
             if dim not in patch.dims:
-                from dascore.exceptions import ParameterError  # noqa: PLC0415
-
                 msg = f"Dimension '{dim}' not found in patch dimensions {patch.dims}"
                 raise ParameterError(msg)
             axis = patch.get_axis(dim)
@@ -1531,8 +1529,6 @@ def swap_kwargs_dim_to_axis(patch, kwargs):
             axis = []
             for d in dim:
                 if d not in patch.dims:
-                    from dascore.exceptions import ParameterError  # noqa: PLC0415
-
                     msg = f"Dimension '{d}' not found in patch dimensions {patch.dims}"
                     raise ParameterError(msg)
                 axis.append(patch.get_axis(d))

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -487,7 +487,7 @@ def _get_merged_coord(
     `tolerance * step`. Merges whose gaps exceed that stay segmented
     (honestly non-uniform) rather than being relabeled.
     """
-    from dascore.core.coords import concat_coords
+    from dascore.core.coords import concat_coords  # noqa: PLC0415
 
     try:
         merged = concat_coords(*[cm.coord_map[merge_dim] for cm in coords])
@@ -1521,7 +1521,7 @@ def swap_kwargs_dim_to_axis(patch, kwargs):
     if dim is not None:
         if isinstance(dim, str):
             if dim not in patch.dims:
-                from dascore.exceptions import ParameterError
+                from dascore.exceptions import ParameterError  # noqa: PLC0415
 
                 msg = f"Dimension '{dim}' not found in patch dimensions {patch.dims}"
                 raise ParameterError(msg)
@@ -1531,7 +1531,7 @@ def swap_kwargs_dim_to_axis(patch, kwargs):
             axis = []
             for d in dim:
                 if d not in patch.dims:
-                    from dascore.exceptions import ParameterError
+                    from dascore.exceptions import ParameterError  # noqa: PLC0415
 
                     msg = f"Dimension '{d}' not found in patch dimensions {patch.dims}"
                     raise ParameterError(msg)

--- a/dascore/utils/patch_assembly.py
+++ b/dascore/utils/patch_assembly.py
@@ -86,7 +86,7 @@ def _match_merge_units(patch, merge_dim, target_units):
     (patch, target_units); incompatible or missing units pass through
     for the merge itself to police.
     """
-    from dascore.exceptions import UnitError
+    from dascore.exceptions import UnitError  # noqa: PLC0415
 
     if merge_dim is None or merge_dim not in getattr(patch.coords, "coord_map", {}):
         return patch, target_units

--- a/dascore/utils/patch_assembly.py
+++ b/dascore/utils/patch_assembly.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 
 import dascore as dc
-from dascore.exceptions import CoordMergeError
+from dascore.exceptions import CoordMergeError, UnitError
 from dascore.utils.attrs import combine_patch_attrs
 from dascore.utils.misc import broadcast_for_index
 from dascore.utils.patch import (
@@ -86,8 +86,6 @@ def _match_merge_units(patch, merge_dim, target_units):
     (patch, target_units); incompatible or missing units pass through
     for the merge itself to police.
     """
-    from dascore.exceptions import UnitError  # noqa: PLC0415
-
     if merge_dim is None or merge_dim not in getattr(patch.coords, "coord_map", {}):
         return patch, target_units
     units = patch.coords.coord_map[merge_dim].units

--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -15,7 +15,11 @@ from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_compatible_values, get_coord
 from dascore.units import invert_quantity
 from dascore.utils.misc import iterate
-from dascore.utils.patch import patch_function
+from dascore.utils.patch import (
+    _get_data_units_from_dims,
+    _get_dx_or_spacing_and_axes,
+    patch_function,
+)
 from dascore.utils.transformatter import FourierTransformatter
 
 
@@ -53,11 +57,6 @@ def _get_new_dims(patch, dim, new_coord_name):
 
 def _spectrogram_patch(patch: PatchType, dim: str = "time", **kwargs) -> PatchType:
     """Create a spectrogram patch for visualization."""
-    from dascore.utils.patch import (  # noqa: PLC0415
-        _get_data_units_from_dims,
-        _get_dx_or_spacing_and_axes,
-    )
-
     assert len(iterate(dim)) == 1, "only one dimension allowed."
     coord = patch.get_coord(dim)
     dxs, axes = _get_dx_or_spacing_and_axes(patch, dim, require_evenly_spaced=True)

--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -53,7 +53,7 @@ def _get_new_dims(patch, dim, new_coord_name):
 
 def _spectrogram_patch(patch: PatchType, dim: str = "time", **kwargs) -> PatchType:
     """Create a spectrogram patch for visualization."""
-    from dascore.utils.patch import (
+    from dascore.utils.patch import (  # noqa: PLC0415
         _get_data_units_from_dims,
         _get_dx_or_spacing_and_axes,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ lint.select = [
     "N",
     "NPY",
     "NPY201",
+    "PLC0415",
 ]
 
 # Exclude a variety of commonly ignored directories.

--- a/scripts/test_render_api.py
+++ b/scripts/test_render_api.py
@@ -44,7 +44,7 @@ class TestGetTypeHints:
 
     def test_signature_of_type_checking_annotated_class(self):
         """Spool annotates a TYPE_CHECKING-only import; it must still render."""
-        from dascore.core.spool import Spool
+        from dascore.core.spool import Spool  # noqa: PLC0415
 
         data = {
             "signature": inspect.signature(Spool),

--- a/scripts/test_render_api.py
+++ b/scripts/test_render_api.py
@@ -7,6 +7,8 @@ import typing
 
 import pytest
 
+from dascore.core.spool import Spool
+
 # These tests only work if doc deps are installed.
 pytest.importorskip("jinja2")
 
@@ -44,8 +46,6 @@ class TestGetTypeHints:
 
     def test_signature_of_type_checking_annotated_class(self):
         """Spool annotates a TYPE_CHECKING-only import; it must still render."""
-        from dascore.core.spool import Spool  # noqa: PLC0415
-
         data = {
             "signature": inspect.signature(Spool),
             "object": Spool,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -530,7 +530,7 @@ def terra15_das_unfinished_path() -> Path:
 @register_func(SPOOL_FIXTURES)
 def random_spool() -> SpoolType:
     """Init a random array."""
-    from dascore.examples import get_example_spool
+    from dascore.examples import get_example_spool  # noqa: PLC0415
 
     return get_example_spool("random_das")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ from dascore.config import get_config, set_config
 from dascore.constants import SpoolType
 from dascore.core import Patch
 from dascore.core.spool import Spool
-from dascore.examples import get_example_patch
+from dascore.examples import get_example_patch, get_example_spool
 from dascore.io.core import read
 from dascore.utils.coordmanager import merge_coord_managers
 from dascore.utils.downloader import fetch
@@ -530,8 +530,6 @@ def terra15_das_unfinished_path() -> Path:
 @register_func(SPOOL_FIXTURES)
 def random_spool() -> SpoolType:
     """Init a random array."""
-    from dascore.examples import get_example_spool  # noqa: PLC0415
-
     return get_example_spool("random_das")
 
 

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pickle
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -11,6 +12,7 @@ from pydantic import ValidationError
 
 import dascore as dc
 from dascore.core.coords import (
+    CoordArray,
     CoordMonotonicArray,
     CoordPartial,
     CoordRange,
@@ -724,8 +726,6 @@ class TestEdgeCases:
 
     def test_unsupported_segment_class_raises(self):
         """Coord classes other than range/monotonic are rejected."""
-        from dascore.core.coords import CoordArray  # noqa: PLC0415
-
         bad = CoordArray(values=np.array([3.0, 1.0, 2.0]))
         good = get_coord(start=10.0, stop=20.0, step=1.0)
         with pytest.raises(ValidationError, match="CoordRange or CoordMonotonic"):
@@ -1136,8 +1136,6 @@ class TestPlannedSpoolWriteGuard:
     @pytest.fixture()
     def gapped_planned_spool(self, tmp_path):
         """A file-backed planned spool whose output spans a real gap."""
-        import warnings  # noqa: PLC0415
-
         src = tmp_path / "src"
         src.mkdir()
         p1 = dc.get_example_patch()

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -724,7 +724,7 @@ class TestEdgeCases:
 
     def test_unsupported_segment_class_raises(self):
         """Coord classes other than range/monotonic are rejected."""
-        from dascore.core.coords import CoordArray
+        from dascore.core.coords import CoordArray  # noqa: PLC0415
 
         bad = CoordArray(values=np.array([3.0, 1.0, 2.0]))
         good = get_coord(start=10.0, stop=20.0, step=1.0)
@@ -1136,7 +1136,7 @@ class TestPlannedSpoolWriteGuard:
     @pytest.fixture()
     def gapped_planned_spool(self, tmp_path):
         """A file-backed planned spool whose output spans a real gap."""
-        import warnings
+        import warnings  # noqa: PLC0415
 
         src = tmp_path / "src"
         src.mkdir()

--- a/tests/test_core/test_directory_spool.py
+++ b/tests/test_core/test_directory_spool.py
@@ -259,7 +259,7 @@ class TestSelectedDirectorySpools:
         self, spool_dir, random_spool, first_patch_range
     ):
         """D1: any operation severs update()."""
-        from dascore.exceptions import InvalidSpoolError
+        from dascore.exceptions import InvalidSpoolError  # noqa: PLC0415
 
         spool = Spool.from_directory(spool_dir).update().select(time=first_patch_range)
         with pytest.raises(InvalidSpoolError, match="root spool"):
@@ -728,7 +728,7 @@ class TestDirectorySpoolSerialization:
 
     def test_pickle_round_trip(self, basic_file_spool):
         """A directory spool pickles and reopens its own connection."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         loaded = pickle.loads(pickle.dumps(basic_file_spool))
         assert len(loaded) == len(basic_file_spool)
@@ -736,7 +736,7 @@ class TestDirectorySpoolSerialization:
 
     def test_pickle_selected_view(self, basic_file_spool):
         """Selected views keep their selection through pickling."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         df = basic_file_spool.get_contents()
         sub = basic_file_spool.select(time=(df["time_min"].min(), None))
@@ -746,7 +746,7 @@ class TestDirectorySpoolSerialization:
     @pytest.mark.concurrency
     def test_process_pool_map(self, basic_file_spool):
         """Spool.map works with a process pool executor."""
-        from concurrent.futures import ProcessPoolExecutor
+        from concurrent.futures import ProcessPoolExecutor  # noqa: PLC0415
 
         with ProcessPoolExecutor(max_workers=1) as client:
             out = list(

--- a/tests/test_core/test_directory_spool.py
+++ b/tests/test_core/test_directory_spool.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pickle
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 import numpy as np
@@ -12,7 +14,7 @@ import dascore as dc
 import dascore.examples
 from dascore.constants import ONE_SECOND
 from dascore.core.spool import Spool
-from dascore.exceptions import MissingPatchError, ParameterError
+from dascore.exceptions import InvalidSpoolError, MissingPatchError, ParameterError
 from dascore.utils.misc import register_func, suppress_warnings
 
 DIRECTORY_SPOOLS = []
@@ -259,8 +261,6 @@ class TestSelectedDirectorySpools:
         self, spool_dir, random_spool, first_patch_range
     ):
         """D1: any operation severs update()."""
-        from dascore.exceptions import InvalidSpoolError  # noqa: PLC0415
-
         spool = Spool.from_directory(spool_dir).update().select(time=first_patch_range)
         with pytest.raises(InvalidSpoolError, match="root spool"):
             spool.update()
@@ -728,16 +728,12 @@ class TestDirectorySpoolSerialization:
 
     def test_pickle_round_trip(self, basic_file_spool):
         """A directory spool pickles and reopens its own connection."""
-        import pickle  # noqa: PLC0415
-
         loaded = pickle.loads(pickle.dumps(basic_file_spool))
         assert len(loaded) == len(basic_file_spool)
         assert loaded[0].shape == basic_file_spool[0].shape
 
     def test_pickle_selected_view(self, basic_file_spool):
         """Selected views keep their selection through pickling."""
-        import pickle  # noqa: PLC0415
-
         df = basic_file_spool.get_contents()
         sub = basic_file_spool.select(time=(df["time_min"].min(), None))
         loaded = pickle.loads(pickle.dumps(sub))
@@ -746,8 +742,6 @@ class TestDirectorySpoolSerialization:
     @pytest.mark.concurrency
     def test_process_pool_map(self, basic_file_spool):
         """Spool.map works with a process pool executor."""
-        from concurrent.futures import ProcessPoolExecutor  # noqa: PLC0415
-
         with ProcessPoolExecutor(max_workers=1) as client:
             out = list(
                 basic_file_spool.map(_patch_shape, client=client, progress=False)

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -420,7 +420,7 @@ class TestChunkMerge:
 
     def test_non_si_merge_tolerance_uses_coord_units(self, random_patch):
         """Canonical index steps are not interpreted in native coord units."""
-        from dascore.utils.patch import _get_merged_coord
+        from dascore.utils.patch import _get_merged_coord  # noqa: PLC0415
 
         size = len(random_patch.get_coord("distance"))
         first = dc.get_coord(data=np.arange(size, dtype=float), units="km")
@@ -702,7 +702,7 @@ class TestChunkMerge:
 
 def _bare_assembler():
     """An assembler with no frames, for direct streaming-merge tests."""
-    from dascore.utils.patch_assembly import PatchAssembler
+    from dascore.utils.patch_assembly import PatchAssembler  # noqa: PLC0415
 
     return PatchAssembler(load_patch=None, merge_kwargs={})
 
@@ -715,7 +715,7 @@ class TestStreamingMerge:
 
     def test_streaming_path_used(self, adjacent_spool_no_overlap, monkeypatch):
         """Ensure simple merges take the streaming path."""
-        from dascore.utils.patch_assembly import PatchAssembler
+        from dascore.utils.patch_assembly import PatchAssembler  # noqa: PLC0415
 
         called = []
         original = PatchAssembler._merge_patches_streaming
@@ -731,7 +731,7 @@ class TestStreamingMerge:
 
     def test_matches_materialized_merge(self, adjacent_spool_no_overlap, monkeypatch):
         """Streaming and concatenating merges must produce identical patches."""
-        import dascore.utils.patch_assembly as assembly_module
+        import dascore.utils.patch_assembly as assembly_module  # noqa: PLC0415
 
         streamed = adjacent_spool_no_overlap.chunk(time=None)[0]
         # Disabling the sample estimate forces the materialized path.
@@ -961,8 +961,8 @@ class TestMatchMergeUnits:
 
     def test_incompatible_units_pass_through(self):
         """Dimensionality mismatches pass through for the merge to police."""
-        from dascore.units import get_quantity
-        from dascore.utils.patch_assembly import _match_merge_units
+        from dascore.units import get_quantity  # noqa: PLC0415
+        from dascore.utils.patch_assembly import _match_merge_units  # noqa: PLC0415
 
         patch = dc.get_example_patch().set_units(distance="m")
         target = get_quantity("s").units

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -15,8 +15,12 @@ import pandas as pd
 import pytest
 
 import dascore as dc
+import dascore.utils.patch_assembly as assembly_module
 from dascore.exceptions import ChunkError, CoordMergeError, ParameterError, UnitError
+from dascore.units import get_quantity
 from dascore.utils.misc import get_middle_value
+from dascore.utils.patch import _get_merged_coord
+from dascore.utils.patch_assembly import PatchAssembler, _match_merge_units
 from dascore.utils.time import to_timedelta64
 
 
@@ -420,8 +424,6 @@ class TestChunkMerge:
 
     def test_non_si_merge_tolerance_uses_coord_units(self, random_patch):
         """Canonical index steps are not interpreted in native coord units."""
-        from dascore.utils.patch import _get_merged_coord  # noqa: PLC0415
-
         size = len(random_patch.get_coord("distance"))
         first = dc.get_coord(data=np.arange(size, dtype=float), units="km")
         second = dc.get_coord(
@@ -702,8 +704,6 @@ class TestChunkMerge:
 
 def _bare_assembler():
     """An assembler with no frames, for direct streaming-merge tests."""
-    from dascore.utils.patch_assembly import PatchAssembler  # noqa: PLC0415
-
     return PatchAssembler(load_patch=None, merge_kwargs={})
 
 
@@ -715,8 +715,6 @@ class TestStreamingMerge:
 
     def test_streaming_path_used(self, adjacent_spool_no_overlap, monkeypatch):
         """Ensure simple merges take the streaming path."""
-        from dascore.utils.patch_assembly import PatchAssembler  # noqa: PLC0415
-
         called = []
         original = PatchAssembler._merge_patches_streaming
 
@@ -731,8 +729,6 @@ class TestStreamingMerge:
 
     def test_matches_materialized_merge(self, adjacent_spool_no_overlap, monkeypatch):
         """Streaming and concatenating merges must produce identical patches."""
-        import dascore.utils.patch_assembly as assembly_module  # noqa: PLC0415
-
         streamed = adjacent_spool_no_overlap.chunk(time=None)[0]
         # Disabling the sample estimate forces the materialized path.
         monkeypatch.setattr(
@@ -961,9 +957,6 @@ class TestMatchMergeUnits:
 
     def test_incompatible_units_pass_through(self):
         """Dimensionality mismatches pass through for the merge to police."""
-        from dascore.units import get_quantity  # noqa: PLC0415
-        from dascore.utils.patch_assembly import _match_merge_units  # noqa: PLC0415
-
         patch = dc.get_example_patch().set_units(distance="m")
         target = get_quantity("s").units
         out, kept = _match_merge_units(patch, "distance", target)

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -11,14 +11,19 @@ import pandas as pd
 import pytest
 
 import dascore as dc
+import dascore.utils.patch_assembly as assembly_mod
 from dascore.core.spool import _COPY_ON_WRITE_ALWAYS, BaseSpool, Spool
+from dascore.examples import ricker_moveout
 from dascore.exceptions import (
     InvalidSpoolError,
     MissingOptionalDependencyError,
     MissingPatchError,
     ParameterError,
 )
+from dascore.io.index.planned import PlanResolver
+from dascore.io.segy import SegyV1_0
 from dascore.utils.downloader import fetch
+from dascore.utils.misc import deep_equality_check
 from dascore.utils.patch_assembly import _estimate_merge_samples, _get_varying_dim
 from dascore.utils.time import to_datetime64, to_timedelta64
 
@@ -191,8 +196,6 @@ class TestLiveSpoolLazy:
 
     def test_derived_spool_is_own_catalog(self, patch_list):
         """A chunked spool is a fresh derived catalog sharing patches."""
-        from dascore.io.index.planned import PlanResolver  # noqa: PLC0415
-
         spool = dc.spool(patch_list)
         chunked = spool.chunk(time=1)
         assert chunked._catalog is not spool._catalog
@@ -779,7 +782,6 @@ class TestSpoolBehaviorOptionalImports:
     def monkey_patch_segy(self, monkeypatch):
         """Monkey patch the name of the imported library for segy."""
         # TODO we should find a cleaner way to do this in the future.
-        from dascore.io.segy import SegyV1_0  # noqa: PLC0415
 
         monkeypatch.setattr(SegyV1_0, "_package_name", "not_segyio_clearly")
 
@@ -828,8 +830,6 @@ class TestMisc:
         Chunking a spool whose time coordinate is timedelta64 (rather than
         datetime64) should work with a numeric chunk size (see #553).
         """
-        from dascore.examples import ricker_moveout  # noqa: PLC0415
-
         patch = ricker_moveout()
         assert np.issubdtype(patch.get_coord("time").dtype, np.timedelta64)
         spool = dc.spool(patch)
@@ -878,14 +878,11 @@ class TestDeepEqualityCheck:
 
     def test_non_dict_comparison(self):
         """Plain value comparison inside dicts."""
-        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
-
         assert deep_equality_check({"a": "hello"}, {"a": "hello"})
         assert not deep_equality_check({"a": "hello"}, {"a": "world"})
 
     def test_objects_with_dict(self):
         """Objects compare via recursive __dict__ comparison."""
-        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
 
         class TestObject:
             def __init__(self, value):
@@ -896,8 +893,6 @@ class TestDeepEqualityCheck:
 
     def test_mixed_types(self):
         """Ints, lists, and numpy arrays compare by value."""
-        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
-
         d1 = {"i": 42, "l": [1, 2, 3], "a": np.array([1, 2, 3])}
         d2 = {"i": 42, "l": [1, 2, 3], "a": np.array([1, 2, 3])}
         assert deep_equality_check(d1, d2)
@@ -906,8 +901,6 @@ class TestDeepEqualityCheck:
 
     def test_dataframes(self):
         """DataFrames compare via .equals."""
-        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
-
         df1 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         df2 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         assert deep_equality_check({"df": df1}, {"df": df2})
@@ -916,8 +909,6 @@ class TestDeepEqualityCheck:
 
     def test_unequal_sub_dicts(self):
         """Nested dicts with different values are unequal."""
-        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
-
         assert not deep_equality_check({"d": {1: 2}}, {"d": {2: 3}})
 
 
@@ -982,8 +973,6 @@ class TestSpoolCoverageEdges:
 
     def test_union_of_chunked_spool(self, many_contiguous):
         """A chunked spool is a derived catalog; unions compose it."""
-        from dascore.io.index.planned import PlanResolver  # noqa: PLC0415
-
         chunked = dc.spool(many_contiguous).chunk(time=None)
         assert isinstance(chunked._catalog.resolver, PlanResolver)
         combined = chunked + dc.spool([dc.get_example_patch(tag="other")])
@@ -1016,8 +1005,6 @@ class TestSpoolCoverageEdges:
 
     def test_merge_buffer_grows_when_estimate_short(self, many_contiguous, monkeypatch):
         """An under-estimated merge buffer is grown to fit (uneven sampling)."""
-        import dascore.utils.patch_assembly as assembly_mod  # noqa: PLC0415
-
         # Force the pre-merge sample estimate to be too small so the
         # streaming buffer must grow mid-merge.
         monkeypatch.setattr(assembly_mod, "_estimate_merge_samples", lambda *a, **k: 1)

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -191,7 +191,7 @@ class TestLiveSpoolLazy:
 
     def test_derived_spool_is_own_catalog(self, patch_list):
         """A chunked spool is a fresh derived catalog sharing patches."""
-        from dascore.io.index.planned import PlanResolver
+        from dascore.io.index.planned import PlanResolver  # noqa: PLC0415
 
         spool = dc.spool(patch_list)
         chunked = spool.chunk(time=1)
@@ -779,7 +779,7 @@ class TestSpoolBehaviorOptionalImports:
     def monkey_patch_segy(self, monkeypatch):
         """Monkey patch the name of the imported library for segy."""
         # TODO we should find a cleaner way to do this in the future.
-        from dascore.io.segy import SegyV1_0
+        from dascore.io.segy import SegyV1_0  # noqa: PLC0415
 
         monkeypatch.setattr(SegyV1_0, "_package_name", "not_segyio_clearly")
 
@@ -828,7 +828,7 @@ class TestMisc:
         Chunking a spool whose time coordinate is timedelta64 (rather than
         datetime64) should work with a numeric chunk size (see #553).
         """
-        from dascore.examples import ricker_moveout
+        from dascore.examples import ricker_moveout  # noqa: PLC0415
 
         patch = ricker_moveout()
         assert np.issubdtype(patch.get_coord("time").dtype, np.timedelta64)
@@ -878,14 +878,14 @@ class TestDeepEqualityCheck:
 
     def test_non_dict_comparison(self):
         """Plain value comparison inside dicts."""
-        from dascore.utils.misc import deep_equality_check
+        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
 
         assert deep_equality_check({"a": "hello"}, {"a": "hello"})
         assert not deep_equality_check({"a": "hello"}, {"a": "world"})
 
     def test_objects_with_dict(self):
         """Objects compare via recursive __dict__ comparison."""
-        from dascore.utils.misc import deep_equality_check
+        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
 
         class TestObject:
             def __init__(self, value):
@@ -896,7 +896,7 @@ class TestDeepEqualityCheck:
 
     def test_mixed_types(self):
         """Ints, lists, and numpy arrays compare by value."""
-        from dascore.utils.misc import deep_equality_check
+        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
 
         d1 = {"i": 42, "l": [1, 2, 3], "a": np.array([1, 2, 3])}
         d2 = {"i": 42, "l": [1, 2, 3], "a": np.array([1, 2, 3])}
@@ -906,7 +906,7 @@ class TestDeepEqualityCheck:
 
     def test_dataframes(self):
         """DataFrames compare via .equals."""
-        from dascore.utils.misc import deep_equality_check
+        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
 
         df1 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         df2 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
@@ -916,7 +916,7 @@ class TestDeepEqualityCheck:
 
     def test_unequal_sub_dicts(self):
         """Nested dicts with different values are unequal."""
-        from dascore.utils.misc import deep_equality_check
+        from dascore.utils.misc import deep_equality_check  # noqa: PLC0415
 
         assert not deep_equality_check({"d": {1: 2}}, {"d": {2: 3}})
 
@@ -982,7 +982,7 @@ class TestSpoolCoverageEdges:
 
     def test_union_of_chunked_spool(self, many_contiguous):
         """A chunked spool is a derived catalog; unions compose it."""
-        from dascore.io.index.planned import PlanResolver
+        from dascore.io.index.planned import PlanResolver  # noqa: PLC0415
 
         chunked = dc.spool(many_contiguous).chunk(time=None)
         assert isinstance(chunked._catalog.resolver, PlanResolver)
@@ -1016,7 +1016,7 @@ class TestSpoolCoverageEdges:
 
     def test_merge_buffer_grows_when_estimate_short(self, many_contiguous, monkeypatch):
         """An under-estimated merge buffer is grown to fit (uneven sampling)."""
-        import dascore.utils.patch_assembly as assembly_mod
+        import dascore.utils.patch_assembly as assembly_mod  # noqa: PLC0415
 
         # Force the pre-merge sample estimate to be too small so the
         # streaming buffer must grow mid-merge.

--- a/tests/test_core/test_spool_contracts.py
+++ b/tests/test_core/test_spool_contracts.py
@@ -132,7 +132,7 @@ class TestChunkPlanContract:
 
     def test_planned_state_is_derived(self, patches):
         """A chunked spool is a fresh derived catalog, not a mode flag."""
-        from dascore.io.index.planned import PlanResolver
+        from dascore.io.index.planned import PlanResolver  # noqa: PLC0415
 
         spool = dc.spool(patches)
         chunked = spool.chunk(time=2)
@@ -159,7 +159,7 @@ class TestTypeSurface:
 
     def test_removed_names_gone(self):
         """The old concrete class names are deleted outright."""
-        import dascore.core.spool as spool_module
+        import dascore.core.spool as spool_module  # noqa: PLC0415
 
         for name in ("MemorySpool", "DirectorySpool", "FileSpool"):
             assert not hasattr(spool_module, name)

--- a/tests/test_core/test_spool_contracts.py
+++ b/tests/test_core/test_spool_contracts.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import pytest
 
 import dascore as dc
+import dascore.core.spool as spool_module
 from dascore.exceptions import InvalidSpoolError
+from dascore.io.index.planned import PlanResolver
 
 
 @pytest.fixture(scope="module")
@@ -132,8 +134,6 @@ class TestChunkPlanContract:
 
     def test_planned_state_is_derived(self, patches):
         """A chunked spool is a fresh derived catalog, not a mode flag."""
-        from dascore.io.index.planned import PlanResolver  # noqa: PLC0415
-
         spool = dc.spool(patches)
         chunked = spool.chunk(time=2)
         assert chunked._catalog is not spool._catalog
@@ -159,8 +159,6 @@ class TestTypeSurface:
 
     def test_removed_names_gone(self):
         """The old concrete class names are deleted outright."""
-        import dascore.core.spool as spool_module  # noqa: PLC0415
-
         for name in ("MemorySpool", "DirectorySpool", "FileSpool"):
             assert not hasattr(spool_module, name)
         with pytest.raises(ImportError):

--- a/tests/test_core/test_spool_select_spec.py
+++ b/tests/test_core/test_spool_select_spec.py
@@ -37,7 +37,7 @@ def spool(request, tmp_path_factory):
         )
         out = dc.spool(path).update(progress=None)
     if request.param.endswith("_derived"):
-        from dascore.io.index.planned import PlanResolver
+        from dascore.io.index.planned import PlanResolver  # noqa: PLC0415
 
         out = out.concatenate(time=1)
         assert isinstance(out._catalog.resolver, PlanResolver)
@@ -120,7 +120,7 @@ class TestLazySelection:
     @pytest.fixture()
     def forbid_realization(self, monkeypatch):
         """Return a callable that makes flat realization fail loudly."""
-        from dascore.io.index.catalog import PatchCatalog
+        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
         def _boom(self):
             msg = "flat relation realized during selection construction"
@@ -307,7 +307,7 @@ class TestUnitCanonicalSelection:
 
     def test_quantity_selector(self, ft_patch):
         """Quantity bounds select the same physical interval."""
-        from dascore.units import m
+        from dascore.units import m  # noqa: PLC0415
 
         selected = dc.spool([ft_patch]).select(distance=(20 * m, 60 * m))
         assert len(selected.get_contents()) == 1  # no DimensionalityError
@@ -317,7 +317,7 @@ class TestUnitCanonicalSelection:
 
     def test_quantity_in_native_units(self, ft_patch):
         """Quantities in the coordinate's own units also work."""
-        from dascore.units import get_quantity
+        from dascore.units import get_quantity  # noqa: PLC0415
 
         ft = get_quantity("ft")
         coord = (
@@ -336,7 +336,7 @@ class TestUnitCanonicalSelection:
 
     def test_directory_spool(self, ft_patch, tmp_path):
         """The same semantics hold for file-backed spools."""
-        from dascore.units import m
+        from dascore.units import m  # noqa: PLC0415
 
         dc.write(ft_patch, tmp_path / "ft.h5", "dasdae")
         spool = dc.spool(tmp_path).update()
@@ -363,7 +363,7 @@ class TestUnitCanonicalSelection:
 
     def test_mixed_unitless_and_feet_quantity(self, ft_patch):
         """A metre quantity range works across a mixed population."""
-        from dascore.units import m
+        from dascore.units import m  # noqa: PLC0415
 
         plain = dc.get_example_patch()
         plain = plain.update_coords(
@@ -379,14 +379,14 @@ class TestUnitCanonicalSelection:
 
     def test_value_membership_rejected(self, ft_patch):
         """A wrong-arity list is reported as a malformed range."""
-        from dascore.exceptions import ParameterError
+        from dascore.exceptions import ParameterError  # noqa: PLC0415
 
         with pytest.raises(ParameterError, match="length 2 sequence"):
             dc.spool([ft_patch]).select(distance=[10, 20, 50])
 
     def test_chained_views(self, ft_patch):
         """Canonicalization holds across chained selections."""
-        from dascore.units import m
+        from dascore.units import m  # noqa: PLC0415
 
         coord = (
             dc.spool([ft_patch])
@@ -425,7 +425,7 @@ class TestQuantityDimensionality:
 
     def test_incompatible_coord_excluded(self, mixed_unit_spool):
         """A metre query never returns (or trims) a seconds coordinate."""
-        from dascore.units import get_quantity, m
+        from dascore.units import get_quantity, m  # noqa: PLC0415
 
         out = mixed_unit_spool.select(_coords={"distance": (1 * m, 2 * m)})
         patches = list(out)
@@ -435,8 +435,8 @@ class TestQuantityDimensionality:
 
     def test_all_incompatible_raises(self):
         """A query incompatible with every stored unit raises UnitError."""
-        from dascore.exceptions import UnitError
-        from dascore.units import m
+        from dascore.exceptions import UnitError  # noqa: PLC0415
+        from dascore.units import m  # noqa: PLC0415
 
         p_s = dc.get_example_patch().update_coords(
             distance=dc.get_example_patch().get_coord("distance").set_units("s")
@@ -493,7 +493,7 @@ class TestLazyOrderAndWindow:
 
     def test_split_parts_pickle_small(self):
         """split() windows keep map() payloads at member size."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         base = dc.get_example_patch()
         rng = np.random.default_rng(0)

--- a/tests/test_core/test_spool_select_spec.py
+++ b/tests/test_core/test_spool_select_spec.py
@@ -8,11 +8,16 @@ work at spool level (#362), and _attrs/_coords disambiguate explicitly.
 
 from __future__ import annotations
 
+import pickle
+
 import numpy as np
 import pytest
 
 import dascore as dc
-from dascore.exceptions import InvalidSpoolQueryError
+from dascore.exceptions import InvalidSpoolQueryError, ParameterError, UnitError
+from dascore.io.index.catalog import PatchCatalog
+from dascore.io.index.planned import PlanResolver
+from dascore.units import get_quantity, m
 
 
 @pytest.fixture(
@@ -37,8 +42,6 @@ def spool(request, tmp_path_factory):
         )
         out = dc.spool(path).update(progress=None)
     if request.param.endswith("_derived"):
-        from dascore.io.index.planned import PlanResolver  # noqa: PLC0415
-
         out = out.concatenate(time=1)
         assert isinstance(out._catalog.resolver, PlanResolver)
     return out
@@ -120,7 +123,6 @@ class TestLazySelection:
     @pytest.fixture()
     def forbid_realization(self, monkeypatch):
         """Return a callable that makes flat realization fail loudly."""
-        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
         def _boom(self):
             msg = "flat relation realized during selection construction"
@@ -307,8 +309,6 @@ class TestUnitCanonicalSelection:
 
     def test_quantity_selector(self, ft_patch):
         """Quantity bounds select the same physical interval."""
-        from dascore.units import m  # noqa: PLC0415
-
         selected = dc.spool([ft_patch]).select(distance=(20 * m, 60 * m))
         assert len(selected.get_contents()) == 1  # no DimensionalityError
         coord = selected[0].get_coord("distance")
@@ -317,8 +317,6 @@ class TestUnitCanonicalSelection:
 
     def test_quantity_in_native_units(self, ft_patch):
         """Quantities in the coordinate's own units also work."""
-        from dascore.units import get_quantity  # noqa: PLC0415
-
         ft = get_quantity("ft")
         coord = (
             dc.spool([ft_patch])
@@ -336,8 +334,6 @@ class TestUnitCanonicalSelection:
 
     def test_directory_spool(self, ft_patch, tmp_path):
         """The same semantics hold for file-backed spools."""
-        from dascore.units import m  # noqa: PLC0415
-
         dc.write(ft_patch, tmp_path / "ft.h5", "dasdae")
         spool = dc.spool(tmp_path).update()
         coord = spool.select(distance=(20 * m, 60 * m))[0].get_coord("distance")
@@ -363,8 +359,6 @@ class TestUnitCanonicalSelection:
 
     def test_mixed_unitless_and_feet_quantity(self, ft_patch):
         """A metre quantity range works across a mixed population."""
-        from dascore.units import m  # noqa: PLC0415
-
         plain = dc.get_example_patch()
         plain = plain.update_coords(
             distance=plain.get_coord("distance").set_units(None)
@@ -379,15 +373,11 @@ class TestUnitCanonicalSelection:
 
     def test_value_membership_rejected(self, ft_patch):
         """A wrong-arity list is reported as a malformed range."""
-        from dascore.exceptions import ParameterError  # noqa: PLC0415
-
         with pytest.raises(ParameterError, match="length 2 sequence"):
             dc.spool([ft_patch]).select(distance=[10, 20, 50])
 
     def test_chained_views(self, ft_patch):
         """Canonicalization holds across chained selections."""
-        from dascore.units import m  # noqa: PLC0415
-
         coord = (
             dc.spool([ft_patch])
             .select(distance=(0 * m, 90 * m))
@@ -425,8 +415,6 @@ class TestQuantityDimensionality:
 
     def test_incompatible_coord_excluded(self, mixed_unit_spool):
         """A metre query never returns (or trims) a seconds coordinate."""
-        from dascore.units import get_quantity, m  # noqa: PLC0415
-
         out = mixed_unit_spool.select(_coords={"distance": (1 * m, 2 * m)})
         patches = list(out)
         assert len(patches) == 1
@@ -435,9 +423,6 @@ class TestQuantityDimensionality:
 
     def test_all_incompatible_raises(self):
         """A query incompatible with every stored unit raises UnitError."""
-        from dascore.exceptions import UnitError  # noqa: PLC0415
-        from dascore.units import m  # noqa: PLC0415
-
         p_s = dc.get_example_patch().update_coords(
             distance=dc.get_example_patch().get_coord("distance").set_units("s")
         )
@@ -493,8 +478,6 @@ class TestLazyOrderAndWindow:
 
     def test_split_parts_pickle_small(self):
         """split() windows keep map() payloads at member size."""
-        import pickle  # noqa: PLC0415
-
         base = dc.get_example_patch()
         rng = np.random.default_rng(0)
         patches = [base.new(data=rng.random(base.shape)) for _ in range(5)]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -9,6 +9,9 @@ import sys
 
 import pytest
 
+import dascore
+from dascore.utils.imports import lazy_import
+
 
 def _run_snippet(code: str) -> None:
     """Run a python snippet in a subprocess."""
@@ -51,8 +54,6 @@ class TestLazyImports:
 
     def test_lazy_import_proxy_forwards_calls_and_attrs(self):
         """The lazy proxy should behave like the resolved target object."""
-        from dascore.utils.imports import lazy_import  # noqa: PLC0415
-
         sqrt = lazy_import("math", "sqrt")
         assert sqrt(4) == 2
         assert sqrt.__name__ == "sqrt"
@@ -69,8 +70,6 @@ class TestLazyImports:
 
     def test_viz_module_lazy_loads_in_process(self):
         """Accessing dascore.viz should use the package attribute hook."""
-        import dascore  # noqa: PLC0415
-
         assert callable(dascore.__getattr__("viz").waterfall)
 
     @pytest.mark.concurrency
@@ -95,7 +94,5 @@ class TestLazyImports:
 
     def test_missing_attribute_raises_in_process(self):
         """Unknown package attributes should raise in the parent process too."""
-        import dascore  # noqa: PLC0415
-
         with pytest.raises(AttributeError, match="not_a_real_attribute"):
             dascore.__getattr__("not_a_real_attribute")

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -51,7 +51,7 @@ class TestLazyImports:
 
     def test_lazy_import_proxy_forwards_calls_and_attrs(self):
         """The lazy proxy should behave like the resolved target object."""
-        from dascore.utils.imports import lazy_import
+        from dascore.utils.imports import lazy_import  # noqa: PLC0415
 
         sqrt = lazy_import("math", "sqrt")
         assert sqrt(4) == 2
@@ -69,7 +69,7 @@ class TestLazyImports:
 
     def test_viz_module_lazy_loads_in_process(self):
         """Accessing dascore.viz should use the package attribute hook."""
-        import dascore
+        import dascore  # noqa: PLC0415
 
         assert callable(dascore.__getattr__("viz").waterfall)
 
@@ -95,7 +95,7 @@ class TestLazyImports:
 
     def test_missing_attribute_raises_in_process(self):
         """Unknown package attributes should raise in the parent process too."""
-        import dascore
+        import dascore  # noqa: PLC0415
 
         with pytest.raises(AttributeError, match="not_a_real_attribute"):
             dascore.__getattr__("not_a_real_attribute")

--- a/tests/test_integrations/test_attr_coord_independence.py
+++ b/tests/test_integrations/test_attr_coord_independence.py
@@ -11,13 +11,16 @@ envelope column warns and the coordinate wins.
 
 from __future__ import annotations
 
+import re
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pytest
 
 import dascore as dc
 from dascore.core.coordmanager import get_coord_manager
+from dascore.utils.downloader import fetch
 
 # The suffix-capture family from the original bug report: each of these was
 # previously reinterpreted as coordinate metadata for a phantom coordinate.
@@ -191,8 +194,6 @@ class TestGetContentsClobberWarning:
 
     def test_regex_query_reads_attr_under_collision(self, random_patch):
         """A regex _attrs query evaluates the attr, not the coord column."""
-        import re  # noqa: PLC0415
-
         # one patch carrying both the coord and a same-named string attr:
         # the flat column is the (numeric) envelope even in the filtered
         # frame, so the residual must fall back to the real attr values
@@ -240,9 +241,6 @@ class TestCompatStaysInDasdae:
 
     def test_import_graph(self):
         """Nothing outside dascore.io.dasdae imports the _compat module."""
-        import re  # noqa: PLC0415
-        from pathlib import Path  # noqa: PLC0415
-
         root = Path(dc.__file__).parent
         dasdae_dir = root / "io" / "dasdae"
         pattern = re.compile(r"\b_compat\b")
@@ -261,7 +259,6 @@ class TestLegacyDasdaeFile:
     def test_legacy_fixture_reads(self):
         """The shipped legacy file loads with coords intact, attrs pure."""
         pytest.importorskip("pooch")
-        from dascore.utils.downloader import fetch  # noqa: PLC0415
 
         path = fetch("example_dasdae_event_1.h5")
         patch = dc.spool(path)[0]

--- a/tests/test_integrations/test_attr_coord_independence.py
+++ b/tests/test_integrations/test_attr_coord_independence.py
@@ -191,7 +191,7 @@ class TestGetContentsClobberWarning:
 
     def test_regex_query_reads_attr_under_collision(self, random_patch):
         """A regex _attrs query evaluates the attr, not the coord column."""
-        import re
+        import re  # noqa: PLC0415
 
         # one patch carrying both the coord and a same-named string attr:
         # the flat column is the (numeric) envelope even in the filtered
@@ -240,8 +240,8 @@ class TestCompatStaysInDasdae:
 
     def test_import_graph(self):
         """Nothing outside dascore.io.dasdae imports the _compat module."""
-        import re
-        from pathlib import Path
+        import re  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
 
         root = Path(dc.__file__).parent
         dasdae_dir = root / "io" / "dasdae"
@@ -261,7 +261,7 @@ class TestLegacyDasdaeFile:
     def test_legacy_fixture_reads(self):
         """The shipped legacy file loads with coords intact, attrs pure."""
         pytest.importorskip("pooch")
-        from dascore.utils.downloader import fetch
+        from dascore.utils.downloader import fetch  # noqa: PLC0415
 
         path = fetch("example_dasdae_event_1.h5")
         patch = dc.spool(path)[0]

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -168,7 +168,7 @@ class TestReadDASDAE:
         self, random_patch, tmp_path_factory
     ):
         """New groups appended to a legacy file must not be legacy-stripped."""
-        from dascore.io.dasdae.utils import _SEPARATE_ATTRS_KEY
+        from dascore.io.dasdae.utils import _SEPARATE_ATTRS_KEY  # noqa: PLC0415
 
         path = tmp_path_factory.mktemp("dasdae_legacy_append") / "mixed.h5"
         old_patch = random_patch.update_attrs(tag="old")

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -21,6 +21,7 @@ from dascore.io.dasdae import utils as dasdae_utils
 from dascore.io.dasdae._compat import translate_legacy_attrs
 from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.dasdae.utils import (
+    _SEPARATE_ATTRS_KEY,
     _decode_attr_value,
     _decode_legacy_attr_value,
     _encode_attr_value,
@@ -168,8 +169,6 @@ class TestReadDASDAE:
         self, random_patch, tmp_path_factory
     ):
         """New groups appended to a legacy file must not be legacy-stripped."""
-        from dascore.io.dasdae.utils import _SEPARATE_ATTRS_KEY  # noqa: PLC0415
-
         path = tmp_path_factory.mktemp("dasdae_legacy_append") / "mixed.h5"
         old_patch = random_patch.update_attrs(tag="old")
         old_patch.io.write(path, "dasdae")

--- a/tests/test_io/test_index/test_catalog.py
+++ b/tests/test_io/test_index/test_catalog.py
@@ -260,7 +260,7 @@ class TestCount:
 
     def _selections(self, catalog):
         """Views spanning attr, coord range, regex, and chained forms."""
-        import re
+        import re  # noqa: PLC0415
 
         df = catalog.to_df()
         t0 = df["time_min"].min()
@@ -318,7 +318,7 @@ class TestCanonicalRange:
 
     def test_eq_and_hash(self):
         """Equal magnitudes compare and hash equal; other types don't."""
-        from dascore.io.index.catalog import _CanonicalRange
+        from dascore.io.index.catalog import _CanonicalRange  # noqa: PLC0415
 
         r1, r2 = _CanonicalRange((1.0, 2.0)), _CanonicalRange((1.0, 2.0))
         assert r1 == r2
@@ -332,7 +332,7 @@ class TestViewSerialization:
 
     def test_view_pickles_membership_only(self):
         """A one-patch view of an N-patch live spool ships one patch."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         base = dc.get_example_patch()
         patches = [

--- a/tests/test_io/test_index/test_catalog.py
+++ b/tests/test_io/test_index/test_catalog.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import pickle
+import re
 
 import numpy as np
 import pytest
 
 import dascore as dc
 from dascore.io.index import PatchCatalog
-from dascore.io.index.catalog import _canonical_range
+from dascore.io.index.catalog import _canonical_range, _CanonicalRange
 from dascore.io.index.query import InvalidSpoolQueryError
 
 
@@ -260,8 +261,6 @@ class TestCount:
 
     def _selections(self, catalog):
         """Views spanning attr, coord range, regex, and chained forms."""
-        import re  # noqa: PLC0415
-
         df = catalog.to_df()
         t0 = df["time_min"].min()
         window = (t0, t0 + dc.to_timedelta64(1))
@@ -318,8 +317,6 @@ class TestCanonicalRange:
 
     def test_eq_and_hash(self):
         """Equal magnitudes compare and hash equal; other types don't."""
-        from dascore.io.index.catalog import _CanonicalRange  # noqa: PLC0415
-
         r1, r2 = _CanonicalRange((1.0, 2.0)), _CanonicalRange((1.0, 2.0))
         assert r1 == r2
         assert hash(r1) == hash(r2)
@@ -332,8 +329,6 @@ class TestViewSerialization:
 
     def test_view_pickles_membership_only(self):
         """A one-patch view of an N-patch live spool ships one patch."""
-        import pickle  # noqa: PLC0415
-
         base = dc.get_example_patch()
         patches = [
             base.update_attrs(tag=str(i)).new(

--- a/tests/test_io/test_index/test_hive_attrs.py
+++ b/tests/test_io/test_index/test_hive_attrs.py
@@ -164,7 +164,7 @@ class TestPatchStamping:
 
     def test_chunked(self, tmp_path):
         """Patches from a chunked spool keep hive attrs."""
-        from dascore.examples import spool_to_directory
+        from dascore.examples import spool_to_directory  # noqa: PLC0415
 
         sub = tmp_path / "network=XX"
         sub.mkdir()
@@ -310,7 +310,7 @@ class TestEdgeCases:
 
     def test_old_index_version_rebuilds(self, hive_dir):
         """An index stamped with an older version rebuilds transparently."""
-        import sqlite3
+        import sqlite3  # noqa: PLC0415
 
         spool = Spool.from_directory(hive_dir).update(progress=None)
         spool.indexer.close()

--- a/tests/test_io/test_index/test_hive_attrs.py
+++ b/tests/test_io/test_index/test_hive_attrs.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 import os
 import pickle
+import sqlite3
 
 import pytest
 
 import dascore as dc
 from dascore.core.spool import Spool
+from dascore.examples import spool_to_directory
 from dascore.utils.paths import parse_hive_path_attrs
 
 
@@ -164,8 +166,6 @@ class TestPatchStamping:
 
     def test_chunked(self, tmp_path):
         """Patches from a chunked spool keep hive attrs."""
-        from dascore.examples import spool_to_directory  # noqa: PLC0415
-
         sub = tmp_path / "network=XX"
         sub.mkdir()
         spool_to_directory(dc.get_example_spool("random_das"), path=sub)
@@ -310,8 +310,6 @@ class TestEdgeCases:
 
     def test_old_index_version_rebuilds(self, hive_dir):
         """An index stamped with an older version rebuilds transparently."""
-        import sqlite3  # noqa: PLC0415
-
         spool = Spool.from_directory(hive_dir).update(progress=None)
         spool.indexer.close()
         index_path = hive_dir / ".dascore_index.sqlite3"

--- a/tests/test_io/test_index/test_index_contract.py
+++ b/tests/test_io/test_index/test_index_contract.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import dascore as dc
 from dascore.core.summary import PatchSummary
 from dascore.exceptions import UnitError
 from dascore.io.index import Query, get_backend, summaries_to_records
@@ -208,8 +209,6 @@ class TestElementDtype:
 
     def test_dtype_is_private_in_flat_relation(self):
         """The spool sees `_dtype`, never a public `dtype` column."""
-        import dascore as dc
-
         spool = dc.get_example_spool("random_das")
         df = spool.get_contents()
         assert "dtype" not in df.columns

--- a/tests/test_io/test_index/test_index_edge_cases.py
+++ b/tests/test_io/test_index/test_index_edge_cases.py
@@ -41,8 +41,8 @@ class TestIndexCoverageEdges:
 
     def test_live_resolver_missing_patch(self):
         """A row for a patch absent from the registry raises MissingPatchError."""
-        from dascore.exceptions import MissingPatchError
-        from dascore.io.index.catalog import LiveResolver
+        from dascore.exceptions import MissingPatchError  # noqa: PLC0415
+        from dascore.io.index.catalog import LiveResolver  # noqa: PLC0415
 
         resolver = LiveResolver([dc.get_example_patch()])
         with pytest.raises(MissingPatchError, match="not available"):
@@ -50,7 +50,7 @@ class TestIndexCoverageEdges:
 
     def test_mixed_compatible_unit_range(self):
         """A coord range mixing compatible units resolves."""
-        from dascore.units import get_quantity
+        from dascore.units import get_quantity  # noqa: PLC0415
 
         cm = get_quantity("cm")
         out = dc.spool([dc.get_example_patch()]).select(distance=(1 * m, 200 * cm))
@@ -62,7 +62,7 @@ class TestIndexCoverageEdges:
         The catalog canonicalizes units before the backend, so only a
         direct Query reaches the multi-unit compatibility check.
         """
-        from dascore.units import s
+        from dascore.units import s  # noqa: PLC0415
 
         with pytest.raises(UnitError, match="Cannot convert"):
             backend.query(Query(coords={"distance": (1 * m, 2 * s)}))
@@ -79,7 +79,7 @@ class TestIndexCoverageEdges:
 
     def test_attr_meta_units_backfilled(self, tmp_path):
         """An attr first seen unitless gets its unit backfilled by a later write."""
-        from dascore.core.summary import PatchSummary
+        from dascore.core.summary import PatchSummary  # noqa: PLC0415
 
         def _summary(gain, path):
             return PatchSummary(
@@ -116,9 +116,9 @@ class TestIndexCoverageEdges:
 
     def test_reopen_missing_meta_row(self, tmp_path):
         """An index whose meta row was lost is rejected on reopen."""
-        import sqlite3
+        import sqlite3  # noqa: PLC0415
 
-        from dascore.exceptions import InvalidIndexError
+        from dascore.exceptions import InvalidIndexError  # noqa: PLC0415
 
         path = tmp_path / "i.sqlite3"
         get_backend(path).close()
@@ -131,9 +131,9 @@ class TestIndexCoverageEdges:
 
     def test_reopen_table_missing_column(self, tmp_path):
         """An index whose table lost a column is rejected on reopen."""
-        import sqlite3
+        import sqlite3  # noqa: PLC0415
 
-        from dascore.exceptions import InvalidIndexError
+        from dascore.exceptions import InvalidIndexError  # noqa: PLC0415
 
         path = tmp_path / "i.sqlite3"
         get_backend(path).close()
@@ -155,7 +155,7 @@ class TestIndexCoverageEdges:
 
     def test_schema_creation_rolls_back_on_failure(self, tmp_path):
         """A failure while creating the schema rolls back and re-raises."""
-        from dascore.io.index.lite import SQLiteBackend
+        from dascore.io.index.lite import SQLiteBackend  # noqa: PLC0415
 
         class _BoomBackend(SQLiteBackend):
             def _execute(self, sql, params=()):
@@ -168,7 +168,7 @@ class TestIndexCoverageEdges:
 
     def test_schema_commit_failure_rolls_back(self, tmp_path):
         """A schema commit failure follows the protected rollback path."""
-        from dascore.io.index.lite import SQLiteBackend
+        from dascore.io.index.lite import SQLiteBackend  # noqa: PLC0415
 
         class _CommitBoomBackend(SQLiteBackend):
             rolled_back = False
@@ -186,9 +186,9 @@ class TestIndexCoverageEdges:
 
     def test_reopen_missing_dynamic_attr_column(self, tmp_path):
         """attr_meta referencing an absent attrs column is rejected on reopen."""
-        import sqlite3
+        import sqlite3  # noqa: PLC0415
 
-        from dascore.exceptions import InvalidIndexError
+        from dascore.exceptions import InvalidIndexError  # noqa: PLC0415
 
         path = tmp_path / "i.sqlite3"
         get_backend(path).close()
@@ -208,7 +208,7 @@ class TestPureHelpers:
 
     def test_is_directory_format_on_file(self, tmp_path):
         """A plain file is never a directory scan unit."""
-        from dascore.io.core import is_directory_format
+        from dascore.io.core import is_directory_format  # noqa: PLC0415
 
         f = tmp_path / "a.txt"
         f.write_text("x")
@@ -216,9 +216,9 @@ class TestPureHelpers:
 
     def test_memory_backend_refuses_pickle(self):
         """An in-memory backend cannot be pickled (owners serialize rows)."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
-        from dascore.io.index.lite import SQLiteBackend
+        from dascore.io.index.lite import SQLiteBackend  # noqa: PLC0415
 
         back = SQLiteBackend(":memory:")
         try:
@@ -229,7 +229,7 @@ class TestPureHelpers:
 
     def test_py_scalar_bool_and_int(self):
         """_py_scalar unwraps numpy bool/int to plain python scalars."""
-        from dascore.io.index.ingest import _py_scalar
+        from dascore.io.index.ingest import _py_scalar  # noqa: PLC0415
 
         assert _py_scalar(np.bool_(True)) is True
         assert _py_scalar(np.int64(5)) == 5
@@ -237,14 +237,14 @@ class TestPureHelpers:
 
     def test_assemble_records_empty_sources(self):
         """No sources yields no records."""
-        from dascore.io.index.ingest import assemble_source_records
+        from dascore.io.index.ingest import assemble_source_records  # noqa: PLC0415
 
         empty = pd.DataFrame()
         assert assemble_source_records(empty, empty, empty, empty, empty, empty) == []
 
     def test_units_compatible(self):
         """_units_compatible is True for same dimensionality, False otherwise."""
-        from dascore.io.index.backend import SQLIndexBackend
+        from dascore.io.index.backend import SQLIndexBackend  # noqa: PLC0415
 
         assert SQLIndexBackend._units_compatible("m", "ft") is True
         assert SQLIndexBackend._units_compatible("m", "s") is False
@@ -256,15 +256,15 @@ class TestPureHelpers:
 
     def test_wrong_arity_coord_query_raises(self, backend):
         """A hand-built coord range of the wrong length is rejected."""
-        from dascore.exceptions import ParameterError
+        from dascore.exceptions import ParameterError  # noqa: PLC0415
 
         with pytest.raises(ParameterError, match="length 2 sequence"):
             backend.query(Query(coords={"distance": (1, 2, 3)}))
 
     def test_to_target_unit_paths(self):
         """Quantity on a unitless target raises; on a unit target it converts."""
-        from dascore.io.index.query import _to_target_unit
-        from dascore.units import get_quantity as _gq
+        from dascore.io.index.query import _to_target_unit  # noqa: PLC0415
+        from dascore.units import get_quantity as _gq  # noqa: PLC0415
 
         typed = typed_value(5 * m)  # a numeric TypedValue carrying units
         with pytest.raises(UnitError, match="unitless"):
@@ -275,7 +275,7 @@ class TestPureHelpers:
 
     def test_range_bounds_unset_is_not_none(self):
         """Omitting target units must not mean the target is unitless."""
-        from dascore.io.index.query import _UNSET, _range_bounds
+        from dascore.io.index.query import _UNSET, _range_bounds  # noqa: PLC0415
 
         value = (5 * m, 10 * m)
         kind_probe = typed_value(5 * m)
@@ -295,7 +295,7 @@ class TestNormalizeSourcePatchId:
 
     def test_missing_forms_become_empty(self):
         """None, empty string, and pandas NaN/NaT all normalize to ''."""
-        from dascore.core.summary import normalize_source_patch_id
+        from dascore.core.summary import normalize_source_patch_id  # noqa: PLC0415
 
         assert normalize_source_patch_id(None) == ""
         assert normalize_source_patch_id("") == ""
@@ -305,20 +305,20 @@ class TestNormalizeSourcePatchId:
 
     def test_numpy_scalar_becomes_plain_string(self):
         """A numpy scalar is unwrapped before stringifying."""
-        from dascore.core.summary import normalize_source_patch_id
+        from dascore.core.summary import normalize_source_patch_id  # noqa: PLC0415
 
         assert normalize_source_patch_id(np.int64(42)) == "42"
 
     def test_plain_values_stringify(self):
         """Ordinary ids pass through as strings."""
-        from dascore.core.summary import normalize_source_patch_id
+        from dascore.core.summary import normalize_source_patch_id  # noqa: PLC0415
 
         assert normalize_source_patch_id("abc") == "abc"
         assert normalize_source_patch_id(7) == "7"
 
     def test_non_scalar_falls_through(self):
         """A value pd.isnull cannot evaluate as a scalar still stringifies."""
-        from dascore.core.summary import normalize_source_patch_id
+        from dascore.core.summary import normalize_source_patch_id  # noqa: PLC0415
 
         # pd.isnull on a list returns an array (truth value is ambiguous),
         # so the helper must swallow that and fall through to str().
@@ -330,7 +330,7 @@ class TestCanonicalRange:
 
     def test_bare_and_quantity_bounds(self):
         """Bare numbers and quantities become SI magnitudes."""
-        from dascore.io.index.catalog import _canonical_range
+        from dascore.io.index.catalog import _canonical_range  # noqa: PLC0415
 
         bare = _canonical_range((20, 60))
         assert bare is not None
@@ -342,7 +342,7 @@ class TestCanonicalRange:
 
     def test_open_bounds_kept(self):
         """A half-open numeric range keeps its open end as None."""
-        from dascore.io.index.catalog import _canonical_range
+        from dascore.io.index.catalog import _canonical_range  # noqa: PLC0415
 
         half_open = _canonical_range((None, 60))
         assert half_open is not None
@@ -360,7 +360,7 @@ class TestCanonicalRange:
     )
     def test_non_numeric_ranges_return_none(self, value):
         """Anything that is not a bounded numeric range yields None."""
-        from dascore.io.index.catalog import _canonical_range
+        from dascore.io.index.catalog import _canonical_range  # noqa: PLC0415
 
         assert _canonical_range(value) is None
 
@@ -974,10 +974,10 @@ class TestIndexerEdges:
 
     def test_directory_format_unit(self, tmp_path):
         """Directory-format sources (xml binary) group as one scan unit."""
-        import sys
+        import sys  # noqa: PLC0415
 
         sys.path.insert(0, "tests/test_io/test_xml_binary")
-        from test_xml_binary import metadata
+        from test_xml_binary import metadata  # noqa: PLC0415
 
         sub = tmp_path / "unit"
         sub.mkdir()
@@ -1008,7 +1008,7 @@ class TestDirSpoolPassthrough:
 
     def test_spool_from_indexer(self, tmp_path, random_patch):
         """Passing an indexer instance to from_directory works."""
-        from dascore.core.spool import Spool
+        from dascore.core.spool import Spool  # noqa: PLC0415
 
         random_patch.io.write(tmp_path / "one.hdf5", "dasdae")
         indexer = DBDirectoryIndexer(tmp_path)
@@ -1021,7 +1021,7 @@ class TestFinalCoverage:
 
     def test_datetime_object_becomes_time(self):
         """A python datetime routes through the datetime fallback."""
-        import datetime
+        import datetime  # noqa: PLC0415
 
         out = typed_value(datetime.datetime(2024, 1, 1))
         assert out is not None and out.kind == "time"
@@ -1207,10 +1207,10 @@ class TestResourceCleanup:
 
     def test_gc_closes_connection(self):
         """Garbage collection closes the backend connection silently."""
-        import gc
-        import warnings as warnings_mod
+        import gc  # noqa: PLC0415
+        import warnings as warnings_mod  # noqa: PLC0415
 
-        import dascore as dc
+        import dascore as dc  # noqa: PLC0415
 
         spool = dc.spool([dc.get_example_patch()])
         spool.get_contents()  # realize the backend
@@ -1228,8 +1228,8 @@ class TestResourceCleanup:
 
     def test_explicit_close_idempotent(self):
         """Explicit close works and GC afterwards stays quiet."""
-        import dascore as dc
-        from dascore.io.index.catalog import PatchCatalog
+        import dascore as dc  # noqa: PLC0415
+        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
         catalog = PatchCatalog.from_patches([dc.get_example_patch()])
         catalog.to_df()
@@ -1238,11 +1238,11 @@ class TestResourceCleanup:
     @pytest.mark.concurrency
     def test_finalization_from_worker_thread(self):
         """Dropping the last backend reference off-thread does not raise."""
-        import gc
-        import sys
-        import threading
+        import gc  # noqa: PLC0415
+        import sys  # noqa: PLC0415
+        import threading  # noqa: PLC0415
 
-        from dascore.io.index.lite import SQLiteBackend
+        from dascore.io.index.lite import SQLiteBackend  # noqa: PLC0415
 
         holder = [SQLiteBackend(":memory:")]
         unraisable = []
@@ -1269,10 +1269,10 @@ class TestLegacyIndexMap:
 
     def test_legacy_entry_ignored(self, tmp_path):
         """A mapped legacy HDF5 index does not break index creation."""
-        import h5py
+        import h5py  # noqa: PLC0415
 
-        import dascore as dc
-        from dascore.io.index.indexer import (
+        import dascore as dc  # noqa: PLC0415
+        from dascore.io.index.indexer import (  # noqa: PLC0415
             _set_mapped_index_path,
         )
 
@@ -1299,7 +1299,7 @@ class TestReservedAttrNames:
     )
     def test_reserved_attr_warns_and_skips(self, name, value):
         """Reserved names warn at ingest and never corrupt the relation."""
-        import dascore as dc
+        import dascore as dc  # noqa: PLC0415
 
         patch = dc.get_example_patch().update_attrs(**{name: value})
         with pytest.warns(UserWarning, match="reserved attr"):
@@ -1310,7 +1310,7 @@ class TestReservedAttrNames:
 
     def test_non_reserved_attr_round_trips(self):
         """Ordinary arbitrary attrs still index and select normally."""
-        import dascore as dc
+        import dascore as dc  # noqa: PLC0415
 
         patch = dc.get_example_patch().update_attrs(experiment="exp42")
         spool = dc.spool([patch])
@@ -1319,7 +1319,7 @@ class TestReservedAttrNames:
 
     def test_cross_patch_envelope_attr_clobbered_not_reserved(self):
         """An envelope-shaped attr indexes normally; the coord wins the column."""
-        import dascore as dc
+        import dascore as dc  # noqa: PLC0415
 
         base = dc.get_example_patch()
         p1 = base.update_attrs(event_time_min=123.0)
@@ -1337,7 +1337,7 @@ class TestReservedAttrNames:
 
     def test_data_units_attr_still_indexed(self):
         """A real ``*_units`` attr is not an envelope column; stays queryable."""
-        import dascore as dc
+        import dascore as dc  # noqa: PLC0415
 
         patch = dc.get_example_patch().update_attrs(data_units="strain")
         spool = dc.spool([patch])
@@ -1350,10 +1350,10 @@ class TestTransactionIsolation:
     @pytest.mark.concurrency
     def test_reader_never_sees_half_written_replacement(self, tmp_path, monkeypatch):
         """A concurrent reader blocks during a source replacement."""
-        import threading
+        import threading  # noqa: PLC0415
 
-        from dascore.io.index.backend import get_backend
-        from dascore.io.index.ingest import SourceRecord, patch_record
+        from dascore.io.index.backend import get_backend  # noqa: PLC0415
+        from dascore.io.index.ingest import SourceRecord, patch_record  # noqa: PLC0415
 
         patch = dc.get_example_patch()
         record = SourceRecord(

--- a/tests/test_io/test_index/test_index_edge_cases.py
+++ b/tests/test_io/test_index/test_index_edge_cases.py
@@ -8,32 +8,66 @@ full line coverage.
 
 from __future__ import annotations
 
+import datetime
+import gc
 import os
+import pickle
 import re
 import sqlite3
+import sys
+import threading
+import warnings as warnings_mod
 from typing import Any
 
+import h5py
 import numpy as np
 import pandas as pd
 import pytest
 from test_index_contract import _time_coord, make_summaries
 
 import dascore as dc
-from dascore.core.summary import PatchSummary
-from dascore.exceptions import UnitError
-from dascore.io.index import Query, get_backend, summaries_to_records
-from dascore.io.index.backend import _ns_to_time, adapt_params, resolve_query
-from dascore.io.index.indexer import DBDirectoryIndexer
+from dascore.core.spool import Spool
+from dascore.core.summary import PatchSummary, normalize_source_patch_id
+from dascore.exceptions import (
+    InvalidIndexError,
+    MissingPatchError,
+    ParameterError,
+    UnitError,
+)
+from dascore.io.core import is_directory_format
+from dascore.io.index import Query, summaries_to_records
+from dascore.io.index.backend import (
+    SQLIndexBackend,
+    _ns_to_time,
+    adapt_params,
+    get_backend,
+    resolve_query,
+)
+from dascore.io.index.catalog import LiveResolver, PatchCatalog, _canonical_range
+from dascore.io.index.indexer import (
+    DBDirectoryIndexer,
+    _set_mapped_index_path,
+)
 from dascore.io.index.ingest import (
     SourceRecord,
     _coord_record,
+    _py_scalar,
+    assemble_source_records,
+    patch_record,
     typed_value,
 )
 from dascore.io.index.ingest import (
     summaries_to_records as s2r,
 )
-from dascore.io.index.query import InvalidSpoolQueryError
-from dascore.units import get_quantity, m
+from dascore.io.index.lite import SQLiteBackend
+from dascore.io.index.query import (
+    _UNSET,
+    InvalidSpoolQueryError,
+    _range_bounds,
+    _to_target_unit,
+)
+from dascore.units import get_quantity, m, s
+from dascore.units import get_quantity as _gq
 
 
 class TestIndexCoverageEdges:
@@ -41,17 +75,12 @@ class TestIndexCoverageEdges:
 
     def test_live_resolver_missing_patch(self):
         """A row for a patch absent from the registry raises MissingPatchError."""
-        from dascore.exceptions import MissingPatchError  # noqa: PLC0415
-        from dascore.io.index.catalog import LiveResolver  # noqa: PLC0415
-
         resolver = LiveResolver([dc.get_example_patch()])
         with pytest.raises(MissingPatchError, match="not available"):
             resolver.resolve({"path": "memorypatch://not-a-real-id"})
 
     def test_mixed_compatible_unit_range(self):
         """A coord range mixing compatible units resolves."""
-        from dascore.units import get_quantity  # noqa: PLC0415
-
         cm = get_quantity("cm")
         out = dc.spool([dc.get_example_patch()]).select(distance=(1 * m, 200 * cm))
         assert len(out.get_contents()) == 1
@@ -62,8 +91,6 @@ class TestIndexCoverageEdges:
         The catalog canonicalizes units before the backend, so only a
         direct Query reaches the multi-unit compatibility check.
         """
-        from dascore.units import s  # noqa: PLC0415
-
         with pytest.raises(UnitError, match="Cannot convert"):
             backend.query(Query(coords={"distance": (1 * m, 2 * s)}))
 
@@ -79,7 +106,6 @@ class TestIndexCoverageEdges:
 
     def test_attr_meta_units_backfilled(self, tmp_path):
         """An attr first seen unitless gets its unit backfilled by a later write."""
-        from dascore.core.summary import PatchSummary  # noqa: PLC0415
 
         def _summary(gain, path):
             return PatchSummary(
@@ -116,10 +142,6 @@ class TestIndexCoverageEdges:
 
     def test_reopen_missing_meta_row(self, tmp_path):
         """An index whose meta row was lost is rejected on reopen."""
-        import sqlite3  # noqa: PLC0415
-
-        from dascore.exceptions import InvalidIndexError  # noqa: PLC0415
-
         path = tmp_path / "i.sqlite3"
         get_backend(path).close()
         con = sqlite3.connect(path)
@@ -131,10 +153,6 @@ class TestIndexCoverageEdges:
 
     def test_reopen_table_missing_column(self, tmp_path):
         """An index whose table lost a column is rejected on reopen."""
-        import sqlite3  # noqa: PLC0415
-
-        from dascore.exceptions import InvalidIndexError  # noqa: PLC0415
-
         path = tmp_path / "i.sqlite3"
         get_backend(path).close()
         con = sqlite3.connect(path)
@@ -155,7 +173,6 @@ class TestIndexCoverageEdges:
 
     def test_schema_creation_rolls_back_on_failure(self, tmp_path):
         """A failure while creating the schema rolls back and re-raises."""
-        from dascore.io.index.lite import SQLiteBackend  # noqa: PLC0415
 
         class _BoomBackend(SQLiteBackend):
             def _execute(self, sql, params=()):
@@ -168,7 +185,6 @@ class TestIndexCoverageEdges:
 
     def test_schema_commit_failure_rolls_back(self, tmp_path):
         """A schema commit failure follows the protected rollback path."""
-        from dascore.io.index.lite import SQLiteBackend  # noqa: PLC0415
 
         class _CommitBoomBackend(SQLiteBackend):
             rolled_back = False
@@ -186,10 +202,6 @@ class TestIndexCoverageEdges:
 
     def test_reopen_missing_dynamic_attr_column(self, tmp_path):
         """attr_meta referencing an absent attrs column is rejected on reopen."""
-        import sqlite3  # noqa: PLC0415
-
-        from dascore.exceptions import InvalidIndexError  # noqa: PLC0415
-
         path = tmp_path / "i.sqlite3"
         get_backend(path).close()
         con = sqlite3.connect(path)
@@ -208,18 +220,12 @@ class TestPureHelpers:
 
     def test_is_directory_format_on_file(self, tmp_path):
         """A plain file is never a directory scan unit."""
-        from dascore.io.core import is_directory_format  # noqa: PLC0415
-
         f = tmp_path / "a.txt"
         f.write_text("x")
         assert is_directory_format(f) is False
 
     def test_memory_backend_refuses_pickle(self):
         """An in-memory backend cannot be pickled (owners serialize rows)."""
-        import pickle  # noqa: PLC0415
-
-        from dascore.io.index.lite import SQLiteBackend  # noqa: PLC0415
-
         back = SQLiteBackend(":memory:")
         try:
             with pytest.raises(TypeError, match="cannot be pickled"):
@@ -229,23 +235,17 @@ class TestPureHelpers:
 
     def test_py_scalar_bool_and_int(self):
         """_py_scalar unwraps numpy bool/int to plain python scalars."""
-        from dascore.io.index.ingest import _py_scalar  # noqa: PLC0415
-
         assert _py_scalar(np.bool_(True)) is True
         assert _py_scalar(np.int64(5)) == 5
         assert isinstance(_py_scalar(np.int64(5)), int)
 
     def test_assemble_records_empty_sources(self):
         """No sources yields no records."""
-        from dascore.io.index.ingest import assemble_source_records  # noqa: PLC0415
-
         empty = pd.DataFrame()
         assert assemble_source_records(empty, empty, empty, empty, empty, empty) == []
 
     def test_units_compatible(self):
         """_units_compatible is True for same dimensionality, False otherwise."""
-        from dascore.io.index.backend import SQLIndexBackend  # noqa: PLC0415
-
         assert SQLIndexBackend._units_compatible("m", "ft") is True
         assert SQLIndexBackend._units_compatible("m", "s") is False
 
@@ -256,16 +256,11 @@ class TestPureHelpers:
 
     def test_wrong_arity_coord_query_raises(self, backend):
         """A hand-built coord range of the wrong length is rejected."""
-        from dascore.exceptions import ParameterError  # noqa: PLC0415
-
         with pytest.raises(ParameterError, match="length 2 sequence"):
             backend.query(Query(coords={"distance": (1, 2, 3)}))
 
     def test_to_target_unit_paths(self):
         """Quantity on a unitless target raises; on a unit target it converts."""
-        from dascore.io.index.query import _to_target_unit  # noqa: PLC0415
-        from dascore.units import get_quantity as _gq  # noqa: PLC0415
-
         typed = typed_value(5 * m)  # a numeric TypedValue carrying units
         with pytest.raises(UnitError, match="unitless"):
             _to_target_unit(typed, None, "distance")
@@ -275,8 +270,6 @@ class TestPureHelpers:
 
     def test_range_bounds_unset_is_not_none(self):
         """Omitting target units must not mean the target is unitless."""
-        from dascore.io.index.query import _UNSET, _range_bounds  # noqa: PLC0415
-
         value = (5 * m, 10 * m)
         kind_probe = typed_value(5 * m)
         assert kind_probe is not None
@@ -295,8 +288,6 @@ class TestNormalizeSourcePatchId:
 
     def test_missing_forms_become_empty(self):
         """None, empty string, and pandas NaN/NaT all normalize to ''."""
-        from dascore.core.summary import normalize_source_patch_id  # noqa: PLC0415
-
         assert normalize_source_patch_id(None) == ""
         assert normalize_source_patch_id("") == ""
         assert normalize_source_patch_id(float("nan")) == ""
@@ -305,21 +296,15 @@ class TestNormalizeSourcePatchId:
 
     def test_numpy_scalar_becomes_plain_string(self):
         """A numpy scalar is unwrapped before stringifying."""
-        from dascore.core.summary import normalize_source_patch_id  # noqa: PLC0415
-
         assert normalize_source_patch_id(np.int64(42)) == "42"
 
     def test_plain_values_stringify(self):
         """Ordinary ids pass through as strings."""
-        from dascore.core.summary import normalize_source_patch_id  # noqa: PLC0415
-
         assert normalize_source_patch_id("abc") == "abc"
         assert normalize_source_patch_id(7) == "7"
 
     def test_non_scalar_falls_through(self):
         """A value pd.isnull cannot evaluate as a scalar still stringifies."""
-        from dascore.core.summary import normalize_source_patch_id  # noqa: PLC0415
-
         # pd.isnull on a list returns an array (truth value is ambiguous),
         # so the helper must swallow that and fall through to str().
         assert normalize_source_patch_id([1, 2]) == "[1, 2]"
@@ -330,8 +315,6 @@ class TestCanonicalRange:
 
     def test_bare_and_quantity_bounds(self):
         """Bare numbers and quantities become SI magnitudes."""
-        from dascore.io.index.catalog import _canonical_range  # noqa: PLC0415
-
         bare = _canonical_range((20, 60))
         assert bare is not None
         assert bare.magnitudes == (20.0, 60.0)
@@ -342,8 +325,6 @@ class TestCanonicalRange:
 
     def test_open_bounds_kept(self):
         """A half-open numeric range keeps its open end as None."""
-        from dascore.io.index.catalog import _canonical_range  # noqa: PLC0415
-
         half_open = _canonical_range((None, 60))
         assert half_open is not None
         assert half_open.magnitudes == (None, 60.0)
@@ -360,8 +341,6 @@ class TestCanonicalRange:
     )
     def test_non_numeric_ranges_return_none(self, value):
         """Anything that is not a bounded numeric range yields None."""
-        from dascore.io.index.catalog import _canonical_range  # noqa: PLC0415
-
         assert _canonical_range(value) is None
 
 
@@ -974,8 +953,6 @@ class TestIndexerEdges:
 
     def test_directory_format_unit(self, tmp_path):
         """Directory-format sources (xml binary) group as one scan unit."""
-        import sys  # noqa: PLC0415
-
         sys.path.insert(0, "tests/test_io/test_xml_binary")
         from test_xml_binary import metadata  # noqa: PLC0415
 
@@ -1008,8 +985,6 @@ class TestDirSpoolPassthrough:
 
     def test_spool_from_indexer(self, tmp_path, random_patch):
         """Passing an indexer instance to from_directory works."""
-        from dascore.core.spool import Spool  # noqa: PLC0415
-
         random_patch.io.write(tmp_path / "one.hdf5", "dasdae")
         indexer = DBDirectoryIndexer(tmp_path)
         spool = Spool.from_directory(indexer).update(progress=None)
@@ -1021,8 +996,6 @@ class TestFinalCoverage:
 
     def test_datetime_object_becomes_time(self):
         """A python datetime routes through the datetime fallback."""
-        import datetime  # noqa: PLC0415
-
         out = typed_value(datetime.datetime(2024, 1, 1))
         assert out is not None and out.kind == "time"
 
@@ -1207,11 +1180,6 @@ class TestResourceCleanup:
 
     def test_gc_closes_connection(self):
         """Garbage collection closes the backend connection silently."""
-        import gc  # noqa: PLC0415
-        import warnings as warnings_mod  # noqa: PLC0415
-
-        import dascore as dc  # noqa: PLC0415
-
         spool = dc.spool([dc.get_example_patch()])
         spool.get_contents()  # realize the backend
         # Drain any garbage other tests left behind before opening the
@@ -1228,9 +1196,6 @@ class TestResourceCleanup:
 
     def test_explicit_close_idempotent(self):
         """Explicit close works and GC afterwards stays quiet."""
-        import dascore as dc  # noqa: PLC0415
-        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
-
         catalog = PatchCatalog.from_patches([dc.get_example_patch()])
         catalog.to_df()
         catalog.close()
@@ -1238,12 +1203,6 @@ class TestResourceCleanup:
     @pytest.mark.concurrency
     def test_finalization_from_worker_thread(self):
         """Dropping the last backend reference off-thread does not raise."""
-        import gc  # noqa: PLC0415
-        import sys  # noqa: PLC0415
-        import threading  # noqa: PLC0415
-
-        from dascore.io.index.lite import SQLiteBackend  # noqa: PLC0415
-
         holder = [SQLiteBackend(":memory:")]
         unraisable = []
         original = sys.unraisablehook
@@ -1269,13 +1228,6 @@ class TestLegacyIndexMap:
 
     def test_legacy_entry_ignored(self, tmp_path):
         """A mapped legacy HDF5 index does not break index creation."""
-        import h5py  # noqa: PLC0415
-
-        import dascore as dc  # noqa: PLC0415
-        from dascore.io.index.indexer import (  # noqa: PLC0415
-            _set_mapped_index_path,
-        )
-
         # data directory with one file, plus a fake legacy index mapping.
         data_dir = tmp_path / "data"
         data_dir.mkdir()
@@ -1299,8 +1251,6 @@ class TestReservedAttrNames:
     )
     def test_reserved_attr_warns_and_skips(self, name, value):
         """Reserved names warn at ingest and never corrupt the relation."""
-        import dascore as dc  # noqa: PLC0415
-
         patch = dc.get_example_patch().update_attrs(**{name: value})
         with pytest.warns(UserWarning, match="reserved attr"):
             df = dc.spool([patch]).get_contents()
@@ -1310,8 +1260,6 @@ class TestReservedAttrNames:
 
     def test_non_reserved_attr_round_trips(self):
         """Ordinary arbitrary attrs still index and select normally."""
-        import dascore as dc  # noqa: PLC0415
-
         patch = dc.get_example_patch().update_attrs(experiment="exp42")
         spool = dc.spool([patch])
         assert spool.get_contents()["experiment"].iloc[0] == "exp42"
@@ -1319,8 +1267,6 @@ class TestReservedAttrNames:
 
     def test_cross_patch_envelope_attr_clobbered_not_reserved(self):
         """An envelope-shaped attr indexes normally; the coord wins the column."""
-        import dascore as dc  # noqa: PLC0415
-
         base = dc.get_example_patch()
         p1 = base.update_attrs(event_time_min=123.0)
         p2 = dc.get_example_patch().rename_coords(time="event_time")
@@ -1337,8 +1283,6 @@ class TestReservedAttrNames:
 
     def test_data_units_attr_still_indexed(self):
         """A real ``*_units`` attr is not an envelope column; stays queryable."""
-        import dascore as dc  # noqa: PLC0415
-
         patch = dc.get_example_patch().update_attrs(data_units="strain")
         spool = dc.spool([patch])
         assert "data_units" in spool._catalog.backend.attr_names()
@@ -1350,11 +1294,6 @@ class TestTransactionIsolation:
     @pytest.mark.concurrency
     def test_reader_never_sees_half_written_replacement(self, tmp_path, monkeypatch):
         """A concurrent reader blocks during a source replacement."""
-        import threading  # noqa: PLC0415
-
-        from dascore.io.index.backend import get_backend  # noqa: PLC0415
-        from dascore.io.index.ingest import SourceRecord, patch_record  # noqa: PLC0415
-
         patch = dc.get_example_patch()
         record = SourceRecord(
             source_path="mem://one",

--- a/tests/test_io/test_index/test_ordering.py
+++ b/tests/test_io/test_index/test_ordering.py
@@ -9,10 +9,14 @@ renumbers after each sync).
 
 from __future__ import annotations
 
+import copy
+import sqlite3
+
 import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.io.index.indexer import DBDirectoryIndexer
 
 
 @pytest.fixture(scope="module")
@@ -116,8 +120,6 @@ class TestIndexVersionRebuild:
 
     def test_version_mismatch_rebuilds(self, tmp_path):
         """An index of another schema version is replaced, not fatal."""
-        import sqlite3  # noqa: PLC0415
-
         patch = dc.get_example_patch()
         dc.write(patch, tmp_path / "a.h5", "dasdae")
         spool = dc.spool(tmp_path).update(progress=None)
@@ -138,8 +140,6 @@ class TestIndexVersionRebuild:
 
     def test_indexer_deepcopy_shares_instance(self, tmp_path):
         """Derived spools share the indexer (and its live DB connection)."""
-        import copy  # noqa: PLC0415
-
         dc.write(dc.get_example_patch(), tmp_path / "a.h5", "dasdae")
         spool = dc.spool(tmp_path).update(progress=None)
         assert copy.deepcopy(spool.indexer) is spool.indexer
@@ -231,8 +231,6 @@ class TestInterruptedInitialUpdate:
 
     def test_interruption_before_renumber_recovers(self, tmp_path):
         """A crash after write_sources still renumbers on the retry."""
-        from dascore.io.index.indexer import DBDirectoryIndexer  # noqa: PLC0415
-
         p0 = dc.get_example_patch()
         t = p0.get_coord("time")
         span = t.max() - t.min() + t.step

--- a/tests/test_io/test_index/test_ordering.py
+++ b/tests/test_io/test_index/test_ordering.py
@@ -116,7 +116,7 @@ class TestIndexVersionRebuild:
 
     def test_version_mismatch_rebuilds(self, tmp_path):
         """An index of another schema version is replaced, not fatal."""
-        import sqlite3
+        import sqlite3  # noqa: PLC0415
 
         patch = dc.get_example_patch()
         dc.write(patch, tmp_path / "a.h5", "dasdae")
@@ -138,7 +138,7 @@ class TestIndexVersionRebuild:
 
     def test_indexer_deepcopy_shares_instance(self, tmp_path):
         """Derived spools share the indexer (and its live DB connection)."""
-        import copy
+        import copy  # noqa: PLC0415
 
         dc.write(dc.get_example_patch(), tmp_path / "a.h5", "dasdae")
         spool = dc.spool(tmp_path).update(progress=None)
@@ -231,7 +231,7 @@ class TestInterruptedInitialUpdate:
 
     def test_interruption_before_renumber_recovers(self, tmp_path):
         """A crash after write_sources still renumbers on the retry."""
-        from dascore.io.index.indexer import DBDirectoryIndexer
+        from dascore.io.index.indexer import DBDirectoryIndexer  # noqa: PLC0415
 
         p0 = dc.get_example_patch()
         t = p0.get_coord("time")

--- a/tests/test_io/test_index/test_plan.py
+++ b/tests/test_io/test_index/test_plan.py
@@ -402,7 +402,7 @@ class TestChunkPlanCoverageEdges:
 
     def test_partial_overlap_members(self):
         """Overlapping sources drop the covered span (non-overlap skip)."""
-        import numpy as np
+        import numpy as np  # noqa: PLC0415
 
         t0 = np.datetime64("2020-01-01", "ns")
         p1 = dc.get_example_patch(time_min=t0)
@@ -416,9 +416,9 @@ class TestChunkPlanCoverageEdges:
 
     def test_user_stacklevel_fallback(self, monkeypatch):
         """With no user frame in the stack, the stacklevel falls back to 1."""
-        import inspect as _inspect
+        import inspect as _inspect  # noqa: PLC0415
 
-        import dascore.utils.chunk_plan as cp
+        import dascore.utils.chunk_plan as cp  # noqa: PLC0415
 
         # Every frame reports a dascore path, so no "user" frame is found.
         class _Frame:
@@ -433,35 +433,35 @@ class TestSamplingGroups:
 
     def test_close_steps_group(self):
         """Steps within tolerance of the anchor share a group."""
-        from dascore.utils.chunk_plan import _sampling_group
+        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
 
         labels = _sampling_group(pd.Series([1.0, 1.04]), 0.05)
         assert labels.nunique() == 1
 
     def test_chain_does_not_drift_past_tolerance(self):
         """Adjacent-close steps cannot chain past the group anchor."""
-        from dascore.utils.chunk_plan import _sampling_group
+        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
 
         labels = _sampling_group(pd.Series([1.00, 1.04, 1.08]), 0.05)
         assert list(labels) == [0, 0, 1]
 
     def test_negative_steps_group_by_magnitude(self):
         """Widely different negative steps never share a group."""
-        from dascore.utils.chunk_plan import _sampling_group
+        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
 
         labels = _sampling_group(pd.Series([-1.0, -5.0]), 0.05)
         assert labels.nunique() == 2
 
     def test_mixed_orientation_never_groups(self):
         """Equal magnitudes with opposite signs stay separate."""
-        from dascore.utils.chunk_plan import _sampling_group
+        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
 
         labels = _sampling_group(pd.Series([1.0, -1.0]), 0.05)
         assert labels.nunique() == 2
 
     def test_unknown_steps_share_one_group(self):
         """NaN steps keep their historical single-group behavior."""
-        from dascore.utils.chunk_plan import _sampling_group
+        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
 
         labels = _sampling_group(pd.Series([1.0, np.nan, np.nan]), 0.05)
         assert labels.nunique() == 2
@@ -489,28 +489,28 @@ class TestSamplesAdjustedEnvelopes:
 
     def test_exclusive_stop(self):
         """The stop index is exclusive: (0, 5) ends at sample 4."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         out = samples_adjusted_envelopes(self._frame(), (({"time": (0, 5)}, True),))
         assert out["time_max"].iloc[0] == 4.0
 
     def test_empty_window_drops_row(self):
         """A zero-length window contributes nothing."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         out = samples_adjusted_envelopes(self._frame(), (({"time": (3, 3)}, True),))
         assert len(out) == 0
 
     def test_start_past_end_drops_row(self):
         """A window beyond the patch contributes nothing."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         out = samples_adjusted_envelopes(self._frame(), (({"time": (50, 60)}, True),))
         assert len(out) == 0
 
     def test_stop_clamps(self):
         """A stop past the end clamps to the envelope max."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         out = samples_adjusted_envelopes(self._frame(), (({"time": (2, 99)}, True),))
         assert out["time_min"].iloc[0] == 2.0
@@ -518,7 +518,7 @@ class TestSamplesAdjustedEnvelopes:
 
     def test_descending_orientation(self):
         """On a descending coord, sample 0 sits at the envelope max."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         df = pd.DataFrame({"time_min": [0.0], "time_max": [9.0], "time_step": [-1.0]})
         out = samples_adjusted_envelopes(df, (({"time": (0, 5)}, True),))
@@ -550,14 +550,14 @@ class TestChunkOnlyOnDims:
 
     def test_aux_only_raises_with_detail(self, aux_time_patch):
         """The default error explains the name rides as a coordinate."""
-        from dascore.exceptions import ChunkError
+        from dascore.exceptions import ChunkError  # noqa: PLC0415
 
         with pytest.raises(ChunkError, match="non-dimensional coordinate"):
             dc.spool([aux_time_patch]).chunk(time=None)
 
     def test_mixed_population_raises_by_default(self, aux_time_patch):
         """Mixed dim/aux populations fail eagerly, not at patch access."""
-        from dascore.exceptions import ChunkError
+        from dascore.exceptions import ChunkError  # noqa: PLC0415
 
         sp = dc.spool([dc.get_example_patch(), aux_time_patch])
         with pytest.raises(ChunkError, match="lack the chunk dimension"):
@@ -572,9 +572,9 @@ class TestChunkOnlyOnDims:
 
     def test_segmenting_aux_coord_raises(self):
         """chunk(<aux coord>=value) is rejected, not accidentally served."""
-        import numpy as np
+        import numpy as np  # noqa: PLC0415
 
-        from dascore.exceptions import ChunkError
+        from dascore.exceptions import ChunkError  # noqa: PLC0415
 
         p = dc.get_example_patch()
         q = p.update_coords(sensor=("distance", np.arange(p.shape[0], dtype=float)))
@@ -609,7 +609,7 @@ class TestNegativeSamplesEnvelopes:
 
     def test_negative_start_resolves(self):
         """(-3, None) selects the last three samples."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         out = samples_adjusted_envelopes(self._frame(), (({"time": (-3, None)}, True),))
         assert out["time_min"].iloc[0] == 7.0
@@ -617,14 +617,14 @@ class TestNegativeSamplesEnvelopes:
 
     def test_negative_stop_resolves(self):
         """(None, -2) drops the last two samples."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         out = samples_adjusted_envelopes(self._frame(), (({"time": (None, -2)}, True),))
         assert out["time_max"].iloc[0] == 7.0
 
     def test_unknown_step_keeps_envelope(self):
         """Rows whose count is unknown keep their candidacy envelope."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         df = pd.DataFrame({"time_min": [0.0], "time_max": [9.0], "time_step": [np.nan]})
         out = samples_adjusted_envelopes(df, (({"time": (-3, None)}, True),))
@@ -634,7 +634,7 @@ class TestNegativeSamplesEnvelopes:
 
     def test_drop_empty_false_keeps_rows(self):
         """Equality's variant keeps presented-but-empty rows."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         out = samples_adjusted_envelopes(
             self._frame(), (({"time": (3, 3)}, True),), drop_empty=False
@@ -656,7 +656,7 @@ class TestNonIntSamplesIndices:
 
     def test_float_index_skipped(self):
         """A float index cannot adjust; the envelope stays candidacy."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         df = pd.DataFrame({"time_min": [0.0], "time_max": [9.0], "time_step": [1.0]})
         out = samples_adjusted_envelopes(df, (({"time": (0.5, None)}, True),))

--- a/tests/test_io/test_index/test_plan.py
+++ b/tests/test_io/test_index/test_plan.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import inspect as _inspect
+
 import numpy as np
 import pandas as pd
 import pytest
 
 import dascore as dc
+import dascore.utils.chunk_plan as cp
 from dascore.exceptions import (
     ChunkError,
     CoordMergeError,
@@ -14,7 +17,12 @@ from dascore.exceptions import (
     ParameterError,
 )
 from dascore.io.index.catalog import PatchCatalog
-from dascore.utils.chunk_plan import ChunkPlan, build_chunk_plan
+from dascore.utils.chunk_plan import (
+    ChunkPlan,
+    _sampling_group,
+    build_chunk_plan,
+    samples_adjusted_envelopes,
+)
 from dascore.utils.time import to_timedelta64
 
 ONE_S = np.timedelta64(1, "s")
@@ -402,8 +410,6 @@ class TestChunkPlanCoverageEdges:
 
     def test_partial_overlap_members(self):
         """Overlapping sources drop the covered span (non-overlap skip)."""
-        import numpy as np  # noqa: PLC0415
-
         t0 = np.datetime64("2020-01-01", "ns")
         p1 = dc.get_example_patch(time_min=t0)
         step = p1.get_coord("time").step
@@ -416,9 +422,6 @@ class TestChunkPlanCoverageEdges:
 
     def test_user_stacklevel_fallback(self, monkeypatch):
         """With no user frame in the stack, the stacklevel falls back to 1."""
-        import inspect as _inspect  # noqa: PLC0415
-
-        import dascore.utils.chunk_plan as cp  # noqa: PLC0415
 
         # Every frame reports a dascore path, so no "user" frame is found.
         class _Frame:
@@ -433,36 +436,26 @@ class TestSamplingGroups:
 
     def test_close_steps_group(self):
         """Steps within tolerance of the anchor share a group."""
-        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
-
         labels = _sampling_group(pd.Series([1.0, 1.04]), 0.05)
         assert labels.nunique() == 1
 
     def test_chain_does_not_drift_past_tolerance(self):
         """Adjacent-close steps cannot chain past the group anchor."""
-        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
-
         labels = _sampling_group(pd.Series([1.00, 1.04, 1.08]), 0.05)
         assert list(labels) == [0, 0, 1]
 
     def test_negative_steps_group_by_magnitude(self):
         """Widely different negative steps never share a group."""
-        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
-
         labels = _sampling_group(pd.Series([-1.0, -5.0]), 0.05)
         assert labels.nunique() == 2
 
     def test_mixed_orientation_never_groups(self):
         """Equal magnitudes with opposite signs stay separate."""
-        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
-
         labels = _sampling_group(pd.Series([1.0, -1.0]), 0.05)
         assert labels.nunique() == 2
 
     def test_unknown_steps_share_one_group(self):
         """NaN steps keep their historical single-group behavior."""
-        from dascore.utils.chunk_plan import _sampling_group  # noqa: PLC0415
-
         labels = _sampling_group(pd.Series([1.0, np.nan, np.nan]), 0.05)
         assert labels.nunique() == 2
         assert labels.iloc[1] == labels.iloc[2]
@@ -489,37 +482,27 @@ class TestSamplesAdjustedEnvelopes:
 
     def test_exclusive_stop(self):
         """The stop index is exclusive: (0, 5) ends at sample 4."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         out = samples_adjusted_envelopes(self._frame(), (({"time": (0, 5)}, True),))
         assert out["time_max"].iloc[0] == 4.0
 
     def test_empty_window_drops_row(self):
         """A zero-length window contributes nothing."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         out = samples_adjusted_envelopes(self._frame(), (({"time": (3, 3)}, True),))
         assert len(out) == 0
 
     def test_start_past_end_drops_row(self):
         """A window beyond the patch contributes nothing."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         out = samples_adjusted_envelopes(self._frame(), (({"time": (50, 60)}, True),))
         assert len(out) == 0
 
     def test_stop_clamps(self):
         """A stop past the end clamps to the envelope max."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         out = samples_adjusted_envelopes(self._frame(), (({"time": (2, 99)}, True),))
         assert out["time_min"].iloc[0] == 2.0
         assert out["time_max"].iloc[0] == 9.0
 
     def test_descending_orientation(self):
         """On a descending coord, sample 0 sits at the envelope max."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         df = pd.DataFrame({"time_min": [0.0], "time_max": [9.0], "time_step": [-1.0]})
         out = samples_adjusted_envelopes(df, (({"time": (0, 5)}, True),))
         assert out["time_max"].iloc[0] == 9.0
@@ -550,15 +533,11 @@ class TestChunkOnlyOnDims:
 
     def test_aux_only_raises_with_detail(self, aux_time_patch):
         """The default error explains the name rides as a coordinate."""
-        from dascore.exceptions import ChunkError  # noqa: PLC0415
-
         with pytest.raises(ChunkError, match="non-dimensional coordinate"):
             dc.spool([aux_time_patch]).chunk(time=None)
 
     def test_mixed_population_raises_by_default(self, aux_time_patch):
         """Mixed dim/aux populations fail eagerly, not at patch access."""
-        from dascore.exceptions import ChunkError  # noqa: PLC0415
-
         sp = dc.spool([dc.get_example_patch(), aux_time_patch])
         with pytest.raises(ChunkError, match="lack the chunk dimension"):
             sp.chunk(time=None)
@@ -572,10 +551,6 @@ class TestChunkOnlyOnDims:
 
     def test_segmenting_aux_coord_raises(self):
         """chunk(<aux coord>=value) is rejected, not accidentally served."""
-        import numpy as np  # noqa: PLC0415
-
-        from dascore.exceptions import ChunkError  # noqa: PLC0415
-
         p = dc.get_example_patch()
         q = p.update_coords(sensor=("distance", np.arange(p.shape[0], dtype=float)))
         with pytest.raises(ChunkError, match="non-dimensional coordinate"):
@@ -609,23 +584,17 @@ class TestNegativeSamplesEnvelopes:
 
     def test_negative_start_resolves(self):
         """(-3, None) selects the last three samples."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         out = samples_adjusted_envelopes(self._frame(), (({"time": (-3, None)}, True),))
         assert out["time_min"].iloc[0] == 7.0
         assert out["time_max"].iloc[0] == 9.0
 
     def test_negative_stop_resolves(self):
         """(None, -2) drops the last two samples."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         out = samples_adjusted_envelopes(self._frame(), (({"time": (None, -2)}, True),))
         assert out["time_max"].iloc[0] == 7.0
 
     def test_unknown_step_keeps_envelope(self):
         """Rows whose count is unknown keep their candidacy envelope."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         df = pd.DataFrame({"time_min": [0.0], "time_max": [9.0], "time_step": [np.nan]})
         out = samples_adjusted_envelopes(df, (({"time": (-3, None)}, True),))
         assert len(out) == 1
@@ -634,8 +603,6 @@ class TestNegativeSamplesEnvelopes:
 
     def test_drop_empty_false_keeps_rows(self):
         """Equality's variant keeps presented-but-empty rows."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         out = samples_adjusted_envelopes(
             self._frame(), (({"time": (3, 3)}, True),), drop_empty=False
         )
@@ -656,8 +623,6 @@ class TestNonIntSamplesIndices:
 
     def test_float_index_skipped(self):
         """A float index cannot adjust; the envelope stays candidacy."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         df = pd.DataFrame({"time_min": [0.0], "time_max": [9.0], "time_step": [1.0]})
         out = samples_adjusted_envelopes(df, (({"time": (0.5, None)}, True),))
         assert out["time_min"].iloc[0] == 0.0

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -4,6 +4,7 @@ Tests for derived catalogs (plan-as-catalog) and coverage of their edges.
 
 from __future__ import annotations
 
+import pickle
 import re
 
 import numpy as np
@@ -11,14 +12,18 @@ import pandas as pd
 import pytest
 
 import dascore as dc
-from dascore.exceptions import ParameterError
+from dascore.core.spool import BaseSpool
+from dascore.exceptions import MissingPatchError, ParameterError
 from dascore.io.index.planned import (
     PlanResolver,
+    _aux_coord_info,
     _coord_record_from_row,
     _ns,
     collapse_working_df,
     derived_catalog,
 )
+from dascore.units import m
+from dascore.utils.chunk_plan import ChunkPlan, samples_adjusted_envelopes
 
 
 @pytest.fixture(scope="module")
@@ -91,8 +96,6 @@ class TestHelpers:
 
     def test_derived_catalog_adds_patch_ids(self, patches):
         """source_rows without _patch_id get positional ids."""
-        from dascore.utils.chunk_plan import ChunkPlan  # noqa: PLC0415
-
         spool = dc.spool(patches)
         rows = spool.get_contents().drop(columns=["_patch_id"], errors="ignore")
         rows = rows.reset_index(drop=True)
@@ -158,8 +161,6 @@ class TestDerivedComposition:
 
     def test_union_view_of_live_spools_pickles_composite(self, patches):
         """A selected union pickles a membership-restricted composite."""
-        import pickle  # noqa: PLC0415
-
         t0 = patches[0].get_coord("time")
         combined = dc.spool(patches[:2]) + dc.spool(patches[2:])
         view = combined.select(time=(None, t0.max()))
@@ -172,8 +173,6 @@ class TestDerivedComposition:
         """A missing registry entry surfaces as MissingPatchError, not
         out-of-bounds.
         """
-        from dascore.exceptions import MissingPatchError  # noqa: PLC0415
-
         spool = dc.spool(patches[:1])
         _ = spool.get_contents()  # realize rows
         spool._catalog.resolver._registry.clear()
@@ -182,7 +181,6 @@ class TestDerivedComposition:
 
     def test_union_with_third_party_spool(self, patches):
         """The BaseSpool fallback materializes third-party members."""
-        from dascore.core.spool import BaseSpool  # noqa: PLC0415
 
         class MiniSpool(BaseSpool):
             def __init__(self, inner):
@@ -231,8 +229,6 @@ class TestRemainingEdges:
         """A quantity-selected chunked view re-chunks without applying
         unit-bearing bounds to envelopes (they stay load residuals).
         """
-        from dascore.units import m  # noqa: PLC0415
-
         chunked = dc.spool(patches).chunk(time=2)
         selected = chunked.select(_coords={"distance": (0 * m, 10 * m)})
         merged = selected.chunk(time=None)
@@ -242,8 +238,6 @@ class TestRemainingEdges:
 
     def test_samples_adjust_skips_missing_columns(self):
         """Residuals naming absent envelope columns pass through."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
-
         df = pd.DataFrame({"time_min": [0.0], "time_max": [1.0]})
         residuals = (({"depth": (0, 5)}, True),)
         out = samples_adjusted_envelopes(df, residuals)
@@ -317,14 +311,10 @@ class TestAuxInfoEdges:
 
     def test_coord_record_missing_envelope_returns_none(self):
         """A row without envelope values yields no coord record."""
-        from dascore.io.index.planned import _coord_record_from_row  # noqa: PLC0415
-
         assert _coord_record_from_row({}, "time") is None
 
     def test_absent_envelope_columns_skipped(self):
         """A mapped coord with no envelope columns contributes nothing."""
-        from dascore.io.index.planned import _aux_coord_info  # noqa: PLC0415
-
         members = pd.DataFrame(
             {"output_id": [0], "_patch_id": [1], "_modified": [False]}
         )
@@ -333,8 +323,6 @@ class TestAuxInfoEdges:
 
     def test_all_null_group_skipped(self):
         """An output whose members carry no values for a coord is skipped."""
-        from dascore.io.index.planned import _aux_coord_info  # noqa: PLC0415
-
         members = pd.DataFrame(
             {"output_id": [0], "_patch_id": [1], "_modified": [False]}
         )

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -91,7 +91,7 @@ class TestHelpers:
 
     def test_derived_catalog_adds_patch_ids(self, patches):
         """source_rows without _patch_id get positional ids."""
-        from dascore.utils.chunk_plan import ChunkPlan
+        from dascore.utils.chunk_plan import ChunkPlan  # noqa: PLC0415
 
         spool = dc.spool(patches)
         rows = spool.get_contents().drop(columns=["_patch_id"], errors="ignore")
@@ -158,7 +158,7 @@ class TestDerivedComposition:
 
     def test_union_view_of_live_spools_pickles_composite(self, patches):
         """A selected union pickles a membership-restricted composite."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         t0 = patches[0].get_coord("time")
         combined = dc.spool(patches[:2]) + dc.spool(patches[2:])
@@ -172,7 +172,7 @@ class TestDerivedComposition:
         """A missing registry entry surfaces as MissingPatchError, not
         out-of-bounds.
         """
-        from dascore.exceptions import MissingPatchError
+        from dascore.exceptions import MissingPatchError  # noqa: PLC0415
 
         spool = dc.spool(patches[:1])
         _ = spool.get_contents()  # realize rows
@@ -182,7 +182,7 @@ class TestDerivedComposition:
 
     def test_union_with_third_party_spool(self, patches):
         """The BaseSpool fallback materializes third-party members."""
-        from dascore.core.spool import BaseSpool
+        from dascore.core.spool import BaseSpool  # noqa: PLC0415
 
         class MiniSpool(BaseSpool):
             def __init__(self, inner):
@@ -231,7 +231,7 @@ class TestRemainingEdges:
         """A quantity-selected chunked view re-chunks without applying
         unit-bearing bounds to envelopes (they stay load residuals).
         """
-        from dascore.units import m
+        from dascore.units import m  # noqa: PLC0415
 
         chunked = dc.spool(patches).chunk(time=2)
         selected = chunked.select(_coords={"distance": (0 * m, 10 * m)})
@@ -242,7 +242,7 @@ class TestRemainingEdges:
 
     def test_samples_adjust_skips_missing_columns(self):
         """Residuals naming absent envelope columns pass through."""
-        from dascore.utils.chunk_plan import samples_adjusted_envelopes
+        from dascore.utils.chunk_plan import samples_adjusted_envelopes  # noqa: PLC0415
 
         df = pd.DataFrame({"time_min": [0.0], "time_max": [1.0]})
         residuals = (({"depth": (0, 5)}, True),)
@@ -317,13 +317,13 @@ class TestAuxInfoEdges:
 
     def test_coord_record_missing_envelope_returns_none(self):
         """A row without envelope values yields no coord record."""
-        from dascore.io.index.planned import _coord_record_from_row
+        from dascore.io.index.planned import _coord_record_from_row  # noqa: PLC0415
 
         assert _coord_record_from_row({}, "time") is None
 
     def test_absent_envelope_columns_skipped(self):
         """A mapped coord with no envelope columns contributes nothing."""
-        from dascore.io.index.planned import _aux_coord_info
+        from dascore.io.index.planned import _aux_coord_info  # noqa: PLC0415
 
         members = pd.DataFrame(
             {"output_id": [0], "_patch_id": [1], "_modified": [False]}
@@ -333,7 +333,7 @@ class TestAuxInfoEdges:
 
     def test_all_null_group_skipped(self):
         """An output whose members carry no values for a coord is skipped."""
-        from dascore.io.index.planned import _aux_coord_info
+        from dascore.io.index.planned import _aux_coord_info  # noqa: PLC0415
 
         members = pd.DataFrame(
             {"output_id": [0], "_patch_id": [1], "_modified": [False]}

--- a/tests/test_io/test_index/test_union.py
+++ b/tests/test_io/test_index/test_union.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import copy
+import pickle
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 import dascore as dc
 from dascore.core.coords import CoordRange
-from dascore.io.index.catalog import CompositeResolver, PatchCatalog
+from dascore.io.index.catalog import CompositeResolver, PatchCatalog, _absolutize_record
+from dascore.io.index.ingest import SourceRecord
 
 
 @pytest.fixture(scope="module")
@@ -182,8 +188,6 @@ class TestPatchIdentity:
         Identity is minted eagerly at construction, so copies share it
         regardless of when they are made (no access-order dependence).
         """
-        import copy  # noqa: PLC0415
-
         patch = dc.get_example_patch()
         clone = copy.deepcopy(patch)
         assert clone._instance_id == patch._instance_id
@@ -202,8 +206,6 @@ class TestPatchIdentity:
 
     def test_pickle_round_trip_preserves_content(self):
         """Spools of live patches pickle and rebuild their backend."""
-        import pickle  # noqa: PLC0415
-
         patch = dc.get_example_patch()
         spool = dc.spool([patch])
         _ = len(spool)  # realize the catalog
@@ -213,8 +215,6 @@ class TestPatchIdentity:
 
     def test_union_pickles(self):
         """Union spools survive pickling (rows ride along as records)."""
-        import pickle  # noqa: PLC0415
-
         p1 = dc.get_example_patch()
         p2 = p1.new()
         combined = dc.spool([p1]) + dc.spool([p2])
@@ -223,8 +223,6 @@ class TestPatchIdentity:
 
     def test_remove_updates_live_registry(self):
         """Removing a live source removes it from the store as well."""
-        import pickle  # noqa: PLC0415
-
         patch = dc.get_example_patch()
         catalog = PatchCatalog.from_patches([patch])
         path = catalog.to_df().iloc[0]["path"]
@@ -287,11 +285,6 @@ class TestExportPushdown:
 
     def test_absolutize_record_passthrough(self, tmp_path):
         """A record already carrying an absolute/URI path is returned as-is."""
-        from pathlib import Path  # noqa: PLC0415
-
-        from dascore.io.index.catalog import _absolutize_record  # noqa: PLC0415
-        from dascore.io.index.ingest import SourceRecord  # noqa: PLC0415
-
         # an OS-native absolute path (drive-qualified on Windows)
         abs_path = str((tmp_path / "a.h5").resolve())
         assert Path(abs_path).is_absolute()
@@ -444,8 +437,6 @@ class TestLossyStateUnion:
 
     def test_combined_pickles(self):
         """A union holding a materialized operand round-trips pickling."""
-        import pickle  # noqa: PLC0415
-
         p = dc.get_example_patch()
         t = p.get_coord("time")
         lo, hi = t.min() + 10 * t.step, t.min() + 20 * t.step
@@ -465,8 +456,6 @@ class TestMixedViewPickle:
 
     def test_sliced_mixed_union_pickles(self):
         """A sliced union of planned and live rows loads all rows back."""
-        import pickle  # noqa: PLC0415
-
         p = dc.get_example_patch()
         t = p.get_coord("time")
         trimmed = dc.spool([p]).select(
@@ -481,8 +470,6 @@ class TestMixedViewPickle:
     @pytest.mark.concurrency
     def test_mixed_union_map_processes(self):
         """Process-backed map ships plan routes with each task."""
-        from concurrent.futures import ProcessPoolExecutor  # noqa: PLC0415
-
         p = dc.get_example_patch()
         t = p.get_coord("time")
         trimmed = dc.spool([p]).select(

--- a/tests/test_io/test_index/test_union.py
+++ b/tests/test_io/test_index/test_union.py
@@ -182,7 +182,7 @@ class TestPatchIdentity:
         Identity is minted eagerly at construction, so copies share it
         regardless of when they are made (no access-order dependence).
         """
-        import copy
+        import copy  # noqa: PLC0415
 
         patch = dc.get_example_patch()
         clone = copy.deepcopy(patch)
@@ -202,7 +202,7 @@ class TestPatchIdentity:
 
     def test_pickle_round_trip_preserves_content(self):
         """Spools of live patches pickle and rebuild their backend."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         patch = dc.get_example_patch()
         spool = dc.spool([patch])
@@ -213,7 +213,7 @@ class TestPatchIdentity:
 
     def test_union_pickles(self):
         """Union spools survive pickling (rows ride along as records)."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         p1 = dc.get_example_patch()
         p2 = p1.new()
@@ -223,7 +223,7 @@ class TestPatchIdentity:
 
     def test_remove_updates_live_registry(self):
         """Removing a live source removes it from the store as well."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         patch = dc.get_example_patch()
         catalog = PatchCatalog.from_patches([patch])
@@ -287,10 +287,10 @@ class TestExportPushdown:
 
     def test_absolutize_record_passthrough(self, tmp_path):
         """A record already carrying an absolute/URI path is returned as-is."""
-        from pathlib import Path
+        from pathlib import Path  # noqa: PLC0415
 
-        from dascore.io.index.catalog import _absolutize_record
-        from dascore.io.index.ingest import SourceRecord
+        from dascore.io.index.catalog import _absolutize_record  # noqa: PLC0415
+        from dascore.io.index.ingest import SourceRecord  # noqa: PLC0415
 
         # an OS-native absolute path (drive-qualified on Windows)
         abs_path = str((tmp_path / "a.h5").resolve())
@@ -444,7 +444,7 @@ class TestLossyStateUnion:
 
     def test_combined_pickles(self):
         """A union holding a materialized operand round-trips pickling."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         p = dc.get_example_patch()
         t = p.get_coord("time")
@@ -465,7 +465,7 @@ class TestMixedViewPickle:
 
     def test_sliced_mixed_union_pickles(self):
         """A sliced union of planned and live rows loads all rows back."""
-        import pickle
+        import pickle  # noqa: PLC0415
 
         p = dc.get_example_patch()
         t = p.get_coord("time")
@@ -481,7 +481,7 @@ class TestMixedViewPickle:
     @pytest.mark.concurrency
     def test_mixed_union_map_processes(self):
         """Process-backed map ships plan routes with each task."""
-        from concurrent.futures import ProcessPoolExecutor
+        from concurrent.futures import ProcessPoolExecutor  # noqa: PLC0415
 
         p = dc.get_example_patch()
         t = p.get_coord("time")

--- a/tests/test_io/test_indexer.py
+++ b/tests/test_io/test_indexer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import platform
@@ -15,7 +16,15 @@ from upath import UPath
 
 from dascore.config import config_context
 from dascore.exceptions import InvalidSpoolError
-from dascore.io.index.indexer import DBDirectoryIndexer
+from dascore.io.index import indexer as indexer_mod
+from dascore.io.index.indexer import (
+    DBDirectoryIndexer,
+    _get_mapped_index_path,
+    _map_entry_path,
+    _path_digest,
+    _set_mapped_index_path,
+)
+from dascore.io.index.query import InvalidSpoolQueryError
 from dascore.utils.patch import get_patch_names
 
 
@@ -76,8 +85,6 @@ class TestFindIndex:
         name would differ every session and orphan the prior index. The
         name is a stable digest of the directory path.
         """
-        from dascore.io.index.indexer import _path_digest  # noqa: PLC0415
-
         map_dir = tmp_path / "path_map"
         with config_context(directory_index_map_dir=map_dir):
             first = DBDirectoryIndexer(unwritable_directory).index_path
@@ -110,8 +117,6 @@ class TestFindIndex:
 
     def test_corrupt_cache(self, tmp_path):
         """Ensure a corrupt map entry doesn't crash indexing. See #508."""
-        from dascore.io.index.indexer import _map_entry_path  # noqa: PLC0415
-
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         map_dir = tmp_path / "path_map"
@@ -152,9 +157,6 @@ class TestIndexMap:
 
     def test_digest_falls_back_for_non_fspath(self):
         """A directory os.fsencode rejects still digests (future URL support)."""
-        import hashlib  # noqa: PLC0415
-
-        from dascore.io.index.indexer import _path_digest  # noqa: PLC0415
 
         class _Remote:
             """Stand-in for a remote UPath whose fspath is unavailable."""
@@ -170,11 +172,6 @@ class TestIndexMap:
 
     def test_roundtrip(self, tmp_path):
         """A recorded index path is read back for the same directory."""
-        from dascore.io.index.indexer import (  # noqa: PLC0415
-            _get_mapped_index_path,
-            _set_mapped_index_path,
-        )
-
         map_dir = tmp_path / "path_map"
         index_path = tmp_path / "idx.sqlite3"
         _set_mapped_index_path(tmp_path / "data", index_path, map_dir)
@@ -182,17 +179,10 @@ class TestIndexMap:
 
     def test_missing_entry_is_none(self, tmp_path):
         """An unmapped directory reads back as None (a cache miss)."""
-        from dascore.io.index.indexer import _get_mapped_index_path  # noqa: PLC0415
-
         assert _get_mapped_index_path(tmp_path / "nope", tmp_path / "path_map") is None
 
     def test_distinct_dirs_dont_collide(self, tmp_path):
         """Separate directories use separate entry files (no lost writes)."""
-        from dascore.io.index.indexer import (  # noqa: PLC0415
-            _get_mapped_index_path,
-            _set_mapped_index_path,
-        )
-
         map_dir = tmp_path / "path_map"
         _set_mapped_index_path(tmp_path / "a", "index-a", map_dir)
         _set_mapped_index_path(tmp_path / "b", "index-b", map_dir)
@@ -201,11 +191,6 @@ class TestIndexMap:
 
     def test_corrupt_entry_is_miss(self, tmp_path):
         """A corrupt entry reads as a miss (and is not deleted). See #508."""
-        from dascore.io.index.indexer import (  # noqa: PLC0415
-            _get_mapped_index_path,
-            _map_entry_path,
-        )
-
         map_dir = tmp_path / "path_map"
         entry = _map_entry_path(tmp_path / "a", map_dir)
         entry.parent.mkdir(parents=True)
@@ -216,11 +201,6 @@ class TestIndexMap:
 
     def test_bad_payload_shapes_are_miss(self, tmp_path):
         """Non-string or empty index paths read as a miss, not an error."""
-        from dascore.io.index.indexer import (  # noqa: PLC0415
-            _get_mapped_index_path,
-            _map_entry_path,
-        )
-
         map_dir = tmp_path / "path_map"
         entry = _map_entry_path(tmp_path / "a", map_dir)
         entry.parent.mkdir(parents=True)
@@ -231,11 +211,6 @@ class TestIndexMap:
 
     def test_digest_collision_is_miss(self, tmp_path):
         """An entry whose stored directory differs reads as a miss."""
-        from dascore.io.index.indexer import (  # noqa: PLC0415
-            _get_mapped_index_path,
-            _map_entry_path,
-        )
-
         map_dir = tmp_path / "path_map"
         entry = _map_entry_path(tmp_path / "a", map_dir)
         entry.parent.mkdir(parents=True)
@@ -245,12 +220,6 @@ class TestIndexMap:
 
     def test_update_is_atomic_and_leaves_no_temp(self, tmp_path):
         """Writes swap a temp file into place, leaving no debris."""
-        from dascore.io.index.indexer import (  # noqa: PLC0415
-            _get_mapped_index_path,
-            _map_entry_path,
-            _set_mapped_index_path,
-        )
-
         map_dir = tmp_path / "path_map"
         _set_mapped_index_path(tmp_path / "a", "1", map_dir)
         _set_mapped_index_path(tmp_path / "a", "2", map_dir)
@@ -260,8 +229,6 @@ class TestIndexMap:
 
     def test_failed_swap_cleans_up_temp(self, tmp_path, monkeypatch):
         """A failure during the atomic swap unlinks the temp file and re-raises."""
-        from dascore.io.index import indexer as indexer_mod  # noqa: PLC0415
-
         map_dir = tmp_path / "path_map"
 
         def boom(*args, **kwargs):
@@ -279,8 +246,6 @@ class TestWalkResilience:
 
     def test_walk_skips_file_removed_mid_scan(self, tmp_path, monkeypatch):
         """A file vanishing between the walk and its stat is skipped, not fatal."""
-        from dascore.io.index import indexer as indexer_mod  # noqa: PLC0415
-
         good = tmp_path / "good.h5"
         good.write_bytes(b"")
         # Never created: models a file deleted between the walk yielding it and
@@ -445,7 +410,5 @@ class TestNameResolution:
 
     def test_unknown_name_raises(self, basic_indexer):
         """Names in neither namespace error clearly (#435)."""
-        from dascore.io.index.query import InvalidSpoolQueryError  # noqa: PLC0415
-
         with pytest.raises(InvalidSpoolQueryError, match="neither an attribute"):
             basic_indexer(bad_dimension=(1, 2))

--- a/tests/test_io/test_indexer.py
+++ b/tests/test_io/test_indexer.py
@@ -76,7 +76,7 @@ class TestFindIndex:
         name would differ every session and orphan the prior index. The
         name is a stable digest of the directory path.
         """
-        from dascore.io.index.indexer import _path_digest
+        from dascore.io.index.indexer import _path_digest  # noqa: PLC0415
 
         map_dir = tmp_path / "path_map"
         with config_context(directory_index_map_dir=map_dir):
@@ -110,7 +110,7 @@ class TestFindIndex:
 
     def test_corrupt_cache(self, tmp_path):
         """Ensure a corrupt map entry doesn't crash indexing. See #508."""
-        from dascore.io.index.indexer import _map_entry_path
+        from dascore.io.index.indexer import _map_entry_path  # noqa: PLC0415
 
         data_dir = tmp_path / "data"
         data_dir.mkdir()
@@ -152,9 +152,9 @@ class TestIndexMap:
 
     def test_digest_falls_back_for_non_fspath(self):
         """A directory os.fsencode rejects still digests (future URL support)."""
-        import hashlib
+        import hashlib  # noqa: PLC0415
 
-        from dascore.io.index.indexer import _path_digest
+        from dascore.io.index.indexer import _path_digest  # noqa: PLC0415
 
         class _Remote:
             """Stand-in for a remote UPath whose fspath is unavailable."""
@@ -170,7 +170,7 @@ class TestIndexMap:
 
     def test_roundtrip(self, tmp_path):
         """A recorded index path is read back for the same directory."""
-        from dascore.io.index.indexer import (
+        from dascore.io.index.indexer import (  # noqa: PLC0415
             _get_mapped_index_path,
             _set_mapped_index_path,
         )
@@ -182,13 +182,13 @@ class TestIndexMap:
 
     def test_missing_entry_is_none(self, tmp_path):
         """An unmapped directory reads back as None (a cache miss)."""
-        from dascore.io.index.indexer import _get_mapped_index_path
+        from dascore.io.index.indexer import _get_mapped_index_path  # noqa: PLC0415
 
         assert _get_mapped_index_path(tmp_path / "nope", tmp_path / "path_map") is None
 
     def test_distinct_dirs_dont_collide(self, tmp_path):
         """Separate directories use separate entry files (no lost writes)."""
-        from dascore.io.index.indexer import (
+        from dascore.io.index.indexer import (  # noqa: PLC0415
             _get_mapped_index_path,
             _set_mapped_index_path,
         )
@@ -201,7 +201,7 @@ class TestIndexMap:
 
     def test_corrupt_entry_is_miss(self, tmp_path):
         """A corrupt entry reads as a miss (and is not deleted). See #508."""
-        from dascore.io.index.indexer import (
+        from dascore.io.index.indexer import (  # noqa: PLC0415
             _get_mapped_index_path,
             _map_entry_path,
         )
@@ -216,7 +216,10 @@ class TestIndexMap:
 
     def test_bad_payload_shapes_are_miss(self, tmp_path):
         """Non-string or empty index paths read as a miss, not an error."""
-        from dascore.io.index.indexer import _get_mapped_index_path, _map_entry_path
+        from dascore.io.index.indexer import (  # noqa: PLC0415
+            _get_mapped_index_path,
+            _map_entry_path,
+        )
 
         map_dir = tmp_path / "path_map"
         entry = _map_entry_path(tmp_path / "a", map_dir)
@@ -228,7 +231,10 @@ class TestIndexMap:
 
     def test_digest_collision_is_miss(self, tmp_path):
         """An entry whose stored directory differs reads as a miss."""
-        from dascore.io.index.indexer import _get_mapped_index_path, _map_entry_path
+        from dascore.io.index.indexer import (  # noqa: PLC0415
+            _get_mapped_index_path,
+            _map_entry_path,
+        )
 
         map_dir = tmp_path / "path_map"
         entry = _map_entry_path(tmp_path / "a", map_dir)
@@ -239,7 +245,7 @@ class TestIndexMap:
 
     def test_update_is_atomic_and_leaves_no_temp(self, tmp_path):
         """Writes swap a temp file into place, leaving no debris."""
-        from dascore.io.index.indexer import (
+        from dascore.io.index.indexer import (  # noqa: PLC0415
             _get_mapped_index_path,
             _map_entry_path,
             _set_mapped_index_path,
@@ -254,7 +260,7 @@ class TestIndexMap:
 
     def test_failed_swap_cleans_up_temp(self, tmp_path, monkeypatch):
         """A failure during the atomic swap unlinks the temp file and re-raises."""
-        from dascore.io.index import indexer as indexer_mod
+        from dascore.io.index import indexer as indexer_mod  # noqa: PLC0415
 
         map_dir = tmp_path / "path_map"
 
@@ -273,7 +279,7 @@ class TestWalkResilience:
 
     def test_walk_skips_file_removed_mid_scan(self, tmp_path, monkeypatch):
         """A file vanishing between the walk and its stat is skipped, not fatal."""
-        from dascore.io.index import indexer as indexer_mod
+        from dascore.io.index import indexer as indexer_mod  # noqa: PLC0415
 
         good = tmp_path / "good.h5"
         good.write_bytes(b"")
@@ -439,7 +445,7 @@ class TestNameResolution:
 
     def test_unknown_name_raises(self, basic_indexer):
         """Names in neither namespace error clearly (#435)."""
-        from dascore.io.index.query import InvalidSpoolQueryError
+        from dascore.io.index.query import InvalidSpoolQueryError  # noqa: PLC0415
 
         with pytest.raises(InvalidSpoolQueryError, match="neither an attribute"):
             basic_indexer(bad_dimension=(1, 2))

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -241,7 +241,7 @@ class TestGetExactCoord:
 
     def test_jittery_array_does_not_over_segment(self):
         """Sub-step jitter must not explode into a per-sample segmented coord."""
-        from dascore.core.coords import CoordSegmented
+        from dascore.core.coords import CoordSegmented  # noqa: PLC0415
 
         rng = np.random.default_rng(0)
         n = 5_000
@@ -267,7 +267,7 @@ class TestGetExactCoord:
 
     def test_piecewise_uniform_array_stays_segmented(self):
         """Genuinely piecewise-uniform arrays keep their queryable seams."""
-        from dascore.core.coords import CoordSegmented
+        from dascore.core.coords import CoordSegmented  # noqa: PLC0415
 
         values = np.concatenate([np.arange(0.0, 2_000.0), np.arange(3_000.0, 5_000.0)])
 
@@ -1470,7 +1470,7 @@ class TestIOCoreCoverageEdges:
 
     def test_directory_format_ignores_unknown_format(self, monkeypatch, tmp_path):
         """An unsupported directory is not itself a scan unit."""
-        from dascore.io.core import is_directory_format
+        from dascore.io.core import is_directory_format  # noqa: PLC0415
 
         def _raise_unknown_format(_path):
             raise UnknownFiberFormatError
@@ -1480,7 +1480,7 @@ class TestIOCoreCoverageEdges:
 
     def test_directory_format_propagates_unexpected_error(self, monkeypatch, tmp_path):
         """Unexpected format-detection failures remain visible to callers."""
-        from dascore.io.core import is_directory_format
+        from dascore.io.core import is_directory_format  # noqa: PLC0415
 
         def _raise_unexpected_error(_path):
             raise RuntimeError("format detection failed")
@@ -1491,8 +1491,8 @@ class TestIOCoreCoverageEdges:
 
     def test_numeric_singleton_without_identity_not_trusted(self):
         """A positional ID cannot resolve an anonymous trimmed singleton."""
-        from dascore.exceptions import PatchAttributeError
-        from dascore.io.core import _resolve_read_spool
+        from dascore.exceptions import PatchAttributeError  # noqa: PLC0415
+        from dascore.io.core import _resolve_read_spool  # noqa: PLC0415
 
         spool = dc.spool([dc.get_example_patch()])
         with pytest.raises(PatchAttributeError, match="uniquely resolved"):
@@ -1500,8 +1500,8 @@ class TestIOCoreCoverageEdges:
 
     def test_non_unique_patch_resolution_raises(self):
         """An unresolvable source id in a multi-patch read raises clearly."""
-        from dascore.exceptions import PatchAttributeError
-        from dascore.io.core import _select_patch_from_spool
+        from dascore.exceptions import PatchAttributeError  # noqa: PLC0415
+        from dascore.io.core import _select_patch_from_spool  # noqa: PLC0415
 
         spool = dc.spool([dc.get_example_patch(tag="a"), dc.get_example_patch(tag="b")])
         with pytest.raises(PatchAttributeError, match="uniquely resolved"):
@@ -1515,14 +1515,14 @@ class TestIOCoreCoverageEdges:
         these (see #583); the guard must fire before any identity matching,
         with or without a requested source id.
         """
-        from dascore.io.core import _select_patch_from_spool
+        from dascore.io.core import _select_patch_from_spool  # noqa: PLC0415
 
         with pytest.raises(MissingPatchError, match="No patch remained"):
             _select_patch_from_spool(dc.spool([]), source_patch_id=source_patch_id)
 
     def test_single_patch_resolved_by_name(self):
         """A one-patch read resolves when the id matches the patch name."""
-        from dascore.io.core import _select_patch_from_spool
+        from dascore.io.core import _select_patch_from_spool  # noqa: PLC0415
 
         patch = dc.get_example_patch()
         spool = dc.spool([patch])
@@ -1533,7 +1533,7 @@ class TestIOCoreCoverageEdges:
 
     def test_corrupt_file_format_detection_is_robust(self, tmp_path):
         """A reader raising during format detection is caught, not propagated."""
-        from dascore.exceptions import UnknownFiberFormatError
+        from dascore.exceptions import UnknownFiberFormatError  # noqa: PLC0415
 
         # valid HDF5 magic followed by garbage: an HDF5 reader raises while
         # probing, which format detection must swallow before giving up.

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -17,11 +17,13 @@ from upath import UPath
 
 import dascore as dc
 from dascore.config import config_context
+from dascore.core.coords import CoordSegmented
 from dascore.exceptions import (
     DependencyError,
     InvalidFiberIOError,
     MissingOptionalDependencyError,
     MissingPatchError,
+    PatchAttributeError,
     RemoteCacheError,
     UnknownFiberFormatError,
 )
@@ -31,8 +33,11 @@ from dascore.io.core import (
     _get_reloadable_source_path,
     _make_scan_payload,
     _reinit_manager_lock,
+    _resolve_read_spool,
     _scan_result_to_summary,
+    _select_patch_from_spool,
     _validate_scan_payload,
+    is_directory_format,
 )
 from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.utils import get_exact_coord
@@ -241,8 +246,6 @@ class TestGetExactCoord:
 
     def test_jittery_array_does_not_over_segment(self):
         """Sub-step jitter must not explode into a per-sample segmented coord."""
-        from dascore.core.coords import CoordSegmented  # noqa: PLC0415
-
         rng = np.random.default_rng(0)
         n = 5_000
         values = np.maximum.accumulate(
@@ -267,8 +270,6 @@ class TestGetExactCoord:
 
     def test_piecewise_uniform_array_stays_segmented(self):
         """Genuinely piecewise-uniform arrays keep their queryable seams."""
-        from dascore.core.coords import CoordSegmented  # noqa: PLC0415
-
         values = np.concatenate([np.arange(0.0, 2_000.0), np.arange(3_000.0, 5_000.0)])
 
         coord = get_exact_coord(values, units="m")
@@ -1470,7 +1471,6 @@ class TestIOCoreCoverageEdges:
 
     def test_directory_format_ignores_unknown_format(self, monkeypatch, tmp_path):
         """An unsupported directory is not itself a scan unit."""
-        from dascore.io.core import is_directory_format  # noqa: PLC0415
 
         def _raise_unknown_format(_path):
             raise UnknownFiberFormatError
@@ -1480,7 +1480,6 @@ class TestIOCoreCoverageEdges:
 
     def test_directory_format_propagates_unexpected_error(self, monkeypatch, tmp_path):
         """Unexpected format-detection failures remain visible to callers."""
-        from dascore.io.core import is_directory_format  # noqa: PLC0415
 
         def _raise_unexpected_error(_path):
             raise RuntimeError("format detection failed")
@@ -1491,18 +1490,12 @@ class TestIOCoreCoverageEdges:
 
     def test_numeric_singleton_without_identity_not_trusted(self):
         """A positional ID cannot resolve an anonymous trimmed singleton."""
-        from dascore.exceptions import PatchAttributeError  # noqa: PLC0415
-        from dascore.io.core import _resolve_read_spool  # noqa: PLC0415
-
         spool = dc.spool([dc.get_example_patch()])
         with pytest.raises(PatchAttributeError, match="uniquely resolved"):
             _resolve_read_spool(spool, source_patch_id="1")
 
     def test_non_unique_patch_resolution_raises(self):
         """An unresolvable source id in a multi-patch read raises clearly."""
-        from dascore.exceptions import PatchAttributeError  # noqa: PLC0415
-        from dascore.io.core import _select_patch_from_spool  # noqa: PLC0415
-
         spool = dc.spool([dc.get_example_patch(tag="a"), dc.get_example_patch(tag="b")])
         with pytest.raises(PatchAttributeError, match="uniquely resolved"):
             _select_patch_from_spool(spool, source_patch_id="neither-id-nor-index")
@@ -1515,15 +1508,11 @@ class TestIOCoreCoverageEdges:
         these (see #583); the guard must fire before any identity matching,
         with or without a requested source id.
         """
-        from dascore.io.core import _select_patch_from_spool  # noqa: PLC0415
-
         with pytest.raises(MissingPatchError, match="No patch remained"):
             _select_patch_from_spool(dc.spool([]), source_patch_id=source_patch_id)
 
     def test_single_patch_resolved_by_name(self):
         """A one-patch read resolves when the id matches the patch name."""
-        from dascore.io.core import _select_patch_from_spool  # noqa: PLC0415
-
         patch = dc.get_example_patch()
         spool = dc.spool([patch])
         resolved = _select_patch_from_spool(
@@ -1533,8 +1522,6 @@ class TestIOCoreCoverageEdges:
 
     def test_corrupt_file_format_detection_is_robust(self, tmp_path):
         """A reader raising during format detection is caught, not propagated."""
-        from dascore.exceptions import UnknownFiberFormatError  # noqa: PLC0415
-
         # valid HDF5 magic followed by garbage: an HDF5 reader raises while
         # probing, which format detection must swallow before giving up.
         bad = tmp_path / "bad.h5"

--- a/tests/test_io/test_mseed/test_mseed.py
+++ b/tests/test_io/test_mseed/test_mseed.py
@@ -8,9 +8,11 @@ import numpy as np
 import pytest
 
 import dascore as dc
+import dascore.io.mseed.core as mseed_core
 from dascore.exceptions import MissingOptionalDependencyError
 from dascore.io.mseed import utils as mseed_utils
 from dascore.io.mseed.core import MSeedV2
+from dascore.utils.downloader import fetch
 from tests.test_io._common_io_test_utils import skip_timeout
 
 
@@ -188,7 +190,6 @@ class TestMiniSeedGetFormat:
 
     def test_get_format_without_pymseed(self, tmp_path, monkeypatch):
         """MiniSEED headers can be detected without PyMseed installed."""
-        import dascore.io.mseed.core as mseed_core  # noqa: PLC0415
 
         def _optional_import(*args, **kwargs):
             raise MissingOptionalDependencyError("missing")
@@ -498,7 +499,6 @@ class TestMiniSeedScan:
 
     def test_missing_pymseed_raises(self, mseed_v3_path, monkeypatch):
         """Explicit MiniSEED reads require PyMseed."""
-        import dascore.io.mseed.core as mseed_core  # noqa: PLC0415
 
         def _optional_import(*args, **kwargs):
             raise MissingOptionalDependencyError("missing")
@@ -745,7 +745,6 @@ class TestRealMiniSeed:
     def test_read_das_station_channels(self):
         """Etna DAS station-coded channels preserve their full sample counts."""
         pytest.importorskip("pymseed")
-        from dascore.utils.downloader import fetch  # noqa: PLC0415
 
         with skip_timeout():
             path = fetch("etna_9n_3chan_10s.mseed")

--- a/tests/test_io/test_mseed/test_mseed.py
+++ b/tests/test_io/test_mseed/test_mseed.py
@@ -188,7 +188,7 @@ class TestMiniSeedGetFormat:
 
     def test_get_format_without_pymseed(self, tmp_path, monkeypatch):
         """MiniSEED headers can be detected without PyMseed installed."""
-        import dascore.io.mseed.core as mseed_core
+        import dascore.io.mseed.core as mseed_core  # noqa: PLC0415
 
         def _optional_import(*args, **kwargs):
             raise MissingOptionalDependencyError("missing")
@@ -498,7 +498,7 @@ class TestMiniSeedScan:
 
     def test_missing_pymseed_raises(self, mseed_v3_path, monkeypatch):
         """Explicit MiniSEED reads require PyMseed."""
-        import dascore.io.mseed.core as mseed_core
+        import dascore.io.mseed.core as mseed_core  # noqa: PLC0415
 
         def _optional_import(*args, **kwargs):
             raise MissingOptionalDependencyError("missing")
@@ -745,7 +745,7 @@ class TestRealMiniSeed:
     def test_read_das_station_channels(self):
         """Etna DAS station-coded channels preserve their full sample counts."""
         pytest.importorskip("pymseed")
-        from dascore.utils.downloader import fetch
+        from dascore.utils.downloader import fetch  # noqa: PLC0415
 
         with skip_timeout():
             path = fetch("etna_9n_3chan_10s.mseed")

--- a/tests/test_io/test_netcdf/test_netcdf.py
+++ b/tests/test_io/test_netcdf/test_netcdf.py
@@ -526,9 +526,9 @@ class TestNetCDFIO:
     def test_remote_stream_no_download(self, example_patch, netcdf_path):
         """Remote NetCDF should stream via h5netcdf, not download to the cache."""
         pytest.importorskip("h5netcdf")
-        from upath import UPath
+        from upath import UPath  # noqa: PLC0415
 
-        from dascore.utils.remote_io import (
+        from dascore.utils.remote_io import (  # noqa: PLC0415
             clear_remote_file_cache,
             get_remote_cache_path,
         )
@@ -562,7 +562,7 @@ class TestNetCDFIO:
         self, minimal_cf_netcdf_path, monkeypatch
     ):
         """Format detection should not depend on xarray being importable."""
-        import importlib
+        import importlib  # noqa: PLC0415
 
         original_import_module = importlib.import_module
 

--- a/tests/test_io/test_netcdf/test_netcdf.py
+++ b/tests/test_io/test_netcdf/test_netcdf.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 from typing import ClassVar
 
 import h5py
 import numpy as np
 import pytest
+from upath import UPath
 
 import dascore as dc
 from dascore.io.netcdf import core as netcdf_core
@@ -17,6 +19,10 @@ from dascore.io.netcdf.utils import (
     is_netcdf4_file,
 )
 from dascore.utils.downloader import fetch
+from dascore.utils.remote_io import (
+    clear_remote_file_cache,
+    get_remote_cache_path,
+)
 
 pytest.importorskip("xarray")
 
@@ -526,12 +532,6 @@ class TestNetCDFIO:
     def test_remote_stream_no_download(self, example_patch, netcdf_path):
         """Remote NetCDF should stream via h5netcdf, not download to the cache."""
         pytest.importorskip("h5netcdf")
-        from upath import UPath  # noqa: PLC0415
-
-        from dascore.utils.remote_io import (  # noqa: PLC0415
-            clear_remote_file_cache,
-            get_remote_cache_path,
-        )
 
         # Publish the file onto a non-local (memory) filesystem.
         remote = UPath("memory://netcdf_stream_test/remote.nc")
@@ -562,8 +562,6 @@ class TestNetCDFIO:
         self, minimal_cf_netcdf_path, monkeypatch
     ):
         """Format detection should not depend on xarray being importable."""
-        import importlib  # noqa: PLC0415
-
         original_import_module = importlib.import_module
 
         def _import_module(name, package=None):

--- a/tests/test_io/test_sintela/test_protobuf.py
+++ b/tests/test_io/test_sintela/test_protobuf.py
@@ -85,7 +85,7 @@ def _build_meta_payload_without_fiber_id():
 
 def _payload_to_summary(payload):
     """Convert a raw FiberIO scan payload using the production scan path."""
-    from dascore.io.core import _scan_payload_to_summary
+    from dascore.io.core import _scan_payload_to_summary  # noqa: PLC0415
 
     return _scan_payload_to_summary(payload)
 

--- a/tests/test_io/test_sintela/test_protobuf.py
+++ b/tests/test_io/test_sintela/test_protobuf.py
@@ -14,6 +14,7 @@ import pytest
 
 import dascore as dc
 from dascore.exceptions import InvalidFiberFileError, MissingOptionalDependencyError
+from dascore.io.core import _scan_payload_to_summary
 from dascore.io.sintela import SintelaProtobufV1
 from dascore.io.sintela import protobuf_utils as sintela_utils
 from dascore.units import get_quantity
@@ -85,8 +86,6 @@ def _build_meta_payload_without_fiber_id():
 
 def _payload_to_summary(payload):
     """Convert a raw FiberIO scan payload using the production scan path."""
-    from dascore.io.core import _scan_payload_to_summary  # noqa: PLC0415
-
     return _scan_payload_to_summary(payload)
 
 

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import io
 import struct
 
@@ -52,7 +53,6 @@ class TestTDMSUtils:
         """Test that parse_time_stamp works with valid input."""
         # Test with valid timestamp - using a reasonable epoch timestamp
         # LabVIEW epoch starts at 1904-01-01, so we need a positive value
-        import datetime  # noqa: PLC0415
 
         # Use a timestamp that represents a valid date after 1904
         seconds = 365 * 24 * 3600 * 100  # 100 years after 1904

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -52,7 +52,7 @@ class TestTDMSUtils:
         """Test that parse_time_stamp works with valid input."""
         # Test with valid timestamp - using a reasonable epoch timestamp
         # LabVIEW epoch starts at 1904-01-01, so we need a positive value
-        import datetime
+        import datetime  # noqa: PLC0415
 
         # Use a timestamp that represents a valid date after 1904
         seconds = 365 * 24 * 3600 * 100  # 100 years after 1904

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -92,7 +92,7 @@ class TestTerra15:
 
     def test_unsupported_version_error(self):
         """Test that unsupported Terra15 version raises NotImplementedError."""
-        from dascore.io.terra15.utils import _get_version_data_node
+        from dascore.io.terra15.utils import _get_version_data_node  # noqa: PLC0415
 
         # Create a mock HDF5 root object with unsupported version
         class MockRoot:

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -12,6 +12,7 @@ import pytest
 
 import dascore as dc
 from dascore.io.terra15 import Terra15FormatterV4
+from dascore.io.terra15.utils import _get_version_data_node
 
 
 class TestTerra15:
@@ -92,7 +93,6 @@ class TestTerra15:
 
     def test_unsupported_version_error(self):
         """Test that unsupported Terra15 version raises NotImplementedError."""
-        from dascore.io.terra15.utils import _get_version_data_node  # noqa: PLC0415
 
         # Create a mock HDF5 root object with unsupported version
         class MockRoot:

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -129,7 +129,7 @@ class TestWhiten:
         patch = get_example_patch("sin_wav", frequency=100, sample_rate=500)
         dft_pre = patch.dft("time", real=True)
 
-        import dascore as dc
+        import dascore as dc  # noqa: PLC0415
 
         dc._bob = True
 

--- a/tests/test_proc/test_whiten.py
+++ b/tests/test_proc/test_whiten.py
@@ -129,8 +129,6 @@ class TestWhiten:
         patch = get_example_patch("sin_wav", frequency=100, sample_rate=500)
         dft_pre = patch.dft("time", real=True)
 
-        import dascore as dc  # noqa: PLC0415
-
         dc._bob = True
 
         white_patch = patch.whiten(smooth_size=5, time=[80, 120])

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -7,12 +7,16 @@ import pint
 import pytest
 
 import dascore as dc
+import dascore.units
 import dascore.units as units_module
+from dascore import units
 from dascore.exceptions import UnitError
 from dascore.units import (
+    Hz,
     Quantity,
     assert_dtype_compatible_with_units,
     convert_units,
+    ft,
     get_byte_count,
     get_factor_and_unit,
     get_filter_units,
@@ -21,7 +25,10 @@ from dascore.units import (
     get_unit,
     invert_quantity,
     is_data_size,
+    km,
+    m,
     maybe_convert_percent_to_fraction,
+    miles,
     quant_sequence_to_quant_array,
 )
 from dascore.utils.time import to_float
@@ -32,7 +39,6 @@ class TestUnitInit:
 
     def test_stale_pint_cache_falls_back(self, monkeypatch):
         """Stale Pint disk cache should not prevent registry creation."""
-        from dascore import units  # noqa: PLC0415
 
         class FakeRegistry:
             pass
@@ -213,8 +219,6 @@ class TestConvenientImport:
 
     def test_import_common(self):
         """Ensure common units are importable."""
-        from dascore.units import Hz, ft, km, m, miles  # noqa: PLC0415
-
         assert m == get_quantity("m")
         assert ft == get_quantity("ft")
         assert miles == get_quantity("miles")
@@ -228,8 +232,6 @@ class TestConvenientImport:
 
     def test_empty_name_raises(self):
         """The empty string is the one name get_quantity maps to None."""
-        import dascore.units  # noqa: PLC0415
-
         with pytest.raises(AttributeError):
             getattr(dascore.units, "")
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -32,7 +32,7 @@ class TestUnitInit:
 
     def test_stale_pint_cache_falls_back(self, monkeypatch):
         """Stale Pint disk cache should not prevent registry creation."""
-        from dascore import units
+        from dascore import units  # noqa: PLC0415
 
         class FakeRegistry:
             pass
@@ -213,7 +213,7 @@ class TestConvenientImport:
 
     def test_import_common(self):
         """Ensure common units are importable."""
-        from dascore.units import Hz, ft, km, m, miles
+        from dascore.units import Hz, ft, km, m, miles  # noqa: PLC0415
 
         assert m == get_quantity("m")
         assert ft == get_quantity("ft")
@@ -228,7 +228,7 @@ class TestConvenientImport:
 
     def test_empty_name_raises(self):
         """The empty string is the one name get_quantity maps to None."""
-        import dascore.units
+        import dascore.units  # noqa: PLC0415
 
         with pytest.raises(AttributeError):
             getattr(dascore.units, "")

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -16,6 +16,7 @@ from dascore.exceptions import ParameterError, UnitError
 from dascore.units import furlongs, m, s
 from dascore.utils.array import (
     PatchUFunc,
+    _BoundPatchUFunc,
     apply_array_func,
     apply_ufunc,
     convert_bytes_to_strings,
@@ -521,7 +522,6 @@ class TestStringArrayHelpers:
         bound_once = ufunc.__get__(random_patch, type(random_patch))
 
         # Verify the bound instance is a _BoundPatchUFunc
-        from dascore.utils.array import _BoundPatchUFunc  # noqa: PLC0415
 
         assert isinstance(bound_once, _BoundPatchUFunc)
 
@@ -538,8 +538,6 @@ class TestStringArrayHelpers:
 
     def test_patch_ufunc_class_properties(self, random_patch):
         """Test _BoundPatchUFunc class has proper attributes."""
-        from dascore.utils.array import _BoundPatchUFunc  # noqa: PLC0415
-
         ufunc = PatchUFunc(np.multiply)
         bound_ufunc = ufunc.__get__(random_patch, type(random_patch))
 

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -521,7 +521,7 @@ class TestStringArrayHelpers:
         bound_once = ufunc.__get__(random_patch, type(random_patch))
 
         # Verify the bound instance is a _BoundPatchUFunc
-        from dascore.utils.array import _BoundPatchUFunc
+        from dascore.utils.array import _BoundPatchUFunc  # noqa: PLC0415
 
         assert isinstance(bound_once, _BoundPatchUFunc)
 
@@ -538,7 +538,7 @@ class TestStringArrayHelpers:
 
     def test_patch_ufunc_class_properties(self, random_patch):
         """Test _BoundPatchUFunc class has proper attributes."""
-        from dascore.utils.array import _BoundPatchUFunc
+        from dascore.utils.array import _BoundPatchUFunc  # noqa: PLC0415
 
         ufunc = PatchUFunc(np.multiply)
         bound_ufunc = ufunc.__get__(random_patch, type(random_patch))

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
 import pytest
 
@@ -218,8 +219,6 @@ class TestMapConfigBinding:
     @pytest.mark.concurrency
     def test_thread_pool_sees_call_time_config(self):
         """A thread-pool map sees the caller's scoped override."""
-        from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
-
         spool = dc.get_example_spool()
         with config_context(display_float_precision=8):
             with ThreadPoolExecutor(2) as executor:
@@ -229,8 +228,6 @@ class TestMapConfigBinding:
     @pytest.mark.concurrency
     def test_process_pool_sees_call_time_config(self):
         """A process-pool map sees the caller's scoped override too."""
-        from concurrent.futures import ProcessPoolExecutor  # noqa: PLC0415
-
         spool = dc.get_example_spool()
         with config_context(display_float_precision=8):
             with ProcessPoolExecutor(2) as executor:

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -218,7 +218,7 @@ class TestMapConfigBinding:
     @pytest.mark.concurrency
     def test_thread_pool_sees_call_time_config(self):
         """A thread-pool map sees the caller's scoped override."""
-        from concurrent.futures import ThreadPoolExecutor
+        from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
 
         spool = dc.get_example_spool()
         with config_context(display_float_precision=8):
@@ -229,7 +229,7 @@ class TestMapConfigBinding:
     @pytest.mark.concurrency
     def test_process_pool_sees_call_time_config(self):
         """A process-pool map sees the caller's scoped override too."""
-        from concurrent.futures import ProcessPoolExecutor
+        from concurrent.futures import ProcessPoolExecutor  # noqa: PLC0415
 
         spool = dc.get_example_spool()
         with config_context(display_float_precision=8):

--- a/tests/test_utils/test_coordmanager_utils.py
+++ b/tests/test_utils/test_coordmanager_utils.py
@@ -172,10 +172,10 @@ class TestRawMergeKeepsUnits:
 
     def test_units_survive_value_merge(self):
         """Merging value-backed coords with one common unit keeps it."""
-        import numpy as np
+        import numpy as np  # noqa: PLC0415
 
-        import dascore as dc
-        from dascore.utils.coordmanager import merge_coord_managers
+        import dascore as dc  # noqa: PLC0415
+        from dascore.utils.coordmanager import merge_coord_managers  # noqa: PLC0415
 
         p1 = dc.get_example_patch().set_units(distance="m")
         d = p1.get_coord("distance")

--- a/tests/test_utils/test_coordmanager_utils.py
+++ b/tests/test_utils/test_coordmanager_utils.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+import dascore as dc
 from dascore.core.coords import CoordArray, CoordMonotonicArray, CoordRange
 from dascore.exceptions import CoordMergeError
 from dascore.utils.coordmanager import merge_coord_managers
@@ -172,11 +173,6 @@ class TestRawMergeKeepsUnits:
 
     def test_units_survive_value_merge(self):
         """Merging value-backed coords with one common unit keeps it."""
-        import numpy as np  # noqa: PLC0415
-
-        import dascore as dc  # noqa: PLC0415
-        from dascore.utils.coordmanager import merge_coord_managers  # noqa: PLC0415
-
         p1 = dc.get_example_patch().set_units(distance="m")
         d = p1.get_coord("distance")
         # non-uniform values force the raw concatenation path

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -132,7 +132,7 @@ class TestGetPluginTable:
 
     def test_empty_registry_returns_empty_dataframe(self, monkeypatch, tmp_path):
         """An empty registry directory returns a DataFrame with the correct columns."""
-        import dascore.utils.namespace as ns_module
+        import dascore.utils.namespace as ns_module  # noqa: PLC0415
 
         monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
         df = get_plugin_table()

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -7,6 +7,7 @@ import textwrap
 import pandas as pd
 import pytest
 
+import dascore.utils.namespace as ns_module
 from dascore.core.attrs import PatchAttrs
 from dascore.examples import EXAMPLE_PATCHES
 from dascore.utils.docs import (
@@ -132,8 +133,6 @@ class TestGetPluginTable:
 
     def test_empty_registry_returns_empty_dataframe(self, monkeypatch, tmp_path):
         """An empty registry directory returns a DataFrame with the correct columns."""
-        import dascore.utils.namespace as ns_module  # noqa: PLC0415
-
         monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
         df = get_plugin_table()
         assert list(df.columns) == ["namespace", "package_name", "package_url"]

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -1132,7 +1132,7 @@ class TestXarray:
 
     def test_convert_to_xarray(self, data_array_from_patch):
         """Tests for converting to xarray object."""
-        import xarray as xr
+        import xarray as xr  # noqa: PLC0415
 
         assert isinstance(data_array_from_patch, xr.DataArray)
 
@@ -1174,7 +1174,7 @@ class TestObsPy:
 
     def test_convert_to_obspy(self, stream_from_patch):
         """Ensure a patch can be converted to a stream."""
-        import obspy
+        import obspy  # noqa: PLC0415
 
         assert isinstance(stream_from_patch, obspy.Stream)
 

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -423,7 +423,7 @@ class TestOptionalImport:
 
     def test_import_installed_module(self):
         """Test to ensure an installed module imports."""
-        import dascore as dc
+        import dascore as dc  # noqa: PLC0415
 
         mod = optional_import("dascore")
         assert mod is dc

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -423,8 +423,6 @@ class TestOptionalImport:
 
     def test_import_installed_module(self):
         """Test to ensure an installed module imports."""
-        import dascore as dc  # noqa: PLC0415
-
         mod = optional_import("dascore")
         assert mod is dc
         sub_mod = optional_import("dascore.core")

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -278,7 +278,7 @@ class TestHistory:
         """
         Ensure patch arguments are truncated in history (issue #529).
         """
-        from dascore.utils.patch import patch_function
+        from dascore.utils.patch import patch_function  # noqa: PLC0415
 
         @patch_function()
         def func_with_patch_arg(patch, other_patch):
@@ -844,7 +844,7 @@ class TestGetPatchName:
         The docs renderer resolves annotations at runtime and falls back to
         raw strings for the whole signature if any name is undefined.
         """
-        from typing import get_type_hints
+        from typing import get_type_hints  # noqa: PLC0415
 
         assert get_type_hints(get_patch_names)
 
@@ -1150,7 +1150,7 @@ class TestForcePatchMergeOverlap:
 
     def test_complete_overlap_keeps_first(self, random_patch):
         """Identical envelopes merge to the first patch."""
-        from dascore.utils.patch import _force_patch_merge
+        from dascore.utils.patch import _force_patch_merge  # noqa: PLC0415
 
         twin = random_patch.new()
         infos = []

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, get_type_hints
 
 import numpy as np
 import pandas as pd
@@ -11,7 +11,6 @@ import pytest
 from pydantic import Field
 
 import dascore as dc
-from dascore import patch_function
 from dascore.config import config_context
 from dascore.constants import PatchType
 from dascore.exceptions import (
@@ -24,6 +23,7 @@ from dascore.exceptions import (
 from dascore.units import percent
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch import (
+    _force_patch_merge,
     _spool_up,
     align_patch_coords,
     concatenate_patches,
@@ -33,6 +33,7 @@ from dascore.utils.patch import (
     get_window_axis_step,
     merge_compatible_coords_attrs,
     merge_patches,
+    patch_function,
     patches_to_df,
     stack_patches,
     swap_kwargs_dim_to_axis,
@@ -278,7 +279,6 @@ class TestHistory:
         """
         Ensure patch arguments are truncated in history (issue #529).
         """
-        from dascore.utils.patch import patch_function  # noqa: PLC0415
 
         @patch_function()
         def func_with_patch_arg(patch, other_patch):
@@ -844,8 +844,6 @@ class TestGetPatchName:
         The docs renderer resolves annotations at runtime and falls back to
         raw strings for the whole signature if any name is undefined.
         """
-        from typing import get_type_hints  # noqa: PLC0415
-
         assert get_type_hints(get_patch_names)
 
     def test_name_column_exists(self, random_spool):
@@ -1150,8 +1148,6 @@ class TestForcePatchMergeOverlap:
 
     def test_complete_overlap_keeps_first(self, random_patch):
         """Identical envelopes merge to the first patch."""
-        from dascore.utils.patch import _force_patch_merge  # noqa: PLC0415
-
         twin = random_patch.new()
         infos = []
         for patch in (random_patch, twin):

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -8,7 +8,7 @@ import pydantic
 import pytest
 
 import dascore as dc
-from dascore.exceptions import ParameterError
+from dascore.exceptions import InvalidSpoolQueryError, ParameterError
 from dascore.utils.pd import (
     _model_list_to_df,
     adjust_segments,
@@ -18,6 +18,7 @@ from dascore.utils.pd import (
     get_interval_columns,
     list_ser_to_str,
     patch_to_dataframe,
+    relative_ranges_to_absolute,
 )
 from dascore.utils.time import to_datetime64, to_timedelta64
 
@@ -553,18 +554,12 @@ class TestRelativeRangesToAbsolute:
 
     def test_missing_max_column_raises_spool_error(self):
         """A frame with the min but not the max column raises the doc'd error."""
-        from dascore.exceptions import InvalidSpoolQueryError  # noqa: PLC0415
-        from dascore.utils.pd import relative_ranges_to_absolute  # noqa: PLC0415
-
         df = pd.DataFrame({"time_min": [0.0]})  # no time_max
         with pytest.raises(InvalidSpoolQueryError, match="relative select"):
             relative_ranges_to_absolute(df, {"time": (1, -1)})
 
     def test_non_tuple_value_raises(self):
         """A non-(start, stop) relative value raises rather than mis-resolving."""
-        from dascore.exceptions import InvalidSpoolQueryError  # noqa: PLC0415
-        from dascore.utils.pd import relative_ranges_to_absolute  # noqa: PLC0415
-
         df = pd.DataFrame({"time_min": [0.0], "time_max": [1.0]})
         with pytest.raises(InvalidSpoolQueryError, match="range selectors"):
             relative_ranges_to_absolute(df, {"time": 5})

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -553,8 +553,8 @@ class TestRelativeRangesToAbsolute:
 
     def test_missing_max_column_raises_spool_error(self):
         """A frame with the min but not the max column raises the doc'd error."""
-        from dascore.exceptions import InvalidSpoolQueryError
-        from dascore.utils.pd import relative_ranges_to_absolute
+        from dascore.exceptions import InvalidSpoolQueryError  # noqa: PLC0415
+        from dascore.utils.pd import relative_ranges_to_absolute  # noqa: PLC0415
 
         df = pd.DataFrame({"time_min": [0.0]})  # no time_max
         with pytest.raises(InvalidSpoolQueryError, match="relative select"):
@@ -562,8 +562,8 @@ class TestRelativeRangesToAbsolute:
 
     def test_non_tuple_value_raises(self):
         """A non-(start, stop) relative value raises rather than mis-resolving."""
-        from dascore.exceptions import InvalidSpoolQueryError
-        from dascore.utils.pd import relative_ranges_to_absolute
+        from dascore.exceptions import InvalidSpoolQueryError  # noqa: PLC0415
+        from dascore.utils.pd import relative_ranges_to_absolute  # noqa: PLC0415
 
         df = pd.DataFrame({"time_min": [0.0], "time_max": [1.0]})
         with pytest.raises(InvalidSpoolQueryError, match="range selectors"):

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -392,7 +392,7 @@ class TestWaterfall:
 
     def test_percent_scale(self, random_patch):
         """Ensure the percent unit works with scale."""
-        from dascore.units import percent
+        from dascore.units import percent  # noqa: PLC0415
 
         ax = random_patch.viz.waterfall(scale=10 * percent, scale_type="absolute")
         assert ax is not None

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -10,7 +10,7 @@ from matplotlib.image import AxesImage
 
 import dascore as dc
 from dascore.exceptions import ParameterError
-from dascore.units import get_quantity_str
+from dascore.units import get_quantity_str, percent
 from dascore.utils.time import is_datetime64, to_timedelta64
 
 
@@ -392,8 +392,6 @@ class TestWaterfall:
 
     def test_percent_scale(self, random_patch):
         """Ensure the percent unit works with scale."""
-        from dascore.units import percent  # noqa: PLC0415
-
         ax = random_patch.viz.waterfall(scale=10 * percent, scale_type="absolute")
         assert ax is not None
 


### PR DESCRIPTION
## Description

Function-level imports were invisible to lint: E402 only covers module-level imports that appear after other top-level statements, and the pylint (`PL`) rules were not selected, so ruff never ran PLC0415 (`import-outside-top-level`).

This enables PLC0415 in `lint.select` and marks the existing sites with `# noqa: PLC0415` directives, inserted mechanically with `ruff check --add-noqa` (45 in `dascore/`, mostly circular-import avoidance; 204 in `tests/`; 1 in `scripts/`). Three long import lines were re-wrapped by the ruff hook to stay under the line length; there are no semantic changes. New function-level imports now require an explicit opt-out, and the existing directives are visible debt that can be hoisted or kept deliberately over time.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests (lint-config and comment-only change; enforced by the existing pre-commit CI job).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized import organization throughout the application and test suite.
  * Reduced repeated in-function imports while preserving existing behavior and public APIs.

* **Chores**
  * Expanded linting rules to detect imports inside functions.
  * Added targeted lint exceptions where deferred imports remain necessary.

* **Tests**
  * Consolidated test dependencies without changing test coverage or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->