### PR TITLE
Satisfy the tightened numpy signatures ty now sees

### DIFF
--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -478,7 +478,9 @@ def dropna(
     assert len(to_keep.shape) == 1
     assert to_keep.shape[0] == patch.data.shape[axis]
     # get slices for trimming data.
-    slices = [slice(None)] * len(patch.dims)
+    # Annotated because the entries are not all slices; ty reads the
+    # list as list[slice] from its initializer otherwise.
+    slices: list[Any] = [slice(None)] * len(patch.dims)
     slices[axis] = to_keep
     new_data = patch.data[tuple(slices)]
     coord = patch.get_coord(dim)

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -725,7 +725,7 @@ def append_dims(patch: PatchType, *empty_dims, **dim_kwargs) -> PatchType:
     ndim = patch.ndim
     # First get data with empty dimensions
     insert_inds = [x + ndim for x in range(len(kwargs))]
-    data = np.expand_dims(patch.data, insert_inds)
+    data = np.expand_dims(patch.data, tuple(insert_inds))
     shapes = list(data.shape)
     for ind, (_, cdata) in zip(insert_inds, kwargs.values()):
         shapes[ind] = cdata if isinstance(cdata, int) else len(cdata)


### PR DESCRIPTION
## Description

`lint_code` started failing on `dev` and on every open PR, without any of them changing the code it flags. The `ty` hook runs `--isolated`, so it resolves its own dependencies rather than using a lockfile, and a numpy release tightened two signatures overnight. Same source, same pinned ty (v0.0.65), new result: `dev`'s last lint run passed at 541b25ae on 2026-08-11, and the identical files now report two diagnostics.

Both are genuine type errors that the older stubs simply did not catch.

`np.expand_dims` no longer accepts a `list` for `axis` — every overload takes `int` or `tuple[int, ...]`. The call passes a list comprehension, so it now matches nothing. Passing a tuple is what the signature has always meant.

`slices` is initialized as `[slice(None)] * len(patch.dims)`, which types it `list[slice]`, and one element is then replaced with a boolean mask for the fancy-indexing step. That was always a heterogeneous list; the annotation says so.

Both changes are behaviour-preserving: `np.expand_dims` treats a list and a tuple of axes identically, and an annotation has no runtime effect.

Worth noting for later: because the hook is `--isolated` with no lockfile, this can recur whenever a dependency tightens its stubs. Pinning the type-check environment would trade these surprise breakages for explicit upgrade commits, if that seems worthwhile.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
