### PR TITLE
Add a tunnel inventory recipe

### DIFF
--- a/docs/_static/borehole_fiber.svg
+++ b/docs/_static/borehole_fiber.svg
@@ -1,0 +1,491 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="140.14871mm"
+   height="235.66652mm"
+   viewBox="0 0 140.14871 235.66652"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (1:1.4.4+202605061436+dcaf3e7d9e)"
+   sodipodi:docname="borehole_fiber.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.0393815"
+     inkscape:cx="310.28068"
+     inkscape:cy="164.03987"
+     inkscape:window-width="1854"
+     inkscape:window-height="1011"
+     inkscape:window-x="66"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="simplify"
+       id="path-effect4"
+       is_visible="true"
+       lpeversion="1.3"
+       threshold="30"
+       steps="5"
+       smooth_angles="360"
+       helper_size="10"
+       simplify_individual_paths="false"
+       simplify_just_coalesce="false" />
+    <inkscape:path-effect
+       effect="simplify"
+       id="path-effect3"
+       is_visible="true"
+       lpeversion="1.3"
+       threshold="30"
+       steps="1"
+       smooth_angles="360"
+       helper_size="10"
+       simplify_individual_paths="false"
+       simplify_just_coalesce="false" />
+    <inkscape:path-effect
+       effect="simplify"
+       id="path-effect2"
+       is_visible="true"
+       lpeversion="1.3"
+       threshold="30"
+       steps="1"
+       smooth_angles="360"
+       helper_size="10"
+       simplify_individual_paths="false"
+       simplify_just_coalesce="false" />
+    <inkscape:path-effect
+       effect="simplify"
+       id="path-effect1"
+       is_visible="true"
+       lpeversion="1.3"
+       threshold="30"
+       steps="1"
+       smooth_angles="291"
+       helper_size="10.69797"
+       simplify_individual_paths="false"
+       simplify_just_coalesce="false" />
+    <rect
+       x="-142.86613"
+       y="829.98425"
+       width="212.25827"
+       height="151.02992"
+       id="rect8" />
+    <rect
+       x="-142.86613"
+       y="829.98425"
+       width="310.39355"
+       height="87.530617"
+       id="rect8-7" />
+    <rect
+       x="-142.86613"
+       y="829.98425"
+       width="495.1188"
+       height="139.48459"
+       id="rect8-8" />
+    <rect
+       x="-142.86613"
+       y="829.98425"
+       width="495.1188"
+       height="139.48459"
+       id="rect8-8-5" />
+    <rect
+       x="-142.86613"
+       y="829.98425"
+       width="212.25827"
+       height="151.02992"
+       id="rect8-4" />
+    <rect
+       x="-142.86613"
+       y="829.98425"
+       width="310.39355"
+       height="87.530617"
+       id="rect8-7-7" />
+    <rect
+       x="-142.86613"
+       y="829.98425"
+       width="310.39355"
+       height="87.530617"
+       id="rect8-7-7-9" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-22.223618,-41.687649)">
+    <rect
+       style="fill:none;stroke:#010000;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4"
+       width="19.080002"
+       height="167.75999"
+       x="61.559998"
+       y="70.199997"
+       rx="0.64721155" />
+    <rect
+       style="fill:none;stroke:#010000;stroke-width:0.999996;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5"
+       width="24.65877"
+       height="38.89418"
+       x="58.770615"
+       y="237.95999"
+       rx="0.43040565" />
+    <path
+       style="fill:none;stroke:#f08000;stroke-width:0.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 32.074363,63.130493 c 6.403814,-0.773529 13.203773,-4.669011 19.211441,-2.320586 4.01035,1.567664 10.036644,2.501616 10.943301,6.672488 1.192172,5.48432 2.484451,11.062886 2.396747,16.667739 -0.622627,39.790046 -0.780183,79.583816 -0.988996,119.379976 -0.07674,14.62574 0.852053,29.29921 -0.150404,43.88343 -0.429875,6.25402 -2.695717,12.41152 -1.795191,18.74716 0.698094,4.91142 5.832778,3.81878 9.365159,3.9793"
+       id="path5"
+       inkscape:path-effect="#path-effect1"
+       inkscape:original-d="m 32.074363,63.130493 19.211441,-2.320586 c 3.902037,1.470955 8.1213,4.760934 10.943301,6.672488 1.205923,5.226613 1.801837,10.47044 2.410068,15.773576 -0.567661,38.150949 -1.225106,76.301859 -0.999564,114.458509 0.06638,15.5052 -0.521187,31.03882 -0.222607,46.52536 0.974226,5.85548 -4.069913,18.2801 -1.086831,23.59079 1.336479,3.17298 5.512401,2.01607 8.726249,2.30937"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:none;stroke:#ff1b1b;stroke-width:0.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 33.092854,58.486277 c 6.92329,-1.16755 13.872167,-4.812926 20.769869,-3.502651 3.714746,0.705647 7.471078,2.353418 10.071438,5.080334 1.154916,1.211124 2.084687,2.260443 2.430716,4.015949 0.871243,4.420075 2.780052,8.759819 2.68907,13.253165 -0.27108,13.387902 -0.485426,26.776146 -0.99627,40.158626 -0.64121,16.79765 -1.326034,33.59748 -1.565086,50.40526 -0.253084,17.79436 -0.60324,35.58635 -0.980623,53.37883 -0.177182,8.35363 -0.242943,16.70991 -0.494693,25.06242 -0.112155,3.72105 -1.64348,7.94254 0.341911,11.2351 1.375227,2.28066 4.910883,2.30185 7.284997,2.53579"
+       id="path6"
+       sodipodi:nodetypes="ccsccccccccsc"
+       inkscape:path-effect="#path-effect2"
+       inkscape:original-d="m 33.092854,58.486277 20.769869,-3.502651 c 1.835584,0 8.357153,2.949448 10.527091,5.575754 0.980981,1.187295 1.699789,1.742299 1.56724,1.565566 l 3.103132,14.875345 -0.506584,27.020459 -1.013163,27.52083 -1.013164,34.02575 -0.506581,34.02576 -0.506582,21.51629 -0.258418,20.06014 c -0.107959,9.55883 -2.530727,17.49436 2.812027,18.20241 1.492679,0.19782 2.072289,0.83146 4.576462,0.73717" />
+    <path
+       style="fill:none;stroke:#088000;stroke-width:0.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 97.74593,61.605778 c -5.972091,2.00156 -17.430997,-0.275177 -17.916272,6.004681 -1.120207,14.49639 -1.634448,29.046292 -1.448574,43.575391 0.188909,14.76643 0.34087,29.53025 0.337189,44.30044 -0.0039,15.72813 1.239301,31.48338 0.30571,47.18395 -0.55938,9.4073 -0.823054,18.81432 -0.306285,28.26812 0.555269,10.15813 1.909613,20.26976 2.289966,30.43055 0.104126,2.78162 0.111913,6.65312 -3.011433,7.76131 -2.216241,0.78635 -4.61462,0.44525 -6.884772,0.94125"
+       id="path7"
+       sodipodi:nodetypes="cccccccccccc"
+       inkscape:path-effect="#path-effect4"
+       inkscape:original-d="m 97.74593,61.605778 -17.916272,6.004681 -0.601723,7.81883 -0.47482,18.076901 -0.474823,17.01355 0.474823,20.73527 v 34.02711 l 0.47482,33.49544 -1.215,21.70861 1.590538,23.67196 c 0.02331,8.17386 3.156863,20.04079 0.06994,24.52159 -3.206273,0.49565 -5.118253,1.4236 -8.561954,1.39175" />
+    <path
+       style="fill:none;stroke:#0880dd;stroke-width:0.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 97.241571,53.965714 c -4.153916,1.489053 -10.126751,-0.07602 -12.752367,3.507754 -1.685885,2.301106 -4.544976,4.102582 -5.123745,6.873216 -1.099154,5.261775 -3.464422,10.412565 -3.297462,15.785324 0.156749,5.044187 -0.615354,10.06177 -0.511768,15.108316 0.170932,8.327516 0.531005,16.649456 0.402621,24.983236 -0.206271,13.3896 -0.407811,26.77823 -0.39997,40.17053 0.0071,12.06034 0.06381,24.11847 0.24593,36.1789 0.167157,11.06961 1.239359,22.15365 0.666718,33.20713 -0.522531,10.08621 8.52679,29.92979 -1.567592,30.25863 -0.775613,0.0253 -1.551227,0.0505 -2.32684,0.0758"
+       id="path8"
+       sodipodi:nodetypes="cccccccccccc"
+       inkscape:path-effect="#path-effect3"
+       inkscape:original-d="m 97.241571,53.965714 c -4.076762,1.344064 -6.458811,2.607049 -12.752367,3.507754 l -5.089927,6.711325 -3.33128,15.947215 c 0.205533,11.422415 -0.1746,10.089277 -0.516458,14.942997 l 0.516458,18.203205 -0.509117,32.39653 v 37.83508 l 0.381838,20.28229 0.565036,25.32735 -1.601818,30.91929 -2.32684,0.0758" />
+    <g
+       id="g15-0-1"
+       transform="translate(38.758318,282.28113)">
+      <path
+         style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+         id="path15-81-4" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+         id="path15-0-3-6" />
+    </g>
+    <g
+       id="g15-0-1-9"
+       transform="translate(37.732537,292.1026)">
+      <path
+         style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+         id="path15-81-4-2" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+         id="path15-0-3-6-0" />
+    </g>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,124.82516,22.505299)"
+       id="text8"
+       style="font-size:33.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect8);display:inline"><tspan
+         x="-142.86523"
+         y="860.31352"
+         id="tspan2">Downhole </tspan><tspan
+         x="-142.86523"
+         y="901.98014"
+         id="tspan3">splice </tspan><tspan
+         x="-142.86523"
+         y="943.64677"
+         id="tspan4">enclosure</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0,-0.26458333,0.26458333,0,-171.90808,188.28504)"
+       id="text8-4"
+       style="font-size:33.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect8-8);display:inline"><tspan
+         x="-142.86523"
+         y="860.31352"
+         id="tspan5">Strain coupling segment: 40 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,62.090613,-178.51421)"
+       id="text8-4-5"
+       style="font-size:33.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect8-8-5);display:inline"><tspan
+         x="-142.86523"
+         y="860.31352"
+         id="tspan7">Armored pigtails: 15 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,122.28768,-110.93323)"
+       id="text8-2"
+       style="font-size:33.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect8-7);display:inline"><tspan
+         x="-142.86523"
+         y="860.31352"
+         id="tspan8">Fiber Cross Section</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,144.15369,-41.257241)"
+       id="text8-2-3"
+       style="font-size:33.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect8-7-7);display:inline"><tspan
+         x="-142.86523"
+         y="860.31352"
+         id="tspan9">splice</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,143.748,-30.857226)"
+       id="text8-2-3-4"
+       style="font-size:33.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect8-7-7-9);display:inline"><tspan
+         x="-142.86523"
+         y="860.31352"
+         id="tspan10">Connector</tspan></text>
+    <g
+       id="g16-0"
+       transform="matrix(0,-0.89009618,0.89009618,0,10.619053,89.306806)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-4" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-2" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-2" />
+    </g>
+    <g
+       id="g16-0-9"
+       transform="matrix(0,-0.89009618,0.89009618,0,10.819813,94.155521)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-4-3" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-2-1" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-2-9" />
+    </g>
+    <g
+       id="g16-0-5"
+       transform="matrix(0,-0.89009618,0.89009618,0,91.016446,85.202847)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-4-0" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-2-3" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-2-6" />
+    </g>
+    <g
+       id="g16-0-2"
+       transform="matrix(0,-0.89009618,0.89009618,0,91.62934,92.557822)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-4-06" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-2-15" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-2-5" />
+    </g>
+    <g
+       id="g6"
+       transform="translate(-16.037182,-3.5638182)">
+      <circle
+         style="fill:none;stroke:#010000;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="path3"
+         cx="137.79292"
+         cy="149.34731"
+         r="24.5" />
+      <ellipse
+         style="fill:#f08000;fill-opacity:1;stroke:#010000;stroke-width:0.999994;stroke-dasharray:none;stroke-opacity:1"
+         id="path4"
+         cx="123.50751"
+         cy="148.9073"
+         rx="5.5000014"
+         ry="5.5000029" />
+      <circle
+         style="fill:#088000;fill-opacity:1;stroke:#010000;stroke-width:0.999996;stroke-dasharray:none;stroke-opacity:1"
+         id="path4-3"
+         cx="138.07294"
+         cy="164.71884"
+         r="5.5" />
+      <circle
+         style="fill:#ff1b1b;fill-opacity:1;stroke:#010000;stroke-width:0.999996;stroke-dasharray:none;stroke-opacity:1"
+         id="path4-1"
+         cx="138.07294"
+         cy="134.2066"
+         r="5.5" />
+      <ellipse
+         style="fill:#0880dd;fill-opacity:1;stroke:#010000;stroke-width:0.999994;stroke-dasharray:none;stroke-opacity:1"
+         id="path4-36"
+         cx="152.83307"
+         cy="149.23705"
+         inkscape:transform-center-x="4.2654448"
+         inkscape:transform-center-y="3.0109065"
+         rx="5.5000014"
+         ry="5.5000029" />
+      <g
+         id="g16-0-6"
+         transform="matrix(0.62939304,-0.62939304,0.62939304,0.62939304,98.046718,138.65068)"
+         style="stroke-width:1.12347"
+         inkscape:transform-center-x="3.6122648"
+         inkscape:transform-center-y="-0.0065322986">
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+           id="path15-0-1-4-9" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+           id="path15-0-1-7-2-37" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+           id="path15-0-1-7-4-2-4" />
+      </g>
+      <g
+         id="g16-0-7"
+         transform="matrix(0.62939304,-0.62939304,0.62939304,0.62939304,83.121715,153.24152)"
+         style="stroke-width:1.12347">
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+           id="path15-0-1-4-4" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+           id="path15-0-1-7-2-4" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+           id="path15-0-1-7-4-2-3" />
+      </g>
+      <g
+         id="g16-0-8"
+         transform="matrix(0.62939304,-0.62939304,0.62939304,0.62939304,128.70569,167.76797)"
+         style="stroke-width:1.12347">
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+           id="path15-0-1-4-8" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+           id="path15-0-1-7-2-43" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+           id="path15-0-1-7-4-2-1" />
+      </g>
+      <g
+         id="g16-0-68"
+         transform="matrix(0.62939304,-0.62939304,0.62939304,0.62939304,113.73547,183.46277)"
+         style="stroke-width:1.12347">
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+           id="path15-0-1-4-92" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+           id="path15-0-1-7-2-6" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+           id="path15-0-1-7-4-2-64" />
+      </g>
+    </g>
+    <g
+       id="g15-0-1-3"
+       transform="translate(67.973232,206.32397)">
+      <path
+         style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+         id="path15-81-4-3" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+         id="path15-0-3-6-8" />
+    </g>
+    <rect
+       style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6"
+       width="6.2501149"
+       height="3.4184477"
+       x="97.906967"
+       y="192.08904"
+       rx="0.19295804" />
+    <rect
+       style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6-1"
+       width="6.2501149"
+       height="3.4184477"
+       x="95.716896"
+       y="52.682705"
+       rx="0.19295804" />
+    <rect
+       style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6-0"
+       width="6.2501149"
+       height="3.4184477"
+       x="96.235237"
+       y="59.938114"
+       rx="0.19295804" />
+    <rect
+       style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6-5"
+       width="6.2501149"
+       height="3.4184477"
+       x="28.814596"
+       y="56.547092"
+       rx="0.19295804" />
+    <rect
+       style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6-4"
+       width="6.2501149"
+       height="3.4184477"
+       x="29.343763"
+       y="61.306549"
+       rx="0.19295804" />
+    <text
+       xml:space="preserve"
+       style="font-size:5.29167px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583"
+       x="105.71879"
+       y="45.760586"
+       id="text6"><tspan
+         sodipodi:role="line"
+         id="tspan6"
+         style="stroke-width:0.264583"
+         x="105.71879"
+         y="45.760586" /></text>
+  </g>
+</svg>

