### PR TITLE
Select a spool on the facts an inventory states

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import textwrap
 from collections.abc import Callable, Iterable, Mapping
 from functools import partial
 from pathlib import Path
@@ -250,6 +251,49 @@ check_behavior
     [`IncompatiblePatchError`](`dascore.exceptions.IncompatiblePatchError`)
     if any incompatible patches are found.
 """
+
+# Enrichment parameters, shared by Patch.enrich and Spool.enrich so the
+# two cannot describe the same arguments differently.
+
+enrich_attrs_description = """
+attrs
+    True (the default) to copy the observing-system facts the inventory
+    is authoritative for, a tuple of names to copy exactly those, or
+    False to copy none. The blanket form excludes `data_type`,
+    `data_category`, and `data_units`, which describe the data as it
+    now stands, and `sample_rate` and `spatial_interval`, which the
+    patch's own coordinates already state; naming one restores the
+    as-acquired value.
+""".strip()
+
+enrich_coords_description = """
+coords
+    True (the default) to add the geometry axes and annotation groups of
+    the resolved optical path, a tuple of names to add exactly those, or
+    False to add none. Names may be `distance` for optical distance, a
+    coordinate label the inventory's CRS defines, an annotation group, or
+    a qualified track field such as `coupling.medium`.
+""".strip()
+
+enrich_on_missing_description = """
+on_missing
+    What to do when an explicitly requested name is one the inventory does
+    not define: "raise" (the default), "null" to fill the dtype-appropriate
+    missing marker, or "ignore" to leave it off. Blanket requests copy what
+    is applicable and never trigger it, and per-channel coverage gaps are
+    always missing values rather than errors.
+""".strip()
+
+enrich_conflicts_description = f"""
+conflicts
+{textwrap.indent(attr_conflict_description.strip(), "    ")}
+
+    Enrichment combines the inventory's values with the patch's own, so
+    the default `keep_first` lets the inventory win and re-enriching is
+    a refresh. `raise` is the misresolution guard: a header disagreeing
+    with the resolved acquisition usually means the `acquisition_key`
+    resolved to the wrong place.
+""".strip()
 
 
 # Rich styles for various object displays.

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -284,10 +284,11 @@ on_missing
     always missing values rather than errors.
 """.strip()
 
+# One paragraph, not two: a blank line inside a parameter description
+# reads as the start of the next parameter when the API docs are built.
 enrich_conflicts_description = f"""
 conflicts
 {textwrap.indent(attr_conflict_description.strip(), "    ")}
-
     Enrichment combines the inventory's values with the patch's own, so
     the default `keep_first` lets the inventory win and re-enriching is
     a refresh. `raise` is the misresolution guard: a header disagreeing

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import itertools
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sized
 from types import MappingProxyType, UnionType
 from typing import (
     Annotated,
@@ -1684,10 +1684,22 @@ _COLLECTION_ORIGINS = (tuple, list, set, frozenset, dict)
 
 
 def _annotation_members(annotation) -> list:
-    """Return the alternatives a possibly-optional union annotation admits."""
-    if get_origin(annotation) not in (Union, UnionType):
-        return [annotation]
-    return [x for member in get_args(annotation) for x in _annotation_members(member)]
+    """
+    Return the alternatives a possibly-optional union annotation admits.
+
+    `Annotated` is transparent: this file writes several of its unions as
+    `Annotated[A | B, Field(discriminator=...)]`, and the wrapper must not
+    hide what they hold. `None` is dropped, since "or nothing" says what
+    the field does when it is unset rather than what it can hold.
+    """
+    if get_origin(annotation) is Annotated:
+        return _annotation_members(get_args(annotation)[0])
+    if get_origin(annotation) in (Union, UnionType):
+        out = [
+            x for member in get_args(annotation) for x in _annotation_members(member)
+        ]
+        return [x for x in out if x is not type(None)]
+    return [annotation]
 
 
 def _is_value_field(info) -> bool:
@@ -1702,6 +1714,12 @@ def _is_value_field(info) -> bool:
     if any(isinstance(x, type) and issubclass(x, InventoryModel) for x in members):
         return False
     return any(get_origin(x) not in _COLLECTION_ORIGINS for x in members)
+
+
+def _is_multi_valued(item, field: str) -> bool:
+    """Return True when an item states a field as several values at once."""
+    value = getattr(item, field, None)
+    return isinstance(value, Sized) and not isinstance(value, str)
 
 
 def _value_field_names(model) -> list[str]:
@@ -1960,15 +1978,24 @@ class Inventory(InventoryModel):
         out = dict.fromkeys(["distance", *("x", "y", "z")[: len(labels)], *labels])
         groups: dict[str, None] = {}
         tracks: dict[str, dict[str, None]] = {}
+        multi: set[str] = set()
         for path in self._optical_paths():
             groups.update(dict.fromkeys(x.group for x in path.annotations if x.group))
             for track in TRACK_IDENTITY_FIELDS:
                 for item in getattr(path, track):
                     fields = tracks.setdefault(track, {})
-                    fields.update(dict.fromkeys(_value_field_names(type(item))))
+                    names = _value_field_names(type(item))
+                    fields.update(dict.fromkeys(names))
+                    # A field this item states as several values -- a
+                    # multi-wavelength loss, say -- has no one value to
+                    # give a channel, however scalar its annotation reads.
+                    multi.update(
+                        f"{track}.{x}" for x in names if _is_multi_valued(item, x)
+                    )
         for track, fields in tracks.items():
             out[track] = None
-            out.update(dict.fromkeys(f"{track}.{x}" for x in fields))
+            names = (f"{track}.{x}" for x in fields)
+            out.update(dict.fromkeys(x for x in names if x not in multi))
         out.update(groups)
         return tuple(out)
 

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import itertools
 import os
 from collections.abc import Mapping, Sized
+from functools import cache
 from types import MappingProxyType, UnionType
 from typing import (
     Annotated,
@@ -1722,15 +1723,21 @@ def _is_multi_valued(item, field: str) -> bool:
     return isinstance(value, Sized) and not isinstance(value, str)
 
 
-def _value_field_names(model) -> list[str]:
-    """Return the fields of a model which state a fact about one thing."""
+@cache
+def _value_field_names(model) -> tuple[str, ...]:
+    """
+    Return the fields of a model which state a fact about one thing.
+
+    Cached on the class: the answer is a property of the model, and an
+    inventory asked for its names walks every item of every track.
+    """
     structural = frozenset(TimeRangedModel.model_fields) | _IDENTITY_FIELDS
     structural |= _EXTENT_FIELDS
-    return [
+    return tuple(
         name
         for name, info in model.model_fields.items()
         if name not in structural and _is_value_field(info)
-    ]
+    )
 
 
 # The observing-system facts, read off the models rather than listed, so a
@@ -1739,7 +1746,7 @@ def _value_field_names(model) -> list[str]:
 # vocabulary, and a new field has to reach the readers as well.
 _SYSTEM_FACT_NAMES = tuple(
     sorted(
-        _value_field_names(Acquisition)
+        list(_value_field_names(Acquisition))
         + [f"interrogator.{x}" for x in _value_field_names(Interrogator)]
     )
 )

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -22,6 +22,7 @@ from types import MappingProxyType, UnionType
 from typing import (
     Annotated,
     Any,
+    ClassVar,
     Literal,
     NamedTuple,
     TypeAlias,
@@ -373,6 +374,7 @@ class _OpticalComponentBase(InventoryModel):
     with their measurements, which carry the wavelengths.
     """
 
+    _identity_field: ClassVar[str] = "name"
     optical_length: FiniteFloat = Field(
         default=0.0,
         ge=0.0,
@@ -516,6 +518,7 @@ class Geometry(InventoryModel):
     crosses segments; uncovered distance has undefined coordinates.
     """
 
+    _identity_field: ClassVar[str] = "name"
     name: str = Field(default="", description="Human-readable geometry name.")
     distance: tuple[float, ...] = Field(
         description=(
@@ -646,6 +649,7 @@ class CouplingCondition(_IntervalModel):
     and conditions may not overlap.
     """
 
+    _identity_field: ClassVar[str] = "coupling_type"
     coupling_type: CouplingType = Field(description="Controlled coupling category.")
     medium: str = Field(default="", description="Surrounding medium.")
     attachment: str = Field(default="", description="Attachment method.")
@@ -980,26 +984,38 @@ def _overlapping_epochs(items, key) -> list[tuple]:
 
 _MIXED_DIMS_MSG = "Geometry segments mix coordinate dimensionalities {dims}."
 
-# The typed tracks of an optical path, each mapped to the field a bare use
-# of its name means: `coupling="trench"` asks about coupling_type, and a
-# geometry or component is asked about by name. Every other field of a
-# track is reached by its qualified name (`coupling.medium`). This is the
-# one place the mapping is written down; a test pins each entry to the
-# model it names.
-TRACK_IDENTITY_FIELDS = MappingProxyType(
-    {
-        "optical_components": "name",
-        "geometry": "name",
-        "coupling": "coupling_type",
-    }
-)
+
+def _track_identity_fields() -> Mapping[str, str]:
+    """
+    Map each typed track of an optical path to the field its name means.
+
+    `coupling="trench"` asks about coupling_type; every other field of a
+    track is reached by its qualified name (`coupling.medium`). Each
+    track model declares which of its fields is its identity, so the
+    pairing lives beside the field rather than in a list to keep in step
+    with it.
+    """
+    out = {}
+    for track, info in OpticalPath.model_fields.items():
+        # A track is a tuple of items; the path's scalar fields are not.
+        if get_origin(info.annotation) is not tuple:
+            continue
+        for model in _annotation_members(get_args(info.annotation)[0]):
+            field = getattr(model, "_identity_field", None)
+            if field is None:
+                continue
+            # The model names one of its own fields, or the map it builds
+            # would point at nothing.
+            assert field in model.model_fields, (model, field)
+            out[track] = field
+    return MappingProxyType(out)
+
 
 # Names an annotation group may not take: a group becomes a patch coordinate
 # at enrichment, where it would shadow one of these.
 RESERVED_GROUP_NAMES = frozenset(
     {"time", "distance", "channel", "instrument_distance"}
-    | set(TRACK_IDENTITY_FIELDS)
-    | {"annotations"}
+    | {"optical_components", "geometry", "coupling", "annotations"}
     | set(VALID_COORDINATE_LABELS)
 )
 
@@ -1745,6 +1761,9 @@ def _value_field_names(model) -> tuple[str, ...]:
         for name, info in model.model_fields.items()
         if name not in structural and _is_value_field(info)
     )
+
+
+TRACK_IDENTITY_FIELDS = _track_identity_fields()
 
 
 # The observing-system facts, read off the models rather than listed, so a

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -17,7 +17,17 @@ from __future__ import annotations
 import itertools
 import os
 from collections.abc import Mapping
-from typing import Annotated, Any, Literal, NamedTuple, TypeAlias, get_args
+from types import MappingProxyType, UnionType
+from typing import (
+    Annotated,
+    Any,
+    Literal,
+    NamedTuple,
+    TypeAlias,
+    Union,
+    get_args,
+    get_origin,
+)
 from uuid import uuid4
 
 import numpy as np
@@ -969,11 +979,26 @@ def _overlapping_epochs(items, key) -> list[tuple]:
 
 _MIXED_DIMS_MSG = "Geometry segments mix coordinate dimensionalities {dims}."
 
+# The typed tracks of an optical path, each mapped to the field a bare use
+# of its name means: `coupling="trench"` asks about coupling_type, and a
+# geometry or component is asked about by name. Every other field of a
+# track is reached by its qualified name (`coupling.medium`). This is the
+# one place the mapping is written down; a test pins each entry to the
+# model it names.
+TRACK_IDENTITY_FIELDS = MappingProxyType(
+    {
+        "optical_components": "name",
+        "geometry": "name",
+        "coupling": "coupling_type",
+    }
+)
+
 # Names an annotation group may not take: a group becomes a patch coordinate
 # at enrichment, where it would shadow one of these.
 RESERVED_GROUP_NAMES = frozenset(
     {"time", "distance", "channel", "instrument_distance"}
-    | {"optical_components", "geometry", "coupling", "annotations"}
+    | set(TRACK_IDENTITY_FIELDS)
+    | {"annotations"}
     | set(VALID_COORDINATE_LABELS)
 )
 
@@ -1628,6 +1653,80 @@ class ResolvedContext(NamedTuple):
     optical_path: OpticalPath | None
 
 
+class InventoryNames(NamedTuple):
+    """
+    The names an inventory could contribute to a patch.
+
+    Split by where each lands: `attrs` are the scalar facts about the
+    observing system, `coords` the names which take a value per channel.
+    """
+
+    attrs: tuple[str, ...]
+    coords: tuple[str, ...]
+
+
+# Fields which name or tag a record rather than describe it: the type
+# discriminator and resource id a shareable record carries, and the codes
+# locating an acquisition (a patch's acquisition_key already states them).
+_IDENTITY_FIELDS = frozenset({"type", "resource_id", "code", "location_code"})
+
+# What a distance-ranged track carries to place itself, which is its extent
+# rather than a value the channels inside it take.
+_EXTENT_FIELDS = frozenset(_IntervalModel.model_fields) - frozenset(
+    InventoryModel.model_fields
+)
+
+
+# The generics a field annotation uses to say it holds many values. Only
+# these are unwrapped further, so `tuple[float, ...]` stays a tuple rather
+# than reading as the float it contains.
+_COLLECTION_ORIGINS = (tuple, list, set, frozenset, dict)
+
+
+def _annotation_members(annotation) -> list:
+    """Return the alternatives a possibly-optional union annotation admits."""
+    if get_origin(annotation) not in (Union, UnionType):
+        return [annotation]
+    return [x for member in get_args(annotation) for x in _annotation_members(member)]
+
+
+def _is_value_field(info) -> bool:
+    """
+    Return True when a field could hold one value describing one thing.
+
+    A field which may hold another inventory model is a reference to a
+    second record rather than a fact of this one, and one which can only
+    hold a collection has no single value to state, or to give a channel.
+    """
+    members = _annotation_members(info.annotation)
+    if any(isinstance(x, type) and issubclass(x, InventoryModel) for x in members):
+        return False
+    return any(get_origin(x) not in _COLLECTION_ORIGINS for x in members)
+
+
+def _value_field_names(model) -> list[str]:
+    """Return the fields of a model which state a fact about one thing."""
+    structural = frozenset(TimeRangedModel.model_fields) | _IDENTITY_FIELDS
+    structural |= _EXTENT_FIELDS
+    return [
+        name
+        for name, info in model.model_fields.items()
+        if name not in structural and _is_value_field(info)
+    ]
+
+
+# The observing-system facts, read off the models rather than listed, so a
+# field added to either automatically becomes something an inventory can
+# contribute. Pinned to INVENTORY_ATTRS by a test: the two are one
+# vocabulary, and a new field has to reach the readers as well.
+_SYSTEM_FACT_NAMES = tuple(
+    sorted(
+        _value_field_names(Acquisition)
+        + [f"interrogator.{x}" for x in _value_field_names(Interrogator)]
+    )
+)
+
+
 class Inventory(InventoryModel):
     """
     Top-level DASDAE inventory manifest.
@@ -1810,6 +1909,68 @@ class Inventory(InventoryModel):
         except KeyError:
             msg = f"No resource with resource_id {resource_id!r}."
             raise InvalidInventoryError(msg) from None
+
+    def get_names(self) -> InventoryNames:
+        """
+        Return the names this inventory could contribute to a patch.
+
+        These are the names
+        [`Patch.enrich`](`dascore.proc.inventory.enrich`) can be asked for
+        and selection can query, split by where each lands: `attrs` for
+        the observing-system facts, which are scalar per patch, and
+        `coords` for the names taking a value per channel. `attrs` is the
+        same for every inventory, since the models decide it; `coords`
+        depends on what this inventory holds.
+
+        Contributing a name is not promising a value for it: a name is
+        listed when some acquisition or optical path could define it, and
+        one which none does simply resolves to nothing.
+
+        Examples
+        --------
+        >>> from dascore.examples import inventory_patch_pair
+        >>>
+        >>> _, inventory = inventory_patch_pair()
+        >>> names = inventory.get_names()
+        >>> assert "gauge_length" in names.attrs
+        >>> assert "interrogator.model" in names.attrs
+        >>> assert "coupling" in names.coords  # its coupling_type
+        >>> assert "coupling.medium" in names.coords
+        """
+        return InventoryNames(attrs=_SYSTEM_FACT_NAMES, coords=self._coord_names())
+
+    def _optical_paths(self):
+        """Iterate every optical path this inventory holds."""
+        for network in self.networks:
+            for array in network.fiber_arrays:
+                yield from array.optical_paths
+
+    def _coord_names(self) -> tuple[str, ...]:
+        """
+        Return the per-channel names this inventory's paths could define.
+
+        The CRS's axes and optical distance come from the model, while the
+        annotation groups and the tracks which are actually described come
+        from the paths themselves: an inventory with no coupling track has
+        no coupling to select on.
+        """
+        labels = self.coordinate_reference_system.coordinate_labels
+        # Both spellings of the same axes: the canonical storage names and
+        # whatever this CRS declares they mean.
+        out = dict.fromkeys(["distance", *("x", "y", "z")[: len(labels)], *labels])
+        groups: dict[str, None] = {}
+        tracks: dict[str, dict[str, None]] = {}
+        for path in self._optical_paths():
+            groups.update(dict.fromkeys(x.group for x in path.annotations if x.group))
+            for track in TRACK_IDENTITY_FIELDS:
+                for item in getattr(path, track):
+                    fields = tracks.setdefault(track, {})
+                    fields.update(dict.fromkeys(_value_field_names(type(item))))
+        for track, fields in tracks.items():
+            out[track] = None
+            out.update(dict.fromkeys(f"{track}.{x}" for x in fields))
+        out.update(groups)
+        return tuple(out)
 
     def check(self) -> Self:
         """Check the whole inventory tree against the model rules."""

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -1717,10 +1717,17 @@ def _is_value_field(info) -> bool:
     return any(get_origin(x) not in _COLLECTION_ORIGINS for x in members)
 
 
-def _is_multi_valued(item, field: str) -> bool:
-    """Return True when an item states a field as several values at once."""
+def _value_shape(item, field: str) -> str | None:
+    """
+    Return how an item states a field: as one value, several, or not at all.
+
+    A field stated as several values -- a multi-wavelength loss, say --
+    has none to give a channel, however scalar its annotation reads.
+    """
     value = getattr(item, field, None)
-    return isinstance(value, Sized) and not isinstance(value, str)
+    if value is None or (isinstance(value, str) and not value):
+        return None
+    return "many" if isinstance(value, Sized) and not isinstance(value, str) else "one"
 
 
 @cache
@@ -1985,7 +1992,7 @@ class Inventory(InventoryModel):
         out = dict.fromkeys(["distance", *("x", "y", "z")[: len(labels)], *labels])
         groups: dict[str, None] = {}
         tracks: dict[str, dict[str, None]] = {}
-        multi: set[str] = set()
+        shapes: dict[str, set[str]] = {}
         for path in self._optical_paths():
             groups.update(dict.fromkeys(x.group for x in path.annotations if x.group))
             for track in TRACK_IDENTITY_FIELDS:
@@ -1993,16 +2000,17 @@ class Inventory(InventoryModel):
                     fields = tracks.setdefault(track, {})
                     names = _value_field_names(type(item))
                     fields.update(dict.fromkeys(names))
-                    # A field this item states as several values -- a
-                    # multi-wavelength loss, say -- has no one value to
-                    # give a channel, however scalar its annotation reads.
-                    multi.update(
-                        f"{track}.{x}" for x in names if _is_multi_valued(item, x)
-                    )
+                    for field in names:
+                        if (shape := _value_shape(item, field)) is not None:
+                            shapes.setdefault(f"{track}.{field}", set()).add(shape)
+        # Dropped only where nothing states it as one value: another path
+        # may record a scalar where this one records several, and that
+        # path can still give it to a channel.
+        unusable = {x for x, kinds in shapes.items() if kinds == {"many"}}
         for track, fields in tracks.items():
             out[track] = None
             names = (f"{track}.{x}" for x in fields)
-            out.update(dict.fromkeys(x for x in names if x not in multi))
+            out.update(dict.fromkeys(x for x in names if x not in unusable))
         out.update(groups)
         return tuple(out)
 

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -123,7 +123,7 @@ def _requested_names(_attrs, _coords, kwargs) -> set[str]:
     return out
 
 
-def _match_resolved(values, name: str, selector) -> np.ndarray:
+def _match_resolved(values, name: str, selector, units=None) -> np.ndarray:
     """Return which of the values an inventory states match a selector."""
     from dascore.io.index.query import evaluate_attr_predicate  # noqa: PLC0415
 
@@ -133,7 +133,7 @@ def _match_resolved(values, name: str, selector) -> np.ndarray:
     # and the predicate would be comparing against the missing marker.
     stated = ~_unstated(values)
     if stated.any():
-        out[stated] = evaluate_attr_predicate(values[stated], name, selector)
+        out[stated] = evaluate_attr_predicate(values[stated], name, selector, units)
     return out
 
 
@@ -489,10 +489,11 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         overlaps the range would throw away the part that does not.
         Select the ranges to keep instead.
 
-        Naming nothing raises. `select()` with no selection is the whole
-        spool, so its complement is an empty one — but "remove nothing"
-        reads just as naturally, and silently emptying a spool is not
-        something to guess at.
+        Naming nothing raises, and so does naming only no-op selectors
+        (`None`, `...`). `select()` with no selection is the whole spool,
+        so its complement is an empty one — but "remove nothing" reads
+        just as naturally, and silently emptying a spool is not something
+        to guess at.
 
         Parameters
         ----------
@@ -818,13 +819,6 @@ class Spool(BaseSpool):
     ) -> Self:
         """{doc}."""
         requested = _requested_names(_attrs, _coords, kwargs)
-        if not requested:
-            msg = (
-                "unselect needs something to remove. Naming nothing could "
-                "mean the whole spool (the complement of selecting all of "
-                "it) or none of it, so it says neither."
-            )
-            raise ParameterError(msg)
         known_attrs, known_coords = self._index_names()
         selectable = set()
         if self._inventory is not None:
@@ -849,9 +843,20 @@ class Spool(BaseSpool):
                 "to keep instead."
             )
             raise InvalidSpoolQueryError(msg)
+        # A no-op selector selects everything, so its complement is an
+        # empty spool -- and "remove nothing" reads just as naturally.
+        stated = {k: v for k, v in attrs.items() if v is not None and v is not Ellipsis}
+        if not stated:
+            msg = (
+                "unselect needs something to remove; "
+                f"{sorted(requested) or 'nothing'} names no selection. "
+                "Naming nothing could mean the whole spool (the complement "
+                "of selecting all of it) or none of it, so it says neither."
+            )
+            raise ParameterError(msg)
         # The complement is taken against select itself rather than by
         # negating each predicate, so the two can never drift apart.
-        removed = self.select(_attrs=attrs)._catalog._ordered_ids()
+        removed = self.select(_attrs=stated)._catalog._ordered_ids()
         ids = np.asarray(self._catalog._ordered_ids(), dtype=np.int64)
         keep = ~np.isin(ids, np.asarray(removed, dtype=np.int64))
         return self._new_from_catalog(self._catalog.restrict(keep))
@@ -949,6 +954,7 @@ class Spool(BaseSpool):
                     get_attr_values(self._inventory, contexts[~stated], name),
                     name,
                     selector,
+                    backend.attr_units(name),
                 )
             mask &= matched
         return self._new_from_catalog(self._catalog.restrict(mask, ids=ids))
@@ -968,16 +974,27 @@ class Spool(BaseSpool):
         """
         from dascore.proc.inventory import resolve_contexts  # noqa: PLC0415
 
