### PR TITLE
Merge BaseSpool into Spool

### DIFF
--- a/dascore/config.py
+++ b/dascore/config.py
@@ -298,7 +298,7 @@ def config_context(
     block's exit. For deterministic propagation, capture
     ``contextvars.copy_context()`` and run the worker with it, or rely on APIs
     that bind the config for you such as
-    [`Spool.map`](`dascore.core.spool.BaseSpool.map`).
+    [`Spool.map`](`dascore.core.spool.Spool.map`).
 
     Examples
     --------

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -17,7 +17,7 @@ from dascore.compat import UPath
 
 PatchType = TypeVar("PatchType", bound="dc.Patch")
 
-SpoolType = TypeVar("SpoolType", bound="dc.BaseSpool")
+SpoolType = TypeVar("SpoolType", bound="dc.Spool")
 
 
 @runtime_checkable

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -571,7 +571,7 @@ def _combine_inventories(first, second) -> tuple:
 
 class Spool(NamespaceOwner):
     """
-    The concrete spool: a view over a `PatchCatalog`.
+    A container of patches: a view over a `PatchCatalog`.
 
     Constructed from in-memory patches directly (or via
     [`dascore.spool`](`dascore.spool`)), from a directory of files with
@@ -582,8 +582,9 @@ class Spool(NamespaceOwner):
     Parameters
     ----------
     data
-        A patch, sequence of patches, or another spool whose (in-memory)
-        patches this spool should hold; None creates an empty spool.
+        A patch or sequence of patches this spool should hold, or
+        another spool, whose catalog and provenance the new spool shares
+        rather than copies; None creates an empty spool.
 
     Notes
     -----
@@ -638,7 +639,12 @@ class Spool(NamespaceOwner):
         from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
         if isinstance(data, Spool):
-            # copy-construction: share the catalog and provenance
+            # copy-construction: share the catalog and provenance. A
+            # subclass which never ran this __init__ has no catalog, and
+            # copying its state would defer the failure to some later call.
+            if not hasattr(data, "_catalog"):
+                msg = f"{type(data).__name__} has no catalog; Spool.__init__ never ran."
+                raise InvalidSpoolError(msg)
             self.__dict__.update(data.__dict__)
             return
         if data is None:
@@ -1886,7 +1892,7 @@ class Spool(NamespaceOwner):
         When a client is specified, the spool is split then passed to the
         client's map method. This is to avoid serializing loaded patches.
         See [`Spool.split`](`dascore.core.spool.Spool.split`) for more
-        details about the `spool_count` and `spool_size` parameters.
+        details about the `size` and `count` parameters.
 
         Examples
         --------
@@ -2517,6 +2523,7 @@ class Spool(NamespaceOwner):
 
 # There is one spool class; the old ABC name stays as an alias so
 # annotations and isinstance checks written against it keep working.
+# `Spool` is the name to use in new code.
 BaseSpool = Spool
 
 

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import abc
 import inspect
 import os
 import threading
@@ -570,8 +569,31 @@ def _combine_inventories(first, second) -> tuple:
     return inventory, enrichment
 
 
-class BaseSpool(NamespaceOwner, abc.ABC):
-    """Spool Abstract Base Class (ABC) for defining Spool interface."""
+class Spool(NamespaceOwner):
+    """
+    The concrete spool: a view over a `PatchCatalog`.
+
+    Constructed from in-memory patches directly (or via
+    [`dascore.spool`](`dascore.spool`)), from a directory of files with
+    [`Spool.from_directory`](`dascore.core.spool.Spool.from_directory`),
+    or from a single file with
+    [`Spool.from_file`](`dascore.core.spool.Spool.from_file`).
+
+    Parameters
+    ----------
+    data
+        A patch, sequence of patches, or another spool whose (in-memory)
+        patches this spool should hold; None creates an empty spool.
+
+    Notes
+    -----
+    The catalog is the spool's entire state: live patches sit in its
+    resolver registry, file-backed patches in its index tables, and
+    restructured views (chunk/concat) are derived in-memory catalogs
+    whose rows are the plan outputs. Selection, ordering, and windowing
+    are lazy specs composed on the catalog; one engine serves every
+    construction path.
+    """
 
     _rich_style = "bold"
     _namespace_entry_point_group = "dascore.spool_namespace"
@@ -583,19 +605,119 @@ class BaseSpool(NamespaceOwner, abc.ABC):
             "the Chunk function. i.e., spool.chunk(time=None)[0].viz.waterfall())"
         )
     }
+    # synthetic catalog identity columns must not join patch kwargs
+    # comparisons or chunk merge-compatibility checks
+    _drop_columns = (
+        "patch",
+        "source_path",
+        "source_format",
+        "source_version",
+        "source_patch_id",
+    )
+    # The catalog backing this spool; every construction path sets one.
+    _catalog: PatchCatalog
+    # An attached inventory -- itself, or a reference which reads it when
+    # something asks -- the enrich kwargs to apply on extraction (None
+    # means attached without automatic enrichment), and what to do with a
+    # patch the inventory does not describe.
+    _inventory = None
+    _enrich_kwargs: dict | None = None
+    _on_unresolved: str = "warn"
+    # Whether this spool has already said its inventory covers only part of
+    # it; the warning is worth making once, not once per patch.
+    _warned_unresolved: bool = False
+    # single-file provenance (set by from_file; drives update())
+    _file_path = None
+    _file_format = None
+    _file_version = None
+
+    def __init__(
+        self,
+        data: PatchType | Sequence[PatchType] | Spool | None = None,
+    ):
+        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
+
+        if isinstance(data, Spool):
+            # copy-construction: share the catalog and provenance
+            self.__dict__.update(data.__dict__)
+            return
+        if data is None:
+            patches = ()
+        elif isinstance(data, dc.Patch):
+            patches = (data,)
+        elif isinstance(data, Sequence) and all(isinstance(x, dc.Patch) for x in data):
+            patches = data
+        else:
+            msg = (
+                "Spool accepts a Patch, a sequence of patches, or a "
+                f"spool; got {type(data)}."
+            )
+            raise InvalidSpoolError(msg)
+        self._catalog = PatchCatalog.from_patches(patches)
+
+    # --- presented relation --------------------------------------------
+
+    @property
+    def _df(self) -> pd.DataFrame:
+        """The realized flat relation (cached by the catalog)."""
+        return self._catalog.to_df()
+
+    def get_contents(self) -> pd.DataFrame:
+        """
+        Get a dataframe of the spool contents.
+
+        Notes
+        -----
+        Each call returns a caller-owned dataframe; mutating it never
+        changes the spool. Use ``frame.copy(deep=True)`` when an eager
+        block copy is needed.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> spool = dc.get_example_spool("random_das")
+        >>> df = spool.get_contents()
+        """
+        return present_units_columns(_copy_public_dataframe(self._df))
+
+    def __len__(self) -> int:
+        """Return len of spool."""
+        # counting pushes to SQL (or the cold live registry); the flat
+        # relation is never realized just for a length
+        return len(self._catalog)
 
     # An int selects one patch; a slice or array selects a sub-spool.
     @overload
     def __getitem__(self, item: int) -> dc.Patch: ...
 
     @overload
-    def __getitem__(self, item: slice | np.ndarray) -> BaseSpool: ...
+    def __getitem__(self, item: slice | np.ndarray) -> Spool: ...
 
-    @abc.abstractmethod
-    def __getitem__(self, item: int | slice | np.ndarray) -> dc.Patch | BaseSpool:
+    def __getitem__(self, item) -> dc.Patch | Spool:
         """Return a patch, or a spool for a slice or array of indices."""
+        if isinstance(item, slice):
+            # a lazy id-membership window (D2); never realizes the flat
+            # relation, and keeps split()/map() parts cheap
+            return self._new_from_catalog(self._catalog.window(item))
+        if is_array(item):
+            array = np.asarray(item)
+            if not (
+                np.issubdtype(array.dtype, np.bool_)
+                or np.issubdtype(array.dtype, np.integer)
+            ):
+                msg = "Only bool or int dtypes are supported for spool array selection."
+                raise ValueError(msg)
+            return self._new_from_catalog(self._catalog.restrict(array))
+        try:
+            return self._maybe_enrich(self._catalog.get_patch(int(item)))
+        except MissingPatchError:
+            # MissingPatchError subclasses IndexError for backwards
+            # compatibility; it must never masquerade as out-of-bounds
+            raise
+        except IndexError:
+            msg = f"index of [{item}] is out of bounds for spool."
+            raise IndexError(msg) from None
 
-    @abc.abstractmethod
     def __iter__(self) -> Iterator[dc.Patch]:
         """
         Iterate through the Patches in the spool.
@@ -606,33 +728,12 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         mismatches occur as described in issue #583). Therefore, the number
         of patches yielded during iteration may differ from len(spool).
         """
+        # The catalog snapshots the relation once and skips patches which
+        # cannot be resolved (see #583).
+        for patch in self._catalog:
+            yield self._maybe_enrich(patch)
 
-    @abc.abstractmethod
-    def __len__(self) -> int:
-        """Return len of spool."""
-
-    def __rich__(self):
-        """Rich rep. of spool."""
-        text = get_dascore_text() + Text(" ")
-        text += Text(self.__class__.__name__, style=self._rich_style)
-        text += Text(" 🧵 ")
-        patch_len = len(self)
-        text += Text(f"({patch_len:d}")
-        text += Text(" Patches)") if patch_len != 1 else Text(" Patch)")
-        return text
-
-    def __str__(self):
-        return str(self.__rich__())
-
-    __repr__ = __str__
-
-    def __eq__(self, other) -> bool:
-        """Simple equality checks on spools."""
-        my_dict = self.__dict__
-        other_dict = getattr(other, "__dict__", {})
-        return deep_equality_check(my_dict, other_dict)
-
-    def __add__(self, other) -> BaseSpool:
+    def __add__(self, other) -> Spool:
         """
         Combine two spools into one containing the patches of both.
 
@@ -650,7 +751,7 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         >>> combined = sp1 + sp2
         >>> assert len(combined) == len(sp1) + len(sp2)
         """
-        if not isinstance(other, BaseSpool):
+        if not isinstance(other, Spool):
             return NotImplemented
         from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
@@ -665,105 +766,8 @@ class BaseSpool(NamespaceOwner, abc.ABC):
             new._enrich_kwargs, new._on_unresolved = enrichment
         return new
 
-    def _as_catalog_member(self):
-        """
-        Return (catalog, patch_ids) describing this spool for a union.
+    # --- selection and presentation specs -------------------------------
 
-        `patch_ids` limits membership to the spool's current rows; None
-        means the whole catalog (or the catalog view itself carries the
-        selection). The base implementation materializes the patches.
-        """
-        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
-
-        return PatchCatalog.from_patches(list(self)), None
-
-    @abc.abstractmethod
-    @compose_docstring(conflict_desc=attr_conflict_description)
-    def chunk(
-        self,
-        overlap: numeric_types | timeable_types | None = None,
-        keep_partial: bool = False,
-        snap_coords: bool = True,
-        tolerance: float = 1.5,
-        conflict: Literal["drop", "raise", "keep_first"] = "raise",
-        group: str | Sequence[str] | None = None,
-        missing_dim: Literal["raise", "drop"] = "raise",
-        **kwargs,
-    ) -> Self:
-        """
-        Chunk the data in the spool along specified dimension.
-
-        Parameters
-        ----------
-        overlap
-            The amount of overlap between each segment, starting with the end of
-            first patch. Negative values can be used to create gaps.
-        keep_partial
-            If True, keep the segments which are smaller than chunk size.
-            This often occurs because of data gaps or at end of chunks.
-        snap_coords
-            If True (default), simplify the coordinates of joined patches to
-            an evenly sampled range when doing so moves no coordinate value
-            by more than `tolerance` samples. Merges whose gaps exceed that
-            keep an exact segmented coordinate instead.
-        tolerance
-            The maximum number of samples a block of data can be spaced (gap)
-            and still be considered contiguous.
-        conflict
-            {conflict_desc}
-        group
-            Attributes which partition patches into separate outputs (their
-            values differing is never an error). Defaults to the config
-            option `groupby_attrs`; unlike the default, explicitly passed
-            names must exist on at least one patch. Dimensions and
-            coordinate identities always partition implicitly.
-        missing_dim
-            What to do when patches lack the chunked dimension: "raise"
-            (default) or "drop" (exclude them from the output).
-        kwargs
-            kwargs are used to specify the dimension along which to chunk, eg:
-            `time=10` chunks along the time axis in 10 second increments.
-            The value may also be a quantity: one of the coordinate's own
-            units (`time=10 * s`) or a data size (`time=25 * megabytes`),
-            which chunks so each patch's data array is about that large.
-            `overlap` accepts the same forms.
-
-        Examples
-        --------
-        >>> import dascore as dc
-        >>> from dascore.units import s, megabytes
-        >>>
-        >>> spool = dc.get_example_spool("random_das")
-        >>> # get spools with time duration of 10 seconds
-        >>> time_chunked = spool.chunk(time=10, overlap=1)
-        >>> # the same, with the units stated explicitly
-        >>> unit_chunked = spool.chunk(time=10 * s)
-        >>> # get patches whose data arrays are at most ~1 MB
-        >>> size_chunked = spool.chunk(time=1 * megabytes)
-        >>> # merge along time axis
-        >>> time_merged = spool.chunk(time=...)
-
-        Notes
-        -----
-        A data size measures the patch's data array only; coordinates and
-        attrs are extra, as are any copies a later processing step makes,
-        so the patch as a whole is somewhat larger. The sample count is
-        rounded down, so the data never exceeds the requested size, and a
-        merge of patches with different dtypes is sized against the dtype
-        they upcast to.
-
-        [`Spool.concatenate`](`dascore.BaseSpool.concatenate`) performs a
-        similar operation but disregards the coordinate values.
-
-        To inspect what a chunk call will do before running it — which
-        output patches it produces and which slice of which source patch
-        feeds each one — use
-        [`Spool.chunk_plan`](`dascore.core.spool.Spool.chunk_plan`),
-        which takes the same arguments and returns the plan without
-        touching any data.
-        """
-
-    @abc.abstractmethod
     def select(
         self,
         *,
@@ -811,29 +815,22 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         >>> # subselect based on matching tag parameter
         >>> tag_spool = spool.select(tag='some*')
         """
-
-    @abc.abstractmethod
-    def get_contents(self) -> pd.DataFrame:
-        """
-        Get a dataframe of the spool contents.
-
-        Notes
-        -----
-        Each call returns a caller-owned dataframe; mutating it never
-        changes the spool. Use ``frame.copy(deep=True)`` when an eager
-        block copy is needed.
-
-        Examples
-        --------
-        >>> import dascore as dc
-        >>> spool = dc.get_example_spool("random_das")
-        >>> df = spool.get_contents()
-        """
-
-    # Bind get_patch names as a spool method.
-    get_patch_names = get_patch_names
-
-    # --- optional methods
+        attr_query, channel_query, _attrs, _coords, kwargs = (
+            self._split_inventory_query(_attrs, _coords, kwargs, samples, relative)
+        )
+        catalog = self._catalog.select(
+            _attrs=_attrs,
+            _coords=_coords,
+            samples=samples,
+            relative=relative,
+            **kwargs,
+        )
+        out = self._new_from_catalog(catalog)
+        if attr_query:
+            out = out._select_from_inventory(attr_query)
+        if channel_query := _stated_channels(channel_query):
+            out = out._select_channels(channel_query)
+        return out
 
     def unselect(
         self,
@@ -890,314 +887,6 @@ class BaseSpool(NamespaceOwner, abc.ABC):
         >>> rest = spool.unselect(tag='some_tag')
         >>> assert len(rest) + len(spool.select(tag='some_tag')) == len(spool)
         """
-        msg = f"spool of type {self.__class__} has no unselect implementation"
-        raise NotImplementedError(msg)
-
-    def sort(self, attribute) -> Self:
-        """
-        Sort the Spool based on a specific attribute.
-
-        Parameters
-        ----------
-        attribute
-            The attribute or coordinate used for sorting. If a coordinate name
-            is used, the sorting will be based on the minimum value.
-
-        Examples
-        --------
-        >>> import dascore as dc
-        >>> spool = dc.get_example_spool()
-        >>> # sort spool based on values in time coordinate.
-        >>> spool_time_sorted = spool.sort("time")
-        >>> # sort spool based on values in tag
-        >>> spool_tag_sorted = spool.sort("tag")
-        """
-        msg = f"spool of type {self.__class__} has no sort implementation"
-        raise NotImplementedError(msg)
-
-    def split(
-        self,
-        size: int | None = None,
-        count: int | None = None,
-    ) -> Generator[BaseSpool, None, None]:
-        """
-        Yield sub-patches based on specified parameters.
-
-        Parameters
-        ----------
-        size
-            The number of patches desired in each output spool. The last
-            spool may have fewer patches. Must be greater than zero.
-        count
-            The number of spools to include. If count is greater than
-            the length of the spool then the output will be smaller than
-            count, with one patch per spool. Must be greater than zero.
-
-        Examples
-        --------
-        >>> import dascore as dc
-        >>> spool = dc.get_example_spool("diverse_das")
-        >>> # split spool into list of spools each with 3 patches.
-        >>> split = spool.split(size=3)
-        >>> # split spool into 3 evenly sized (if possible) spools
-        >>> split = spool.split(count=3)
-        """
-        msg = f"spool of type {self.__class__} has no split implementation"
-        raise NotImplementedError(msg)
-
-    def update(self, progress: PROGRESS_LEVELS = "standard") -> Self:
-        """
-        Updates the contents of the spool, return the updated spool.
-
-        Parameters
-        ----------
-        progress
-            Controls the progress bar. "standard" produces the standard
-            progress bar. "basic" is a simplified version with lower refresh
-            rates, best for high-latency environments, and None disables
-            the progress bar.
-        """
-        return self
-
-    @compose_docstring(desc=get_docstring(concatenate_patches))
-    def concatenate(self, check_behavior: WARN_LEVELS = "warn", **kwargs):
-        """{desc}"""
-        msg = f"spool of type {self.__class__} has no concatenate implementation"
-        raise NotImplementedError(msg)
-
-    def map(
-        self,
-        func: Callable[..., T],
-        *,
-        client: ExecutorType | None = None,
-        size: int | None = None,
-        progress: bool = True,
-        **kwargs,
-    ) -> list[T]:
-        """
-        Map a function of all the contents of the spool.
-
-        Parameters
-        ----------
-        func
-            A callable which takes a patch as its first argument.
-        client
-            A client, or executor, which has a `map` method.
-        size
-            The number of patches in each spool mapped to a client.
-            If not set, defaults to the number of processors on the host.
-            Does nothing unless client is defined.
-        progress
-            If True, display a progress bar.
-        **kwargs
-            kwargs passed to func.
-
-        Notes
-        -----
-        When a client is specified, the spool is split then passed to the
-        client's map method. This is to avoid serializing loaded patches.
-        See [`Spool.split`](`dascore.core.spool.BaseSpool.split`) for more
-        details about the `spool_count` and `spool_size` parameters.
-
-        Examples
-        --------
-        import numpy as np
-        import dascore as dc
-
-        spool = dc.get_example_spool("random_das")
-
-        # Calculate the std for each channel in 5 second chunks
-        results = (
-             spool.chunk(time=5)
-             .map(lambda x: np.std(x.data, axis=0))
-        )
-        # stack back into array. dims are (distance, time chunk)
-        out = np.stack(results, axis=-1)
-        """
-        return _spool_map(
-            self,
-            func,
-            client=client,
-            size=size,
-            progress=progress,
-            **kwargs,
-        )
-
-    # Add method for stacking (adding the data arrays) patches in spool.
-    stack = stack_patches
-
-
-class Spool(BaseSpool):
-    """
-    The concrete spool: a view over a `PatchCatalog`.
-
-    Constructed from in-memory patches directly (or via
-    [`dascore.spool`](`dascore.spool`)), from a directory of files with
-    [`Spool.from_directory`](`dascore.core.spool.Spool.from_directory`),
-    or from a single file with
-    [`Spool.from_file`](`dascore.core.spool.Spool.from_file`).
-
-    Parameters
-    ----------
-    data
-        A patch, sequence of patches, or another spool whose (in-memory)
-        patches this spool should hold; None creates an empty spool.
-
-    Notes
-    -----
-    The catalog is the spool's entire state: live patches sit in its
-    resolver registry, file-backed patches in its index tables, and
-    restructured views (chunk/concat) are derived in-memory catalogs
-    whose rows are the plan outputs. Selection, ordering, and windowing
-    are lazy specs composed on the catalog; one engine serves every
-    construction path.
-    """
-
-    # synthetic catalog identity columns must not join patch kwargs
-    # comparisons or chunk merge-compatibility checks
-    _drop_columns = (
-        "patch",
-        "source_path",
-        "source_format",
-        "source_version",
-        "source_patch_id",
-    )
-    # The catalog backing this spool; every construction path sets one.
-    _catalog: PatchCatalog
-    # An attached inventory -- itself, or a reference which reads it when
-    # something asks -- the enrich kwargs to apply on extraction (None
-    # means attached without automatic enrichment), and what to do with a
-    # patch the inventory does not describe.
-    _inventory = None
-    _enrich_kwargs: dict | None = None
-    _on_unresolved: str = "warn"
-    # Whether this spool has already said its inventory covers only part of
-    # it; the warning is worth making once, not once per patch.
-    _warned_unresolved: bool = False
-    # single-file provenance (set by from_file; drives update())
-    _file_path = None
-    _file_format = None
-    _file_version = None
-
-    def __init__(
-        self,
-        data: PatchType | Sequence[PatchType] | BaseSpool | None = None,
-    ):
-        from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
-
-        if isinstance(data, Spool):
-            # copy-construction: share the catalog and provenance
-            self.__dict__.update(data.__dict__)
-            return
-        if data is None:
-            patches = ()
-        elif isinstance(data, dc.Patch):
-            patches = (data,)
-        elif isinstance(data, BaseSpool):
-            # e.g. wrapping dc.read output; the patches are in memory
-            patches = tuple(data)
-        elif isinstance(data, Sequence) and all(isinstance(x, dc.Patch) for x in data):
-            patches = data
-        else:
-            msg = (
-                "Spool accepts a Patch, a sequence of patches, or a "
-                f"spool; got {type(data)}."
-            )
-            raise InvalidSpoolError(msg)
-        self._catalog = PatchCatalog.from_patches(patches)
-
-    # --- presented relation --------------------------------------------
-
-    @property
-    def _df(self) -> pd.DataFrame:
-        """The realized flat relation (cached by the catalog)."""
-        return self._catalog.to_df()
-
-    @compose_docstring(doc=get_docstring(BaseSpool.get_contents))
-    def get_contents(self) -> pd.DataFrame:
-        """{doc}."""
-        return present_units_columns(_copy_public_dataframe(self._df))
-
-    def __len__(self):
-        # counting pushes to SQL (or the cold live registry); the flat
-        # relation is never realized just for a length
-        return len(self._catalog)
-
-    @overload
-    def __getitem__(self, item: int) -> dc.Patch: ...
-
-    @overload
-    def __getitem__(self, item: slice | np.ndarray) -> BaseSpool: ...
-
-    def __getitem__(self, item) -> dc.Patch | BaseSpool:
-        if isinstance(item, slice):
-            # a lazy id-membership window (D2); never realizes the flat
-            # relation, and keeps split()/map() parts cheap
-            return self._new_from_catalog(self._catalog.window(item))
-        if is_array(item):
-            array = np.asarray(item)
-            if not (
-                np.issubdtype(array.dtype, np.bool_)
-                or np.issubdtype(array.dtype, np.integer)
-            ):
-                msg = "Only bool or int dtypes are supported for spool array selection."
-                raise ValueError(msg)
-            return self._new_from_catalog(self._catalog.restrict(array))
-        try:
-            return self._maybe_enrich(self._catalog.get_patch(int(item)))
-        except MissingPatchError:
-            # MissingPatchError subclasses IndexError for backwards
-            # compatibility; it must never masquerade as out-of-bounds
-            raise
-        except IndexError:
-            msg = f"index of [{item}] is out of bounds for spool."
-            raise IndexError(msg) from None
-
-    def __iter__(self):
-        # The catalog snapshots the relation once and skips patches which
-        # cannot be resolved (see #583).
-        for patch in self._catalog:
-            yield self._maybe_enrich(patch)
-
-    # --- selection and presentation specs -------------------------------
-
-    @compose_docstring(doc=get_docstring(BaseSpool.select))
-    def select(
-        self,
-        *,
-        _attrs: namespace_select_type = None,
-        _coords: namespace_select_type = None,
-        samples: bool = False,
-        relative: bool = False,
-        **kwargs,
-    ) -> Self:
-        """{doc}."""
-        attr_query, channel_query, _attrs, _coords, kwargs = (
-            self._split_inventory_query(_attrs, _coords, kwargs, samples, relative)
-        )
-        catalog = self._catalog.select(
-            _attrs=_attrs,
-            _coords=_coords,
-            samples=samples,
-            relative=relative,
-            **kwargs,
-        )
-        out = self._new_from_catalog(catalog)
-        if attr_query:
-            out = out._select_from_inventory(attr_query)
-        if channel_query := _stated_channels(channel_query):
-            out = out._select_channels(channel_query)
-        return out
-
-    @compose_docstring(doc=get_docstring(BaseSpool.unselect))
-    def unselect(
-        self,
-        *,
-        _attrs: namespace_select_type = None,
-        _coords: namespace_select_type = None,
-        **kwargs,
-    ) -> Self:
-        """{doc}."""
         requested = _requested_names(_attrs, _coords, kwargs)
         known_attrs, known_coords = self._index_names()
         channels, selectable = self._inventory_query(
@@ -2096,20 +1785,56 @@ class Spool(BaseSpool):
                 )
             return patch
 
-    @compose_docstring(doc=get_docstring(BaseSpool.sort))
     def sort(self, attribute) -> Self:
-        """{doc}."""
+        """
+        Sort the Spool based on a specific attribute.
+
+        Parameters
+        ----------
+        attribute
+            The attribute or coordinate used for sorting. If a coordinate name
+            is used, the sorting will be based on the minimum value.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> spool = dc.get_example_spool()
+        >>> # sort spool based on values in time coordinate.
+        >>> spool_time_sorted = spool.sort("time")
+        >>> # sort spool based on values in tag
+        >>> spool_tag_sorted = spool.sort("tag")
+        """
         # a lazy ORDER BY spec (D2): no copy, no realization; the
         # ordinal contract supplies the deterministic tiebreak
         return self._new_from_catalog(self._catalog.order_by(attribute))
 
-    @compose_docstring(doc=get_docstring(BaseSpool.split))
     def split(
         self,
         size: int | None = None,
         count: int | None = None,
-    ) -> Generator[BaseSpool, None, None]:
-        """{doc}."""
+    ) -> Generator[Spool, None, None]:
+        """
+        Yield sub-patches based on specified parameters.
+
+        Parameters
+        ----------
+        size
+            The number of patches desired in each output spool. The last
+            spool may have fewer patches. Must be greater than zero.
+        count
+            The number of spools to include. If count is greater than
+            the length of the spool then the output will be smaller than
+            count, with one patch per spool. Must be greater than zero.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> spool = dc.get_example_spool("diverse_das")
+        >>> # split spool into list of spools each with 3 patches.
+        >>> split = spool.split(size=3)
+        >>> # split spool into 3 evenly sized (if possible) spools
+        >>> split = spool.split(count=3)
+        """
         if not ((count is not None) ^ (size is not None)):
             msg = "Spool.split requires either spool_count or spool_size."
             raise ParameterError(msg)
@@ -2128,6 +1853,70 @@ class Spool(BaseSpool):
         while start < len(self):
             yield self[start : start + step]
             start += step
+
+    def map(
+        self,
+        func: Callable[..., T],
+        *,
+        client: ExecutorType | None = None,
+        size: int | None = None,
+        progress: bool = True,
+        **kwargs,
+    ) -> list[T]:
+        """
+        Map a function of all the contents of the spool.
+
+        Parameters
+        ----------
+        func
+            A callable which takes a patch as its first argument.
+        client
+            A client, or executor, which has a `map` method.
+        size
+            The number of patches in each spool mapped to a client.
+            If not set, defaults to the number of processors on the host.
+            Does nothing unless client is defined.
+        progress
+            If True, display a progress bar.
+        **kwargs
+            kwargs passed to func.
+
+        Notes
+        -----
+        When a client is specified, the spool is split then passed to the
+        client's map method. This is to avoid serializing loaded patches.
+        See [`Spool.split`](`dascore.core.spool.Spool.split`) for more
+        details about the `spool_count` and `spool_size` parameters.
+
+        Examples
+        --------
+        import numpy as np
+        import dascore as dc
+
+        spool = dc.get_example_spool("random_das")
+
+        # Calculate the std for each channel in 5 second chunks
+        results = (
+             spool.chunk(time=5)
+             .map(lambda x: np.std(x.data, axis=0))
+        )
+        # stack back into array. dims are (distance, time chunk)
+        out = np.stack(results, axis=-1)
+        """
+        return _spool_map(
+            self,
+            func,
+            client=client,
+            size=size,
+            progress=progress,
+            **kwargs,
+        )
+
+    # Bind get_patch names as a spool method.
+    get_patch_names = get_patch_names
+
+    # Add method for stacking (adding the data arrays) patches in spool.
+    stack = stack_patches
 
     def _new_from_catalog(self, catalog) -> Self:
         """Create a spool view over a (possibly derived) catalog."""
@@ -2258,7 +2047,7 @@ class Spool(BaseSpool):
         feeds each output, and `params` records every resolved parameter
         (including the group attributes and sampling tolerance in effect).
         Accepts the same arguments as
-        [`chunk`](`dascore.BaseSpool.chunk`).
+        [`chunk`](`dascore.Spool.chunk`).
 
         Examples
         --------
@@ -2283,7 +2072,7 @@ class Spool(BaseSpool):
             **kwargs,
         )
 
-    @compose_docstring(doc=get_docstring(BaseSpool.chunk))
+    @compose_docstring(conflict_desc=attr_conflict_description)
     def chunk(
         self,
         overlap: numeric_types | timeable_types | None = None,
@@ -2295,7 +2084,78 @@ class Spool(BaseSpool):
         missing_dim: Literal["raise", "drop"] = "raise",
         **kwargs,
     ) -> Self:
-        """{doc}"""
+        """
+        Chunk the data in the spool along specified dimension.
+
+        Parameters
+        ----------
+        overlap
+            The amount of overlap between each segment, starting with the end of
+            first patch. Negative values can be used to create gaps.
+        keep_partial
+            If True, keep the segments which are smaller than chunk size.
+            This often occurs because of data gaps or at end of chunks.
+        snap_coords
+            If True (default), simplify the coordinates of joined patches to
+            an evenly sampled range when doing so moves no coordinate value
+            by more than `tolerance` samples. Merges whose gaps exceed that
+            keep an exact segmented coordinate instead.
+        tolerance
+            The maximum number of samples a block of data can be spaced (gap)
+            and still be considered contiguous.
+        conflict
+            {conflict_desc}
+        group
+            Attributes which partition patches into separate outputs (their
+            values differing is never an error). Defaults to the config
+            option `groupby_attrs`; unlike the default, explicitly passed
+            names must exist on at least one patch. Dimensions and
+            coordinate identities always partition implicitly.
+        missing_dim
+            What to do when patches lack the chunked dimension: "raise"
+            (default) or "drop" (exclude them from the output).
+        kwargs
+            kwargs are used to specify the dimension along which to chunk, eg:
+            `time=10` chunks along the time axis in 10 second increments.
+            The value may also be a quantity: one of the coordinate's own
+            units (`time=10 * s`) or a data size (`time=25 * megabytes`),
+            which chunks so each patch's data array is about that large.
+            `overlap` accepts the same forms.
+
+        Examples
+        --------
+        >>> import dascore as dc
+        >>> from dascore.units import s, megabytes
+        >>>
+        >>> spool = dc.get_example_spool("random_das")
+        >>> # get spools with time duration of 10 seconds
+        >>> time_chunked = spool.chunk(time=10, overlap=1)
+        >>> # the same, with the units stated explicitly
+        >>> unit_chunked = spool.chunk(time=10 * s)
+        >>> # get patches whose data arrays are at most ~1 MB
+        >>> size_chunked = spool.chunk(time=1 * megabytes)
+        >>> # merge along time axis
+        >>> time_merged = spool.chunk(time=...)
+
+        Notes
+        -----
+        A data size measures the patch's data array only; coordinates and
+        attrs are extra, as are any copies a later processing step makes,
+        so the patch as a whole is somewhat larger. The sample count is
+        rounded down, so the data never exceeds the requested size, and a
+        merge of patches with different dtypes is sized against the dtype
+        they upcast to.
+
+        [`Spool.concatenate`](`dascore.Spool.concatenate`) performs a
+        similar operation but disregards the coordinate values.
+
+        To inspect what a chunk call will do before running it — which
+        output patches it produces and which slice of which source patch
+        feeds each one — use
+        [`Spool.chunk_plan`](`dascore.core.spool.Spool.chunk_plan`),
+        which takes the same arguments and returns the plan without
+        touching any data.
+        """
         from dascore.io.index.planned import derived_catalog  # noqa: PLC0415
 
         source_rows, working = self._plan_frames(next(iter(kwargs), None))
@@ -2480,10 +2340,9 @@ class Spool(BaseSpool):
         """True when any of this spool's patches live in memory."""
         return bool(self._catalog.resolver.live_entries())
 
-    @compose_docstring(doc=get_docstring(BaseSpool.update))
     def update(self, progress: PROGRESS_LEVELS = "standard") -> Self:
         """
-        {doc}
+        Updates the contents of the spool, return the updated spool.
 
         Update is allowed only on a root spool — one no operation has
         been applied to. Directory roots re-index their directory,
@@ -2491,6 +2350,14 @@ class Spool(BaseSpool):
         are trivially current (no-op). Any derived spool (the result of
         select, slicing, sort, chunk, concatenate, or combining spools)
         raises: update the root and re-apply the operations.
+
+        Parameters
+        ----------
+        progress
+            Controls the progress bar. "standard" produces the standard
+            progress bar. "basic" is a simplified version with lower refresh
+            rates, best for high-latency environments, and None disables
+            the progress bar.
         """
         from dascore.io.index.catalog import LiveResolver  # noqa: PLC0415
 
@@ -2540,7 +2407,8 @@ class Spool(BaseSpool):
         if self is other:
             return True
         if not isinstance(other, Spool):
-            return super().__eq__(other)
+            other_dict = getattr(other, "__dict__", {})
+            return deep_equality_check(self.__dict__, other_dict)
         # Models compare with ==; deep_equality_check walks their fields,
         # where an unset (NaT) time never equals itself.
         if (self._inventory, self._enrichment()) != (
@@ -2615,7 +2483,13 @@ class Spool(BaseSpool):
         return {"rows": _strip_identity(rows)}
 
     def __rich__(self):
-        base = super().__rich__()
+        """Rich rep. of spool."""
+        base = get_dascore_text() + Text(" ")
+        base += Text(self.__class__.__name__, style=self._rich_style)
+        base += Text(" 🧵 ")
+        patch_len = len(self)
+        base += Text(f"({patch_len:d}")
+        base += Text(" Patches)") if patch_len != 1 else Text(" Patch)")
         path = self.spool_path
         if path is not None:
             base += Text(f"\n    Path: {path}")
@@ -2635,9 +2509,19 @@ class Spool(BaseSpool):
                     )
         return base
 
+    def __str__(self):
+        return str(self.__rich__())
+
+    __repr__ = __str__
+
+
+# There is one spool class; the old ABC name stays as an alias so
+# annotations and isinstance checks written against it keep working.
+BaseSpool = Spool
+
 
 @singledispatch
-def spool(obj: path_types | BaseSpool | Sequence[PatchType], **kwargs) -> BaseSpool:
+def spool(obj: path_types | Spool | Sequence[PatchType], **kwargs) -> Spool:
     """
     Create a spool from a data source.
 
@@ -2696,7 +2580,7 @@ def _spool_from_str(path, **kwargs):
         raise InvalidSpoolError(msg)
 
 
-@spool.register(BaseSpool)
+@spool.register(Spool)
 def _spool_from_spool(spool, **kwargs):
     """Return a spool from a spool."""
     return spool

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -717,7 +717,7 @@ def get_example_patch(example_name="random_das", **kwargs) -> dc.Patch:
     return EXAMPLE_PATCHES[example_name](**kwargs)
 
 
-def get_example_spool(example_name="random_das", **kwargs) -> dc.BaseSpool:
+def get_example_spool(example_name="random_das", **kwargs) -> dc.Spool:
     """
     Load an example Spool.
 

--- a/dascore/io/ai4eps/core.py
+++ b/dascore/io/ai4eps/core.py
@@ -73,7 +73,7 @@ class AI4EPSV1(FiberIO):
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read an AI4EPS file into a spool."""
         patches = _get_patches(
             resource, time=time, distance=distance, attr_cls=AI4EPSPatchAttrs

--- a/dascore/io/ap_sensing/core.py
+++ b/dascore/io/ap_sensing/core.py
@@ -63,7 +63,7 @@ class APSensingV10(FiberIO):
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a single file with APSensing data inside."""
         patches = _get_patches(
             resource, time=time, distance=distance, attr_cls=APSensingPatchAttrs

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -94,7 +94,7 @@ from dascore.utils.remote_io import (
 ScanInput = (
     path_types
     | dc.Patch
-    | dc.BaseSpool
+    | dc.Spool
     | IOResourceManager
     | Iterable[path_types | dc.Patch | IOResourceManager]
 )
@@ -953,7 +953,7 @@ class FiberIO:
         }
     )
 
-    def read(self, resource, **kwargs) -> dc.BaseSpool:
+    def read(self, resource, **kwargs) -> dc.Spool:
         """
         Load data from a path.
 
@@ -1004,7 +1004,7 @@ class FiberIO:
             raise NotImplementedError(msg)
         return [_patch_to_scan_payload(pa) for pa in spool]
 
-    def write(self, spool: dc.Patch | dc.BaseSpool, resource, **kwargs):
+    def write(self, spool: dc.Patch | dc.Spool, resource, **kwargs):
         """Write the spool to a resource (eg path, stream, etc.)."""
         msg = f"FiberIO: {self.name} has no write method"
         raise NotImplementedError(msg)
@@ -1120,7 +1120,7 @@ def read(
     time: time_select_type | None = None,
     distance: float_select_type | None = None,
     **kwargs,
-) -> dc.BaseSpool:
+) -> dc.Spool:
     """
     Read a fiber file.
 
@@ -1821,7 +1821,7 @@ def write(
     >>> path.unlink()
     """
     fiber_io = FiberIO.manager.get_fiberio(format=file_format, version=file_version)
-    if not isinstance(patch_or_spool, dc.BaseSpool):
+    if not isinstance(patch_or_spool, dc.Spool):
         patch_or_spool = dc.spool([patch_or_spool])
     patch_or_spool = _maybe_split_gapped_patches(patch_or_spool, fiber_io, split)
     with IOResourceManager(path) as man:

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -55,7 +55,7 @@ class DASDAEV1(FiberIO):
 
     def write(
         self,
-        spool: dc.Patch | dc.BaseSpool,
+        spool: dc.Patch | dc.Spool,
         resource: H5Writer,
         **kwargs,
     ):
@@ -116,7 +116,7 @@ class DASDAEV1(FiberIO):
         version = unbyte(attrs.get("__DASDAE_version__", ""))
         return file_format, version
 
-    def read(self, resource: H5Reader, source_patch_id=(), **kwargs) -> dc.BaseSpool:
+    def read(self, resource: H5Reader, source_patch_id=(), **kwargs) -> dc.Spool:
         """Read a dascore file."""
         patches = []
         source_patch_ids = _normalize_source_patch_ids(source_patch_id)

--- a/dascore/io/dasvader/core.py
+++ b/dascore/io/dasvader/core.py
@@ -79,7 +79,7 @@ class DASVaderV1(FiberIO):
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a DASVader spool of patches."""
         patches = _read_dasvader(resource, time=time, distance=distance)
         return dc.spool(patches)

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -129,7 +129,7 @@ class Febus2(FiberIO):
         distance: tuple[float | None, float | None] | None = None,
         source_patch_id=(),
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a febus spool of patches."""
         patches = _read_febus(
             resource,
@@ -181,7 +181,7 @@ class FebusG1CSV1(FiberIO):
         attrs = FebusBOTDRStrainAttrs(**attrs_no_private)
         return [make_scan_payload(attrs=attrs, coords=coords, dtype="float64")]
 
-    def read(self, resource: TextReader, **kwargs) -> dc.BaseSpool:
+    def read(self, resource: TextReader, **kwargs) -> dc.Spool:
         """Read a G1 file, return a Patch object."""
         pa = _get_g1_patch(resource, attr_cls=FebusBOTDRStrainAttrs)
         return dc.spool([pa])
@@ -229,7 +229,7 @@ class FebusMTXH5V1(FiberIO):
         time: _time_select_type | None = None,
         distance: _float_select_type | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a Febus MTX HDF5 file into a spool."""
         select_kwargs = {
             key: value
@@ -292,7 +292,7 @@ class FebusBSLH5V1(FiberIO):
         time: _time_select_type | None = None,
         distance: _float_select_type | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a Febus BSL HDF5 file into a spool."""
         select_kwargs = {
             key: value
@@ -348,7 +348,7 @@ class FebusT1V1(FiberIO):
         time: tuple[timeable_types, timeable_types] | None = None,
         distance: tuple[float, float] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """
         Read temperature data into a list containing one Patch.
 

--- a/dascore/io/gdr/core.py
+++ b/dascore/io/gdr/core.py
@@ -44,7 +44,7 @@ class GDR_V1(FiberIO):  # noqa
 
     def read(
         self, resource: H5Reader, snap=True, time=None, distance=None, **kwargs
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """
         Read a resource belonging to this format.
 

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -29,7 +29,7 @@ class H5Simple(FiberIO):
             return self.name, self.version
         return False
 
-    def read(self, resource: H5Reader, snap=True, **kwargs) -> dc.BaseSpool:
+    def read(self, resource: H5Reader, snap=True, **kwargs) -> dc.Spool:
         """
         Read a simple h5 file.
 

--- a/dascore/io/hdas/core.py
+++ b/dascore/io/hdas/core.py
@@ -81,7 +81,7 @@ class HDASV1(FiberIO):
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read an HDAS file into a spool."""
         coords, attrs_dict = self._get_coords_and_attrs(resource)
         patches = _get_patches(

--- a/dascore/io/mseed/core.py
+++ b/dascore/io/mseed/core.py
@@ -68,7 +68,7 @@ class MSeedV2(FiberIO):
         channel: tuple[int | None, int | None] | None = None,
         source_patch_id=(),
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a MiniSEED file."""
         pymseed = optional_import("pymseed")
         patches = _get_patches(

--- a/dascore/io/netcdf/core.py
+++ b/dascore/io/netcdf/core.py
@@ -119,7 +119,7 @@ class NetCDFCFV18(FiberIO):
             pass
         return False
 
-    def read(self, resource: H5Reader, **kwargs) -> dc.BaseSpool:
+    def read(self, resource: H5Reader, **kwargs) -> dc.Spool:
         """Read a NetCDF-4 file into a Spool, streaming remote resources."""
         with _open_xarray_dataset(resource) as dataset:
             data_var_name = get_xarray_data_var_name(dataset)
@@ -146,7 +146,7 @@ class NetCDFCFV18(FiberIO):
             encoding["shuffle"] = True
         return encoding
 
-    def write(self, spool: dc.Patch | dc.BaseSpool, resource: Path, **kwargs) -> None:
+    def write(self, spool: dc.Patch | dc.Spool, resource: Path, **kwargs) -> None:
         """
         Write a Spool to NetCDF-4 through xarray.
 
@@ -260,7 +260,7 @@ class NetCDFCFV18(FiberIO):
         coord_kwargs = {k: v for k, v in kwargs.items() if k in patch.coords.coord_map}
         return patch.select(**coord_kwargs) if coord_kwargs else patch
 
-    def _validate_and_extract_patch(self, spool: dc.Patch | dc.BaseSpool) -> dc.Patch:
+    def _validate_and_extract_patch(self, spool: dc.Patch | dc.Spool) -> dc.Patch:
         """Validate write input and return the single supported patch."""
         patches = [spool] if isinstance(spool, dc.Patch) else list(spool)
         if len(patches) == 0:

--- a/dascore/io/neubrex/core.py
+++ b/dascore/io/neubrex/core.py
@@ -62,7 +62,7 @@ class NeubrexRFSV1(FiberIO):
 
     def read(
         self, resource: H5Reader, snap=True, time=None, distance=None, **kwargs
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """
         Read a resource belonging to this format.
 
@@ -115,9 +115,7 @@ class NeubrexDASV1(FiberIO):
             return self.name, self.version
         return False
 
-    def read(
-        self, resource: H5Reader, time=None, distance=None, **kwargs
-    ) -> dc.BaseSpool:
+    def read(self, resource: H5Reader, time=None, distance=None, **kwargs) -> dc.Spool:
         """
         Read a resource of this format.
 

--- a/dascore/io/odh4/core.py
+++ b/dascore/io/odh4/core.py
@@ -68,7 +68,7 @@ class ODH4V1(FiberIO):
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read an ODH4 file into a spool."""
         patches = _get_patches(
             resource, time=time, distance=distance, attr_cls=ODH4PatchAttrs

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -63,7 +63,7 @@ class OptoDASV8(FiberIO):
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a OptoDAS spool of patches."""
         patches = _read_opto_das(
             resource, time=time, distance=distance, attr_cls=OptoDASPatchAttrs

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -68,7 +68,7 @@ class ProdMLV2_0(FiberIO):  # noqa
         distance: tuple[float | None, float | None] | None = None,
         source_patch_id=(),
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a ProdML file."""
         patches = _read_prodml(
             resource,
@@ -84,8 +84,6 @@ class ProdMLV2_1(ProdMLV2_0):  # noqa
 
     version = "2.1"
 
-    def write(
-        self, spool: dc.Patch | dc.BaseSpool, resource: H5Writer, **kwargs
-    ) -> None:
+    def write(self, spool: dc.Patch | dc.Spool, resource: H5Writer, **kwargs) -> None:
         """Write one raw Patch to a standalone ProdML HDF5 file."""
         _write_prodml(spool, resource)

--- a/dascore/io/segy/core.py
+++ b/dascore/io/segy/core.py
@@ -73,7 +73,7 @@ class SegyV1_0(FiberIO):  # noqa
             dtype = str(fi.dtype)
         return [make_scan_payload(attrs=attrs, coords=coords, dtype=dtype)]
 
-    def write(self, spool: dc.Patch | dc.BaseSpool, resource, **kwargs):
+    def write(self, spool: dc.Patch | dc.Spool, resource, **kwargs):
         """
         Create a segy file from length 1 spool or patch.
 

--- a/dascore/io/sentek/core.py
+++ b/dascore/io/sentek/core.py
@@ -26,7 +26,7 @@ class SentekV5(FiberIO):
         time=None,
         distance=None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a Sentek das file, return a DataArray."""
         attrs, coords, offsets = _get_patch_attrs(resource)
         resource.seek(offsets[0])

--- a/dascore/io/silixah5/core.py
+++ b/dascore/io/silixah5/core.py
@@ -74,7 +74,7 @@ class SilixaH5V1(FiberIO):
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a single file with Silixa H5 data inside."""
         patches = self._patch_getter(
             resource, time=time, distance=distance, attr_cls=SilixaPatchAttrs

--- a/dascore/io/sintela/core.py
+++ b/dascore/io/sintela/core.py
@@ -77,7 +77,7 @@ class SintelaBinaryV3(FiberIO):
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a single Sintela binary file."""
         patch = _get_patches(
             resource, time=time, distance=distance, attr_class=SintelaPatchAttrs
@@ -110,7 +110,7 @@ class SintelaProtobufV1(FiberIO):
         """Scan a Sintela protobuf recording."""
         return scan_payload(resource)
 
-    def read(self, resource: BinaryReader, **kwargs) -> dc.BaseSpool:
+    def read(self, resource: BinaryReader, **kwargs) -> dc.Spool:
         """Read a Sintela protobuf recording into a spool."""
         data, coords, attrs = read_payload(resource)
         selectors = {name: kwargs[name] for name in coords.dims if name in kwargs}

--- a/dascore/io/sr4731/core.py
+++ b/dascore/io/sr4731/core.py
@@ -42,7 +42,7 @@ class SR4731V200(FiberIO):
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read an SR-4731 SOR file."""
         patches = _get_patches(
             resource,

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -64,7 +64,7 @@ class TDMSFormatterV4713(FiberIO):
         time: tuple[timeable_types, timeable_types] | None = None,
         distance: tuple[float, float] | None = None,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """Read a silixa tdms file, return a DataArray."""
         # get all data, total amount of samples and associated attributes
         data, _channel_length, attrs_full = _get_data(resource, lead_in_length=28)

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -56,7 +56,7 @@ class Terra15FormatterV4(FiberIO):
         distance: tuple[float, float] | None = None,
         snap_dims: bool = True,
         **kwargs,
-    ) -> dc.BaseSpool:
+    ) -> dc.Spool:
         """
         Read a terra15 file.
 

--- a/dascore/io/wav/core.py
+++ b/dascore/io/wav/core.py
@@ -23,7 +23,7 @@ class WavIO(FiberIO):
 
     def write(
         self,
-        spool: dc.Patch | dc.BaseSpool,
+        spool: dc.Patch | dc.Spool,
         resource: str | Path | UPath,
         resample_frequency=None,
         **kwargs,

--- a/dascore/io/xml_binary/core.py
+++ b/dascore/io/xml_binary/core.py
@@ -53,7 +53,7 @@ class XMLBinaryV1(FiberIO):
             attr_cls=BinaryPatchAttrs,
         )
 
-    def read(self, resource, time=None, distance=None, **kwargs) -> dc.BaseSpool:
+    def read(self, resource, time=None, distance=None, **kwargs) -> dc.Spool:
         """
         Load data from the directory structure.
 

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -953,7 +953,7 @@ def get_axis(self: PatchType, dim: str) -> int:
     return self.coords.get_axis(dim)
 
 
-def split_gaps(self: PatchType, dim: str | None = None) -> dc.BaseSpool:
+def split_gaps(self: PatchType, dim: str | None = None) -> dc.Spool:
     """
     Split the patch into contiguous patches at coordinate gaps.
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -353,7 +353,7 @@ def patch_function(
 
 
 def patches_to_df(
-    patches: Sequence[dc.Patch] | dc.BaseSpool | pd.DataFrame,
+    patches: Sequence[dc.Patch] | dc.Spool | pd.DataFrame,
 ) -> pd.DataFrame:
     """
     Return a dataframe.
@@ -406,11 +406,11 @@ def patches_to_df(
     removed_in="0.2.0",
 )
 def merge_patches(
-    patches: Sequence[dc.Patch] | pd.DataFrame | dc.BaseSpool,
+    patches: Sequence[dc.Patch] | pd.DataFrame | dc.Spool,
     dim: str = "time",
     check_history: bool = True,
     tolerance: float = 1.5,
-) -> dc.BaseSpool:
+) -> dc.Spool:
     """
     Merge all compatible patches in spool or patch list together.
 
@@ -564,7 +564,7 @@ def get_patch_names(
     # io.core.ScanInput: importing that is circular, and hiding it behind
     # TYPE_CHECKING leaves the annotation unresolvable at runtime, which
     # breaks get_type_hints and the API doc renderer.
-    patch_data: pd.DataFrame | dc.Patch | dc.BaseSpool | Iterable[dc.Patch],
+    patch_data: pd.DataFrame | dc.Patch | dc.Spool | Iterable[dc.Patch],
     prefix="DAS",
     attrs=("acquisition_key", "tag"),
     coords=("time",),
@@ -603,7 +603,7 @@ def get_patch_names(
     See Also
     --------
     - [`Patch.get_patch_name`](`dascore.Patch.get_patch_name`)
-    - [`Spool.get_patch_names`](`dascore.BaseSpool.get_patch_names`)
+    - [`Spool.get_patch_names`](`dascore.Spool.get_patch_names`)
 
     Examples
     --------
@@ -1331,7 +1331,7 @@ def _spool_up(func):
 
 @compose_docstring(check_bev=check_behavior_description)
 def concatenate_patches(
-    patches: Sequence[dc.Patch] | dc.BaseSpool,
+    patches: Sequence[dc.Patch] | dc.Spool,
     check_behavior: WARN_LEVELS = "warn",
     **kwargs,
 ) -> Sequence[dc.Patch]:
@@ -1373,7 +1373,7 @@ def concatenate_patches(
 
     Notes
     -----
-    - [`Spool.chunk`](`dascore.BaseSpool.chunk`) performs a similar operation
+    - [`Spool.chunk`](`dascore.Spool.chunk`) performs a similar operation
       but accounts for coordinate values.
     - See also the
       [chunk section of the spool tutorial](`docs/tutorial/spool`#concatenate)

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -6,7 +6,7 @@ This page explains how to extend DASCore with `Patch` and `Spool` namespaces. Us
 
 ## When to use a namespace
 
-A namespace is appropriate when you want to group related functionality under a stable access point instead of adding many methods directly to `Patch` or `BaseSpool`. Good candidates include:
+A namespace is appropriate when you want to group related functionality under a stable access point instead of adding many methods directly to `Patch` or `Spool`. Good candidates include:
 
 - Optional integrations that should live in a separate package.
 - Domain-specific processing that is useful to a subset of users.

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -14,7 +14,7 @@ A namespace is appropriate when you want to group related functionality under a 
 
 If you are adding support for a new file format, see [Adding a New Format](new_format.qmd). File formats use `FiberIO` plugins, not method namespaces.
 
-Namespaces and `FiberIO` plugins are the extension points; subclassing `Patch` or `Spool` is not one. There is a single `Spool` class, whose state is the catalog its `__init__` builds, so a subclass which replaces that state is refused rather than silently accepted.
+Namespaces and `FiberIO` plugins are the extension points; subclassing `Patch` or `Spool` is not one. There is a single `Spool` class, whose state is the catalog its `__init__` builds, so copying a subclass instance which never ran that `__init__` is refused rather than silently accepted.
 
 ## The namespace model
 

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -14,6 +14,8 @@ A namespace is appropriate when you want to group related functionality under a 
 
 If you are adding support for a new file format, see [Adding a New Format](new_format.qmd). File formats use `FiberIO` plugins, not method namespaces.
 
+Namespaces and `FiberIO` plugins are the extension points; subclassing `Patch` or `Spool` is not one. There is a single `Spool` class, whose state is the catalog its `__init__` builds, so a subclass which replaces that state is refused rather than silently accepted.
+
 ## The namespace model
 
 DASCore namespaces inherit from either `PatchNameSpace` or `SpoolNameSpace`. Namespace methods receive the parent object, so they look like normal `Patch` or `Spool` methods. Using `patch` or `spool` as the first argument name can make this explicit:

--- a/docs/recipes/parallelization.qmd
+++ b/docs/recipes/parallelization.qmd
@@ -7,7 +7,7 @@ execute:
 This recipe shows a few strategies to parallelize "embarrassingly parallel" spool processing workflows.
 
 # Processes and Threads
-[`Spool.map`](`dascore.core.spool.BaseSpool.map`) is the easiest way to process patches in a spool in parallel. Here is an example using the Python standard library module [concurrent.futures](https://docs.python.org/3/library/concurrent.futures.html):
+[`Spool.map`](`dascore.core.spool.Spool.map`) is the easiest way to process patches in a spool in parallel. Here is an example using the Python standard library module [concurrent.futures](https://docs.python.org/3/library/concurrent.futures.html):
 
 ```{python}
 from concurrent.futures import ProcessPoolExecutor
@@ -37,7 +37,7 @@ DASCore's core test suite — no optional dependencies, no network tests — run
 
 Patches are immutable, so any number of threads may read the same patch. Spools may also be read concurrently: iterating, selecting, chunking, indexing and taking their length are safe from several threads at once, because the underlying metadata caches are synchronized internally.
 
-[`Spool.get_contents`](`dascore.core.spool.BaseSpool.get_contents`) hands back a dataframe you own. Mutating it never changes the spool, so each thread may modify its own copy freely. Arrays reached through coordinates go the other way: they are shared and read-only, so copy one before writing to it.
+[`Spool.get_contents`](`dascore.core.spool.Spool.get_contents`) hands back a dataframe you own. Mutating it never changes the spool, so each thread may modify its own copy freely. Arrays reached through coordinates go the other way: they are shared and read-only, so copy one before writing to it.
 
 The process-wide registries take care of themselves. The file-format (`FiberIO`) registry, the method-namespace registry and the [pint](https://pint.readthedocs.io) unit registry are each guarded by a single lock, so first use from several threads at once is safe. Loading the plugins for one format is serialized: the first thread to need a format loads it while the others wait, and none of them can observe a partially registered format.
 
@@ -55,7 +55,7 @@ Third-party `FiberIO` plugins are responsible for their own thread safety. DASCo
 
 Configuration has two tiers, described in [runtime configuration](../tutorial/configuration.qmd). `set_config` changes the process-wide base and is visible from every thread. `config_context` overrides the config for the current context only, and a newly started thread begins with a fresh context, so a scoped override does not automatically reach threads started inside it.
 
-[`Spool.map`](`dascore.core.spool.BaseSpool.map`) handles this for you: it binds the configuration active when `map` is called and re-applies it inside each worker, for thread pools and process pools alike. When starting threads yourself, either set the configuration permanently before starting them or re-apply the scoped override inside each thread.
+[`Spool.map`](`dascore.core.spool.Spool.map`) handles this for you: it binds the configuration active when `map` is called and re-applies it inside each worker, for thread pools and process pools alike. When starting threads yourself, either set the configuration permanently before starting them or re-apply the scoped override inside each thread.
 
 # MPI4Py
 

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -33,7 +33,7 @@ with dc.config_context(display_float_precision=8):  # scoped to this block
 dc.reset_config()  # drop the permanent change
 ```
 
-[`Spool.map`](`dascore.core.spool.BaseSpool.map`) binds the config active when `map` is called and re-applies it in each worker, so overrides also reach thread- and process-pool workers.
+[`Spool.map`](`dascore.core.spool.Spool.map`) binds the config active when `map` is called and re-applies it in each worker, so overrides also reach thread- and process-pool workers.
 
 History recording is also configurable:
 

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -14,7 +14,7 @@ In order to manage coordinate labels and array manipulations, DASCore implements
 
 Coordinates usually keep track of labels along an associated dimension of an array, but they can also be independent of array data. They provide methods for slicing, re-ordering, filtering etc. and are used internally by DASCore for such operations.
 
-Much like DASCore's [`Spool`](`dascore.core.spool.BaseSpool`), Coordinates are a collection of classes which implement a common interface. 
+Much like DASCore's [`Spool`](`dascore.core.spool.Spool`), Coordinates are a collection of classes which implement a common interface. 
 
 
 :::{.callout-note}

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -14,7 +14,7 @@ In order to manage coordinate labels and array manipulations, DASCore implements
 
 Coordinates usually keep track of labels along an associated dimension of an array, but they can also be independent of array data. They provide methods for slicing, re-ordering, filtering etc. and are used internally by DASCore for such operations.
 
-Much like DASCore's [`Spool`](`dascore.core.spool.Spool`), Coordinates are a collection of classes which implement a common interface. 
+Coordinates are a collection of classes which implement a common interface. 
 
 
 :::{.callout-note}

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -115,7 +115,7 @@ print(time_coord.get_discontinuities("gaps"))
 
 ## Directory spools
 
-A spool over a directory of dascore-readable files is created with the [`dascore.spool`](`dascore.spool`) function. It has the same interface as every other spool; the only difference is how it was constructed.
+A spool over a directory of dascore-readable files is created with the [`dascore.spool`](`dascore.spool`) function. It is the same class as any other spool; the only difference is how it was constructed.
 
 For example:
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -321,7 +321,7 @@ print(patch.channel_count)  # number of channels in the patch
 
 These shortcuts only work for patches with dimensions "time" and "distance", but they can help new users who may be unfamiliar with datetimes and coordinates.
 
-The "name" of a patch (the filename DASCore would use if the patch were saved to disk) can be generated with [`Patch.get_patch_name`](`dascore.Patch.get_patch_name`). For a spool, use [`Spool.get_patch_names`](`dascore.BaseSpool.get_patch_names`) to get the names of its managed patches.
+The "name" of a patch (the filename DASCore would use if the patch were saved to disk) can be generated with [`Patch.get_patch_name`](`dascore.Patch.get_patch_name`). For a spool, use [`Spool.get_patch_names`](`dascore.Spool.get_patch_names`) to get the names of its managed patches.
 
 ```python 
 import dascore as dc

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -10,7 +10,7 @@ For file-backed spools, DASCore first scans metadata and coordinate summaries, t
 
 # Data Sources
 
-The simplest way to get the appropriate spool for a specified input is to use the [`spool`](`dascore.spool`) function, which knows about many different input types and returns an appropriate [`BaseSpool`](`dascore.core.spool.BaseSpool`) subclass instance.
+The simplest way to get the appropriate spool for a specified input is to use the [`spool`](`dascore.spool`) function, which knows about many different input types and returns a [`Spool`](`dascore.core.spool.Spool`) instance.
 
 ## Patches (in-memory)
 
@@ -195,7 +195,7 @@ new = spool[index_array]
 
 # get_contents
 
-The [`get_contents`](`dascore.core.spool.BaseSpool.get_contents`) method returns a dataframe listing the spool contents. This method may not be supported on all spools, especially those interfacing with large remote resources.
+The [`get_contents`](`dascore.core.spool.Spool.get_contents`) method returns a dataframe listing the spool contents. This method may not be supported on all spools, especially those interfacing with large remote resources.
 
 ```{python}
 #| output: false
@@ -217,7 +217,7 @@ The columns returned by `get_contents()` come from the same patch summary metada
 
 # select
 
-The [select](`dascore.core.spool.BaseSpool.select`) method selects a subset of a spool and returns a new spool. [`get_contents`](`dascore.core.spool.BaseSpool.get_contents`) will now reflect a subset of the original data requested by the select operation.
+The [select](`dascore.core.spool.Spool.select`) method selects a subset of a spool and returns a new spool. [`get_contents`](`dascore.core.spool.Spool.get_contents`) will now reflect a subset of the original data requested by the select operation.
 
 ```{python}
 import dascore as dc
@@ -244,7 +244,7 @@ subspool = spool.select(tag='some*')
 
 # unselect
 
-[`unselect`](`dascore.core.spool.BaseSpool.unselect`) is the complement of `select`: it returns the patches the same selection would have removed. Each keyword means what it means in `select`, so this is how to name what a spool does *not* want without spelling out the rest of the archive.
+[`unselect`](`dascore.core.spool.Spool.unselect`) is the complement of `select`: it returns the patches the same selection would have removed. Each keyword means what it means in `select`, so this is how to name what a spool does *not* want without spelling out the rest of the archive.
 
 ```{python}
 import dascore as dc
@@ -259,7 +259,7 @@ Coordinates are not accepted yet. Selecting on a coordinate trims each patch to 
 
 # chunk
 
-The [`chunk`](`dascore.core.spool.BaseSpool.chunk`) method controls how data are grouped together in patches within the spool. It can be used to merge contiguous patches together, specify the size of patches for processing, specify overlap with previous patches, etc.
+The [`chunk`](`dascore.core.spool.Spool.chunk`) method controls how data are grouped together in patches within the spool. It can be used to merge contiguous patches together, specify the size of patches for processing, specify overlap with previous patches, etc.
 
 ```{python}
 import dascore as dc
@@ -288,7 +288,7 @@ size_chunked = spool.chunk(time=1 * megabytes)
 A data size measures the data array only; coordinates, attrs, and any copies made later during processing are extra, so the patch as a whole is somewhat larger. The sample count is rounded down, so the patch's data never exceeds the requested size, and `MB` is 10^6^ bytes while `MiB` is 2^20^. `overlap` accepts the same forms.
 
 # concatenate
-Similar to `chunk`, [`Spool.concatenate`](`dascore.BaseSpool.concatenate`) is used to combine patches together. However, `concatenate` doesn't account for coordinate values along the concatenation axis, and can even be used to create new patch dimensions. Like `chunk`, it is available on every spool and produces a lazy, plan-backed result.
+Similar to `chunk`, [`Spool.concatenate`](`dascore.Spool.concatenate`) is used to combine patches together. However, `concatenate` doesn't account for coordinate values along the concatenation axis, and can even be used to create new patch dimensions. Like `chunk`, it is available on every spool and produces a lazy, plan-backed result.
 
 ```python 
 import dascore as dc
@@ -308,7 +308,7 @@ print(merged[0].coords)
 
 # map
 
-The [`map`](`dascore.core.spool.BaseSpool.map`) method applies a function to all patches in the spool. It provides an efficient way to process large datasets, especially when combined with clients (aka executors).
+The [`map`](`dascore.core.spool.Spool.map`) method applies a function to all patches in the spool. It provides an efficient way to process large datasets, especially when combined with clients (aka executors).
 
 For example, calculating the maximum value for each channel (distance) for 5 second increments with 1 second overlap can be done like so:
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -127,7 +127,7 @@ A few details worth knowing:
 - Removing a `key=value` pair from a path triggers a rescan of the affected files (the file's own value has to be recovered), while adding or changing pairs does not.
 - A path key that matches a coordinate name (e.g. `distance=...`) resolves attrs-first in bare `select` kwargs; use the `_coords` argument to target the coordinate explicitly.
 
-Despite some implementation differences, all spools have common behavior/methods.
+However they were constructed, all spools are the same class and share the same behavior and methods.
 
 :::{.callout-note}
 Remote file resources work with `dc.spool(...)`, `dc.read(...)`, `dc.scan(...)`, and `dc.scan_payloads(...)`.
@@ -195,7 +195,7 @@ new = spool[index_array]
 
 # get_contents
 
-The [`get_contents`](`dascore.core.spool.Spool.get_contents`) method returns a dataframe listing the spool contents. This method may not be supported on all spools, especially those interfacing with large remote resources.
+The [`get_contents`](`dascore.core.spool.Spool.get_contents`) method returns a dataframe listing the spool contents. It realizes the whole relation, so it can be expensive over a large remote archive.
 
 ```{python}
 #| output: false
@@ -288,7 +288,7 @@ size_chunked = spool.chunk(time=1 * megabytes)
 A data size measures the data array only; coordinates, attrs, and any copies made later during processing are extra, so the patch as a whole is somewhat larger. The sample count is rounded down, so the patch's data never exceeds the requested size, and `MB` is 10^6^ bytes while `MiB` is 2^20^. `overlap` accepts the same forms.
 
 # concatenate
-Similar to `chunk`, [`Spool.concatenate`](`dascore.Spool.concatenate`) is used to combine patches together. However, `concatenate` doesn't account for coordinate values along the concatenation axis, and can even be used to create new patch dimensions. Like `chunk`, it is available on every spool and produces a lazy, plan-backed result.
+Similar to `chunk`, [`Spool.concatenate`](`dascore.Spool.concatenate`) is used to combine patches together. However, `concatenate` doesn't account for coordinate values along the concatenation axis, and can even be used to create new patch dimensions. Like `chunk`, it produces a lazy, plan-backed result.
 
 ```python 
 import dascore as dc

--- a/scripts/_index_api.py
+++ b/scripts/_index_api.py
@@ -204,6 +204,13 @@ def parse_project(obj, key=None):
             # another would claim as its own everything it merely imports.
             if key != base_address and not key.startswith(f"{base_address}."):
                 return
+            # A second module-level name bound to the same object (eg
+            # BaseSpool = Spool) is an alias, not its own entity. Members
+            # are sorted by name, so without this the alias can claim the
+            # page and every cross ref to the real name then dangles.
+            name = key.split(".")[-1]
+            if not parent_is_class and getattr(obj, "__name__", name) != name:
+                return
 
             data_dict[str(id(obj))] = get_data(obj, key, base_path, parent_is_class)
             # recurse attributes and methods of classes

--- a/scripts/_index_api.py
+++ b/scripts/_index_api.py
@@ -205,9 +205,10 @@ def parse_project(obj, key=None):
             if key != base_address and not key.startswith(f"{base_address}."):
                 return
             # A second module-level name bound to the same object (eg
-            # BaseSpool = Spool) is an alias, not its own entity. Members
-            # are sorted by name, so without this the alias can claim the
-            # page and every cross ref to the real name then dangles.
+            # BaseSpool = Spool) is an alias, not its own entity. The
+            # getmembers call above yields names alphabetically, so
+            # BaseSpool would arrive first, claim the page, and leave
+            # every cross ref to Spool dangling.
             name = key.split(".")[-1]
             if not parent_is_class and getattr(obj, "__name__", name) != name:
                 return

--- a/scripts/test_index_api.py
+++ b/scripts/test_index_api.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from _index_api import _get_base_address, _is_environment_path
+from _index_api import _get_base_address, _is_environment_path, parse_project
+
+import dascore as dc
 
 
 class TestIsEnvironmentPath:
@@ -33,3 +35,12 @@ class TestGetBaseAddress:
         """Project paths should convert to dotted addresses."""
         path = "/repo/dascore/core/patch.py"
         assert _get_base_address(path, "/repo") == "dascore.core.patch"
+
+
+class TestAliases:
+    """Tests that a second name for one object doesn't claim its page."""
+
+    def test_class_documented_under_defined_name(self):
+        """BaseSpool is an alias of Spool; only Spool gets documented."""
+        data = parse_project(dc)
+        assert data[str(id(dc.Spool))]["name"] == "Spool"

--- a/scripts/test_index_api.py
+++ b/scripts/test_index_api.py
@@ -44,3 +44,8 @@ class TestAliases:
         """BaseSpool is an alias of Spool; only Spool gets documented."""
         data = parse_project(dc)
         assert data[str(id(dc.Spool))]["name"] == "Spool"
+
+    def test_non_alias_still_documented(self):
+        """A name matching its object's own name is not treated as an alias."""
+        data = parse_project(dc)
+        assert data[str(id(dc.Patch))]["name"] == "Patch"

--- a/tests/test_core/test_directory_spool.py
+++ b/tests/test_core/test_directory_spool.py
@@ -336,7 +336,7 @@ class TestDirectoryIndex:
         path = tmp_path / "test.h5"
         new.io.write(path, "dasdae")
         spool = dc.spool(path).update()
-        isinstance(spool, dc.BaseSpool)
+        assert isinstance(spool, dc.Spool)
 
     def test_specify_index_path(self, random_patch, tmp_path_factory):
         """Ensure an external path can be specified for the index. See #129."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -78,52 +78,15 @@ class TestSpoolBasics:
         spool_str = str(spool)
         assert "Spool" in spool_str
 
-    def test_base_concat_raises(self, random_spool):
-        """Ensure BaseSpool.concatenate raises NotImplementedError."""
-        msg = "has no concatenate implementation"
-        with pytest.raises(NotImplementedError, match=msg):
-            BaseSpool.concatenate(random_spool, time=2)
-
-    def test_base_update_returns_self(self, random_spool):
-        """The BaseSpool update default (for third-party spools) no-ops."""
-        assert BaseSpool.update(random_spool) is random_spool
-
     def test_invalid_input_raises(self):
         """A non-patch, non-spool input raises a clear error."""
         with pytest.raises(InvalidSpoolError, match="accepts a Patch"):
             Spool(42)
 
-    def test_wraps_third_party_spool(self, random_spool):
-        """A non-Spool BaseSpool input realizes into the registry."""
-
-        class MiniSpool(BaseSpool):
-            """Minimal third-party spool over a patch list."""
-
-            def __init__(self, patches):
-                self._patches = list(patches)
-
-            def __getitem__(self, item):
-                return self._patches[item]
-
-            def __iter__(self):
-                return iter(self._patches)
-
-            def __len__(self):
-                return len(self._patches)
-
-            def chunk(self, **kwargs):
-                raise NotImplementedError
-
-            def select(self, **kwargs):
-                raise NotImplementedError
-
-            def get_contents(self):
-                raise NotImplementedError
-
-        patches = list(random_spool)
-        wrapped = Spool(MiniSpool(patches))
-        assert isinstance(wrapped, Spool)
-        assert list(wrapped) == patches
+    def test_base_spool_alias(self, random_spool):
+        """BaseSpool is kept as an alias of the one spool class."""
+        assert BaseSpool is Spool
+        assert isinstance(random_spool, BaseSpool)
 
     def test_viz_raises(self, random_spool):
         """Ensure Spool.viz raises AttributeError."""
@@ -656,20 +619,9 @@ class TestUnselect:
         with pytest.raises(InvalidSpoolQueryError, match="unselect cannot take"):
             diverse_spool.unselect(_coords="time", time=("2020-01-03", None))
 
-    def test_base_spool_unselect_raises(self, random_spool):
-        """A spool implementation which does not provide one says so."""
-        with pytest.raises(NotImplementedError, match="spool of type"):
-            BaseSpool.unselect(random_spool, tag="random")
-
 
 class TestSort:
     """Tests for sorting spools."""
-
-    def test_base_spool_sort_raises(self, random_spool):
-        """Ensure base spool's sort raises."""
-        expected_str = "spool of type"
-        with pytest.raises(NotImplementedError, match=expected_str):
-            BaseSpool.sort(random_spool, "time")
 
     def test_sorting_attr_not_exists(self, diverse_spool):
         """Test sorting by an attribute that does not exist in the DataFrame."""
@@ -711,11 +663,12 @@ class TestSplit:
         spools = tuple(random_spool_len_10.split(size=3))
         return spools
 
-    def test_both_parameters_raises(self, random_spool):
-        """Ensure split raises when both spool_size and spool_count are defined."""
+    @pytest.mark.parametrize("kwargs", [{"size": 1, "count": 2}, {}])
+    def test_needs_exactly_one_parameter(self, random_spool, kwargs):
+        """Ensure split raises unless exactly one of size/count is given."""
         msg = "requires either spool_count or spool_size"
         with pytest.raises(ParameterError, match=msg):
-            list(random_spool.split(size=1, count=2))
+            list(random_spool.split(**kwargs))
 
     def test_spool_size(self, split_10):
         """Ensure spool size can be split."""
@@ -755,14 +708,6 @@ class TestSplit:
         split = list(random_spool_len_10.split(count=3))
         assert len(split) == 3
         assert sum(len(x) for x in split) == 10
-
-    def test_base_split_raises(self, random_spool):
-        """Ensure BaseSpool split raises NotImplementedError."""
-        msg = "has no split implementation"
-        with pytest.raises(NotImplementedError, match=msg):
-            BaseSpool.split(
-                random_spool,
-            )
 
 
 class TestMap:

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -83,10 +83,21 @@ class TestSpoolBasics:
         with pytest.raises(InvalidSpoolError, match="accepts a Patch"):
             Spool(42)
 
-    def test_base_spool_alias(self, random_spool):
+    def test_base_spool_alias(self):
         """BaseSpool is kept as an alias of the one spool class."""
-        assert BaseSpool is Spool
-        assert isinstance(random_spool, BaseSpool)
+        assert BaseSpool is Spool is dc.BaseSpool
+
+    def test_uninitialized_subclass_raises(self, random_spool):
+        """A subclass which skips Spool.__init__ is refused, not copied."""
+
+        class SubSpool(Spool):
+            """A subclass which never builds a catalog."""
+
+            def __init__(self, patches):
+                self._patches = list(patches)
+
+        with pytest.raises(InvalidSpoolError, match="has no catalog"):
+            Spool(SubSpool(random_spool))
 
     def test_viz_raises(self, random_spool):
         """Ensure Spool.viz raises AttributeError."""

--- a/tests/test_core/test_spool_contracts.py
+++ b/tests/test_core/test_spool_contracts.py
@@ -141,7 +141,7 @@ class TestChunkPlanContract:
 
 
 class TestTypeSurface:
-    """The collapsed hierarchy: BaseSpool ABC with one concrete Spool."""
+    """The collapsed hierarchy: one concrete Spool class."""
 
     def test_every_spool_is_spool(self, patches, tmp_path):
         """All construction paths yield the same concrete class."""

--- a/tests/test_core/test_spool_contracts.py
+++ b/tests/test_core/test_spool_contracts.py
@@ -155,7 +155,6 @@ class TestTypeSurface:
         file_spool = dc.spool(file_path)
         for spool in (live, dir_spool, file_spool, live.chunk(time=2)):
             assert type(spool) is dc.Spool
-            assert isinstance(spool, dc.BaseSpool)
 
     def test_removed_names_gone(self):
         """The old concrete class names are deleted outright."""

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -179,11 +179,6 @@ class TestDerivedComposition:
         with pytest.raises(MissingPatchError, match="not available"):
             spool[0]
 
-    def test_union_with_non_spool_is_not_implemented(self, patches):
-        """Adding something which is not a spool defers to Python."""
-        with pytest.raises(TypeError):
-            _ = dc.spool(patches[:1]) + object()
-
     def test_samples_negative_index_skips_envelope_adjust(self, patches):
         """Negative samples windows stay candidacy supersets (no crash)."""
         spool = dc.spool(patches[:1]).select(time=(0, -10), samples=True)

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -12,7 +12,6 @@ import pandas as pd
 import pytest
 
 import dascore as dc
-from dascore.core.spool import BaseSpool
 from dascore.exceptions import MissingPatchError, ParameterError
 from dascore.io.index.planned import (
     PlanResolver,
@@ -180,33 +179,10 @@ class TestDerivedComposition:
         with pytest.raises(MissingPatchError, match="not available"):
             spool[0]
 
-    def test_union_with_third_party_spool(self, patches):
-        """The BaseSpool fallback materializes third-party members."""
-
-        class MiniSpool(BaseSpool):
-            def __init__(self, inner):
-                self._inner = list(inner)
-
-            def __getitem__(self, item):
-                return self._inner[item]
-
-            def __iter__(self):
-                return iter(self._inner)
-
-            def __len__(self):
-                return len(self._inner)
-
-            def chunk(self, **kwargs):
-                raise NotImplementedError
-
-            def select(self, **kwargs):
-                raise NotImplementedError
-
-            def get_contents(self):
-                raise NotImplementedError
-
-        combined = dc.spool(patches[:1]) + MiniSpool(patches[1:])
-        assert len(combined) == len(patches)
+    def test_union_with_non_spool_is_not_implemented(self, patches):
+        """Adding something which is not a spool defers to Python."""
+        with pytest.raises(TypeError):
+            _ = dc.spool(patches[:1]) + object()
 
     def test_samples_negative_index_skips_envelope_adjust(self, patches):
         """Negative samples windows stay candidacy supersets (no crash)."""


### PR DESCRIPTION
## Description

First PR of the pre-release simplification roadmap: there is one spool class, so the `BaseSpool` ABC only added indirection.

`BaseSpool` held docstrings that `Spool` pulled back with `compose_docstring(doc=get_docstring(BaseSpool.x))` for methods it fully implemented, plus `NotImplementedError` stubs (`unselect`, `sort`, `split`, `concatenate`) describing spool types that never shipped. Everything concrete on it — `map`, `stack`, `__add__`, `get_patch_names`, the dunders — belongs on `Spool`.

So:

- The seven donated docstrings now live directly on the `Spool` methods they describe.
- The ABC, its abstract decorators, its stubs, and its `_as_catalog_member` fallback are gone. `Spool.__init__` loses the branch that realized a non-`Spool` `BaseSpool` (unreachable once the alias points at `Spool`). In its place it checks that what it copy-constructs from actually has a catalog: subclassing is not an extension point, and a subclass that skipped `Spool.__init__` should be refused at construction rather than fail later on an `AttributeError` about a private attribute.
- `BaseSpool = Spool` stays as a module-level alias, still exported from `dascore/__init__.py`, so annotations and `isinstance` checks written against it keep working. Internal annotations were retyped to `dc.Spool`.
- `Spool.__eq__`'s non-spool branch inlines what the ABC's `__eq__` did, and `__rich__` inlines the base header it used to call through `super()`.

Extracting a real base class is worth doing when the streaming spool exists — today's abstract kernel (`__getitem__`/`__len__`/`get_contents`/`chunk`) is exactly what a streaming spool cannot provide, so the current boundary would be the wrong one to build on anyway.

One tooling fix rides along. The API doc generator keys pages by object id and walks members alphabetically, so `BaseSpool` would claim `Spool`'s page and every cross reference to `dascore.core.spool.Spool.*` would dangle (the link validator caught it). `scripts/_index_api.py` now skips a module-level name that differs from the object's own `__name__` — an alias is not its own entity.

Docs the collapse made false were fixed along the way: several pages still promised a family of spool classes sharing a common interface, and `get_contents` was described as possibly unsupported when the real caveat is that it realizes the whole relation.

`dascore/core/spool.py` drops from 2715 to 2606 lines and keeps 100% coverage.

## Changelog

- changed: `BaseSpool` is now an alias of `Spool` rather than an abstract base class; both names still work.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Consolidated spool functionality into the public `Spool` class.
  - Preserved `BaseSpool` as a compatibility alias.
  - Invalid uninitialized spool copies now raise a clear error.
  - Spool operations and I/O interfaces consistently expose `Spool`.

- **Documentation**
  - Updated tutorials, extension guidance, and API references to use `Spool`.
  - Clarified spool behavior, performance considerations, and supported extension points.

- **Tests**
  - Added coverage for compatibility aliasing, invalid copies, and updated spool contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->