--- a/docs/_static/tunnel_deployment.svg
+++ b/docs/_static/tunnel_deployment.svg
@@ -1,0 +1,2312 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="194.95705mm"
+   height="216.91768mm"
+   viewBox="0 0 194.95705 216.91768"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (1:1.4.4+202605061436+dcaf3e7d9e)"
+   sodipodi:docname="tunnel.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.6746423"
+     inkscape:cx="28.904206"
+     inkscape:cy="448.38576"
+     inkscape:window-width="1854"
+     inkscape:window-height="1011"
+     inkscape:window-x="66"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g37-33" />
+  <defs
+     id="defs1">
+    <rect
+       x="19.822003"
+       y="190.6688"
+       width="69.848965"
+       height="40.587912"
+       id="rect3" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387075"
+       id="rect2" />
+    <rect
+       x="-227.99385"
+       y="143.94942"
+       width="64.176048"
+       height="61.245049"
+       id="rect1" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14" />
+    <rect
+       x="-42.332867"
+       y="-327.11761"
+       width="513.76709"
+       height="219.36124"
+       id="rect13" />
+    <rect
+       x="78.472733"
+       y="260.81631"
+       width="327.53796"
+       height="47.059082"
+       id="rect11" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-1" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-7" />
+    <rect
+       x="78.472733"
+       y="260.81631"
+       width="327.53796"
+       height="47.059082"
+       id="rect11-8" />
+    <rect
+       x="78.472733"
+       y="260.81631"
+       width="327.53796"
+       height="47.059082"
+       id="rect11-8-5" />
+    <rect
+       x="78.472733"
+       y="260.81631"
+       width="327.53796"
+       height="47.059082"
+       id="rect11-8-5-4" />
+    <rect
+       x="78.472733"
+       y="260.81631"
+       width="327.53796"
+       height="47.059082"
+       id="rect11-8-6" />
+    <rect
+       x="-42.332867"
+       y="-327.11761"
+       width="513.76709"
+       height="219.36124"
+       id="rect13-4" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-6" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-7-8" />
+    <rect
+       x="-42.332867"
+       y="-327.11761"
+       width="513.76709"
+       height="219.36124"
+       id="rect13-43" />
+    <rect
+       x="-42.332867"
+       y="-327.11761"
+       width="513.76709"
+       height="219.36124"
+       id="rect13-43-0" />
+    <rect
+       x="-42.332867"
+       y="-327.11761"
+       width="513.76709"
+       height="219.36124"
+       id="rect13-43-2" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2" />
+    <rect
+       x="78.472733"
+       y="260.81631"
+       width="327.53796"
+       height="47.059082"
+       id="rect11-7" />
+    <rect
+       x="78.472733"
+       y="260.81631"
+       width="327.53796"
+       height="47.059082"
+       id="rect11-8-5-2" />
+    <rect
+       x="-227.99385"
+       y="143.94942"
+       width="64.176048"
+       height="61.245049"
+       id="rect1-7" />
+    <rect
+       x="-227.99385"
+       y="143.94942"
+       width="64.176048"
+       height="61.245049"
+       id="rect1-1" />
+    <rect
+       x="-227.99385"
+       y="143.94942"
+       width="64.176048"
+       height="61.245049"
+       id="rect1-0" />
+    <rect
+       x="-227.99385"
+       y="143.94942"
+       width="64.176048"
+       height="61.245049"
+       id="rect1-9" />
+    <rect
+       x="-227.99385"
+       y="143.94942"
+       width="64.176048"
+       height="61.245049"
+       id="rect1-9-9" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-1" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-6" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-7" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-9" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-4" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-7-8-9" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-4-4" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-8" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-8-4" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-8-4-6" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-8-4-7" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-1" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-1-1" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-1-1-3" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-1-0" />
+    <rect
+       x="78.472733"
+       y="260.81631"
+       width="327.53796"
+       height="47.059082"
+       id="rect11-8-5-2-1" />
+    <rect
+       x="78.472733"
+       y="260.81631"
+       width="327.53796"
+       height="47.059082"
+       id="rect11-8-62" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-3" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-3-2" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-3-4" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-3-2-8" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-3-2-8-8" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-3-2-8-5" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-3-2-8-9" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-3-2-8-9-5" />
+    <rect
+       x="251.11089"
+       y="522.42609"
+       width="93.32473"
+       height="32.711761"
+       id="rect10-3-2-8-5-1" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-9-6" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="148.11569"
+       height="22.973045"
+       id="rect2-7" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7-9" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7-9-1" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7-9-1-8" />
+    <rect
+       x="-42.332867"
+       y="-327.11761"
+       width="513.76709"
+       height="219.36124"
+       id="rect13-6" />
+    <rect
+       x="-42.332867"
+       y="-327.11761"
+       width="513.76709"
+       height="219.36124"
+       id="rect13-43-3" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-20" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-6" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-4-1" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-4-4-5" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-5" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-1-4" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-6-7" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-7-6" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-9-5" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-7-9-6-6" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-9" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-8-3" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-8-4-74" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-8-4-6-5" />
+    <rect
+       x="47.924412"
+       y="-30.78754"
+       width="58.47575"
+       height="23.916016"
+       id="rect14-2-2-8-4-7-2" />
+    <rect
+       x="-227.99385"
+       y="143.94942"
+       width="64.176048"
+       height="61.245049"
+       id="rect1-5" />
+    <rect
+       x="-227.99385"
+       y="143.94942"
+       width="64.176048"
+       height="61.245049"
+       id="rect1-7-4" />
+    <rect
+       x="-227.99385"
+       y="143.94942"
+       width="64.176048"
+       height="61.245049"
+       id="rect1-1-7" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-4" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-4" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-3" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7-0" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7-9-7" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7-9-1-86" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7-9-1-8-8" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7-9-1-8-0" />
+    <rect
+       x="29.623137"
+       y="12.69563"
+       width="121.51532"
+       height="51.387074"
+       id="rect2-9-6-7-9-1-8-0-4" />
+    <rect
+       x="-42.332867"
+       y="-327.11761"
+       width="513.76709"
+       height="219.36124"
+       id="rect13-43-5" />
+    <rect
+       x="19.822002"
+       y="190.66879"
+       width="69.848969"
+       height="40.587914"
+       id="rect3-9" />
+    <rect
+       x="19.822002"
+       y="190.66879"
+       width="69.848969"
+       height="40.587914"
+       id="rect3-9-0" />
+    <rect
+       x="19.822002"
+       y="190.66879"
+       width="69.848969"
+       height="40.587914"
+       id="rect3-9-0-6" />
+    <rect
+       x="19.822002"
+       y="190.66879"
+       width="69.848969"
+       height="40.587914"
+       id="rect3-9-0-6-2" />
+    <rect
+       x="19.822002"
+       y="190.66879"
+       width="69.848969"
+       height="40.587914"
+       id="rect3-9-0-6-2-2" />
+    <rect
+       x="19.822002"
+       y="190.66879"
+       width="69.848969"
+       height="40.587914"
+       id="rect3-9-0-6-2-2-1" />
+    <rect
+       x="19.822002"
+       y="190.66879"
+       width="69.848969"
+       height="40.587914"
+       id="rect3-9-0-6-2-2-9" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0.85355186,-3.9413331)">
+    <g
+       id="g21"
+       transform="translate(0,99.278392)">
+      <path
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:3.99999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 45.652941,199.81372 V 160.54371"
+         id="path1" />
+      <circle
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:1.25;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path14"
+         cx="45.652943"
+         cy="204.18411"
+         r="1.875" />
+      <circle
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:1.25;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path14-5"
+         cx="45.652943"
+         cy="211.15109"
+         r="1.875" />
+      <circle
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:1.25;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path14-6"
+         cx="45.652943"
+         cy="218.11809"
+         r="1.875" />
+    </g>
+    <g
+       id="g21-8"
+       transform="translate(66.280689,99.519317)">
+      <path
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:3.99999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 45.652941,199.81372 V 160.54371"
+         id="path1-9" />
+      <circle
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:1.25;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path14-60"
+         cx="45.652943"
+         cy="204.18411"
+         r="1.875" />
+      <circle
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:1.25;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path14-5-7"
+         cx="45.652943"
+         cy="211.15109"
+         r="1.875" />
+      <circle
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:1.25;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path14-6-0"
+         cx="45.652943"
+         cy="218.11809"
+         r="1.875" />
+    </g>
+    <g
+       id="g21-8-5"
+       transform="translate(132.986,99.391537)">
+      <path
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:3.99999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 45.652941,199.81372 V 160.54371"
+         id="path1-9-2" />
+      <circle
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:1.25;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path14-60-0"
+         cx="45.652943"
+         cy="204.18411"
+         r="1.875" />
+      <circle
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:1.25;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path14-5-7-2"
+         cx="45.652943"
+         cy="211.15109"
+         r="1.875" />
+      <circle
+         style="fill:#f08000;fill-opacity:1;stroke:#f08000;stroke-width:1.25;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path14-6-0-9"
+         cx="45.652943"
+         cy="218.11809"
+         r="1.875" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6.2540349,148.5656 H 189.89403"
+       id="path4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 190.59224,26.640005 H 6.9522422"
+       id="path9" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.8052276,259.95438 c 191.1599924,0 191.1599924,0 191.1599924,0"
+       id="path2" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 45.65294,259.70707 v -5.7343 h 66.31436 v 5.7343"
+       id="path5" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 112.41168,259.70707 v -5.7343 h 66.31436 v 5.7343"
+       id="path5-3" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.160001,43.060006 H 187.98001"
+       id="path6" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 13.40259,272.00555 h 170.82"
+       id="path6-31" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 18.226106,264.94885 V 244.48611"
+       id="path6-31-7" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 13.822848,271.73466 4.603406,-7.1416"
+       id="path6-31-7-0" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 184.06335,272.24401 4.74831,-8.1462"
+       id="path6-31-7-0-5" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.070001,27.123677 V 43.560006"
+       id="path6-3-4" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 187.97892,27.006177 V 43.442506"
+       id="path6-3-4-5" />
+    <ellipse
+       style="fill:#f08000;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="path7"
+       cx="178.72083"
+       cy="29.933279"
+       rx="3.804105"
+       ry="3.7821021" />
+    <ellipse
+       style="fill:#f08000;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="path7-2"
+       cx="45.647713"
+       cy="30.17531"
+       rx="3.804105"
+       ry="3.7821021" />
+    <ellipse
+       style="fill:#f08000;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="path7-6"
+       cx="112.09437"
+       cy="29.888474"
+       rx="3.804105"
+       ry="3.7821021" />
+    <path
+       style="fill:none;stroke:#fc0000;stroke-width:0.749999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.160001,26.895545 H -0.7875053"
+       id="path8" />
+    <path
+       style="fill:none;stroke:#fc0000;stroke-width:0.749999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.093955,243.56579 H -0.85355186"
+       id="path8-2" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,6.2768999,109.77093)"
+       id="text10"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan2">20 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0,-0.26458333,0.26458333,0,-100.61741,324.33987)"
+       id="text10-7"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-3);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan3">1.5 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0,-0.26458333,0.26458333,0,-34.251068,324.93052)"
+       id="text10-7-8"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-3-2);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan4">1.5 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,20.008707,97.775659)"
+       id="text10-7-8-4"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-3-2-8);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan5">10.0 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,54.0042,97.95112)"
+       id="text10-7-8-4-1"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-3-2-8-8);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan6">10.0 m </tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-11.459268,97.895452)"
+       id="text10-7-8-4-2"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-3-2-8-5);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan7">10.0 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-30.620445,98.129791)"
+       id="text10-7-8-4-2-2"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-3-2-8-5-1);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan8">5 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0,-0.26458333,0.26458333,0,32.491688,324.22531)"
+       id="text10-7-4"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-3-4);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan9">1.5 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0,-0.26458333,0.26458333,0,-102.30733,366.55946)"
+       id="text10-33"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-6);display:inline"
+       inkscape:transform-center-x="19.091883"
+       inkscape:transform-center-y="-3.0547013"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan10">40  m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-40.296934,121.20818)"
+       id="text10-6"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-7);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan11">0.5 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-11.926684,127.51308)"
+       id="text10-6-9"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-7-8);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan13">25 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,74.849283,127.51308)"
+       id="text10-6-9-4"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-7-8-9);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan14">25 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,73.035643,109.77093)"
+       id="text10-3"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-1);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan15">20 m</tspan></text>
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764997;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764997, 0.764997;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 113.99694,26.261277 -0.0837,5.528052"
+       id="path11-2-48"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765001;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765001, 0.765001;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 47.265519,26.686077 -0.08373,5.349099"
+       id="path11-2-48-77"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765001;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765001, 0.765001;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 43.626999,26.391699 -0.08373,5.349099"
+       id="path11-2-48-77-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765, 0.765;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 43.797162,26.802796 36.088158,26.550099"
+       id="path11-2-48-77-2"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 110.53385,26.843741 c -4.17805,0.08461 -31.758774,-0.07706 -31.758774,-0.07706"
+       id="path11-2-4-6-6-0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765001;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765001, 0.765001;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 110.02043,31.701961 0.0837,-5.487727"
+       id="path11-2-48-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765, 0.765;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 180.80241,31.572478 0.14175,-5.55634"
+       id="path11-2-4"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765, 0.765;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 176.9026,31.656922 0.14175,-5.55634"
+       id="path11-2-4-68"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 177.48743,26.837727 c -4.24943,0.06364 -32.30128,-0.05796 -32.30128,-0.05796"
+       id="path11-2-4-6"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 152.97926,26.837727 c -5.20023,0.06364 -39.52872,-0.05796 -39.52872,-0.05796"
+       id="path11-2-4-6-6"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764998;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764998, 0.764998;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 78.792381,26.786709 c -4.204173,0.08785 -31.957306,-0.08 -31.957306,-0.08"
+       id="path11-2-4-6-6-0-4"
+       sodipodi:nodetypes="cc" />
+    <g
+       id="g16"
+       transform="translate(16.918379,86.28949)">
+      <path
+         style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 18.75427,68.299668 H 35.1906"
+         id="path6-3" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.26458333,0,0,0.26458333,16.20993,-4.1469319)"
+         id="text11"
+         style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect11);display:inline"><tspan
+           x="78.472656"
+           y="279.01391"
+           id="tspan16">Trenched Fiber</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-13.876216,-56.046699)"
+       id="text11-3"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect11-7);display:inline" />
+    <g
+       id="g17"
+       transform="translate(16.918379,86.53949)">
+      <path
+         style="fill:none;stroke:#fc0000;stroke-width:0.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 35.0106,77.589671 H 18.845445"
+         id="path8-7" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.26458333,0,0,0.26458333,16.20993,5.1430709)"
+         id="text11-0"
+         style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect11-8);display:inline"><tspan
+           x="78.472656"
+           y="279.01391"
+           id="tspan17">Telemetry Fiber</tspan></text>
+      <text
+         xml:space="preserve"
+         transform="matrix(0.26458333,0,0,0.26458333,15.910645,23.946245)"
+         id="text11-0-5"
+         style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect11-8-62);display:inline"><tspan
+           x="78.472656"
+           y="279.01391"
+           id="tspan18">Cable Coil</tspan></text>
+    </g>
+    <g
+       id="g18"
+       transform="translate(16.918379,86.28949)">
+      <path
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 34.995018,87.399248 c -2.122737,0.0636 -16.13563,-0.058 -16.13563,-0.058"
+         id="path11-2-4-6-7"
+         sodipodi:nodetypes="cc" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.26458333,0,0,0.26458333,16.20993,14.933074)"
+         id="text11-0-7"
+         style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect11-8-6);display:inline"><tspan
+           x="78.472656"
+           y="279.01391"
+           id="tspan19">Connecting Fiber</tspan></text>
+    </g>
+    <g
+       id="g19"
+       transform="translate(-16.480604,88.269608)">
+      <ellipse
+         style="fill:#f08000;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="path7-2-6"
+         cx="124.40694"
+         cy="66.31955"
+         rx="3.804105"
+         ry="3.7821021" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.26458333,0,0,0.26458333,110.94067,-5.5185049)"
+         id="text11-0-1"
+         style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect11-8-5);display:inline"><tspan
+           x="78.472656"
+           y="279.01391"
+           id="tspan20">Instrumented Borehole</tspan></text>
+    </g>
+    <g
+       id="g20"
+       transform="translate(-16.602725,87.318724)">
+      <rect
+         style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="rect7-5-9-4"
+         width="6.3639612"
+         height="7.3026814"
+         x="121.22495"
+         y="73.159096"
+         rx="0.79374999"
+         inkscape:transform-center-x="-17.64" />
+      <text
+         xml:space="preserve"
+         transform="matrix(0.26458333,0,0,0.26458333,110.39731,4.3638366)"
+         id="text11-0-1-0"
+         style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect11-8-5-4);display:inline"><tspan
+           x="78.472656"
+           y="279.01391"
+           id="tspan21">Connector/Splice Box</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-size:5.29167px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583"
+       x="81.999168"
+       y="99.800125"
+       id="text12"><tspan
+         sodipodi:role="line"
+         id="tspan12"
+         style="stroke-width:0.264583"
+         x="81.999168"
+         y="99.800125" /></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,95.840687,88.966422)"
+       id="text13"
+       style="font-size:33.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect13);display:inline"><tspan
+         x="-42.332031"
+         y="-296.78804"
+         id="tspan22">Map View</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,94.706274,97.785841)"
+       id="text13-0"
+       style="font-size:18.6667px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect13-43);display:inline"><tspan
+         x="-42.332031"
+         y="-310.13282"
+         id="tspan23">(Optical Distances)</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,94.706274,151.6428)"
+       id="text13-0-1"
+       style="font-size:18.6667px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect13-43-5);display:inline"><tspan
+         x="-42.332031"
+         y="-310.13282"
+         id="tspan24">(Coordinates)</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,94.14878,312.97065)"
+       id="text13-0-7"
+       style="font-size:18.6667px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect13-43-2);display:inline"><tspan
+         x="-42.332031"
+         y="-310.13282"
+         id="tspan38">(Physical Distances)</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,92.244034,302.62471)"
+       id="text13-5"
+       style="font-size:33.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect13-4);display:inline"><tspan
+         x="-42.332031"
+         y="-296.78804"
+         id="tspan39">Profile View</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-13.180253,37.106473)"
+       id="text14"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan40">1500 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,39.980678,52.579712)"
+       id="text14-3"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan41">25 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,131.19321,52.579712)"
+       id="text14-3-3"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-4);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan42">25 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,86.370152,57.965813)"
+       id="text14-3-3-4"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-4-4);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan43">10 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,143.99529,29.094949)"
+       id="text14-3-56"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-7);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan44">15 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,115.06562,28.221557)"
+       id="text14-3-56-0"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-7-1);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan64">15 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,76.13195,29.530789)"
+       id="text14-3-56-2"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-7-6);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan65">15 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,47.241617,28.051632)"
+       id="text14-3-56-02"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-7-7);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan66">15 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,18.100388,28.051632)"
+       id="text14-3-56-8"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-7-9);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan67">15 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,165.22239,25.733981)"
+       id="text14-3-56-8-4"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-7-9-6);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan68">15 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0,-0.26458333,0.26458333,0,18.280782,58.013569)"
+       id="text14-3-5"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-2);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan69">2.5 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0,-0.26458333,0.26458333,0,19.870541,271.92304)"
+       id="text14-3-5-3"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-2-1);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan70">2 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.13229166,-0.22913589,0.22913589,0.13229166,6.4819141,285.14608)"
+       id="text14-3-5-3-8"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-2-1-1);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan71">2.5 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0,-0.26458333,0.26458333,0,191.40129,271.45701)"
+       id="text14-3-5-3-4"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-2-1-0);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan72">2 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.13229166,-0.22913589,0.22913589,0.13229166,185.08167,288.36691)"
+       id="text14-3-5-3-8-6"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-2-1-1-3);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan73">2.5 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0,-0.26458333,0.26458333,0,198.33818,54.203793)"
+       id="text14-3-5-8"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-2-8);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan74">2.5 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,161.21709,43.094672)"
+       id="text14-3-5-8-0"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-2-8-4);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan75">40 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,94.20956,43.256854)"
+       id="text14-3-5-8-0-9"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-2-8-4-6);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan76">40 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,27.78608,43.357642)"
+       id="text14-3-5-8-0-2"
+       style="font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect14-2-2-8-4-7);display:inline"><tspan
+         x="47.923828"
+         y="-16.229106"
+         id="tspan77">40 m</tspan></text>
+    <rect
+       style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7-5"
+       width="6.3639612"
+       height="7.3026814"
+       x="142.22562"
+       y="22.488665"
+       rx="0.79374999"
+       inkscape:transform-center-x="-17.64" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,94.28041,102.02316)"
+       id="text11-0-1-4"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect11-8-5-2);display:inline"><tspan
+         x="78.472656"
+         y="279.01391"
+         id="tspan78">Fiber Splice</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,93.08002,111.61728)"
+       id="text11-0-1-4-3"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect11-8-5-2-1);display:inline"><tspan
+         x="78.472656"
+         y="279.01391"
+         id="tspan79">Fiber Coupler</tspan></text>
+    <g
+       id="g15-0-1"
+       transform="translate(74.480385,196.7194)">
+      <path
+         style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+         id="path15-81-4" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+         id="path15-0-3-6" />
+    </g>
+    <rect
+       style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7"
+       width="6.3639612"
+       height="7.3026814"
+       x="184.79802"
+       y="22.488665"
+       rx="0.79374999" />
+    <g
+       id="g15-2"
+       transform="translate(154.41208,48.198911)">
+      <path
+         style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+         id="path15-4" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+         id="path15-0-0" />
+    </g>
+    <g
+       id="g10">
+      <rect
+         style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="rect7-5-9-4-3"
+         width="6.3639612"
+         height="7.3026814"
+         x="13.978022"
+         y="23.244204"
+         rx="0.79374999"
+         inkscape:transform-center-x="-17.64" />
+      <g
+         id="g15"
+         transform="translate(-16.407915,49.145187)">
+        <path
+           style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+           id="path15" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+           id="path15-0" />
+      </g>
+    </g>
+    <g
+       id="g9"
+       transform="translate(7.7061538,134.94297)">
+      <rect
+         style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="rect7-5-9-4-3-9"
+         width="6.3639612"
+         height="7.3026814"
+         x="6.8379722"
+         y="-111.89917"
+         rx="0.79374999"
+         inkscape:transform-center-x="-17.64"
+         transform="scale(1,-1)"
+         inkscape:transform-center-y="-4.4189454e-06" />
+      <g
+         id="g15-1"
+         transform="matrix(1,0,0,-1,-23.547965,85.998185)">
+        <path
+           style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+           id="path15-7" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+           id="path15-0-7" />
+      </g>
+    </g>
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 188.59992,244.35967 v 20.46274"
+       id="path6-31-7-6" />
+    <rect
+       style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7-5-9-4-3-9-5"
+       width="6.3639612"
+       height="7.3026814"
+       x="184.91794"
+       y="238.72086"
+       rx="0.79374999"
+       inkscape:transform-center-x="-17.64" />
+    <g
+       id="g15-1-6"
+       transform="translate(154.532,264.62182)">
+      <path
+         style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+         id="path15-7-3" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+         id="path15-0-7-9" />
+    </g>
+    <g
+       id="g16-4"
+       transform="matrix(0,0.89009618,-0.89009618,0,144.52742,-1.6034592)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-99" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-3" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-6" />
+    </g>
+    <g
+       id="g16-4-9"
+       transform="matrix(0,0.89009618,-0.89009618,0,79.1154,-0.43858117)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-99-4" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-3-3" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-6-5" />
+    </g>
+    <g
+       id="g16-2"
+       transform="matrix(0,-0.89009618,0.89009618,0,87.599177,71.345883)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-9" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-0" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-28" />
+    </g>
+    <g
+       id="g16-2-0"
+       transform="matrix(-0.89009618,0,0,-0.89009618,216.44215,51.338533)"
+       style="stroke-width:1.12347"
+       inkscape:transform-center-x="6.39"
+       inkscape:transform-center-y="7.2989296">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-9-9" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-0-1" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-28-9" />
+    </g>
+    <g
+       id="g16-0"
+       transform="matrix(0.89009618,0,0,0.89009618,-11.302158,22.484602)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-4" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-2" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-2" />
+    </g>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,104.43851,-10.596233)"
+       id="text1"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1);display:inline"><tspan
+         x="-227.99414"
+         y="162.14672"
+         id="tspan80">1</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,170.79122,-10.890219)"
+       id="text1-5"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1-7);display:inline"><tspan
+         x="-227.99414"
+         y="162.14672"
+         id="tspan81">2</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,237.52885,-10.784664)"
+       id="text1-0"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1-1);display:inline"><tspan
+         x="-227.99414"
+         y="162.14672"
+         id="tspan82">3</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,104.80163,243.99889)"
+       id="text1-6"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1-0);display:inline"><tspan
+         x="-227.99414"
+         y="162.14672"
+         id="tspan83">1</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,170.92021,244.02535)"
+       id="text1-2"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1-9);display:inline"><tspan
+         x="-227.99414"
+         y="162.14672"
+         id="tspan84">2</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,237.70012,243.9989)"
+       id="text1-2-8"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1-9-9);display:inline"><tspan
+         x="-227.99414"
+         y="162.14672"
+         id="tspan85">3</tspan></text>
+    <g
+       id="g14">
+      <circle
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.75;stroke-dasharray:0.75, 0.75;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3"
+         cx="34.611988"
+         cy="27.027479"
+         r="2.4413249" />
+      <ellipse
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.750001;stroke-dasharray:0.750001, 0.750001;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-0"
+         cx="34.604832"
+         cy="27.059286"
+         rx="3.3423033"
+         ry="3.3426566" />
+    </g>
+    <g
+       id="g14-6"
+       transform="translate(-2.7835651,214.99168)">
+      <circle
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.75;stroke-dasharray:0.75, 0.75;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-9"
+         cx="34.611988"
+         cy="27.027479"
+         r="2.4413249" />
+      <ellipse
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.750001;stroke-dasharray:0.750001, 0.750001;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-0-4"
+         cx="34.604832"
+         cy="27.059286"
+         rx="3.3423033"
+         ry="3.3426566" />
+    </g>
+    <g
+       id="g14-6-9"
+       transform="translate(147.73239,215.3287)">
+      <circle
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.75;stroke-dasharray:0.75, 0.75;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-9-9"
+         cx="34.611988"
+         cy="27.027479"
+         r="2.4413249" />
+      <ellipse
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.750001;stroke-dasharray:0.750001, 0.750001;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-0-4-7"
+         cx="34.604832"
+         cy="27.059286"
+         rx="3.3423033"
+         ry="3.3426566" />
+    </g>
+    <g
+       id="g14-6-9-1"
+       transform="translate(148.30701,-1.0450584)">
+      <circle
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.75;stroke-dasharray:0.75, 0.75;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-9-9-1"
+         cx="34.611988"
+         cy="27.027479"
+         r="2.4413249" />
+      <ellipse
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.750001;stroke-dasharray:0.750001, 0.750001;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-0-4-7-9"
+         cx="34.604832"
+         cy="27.059286"
+         rx="3.3423033"
+         ry="3.3426566" />
+    </g>
+    <circle
+       style="fill:none;stroke:#585cff;stroke-width:0.75;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3-2"
+       cx="102.54069"
+       cy="45.649364"
+       r="2.3037231" />
+    <ellipse
+       style="fill:none;stroke:#585cff;stroke-width:0.750001;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3-2-4"
+       cx="102.54069"
+       cy="45.649364"
+       rx="3.2182388"
+       ry="3.2186263" />
+    <circle
+       style="fill:none;stroke:#585cff;stroke-width:0.75;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3-2-47"
+       cx="104.90033"
+       cy="267.92715"
+       r="2.3037231" />
+    <ellipse
+       style="fill:none;stroke:#585cff;stroke-width:0.750001;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3-2-4-6"
+       cx="104.90033"
+       cy="267.92715"
+       rx="3.2182388"
+       ry="3.2186263" />
+    <g
+       id="g11"
+       transform="translate(13.06182,76.611067)">
+      <circle
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.75;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-2-6"
+         cx="30.787302"
+         cy="105.71272"
+         r="2.3037231" />
+      <ellipse
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.750001;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-2-4-2"
+         cx="30.787302"
+         cy="105.71272"
+         rx="3.2182388"
+         ry="3.2186263" />
+    </g>
+    <rect
+       style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6-0"
+       width="6.2501149"
+       height="3.4184477"
+       x="104.92324"
+       y="182.35466"
+       rx="0.19295804" />
+    <g
+       id="g13">
+      <rect
+         style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="rect7-5-9"
+         width="6.3639612"
+         height="7.3026814"
+         x="75.599159"
+         y="22.745932"
+         rx="0.79374999"
+         inkscape:transform-center-x="-17.64" />
+      <rect
+         style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6-0-6"
+         width="6.2501149"
+         height="3.4184477"
+         x="75.656082"
+         y="24.688049"
+         rx="0.19295804" />
+    </g>
+    <rect
+       style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6-0-0"
+       width="6.2501149"
+       height="3.4184477"
+       x="142.28255"
+       y="24.430782"
+       rx="0.19295804" />
+    <g
+       id="g12"
+       transform="translate(-2.4426727,100.19038)">
+      <rect
+         style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="rect7-5-99"
+         width="6.3639612"
+         height="7.3026814"
+         x="144.66829"
+         y="138.53047"
+         rx="0.79374999"
+         inkscape:transform-center-x="-17.64" />
+      <rect
+         style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6-0-0-1"
+         width="6.2501149"
+         height="3.4184477"
+         x="144.72522"
+         y="140.47258"
+         rx="0.19295804" />
+    </g>
+    <g
+       id="g12-7"
+       transform="translate(-69.06913,100.19038)">
+      <rect
+         style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="rect7-5-99-5"
+         width="6.3639612"
+         height="7.3026814"
+         x="144.66829"
+         y="138.53047"
+         rx="0.79374999"
+         inkscape:transform-center-x="-17.64" />
+      <rect
+         style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6-0-0-1-8"
+         width="6.2501149"
+         height="3.4184477"
+         x="144.72522"
+         y="140.47258"
+         rx="0.19295804" />
+    </g>
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 180.15082,260.60897 c -0.0636,-2.47395 0.058,-18.8053 0.058,-18.8053"
+       id="path11-2-4-6-1"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 177.30803,260.60897 c -0.0636,-2.47395 0.058,-18.8053 0.058,-18.8053"
+       id="path11-2-4-6-1-2"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 113.06502,260.04107 c -0.0636,-2.37928 0.058,-18.08564 0.058,-18.08564"
+       id="path11-2-4-6-1-2-1"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 110.85309,260.01011 c -0.0636,-2.36152 0.058,-17.95071 0.058,-17.95071"
+       id="path11-2-4-6-1-2-4"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 47.466817,258.22877 c -0.0636,-2.13922 0.058,-16.26092 0.058,-16.26092"
+       id="path11-2-4-6-1-2-4-8"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 44.250049,260.03466 c -0.0636,-2.36152 0.058,-17.95071 0.058,-17.95071"
+       id="path11-2-4-6-1-2-4-2"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764996;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764996, 0.764996;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 34.909136,242.3544 c 1.35157,-0.0636 10.27372,0.058 10.27372,0.058"
+       id="path11-2-4-6-1-2-4-2-3"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 145.28471,242.3523 c 4.28112,-0.0636 32.54214,0.058 32.54214,0.058"
+       id="path11-2-4-6-1-2-9"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 112.88791,242.3523 c 4.2634,-0.0636 32.40747,0.058 32.40747,0.058"
+       id="path11-2-4-6-1-2-9-8"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 79.250455,242.3523 c 4.11282,-0.0636 31.262845,0.058 31.262845,0.058"
+       id="path11-2-4-6-1-2-9-8-6"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 47.782482,242.3523 c 4.11282,-0.0636 31.26284,0.058 31.26284,0.058"
+       id="path11-2-4-6-1-2-9-8-6-1"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,86.68265,98.176998)"
+       id="text10-7-8-4-9"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-3-2-8-9);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan86">10.0 m</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,111.09812,94.195525)"
+       id="text10-7-8-4-9-9"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect10-3-2-8-9-5);display:inline"><tspan
+         x="251.11133"
+         y="540.62328"
+         id="tspan87">1.0 m </tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,94.98561,12.288334)"
+       id="text2-7-2-0-8-3-0"
+       style="font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2-9-6-7-9-1-8);display:inline"><tspan
+         x="29.623047"
+         y="28.466452"
+         id="tspan88">x=126.00
+</tspan><tspan
+         x="29.623047"
+         y="50.133078"
+         id="tspan89">y=100.00</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,97.304647,76.928429)"
+       id="text2-7-2-0-8-3-0-5"
+       style="font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2-9-6-7-9-1-8-0);display:inline"><tspan
+         x="29.623047"
+         y="28.466452"
+         id="tspan90">x=126.00
+</tspan><tspan
+         x="29.623047"
+         y="50.133078"
+         id="tspan91">y=100.00</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,30.103197,76.769374)"
+       id="text2-7-2-0-8-3-0-5-2"
+       style="font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2-9-6-7-9-1-8-0-4);display:inline"><tspan
+         x="29.623047"
+         y="28.466452"
+         id="tspan92">x=108.00
+</tspan><tspan
+         x="29.623047"
+         y="50.133078"
+         id="tspan93">y=100.00</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 191.13895,95.056959 H 7.4989497"
+       id="path9-3" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.706709,111.47696 H 188.52672"
+       id="path6-1" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.616709,95.540631 V 111.97696"
+       id="path6-3-4-4" />
+    <path
+       style="fill:none;stroke:#585cff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 188.52563,95.423131 V 111.85946"
+       id="path6-3-4-5-9" />
+    <ellipse
+       style="fill:#f08000;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="path7-20"
+       cx="179.26753"
+       cy="98.350227"
+       rx="3.804105"
+       ry="3.7821021" />
+    <ellipse
+       style="fill:#f08000;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="path7-2-68"
+       cx="46.19442"
+       cy="98.592262"
+       rx="3.804105"
+       ry="3.7821021" />
+    <ellipse
+       style="fill:#f08000;fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="path7-6-9"
+       cx="112.64108"
+       cy="98.305428"
+       rx="3.804105"
+       ry="3.7821021" />
+    <path
+       style="fill:none;stroke:#fc0000;stroke-width:0.749999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.706709,95.312499 H -0.24079726"
+       id="path8-26" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764997;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764997, 0.764997;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 114.54365,94.678231 -0.0837,5.528049"
+       id="path11-2-48-6"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765001;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765001, 0.765001;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 47.812227,95.103031 -0.08373,5.349099"
+       id="path11-2-48-77-4"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765001;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765001, 0.765001;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 44.173707,94.808653 -0.08373,5.349097"
+       id="path11-2-48-77-7-9"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765, 0.765;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 44.34387,95.21975 36.634866,94.967053"
+       id="path11-2-48-77-2-5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 111.08056,95.260695 c -4.17805,0.08461 -31.758776,-0.07706 -31.758776,-0.07706"
+       id="path11-2-4-6-6-0-0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765001;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765001, 0.765001;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 110.56714,100.11891 0.0837,-5.487722"
+       id="path11-2-48-7-4"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765, 0.765;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 181.34912,99.989432 0.14175,-5.55634"
+       id="path11-2-4-8"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.765;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.765, 0.765;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 177.44931,100.07388 0.14175,-5.556344"
+       id="path11-2-4-68-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 178.03414,95.254681 c -4.24943,0.06364 -32.30128,-0.05796 -32.30128,-0.05796"
+       id="path11-2-4-6-17"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764999, 0.764999;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 153.52597,95.254681 c -5.20023,0.06364 -39.52872,-0.05796 -39.52872,-0.05796"
+       id="path11-2-4-6-6-2"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#7c7c7d;stroke-width:0.764998;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.764998, 0.764998;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 79.339089,95.203663 c -4.204173,0.08785 -31.957306,-0.08 -31.957306,-0.08"
+       id="path11-2-4-6-6-0-4-7"
+       sodipodi:nodetypes="cc" />
+    <rect
+       style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7-5-90"
+       width="6.3639612"
+       height="7.3026814"
+       x="142.77232"
+       y="90.905617"
+       rx="0.79374999"
+       inkscape:transform-center-x="-17.64" />
+    <rect
+       style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7-8"
+       width="6.3639612"
+       height="7.3026814"
+       x="185.34473"
+       y="90.905617"
+       rx="0.79374999" />
+    <g
+       id="g15-2-8"
+       transform="translate(154.95879,116.61586)">
+      <path
+         style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+         id="path15-4-5" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+         id="path15-0-0-0" />
+    </g>
+    <g
+       id="g10-9"
+       transform="translate(0.54670774,68.416954)">
+      <rect
+         style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="rect7-5-9-4-3-6"
+         width="6.3639612"
+         height="7.3026814"
+         x="13.978022"
+         y="23.244204"
+         rx="0.79374999"
+         inkscape:transform-center-x="-17.64" />
+      <g
+         id="g15-3"
+         transform="translate(-16.407915,49.145187)">
+        <path
+           style="fill:none;stroke:#ff0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 31.272689,-24.544869 c 4.590453,4.590453 4.590453,4.590453 4.590453,4.590453"
+           id="path15-8" />
+        <path
+           style="fill:none;stroke:#fa0000;stroke-width:0.65;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 35.863142,-24.544869 c -4.590453,4.590453 -4.590453,4.590453 -4.590453,4.590453"
+           id="path15-0-5" />
+      </g>
+    </g>
+    <g
+       id="g16-4-6"
+       transform="matrix(0,0.89009618,-0.89009618,0,145.07413,66.813495)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-99-1" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-3-1" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-6-59" />
+    </g>
+    <g
+       id="g16-4-9-8"
+       transform="matrix(0,0.89009618,-0.89009618,0,79.662108,67.978373)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-99-4-4" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-3-3-8" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-6-5-1" />
+    </g>
+    <g
+       id="g16-2-03"
+       transform="matrix(0,-0.89009618,0.89009618,0,88.145885,139.76283)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-9-0" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-0-4" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-28-4" />
+    </g>
+    <g
+       id="g16-2-0-4"
+       transform="matrix(-0.89009618,0,0,-0.89009618,216.98886,119.75548)"
+       style="stroke-width:1.12347"
+       inkscape:transform-center-x="6.39"
+       inkscape:transform-center-y="7.2989296">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-9-9-4" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-0-1-7" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-28-9-6" />
+    </g>
+    <g
+       id="g16-0-3"
+       transform="matrix(0.89009618,0,0,0.89009618,-10.75545,90.901556)"
+       style="stroke-width:1.12347">
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 34.804202,13.037428 c 0,6.491881 0,6.491881 0,6.491881"
+         id="path15-0-1-4-1" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 36.047969,17.33002 c -1.17594,2.036789 -1.17594,2.036789 -1.17594,2.036789"
+         id="path15-0-1-7-2-7" />
+      <path
+         style="fill:none;stroke:#fa0000;stroke-width:0.730258;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 33.578651,17.33002 c 1.17594,2.036789 1.17594,2.036789 1.17594,2.036789"
+         id="path15-0-1-7-4-2-5" />
+    </g>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,104.98522,57.820721)"
+       id="text1-9"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1-5);display:inline"><tspan
+         x="-227.99414"
+         y="162.14672"
+         id="tspan94">1</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,171.33793,57.526735)"
+       id="text1-5-2"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1-7-4);display:inline"><tspan
+         x="-227.99414"
+         y="162.14672"
+         id="tspan95">2</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,238.07556,57.63229)"
+       id="text1-0-7"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1-1-7);display:inline"><tspan
+         x="-227.99414"
+         y="162.14672"
+         id="tspan96">3</tspan></text>
+    <g
+       id="g14-5"
+       transform="translate(0.54670774,68.416954)">
+      <circle
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.75;stroke-dasharray:0.75, 0.75;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-7"
+         cx="34.611988"
+         cy="27.027479"
+         r="2.4413249" />
+      <ellipse
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.750001;stroke-dasharray:0.750001, 0.750001;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-0-41"
+         cx="34.604832"
+         cy="27.059286"
+         rx="3.3423033"
+         ry="3.3426566" />
+    </g>
+    <g
+       id="g14-6-9-1-8"
+       transform="translate(148.85372,67.371896)">
+      <circle
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.75;stroke-dasharray:0.75, 0.75;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-9-9-1-5"
+         cx="34.611988"
+         cy="27.027479"
+         r="2.4413249" />
+      <ellipse
+         style="fill:none;stroke:#7c7c7d;stroke-width:0.750001;stroke-dasharray:0.750001, 0.750001;stroke-dashoffset:0;stroke-opacity:1"
+         id="path3-0-4-7-9-9"
+         cx="34.604832"
+         cy="27.059286"
+         rx="3.3423033"
+         ry="3.3426566" />
+    </g>
+    <circle
+       style="fill:none;stroke:#585cff;stroke-width:0.75;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3-2-7"
+       cx="103.08739"
+       cy="114.06631"
+       r="2.3037231" />
+    <ellipse
+       style="fill:none;stroke:#585cff;stroke-width:0.750001;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3-2-4-5"
+       cx="103.08739"
+       cy="114.06631"
+       rx="3.2182388"
+       ry="3.2186263" />
+    <g
+       id="g13-3"
+       transform="translate(0.54670774,68.416954)">
+      <rect
+         style="fill:#f0d56e;fill-opacity:1;stroke:#f0d56e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+         id="rect7-5-9-8"
+         width="6.3639612"
+         height="7.3026814"
+         x="75.599159"
+         y="22.745932"
+         rx="0.79374999"
+         inkscape:transform-center-x="-17.64" />
+      <rect
+         style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6-0-6-8"
+         width="6.2501149"
+         height="3.4184477"
+         x="75.656082"
+         y="24.688049"
+         rx="0.19295804" />
+    </g>
+    <rect
+       style="fill:#007e00;fill-opacity:1;stroke:#020000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6-0-0-3"
+       width="6.2501149"
+       height="3.4184477"
+       x="142.82925"
+       y="92.847733"
+       rx="0.19295804" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,0.17302074,74.597655)"
+       id="text2-1"
+       style="font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2-4);display:inline"><tspan
+         x="29.623047"
+         y="28.466452"
+         id="tspan97">x=100.00
+</tspan><tspan
+         x="29.623047"
+         y="50.133078"
+         id="tspan98">y=100.00</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,0.80336374,111.65869)"
+       id="text2-7-6"
+       style="font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2-9-4);display:inline"><tspan
+         x="29.623047"
+         y="28.466452"
+         id="tspan99">x=100.00
+</tspan><tspan
+         x="29.623047"
+         y="50.133078"
+         id="tspan100">y=097.79</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,85.579422,119.74369)"
+       id="text2-7-2-3"
+       style="font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2-9-6-3);display:inline"><tspan
+         x="29.623047"
+         y="28.466452"
+         id="tspan101">x=122.15
+</tspan><tspan
+         x="29.623047"
+         y="50.133078"
+         id="tspan102">y=097.79</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,169.77663,110.5246)"
+       id="text2-7-2-0-6"
+       style="font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2-9-6-7-0);display:inline"><tspan
+         x="29.623047"
+         y="28.466452"
+         id="tspan103">x=144.30
+</tspan><tspan
+         x="29.623047"
+         y="50.133078"
+         id="tspan104">y=097.79</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,177.76963,71.764024)"
+       id="text2-7-2-0-8-8"
+       style="font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2-9-6-7-9-7);display:inline"><tspan
+         x="29.623047"
+         y="28.466452"
+         id="tspan105">x=144.30
+</tspan><tspan
+         x="29.623047"
+         y="50.133078"
+         id="tspan106">y=100.00</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,151.8673,71.134948)"
+       id="text2-7-2-0-8-3-9"
+       style="font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2-9-6-7-9-1-86);display:inline"><tspan
+         x="29.623047"
+         y="28.466452"
+         id="tspan107">x=142.00
+</tspan><tspan
+         x="29.623047"
+         y="50.133078"
+         id="tspan108">y=100.00</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,9.6355916,-34.269118)"
+       id="text2"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect3)"><tspan
+         x="19.822266"
+         y="208.86547"
+         id="tspan109">A</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,9.3689437,-4.9831804)"
+       id="text2-8"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect3-9);display:inline"><tspan
+         x="19.822266"
+         y="208.86547"
+         id="tspan110">B</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,89.868319,-7.0920544)"
+       id="text2-8-1"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect3-9-0);display:inline"><tspan
+         x="19.822266"
+         y="208.86547"
+         id="tspan111">C</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,180.60361,-6.7683497)"
+       id="text2-8-1-2"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect3-9-0-6);display:inline"><tspan
+         x="19.822266"
+         y="208.86547"
+         id="tspan112">D</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,183.89855,-33.996462)"
+       id="text2-8-1-2-7"
+       style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect3-9-0-6-2);display:inline"><tspan
+         x="19.822266"
+         y="208.86547"
+         id="tspan113">E</tspan></text>
+    <g
+       id="g37">
+      <text
+         xml:space="preserve"
+         transform="matrix(0.26458333,0,0,0.26458333,165.60026,-23.346736)"
+         id="text2-8-1-2-7-0"
+         style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect3-9-0-6-2-2);display:inline"><tspan
+           x="19.822266"
+           y="208.86547"
+           id="tspan114">F</tspan></text>
+    </g>
+    <g
+       id="g37-3"
+       transform="translate(-27.220073,5.4373243)">
+      <text
+         xml:space="preserve"
+         transform="matrix(0.26458333,0,0,0.26458333,165.40636,-39.828254)"
+         id="text2-8-1-2-7-0-4"
+         style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect3-9-0-6-2-2-1);display:inline"><tspan
+           x="19.822266"
+           y="208.86547"
+           id="tspan115">G</tspan></text>
+      <g
+         id="g37-33"
+         transform="translate(-66.242777,-15.875)">
+        <text
+           xml:space="preserve"
+           transform="matrix(0.26458333,0,0,0.26458333,165.60026,-23.346736)"
+           id="text2-8-1-2-7-0-8"
+           style="font-size:20px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect3-9-0-6-2-2-9);display:inline"><tspan
+             x="19.822266"
+             y="208.86547"
+             id="tspan116">H</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/recipes/tunnel_inventory.qmd
+++ b/docs/recipes/tunnel_inventory.qmd
@@ -79,6 +79,15 @@ resources = {
         "manufacturer: Corning\n"
         "model: MIC tight-buffered 4F OS2\n"
         "fiber_count: 4\n"
+        "description: The run in from the instrument room.\n"
+    ),
+    "connecting-cable": (
+        "object_type: Cable\n"
+        "name: tunnel connecting cable\n"
+        "manufacturer: Corning\n"
+        "model: MIC tight-buffered 4F OS2\n"
+        "fiber_count: 4\n"
+        "description: The links between boxes, couplers, and borehole heads.\n"
     ),
     "borehole-cable": (
         "object_type: Cable\n"
@@ -95,14 +104,6 @@ resources = {
         "model: HWC\n"
         "fiber_count: 1\n"
     ),
-    "splice-box": (
-        "object_type: Enclosure\nname: tunnel splice box\nenclosure_type: box\n"
-    ),
-    "turnaround": (
-        "object_type: Enclosure\n"
-        "name: downhole turnaround housing\n"
-        "enclosure_type: housing\n"
-    ),
     "das-interrogator": (
         "object_type: Interrogator\n"
         "name: tunnel DAS interrogator\n"
@@ -111,6 +112,20 @@ resources = {
         "instrument_type: DAS interrogator\n"
     ),
 }
+# One enclosure per housing, because a resource_id names an asset rather
+# than a kind: box A and box E are two boxes, and each borehole has its own
+# turnaround down the hole.
+for label, name in [
+    ("splice-box-a", "splice box at A"),
+    ("splice-box-e", "splice box at E"),
+    ("turnaround-1", "borehole 1 turnaround housing"),
+    ("turnaround-2", "borehole 2 turnaround housing"),
+    ("turnaround-3", "borehole 3 turnaround housing"),
+]:
+    kind = "box" if "splice" in label else "housing"
+    resources[label] = (
+        f"object_type: Enclosure\nname: tunnel {name}\nenclosure_type: {kind}\n"
+    )
 for name, text in resources.items():
     write(f"resources/{name}.yaml", text)
 ```
@@ -149,30 +164,30 @@ This is @tbl-path with the parts named, and it goes in `path.00` — the directo
 components_csv = dedent("""\
 sequence,object_type,optical_length,name,container
 1,FiberSegment,1500.0,telemetry lead-in,telemetry-cable
-2,Splice,0.0,splice at box A,splice-box
+2,Splice,0.0,splice at box A,splice-box-a
 3,FiberSegment,2.5,drop into the trench,trench-cable
 4,FiberSegment,25.0,trench B to the coil,trench-cable
 5,FiberSegment,10.0,cable coil at C,trench-cable
 6,FiberSegment,25.0,trench from the coil to D,trench-cable
 7,FiberSegment,2.5,rise out of the trench,trench-cable
-8,Splice,0.0,splice at box E,splice-box
-9,FiberSegment,15.0,link E to borehole 3,telemetry-cable
+8,Splice,0.0,splice at box E,splice-box-e
+9,FiberSegment,15.0,link E to borehole 3,connecting-cable
 10,FiberSegment,20.0,borehole 3 down,borehole-cable
-11,Splice,0.0,borehole 3 turnaround,turnaround
+11,Splice,0.0,borehole 3 turnaround,turnaround-3
 12,FiberSegment,20.0,borehole 3 up,borehole-cable
-13,FiberSegment,15.0,link borehole 3 to coupler G,telemetry-cable
-14,Connector,0.0,coupler G,splice-box
-15,FiberSegment,15.0,link coupler G to borehole 2,telemetry-cable
+13,FiberSegment,15.0,link borehole 3 to coupler G,connecting-cable
+14,Connector,0.0,coupler G,
+15,FiberSegment,15.0,link coupler G to borehole 2,connecting-cable
 16,FiberSegment,20.0,borehole 2 down,borehole-cable
-17,Splice,0.0,borehole 2 turnaround,turnaround
+17,Splice,0.0,borehole 2 turnaround,turnaround-2
 18,FiberSegment,20.0,borehole 2 up,borehole-cable
-19,FiberSegment,15.0,link borehole 2 to coupler H,telemetry-cable
-20,Connector,0.0,coupler H,splice-box
-21,FiberSegment,15.0,link coupler H to borehole 1,telemetry-cable
+19,FiberSegment,15.0,link borehole 2 to coupler H,connecting-cable
+20,Connector,0.0,coupler H,
+21,FiberSegment,15.0,link coupler H to borehole 1,connecting-cable
 22,FiberSegment,20.0,borehole 1 down,borehole-cable
-23,Splice,0.0,borehole 1 turnaround,turnaround
+23,Splice,0.0,borehole 1 turnaround,turnaround-1
 24,FiberSegment,20.0,borehole 1 up,borehole-cable
-25,FiberSegment,15.0,link borehole 1 back to box A,telemetry-cable
+25,FiberSegment,15.0,link borehole 1 back to box A,connecting-cable
 26,Terminator,0.0,path end,
 """)
 
@@ -254,7 +269,7 @@ geometry.to_csv(root / PATH / "geometry.csv", index=False)
 geometry.head(8)
 ```
 
-The coil and the six 15 m links appear nowhere in that table, so their channels get no position at all. That is the honest answer rather than a gap: the links are slack cable in a tray, and ten meters of fiber wound into a one-meter loop has no useful position per channel. A made-up polyline would be worse than a `nan`.
+The coil and the six 15 m links appear nowhere in that table, so their interiors get no position at all — only the channel at the very start of a link, which is the surveyed point the run before it ended on. That is the honest answer rather than a gap: the links are slack cable in a tray, and ten meters of fiber wound into a one-meter loop has no useful position per channel. A made-up polyline would be worse than a `nan`.
 
 Notice also what the table does *not* say. It never mentions the wind angle. Two control points state that 25 m of fiber runs from B to C, every channel between them is placed by interpolating that, and $\cos\phi$ stops being anyone's problem at this line.
 
@@ -388,7 +403,7 @@ patch = dc.get_example_patch(
     "random_das",
     acquisition_key="XT.TUN1.00.DAS",
     time_min="2024-06-01",
-    shape=(1780, 200),
+    shape=(1776, 200),
 )
 spool = dc.spool(patch).attach_inventory(inventory)
 ```
@@ -428,24 +443,35 @@ assert np.isnan(depth[1000])
 
 # A repair, and what it does to the data
 
-In September a contractor puts a bucket through the trench cable, fifteen meters of fiber past box A. It is repaired with two splices and a two-meter patch cord, and every channel beyond the repair now sits two meters further along the fiber than it used to.
+In September a contractor puts a bucket through the trench cable, fifteen meters of fiber into the trench. It is repaired with two splices and a two-meter patch cord, and every channel beyond the repair now sits two meters further along the fiber than it used to.
 
 This is what epochs are for. The old description is not edited. A second directory is added, named for the day of the repair, and the first path runs until the second begins.
 
 The components table is where the repair happens: one row becomes five, and the table is renumbered.
 
 ```{python}
+# The repair is new hardware, so it is new resources: a patch cord, and the
+# box holding the slack.
+write(
+    "resources/repair-cord.yaml",
+    "object_type: Cable\nname: trench repair patch cord\nfiber_count: 1\n",
+)
+write(
+    "resources/repair-box.yaml",
+    "object_type: Enclosure\nname: trench repair box\nenclosure_type: box\n",
+)
+
 rows = pd.read_csv(io.StringIO(components_csv)).to_dict("records")
 index = next(i for i, row in enumerate(rows) if row["name"] == "trench B to the coil")
 rows[index : index + 1] = [
     dict(object_type="FiberSegment", optical_length=15.0,
          name="trench B to the break", container="trench-cable"),
     dict(object_type="Splice", optical_length=0.0,
-         name="repair splice near side", container="splice-box"),
+         name="repair splice near side", container="repair-box"),
     dict(object_type="FiberSegment", optical_length=2.0,
-         name="repair patch cord", container="trench-cable"),
+         name="repair patch cord", container="repair-cord"),
     dict(object_type="Splice", optical_length=0.0,
-         name="repair splice far side", container="splice-box"),
+         name="repair splice far side", container="repair-box"),
     dict(object_type="FiberSegment", optical_length=10.0,
          name="trench from the break to the coil", container="trench-cable"),
 ]
