### PR TITLE
Canonicalize a coordinate only when it keeps its values

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -55,6 +55,7 @@ from typing_extensions import Self
 from dascore.constants import dascore_styles, select_values_description
 from dascore.core.coords import (
     BaseCoord,
+    CoordPartial,
     CoordRange,
     CoordSummary,
     get_coord,
@@ -1219,6 +1220,29 @@ def get_coord_manager(
     return out
 
 
+def _canonicalization_moved_values(original, out) -> bool:
+    """
+    Return True if canonicalizing `original` to `out` changed any value.
+
+    Collapsing an array coord to a CoordRange is meant to be a change of
+    representation, but the evenness test behind it is tolerant, so a
+    coordinate carrying small real irregularity (measured positions, timing
+    jitter) would be replaced by an idealized ramp. Only the exact case is a
+    canonicalization; the rest is data loss.
+    """
+    # Only collapsing to a range can move values, and only a coord we were
+    # handed can be kept, so everything else skips the comparison.
+    if original is None or not isinstance(out, CoordRange):
+        return False
+    # A CoordPartial is a placeholder whose values are all NaN, so it has
+    # nothing to lose; canonicalizing it is the whole point.
+    if isinstance(original, CoordRange | CoordPartial):
+        return False
+    if original.shape != out.shape:
+        return False
+    return not np.array_equal(original.values, out.values)
+
+
 def _get_coord_dim_map(coords, dims):
     """Get coord_map, dim_map, and new dims from coord input."""
 
@@ -1233,12 +1257,15 @@ def _get_coord_dim_map(coords, dims):
         # CoordRange -- get_coord performs that inference.
         if isinstance(coord, CoordRange):
             return coord
+        original = coord if isinstance(coord, BaseCoord) else None
         if hasattr(coord, "model_dump"):
             coord = coord.model_dump(exclude_defaults=True)
         if isinstance(coord, Mapping):  # input is a dict
             out = get_coord(**coord)
         else:
             out = get_coord(data=coord)
+        if _canonicalization_moved_values(original, out):
+            return original
         return out
 
     def _coord_from_simple(name, coord):

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -1231,15 +1231,16 @@ def _canonicalization_moved_values(original, out) -> bool:
     canonicalization; the rest is data loss.
     """
     # Only collapsing to a range can move values, and only a coord we were
-    # handed can be kept, so everything else skips the comparison.
+    # handed can be kept, so everything else skips the comparison. A CoordRange
+    # cannot reach here; the caller returns it before this is consulted.
     if original is None or not isinstance(out, CoordRange):
         return False
     # A CoordPartial is a placeholder whose values are all NaN, so it has
     # nothing to lose; canonicalizing it is the whole point.
-    if isinstance(original, CoordRange | CoordPartial):
+    if isinstance(original, CoordPartial):
         return False
-    if original.shape != out.shape:
-        return False
+    # Canonicalization re-labels a coordinate, it never resamples one.
+    assert original.shape == out.shape
     return not np.array_equal(original.values, out.values)
 
 

--- a/dascore/io/febus/g1utils.py
+++ b/dascore/io/febus/g1utils.py
@@ -205,8 +205,7 @@ def _get_g1_h5_base_coords(resource, dims, extra_coords=None, snap=True):
     # stored as end_times: starts and ends are each near-regular and snap to
     # slightly different steps, so subtracting the two built coords would turn
     # the jitter into a linear drift. Built exactly, and ignoring `snap`,
-    # because that jitter is the signal -- though a span array regular enough
-    # to look like a range is still normalized to one by the coord manager.
+    # because that jitter is the signal.
     sample_span = get_exact_coord(dc.to_timedelta64(ends - starts))
     distance = _coord(resource["distances"][...], units="m")
     temperature = _coord(resource["temperatures"][...], units="°C")

--- a/tests/test_core/test_coordmanager.py
+++ b/tests/test_core/test_coordmanager.py
@@ -17,6 +17,7 @@ from dascore.core.coordmanager import (
 )
 from dascore.core.coords import (
     BaseCoord,
+    CoordMonotonicArray,
     CoordPartial,
     CoordRange,
     get_coord,
@@ -1068,7 +1069,9 @@ class TestPreserveBaseCoord:
     Only CoordRange (the canonical evenly-sampled representation) is returned
     unchanged. Other coord types (CoordPartial, CoordArray, CoordMonotonicArray)
     are still re-inferred so a fully-specified partial, or slicing that yields an
-    even/empty subset, is canonicalized.
+    even/empty subset, is canonicalized. That re-inference keeps the coord it was
+    given whenever collapsing it to a range would move any value, since only the
+    exact case is a change of representation rather than of data.
     """
 
     def test_update_preserves_range_coord_identity(self, cm_basic):
@@ -1134,6 +1137,37 @@ class TestPreserveBaseCoord:
         new_coord = out.coords.coord_map["x"]
         assert isinstance(new_coord, CoordRange)
         assert new_coord.evenly_sampled
+
+    def test_near_even_coord_keeps_its_values(self):
+        """Small real irregularity must survive; see #896.
+
+        The evenness test is tolerant (rtol 1e-3), so spacing that varies by
+        less than that used to be replaced by an idealized ramp -- silently
+        inventing sample positions.
+        """
+        values = np.array([0.0, 1.0, 2.0005, 3.0015, 4.002])
+        coord = CoordMonotonicArray(values=values)
+        cm = get_coord_manager({"distance": coord}, dims=("distance",))
+        out = cm.coord_map["distance"]
+        assert np.array_equal(out.values, values)
+        # a range here would mean the spacing was made up
+        assert not isinstance(out, CoordRange)
+
+    def test_near_even_coord_survives_patch(self):
+        """The public Patch path must not move the values either."""
+        values = np.array([0.0, 1.0, 2.0005, 3.0015, 4.002])
+        coord = CoordMonotonicArray(values=values)
+        patch = dc.Patch(data=np.zeros(5), coords={"x": coord}, dims=("x",))
+        assert np.array_equal(patch.get_coord("x").values, values)
+
+    def test_exactly_even_array_still_canonicalizes(self):
+        """Preserving values must not disable the lossless collapse."""
+        values = np.arange(5, dtype=float)
+        coord = CoordMonotonicArray(values=values)
+        cm = get_coord_manager({"distance": coord}, dims=("distance",))
+        out = cm.coord_map["distance"]
+        assert isinstance(out, CoordRange)
+        assert np.array_equal(out.values, values)
 
 
 class TestSqueeze:

--- a/tests/test_io/test_febus/test_febusbsl.py
+++ b/tests/test_io/test_febus/test_febusbsl.py
@@ -131,6 +131,26 @@ class TestFebusBSL:
         # the snapped time coord would have given a constant span
         assert len(np.unique(span.values)) > 1
 
+    def test_sample_span_keeps_a_monotonic_drift(self):
+        """Spans that drift steadily are regular enough to be snapped away.
+
+        They survive because the coord manager no longer collapses a coord
+        when doing so would move its values (#896).
+        """
+        starts = np.arange(4, dtype=np.float64)
+        ends = starts + np.array([1.0, 1.001, 1.0020005, 1.0030015])
+        coords = _get_g1_h5_base_coords(
+            {
+                "start_times": starts,
+                "end_times": ends,
+                "distances": np.arange(2, dtype=np.float64),
+                "temperatures": np.zeros(4, dtype=np.float64),
+            },
+            dims=("time", "distance"),
+        )
+        span = coords.coord_map["sample_span"]
+        assert np.array_equal(span.values, dc.to_timedelta64(ends - starts))
+
     def test_mismatched_time_dataset_lengths_raise(self, bsl_path, tmp_path):
         """A half-written file should fail loudly, not broadcast to garbage."""
         new_path = tmp_path / bsl_path.name


### PR DESCRIPTION
## Description

Closes #896.

Passing an already-constructed `BaseCoord` to `get_coord_manager` did not preserve it. Anything that was not a `CoordRange` was dumped back to a dict and re-inferred through `get_coord`, which snaps near-evenly-sampled values onto a regular range. Because that evenness test is tolerant — `all_diffs_close_enough` uses `rtol=0.001` — the result was not merely a different coordinate class; the sample values themselves were silently rewritten:

```python
vals = np.array([0.0, 1.0, 2.0005, 3.0015, 4.002])
coord = CoordMonotonicArray(values=vals)
cm = dc.get_coord_manager({"distance": coord}, dims=("distance",))
cm.coord_map["distance"].values
# array([0.    , 1.0005, 2.001 , 3.0015, 4.002 ])   <- values 1 and 2 invented
```

The same happened through the public `Patch` constructor. Afterwards the coordinate reported itself as an evenly sampled `CoordRange`, so nothing downstream could tell the spacing had been made up.

The re-parse itself is deliberate and worth keeping: array coords can be left non-canonical by slicing, so an evenly spaced subset should collapse back to a `CoordRange`. The problem is only that the collapse was allowed to move values. This keeps the canonicalization and restricts it to the case where it is a pure change of representation — if the resulting range does not reproduce the original values exactly, the coordinate that was passed in is kept.

A `CoordPartial` is explicitly excluded: its values are all `NaN` placeholders, so it has nothing to lose and canonicalizing it is the entire point. An existing test (`test_full_partial_canonicalizes_to_range`) caught that when I first wrote the guard too broadly.

This is the mechanism behind the caveat noted in #895, where a Febus reader could build an exact acquisition-window coordinate with `get_exact_coord` and still have the coord manager convert it back to a range. That comment is now stale, so it is corrected here, and a Febus test pins the end-to-end behavior: spans that drift steadily — the shape most vulnerable to being snapped away — now survive the read.

Nothing about this is Febus-specific. It applies to any coordinate carrying small, physically real irregularity: GPS-derived positions, per-sample timing jitter, measured channel spacing.

### Notes

- Behavior only changes where the old path was lossy. An exactly evenly spaced array coord still canonicalizes to a `CoordRange`, raw-array inference through `get_coord(data=...)` is untouched, and `CoordRange` inputs keep their existing short-circuit.
- The comparison is skipped unless the result is a `CoordRange` built from a non-range, non-partial coord we were handed, so the common paths do no extra work.
- Whether `get_coord(data=...)` should keep snapping this aggressively when inferring from a raw array is left alone. That path is documented as tolerant inference and is defensible; silently discarding a caller's explicit, exact coordinate was not.

## Changelog

- fixed: Building a coordinate manager or patch from an explicitly constructed coordinate no longer rewrites its values, which previously happened when the sample spacing was within a tenth of a percent of being even.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
