### PR TITLE
One vocabulary, one door, one name per operation

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -184,7 +184,7 @@ PROGRESS_LEVELS = Literal["standard", "basic", None]
 
 # Options for handling specific warnings. "ignore" and None both mean
 # "do nothing"; warn_or_raise has always accepted either.
-WARN_LEVELS = Literal["warn", "raise", "ignore", None]
+WARN_LEVELS = Literal["warn", "raise", "ignore"]
 
 # The actions warnings.simplefilter and warnings.filterwarnings accept.
 # Spelled out because the standard library's alias for them is stub-only.
@@ -281,16 +281,17 @@ coords
 enrich_on_missing_description = """
 on_missing
     What to do when an explicitly requested name is one the inventory does
-    not define: "raise" (the default), "null" to fill the dtype-appropriate
-    missing marker, or "ignore" to leave it off. Blanket requests copy what
-    is applicable and never trigger it, and per-channel coverage gaps are
-    always missing values rather than errors.
+    not define: "raise" (the default), "warn" to say so and leave it off,
+    "ignore" to leave it off silently, or "null" to fill the
+    dtype-appropriate missing marker so the name is present either way.
+    Blanket requests copy what is applicable and never trigger it, and
+    per-channel coverage gaps are always missing values rather than errors.
 """.strip()
 
 # One paragraph, not two: a blank line inside a parameter description
 # reads as the start of the next parameter when the API docs are built.
-enrich_conflicts_description = f"""
-conflicts
+enrich_conflict_description = f"""
+conflict
 {textwrap.indent(attr_conflict_description.strip(), "    ")}
     Enrichment combines the inventory's values with the patch's own, so
     the default `keep_first` lets the inventory win and re-enriching is

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -182,8 +182,15 @@ STORAGE_PROVENANCE_ATTRS = (
 # Level of progress bar
 PROGRESS_LEVELS = Literal["standard", "basic", None]
 
-# Options for handling specific warnings. "ignore" and None both mean
-# "do nothing"; warn_or_raise has always accepted either.
+progress_description = """
+progress
+    Controls the progress bar. "standard" produces the standard progress
+    bar. "basic" is a simplified version with lower refresh rates, best
+    for high-latency environments, and None disables the progress bar.
+""".strip()
+
+# Options for handling specific warnings. One spelling of "do nothing":
+# "ignore", which every policy argument in the library also spells.
 WARN_LEVELS = Literal["warn", "raise", "ignore"]
 
 # The actions warnings.simplefilter and warnings.filterwarnings accept.
@@ -248,7 +255,7 @@ Any dimension name can be passed as key, and the values can be:
 check_behavior_description = """
 check_behavior
     Indicates what to do when an incompatible patch is found in the
-    spool. `None` will silently skip any incompatible patches,
+    spool. 'ignore' will silently skip any incompatible patches,
     'warn' will issue a warning and then skip incompatible patches,
     'raise' will raise an
     [`IncompatiblePatchError`](`dascore.exceptions.IncompatiblePatchError`)

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -1781,16 +1781,15 @@ _SYSTEM_FACT_NAMES = tuple(
 )
 
 
-def _yaml_label(text) -> str:
+def _yaml_label(text: str) -> str:
     """
     Name YAML text in an error without quoting a whole document at it.
 
-    A one-line string is nearly always a path someone expected to be
-    read, so it is worth showing and worth a word about why it was not.
+    A short document is worth showing; a long one would bury the reason
+    it was rejected under itself.
     """
-    if isinstance(text, str) and "\n" not in text:
-        return f"{text!r} (read as YAML text; no such file or directory)"
-    return "the given YAML text"
+    short = len(text) <= 60 and "\n" not in text
+    return f"{text!r}" if short else "the given YAML text"
 
 
 class Inventory(InventoryModel):
@@ -2306,6 +2305,14 @@ class Inventory(InventoryModel):
             through [`dascore.inventory`](`dascore.inventory`), which is
             the one door every source goes through.
         """
+        if not isinstance(text, str):
+            # Otherwise the parser raises about the object's missing
+            # read method, naming neither this function nor the path.
+            msg = (
+                f"from_yaml reads YAML text, got {type(text).__name__}. "
+                "Load a path with dascore.inventory."
+            )
+            raise InvalidInventoryError(msg)
         yaml = optional_import("yaml", required_for="YAML inventory serialization")
         try:
             data = yaml.safe_load(text)

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -2313,7 +2313,7 @@ class Inventory(InventoryModel):
                 "Load a path with dascore.inventory."
             )
             raise InvalidInventoryError(msg)
-        yaml = optional_import("yaml", required_for="YAML inventory serialization")
+        yaml = optional_import("yaml", required_for="YAML inventory parsing")
         try:
             data = yaml.safe_load(text)
         except yaml.YAMLError as error:

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -15,7 +15,6 @@ Each object documents the rules it enforces.
 from __future__ import annotations
 
 import itertools
-import os
 from collections.abc import Mapping, Sized
 from functools import cache
 from types import MappingProxyType, UnionType
@@ -1782,6 +1781,18 @@ _SYSTEM_FACT_NAMES = tuple(
 )
 
 
+def _yaml_label(text) -> str:
+    """
+    Name YAML text in an error without quoting a whole document at it.
+
+    A one-line string is nearly always a path someone expected to be
+    read, so it is worth showing and worth a word about why it was not.
+    """
+    if isinstance(text, str) and "\n" not in text:
+        return f"{text!r} (read as YAML text; no such file or directory)"
+    return "the given YAML text"
+
+
 class Inventory(InventoryModel):
     """
     Top-level DASDAE inventory manifest.
@@ -2278,9 +2289,9 @@ class Inventory(InventoryModel):
         return out
 
     @classmethod
-    def from_yaml(cls, source) -> Self:
+    def from_yaml(cls, text: str) -> Self:
         """
-        Load an inventory from a YAML string or file path.
+        Load an inventory from YAML text.
 
         A loaded document is checked before it is returned: reading one asks
         whether it is a valid inventory, and a document which fails should
@@ -2290,23 +2301,11 @@ class Inventory(InventoryModel):
 
         Parameters
         ----------
-        source
-            A path to a YAML file, or YAML text (must contain a newline to
-            be treated as text rather than a missing path).
+        text
+            YAML text. Paths — a file or an authoring directory — load
+            through [`dascore.inventory`](`dascore.inventory`), which is
+            the one door every source goes through.
         """
-        text = source
-        if isinstance(source, os.PathLike) or (
-            isinstance(source, str) and "\n" not in source
-        ):
-            if not os.path.exists(source):
-                msg = f"No such inventory file: {source!r}."
-                raise InvalidInventoryError(msg)
-            try:
-                with open(source) as fh:
-                    text = fh.read()
-            except (OSError, UnicodeDecodeError) as error:
-                msg = f"Could not read {source!r}: {error}."
-                raise InvalidInventoryError(msg) from error
         yaml = optional_import("yaml", required_for="YAML inventory serialization")
         try:
             data = yaml.safe_load(text)
@@ -2314,9 +2313,9 @@ class Inventory(InventoryModel):
             # A document which does not parse is an invalid inventory, and
             # says so as one: a caller who asked for an inventory should
             # not have to know which parser was reaching for the file.
-            msg = f"Could not parse YAML from {source!r}: {error}."
+            msg = f"Could not parse YAML from {_yaml_label(text)}: {error}."
             raise InvalidInventoryError(msg) from error
-        return cls._from_mapping(data, f"{source!r}")
+        return cls._from_mapping(data, _yaml_label(text))
 
     @classmethod
     def _from_mapping(cls, data, source: str) -> Self:

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -1583,12 +1583,16 @@ def inventory(source: Inventory | str | os.PathLike | None = None) -> Inventory:
     """
     Load or create a DASDAE inventory.
 
+    The one door every source goes through: what a source is decides how
+    it is read, so nothing else has to guess.
+
     Parameters
     ----------
     source
         An existing Inventory (returned as is), a directory in the
-        authoring format, a YAML file path or YAML text, or None for an
-        empty inventory.
+        authoring format, the path of a serialized document, the text of
+        one, or None for an empty inventory. A path is a path when it
+        exists; a string naming nothing is read as the document itself.
 
     Examples
     --------
@@ -1603,13 +1607,27 @@ def inventory(source: Inventory | str | os.PathLike | None = None) -> Inventory:
     if isinstance(source, str | os.PathLike):
         if os.path.isdir(source):
             return load_directory(source)
-        # A serialized document is read the way the format reads its own
-        # object files: the suffix picks the parser, so a JSON inventory
-        # loads where PyYAML is not installed, and a file which does not
-        # parse says so as an invalid inventory rather than as whatever
-        # the parser happened to raise.
-        if os.path.isfile(source) and _object_suffix(Path(source)) is not None:
-            return _load_file(Path(source))
+        if os.path.isfile(source):
+            # A serialized document is read the way the format reads its
+            # own object files: the suffix picks the parser, so a JSON
+            # inventory loads where PyYAML is not installed, and a file
+            # which does not parse says so as an invalid inventory rather
+            # than as whatever the parser happened to raise. A document
+            # named nothing in particular is the format's own YAML.
+            path = Path(source)
+            if _object_suffix(path) is not None:
+                return _load_file(path)
+            try:
+                text = path.read_text()
+            except (OSError, UnicodeDecodeError) as error:
+                msg = f"Could not read {str(source)!r}: {error}."
+                raise InvalidInventoryError(msg) from error
+            return Inventory.from_yaml(text)
+        # Not a path that exists, so it is the text of a document. A
+        # mistyped path lands here too, which the error says.
+        if isinstance(source, os.PathLike):
+            msg = f"No such inventory file: {str(source)!r}."
+            raise InvalidInventoryError(msg)
         return Inventory.from_yaml(source)
     msg = f"Could not get an inventory from {source!r}."
     raise InvalidInventoryError(msg)

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -1579,6 +1579,18 @@ def find_inventory(directory: str | os.PathLike) -> Path | None:
     return only
 
 
+def _looks_like_a_path(source: str) -> bool:
+    """
+    Return whether a string which names nothing was meant as a path.
+
+    A document is a mapping, so it holds a colon and usually a newline;
+    a bare name ending in one of the suffixes the format writes is a
+    path that is not there rather than the smallest inventory anyone
+    ever wrote.
+    """
+    return "\n" not in source and _object_suffix(Path(source)) is not None
+
+
 def inventory(source: Inventory | str | os.PathLike | None = None) -> Inventory:
     """
     Load or create a DASDAE inventory.
@@ -1610,22 +1622,14 @@ def inventory(source: Inventory | str | os.PathLike | None = None) -> Inventory:
         if os.path.isfile(source):
             # A serialized document is read the way the format reads its
             # own object files: the suffix picks the parser, so a JSON
-            # inventory loads where PyYAML is not installed, and a file
-            # which does not parse says so as an invalid inventory rather
-            # than as whatever the parser happened to raise. A document
-            # named nothing in particular is the format's own YAML.
-            path = Path(source)
-            if _object_suffix(path) is not None:
-                return _load_file(path)
-            try:
-                text = path.read_text()
-            except (OSError, UnicodeDecodeError) as error:
-                msg = f"Could not read {str(source)!r}: {error}."
-                raise InvalidInventoryError(msg) from error
-            return Inventory.from_yaml(text)
-        # Not a path that exists, so it is the text of a document. A
-        # mistyped path lands here too, which the error says.
-        if isinstance(source, os.PathLike):
+            # inventory loads where PyYAML is not installed, a document
+            # named nothing in particular is the format's own YAML, and
+            # every failure names the file it came from.
+            return _load_file(Path(source))
+        # Nothing exists there, so it is the text of a document -- unless
+        # it is spelled like the path of one, which is the mistake worth
+        # a better error than "that is not an inventory".
+        if isinstance(source, os.PathLike) or _looks_like_a_path(source):
             msg = f"No such inventory file: {str(source)!r}."
             raise InvalidInventoryError(msg)
         return Inventory.from_yaml(source)

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -1583,12 +1583,14 @@ def _looks_like_a_path(source: str) -> bool:
     """
     Return whether a string which names nothing was meant as a path.
 
-    A document is a mapping, so it holds a colon and usually a newline;
-    a bare name ending in one of the suffixes the format writes is a
-    path that is not there rather than the smallest inventory anyone
-    ever wrote.
+    An inventory is a mapping, so a document holds a key -- a newline or
+    a `key: value` -- and a bare name ending in one of the suffixes the
+    format writes holds neither. `resource_id: archive.yaml` is a
+    document whose value happens to look like a filename, and a Windows
+    drive letter is a colon this test must not read as a key.
     """
-    return "\n" not in source and _object_suffix(Path(source)) is not None
+    document = "\n" in source or ": " in source or source.endswith(":")
+    return not document and _object_suffix(Path(source)) is not None
 
 
 def inventory(source: Inventory | str | os.PathLike | None = None) -> Inventory:

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -34,6 +34,7 @@ from dascore.constants import (
     namespace_select_type,
     numeric_types,
     path_types,
+    progress_description,
     timeable_types,
 )
 from dascore.core.inventory import _SYSTEM_FACT_NAMES, Inventory
@@ -102,11 +103,10 @@ def _copy_public_dataframe(frame: pd.DataFrame) -> pd.DataFrame:
     return frame.copy(deep=not copy_on_write)
 
 
-_VALID_ON_UNRESOLVED = ("warn", "raise", "ignore")
-# Conform decides membership, not metadata, so where enrich's quiet option
-# is "ignore" -- leave the patch as it was -- conform's is "drop": every
-# policy here removes the patch, and only the noise differs.
-_VALID_ON_UNRESOLVED_CONFORM = ("raise", "warn", "ignore")
+# One vocabulary for both fiber verbs. What the quiet option leaves
+# behind still differs -- enrich leaves the patch as it was, conform
+# removes it -- but that is the verb's business rather than the value's.
+_VALID_ON_UNRESOLVED = ("raise", "warn", "ignore")
 
 # Written once because both fiber verbs refuse for it, and two spellings
 # would let them start explaining the same refusal differently.
@@ -417,6 +417,16 @@ def _normalize_enrich_kwargs(kwargs) -> dict:
         raise ParameterError(msg)
     bound = signature.bind_partial(**kwargs)
     bound.apply_defaults()
+    # False is enrich's off switch, and None is not a second spelling of
+    # it -- said here so the refusal lands on this call rather than on
+    # whichever patch is pulled first.
+    for label in ("attrs", "coords"):
+        if bound.arguments.get(label, False) is None:
+            msg = (
+                f"enrich's {label} must be True, False, or a collection of "
+                "names; pass False to copy none."
+            )
+            raise ParameterError(msg)
     # A collection of names means what it holds, not which container holds it.
     return {
         name: tuple(value) if isinstance(value, list) else value
@@ -1443,7 +1453,8 @@ class Spool(NamespaceOwner):
         # Settled now rather than on extraction: a misspelled argument
         # should be an error here, not on some patch pulled much later.
         enrich_kwargs = _normalize_enrich_kwargs(kwargs)
-        new = self._checked_inventory(on_unresolved, _VALID_ON_UNRESOLVED, "enrich")
+        self._check_inventory_policy(on_unresolved, "enrich")
+        new = self.__class__(self)
         new._enrich_kwargs = enrich_kwargs
         new._on_unresolved = on_unresolved
         return new
@@ -1459,7 +1470,7 @@ class Spool(NamespaceOwner):
         """
         Expand the spool into one patch per value of an inventory coordinate.
 
-        Most often an annotation group. Every kind of group splits: a
+        Most often an annotation group. Every kind of group expands: a
         categorical one by each of its strings, a membership group into
         the channels it includes and those it does not, and a numeric one
         by each distinct measurement. Intervals of one group may overlap,
@@ -1471,7 +1482,7 @@ class Spool(NamespaceOwner):
         Parameters
         ----------
         name
-            The inventory-derived coordinate to split on.
+            The inventory-derived coordinate to expand by.
         include, exclude
             Glob patterns matched against each value *written as a
             string*, which is what lets one spelling cover all three
@@ -1485,7 +1496,7 @@ class Spool(NamespaceOwner):
             Whether to record the value on each output patch as an attr
             named after the coordinate, so overlapping siblings stay
             distinguishable and later operations can select on it. Pass
-            False for a nested split, where the second should not
+            False for a nested expansion, where the second should not
             overwrite the first.
 
         Examples
@@ -1513,8 +1524,8 @@ class Spool(NamespaceOwner):
                 "fiber. Attach one with Spool.attach_inventory."
             )
             raise ParameterError(msg)