@@ -505,7 +531,7 @@ straddling = dc.get_example_patch(
     "random_das",
     acquisition_key="XT.TUN1.00.DAS",
     time_min="2024-08-31T23:59:59",
-    shape=(1780, 500),
+    shape=(1776, 500),
 )
 crossed = dc.spool(straddling).attach_inventory(repaired)
 
@@ -544,7 +570,7 @@ print(f"{len(text.splitlines())} lines of yaml")
 assert dc.inventory(text) == repaired
 ```
 
-Dropping either into the data directory means every spool opened there finds it without being told: the authoring directory as `.inventory/`, or the single file as `.inventory.yaml`, `.inventory.yml`, or `.inventory.json`. The name states the format, so a file called plainly `.inventory` is not one of the spellings.
+Dropping either into the data directory means every spool opened there finds it without being told: the authoring directory as `.inventory/`, or the single file as `.inventory.yaml` or `.inventory.yml`. The suffix states the format rather than decorating it, so a file called plainly `.inventory` is not one of the spellings, and the third one — `.inventory.json` — holds what `model_dump_json` writes rather than what `to_yaml` does.
 
 # Where the boundaries fell
 

--- a/docs/recipes/tunnel_inventory.qmd
+++ b/docs/recipes/tunnel_inventory.qmd
@@ -1,0 +1,498 @@
+---
+title: A Tunnel Inventory
+execute:
+  warning: false
+---
+
+The [inventory tutorial](../tutorial/inventory.qmd) shows the shape of the model and the verbs which use it. This recipe writes a whole inventory for one deployment, from field notes to enriched patches. It is long on purpose: real installations are made of parts that each need saying, and the point is to watch them fit together.
+
+The deployment is an underground tunnel instrumented to watch for floor instability and to record seismicity. Three boreholes are drilled from the tunnel floor, a cable is trenched along its length, and a coil of cable is buried at the far end as a horizontally sensitive "clump" sensor. Two interrogators share the installation: a Brillouin DSS system watching the trench for slow strain, and a Rayleigh DAS interrogator on the boreholes, the trench, and the coil.
+
+![Map view of the tunnel deployment. Distances along the fiber are optical; the boreholes are 20 m apart.](../_static/tunnel_deployment.svg){#fig-tunnel}
+
+The inventory is written the way a field crew would keep it: a directory of small YAML files for the hardware and CSV tables for the things that come in rows. Everything below runs, and nothing is downloaded.
+
+```{python}
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+import pandas as pd
+
+import dascore as dc
+
+root = Path(tempfile.mkdtemp()) / "tunnel_inventory"
+
+
+def write(name, text):
+    """Write one file into the inventory directory."""
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+```
+
+# What the field notes say
+
+The parts of the installation, as an engineer would write them down:
+
+| Part | What it is | Length |
+|---|---|---|
+| telemetry lead-in | tight-buffered 4-fiber telecom cable from the instrument room | 40 m |
+| splice box | E2000 APC connectors at the tunnel entrance | — |
+| borehole ×3 | rock-coupled downhole cable, turnaround at the bottom, armored pigtails | 5 + 40 + 40 + 5 m each |
+| connecting fiber | telemetry cable between borehole heads | 20 m each |
+| trenched fiber | helically wound sensing cable, buried 0.5 m in soil | 50 m of trench |
+| coil | the same cable wound into a 1 m loop | 10 m |
+
+: The tunnel installation. {#tbl-parts}
+
+Two numbers there are worth pausing on. A borehole is 40 m deep but contributes 80 m of fiber, because the cable goes down, turns around at the bottom, and comes back up — the light travels both legs, and both legs are sensing.
+
+![The borehole cable: armored pigtails above ground, rock-coupled fiber below, and a turnaround at the bottom.](../_static/borehole_fiber.svg){#fig-borehole width="30%"}
+
+The trench is worse. Its cable is wound helically at 30° off-axis, which buys sensitivity to broadside motion at the cost of length: the fiber is longer than the trench it lies in. With a wind angle $\phi$, a trench distance $d_r$, and an optical distance $d_o$,
+
+$$
+d_r \approx d_o \cos \phi \approx 0.866\, d_o
+$$
+
+so 50 m of trench takes about 57.7 m of fiber. This is the distinction the inventory exists to keep: optical distance is what the interrogator measures, and where a channel actually *is* comes from the geometry track rather than from arithmetic on the channel number.
+
+# The hardware
+
+Cables, enclosures, and interrogators are named once and referred to from everywhere they appear. Each is a small file under `resources/`, and the file's name is the `resource_id` other files refer to it by.
+
+```{python}
+#| code-fold: true
+#| code-summary: "resources/*.yaml — the hardware, from the purchase orders"
+resources = {
+    "telemetry-cable": (
+        "object_type: Cable\n"
+        "name: tunnel telemetry cable\n"
+        "manufacturer: Corning\n"
+        "model: MIC tight-buffered 4F OS2\n"
+        "fiber_count: 4\n"
+    ),
+    "borehole-cable": (
+        "object_type: Cable\n"
+        "name: borehole sensing cable\n"
+        "manufacturer: Nerve Sensors\n"
+        "model: Epsilon\n"
+        "fiber_count: 4\n"
+        "description: Rock-coupled downhole cable with an armored pigtail.\n"
+    ),
+    "trench-cable": (
+        "object_type: Cable\n"
+        "name: helically wound trench cable\n"
+        "manufacturer: Silixa\n"
+        "model: HWC 30 degree\n"
+        "fiber_count: 1\n"
+    ),
+    "splice-box": (
+        "object_type: Enclosure\nname: tunnel splice box\nenclosure_type: box\n"
+    ),
+    "turnaround": (
+        "object_type: Enclosure\n"
+        "name: downhole turnaround housing\n"
+        "enclosure_type: housing\n"
+    ),
+    "das-interrogator": (
+        "object_type: Interrogator\n"
+        "name: tunnel DAS interrogator\n"
+        "manufacturer: Sintela\n"
+        "model: Onyxia\n"
+        "instrument_type: DAS interrogator\n"
+    ),
+    "dss-interrogator": (
+        "object_type: Interrogator\n"
+        "name: tunnel DSS interrogator\n"
+        "manufacturer: Febus\n"
+        "model: G1\n"
+        "instrument_type: Brillouin DSS interrogator\n"
+    ),
+}
+for name, text in resources.items():
+    write(f"resources/{name}.yaml", text)
+```
+
+These stay objects rather than rows because they have nothing in common: a cable has a fiber count, an enclosure has an inner diameter, an interrogator has firmware. A table of one row with twelve mostly-empty columns would be worse than the file.
+
+The envelope names the document and states the coordinate reference system everything else is expressed in. This tunnel has its own survey grid rather than a global reference, so the axes are `x`, `y`, and `z` in meters, `z` positive up.
+
+```{python}
+write(
+    "inventory.yaml",
+    "object_type: Inventory\n"
+    "coordinate_reference_system:\n"
+    "  authority: local\n"
+    "  code: tunnel\n"
+    "  name: tunnel engineering grid\n"
+    "  coordinate_labels: [x, y, z]\n"
+    "  units: [meter, meter, meter]\n",
+)
+
+write(
+    "fiber_arrays/XT.TUN1/attrs.yaml",
+    "object_type: FiberArray\nname: tunnel fiber array\n",
+)
+```
+
+# The path, as a table
+
+An optical path is the ordered list of things the light passes through. Each component states its own optical length, and they tile the path end to end — which is what gives the path its length. Nothing states a start distance, because the `sequence` column already did.
+
+This is the table the field crew keeps in a spreadsheet, and it goes in `path.00`, the directory naming the optical path at location code `00`.
+
+```{python}
+#| code-fold: true
+#| code-summary: "path.00/optical_components.csv"
+components_csv = dedent("""\
+sequence,object_type,optical_length,name,container
+1,FiberSegment,40.0,telemetry lead-in,telemetry-cable
+2,Connector,0.0,splice box connector,splice-box
+3,FiberSegment,5.0,borehole 1 pigtail down,borehole-cable
+4,FiberSegment,40.0,borehole 1 sensing down,borehole-cable
+5,Splice,0.0,borehole 1 turnaround,turnaround
+6,FiberSegment,40.0,borehole 1 sensing up,borehole-cable
+7,FiberSegment,5.0,borehole 1 pigtail up,borehole-cable
+8,FiberSegment,20.0,connecting fiber 1 to 2,telemetry-cable
+9,FiberSegment,5.0,borehole 2 pigtail down,borehole-cable
+10,FiberSegment,40.0,borehole 2 sensing down,borehole-cable
+11,Splice,0.0,borehole 2 turnaround,turnaround
+12,FiberSegment,40.0,borehole 2 sensing up,borehole-cable
+13,FiberSegment,5.0,borehole 2 pigtail up,borehole-cable
+14,FiberSegment,20.0,connecting fiber 2 to 3,telemetry-cable
+15,FiberSegment,5.0,borehole 3 pigtail down,borehole-cable
+16,FiberSegment,40.0,borehole 3 sensing down,borehole-cable
+17,Splice,0.0,borehole 3 turnaround,turnaround
+18,FiberSegment,40.0,borehole 3 sensing up,borehole-cable
+19,FiberSegment,5.0,borehole 3 pigtail up,borehole-cable
+20,FiberSegment,20.0,connecting fiber to the trench,telemetry-cable
+21,FiberSegment,57.7,trenched sensing fiber,trench-cable
+22,FiberSegment,10.0,clump coil,trench-cable
+23,Terminator,0.0,path end,
+""")
+
+write("fiber_arrays/XT.TUN1/path.00/attrs.yaml", "object_type: OpticalPath\n")
+write("fiber_arrays/XT.TUN1/path.00/optical_components.csv", components_csv)
+
+pd.read_csv(root / "fiber_arrays/XT.TUN1/path.00/optical_components.csv")
+```
+
+Every column there is a field of the class the `object_type` column names, so the table is not a format of its own — it is the objects, written the way rows of the same shape are worth writing. The blank `container` on the terminator is a field left unset, and the ones which are filled are `resource_id`s pointing back at the files written above.
+
+Nothing else in the inventory has to repeat these numbers. The distances the other three tables are written against are the running totals of this one:
+
+```{python}
+LEAD_IN = 40.0
+BOREHOLE_SPAN = {1: (45.0, 125.0), 2: (155.0, 235.0), 3: (265.0, 345.0)}
+TRENCH_SPAN = (370.0, 427.7)
+COIL_SPAN = (427.7, 437.7)
+```
+
+# Where the fiber is
+
+Geometry places optical distance in space, one row per control point, grouped into segments. A borehole is two straight legs, down and back up over the same hole; the trench is a straight run at 0.5 m depth. The columns after `segment` and `distance` are the axes the coordinate reference system declared, and naming any others is an error rather than an extra.
+
+```{python}
+#| code-fold: true
+#| code-summary: "path.00/geometry.csv"
+geometry_csv = dedent("""\
+segment,distance,x,y,z
+borehole 1 down,45.0,20.0,0.0,0.0
+borehole 1 down,85.0,20.0,0.0,-40.0
+borehole 1 up,85.0,20.0,0.0,-40.0
+borehole 1 up,125.0,20.0,0.0,0.0
+borehole 2 down,155.0,40.0,0.0,0.0
+borehole 2 down,195.0,40.0,0.0,-40.0
+borehole 2 up,195.0,40.0,0.0,-40.0
+borehole 2 up,235.0,40.0,0.0,0.0
+borehole 3 down,265.0,60.0,0.0,0.0
+borehole 3 down,305.0,60.0,0.0,-40.0
+borehole 3 up,305.0,60.0,0.0,-40.0
+borehole 3 up,345.0,60.0,0.0,0.0
+trench,370.0,0.0,0.0,-0.5
+trench,427.7,50.0,0.0,-0.5
+""")
+
+write("fiber_arrays/XT.TUN1/path.00/geometry.csv", geometry_csv)
+
+pd.read_csv(root / "fiber_arrays/XT.TUN1/path.00/geometry.csv").head(6)
+```
+
+The lead-in, the connecting fibers, and the coil appear nowhere in that table, and they get no position. That is the honest answer: nobody surveyed the lead-in, because it is coiled in a rack.
+
+The trench segment is also where the wind angle stops mattering to anyone downstream. Its two control points say that 57.7 m of fiber covers 50 m of ground; every channel between them is placed by interpolating that, and no consumer has to know about $\cos\phi$.
+
+# How it is attached to the ground
+
+Coupling is what decides whether a wiggle means anything, and it is an interval property. The controlled `coupling_type` carries the part a program can act on; `medium` and `attachment` carry the rest.
+
+```{python}
+#| code-fold: true
+#| code-summary: "path.00/coupling.csv"
+coupling_csv = dedent("""\
+start_distance,end_distance,coupling_type,medium,attachment,depth
+45.0,125.0,outside_borehole_casing,rock,cemented,
+155.0,235.0,outside_borehole_casing,rock,cemented,
+265.0,345.0,outside_borehole_casing,rock,cemented,
+370.0,427.7,trench,soil,direct_burial,0.5
+427.7,437.7,coiled,soil,,0.5
+""")
+
+write("fiber_arrays/XT.TUN1/path.00/coupling.csv", coupling_csv)
+
+pd.read_csv(root / "fiber_arrays/XT.TUN1/path.00/coupling.csv")
+```
+
+The coil is `coiled` rather than `trench`, which is the whole reason that value exists: ten meters of fiber wound into a one-meter loop has no useful position per channel, and saying so is better than a made-up polyline.
+
+# Everything else
+
+Annotations are for what the model has no field for. Each group becomes a coordinate on the patches, named after the group, so pick names you would want to select on later. Here `section` names what kind of installation a channel belongs to and `borehole` numbers the three holes.
+
+```{python}
+#| code-fold: true
+#| code-summary: "path.00/annotations.csv"
+annotations_csv = dedent("""\
+start_distance,end_distance,group,value
+45.0,125.0,section,borehole
+155.0,235.0,section,borehole
+265.0,345.0,section,borehole
+370.0,427.7,section,trench
+427.7,437.7,section,coil
+45.0,125.0,borehole,1
+155.0,235.0,borehole,2
+265.0,345.0,borehole,3
+""")
+
+write("fiber_arrays/XT.TUN1/path.00/annotations.csv", annotations_csv)
+
+pd.read_csv(root / "fiber_arrays/XT.TUN1/path.00/annotations.csv")
+```
+
+A group holds one kind of value: `section` is text everywhere and `borehole` is a number everywhere. Mixing them would be two tracks sharing a name, and is refused when the directory is read.
+
+# The second interrogator
+
+The DSS system is on its own fiber and sees only the trench, so it is a second optical path under the same fiber array, at its own location code.
+
+```{python}
+#| code-fold: true
+#| code-summary: "path.01 — the DSS fiber"
+write("fiber_arrays/XT.TUN1/path.01/attrs.yaml", "object_type: OpticalPath\n")
+write(
+    "fiber_arrays/XT.TUN1/path.01/optical_components.csv",
+    "sequence,object_type,optical_length,name,container\n"
+    "1,FiberSegment,40.0,DSS lead-in,telemetry-cable\n"
+    "2,FiberSegment,57.7,DSS trenched fiber,trench-cable\n"
+    "3,Terminator,0.0,DSS path end,\n",
+)
+write(
+    "fiber_arrays/XT.TUN1/path.01/coupling.csv",
+    "start_distance,end_distance,coupling_type,medium,attachment,depth\n"
+    "40.0,97.7,trench,soil,direct_burial,0.5\n",
+)
+```
+
+# How each instrument was set up
+
+A path is the fiber; an acquisition is a configuration of an instrument recording through it. The file's name states the identity — network, fiber array, location code, and acquisition code — and `XT.TUN1.00.DAS` is what a patch recorded here carries as its `acquisition_key`.
+
+The `distance_map` is the join between instrument and fiber: it says where the interrogator's own distance axis lands on the path. Both instruments here are zeroed at themselves, so the map is the identity — but it is stated rather than assumed, because a re-zeroed instrument is the usual cause of metadata that is quietly off by a lead-in.
+
+```{python}
+write(
+    "acquisitions/XT.TUN1.00.DAS.yaml",
+    "object_type: Acquisition\n"
+    "data_category: DAS\n"
+    "data_type: strain_rate\n"
+    "data_units: 1/s\n"
+    "interrogator: das-interrogator\n"
+    "gauge_length: 10.0\n"
+    "spatial_interval: 1.0\n"
+    "sample_rate: 250.0\n"
+    "distance_map:\n"
+    "  instrument_distance: [0.0, 437.7]\n"
+    "  distance: [0.0, 437.7]\n",
+)
+
+write(
+    "acquisitions/XT.TUN1.01.DSS.yaml",
+    "object_type: Acquisition\n"
+    "data_category: DSS\n"
+    "data_type: strain\n"
+    "interrogator: dss-interrogator\n"
+    "spatial_interval: 1.0\n"
+    "distance_map:\n"
+    "  instrument_distance: [0.0, 97.7]\n"
+    "  distance: [0.0, 97.7]\n",
+)
+```
+
+# Reading it back
+
+The directory is now an inventory, and loading it is the moment every rule is checked: that each file is what it says it is, that each `container` resolves to a resource, that no track runs off the end of its path.
+
+```{python}
+inventory = dc.inventory(root)
+
+array = inventory.networks[0].fiber_arrays[0]
+for path in array.optical_paths:
+    print(f"path {path.location_code}: {path.optical_length:.1f} m of fiber")
+
+names = inventory.get_names()
+print("coords:", [x for x in names.coords if "." not in x])
+```
+
+`section` and `borehole` are among the coordinates because the annotations table named them. `x`, `y`, and `z` are there because the CRS declares those axes and the geometry table resolves to them.
+
+# What the data gets out of it
+
+A patch recorded here carries the acquisition key, and that key with the time the patch covers is the whole of the join.
+
+```{python}
+patch = dc.get_example_patch(
+    "random_das",
+    acquisition_key="XT.TUN1.00.DAS",
+    time_min="2024-06-01",
+    shape=(440, 500),
+)
+spool = dc.spool(patch).attach_inventory(inventory)
+```
+
+Attaching reads no data and changes no patch. What it changes is which names resolve — the fiber's own vocabulary is now among them, so the boreholes can be asked for by name:
+
+```{python}
+boreholes = spool.select(section="borehole")
+
+print(f"{len(boreholes)} runs of borehole fiber")
+for sub in boreholes:
+    distance = sub.get_coord("distance")
+    print(f"  {distance.min()} to {distance.max()} m, {sub.shape[0]} channels")
+```
+
+Three patches, not one: the three holes are three separate runs of fiber, and a patch is a dense block of channels, so a selection matching three disjoint runs gives back three patches rather than silently gluing them together.
+
+[`Spool.enrich`](`dascore.core.spool.Spool.enrich`) is what actually puts the metadata on a patch:
+
+```{python}
+import numpy as np
+
+enriched = spool.enrich()[0]
+
+print("gauge length:", enriched.attrs.gauge_length)
+print("coordinates:", sorted(enriched.coords.coord_map))
+
+# 60 m along the fiber is 15 m down borehole 1.
+depth = enriched.get_coord("z").values
+assert depth[60] == -15.0
+
+# The lead-in was never surveyed, so it has no position.
+assert np.isnan(depth[10])
+```
+
+# A repair, and what it does to the data
+
+In September a contractor puts a bucket through the trench cable 25 m in. It is repaired with two splices and a two-meter patch cord, and every channel past the repair now sits two meters further along the fiber than it used to.
+
+This is what epochs are for. The old description is not edited: a second directory is added, named for the day the repair happened, and the first path runs until the second begins.
+
+```{python}
+#| code-fold: true
+#| code-summary: "path.00@2024-09-01 — the same path, after the repair"
+epoch = "fiber_arrays/XT.TUN1/path.00@2024-09-01"
+write(f"{epoch}/attrs.yaml", "object_type: OpticalPath\n")
+write(f"{epoch}/annotations.csv", annotations_csv.replace("427.7", "429.7"))
+
+# The trench is now two runs of fiber with the repair between them, and
+# everything past it moves two meters.
+write(
+    f"{epoch}/optical_components.csv",
+    components_csv.replace(
+        "21,FiberSegment,57.7,trenched sensing fiber,trench-cable\n"
+        "22,FiberSegment,10.0,clump coil,trench-cable\n"
+        "23,Terminator,0.0,path end,\n",
+        "21,FiberSegment,25.0,trenched fiber to the break,trench-cable\n"
+        "22,Splice,0.0,repair splice near side,splice-box\n"
+        "23,FiberSegment,2.0,repair patch cord,trench-cable\n"
+        "24,Splice,0.0,repair splice far side,splice-box\n"
+        "25,FiberSegment,32.7,trenched fiber past the break,trench-cable\n"
+        "26,FiberSegment,10.0,clump coil,trench-cable\n"
+        "27,Terminator,0.0,path end,\n",
+    ),
+)
+write(
+    f"{epoch}/coupling.csv",
+    coupling_csv.replace("370.0,427.7", "370.0,429.7").replace(
+        "427.7,437.7", "429.7,439.7"
+    ),
+)
+# The patch cord is coiled in the splice box, so it gets no geometry: the
+# trench is described up to the break and again from it.
+write(
+    f"{epoch}/geometry.csv",
+    geometry_csv.replace(
+        "trench,370.0,0.0,0.0,-0.5\ntrench,427.7,50.0,0.0,-0.5\n",
+        "trench before,370.0,0.0,0.0,-0.5\n"
+        "trench before,395.0,21.65,0.0,-0.5\n"
+        "trench after,397.0,21.65,0.0,-0.5\n"
+        "trench after,429.7,50.0,0.0,-0.5\n",
+    ),
+)
+
+repaired = dc.inventory(root)
+for path in repaired.networks[0].fiber_arrays[0].optical_paths:
+    if path.location_code == "00":
+        print(f"from {path.start_time}: {path.optical_length:.1f} m")
+```
+
+A patch recorded across midnight on the first of September was recorded through both. [`Spool.conform_to_inventory`](`dascore.core.spool.Spool.conform_to_inventory`) is the step which insists every patch be describable by exactly one entry, and it subdivides that patch rather than choosing for you:
+
+```{python}
+straddling = dc.get_example_patch(
+    "random_das",
+    acquisition_key="XT.TUN1.00.DAS",
+    time_min="2024-08-31T23:59:59",
+    shape=(440, 500),
+)
+crossed = dc.spool(straddling).attach_inventory(repaired)
+
+print("patches before:", len(crossed))
+conformed = crossed.conform_to_inventory()
+print("patches after: ", len(conformed))
+print(conformed.get_contents()[["time_min", "time_max"]].to_string(index=False))
+```
+
+The split is exact: every sample the patch held is in one piece or the other, and none is in both. Each piece now enriches with the geometry that was true while it was recording, which is the entire reason the repair was written as an epoch instead of an edit.
+
+```{python}
+before, after = conformed.enrich()
+
+# The coil sat at 427.7 m before the repair and 429.7 m after it.
+assert before.get_coord("section").values[428] == "coil"
+assert after.get_coord("section").values[428] == "trench"
+```
+
+# Shipping it
+
+The directory is the authoring format — good for a deployment still being surveyed, because the tracks are spreadsheets. [`Inventory.to_yaml`](`dascore.core.inventory.Inventory.to_yaml`) writes the single-file form to ship beside a data archive, and [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads either back.
+
+```{python}
+text = repaired.to_yaml()
+
+print(f"{len(text.splitlines())} lines of yaml")
+assert dc.inventory(text) == repaired
+```
+
+Dropping either form into the data directory under the name `.inventory` means every spool opened on that directory finds it without being told.
+
+# Where the boundaries fell
+
+The choices worth restating, because a second deployment will have to make them again:
+
+- **Three boreholes, one fiber array.** They are one continuous run of fiber recorded as one channel axis, so they are one array with one path. Five dissimilar arms radiating from a hut, each with its own cable and its own break history, would be five fiber arrays instead — the question to ask is whether a break in one changes the others' metadata.
+- **The DSS is a second path, not a second array.** Same installation, same operator, different instrument on different fiber. The location code separates them, and both stay under one array so they share its identity and its lifetime.
+- **The turnaround is a component; its housing is a resource.** The splice is on the path because the light goes through it. The housing it sits in is a thing the site owns, referred to by any component inside it.
+- **The repair is an epoch, not an edit.** Data recorded before it is still described by what was true then. Editing the path in place would have silently moved every channel in the archive's history.

--- a/docs/recipes/tunnel_inventory.qmd
+++ b/docs/recipes/tunnel_inventory.qmd
@@ -4,19 +4,21 @@ execute:
   warning: false
 ---
 
-The [inventory tutorial](../tutorial/inventory.qmd) shows the shape of the model and the verbs which use it. This recipe writes a whole inventory for one deployment, from field notes to enriched patches. It is long on purpose: real installations are made of parts that each need saying, and the point is to watch them fit together.
+The [inventory tutorial](../tutorial/inventory.qmd) shows the shape of the model and the verbs which use it. This recipe writes a whole inventory for one deployment, from a survey drawing to enriched patches. It is long on purpose: real installations are made of parts that each need saying, and the point is to watch them fit together.
 
-The deployment is an underground tunnel instrumented to watch for floor instability and to record seismicity. Three boreholes are drilled from the tunnel floor, a cable is trenched along its length, and a coil of cable is buried at the far end as a horizontally sensitive "clump" sensor. Two interrogators share the installation: a Brillouin DSS system watching the trench for slow strain, and a Rayleigh DAS interrogator on the boreholes, the trench, and the coil.
+The deployment is an underground tunnel instrumented to watch for floor instability and to record seismicity. A telemetry cable arrives from an instrument room 1500 m away; from the splice box the fiber drops into a trench along the tunnel floor, passes a buried coil, rises again, and then works back along the tunnel through three instrumented boreholes.
 
-![Map view of the tunnel deployment. Distances along the fiber are optical; the boreholes are 20 m apart.](../_static/tunnel_deployment.svg){#fig-tunnel}
+![The deployment as surveyed. The upper panel is optical distance along the fiber; the lower one is the tunnel's own survey grid.](../_static/tunnel_deployment.svg){#fig-tunnel}
 
-The inventory is written the way a field crew would keep it: a directory of small YAML files for the hardware and CSV tables for the things that come in rows. Everything below runs, and nothing is downloaded.
+The inventory is written the way a field crew would keep it: a directory of small YAML files for the hardware, and CSV tables for everything that comes in rows. Everything below runs, and nothing is downloaded.
 
 ```{python}
