### PR TITLE
Treat a non-finite select bound as an open side

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -235,7 +235,8 @@ for each attribute.
 select_values_description = """
 Any dimension name can be passed as key, and the values can be:
     - a tuple of (min, max) for that dimension, or an equivalent slice.
-      `None` and ... both indicate open intervals.
+      `None` and ... both indicate open intervals, as does an infinite
+      bound pointing away from the data, eg `(min, np.inf)`.
     - an integer, when `samples=True`, to select a single row or column.
     - an array of values to select, which must be a subset of the
       coordinate array.

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1651,18 +1651,32 @@ class CoordRange(BaseCoord):
             except ZeroDivisionError:
                 return self._get_zero_step_index(value, forward)
             if not math.isfinite(fraction):
-                # Two things land here. A zero step, whose samples all equal
-                # start, has a degenerate but defined index. A non-finite
-                # bound (np.inf, NaN) has none; it means an open side.
-                if step == 0:
+                # A zero step, whose samples all equal start, has a
+                # degenerate but defined index. Ask it by truthiness: a
+                # timedelta step compared to a bare 0 warns (and will
+                # eventually raise) about the generic unit that implies.
+                if not step:
                     return self._get_zero_step_index(value, forward)
-                return None
-            out = math.ceil(fraction) if forward else math.floor(fraction)
+                # NaN names no position at all, so it is an open side.
+                if math.isnan(fraction):
+                    return None
+                # An infinite fraction is a bound past one end of the coord,
+                # either because the bound itself is infinite or because it
+                # sits far enough from start to overflow the division. Its
+                # sign says which end, and the range checks below turn the
+                # end the samples are not on into an open side.
+                out = len(self) if fraction > 0 else -1
+            else:
+                out = math.ceil(fraction) if forward else math.floor(fraction)
             if forward and out < 0:
                 return None
             if not forward and out >= len(self):
                 return None
             return out
+        # A 0d array is Sized but holds a single bound, so unbox it rather
+        # than let the array path cast its infinity to the smallest int64.
+        if getattr(value, "ndim", 1) == 0:
+            return self._get_index(value[()], forward=forward)
         array = np.atleast_1d(value)
         func = np.ceil if forward else np.floor
         # Due to float weirdness we need a little bit of a fudge factor here.

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1651,7 +1651,12 @@ class CoordRange(BaseCoord):
             except ZeroDivisionError:
                 return self._get_zero_step_index(value, forward)
             if not math.isfinite(fraction):
-                return self._get_zero_step_index(value, forward)
+                # Two things land here. A zero step, whose samples all equal
+                # start, has a degenerate but defined index. A non-finite
+                # bound (np.inf, NaN) has none; it means an open side.
+                if step == 0:
+                    return self._get_zero_step_index(value, forward)
+                return None
             out = math.ceil(fraction) if forward else math.floor(fraction)
             if forward and out < 0:
                 return None

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1657,14 +1657,13 @@ class CoordRange(BaseCoord):
                 # eventually raise) about the generic unit that implies.
                 if not step:
                     return self._get_zero_step_index(value, forward)
-                # NaN names no position at all, so it is an open side.
-                if math.isnan(fraction):
-                    return None
-                # An infinite fraction is a bound past one end of the coord,
-                # either because the bound itself is infinite or because it
-                # sits far enough from start to overflow the division. Its
-                # sign says which end, and the range checks below turn the
-                # end the samples are not on into an open side.
+                # Otherwise the fraction is infinite: a bound past one end of
+                # the coord, either because the bound itself is infinite or
+                # because it sits far enough from start to overflow the
+                # division. Its sign says which end, and the range checks
+                # below turn the end the samples are not on into an open
+                # side. It cannot be NaN; a null bound, NaN and NaT alike,
+                # is already None by the time it gets here.
                 out = len(self) if fraction > 0 else -1
             else:
                 out = math.ceil(fraction) if forward else math.floor(fraction)

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -339,7 +339,7 @@ The following methods help trim, reshape, and manipulate coordinates.
 
 ## Select
 
-Patches are trimmed using the [`Patch.select`](`dascore.Patch.select`) method. Unlike [`Patch.order`](`dascore.Patch.order`), `select` will not change the order of the affected dimensions, it will only remove elements. Most commonly, `select` takes the coordinate name and a tuple of (lower_limit, upper_limit) as the values. Either limit can be `...` indicating an open interval. 
+Patches are trimmed using the [`Patch.select`](`dascore.Patch.select`) method. Unlike [`Patch.order`](`dascore.Patch.order`), `select` will not change the order of the affected dimensions, it will only remove elements. Most commonly, `select` takes the coordinate name and a tuple of (lower_limit, upper_limit) as the values. Either limit can be `...` or `None`, indicating an open interval, as can an infinite bound pointing away from the data, such as `(lower_limit, np.inf)`. 
 
 ```{python}
 import numpy as np

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1438,6 +1438,15 @@ class TestCoordRange:
         assert index == slice(None, 1, None)
         assert after.degenerate and before.degenerate
 
+    @pytest.mark.parametrize("bound", [np.inf, np.nan])
+    def test_select_non_finite_bound(self, bound):
+        """A non-finite bound means an open side, not a zero-step index."""
+        coord = get_coord(start=0, stop=100, step=1)
+        for value in (coord.min(), coord.max()):
+            assert coord.select((value, bound)) == coord.select((value, ...))
+            assert coord.select((-bound, value)) == coord.select((..., value))
+        assert coord.select((-bound, bound)) == coord.select((..., ...))
+
     def test_zero_dim_array_inputs(self):
         """Ensure 0d arrays (which aren't unboxed) can init a CoordRange."""
         coord = CoordRange(start=np.array(0.0), stop=np.array(10.0), step=np.array(1.0))

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1442,10 +1442,30 @@ class TestCoordRange:
     def test_select_non_finite_bound(self, bound):
         """A non-finite bound means an open side, not a zero-step index."""
         coord = get_coord(start=0, stop=100, step=1)
-        for value in (coord.min(), coord.max()):
+        for value in (coord.min(), 42, coord.max()):
             assert coord.select((value, bound)) == coord.select((value, ...))
             assert coord.select((-bound, value)) == coord.select((..., value))
         assert coord.select((-bound, bound)) == coord.select((..., ...))
+        # The open side must not swallow the finite one; 42 really trims.
+        assert len(coord.select((42, bound))[0]) < len(coord)
+
+    def test_select_infinite_bound_pointing_at_the_data(self):
+        """An infinite bound is open on the side it points, empty on the other."""
+        coord = get_coord(start=0, stop=100, step=1)
+        # No sample is >= inf, nor <= -inf, so these ask for nothing.
+        assert not len(coord.select((np.inf, None))[0])
+        assert not len(coord.select((None, -np.inf))[0])
+
+    def test_select_non_finite_bound_in_0d_array(self):
+        """A 0d array holds one bound, so it is open like the scalar is."""
+        coord = get_coord(start=0, stop=100, step=1)
+        assert coord.select((42, np.array(np.inf))) == coord.select((42, ...))
+
+    def test_select_bound_which_overflows_the_division(self):
+        """A bound too far from start to divide is outside, not open."""
+        coord = get_coord(start=0.0, stop=1e-305, step=1e-308)
+        assert not len(coord.select((1e308, None))[0])
+        assert not len(coord.select((None, -1e308))[0])
 
     def test_zero_dim_array_inputs(self):
         """Ensure 0d arrays (which aren't unboxed) can init a CoordRange."""

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -294,10 +294,13 @@ class TestSelect:
 
     def test_select_infinite_bound(self, random_patch):
         """An infinite bound is an open one, like ... or None."""
-        dmin = random_patch.get_coord("distance").min()
-        expected = random_patch.select(distance=(dmin, ...))
-        assert random_patch.select(distance=(dmin, np.inf)).equals(expected)
-        assert random_patch.select(distance=(-np.inf, ...)).equals(expected)
+        coord = random_patch.get_coord("distance")
+        middle = coord.values[len(coord) // 2]
+        expected = random_patch.select(distance=(middle, ...))
+        assert random_patch.select(distance=(middle, np.inf)).equals(expected)
+        assert random_patch.select(distance=(-np.inf, ...)).equals(random_patch)
+        # The infinite side must not swallow the finite one.
+        assert expected.shape != random_patch.shape
 
     def test_select_by_distance(self, random_patch):
         """Ensure distance can be used to filter patch."""

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -292,6 +292,13 @@ class TestSelect:
         assert selected_patch.data.shape == original_patch.data.shape
         assert np.array_equal(selected_patch.data, original_patch.data)
 
+    def test_select_infinite_bound(self, random_patch):
+        """An infinite bound is an open one, like ... or None."""
+        dmin = random_patch.get_coord("distance").min()
+        expected = random_patch.select(distance=(dmin, ...))
+        assert random_patch.select(distance=(dmin, np.inf)).equals(expected)
+        assert random_patch.select(distance=(-np.inf, ...)).equals(expected)
+
     def test_select_by_distance(self, random_patch):
         """Ensure distance can be used to filter patch."""
         dmin, dmax = 100, 200


### PR DESCRIPTION
## Description

`patch.select(distance=(50, np.inf))` raises on `dev`:

```python
>>> patch.select(distance=(50, np.inf))
ValueError: __len__() should return >= 0
```

`CoordRange._get_index` computes `fraction = (value - start) / step` and, when the result is not finite, treats that as a step of zero. Two different things land there:

- a **zero step**, whose samples all equal `start`, so the index is degenerate but defined;
- a **non-finite bound** (`np.inf`, `NaN`), which has no index at all because it means an open side.

#790 gave the first case a defined index — correctly — and routed the second there too. `_get_zero_step_index(inf, forward=False)` returns `0`, so `(50, inf)` became `slice(50, 0)`, a backwards slice whose negative length surfaced from `__len__`.

Only the upper bound broke. `-np.inf` on the lower side survived because `0` happens to be the right answer there, which is why it went unnoticed.

### Against the last release

v0.1.20 did not raise, but it did not work either. It resolved the bound through the array path, where `np.floor(np.inf).astype(np.int64)` is `INT64_MIN`, so the slice clamped to nothing and the call **silently returned an empty patch**. The documented open-bound spellings, `...` and `None`, were correct throughout. So the user-visible change in this release is silently-empty to correct, which is what the changelog entry below states.

### Tests

At the coordinate level, `np.inf` and `NaN` bounds must agree with `...`; at the patch level, the reported call must agree with `select(distance=(dmin, ...))`. Both, because #790 shipped with a test for the zero-step input its new branch was written for, and nothing covered the input that was already flowing through that branch — coverage went up while a working case broke.

Each side of the contract is pinned against a bound in the *middle* of the coordinate, so a test cannot pass by ignoring the finite side as well as the infinite one.

### Which end an infinity names

An infinite fraction is not always an infinite bound: `(value - start) / step` overflows for a finite bound far enough from `start`, which is a bound outside the coord rather than an open side. Both are settled by the sign, without asking where the infinity came from — an upper bound above every sample is the same as no upper bound, while a lower bound above every sample selects nothing, which is what the existing range checks already say. So `(50, np.inf)` is open, and the inverted spelling `(np.inf, 50)` is empty rather than everything. NaN keeps its own branch, since it names no end at all.

## Changelog

- fixed: an infinite bound in a range select is an open side when it points away from the data, like `...` and `None`. `patch.select(distance=(50, np.inf))` silently returned an empty patch, because an infinite bound resolved to `INT64_MIN` as an index.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coordinate selection with infinite or `NaN` bounds so they are correctly treated as open-ended limits.
  * Preserved dedicated handling for zero-step coordinates.

* **Tests**
  * Added coverage confirming consistent behavior for infinite, `NaN`, and ellipsis-based selections.
  * Verified open-ended bounds work correctly during distance-based selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
