### PR TITLE
Auto-remove the ready_for_review label when a PR closes

### DIFF
--- a/.github/workflows/remove_review_label.yml
+++ b/.github/workflows/remove_review_label.yml
@@ -1,0 +1,29 @@
+# Remove the ready_for_review label once a PR is closed or merged.
+name: RemoveReviewLabel
+# pull_request_target is needed so the token can write labels on fork PRs.
+# It is safe here: no PR code is checked out and no PR content is interpolated.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+
+    # Only do the API call if the label is actually there.
+    if: contains(github.event.pull_request.labels.*.name, 'ready_for_review')
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: remove ready_for_review label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh api -X DELETE "repos/{owner}/{repo}/issues/$PR_NUMBER/labels/ready_for_review"


### PR DESCRIPTION
## Description

Adds a small CI job that removes the `ready_for_review` label as soon as a PR is closed or merged, so the label always reflects PRs that actually still need review.

`pull_request_target` is used rather than `pull_request` because fork PRs get a read-only `GITHUB_TOKEN` under `pull_request`, which cannot write labels. The trigger is safe here — nothing is checked out and no PR-controlled text reaches the shell — so zizmor's `dangerous-triggers` audit is suppressed inline with a note, matching the existing suppression style in `test_wasm.yml`. Permissions are scoped to `pull-requests: write` on the job only, and a job-level `if` skips the API call entirely when the label isn't present.

The `closed` event type covers both merged and closed-unmerged PRs; GitHub has no separate merge event.

Verified the exact `gh api` call against a real merged PR (#873, which was still carrying a stale label) — it succeeds and clears the label.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
