### PR TITLE
Keep _modified when collapsing a plan for a re-plan

### DIFF
--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -618,7 +618,12 @@ def collapse_working_df(catalog: PatchCatalog) -> pd.DataFrame | None:
         }
         members = members[members["output_id"].isin(present)]
     ranges = _residual_ranges(catalog._residuals)
-    working = members.drop(columns=["output_id", "_modified"], errors="ignore")
+    # `_modified` carries: it says the member is a *trim* of its source
+    # rather than the whole of it, which is exactly what the re-plan needs
+    # to know. Dropping it left `_build_members` to assume no source was
+    # modified, so a member which was a slice of a file came back marked
+    # "load whole" and the loader read all of it.
+    working = members.drop(columns=["output_id"], errors="ignore")
     bare = {
         name: value
         for name, value in ranges.items()

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -341,6 +341,68 @@ class TestCollapseGuard:
         catalog = dc.spool([dc.get_example_patch()])._catalog
         assert collapse_working_df(catalog) is None
 
+    def test_collapse_keeps_modified(self):
+        """
+        The flag says a member is a trim rather than a whole source.
+
+        Losing it makes the next plan mark such a member "load whole",
+        and the loader then reads the entire file it was a slice of.
+        """
+        chunked = dc.spool(dc.get_example_patch()).chunk(time=2)
+        collapsed = collapse_working_df(chunked._catalog)
+        assert "_modified" in collapsed.columns
+        assert collapsed["_modified"].all()
+
+
+class TestRePlanKeepsTheTrim:
+    """Re-planning a dimension must not load back what was trimmed off."""
+
+    def test_nested_chunk_matches_a_direct_one(self):
+        """
+        Chunking twice gives what chunking once does, data included.
+
+        The example patch spans 8 s, so `chunk(time=3)` keeps two full
+        chunks and drops the 2 s remainder; the nested form used to
+        report 4500 samples from a 2000 sample patch instead.
+        """
+        patch = dc.get_example_patch()
+        direct = dc.spool(patch).chunk(time=3)
+        nested = dc.spool(patch).chunk(time=2).chunk(time=3)
+        assert len(nested) == len(direct)
+        assert sum(x.shape[1] for x in nested) == sum(x.shape[1] for x in direct)
+        for one, two in zip(direct, nested, strict=True):
+            assert np.array_equal(one.data, two.data)
+            assert np.array_equal(one.get_array("time"), two.get_array("time"))
+
+    def test_a_re_chunked_selection_keeps_its_range(self):
+        """
+        The reported case: the second chunk ignored the selection.
+
+        A member reloaded whole overlaps its neighbour, so the merge
+        repeated the overlap and the coordinate stopped increasing.
+        """
+        patch = dc.get_example_patch().set_units(distance="m")
+        coord = patch.get_coord("distance")
+        span = float(coord.max() - coord.min() + coord.step)
+        moved = patch.update_coords(distance=coord.data + span).set_units(distance="m")
+        chunked = dc.spool([patch, moved]).chunk(
+            distance=200, conflict="keep_first", keep_partial=True
+        )
+        selected = chunked.select(distance=(250 * m, 450 * m))
+        wanted = sum(x.shape[x.get_axis("distance")] for x in selected)
+        merged = selected.chunk(distance=None, conflict="keep_first")
+        values = np.asarray(merged[0].get_coord("distance").values)
+        assert len(values) == wanted
+        assert len(np.unique(values)) == len(values)
+
+    def test_merging_chunks_of_one_patch_rebuilds_it(self):
+        """Every piece is a trim, so none of them may load whole."""
+        patch = dc.get_example_patch()
+        merged = dc.spool(patch).chunk(distance=100).chunk(distance=None)
+        assert len(merged) == 1
+        assert merged[0].shape == patch.shape
+        assert np.array_equal(merged[0].data, patch.data)
+
 
 class TestStatedUnits:
     """Row values arrive from dataframes, so absence is NaN."""


### PR DESCRIPTION
## Description

Fixes #871.

`_modified` on a plan member says the member is a *trim* of its source rather than the whole of it, and `PlanResolver._load_member` reads it as exactly that: a member without it loads its source with no trim at all.

`collapse_working_df` dropped the column one line before the re-plan read it, and `_build_members` falls back to "no source was modified" when it is absent. Every collapsed row *was* a trim, so the fallback asserted the opposite of the truth, the `unchanged` test below it was then satisfied trivially — a member's range always equals its own range — and a 500-sample slice of a 2000-sample file came back marked "load whole".

Keeping the column is the whole fix.

```python
patch = dc.get_example_patch()                       # 8 s, 2000 samples
first = dc.spool(patch).chunk(time=2)
first._catalog.resolver.member_rows["_modified"]     # [True, True, True, True]
second = first.chunk(time=3)
second._catalog.resolver.member_rows["_modified"]    # [False, True, True, False]  <- before
sum(p.shape[1] for p in second)                      # 4500, from a 2000-sample patch
```

The `else np.zeros(...)` fallback in `_build_members` stays: `build_chunk_plan` is also called on plain relations which never had the column. It was only wrong for a frame which had one and lost it.

### What changes

- **This issue's case**: the re-chunked selection held 252 samples of which 201 were distinct; it now holds the 201 the selection holds, all distinct.
- **`chunk(time=2).chunk(time=3)`**: 4500 samples → 1500, which is what `chunk(time=3)` gives directly (two full 3-second chunks; the trailing 2 s is partial and dropped by default). The two paths now yield byte-identical data.
- **`chunk(distance=100).chunk(distance=None)`**: raised `CoordMergeError` — three members each reloading the full 300-channel patch, handed to an assembler asked to vary them along `distance` — and now rebuilds the original patch exactly.

No existing test needed updating.

### Note for #883

#883 (phase 3c of the inventory work) met this from the other side: channel-level `select` builds a plan whose pieces deliberately do not cover their source, so collapsing one loaded back the channels it had removed. It guards against that with a `lossy` flag which refuses to collapse such a plan.

With this fix applied and that guard disabled, `select(coupling="trench").chunk(distance=None)` already loads the correct channels — so the guard is belt-and-braces rather than the fix. It is worth keeping either way ("a plan which dropped data must not be re-derived from the data it dropped" holds however the bookkeeping is spelled), and the two do not conflict: a lossy plan simply never reaches the collapse this corrects.

## Changelog

- fixed: re-planning a dimension after a chunk loaded whole source patches instead of the trimmed pieces the first plan described, so `chunk(...).chunk(...)` and a re-chunked selection over-included and duplicated samples (#871).

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved trim status when preparing indexed data for reprocessing.
  * Prevented trimmed data from being incorrectly reloaded as complete source patches.
  * Improved consistency when rechunking nested or repeated data selections.
  * Ensured selected coordinate ranges are retained during rechunking.

* **Tests**
  * Added regression coverage for trimmed data handling and patch reconstruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->