### PR TITLE
Don't import numba when dascore is imported

### DIFF
--- a/dascore/transform/_kurtosis_kernels.py
+++ b/dascore/transform/_kurtosis_kernels.py
@@ -1,0 +1,102 @@
+"""
+Numba kernels for the kurtosis transform.
+
+These live apart from `dascore.transform.kurtosis` because decorating with
+`maybe_numba_jit` imports numba, which is slow. `kurtosis` imports this module
+when it is called so `import dascore` stays fast.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from dascore.utils.jit import maybe_numba_jit
+
+
+@maybe_numba_jit
+def _moving_sum(x: np.ndarray, nwin: int):
+    """Moving sum along axis 0 using clipped centered windows."""
+    npts = x.shape[0]
+    left = nwin // 2
+    right = nwin - left
+
+    out = np.empty_like(x, dtype=np.float64)
+    counts = np.empty(npts, dtype=np.float64)
+
+    for i in range(npts):
+        start = max(i - left, 0)
+        stop = min(i + right, npts)
+        counts[i] = stop - start
+
+        for j in range(x.shape[1]):
+            out[i, j] = np.sum(x[start:stop, j])
+
+    return out, counts
+
+
+@maybe_numba_jit
+def _windowed_kurtosis(data: np.ndarray, nwin: int) -> np.ndarray:
+    """Compute Pearson kurtosis in moving windows along axis 0."""
+    s1, counts = _moving_sum(data, nwin)
+    s2, _ = _moving_sum(data**2, nwin)
+    s3, _ = _moving_sum(data**3, nwin)
+    s4, _ = _moving_sum(data**4, nwin)
+
+    out = np.empty_like(data, dtype=np.float64)
+
+    for i in range(data.shape[0]):
+        for j in range(data.shape[1]):
+            count = counts[i]
+
+            m1 = s1[i, j] / count
+            m2 = s2[i, j] / count
+            m3 = s3[i, j] / count
+            m4 = s4[i, j] / count
+
+            mu2 = m2 - m1**2
+            mu4 = m4 - 4 * m1 * m3 + 6 * m1**2 * m2 - 3 * m1**4
+
+            if mu2 > 0:
+                out[i, j] = mu4 / mu2**2
+            else:
+                out[i, j] = np.nan
+
+    return out
+
+
+@maybe_numba_jit
+def _recursive_kurtosis(
+    data: np.ndarray, step: float, winlen: float, varx: np.ndarray
+) -> np.ndarray:
+    """Recursive pseudo-kurtosis after Langet et al.-style formulation."""
+    c = 1.0 - step / winlen
+    npts = data.shape[0]
+    nchans = data.shape[1]
+
+    out = np.empty_like(data, dtype=np.float64)
+    mean_value = np.zeros(nchans, dtype=np.float64)
+    var_value = np.zeros(nchans, dtype=np.float64)
+    kurt_value = np.zeros(nchans, dtype=np.float64)
+
+    for i in range(npts):
+        for j in range(nchans):
+            xi = data[i, j]
+
+            mean_value[j] = c * mean_value[j] + (1.0 - c) * xi
+            var_value[j] = c * var_value[j] + (1.0 - c) * (xi - mean_value[j]) ** 2
+
+            if var_value[j] > varx[j]:
+                norm_factor = var_value[j] ** 2
+            else:
+                norm_factor = varx[j] ** 2
+
+            if norm_factor > 0:
+                kurt_value[j] = (
+                    c * kurt_value[j]
+                    + (1.0 - c) * (xi - mean_value[j]) ** 4 / norm_factor
+                )
+            else:
+                kurt_value[j] = np.nan
+            out[i, j] = kurt_value[j]
+
+    return out

--- a/dascore/transform/_taup_kernels.py
+++ b/dascore/transform/_taup_kernels.py
@@ -1,0 +1,75 @@
+"""
+Numba kernels for the tau-p transform.
+
+These live apart from `dascore.transform.taup` because decorating with
+`maybe_numba_jit` imports numba, which is slow. `tau_p` imports this module
+when it is called so `import dascore` stays fast.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from dascore.utils.jit import maybe_numba_jit
+
+
+@maybe_numba_jit(nopython=True)
+def _jit_taup_uniform(data, dx, dt, p_vals):
+    """
+    A numba version of uniform Tau-P transform.
+
+    See [`tau_p`](`dascore.transform.taup.tau_p`) for details.
+    """
+    (nx, nt) = data.shape
+    n_slo = p_vals.size
+    two_sided_p_vals = np.concatenate((-np.flip(p_vals), p_vals))
+    taup = np.zeros(shape=(2 * n_slo, nt))
+
+    for ip in numba.prange(n_slo):  # noqa  # ty: ignore[unresolved-reference]
+        pdx = p_vals[ip] * dx
+        for tau in range(nt):
+            for ix in range(nx):
+                samp_val = tau + pdx * ix / dt
+                ind = int(samp_val)
+                if ind + 1 < nt:
+                    taup[ip + n_slo, tau] += (1.0 + ind - samp_val) * data[ix, ind] + (
+                        samp_val - ind
+                    ) * data[ix, ind + 1]
+                    taup[n_slo - 1 - ip, tau] += (1.0 + ind - samp_val) * data[
+                        nx - 1 - ix, ind
+                    ] + (samp_val - ind) * data[nx - 1 - ix, ind + 1]
+    return two_sided_p_vals, taup
+
+
+@maybe_numba_jit(nopython=True)
+def _jit_taup_general(data, distance, dt, p_vals):
+    """
+    A numba version of general Tau-P transform.
+
+    See [`tau_p`](`dascore.transform.taup.tau_p`) for details.
+    """
+    (nx, nt) = data.shape
+    n_slo = p_vals.size
+    two_sided_p_vals = np.concatenate((-np.flip(p_vals), p_vals))
+    taup = np.zeros(shape=(2 * n_slo, nt))
+    mod_distance = distance - distance[0]
+
+    for ip in numba.prange(n_slo):  # noqa  # ty: ignore[unresolved-reference]
+        p = p_vals[ip]
+        for tau in range(nt):
+            for ix in range(nx):
+                samp_val_pos = tau + p * mod_distance[ix] / dt
+                ind_pos = int(samp_val_pos)
+                samp_val_neg = (
+                    tau + p * (mod_distance[-1] - mod_distance[nx - 1 - ix]) / dt
+                )
+                ind_neg = int(samp_val_pos)
+                if ind_pos + 1 < nt:
+                    taup[ip + n_slo, tau] += (1.0 + ind_pos - samp_val_pos) * data[
+                        ix, ind_pos
+                    ] + (samp_val_pos - ind_pos) * data[ix, ind_pos + 1]
+                if ind_neg + 1 < nt:
+                    taup[n_slo - 1 - ip, tau] += (1.0 + ind_neg - samp_val_neg) * data[
+                        nx - 1 - ix, ind_neg
+                    ] + (samp_val_neg - ind_neg) * data[nx - 1 - ix, ind_neg + 1]
+    return two_sided_p_vals, taup