+        out = np.full(len(ids), None, dtype=object)
         df = self._df
-        # The relation and the id list are one presentation of one view.
-        assert np.array_equal(df["_patch_id"].to_numpy(), ids)
         columns = [df.get(x) for x in ("acquisition_key", "time_min", "time_max")]
         physical = all(column is not None for column in columns) and all(
             np.issubdtype(column.dtype, np.datetime64) for column in columns[1:]
         )
         if not physical:
-            return np.full(len(df), None, dtype=object)
-        return resolve_contexts(self._inventory, *columns)
+            return out
+        # Aligned by id rather than by position: the relation is realized
+        # by a route of its own and need not present every row the id list
+        # does, and a row it leaves out is one nothing was resolved for.
+        resolved = dict(
+            zip(
+                df["_patch_id"].to_numpy(),
+                resolve_contexts(self._inventory, *columns),
+                strict=True,
+            )
+        )
+        for position, patch_id in enumerate(ids):
+            out[position] = resolved.get(patch_id)
+        return out
 
     def _index_matches(self, name: str, selector) -> np.ndarray:
         """Return the ids of the rows the index itself selects for one name."""

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -489,6 +489,11 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         overlaps the range would throw away the part that does not.
         Select the ranges to keep instead.
 
+        Naming nothing raises. `select()` with no selection is the whole
+        spool, so its complement is an empty one — but "remove nothing"
+        reads just as naturally, and silently emptying a spool is not
+        something to guess at.
+
         Parameters
         ----------
         _attrs
@@ -812,7 +817,15 @@ class Spool(BaseSpool):
         **kwargs,
     ) -> Self:
         """{doc}."""