+import io
 import tempfile
 from pathlib import Path
 from textwrap import dedent
 
+import numpy as np
 import pandas as pd
 
 import dascore as dc
@@ -32,36 +34,40 @@ def write(name, text):
     return path
 ```
 
-# What the field notes say
+# What the drawing says
 
-The parts of the installation, as an engineer would write them down:
+Reading @fig-tunnel along the fiber, from the interrogator:
 
-| Part | What it is | Length |
-|---|---|---|
-| telemetry lead-in | tight-buffered 4-fiber telecom cable from the instrument room | 40 m |
-| splice box | E2000 APC connectors at the tunnel entrance | — |
-| borehole ×3 | rock-coupled downhole cable, turnaround at the bottom, armored pigtails | 5 + 40 + 40 + 5 m each |
-| connecting fiber | telemetry cable between borehole heads | 20 m each |
-| trenched fiber | helically wound sensing cable, buried 0.5 m in soil | 50 m of trench |
-| coil | the same cable wound into a 1 m loop | 10 m |
+| From | To | What the light passes through | Optical |
+|---|---|---|---:|
+| instrument room | A | telemetry cable | 1500 m |
+| A | B | drop into the trench | 2.5 m |
+| B | C | trenched sensing fiber | 25 m |
+| C | | the buried coil | 10 m |
+| C | D | trenched sensing fiber | 25 m |
+| D | E | rise out of the trench | 2.5 m |
+| E | 3, 2, 1 | six links between splice boxes, couplers, and borehole heads | 15 m each |
+| | | three boreholes, down and back | 40 m each |
 
-: The tunnel installation. {#tbl-parts}
+: The path, waypoint by waypoint. {#tbl-path}
 
-Two numbers there are worth pausing on. A borehole is 40 m deep but contributes 80 m of fiber, because the cable goes down, turns around at the bottom, and comes back up — the light travels both legs, and both legs are sensing.
+Two of those numbers need a word.
 
-![The borehole cable: armored pigtails above ground, rock-coupled fiber below, and a turnaround at the bottom.](../_static/borehole_fiber.svg){#fig-borehole width="30%"}
+A borehole holds 40 m of fiber but is only 20 m deep, because the cable goes down, turns around at the bottom, and comes back up. Both legs are coupled to the rock and both are sensing.
 
-The trench is worse. Its cable is wound helically at 30° off-axis, which buys sensitivity to broadside motion at the cost of length: the fiber is longer than the trench it lies in. With a wind angle $\phi$, a trench distance $d_r$, and an optical distance $d_o$,
+![The borehole cable: armored pigtail above ground, rock-coupled fiber below, and a turnaround enclosure at the bottom.](../_static/borehole_fiber.svg){#fig-borehole width="30%"}
+
+The trench cable is wound helically off-axis, which buys sensitivity to broadside motion at the cost of length: the fiber is longer than the trench it lies in. With a wind angle $\phi$, a distance $d_r$ along the ground and $d_o$ along the fiber,
 
 $$
-d_r \approx d_o \cos \phi \approx 0.866\, d_o
+d_r \approx d_o \cos \phi \approx 0.886\, d_o
 $$
 
-so 50 m of trench takes about 57.7 m of fiber. This is the distinction the inventory exists to keep: optical distance is what the interrogator measures, and where a channel actually *is* comes from the geometry track rather than from arithmetic on the channel number.
+which is why the drawing's 25 m of fiber between B and C covers 22.15 m of tunnel. This is the distinction the inventory exists to keep. Optical distance is what the interrogator measures; where a channel actually *is* comes from the geometry track, and no consumer downstream ever has to know the wind angle.
 
 # The hardware
 
-Cables, enclosures, and interrogators are named once and referred to from everywhere they appear. Each is a small file under `resources/`, and the file's name is the `resource_id` other files refer to it by.
+Cables, enclosures, and interrogators are named once and referred to from everywhere they appear. Each is a small file under `resources/`, and the file's name is the `resource_id` other files use to point at it.
 
 ```{python}
 #| code-fold: true