--- a/dascore/transform/kurtosis.py
+++ b/dascore/transform/kurtosis.py
@@ -9,7 +9,6 @@ import numpy as np
 from dascore.constants import PatchType, samples_arg_description
 from dascore.exceptions import ParameterError
 from dascore.utils.docs import compose_docstring
-from dascore.utils.jit import maybe_numba_jit
 from dascore.utils.patch import get_dim_axis_value, patch_function
 from dascore.utils.time import to_float
 
@@ -27,95 +26,6 @@ def _get_window_samples(coord, dim, value, samples: bool) -> int:
         )
         raise ParameterError(msg)
     return nwin
-
-
-@maybe_numba_jit
-def _moving_sum(x: np.ndarray, nwin: int):
-    """Moving sum along axis 0 using clipped centered windows."""
-    npts = x.shape[0]
-    left = nwin // 2
-    right = nwin - left
-
-    out = np.empty_like(x, dtype=np.float64)
-    counts = np.empty(npts, dtype=np.float64)
-
-    for i in range(npts):
-        start = max(i - left, 0)
-        stop = min(i + right, npts)
-        counts[i] = stop - start
-
-        for j in range(x.shape[1]):
-            out[i, j] = np.sum(x[start:stop, j])
-
-    return out, counts
-
-
-@maybe_numba_jit
-def _windowed_kurtosis(data: np.ndarray, nwin: int) -> np.ndarray:
-    """Compute Pearson kurtosis in moving windows along axis 0."""
-    s1, counts = _moving_sum(data, nwin)
-    s2, _ = _moving_sum(data**2, nwin)
-    s3, _ = _moving_sum(data**3, nwin)
-    s4, _ = _moving_sum(data**4, nwin)
-
-    out = np.empty_like(data, dtype=np.float64)
-
-    for i in range(data.shape[0]):
-        for j in range(data.shape[1]):
-            count = counts[i]
-
-            m1 = s1[i, j] / count
-            m2 = s2[i, j] / count
-            m3 = s3[i, j] / count
-            m4 = s4[i, j] / count
-
-            mu2 = m2 - m1**2
-            mu4 = m4 - 4 * m1 * m3 + 6 * m1**2 * m2 - 3 * m1**4
-
-            if mu2 > 0:
-                out[i, j] = mu4 / mu2**2
-            else:
-                out[i, j] = np.nan
-
-    return out
-
-
-@maybe_numba_jit
-def _recursive_kurtosis(
-    data: np.ndarray, step: float, winlen: float, varx: np.ndarray
-) -> np.ndarray:
-    """Recursive pseudo-kurtosis after Langet et al.-style formulation."""
-    c = 1.0 - step / winlen
-    npts = data.shape[0]
-    nchans = data.shape[1]
-
-    out = np.empty_like(data, dtype=np.float64)
-    mean_value = np.zeros(nchans, dtype=np.float64)
-    var_value = np.zeros(nchans, dtype=np.float64)
-    kurt_value = np.zeros(nchans, dtype=np.float64)
-
-    for i in range(npts):
-        for j in range(nchans):
-            xi = data[i, j]
-
-            mean_value[j] = c * mean_value[j] + (1.0 - c) * xi
-            var_value[j] = c * var_value[j] + (1.0 - c) * (xi - mean_value[j]) ** 2
-
-            if var_value[j] > varx[j]:
-                norm_factor = var_value[j] ** 2
-            else:
-                norm_factor = varx[j] ** 2
-
-            if norm_factor > 0:
-                kurt_value[j] = (
-                    c * kurt_value[j]
-                    + (1.0 - c) * (xi - mean_value[j]) ** 4 / norm_factor
-                )
-            else:
-                kurt_value[j] = np.nan
-            out[i, j] = kurt_value[j]
-
-    return out
 
 
 @patch_function()