-        self._check_channel_level(_requested_names(_attrs, _coords, kwargs))
+        requested = _requested_names(_attrs, _coords, kwargs)
+        if not requested:
+            msg = (
+                "unselect needs something to remove. Naming nothing could "
+                "mean the whole spool (the complement of selecting all of "
+                "it) or none of it, so it says neither."
+            )
+            raise ParameterError(msg)
+        self._check_channel_level(requested)
         attrs, coords = resolve_selector_namespaces(
             set(self._catalog.backend.attr_names()) | self._inventory_attr_names(),
             self._catalog.backend.coord_names(),
@@ -899,19 +912,15 @@ class Spool(BaseSpool):
         state everything therefore never touches the inventory, and one
         which states nothing resolves once per epoch rather than per row.
         A row the inventory has no answer for is not selected, as a patch
-        lacking the attr entirely is not.
+        lacking the attr entirely is not. Straddling is decided against
+        the row as it now stands, so a range which has already trimmed a
+        row inside one epoch leaves it resolvable.
         """
-        from dascore.proc.inventory import (  # noqa: PLC0415
-            get_attr_values,
-            resolve_contexts,
-        )
+        from dascore.proc.inventory import get_attr_values  # noqa: PLC0415
 
         df = self._df
         if not len(df):
             return self
-        # Resolution needs an identity and a time, which the relation
-        # always carries: they are structural columns of the index.
-        assert {"acquisition_key", "time_min", "time_max"} <= set(df.columns)
         ids = df["_patch_id"].to_numpy()
         contexts = None
         mask = np.ones(len(df), dtype=bool)
@@ -926,12 +935,7 @@ class Spool(BaseSpool):
             matched = np.isin(ids, self._index_matches(name, selector))
             if not stated.all():
                 if contexts is None:
-                    contexts = resolve_contexts(
-                        self._inventory,
-                        df["acquisition_key"],
-                        df["time_min"],
-                        df["time_max"],
-                    )
+                    contexts = self._resolve_rows(df)
                 matched[~stated] = _match_resolved(
                     get_attr_values(self._inventory, contexts[~stated], name),
                     name,
@@ -939,6 +943,26 @@ class Spool(BaseSpool):
                 )
             mask &= matched
         return self._new_from_catalog(self._catalog.restrict(mask))
+
+    def _resolve_rows(self, df) -> np.ndarray:
+        """
+        Resolve each presented row to its inventory context, or to None.
+
+        Resolution needs an identity and the instants to resolve it at. A
+        spool whose patches carry no `acquisition_key` has no identity to
+        offer, and one whose time axis is not physical — lag times from a
+        correlation, say — has no instants, which is the same thing
+        `Patch.enrich` refuses to guess at.
+        """
+        from dascore.proc.inventory import resolve_contexts  # noqa: PLC0415
+
+        columns = [df.get(x) for x in ("acquisition_key", "time_min", "time_max")]
+        physical = all(column is not None for column in columns) and all(
+            np.issubdtype(column.dtype, np.datetime64) for column in columns[1:]
+        )
+        if not physical:
+            return np.full(len(df), None, dtype=object)
+        return resolve_contexts(self._inventory, *columns)
 
     def _index_matches(self, name: str, selector) -> np.ndarray:
         """Return the ids of the rows the index itself selects for one name."""

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -23,6 +23,10 @@ from dascore.constants import (
     ExecutorType,
     PatchType,
     attr_conflict_description,
+    enrich_attrs_description,
+    enrich_conflicts_description,
+    enrich_coords_description,
+    enrich_on_missing_description,
     namespace_select_type,
     numeric_types,
     path_types,
@@ -789,6 +793,12 @@ class Spool(BaseSpool):
         new._enrich_kwargs = None
         return new
 
+    @compose_docstring(
+        attrs_desc=enrich_attrs_description,
+        coords_desc=enrich_coords_description,
+        on_missing_desc=enrich_on_missing_description,
+        conflicts_desc=enrich_conflicts_description,
+    )
     def enrich(
         self,
         inventory=None,
@@ -824,12 +834,27 @@ class Spool(BaseSpool):
             A patch which *straddles* two epochs is described twice rather
             than not at all, and raises regardless: it needs subdividing.
         **kwargs
-            Passed to [`Patch.enrich`](`dascore.proc.inventory.enrich`) for
-            each extracted patch, which documents them; the names accepted
-            here are read from its signature, so the two cannot disagree.
-            Only the names are checked at this point — the values each
-            patch's own enrichment checks as it is extracted. Calling
-            `enrich` again replaces these rather than adding to them.
+            Held and passed to
+            [`Patch.enrich`](`dascore.proc.inventory.enrich`) for each
+            extracted patch. The names accepted are read from its
+            signature, so the two cannot disagree, and only the names are
+            checked at this point — the values each patch's own enrichment
+            checks as it is extracted. Calling `enrich` again replaces
+            these rather than adding to them. They are:
+
+        Other Parameters
+        ----------------
+        {attrs_desc}
+        {coords_desc}
+        acquisition_key
+            The inventory identity to resolve, for patches which do not
+            carry one. Given both, each patch and this argument must agree.
+        time
+            The instant to resolve at, for patches whose time axis is not
+            physical. A patch with a real time coordinate resolves at its
+            own time and passing this raises.
+        {on_missing_desc}
+        {conflicts_desc}
 
         Examples
         --------

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -825,10 +825,17 @@ class Spool(BaseSpool):
                 "it) or none of it, so it says neither."
             )
             raise ParameterError(msg)
-        self._check_channel_level(requested)
+        known_attrs, known_coords = self._index_names()
+        selectable = set()
+        if self._inventory is not None:
+            names = self._inventory.get_names()
+            self._check_channel_level(
+                requested, set(names.coords), known_attrs | known_coords
+            )
+            selectable = set(names.attrs) - known_coords
         attrs, coords = resolve_selector_namespaces(
-            set(self._catalog.backend.attr_names()) | self._inventory_attr_names(),
-            self._catalog.backend.coord_names(),
+            known_attrs | selectable,
+            known_coords,
             _attrs=_attrs,
             _coords=_coords,
             kwargs=kwargs,
@@ -849,23 +856,13 @@ class Spool(BaseSpool):
         keep = ~np.isin(ids, np.asarray(removed, dtype=np.int64))
         return self._new_from_catalog(self._catalog.restrict(keep))
 
-    def _inventory_attr_names(self) -> set[str]:
-        """The attrs an attached inventory adds to what this spool selects on."""
-        if self._inventory is None:
-            return set()
-        # A name the index already uses for a coordinate keeps its meaning;
-        # bare names resolve to attrs first, and an inventory must not
-        # quietly move one out of the namespace it has always been in.
-        names = set(self._inventory.get_names().attrs)
-        return names - set(self._catalog.backend.coord_names())
-
-    def _check_channel_level(self, requested: set[str]) -> None:
-        """Raise for a name the inventory defines along the fiber."""
-        if self._inventory is None:
-            return
+    def _index_names(self) -> tuple[set[str], set[str]]:
+        """The attr and coord names the index knows, read once per call."""
         backend = self._catalog.backend
-        known = set(backend.attr_names()) | set(backend.coord_names())
-        coords = set(self._inventory.get_names().coords)
+        return set(backend.attr_names()), set(backend.coord_names())
+
+    def _check_channel_level(self, requested, coords, known) -> None:
+        """Raise for a name the inventory defines along the fiber."""
         if channel_level := sorted(requested & coords - known):
             msg = (
                 f"{channel_level} name coordinates the attached inventory "
@@ -885,21 +882,34 @@ class Spool(BaseSpool):
         if self._inventory is None:
             return {}, _attrs, _coords, kwargs
         requested = _requested_names(_attrs, _coords, kwargs)
-        self._check_channel_level(requested)
+        known_attrs, known_coords = self._index_names()
+        names = self._inventory.get_names()
+        self._check_channel_level(
+            requested, set(names.coords), known_attrs | known_coords
+        )
+        # A name the index already uses for a coordinate keeps its meaning;
+        # bare names resolve to attrs first, and an inventory must not
+        # quietly move one out of the namespace it has always been in.
+        selectable = set(names.attrs) - known_coords
         # samples=True selections are coordinate-only, so an attr among
         # them is an error the index states better than this can.
-        selectable = self._inventory_attr_names()
         if samples or not requested & selectable:
             return {}, _attrs, _coords, kwargs
-        backend = self._catalog.backend
         attrs, coords = resolve_selector_namespaces(
-            set(backend.attr_names()) | selectable,
-            backend.coord_names(),
+            known_attrs | selectable,
+            known_coords,
             _attrs=_attrs,
             _coords=_coords,
             kwargs=kwargs,
         )
-        query = {x: attrs.pop(x) for x in list(attrs) if x in selectable}
+        query = {}
+        for name in list(attrs):
+            if name not in selectable:
+                continue
+            value = attrs.pop(name)
+            # A bare None or ... selects everything, here as everywhere.
+            if value is not None and value is not Ellipsis:
+                query[name] = value
         return query, attrs, coords, {}
 
     def _select_from_inventory(self, query: dict) -> Self:
@@ -918,33 +928,32 @@ class Spool(BaseSpool):
         """
         from dascore.proc.inventory import get_attr_values  # noqa: PLC0415
 
-        df = self._df
-        if not len(df):
+        ids = np.asarray(self._catalog._ordered_ids(), dtype=np.int64)
+        if not len(ids):
             return self
-        ids = df["_patch_id"].to_numpy()
+        backend = self._catalog.backend
         contexts = None
-        mask = np.ones(len(df), dtype=bool)
+        mask = np.ones(len(ids), dtype=bool)
         for name, selector in query.items():
-            stated = (
-                ~_unstated(df[name])
-                if name in df.columns
-                else np.zeros(len(df), dtype=bool)
-            )
+            # Which rows state the name is asked of the index rather than
+            # read off the relation, so a spool whose headers state it
+            # everywhere is never realized: the index alone answers.
+            stated = np.isin(ids, list(backend.attr_stated_ids(name, patch_ids=ids)))
             # SQL never matches a row which states nothing, so this is the
             # verdict for the stated rows and False everywhere else.
             matched = np.isin(ids, self._index_matches(name, selector))
             if not stated.all():
                 if contexts is None:
-                    contexts = self._resolve_rows(df)
+                    contexts = self._resolve_rows(ids)
                 matched[~stated] = _match_resolved(
                     get_attr_values(self._inventory, contexts[~stated], name),
                     name,
                     selector,
                 )
             mask &= matched
-        return self._new_from_catalog(self._catalog.restrict(mask))
+        return self._new_from_catalog(self._catalog.restrict(mask, ids=ids))
 
-    def _resolve_rows(self, df) -> np.ndarray:
+    def _resolve_rows(self, ids) -> np.ndarray:
         """
         Resolve each presented row to its inventory context, or to None.
 
@@ -953,9 +962,15 @@ class Spool(BaseSpool):
         offer, and one whose time axis is not physical — lag times from a
         correlation, say — has no instants, which is the same thing
         `Patch.enrich` refuses to guess at.
+
+        This is where the relation is realized, which is why it is only
+        reached for a name the index does not state for every row.
         """
         from dascore.proc.inventory import resolve_contexts  # noqa: PLC0415
 
+        df = self._df
+        # The relation and the id list are one presentation of one view.
+        assert np.array_equal(df["_patch_id"].to_numpy(), ids)
         columns = [df.get(x) for x in ("acquisition_key", "time_min", "time_max")]
         physical = all(column is not None for column in columns) and all(
             np.issubdtype(column.dtype, np.datetime64) for column in columns[1:]

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 import inspect
 import warnings
-from collections.abc import Callable, Generator, Iterator, Sequence
+from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
 from functools import singledispatch
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar, overload
@@ -61,7 +61,7 @@ from dascore.utils.patch import (
     stack_patches,
 )
 from dascore.utils.paths import coerce_to_upath, requires_local_directory
-from dascore.utils.pd import present_units_columns
+from dascore.utils.pd import present_units_columns, resolve_selector_namespaces
 
 if TYPE_CHECKING:
     from dascore.io.index.catalog import PatchCatalog
@@ -95,6 +95,32 @@ _UNRESOLVED_WARNING = (
     "to see which, 'ignore' to silence this, or remove them from the spool "
     "once Spool.prune_to_inventory exists."
 )
+
+
+def _unstated(values) -> np.ndarray:
+    """
+    Return a mask of the entries which state no value.
+
+    A patch says it does not know a name by leaving it null, which a
+    string column spells as the empty string; both are what an attached
+    inventory is asked to fill in.
+    """
+    series = pd.Series(np.asarray(values, dtype=object))
+    return (series.isna() | series.eq("")).to_numpy()
+
+
+def _match_resolved(values, name: str, selector) -> np.ndarray:
+    """Return which of the values an inventory states match a selector."""
+    from dascore.io.index.query import evaluate_attr_predicate  # noqa: PLC0415
+
+    values = np.asarray(values, dtype=object)
+    out = np.zeros(len(values), dtype=bool)
+    # A name the inventory has no answer for is not one it can select on,
+    # and the predicate would be comparing against the missing marker.
+    stated = ~_unstated(values)
+    if stated.any():
+        out[stated] = evaluate_attr_predicate(values[stated], name, selector)
+    return out
 
 
 def _normalize_enrich_kwargs(kwargs) -> dict:
@@ -704,26 +730,127 @@ class Spool(BaseSpool):
         **kwargs,
     ) -> Self:
         """{doc}."""
-        try:
-            catalog = self._catalog.select(
-                _attrs=_attrs,
-                _coords=_coords,
-                samples=samples,
-                relative=relative,
-                **kwargs,
-            )
-        except InvalidSpoolQueryError as error:
-            # A name the index does not know may still be one the attached
-            # inventory defines, and the index's message would deny it exists.
-            if self._inventory is None:
-                raise
+        inventory_query, _attrs, _coords, kwargs = self._split_inventory_query(
+            _attrs, _coords, kwargs, samples
+        )
+        catalog = self._catalog.select(
+            _attrs=_attrs,
+            _coords=_coords,
+            samples=samples,
+            relative=relative,
+            **kwargs,
+        )
+        out = self._new_from_catalog(catalog)
+        if inventory_query:
+            out = out._select_from_inventory(inventory_query)
+        return out
+
+    def _split_inventory_query(self, _attrs, _coords, kwargs, samples):
+        """
+        Split selectors into the ones the index answers and the rest.
+
+        A name the attached inventory could contribute is evaluated per
+        row rather than pushed into SQL: the index states it for some rows
+        and the inventory only fills in the others.
+        """
+        if self._inventory is None:
+            return {}, _attrs, _coords, kwargs
+        names = self._inventory.get_names()
+        backend = self._catalog.backend
+        known_attrs, known_coords = (
+            set(backend.attr_names()),
+            set(backend.coord_names()),
+        )
+        # A tag-form _attrs/_coords names bare kwargs, so every requested
+        # name is either a bare kwarg or a key of a mapping form.
+        requested = set(kwargs)
+        for spec in (_attrs, _coords):
+            if isinstance(spec, Mapping):
+                requested |= set(spec)
+        if channel_level := sorted(
+            requested & set(names.coords) - known_attrs - known_coords
+        ):
             msg = (
-                f"{error} If this names a field the attached inventory "
-                "defines, selecting on it is not supported yet: enrich the "
-                "patches and select on each one instead."
+                f"{channel_level} name coordinates the attached inventory "
+                "defines along the fiber, which selection cannot trim to "
+                "yet. Enrich the patches and select on each one instead."
             )
-            raise InvalidSpoolQueryError(msg) from error
-        return self._new_from_catalog(catalog)
+            raise InvalidSpoolQueryError(msg)
+        # samples=True selections are coordinate-only, so an attr among
+        # them is an error the index states better than this can.
+        selectable = set(names.attrs) - known_coords
+        if samples or not requested & selectable:
+            return {}, _attrs, _coords, kwargs
+        attrs, coords = resolve_selector_namespaces(
+            known_attrs | selectable,
+            known_coords,
+            _attrs=_attrs,
+            _coords=_coords,
+            kwargs=kwargs,
+        )
+        query = {x: attrs.pop(x) for x in list(attrs) if x in selectable}
+        return query, attrs, coords, {}
+
+    def _select_from_inventory(self, query: dict) -> Self:
+        """
+        Keep the rows whose inventory-backed values match.
+
+        Precedence is per row: a row which states the name is judged by
+        the index, exactly as it would be without an inventory, and only
+        the rows leaving it unstated are resolved. A spool whose headers
+        state everything therefore never touches the inventory, and one
+        which states nothing resolves once per epoch rather than per row.
+        A row the inventory has no answer for is not selected, as a patch
+        lacking the attr entirely is not.
+        """
+        from dascore.proc.inventory import (  # noqa: PLC0415
+            get_attr_values,
+            resolve_contexts,
+        )
+
+        df = self._df
+        if not len(df):
+            return self
+        # Resolution needs an identity and a time, which the relation
+        # always carries: they are structural columns of the index.
+        assert {"acquisition_key", "time_min", "time_max"} <= set(df.columns)
+        ids = df["_patch_id"].to_numpy()
+        contexts = None
+        mask = np.ones(len(df), dtype=bool)
+        for name, selector in query.items():
+            stated = (
+                ~_unstated(df[name])
+                if name in df.columns
+                else np.zeros(len(df), dtype=bool)
+            )
+            # SQL never matches a row which states nothing, so this is the
+            # verdict for the stated rows and False everywhere else.
+            matched = np.isin(ids, self._index_matches(name, selector))
+            if not stated.all():
+                if contexts is None:
+                    contexts = resolve_contexts(
+                        self._inventory,
+                        df["acquisition_key"],
+                        df["time_min"],
+                        df["time_max"],
+                    )
+                matched[~stated] = _match_resolved(
+                    get_attr_values(self._inventory, contexts[~stated], name),
+                    name,
+                    selector,
+                )
+            mask &= matched
+        return self._new_from_catalog(self._catalog.restrict(mask))
+
+    def _index_matches(self, name: str, selector) -> np.ndarray:
+        """Return the ids of the rows the index itself selects for one name."""
+        try:
+            catalog = self._catalog.select(_attrs={name: selector})
+        except InvalidSpoolQueryError:
+            # No patch in this spool states the name, so the index selects
+            # none of them and the inventory answers for every row.
+            return np.empty(0, dtype=np.int64)
+        return np.asarray(catalog._ordered_ids(), dtype=np.int64)
 
     def attach_inventory(self, inventory) -> Self:
         """

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -483,11 +483,12 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         one bad tag, an instrument being serviced — without spelling the
         rest of the archive as a selection.
 
-        Coordinates are not accepted. A coordinate range decides how much
-        of each patch to keep rather than which patches to keep, and its
-        complement is a hole in the middle: removing a patch which merely
-        overlaps the range would throw away the part that does not.
-        Select the ranges to keep instead.
+        Coordinates are not accepted yet. Selecting on one trims each
+        patch to the range rather than choosing between patches, so the
+        complement is every patch cut into the pieces outside it — one
+        patch becoming two. That is subdivision rather than filtering,
+        and it needs machinery this does not have; until it does, select
+        the ranges to keep.
 
         Naming nothing raises, and so does naming only no-op selectors
         (`None`, `...`). `select()` with no selection is the whole spool,
@@ -836,10 +837,10 @@ class Spool(BaseSpool):
         )
         if coords:
             msg = (
-                f"{sorted(coords)} name coordinates, which unselect does not "
-                "take: a range says how much of each patch to keep rather "
-                "than which patches, so removing every patch it touches "
-                "would throw away the parts outside it. Select the ranges "
+                f"{sorted(coords)} name coordinates, which unselect cannot "
+                "take yet: selecting on one trims each patch, so removing "
+                "a range means cutting every patch into the pieces outside "
+                "it rather than choosing between patches. Select the ranges "
                 "to keep instead."
             )
             raise InvalidSpoolQueryError(msg)

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -123,6 +123,21 @@ def _requested_names(_attrs, _coords, kwargs) -> set[str]:
     return out
 
 
+def _namespace_names(spec: namespace_select_type) -> set[str]:
+    """
+    Return the names an `_attrs`/`_coords` argument designates.
+
+    Either form: a mapping of name -> selector, or a name (or names)
+    tagging bare kwargs. A malformed spec keeps only what is a name, so
+    the resolver is left to complain about the rest properly.
+    """
+    if spec is None:
+        return set()
+    if isinstance(spec, str):
+        return {spec}
+    return {x for x in spec if isinstance(x, str)}
+
+
 def _match_resolved(values, name: str, selector, units=None) -> np.ndarray:
     """Return which of the values an inventory states match a selector."""
     from dascore.io.index.query import evaluate_attr_predicate  # noqa: PLC0415
@@ -825,7 +840,10 @@ class Spool(BaseSpool):
         if self._inventory is not None:
             names = self._inventory.get_names()
             self._check_channel_level(
-                requested, set(names.coords), known_attrs | known_coords
+                requested,
+                set(names.coords),
+                known_attrs | known_coords | set(names.attrs),
+                _namespace_names(_coords),
             )
             selectable = set(names.attrs) - known_coords
         attrs, coords = resolve_selector_namespaces(
@@ -867,9 +885,17 @@ class Spool(BaseSpool):
         backend = self._catalog.backend
         return set(backend.attr_names()), set(backend.coord_names())
 
-    def _check_channel_level(self, requested, coords, known) -> None:
-        """Raise for a name the inventory defines along the fiber."""
-        if channel_level := sorted(requested & coords - known):
+    def _check_channel_level(self, requested, coords, known, wanted_coords) -> None:
+        """
+        Raise for a name the inventory defines along the fiber.
+
+        A name which is also an attr resolves to the attr, as bare names
+        always do, so only one the caller put in `_coords` is read as the
+        coordinate — an annotation group may share an acquisition field's
+        name, and selecting on the field must keep working.
+        """
+        candidates = (requested - known) | (wanted_coords & coords)
+        if channel_level := sorted(candidates & coords):
             msg = (
                 f"{channel_level} name coordinates the attached inventory "
                 "defines along the fiber, which selection cannot trim to "
@@ -891,7 +917,10 @@ class Spool(BaseSpool):
         known_attrs, known_coords = self._index_names()
         names = self._inventory.get_names()
         self._check_channel_level(
-            requested, set(names.coords), known_attrs | known_coords
+            requested,
+            set(names.coords),
+            known_attrs | known_coords | set(names.attrs),
+            _namespace_names(_coords),
         )
         # A name the index already uses for a coordinate keeps its meaning;
         # bare names resolve to attrs first, and an inventory must not

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -109,6 +109,20 @@ def _unstated(values) -> np.ndarray:
     return (series.isna() | series.eq("")).to_numpy()
 
 
+def _requested_names(_attrs, _coords, kwargs) -> set[str]:
+    """
+    Return every name a selection call names, whatever form it arrives in.
+
+    A tag-form `_attrs`/`_coords` names bare kwargs, so a requested name
+    is always either a bare kwarg or a key of a mapping form.
+    """
+    out = set(kwargs)
+    for spec in (_attrs, _coords):
+        if isinstance(spec, Mapping):
+            out |= set(spec)
+    return out
+
+
 def _match_resolved(values, name: str, selector) -> np.ndarray:
     """Return which of the values an inventory states match a selector."""
     from dascore.io.index.query import evaluate_attr_predicate  # noqa: PLC0415
@@ -452,6 +466,50 @@ class BaseSpool(NamespaceOwner, abc.ABC):
 
     # --- optional methods
 
+    def unselect(
+        self,
+        *,
+        _attrs: namespace_select_type = None,
+        _coords: namespace_select_type = None,
+        **kwargs,
+    ) -> Self:
+        """
+        Return the spool without the patches a selection would keep.
+
+        The complement of
+        [`select`](`dascore.core.spool.Spool.select`): each keyword means
+        exactly what it means there, and the patches it would match are
+        the ones removed. This is how a spool says what it does not want —
+        one bad tag, an instrument being serviced — without spelling the
+        rest of the archive as a selection.
+
+        Coordinates are not accepted. A coordinate range decides how much
+        of each patch to keep rather than which patches to keep, and its
+        complement is a hole in the middle: removing a patch which merely
+        overlaps the range would throw away the part that does not.
+        Select the ranges to keep instead.
+
+        Parameters
+        ----------
+        _attrs
+            Attribute selections, in the forms
+            [`select`](`dascore.core.spool.Spool.select`) accepts.
+        _coords
+            Accepted only to say so; see above.
+        **kwargs
+            The selection whose matches are removed.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> spool = dc.get_example_spool("diverse_das")
+        >>> # everything except the patches tagged 'some_tag'
+        >>> rest = spool.unselect(tag='some_tag')
+        >>> assert len(rest) + len(spool.select(tag='some_tag')) == len(spool)
+        """
+        msg = f"spool of type {self.__class__} has no unselect implementation"
+        raise NotImplementedError(msg)
+
     def sort(self, attribute) -> Self:
         """
         Sort the Spool based on a specific attribute.
@@ -745,6 +803,64 @@ class Spool(BaseSpool):
             out = out._select_from_inventory(inventory_query)
         return out
 
+    @compose_docstring(doc=get_docstring(BaseSpool.unselect))
+    def unselect(
+        self,
+        *,
+        _attrs: namespace_select_type = None,
+        _coords: namespace_select_type = None,
+        **kwargs,
+    ) -> Self:
+        """{doc}."""
+        self._check_channel_level(_requested_names(_attrs, _coords, kwargs))
+        attrs, coords = resolve_selector_namespaces(
+            set(self._catalog.backend.attr_names()) | self._inventory_attr_names(),
+            self._catalog.backend.coord_names(),
+            _attrs=_attrs,
+            _coords=_coords,
+            kwargs=kwargs,
+        )
+        if coords:
+            msg = (
+                f"{sorted(coords)} name coordinates, which unselect does not "
+                "take: a range says how much of each patch to keep rather "
+                "than which patches, so removing every patch it touches "
+                "would throw away the parts outside it. Select the ranges "
+                "to keep instead."
+            )
+            raise InvalidSpoolQueryError(msg)
+        # The complement is taken against select itself rather than by
+        # negating each predicate, so the two can never drift apart.
+        removed = self.select(_attrs=attrs)._catalog._ordered_ids()
+        ids = np.asarray(self._catalog._ordered_ids(), dtype=np.int64)
+        keep = ~np.isin(ids, np.asarray(removed, dtype=np.int64))
+        return self._new_from_catalog(self._catalog.restrict(keep))
+
+    def _inventory_attr_names(self) -> set[str]:
+        """The attrs an attached inventory adds to what this spool selects on."""
+        if self._inventory is None:
+            return set()
+        # A name the index already uses for a coordinate keeps its meaning;
+        # bare names resolve to attrs first, and an inventory must not
+        # quietly move one out of the namespace it has always been in.
+        names = set(self._inventory.get_names().attrs)
+        return names - set(self._catalog.backend.coord_names())
+
+    def _check_channel_level(self, requested: set[str]) -> None:
+        """Raise for a name the inventory defines along the fiber."""
+        if self._inventory is None:
+            return
+        backend = self._catalog.backend
+        known = set(backend.attr_names()) | set(backend.coord_names())
+        coords = set(self._inventory.get_names().coords)
+        if channel_level := sorted(requested & coords - known):
+            msg = (
+                f"{channel_level} name coordinates the attached inventory "
+                "defines along the fiber, which selection cannot trim to "
+                "yet. Enrich the patches and select on each one instead."
+            )
+            raise InvalidSpoolQueryError(msg)
+
     def _split_inventory_query(self, _attrs, _coords, kwargs, samples):
         """
         Split selectors into the ones the index answers and the rest.
@@ -755,35 +871,17 @@ class Spool(BaseSpool):
         """
         if self._inventory is None:
             return {}, _attrs, _coords, kwargs
-        names = self._inventory.get_names()
-        backend = self._catalog.backend
-        known_attrs, known_coords = (
-            set(backend.attr_names()),
-            set(backend.coord_names()),
-        )
-        # A tag-form _attrs/_coords names bare kwargs, so every requested
-        # name is either a bare kwarg or a key of a mapping form.
-        requested = set(kwargs)
-        for spec in (_attrs, _coords):
-            if isinstance(spec, Mapping):
-                requested |= set(spec)
-        if channel_level := sorted(
-            requested & set(names.coords) - known_attrs - known_coords
-        ):
-            msg = (
-                f"{channel_level} name coordinates the attached inventory "
-                "defines along the fiber, which selection cannot trim to "
-                "yet. Enrich the patches and select on each one instead."
-            )
-            raise InvalidSpoolQueryError(msg)
+        requested = _requested_names(_attrs, _coords, kwargs)
+        self._check_channel_level(requested)
         # samples=True selections are coordinate-only, so an attr among
         # them is an error the index states better than this can.
-        selectable = set(names.attrs) - known_coords
+        selectable = self._inventory_attr_names()
         if samples or not requested & selectable:
             return {}, _attrs, _coords, kwargs
+        backend = self._catalog.backend
         attrs, coords = resolve_selector_namespaces(
-            known_attrs | selectable,
-            known_coords,
+            set(backend.attr_names()) | selectable,
+            backend.coord_names(),
             _attrs=_attrs,
             _coords=_coords,
             kwargs=kwargs,

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -859,7 +859,7 @@ class Spool(BaseSpool):
         removed = self.select(_attrs=stated)._catalog._ordered_ids()
         ids = np.asarray(self._catalog._ordered_ids(), dtype=np.int64)
         keep = ~np.isin(ids, np.asarray(removed, dtype=np.int64))
-        return self._new_from_catalog(self._catalog.restrict(keep))
+        return self._new_from_catalog(self._catalog.restrict(keep, ids=ids))
 
     def _index_names(self) -> tuple[set[str], set[str]]:
         """The attr and coord names the index knows, read once per call."""
@@ -937,6 +937,7 @@ class Spool(BaseSpool):
         if not len(ids):
             return self
         backend = self._catalog.backend
+        known = set(backend.attr_names())
         contexts = None
         mask = np.ones(len(ids), dtype=bool)
         for name, selector in query.items():
@@ -946,7 +947,7 @@ class Spool(BaseSpool):
             stated = np.isin(ids, list(backend.attr_stated_ids(name, patch_ids=ids)))
             # SQL never matches a row which states nothing, so this is the
             # verdict for the stated rows and False everywhere else.
-            matched = np.isin(ids, self._index_matches(name, selector))
+            matched = np.isin(ids, self._index_matches(name, selector, known))
             if not stated.all():
                 if contexts is None:
                     contexts = self._resolve_rows(ids)
@@ -996,15 +997,20 @@ class Spool(BaseSpool):
             out[position] = resolved.get(patch_id)
         return out
 
-    def _index_matches(self, name: str, selector) -> np.ndarray:
-        """Return the ids of the rows the index itself selects for one name."""
-        try:
-            catalog = self._catalog.select(_attrs={name: selector})
-        except InvalidSpoolQueryError:
-            # No patch in this spool states the name, so the index selects
-            # none of them and the inventory answers for every row.
+    def _index_matches(self, name: str, selector, known: set[str]) -> np.ndarray:
+        """
+        Return the ids of the rows the index itself selects for one name.
+
+        A name no patch states is asked about rather than tried: the index
+        rejects it and the inventory answers for every row, and catching
+        that rejection would catch a malformed selector with it.
+        """
+        if name not in known:
             return np.empty(0, dtype=np.int64)
-        return np.asarray(catalog._ordered_ids(), dtype=np.int64)
+        return np.asarray(
+            self._catalog.select(_attrs={name: selector})._ordered_ids(),
+            dtype=np.int64,
+        )
 
     def attach_inventory(self, inventory) -> Self:
         """

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -37,6 +37,7 @@ from dascore.io.index.query import (
     InvalidSpoolQueryError,
     Query,
     _as_query_list,
+    _normalize_unit,
     apply_residuals,
     build_sql,
 )
@@ -1089,6 +1090,15 @@ class SQLIndexBackend(abc.ABC):
         """Return coord names known to the index."""
         df = self._fetch_df("SELECT DISTINCT coord_name FROM patch_coords")
         return set(df["coord_name"])
+
+    def attr_units(self, name: str) -> dict[str, str | None]:
+        """Return the canonical units the index stores one attr's kinds in."""
+        rows = self._attr_meta()
+        rows = rows[rows["attr_name"] == name]
+        return {
+            str(kind): _normalize_unit(unit)
+            for kind, unit in zip(rows["value_kind"], rows["units"], strict=True)
+        }
 
     def attr_stated_ids(self, name: str, patch_ids=None) -> set[int]:
         """

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -9,6 +9,7 @@ has a clear boundary.
 from __future__ import annotations
 
 import abc
+import json
 import time
 import warnings
 from contextlib import contextmanager, nullcontext, suppress
@@ -1088,6 +1089,27 @@ class SQLIndexBackend(abc.ABC):
         """Return coord names known to the index."""
         df = self._fetch_df("SELECT DISTINCT coord_name FROM patch_coords")
         return set(df["coord_name"])
+
+    def attr_stated_ids(self, name: str, patch_ids=None) -> set[int]:
+        """
+        Return the ids of the patches which state a value for one attr.
+
+        An attr may be stored in more than one typed column across an
+        archive, and a patch states it when any of them holds a value.
+        This answers without projecting the relation, so a caller can
+        tell whether it needs to look anywhere else for the rest.
+        """
+        rows = self._attr_meta()
+        columns = rows[rows["attr_name"] == name]["column_name"].unique()
+        if not len(columns):
+            return set()
+        stated = " OR ".join(f"{self.dialect.quote(x)} IS NOT NULL" for x in columns)
+        sql = f"SELECT patch_id FROM attrs WHERE ({stated})"
+        params: list = []
+        if patch_ids is not None:
+            sql += " AND patch_id IN (SELECT value FROM json_each(?))"
+            params.append(json.dumps([int(x) for x in patch_ids]))
+        return {int(x) for x in self._fetch_df(sql, params)["patch_id"]}
 
     def coord_dims_map(self) -> dict[str, str]:
         """Return each coord name's dims string (first observed wins)."""

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -742,15 +742,16 @@ class PatchCatalog:
         ids = self._ordered_ids()[item]
         return self._view(self._queries, self._residuals, ids=tuple(ids))
 
-    def restrict(self, indices) -> PatchCatalog:
+    def restrict(self, indices, ids=None) -> PatchCatalog:
         """
         Return a view keeping the presented rows an array selects.
 
         ``indices`` is a boolean mask over rows or an array of integer
         positions (order-preserving; duplicate positions collapse to
-        one row, matching the spool's set semantics).
+        one row, matching the spool's set semantics). ``ids`` is this
+        view's presented ids, for a caller which has just read them.
         """
-        ids = np.asarray(self._ordered_ids())
+        ids = np.asarray(self._ordered_ids() if ids is None else ids)
         picked = ids[np.asarray(indices)]
         deduped = tuple(dict.fromkeys(int(x) for x in picked))
         return self._view(self._queries, self._residuals, ids=deduped)

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -707,9 +707,22 @@ class PatchCatalog:
         return self._order if self._order is not None else self._default_order
 
     def _ordered_ids(self) -> tuple[int, ...]:
-        """The view's patch ids in presentation order (ids only, cheap)."""
+        """
+        The view's patch ids in presentation order (ids only, cheap).
+
+        A fixed membership is its own presentation order — an integer
+        array may have reordered it — so predicates composed *after* it
+        was fixed filter that order rather than replacing it. Returning
+        the membership unfiltered would ignore them entirely, and letting
+        SQL order the result would undo the arrangement.
+        """
         if self._ids is not None and self._order is None:
-            return self._ids
+            if not self._queries:
+                return self._ids
+            matched = set(
+                self.backend.query_ids(list(self._queries), patch_ids=self._ids)
+            )
+            return tuple(x for x in self._ids if x in matched)
         return tuple(
             self.backend.query_ids(
                 list(self._queries) or None,

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -325,6 +325,26 @@ def hive_path_attrs(rel_posix: str, warn: bool = True) -> dict[str, str]:
     return out
 
 
+def _states_something_else(existing: TypedValue, path_value: str) -> bool:
+    """
+    Return True when a path segment changes what an attr says.
+
+    The comparison is on meaning rather than spelling: a directory named
+    `gauge_length=10` over a file stating `10.0` restates it, and warning
+    there would send someone looking for a disagreement the layout does
+    not contain. A path value which cannot be read as the stored kind at
+    all does change what the attr says, whatever it then says.
+    """
+    if existing.kind == "num":
+        try:
+            return float(path_value) != float(existing.value)
+        except ValueError:
+            return True
+    if existing.kind == "bool":
+        return path_value.strip().lower() != str(existing.value).lower()
+    return str(existing.value) != path_value
+
+
 def hive_typed_attrs(path_attrs: dict[str, str]) -> dict[str, TypedValue]:
     """Wrap hive path attrs as string TypedValues (no type inference)."""
     return {name: TypedValue("str", value) for name, value in path_attrs.items()}
@@ -474,7 +494,9 @@ def summaries_to_records(
     # Names a directory renamed out from under the file which states them,
     # with one path each: the layout is the correction mechanism, so this
     # is legal, but a whole archive silently disagreeing with its own
-    # headers is worth hearing about once.
+    # headers is worth hearing about once. Only sources being scanned are
+    # compared -- a detected move rewrites the stored attrs without
+    # reopening the file, so what the file itself says is not on hand.
     overridden: dict[str, str] = {}
     for path, group in by_source.items():
         first = group[0]
@@ -501,7 +523,7 @@ def summaries_to_records(
                 typed = hive_typed_attrs(path_attrs)
                 for patch in patches:
                     for name in typed.keys() & patch.attrs.keys():
-                        if str(patch.attrs[name].value) != typed[name].value:
+                        if _states_something_else(patch.attrs[name], path_attrs[name]):
                             overridden.setdefault(name, store_path)
                 patches = [replace(p, attrs={**p.attrs, **typed}) for p in patches]
         out.append(

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -342,6 +342,15 @@ def _states_something_else(existing: TypedValue, path_value: str) -> bool:
             return True
     if existing.kind == "bool":
         return path_value.strip().lower() != str(existing.value).lower()
+    if existing.kind in {"time", "dur"}:
+        # Stored as integer nanoseconds, which a path segment never spells
+        # that way; read the segment as an instant before comparing.
+        convert = to_datetime64 if existing.kind == "time" else to_timedelta64
+        try:
+            stated = typed_value(convert(path_value))
+        except (ValueError, TypeError):
+            return True
+        return stated is None or stated.value != existing.value
     return str(existing.value) != path_value
 
 

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -471,6 +471,11 @@ def summaries_to_records(
     root_posix = str(root).replace("\\", "/") if root else None
     root_prefix = root_posix.rstrip("/") if root_posix else None
     out = []
+    # Names a directory renamed out from under the file which states them,
+    # with one path each: the layout is the correction mechanism, so this
+    # is legal, but a whole archive silently disagreeing with its own
+    # headers is worth hearing about once.
+    overridden: dict[str, str] = {}
     for path, group in by_source.items():
         first = group[0]
         patches = []
@@ -494,6 +499,10 @@ def summaries_to_records(
             path_attrs = hive_path_attrs(store_path) or None
             if path_attrs:
                 typed = hive_typed_attrs(path_attrs)
+                for patch in patches:
+                    for name in typed.keys() & patch.attrs.keys():
+                        if str(patch.attrs[name].value) != typed[name].value:
+                            overridden.setdefault(name, store_path)
                 patches = [replace(p, attrs={**p.attrs, **typed}) for p in patches]
         out.append(
             SourceRecord(
@@ -507,6 +516,14 @@ def summaries_to_records(
                 patches=tuple(patches),
             )
         )
+    if overridden:
+        shown = ", ".join(f"{k!r} (e.g. {v!r})" for k, v in sorted(overridden.items()))
+        msg = (
+            f"Hive-style path segments override attrs the files themselves "
+            f"state: {shown}. The path wins, which is how a directory rename "
+            "corrects metadata; check the layout if that was not intended."
+        )
+        warnings.warn(msg, UserWarning, stacklevel=2)
     return out
 
 

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -11,10 +11,12 @@ exactly are applied as pandas residual filters.
 from __future__ import annotations
 
 import json
+import operator
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum, auto
+from fnmatch import fnmatch
 
 import numpy as np
 import pandas as pd
@@ -322,6 +324,58 @@ def build_attr_clause(
     val = _to_target_unit(typed, units.get(kind), name)
     where.add(f"{col(kind)} = ?", val)
     return None
+
+
+def evaluate_attr_predicate(values, name: str, value) -> np.ndarray:
+    """
+    Evaluate one attr selector against values held in memory.
+
+    The in-memory twin of `build_attr_clause`, for values which never
+    reach the index — those an inventory states rather than a file. It
+    takes the same selector shapes and means the same thing by each, so a
+    selector cannot mean one thing for a patch which states the attr and
+    another for a patch the inventory answers for. The values carry no
+    units of their own, which makes a unit-bearing selector the same
+    error the index gives against a unitless column.
+
+    Parameters
+    ----------
+    values
+        The value each row holds; every one of them states something.
+    name
+        The attr the selector names, for error messages.
+    value
+        The selector, in any shape `build_attr_clause` accepts.
+
+    Returns
+    -------
+    A boolean array of the same length as ``values``.
+    """
+
+    def scalar(item):
+        """Coerce one selector value the way the index would."""
+        return _to_target_unit(_coerce_scalar(item, set()), None, name)
+
+    def each(func) -> np.ndarray:
+        return np.array([bool(func(x)) for x in values], dtype=bool)
+
+    if isinstance(value, re.Pattern):
+        return each(lambda x: isinstance(x, str) and value.match(x))
+    if is_range(value):
+        out = np.ones(len(values), dtype=bool)
+        for bound, compare in zip(value, (operator.ge, operator.le), strict=True):
+            if bound is None or bound is Ellipsis:
+                continue
+            limit = scalar(bound)
+            out &= each(lambda x, c=compare, b=limit: c(x, b))
+        return out
+    if _is_collection(value):
+        wanted = [scalar(x) for x in value]
+        return each(lambda x: any(x == item for item in wanted))
+    if isinstance(value, str) and _GLOB_CHARS & set(value):
+        return each(lambda x: isinstance(x, str) and fnmatch(x, value))
+    wanted = scalar(value)
+    return each(lambda x: x == wanted)
 
 
 def build_coord_clause(

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -16,7 +16,6 @@ import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from fnmatch import fnmatch
 
 import numpy as np
 import pandas as pd
@@ -326,6 +325,69 @@ def build_attr_clause(
     return None
 
 
+def glob_to_regex(pattern: str) -> re.Pattern:
+    """
+    Translate a glob to the regex which matches what SQLite's GLOB does.
+
+    SQLite is the authority on what a glob selector means, since that is
+    what the index applies, and it is not `fnmatch`: a character class is
+    negated with `[^...]`, where fnmatch spells that `[!...]` and reads a
+    leading `!` as a literal. Translating here rather than reaching for
+    fnmatch is what keeps one pattern from selecting opposite halves of a
+    spool depending on which side answered it. An unterminated class
+    matches nothing, as it does in SQLite; a class a regex cannot express
+    at all (a reversed range, which SQLite reads leniently) matches
+    nothing here rather than being guessed at.
+    """
+    out, index, size = [], 0, len(pattern)
+    while index < size:
+        char = pattern[index]
+        if char in "*?":
+            out.append(".*" if char == "*" else ".")
+        elif char == "[":
+            # A class may open with '^' to negate and may hold ']' as its
+            # first member; the class ends at the next ']' after those.
+            end = index + 1 + pattern[index + 1 : index + 2].count("^")
+            end += pattern[end : end + 1].count("]")
+            end = pattern.find("]", end)
+            if end < 0:
+                return _MATCHES_NOTHING
+            body = pattern[index + 1 : end]
+            negate, body = body.startswith("^"), body.removeprefix("^")
+            out.append(f"[{'^' if negate else ''}{_class_body(body)}]")
+            index = end
+        else:
+            out.append(re.escape(char))
+        index += 1
+    try:
+        return re.compile("".join(out) + r"\Z")
+    except re.error:
+        return _MATCHES_NOTHING
+
+
+# A pattern which matches nothing, for a glob SQLite would not read.
+_MATCHES_NOTHING = re.compile(r"(?!)")
+
+
+def _class_body(body: str) -> str:
+    """
+    Escape the members of a glob character class for a regex one.
+
+    Ranges are kept as ranges, since a glob class means them, and both
+    endpoints are escaped on their own: escaping the body wholesale would
+    turn the dash of a range into a member.
+    """
+    out, index, size = [], 0, len(body)
+    while index < size:
+        if index + 2 < size and body[index + 1] == "-":
+            out.append(f"{re.escape(body[index])}-{re.escape(body[index + 2])}")
+            index += 3
+            continue
+        out.append(re.escape(body[index]))
+        index += 1
+    return "".join(out)
+
+
 def evaluate_attr_predicate(values, name: str, value) -> np.ndarray:
     """
     Evaluate one attr selector against values held in memory.
@@ -351,31 +413,48 @@ def evaluate_attr_predicate(values, name: str, value) -> np.ndarray:
     -------
     A boolean array of the same length as ``values``.
     """
+    # Typed the way the index types a stored value, so a predicate
+    # compares within one kind here too: SQL reaches for the typed column
+    # a selector names and matches nothing when the values are of another
+    # kind, and `1` must not match a stored `True` on either side.
+    typed = [typed_value(x) for x in values]
+    kinds = {x.kind for x in typed if x is not None}
 
-    def scalar(item):
-        """Coerce one selector value the way the index would."""
-        return _to_target_unit(_coerce_scalar(item, set()), None, name)
+    def selector(item):
+        """Type one selector value the way the index would."""
+        out = _coerce_scalar(item, kinds)
+        # Unit-bearing selectors have nothing to convert to here, exactly
+        # as against a column the index stores without units.
+        _to_target_unit(out, None, name)
+        return out
 
     def each(func) -> np.ndarray:
-        return np.array([bool(func(x)) for x in values], dtype=bool)
+        return np.array([x is not None and bool(func(x)) for x in typed], dtype=bool)
+
+    def compare(item, op):
+        """Match rows of the selector's own kind under one operator."""
+        wanted = selector(item)
+        return each(lambda x, w=wanted, o=op: x.kind == w.kind and o(x.value, w.value))
 
     if isinstance(value, re.Pattern):
-        return each(lambda x: isinstance(x, str) and value.match(x))
+        # `search`, which is what the index's regex residual applies.
+        return each(lambda x: x.kind == "str" and value.search(x.value))
     if is_range(value):
         out = np.ones(len(values), dtype=bool)
-        for bound, compare in zip(value, (operator.ge, operator.le), strict=True):
+        for bound, op in zip(value, (operator.ge, operator.le), strict=True):
             if bound is None or bound is Ellipsis:
                 continue
-            limit = scalar(bound)
-            out &= each(lambda x, c=compare, b=limit: c(x, b))
+            out &= compare(bound, op)
         return out
     if _is_collection(value):
-        wanted = [scalar(x) for x in value]
-        return each(lambda x: any(x == item for item in wanted))
+        out = np.zeros(len(values), dtype=bool)
+        for item in value:
+            out |= compare(item, operator.eq)
+        return out
     if isinstance(value, str) and _GLOB_CHARS & set(value):
-        return each(lambda x: isinstance(x, str) and fnmatch(x, value))
-    wanted = scalar(value)
-    return each(lambda x: x == wanted)
+        pattern = glob_to_regex(value)
+        return each(lambda x: x.kind == "str" and pattern.match(x.value))
+    return compare(value, operator.eq)
 
 
 def build_coord_clause(

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -354,7 +354,13 @@ def glob_to_regex(pattern: str) -> re.Pattern:
                 return _MATCHES_NOTHING
             body = pattern[index + 1 : end]
             negate, body = body.startswith("^"), body.removeprefix("^")
-            out.append(f"[{'^' if negate else ''}{_class_body(body)}]")
+            # A ']' opening a class is one of its members, and SQLite takes
+            # it as a plain one: it is not the low end of a range, so the
+            # dash which may follow it is a member too.
+            leading = ""
+            if body.startswith("]"):
+                leading, body = re.escape("]"), body[1:]
+            out.append(f"[{'^' if negate else ''}{leading}{_class_body(body)}]")
             index = end
         else:
             out.append(re.escape(char))

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -359,10 +359,8 @@ def glob_to_regex(pattern: str) -> re.Pattern:
         else:
             out.append(re.escape(char))
         index += 1
-    try:
-        return re.compile("".join(out) + r"\Z")
-    except re.error:
-        return _MATCHES_NOTHING
+    # DOTALL, since SQLite's wildcards cross a newline like any other byte.
+    return re.compile("".join(out) + r"\Z", re.DOTALL)
 
 
 # A pattern which matches nothing, for a glob SQLite would not read.
@@ -373,22 +371,28 @@ def _class_body(body: str) -> str:
     """
     Escape the members of a glob character class for a regex one.
 
-    Ranges are kept as ranges, since a glob class means them, and both
-    endpoints are escaped on their own: escaping the body wholesale would
-    turn the dash of a range into a member.
+    Ranges stay ranges, since a glob class means them, with each endpoint
+    escaped on its own — escaping the body wholesale would turn the dash
+    of a range into a member. A range's low endpoint is also emitted as a
+    member: SQLite tests it before testing the range, so `[z-a]` matches
+    `z` where the reversed range alone matches nothing.
     """
     out, index, size = [], 0, len(body)
     while index < size:
+        low = body[index]
         if index + 2 < size and body[index + 1] == "-":
-            out.append(f"{re.escape(body[index])}-{re.escape(body[index + 2])}")
+            high = body[index + 2]
+            out.append(re.escape(low))
+            if low <= high:
+                out.append(f"{re.escape(low)}-{re.escape(high)}")
             index += 3
             continue
-        out.append(re.escape(body[index]))
+        out.append(re.escape(low))
         index += 1
     return "".join(out)
 
 
-def evaluate_attr_predicate(values, name: str, value) -> np.ndarray:
+def evaluate_attr_predicate(values, name: str, value, units=None) -> np.ndarray:
     """
     Evaluate one attr selector against values held in memory.
 
@@ -396,9 +400,7 @@ def evaluate_attr_predicate(values, name: str, value) -> np.ndarray:
     reach the index — those an inventory states rather than a file. It
     takes the same selector shapes and means the same thing by each, so a
     selector cannot mean one thing for a patch which states the attr and
-    another for a patch the inventory answers for. The values carry no
-    units of their own, which makes a unit-bearing selector the same
-    error the index gives against a unitless column.
+    another for a patch the inventory answers for.
 
     Parameters
     ----------
@@ -408,6 +410,11 @@ def evaluate_attr_predicate(values, name: str, value) -> np.ndarray:
         The attr the selector names, for error messages.
     value
         The selector, in any shape `build_attr_clause` accepts.
+    units
+        The canonical units the index stores each kind of this attr in,
+        for converting a unit-bearing selector exactly as the index side
+        would. A kind the index knows nothing about is unitless, and a
+        selector carrying units against one is the error it is there.
 
     Returns
     -------
@@ -419,13 +426,12 @@ def evaluate_attr_predicate(values, name: str, value) -> np.ndarray:
     # kind, and `1` must not match a stored `True` on either side.
     typed = [typed_value(x) for x in values]
     kinds = {x.kind for x in typed if x is not None}
+    units = units or {}
 
     def selector(item):
         """Type one selector value the way the index would."""
         out = _coerce_scalar(item, kinds)
-        # Unit-bearing selectors have nothing to convert to here, exactly
-        # as against a column the index stores without units.
-        _to_target_unit(out, None, name)
+        _to_target_unit(out, units.get(out.kind), name)
         return out
 
     def each(func) -> np.ndarray:
@@ -440,11 +446,25 @@ def evaluate_attr_predicate(values, name: str, value) -> np.ndarray:
         # `search`, which is what the index's regex residual applies.
         return each(lambda x: x.kind == "str" and value.search(x.value))
     if is_range(value):
-        out = np.ones(len(values), dtype=bool)
-        for bound, op in zip(value, (operator.ge, operator.le), strict=True):
-            if bound is None or bound is Ellipsis:
-                continue
-            out &= compare(bound, op)
+        # The same reading of a range the index performs, so a range with
+        # no usable bounds, mixed-kind bounds, or lo above hi is the error
+        # it is there rather than a selector which quietly keeps every row.
+        probe = next(
+            (
+                _coerce_scalar(x, kinds)
+                for x in value
+                if x is not None and x is not Ellipsis
+            ),
+            None,
+        )
+        target = units.get(probe.kind) if probe is not None else None
+        kind, low, high, _ = _range_bounds(value, kinds, target, name)
+        out = each(lambda x, k=kind: x.kind == k)
+        for bound, op in ((low, operator.ge), (high, operator.le)):
+            if bound is not None:
+                out &= each(
+                    lambda x, o=op, b=bound, k=kind: x.kind == k and o(x.value, b)
+                )
         return out
     if _is_collection(value):
         out = np.zeros(len(values), dtype=bool)

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -35,6 +35,7 @@ from dascore.exceptions import (
     UnresolvedPatchError,
 )
 from dascore.proc.coords import update_coords
+from dascore.units import get_quantity_str
 from dascore.utils.attrs import validate_conflict
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import iterate, validate_acquisition_key
@@ -238,18 +239,22 @@ def resolve_contexts(inventory, keys, starts, ends) -> np.ndarray:
         if len(codes) != 4:
             continue
         bounds = _epoch_bounds(inventory, codes)
-        starts_at = np.searchsorted(bounds, sub["start"].to_numpy(), side="right")
-        ends_at = np.searchsorted(bounds, sub["end"].to_numpy(), side="right")
-        straddles = starts_at != ends_at
+        first, last = sub["start"].to_numpy(), sub["end"].to_numpy()
+        starts_at = np.searchsorted(bounds, first, side="right")
+        ends_at = np.searchsorted(bounds, last, side="right")
+        # A row with no instant of its own says nothing about which epoch
+        # applies, and resolving at NaT holds every epoch effective; that
+        # is the whole inventory answering rather than one entry.
+        unresolved = (starts_at != ends_at) | np.isnat(first) | np.isnat(last)
         contexts: dict[int, ResolvedContext | None] = {}
-        for epoch in np.unique(starts_at[~straddles]):
-            when = sub["start"].to_numpy()[starts_at == epoch][0]
+        for epoch in np.unique(starts_at[~unresolved]):
+            when = first[(starts_at == epoch) & ~unresolved][0]
             try:
                 contexts[int(epoch)] = inventory.resolve(key, time=when)
             except InvalidInventoryError:
                 contexts[int(epoch)] = None
-        for row, epoch, straddle in zip(sub.index, starts_at, straddles, strict=True):
-            out[row] = None if straddle else contexts[int(epoch)]
+        for row, epoch, skip in zip(sub.index, starts_at, unresolved, strict=True):
+            out[row] = None if skip else contexts[int(epoch)]
     return out
 
 
@@ -258,7 +263,9 @@ def get_attr_values(inventory, contexts, name: str) -> list:
     Return the value each resolved context states for one attr name.
 
     A context which does not state the name, and a row with no context at
-    all, both give None: the inventory has no answer either way.
+    all, both give None: the inventory has no answer either way. Values
+    are spelled the way a patch carrying the same fact spells them, so a
+    selector matches an inventory answer and a stated header alike.
     """
     cache: dict[int, Any] = {}
     out = []
@@ -270,10 +277,23 @@ def get_attr_values(inventory, contexts, name: str) -> list:
             interrogator = _get_interrogator(inventory, context.acquisition)
             owner, field = _attr_owner(context, interrogator, name)
             value = getattr(owner, field, None)
-            value = None if _is_unset(value) else value
+            value = None if _is_unset(value) else _as_patch_value(value)
             cache[id(context)] = value
         out.append(value)
     return out
+
+
+def _as_patch_value(value):
+    """
+    Return an inventory value in the spelling a patch attr would hold.
+
+    The inventory models units as quantities and a patch carries the
+    string it renders to, so comparing the two directly would never
+    match — the same fact stored two ways.
+    """
+    if hasattr(value, "units") and hasattr(value, "dimensionality"):
+        return get_quantity_str(value)
+    return value
 
 
 # A cache miss, told apart from a cached None (the inventory saying nothing).

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -8,7 +8,14 @@ from typing import Literal, get_args
 import numpy as np
 
 import dascore as dc
-from dascore.constants import INVENTORY_ATTRS, PatchType, attr_conflict_description
+from dascore.constants import (
+    INVENTORY_ATTRS,
+    PatchType,
+    enrich_attrs_description,
+    enrich_conflicts_description,
+    enrich_coords_description,
+    enrich_on_missing_description,
+)
 from dascore.core.coords import BaseCoord, get_coord
 from dascore.core.inventory import (
     DISTANCE_MAP_AXES,
@@ -56,15 +63,6 @@ _TRACK_FIELD_UNITS = {
     "coupling.depth": "m",
     "optical_components.optical_length": "m",
 }
-
-on_missing_description = """
-on_missing
-    What to do when an explicitly requested name is one the inventory does
-    not define: "raise" (the default), "null" to fill the dtype-appropriate
-    missing marker, or "ignore" to leave it off. Blanket requests copy what is
-    applicable and never trigger it, and per-channel coverage gaps are always
-    missing values rather than errors.
-""".strip()
 
 
 def _get_acquisition_key(patch, acquisition_key) -> str:
@@ -572,7 +570,10 @@ def _get_coords(inventory, context, patch, coords, on_missing) -> dict:
 
 @patch_function()
 @compose_docstring(
-    conflict_desc=attr_conflict_description, on_missing_desc=on_missing_description
+    attrs_desc=enrich_attrs_description,
+    coords_desc=enrich_coords_description,
+    on_missing_desc=enrich_on_missing_description,
+    conflicts_desc=enrich_conflicts_description,
 )
 def enrich(
     patch: PatchType,
@@ -598,20 +599,8 @@ def enrich(
         The patch to enrich.
     inventory
         The inventory to resolve against.
-    attrs
-        True (the default) to copy the observing-system facts the inventory
-        is authoritative for, a tuple of names to copy exactly those, or
-        False to copy none. The blanket form excludes `data_type`,
-        `data_category`, and `data_units`, which describe the data as it
-        now stands, and `sample_rate` and `spatial_interval`, which the
-        patch's own coordinates already state; naming one restores the
-        as-acquired value.
-    coords
-        True (the default) to add the geometry axes and annotation groups of
-        the resolved optical path, a tuple of names to add exactly those, or
-        False to add none. Names may be `distance` for optical distance, a
-        coordinate label the inventory's CRS defines, an annotation group, or
-        a qualified track field such as `coupling.medium`.
+    {attrs_desc}
+    {coords_desc}
     acquisition_key
         The inventory identity to resolve, for a patch which does not carry
         one. Given both, the patch and this argument must agree.
@@ -620,13 +609,7 @@ def enrich(
         physical. A patch with a real time coordinate resolves at its own
         time and passing this raises.
     {on_missing_desc}
-    conflicts
-        {conflict_desc}
-        Enrichment combines the inventory's values with the patch's own, so
-        the default `keep_first` lets the inventory win and re-enriching is
-        a refresh. `raise` is the misresolution guard: a header disagreeing
-        with the resolved acquisition usually means the `acquisition_key`
-        resolved to the wrong place.
+    {conflicts_desc}
 
     Examples
     --------

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Sized
-from typing import Literal, get_args
+from collections.abc import Sequence, Sized
+from typing import Any, Literal, get_args
 
 import numpy as np
+import pandas as pd
 
 import dascore as dc
 from dascore.constants import (
@@ -163,6 +164,120 @@ def _attr_owner(context, interrogator, name):
     prefix, _, field = name.rpartition(".")
     owner = interrogator if prefix == "interrogator" else context.acquisition
     return owner, field
+
+
+def _epoch_bounds(inventory, acquisition_key: Sequence[str]) -> np.ndarray:
+    """
+    Return the instants at which resolving one key can change its answer.
+
+    Every epoch bound along the key's branch, so two times falling between
+    the same pair of them resolve identically at every level and one
+    resolution serves both.
+    """
+    net_code, array_code, location, acq_code = acquisition_key
+    times = []
+    for network in inventory.networks:
+        if network.code != net_code:
+            continue
+        times += [network.start_time, network.end_time]
+        for array in network.fiber_arrays:
+            if array.code != array_code:
+                continue
+            times += [array.start_time, array.end_time]
+            times += [
+                x
+                for acq in array.acquisitions
+                if acq.code == acq_code and acq.location_code == location
+                for x in (acq.start_time, acq.end_time)
+            ]
+            times += [
+                x
+                for path in array.optical_paths
+                if path.location_code == location
+                for x in (path.start_time, path.end_time)
+            ]
+    stamps = [x for x in times if not np.isnat(x)]
+    return np.unique(np.array(stamps, dtype="datetime64[ns]"))
+
+
+def resolve_contexts(inventory, keys, starts, ends) -> np.ndarray:
+    """
+    Resolve index rows to their inventory contexts, one resolution per epoch.
+
+    Each row is the half-open span of one patch. A row the inventory does
+    not describe, and a row whose span crosses an epoch boundary — which
+    the inventory describes twice rather than not at all, and which
+    `conform_to_inventory` exists to subdivide — resolve to None.
+
+    Parameters
+    ----------
+    inventory
+        The inventory to resolve against.
+    keys
+        Each row's acquisition_key.
+    starts, ends
+        Each row's first and last instant.
+
+    Returns
+    -------
+    An object array of `ResolvedContext` or None, one per row.
+    """
+    frame = pd.DataFrame(
+        {
+            "key": np.asarray(keys, dtype=object),
+            "start": np.asarray(starts, dtype="datetime64[ns]"),
+            "end": np.asarray(ends, dtype="datetime64[ns]"),
+        }
+    )
+    out = np.full(len(frame), None, dtype=object)
+    for key, sub in frame.groupby("key", sort=False):
+        # The empty string is how a patch spells "no identity"; it names
+        # no entry, which is not the same as naming a missing one. A
+        # malformed key names none either, and resolve would say so.
+        codes = key.split(".") if isinstance(key, str) else []
+        if len(codes) != 4:
+            continue
+        bounds = _epoch_bounds(inventory, codes)
+        starts_at = np.searchsorted(bounds, sub["start"].to_numpy(), side="right")
+        ends_at = np.searchsorted(bounds, sub["end"].to_numpy(), side="right")
+        straddles = starts_at != ends_at
+        contexts: dict[int, ResolvedContext | None] = {}
+        for epoch in np.unique(starts_at[~straddles]):
+            when = sub["start"].to_numpy()[starts_at == epoch][0]
+            try:
+                contexts[int(epoch)] = inventory.resolve(key, time=when)
+            except InvalidInventoryError:
+                contexts[int(epoch)] = None
+        for row, epoch, straddle in zip(sub.index, starts_at, straddles, strict=True):
+            out[row] = None if straddle else contexts[int(epoch)]
+    return out
+
+
+def get_attr_values(inventory, contexts, name: str) -> list:
+    """
+    Return the value each resolved context states for one attr name.
+
+    A context which does not state the name, and a row with no context at
+    all, both give None: the inventory has no answer either way.
+    """
+    cache: dict[int, Any] = {}
+    out = []
+    for context in contexts:
+        if context is None:
+            out.append(None)
+            continue
+        if (value := cache.get(id(context), _UNCACHED)) is _UNCACHED:
+            interrogator = _get_interrogator(inventory, context.acquisition)
+            owner, field = _attr_owner(context, interrogator, name)
+            value = getattr(owner, field, None)
+            value = None if _is_unset(value) else value
+            cache[id(context)] = value
+        out.append(value)
+    return out
+
+
+# A cache miss, told apart from a cached None (the inventory saying nothing).
+_UNCACHED = object()
 
 
 def _get_system_attrs(inventory, context) -> dict:

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -607,8 +607,13 @@ def _get_coord_values(inventory, path, name, distances):
         # The distances are already the optical path's, in meters.
         return get_coord(data=distances, units="m")
     track, _, field = name.partition(".")
-    if track in _TRACK_NAMES and field:
-        return _get_track_coord(path, track, field, distances)
+    if track in _TRACK_NAMES:
+        # A bare track name means the track's identity: which coupling
+        # condition, which geometry segment, which component a channel
+        # falls in. Every other field is asked for by its qualified name.
+        return _get_track_coord(
+            path, track, field or TRACK_IDENTITY_FIELDS[track], distances
+        )
     if name in VALID_COORDINATE_LABELS:
         return _get_geometry_coord(inventory, path, name, distances)
     return _get_annotation_coord(path, name, distances)

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -19,6 +19,7 @@ from dascore.constants import (
 from dascore.core.coords import BaseCoord, get_coord
 from dascore.core.inventory import (
     DISTANCE_MAP_AXES,
+    TRACK_IDENTITY_FIELDS,
     VALID_COORDINATE_LABELS,
     Interrogator,
     Inventory,
@@ -55,8 +56,9 @@ _COORD_REDUNDANT_ATTRS = ("sample_rate", "spatial_interval")
 OnMissing = Literal["raise", "null", "ignore"]
 _VALID_ON_MISSING = get_args(OnMissing)
 
-# Tracks whose fields enrich can project, and where their intervals live.
-_TRACK_NAMES = ("optical_components", "geometry", "coupling")
+# Tracks whose fields enrich can project. The inventory names them, so a
+# track enrich can project and one selection can ask about are the same set.
+_TRACK_NAMES = tuple(TRACK_IDENTITY_FIELDS)
 
 # Track fields whose units the inventory documents.
 _TRACK_FIELD_UNITS = {

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -45,7 +45,7 @@ _DATA_STATE_ATTRS = ("data_type", "data_category", "data_units")
 # as-acquired value.
 _COORD_REDUNDANT_ATTRS = ("sample_rate", "spatial_interval")
 
-OnMissing = Literal["raise", "null", "skip"]
+OnMissing = Literal["raise", "null", "ignore"]
 _VALID_ON_MISSING = get_args(OnMissing)
 
 # Tracks whose fields enrich can project, and where their intervals live.
@@ -61,7 +61,7 @@ on_missing_description = """
 on_missing
     What to do when an explicitly requested name is one the inventory does
     not define: "raise" (the default), "null" to fill the dtype-appropriate
-    missing marker, or "skip" to leave it off. Blanket requests copy what is
+    missing marker, or "ignore" to leave it off. Blanket requests copy what is
     applicable and never trigger it, and per-channel coverage gaps are always
     missing values rather than errors.
 """.strip()
@@ -556,7 +556,7 @@ def _get_coords(inventory, context, patch, coords, on_missing) -> dict:
             )
             raise PatchError(msg)
         if values is None:
-            if blanket or on_missing == "skip":
+            if blanket or on_missing == "ignore":
                 continue
             if on_missing == "raise":
                 msg = (

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -255,7 +255,7 @@ subspool = spool.unselect(tag='some_tag')
 assert len(subspool) + len(spool.select(tag='some_tag')) == len(spool)
 ```
 
-Coordinates are not accepted. A coordinate range says how much of each patch to keep rather than which patches to keep, so its complement is a hole in the middle of each patch rather than a filter over them; select the ranges to keep instead.
+Coordinates are not accepted yet. Selecting on a coordinate trims each patch to the range as well as dropping the patches which miss it entirely, so the complement of `time=(t1, t2)` is the part of every patch *before* `t1` together with the part *after* `t2` — one patch becoming two. That is subdivision rather than filtering, and `unselect` does not do it yet; select the ranges to keep instead.
 
 # chunk
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -242,6 +242,21 @@ subspool = spool.select(acquisition_key={'DAS2.R2D1..RAW', 'DAS3.R2D1..RAW'})
 subspool = spool.select(tag='some*')
 ```
 
+# unselect
+
+[`unselect`](`dascore.core.spool.BaseSpool.unselect`) is the complement of `select`: it returns the patches the same selection would have removed. Each keyword means what it means in `select`, so this is how to name what a spool does *not* want without spelling out the rest of the archive.
+
+```{python}
+import dascore as dc
+spool = dc.get_example_spool('diverse_das')
+
+# Everything except the patches tagged 'some_tag'.
+subspool = spool.unselect(tag='some_tag')
+assert len(subspool) + len(spool.select(tag='some_tag')) == len(spool)
+```
+
+Coordinates are not accepted. A coordinate range says how much of each patch to keep rather than which patches to keep, so its complement is a hole in the middle of each patch rather than a filter over them; select the ranges to keep instead.
+
 # chunk
 
 The [`chunk`](`dascore.core.spool.BaseSpool.chunk`) method controls how data are grouped together in patches within the spool. It can be used to merge contiguous patches together, specify the size of patches for processing, specify overlap with previous patches, etc.

--- a/scripts/_render_api.py
+++ b/scripts/_render_api.py
@@ -323,6 +323,9 @@ class NumpyDocStrParser:
     stylers = {  # noqa
         "parameter": style_parameters,
         "parameters": style_parameters,
+        # Numpydoc's section for arguments a function holds and forwards
+        # rather than reads; they are parameters and render as one.
+        "other parameters": style_parameters,
         "attributes": style_parameters,
         "examples": style_examples,
         "example": style_examples,

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from typing import get_args, get_origin
+
 import numpy as np
 import pytest
 from pydantic import ValidationError
 
 import dascore as dc
+from dascore.constants import INVENTORY_ATTRS
 from dascore.core import Inventory
 from dascore.core import inventory as inv
 from dascore.exceptions import InvalidInventoryError
@@ -1753,3 +1756,110 @@ class TestDistanceMapAxisAgreement:
         dmap = inv.DistanceMap(channel=(0.0, 1.0), distance=(5.0, 6.0))
         with pytest.raises(InvalidInventoryError, match="not a DistanceMap input"):
             dmap.map_to_distance([0.5], axis="distance")
+
+
+class TestGetNames:
+    """The names an inventory could contribute to a patch."""
+
+    @pytest.fixture(scope="class")
+    def names(self):
+        """The names of the shared test inventory."""
+        return build_inventory().get_names()
+
+    def test_attrs_match_the_reader_vocabulary(self, names):
+        """
+        The names read off the models are the ones readers write.
+
+        INVENTORY_ATTRS is what a reader puts in patch attrs and this is
+        what enrichment could copy there; the two being one vocabulary is
+        what keeps a header value and an enriched value one attr. The
+        data-state trio is the only difference: enrichment copies it when
+        asked by name rather than in the blanket form.
+        """
+        data_state = {"data_type", "data_category", "data_units"}
+        assert set(names.attrs) == set(INVENTORY_ATTRS) | data_state
+
+    def test_attrs_are_model_fields(self, names):
+        """Every attr name is a field of the model it is read from."""
+        for name in names.attrs:
+            prefix, _, field = name.rpartition(".")
+            model = inv.Interrogator if prefix == "interrogator" else inv.Acquisition
+            assert not prefix or prefix == "interrogator", name
+            assert field in model.model_fields, name
+
+    def test_attrs_exclude_structure(self, names):
+        """
+        What locates an entry is not a fact about the system.
+
+        The codes and epoch bounds resolve a patch to its acquisition, and
+        the distance map and interrogator hold whole records rather than
+        values; none of them is something a patch could carry as an attr.
+        """
+        excluded = {"code", "location_code", "start_time", "end_time"}
+        excluded |= {"distance_map", "interrogator", "extra_fields", "description"}
+        assert not set(names.attrs) & excluded
+
+    def test_track_identity_fields_exist(self):
+        """
+        Each blessed track name maps to a real field of that track's model.
+
+        The map is the one hand-written piece of the vocabulary, so it is
+        the one piece which can drift away from the models.
+        """
+        path_fields = inv.OpticalPath.model_fields
+        for track, field in inv.TRACK_IDENTITY_FIELDS.items():
+            assert track in path_fields, track
+            members = inv._annotation_members(path_fields[track].annotation)
+            (item,) = [x for x in members if get_origin(x) is tuple]
+            for model in inv._annotation_members(get_args(item)[0]):
+                if isinstance(model, type) and issubclass(model, inv.InventoryModel):
+                    assert field in model.model_fields, (track, model)
+
+    def test_coords_hold_the_tracks_and_groups(self, names):
+        """The path's tracks, their fields, and its annotation groups."""
+        assert "coupling" in names.coords  # bare: the identity field
+        assert "coupling.medium" in names.coords
+        assert "geometry" in names.coords
+        assert "optical_components.fiber_type" in names.coords
+        assert "zone" in names.coords  # the annotation group
+
+    def test_coords_hold_both_axis_spellings(self, names):
+        """A CRS axis is selectable as stored and as this CRS reads it."""
+        crs = build_inventory().coordinate_reference_system
+        assert set("xyz") <= set(names.coords)
+        assert set(crs.coordinate_labels) <= set(names.coords)
+
+    def test_coords_hold_optical_distance(self, names):
+        """Optical distance is a coordinate enrich can be asked for."""
+        assert "distance" in names.coords
+
+    def test_coords_exclude_track_structure(self, names):
+        """
+        A track's placement is not a value its channels take.
+
+        The interval bounds say where a coupling condition applies, and a
+        geometry's control points are the segment itself; neither is a
+        number a channel inside it carries.
+        """
+        excluded = {"coupling.start_distance", "coupling.end_distance"}
+        excluded |= {"geometry.distance", "geometry.coordinates"}
+        assert not set(names.coords) & excluded
+
+    def test_coords_omit_absent_tracks(self):
+        """An inventory with no coupling has no coupling to select on."""
+        base = build_inventory()
+        path = base.networks[0].fiber_arrays[0].optical_paths[0]
+        bare = base.replace(path, path.new(coupling=(), annotations=()))
+        coords = set(bare.get_names().coords)
+        assert not {x for x in coords if x.startswith("coupling")}
+        assert "zone" not in coords
+        assert "geometry" in coords  # the tracks it does have remain
+
+    def test_names_are_unique(self, names):
+        """A name means one thing, so it is listed once."""
+        assert len(set(names.attrs)) == len(names.attrs)
+        assert len(set(names.coords)) == len(names.coords)
+
+    def test_attrs_do_not_depend_on_contents(self):
+        """The models decide the attrs, so every inventory has the same."""
+        assert Inventory().get_names().attrs == build_inventory().get_names().attrs

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -1863,3 +1863,96 @@ class TestGetNames:
     def test_attrs_do_not_depend_on_contents(self):
         """The models decide the attrs, so every inventory has the same."""
         assert Inventory().get_names().attrs == build_inventory().get_names().attrs
+
+
+class TestGetNamesRoundTrip:
+    """Every name the accessor lists is one enrichment can be asked for."""
+
+    def test_every_coord_name_projects(self):
+        """
+        Enriching by each listed name gives a coordinate, or says nothing.
+
+        Contributing a name is not promising a value for it, but it is
+        promising the name is one enrichment understands: a name it
+        cannot project at all would be listed and unusable.
+        """
+        patch, inventory = dc.examples.inventory_patch_pair()
+        for name in inventory.get_names().coords:
+            if name in patch.coords.coord_map:
+                continue  # the patch's own axis, which enrich will not touch
+            out = patch.enrich(
+                inventory, attrs=False, coords=(name,), on_missing="null"
+            )
+            assert name in out.coords.coord_map, name
+
+    def test_bare_track_name_is_its_identity(self):
+        """
+        A bare track name means the field the blessed map points at.
+
+        The map is what makes `coupling` a name at all, so a bare use of
+        it has to give the same values as the qualified one.
+        """
+        patch, inventory = dc.examples.inventory_patch_pair()
+        for track, field in inv.TRACK_IDENTITY_FIELDS.items():
+            bare = patch.enrich(inventory, attrs=False, coords=(track,))
+            qualified = patch.enrich(
+                inventory, attrs=False, coords=(f"{track}.{field}",)
+            )
+            assert np.array_equal(
+                bare.get_coord(track).values,
+                qualified.get_coord(f"{track}.{field}").values,
+            ), track
+
+    def test_multi_valued_field_is_not_listed(self):
+        """
+        A field stated as several values has none to give a channel.
+
+        A multi-wavelength loss is a legitimate thing for a component to
+        record and an impossible thing to project, so the name is not one
+        this inventory contributes however scalar its annotation reads.
+        """
+        base = build_inventory()
+        path = base.networks[0].fiber_arrays[0].optical_paths[0]
+        component = path.optical_components[0]
+        measured = base.new(
+            resources={"m1": inv.OpticalMeasurement(resource_id="m1")}
+        ).replace(
+            component,
+            component.new(loss_db=(0.2, 0.25), loss_measurement=("m1", "m1")),
+        )
+        coords = set(measured.get_names().coords)
+        assert "optical_components.loss_db" not in coords
+        assert "optical_components.name" in coords
+        assert "optical_components.loss_db" in set(base.get_names().coords)
+
+    def test_optional_collection_is_not_a_value(self):
+        """
+        "A tuple or nothing" is still a tuple, not a value.
+
+        `tuple[float, ...] | None` is how this file spells several of its
+        fields, so reading the `None` arm as the scalar would list them.
+        """
+
+        class _Probe(inv.InventoryModel):
+            """A model shaped like the optional collections here."""
+
+            wavelengths: tuple[float, ...] | None = None
+            plain: float | None = None
+
+        assert inv._value_field_names(_Probe) == ["plain"]
+
+    def test_annotated_unions_are_transparent(self):
+        """
+        A discriminated union is written Annotated, and holds models.
+
+        The models here spell their unions that way, so a field holding
+        one must read as a reference rather than as a value.
+        """
+
+        class _Probe(inv.InventoryModel):
+            """A model whose reference is spelled the way this file does."""
+
+            resource: inv._Resource | None = None
+            plain: float | None = None
+
+        assert inv._value_field_names(_Probe) == ["plain"]

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import get_args, get_origin
-
 import numpy as np
 import pytest
 from pydantic import ValidationError
@@ -1799,21 +1797,17 @@ class TestGetNames:
         excluded |= {"distance_map", "interrogator", "extra_fields", "description"}
         assert not set(names.attrs) & excluded
 
-    def test_track_identity_fields_exist(self):
+    def test_a_declaration_naming_nothing_is_refused(self, monkeypatch):
         """
-        Each blessed track name maps to a real field of that track's model.
+        The map is derived, and the derivation checks what it derives.
 
-        The map is the one hand-written piece of the vocabulary, so it is
-        the one piece which can drift away from the models.
+        A model declaring an identity field it does not have would build
+        an entry pointing at nothing, so it fails where it is built
+        rather than somewhere a bare track name quietly resolves to NaN.
         """
-        path_fields = inv.OpticalPath.model_fields
-        for track, field in inv.TRACK_IDENTITY_FIELDS.items():
-            assert track in path_fields, track
-            members = inv._annotation_members(path_fields[track].annotation)
-            (item,) = [x for x in members if get_origin(x) is tuple]
-            for model in inv._annotation_members(get_args(item)[0]):
-                if isinstance(model, type) and issubclass(model, inv.InventoryModel):
-                    assert field in model.model_fields, (track, model)
+        monkeypatch.setattr(inv.CouplingCondition, "_identity_field", "not_a_field")
+        with pytest.raises(AssertionError):
+            inv._track_identity_fields()
 
     def test_coords_hold_the_tracks_and_groups(self, names):
         """The path's tracks, their fields, and its annotation groups."""

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -1939,7 +1939,7 @@ class TestGetNamesRoundTrip:
             wavelengths: tuple[float, ...] | None = None
             plain: float | None = None
 
-        assert inv._value_field_names(_Probe) == ["plain"]
+        assert inv._value_field_names(_Probe) == ("plain",)
 
     def test_annotated_unions_are_transparent(self):
         """
@@ -1955,4 +1955,4 @@ class TestGetNamesRoundTrip:
             resource: inv._Resource | None = None
             plain: float | None = None
 
-        assert inv._value_field_names(_Probe) == ["plain"]
+        assert inv._value_field_names(_Probe) == ("plain",)

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -602,9 +602,26 @@ class TestUnselect:
 
     def test_composes(self, diverse_spool):
         """A spool with patches removed is a spool."""
+        tags = diverse_spool.get_contents()["tag"].tolist()
+        removed = {"some_tag", "random"}
         out = diverse_spool.unselect(tag="some_tag").unselect(tag="random")
+        assert len(out) == sum(x not in removed for x in tags)
         for patch in out:
-            assert patch.attrs["tag"] not in {"some_tag", "random"}
+            assert patch.attrs["tag"] not in removed
+
+    def test_complements_within_a_window(self, diverse_spool):
+        """
+        A window fixes which rows are present, not which ones match.
+
+        The complement of a selection over a windowed spool is the rest
+        of the window, not nothing.
+        """
+        window = diverse_spool[2:8]
+        tags = window.get_contents()["tag"].tolist()
+        for tag in set(tags):
+            expected = sum(x != tag for x in tags)
+            assert len(window.unselect(tag=tag)) == expected
+        assert len(window.unselect(tag="not_a_tag")) == len(window)
 
     def test_original_is_unchanged(self, diverse_spool):
         """As everywhere else, the spool it came from is left alone."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -585,14 +585,15 @@ class TestUnselect:
 
     def test_coordinates_raise(self, diverse_spool):
         """
-        A coordinate range has no patch-level complement.
+        A coordinate complement is subdivision, which this cannot do yet.
 
-        Its complement is a hole in the middle of each patch, which is a
-        trim rather than a filter.
+        Selecting on a coordinate trims each patch, so removing a range
+        cuts every patch into the pieces outside it -- one patch becoming
+        two -- rather than choosing between patches.
         """
-        with pytest.raises(InvalidSpoolQueryError, match="how much of each patch"):
+        with pytest.raises(InvalidSpoolQueryError, match="cannot take yet"):
             diverse_spool.unselect(time=("2020-01-03", None))
-        with pytest.raises(InvalidSpoolQueryError, match="how much of each patch"):
+        with pytest.raises(InvalidSpoolQueryError, match="cannot take yet"):
             diverse_spool.unselect(_coords={"time": ("2020-01-03", None)})
 
     def test_unknown_name_raises(self, diverse_spool):
@@ -652,7 +653,7 @@ class TestUnselect:
 
     def test_coords_tag_form_raises(self, diverse_spool):
         """The tag form names bare kwargs, and is refused the same way."""
-        with pytest.raises(InvalidSpoolQueryError, match="how much of each patch"):
+        with pytest.raises(InvalidSpoolQueryError, match="cannot take yet"):
             diverse_spool.unselect(_coords="time", time=("2020-01-03", None))
 
     def test_base_spool_unselect_raises(self, random_spool):

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -16,6 +16,7 @@ from dascore.core.spool import _COPY_ON_WRITE_ALWAYS, BaseSpool, Spool
 from dascore.examples import ricker_moveout
 from dascore.exceptions import (
     InvalidSpoolError,
+    InvalidSpoolQueryError,
     MissingOptionalDependencyError,
     MissingPatchError,
     ParameterError,
@@ -537,6 +538,89 @@ class TestSelect:
         for patch in out:
             assert isinstance(patch, dc.Patch)
             assert not np.any(pd.isnull(patch.get_array("time")))
+
+
+class TestUnselect:
+    """Tests for removing the patches a selection would keep."""
+
+    def test_complements_select(self, diverse_spool):
+        """Every patch is in exactly one of the two halves."""
+        kept = diverse_spool.select(tag="some_tag")
+        dropped = diverse_spool.unselect(tag="some_tag")
+        assert len(kept) + len(dropped) == len(diverse_spool)
+        assert not set(kept.get_contents()["_patch_id"]) & set(
+            dropped.get_contents()["_patch_id"]
+        )
+
+    def test_removes_the_matches(self, diverse_spool):
+        """What comes back is what the selection would not have kept."""
+        out = diverse_spool.unselect(tag="some_tag")
+        assert len(out), "an empty result would pass the check below"
+        for patch in out:
+            assert patch.attrs["tag"] != "some_tag"
+
+    def test_selector_shapes(self, diverse_spool):
+        """A keyword means what it means in select, then is negated."""
+        keys = {"DAS2.R2D1..RAW", "DAS3.R2D1..RAW"}
+        out = diverse_spool.unselect(acquisition_key=keys)
+        assert len(out), "an empty result would pass the check below"
+        for patch in out:
+            assert patch.attrs["acquisition_key"] not in keys
+        wild = diverse_spool.unselect(tag="some*")
+        for patch in wild:
+            assert not patch.attrs["tag"].startswith("some")
+
+    def test_attrs_namespace(self, diverse_spool):
+        """The explicit namespace form works as it does in select."""
+        out = diverse_spool.unselect(_attrs={"tag": "some_tag"})
+        assert len(out) == len(diverse_spool.unselect(tag="some_tag"))
+
+    def test_matching_nothing_keeps_everything(self, diverse_spool):
+        """Removing what is not there removes nothing."""
+        assert len(diverse_spool.unselect(tag="not_a_tag")) == len(diverse_spool)
+
+    def test_matching_everything_keeps_nothing(self, random_spool):
+        """And removing what is all of it leaves an empty spool."""
+        assert len(random_spool.unselect(tag="*")) == 0
+
+    def test_coordinates_raise(self, diverse_spool):
+        """
+        A coordinate range has no patch-level complement.
+
+        Its complement is a hole in the middle of each patch, which is a
+        trim rather than a filter.
+        """
+        with pytest.raises(InvalidSpoolQueryError, match="how much of each patch"):
+            diverse_spool.unselect(time=("2020-01-03", None))
+        with pytest.raises(InvalidSpoolQueryError, match="how much of each patch"):
+            diverse_spool.unselect(_coords={"time": ("2020-01-03", None)})
+
+    def test_unknown_name_raises(self, diverse_spool):
+        """A misspelling is one here too."""
+        with pytest.raises(InvalidSpoolQueryError, match="neither an attribute"):
+            diverse_spool.unselect(not_a_name=1)
+
+    def test_composes(self, diverse_spool):
+        """A spool with patches removed is a spool."""
+        out = diverse_spool.unselect(tag="some_tag").unselect(tag="random")
+        for patch in out:
+            assert patch.attrs["tag"] not in {"some_tag", "random"}
+
+    def test_original_is_unchanged(self, diverse_spool):
+        """As everywhere else, the spool it came from is left alone."""
+        before = len(diverse_spool)
+        diverse_spool.unselect(tag="some_tag")
+        assert len(diverse_spool) == before
+
+    def test_empty_spool_names_nothing(self):
+        """A spool with no patches has no attrs, exactly as for select."""
+        with pytest.raises(InvalidSpoolQueryError, match="neither an attribute"):
+            dc.spool([]).unselect(tag="anything")
+
+    def test_base_spool_unselect_raises(self, random_spool):
+        """A spool implementation which does not provide one says so."""
+        with pytest.raises(NotImplementedError, match="spool of type"):
+            BaseSpool.unselect(random_spool, tag="random")
 
 
 class TestSort:

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -617,6 +617,16 @@ class TestUnselect:
         with pytest.raises(InvalidSpoolQueryError, match="neither an attribute"):
             dc.spool([]).unselect(tag="anything")
 
+    def test_naming_nothing_raises(self, diverse_spool):
+        """Emptying a spool is not something to guess at."""
+        with pytest.raises(ParameterError, match="needs something to remove"):
+            diverse_spool.unselect()
+
+    def test_coords_tag_form_raises(self, diverse_spool):
+        """The tag form names bare kwargs, and is refused the same way."""
+        with pytest.raises(InvalidSpoolQueryError, match="how much of each patch"):
+            diverse_spool.unselect(_coords="time", time=("2020-01-03", None))
+
     def test_base_spool_unselect_raises(self, random_spool):
         """A spool implementation which does not provide one says so."""
         with pytest.raises(NotImplementedError, match="spool of type"):

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -639,6 +639,17 @@ class TestUnselect:
         with pytest.raises(ParameterError, match="needs something to remove"):
             diverse_spool.unselect()
 
+    def test_naming_only_a_no_op_raises(self, diverse_spool):
+        """
+        A no-op selector names nothing to remove either.
+
+        `select(tag=None)` is the whole spool, so its complement is an
+        empty one; that is the same guess bare `unselect()` refuses.
+        """
+        for empty in (None, ...):
+            with pytest.raises(ParameterError, match="needs something to remove"):
+                diverse_spool.unselect(tag=empty)
+
     def test_coords_tag_form_raises(self, diverse_spool):
         """The tag form names bare kwargs, and is refused the same way."""
         with pytest.raises(InvalidSpoolQueryError, match="how much of each patch"):

--- a/tests/test_io/test_index/test_catalog.py
+++ b/tests/test_io/test_index/test_catalog.py
@@ -461,6 +461,8 @@ class TestGlobTranslation:
             "no_meta",
             "a[",
             "[]",
+            "[z-a]",
+            "[^z-a]",
         ],
     )
     def test_agrees_with_sqlite(self, pattern):
@@ -480,11 +482,14 @@ class TestGlobTranslation:
                 ).fetchone()[0]
                 assert bool(expected) == bool(regex.match(value)), (pattern, value)
 
-    def test_a_pattern_no_regex_can_express_matches_nothing(self):
+    def test_a_reversed_range_matches_its_low_endpoint(self):
         """
-        SQLite reads a reversed range more leniently than a regex can.
+        A reversed range is not simply nothing.
 
-        There is no honest translation, so the pattern selects nothing
-        rather than being guessed at; the docstring says so.
+        SQLite tests a range's low endpoint as a member before testing
+        the range itself, so `[b-a]` matches `b` and nothing else.
         """
-        assert glob_to_regex("[b-a]").match("b") is None
+        pattern = glob_to_regex("[b-a]")
+        assert pattern.match("b")
+        assert pattern.match("a") is None
+        assert pattern.match("-") is None

--- a/tests/test_io/test_index/test_catalog.py
+++ b/tests/test_io/test_index/test_catalog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pickle
 import re
+import sqlite3
 
 import numpy as np
 import pandas as pd
@@ -12,7 +13,7 @@ import pytest
 import dascore as dc
 from dascore.io.index import PatchCatalog
 from dascore.io.index.catalog import _adjust_unit_segments
-from dascore.io.index.query import InvalidSpoolQueryError
+from dascore.io.index.query import InvalidSpoolQueryError, glob_to_regex
 from dascore.units import m
 from dascore.utils.misc import _canonical_range, _CanonicalRange
 
@@ -402,3 +403,88 @@ class TestCatalogConcurrency:
         rebuilt = pickle.loads(pickle.dumps(live_catalog))
         assert rebuilt._revision.lock is not live_catalog._revision.lock
         assert len(rebuilt) == len(live_catalog)
+
+
+class TestSelectingWithinAMembership:
+    """A view whose membership is fixed still applies later predicates."""
+
+    def test_select_after_a_window(self):
+        """
+        A window says which rows are present, not that they all match.
+
+        The membership was already the answer to the predicates composed
+        before it, so returning it unfiltered would ignore every one
+        composed after.
+        """
+        spool = dc.get_example_spool("diverse_das")
+        window = spool[2:8]
+        tags = window.get_contents()["tag"].tolist()
+        for tag in set(tags):
+            expected = sum(x == tag for x in tags)
+            assert len(window.select(tag=tag)) == expected
+
+    def test_window_after_a_window(self):
+        """Windowing a windowed selection narrows rather than empties."""
+        spool = dc.get_example_spool("diverse_das")
+        assert len(spool[2:8].select(tag="big_gaps")[0:1]) == 1
+
+    def test_membership_order_survives_a_predicate(self):
+        """
+        An integer array arranges the rows, and a predicate filters it.
+
+        The arrangement is the presentation order, so re-deriving the
+        order from SQL would quietly undo it.
+        """
+        spool = dc.get_example_spool("diverse_das")
+        picked = spool[np.array([3, 1, 0])]
+        before = picked.get_contents()["_patch_id"].tolist()
+        assert picked.select(tag="*").get_contents()["_patch_id"].tolist() == before
+
+
+class TestGlobTranslation:
+    """The in-memory glob has to mean what the index's GLOB means."""
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "a*",
+            "a?c",
+            "*",
+            "?",
+            "v[^x]*",
+            "v[!x]*",
+            "[abc]d",
+            "[]]x",
+            "a[b-d]e",
+            "[^]]a",
+            "x\\y*",
+            "no_meta",
+            "a[",
+            "[]",
+        ],
+    )
+    def test_agrees_with_sqlite(self, pattern):
+        """
+        SQLite decides what a glob means, since it is what answers one.
+
+        Reaching for fnmatch instead made `[!x]` and `[^x]` each select
+        the half of a spool the other did not.
+        """
+        values = ["abc", "a1c", "vax", "vxx", "ad", "]x", "ace", "", "a", "a["]
+        values += ["x\\yz", "!a", "^a", "]a", "no_meta", "[]"]
+        with sqlite3.connect(":memory:") as connection:
+            regex = glob_to_regex(pattern)
+            for value in values:
+                expected = connection.execute(
+                    "SELECT ? GLOB ?", (value, pattern)
+                ).fetchone()[0]
+                assert bool(expected) == bool(regex.match(value)), (pattern, value)
+
+    def test_a_pattern_no_regex_can_express_matches_nothing(self):
+        """
+        SQLite reads a reversed range more leniently than a regex can.
+
+        There is no honest translation, so the pattern selects nothing
+        rather than being guessed at; the docstring says so.
+        """
+        assert glob_to_regex("[b-a]").match("b") is None

--- a/tests/test_io/test_index/test_catalog.py
+++ b/tests/test_io/test_index/test_catalog.py
@@ -463,6 +463,9 @@ class TestGlobTranslation:
             "[]",
             "[z-a]",
             "[^z-a]",
+            "[]-a]",
+            "[^]-a]",
+            "[]a]",
         ],
     )
     def test_agrees_with_sqlite(self, pattern):
@@ -473,7 +476,7 @@ class TestGlobTranslation:
         the half of a spool the other did not.
         """
         values = ["abc", "a1c", "vax", "vxx", "ad", "]x", "ace", "", "a", "a["]
-        values += ["x\\yz", "!a", "^a", "]a", "no_meta", "[]"]
+        values += ["x\\yz", "!a", "^a", "]a", "no_meta", "[]", "-", "]", "_"]
         with sqlite3.connect(":memory:") as connection:
             regex = glob_to_regex(pattern)
             for value in values:

--- a/tests/test_io/test_index/test_hive_attrs.py
+++ b/tests/test_io/test_index/test_hive_attrs.py
@@ -182,9 +182,10 @@ class TestHiveWins:
         sub.mkdir()
         patch = dc.get_example_patch().update_attrs(station="A")
         patch.io.write(sub / "agree.h5", "dasdae")
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             spool = Spool.from_directory(tmp_path).update(progress=None)
+        assert not [x for x in caught if "override attrs" in str(x.message)]
         assert spool.get_contents()["station"].iloc[0] == "A"
         spool.indexer.close()
 
@@ -193,9 +194,10 @@ class TestHiveWins:
         sub = tmp_path / "cable=north"
         sub.mkdir()
         dc.get_example_patch().io.write(sub / "quiet.h5", "dasdae")
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             spool = Spool.from_directory(tmp_path).update(progress=None)
+        assert not [x for x in caught if "override attrs" in str(x.message)]
         assert spool.get_contents()["cable"].iloc[0] == "north"
         spool.indexer.close()
 

--- a/tests/test_io/test_index/test_hive_attrs.py
+++ b/tests/test_io/test_index/test_hive_attrs.py
@@ -403,3 +403,40 @@ class TestHiveAcquisitionKey:
             spool = self._write(tmp_path, f"acquisition_key={value}").update()
         assert "acquisition_key" not in spool.get_contents().columns
         assert spool[0].attrs.acquisition_key == ""
+
+
+class TestOverrideComparesMeaning:
+    """The warning is about a disagreement, not about a spelling."""
+
+    def _index(self, tmp_path, segment, **attrs):
+        """Index one patch stating attrs under a hive segment."""
+        sub = tmp_path / segment
+        sub.mkdir()
+        dc.get_example_patch().update_attrs(**attrs).io.write(sub / "f.h5", "dasdae")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            spool = Spool.from_directory(tmp_path).update(progress=None)
+        spool.indexer.close()
+        return [x for x in caught if "override attrs" in str(x.message)]
+
+    def test_a_number_restated_differently_is_silent(self, tmp_path):
+        """`10` and `10.0` are the same gauge length."""
+        assert not self._index(tmp_path, "gauge_length=10", gauge_length=10.0)
+
+    def test_a_different_number_warns(self, tmp_path):
+        """A path stating another value is the disagreement to report."""
+        assert self._index(tmp_path, "gauge_length=20", gauge_length=10.0)
+
+    def test_an_unreadable_number_warns(self, tmp_path):
+        """A path which is not a number at all changes what the attr says."""
+        assert self._index(tmp_path, "gauge_length=ten", gauge_length=10.0)
+
+    def test_a_bool_restated_differently_is_silent(self, tmp_path):
+        """Hive spells a flag in lower case; it is still the same flag."""
+        segment = "closed_fiber_loop=true"
+        assert not self._index(tmp_path, segment, closed_fiber_loop=True)
+
+    def test_a_flipped_bool_warns(self, tmp_path):
+        """And the opposite flag is a disagreement."""
+        segment = "closed_fiber_loop=false"
+        assert self._index(tmp_path, segment, closed_fiber_loop=True)

--- a/tests/test_io/test_index/test_hive_attrs.py
+++ b/tests/test_io/test_index/test_hive_attrs.py
@@ -13,6 +13,7 @@ import pickle
 import sqlite3
 import warnings
 
+import numpy as np
 import pytest
 
 import dascore as dc
@@ -413,7 +414,7 @@ class TestOverrideComparesMeaning:
     def _index(self, tmp_path, segment, **attrs):
         """Index one patch stating attrs under a hive segment."""
         sub = tmp_path / segment
-        sub.mkdir()
+        sub.mkdir(parents=True)
         dc.get_example_patch().update_attrs(**attrs).io.write(sub / "f.h5", "dasdae")
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
@@ -442,3 +443,20 @@ class TestOverrideComparesMeaning:
         """And the opposite flag is a disagreement."""
         segment = "closed_fiber_loop=false"
         assert self._index(tmp_path, segment, closed_fiber_loop=True)
+
+    def test_a_restated_instant_is_silent(self, tmp_path):
+        """
+        A time is stored as integer nanoseconds, not as its own spelling.
+
+        Comparing that integer's text against the path segment would call
+        every datetime attr a disagreement.
+        """
+        stamp = np.datetime64("2020-01-01", "ns")
+        cases = [
+            ("observed=2020-01-01", False),
+            ("observed=2021-06-05", True),
+            ("observed=nonsense", True),
+        ]
+        for number, (segment, warns) in enumerate(cases):
+            root = tmp_path / str(number)
+            assert bool(self._index(root, segment, observed=stamp)) is warns, segment

--- a/tests/test_io/test_index/test_hive_attrs.py
+++ b/tests/test_io/test_index/test_hive_attrs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import pickle
 import sqlite3
+import warnings
 
 import pytest
 
@@ -141,7 +142,8 @@ class TestHiveWins:
         sub.mkdir()
         patch = dc.get_example_patch().update_attrs(station="B")
         patch.io.write(sub / "conflict.h5", "dasdae")
-        spool = Spool.from_directory(tmp_path).update(progress=None)
+        with pytest.warns(UserWarning, match="override attrs"):
+            spool = Spool.from_directory(tmp_path).update(progress=None)
         yield spool
         spool.indexer.close()
 
@@ -152,6 +154,50 @@ class TestHiveWins:
     def test_loaded_patch_shows_path_value(self, conflict_spool):
         """The loaded patch also shows the path's value."""
         assert conflict_spool[0].attrs.station == "A"
+
+    def test_override_names_the_key_and_a_path(self, tmp_path):
+        """
+        The warning says which name and where, once for the archive.
+
+        A layout disagreeing with every file it holds is a legitimate
+        correction and a common mistake, and the two look identical from
+        inside; naming one path is enough to go and look.
+        """
+        sub = tmp_path / "station=A"
+        sub.mkdir()
+        patch = dc.get_example_patch().update_attrs(station="B")
+        for name in ("one.h5", "two.h5"):
+            patch.io.write(sub / name, "dasdae")
+        with pytest.warns(UserWarning, match="override attrs") as record:
+            spool = Spool.from_directory(tmp_path).update(progress=None)
+        overrides = [x for x in record if "override attrs" in str(x.message)]
+        assert len(overrides) == 1
+        assert "'station'" in str(overrides[0].message)
+        assert "station=A" in str(overrides[0].message)
+        spool.indexer.close()
+
+    def test_agreeing_path_is_silent(self, tmp_path):
+        """Restating what the file already says overrides nothing."""
+        sub = tmp_path / "station=A"
+        sub.mkdir()
+        patch = dc.get_example_patch().update_attrs(station="A")
+        patch.io.write(sub / "agree.h5", "dasdae")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            spool = Spool.from_directory(tmp_path).update(progress=None)
+        assert spool.get_contents()["station"].iloc[0] == "A"
+        spool.indexer.close()
+
+    def test_unstated_attr_is_silent(self, tmp_path):
+        """A name the file never states is not one the path overrides."""
+        sub = tmp_path / "cable=north"
+        sub.mkdir()
+        dc.get_example_patch().io.write(sub / "quiet.h5", "dasdae")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            spool = Spool.from_directory(tmp_path).update(progress=None)
+        assert spool.get_contents()["cable"].iloc[0] == "north"
+        spool.indexer.close()
 
 
 class TestPatchStamping:

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -36,6 +36,7 @@ from dascore.exceptions import (
     InvalidSpoolQueryError,
     ParameterError,
     PatchError,
+    UnitError,
     UnresolvedPatchError,
 )
 
@@ -717,7 +718,7 @@ class TestInventoryQueryError:
     def test_inventory_field_names_the_inventory(self, patch, inventory):
         """The index's 'no such attribute' would deny a field which exists."""
         spool = dc.spool(patch).attach_inventory(inventory)
-        with pytest.raises(InvalidSpoolQueryError, match="not supported yet"):
+        with pytest.raises(InvalidSpoolQueryError, match="along the fiber"):
             spool.select(coupling="cement")
 
     def test_plain_spool_keeps_its_message(self, patch):
@@ -1277,3 +1278,219 @@ class TestThirdReviewFindings:
         )
         with pytest.raises(InvalidInventoryError, match="characters"):
             spool[0]
+
+
+@pytest.fixture(scope="module")
+def two_patch_spool(patch):
+    """Two patches from one acquisition, neither stating gauge_length."""
+    return dc.spool([patch, patch.update_attrs(tag="second")])
+
+
+class TestInventorySelect:
+    """Selecting a spool on the facts an inventory states."""
+
+    def test_selects_on_an_unstated_attr(self, two_patch_spool, inventory):
+        """A name no patch states is answered by the inventory."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        assert "gauge_length" not in spool.get_contents().columns
+        assert len(spool.select(gauge_length=10.0)) == 2
+
+    def test_non_matching_value_selects_nothing(self, two_patch_spool, inventory):
+        """The inventory's answer has to match to keep a patch."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        assert len(spool.select(gauge_length=99.0)) == 0
+
+    def test_needs_an_inventory(self, two_patch_spool):
+        """Without one the name is simply not something the spool knows."""
+        with pytest.raises(InvalidSpoolQueryError, match="neither an attribute"):
+            two_patch_spool.select(gauge_length=10.0)
+
+    def test_len_is_exact_and_nothing_is_read(self, two_patch_spool, inventory):
+        """Selection is metadata work: the count is final and exact."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        out = spool.select(gauge_length=10.0)
+        assert len(out) == len(out.get_contents()) == 2
+
+    def test_dotted_names_select(self, two_patch_spool, inventory):
+        """An interrogator fact is reached by its qualified name."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        query = {"interrogator.model": "FI-1"}
+        assert len(spool.select(**query)) == 2
+        assert len(spool.select(_attrs=query)) == 2
+        assert len(spool.select(**{"interrogator.model": "nope"})) == 0
+
+    def test_selector_shapes(self, two_patch_spool, inventory):
+        """A range, a collection, and a glob mean what they do on the index."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        assert len(spool.select(gauge_length=(5.0, 15.0))) == 2
+        assert len(spool.select(gauge_length=(15.0, 25.0))) == 0
+        assert len(spool.select(gauge_length=[10.0, 20.0])) == 2
+        assert len(spool.select(gauge_length=[20.0, 30.0])) == 0
+        assert len(spool.select(**{"interrogator.model": "FI-*"})) == 2
+        assert len(spool.select(**{"interrogator.model": "XX-*"})) == 0
+
+    def test_names_combine_with_and(self, two_patch_spool, inventory):
+        """Two inventory-backed selectors both have to hold."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        both = spool.select(gauge_length=10.0, **{"interrogator.model": "FI-1"})
+        assert len(both) == 2
+        one = spool.select(gauge_length=10.0, **{"interrogator.model": "nope"})
+        assert len(one) == 0
+
+    def test_combines_with_index_selectors(self, two_patch_spool, inventory):
+        """An index name and an inventory name compose in one call."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        out = spool.select(tag="second", gauge_length=10.0)
+        assert len(out) == 1
+        assert out.get_contents()["tag"].tolist() == ["second"]
+
+    def test_undescribed_patch_is_not_selected(self, patch, inventory):
+        """
+        A patch the inventory does not describe silently does not match.
+
+        Select is a filter, and a patch with no entry has no gauge length
+        any more than one which never states the attr does.
+        """
+        other = patch.update_attrs(tag="other", acquisition_key="DAS.R2D1..OTHER")
+        spool = dc.spool([patch, other]).attach_inventory(inventory)
+        out = spool.select(gauge_length=10.0)
+        assert len(out) == 1
+        assert out.get_contents()["tag"].tolist() == ["random"]
+
+    def test_patch_without_identity_is_not_selected(self, patch, inventory):
+        """One naming no entry resolves to nothing, and matches nothing."""
+        bare = patch.update_attrs(tag="bare", acquisition_key="")
+        spool = dc.spool([patch, bare]).attach_inventory(inventory)
+        assert len(spool.select(gauge_length=10.0)) == 1
+
+    def test_stated_value_wins(self, patch, inventory):
+        """
+        Precedence is per row: the patch states it, the inventory fills in.
+
+        A file which recorded its own gauge length is the authority for
+        that patch even when the inventory disagrees, and the inventory
+        answers only for the patches which left it unstated.
+        """
+        stated = patch.update_attrs(tag="stated", gauge_length=20.0)
+        spool = dc.spool([patch, stated]).attach_inventory(inventory)
+        by_patch = spool.select(gauge_length=20.0)
+        by_inventory = spool.select(gauge_length=10.0)
+        assert by_patch.get_contents()["tag"].tolist() == ["stated"]
+        assert by_inventory.get_contents()["tag"].tolist() == ["random"]
+
+    def test_empty_string_is_unstated(self, patch, inventory):
+        """
+        A string column spells "not known" as the empty string.
+
+        It is a value the index stores and can compare, which is exactly
+        why the inventory has to be asked for it anyway.
+        """
+        described = _replace_acquisition(inventory, firmware_version="v1.2.3")
+        spool = dc.spool(
+            [
+                patch.update_attrs(tag="blank", firmware_version=""),
+                patch.update_attrs(tag="stated", firmware_version="v9"),
+            ]
+        ).attach_inventory(described)
+        assert "firmware_version" in spool.get_contents().columns
+        assert spool.select(firmware_version="v1.2.3").get_contents()[
+            "tag"
+        ].tolist() == ["blank"]
+        assert spool.select(firmware_version="v9").get_contents()["tag"].tolist() == [
+            "stated"
+        ]
+
+    def test_straddling_patch_is_not_selected(self, patch, inventory):
+        """
+        A patch described twice has no single answer, so it matches neither.
+
+        Subdividing it is `conform_to_inventory`'s job; until it runs, a
+        straddling patch is one the selection cannot speak for.
+        """
+        old = inventory.networks[0].fiber_arrays[0]
+        acq = old.acquisitions[0]
+        times = patch.get_coord("time").values
+        middle = times[len(times) // 2]
+        split = inventory.replace(
+            old,
+            old.new(
+                acquisitions=(
+                    acq.new(end_time=middle, gauge_length=10.0),
+                    acq.new(start_time=middle, gauge_length=20.0),
+                )
+            ),
+        )
+        spool = dc.spool([patch]).attach_inventory(split)
+        assert len(spool.select(gauge_length=10.0)) == 0
+        assert len(spool.select(gauge_length=20.0)) == 0
+
+    def test_empty_spool(self, inventory):
+        """Nothing to select from stays nothing."""
+        spool = dc.spool([]).attach_inventory(inventory)
+        assert len(spool.select(gauge_length=10.0)) == 0
+
+    def test_selection_composes(self, two_patch_spool, inventory):
+        """A selection is a spool, so it selects again."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        out = spool.select(gauge_length=10.0).select(tag="second")
+        assert len(out) == 1
+
+    def test_enrichment_survives(self, two_patch_spool, inventory):
+        """The derived spool is the same spool, inventory and all."""
+        spool = two_patch_spool.enrich(inventory)
+        out = spool.select(gauge_length=10.0)
+        assert out[0].attrs.gauge_length == 10.0
+
+    def test_original_is_unchanged(self, two_patch_spool, inventory):
+        """Selecting leaves the spool it came from alone."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        spool.select(gauge_length=99.0)
+        assert len(spool) == 2
+
+    def test_channel_level_name_says_so(self, two_patch_spool, inventory):
+        """
+        A track name is a real inventory name which select cannot use yet.
+
+        Saying which of the two it is takes the names accessor, and this
+        is what it was added for.
+        """
+        spool = two_patch_spool.attach_inventory(inventory)
+        with pytest.raises(InvalidSpoolQueryError, match="along the fiber"):
+            spool.select(coupling="trench")
+        with pytest.raises(InvalidSpoolQueryError, match="along the fiber"):
+            spool.select(zone="east")
+
+    def test_unknown_name_still_raises(self, two_patch_spool, inventory):
+        """A name neither side knows is a misspelling, and says so."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        with pytest.raises(InvalidSpoolQueryError, match="neither an attribute"):
+            spool.select(not_a_name=1)
+
+    def test_samples_stays_coordinate_only(self, two_patch_spool, inventory):
+        """samples=True is a coordinate form; an attr is an error there."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        with pytest.raises(InvalidSpoolQueryError):
+            spool.select(gauge_length=10.0, samples=True)
+
+    def test_indexed_coordinate_is_not_intercepted(self, two_patch_spool, inventory):
+        """
+        `distance` names both an inventory coordinate and a real one.
+
+        The patch's own axis is what a range on it means, exactly as
+        without an inventory.
+        """
+        spool = two_patch_spool.attach_inventory(inventory)
+        coord = spool[0].get_coord("distance")
+        out = spool.select(distance=(coord.min(), coord.max()))
+        assert len(out) == 2
+
+    def test_units_are_the_inventory_s(self, two_patch_spool, inventory):
+        """
+        These values carry no units of their own, as the index's do not.
+
+        A unit-bearing selector is the same error either way, which is
+        what keeps one selector from meaning two things.
+        """
+        spool = two_patch_spool.attach_inventory(inventory)
+        with pytest.raises(UnitError, match="unitless"):
+            spool.select(gauge_length=10.0 * dc.get_quantity("m"))

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -822,7 +822,9 @@ class TestSpoolEnrich:
             assert body in " ".join(spool_doc.split())
             assert body in " ".join(patch_doc.split())
         for name in forwarded:
-            assert f"\n        {name}\n" in spool_doc
+            # Whatever it is indented by: Python 3.13 dedents a docstring
+            # as it compiles it, so the depth is not the same everywhere.
+            assert re.search(rf"^\s*{re.escape(name)}$", spool_doc, re.MULTILINE), name
 
 
 class TestReviewFindings:
@@ -1499,7 +1501,7 @@ class TestInventorySelect:
         with pytest.raises(UnitError, match="unitless"):
             spool.select(gauge_length=10.0 * dc.get_quantity("m"))
 
-    def test_unit_bearing_selector_uses_the_indexs_units(self, patch, inventory):
+    def test_unit_bearing_selector_uses_the_index_units(self, patch, inventory):
         """
         Where the index does record units, a quantity converts to them.
 

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import pickle
+import re
 import warnings
 
 import numpy as np
@@ -1530,3 +1531,171 @@ class TestInventoryUnselect:
         spool = two_patch_spool.attach_inventory(inventory)
         with pytest.raises(InvalidSpoolQueryError, match="along the fiber"):
             spool.unselect(coupling="trench")
+
+
+class TestInventorySelectCoverage:
+    """Selector shapes and inventory shapes the main tests do not reach."""
+
+    def test_regex_selector(self, two_patch_spool, inventory):
+        """A compiled pattern is a selector shape the index takes too."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        assert len(spool.select(**{"interrogator.model": re.compile("FI-")})) == 2
+        assert len(spool.select(**{"interrogator.model": re.compile("^ZZ")})) == 0
+
+    def test_half_open_ranges(self, two_patch_spool, inventory):
+        """An open end bounds nothing, exactly as on an indexed attr."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        assert len(spool.select(gauge_length=(5.0, None))) == 2
+        assert len(spool.select(gauge_length=(None, 5.0))) == 0
+        assert len(spool.select(gauge_length=(None, 15.0))) == 2
+
+    def test_unrelated_branches_are_skipped(self, patch, inventory):
+        """
+        Only the key's own branch decides where its epochs are.
+
+        An inventory describing several networks and arrays must not have
+        another one's epoch boundaries chop up this one's patches.
+        """
+        network = inventory.networks[0]
+        array = network.fiber_arrays[0]
+        elsewhere = network.new(
+            code="ZZ",
+            fiber_arrays=(array.new(code="L999", start_time="2001-01-01"),),
+        )
+        sibling = array.new(code="L998", start_time="2001-01-02")
+        crowded = inventory.new(
+            networks=(
+                elsewhere,
+                network.new(fiber_arrays=(sibling, *network.fiber_arrays)),
+            )
+        )
+        spool = dc.spool([patch]).attach_inventory(crowded)
+        assert len(spool.select(gauge_length=10.0)) == 1
+
+
+def _two_row_spool(inventory, **acquisition):
+    """One row the index states and one the inventory answers, same value."""
+    patch = inventory_patch_pair()[0]
+    ((name, value),) = acquisition.items()
+    described = _replace_acquisition(inventory, **acquisition)
+    return dc.spool(
+        [
+            patch.update_attrs(tag="unstated", **{name: type(value)()}),
+            patch.update_attrs(tag="stated", **{name: value}),
+        ]
+    ).attach_inventory(described)
+
+
+class TestSelectorMeansOneThing:
+    """
+    A selector must mean the same thing on both sides of the split.
+
+    Each of these puts the identical value in two rows -- one stated in
+    the header, one answered by the inventory -- so any difference in the
+    verdict is the two predicates disagreeing rather than the data.
+    """
+
+    def test_a_regex_searches(self, inventory):
+        """The index applies its regex residual with search, not match."""
+        spool = _two_row_spool(inventory, firmware_version="v1.2.3")
+        out = spool.select(firmware_version=re.compile("1.2"))
+        assert sorted(out.get_contents()["tag"]) == ["stated", "unstated"]
+
+    def test_a_glob_is_sqlites(self, inventory):
+        """
+        A negated class is spelled the way the index reads it.
+
+        `[!x]` is fnmatch's spelling and `[^x]` SQLite's; reaching for
+        fnmatch made each spelling select the half the other did not.
+        """
+        spool = _two_row_spool(inventory, firmware_version="v1.2.3")
+        assert len(spool.select(firmware_version="v[^x]*")) == 2
+        assert len(spool.select(firmware_version="v[!x]*")) == 0
+        assert len(spool.select(firmware_version="v[^1]*")) == 0
+
+    def test_a_range_of_the_wrong_kind_matches_nothing(self, inventory):
+        """
+        The index reaches for the typed column a selector names.
+
+        A numeric range against a string column matches nothing there, so
+        it matches nothing here rather than comparing across types.
+        """
+        spool = _two_row_spool(inventory, firmware_version="v1.2.3")
+        assert len(spool.select(firmware_version=(1.0, 2.0))) == 0
+
+    def test_a_number_does_not_match_a_bool(self, patch, inventory):
+        """`1` and `True` are stored as different kinds, so they differ."""
+        described = _replace_acquisition(inventory, closed_fiber_loop=True)
+        spool = dc.spool(
+            [
+                patch.update_attrs(tag="unstated"),
+                patch.update_attrs(tag="stated", closed_fiber_loop=True),
+            ]
+        ).attach_inventory(described)
+        assert len(spool.select(closed_fiber_loop=1)) == 0
+        assert len(spool.select(closed_fiber_loop=True)) == 2
+
+
+class TestNothingToResolveWith:
+    """Rows which offer no identity, or no instant to resolve it at."""
+
+    def test_spool_without_acquisition_keys(self, inventory):
+        """A patch naming no entry is one the inventory cannot describe."""
+        spool = dc.spool([dc.get_example_patch()]).attach_inventory(inventory)
+        assert "acquisition_key" not in spool.get_contents().columns
+        assert len(spool.select(gauge_length=10.0)) == 0
+
+    def test_lag_times_are_not_instants(self, patch, inventory):
+        """
+        A relative time axis says nothing about which epoch applies.
+
+        `Patch.enrich` refuses such a patch outright; reading its lags as
+        instants since 1970 would pick an epoch from an offset.
+        """
+        array = inventory.networks[0].fiber_arrays[0]
+        acquisition = array.acquisitions[0]
+        split = np.datetime64("1970-01-01T00:00:10", "ns")
+        described = inventory.replace(
+            array,
+            array.new(
+                acquisitions=(
+                    acquisition.new(end_time=split, gauge_length=10.0),
+                    acquisition.new(start_time=split, gauge_length=20.0),
+                )
+            ),
+        )
+        lags = patch.get_coord("time").values - patch.get_coord("time").min()
+        spool = dc.spool(
+            [
+                patch.update_coords(time=lags).update_attrs(tag="early"),
+                patch.update_coords(time=lags + np.timedelta64(20, "s")).update_attrs(
+                    tag="late"
+                ),
+            ]
+        ).attach_inventory(described)
+        assert len(spool.select(gauge_length=10.0)) == 0
+        assert len(spool.select(gauge_length=20.0)) == 0
+
+
+class TestSelectOnAView:
+    """A spool whose membership is already fixed still selects correctly."""
+
+    def test_windowed_spool_respects_stated_values(self, patch, inventory):
+        """
+        A window fixes which rows are present, not what they say.
+
+        The index's verdict for a windowed spool has to be the predicate's,
+        not the whole membership, or a row contradicting the selector
+        would ride along on the strength of being present.
+        """
+        spool = dc.spool(
+            [
+                patch.update_attrs(tag="states", gauge_length=99.0),
+                patch.update_attrs(tag="blank"),
+            ]
+        ).attach_inventory(inventory)
+        window = spool[0:2]
+        assert len(window) == 2
+        assert window.select(gauge_length=10.0).get_contents()["tag"].tolist() == [
+            "blank"
+        ]

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -1775,6 +1775,29 @@ class TestCodexReviewFindings:
         with pytest.raises(InvalidSpoolQueryError, match="lo > hi"):
             spool.select(gauge_length=(20.0, 5.0))
 
+    def test_a_malformed_selector_raises_where_the_index_answers(
+        self, patch, inventory
+    ):
+        """
+        A bad selector is bad whether or not an inventory is attached.
+
+        Every patch here states the name, so the inventory is never
+        consulted and the index's own complaint is the only one there is;
+        swallowing it as "the index selects nothing" would turn the error
+        into an empty spool.
+
+        The count is what forces it: an index-only select composes the
+        predicate lazily and complains when the rows are realized, while
+        an inventory-backed one realizes them at the call.
+        """
+        stated = patch.update_attrs(gauge_length=10.0)
+        for spool in (
+            dc.spool([stated]),
+            dc.spool([stated]).attach_inventory(inventory),
+        ):
+            with pytest.raises(InvalidSpoolQueryError, match="lo > hi"):
+                len(spool.select(gauge_length=(20.0, 5.0)))
+
     def test_units_are_spelled_the_way_a_patch_spells_them(self, patch, inventory):
         """
         The inventory models units as a quantity; a patch carries a string.

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -174,17 +174,17 @@ class TestAttrs:
         with pytest.raises(PatchError, match="defines no 'pulse_rate'"):
             patch.enrich(inventory, attrs=("pulse_rate",), coords=False)
 
-    def test_missing_named_attr_nan(self, patch, inventory):
+    def test_missing_named_attr_null(self, patch, inventory):
         """It can instead be filled with the missing marker."""
         out = patch.enrich(
             inventory, attrs=("pulse_rate",), coords=False, on_missing="null"
         )
         assert np.isnan(out.attrs.pulse_rate)
 
-    def test_missing_named_attr_skip(self, patch, inventory):
+    def test_missing_named_attr_ignore(self, patch, inventory):
         """Or omitted entirely."""
         out = patch.enrich(
-            inventory, attrs=("pulse_rate",), coords=False, on_missing="skip"
+            inventory, attrs=("pulse_rate",), coords=False, on_missing="ignore"
         )
         assert "pulse_rate" not in dict(out.attrs)
 
@@ -371,7 +371,7 @@ class TestCoords:
         with pytest.raises(PatchError, match="defines no 'northing'"):
             patch.enrich(inventory, attrs=False, coords=("northing",))
         out = patch.enrich(
-            inventory, attrs=False, coords=("northing",), on_missing="skip"
+            inventory, attrs=False, coords=("northing",), on_missing="ignore"
         )
         assert "northing" not in set(out.coords.coord_map)
 
@@ -398,14 +398,14 @@ class TestCoords:
         with pytest.raises(PatchError, match="defines no 'nope'"):
             patch.enrich(inventory, attrs=False, coords=("nope",))
 
-    def test_missing_coord_nan(self, patch, inventory):
+    def test_missing_coord_null(self, patch, inventory):
         """It can instead be filled with the missing marker."""
         out = patch.enrich(inventory, attrs=False, coords=("nope",), on_missing="null")
         assert np.isnan(out.get_coord("nope").values).all()
 
-    def test_missing_coord_skip(self, patch, inventory):
+    def test_missing_coord_ignore(self, patch, inventory):
         """Or omitted entirely."""
-        out = patch.enrich(inventory, attrs=False, coords=("nope",), on_missing="skip")
+        out = patch.enrich(inventory, attrs=False, coords=("nope",), on_missing="ignore")
         assert "nope" not in set(out.coords.coord_map)
 
     def test_blanket_without_geometry(self, patch, inventory):
@@ -844,7 +844,7 @@ class TestReviewFindings:
     def test_unknown_track_field_is_missing(self, patch, inventory):
         """A misspelled field is missing rather than an all-null coordinate."""
         out = patch.enrich(
-            inventory, attrs=False, coords=("coupling.nope",), on_missing="skip"
+            inventory, attrs=False, coords=("coupling.nope",), on_missing="ignore"
         )
         assert "coupling.nope" not in set(out.coords.coord_map)
 

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -1485,16 +1485,38 @@ class TestInventorySelect:
         out = spool.select(distance=(coord.min(), coord.max()))
         assert len(out) == 2
 
-    def test_units_are_the_inventory_s(self, two_patch_spool, inventory):
+    def test_unit_bearing_selector_against_a_unitless_index(
+        self, two_patch_spool, inventory
+    ):
         """
-        These values carry no units of their own, as the index's do not.
+        With nothing on either side to convert to, this is the same error.
 
-        A unit-bearing selector is the same error either way, which is
-        what keeps one selector from meaning two things.
+        The inventory's own units are fixed rather than recorded, so a
+        spool no patch of which states the attr has nothing to read a
+        quantity against — exactly as the index has not.
         """
         spool = two_patch_spool.attach_inventory(inventory)
         with pytest.raises(UnitError, match="unitless"):
             spool.select(gauge_length=10.0 * dc.get_quantity("m"))
+
+    def test_unit_bearing_selector_uses_the_indexs_units(self, patch, inventory):
+        """
+        Where the index does record units, a quantity converts to them.
+
+        Attaching an inventory must not turn a selector which works into
+        an error; the rows the index alone would have answered are still
+        its to answer.
+        """
+        meters = dc.get_quantity("m")
+        spool = dc.spool(
+            [
+                patch.update_attrs(tag="stated", gauge_length=10.0 * meters),
+                patch.update_attrs(tag="blank"),
+            ]
+        ).attach_inventory(inventory)
+        for selector in (10.0 * meters, (5.0 * meters, 15.0 * meters), [10.0 * meters]):
+            out = sorted(spool.select(gauge_length=selector).get_contents()["tag"])
+            assert out == ["blank", "stated"], selector
 
 
 class TestInventoryUnselect:
@@ -1699,3 +1721,98 @@ class TestSelectOnAView:
         assert window.select(gauge_length=10.0).get_contents()["tag"].tolist() == [
             "blank"
         ]
+
+
+class TestCodexReviewFindings:
+    """Defects found reviewing inventory-backed selection."""
+
+    def test_a_patch_with_no_instant_is_not_resolved(self, patch, inventory):
+        """
+        A row whose times are NaT says nothing about which epoch applies.
+
+        Resolving at NaT holds every epoch effective, which is the whole
+        inventory answering rather than the one entry describing the row.
+        """
+        stamps = np.full(len(patch.get_coord("time")), np.datetime64("NaT", "ns"))
+        spool = dc.spool(
+            [
+                patch.update_attrs(tag="good"),
+                patch.update_coords(time=stamps).update_attrs(tag="undated"),
+            ]
+        ).attach_inventory(inventory)
+        out = spool.select(gauge_length=10.0)
+        assert out.get_contents()["tag"].tolist() == ["good"]
+
+    def test_a_reversed_glob_range_means_one_thing(self, inventory):
+        """
+        SQLite tests a range's low endpoint before testing the range.
+
+        So `[z-a]` matches `z` there, and the in-memory twin has to agree
+        rather than reading the reversed range as matching nothing.
+        """
+        spool = _two_row_spool(inventory, firmware_version="z")
+        assert len(spool.select(firmware_version="[z-a]")) == 2
+        assert len(spool.select(firmware_version="[^z-a]")) == 0
+
+    def test_a_range_with_no_bounds_raises(self, inventory):
+        """
+        An unusable range is the error it is on the index side.
+
+        Applying no bounds instead would keep every row the inventory
+        describes, and the same selector would raise or not depending on
+        whether some unrelated patch happened to state the name.
+        """
+        spool = _two_row_spool(inventory, firmware_version="v1")
+        for empty in ((None, None), (..., ...)):
+            with pytest.raises(InvalidSpoolQueryError, match="no usable bounds"):
+                spool.select(**{"firmware_version": empty})
+
+    def test_a_backwards_range_raises(self, patch, inventory):
+        """And so is one whose bounds are the wrong way round."""
+        spool = dc.spool([patch]).attach_inventory(inventory)
+        with pytest.raises(InvalidSpoolQueryError, match="lo > hi"):
+            spool.select(gauge_length=(20.0, 5.0))
+
+    def test_units_are_spelled_the_way_a_patch_spells_them(self, patch, inventory):
+        """
+        The inventory models units as a quantity; a patch carries a string.
+
+        The same fact stored two ways would never match one selector, so
+        the inventory's answer is rendered the way a header states it.
+        """
+        described = _replace_acquisition(inventory, data_units="m/s")
+        spool = dc.spool(
+            [
+                patch.update_attrs(tag="stated", data_units="m/s"),
+                patch.update_attrs(tag="blank", data_units=""),
+            ]
+        ).attach_inventory(described)
+        out = sorted(spool.select(data_units="m / s").get_contents()["tag"])
+        assert out == ["blank", "stated"]
+
+    def test_a_wildcard_crosses_a_newline(self, inventory):
+        """SQLite's wildcards match any byte, newlines included."""
+        spool = _two_row_spool(inventory, firmware_version="a\nb")
+        assert len(spool.select(firmware_version="a*")) == 2
+
+
+class TestRelationAndIdListDisagree:
+    """The relation is realized by a route of its own."""
+
+    def test_rows_it_omits_resolve_to_nothing(self, patch, inventory, monkeypatch):
+        """
+        A row the relation leaves out is one nothing was resolved for.
+
+        The two are aligned by id rather than by position, so a relation
+        presenting fewer rows than the id list cannot silently shift
+        every context onto the wrong patch.
+        """
+        spool = dc.spool(
+            [patch.update_attrs(tag="first"), patch.update_attrs(tag="second")]
+        ).attach_inventory(inventory)
+        full = spool._df
+        monkeypatch.setattr(
+            type(spool), "_df", property(lambda self, df=full.iloc[1:]: df)
+        )
+        out = spool.select(gauge_length=10.0)
+        assert out.get_contents()["tag"].tolist() == ["second"]

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import pickle
 import warnings
 
@@ -10,6 +11,12 @@ import pytest
 from pydantic import ValidationError
 
 import dascore as dc
+from dascore.constants import (
+    enrich_attrs_description,
+    enrich_conflicts_description,
+    enrich_coords_description,
+    enrich_on_missing_description,
+)
 from dascore.core.inventory import (
     Acquisition,
     CoordinateReferenceSystem,
@@ -405,7 +412,9 @@ class TestCoords:
 
     def test_missing_coord_ignore(self, patch, inventory):
         """Or omitted entirely."""
-        out = patch.enrich(inventory, attrs=False, coords=("nope",), on_missing="ignore")
+        out = patch.enrich(
+            inventory, attrs=False, coords=("nope",), on_missing="ignore"
+        )
         assert "nope" not in set(out.coords.coord_map)
 
     def test_blanket_without_geometry(self, patch, inventory):
@@ -785,6 +794,33 @@ class TestSpoolEnrich:
         """The last call says what enrichment means."""
         spool = dc.spool(patch).enrich(inventory, coords=False).enrich(inventory)
         assert "zone" in set(spool[0].coords.coord_map)
+
+    def test_documents_the_arguments_it_forwards(self):
+        """
+        Spool.enrich documents the arguments it holds, from one source.
+
+        The two enrich methods take the same arguments and describing them
+        twice is how they drift, so both compose the same fragments.
+        """
+        spool_doc = dc.core.spool.Spool.enrich.__doc__
+        patch_doc = dc.Patch.enrich.__doc__
+        forwarded = set(inspect.signature(dc.Patch.enrich).parameters) - {
+            "patch",
+            "inventory",
+        }
+        for fragment in (
+            enrich_attrs_description,
+            enrich_coords_description,
+            enrich_on_missing_description,
+            enrich_conflicts_description,
+        ):
+            # Indentation differs between a function and a method body, so
+            # the shared text is compared with it removed.
+            body = " ".join(fragment.split())
+            assert body in " ".join(spool_doc.split())
+            assert body in " ".join(patch_doc.split())
+        for name in forwarded:
+            assert f"\n        {name}\n" in spool_doc
 
 
 class TestReviewFindings:

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import inspect
+import itertools
 import pickle
 import re
 import warnings
+from collections.abc import Mapping
 
 import numpy as np
 import pytest
@@ -23,6 +25,7 @@ from dascore.core.inventory import (
     CoordinateReferenceSystem,
     DistanceMap,
     FiberArray,
+    FiberSegment,
     Geometry,
     Inventory,
     Network,
@@ -821,10 +824,10 @@ class TestSpoolEnrich:
             body = " ".join(fragment.split())
             assert body in " ".join(spool_doc.split())
             assert body in " ".join(patch_doc.split())
-        for name in forwarded:
+        for doc, name in itertools.product((spool_doc, patch_doc), forwarded):
             # Whatever it is indented by: Python 3.13 dedents a docstring
             # as it compiles it, so the depth is not the same everywhere.
-            assert re.search(rf"^\s*{re.escape(name)}$", spool_doc, re.MULTILINE), name
+            assert re.search(rf"^\s*{re.escape(name)}$", doc, re.MULTILINE), name
 
 
 class TestReviewFindings:
@@ -1841,3 +1844,75 @@ class TestRelationAndIdListDisagree:
         )
         out = spool.select(gauge_length=10.0)
         assert out.get_contents()["tag"].tolist() == ["second"]
+
+
+class TestConnectorReviewFindings:
+    """Defects the PR's automated reviewers found."""
+
+    def test_a_group_may_share_an_attrs_name(self, patch, inventory):
+        """
+        An annotation group is free to be named after an acquisition field.
+
+        Bare names resolve to attrs first, so selecting on the field has
+        to keep working; only a caller who asked for `_coords` means the
+        group, which is the channel-level half and not supported yet.
+        """
+        path = inventory.networks[0].fiber_arrays[0].optical_paths[0]
+        clash = inventory.replace(
+            path,
+            path.new(
+                annotations=(
+                    *path.annotations,
+                    OpticalPathAnnotation(
+                        start_distance=0.0,
+                        end_distance=100.0,
+                        group="gauge_length",
+                        value="odd",
+                    ),
+                )
+            ),
+        )
+        names = clash.get_names()
+        assert "gauge_length" in names.attrs and "gauge_length" in names.coords
+        spool = dc.spool([patch]).attach_inventory(clash)
+        assert len(spool.select(gauge_length=10.0)) == 1
+        assert len(spool.select(_attrs={"gauge_length": 10.0})) == 1
+        for form in ({"gauge_length": 10.0}, "gauge_length", ["gauge_length"]):
+            # The mapping form and both tag forms all name the coordinate.
+            kwargs = {} if isinstance(form, Mapping) else {"gauge_length": 10.0}
+            with pytest.raises(InvalidSpoolQueryError, match="along the fiber"):
+                spool.select(_coords=form, **kwargs)
+
+    def test_a_field_scalar_on_another_path_is_kept(self):
+        """
+        One path stating several values does not silence the others.
+
+        A field is only unusable where nothing states it as one value; a
+        path which records a scalar can still give it to a channel.
+        """
+
+        def path(loss, measurement):
+            return OpticalPath(
+                location_code="",
+                optical_components=(
+                    FiberSegment(
+                        name="c",
+                        optical_length=100.0,
+                        loss_db=loss,
+                        loss_measurement=measurement,
+                    ),
+                ),
+            )
+
+        def build(*paths):
+            array = FiberArray(code="R2D1", optical_paths=paths)
+            return Inventory(
+                networks=(Network(code="DAS", fiber_arrays=(array,)),),
+                resources={"m1": OpticalMeasurement(resource_id="m1")},
+            )
+
+        many = path((0.2, 0.25), ("m1", "m1"))
+        one = path(0.3, "m1")
+        assert "optical_components.loss_db" not in build(many).get_names().coords
+        assert "optical_components.loss_db" in build(many, one).get_names().coords
+        assert "optical_components.loss_db" in build(one).get_names().coords

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -1494,3 +1494,39 @@ class TestInventorySelect:
         spool = two_patch_spool.attach_inventory(inventory)
         with pytest.raises(UnitError, match="unitless"):
             spool.select(gauge_length=10.0 * dc.get_quantity("m"))
+
+
+class TestInventoryUnselect:
+    """Unselect reaches whatever select reaches."""
+
+    def test_removes_what_select_keeps(self, two_patch_spool, inventory):
+        """The complement holds for an inventory-backed name too."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        assert len(spool.unselect(gauge_length=10.0)) == 0
+        assert len(spool.unselect(gauge_length=99.0)) == 2
+
+    def test_undescribed_patch_is_kept(self, patch, inventory):
+        """
+        Silently not matching means silently not being removed.
+
+        Unselect is the complement of a filter, so a patch the inventory
+        cannot speak for stays for the same reason it is never selected.
+        """
+        other = patch.update_attrs(tag="other", acquisition_key="DAS.R2D1..OTHER")
+        spool = dc.spool([patch, other]).attach_inventory(inventory)
+        out = spool.unselect(gauge_length=10.0)
+        assert out.get_contents()["tag"].tolist() == ["other"]
+
+    def test_stated_value_wins(self, patch, inventory):
+        """Per-row precedence is the same on the way out."""
+        stated = patch.update_attrs(tag="stated", gauge_length=20.0)
+        spool = dc.spool([patch, stated]).attach_inventory(inventory)
+        assert spool.unselect(gauge_length=20.0).get_contents()["tag"].tolist() == [
+            "random"
+        ]
+
+    def test_channel_level_name_says_so(self, two_patch_spool, inventory):
+        """A track name is as unsupported here as it is in select."""
+        spool = two_patch_spool.attach_inventory(inventory)
+        with pytest.raises(InvalidSpoolQueryError, match="along the fiber"):
+            spool.unselect(coupling="trench")


### PR DESCRIPTION
## Description

The first of three PRs implementing inventory-backed spool selection ([#857](https://github.com/DASDAE/dascore/issues/857)). This one covers the acquisition-level half — whole-patch metadata — and the pieces the other two need. Selecting on the coordinates an inventory defines *along the fiber* (coupling, geometry, annotation groups) is PR (c), and `conform_to_inventory`, which owns row subdivision, is PR (b).

**Selecting on what the inventory states.** `spool.select(gauge_length=10.0)` and `spool.select(**{"interrogator.model": "FI-1"})` now filter an archive whose files never recorded either. Precedence is per row: a patch which states the name is judged by the index exactly as it would be without an inventory, and only the rows leaving it unstated are resolved — once per `(acquisition_key, epoch)` rather than once per patch. A spool whose headers are complete never consults the inventory at all, and which rows state a name is asked of the index rather than read off a realized relation, so that spool is never realized either.

A patch the inventory does not describe, or describes *twice* because it straddles an epoch boundary, is simply not selected. Select is a filter, and a patch with no single answer is no more selected than one lacking the attr entirely — the one deliberate exception to loud-by-default, because warning here would make composed selects noisy on intentionally partial inventories. Subdividing the straddlers is `conform_to_inventory`'s job.

The inventory never writes into the SQLite index. The filter rewrites the contents of a new spool, so `len` and `get_contents` stay exact, no data is read, and swapping inventories cannot leave a stale derived value behind. The one route by which inventory facts become index facts is still the ordinary round trip: enrich, write, rescan.

**One selector, one meaning.** `evaluate_attr_predicate` is the in-memory twin of the SQL `build_attr_clause` and is held to it: it types its values the way the index types a stored one (so a numeric range against a string attr matches nothing rather than raising, and `1` does not match a stored `True`), a regex `search`es as the index's residual does, and a glob is translated from SQLite's own semantics rather than handed to `fnmatch` — `[!x]` and `[^x]` are each other's complement in the two, which would have made one pattern select opposite halves of a spool depending on which side answered it.

**`Inventory.get_names`** returns the names an inventory could contribute to a patch, split into `attrs` and `coords` the way `Patch.enrich` and select's `_attrs`/`_coords` already split them. The attrs side is read off the pydantic models, so a field added to an acquisition or interrogator is selectable without a second list to maintain, and a test pins it to `INVENTORY_ATTRS` — the two are one vocabulary, and a new field has to reach the readers as well. The coords side comes from the inventory itself. This is what lets a spool tell an inventory field from a misspelled attr, replacing a hedge that could not.

**`Spool.unselect`** is the complement of `select`, taken against `select` itself rather than by negating each predicate, so one keyword cannot come to mean different things in the two, and an attached inventory's names work here because they work there. Coordinates are refused: a range decides how much of each patch to keep rather than which patches, so its complement is a hole in the middle rather than a filter.

**Two fixes found on the way.** `PatchCatalog._ordered_ids` returned a fixed membership unfiltered whenever one was set, ignoring every predicate composed after it — so `div[2:8].select(tag="big_gaps")[0:1]` came back empty on `dev`. It now filters the membership while keeping its order, since an integer array may have arranged it. And `Patch.enrich` accepted a bare track name (`coords=("coupling",)`) without implementing what it means, silently filling NaN instead of the coupling type.

### Performance

Attaching stays free, which is the point of it being a separate step. On one 10k-patch in-memory spool, best of 9:

| | no inventory | inventory attached |
|---|---|---|
| `select(tag=...)` | 3.0 ms | 4.2 ms (10 optical paths) / 5.8 ms (250) |
| `select(gauge_length=...)`, every patch states it | 2.9 ms | 35 ms |
| `select(gauge_length=...)`, no patch states it | n/a | 264 ms |

The last row is the feature's real cost: resolving rows the index cannot answer for realizes the spool's contents, where an index-only select stays lazy. It is linear in the spool (~25 µs/row) and pays for one resolution per epoch, not per patch. The first two rows are what an adversarial review turned up and this branch then fixed — before it, the same three cases cost 3.7×/29× and 225× their no-inventory counterparts, because every select walked the inventory twice, re-read the index's name lists three times, and realized the relation to discover the index had already answered.

### Also here

- `Patch.enrich`'s `on_missing="skip"` is renamed `"ignore"`, so every policy knob draws from one word set (`raise`/`warn`/`ignore`, plus `"null"`, which is an action rather than a volume). Nothing is released, so no compatibility spelling is kept.
- `Patch.enrich` and `Spool.enrich` document the same arguments from one source instead of describing them twice.
- Indexing warns once when hive-style `key=value` path segments override attrs the files themselves state. The path winning is deliberate — renaming a directory is how a layout corrects metadata — but it is also what a mis-sorted archive looks like from the inside. The comparison is on meaning rather than spelling, so `gauge_length=10` over a file stating `10.0` stays silent.

## Changelog

- added: `Spool.select` filters on the observing-system facts an attached inventory states (`spool.select(gauge_length=10.0)`, `spool.select(**{"interrogator.model": "FI-1"})`), even when no file recorded them. A patch which states the name is judged by the index as before and only the rest are resolved, once per epoch; a patch the inventory does not describe, or describes twice, is not selected. The inventory never writes into the index, so `len` and `get_contents` stay exact and no data is read. Unlike an index-only select, this realizes the spool's contents.
- added: `Spool.unselect`, the complement of `select` — `spool.unselect(tag="bad")` returns everything the matching selection would have removed. Every keyword means what it means in `select`. Coordinates are refused, since a range trims each patch rather than filtering the spool.
- added: `Inventory.get_names` returns the names an inventory could contribute to a patch, split into `attrs` and `coords`. The attrs side is read off the models, so a field added to an acquisition or interrogator becomes selectable without a second list to maintain.
- added: indexing warns once when hive-style `key=value` path segments override attrs the files themselves state, naming each attr and one path carrying it. A segment restating what a file already says is silent.
- fixed: a spool whose membership was already fixed — by a slice, an integer array, or a previous selection — ignored predicates composed afterwards, so `spool[2:8].select(tag="x")[0:1]` came back empty.
- fixed: `Patch.enrich(coords=("coupling",))` and the other bare track names now give the track's identity field (the coupling type, the geometry or component name) instead of silently filling missing values.
- changed: `Patch.enrich`'s `on_missing="skip"` is renamed `"ignore"`, so every policy argument draws from one word set. Breaking only against unreleased work on `dev`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inventory-aware patch selection and `unselect` for removing matching patches.
  * Expanded inventory introspection with available attribute and coordinate names.
  * Added glob, regex, range, collection, and unit-aware attribute filtering.
  * Added backend reporting for attribute units and stated values.
  * Improved inventory enrichment with track-based lookups and batched context handling.
  * Added support for `on_missing="ignore"` during enrichment.

* **Bug Fixes**
  * Improved attribute conflict detection and ingestion warnings.
  * Preserved selection ordering and membership across composed queries.

* **Documentation**
  * Documented patch unselection and enrichment parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->