### PR TITLE
Make the inventory immutable and hash it the way it compares

### DIFF
--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -1815,12 +1815,13 @@ class Inventory(InventoryModel):
     @classmethod
     def _key_resources(cls, value):
         """Accept an iterable of resources, keying them by resource_id."""
-        # Mapping, not dict: FrozenDict is not a dict, so another inventory's
-        # pool would fall through to the iterable-of-resources branch.
+        # Mapping, not dict, at both levels: FrozenDict is not a dict, so a
+        # pool would fall through to the iterable-of-resources branch and a
+        # record would be read as an object, hiding a key that disagrees.
         if isinstance(value, Mapping):
             out = {}
             for key, resource in value.items():
-                if isinstance(resource, dict):
+                if isinstance(resource, Mapping):
                     rid = resource.get("resource_id")
                     if rid is None:
                         resource = {**resource, "resource_id": key}

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -44,6 +44,7 @@ from typing_extensions import Self
 
 from dascore.constants import DataCategory, DataType
 from dascore.exceptions import InvalidInventoryError, ParameterError
+from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import (
     check_code,
     is_strictly_monotonic,
@@ -52,6 +53,7 @@ from dascore.utils.misc import (
 )
 from dascore.utils.models import (
     DateTime64,
+    FrozenDictType,
     InventoryModel,
     TimeRangedModel,
     UnitQuantity,
@@ -1797,7 +1799,7 @@ class Inventory(InventoryModel):
         default_factory=CreationInfo,
         description="QuakeML-style creation and update metadata.",
     )
-    resources: dict[str, _Resource] = Field(
+    resources: FrozenDictType[str, _Resource] = Field(
         default_factory=dict,
         description="Shareable resources keyed by resource_id.",
     )
@@ -1813,7 +1815,9 @@ class Inventory(InventoryModel):
     @classmethod
     def _key_resources(cls, value):
         """Accept an iterable of resources, keying them by resource_id."""
-        if isinstance(value, dict):
+        # Mapping, not dict: FrozenDict is not a dict, so another inventory's
+        # pool would fall through to the iterable-of-resources branch.
+        if isinstance(value, Mapping):
             out = {}
             for key, resource in value.items():
                 if isinstance(resource, dict):
@@ -1948,7 +1952,8 @@ class Inventory(InventoryModel):
                     f"{type(pool[rid]).__name__}, expected one of {names}."
                 )
                 raise InvalidInventoryError(msg)
-        object.__setattr__(self, "resources", pool)
+        # object.__setattr__ bypasses the field validator, so freeze here.
+        object.__setattr__(self, "resources", FrozenDict(pool))
         object.__setattr__(self, "networks", networks)
         self.__pydantic_fields_set__.update({"resources", "networks"})
         return self

--- a/dascore/utils/models.py
+++ b/dascore/utils/models.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from functools import cached_property
-from typing import Annotated
+from typing import Annotated, TypeVar
 
 import numpy as np
 import pandas as pd
 from pydantic import (
+    AfterValidator,
     BaseModel,
     ConfigDict,
     Field,
@@ -28,6 +29,8 @@ from dascore.utils.time import to_datetime64, to_timedelta64
 # --- A list of custom types with appropriate serialization/deserialization
 # these can just be use with pydantic type-hints.
 
+# Freezes without validating contents. Use FrozenDictType below when the
+# declared value types must still be enforced.
 frozen_dict_validator = PlainValidator(lambda x: FrozenDict(x))
 frozen_dict_serializer = PlainSerializer(lambda x: dict(x))
 
@@ -67,10 +70,16 @@ CommaSeparatedStr = Annotated[
     str, PlainValidator(lambda x: x if isinstance(x, str) else ",".join(x))
 ]
 
+K = TypeVar("K")
+V = TypeVar("V")
+
+# Mapping, not dict: the runtime value is a FrozenDict, so a dict annotation
+# would let type checkers pass writes that raise. AfterValidator, not
+# PlainValidator: a plain validator would replace the declared value-type check.
 FrozenDictType = Annotated[
-    FrozenDict,
-    frozen_dict_validator,
-    frozen_dict_serializer,
+    Mapping[K, V],
+    AfterValidator(lambda x: FrozenDict(x)),
+    PlainSerializer(dict),
 ]
 
 UTF8Str = Annotated[str, PlainValidator(unbyte)]
@@ -120,6 +129,29 @@ def values_equal(val1, val2) -> bool:
     return bool(val1 == val2 or (_all_null(val1) and _all_null(val2)))
 
 
+def _hash_key(value):
+    """Map a value onto one that hashes the way values_equal compares."""
+    if value is None or isinstance(value, str | int):
+        return value
+    # Nulls count as equal to one another above, but every nan and NaT is a
+    # fresh object and both hash by identity, so they collapse to one key.
+    if isinstance(value, float):
+        return None if value != value else value
+    if isinstance(value, np.datetime64 | np.timedelta64):
+        return None if np.isnat(value) else value
+    # Mappings are compared without regard to order.
+    if isinstance(value, Mapping):
+        return frozenset((k, _hash_key(v)) for k, v in value.items())
+    if isinstance(value, tuple):
+        return tuple(_hash_key(v) for v in value)
+    return value
+
+
+def sensible_model_hash(self: BaseModel) -> int:
+    """Hash a model on its fields, agreeing with sensible_model_equals."""
+    return hash(tuple(_hash_key(getattr(self, x)) for x in type(self).model_fields))
+
+
 class DascoreBaseModel(BaseModel):
     """A base model with sensible configurations."""
 
@@ -154,6 +186,9 @@ class DascoreBaseModel(BaseModel):
         return out
 
     __eq__ = sensible_model_equals
+    # Defined together: pydantic would otherwise derive a hash straight from
+    # the field values, which disagrees with how __eq__ treats nulls.
+    __hash__ = sensible_model_hash
 
 
 class InventoryModel(DascoreBaseModel):
@@ -165,10 +200,14 @@ class InventoryModel(DascoreBaseModel):
     (free prose for humans, matching StationXML's Description element)
     and ``extra_fields`` (typed key-values, e.g. for round-tripping
     unmodeled metadata from external formats).
+
+    Every field is immutable: collections are tuples and mappings are
+    frozen, so instances are safe to hold by reference. They hash on their
+    field values whenever those values are themselves hashable.
     """
 
     description: str = Field(default="", description="Free-text description.")
-    extra_fields: dict[str, str | int | float | bool] = Field(
+    extra_fields: FrozenDictType[str, str | int | float | bool] = Field(
         default_factory=dict,
         description="Extra metadata not represented by standardized fields.",
     )

--- a/dascore/utils/models.py
+++ b/dascore/utils/models.py
@@ -60,9 +60,24 @@ DTypeLike = Annotated[
     PlainValidator(np.dtype),
 ]
 
+
+def _to_unit_quantity(value):
+    """Read units, refusing a quantity that carries many magnitudes."""
+    out = get_quantity(value)
+    try:
+        # Passing a sequence makes pint build an array magnitude, which is
+        # writable through the frozen model holding it. Asking whether it can
+        # be hashed is the direct question; no real unit spelling fails it.
+        hash(out)
+    except TypeError:
+        msg = f"Units must name a single unit, got {value!r}."
+        raise ValueError(msg) from None
+    return out
+
+
 UnitQuantity = Annotated[
     Quantity | str | None,
-    PlainValidator(get_quantity),
+    PlainValidator(_to_unit_quantity),
     PlainSerializer(get_quantity_str),
 ]
 

--- a/dascore/utils/models.py
+++ b/dascore/utils/models.py
@@ -149,7 +149,10 @@ def _hash_key(value):
 
 def sensible_model_hash(self: BaseModel) -> int:
     """Hash a model on its fields, agreeing with sensible_model_equals."""
-    return hash(tuple(_hash_key(getattr(self, x)) for x in type(self).model_fields))
+    # Keyed by name and unordered, because equality compares the field names
+    # it finds rather than the order they were declared in.
+    fields = type(self).model_fields
+    return hash(frozenset((x, _hash_key(getattr(self, x))) for x in fields))
 
 
 class DascoreBaseModel(BaseModel):

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -14,6 +14,7 @@ from dascore.constants import INVENTORY_ATTRS
 from dascore.core import Inventory
 from dascore.core import inventory as inv
 from dascore.exceptions import InvalidInventoryError
+from dascore.utils.mapping import FrozenDict
 from dascore.utils.models import values_equal
 
 
@@ -1235,6 +1236,14 @@ class TestImmutability:
         second = inv.Inventory(resources=first.resources)
         assert isinstance(second.resources["cable_01"], inv.Cable)
         assert second.resources == first.resources
+
+    def test_frozen_record_disagreeing_with_its_key_is_refused(self):
+        """A record is read as a record whatever kind of mapping it is."""
+        # Read as an object instead, its resource_id goes unseen and the
+        # mismatch only surfaces on the next load.
+        record = FrozenDict({"type": "Cable", "resource_id": "elsewhere"})
+        with pytest.raises(ValidationError, match="disagrees with resource_id"):
+            inv.Inventory(resources={"cable-01": record})
 
     def test_equal_inventories_hash_equally(self):
         """Equality and hashing agree, so an inventory works as a dict key."""

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import pickle
+
 import numpy as np
 import pytest
 from pydantic import ValidationError
@@ -1174,6 +1177,113 @@ class TestUniformAttachments:
         loaded = inv.Inventory.from_yaml(inventory.to_yaml())
         got = loaded.networks[0].fiber_arrays[0].acquisitions[0]
         assert got.extra_fields == {"vendor_flag": ""}
+
+
+class TestImmutability:
+    """Inventory fields cannot be written to."""
+
+    @staticmethod
+    def _stocked_inventory(resource_id="fixed"):
+        """An inventory whose frozen mappings both carry contents."""
+        cable = inv.Cable(resource_id="cable-01", name="c")
+        segment = inv.FiberSegment(optical_length=100.0, container=cable)
+        array = inv.FiberArray(
+            code="L001",
+            optical_paths=(inv.OpticalPath(optical_components=(segment,)),),
+        )
+        return inv.Inventory(
+            resource_id=resource_id,
+            extra_fields={"vendor": "x", "gain": 1.5},
+            networks=(inv.Network(code="DAS", fiber_arrays=(array,)),),
+        )
+
+    def test_extra_fields_refuses_writes(self):
+        """extra_fields rejects item assignment."""
+        acquisition = inv.Acquisition(code="RAW", extra_fields={"vendor": "x"})
+        with pytest.raises(TypeError, match="item assignment"):
+            acquisition.extra_fields["vendor"] = "y"
+
+    def test_nested_extra_fields_refuses_writes(self):
+        """The refusal holds everywhere in the tree, not just at the top."""
+        inventory = build_inventory()
+        nested = inventory.networks[0].fiber_arrays[0].acquisitions[0]
+        with pytest.raises(TypeError, match="item assignment"):
+            nested.extra_fields["vendor"] = "y"
+
+    def test_extra_fields_still_checks_value_types(self):
+        """AfterValidator keeps the declared value types enforced."""
+        with pytest.raises(ValidationError):
+            inv.Acquisition(code="RAW", extra_fields={"vendor": [1, 2]})
+
+    def test_resource_pool_refuses_writes(self):
+        """Inventory.resources rejects item assignment."""
+        inventory = inv.Inventory(resources=[inv.Cable(resource_id="cable_01")])
+        with pytest.raises(TypeError, match="item assignment"):
+            inventory.resources["cable_02"] = inv.Cable(resource_id="cable_02")
+
+    def test_pool_built_by_validation_is_frozen(self):
+        """Inline resources hoisted into the pool land in a frozen mapping."""
+        # Exercises _normalize_resources, which bypasses the field validator.
+        inventory = self._stocked_inventory()
+        assert list(inventory.resources) == ["cable-01"]
+        with pytest.raises(TypeError, match="item assignment"):
+            inventory.resources["anything"] = None
+
+    def test_frozen_pool_accepted_as_input(self):
+        """A FrozenDict pool is keyed, not iterated."""
+        first = inv.Inventory(resources=[inv.Cable(resource_id="cable_01")])
+        second = inv.Inventory(resources=first.resources)
+        assert isinstance(second.resources["cable_01"], inv.Cable)
+        assert second.resources == first.resources
+
+    def test_equal_inventories_hash_equally(self):
+        """Equality and hashing agree, so an inventory works as a dict key."""
+        # resource_id is pinned; it otherwise defaults to a fresh uuid.
+        first, second = self._stocked_inventory(), self._stocked_inventory()
+        assert first == second
+        assert hash(first) == hash(second)
+        assert {first: "found"}[second] == "found"
+
+    def test_hash_survives_a_pickle_round_trip(self):
+        """Pickle restores fields without validating, and spools are pickled."""
+        inventory = self._stocked_inventory()
+        loaded = pickle.loads(pickle.dumps(inventory))
+        assert loaded == inventory
+        assert hash(loaded) == hash(inventory)
+
+    def test_hash_survives_a_yaml_round_trip(self):
+        """Serializing and reloading does not move an inventory's hash."""
+        pytest.importorskip("yaml")
+        inventory = self._stocked_inventory()
+        loaded = inv.Inventory.from_yaml(inventory.to_yaml())
+        assert loaded == inventory
+        assert hash(loaded) == hash(inventory)
+
+    def test_dumps_are_ordinary_dicts(self):
+        """Frozen mappings serialize back to plain dicts at every depth."""
+        inventory = inv.Inventory(
+            resources=[inv.Cable(resource_id="cable_01", description="a cable")],
+            extra_fields={"vendor": "x"},
+        )
+        dumped = inventory.model_dump()
+        assert type(dumped["extra_fields"]) is dict
+        assert type(dumped["resources"]) is dict
+        assert type(dumped["resources"]["cable_01"]) is dict
+
+    def test_json_mode_still_reaches_pooled_resources(self):
+        """The pool's own serializer does not shadow what it holds."""
+        run = inv.OpticalMeasurement(resource_id="otdr-1", time="2020-01-01")
+        segment = inv.FiberSegment(optical_length=10.0, loss_measurement=run)
+        array = inv.FiberArray(
+            code="L001",
+            optical_paths=(inv.OpticalPath(optical_components=(segment,)),),
+        )
+        inventory = inv.Inventory(
+            networks=(inv.Network(code="DAS", fiber_arrays=(array,)),)
+        )
+        dumped = inventory.model_dump(mode="json")
+        assert dumped["resources"]["otdr-1"]["time"].startswith("2020-01-01")
+        assert json.dumps(dumped)
 
 
 class TestStationXmlAlignment:

--- a/tests/test_utils/test_models.py
+++ b/tests/test_utils/test_models.py
@@ -6,13 +6,15 @@ import pickle
 
 import numpy as np
 import pytest
-from pydantic import Field
+from pydantic import Field, ValidationError
 
+from dascore.units import Quantity
 from dascore.utils.models import (
     DascoreBaseModel,
     DateTime64,
     FrozenDictType,
     TimeDelta64,
+    UnitQuantity,
     sensible_model_equals,
 )
 
@@ -54,6 +56,41 @@ class TestModelEquals:
         new = mod.new(some_str="bob")
         assert new.some_str == "bob"
         assert new is not mod
+
+
+class _UnitModel(DascoreBaseModel):
+    """A model carrying units."""
+
+    units: UnitQuantity | None = None
+
+
+class TestUnitQuantity:
+    """Units name a single unit, so they stay scalar."""
+
+    @pytest.mark.parametrize(
+        "spec", ["m/s", "1/s", "Hz", "2*degC", "2.5*degC", "10 m/s", 1.0, None, ""]
+    )
+    def test_real_spellings_accepted(self, spec):
+        """Every real unit spelling has a scalar magnitude, so it hashes."""
+        assert isinstance(hash(_UnitModel(units=spec)), int)
+
+    def test_sequence_refused(self):
+        """A sequence makes pint build a mutable, unhashable magnitude."""
+        with pytest.raises(ValidationError, match="single unit"):
+            _UnitModel(units=(1.0, 2.0))
+
+    @pytest.mark.parametrize("magnitude", [np.array([1.0, 2.0]), np.array(1.0)])
+    def test_array_magnitude_refused(self, magnitude):
+        """A quantity built by hand is held to the same rule."""
+        # A zero dimensional array is as writable as any other, so measuring
+        # how many dimensions it has would let this one through.
+        with pytest.raises(ValidationError, match="single unit"):
+            _UnitModel(units=Quantity(magnitude, "m"))
+
+    def test_serialized_units_validate_again(self):
+        """What the serializer writes has to survive being read back."""
+        model = _UnitModel(units="m/s")
+        assert _UnitModel(**model.model_dump()) == model
 
 
 class _NullModel(DascoreBaseModel):
@@ -108,15 +145,15 @@ class TestModelHash:
     def test_declaration_order_does_not_change_the_hash(self):
         """Equality compares field names, so declaration order cannot matter."""
 
-        class Ab(DascoreBaseModel):
+        class Forward(DascoreBaseModel):
             a: int = 1
             b: int = 2
 
-        class Ba(DascoreBaseModel):
+        class Reversed(DascoreBaseModel):
             b: int = 2
             a: int = 1
 
-        first, second = Ab(), Ba()
+        first, second = Forward(), Reversed()
         assert first == second
         assert hash(first) == hash(second)
 

--- a/tests/test_utils/test_models.py
+++ b/tests/test_utils/test_models.py
@@ -105,6 +105,21 @@ class TestModelHash:
         """A real value is not confused with the null it replaces."""
         assert hash(_NullModel(number=1.0)) != hash(_NullModel())
 
+    def test_declaration_order_does_not_change_the_hash(self):
+        """Equality compares field names, so declaration order cannot matter."""
+
+        class Ab(DascoreBaseModel):
+            a: int = 1
+            b: int = 2
+
+        class Ba(DascoreBaseModel):
+            b: int = 2
+            a: int = 1
+
+        first, second = Ab(), Ba()
+        assert first == second
+        assert hash(first) == hash(second)
+
     def test_unhashable_field_still_refuses(self):
         """A model holding an array is unhashable, and says so."""
         with pytest.raises(TypeError, match="unhashable"):

--- a/tests/test_utils/test_models.py
+++ b/tests/test_utils/test_models.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-import numpy as np
+import pickle
 
-from dascore.utils.models import DascoreBaseModel, sensible_model_equals
+import numpy as np
+import pytest
+from pydantic import Field
+
+from dascore.utils.models import (
+    DascoreBaseModel,
+    DateTime64,
+    FrozenDictType,
+    TimeDelta64,
+    sensible_model_equals,
+)
 
 
 class _TestModel(DascoreBaseModel):
@@ -44,3 +54,58 @@ class TestModelEquals:
         new = mod.new(some_str="bob")
         assert new.some_str == "bob"
         assert new is not mod
+
+
+class _NullModel(DascoreBaseModel):
+    """A model holding every flavor of null a field can carry."""
+
+    time: DateTime64 = np.datetime64("NaT", "ns")
+    duration: TimeDelta64 = np.timedelta64("NaT", "ns")
+    number: float = np.nan
+    mapping: FrozenDictType[str, float] = Field(default_factory=dict)
+
+
+class TestModelHash:
+    """Hashing agrees with equality, so models work as dict keys."""
+
+    def test_unset_models_hash_equally(self):
+        """Nulls compare equal to nulls, so they must hash alike."""
+        # Each null is a fresh object, and nan and NaT both hash by identity.
+        first, second = _NullModel(), _NullModel()
+        assert first == second
+        assert hash(first) == hash(second)
+        assert {first: "found"}[second] == "found"
+
+    def test_null_from_any_input_hashes_alike(self):
+        """None and the string 'NaT' reach the same null."""
+        assert hash(_NullModel(time=None)) == hash(_NullModel(time="NaT"))
+
+    def test_nulls_inside_a_mapping_hash_alike(self):
+        """A null nested in a frozen mapping is normalized too."""
+        first = _NullModel(mapping={"gain": float("nan")})
+        second = _NullModel(mapping={"gain": float("nan")})
+        assert first == second
+        assert hash(first) == hash(second)
+
+    def test_mapping_order_does_not_change_the_hash(self):
+        """Mappings compare without regard to order, so they hash that way."""
+        first = _NullModel(mapping={"a": 1.0, "b": 2.0})
+        second = _NullModel(mapping={"b": 2.0, "a": 1.0})
+        assert first == second
+        assert hash(first) == hash(second)
+
+    def test_hash_survives_a_pickle_round_trip(self):
+        """Unpickling skips validation, so the hash cannot depend on it."""
+        model = _NullModel()
+        loaded = pickle.loads(pickle.dumps(model))
+        assert loaded == model
+        assert hash(loaded) == hash(model)
+
+    def test_differing_models_hash_apart(self):
+        """A real value is not confused with the null it replaces."""
+        assert hash(_NullModel(number=1.0)) != hash(_NullModel())
+
+    def test_unhashable_field_still_refuses(self):
+        """A model holding an array is unhashable, and says so."""
+        with pytest.raises(TypeError, match="unhashable"):
+            hash(_TestModel(array=np.arange(10)))


### PR DESCRIPTION
## Description

Closes #878.

Every inventory model sets `frozen=True`, but two fields were plain `dict`s and could still be written in place, so the tree was only *mostly* immutable and `hash(inventory)` raised `TypeError`:

```python
acq.gauge_length = 99.0     # ValidationError: Instance is frozen  ✅
acq.extra_fields["x"] = 1   # succeeded                            ❌
hash(inv)                   # TypeError: unhashable type: 'dict'   ❌
```

`extra_fields` (declared on `InventoryModel`, so present on every inventory model class) and `Inventory.resources` are now frozen mappings. Nothing wrote into either in place, so this removes unused capability rather than anything relied on. A `Spool` holds its inventory by reference and re-reads it on every operation, which is safe only because the inventory cannot change underneath it — `extra_fields` was the one field that could.

### Freezing the two fields

`FrozenDictType` in `dascore/utils/models.py` already existed but was unused and built on `PlainValidator`. It is redefined as `Annotated[Mapping[K, V], AfterValidator(FrozenDict), PlainSerializer(dict)]`:

- **`AfterValidator`, not `PlainValidator`** — a plain validator *replaces* validation, which silently drops the declared `str | int | float | bool` constraint on `extra_fields` values. After-validation keeps the check and wraps the result.
- **declared `Mapping`, not `dict`** — the runtime value really is a `FrozenDict`, and a `dict` annotation would let a type checker wave through writes that raise.
- **`PlainSerializer(dict)`** — dumps stay ordinary dicts in both python and json mode, at every depth, so the YAML round trip is unaffected.

Two collaborators had to move with it. `_key_resources` tested `isinstance(value, dict)`, and `FrozenDict` subclasses `abc.Mapping` rather than `dict`, so handing one inventory's pool to another fell into the "iterable of resources" branch and raised `AttributeError: 'str' object has no attribute 'resource_id'`. And `_normalize_resources` rebinds `resources` through `object.__setattr__`, bypassing the validator, so it now freezes the pool itself.

### Making the hash agree with equality

Freezing alone makes `hash()` stop raising but leaves it *wrong*:

```python
a, b = Acquisition(code="X"), Acquisition(code="X")
a == b              # True
hash(a) == hash(b)  # False
{a: 1}.get(b)       # None -- silent miss
```

`values_equal` counts null as equal to null, but every `nan` and `NaT` is a fresh object and **both hash by identity** (numpy for `NaT`; CPython for `nan` since 3.10). Every `TimeRangedModel` defaults its epoch fields to `NaT`, so this was the ordinary case rather than a corner.

`DascoreBaseModel` therefore defines `__hash__` next to the `__eq__` it already had, mapping nulls onto a single key and comparing mappings without regard to order — the same rules `values_equal` uses. Equality and hashing now come from one place and cannot drift apart.

An earlier revision of this PR instead interned `NaT` to a shared object inside the `DateTime64` validator. Review killed it: interning only happens during validation, and **pickle restores fields without validating**, so an unpickled inventory compared equal to the original while hashing differently. Pickle is not a corner either — it is how spools cross a `ProcessPoolExecutor` and how `dascore.io.pickle` stores them. Hashing on the values instead of on object identity is immune to how the instance was built, and it also fixes `nan` in `extra_fields` and a stale memoized hash surviving a pickle inside `FrozenDict`.

This also fixes `AI4EPSPatchAttrs`, which is frozen, hashable, and broken the same way on dev today.

The hash costs 6.9 ms on a 250-optical-path inventory against 0.5 ms for the one pydantic derives. Nothing in DASCore hashes a model, and the caching this might have served is explicitly out of scope (below), so correctness wins over an operation nobody calls in a loop.

### What still fails, and how

A model holding an unhashable value — an ndarray, or a `Quantity` with an array magnitude, which `data_units` accepts today — raises `TypeError` from `hash()`. That is pre-existing permissiveness in those fields and is left alone here; the point is that it fails **loudly**. Likewise `model_copy(update=...)` and `model_construct` skip validation by design and can put a plain `dict` back in the field; that is a general pydantic escape hatch, not something this PR claims to close.

### Deliberately not here

- **Memoizing `Inventory.get_names()` on the hash**, which is how #878 motivated hashability. Measured on a 250-optical-path inventory: `get_names()` is 1.4 ms but `__eq__` is **35 ms**, because `sensible_model_equals` dumps both whole trees. Any dict lookup that misses the identity fast path pays that to confirm a hit, so value-keyed caching is a pessimization. If we want the 1.4 ms back, identity-keyed memoization is the right shape and deserves its own discussion.
- **The four unrelated mutable dict fields** on `PatchSummary` and `XMLBinaryInfo`.
- **`CoordManager`**, which keeps `frozen_dict_validator` deliberately: it builds these on a hot path from objects it has already checked, and does not want the values revalidated.

## Changelog

- fixed: an `Inventory` is now fully immutable and can be hashed or used as a dict key; `extra_fields` and the shareable resource pool were plain dicts that could be written in place.
- fixed: models now hash consistently with equality. `nan` and `NaT` hash by identity, so two equal models — including `AI4EPSPatchAttrs` — previously landed in different buckets of a dict.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inventory resource pools and additional fields are now read-only after creation.
  * Resource mappings accept flexible mapping inputs while preserving validation and dictionary serialization.
  * Models now provide stable hashing consistent with equality, including across serialization round trips.

* **Bug Fixes**
  * Improved handling of mapping order, null values, and frozen data during comparisons and serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->