@@ -216,6 +126,12 @@ def kurtosis(
     >>> _ = axs[1,0].set_xlabel('Amplitude')
     >>> _ = axs[1,0].set_ylabel('Probability of occurrence')
     """
+    # Imported here (not at module scope) to keep numba out of `import dascore`.
+    from dascore.transform._kurtosis_kernels import (  # noqa: PLC0415
+        _recursive_kurtosis,
+        _windowed_kurtosis,
+    )
+
     dim, _, winlen = get_dim_axis_value(patch, kwargs=kwargs)[0]
     orig_dims = patch.dims
     patch_t = patch.transpose(dim, ...)

--- a/dascore/transform/taup.py
+++ b/dascore/transform/taup.py
@@ -8,71 +8,8 @@ from numpy.typing import NDArray
 from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
 from dascore.units import convert_units
-from dascore.utils.jit import maybe_numba_jit
 from dascore.utils.patch import patch_function
 from dascore.utils.time import to_float
-
-
-@maybe_numba_jit(nopython=True)
-def _jit_taup_uniform(data, dx, dt, p_vals):
-    """
-    A numba version of uniform Tau-P transform.
-
-    See [`tau_p`](`dascore.transform.taup.tau_p`) for details.
-    """
-    (nx, nt) = data.shape
-    n_slo = p_vals.size
-    two_sided_p_vals = np.concatenate((-np.flip(p_vals), p_vals))
-    taup = np.zeros(shape=(2 * n_slo, nt))
-
-    for ip in numba.prange(n_slo):  # noqa  # ty: ignore[unresolved-reference]
-        pdx = p_vals[ip] * dx
-        for tau in range(nt):
-            for ix in range(nx):
-                samp_val = tau + pdx * ix / dt
-                ind = int(samp_val)
-                if ind + 1 < nt:
-                    taup[ip + n_slo, tau] += (1.0 + ind - samp_val) * data[ix, ind] + (
-                        samp_val - ind
-                    ) * data[ix, ind + 1]
-                    taup[n_slo - 1 - ip, tau] += (1.0 + ind - samp_val) * data[
-                        nx - 1 - ix, ind
-                    ] + (samp_val - ind) * data[nx - 1 - ix, ind + 1]
-    return two_sided_p_vals, taup
-
-
-@maybe_numba_jit(nopython=True)
-def _jit_taup_general(data, distance, dt, p_vals):
-    """
-    A numba version of general Tau-P transform.
-
-    See [`tau_p`](`dascore.transform.taup.tau_p`) for details.
-    """
-    (nx, nt) = data.shape
-    n_slo = p_vals.size
-    two_sided_p_vals = np.concatenate((-np.flip(p_vals), p_vals))
-    taup = np.zeros(shape=(2 * n_slo, nt))
-    mod_distance = distance - distance[0]
-
-    for ip in numba.prange(n_slo):  # noqa  # ty: ignore[unresolved-reference]
-        p = p_vals[ip]
-        for tau in range(nt):
-            for ix in range(nx):
-                samp_val_pos = tau + p * mod_distance[ix] / dt
-                ind_pos = int(samp_val_pos)
-                samp_val_neg = (
-                    tau + p * (mod_distance[-1] - mod_distance[nx - 1 - ix]) / dt
-                )
-                ind_neg = int(samp_val_pos)
-                if ind_pos + 1 < nt:
-                    taup[ip + n_slo, tau] += (1.0 + ind_pos - samp_val_pos) * data[
-                        ix, ind_pos
-                    ] + (samp_val_pos - ind_pos) * data[ix, ind_pos + 1]
-                if ind_neg + 1 < nt:
-                    taup[n_slo - 1 - ip, tau] += (1.0 + ind_neg - samp_val_neg) * data[
-                        nx - 1 - ix, ind_neg
-                    ] + (samp_val_neg - ind_neg) * data[nx - 1 - ix, ind_neg + 1]
-    return two_sided_p_vals, taup
 
 
 @patch_function(required_dims=("time", "distance"), data_type="tau_p")
@@ -133,6 +70,12 @@ def tau_p(
 
     # Handle unit conversions if needed.
     velocities = convert_units(velocities, to_units="m/s")
+
+    # Imported here (not at module scope) to keep numba out of `import dascore`.
+    from dascore.transform._taup_kernels import (  # noqa: PLC0415
+        _jit_taup_general,
+        _jit_taup_uniform,
+    )
 
     # Chooses code version based on whether distance between channels
     # is uniform or not

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -40,6 +40,24 @@ class TestLazyImports:
         _run_snippet(code)
 
     @pytest.mark.concurrency
+    def test_numba_not_imported(self):
+        """Importing dascore should not import numba (it is slow)."""
+        code = "import dascore, sys; assert 'numba' not in sys.modules"
+        _run_snippet(code)
+
+    @pytest.mark.concurrency
+    def test_numba_imported_with_jit_kernels(self):
+        """The jit kernel modules should pull numba in when they are imported."""
+        pytest.importorskip("numba")
+        code = (
+            "import sys, dascore; "
+            "assert 'numba' not in sys.modules; "
+            "import dascore.transform._kurtosis_kernels; "
+            "assert 'numba' in sys.modules"
+        )
+        _run_snippet(code)
+
+    @pytest.mark.concurrency
     def test_lazy_import_doesnt_import_scipy_signal_until_use(self):
         """The lazy proxy should resolve scipy.signal only on first use."""
         code = (

--- a/tests/test_transform/test_kurtosis.py
+++ b/tests/test_transform/test_kurtosis.py
@@ -7,12 +7,12 @@ import pytest
 
 import dascore as dc
 from dascore.exceptions import CoordError, ParameterError
-from dascore.transform.kurtosis import (
-    _get_window_samples,
+from dascore.transform._kurtosis_kernels import (
     _moving_sum,
     _recursive_kurtosis,
     _windowed_kurtosis,
 )
+from dascore.transform.kurtosis import _get_window_samples
 
 
 class TestKurtosisHelpers:

--- a/tests/test_transform/test_tau_p.py
+++ b/tests/test_transform/test_tau_p.py
@@ -5,7 +5,8 @@ import pytest
 
 import dascore as dc
 from dascore.exceptions import ParameterError
-from dascore.transform.taup import _jit_taup_general, _jit_taup_uniform, tau_p
+from dascore.transform._taup_kernels import _jit_taup_general, _jit_taup_uniform
+from dascore.transform.taup import tau_p
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.time import to_timedelta64
 


### PR DESCRIPTION
## Description

`import dascore` spends about 190 ms importing numba, even for users who never touch a jit'ed function.

`maybe_numba_jit` imports numba and builds the dispatcher when it *decorates*, not when the decorated function is called. `Patch` binds the transform functions as class attributes, so `dascore.transform` — and with it `taup.py` and `kurtosis.py` — is part of the eager import graph, and decorating their kernels drags numba in at import time. The decorator's docstring already promises that "users who don't use the function should be unaffected"; that held for the warning and the `ImportError`, but not for the import cost.

This moves the decorated kernels into private `_taup_kernels.py` and `_kurtosis_kernels.py` modules, which `tau_p()` and `kurtosis()` import inside the function body. `dascore/utils/jit.py` is deliberately untouched, so `maybe_numba_jit` still returns a real numba `Dispatcher` and kernels that call other kernels from nopython mode (`_windowed_kurtosis` calls `_moving_sum`) keep working. The kernel bodies are a pure move.

Median `import dascore`, interleaved A/B over 12 runs each:

| | median |
|---|---|
| `dev` | 1082 ms |
| this branch | 896 ms |
| saved | 186 ms (~17%) |

I first tried making `maybe_numba_jit` itself lazy. That breaks the nopython kernel-to-kernel call, because numba resolves globals at compile time and would find a python wrapper instead of a dispatcher; working around it meant republishing into module globals, which introduced a race and left `.signatures`/`.py_func` broken on any alias. Moving the kernels avoids all of that.

Two notes for reviewers:

- The private kernel names (`_jit_taup_uniform`, `_moving_sum`, ...) are no longer importable from `dascore.transform.taup` / `dascore.transform.kurtosis`. In-repo tests are updated. They are underscore-private, so no shims were added.
- This interacts with #850. Once that lands and enables `PLC0415`, the two deferred imports in `tau_p` and `kurtosis` will need `# noqa: PLC0415`. They are omitted here because the rule is not enabled on `dev` yet and ruff would flag them as unused directives. Whichever PR merges second needs that one-line follow-up.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
- changed: `import dascore` no longer imports numba (~190 ms), because the jit'ed `tau_p` and `kurtosis` kernels move to private modules imported when those functions are called.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.