-        # A name the inventory could not contribute has no values to split
-        # into, so it would quietly give an empty spool. Selection refuses
+        # A name the inventory could not contribute has no values to
+        # expand into, so it would quietly give an empty spool. Selection refuses
         # a name it does not know, and a misspelling is no more meaningful
         # here than it is there.
         if name not in set(self._resolved_inventory().get_names().coords):
@@ -1622,11 +1633,8 @@ class Spool(NamespaceOwner):
             resolve_row_epochs,
         )
 
-        new = self._checked_inventory(
-            on_unresolved,
-            _VALID_ON_UNRESOLVED_CONFORM,
-            "conform_to_inventory",
-        )
+        self._check_inventory_policy(on_unresolved, "conform_to_inventory")
+        new = self
         source_rows, working = new._plan_frames()
         # The two frames are one relation split by column, so a row of
         # either is the same patch as the row beside it; the messages
@@ -1697,16 +1705,19 @@ class Spool(NamespaceOwner):
         )
         return self._new_from_catalog(catalog)
 
-    def _checked_inventory(self, on_unresolved, valid, method) -> Self:
+    def _check_inventory_policy(self, on_unresolved, method) -> None:
         """
-        Return the spool an inventory verb works on, arguments checked.
+        Refuse an inventory verb's arguments before it does any work.
 
-        Both verbs read the attached inventory and police their own policy
-        vocabulary before doing any work. Sharing the entry keeps the two
-        from drifting into saying it differently.
+        Both verbs read the attached inventory and police the same policy
+        vocabulary. Sharing the check keeps the two from drifting into
+        saying the same refusal differently.
         """
-        if on_unresolved not in valid:
-            msg = f"on_unresolved must be one of {valid}, got {on_unresolved!r}."
+        if on_unresolved not in _VALID_ON_UNRESOLVED:
+            msg = (
+                f"on_unresolved must be one of {_VALID_ON_UNRESOLVED}, "
+                f"got {on_unresolved!r}."
+            )
             raise ParameterError(msg)
         if self._inventory is None:
             msg = (
@@ -1714,7 +1725,6 @@ class Spool(NamespaceOwner):
                 "Spool.attach_inventory."
             )
             raise ParameterError(msg)
-        return self.__class__(self)
 
     def _restrict_to_rows(self, patch_ids, keep: bool = True) -> Self:
         """
@@ -1850,6 +1860,7 @@ class Spool(NamespaceOwner):
             yield self[start : start + step]
             start += step
 
+    @compose_docstring(progress_desc=progress_description)
     def map(
         self,
         func: Callable[..., T],
@@ -1872,11 +1883,7 @@ class Spool(NamespaceOwner):
             The number of patches in each spool mapped to a client.
             If not set, defaults to the number of processors on the host.
             Does nothing unless client is defined.
-        progress
-            Controls the progress bar. "standard" produces the standard
-            progress bar. "basic" is a simplified version with lower refresh
-            rates, best for high-latency environments, and None disables
-            the progress bar.
+        {progress_desc}
         **kwargs
             kwargs passed to func.
 
@@ -2339,6 +2346,7 @@ class Spool(NamespaceOwner):
         """True when any of this spool's patches live in memory."""
         return bool(self._catalog.resolver.live_entries())
 
+    @compose_docstring(progress_desc=progress_description)
     def update(self, progress: PROGRESS_LEVELS = "standard") -> Self:
         """
         Updates the contents of the spool, return the updated spool.
@@ -2352,11 +2360,7 @@ class Spool(NamespaceOwner):
 
         Parameters
         ----------
-        progress
-            Controls the progress bar. "standard" produces the standard
-            progress bar. "basic" is a simplified version with lower refresh
-            rates, best for high-latency environments, and None disables
-            the progress bar.
+        {progress_desc}
         """
         from dascore.io.index.catalog import LiveResolver  # noqa: PLC0415
 

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -407,6 +407,8 @@ def _normalize_enrich_kwargs(kwargs) -> dict:
     argument stated explicitly at its own default, or given as a list
     where a tuple would do, must reach the same stored form.
     """
+    from dascore.proc.inventory import validate_enrich_selection  # noqa: PLC0415
+
     signature = inspect.signature(dc.Patch.enrich)
     valid = set(signature.parameters) - {"patch", "inventory"}
     if bad := sorted(set(kwargs) - valid):
@@ -417,16 +419,10 @@ def _normalize_enrich_kwargs(kwargs) -> dict:
         raise ParameterError(msg)
     bound = signature.bind_partial(**kwargs)
     bound.apply_defaults()
-    # False is enrich's off switch, and None is not a second spelling of
-    # it -- said here so the refusal lands on this call rather than on
-    # whichever patch is pulled first.
-    for label in ("attrs", "coords"):
-        if bound.arguments.get(label, False) is None:
-            msg = (
-                f"enrich's {label} must be True, False, or a collection of "
-                "names; pass False to copy none."
-            )
-            raise ParameterError(msg)
+    # Refused on this call rather than on whichever patch is pulled first.
+    validate_enrich_selection(
+        bound.arguments.get("attrs", False), bound.arguments.get("coords", False)
+    )
     # A collection of names means what it holds, not which container holds it.
     return {
         name: tuple(value) if isinstance(value, list) else value

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -28,7 +28,7 @@ from dascore.constants import (
     PatchType,
     attr_conflict_description,
     enrich_attrs_description,
-    enrich_conflicts_description,
+    enrich_conflict_description,
     enrich_coords_description,
     enrich_on_missing_description,
     namespace_select_type,
@@ -106,7 +106,7 @@ _VALID_ON_UNRESOLVED = ("warn", "raise", "ignore")
 # Conform decides membership, not metadata, so where enrich's quiet option
 # is "ignore" -- leave the patch as it was -- conform's is "drop": every
 # policy here removes the patch, and only the noise differs.
-_VALID_ON_UNRESOLVED_CONFORM = ("raise", "warn", "drop")
+_VALID_ON_UNRESOLVED_CONFORM = ("raise", "warn", "ignore")
 
 # Written once because both fiber verbs refuse for it, and two spellings
 # would let them start explaining the same refusal differently.
@@ -155,15 +155,15 @@ def _report_unconformed(rows: pd.DataFrame, on_unresolved: str) -> None:
     inventory which covers an archive apart from a handful of patches is
     reporting a gap in itself as often as a stray file.
     """
