### PR TITLE
Pin the changelog checker's indented-heading behavior

### DIFF
--- a/.agents/skills/draft-release/SKILL.md
+++ b/.agents/skills/draft-release/SKILL.md
@@ -43,6 +43,11 @@ Input: `release_type`, one of `major`, `minor`, `patch`/`bugfix` (equivalent). D
    "breaks the last *released* version", so a drastic-looking change may break
    nothing any user has.
 
+   Reuse `extract_section` and `validate` from that script rather than writing
+   a second parser: a body may indent the heading that ends the section, and
+   `none` may be bulleted, so a hand-rolled one reads a later section's
+   checklist as malformed entries.
+
    A literal `none` is trustworthy; an empty or absent section means the PR
    predates the policy, so classify it yourself from title, body, and diff.
    Labels here are topical (`proc`, `spool`, `IO`) rather than semantic: `Added`

--- a/docs/contributing/general_guidelines.qmd
+++ b/docs/contributing/general_guidelines.qmd
@@ -28,6 +28,8 @@ written against the last released version; breaking only against unreleased work
 - changed **breaking**: `dc.set_config` is no longer a context manager; use `dc.config_context`.
 ```
 
+Write the text after the colon as a complete sentence, with a subject and a verb, ending in a period; both entries above do, while a bare noun phrase such as `removed: the tran namespace` does not stand on its own once it is lifted into the release notes.
+
 `none` may be written bare or as the section's only bullet (`- none`); both pass.
 
 # Paths

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -147,7 +147,13 @@ class TestChangelogSectionChecker:
         commented = "<!--\n- added: an example from the template.\n-->"
         assert checker.validate(_body(commented))
 
-    def test_section_ends_at_the_next_heading(self, checker):
-        """Entries belonging to a later section are not read as changelog ones."""
-        body = _body("none") + "\n## Checklist\n\n- [ ] did a thing.\n"
+    @pytest.mark.parametrize("heading", ["## Checklist", "  ## Checklist"])
+    def test_section_ends_at_the_next_heading(self, checker, heading):
+        """Entries belonging to a later section are not read as changelog ones.
+
+        The heading may be indented: several merged pull requests carry an
+        indented template, and reading past it would take the checklist's
+        boxes for malformed entries.
+        """
+        body = _body("none") + f"\n{heading}\n\n- [ ] did a thing.\n"
         assert checker.validate(body) == []


### PR DESCRIPTION
## Description

While drafting the release notes for the next tag, a hand-rolled parse of the `## Changelog` sections misread five merged PRs (#643, #644, #646, #649, #650), reading each one's `## Checklist` boxes as malformed changelog entries.

The checker itself was right: `extract_section` strips each line before matching, so an indented `## Checklist` ends the section correctly, and `_NOTHING` already accepts a bulleted `- none`. Both behaviors pass on all five bodies today. But the indented case is not covered by a test — `test_section_ends_at_the_next_heading` used an unindented heading — so the `.strip()` those PRs depend on could be dropped without anything failing.

This pins that behavior and points the drafting skill at the checker so the next agent does not write a second parser.

- `tests/test_changelog.py`: the existing test is parametrized over an unindented and an indented next heading. Removing the `.strip()` from `extract_section` fails only the indented case, so the guard is real.
- `.agents/skills/draft-release/SKILL.md`: a short note to reuse `extract_section`/`validate` rather than re-deriving the parse, naming the two edge cases that bite.
- `docs/contributing/general_guidelines.qmd`: one sentence asking that an entry's text be a complete sentence, since it is lifted verbatim into the release notes.

No change to the checker or to any published behavior.

## Changelog

none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
