### PR TITLE
Fix typos in docstrings and comments

### DIFF
--- a/dascore/io/dashdf5/__init__.py
+++ b/dascore/io/dashdf5/__init__.py
@@ -1,5 +1,5 @@
 """
-Basic support for DAS-HDF5 a subset of CF (climate and forcasting).
+Basic support for DAS-HDF5 a subset of CF (climate and forecasting).
 
 This was created mainly for reading PoroTomo data from Brady Hotsprings.
 

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -38,7 +38,7 @@ def _get_zone_time(feb):
     """
     Attempt to get time information for the current zone.
 
-    The files are very inconsistent accross versions, so, to try to support
+    The files are very inconsistent across versions, so, to try to support
     as many febus files as possible, this function does a lot of heavy lifting.
 
     Danger: Here be dragons.
@@ -70,7 +70,7 @@ def _get_zone_time(feb):
     # We need to determine if this a v1 file (no version in attrs). See # 589
     # and # 587. This could perhaps be made more robust in the future.
     has_version = "Version" in feb.zone.attrs
-    # When the file has a version, the spacing can be trusted, otherise
+    # When the file has a version, the spacing can be trusted, otherwise
     # use spatial sampling.
     if has_version:
         block_pad = 1 + extents[3] - extents[2]

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -461,7 +461,7 @@ def select(
         array can get gc'ed and memory freed.
     relative
         If True, select ranges are relative to the start of coordinate, if
-        possitive, or the end of the coordinate, if negative.
+        positive, or the end of the coordinate, if negative.
     samples
         If True, the query meaning is in samples.
     **kwargs
@@ -511,7 +511,7 @@ def select(
     Notes
     -----
     - It is important to remember select will not change the order of the
-      patch, only fiter values. If the order of the patch should change, or
+      patch, only filter values. If the order of the patch should change, or
       multiple rows/columns need to be repeated,
       See [`Patch.order`](`dascore.Patch.order`).
 
@@ -607,7 +607,7 @@ def order(
     -----
     - This function is similar to [`Patch.select`](`dascore.Patch.select`)
       but it will also change the patch order to match the inputs exactly.
-      If there are repeated values in the requsted values or in the patch
+      If there are repeated values in the requested values or in the patch
       coordinate arrays, the data will end up being repeated as well.
     """
     new_coords, data = patch.coords.order(

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -116,9 +116,9 @@ def correlate(
         value along that axis. See examples for details.
     **kwargs
         Specifies correlation dimension and the master source(s), to which
-        we want to cross-correlate all other channels/time samples.If the
+        we want to cross-correlate all other channels/time samples. If the
         master source is an array, the function will compute correlations for
-        all the posible pairs.
+        all the possible pairs.
 
     Examples
     --------

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -552,7 +552,7 @@ def slope_filter(
     >>> filt = np.array([2e3,2.2e3,8e3,2e4]) * dc.get_unit("m/s")
     >>> patch_filtered = patch.slope_filter(filt=filt)
 
-    The [FK recipe](`docs/recipes/fk.qmd`) provides addtional examples.
+    The [FK recipe](`docs/recipes/fk.qmd`) provides additional examples.
     """
 
     def _check_inputs(patch, filt, dims):

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -335,12 +335,12 @@ def rolling(
     #### Note 2: Applying custom functions with rolling operation
 
     When `apply` is the desired rolling operation and we are interested to use our
-    own function over a desired window, we need to define our finction the way that
+    own function over a desired window, we need to define our function the way that
     it performs the operation on the last axis of the sliced matrix
 
     Below is an example of applying a custom zero crossing rate function (zcr_std) with
     rolling operation for a window size of 100 samples and skipping every other samples.
-    It applys the desired operation (which is multiplying every sample to its next
+    It applies the desired operation (which is multiplying every sample to its next
     sample to determine the zero crossings) on the last axis of the sliced
     frame (from rolling).
 

--- a/dascore/transform/differentiate.py
+++ b/dascore/transform/differentiate.py
@@ -92,10 +92,10 @@ def differentiate(
         The dimension(s) along which to differentiate. If None differentiates
         over all dimensions.
     order
-        The order of the differentiation operator. Must be a possitive, even
-        integar.
+        The order of the differentiation operator. Must be a positive, even
+        integer.
     step
-        The number of columns/rows to skip for differention.
+        The number of columns/rows to skip for differentiation.
         eg: an array of [a b c d e] uses b and d to calculate diff of c when
         step = 1 and order = 2. When step = 2, a and e are used to calculate
         diff at c.

--- a/dascore/transform/fbe.py
+++ b/dascore/transform/fbe.py
@@ -43,7 +43,7 @@ def fbe(
         Return patch data in decibel [dB] instead of original units.
         Decibel is calculated as 20 * log10( sqrt(mean(x^2)) ).
     **kwargs
-        Used to specify the dimension and asociated frequency, wavelength, or
+        Used to specify the dimension and associated frequency, wavelength, or
         equivalent limits. For example time=(1, 100) applies a time-dimension bandpass
         of 1-100 Hz. See [pass_filter](`dascore.Patch.pass_filter`) for more details.
 

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -218,7 +218,7 @@ def dft(
         None, perform dft over all dimensions.
     real
         Either 1) The name of the axis over which to perform a rfft, 2)
-        True, which means the last (possibly only) dimenson should have an
+        True, which means the last (possibly only) dimension should have an
         rfft performed, or 3) None, meaning no rfft.
     pad
         If True, pad patch before performing dft along desired dimensions to

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -79,9 +79,9 @@ def velocity_to_strain_rate(
     [patch.differentiate](`dascore.transform.differentiate.differentiate`)
     under the hood to calculate spatial derivatives.
 
-    The output gauge length is equal to the step_multiple multuplied by the
+    The output gauge length is equal to the step_multiple multiplied by the
     spacing along the distance coordinate, although the concept of
-    gauge_length is more complex with higher oder filters. See
+    gauge_length is more complex with higher order filters. See
     @yang2022filtering for more info.
 
     See the [`velocity_to_strain_rate` note](docs/notes/velocity_to_strain_rate.qmd)

--- a/dascore/utils/deprecate.py
+++ b/dascore/utils/deprecate.py
@@ -47,7 +47,7 @@ def deprecate(
     """
 
     def _build_msg(func):
-        """Build the message to emmit."""
+        """Build the message to emit."""
         # Build a clear message for both runtime and typing hint
         qual = f"{func.__module__}.{getattr(func, '__qualname__', func.__name__)}"
         since_str = f" since {since}" if since else ""

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -511,7 +511,7 @@ def optional_import(
         If "raise" raise an Error if missing, if "warn" or "ignore",
         return None.
     required_for
-        A string indicating what this import is requried for.
+        A string indicating what this import is required for.
 
     Raises
     ------

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -80,7 +80,7 @@ def track(
     length
         The number of items, for sequences which cannot report their own.
     min_length
-        The minimum length to emmit a progress bar.
+        The minimum length to emit a progress bar.
     """
     total = get_track_length(sequence, length, min_length)
     # This is a dirty hack to allow debugging while running tests.


### PR DESCRIPTION
## Description

Fixes 21 misspellings in docstrings and comments found with `codespell`. Several are in user-facing API documentation (`Patch.select`, `Patch.order`, `Patch.dft`, `Patch.correlate`, `Patch.rolling`, `Patch.differentiate`, `Patch.velocity_to_strain_rate`), so they show up on the rendered docs site.

Prose only — no identifiers, parameter names, or behavior changed.

Deliberately left alone:
- `SystemInfomation.Devices1.SerialNum` in `io/silixah5/utils.py`, which reproduces the vendor's own misspelled HDF5 key (and already carries a comment saying so).
- Informal contractions (`cant`, `doesnt`, `wont`) in test names and messages, which are a style choice rather than typos.

## Changelog

<!-- Retrofitted after #864; derived from this PR's diff. -->
none

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