-    if on_unresolved == "drop":
+    if on_unresolved == "ignore":
         return
     paths = list(rows["source_path"])
     advice = (
-        "Pass on_unresolved='warn' to drop them with a warning, or 'drop' "
-        "to drop them silently."
+        "Pass on_unresolved='warn' to drop them with a warning, or "
+        "'ignore' to drop them silently."
         if on_unresolved == "raise"
-        else "Pass on_unresolved='drop' to silence this, or 'raise' to fail "
-        "on the gap instead."
+        else "Pass on_unresolved='ignore' to silence this, or 'raise' to "
+        "fail on the gap instead."
     )
     msg = (
         f"The inventory does not describe {len(paths)} patch(es) in this "
@@ -297,7 +297,7 @@ def _check_stampable(name: str, rows: pd.DataFrame) -> None:
     msg = (
         f"{name!r} is how the spool itself describes a patch, so stamping "
         "it would overwrite what binds each output to the data it came "
-        "from. Rename the group, or pass stamp=False to split on it "
+        "from. Rename the group, or pass stamp=False to expand by it "
         "without recording the value."
     )
     raise InvalidSpoolQueryError(msg)
@@ -1274,7 +1274,7 @@ class Spool(NamespaceOwner):
         [`conform_to_inventory`](`dascore.core.spool.Spool.conform_to_inventory`)
         is what makes it so. Once attached, the coordinates the
         inventory defines along the fiber become selectable, and
-        [`split_by`](`dascore.core.spool.Spool.split_by`) can expand the
+        [`expand_by`](`dascore.core.spool.Spool.expand_by`) can expand the
         spool by the values of one.
 
         A spool opened on a directory which carries an inventory under
@@ -1352,7 +1352,7 @@ class Spool(NamespaceOwner):
         >>> from dascore.examples import inventory_patch_pair
         >>>
         >>> patch, inventory = inventory_patch_pair()
-        >>> spool = dc.spool(patch).enrich(inventory)
+        >>> spool = dc.spool(patch).attach_inventory(inventory).enrich()
         >>> plain = spool.remove_inventory()
         >>> assert "gauge_length" not in dict(plain[0].attrs)
         >>> assert spool[0].attrs.gauge_length == 10.0  # the original stands
@@ -1366,11 +1366,10 @@ class Spool(NamespaceOwner):
         attrs_desc=enrich_attrs_description,
         coords_desc=enrich_coords_description,
         on_missing_desc=enrich_on_missing_description,
-        conflicts_desc=enrich_conflicts_description,
+        conflict_desc=enrich_conflict_description,
     )
     def enrich(
         self,
-        inventory=None,
         *,
         on_unresolved: Literal["warn", "raise", "ignore"] = "warn",
         **kwargs,
@@ -1392,12 +1391,12 @@ class Spool(NamespaceOwner):
         job, and leaving it there is what keeps this lazy — nothing
         resolves until a patch is pulled.
 
+        The inventory is the one
+        [`attach_inventory`](`dascore.core.spool.Spool.attach_inventory`)
+        put on the spool, which is the only way a spool gets one.
+
         Parameters
         ----------
-        inventory
-            The inventory to enrich from, or the path of one. Defaults to
-            the spool's attached inventory; given one, it is attached as
-            well.
         on_unresolved
             What to do with a patch the inventory does not describe — one
             naming no entry, or naming one the inventory does not resolve
@@ -1426,7 +1425,7 @@ class Spool(NamespaceOwner):
             physical. A patch with a real time coordinate resolves at its
             own time and passing this raises.
         {on_missing_desc}
-        {conflicts_desc}
+        {conflict_desc}
 
         Examples
         --------
@@ -1434,23 +1433,22 @@ class Spool(NamespaceOwner):
         >>> from dascore.examples import inventory_patch_pair
         >>>
         >>> patch, inventory = inventory_patch_pair()
-        >>> spool = dc.spool(patch).enrich(inventory)
+        >>> spool = dc.spool(patch).attach_inventory(inventory).enrich()
         >>> assert spool[0].attrs.gauge_length == 10.0
         >>>
         >>> # Or name what is wanted, as with Patch.enrich.
-        >>> spool = dc.spool(patch).enrich(inventory, coords=False)
+        >>> attached = dc.spool(patch).attach_inventory(inventory)
+        >>> spool = attached.enrich(coords=False)
         """
         # Settled now rather than on extraction: a misspelled argument
         # should be an error here, not on some patch pulled much later.
         enrich_kwargs = _normalize_enrich_kwargs(kwargs)
-        new = self._with_inventory(
-            inventory, on_unresolved, _VALID_ON_UNRESOLVED, "enrich"
-        )
+        new = self._checked_inventory(on_unresolved, _VALID_ON_UNRESOLVED, "enrich")
         new._enrich_kwargs = enrich_kwargs
         new._on_unresolved = on_unresolved
         return new
 
-    def split_by(
+    def expand_by(
         self,
         name: str,
         *,
@@ -1499,18 +1497,18 @@ class Spool(NamespaceOwner):
         >>> spool = dc.spool(patch).attach_inventory(inventory)
         >>>
         >>> # The example path annotates two zones along the fiber.
-        >>> zones = spool.split_by("zone")
+        >>> zones = spool.expand_by("zone")
         >>> assert len(zones) == 2
         >>> assert set(zones.get_contents()["zone"]) == {"north", "south"}
         >>>
         >>> # Which can be narrowed by a glob over the values.
-        >>> assert len(spool.split_by("zone", include="nor*")) == 1
+        >>> assert len(spool.expand_by("zone", include="nor*")) == 1
         """
         from dascore.proc.inventory import resolve_split_pieces  # noqa: PLC0415
 
         if self._inventory is None:
             msg = (
-                "Spool.split_by needs an inventory to split on: the values "
+                "Spool.expand_by needs an inventory to expand by: the values "
                 "it expands into are the ones an inventory states along the "
                 "fiber. Attach one with Spool.attach_inventory."
             )
@@ -1522,7 +1520,7 @@ class Spool(NamespaceOwner):
         if name not in set(self._resolved_inventory().get_names().coords):
             msg = (
                 f"{name!r} is not a coordinate the attached inventory defines "
-                "along the fiber, so there is nothing to split on. "
+                "along the fiber, so there is nothing to expand by. "
                 "Inventory.get_names().coords lists the names it could."
             )
             raise InvalidSpoolQueryError(msg)
@@ -1557,9 +1555,8 @@ class Spool(NamespaceOwner):
 
     def conform_to_inventory(
         self,
-        inventory=None,
         *,
-        on_unresolved: Literal["raise", "warn", "drop"] = "raise",
+        on_unresolved: Literal["raise", "warn", "ignore"] = "raise",
     ) -> Self:
         """
         Return a spool the inventory describes exactly, patch for patch.
@@ -1577,15 +1574,12 @@ class Spool(NamespaceOwner):
         sample the patch held and hold none of them twice, and `len` and
         `get_contents` describe the pieces rather than the original.
 
+        The inventory is the one
+        [`attach_inventory`](`dascore.core.spool.Spool.attach_inventory`)
+        put on the spool, which is the only way a spool gets one.
+
         Parameters
         ----------
-        inventory
-            The inventory to conform to, or the path of one. Defaults to
-            the spool's attached
-            inventory; given one, it is attached as well — and attaching
-            clears enrichment set up from the old one, as it does
-            everywhere. Conforming to the spool's own inventory leaves
-            enrichment alone, since nothing was swapped.
         on_unresolved
             What to do with a patch the inventory does not describe — one
             carrying no `acquisition_key`, one carrying a key the
@@ -1595,7 +1589,7 @@ class Spool(NamespaceOwner):
             judged over its whole span, so one described at its start but
             not at its end is undescribed. "raise" (the default)
             fails and names them, "warn" drops them and says so, and
-            "drop" discards them silently, which is what an inventory
+            "ignore" discards them silently, which is what an inventory
             deliberately covering part of an archive wants.
 
         Raises
@@ -1621,15 +1615,14 @@ class Spool(NamespaceOwner):
         >>> # A patch the inventory says nothing about can be dropped.
         >>> other = patch.update_attrs(acquisition_key="DAS.R2D1..OTHER")
         >>> mixed = dc.spool([patch, other]).attach_inventory(inventory)
-        >>> assert len(mixed.conform_to_inventory(on_unresolved="drop")) == 1
+        >>> assert len(mixed.conform_to_inventory(on_unresolved="ignore")) == 1
         """
         from dascore.proc.inventory import (  # noqa: PLC0415
             _NO_EPOCHS,
             resolve_row_epochs,
         )
 
-        new = self._with_inventory(
-            inventory,
+        new = self._checked_inventory(
             on_unresolved,
             _VALID_ON_UNRESOLVED_CONFORM,
             "conform_to_inventory",
@@ -1704,27 +1697,24 @@ class Spool(NamespaceOwner):
         )
         return self._new_from_catalog(catalog)
 
-    def _with_inventory(self, inventory, on_unresolved, valid, method) -> Self:
+    def _checked_inventory(self, on_unresolved, valid, method) -> Self:
         """
         Return the spool an inventory verb works on, arguments checked.
 
-        Both verbs take an inventory the same way — the attached one by
-        default, and one passed explicitly is attached as well — and both
-        police their own policy vocabulary before doing any work. Sharing
-        the entry keeps the two from drifting into saying it differently.
+        Both verbs read the attached inventory and police their own policy
+        vocabulary before doing any work. Sharing the entry keeps the two
+        from drifting into saying it differently.
         """
         if on_unresolved not in valid:
             msg = f"on_unresolved must be one of {valid}, got {on_unresolved!r}."
             raise ParameterError(msg)
-        if inventory is None and self._inventory is None:
+        if self._inventory is None:
             msg = (
-                f"Spool.{method} needs an inventory: pass one, or attach one "
-                "first with Spool.attach_inventory."
+                f"Spool.{method} needs an inventory; attach one first with "
+                "Spool.attach_inventory."
             )
             raise ParameterError(msg)
-        if inventory is None:
-            return self.__class__(self)
-        return self.attach_inventory(inventory)
+        return self.__class__(self)
 
     def _restrict_to_rows(self, patch_ids, keep: bool = True) -> Self:
         """
@@ -1866,7 +1856,7 @@ class Spool(NamespaceOwner):
         *,
         client: ExecutorType | None = None,
         size: int | None = None,
-        progress: bool = True,
+        progress: PROGRESS_LEVELS = "standard",
         **kwargs,
     ) -> list[T]:
         """
@@ -1883,7 +1873,10 @@ class Spool(NamespaceOwner):
             If not set, defaults to the number of processors on the host.
             Does nothing unless client is defined.
         progress
-            If True, display a progress bar.
+            Controls the progress bar. "standard" produces the standard
+            progress bar. "basic" is a simplified version with lower refresh
+            rates, best for high-latency environments, and None disables
+            the progress bar.
         **kwargs
             kwargs passed to func.
 
@@ -2177,7 +2170,7 @@ class Spool(NamespaceOwner):
             **kwargs,
         )
         merge_kwargs = {
-            "conflicts": conflict,
+            "conflict": conflict,
             "snap_coords": snap_coords,
             "tolerance": tolerance,
         }

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -517,7 +517,7 @@ class PlanResolver(PatchResolver):
 
         An output is assembled from its members, so it carries their
         attrs and knows nothing of why it was cut out. `stamped` is how
-        an operation which does know says so -- `Spool.split_by`
+        an operation which does know says so -- `Spool.expand_by`
         recording which value each patch was split on -- and it keeps
         the patch which comes out agreeing with the row `get_contents`
         shows for it.

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -1197,6 +1197,17 @@ def _get_coords(inventory, context, patch, coords, on_missing) -> dict:
     return out
 
 
+def validate_enrich_selection(attrs, coords) -> None:
+    """Refuse None, the retired spelling of enrich's False off switch."""
+    for label, value in (("attrs", attrs), ("coords", coords)):
+        if value is None:
+            msg = (
+                f"enrich's {label} must be True, False, or a collection of "
+                "names; pass False to copy none."
+            )
+            raise ParameterError(msg)
+
+
 @patch_function()
 @compose_docstring(
     attrs_desc=enrich_attrs_description,
@@ -1257,15 +1268,7 @@ def enrich(
     if on_missing not in _VALID_ON_MISSING:
         msg = f"on_missing must be one of {_VALID_ON_MISSING}, got {on_missing!r}."
         raise ParameterError(msg)
-    # False is the off switch; None used to mean the same thing, and two
-    # spellings of "copy none" is one more than the parameter needs.
-    for label, value in (("attrs", attrs), ("coords", coords)):
-        if value is None:
-            msg = (
-                f"enrich's {label} must be True, False, or a collection of "
-                "names; pass False to copy none."
-            )
-            raise ParameterError(msg)
+    validate_enrich_selection(attrs, coords)
     source_id = _get_acquisition_key(patch, acquisition_key)
     times = _get_resolution_times(patch, time)
     context = _resolve_context(inventory, source_id, times)

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -1185,8 +1185,10 @@ def _get_coords(inventory, context, patch, coords, on_missing) -> dict:
             )
             raise PatchError(msg)
         if values is None:
-            if blanket:
-                continue
+            # A blanket request asks for the names the path itself lists,
+            # so one of those without values would be the inventory
+            # disagreeing with itself rather than a gap to have a policy about.
+            assert not blanket, f"blanket name {name!r} resolved to nothing"
             if on_missing != "null":
                 _report_missing(context, name, on_missing, "the optical path of ")
                 continue

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -13,7 +13,7 @@ from dascore.constants import (
     INVENTORY_ATTRS,
     PatchType,
     enrich_attrs_description,
-    enrich_conflicts_description,
+    enrich_conflict_description,
     enrich_coords_description,
     enrich_on_missing_description,
 )
@@ -40,7 +40,7 @@ from dascore.proc.coords import update_coords
 from dascore.units import get_quantity_str
 from dascore.utils.attrs import validate_conflict
 from dascore.utils.docs import compose_docstring
-from dascore.utils.misc import iterate, validate_acquisition_key
+from dascore.utils.misc import iterate, validate_acquisition_key, warn_or_raise
 from dascore.utils.patch import patch_function
 from dascore.utils.time import to_datetime64
 
@@ -56,7 +56,7 @@ _DATA_STATE_ATTRS = ("data_type", "data_category", "data_units")
 # as-acquired value.
 _COORD_REDUNDANT_ATTRS = ("sample_rate", "spatial_interval")
 
-OnMissing = Literal["raise", "null", "ignore"]
+OnMissing = Literal["raise", "warn", "ignore", "null"]
 _VALID_ON_MISSING = get_args(OnMissing)
 
 # Tracks whose fields enrich can project. The inventory names them, so a
@@ -447,7 +447,7 @@ def _get_system_attrs(inventory, context) -> dict:
 
 def _get_attr_values(inventory, context, attrs, on_missing) -> dict:
     """Return the attrs to copy, honoring on_missing for named requests."""
-    if attrs is False or attrs is None:
+    if attrs is False:
         return {}
     system = _get_system_attrs(inventory, context)
     if attrs is True:
@@ -461,15 +461,20 @@ def _get_attr_values(inventory, context, attrs, on_missing) -> dict:
     for name in iterate(attrs):
         if name in available:
             out[name] = available[name]
-        elif on_missing == "raise":
-            msg = (
-                f"The inventory defines no {name!r} for "
-                f"{context.acquisition.code!r}; use on_missing to allow it."
-            )
-            raise PatchError(msg)
         elif on_missing == "null":
             out[name] = _missing_marker(context, name)
+        else:
+            _report_missing(context, name, on_missing)
     return out
+
+
+def _report_missing(context, name, on_missing, subject: str = "") -> None:
+    """Raise or warn about a requested name the inventory does not define."""
+    msg = (
+        f"The inventory defines no {name!r} for {subject}"
+        f"{context.acquisition.code!r}; use on_missing to allow it."
+    )
+    warn_or_raise(msg, PatchError, behavior=on_missing)
 
 
 def _missing_marker(context, name):
@@ -505,7 +510,7 @@ def _is_unset(value) -> bool:
     return isinstance(value, float | np.floating) and bool(np.isnan(value))
 
 
-def _apply_conflicts(patch, new_attrs, conflicts) -> tuple[dict, list]:
+def _apply_conflict(patch, new_attrs, conflict) -> tuple[dict, list]:
     """
     Return the attrs to set and to drop, given the conflict policy.
 
@@ -518,14 +523,14 @@ def _apply_conflicts(patch, new_attrs, conflicts) -> tuple[dict, list]:
         old = current.get(name, None)
         if _is_unset(old) or values_equal(old, value):
             updates[name] = value
-        elif conflicts == "raise":
+        elif conflict == "raise":
             msg = (
                 f"The patch's {name!r} is {old!r} but the inventory says "
                 f"{value!r}. A disagreement here usually means the "
                 "acquisition_key resolved to the wrong place."
             )
             raise PatchError(msg)
-        elif conflicts == "drop":
+        elif conflict == "drop":
             drops.append(name)
         else:  # keep_first: enrichment puts the inventory's value first
             updates[name] = value
@@ -1180,15 +1185,11 @@ def _get_coords(inventory, context, patch, coords, on_missing) -> dict:
             )
             raise PatchError(msg)
         if values is None:
-            if blanket or on_missing == "ignore":
+            if blanket:
                 continue
-            if on_missing == "raise":
-                msg = (
-                    f"The inventory defines no {name!r} for the optical path "
-                    f"of {context.acquisition.code!r}; use on_missing to "
-                    "allow it."
-                )
-                raise PatchError(msg)
+            if on_missing != "null":
+                _report_missing(context, name, on_missing, "the optical path of ")
+                continue
             values = np.full(len(distances), np.nan)
         out[name] = (dim, values)
     return out
@@ -1199,7 +1200,7 @@ def _get_coords(inventory, context, patch, coords, on_missing) -> dict:
     attrs_desc=enrich_attrs_description,
     coords_desc=enrich_coords_description,
     on_missing_desc=enrich_on_missing_description,
-    conflicts_desc=enrich_conflicts_description,
+    conflict_desc=enrich_conflict_description,
 )
 def enrich(
     patch: PatchType,
@@ -1209,7 +1210,7 @@ def enrich(
     acquisition_key: str | None = None,
     time=None,
     on_missing: OnMissing = "raise",
-    conflicts: Literal["drop", "raise", "keep_first"] = "keep_first",
+    conflict: Literal["drop", "raise", "keep_first"] = "keep_first",
 ) -> PatchType:
     """
     Copy inventory metadata onto a patch.
@@ -1235,7 +1236,7 @@ def enrich(
         physical. A patch with a real time coordinate resolves at its own
         time and passing this raises.
     {on_missing_desc}
-    {conflicts_desc}
+    {conflict_desc}
 
     Examples
     --------
@@ -1250,17 +1251,26 @@ def enrich(
     ...     inventory, attrs=("gauge_length",), coords=("x", "y", "z"),
     ... )
     """
-    validate_conflict(conflicts)
+    validate_conflict(conflict)
     if on_missing not in _VALID_ON_MISSING:
         msg = f"on_missing must be one of {_VALID_ON_MISSING}, got {on_missing!r}."
         raise ParameterError(msg)
+    # False is the off switch; None used to mean the same thing, and two
+    # spellings of "copy none" is one more than the parameter needs.
+    for label, value in (("attrs", attrs), ("coords", coords)):
+        if value is None:
+            msg = (
+                f"enrich's {label} must be True, False, or a collection of "
+                "names; pass False to copy none."
+            )
+            raise ParameterError(msg)
     source_id = _get_acquisition_key(patch, acquisition_key)
     times = _get_resolution_times(patch, time)
     context = _resolve_context(inventory, source_id, times)
     new_attrs = _get_attr_values(inventory, context, attrs, on_missing)
-    updates, drops = _apply_conflicts(patch, new_attrs, conflicts)
+    updates, drops = _apply_conflict(patch, new_attrs, conflict)
     new_coords = {}
-    if coords is not False and coords is not None:
+    if coords is not False:
         new_coords = _get_coords(inventory, context, patch, coords, on_missing)
     out = patch
     if drops:

--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -24,7 +24,7 @@ _VALID_CONFLICT_VALUES = ("drop", "raise", "keep_first")
 
 
 def validate_conflict(conflict: str) -> Literal["drop", "raise", "keep_first"]:
-    """Ensure a conflict(s) argument is a supported value."""
+    """Ensure a conflict argument is a supported value."""
     if conflict not in _VALID_CONFLICT_VALUES:
         msg = f"conflict must be one of {_VALID_CONFLICT_VALUES}, got {conflict!r}."
         raise ParameterError(msg)
@@ -34,7 +34,7 @@ def validate_conflict(conflict: str) -> Literal["drop", "raise", "keep_first"]:
 @compose_docstring(conflict_desc=attr_conflict_description)
 def combine_patch_attrs(
     model_list: Sequence[dc.PatchAttrs],
-    conflicts: Literal["drop", "raise", "keep_first"] = "raise",
+    conflict: Literal["drop", "raise", "keep_first"] = "raise",
     drop_attrs: Sequence[str] | None = None,
 ) -> dc.PatchAttrs:
     """
@@ -44,12 +44,12 @@ def combine_patch_attrs(
     ----------
     model_list
         A list of models.
-    conflicts
+    conflict
         {conflict_desc}
     drop_attrs
         If provided, attributes which should be dropped.
     """
-    validate_conflict(conflicts)
+    validate_conflict(conflict)
 
     def _to_patch_attrs(model):
         """Normalize supported attr-like inputs to PatchAttrs."""
@@ -100,14 +100,14 @@ def combine_patch_attrs(
         return out
 
     def _handle_other_attrs(mod_dict_list):
-        """Check the other attributes and handle based on conflicts param."""
-        if conflicts == "keep_first":
+        """Check the other attributes and handle based on conflict param."""
+        if conflict == "keep_first":
             return [dict(ChainMap(*mod_dict_list))]
         no_null_ = _replace_null_with_none(mod_dict_list)
         all_eq = all(no_null_[0] == x for x in no_null_[1:])
         if all_eq:
             return mod_dict_list
-        if conflicts == "raise":
+        if conflict == "raise":
             # determine which keys are not equal to help debug.
             uneq_keys = _dict_list_diffs(mod_dict_list)
             msg = (

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -1319,7 +1319,7 @@ def build_subdivision_plan(df: pd.DataFrame, pieces, name: str) -> ChunkPlan:
         One sequence of inclusive `(low, high)` envelopes per row, in the
         row's own units and already on its sample grid. They must be
         disjoint within a row but need not be in envelope order —
-        `Spool.split_by` emits them grouped by value. `subdivision_pieces`
+        `Spool.expand_by` emits them grouped by value. `subdivision_pieces`
         builds them from cut values, and a mask over the row's samples
         gives them directly.
     name

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -123,7 +123,8 @@ def warn_or_raise(
         The type of warning to use. Must be a subclass of Warning.
     behavior
         "warn" to issue the warning, "raise" to raise the exception, and
-        "ignore" to do nothing.
+        "ignore" to do nothing. Anything else raises a ParameterError,
+        so a retired spelling cannot quietly pick a behavior.
     """
     if behavior == "ignore":
         return

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -43,7 +43,7 @@ from dascore.utils.paths import (
     is_local_path,
     is_pathlike,
 )
-from dascore.utils.progress import track
+from dascore.utils.progress import track, validate_progress_level
 
 _T = TypeVar("_T")
 
@@ -104,6 +104,20 @@ def suppress_warnings(
         yield caught if record else None
 
 
+def validate_warn_level(behavior) -> WARN_LEVELS:
+    """
+    Ensure a warn-level argument is one of the supported values.
+
+    Called where the argument arrives rather than where it is acted on:
+    only an incompatible patch reaches `warn_or_raise`, so validating
+    there would accept a retired spelling until the data made it matter.
+    """
+    if behavior not in get_args(WARN_LEVELS):
+        msg = f"behavior must be one of {get_args(WARN_LEVELS)}, got {behavior!r}."
+        raise ParameterError(msg)
+    return behavior
+
+
 def warn_or_raise(
     msg: str,
     exception: type[Exception] = Exception,
@@ -126,13 +140,11 @@ def warn_or_raise(
         "ignore" to do nothing. Anything else raises a ParameterError,
         so a retired spelling cannot quietly pick a behavior.
     """
+    validate_warn_level(behavior)
     if behavior == "ignore":
         return
     if behavior == "raise":
         raise exception(msg)
-    if behavior != "warn":
-        msg_ = f"behavior must be one of {get_args(WARN_LEVELS)}, got {behavior!r}."
-        raise ParameterError(msg_)
     warnings.warn(msg, warning)
 
 
@@ -852,6 +864,10 @@ def _spool_map(
     **kwargs
         Keywords passed to func.
     """
+    # Checked before branching: with a client and an empty spool no
+    # patch is ever tracked, so a retired `progress=False` would be
+    # accepted or refused depending on how much data there was.
+    validate_progress_level(progress)
     # no client; simple for loop.
     desc = f"Applying {func.__name__} to spool"
     if client is None:

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -16,7 +16,7 @@ from functools import cache
 from io import IOBase
 from pathlib import Path
 from types import ModuleType
-from typing import Literal, TypeVar, overload
+from typing import Literal, TypeVar, get_args, overload
 
 import numpy as np
 import pandas as pd
@@ -25,7 +25,12 @@ from scipy.special import factorial
 
 from dascore.compat import UPath, is_array
 from dascore.config import config_context, get_config
-from dascore.constants import WARN_LEVELS, WARNING_ACTIONS, max_lens
+from dascore.constants import (
+    PROGRESS_LEVELS,
+    WARN_LEVELS,
+    WARNING_ACTIONS,
+    max_lens,
+)
 from dascore.exceptions import (
     FilterValueError,
     InvalidInventoryError,
@@ -118,12 +123,15 @@ def warn_or_raise(
         The type of warning to use. Must be a subclass of Warning.
     behavior
         "warn" to issue the warning, "raise" to raise the exception, and
-        "ignore" (or None) to do nothing.
+        "ignore" to do nothing.
     """
-    if not behavior or behavior == "ignore":
+    if behavior == "ignore":
         return
     if behavior == "raise":
         raise exception(msg)
+    if behavior != "warn":
+        msg_ = f"behavior must be one of {get_args(WARN_LEVELS)}, got {behavior!r}."
+        raise ParameterError(msg_)
     warnings.warn(msg, warning)
 
 
@@ -797,7 +805,7 @@ def cached_method(func):
 class _MapFuncWrapper:
     """A class for unwrapping spools to base applies."""
 
-    def __init__(self, func, kwargs, config, progress=True):
+    def __init__(self, func, kwargs, config, progress: PROGRESS_LEVELS = "standard"):
         self._func = func
         self._kwargs = kwargs
         self._progress = progress
@@ -815,11 +823,18 @@ class _MapFuncWrapper:
             # way? See #265.
             if not getattr(spool, "_no_progress", False):
                 desc = f"Applying {self._func.__name__} to spool"
-                iterable = track(spool, desc) if self._progress else spool
+                iterable = track(spool, desc, self._progress)
             return [self._func(x, **self._kwargs) for x in iterable]
 
 
-def _spool_map(spool, func, size=None, client=None, progress=True, **kwargs):
+def _spool_map(
+    spool,
+    func,
+    size=None,
+    client=None,
+    progress: PROGRESS_LEVELS = "standard",
+    **kwargs,
+):
     """
     Map a func over a spool.
 
@@ -832,15 +847,14 @@ def _spool_map(spool, func, size=None, client=None, progress=True, **kwargs):
     client
         An object with a map method for applying concurrency.
     progress
-        If True, display a progress bar.
+        Controls the progress bar; see `PROGRESS_LEVELS`.
     **kwargs
         Keywords passed to func.
     """
     # no client; simple for loop.
     desc = f"Applying {func.__name__} to spool"
     if client is None:
-        iterable = track(spool, desc) if progress else spool
-        return [func(patch, **kwargs) for patch in iterable]
+        return [func(patch, **kwargs) for patch in track(spool, desc, progress)]
     # Now things get interesting. We need to split the spool here
     # so that patches don't get serialized.
     if size is None:

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -1130,7 +1130,6 @@ def check_dims(
     """
     validate_warn_level(check_behavior)
     dims1, dims2 = patch1.dims, patch2.dims
-    dims_ok = True
     if not intersection and patch1.dims == patch2.dims:
         return True
     dset1, dset2 = set(dims1), set(dims2)
@@ -1141,7 +1140,9 @@ def check_dims(
         f" Patch1 dims: {dims1}, Patch2 dims: {dims2}"
     )
     warn_or_raise(msg, exception=IncompatiblePatchError, behavior=check_behavior)
-    return dims_ok
+    # The quiet policies skip the patch rather than accept it, as
+    # check_coords does; saying True here stacked it anyway.
+    return False
 
 
 def check_coords(

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -43,6 +43,7 @@ from dascore.utils.misc import (
     get_middle_value,
     iterate,
     to_object_array,
+    validate_warn_level,
     warn_or_raise,
     yield_sub_sequences,
 )
@@ -1127,6 +1128,7 @@ def check_dims(
         when only broadcastability needs to be checked. If false require dims
         to be equal.
     """
+    validate_warn_level(check_behavior)
     dims1, dims2 = patch1.dims, patch2.dims
     dims_ok = True
     if not intersection and patch1.dims == patch2.dims:
@@ -1169,6 +1171,7 @@ def check_coords(
         If True, the ignored dims must be equal shape to pass check.
         If dim_to_ignore is None this has no effect.
     """
+    validate_warn_level(check_behavior)
     cm1 = patch1.coords
     cm2 = patch2.coords
     cset1, cset2 = set(cm1.coord_map), set(cm2.coord_map)

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -1121,7 +1121,7 @@ def check_dims(
         second patch
     check_behavior
         String with 'raise' will raise an error if incompatible,
-        'warn' will provide a warning, None will do nothing.
+        'warn' will provide a warning, 'ignore' will do nothing.
     intersection
         If True, allow any intersection of dimensions to pass. This is useful
         when only broadcastability needs to be checked. If false require dims

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -537,7 +537,7 @@ def _force_patch_merge(patch_dict_list, merge_kwargs, **kwargs):
     attrs = [x.attrs for x in patches]
     new_data = np.concatenate(data, axis=axis)
     # Determine if conflicting non-dimensional coords should be dropped.
-    conf = attr_kwargs.get("conflicts", None)
+    conf = attr_kwargs.get("conflict", None)
     drop_conf_coords = True if conf in {"drop", "keep_first"} else False
     new_coord = _get_merged_coord(
         df, merge_dim, coords, drop_conf_coords, **coord_kwargs
@@ -1244,7 +1244,7 @@ def _merge_models(attrs1, attrs2, attrs_to_ignore=DEFAULT_ATTRS_TO_IGNORE):
             f"are not equal. {ne_attrs}"
         )
         raise IncompatiblePatchError(msg)
-    return combine_patch_attrs([dict1, dict2], conflicts="keep_first")
+    return combine_patch_attrs([dict1, dict2], conflict="keep_first")
 
 
 def merge_compatible_coords_attrs(

--- a/dascore/utils/patch_assembly.py
+++ b/dascore/utils/patch_assembly.py
@@ -278,7 +278,7 @@ class PatchAssembler:
             )
             raise CoordMergeError(msg)
         attr_kwargs, coord_kwargs = _split_coord_merge_kwargs(self.merge_kwargs)
-        conf = attr_kwargs.get("conflicts", None)
+        conf = attr_kwargs.get("conflict", None)
         drop_conflicting = conf in {"drop", "keep_first"}
         new_coord = _get_merged_coord(
             summary_df, merge_dim, coords, drop_conflicting, **coord_kwargs

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import sys
 from collections.abc import Iterable, Sized
 from contextlib import suppress
+from typing import get_args
 
 import rich.progress as prog
 
 from dascore.compat import Progress
 from dascore.config import get_config
 from dascore.constants import PROGRESS_LEVELS
+from dascore.exceptions import ParameterError
 
 
 def get_progress_instance(progress: PROGRESS_LEVELS | Progress = "standard"):
@@ -82,6 +84,14 @@ def track(
     min_length
         The minimum length to emit a progress bar.
     """
+    # Anything else would fall through to the standard bar, so a stale
+    # `progress=False` would turn one on rather than off.
+    if not isinstance(progress, Progress) and progress not in get_args(PROGRESS_LEVELS):
+        msg = (
+            f"progress must be one of {get_args(PROGRESS_LEVELS)} or a "
+            f"rich Progress, got {progress!r}."
+        )
+        raise ParameterError(msg)
     total = get_track_length(sequence, length, min_length)
     # This is a dirty hack to allow debugging while running tests.
     # Otherwise, pdb doesn't work in any tracking scope.

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -57,6 +57,22 @@ def get_track_length(sequence: Iterable, length: int | None, min_length: int) ->
     return length
 
 
+def validate_progress_level(progress):
+    """
+    Ensure a progress argument is a supported level, or a caller's own bar.
+
+    Anything else falls through to the standard bar, so a stale
+    `progress=False` would turn one on rather than off.
+    """
+    if isinstance(progress, Progress) or progress in get_args(PROGRESS_LEVELS):
+        return progress
+    msg = (
+        f"progress must be one of {get_args(PROGRESS_LEVELS)} or a "
+        f"rich Progress, got {progress!r}."
+    )
+    raise ParameterError(msg)
+
+
 def track(
     sequence: Iterable,
     description: str,
@@ -84,14 +100,7 @@ def track(
     min_length
         The minimum length to emit a progress bar.
     """
-    # Anything else would fall through to the standard bar, so a stale
-    # `progress=False` would turn one on rather than off.
-    if not isinstance(progress, Progress) and progress not in get_args(PROGRESS_LEVELS):
-        msg = (
-            f"progress must be one of {get_args(PROGRESS_LEVELS)} or a "
-            f"rich Progress, got {progress!r}."
-        )
-        raise ParameterError(msg)
+    validate_progress_level(progress)
     total = get_track_length(sequence, length, min_length)
     # This is a dirty hack to allow debugging while running tests.
     # Otherwise, pdb doesn't work in any tracking scope.

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -168,6 +168,8 @@ Listing a name is not promising a value for it. This example states no geometry,
 
 [`Spool.attach_inventory`](`dascore.core.spool.Spool.attach_inventory`) carries an inventory on a spool, and touches no data. No patch gains a field, no row moves, `len` does not change. It costs nothing per patch, which is what makes it safe to do early and decide later what to use it for. Attaching a *different* inventory does clear any enrichment set up from the old one, since applying the old instructions to new metadata would rewrite every patch behind your back.
 
+It is also the only way a spool gets an inventory: `enrich` and `conform_to_inventory` read the attached one rather than taking their own, so the spool has one answer to which inventory it means.
+
 ```{python}
 spool = dc.spool(patch).attach_inventory(example_inventory)
 
@@ -175,14 +177,14 @@ spool = dc.spool(patch).attach_inventory(example_inventory)
 assert "gauge_length" not in dict(spool[0].attrs)
 ```
 
-What attaching *does* change is which names resolve. The coordinates the inventory defines along the fiber become selectable, and [`Spool.split_by`](`dascore.core.spool.Spool.split_by`) can expand the spool by the values of one:
+What attaching *does* change is which names resolve. The coordinates the inventory defines along the fiber become selectable, and [`Spool.expand_by`](`dascore.core.spool.Spool.expand_by`) can expand the spool by the values of one:
 
 ```{python}
 # Keep only the channels the inventory places in the northern zone.
 northern = spool.select(zone="north")
 
 # Or get one patch per zone, each holding that zone's channels.
-zones = spool.split_by("zone")
+zones = spool.expand_by("zone")
 assert len(zones) == 2
 assert set(zones.get_contents()["zone"]) == {"north", "south"}
 ```
@@ -203,7 +205,7 @@ assert "zone" in patch_out.coords.coord_map
 
 Enrichment never removes a patch. One the inventory does not describe comes out unchanged rather than missing, with a warning, so an inventory that deliberately covers part of an archive needs no pruning first. Deciding membership is a separate step, below.
 
-A single patch can be enriched directly with [`Patch.enrich`](`dascore.proc.inventory.enrich`), which takes the same arguments apart from `on_unresolved` — one patch either resolves or raises, so there is no policy to state:
+A single patch can be enriched directly with [`Patch.enrich`](`dascore.proc.inventory.enrich`), which takes the same arguments apart from `on_unresolved` — one patch either resolves or raises, so there is no policy to state. It takes the inventory as an argument, since only a spool carries one:
 
 ```{python}
 one = patch.enrich(example_inventory)
@@ -212,7 +214,7 @@ assert one.attrs.gauge_length == 10.0
 
 # Conforming a spool
 
-[`Spool.conform_to_inventory`](`dascore.core.spool.Spool.conform_to_inventory`) is the one eager step of the workflow, and the only one that changes what the spool contains. It resolves every row now, refuses patches the inventory does not describe, and *subdivides* a patch whose span crosses a change of optical path — so the spool can grow as well as shrink. Pass `on_unresolved="drop"` (or `"warn"`) to drop the undescribed patches instead of raising, which is what an inventory deliberately covering part of an archive wants.
+[`Spool.conform_to_inventory`](`dascore.core.spool.Spool.conform_to_inventory`) is the one eager step of the workflow, and the only one that changes what the spool contains. It resolves every row now, refuses patches the inventory does not describe, and *subdivides* a patch whose span crosses a change of optical path — so the spool can grow as well as shrink. Pass `on_unresolved="ignore"` (or `"warn"`) to drop the undescribed patches instead of raising, which is what an inventory deliberately covering part of an archive wants.
 
 ```{python}
 # A second patch this inventory says nothing about.
@@ -221,7 +223,7 @@ mixed = dc.spool([patch, stranger]).attach_inventory(example_inventory)
 assert len(mixed) == 2
 
 # Conforming keeps only what the inventory describes.
-conformed = mixed.conform_to_inventory(on_unresolved="drop")
+conformed = mixed.conform_to_inventory(on_unresolved="ignore")
 assert len(conformed) == 1
 assert conformed[0].attrs.acquisition_key == "DAS.R2D1..RAW"
 ```

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -273,7 +273,7 @@ refreshed = carrying.attach_inventory()
 assert refreshed.enrich()[0].attrs.gauge_length == 12.0
 ```
 
-`attach_inventory`, `enrich`, and `conform_to_inventory` all accept a path as well as an `Inventory`, read on the same terms.
+`attach_inventory` accepts a path as well as an `Inventory`, read on the same terms — and it is the only one of the three that takes either, since `enrich` and `conform_to_inventory` read what it attached.
 
 # Serializing
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -255,7 +255,9 @@ subspool = spool.unselect(tag='some_tag')
 assert len(subspool) + len(spool.select(tag='some_tag')) == len(spool)
 ```
 
-Coordinates are not accepted yet. Selecting on a coordinate trims each patch to the range as well as dropping the patches which miss it entirely, so the complement of `time=(t1, t2)` is the part of every patch *before* `t1` together with the part *after* `t2` — one patch becoming two. That is subdivision rather than filtering, and `unselect` does not do it yet; select the ranges to keep instead.
+The patches' own coordinates are not accepted. Selecting on one trims each patch to the range as well as dropping the patches which miss it entirely, so the complement of `time=(t1, t2)` is the part of every patch *before* `t1` together with the part *after* `t2` — one patch becoming two. That is subdivision rather than filtering; select the ranges to keep instead, or use [`Patch.unselect`](`dascore.Patch.unselect`) on each patch.
+
+The coordinates an attached [inventory](inventory.qmd) defines along the fiber are different, and *are* accepted: removing one of those chooses which channels a patch holds, so `len` can grow here as well.
 
 # chunk
 
@@ -334,7 +336,7 @@ See the [parallel processing recipe](../recipes/parallelization.qmd) for more ex
 
 # Inventory
 
-A spool can carry a DASDAE [inventory](inventory.qmd): a description of the observing system its data was recorded through — the fiber, where it goes, and how the interrogator was configured over time. Attaching one adds nothing to the patches, but makes the names the inventory defines along the fiber available to `select` and [`split_by`](`dascore.core.spool.Spool.split_by`), and lets [`enrich`](`dascore.core.spool.Spool.enrich`) copy that metadata onto patches as they are extracted.
+A spool can carry a DASDAE [inventory](inventory.qmd): a description of the observing system its data was recorded through — the fiber, where it goes, and how the interrogator was configured over time. Attaching one adds nothing to the patches, but makes the names the inventory defines along the fiber available to `select` and [`expand_by`](`dascore.core.spool.Spool.expand_by`), and lets [`enrich`](`dascore.core.spool.Spool.enrich`) copy that metadata onto patches as they are extracted.
 
 ```{python}
 import dascore as dc
@@ -344,7 +346,7 @@ patch, inventory = inventory_patch_pair()
 spool = dc.spool(patch).attach_inventory(inventory)
 
 # The inventory annotates two zones along the fiber, so they can be selected.
-assert len(spool.split_by("zone")) == 2
+assert len(spool.expand_by("zone")) == 2
 ```
 
 A spool opened on a directory which carries an inventory under the name `.inventory` — as a directory, or as `.inventory.yaml`, `.inventory.yml`, or `.inventory.json` — starts out attached to it.

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -257,7 +257,7 @@ assert len(subspool) + len(spool.select(tag='some_tag')) == len(spool)
 
 The patches' own coordinates are not accepted. Selecting on one trims each patch to the range as well as dropping the patches which miss it entirely, so the complement of `time=(t1, t2)` is the part of every patch *before* `t1` together with the part *after* `t2` — one patch becoming two. That is subdivision rather than filtering; select the ranges to keep instead, or use [`Patch.unselect`](`dascore.Patch.unselect`) on each patch.
 
-The coordinates an attached [inventory](inventory.qmd) defines along the fiber are different, and *are* accepted: removing one of those chooses which channels a patch holds, so `len` can grow here as well.
+The coordinates an attached [inventory](inventory.qmd) defines along the fiber are different, and *are* accepted: removing one of those chooses which channels a patch holds. A patch may then be cut into the pieces the query did not match, so `len` can grow here as well.
 
 # chunk
 

--- a/tests/test_core/test_directory_spool.py
+++ b/tests/test_core/test_directory_spool.py
@@ -752,7 +752,5 @@ class TestDirectorySpoolSerialization:
     def test_process_pool_map(self, basic_file_spool):
         """Spool.map works with a process pool executor."""
         with ProcessPoolExecutor(max_workers=1) as client:
-            out = list(
-                basic_file_spool.map(_patch_shape, client=client, progress=False)
-            )
+            out = list(basic_file_spool.map(_patch_shape, client=client, progress=None))
         assert len(out) == len(basic_file_spool)

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -912,12 +912,10 @@ class TestInternalReviewRegressions:
 
     def test_inventory_function_dispatch(self):
         """dc.inventory handles bad input with clear errors."""
-        # A string naming nothing is the document itself, and a mistyped
-        # path is the common way to land there, so the error says both.
-        with pytest.raises(InvalidInventoryError, match="no such file"):
-            dc.inventory("does_not_exist.yaml")
-        with pytest.raises(InvalidInventoryError, match="No such inventory file"):
-            dc.inventory(Path("does_not_exist.yaml"))
+        # However it is spelled, a path which is not there says so.
+        for missing in ("does_not_exist.yaml", Path("does_not_exist.yaml")):
+            with pytest.raises(InvalidInventoryError, match="No such inventory file"):
+                dc.inventory(missing)
         with pytest.raises(InvalidInventoryError, match="Could not get"):
             dc.inventory(123)
         existing = build_inventory()

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import pickle
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -552,7 +553,7 @@ class TestInventory:
         inventory = build_inventory()
         path = tmp_path / "inventory.yaml"
         inventory.to_yaml(path)
-        loaded = inv.Inventory.from_yaml(path)
+        loaded = dc.inventory(path)
         assert loaded.model_dump(mode="json") == inventory.model_dump(mode="json")
 
     def test_resources_accept_iterable(self):
@@ -911,8 +912,12 @@ class TestInternalReviewRegressions:
 
     def test_inventory_function_dispatch(self):
         """dc.inventory handles bad input with clear errors."""
-        with pytest.raises(InvalidInventoryError, match="No such inventory file"):
+        # A string naming nothing is the document itself, and a mistyped
+        # path is the common way to land there, so the error says both.
+        with pytest.raises(InvalidInventoryError, match="no such file"):
             dc.inventory("does_not_exist.yaml")
+        with pytest.raises(InvalidInventoryError, match="No such inventory file"):
+            dc.inventory(Path("does_not_exist.yaml"))
         with pytest.raises(InvalidInventoryError, match="Could not get"):
             dc.inventory(123)
         existing = build_inventory()

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -2178,3 +2178,26 @@ class TestLoadSerializedFile:
         path = tmp_path / "whole.yaml"
         original.to_yaml(path)
         assert dc.inventory(path) == original
+
+
+class TestOneLoadingDoor:
+    """`dc.inventory` decides what a source is; `from_yaml` reads text."""
+
+    def test_text_and_file_agree(self, tmp_path):
+        """The same document loads the same from either side of the door."""
+        original = dc.inventory(write_inventory(tmp_path / "authored", MINIMAL))
+        text = original.to_yaml()
+        path = tmp_path / "whole.yaml"
+        path.write_text(text)
+        assert dc.inventory(text) == dc.inventory(path) == original
+
+    def test_from_yaml_does_not_read_paths(self, tmp_path):
+        """A path handed to the text reader is text, not a file to open."""
+        path = tmp_path / "whole.yaml"
+        path.write_text(dc.inventory().to_yaml())
+        with pytest.raises(InvalidInventoryError, match="no such file"):
+            inv.Inventory.from_yaml(str(path))
+
+    def test_one_line_document_is_text(self):
+        """Existence decides, so a newline is not what makes text text."""
+        assert dc.inventory("networks: []").networks == ()

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -2191,12 +2191,24 @@ class TestOneLoadingDoor:
         path.write_text(text)
         assert dc.inventory(text) == dc.inventory(path) == original
 
-    def test_from_yaml_does_not_read_paths(self, tmp_path):
-        """A path handed to the text reader is text, not a file to open."""
+    def test_from_yaml_refuses_a_path(self, tmp_path):
+        """The text reader says so rather than letting the parser fail."""
         path = tmp_path / "whole.yaml"
         path.write_text(dc.inventory().to_yaml())
-        with pytest.raises(InvalidInventoryError, match="no such file"):
-            inv.Inventory.from_yaml(str(path))
+        with pytest.raises(InvalidInventoryError, match="reads YAML text"):
+            inv.Inventory.from_yaml(path)
+
+    def test_a_mistyped_path_is_not_read_as_a_document(self, tmp_path):
+        """A name spelled like a document's is a path which is not there."""
+        with pytest.raises(InvalidInventoryError, match="No such inventory file"):
+            dc.inventory(str(tmp_path / "absent.yaml"))
+
+    def test_a_file_of_any_suffix_is_named_when_it_fails(self, tmp_path):
+        """The path stays in the message, whichever parser read it."""
+        path = tmp_path / "whole.txt"
+        path.write_text("this: [is not: yaml\n")
+        with pytest.raises(InvalidInventoryError, match=str(path.name)):
+            dc.inventory(path)
 
     def test_one_line_document_is_text(self):
         """Existence decides, so a newline is not what makes text text."""

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -2213,3 +2213,12 @@ class TestOneLoadingDoor:
     def test_one_line_document_is_text(self):
         """Existence decides, so a newline is not what makes text text."""
         assert dc.inventory("networks: []").networks == ()
+
+    def test_a_document_whose_value_looks_like_a_file(self):
+        """A key makes it a document, whatever its value resembles."""
+        assert dc.inventory("description: read from archive.yaml").networks == ()
+
+    def test_unparsable_text_fails_as_an_inventory(self):
+        """The text reader refuses in the format's own words."""
+        with pytest.raises(InvalidInventoryError, match="Could not parse YAML"):
+            dc.inventory("this: [is not: yaml\nnor is this\n")

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -234,6 +234,13 @@ class TestAttrs:
         with pytest.raises(ParameterError, match="pass False to copy none"):
             patch.enrich(inventory, **kwargs)
 
+    @pytest.mark.parametrize("kwargs", [{"attrs": None}, {"coords": None}])
+    def test_spool_refuses_none_when_it_is_passed(self, patch, inventory, kwargs):
+        """And the spool says so now rather than on the first patch out."""
+        spool = dc.spool(patch).attach_inventory(inventory)
+        with pytest.raises(ParameterError, match="pass False to copy none"):
+            spool.enrich(**kwargs)
+
     def test_adds_nothing_unasked(self, patch, inventory):
         """Enrich never leaves the patch holding inventory state."""
         out = patch.enrich(inventory, attrs=False, coords=False)

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -21,7 +21,7 @@ from pydantic import ValidationError
 import dascore as dc
 from dascore.constants import (
     enrich_attrs_description,
-    enrich_conflicts_description,
+    enrich_conflict_description,
     enrich_coords_description,
     enrich_on_missing_description,
 )
@@ -212,6 +212,28 @@ class TestAttrs:
         )
         assert "pulse_rate" not in dict(out.attrs)
 
+    def test_missing_named_attr_warn(self, patch, inventory):
+        """Or omitted with a warning, the middle of the shared vocabulary."""
+        with pytest.warns(UserWarning, match="defines no 'pulse_rate'"):
+            out = patch.enrich(
+                inventory, attrs=("pulse_rate",), coords=False, on_missing="warn"
+            )
+        assert "pulse_rate" not in dict(out.attrs)
+
+    def test_missing_named_coord_warn(self, patch, inventory):
+        """The coordinate half honors the same policy."""
+        with pytest.warns(UserWarning, match="defines no 'nope'"):
+            out = patch.enrich(
+                inventory, attrs=False, coords=("nope",), on_missing="warn"
+            )
+        assert "nope" not in out.coords.coord_map
+
+    @pytest.mark.parametrize("kwargs", [{"attrs": None}, {"coords": None}])
+    def test_none_is_not_the_off_switch(self, patch, inventory, kwargs):
+        """False turns a half off; None is no longer a second spelling."""
+        with pytest.raises(ParameterError, match="pass False to copy none"):
+            patch.enrich(inventory, **kwargs)
+
     def test_adds_nothing_unasked(self, patch, inventory):
         """Enrich never leaves the patch holding inventory state."""
         out = patch.enrich(inventory, attrs=False, coords=False)
@@ -236,23 +258,23 @@ class TestConflicts:
         """The misresolution guard says what disagreed and how."""
         stale = patch.update_attrs(gauge_length=99.0)
         with pytest.raises(PatchError, match=r"99\.0.*10\.0"):
-            stale.enrich(inventory, coords=False, conflicts="raise")
+            stale.enrich(inventory, coords=False, conflict="raise")
 
     def test_drop_removes_the_attr(self, patch, inventory):
         """A dropped conflict leaves neither value behind."""
         stale = patch.update_attrs(gauge_length=99.0)
-        out = stale.enrich(inventory, coords=False, conflicts="drop")
+        out = stale.enrich(inventory, coords=False, conflict="drop")
         assert "gauge_length" not in dict(out.attrs)
 
     def test_equal_values_are_not_conflicts(self, patch, inventory):
         """Agreement is not disagreement, whatever the policy."""
         agreeing = patch.update_attrs(gauge_length=10.0)
-        out = agreeing.enrich(inventory, coords=False, conflicts="raise")
+        out = agreeing.enrich(inventory, coords=False, conflict="raise")
         assert out.attrs.gauge_length == 10.0
 
     def test_filling_is_not_a_conflict(self, patch, inventory):
         """An attr the patch does not have cannot disagree with one it lacks."""
-        out = patch.enrich(inventory, coords=False, conflicts="raise")
+        out = patch.enrich(inventory, coords=False, conflict="raise")
         assert out.attrs.gauge_length == 10.0
 
     def test_re_enrich_is_a_refresh(self, patch, inventory):
@@ -264,7 +286,7 @@ class TestConflicts:
     def test_bad_conflicts_raises(self, patch, inventory):
         """The flag shares chunking's vocabulary and its validation."""
         with pytest.raises(ParameterError, match="conflict"):
-            patch.enrich(inventory, conflicts="whatever")
+            patch.enrich(inventory, conflict="whatever")
 
     def test_bad_on_missing_raises(self, patch, inventory):
         """An unknown policy is a caller error, not a silent default."""
@@ -524,7 +546,7 @@ class TestEdgeCases:
         """An attr which cannot be compared has not been shown to agree."""
         odd = patch.update_attrs(gauge_length=np.array([1.0, 2.0]))
         with pytest.raises(PatchError, match="inventory says"):
-            odd.enrich(inventory, coords=False, conflicts="raise")
+            odd.enrich(inventory, coords=False, conflict="raise")
 
     def test_multidimensional_channel_coord_raises(self, patch, inventory):
         """One channel coordinate maps to one dimension of the patch."""
@@ -590,14 +612,14 @@ class TestRemoveInventory:
 
     def test_removes_inventory_and_enrichment(self, patch, inventory):
         """Nothing is left to enrich from, so nothing is enriched."""
-        spool = dc.spool(patch).enrich(inventory).remove_inventory()
+        spool = dc.spool(patch).attach_inventory(inventory).enrich().remove_inventory()
         assert spool._inventory is None
         assert spool._enrich_kwargs is None
         assert "gauge_length" not in dict(spool[0].attrs)
 
     def test_original_is_unchanged(self, patch, inventory):
         """Removal is a new spool; the one it came from still enriches."""
-        spool = dc.spool(patch).enrich(inventory)
+        spool = dc.spool(patch).attach_inventory(inventory).enrich()
         spool.remove_inventory()
         assert spool[0].attrs.gauge_length == 10.0
 
@@ -608,7 +630,7 @@ class TestRemoveInventory:
 
     def test_keeps_the_patches(self, patch, inventory):
         """Only the metadata goes; the spool's contents do not."""
-        spool = dc.spool(patch).enrich(inventory)
+        spool = dc.spool(patch).attach_inventory(inventory).enrich()
         assert spool.remove_inventory()[0].equals(patch)
 
 
@@ -784,7 +806,7 @@ class TestLazyInventory:
         (tmp_path / f"{BLESSED_NAME}.yaml").write_text("[]\n")
         spool = dc.spool(tmp_path).update()
         with pytest.raises(InvalidInventoryError, match="when the spool was opened"):
-            spool.split_by("zone")
+            spool.expand_by("zone")
 
     def test_an_ambiguous_name_waits_for_a_question(self, tmp_path, patch):
         """Two spellings of the name are still no reason to refuse data."""
@@ -955,13 +977,16 @@ class TestAttachInventoryPath:
         """Both inventory verbs attach what they are given."""
         path = tmp_path / "somewhere.yaml"
         inventory.to_yaml(path)
-        assert dc.spool(patch).enrich(path)[0].attrs.gauge_length == 10.0
+        assert (
+            dc.spool(patch).attach_inventory(path).enrich()[0].attrs.gauge_length
+            == 10.0
+        )
 
     def test_conform_takes_a_path(self, tmp_path, patch, inventory):
         """The same, for the verb which makes the index truthful."""
         path = tmp_path / "somewhere.yaml"
         inventory.to_yaml(path)
-        assert len(dc.spool(patch).conform_to_inventory(path)) == 1
+        assert len(dc.spool(patch).attach_inventory(path).conform_to_inventory()) == 1
 
     def test_no_argument_needs_a_directory(self, patch):
         """There is nowhere an in-memory spool could have carried one."""
@@ -1084,7 +1109,7 @@ class TestOnUnresolved:
     def test_warns_and_leaves_the_patch(self, mixed, inventory):
         """Enriching decides metadata, so the patch itself still comes out."""
         with pytest.warns(UserWarning, match="does not describe every patch"):
-            out = list(mixed.enrich(inventory))
+            out = list(mixed.attach_inventory(inventory).enrich())
         assert len(out) == len(mixed)
         assert out[0].attrs.gauge_length == 10.0
         assert "gauge_length" not in dict(out[1].attrs)
@@ -1098,7 +1123,7 @@ class TestOnUnresolved:
         ]
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("default")
-            list(dc.spool(strangers).enrich(inventory))
+            list(dc.spool(strangers).attach_inventory(inventory).enrich())
         assert len(caught) == 1
 
     def test_each_spool_says_it_once(self, patch, inventory):
@@ -1109,27 +1134,27 @@ class TestOnUnresolved:
         second = dc.spool([patch.update_attrs(acquisition_key="XX.B2..RAW")])
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("default")
-            list(first.enrich(inventory))
-            list(second.enrich(inventory))
+            list(first.attach_inventory(inventory).enrich())
+            list(second.attach_inventory(inventory).enrich())
         assert len(caught) == 2
 
     def test_ignore_is_silent(self, mixed, inventory):
         """The same, without saying so."""
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            out = list(mixed.enrich(inventory, on_unresolved="ignore"))
+            out = list(mixed.attach_inventory(inventory).enrich(on_unresolved="ignore"))
         assert len(out) == len(mixed)
 
     def test_raise_fails(self, mixed, inventory):
         """A spool which must be fully described can say so."""
         with pytest.raises(UnresolvedPatchError, match="no acquisition_key"):
-            list(mixed.enrich(inventory, on_unresolved="raise"))
+            list(mixed.attach_inventory(inventory).enrich(on_unresolved="raise"))
 
     def test_unknown_id_is_unresolved(self, patch, inventory):
         """Naming an entry the inventory lacks is not being described either."""
         stranger = patch.update_attrs(acquisition_key="XX.R2D1..RAW")
         with pytest.warns(UserWarning, match="does not describe every patch"):
-            out = dc.spool(stranger).enrich(inventory)[0]
+            out = dc.spool(stranger).attach_inventory(inventory).enrich()[0]
         assert "gauge_length" not in dict(out.attrs)
 
     def test_straddling_patch_still_raises(self, patch, inventory):
@@ -1147,31 +1172,38 @@ class TestOnUnresolved:
                 )
             ),
         )
-        spool = dc.spool(patch).enrich(split, on_unresolved="ignore")
+        spool = dc.spool(patch).attach_inventory(split).enrich(on_unresolved="ignore")
         with pytest.raises(PatchError, match="spans a change of acquisition"):
             spool[0]
 
     def test_malformed_explicit_id_is_not_swallowed(self, patch, inventory):
         """A caller getting the argument wrong is not the inventory's silence."""
         bare = dc.spool(patch.update_attrs(acquisition_key=""))
-        spool = bare.enrich(inventory, acquisition_key="broken", on_unresolved="ignore")
+        spool = bare.attach_inventory(inventory).enrich(
+            acquisition_key="broken", on_unresolved="ignore"
+        )
         with pytest.raises(ValueError, match="Invalid acquisition_key"):
             spool[0]
 
     def test_bad_policy_raises(self, patch, inventory):
         """An unknown policy names no behavior."""
         with pytest.raises(ParameterError, match="on_unresolved must be one of"):
-            dc.spool(patch).enrich(inventory, on_unresolved="nope")
+            dc.spool(patch).attach_inventory(inventory).enrich(on_unresolved="nope")
 
     def test_policy_is_part_of_the_spool(self, patch, inventory):
         """Two policies mean two different behaviors on extraction."""
         plain = dc.spool(patch)
-        assert plain.enrich(inventory) != plain.enrich(inventory, on_unresolved="raise")
-        assert plain.enrich(inventory) == plain.enrich(inventory, on_unresolved="warn")
+        assert plain.attach_inventory(inventory).enrich() != plain.attach_inventory(
+            inventory
+        ).enrich(on_unresolved="raise")
+        attached = plain.attach_inventory(inventory)
+        assert attached.enrich() == attached.enrich(on_unresolved="warn")
 
     def test_policy_survives_a_union(self, patch, inventory):
         """The policy is part of the enrichment, so it carries with it."""
-        enriched = dc.spool(patch).enrich(inventory, on_unresolved="raise")
+        enriched = (
+            dc.spool(patch).attach_inventory(inventory).enrich(on_unresolved="raise")
+        )
         assert (enriched + dc.spool(patch))._on_unresolved == "raise"
 
 
@@ -1201,12 +1233,12 @@ class TestSpoolEnrich:
 
     def test_getitem_is_enriched(self, patch, inventory):
         """A patch pulled by index arrives with its metadata."""
-        spool = dc.spool(patch).enrich(inventory)
+        spool = dc.spool(patch).attach_inventory(inventory).enrich()
         assert spool[0].attrs.gauge_length == 10.0
 
     def test_iteration_is_enriched(self, patch, inventory):
         """So does one pulled by iteration."""
-        spool = dc.spool(patch).enrich(inventory)
+        spool = dc.spool(patch).attach_inventory(inventory).enrich()
         assert all(x.attrs.gauge_length == 10.0 for x in spool)
 
     def test_uses_attached_inventory(self, patch, inventory):
@@ -1216,33 +1248,37 @@ class TestSpoolEnrich:
 
     def test_enrich_attaches_its_inventory(self, patch, inventory):
         """The spool carries what it enriches from."""
-        spool = dc.spool(patch).enrich(inventory)
+        spool = dc.spool(patch).attach_inventory(inventory).enrich()
         assert spool._inventory is inventory
 
     def test_kwargs_pass_through(self, patch, inventory):
         """Enrich's arguments are the spool's arguments."""
-        spool = dc.spool(patch).enrich(inventory, attrs=("gauge_length",), coords=False)
+        spool = (
+            dc.spool(patch)
+            .attach_inventory(inventory)
+            .enrich(attrs=("gauge_length",), coords=False)
+        )
         out = spool[0]
         assert out.attrs.gauge_length == 10.0
         assert set(out.coords.coord_map) == set(patch.coords.coord_map)
 
     def test_derived_spool_stays_enriched(self, patch, inventory):
         """A selection is still the spool it came from."""
-        spool = dc.spool(patch).enrich(inventory)
+        spool = dc.spool(patch).attach_inventory(inventory).enrich()
         assert spool.select(tag="random")[0].attrs.gauge_length == 10.0
 
     def test_original_is_unchanged(self, patch, inventory):
         """Setting up enrichment leaves the spool it came from alone."""
         plain = dc.spool(patch)
-        plain.enrich(inventory)
+        plain.attach_inventory(inventory).enrich()
         assert "gauge_length" not in dict(plain[0].attrs)
 
     def test_equality_includes_arguments(self, patch, inventory):
         """Different arguments mean different patches come out."""
-        plain = dc.spool(patch)
-        assert plain.enrich(inventory) != plain.attach_inventory(inventory)
-        assert plain.enrich(inventory) == plain.enrich(inventory)
-        assert plain.enrich(inventory) != plain.enrich(inventory, coords=False)
+        attached = dc.spool(patch).attach_inventory(inventory)
+        assert attached.enrich() != attached
+        assert attached.enrich() == attached.enrich()
+        assert attached.enrich() != attached.enrich(coords=False)
 
     def test_requires_an_inventory(self, patch):
         """With none attached and none given there is nothing to copy."""
@@ -1252,11 +1288,12 @@ class TestSpoolEnrich:
     def test_unknown_kwarg_raises_now(self, patch, inventory):
         """A misspelled argument fails here, not on a patch pulled later."""
         with pytest.raises(ParameterError, match="unknown argument"):
-            dc.spool(patch).enrich(inventory, attr=True)
+            dc.spool(patch).attach_inventory(inventory).enrich(attr=True)
 
     def test_re_enriching_replaces_arguments(self, patch, inventory):
         """The last call says what enrichment means."""
-        spool = dc.spool(patch).enrich(inventory, coords=False).enrich(inventory)
+        attached = dc.spool(patch).attach_inventory(inventory)
+        spool = attached.enrich(coords=False).enrich()
         assert "zone" in set(spool[0].coords.coord_map)
 
     def test_documents_the_arguments_it_forwards(self):
@@ -1276,7 +1313,7 @@ class TestSpoolEnrich:
             enrich_attrs_description,
             enrich_coords_description,
             enrich_on_missing_description,
-            enrich_conflicts_description,
+            enrich_conflict_description,
         ):
             # Indentation differs between a function and a method body, so
             # the shared text is compared with it removed.
@@ -1359,15 +1396,15 @@ class TestReviewFindings:
 
     def test_union_carries_the_inventory(self, patch, inventory):
         """Combining spools keeps metadata the operands already had."""
-        enriched = dc.spool(patch).enrich(inventory)
+        enriched = dc.spool(patch).attach_inventory(inventory).enrich()
         combined = enriched + dc.spool(patch)
         assert combined[0].attrs.gauge_length == 10.0
         assert (dc.spool(patch) + enriched)[0].attrs.gauge_length == 10.0
 
     def test_union_of_different_enrichment_raises(self, patch, inventory):
         """Two ways of enriching have no combined meaning."""
-        first = dc.spool(patch).enrich(inventory)
-        second = dc.spool(patch).enrich(inventory, coords=False)
+        first = dc.spool(patch).attach_inventory(inventory).enrich()
+        second = dc.spool(patch).attach_inventory(inventory).enrich(coords=False)
         with pytest.raises(InvalidSpoolError, match="different enrich arguments"):
             first + second
 
@@ -1420,7 +1457,7 @@ class TestSecondReviewFindings:
     def test_nan_attr_is_filled_not_conflicted(self, patch, inventory):
         """NaN is how a reader spells unknown, so the inventory fills it."""
         unknown = patch.update_attrs(gauge_length=np.nan)
-        out = unknown.enrich(inventory, coords=False, conflicts="raise")
+        out = unknown.enrich(inventory, coords=False, conflict="raise")
         assert out.attrs.gauge_length == 10.0
 
     def test_nan_marker_round_trips(self, patch, inventory):
@@ -1433,7 +1470,7 @@ class TestSecondReviewFindings:
             attrs=("pulse_rate",),
             coords=False,
             on_missing="null",
-            conflicts="raise",
+            conflict="raise",
         )
         assert np.isnan(twice.attrs.pulse_rate)
 
@@ -1580,7 +1617,7 @@ class TestSecondReviewFindings:
 
     def test_attached_spool_survives_pickle(self, patch, inventory):
         """A spool and its pickle are the same spool, inventory and all."""
-        spool = dc.spool(patch).enrich(inventory)
+        spool = dc.spool(patch).attach_inventory(inventory).enrich()
         assert pickle.loads(pickle.dumps(spool)) == spool
 
     def test_update_coords_stays_safe_to_bypass(self):
@@ -1619,34 +1656,42 @@ class TestSplitReviewFindings:
         """Swapping the source under a configured enrichment would rewrite
         every patch's metadata without being asked.
         """
-        spool = dc.spool(patch).enrich(inventory).attach_inventory(inventory)
+        spool = (
+            dc.spool(patch)
+            .attach_inventory(inventory)
+            .enrich()
+            .attach_inventory(inventory)
+        )
         assert spool._enrich_kwargs is None
         assert "gauge_length" not in dict(spool[0].attrs)
 
     def test_attaching_the_same_inventory_keeps_a_union_working(self, patch, inventory):
         """Supplying more information must not break what already worked."""
-        enriched = dc.spool(patch).enrich(inventory)
+        enriched = dc.spool(patch).attach_inventory(inventory).enrich()
         attached = dc.spool(patch).attach_inventory(inventory)
         assert (enriched + attached)[0].attrs.gauge_length == 10.0
 
     def test_stating_a_default_does_not_change_the_spool(self, patch, inventory):
         """Spools which enrich identically are the same spool."""
         plain = dc.spool(patch)
-        assert plain.enrich(inventory) == plain.enrich(
-            inventory, attrs=True, coords=True, conflicts="keep_first"
+        attached = plain.attach_inventory(inventory)
+        assert attached.enrich() == attached.enrich(
+            attrs=True, coords=True, conflict="keep_first"
         )
 
     def test_name_collections_compare_by_content(self, patch, inventory):
         """A list of names asks for what a tuple of them asks for."""
         plain = dc.spool(patch)
-        tupled = plain.enrich(inventory, attrs=("gauge_length",))
-        assert tupled == plain.enrich(inventory, attrs=["gauge_length"])
+        tupled = plain.attach_inventory(inventory).enrich(attrs=("gauge_length",))
+        assert tupled == plain.attach_inventory(inventory).enrich(
+            attrs=["gauge_length"]
+        )
 
     def test_update_keeps_the_inventory(self, patch, inventory, tmp_path):
         """Re-reading the file is no reason to stop enriching."""
         path = tmp_path / "patch.h5"
         dc.write(patch, path, "dasdae")
-        spool = dc.spool(path).enrich(inventory)
+        spool = dc.spool(path).attach_inventory(inventory).enrich()
         updated = spool.update()
         assert updated._inventory is inventory
         assert updated[0].attrs.gauge_length == 10.0
@@ -1738,8 +1783,9 @@ class TestThirdReviewFindings:
         long_key = "DAS." + "A" * 70 + "..RAW"
         with pytest.raises(InvalidInventoryError, match="characters"):
             inventory.resolve(long_key)
-        spool = dc.spool(patch.update_attrs(acquisition_key="")).enrich(
-            inventory, acquisition_key=long_key, on_unresolved="ignore"
+        bare = dc.spool(patch.update_attrs(acquisition_key=""))
+        spool = bare.attach_inventory(inventory).enrich(
+            acquisition_key=long_key, on_unresolved="ignore"
         )
         with pytest.raises(InvalidInventoryError, match="characters"):
             spool[0]
@@ -1902,7 +1948,7 @@ class TestInventorySelect:
 
     def test_enrichment_survives(self, two_patch_spool, inventory):
         """The derived spool is the same spool, inventory and all."""
-        spool = two_patch_spool.enrich(inventory)
+        spool = two_patch_spool.attach_inventory(inventory).enrich()
         out = spool.select(gauge_length=10.0)
         assert out[0].attrs.gauge_length == 10.0
 
@@ -2443,7 +2489,7 @@ class TestConformBoundaryPolicy:
         data, so a sample dropped or duplicated at the seam would be the
         one failure the whole operation cannot afford.
         """
-        spool = dc.spool(patch).conform_to_inventory(path_epochs)
+        spool = dc.spool(patch).attach_inventory(path_epochs).conform_to_inventory()
         assert len(spool) == 2
         first, second = spool[0], spool[1]
         times = np.concatenate(
@@ -2467,7 +2513,7 @@ class TestConformBoundaryPolicy:
         coord = patch.get_coord("time")
         naive = off_grid_boundary - coord.step
         (_, first_end), (second_start, _) = _pieces(
-            dc.spool(patch).conform_to_inventory(path_epochs)
+            dc.spool(patch).attach_inventory(path_epochs).conform_to_inventory()
         )
         # the sample the naive convention would have dropped
         assert naive < first_end < off_grid_boundary
@@ -2485,7 +2531,7 @@ class TestConformBoundaryPolicy:
         on_grid = coord.min() + coord.step * 10
         split = _split_epochs(inventory, on_grid, second={"name": "moved"})
         (_, first_end), (second_start, _) = _pieces(
-            dc.spool(patch).conform_to_inventory(split)
+            dc.spool(patch).attach_inventory(split).conform_to_inventory()
         )
         assert second_start == on_grid
         assert first_end == on_grid - coord.step
@@ -2507,7 +2553,7 @@ class TestConformBoundaryPolicy:
         spool = dc.spool(uneven)
         named = re.escape(spool.get_contents()["source_path"].iloc[0])
         with pytest.raises(PatchError, match=f"no time step.*{named}"):
-            spool.conform_to_inventory(split)
+            spool.attach_inventory(split).conform_to_inventory()
 
     def test_a_row_with_no_instants_is_undescribed(self, patch, path_epochs):
         """
@@ -2525,7 +2571,7 @@ class TestConformBoundaryPolicy:
         # instants rather than a time column of another kind entirely
         spool = dc.spool([patch, undated]).attach_inventory(path_epochs)
         assert pd.isnull(spool.get_contents()["time_min"]).any()
-        out = spool.conform_to_inventory(on_unresolved="drop")
+        out = spool.conform_to_inventory(on_unresolved="ignore")
         assert set(out.get_contents()["tag"]) == {"random"}
         with pytest.raises(UnresolvedPatchError, match="does not describe"):
             spool.conform_to_inventory()
@@ -2539,7 +2585,7 @@ class TestConformBoundaryPolicy:
         """
         bare = patch.update_attrs(acquisition_key="", tag="bare")
         spool = dc.spool([patch, bare]).attach_inventory(path_epochs)
-        out = spool.conform_to_inventory(on_unresolved="drop")
+        out = spool.conform_to_inventory(on_unresolved="ignore")
         assert set(out.get_contents()["tag"]) == {"random"}
 
     def test_a_relative_time_axis_is_undescribed(self, patch, path_epochs):
@@ -2553,7 +2599,7 @@ class TestConformBoundaryPolicy:
         coord = patch.get_coord("time")
         lags = patch.update_coords(time=coord.values - coord.min())
         spool = dc.spool(lags).attach_inventory(path_epochs)
-        assert len(spool.conform_to_inventory(on_unresolved="drop")) == 0
+        assert len(spool.conform_to_inventory(on_unresolved="ignore")) == 0
         with pytest.raises(UnresolvedPatchError, match="does not describe"):
             spool.conform_to_inventory()
 
@@ -2574,7 +2620,9 @@ class TestConformBoundaryPolicy:
             "DAS.R2D1..OTHER",
             "DAS.R2D1..RAW",
         ]
-        conformed = merged.conform_to_inventory(path_epochs, on_unresolved="drop")
+        conformed = merged.attach_inventory(path_epochs).conform_to_inventory(
+            on_unresolved="ignore"
+        )
         assert set(conformed.get_contents()["acquisition_key"]) == {"DAS.R2D1..RAW"}
         with pytest.raises(CoordMergeError, match="acquisition_key"):
             spool.chunk(time=None, group="tag")
@@ -2591,7 +2639,7 @@ class TestConformBoundaryPolicy:
         merged = dc.spool([patch, other]).chunk(time=None, group="tag", conflict="drop")
         assert "acquisition_key" not in merged.get_contents().columns
         with pytest.raises(UnresolvedPatchError, match="does not describe"):
-            merged.conform_to_inventory(path_epochs)
+            merged.attach_inventory(path_epochs).conform_to_inventory()
 
 
 class TestConformMembership:
@@ -2606,7 +2654,7 @@ class TestConformMembership:
         """A patch naming an entry the inventory lacks is not conformable."""
         other = patch.update_attrs(acquisition_key="DAS.R2D1..OTHER", tag="other")
         spool = dc.spool([patch, other]).attach_inventory(inventory)
-        out = spool.conform_to_inventory(on_unresolved="drop")
+        out = spool.conform_to_inventory(on_unresolved="ignore")
         assert out.get_contents()["tag"].tolist() == ["random"]
 
     def test_warn_drops_and_names_them(self, patch, inventory):
@@ -2640,7 +2688,7 @@ class TestConformMembership:
         # so an agreement of zeroes cannot stand in for the real thing
         filtered = dc.spool([patch, other]).attach_inventory(inventory)
         for out, expected in ((subdivided, 2), (filtered, 1)):
-            out = out.conform_to_inventory(on_unresolved="drop")
+            out = out.conform_to_inventory(on_unresolved="ignore")
             assert len(out) == len(out.get_contents()) == len(list(out)) == expected
 
     def test_needs_an_inventory(self, patch):
@@ -2650,17 +2698,17 @@ class TestConformMembership:
 
     def test_an_empty_spool_conforms_to_nothing(self, inventory):
         """No rows to resolve is not a reason to fail."""
-        assert len(dc.spool([]).conform_to_inventory(inventory)) == 0
+        assert len(dc.spool([]).attach_inventory(inventory).conform_to_inventory()) == 0
 
     def test_policy_is_checked(self, patch, inventory):
         """A misspelled policy is caught before any row is resolved."""
         spool = dc.spool(patch).attach_inventory(inventory)
         with pytest.raises(ParameterError, match="on_unresolved must be"):
-            spool.conform_to_inventory(on_unresolved="ignore")
+            spool.conform_to_inventory(on_unresolved="drop")
 
-    def test_a_passed_inventory_attaches(self, patch, inventory):
-        """Passing one is also how to attach it, as with enrich."""
-        out = dc.spool(patch).conform_to_inventory(inventory)
+    def test_conform_keeps_the_attached_inventory(self, patch, inventory):
+        """Conforming leaves the spool carrying what it conformed to."""
+        out = dc.spool(patch).attach_inventory(inventory).conform_to_inventory()
         assert out._inventory is inventory
         assert out.enrich()[0].attrs.gauge_length == 10.0
 
@@ -2668,7 +2716,7 @@ class TestConformMembership:
         """A spool whose rows name no entry has nothing to resolve with."""
         spool = dc.spool([dc.get_example_patch()]).attach_inventory(inventory)
         assert "acquisition_key" not in spool.get_contents().columns
-        assert len(spool.conform_to_inventory(on_unresolved="drop")) == 0
+        assert len(spool.conform_to_inventory(on_unresolved="ignore")) == 0
 
 
 class TestConformSubdivision:
@@ -2719,7 +2767,7 @@ class TestConformSubdivision:
             old.new(start_time=edges[1], name="last"),
         )
         split = inventory.replace(array, array.new(optical_paths=paths)).check()
-        out = dc.spool(patch).conform_to_inventory(split)
+        out = dc.spool(patch).attach_inventory(split).conform_to_inventory()
         assert len(out) == 3
         starts = [x[0] for x in _pieces(out)]
         assert starts[1] == edges[0] and starts[2] == edges[1]
@@ -2742,7 +2790,7 @@ class TestConformSubdivision:
             old.new(start_time=edges[1], name="after"),
         )
         split = inventory.replace(array, array.new(optical_paths=paths)).check()
-        out = dc.spool(patch).conform_to_inventory(split)
+        out = dc.spool(patch).attach_inventory(split).conform_to_inventory()
         assert len(out) == 2
         assert _pieces(out)[1][0] == edges[1]
         assert out[0].shape[1] + out[1].shape[1] == patch.shape[1]
@@ -2753,7 +2801,7 @@ class TestConformSubdivision:
         split = _split_epochs(
             inventory, coord.max() + coord.step * 10, second={"name": "later"}
         )
-        assert len(dc.spool(patch).conform_to_inventory(split)) == 1
+        assert len(dc.spool(patch).attach_inventory(split).conform_to_inventory()) == 1
 
     def test_a_boundary_which_changes_nothing_cuts_nothing(self, patch, inventory):
         """
@@ -2780,7 +2828,9 @@ class TestConformSubdivision:
         ).check()
         # the bound really does fall inside the row
         assert coord.min() < when <= coord.max()
-        assert len(dc.spool(patch).conform_to_inventory(renamed)) == 1
+        assert (
+            len(dc.spool(patch).attach_inventory(renamed).conform_to_inventory()) == 1
+        )
         # and enrich agrees, which is the point of comparing by value
         assert patch.enrich(renamed).attrs.gauge_length == 10.0
 
@@ -2827,7 +2877,7 @@ class TestConformSubdivision:
         )
         spool = dc.spool(patch).attach_inventory(split)
         named = re.escape(spool.get_contents()["source_path"].iloc[0])
-        for policy in ("raise", "warn", "drop"):
+        for policy in ("raise", "warn", "ignore"):
             with pytest.raises(
                 PatchError, match=f"change of acquisition.*{named} \\(at .*"
             ):
@@ -2839,7 +2889,7 @@ class TestConformComposition:
 
     def test_conform_is_idempotent(self, patch, path_epochs):
         """The pieces of a conformed spool each sit inside one epoch."""
-        once = dc.spool(patch).conform_to_inventory(path_epochs)
+        once = dc.spool(patch).attach_inventory(path_epochs).conform_to_inventory()
         twice = once.conform_to_inventory()
         assert len(twice) == len(once) == 2
         assert _pieces(twice) == _pieces(once)
@@ -2856,14 +2906,14 @@ class TestConformComposition:
         split = _split_epochs(inventory, when, second={"name": "moved"})
         chunked = dc.spool(patch).chunk(time=4)
         assert len(chunked) == 2
-        out = chunked.conform_to_inventory(split)
+        out = chunked.attach_inventory(split).conform_to_inventory()
         assert len(out) == 3
         assert [x[0] for x in _pieces(out)][2] == when
         assert out[2].get_coord("time").min() == when
 
     def test_selecting_after_conforming(self, patch, path_epochs, off_grid_boundary):
         """The pieces are ordinary rows, so ordinary selection reaches them."""
-        out = dc.spool(patch).conform_to_inventory(path_epochs)
+        out = dc.spool(patch).attach_inventory(path_epochs).conform_to_inventory()
         late = out.select(time=(off_grid_boundary, None))
         assert len(late) == 1
         assert late[0].get_coord("time").min() >= off_grid_boundary
@@ -2887,7 +2937,7 @@ class TestConformComposition:
         split = _split_epochs(
             inventory, coord.min() + coord.step * 500, second={"name": "moved"}
         )
-        out = dc.spool(path).update().conform_to_inventory(split)
+        out = dc.spool(path).update().attach_inventory(split).conform_to_inventory()
         assert len(out) == 2
         first, second = out[0], out[1]
         assert first.shape[1] == 500
@@ -2919,7 +2969,7 @@ class TestConformPartialCoverage:
             ),
         ).check()
         spool = dc.spool(patch).attach_inventory(lapsed)
-        assert len(spool.conform_to_inventory(on_unresolved="drop")) == 0
+        assert len(spool.conform_to_inventory(on_unresolved="ignore")) == 0
         with pytest.raises(UnresolvedPatchError, match="does not describe"):
             spool.conform_to_inventory()
 
@@ -2943,7 +2993,7 @@ class TestConformPartialCoverage:
                 optical_paths=(array.optical_paths[0].new(end_time=off_grid_boundary),)
             ),
         ).check()
-        out = dc.spool(patch).conform_to_inventory(lapsed)
+        out = dc.spool(patch).attach_inventory(lapsed).conform_to_inventory()
         assert len(out) == 2
         first, second = out.enrich(coords=True)
         assert "zone" in first.coords.coord_map
@@ -2980,22 +3030,22 @@ class TestConformAndEnrichment:
 
     def test_conforming_keeps_enrichment(self, patch, path_epochs):
         """The spool's own inventory is not a new one, so nothing is swapped."""
-        spool = dc.spool(patch).enrich(path_epochs, coords=False)
+        spool = dc.spool(patch).attach_inventory(path_epochs).enrich(coords=False)
         out = spool.conform_to_inventory()
         assert out._enrich_kwargs is not None
         assert out[0].attrs.gauge_length == 10.0
 
-    def test_passing_an_inventory_clears_enrichment(self, patch, path_epochs):
+    def test_reattaching_clears_enrichment(self, patch, path_epochs):
         """
-        Passing one attaches it, and attaching always clears enrichment.
+        Attaching always clears enrichment, and conform sees that.
 
         Swapping the source underneath a configured enrichment would
         rewrite every patch's metadata, so the new one has to be asked
-        for — the rule `attach_inventory` sets, which conform inherits
-        by taking its inventory the same way `enrich` does.
+        for. `attach_inventory` is the only way a spool gets an
+        inventory, so it is the only place that rule is needed.
         """
-        spool = dc.spool(patch).enrich(path_epochs, coords=False)
-        out = spool.conform_to_inventory(path_epochs)
+        spool = dc.spool(patch).attach_inventory(path_epochs).enrich(coords=False)
+        out = spool.attach_inventory(path_epochs).conform_to_inventory()
         assert out._enrich_kwargs is None
         assert "gauge_length" not in dict(out[0].attrs)
 
@@ -3345,7 +3395,7 @@ class TestSplitBy:
     def test_one_patch_per_value(self, patch, inventory):
         """The example path annotates two zones, so two patches come out."""
         spool = dc.spool(patch).attach_inventory(inventory)
-        out = spool.split_by("zone")
+        out = spool.expand_by("zone")
         assert len(out) == 2
         assert out.get_contents()["zone"].tolist() == ["north", "south"]
 
@@ -3353,7 +3403,7 @@ class TestSplitBy:
         """Each output holds the rows its value covers, and no others."""
         spool = dc.spool(patch).attach_inventory(inventory)
         whole = patch.get_array("distance")
-        pieces = list(spool.split_by("zone"))
+        pieces = list(spool.expand_by("zone"))
         assert len(pieces) == 2
         for piece in pieces:
             rows = np.searchsorted(whole, piece.get_array("distance"))
@@ -3362,12 +3412,12 @@ class TestSplitBy:
     def test_the_value_is_stamped_on_the_patch(self, patch, inventory):
         """So overlapping siblings stay apart once they are patches."""
         spool = dc.spool(patch).attach_inventory(inventory)
-        assert [x.attrs.zone for x in spool.split_by("zone")] == ["north", "south"]
+        assert [x.attrs.zone for x in spool.expand_by("zone")] == ["north", "south"]
 
     def test_stamp_false_leaves_the_attrs_alone(self, patch, inventory):
         """Which is what a nested split wants of the second one."""
         spool = dc.spool(patch).attach_inventory(inventory)
-        out = spool.split_by("zone", stamp=False)
+        out = spool.expand_by("zone", stamp=False)
         assert len(out) == 2  # the split still happened; only the stamp is off
         assert "zone" not in out.get_contents().columns
         assert not any(dict(x.attrs).get("zone") for x in out)
@@ -3381,7 +3431,7 @@ class TestSplitBy:
         while resolving `zone` along the fiber again would trim it.
         """
         spool = dc.spool(patch).attach_inventory(inventory)
-        out = spool.split_by("zone")
+        out = spool.expand_by("zone")
         north = out.select(zone="north")
         assert len(north) == 1
         assert north[0].shape == out[0].shape
@@ -3389,7 +3439,7 @@ class TestSplitBy:
     def test_a_membership_group_splits_in_two(self, patch, inventory):
         """Both sides come out: the channels included and those not."""
         spool = dc.spool(patch).attach_inventory(inventory)
-        out = spool.split_by("noisy")
+        out = spool.expand_by("noisy")
         assert sorted(out.get_contents()["noisy"].tolist()) == [False, False, True]
 
     def test_one_split_partitions_the_channels(self, patch, inventory):
@@ -3404,31 +3454,31 @@ class TestSplitBy:
         """
         spool = dc.spool(patch).attach_inventory(inventory)
         for group in ("zone", "noisy"):
-            channels = _channels(spool.split_by(group))
+            channels = _channels(spool.expand_by(group))
             assert sorted(channels) == sorted(patch.get_array("distance"))
             assert len(channels) == len(set(channels.tolist()))
         # The two groups do not agree about where the fiber divides.
-        zoned = {tuple(x.get_array("distance")) for x in spool.split_by("zone")}
-        noisy = {tuple(x.get_array("distance")) for x in spool.split_by("noisy")}
+        zoned = {tuple(x.get_array("distance")) for x in spool.expand_by("zone")}
+        noisy = {tuple(x.get_array("distance")) for x in spool.expand_by("noisy")}
         assert zoned != noisy
 
     def test_a_disjoint_value_becomes_several_patches(self, patch, two_zones):
         """One value covering two stretches keeps them apart."""
         spool = dc.spool(patch).attach_inventory(two_zones)
-        out = spool.split_by("hole")
+        out = spool.expand_by("hole")
         assert len(out) == 2
         assert out.get_contents()["hole"].tolist() == ["a", "a"]
 
     def test_include_keeps_only_what_it_names(self, patch, inventory):
         """The globs read the value written as a string."""
         spool = dc.spool(patch).attach_inventory(inventory)
-        out = spool.split_by("zone", include="nor*")
+        out = spool.expand_by("zone", include="nor*")
         assert out.get_contents()["zone"].tolist() == ["north"]
 
     def test_exclude_wins_over_include(self, patch, inventory):
         """So naming a family and carving one out of it reads either way."""
         spool = dc.spool(patch).attach_inventory(inventory)
-        out = spool.split_by("zone", include=("nor*", "sou*"), exclude="north")
+        out = spool.expand_by("zone", include=("nor*", "sou*"), exclude="north")
         assert out.get_contents()["zone"].tolist() == ["south"]
 
     def test_a_name_the_inventory_lacks_raises(self, patch, inventory):
@@ -3441,17 +3491,17 @@ class TestSplitBy:
         """
         spool = dc.spool(patch).attach_inventory(inventory)
         with pytest.raises(InvalidSpoolQueryError, match="not a coordinate"):
-            spool.split_by("not_a_group")
+            spool.expand_by("not_a_group")
 
     def test_needs_an_inventory(self, patch):
         """The values it expands into are ones an inventory states."""
         with pytest.raises(ParameterError, match="needs an inventory"):
-            dc.spool(patch).split_by("zone")
+            dc.spool(patch).expand_by("zone")
 
     def test_a_nested_split_keeps_the_first_stamp(self, patch, inventory):
         """Which is what `stamp=False` is for."""
         spool = dc.spool(patch).attach_inventory(inventory)
-        out = spool.split_by("zone").split_by("noisy", stamp=False)
+        out = spool.expand_by("zone").expand_by("noisy", stamp=False)
         assert set(out.get_contents()["zone"]) == {"north", "south"}
 
 
@@ -3560,13 +3610,13 @@ class TestChannelSelectEdges:
         """No fiber to split on means no output, not an error."""
         other = patch.update_attrs(acquisition_key="DAS.R2D1..OTHER")
         spool = dc.spool(other).attach_inventory(inventory)
-        assert len(spool.split_by("zone")) == 0
+        assert len(spool.expand_by("zone")) == 0
 
     def test_splitting_skips_a_row_it_cannot_place(self, patch, inventory):
         """A described patch splits; one the inventory is silent about does not."""
         other = patch.update_attrs(acquisition_key="DAS.R2D1..OTHER", tag="second")
         spool = dc.spool([patch, other]).attach_inventory(inventory)
-        out = spool.split_by("zone")
+        out = spool.expand_by("zone")
         assert out.get_contents()["zone"].tolist() == ["north", "south"]
 
     def test_splitting_an_unevenly_sampled_patch_refuses(self, patch, inventory):
@@ -3574,7 +3624,7 @@ class TestChannelSelectEdges:
         holed = patch.unselect(distance=(50, 200))
         spool = dc.spool(holed).attach_inventory(inventory)
         with pytest.raises(PatchError, match="no channel spacing"):
-            spool.split_by("zone")
+            spool.expand_by("zone")
 
     def test_one_patch_carrying_two_channel_axes_refuses(self, patch, inventory):
         """
@@ -3612,7 +3662,7 @@ class TestChannelSelectEdges:
         """Without instants there is no context to read a group from."""
         lags = patch.get_coord("time").values - patch.get_coord("time").min()
         spool = dc.spool(patch.update_coords(time=lags)).attach_inventory(inventory)
-        assert len(spool.split_by("zone")) == 0
+        assert len(spool.expand_by("zone")) == 0
 
 
 @pytest.fixture(scope="module")
@@ -3698,11 +3748,11 @@ class TestChannelSelectAlignment:
         assert sorted(dropped["unknown"]) == whole
 
     def test_splitting_keeps_each_patch_with_its_value(self, uneven_spool):
-        """split_by builds the same plan, so it aligns the same way."""
+        """expand_by builds the same plan, so it aligns the same way."""
         spool, patches = uneven_spool
         sources = {x.attrs.tag: x for x in patches}
         whole = patches[0].get_array("distance")
-        out = spool.split_by("hole")
+        out = spool.expand_by("hole")
         assert out.get_contents()["hole"].tolist() == ["a", "a", "a"]
         for piece in out:
             source = sources[piece.attrs.tag]
@@ -3791,7 +3841,7 @@ class TestChannelReviewFindings:
         spool = dc.spool(patch).attach_inventory(pathless)
         assert "x" in pathless.get_names().coords
         assert len(spool.select(x=(-1e9, 1e9))) == 0
-        assert len(spool.split_by("x")) == 0
+        assert len(spool.expand_by("x")) == 0
 
     def test_a_unit_bearing_selector_is_converted(self, patch, inventory):
         """
@@ -3880,7 +3930,7 @@ class TestChannelReviewFindings:
         because chunking a derived catalog is broken on dev already
         (#871) and would fail here for a reason of its own.
         """
-        conformed = dc.spool(patch).conform_to_inventory(path_epochs)
+        conformed = dc.spool(patch).attach_inventory(path_epochs).conform_to_inventory()
         assert len(conformed) == 2
         assert not conformed._catalog.resolver.lossy
         selected = dc.spool(patch).attach_inventory(inventory).select(coupling="trench")
@@ -3909,9 +3959,9 @@ class TestChannelReviewFindings:
         )
         spool = dc.spool(patch).attach_inventory(clash)
         with pytest.raises(InvalidSpoolQueryError, match="overwrite"):
-            spool.split_by("output_id")
+            spool.expand_by("output_id")
         # Splitting on it is still legal; only recording the value is not.
-        assert len(spool.split_by("output_id", stamp=False)) == 1
+        assert len(spool.expand_by("output_id", stamp=False)) == 1
 
     def test_a_no_op_channel_selector_does_not_veto_a_flag(self, patch, inventory):
         """

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -973,20 +973,18 @@ class TestAttachInventoryPath:
             os.chdir(here)
         assert spool.enrich()[0].attrs.gauge_length == 10.0
 
-    def test_enrich_takes_a_path(self, tmp_path, patch, inventory):
-        """Both inventory verbs attach what they are given."""
-        path = tmp_path / "somewhere.yaml"
-        inventory.to_yaml(path)
-        assert (
-            dc.spool(patch).attach_inventory(path).enrich()[0].attrs.gauge_length
-            == 10.0
-        )
-
-    def test_conform_takes_a_path(self, tmp_path, patch, inventory):
-        """The same, for the verb which makes the index truthful."""
+    def test_conform_uses_an_attached_path(self, tmp_path, patch, inventory):
+        """A lazily attached path is read by the eager verb too."""
         path = tmp_path / "somewhere.yaml"
         inventory.to_yaml(path)
         assert len(dc.spool(patch).attach_inventory(path).conform_to_inventory()) == 1
+
+    @pytest.mark.parametrize("verb", ["enrich", "conform_to_inventory"])
+    def test_the_verbs_take_no_inventory(self, patch, inventory, verb):
+        """Attaching is the only way in, so neither verb accepts one."""
+        spool = dc.spool(patch).attach_inventory(inventory)
+        with pytest.raises(TypeError, match="positional argument"):
+            getattr(spool, verb)(inventory)
 
     def test_no_argument_needs_a_directory(self, patch):
         """There is nowhere an in-memory spool could have carried one."""
@@ -1241,12 +1239,7 @@ class TestSpoolEnrich:
         spool = dc.spool(patch).attach_inventory(inventory).enrich()
         assert all(x.attrs.gauge_length == 10.0 for x in spool)
 
-    def test_uses_attached_inventory(self, patch, inventory):
-        """With one already carried, enrich needs no argument."""
-        spool = dc.spool(patch).attach_inventory(inventory).enrich()
-        assert spool[0].attrs.gauge_length == 10.0
-
-    def test_enrich_attaches_its_inventory(self, patch, inventory):
+    def test_enrich_keeps_the_attached_inventory(self, patch, inventory):
         """The spool carries what it enriches from."""
         spool = dc.spool(patch).attach_inventory(inventory).enrich()
         assert spool._inventory is inventory

--- a/tests/test_utils/test_attrs_utils.py
+++ b/tests/test_utils/test_attrs_utils.py
@@ -32,7 +32,7 @@ class TestMergeAttrs:
         """An unsupported conflicts value should raise. See #804."""
         pa1, pa2 = PatchAttrs(tag="bob"), PatchAttrs(tag="bill")
         with pytest.raises(ParameterError, match="conflict must be one of"):
-            combine_patch_attrs([pa1, pa2], conflicts="banana")
+            combine_patch_attrs([pa1, pa2], conflict="banana")
 
     def test_conflicts(self):
         """Ensure when non-dim fields aren't equal merge raises."""
@@ -47,7 +47,7 @@ class TestMergeAttrs:
         attrs = PatchAttrs.from_dict(random_patch.attrs)
         pa1 = attrs.update(tag="bill", acquisition_key="UU.R2D1..RAW")
         pa2 = attrs.update(tag="bob", acquisition_key="TA.R2D1..RAW")
-        out = combine_patch_attrs([pa1, pa2], conflicts="drop")
+        out = combine_patch_attrs([pa1, pa2], conflict="drop")
         defaults = PatchAttrs()
         assert out.tag == defaults.tag
         assert out.acquisition_key == defaults.acquisition_key
@@ -56,7 +56,7 @@ class TestMergeAttrs:
         """Ensure disjoint values can be kept."""
         random_attrs = PatchAttrs.from_dict(random_patch.attrs)
         attrs1 = random_attrs.update(jazz_hands=1984)
-        out = combine_patch_attrs([attrs1, random_attrs], conflicts="keep_first")
+        out = combine_patch_attrs([attrs1, random_attrs], conflict="keep_first")
         assert out.jazz_hands == 1984
 
     def test_patch_input(self, random_patch):
@@ -68,7 +68,7 @@ class TestMergeAttrs:
         """Plain mapping inputs should normalize through PatchAttrs."""
         out = combine_patch_attrs(
             [random_patch.attrs.model_dump(), random_patch.attrs],
-            conflicts="keep_first",
+            conflict="keep_first",
         )
         assert isinstance(out, PatchAttrs)
 
@@ -89,7 +89,7 @@ class TestMergeAttrs:
                 return len(self._data)
 
         mapping = MappingLike(random_patch.attrs.model_dump())
-        out = combine_patch_attrs([mapping, random_patch.attrs], conflicts="keep_first")
+        out = combine_patch_attrs([mapping, random_patch.attrs], conflict="keep_first")
         assert isinstance(out, PatchAttrs)
 
     def test_private_attrs_are_ignored_for_merge_conflicts(self, random_patch):

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -16,7 +16,7 @@ import pytest
 from upath import UPath
 
 import dascore as dc
-from dascore.exceptions import MissingOptionalDependencyError
+from dascore.exceptions import MissingOptionalDependencyError, ParameterError
 from dascore.utils.misc import (
     _get_install_name,
     _iter_filesystem,
@@ -681,11 +681,16 @@ class TestWarnOrRaise:
             warn_or_raise(msg, exception=ValueError, behavior="raise")
 
     def test_nothing(self):
-        """Ensure when  None does nothing."""
+        """Ensure "ignore" does nothing."""
         msg = "Big nothing burger"
         # Now exceptions or warnings will crash the program.
         with suppress_warnings(action="error"):
-            warn_or_raise(msg, behavior=None)
+            warn_or_raise(msg, behavior="ignore")
+
+    def test_unknown_behavior_raises(self):
+        """A behavior outside the vocabulary says so rather than warning."""
+        with pytest.raises(ParameterError, match="behavior must be one of"):
+            warn_or_raise("nope", behavior=None)
 
 
 class TestSuppressWarnings:
@@ -717,7 +722,7 @@ class TestSpoolMap:
         out = _spool_map(
             spool,
             lambda patch, value=1: len(patch.dims) + value,
-            progress=False,
+            progress=None,
         )
         assert out == [3, 3, 3]
 
@@ -725,7 +730,7 @@ class TestSpoolMap:
         """A client should receive split spools and flatten mapped outputs."""
         seen = []
 
-        def fake_track(iterable, desc):
+        def fake_track(iterable, desc, progress="standard"):
             seen.append(desc)
             return iterable
 
@@ -740,7 +745,7 @@ class TestSpoolMap:
             lambda patch, value=1: len(patch.dims) + value,
             client=DummyClient(),
             size=None,
-            progress=True,
+            progress="standard",
         )
         assert out == [3, 3, 3]
         assert seen == ["Applying <lambda> to spool"]
@@ -756,7 +761,7 @@ class TestSpoolMap:
             dc.spool([]),
             lambda patch: patch,
             client=DummyClient(),
-            progress=False,
+            progress=None,
         )
         assert out == []
 

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -26,6 +26,7 @@ from dascore.utils.patch import (
     _force_patch_merge,
     _spool_up,
     align_patch_coords,
+    check_dims,
     concatenate_patches,
     get_dim_axis_value,
     get_patch_names,
@@ -795,6 +796,11 @@ class TestStackPatches:
         spool = dc.spool([patch1, patch2])
         with pytest.raises(ParameterError, match="behavior must be one of"):
             stack_patches(spool, dim_vary="time", check_behavior=None)
+
+    def test_retired_check_behavior_raises_on_compatible_patches(self, random_patch):
+        """Acceptance must not wait for data which happens to disagree."""
+        with pytest.raises(ParameterError, match="behavior must be one of"):
+            check_dims(random_patch, random_patch, check_behavior=None)
 
     def test_different_dimensions(self, random_spool):
         """Tests for when the spool has patches with different dimensions."""

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -784,6 +784,17 @@ class TestStackPatches:
         # Or a warning issued.
         with pytest.warns(UserWarning, match=msg):
             stack_patches(spool, dim_vary="time", check_behavior="warn")
+        # Or the incompatible patch skipped without a word.
+        with suppress_warnings(action="error"):
+            stack_patches(spool, dim_vary="time", check_behavior="ignore")
+
+    def test_retired_check_behavior_raises(self, random_spool):
+        """None used to mean "ignore"; one spelling of it survives."""
+        patch1, patch2 = random_spool[0], random_spool[1]
+        patch2 = patch2.select(time=(1, 30), samples=True)
+        spool = dc.spool([patch1, patch2])
+        with pytest.raises(ParameterError, match="behavior must be one of"):
+            stack_patches(spool, dim_vary="time", check_behavior=None)
 
     def test_different_dimensions(self, random_spool):
         """Tests for when the spool has patches with different dimensions."""

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -785,9 +785,11 @@ class TestStackPatches:
         # Or a warning issued.
         with pytest.warns(UserWarning, match=msg):
             stack_patches(spool, dim_vary="time", check_behavior="warn")
-        # Or the incompatible patch skipped without a word.
+        # Or the incompatible patch skipped without a word -- skipped
+        # being the point: a quiet policy must not stack it anyway.
         with suppress_warnings(action="error"):
-            stack_patches(spool, dim_vary="time", check_behavior="ignore")
+            quiet = stack_patches(spool, dim_vary="time", check_behavior="ignore")
+        assert np.allclose(quiet.data, patch1.data)
 
     def test_retired_check_behavior_raises(self, random_spool):
         """None used to mean "ignore"; one spelling of it survives."""
@@ -804,11 +806,14 @@ class TestStackPatches:
 
     def test_different_dimensions(self, random_spool):
         """Tests for when the spool has patches with different dimensions."""
+        first = random_spool[1]
         new_patch = random_spool[0].rename_coords(time="money")
-        spool = dc.spool([random_spool[1], new_patch])
+        spool = dc.spool([first, new_patch])
         msg = "not compatible for merging"
         with pytest.warns(UserWarning, match=msg):
-            stack_patches(spool, dim_vary="time", check_behavior="warn")
+            out = stack_patches(spool, dim_vary="time", check_behavior="warn")
+        # The mismatched patch is left out rather than summed in.
+        assert np.allclose(out.data, first.data)
 
     def test_bad_dim_vary(self, random_spool):
         """Ensure when dim_vary is not in patch an error is raised."""

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -7,6 +7,7 @@ import pytest
 from rich.progress import Progress
 
 from dascore.config import config_context
+from dascore.exceptions import ParameterError
 from dascore.utils.progress import get_progress_instance, get_track_length, track
 
 
@@ -60,6 +61,22 @@ class TestProgressBar:
         """Ensure we can return a basic progress bar."""
         pbar = get_progress_instance("basic")
         assert isinstance(pbar, Progress)
+
+    def test_none_disables_the_bar(self):
+        """None is the off switch, and iteration is unaffected."""
+        with config_context(debug=False):
+            assert list(track([1, 2, 3], "off_tracker", None)) == [1, 2, 3]
+
+    @pytest.mark.parametrize("bad", [False, True, "quiet"])
+    def test_a_value_outside_the_levels_raises(self, bad):
+        """Anything else would fall through to the standard bar."""
+        with pytest.raises(ParameterError, match="progress must be one of"):
+            list(track([1, 2, 3], "bad_tracker", bad))
+
+    def test_a_progress_instance_is_accepted(self):
+        """A caller's own bar is not a level, and is still allowed."""
+        with config_context(debug=False):
+            assert list(track([1, 2, 3], "own_tracker", Progress())) == [1, 2, 3]
 
     def test_basic_progress_refresh_rate_comes_from_config(self, monkeypatch):
         """The basic progress bar should honor the configured refresh rate."""

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+
 import numpy as np
 import pytest
 from rich.progress import Progress
 
+import dascore as dc
 from dascore.config import config_context
 from dascore.exceptions import ParameterError
 from dascore.utils.progress import get_progress_instance, get_track_length, track
@@ -72,6 +75,15 @@ class TestProgressBar:
         """Anything else would fall through to the standard bar."""
         with pytest.raises(ParameterError, match="progress must be one of"):
             list(track([1, 2, 3], "bad_tracker", bad))
+
+    def test_an_empty_spool_still_refuses_a_bad_level(self):
+        """Acceptance must not depend on there being data to track."""
+        client = ThreadPoolExecutor()
+        try:
+            with pytest.raises(ParameterError, match="progress must be one of"):
+                dc.spool([]).map(lambda patch: patch, client=client, progress=False)
+        finally:
+            client.shutdown()
 
     def test_a_progress_instance_is_accepted(self):
         """A caller's own bar is not a level, and is still allowed."""


### PR DESCRIPTION
## Description

Second PR of the pre-release simplification roadmap, and the user-visible one. The inventory work grew five ways of saying the same things; this picks one of each, while nothing outside the repo depends on them yet.

**One policy vocabulary, `{raise, warn, ignore}`.** `conform_to_inventory`'s `on_unresolved="drop"` becomes `"ignore"` — dropping is what conform does, so the value only had to say how loudly. `WARN_LEVELS` loses `None`, the twin of `"ignore"`, and `warn_or_raise` now refuses a behavior outside the set instead of treating anything unrecognized as "warn". `Patch.enrich`'s `on_missing` gains `"warn"`; `"null"` stays as a fourth value, since it fills a marker rather than choosing a noise level, and is the only way to make the name present either way.

**One spelling of the conflict policy.** `conflict`, singular, everywhere. `chunk` keeps the spelling it has always had, and no longer translates itself into `merge`'s on the way through; `Patch.enrich` and `combine_patch_attrs` change.

**One off switch.** `Patch.enrich(attrs=None)` used to mean what `attrs=False` means. `False` is the documented spelling, so `None` now raises rather than being a second one.

**One progress vocabulary.** `Spool.map(progress=)` takes the `PROGRESS_LEVELS` that `update` already took, so `"basic"` reaches the one place that maps over a whole spool.

**One inventory state-setter.** `attach_inventory` is the only way a spool gets an inventory. `enrich` and `conform_to_inventory` read the attached one rather than accepting their own, so a spool has one answer to which inventory it means, and "passing one also attaches it" — with its footnote about clearing enrichment — stops being a rule to know.

**One name per operation.** `split_by` collided with `split` and shared none of its semantics; it is `expand_by`, which is what its own docstring already called it.

**One loading door.** `dc.inventory` decides what a source is; `Inventory.from_yaml` went back to reading text. The newline path-vs-text sniff is gone: a path is a path when it exists, and a string naming nothing is the document itself — unless it is spelled like one of the format's own filenames, which is a path that is not there rather than the smallest inventory anyone ever wrote. A one-line document therefore loads, which the old rule could not manage, and a mistyped path still says "No such inventory file".

Retiring a spelling is only safe if the old one stops working audibly, and three did not until review caught them: `check_behavior=None` was still documented as the silent option, `map(progress=False)` fell through to the standard bar and so turned one *on*, and `from_yaml` handed a `Path` straight to the parser. Each raises where it is passed now, with a test.

Tests move with the vocabulary, and the docs pages carry the new spellings. `docs/tutorial/spool.qmd` also loses a paragraph that was stale before this PR: `unselect` has accepted inventory coordinates since #883.

## Changelog

- changed **breaking**: `Spool.split_by` is now `Spool.expand_by`.
- changed **breaking**: `Spool.enrich` and `Spool.conform_to_inventory` no longer take an `inventory` argument; attach one with `Spool.attach_inventory` first.
- changed **breaking**: the conflict-policy argument is spelled `conflict` everywhere; `Patch.enrich` and `combine_patch_attrs` no longer accept `conflicts`.
- changed **breaking**: `Inventory.from_yaml` reads YAML text only; load a path with `dc.inventory`.
- changed: `Spool.conform_to_inventory(on_unresolved="drop")` is now `"ignore"`, and `None` is no longer accepted where `"ignore"` is.
- changed: `Spool.map(progress=)` takes the same levels as `Spool.update` ("standard", "basic", None) rather than a bool; a value outside them now raises rather than quietly showing the standard bar.
- added: `Patch.enrich(on_missing="warn")` copies what it can and says what it left off.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Inventory loading now supports YAML text, files, directories, and clearer missing-file handling.
  - Added `"warn"` and `"null"` options for missing inventory attributes.
  - Progress reporting now supports standardized levels and custom progress displays.

- **Changes**
  - Renamed `split_by` to `expand_by`.
  - Spool enrichment and conformance now use an attached inventory.
  - Conflict configuration now uses `conflict`; unresolved handling uses `raise`, `warn`, or `ignore`.
  - Invalid configuration values now raise clear errors.

- **Documentation**
  - Updated inventory and spool tutorials with the revised workflows and terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->