### PR TITLE
Fix ty diagnostics from the crossed #833/#845 merges

### DIFF
--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -644,7 +644,11 @@ def _output_dtypes(sub: pd.DataFrame, members: pd.DataFrame) -> pd.Series | None
         return None
     by_patch = sub.drop_duplicates("_patch_id").set_index("_patch_id")["_dtype"]
     grouped = members.groupby("output_id")["_patch_id"]
-    dtypes = grouped.apply(lambda pids: _combined_dtype(by_patch.reindex(pids)))
+    # A scalar-returning apply on a SeriesGroupBy is always a Series; the
+    # stubs cannot see through the lambda and claim DataFrame | Series.
+    dtypes: pd.Series = grouped.apply(  # ty: ignore[invalid-assignment]
+        lambda pids: _combined_dtype(by_patch.reindex(pids))
+    )
     # "" is the same not-known sentinel ingest writes; never leave NaN,
     # which would reach the derived catalog as the string "nan".
     return dtypes.map(lambda x: "" if x is None else str(x))
@@ -901,6 +905,9 @@ def build_chunk_plan(
         out_frames.append(outputs)
         member_frames.append(members)
     if size_diagnostics:
+        # Diagnostics are only collected on the size-chunk path, where the
+        # chunk value is an information Quantity (is_data_size gated).
+        assert isinstance(value, Quantity)
         params["size"] = {
             "requested_bytes": get_byte_count(value),
             "partitions": tuple(size_diagnostics),


### PR DESCRIPTION
## Description

dev's lint job is currently broken: #833 (chunk-by-size) and #845 (ty-api-audit) each passed CI against pre-merge dev, but their combination fails `pre-commit run ty` with two diagnostics in `dascore/utils/chunk_plan.py`. Every open PR now fails lint on its merge ref until this lands, so this is a small unblock:

- `get_byte_count(value)` in the size-diagnostics block: `value` can be `None` in merge mode, but diagnostics are only collected on the size-chunk path where it is an information `Quantity` — narrowed with an assert.
- `_output_dtypes`: a scalar-returning `apply` on a `SeriesGroupBy` is always a `Series`, but the stubs claim `DataFrame | Series` — pinned with an annotated assignment and a `ty: ignore[invalid-assignment]` at the origin.

No behavioral changes.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests (covered by the existing chunk/spool suites; `tests/test_core/test_patch_chunk.py` and `test_spool.py` pass locally).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.