@@ -86,7 +92,7 @@ resources = {
         "object_type: Cable\n"
         "name: helically wound trench cable\n"
         "manufacturer: Silixa\n"
-        "model: HWC 30 degree\n"
+        "model: HWC\n"
         "fiber_count: 1\n"
     ),
     "splice-box": (
@@ -104,21 +110,14 @@ resources = {
         "model: Onyxia\n"
         "instrument_type: DAS interrogator\n"
     ),
-    "dss-interrogator": (
-        "object_type: Interrogator\n"
-        "name: tunnel DSS interrogator\n"
-        "manufacturer: Febus\n"
-        "model: G1\n"
-        "instrument_type: Brillouin DSS interrogator\n"
-    ),
 }
 for name, text in resources.items():
     write(f"resources/{name}.yaml", text)
 ```
 
-These stay objects rather than rows because they have nothing in common: a cable has a fiber count, an enclosure has an inner diameter, an interrogator has firmware. A table of one row with twelve mostly-empty columns would be worse than the file.
+These stay objects rather than rows because they have nothing in common: a cable has a fiber count, an enclosure has an inner diameter, an interrogator has a serial number. A table of one row with twelve mostly-empty columns would be worse than the file.
 
-The envelope names the document and states the coordinate reference system everything else is expressed in. This tunnel has its own survey grid rather than a global reference, so the axes are `x`, `y`, and `z` in meters, `z` positive up.
+The envelope names the document and states the coordinate reference system everything is expressed in. This tunnel has its own survey grid rather than a global reference, so the axes are `x`, `y`, and `z` in meters, with `z` positive up.
 
 ```{python}
 write(
@@ -140,90 +139,124 @@ write(
 
 # The path, as a table
 
-An optical path is the ordered list of things the light passes through. Each component states its own optical length, and they tile the path end to end — which is what gives the path its length. Nothing states a start distance, because the `sequence` column already did.
+An optical path is the ordered list of things the light passes through. Each component states its own optical length and they tile the path end to end, which is what gives the path its length. No row states a start distance, because the `sequence` column already did.
 
-This is the table the field crew keeps in a spreadsheet, and it goes in `path.00`, the directory naming the optical path at location code `00`.
+This is @tbl-path with the parts named, and it goes in `path.00` — the directory naming the optical path at location code `00`.
 
 ```{python}
 #| code-fold: true
 #| code-summary: "path.00/optical_components.csv"
 components_csv = dedent("""\
 sequence,object_type,optical_length,name,container
-1,FiberSegment,40.0,telemetry lead-in,telemetry-cable
-2,Connector,0.0,splice box connector,splice-box
-3,FiberSegment,5.0,borehole 1 pigtail down,borehole-cable
-4,FiberSegment,40.0,borehole 1 sensing down,borehole-cable
-5,Splice,0.0,borehole 1 turnaround,turnaround
-6,FiberSegment,40.0,borehole 1 sensing up,borehole-cable
-7,FiberSegment,5.0,borehole 1 pigtail up,borehole-cable
-8,FiberSegment,20.0,connecting fiber 1 to 2,telemetry-cable
-9,FiberSegment,5.0,borehole 2 pigtail down,borehole-cable
-10,FiberSegment,40.0,borehole 2 sensing down,borehole-cable
-11,Splice,0.0,borehole 2 turnaround,turnaround
-12,FiberSegment,40.0,borehole 2 sensing up,borehole-cable
-13,FiberSegment,5.0,borehole 2 pigtail up,borehole-cable
-14,FiberSegment,20.0,connecting fiber 2 to 3,telemetry-cable
-15,FiberSegment,5.0,borehole 3 pigtail down,borehole-cable
-16,FiberSegment,40.0,borehole 3 sensing down,borehole-cable
-17,Splice,0.0,borehole 3 turnaround,turnaround
-18,FiberSegment,40.0,borehole 3 sensing up,borehole-cable
-19,FiberSegment,5.0,borehole 3 pigtail up,borehole-cable
-20,FiberSegment,20.0,connecting fiber to the trench,telemetry-cable
-21,FiberSegment,57.7,trenched sensing fiber,trench-cable
-22,FiberSegment,10.0,clump coil,trench-cable
-23,Terminator,0.0,path end,
+1,FiberSegment,1500.0,telemetry lead-in,telemetry-cable
+2,Splice,0.0,splice at box A,splice-box
+3,FiberSegment,2.5,drop into the trench,trench-cable
+4,FiberSegment,25.0,trench B to the coil,trench-cable
+5,FiberSegment,10.0,cable coil at C,trench-cable
+6,FiberSegment,25.0,trench from the coil to D,trench-cable
+7,FiberSegment,2.5,rise out of the trench,trench-cable
+8,Splice,0.0,splice at box E,splice-box
+9,FiberSegment,15.0,link E to borehole 3,telemetry-cable
+10,FiberSegment,20.0,borehole 3 down,borehole-cable
+11,Splice,0.0,borehole 3 turnaround,turnaround
+12,FiberSegment,20.0,borehole 3 up,borehole-cable
+13,FiberSegment,15.0,link borehole 3 to coupler G,telemetry-cable
+14,Connector,0.0,coupler G,splice-box
+15,FiberSegment,15.0,link coupler G to borehole 2,telemetry-cable
+16,FiberSegment,20.0,borehole 2 down,borehole-cable
+17,Splice,0.0,borehole 2 turnaround,turnaround
+18,FiberSegment,20.0,borehole 2 up,borehole-cable
+19,FiberSegment,15.0,link borehole 2 to coupler H,telemetry-cable
+20,Connector,0.0,coupler H,splice-box
+21,FiberSegment,15.0,link coupler H to borehole 1,telemetry-cable
+22,FiberSegment,20.0,borehole 1 down,borehole-cable
+23,Splice,0.0,borehole 1 turnaround,turnaround
+24,FiberSegment,20.0,borehole 1 up,borehole-cable
+25,FiberSegment,15.0,link borehole 1 back to box A,telemetry-cable
+26,Terminator,0.0,path end,
 """)
 
-write("fiber_arrays/XT.TUN1/path.00/attrs.yaml", "object_type: OpticalPath\n")
-write("fiber_arrays/XT.TUN1/path.00/optical_components.csv", components_csv)
+PATH = "fiber_arrays/XT.TUN1/path.00"
+write(f"{PATH}/attrs.yaml", "object_type: OpticalPath\n")
+write(f"{PATH}/optical_components.csv", components_csv)
 
-pd.read_csv(root / "fiber_arrays/XT.TUN1/path.00/optical_components.csv")
+pd.read_csv(root / PATH / "optical_components.csv").head(9)
 ```
 
-Every column there is a field of the class the `object_type` column names, so the table is not a format of its own — it is the objects, written the way rows of the same shape are worth writing. The blank `container` on the terminator is a field left unset, and the ones which are filled are `resource_id`s pointing back at the files written above.
+Every column but `sequence` is a field of the class the `object_type` column names, so the table is barely a format of its own — it is the objects, written the way rows of the same shape are worth writing. `sequence` belongs to the table, and is dropped once it has put the rows in order. The blank `container` on the terminator is a field left unset; the ones which are filled are `resource_id`s pointing back at the files above.
 
-Nothing else in the inventory has to repeat these numbers. The distances the other three tables are written against are the running totals of this one:
+The other three tables are written against distances along this path, and those distances are the running totals of this one column. Adding them up by hand is how a table stops agreeing with its neighbours, so add them up once:
 
 ```{python}
-LEAD_IN = 40.0
-BOREHOLE_SPAN = {1: (45.0, 125.0), 2: (155.0, 235.0), 3: (265.0, 345.0)}
-TRENCH_SPAN = (370.0, 427.7)
-COIL_SPAN = (427.7, 437.7)
+def spans(csv_text):
+    """Map each component's name to the optical interval it covers."""
+    frame = pd.read_csv(io.StringIO(csv_text))
+    end = frame["optical_length"].cumsum()
+    return dict(zip(frame["name"], zip(end - frame["optical_length"], end)))
+
+
+at = spans(components_csv)
+
+print("borehole 3 sensing fiber:", at["borehole 3 down"][0], "to", at["borehole 3 up"][1])
 ```
 
 # Where the fiber is
 
-Geometry places optical distance in space, one row per control point, grouped into segments. A borehole is two straight legs, down and back up over the same hole; the trench is a straight run at 0.5 m depth. The columns after `segment` and `distance` are the axes the coordinate reference system declared, and naming any others is an error rather than an extra.
+Geometry places optical distance in space, one row per control point, grouped into segments. The columns after `segment` and `distance` are the axes the coordinate reference system declared, and naming any others is an error rather than an extra.
+
+The survey points are the ones lettered in @fig-tunnel. Each straight run of fiber goes from one to the next, so the table is those points paired with the component that runs between them.
 
 ```{python}
 #| code-fold: true
-#| code-summary: "path.00/geometry.csv"
-geometry_csv = dedent("""\
-segment,distance,x,y,z
-borehole 1 down,45.0,20.0,0.0,0.0
-borehole 1 down,85.0,20.0,0.0,-40.0
-borehole 1 up,85.0,20.0,0.0,-40.0
-borehole 1 up,125.0,20.0,0.0,0.0
-borehole 2 down,155.0,40.0,0.0,0.0
-borehole 2 down,195.0,40.0,0.0,-40.0
-borehole 2 up,195.0,40.0,0.0,-40.0
-borehole 2 up,235.0,40.0,0.0,0.0
-borehole 3 down,265.0,60.0,0.0,0.0
-borehole 3 down,305.0,60.0,0.0,-40.0
-borehole 3 up,305.0,60.0,0.0,-40.0
-borehole 3 up,345.0,60.0,0.0,0.0
-trench,370.0,0.0,0.0,-0.5
-trench,427.7,50.0,0.0,-0.5
-""")
+#| code-summary: "path.00/geometry.csv — the survey points, paired with the fiber between them"
+A = (100.00, 100.00, 0.0)
+B = (100.00, 97.79, -0.5)
+C = (122.15, 97.79, -0.5)
+D = (144.30, 97.79, -0.5)
+E = (144.30, 100.00, 0.0)
+HEADS = {1: (108.00, 100.00, 0.0), 2: (126.00, 100.00, 0.0), 3: (142.00, 100.00, 0.0)}
+DEPTH = 20.0
 
-write("fiber_arrays/XT.TUN1/path.00/geometry.csv", geometry_csv)
 
-pd.read_csv(root / "fiber_arrays/XT.TUN1/path.00/geometry.csv").head(6)
+def bottom(number):
+    """The bottom of a borehole is its head, straight down."""
+    x, y, _ = HEADS[number]
+    return (x, y, -DEPTH)
+
+
+def surveyed_runs(at):
+    """Which component runs between which two survey points."""
+    runs = [
+        ("drop into the trench", A, B),
+        ("trench B to the coil", B, C),
+        ("trench from the coil to D", C, D),
+        ("rise out of the trench", D, E),
+    ]
+    for number in (3, 2, 1):
+        runs.append((f"borehole {number} down", HEADS[number], bottom(number)))
+        runs.append((f"borehole {number} up", bottom(number), HEADS[number]))
+    return runs
+
+
+def geometry_table(at, runs):
+    """Turn each straight run into its two control points."""
+    rows = []
+    for name, start, end in runs:
+        first, last = at[name]
+        rows.append((name, first, *start))
+        rows.append((name, last, *end))
+    return pd.DataFrame(rows, columns=["segment", "distance", "x", "y", "z"])
+
+
+geometry = geometry_table(at, surveyed_runs(at))
+geometry.to_csv(root / PATH / "geometry.csv", index=False)
+
+geometry.head(8)
 ```
 
-The lead-in, the connecting fibers, and the coil appear nowhere in that table, and they get no position. That is the honest answer: nobody surveyed the lead-in, because it is coiled in a rack.
+The coil and the six 15 m links appear nowhere in that table, so their channels get no position at all. That is the honest answer rather than a gap: the links are slack cable in a tray, and ten meters of fiber wound into a one-meter loop has no useful position per channel. A made-up polyline would be worse than a `nan`.
 
-The trench segment is also where the wind angle stops mattering to anyone downstream. Its two control points say that 57.7 m of fiber covers 50 m of ground; every channel between them is placed by interpolating that, and no consumer has to know about $\cos\phi$.
+Notice also what the table does *not* say. It never mentions the wind angle. Two control points state that 25 m of fiber runs from B to C, every channel between them is placed by interpolating that, and $\cos\phi$ stops being anyone's problem at this line.
 
 # How it is attached to the ground
 
@@ -232,75 +265,84 @@ Coupling is what decides whether a wiggle means anything, and it is an interval 
 ```{python}
 #| code-fold: true
 #| code-summary: "path.00/coupling.csv"
-coupling_csv = dedent("""\
-start_distance,end_distance,coupling_type,medium,attachment,depth
-45.0,125.0,outside_borehole_casing,rock,cemented,
-155.0,235.0,outside_borehole_casing,rock,cemented,
-265.0,345.0,outside_borehole_casing,rock,cemented,
-370.0,427.7,trench,soil,direct_burial,0.5
-427.7,437.7,coiled,soil,,0.5
-""")
+def coupling_table(at, trench_parts):
+    """Buried in the trench, coiled at C, cemented in the boreholes."""
+    rows = [
+        (*at[name], "trench", "soil", "direct_burial", 0.5) for name in trench_parts
+    ]
+    rows.append((*at["cable coil at C"], "coiled", "soil", "", 0.5))
+    rows.extend(
+        (
+            at[f"borehole {number} down"][0],
+            at[f"borehole {number} up"][1],
+            "outside_borehole_casing",
+            "rock",
+            "cemented",
+            "",
+        )
+        for number in (3, 2, 1)
+    )
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "start_distance",
+            "end_distance",
+            "coupling_type",
+            "medium",
+            "attachment",
+            "depth",
+        ],
+    )
 
-write("fiber_arrays/XT.TUN1/path.00/coupling.csv", coupling_csv)
 
-pd.read_csv(root / "fiber_arrays/XT.TUN1/path.00/coupling.csv")
+TRENCH_PARTS = (
+    "drop into the trench",
+    "trench B to the coil",
+    "trench from the coil to D",
+    "rise out of the trench",
+)
+
+coupling = coupling_table(at, TRENCH_PARTS)
+coupling.to_csv(root / PATH / "coupling.csv", index=False)
+
+coupling
 ```
 
-The coil is `coiled` rather than `trench`, which is the whole reason that value exists: ten meters of fiber wound into a one-meter loop has no useful position per channel, and saying so is better than a made-up polyline.
+The coil is `coiled` rather than `trench`, which is the whole reason that value exists: it is buried in the same soil at the same depth, but a channel in it is not sampling a place.
 
 # Everything else
 
-Annotations are for what the model has no field for. Each group becomes a coordinate on the patches, named after the group, so pick names you would want to select on later. Here `section` names what kind of installation a channel belongs to and `borehole` numbers the three holes.
+Annotations are for what the model has no field for. Each group becomes a coordinate on the patches, named after the group, so pick names you would want to select on later. Here `section` says what kind of installation a channel belongs to, and `borehole` numbers the holes.
 
 ```{python}
 #| code-fold: true
 #| code-summary: "path.00/annotations.csv"
-annotations_csv = dedent("""\
-start_distance,end_distance,group,value
-45.0,125.0,section,borehole
-155.0,235.0,section,borehole
-265.0,345.0,section,borehole
-370.0,427.7,section,trench
-427.7,437.7,section,coil
-45.0,125.0,borehole,1
-155.0,235.0,borehole,2
-265.0,345.0,borehole,3
-""")
+def annotation_table(at, trench_parts):
+    """Which section a channel is in, and which borehole if it is in one."""
+    rows = [(*at[name], "section", "trench") for name in trench_parts]
+    rows.append((*at["cable coil at C"], "section", "coil"))
+    for number in (3, 2, 1):
+        span = (at[f"borehole {number} down"][0], at[f"borehole {number} up"][1])
+        rows.append((*span, "section", "borehole"))
+        rows.append((*span, "borehole", number))
+    return pd.DataFrame(
+        rows, columns=["start_distance", "end_distance", "group", "value"]
+    )
 
-write("fiber_arrays/XT.TUN1/path.00/annotations.csv", annotations_csv)
 
-pd.read_csv(root / "fiber_arrays/XT.TUN1/path.00/annotations.csv")
+annotations = annotation_table(at, TRENCH_PARTS)
+annotations.to_csv(root / PATH / "annotations.csv", index=False)
+
+annotations
 ```
 
-A group holds one kind of value: `section` is text everywhere and `borehole` is a number everywhere. Mixing them would be two tracks sharing a name, and is refused when the directory is read.
+A group holds one kind of value: `section` is text in every row and `borehole` is a number in every row. Mixing them would be two tracks sharing a name, and is refused when the directory is read.
 
-# The second interrogator
+# How the instrument was set up
 
-The DSS system is on its own fiber and sees only the trench, so it is a second optical path under the same fiber array, at its own location code.
+A path is the fiber; an acquisition is a configuration of an instrument recording through it. The file's name states the identity — network, fiber array, location code, and acquisition code — so `XT.TUN1.00.DAS` is what a patch recorded here carries as its `acquisition_key`.
 
-```{python}
-#| code-fold: true
-#| code-summary: "path.01 — the DSS fiber"
-write("fiber_arrays/XT.TUN1/path.01/attrs.yaml", "object_type: OpticalPath\n")
-write(
-    "fiber_arrays/XT.TUN1/path.01/optical_components.csv",
-    "sequence,object_type,optical_length,name,container\n"
-    "1,FiberSegment,40.0,DSS lead-in,telemetry-cable\n"
-    "2,FiberSegment,57.7,DSS trenched fiber,trench-cable\n"
-    "3,Terminator,0.0,DSS path end,\n",
-)
-write(
-    "fiber_arrays/XT.TUN1/path.01/coupling.csv",
-    "start_distance,end_distance,coupling_type,medium,attachment,depth\n"
-    "40.0,97.7,trench,soil,direct_burial,0.5\n",
-)
-```
-
-# How each instrument was set up
-
-A path is the fiber; an acquisition is a configuration of an instrument recording through it. The file's name states the identity — network, fiber array, location code, and acquisition code — and `XT.TUN1.00.DAS` is what a patch recorded here carries as its `acquisition_key`.
-
-The `distance_map` is the join between instrument and fiber: it says where the interrogator's own distance axis lands on the path. Both instruments here are zeroed at themselves, so the map is the identity — but it is stated rather than assumed, because a re-zeroed instrument is the usual cause of metadata that is quietly off by a lead-in.
+The `distance_map` is the join between instrument and fiber: it says where the interrogator's own distance axis lands on the path. This one is zeroed at itself, so the map is the identity — but it is stated rather than assumed, because a re-zeroed instrument is the usual cause of metadata that is quietly off by a lead-in. It is also stated past the end of the fiber, so that it keeps working when the fiber gets longer.
 
 ```{python}
 write(
@@ -314,33 +356,22 @@ write(
     "spatial_interval: 1.0\n"
     "sample_rate: 250.0\n"
     "distance_map:\n"
-    "  instrument_distance: [0.0, 437.7]\n"
-    "  distance: [0.0, 437.7]\n",
-)
-
-write(
-    "acquisitions/XT.TUN1.01.DSS.yaml",
-    "object_type: Acquisition\n"
-    "data_category: DSS\n"
-    "data_type: strain\n"
-    "interrogator: dss-interrogator\n"
-    "spatial_interval: 1.0\n"
-    "distance_map:\n"
-    "  instrument_distance: [0.0, 97.7]\n"
-    "  distance: [0.0, 97.7]\n",
+    "  instrument_distance: [0.0, 2000.0]\n"
+    "  distance: [0.0, 2000.0]\n",
 )
 ```
 
+The telemetry cable holds four fibers and only one is in use here. A second interrogator on another of them would be a second optical path under this same fiber array, at its own location code, with its own acquisitions — the array is the installation, not the instrument.
+
 # Reading it back
 
-The directory is now an inventory, and loading it is the moment every rule is checked: that each file is what it says it is, that each `container` resolves to a resource, that no track runs off the end of its path.
+The directory is now an inventory, and loading it is where every rule is checked: that each file is what it says it is, that each `container` resolves to a resource, that no track runs off the end of its path.
 
 ```{python}
 inventory = dc.inventory(root)
 
-array = inventory.networks[0].fiber_arrays[0]
-for path in array.optical_paths:
-    print(f"path {path.location_code}: {path.optical_length:.1f} m of fiber")
+path = inventory.networks[0].fiber_arrays[0].optical_paths[0]
+print(f"{path.optical_length:.1f} m of fiber in {len(path.optical_components)} components")
 
 names = inventory.get_names()
 print("coords:", [x for x in names.coords if "." not in x])
@@ -357,7 +388,7 @@ patch = dc.get_example_patch(
     "random_das",
     acquisition_key="XT.TUN1.00.DAS",
     time_min="2024-06-01",
-    shape=(440, 500),
+    shape=(1780, 200),
 )
 spool = dc.spool(patch).attach_inventory(inventory)
 ```
@@ -375,77 +406,96 @@ for sub in boreholes:
 
 Three patches, not one: the three holes are three separate runs of fiber, and a patch is a dense block of channels, so a selection matching three disjoint runs gives back three patches rather than silently gluing them together.
 
-[`Spool.enrich`](`dascore.core.spool.Spool.enrich`) is what actually puts the metadata on a patch:
+[`Spool.enrich`](`dascore.core.spool.Spool.enrich`) is what puts the metadata on a patch:
 
 ```{python}
-import numpy as np
-
 enriched = spool.enrich()[0]
 
 print("gauge length:", enriched.attrs.gauge_length)
 print("coordinates:", sorted(enriched.coords.coord_map))
+```
 
-# 60 m along the fiber is 15 m down borehole 1.
+And the coordinates are the point of all of it. The channel 1590 m along the fiber is 10 m down borehole 3; the channel 1510 m along it is 6.645 m into the tunnel, which is the wind angle doing its work without having been mentioned; and the channel 1000 m along it is somewhere in a cable tray that nobody surveyed.
+
+```{python}
 depth = enriched.get_coord("z").values
-assert depth[60] == -15.0
+along = enriched.get_coord("x").values
 
-# The lead-in was never surveyed, so it has no position.
-assert np.isnan(depth[10])
+assert depth[1590] == -10.0
+assert np.isclose(along[1510], 100.0 + 7.5 * 0.886)
+assert np.isnan(depth[1000])
 ```
 
 # A repair, and what it does to the data
 
-In September a contractor puts a bucket through the trench cable 25 m in. It is repaired with two splices and a two-meter patch cord, and every channel past the repair now sits two meters further along the fiber than it used to.
+In September a contractor puts a bucket through the trench cable, fifteen meters of fiber past box A. It is repaired with two splices and a two-meter patch cord, and every channel beyond the repair now sits two meters further along the fiber than it used to.
 
-This is what epochs are for. The old description is not edited: a second directory is added, named for the day the repair happened, and the first path runs until the second begins.
+This is what epochs are for. The old description is not edited. A second directory is added, named for the day of the repair, and the first path runs until the second begins.
+
+The components table is where the repair happens: one row becomes five, and the table is renumbered.
+
+```{python}
+rows = pd.read_csv(io.StringIO(components_csv)).to_dict("records")
+index = next(i for i, row in enumerate(rows) if row["name"] == "trench B to the coil")
+rows[index : index + 1] = [
+    dict(object_type="FiberSegment", optical_length=15.0,
+         name="trench B to the break", container="trench-cable"),
+    dict(object_type="Splice", optical_length=0.0,
+         name="repair splice near side", container="splice-box"),
+    dict(object_type="FiberSegment", optical_length=2.0,
+         name="repair patch cord", container="trench-cable"),
+    dict(object_type="Splice", optical_length=0.0,
+         name="repair splice far side", container="splice-box"),
+    dict(object_type="FiberSegment", optical_length=10.0,
+         name="trench from the break to the coil", container="trench-cable"),
+]
+
+repaired_components = pd.DataFrame(rows)
+repaired_components["sequence"] = range(1, len(repaired_components) + 1)
+repaired_csv = repaired_components.to_csv(index=False)
+
+repaired_components.iloc[index - 1 : index + 5]
+```
+
+Everything else follows from that table, which is the argument for having written it this way: the three other tracks are regenerated from the new running totals rather than edited row by row.
 
 ```{python}
 #| code-fold: true
-#| code-summary: "path.00@2024-09-01 — the same path, after the repair"
-epoch = "fiber_arrays/XT.TUN1/path.00@2024-09-01"
-write(f"{epoch}/attrs.yaml", "object_type: OpticalPath\n")
-write(f"{epoch}/annotations.csv", annotations_csv.replace("427.7", "429.7"))
+#| code-summary: "path.00@2024-09-01 — the same tracks, against the new distances"
+EPOCH = "fiber_arrays/XT.TUN1/path.00@2024-09-01"
+BREAK = (100.00 + 15.0 * 0.886, 97.79, -0.5)
 
-# The trench is now two runs of fiber with the repair between them, and
-# everything past it moves two meters.
-write(
-    f"{epoch}/optical_components.csv",
-    components_csv.replace(
-        "21,FiberSegment,57.7,trenched sensing fiber,trench-cable\n"
-        "22,FiberSegment,10.0,clump coil,trench-cable\n"
-        "23,Terminator,0.0,path end,\n",
-        "21,FiberSegment,25.0,trenched fiber to the break,trench-cable\n"
-        "22,Splice,0.0,repair splice near side,splice-box\n"
-        "23,FiberSegment,2.0,repair patch cord,trench-cable\n"
-        "24,Splice,0.0,repair splice far side,splice-box\n"
-        "25,FiberSegment,32.7,trenched fiber past the break,trench-cable\n"
-        "26,FiberSegment,10.0,clump coil,trench-cable\n"
-        "27,Terminator,0.0,path end,\n",
-    ),
+repaired_at = spans(repaired_csv)
+repaired_trench = (
+    "drop into the trench",
+    "trench B to the break",
+    "trench from the break to the coil",
+    "trench from the coil to D",
+    "rise out of the trench",
 )
-write(
-    f"{epoch}/coupling.csv",
-    coupling_csv.replace("370.0,427.7", "370.0,429.7").replace(
-        "427.7,437.7", "429.7,439.7"
-    ),
+# The patch cord is coiled in a splice box, so the trench is surveyed up to
+# the break and again from it, and the two meters between get no position.
+repaired_runs = [
+    ("trench B to the break", B, BREAK),
+    ("trench from the break to the coil", BREAK, C),
+] + [x for x in surveyed_runs(repaired_at) if x[0] != "trench B to the coil"]
+
+write(f"{EPOCH}/attrs.yaml", "object_type: OpticalPath\n")
+write(f"{EPOCH}/optical_components.csv", repaired_csv)
+geometry_table(repaired_at, repaired_runs).to_csv(
+    root / EPOCH / "geometry.csv", index=False
 )
-# The patch cord is coiled in the splice box, so it gets no geometry: the
-# trench is described up to the break and again from it.
-write(
-    f"{epoch}/geometry.csv",
-    geometry_csv.replace(
-        "trench,370.0,0.0,0.0,-0.5\ntrench,427.7,50.0,0.0,-0.5\n",
-        "trench before,370.0,0.0,0.0,-0.5\n"
-        "trench before,395.0,21.65,0.0,-0.5\n"
-        "trench after,397.0,21.65,0.0,-0.5\n"
-        "trench after,429.7,50.0,0.0,-0.5\n",
-    ),
+coupling_table(repaired_at, repaired_trench).to_csv(
+    root / EPOCH / "coupling.csv", index=False
+)
+annotation_table(repaired_at, repaired_trench).to_csv(
+    root / EPOCH / "annotations.csv", index=False
 )
 
 repaired = dc.inventory(root)
-for path in repaired.networks[0].fiber_arrays[0].optical_paths:
-    if path.location_code == "00":
-        print(f"from {path.start_time}: {path.optical_length:.1f} m")
+for epoch in repaired.networks[0].fiber_arrays[0].optical_paths:
+    start = "the beginning" if np.isnat(epoch.start_time) else str(epoch.start_time)[:10]
+    print(f"from {start}: {epoch.optical_length:.1f} m")
 ```
 
 A patch recorded across midnight on the first of September was recorded through both. [`Spool.conform_to_inventory`](`dascore.core.spool.Spool.conform_to_inventory`) is the step which insists every patch be describable by exactly one entry, and it subdivides that patch rather than choosing for you:
@@ -455,7 +505,7 @@ straddling = dc.get_example_patch(
     "random_das",
     acquisition_key="XT.TUN1.00.DAS",
     time_min="2024-08-31T23:59:59",
-    shape=(440, 500),
+    shape=(1780, 500),
 )
 crossed = dc.spool(straddling).attach_inventory(repaired)
 
@@ -465,19 +515,27 @@ print("patches after: ", len(conformed))
 print(conformed.get_contents()[["time_min", "time_max"]].to_string(index=False))
 ```
 
-The split is exact: every sample the patch held is in one piece or the other, and none is in both. Each piece now enriches with the geometry that was true while it was recording, which is the entire reason the repair was written as an epoch instead of an edit.
+The split is exact: every sample the patch held is in one piece or the other, and none is in both. Each piece then enriches with the geometry that was true while it was recording, which is the entire reason the repair was written as an epoch instead of an edit.
 
 ```{python}
 before, after = conformed.enrich()
 
-# The coil sat at 427.7 m before the repair and 429.7 m after it.
-assert before.get_coord("section").values[428] == "coil"
-assert after.get_coord("section").values[428] == "trench"
+# The same channel, ten meters down borehole 3 and then eight, because the
+# repair pushed two meters of fiber in front of it.
+assert before.get_coord("z").values[1590] == -10.0
+assert after.get_coord("z").values[1590] == -8.0
+
+# Nothing before the break moved.
+assert np.isclose(
+    before.get_coord("x").values[1510], after.get_coord("x").values[1510]
+)
 ```
+
+Had the path been edited in place instead, that first assertion would now be false for data recorded in June.
 
 # Shipping it
 
-The directory is the authoring format — good for a deployment still being surveyed, because the tracks are spreadsheets. [`Inventory.to_yaml`](`dascore.core.inventory.Inventory.to_yaml`) writes the single-file form to ship beside a data archive, and [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads either back.
+The directory is the authoring format, and it is the right one while a deployment is still being surveyed, because the tracks are spreadsheets. [`Inventory.to_yaml`](`dascore.core.inventory.Inventory.to_yaml`) writes the single-file form to ship beside a data archive, and [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads either back.
 
 ```{python}
 text = repaired.to_yaml()
@@ -486,13 +544,13 @@ print(f"{len(text.splitlines())} lines of yaml")
 assert dc.inventory(text) == repaired
 ```
 
-Dropping either form into the data directory under the name `.inventory` means every spool opened on that directory finds it without being told.
+Dropping either into the data directory means every spool opened there finds it without being told: the authoring directory as `.inventory/`, or the single file as `.inventory.yaml`, `.inventory.yml`, or `.inventory.json`. The name states the format, so a file called plainly `.inventory` is not one of the spellings.
 
 # Where the boundaries fell
 
 The choices worth restating, because a second deployment will have to make them again:
 
 - **Three boreholes, one fiber array.** They are one continuous run of fiber recorded as one channel axis, so they are one array with one path. Five dissimilar arms radiating from a hut, each with its own cable and its own break history, would be five fiber arrays instead — the question to ask is whether a break in one changes the others' metadata.
-- **The DSS is a second path, not a second array.** Same installation, same operator, different instrument on different fiber. The location code separates them, and both stay under one array so they share its identity and its lifetime.
 - **The turnaround is a component; its housing is a resource.** The splice is on the path because the light goes through it. The housing it sits in is a thing the site owns, referred to by any component inside it.
+- **The wind angle is geometry, not arithmetic.** It is two control points and a straight line, so nothing downstream computes with $\cos\phi$, and a second trench wound at a different angle needs no new code.
 - **The repair is an epoch, not an edit.** Data recorded before it is still described by what was true then. Editing the path in place would have silently moved every channel in the archive's history.

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -157,6 +157,11 @@ website:
             - recipes/parallelization.qmd
             - recipes/low_freq_proc.qmd
 
+        - section: "Inventory"
+          contents:
+
+            - recipes/tunnel_inventory.qmd
+
         - section: "IO"
           contents:
 


### PR DESCRIPTION
## Description

The [inventory tutorial](https://github.com/DASDAE/dascore/pull/899) shows the model and the verbs. This is the worked example: one deployment, from field notes to enriched patches.

The deployment is an underground tunnel — a 1500 m telemetry run in from an instrument room, a helically wound cable trenched along the floor past a buried coil, and three instrumented boreholes worked back along the tunnel. It comes from the survey drawing the DASDAE proposal site carried, which turns out to specify every distance and every coordinate; the recipe follows it rather than inventing its own.

### The tables are the point

Every track in the authoring format is a spreadsheet, so the page writes the CSV and renders it back rather than reciting twenty-three constructor calls a reader would skip. What stays as objects is what has no rows: the cables, enclosures, and interrogators, which share no fields, and the acquisitions.

The hardware is `resources/*.yaml`, the tracks are `optical_components.csv`, `geometry.csv`, `coupling.csv`, and `annotations.csv` under `path.00`, and the whole directory then loads with `dc.inventory`.

### What it documents that nothing else does

- **The wind angle stops at the geometry track.** The trench cable is wound off-axis, so 25 m of fiber covers 22.15 m of tunnel. Two control points say so, every channel between them is placed by interpolating that, and nothing downstream has to know about $\cos\phi$. The page asserts the interpolated position rather than describing it.
- **A repair is an epoch, not an edit.** A contractor puts a bucket through the trench cable fifteen meters of fiber in; it is fixed with two splices and a 2 m patch cord, and every channel past the repair moves. A second directory named `path.00@2024-09-01` records that, the first path runs until the second begins, and a patch recorded across the boundary is subdivided by `conform_to_inventory` rather than assigned to whichever epoch happened to be checked first. The same channel is ten meters down borehole 3 in one piece and eight in the other, which the page asserts.
- **The repair slack has no position.** The patch cord is coiled in a splice box, so the geometry describes the trench up to the break and again from it, and the two meters between get no coordinates. The page asserts that gap rather than describing it.
- **Selection can return more patches than it was given.** `select(section="borehole")` on a spool of one patch gives three, because the three holes are three disjoint runs of fiber and a patch is a dense block of channels.

### Executable, and derived rather than typed

Every `{python}` block runs under the doc-code tests. The components table is the only place a distance is written down: the other three tracks are generated from its running totals, so they cannot drift out of step with it, and the repair is a five-row edit to one table rather than forty hand-shifted distances across four.

The two figures come from the DASDAE inventory proposal site, which is being retired.

### Review

Codex reviewed it and found eight things, of which the sharpest was that the figures and the page described different tunnels — the drawing has a 1500 m lead-in and 15 m links where the page had invented 40 m and 5 m. The page was rebuilt on the drawing. It also caught the `distance_map` running out before the repaired path did, so the last two channels of the longer epoch resolved to nothing; the patch cord being described as buried trench fiber when the point of it is that it has no position; and three smaller claims that were not true of the implementation (`sequence` is not a model field, `Interrogator` has no firmware, and a file named plainly `.inventory` is not one of the accepted spellings).

## Changelog

- added: a [tunnel inventory recipe](https://dascore.org/recipes/tunnel_inventory.html) building a complete inventory for a deployment as an authoring directory of YAML and CSV files, then attaching, selecting, enriching, and conforming with it.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive tunnel-inventory recipe covering DAS/DSS deployment inventory creation and validation.
  * Documented hardware, fiber arrays, optical components, geometry, coupling, annotations, acquisition settings, repairs, serialization, and automatic inventory discovery.
  * Added the recipe to the documentation’s Recipes navigation under a new Inventory section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->