### PR TITLE
Point release-note drafting at the PRs alone

### DIFF
--- a/.agents/skills/draft-release/SKILL.md
+++ b/.agents/skills/draft-release/SKILL.md
@@ -26,7 +26,7 @@ Input: `release_type`, one of `major`, `minor`, `patch`/`bugfix` (equivalent). D
    branch being released; ask if not given. It is **not** always `master` — work
    lands on `dev`, so scoping to `master` silently omits everything not merged
    down. Compare `git rev-list --count` for both first. Read them with `gh`,
-   keeping number, title, merge date, URL, labels, and body; consult diffs when
+   keeping number, title, merge date, labels, and body; consult diffs when
    the body is thin.
 
 4. Drop reverted pairs. When a PR in scope reverts another in scope, omit both
@@ -50,10 +50,8 @@ Input: `release_type`, one of `major`, `minor`, `patch`/`bugfix` (equivalent). D
    else observable including performance. Check the tag before marking anything
    breaking — an API introduced after it cannot break anyone.
 
-   For the first release after `docs/changelog.qmd` became a stub, also read its
-   pre-stub revision, per "Draft the release notes" in
-   `docs/contributing/publish_a_new_release.qmd` — which also lists the sections
-   to use, and their order.
+   See "Draft the release notes" in `docs/contributing/publish_a_new_release.qmd`
+   for the sections to use, and their order.
 
 6. Print the new tag and the changelog. Split a PR's unrelated changes into
    separate entries, omit PRs with no user-facing effect rather than letting them
@@ -61,17 +59,28 @@ Input: `release_type`, one of `major`, `minor`, `patch`/`bugfix` (equivalent). D
 
 ## Output Format
 
+One section per entry category, in this order: `Breaking Changes`, `Added`,
+`Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
+
 ```text
 Next Version: vX.Y.Z
 
 ## Breaking Changes
-- #125: Short summary (https://github.com/OWNER/REPO/pull/125)
+- Short summary (#125)
+
+## Added
+- Short summary (#126)
 
 ## Changed
-- #125: Short summary (https://github.com/OWNER/REPO/pull/125)
+- Short summary (#125)
 
-Reverted (no net change): #126 reverted by #127
+## Fixed
+- Short summary (#127)
+
+Reverted (no net change): #128 reverted by #129
 ```
 
-A `**breaking**` entry appears twice, as #125 does. Omit empty sections and the
-`Reverted` line when unused. If no PRs are in scope, print the version and say so.
+Each entry ends with its pull request in parentheses, which GitHub renders as a
+link; do not write the full URL. A `**breaking**` entry appears twice, as #125
+does. Omit empty sections and the `Reverted` line when unused. If no PRs are in
+scope, print the version and say so.

--- a/docs/contributing/publish_a_new_release.qmd
+++ b/docs/contributing/publish_a_new_release.qmd
@@ -16,9 +16,7 @@ DASCore keeps no changelog in the repository; the release notes *are* the change
 
 Each PR carries its own entries under a `## Changelog` heading, already written and categorized by its author following [Changelog entries](general_guidelines.qmd#changelog-entries), so drafting mostly means collecting and grouping them. Use these sections, omitting any that end up empty: **Breaking Changes** first, holding every `**breaking**` entry repeated from its own category so upgraders see them immediately, then **Added**, **Changed**, **Deprecated**, **Removed**, **Fixed**, and **Security**.
 
-Work merged before this policy was instead described in `docs/changelog.qmd`, and that curated text is richer than those PR bodies. For the first release after the change, find the commit that reduced the page to a stub with `git log --oneline -- docs/changelog.qmd`, then read the revision before it.
-
-The GitHub releases page can generate release notes automatically, but maintainers should review and edit the generated text so it is useful to users. Also note, DASCore includes an agent skill called "draft release" so a coding agent of your choice can help you do this. In the notes, prefer concise descriptions of behavior and API changes over internal implementation details. Include pull request links when they help readers find more context.
+The GitHub releases page can generate release notes automatically, but maintainers should review and edit the generated text so it is useful to users. Also note, DASCore includes an agent skill called "draft release" so a coding agent of your choice can help you do this. In the notes, prefer concise descriptions of behavior and API changes over internal implementation details. End each entry with its pull request in parentheses, e.g. `(#125)`, which GitHub renders as a link.
 
 Then click 'Publish Release'. This will kick off the doc-build and publishing task automatically, as well as publish the tagged source code to PyPI.
 


### PR DESCRIPTION
## Description

Follow-up to #864, which retired the in-repo changelog in favour of PR-sourced release notes. Every merged PR in the current release range now carries its own `## Changelog` section, so the instructions can stop hedging.

**The pre-stub bridge is spent.** `draft-release` step 5 and the matching paragraph in `publish_a_new_release.qmd` both told the drafter to also read the pre-stub revision of `docs/changelog.qmd`, on the grounds that "that curated text is richer than those PR bodies". That is no longer true — the PR bodies now carry entries the page never had, including the fixes that reached `dev` through `master` — and reading both double-counts every entry that came from the page. It also made verification vacuous: any entry missing from a PR body would be silently recovered from the old page, so nothing could detect the gap.

The sentence being removed from the skill did double duty, so the pointer to the section list and its order is kept rather than deleted with it.

**Entry format.** GitHub renders a bare `(#125)` as a link, so the full pull request URL is noise. The output example now shows `- Short summary (#125)`, and step 3 no longer collects a URL the output does not use.

**Sections.** `publish_a_new_release.qmd` already specified Breaking Changes → Added → Changed → Deprecated → Removed → Fixed → Security — the six entry categories plus the breaking roll-up. The skill's own output example illustrated only two of the seven, so the template did not demonstrate its own rule. The order is now stated in the skill and the example shows four sections.

No library code is touched.

## Changelog

none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release-publishing guidance to prioritize GitHub-generated notes and the draft-release workflow.
  * Clarified expectations for concise behavior and API descriptions.
  * Added guidance to include pull request references in every release-note entry.
  * Updated supported release-note categories and reverted pull request notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->