### PR TITLE
Trim the inventory model

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -134,6 +134,13 @@ max_lens = {
 # inventory's: seconds, hertz, and meters. Readers convert at the parse
 # boundary instead of shipping a companion units attr.
 # Tested against the models in tests/test_core/test_attrs.py.
+# Attrs describing the data as it now stands rather than the system which
+# recorded it. Processing maintains them, so blanket enrichment leaves
+# them alone; naming one restores the as-acquired value. Kept beside
+# INVENTORY_ATTRS because the two together are what an inventory can say
+# about a patch.
+DATA_STATE_ATTRS = ("data_type", "data_category", "data_units")
+
 INVENTORY_ATTRS = (
     "closed_fiber_loop",
     "firmware_version",

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -134,13 +134,6 @@ max_lens = {
 # inventory's: seconds, hertz, and meters. Readers convert at the parse
 # boundary instead of shipping a companion units attr.
 # Tested against the models in tests/test_core/test_attrs.py.
-# Attrs describing the data as it now stands rather than the system which
-# recorded it. Processing maintains them, so blanket enrichment leaves
-# them alone; naming one restores the as-acquired value. Kept beside
-# INVENTORY_ATTRS because the two together are what an inventory can say
-# about a patch.
-DATA_STATE_ATTRS = ("data_type", "data_category", "data_units")
-
 INVENTORY_ATTRS = (
     "closed_fiber_loop",
     "firmware_version",
@@ -157,6 +150,13 @@ INVENTORY_ATTRS = (
     "software_version",
     "spatial_interval",
 )
+
+# Attrs describing the data as it now stands rather than the system which
+# recorded it. Processing maintains them, so blanket enrichment leaves them
+# alone; naming one restores the as-acquired value. Together with
+# INVENTORY_ATTRS these are what an inventory can say about a patch.
+DATA_STATE_ATTRS = ("data_type", "data_category", "data_units")
+
 
 # Methods FileFormatter needs to support
 FILE_FORMATTER_METHODS = ("read", "write", "get_format", "scan")

--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -592,10 +592,11 @@ def _fill_from_intervals(distances, intervals, values, kind):
     ):
         if not np.any(covered):
             continue
-        # A mapping like the `extra_fields` every track model carries can
-        # be asked for by name even though the blanket list skips it.
-        # Caught here so the numeric branch below cannot raise a bare
-        # TypeError out of float().
+        # Anything with a length except a string: a tuple field like a
+        # geometry's `distance`, or a mapping like the `extra_fields`
+        # every track model carries, both of which can be asked for by
+        # name. Caught here so the numeric branch below cannot raise a
+        # bare TypeError out of float().
         if isinstance(value, Sized) and not isinstance(value, str):
             msg = (
                 f"Cannot project the multi-valued {value!r} onto channels; "

--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -592,10 +592,10 @@ def _fill_from_intervals(distances, intervals, values, kind):
     ):
         if not np.any(covered):
             continue
-        # Anything with a length except a string holds more than one thing:
-        # a tuple of measurements, or a mapping like the `extra_fields`
-        # every track model carries. Caught here so the numeric branch
-        # below cannot raise a bare TypeError out of float().
+        # A mapping like the `extra_fields` every track model carries can
+        # be asked for by name even though the blanket list skips it.
+        # Caught here so the numeric branch below cannot raise a bare
+        # TypeError out of float().
         if isinstance(value, Sized) and not isinstance(value, str):
             msg = (
                 f"Cannot project the multi-valued {value!r} onto channels; "

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -42,8 +42,6 @@ from pydantic import (
 from typing_extensions import Self
 
 from dascore.constants import (
-    DATA_STATE_ATTRS,
-    INVENTORY_ATTRS,
     DataCategory,
     DataType,
 )
@@ -206,8 +204,9 @@ class CoordinateReferenceSystem(InventoryModel):
         """
         The axes are unique, canonical in number, and paired with units.
 
-        Three statements about one thing -- what this CRS's axes are --
-        so a document naming its axes badly hears every way at once.
+        Three checks of one thing -- what this CRS's axes are -- kept
+        together so they cannot drift apart. The first to fail is the
+        one reported, as it was when these were three validators.
         """
         labels = self.coordinate_labels
         if len(set(labels)) != len(labels):
@@ -370,10 +369,14 @@ class _OpticalComponentBase(InventoryModel):
 
     Every component carries a unified one-way transmission ``loss_db`` and
     return ``reflectance_db`` (the two quantities an OTDR trace shows per
-    event), each paired with the measurement record that produced it. One
-    value each: a component measured at several wavelengths is several
-    components' worth of facts, and the inventory has no channel to give
-    them to.
+    event), each paired with the measurement record that produced it.
+
+    One value each. A channel takes one number from a component, so a
+    per-wavelength set has nothing to be projected onto; state the
+    wavelength the inventory describes, and keep the others with the
+    measurement records they came from. (Repeating the component is not
+    the way: its `optical_length` would be counted twice and shift every
+    channel after it.)
     """
 
     _identity_field: ClassVar[str] = "name"
@@ -1564,10 +1567,14 @@ def _drop_empty(value, _in_extras=False):
     """
     Recursively drop empty strings, mappings, and sequences from a dump.
 
-    Pruned fields default to the empty value they held, so reload is
-    lossless; user-supplied ``extra_fields`` contents are kept verbatim.
-    An annotation value cannot be pruned into a different kind: it is a
-    scalar, and `_reject_empty_string` refuses the one empty form.
+    A field whose default is the empty value it held reloads unchanged;
+    user-supplied ``extra_fields`` contents are kept verbatim.
+
+    This prunes by key without knowing which model a mapping came from,
+    so a field whose default is *not* empty -- a CRS deliberately left
+    without an authority, say -- reloads as that default rather than as
+    the blank it was given. Pruning would have to walk the models
+    alongside the dump to tell those apart.
     """
     if isinstance(value, dict):
         out = {}
@@ -1717,22 +1724,40 @@ def _resource_ref_fields(model) -> Mapping[str, tuple]:
     unreachable by `replace`. Cached on the class, like the value names.
     """
     resources = tuple(_annotation_members(_Resource))
+
+    def held(annotation) -> tuple:
+        """The resource classes a field can hold, through a collection."""
+        out = []
+        for member in _annotation_members(annotation):
+            if get_origin(member) in _COLLECTION_ORIGINS:
+                # a tuple of resources holds them just as a bare field does
+                out.extend(held(get_args(member)[0]))
+            elif isinstance(member, type) and issubclass(member, resources):
+                out.append(member)
+        return tuple(dict.fromkeys(out))
+
     return MappingProxyType(
         {
             name: allowed
             for name, info in model.model_fields.items()
-            if (
-                allowed := tuple(
-                    x
-                    for x in _annotation_members(info.annotation)
-                    if isinstance(x, type) and issubclass(x, resources)
-                )
-            )
+            if (allowed := held(info.annotation))
         }
     )
 
 
-_SYSTEM_FACT_NAMES = tuple(sorted(INVENTORY_ATTRS + DATA_STATE_ATTRS))
+# The observing-system facts an inventory can contribute, read off the
+# models so a field added to either becomes one without being listed
+# anywhere. The data-state trio is included because it can be asked for
+# by name (blanket enrichment leaves it to processing). INVENTORY_ATTRS
+# is the same vocabulary as the readers spell it, and cannot be derived
+# from here without the readers importing the models -- so that one
+# pairing is what the test pins.
+_SYSTEM_FACT_NAMES = tuple(
+    sorted(
+        list(_value_field_names(Acquisition))
+        + [f"interrogator.{x}" for x in _value_field_names(Interrogator)]
+    )
+)
 
 
 def _yaml_label(text: str) -> str:
@@ -1841,8 +1866,11 @@ class Inventory(InventoryModel):
             updates = {}
             for field, allowed in fields.items():
                 value = getattr(obj, field)
-                new_value = register(value, field, allowed)
-                if new_value is not value:
+                if isinstance(value, tuple):
+                    new_value = tuple(register(x, field, allowed) for x in value)
+                    if new_value != value:
+                        updates[field] = new_value
+                elif (new_value := register(value, field, allowed)) is not value:
                     updates[field] = new_value
             return obj.model_copy(update=updates) if updates else obj
 
@@ -1850,15 +1878,15 @@ class Inventory(InventoryModel):
             pool_add(rid, normalize(resource))
 
         def norm_path(path):
+            # the path's own reference fields (measurements) go through
+            # normalize like any other model's; its components are models
+            # of their own and each normalizes itself.
+            path = normalize(path)
             return path.model_copy(
                 update={
                     "optical_components": tuple(
                         normalize(c) for c in path.optical_components
-                    ),
-                    "measurements": tuple(
-                        register(x, "measurements", (OpticalMeasurement,))
-                        for x in path.measurements
-                    ),
+                    )
                 }
             )
 

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Mapping
-from types import MappingProxyType
+from functools import cache
+from types import MappingProxyType, UnionType
 from typing import (
     Annotated,
     Any,
@@ -24,7 +25,9 @@ from typing import (
     Literal,
     NamedTuple,
     TypeAlias,
+    Union,
     get_args,
+    get_origin,
 )
 from uuid import uuid4
 
@@ -1623,92 +1626,112 @@ _EXTENT_FIELDS = frozenset(_IntervalModel.model_fields) - frozenset(
 _COLLECTION_ORIGINS = (tuple, list, set, frozenset, dict)
 
 
-# What each typed track and its models state, written out rather than
-# read off the annotations. `coupling="trench"` asks about coupling_type;
-# every other field is reached by its qualified name (`coupling.medium`).
-# A model field added or renamed without touching these is caught by the
-# drift tests in tests/test_core/test_inventory.py, which do the walking
-# this file used to do at import time.
-TRACK_IDENTITY_FIELDS = MappingProxyType(
-    {
-        "optical_components": "name",
-        "geometry": "name",
-        "coupling": "coupling_type",
-    }
-)
+def _annotation_members(annotation) -> list:
+    """
+    Return the alternatives a possibly-optional union annotation admits.
 
-# Which fields of which models hold a shareable resource, and what each
-# may hold. `_normalize_resources` moves an inline object here into the
-# flat pool and leaves the id behind, so a resource-valued field missing
-# from this table keeps its object where an id belongs -- nothing
-# resolves it, and `replace` cannot reach it. Pinned by a drift test.
-_MEASUREMENT_REFS = MappingProxyType(
-    {
-        "loss_measurement": (OpticalMeasurement,),
-        "reflectance_measurement": (OpticalMeasurement,),
-    }
-)
-RESOURCE_REF_FIELDS = MappingProxyType(
-    {
-        FiberSegment: {"container": (Cable,), **_MEASUREMENT_REFS},
-        Connector: {"container": (Enclosure,), **_MEASUREMENT_REFS},
-        Splice: {"container": (Enclosure,), **_MEASUREMENT_REFS},
-        Terminator: {"container": (Enclosure,), **_MEASUREMENT_REFS},
-        Cable: {
-            "container": (Enclosure, Cable),
-            "specification": (ExternalResource,),
-        },
-        Enclosure: {"specification": (ExternalResource,)},
-        Acquisition: {"interrogator": (Interrogator,)},
-        OpticalMeasurement: {"data": (ExternalResource,)},
-    }
-)
+    `Annotated` is transparent: this file writes several of its unions as
+    `Annotated[A | B, Field(discriminator=...)]`, and the wrapper must not
+    hide what they hold. `None` is dropped, since "or nothing" says what
+    the field does when it is unset rather than what it can hold.
+    """
+    if get_origin(annotation) is Annotated:
+        return _annotation_members(get_args(annotation)[0])
+    if get_origin(annotation) in (Union, UnionType):
+        out = [
+            x for member in get_args(annotation) for x in _annotation_members(member)
+        ]
+        return [x for x in out if x is not type(None)]
+    return [annotation]
 
 
-# The fields of each track model which state one fact about one thing --
-# what an inventory can give a channel. Reference fields (another model)
-# and collections are not among them: they are a second record, or have
-# no single value to hand over.
-TRACK_VALUE_FIELDS = MappingProxyType(
-    {
-        FiberSegment: (
-            "optical_length",
-            "name",
-            "loss_db",
-            "reflectance_db",
-            "fiber_number",
-            "fiber_color",
-            "fiber_type",
-            "fiber_standard",
-            "refractive_index",
-            "buffer_type",
-        ),
-        Connector: (
-            "optical_length",
-            "name",
-            "loss_db",
-            "reflectance_db",
-            "connector_type",
-        ),
-        Splice: ("optical_length", "name", "loss_db", "reflectance_db", "splice_type"),
-        Terminator: (
-            "optical_length",
-            "name",
-            "loss_db",
-            "reflectance_db",
-            "termination_type",
-        ),
-        Geometry: ("name",),
-        CouplingCondition: ("coupling_type", "medium", "attachment", "depth"),
-    }
-)
+def _is_value_field(info) -> bool:
+    """
+    Return True when a field could hold one value describing one thing.
+
+    A field which may hold another inventory model is a reference to a
+    second record rather than a fact of this one, and one which can only
+    hold a collection has no single value to state, or to give a channel.
+    """
+    members = _annotation_members(info.annotation)
+    if any(isinstance(x, type) and issubclass(x, InventoryModel) for x in members):
+        return False
+    return any(get_origin(x) not in _COLLECTION_ORIGINS for x in members)
 
 
-# The observing-system facts an inventory can contribute: the vocabulary
-# constants.py declares, plus the three attrs which describe the data as
-# it now stands rather than the system which recorded it (blanket enrich
-# leaves those alone, but they can be asked for by name). A model field
-# missing from the vocabulary is caught by the drift test.
+@cache
+def _value_field_names(model) -> tuple[str, ...]:
+    """
+    Return the fields of a model which state a fact about one thing.
+
+    Cached on the class: the answer is a property of the model, and an
+    inventory asked for its names walks every item of every track.
+    """
+    structural = frozenset(TimeRangedModel.model_fields) | _IDENTITY_FIELDS
+    structural |= _EXTENT_FIELDS
+    return tuple(
+        name
+        for name, info in model.model_fields.items()
+        if name not in structural and _is_value_field(info)
+    )
+
+
+def _track_identity_fields() -> Mapping[str, str]:
+    """
+    Map each typed track of an optical path to the field its name means.
+
+    `coupling="trench"` asks about coupling_type; every other field of a
+    track is reached by its qualified name (`coupling.medium`). Each
+    track model declares which of its fields is its identity, so the
+    pairing lives beside the field rather than in a list to keep in step
+    with it.
+    """
+    out = {}
+    for track, info in OpticalPath.model_fields.items():
+        # A track is a tuple of items; the path's scalar fields are not.
+        if get_origin(info.annotation) is not tuple:
+            continue
+        for model in _annotation_members(get_args(info.annotation)[0]):
+            field = getattr(model, "_identity_field", None)
+            if field is None:
+                continue
+            # The model names one of its own fields, or the map it builds
+            # would point at nothing.
+            assert field in model.model_fields, (model, field)
+            out[track] = field
+    return MappingProxyType(out)
+
+
+TRACK_IDENTITY_FIELDS = _track_identity_fields()
+
+
+@cache
+def _resource_ref_fields(model) -> Mapping[str, tuple]:
+    """
+    Return the fields of a model which hold a shareable resource.
+
+    Read off the annotations rather than listed beside them: a field
+    which can hold a resource says so in its own type, and a list could
+    name a field that moved or miss one that arrived -- either of which
+    leaves an inline object where an id belongs, out of the pool and
+    unreachable by `replace`. Cached on the class, like the value names.
+    """
+    resources = tuple(_annotation_members(_Resource))
+    return MappingProxyType(
+        {
+            name: allowed
+            for name, info in model.model_fields.items()
+            if (
+                allowed := tuple(
+                    x
+                    for x in _annotation_members(info.annotation)
+                    if isinstance(x, type) and issubclass(x, resources)
+                )
+            )
+        }
+    )
+
+
 _SYSTEM_FACT_NAMES = tuple(sorted(INVENTORY_ATTRS + DATA_STATE_ATTRS))
 
 
@@ -1796,7 +1819,6 @@ class Inventory(InventoryModel):
         """
         pool: dict[str, Any] = {}
         string_refs: list[tuple[str, str, tuple]] = []
-        ref_fields = RESOURCE_REF_FIELDS
 
         def pool_add(rid, resource):
             if rid in pool and pool[rid] != resource:
@@ -1815,9 +1837,7 @@ class Inventory(InventoryModel):
 
         def normalize(obj):
             """Rewrite an object's resource-valued fields to id references."""
-            fields = next(
-                (f for cls, f in ref_fields.items() if isinstance(obj, cls)), {}
-            )
+            fields = _resource_ref_fields(type(obj))
             updates = {}
             for field, allowed in fields.items():
                 value = getattr(obj, field)
@@ -1943,7 +1963,7 @@ class Inventory(InventoryModel):
             for track in TRACK_IDENTITY_FIELDS:
                 for item in getattr(path, track):
                     fields = tracks.setdefault(track, {})
-                    fields.update(dict.fromkeys(TRACK_VALUE_FIELDS[type(item)]))
+                    fields.update(dict.fromkeys(_value_field_names(type(item))))
         for track, fields in tracks.items():
             out[track] = None
             out.update(dict.fromkeys(f"{track}.{x}" for x in fields))

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -15,9 +15,8 @@ Each object documents the rules it enforces.
 from __future__ import annotations
 
 import itertools
-from collections.abc import Mapping, Sized
-from functools import cache
-from types import MappingProxyType, UnionType
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import (
     Annotated,
     Any,
@@ -25,9 +24,7 @@ from typing import (
     Literal,
     NamedTuple,
     TypeAlias,
-    Union,
     get_args,
-    get_origin,
 )
 from uuid import uuid4
 
@@ -41,7 +38,12 @@ from pydantic import (
 )
 from typing_extensions import Self
 
-from dascore.constants import DataCategory, DataType
+from dascore.constants import (
+    DATA_STATE_ATTRS,
+    INVENTORY_ATTRS,
+    DataCategory,
+    DataType,
+)
 from dascore.exceptions import InvalidInventoryError, ParameterError
 from dascore.models import (
     DateTime64,
@@ -196,34 +198,27 @@ class CoordinateReferenceSystem(InventoryModel):
         ),
     )
 
-    @field_validator("coordinate_labels")
-    @classmethod
-    def _check_labels(cls, value):
-        """Labels are unique; the vocabulary itself is enforced by the type."""
-        if len(set(value)) != len(value):
-            msg = f"coordinate_labels must be unique; got {value}."
-            raise InvalidInventoryError(msg)
-        return value
+    @model_validator(mode="after")
+    def _check_axes(self) -> Self:
+        """
+        The axes are unique, canonical in number, and paired with units.
 
-    @field_validator("coordinate_labels")
-    @classmethod
-    def _check_label_count(cls, value):
-        """Coordinates are stored on the canonical (x, y, z) axes."""
-        if not 1 <= len(value) <= 3:
+        Three statements about one thing -- what this CRS's axes are --
+        so a document naming its axes badly hears every way at once.
+        """
+        labels = self.coordinate_labels
+        if len(set(labels)) != len(labels):
+            msg = f"coordinate_labels must be unique; got {labels}."
+            raise InvalidInventoryError(msg)
+        if not 1 <= len(labels) <= 3:
             msg = (
                 "A CRS declares one to three axes, matching the canonical "
-                f"(x, y, z) storage; got {value}."
+                f"(x, y, z) storage; got {labels}."
             )
             raise InvalidInventoryError(msg)
-        return value
-
-    @model_validator(mode="after")
-    def _check_units_length(self) -> Self:
-        """Units pair with the axes, one per coordinate label."""
-        if len(self.units) != len(self.coordinate_labels):
+        if len(self.units) != len(labels):
             msg = (
-                f"units {self.units} must have one entry per coordinate "
-                f"label {self.coordinate_labels}."
+                f"units {self.units} must have one entry per coordinate label {labels}."
             )
             raise InvalidInventoryError(msg)
         return self
@@ -372,9 +367,10 @@ class _OpticalComponentBase(InventoryModel):
 
     Every component carries a unified one-way transmission ``loss_db`` and
     return ``reflectance_db`` (the two quantities an OTDR trace shows per
-    event), each paired with the measurement record that produced it.
-    Multi-wavelength values are equal-length tuples paired elementwise
-    with their measurements, which carry the wavelengths.
+    event), each paired with the measurement record that produced it. One
+    value each: a component measured at several wavelengths is several
+    components' worth of facts, and the inventory has no channel to give
+    them to.
     """
 
     _identity_field: ClassVar[str] = "name"
@@ -385,49 +381,22 @@ class _OpticalComponentBase(InventoryModel):
         description="Optical component length along the optical path in meters.",
     )
     name: str = Field(default="", description="Human-readable component name.")
-    loss_db: FiniteFloat | tuple[FiniteFloat, ...] | None = Field(
+    loss_db: FiniteFloat | None = Field(
         default=None,
         description="One-way transmission loss across this component in dB.",
     )
-    loss_measurement: (
-        OpticalMeasurement | str | tuple[OpticalMeasurement | str, ...] | None
-    ) = Field(
+    loss_measurement: OpticalMeasurement | str | None = Field(
         default=None,
-        description="Measurement record(s) the loss value(s) came from.",
+        description="Measurement record the loss value came from.",
     )
-    reflectance_db: FiniteFloat | tuple[FiniteFloat, ...] | None = Field(
+    reflectance_db: FiniteFloat | None = Field(
         default=None,
         description="Return loss (reflectance) of this component in dB.",
     )
-    reflectance_measurement: (
-        OpticalMeasurement | str | tuple[OpticalMeasurement | str, ...] | None
-    ) = Field(
+    reflectance_measurement: OpticalMeasurement | str | None = Field(
         default=None,
-        description="Measurement record(s) the reflectance value(s) came from.",
+        description="Measurement record the reflectance value came from.",
     )
-
-    @model_validator(mode="after")
-    def _check_measurement_pairing(self) -> Self:
-        """Tuple values pair elementwise with tuple measurement records."""
-        for quantity in ("loss", "reflectance"):
-            value = getattr(self, f"{quantity}_db")
-            meas = getattr(self, f"{quantity}_measurement")
-            value_seq = isinstance(value, tuple)
-            meas_seq = isinstance(meas, tuple)
-            if value_seq != meas_seq:
-                msg = (
-                    f"Multi-valued {quantity}_db requires an equal-length "
-                    f"{quantity}_measurement tuple (each value needs the "
-                    "record carrying its wavelength), and vice versa."
-                )
-                raise InvalidInventoryError(msg)
-            if value_seq and len(value) != len(meas):
-                msg = (
-                    f"{quantity}_db has {len(value)} values but "
-                    f"{quantity}_measurement has {len(meas)}."
-                )
-                raise InvalidInventoryError(msg)
-        return self
 
 
 class FiberSegment(_OpticalComponentBase):
@@ -459,14 +428,11 @@ class FiberSegment(_OpticalComponentBase):
     )
 
     @property
-    def attenuation_db_per_km(self) -> float | tuple[float, ...] | None:
+    def attenuation_db_per_km(self) -> float | None:
         """The familiar per-length loss rate, derived from loss_db."""
         if self.loss_db is None or not self.optical_length:
             return None
-        km = self.optical_length / 1000.0
-        if isinstance(self.loss_db, tuple):
-            return tuple(x / km for x in self.loss_db)
-        return self.loss_db / km
+        return self.loss_db / (self.optical_length / 1000.0)
 
 
 class Connector(_OpticalComponentBase):
@@ -931,21 +897,6 @@ class Acquisition(TimeRangedModel):
         description="True when the interrogator is attached to both path ends.",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def _reject_start_distance(cls, data):
-        """Explain the removed affine form rather than 'extra inputs'."""
-        if isinstance(data, Mapping) and "start_distance" in data:
-            msg = (
-                "Acquisition no longer takes start_distance; the distance_map "
-                "is the one channel-resolution mechanism. Write "
-                f"start_distance: {data['start_distance']} as distance_map: "
-                f"{{channel: [0], distance: [{data['start_distance']}]}}, which "
-                "states the same origin and takes spatial_interval as its slope."
-            )
-            raise InvalidInventoryError(msg)
-        return data
-
     def channel_to_distance(self, values, axis: str | None = None) -> np.ndarray:
         """
         Map channel-like patch coordinates onto optical path distance.
@@ -986,32 +937,6 @@ def _overlapping_epochs(items, key) -> list[tuple]:
 
 
 _MIXED_DIMS_MSG = "Geometry segments mix coordinate dimensionalities {dims}."
-
-
-def _track_identity_fields() -> Mapping[str, str]:
-    """
-    Map each typed track of an optical path to the field its name means.
-
-    `coupling="trench"` asks about coupling_type; every other field of a
-    track is reached by its qualified name (`coupling.medium`). Each
-    track model declares which of its fields is its identity, so the
-    pairing lives beside the field rather than in a list to keep in step
-    with it.
-    """
-    out = {}
-    for track, info in OpticalPath.model_fields.items():
-        # A track is a tuple of items; the path's scalar fields are not.
-        if get_origin(info.annotation) is not tuple:
-            continue
-        for model in _annotation_members(get_args(info.annotation)[0]):
-            field = getattr(model, "_identity_field", None)
-            if field is None:
-                continue
-            # The model names one of its own fields, or the map it builds
-            # would point at nothing.
-            assert field in model.model_fields, (model, field)
-            out[track] = field
-    return MappingProxyType(out)
 
 
 # Names an annotation group may not take: a group becomes a patch coordinate
@@ -1632,19 +1557,14 @@ class Network(TimeRangedModel):
         return self
 
 
-# Fields whose default is not the empty value; dropping them would reload as
-# something else. An annotation value defaults to True, so a pruned empty
-# string would come back as a boolean and change its group's kind.
-_UNPRUNED_KEYS = frozenset({"value"})
-
-
 def _drop_empty(value, _in_extras=False):
     """
     Recursively drop empty strings, mappings, and sequences from a dump.
 
     Pruned fields default to the empty value they held, so reload is
-    lossless; fields in ``_UNPRUNED_KEYS`` and user-supplied ``extra_fields``
-    contents are kept verbatim.
+    lossless; user-supplied ``extra_fields`` contents are kept verbatim.
+    An annotation value cannot be pruned into a different kind: it is a
+    scalar, and `_reject_empty_string` refuses the one empty form.
     """
     if isinstance(value, dict):
         out = {}
@@ -1654,7 +1574,7 @@ def _drop_empty(value, _in_extras=False):
                 if _in_extras
                 else _drop_empty(item, _in_extras=key == "extra_fields")
             )
-            empty = pruned in ("", {}, []) and key not in _UNPRUNED_KEYS
+            empty = pruned in ("", {}, [])
             if empty and not _in_extras:
                 continue
             out[key] = pruned
@@ -1703,82 +1623,93 @@ _EXTENT_FIELDS = frozenset(_IntervalModel.model_fields) - frozenset(
 _COLLECTION_ORIGINS = (tuple, list, set, frozenset, dict)
 
 
-def _annotation_members(annotation) -> list:
-    """
-    Return the alternatives a possibly-optional union annotation admits.
-
-    `Annotated` is transparent: this file writes several of its unions as
-    `Annotated[A | B, Field(discriminator=...)]`, and the wrapper must not
-    hide what they hold. `None` is dropped, since "or nothing" says what
-    the field does when it is unset rather than what it can hold.
-    """
-    if get_origin(annotation) is Annotated:
-        return _annotation_members(get_args(annotation)[0])
-    if get_origin(annotation) in (Union, UnionType):
-        out = [
-            x for member in get_args(annotation) for x in _annotation_members(member)
-        ]
-        return [x for x in out if x is not type(None)]
-    return [annotation]
-
-
-def _is_value_field(info) -> bool:
-    """
-    Return True when a field could hold one value describing one thing.
-
-    A field which may hold another inventory model is a reference to a
-    second record rather than a fact of this one, and one which can only
-    hold a collection has no single value to state, or to give a channel.
-    """
-    members = _annotation_members(info.annotation)
-    if any(isinstance(x, type) and issubclass(x, InventoryModel) for x in members):
-        return False
-    return any(get_origin(x) not in _COLLECTION_ORIGINS for x in members)
-
-
-def _value_shape(item, field: str) -> str | None:
-    """
-    Return how an item states a field: as one value, several, or not at all.
-
-    A field stated as several values -- a multi-wavelength loss, say --
-    has none to give a channel, however scalar its annotation reads.
-    """
-    value = getattr(item, field, None)
-    if value is None or (isinstance(value, str) and not value):
-        return None
-    return "many" if isinstance(value, Sized) and not isinstance(value, str) else "one"
-
-
-@cache
-def _value_field_names(model) -> tuple[str, ...]:
-    """
-    Return the fields of a model which state a fact about one thing.
-
-    Cached on the class: the answer is a property of the model, and an
-    inventory asked for its names walks every item of every track.
-    """
-    structural = frozenset(TimeRangedModel.model_fields) | _IDENTITY_FIELDS
-    structural |= _EXTENT_FIELDS
-    return tuple(
-        name
-        for name, info in model.model_fields.items()
-        if name not in structural and _is_value_field(info)
-    )
-
-
-TRACK_IDENTITY_FIELDS = _track_identity_fields()
-
-
-# The observing-system facts, read off the models rather than listed, so a
-# field added to either automatically becomes something an inventory can
-# contribute. Pinned to INVENTORY_ATTRS by a test: the two are one
-# vocabulary, and a new field has to reach the readers as well.
-_SYSTEM_FACT_NAMES = tuple(
-    sorted(
-        list(_value_field_names(Acquisition))
-        + [f"interrogator.{x}" for x in _value_field_names(Interrogator)]
-    )
+# What each typed track and its models state, written out rather than
+# read off the annotations. `coupling="trench"` asks about coupling_type;
+# every other field is reached by its qualified name (`coupling.medium`).
+# A model field added or renamed without touching these is caught by the
+# drift tests in tests/test_core/test_inventory.py, which do the walking
+# this file used to do at import time.
+TRACK_IDENTITY_FIELDS = MappingProxyType(
+    {
+        "optical_components": "name",
+        "geometry": "name",
+        "coupling": "coupling_type",
+    }
 )
+
+# Which fields of which models hold a shareable resource, and what each
+# may hold. `_normalize_resources` moves an inline object here into the
+# flat pool and leaves the id behind, so a resource-valued field missing
+# from this table keeps its object where an id belongs -- nothing
+# resolves it, and `replace` cannot reach it. Pinned by a drift test.
+_MEASUREMENT_REFS = MappingProxyType(
+    {
+        "loss_measurement": (OpticalMeasurement,),
+        "reflectance_measurement": (OpticalMeasurement,),
+    }
+)
+RESOURCE_REF_FIELDS = MappingProxyType(
+    {
+        FiberSegment: {"container": (Cable,), **_MEASUREMENT_REFS},
+        Connector: {"container": (Enclosure,), **_MEASUREMENT_REFS},
+        Splice: {"container": (Enclosure,), **_MEASUREMENT_REFS},
+        Terminator: {"container": (Enclosure,), **_MEASUREMENT_REFS},
+        Cable: {
+            "container": (Enclosure, Cable),
+            "specification": (ExternalResource,),
+        },
+        Enclosure: {"specification": (ExternalResource,)},
+        Acquisition: {"interrogator": (Interrogator,)},
+        OpticalMeasurement: {"data": (ExternalResource,)},
+    }
+)
+
+
+# The fields of each track model which state one fact about one thing --
+# what an inventory can give a channel. Reference fields (another model)
+# and collections are not among them: they are a second record, or have
+# no single value to hand over.
+TRACK_VALUE_FIELDS = MappingProxyType(
+    {
+        FiberSegment: (
+            "optical_length",
+            "name",
+            "loss_db",
+            "reflectance_db",
+            "fiber_number",
+            "fiber_color",
+            "fiber_type",
+            "fiber_standard",
+            "refractive_index",
+            "buffer_type",
+        ),
+        Connector: (
+            "optical_length",
+            "name",
+            "loss_db",
+            "reflectance_db",
+            "connector_type",
+        ),
+        Splice: ("optical_length", "name", "loss_db", "reflectance_db", "splice_type"),
+        Terminator: (
+            "optical_length",
+            "name",
+            "loss_db",
+            "reflectance_db",
+            "termination_type",
+        ),
+        Geometry: ("name",),
+        CouplingCondition: ("coupling_type", "medium", "attachment", "depth"),
+    }
+)
+
+
+# The observing-system facts an inventory can contribute: the vocabulary
+# constants.py declares, plus the three attrs which describe the data as
+# it now stands rather than the system which recorded it (blanket enrich
+# leaves those alone, but they can be asked for by name). A model field
+# missing from the vocabulary is caught by the drift test.
+_SYSTEM_FACT_NAMES = tuple(sorted(INVENTORY_ATTRS + DATA_STATE_ATTRS))
 
 
 def _yaml_label(text: str) -> str:
@@ -1865,23 +1796,7 @@ class Inventory(InventoryModel):
         """
         pool: dict[str, Any] = {}
         string_refs: list[tuple[str, str, tuple]] = []
-        measurement_refs = {
-            "loss_measurement": (OpticalMeasurement,),
-            "reflectance_measurement": (OpticalMeasurement,),
-        }
-        ref_fields = {
-            FiberSegment: {"container": (Cable,), **measurement_refs},
-            Connector: {"container": (Enclosure,), **measurement_refs},
-            Splice: {"container": (Enclosure,), **measurement_refs},
-            Terminator: {"container": (Enclosure,), **measurement_refs},
-            Cable: {
-                "container": (Enclosure, Cable),
-                "specification": (ExternalResource,),
-            },
-            Enclosure: {"specification": (ExternalResource,)},
-            Acquisition: {"interrogator": (Interrogator,)},
-            OpticalMeasurement: {"data": (ExternalResource,)},
-        }
+        ref_fields = RESOURCE_REF_FIELDS
 
         def pool_add(rid, resource):
             if rid in pool and pool[rid] != resource:
@@ -1906,15 +1821,9 @@ class Inventory(InventoryModel):
             updates = {}
             for field, allowed in fields.items():
                 value = getattr(obj, field)
-                if isinstance(value, tuple):
-                    new_value = tuple(register(x, field, allowed) for x in value)
-                    if new_value == value:
-                        continue
-                else:
-                    new_value = register(value, field, allowed)
-                    if new_value is value:
-                        continue
-                updates[field] = new_value
+                new_value = register(value, field, allowed)
+                if new_value is not value:
+                    updates[field] = new_value
             return obj.model_copy(update=updates) if updates else obj
 
         for rid, resource in self.resources.items():
@@ -2029,25 +1938,15 @@ class Inventory(InventoryModel):
         out = dict.fromkeys(["distance", *("x", "y", "z")[: len(labels)], *labels])
         groups: dict[str, None] = {}
         tracks: dict[str, dict[str, None]] = {}
-        shapes: dict[str, set[str]] = {}
         for path in self._optical_paths():
             groups.update(dict.fromkeys(x.group for x in path.annotations if x.group))
             for track in TRACK_IDENTITY_FIELDS:
                 for item in getattr(path, track):
                     fields = tracks.setdefault(track, {})
-                    names = _value_field_names(type(item))
-                    fields.update(dict.fromkeys(names))
-                    for field in names:
-                        if (shape := _value_shape(item, field)) is not None:
-                            shapes.setdefault(f"{track}.{field}", set()).add(shape)
-        # Dropped only where nothing states it as one value: another path
-        # may record a scalar where this one records several, and that
-        # path can still give it to a channel.
-        unusable = {x for x, kinds in shapes.items() if kinds == {"many"}}
+                    fields.update(dict.fromkeys(TRACK_VALUE_FIELDS[type(item)]))
         for track, fields in tracks.items():
             out[track] = None
-            names = (f"{track}.{x}" for x in fields)
-            out.update(dict.fromkeys(x for x in names if x not in unusable))
+            out.update(dict.fromkeys(f"{track}.{x}" for x in fields))
         out.update(groups)
         return tuple(out)
 
@@ -2141,18 +2040,16 @@ class Inventory(InventoryModel):
             ],
             "fiber arrays",
         )
-        acqs = [
-            exactly_one(
-                [
-                    x
-                    for x in array.acquisitions
-                    if x.code == acq_code
-                    and x.location_code == location
-                    and x.is_effective_at(time)
-                ],
-                "acquisitions",
-            )
-        ]
+        acquisition = exactly_one(
+            [
+                x
+                for x in array.acquisitions
+                if x.code == acq_code
+                and x.location_code == location
+                and x.is_effective_at(time)
+            ],
+            "acquisitions",
+        )
         paths = [
             x
             for x in array.optical_paths
@@ -2162,7 +2059,7 @@ class Inventory(InventoryModel):
             msg = f"{acquisition_key!r} resolves to {len(paths)} optical paths."
             raise InvalidInventoryError(msg)
         path = paths[0] if paths else None
-        return ResolvedContext(network, array, acqs[0], path)
+        return ResolvedContext(network, array, acquisition, path)
 
     def replace(self, old, new) -> Self:
         """

--- a/dascore/models/base.py
+++ b/dascore/models/base.py
@@ -100,6 +100,14 @@ def sensible_model_hash(self: BaseModel) -> int:
 class DascoreBaseModel(BaseModel):
     """A base model with sensible configurations."""
 
+    # Declared, not unused: `cached_method` (dascore.utils.misc) assigns
+    # `self._cache` on first use, and without this pydantic private-attr
+    # declaration the dict lands in `__dict__` beside the field values --
+    # where a `deep_equality_check` over `__dict__` sees two otherwise
+    # equal models differ by which of them has been asked a cached
+    # question.
+    _cache = {}
+
     model_config = ConfigDict(
         extra="ignore",  # TODO: change to raise, then let subclass overwrite
         validate_assignment=True,

--- a/dascore/models/base.py
+++ b/dascore/models/base.py
@@ -100,8 +100,6 @@ def sensible_model_hash(self: BaseModel) -> int:
 class DascoreBaseModel(BaseModel):
     """A base model with sensible configurations."""
 
-    _cache = {}
-
     model_config = ConfigDict(
         extra="ignore",  # TODO: change to raise, then let subclass overwrite
         validate_assignment=True,

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import dascore as dc
 from dascore.constants import (
+    DATA_STATE_ATTRS,
     INVENTORY_ATTRS,
     PatchType,
     enrich_attrs_description,
@@ -39,11 +40,6 @@ from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import iterate, validate_acquisition_key, warn_or_raise
 from dascore.utils.patch import patch_function
 from dascore.utils.time import to_datetime64
-
-# Attrs describing the data as it now stands rather than the system which
-# recorded it. Processing functions maintain them, so blanket enrichment
-# leaves them alone; naming one explicitly restores the as-acquired value.
-_DATA_STATE_ATTRS = ("data_type", "data_category", "data_units")
 
 # Facts the patch's own coordinates already state: the time coordinate has
 # the sample rate and the distance coordinate the channel spacing, and
@@ -160,7 +156,7 @@ def _get_attr_values(inventory, context, attrs, on_missing) -> dict:
     if attrs is True:
         return {i: v for i, v in system.items() if i not in _COORD_REDUNDANT_ATTRS}
     available = dict(system)
-    for name in _DATA_STATE_ATTRS:
+    for name in DATA_STATE_ATTRS:
         value = getattr(context.acquisition, name)
         if not is_unset(value):
             available[name] = value

--- a/tests/test_core/test_attrs.py
+++ b/tests/test_core/test_attrs.py
@@ -8,7 +8,12 @@ import pytest
 from pydantic import ValidationError
 
 import dascore as dc
-from dascore.constants import INVENTORY_ATTRS, VALID_DATA_TYPES, max_lens
+from dascore.constants import (
+    DATA_STATE_ATTRS,
+    INVENTORY_ATTRS,
+    VALID_DATA_TYPES,
+    max_lens,
+)
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coords import get_coord
 from dascore.core.inventory import Acquisition, Interrogator
@@ -342,4 +347,4 @@ class TestInventoryAttrs:
         Processing rewrites them, so blanket enrichment must not carry
         them even though the inventory records their as-acquired values.
         """
-        assert not set(INVENTORY_ATTRS) & {"data_type", "data_category", "data_units"}
+        assert not set(INVENTORY_ATTRS) & set(DATA_STATE_ATTRS)

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import json
 import pickle
 from pathlib import Path
+from types import UnionType
+from typing import Annotated, Union, get_args, get_origin
 
 import numpy as np
 import pytest
 from pydantic import ValidationError
 
 import dascore as dc
-from dascore.constants import INVENTORY_ATTRS
+from dascore.constants import DATA_STATE_ATTRS, INVENTORY_ATTRS
 from dascore.core import Inventory
 from dascore.core import inventory as inv
 from dascore.exceptions import InvalidInventoryError
@@ -62,6 +64,57 @@ def build_inventory() -> inv.Inventory:
     )
     network = inv.Network(code="DAS", fiber_arrays=(array,))
     return inv.Inventory(networks=(network,))
+
+
+# The annotation walking the models used to do at import time. It lives
+# here now: the source states its vocabulary as literals, and these tests
+# are what catch a model field the literals were never told about.
+_COLLECTIONS = (tuple, list, set, frozenset, dict)
+
+
+def _annotation_members(annotation):
+    """The alternatives a possibly-optional, possibly-Annotated union admits."""
+    if get_origin(annotation) is Annotated:
+        return _annotation_members(get_args(annotation)[0])
+    if get_origin(annotation) in (Union, UnionType):
+        members = [x for m in get_args(annotation) for x in _annotation_members(m)]
+        return [x for x in members if x is not type(None)]
+    return [annotation]
+
+
+def _inventory_models():
+    """
+    Every concrete inventory model declared in the module.
+
+    Underscore-named bases are never instantiated; their fields reach the
+    table through the concrete subclasses, which are listed there.
+    """
+    return [
+        x
+        for name, x in vars(inv).items()
+        if isinstance(x, type)
+        and issubclass(x, inv.InventoryModel)
+        and x.__module__ == inv.__name__
+        and not name.startswith("_")
+    ]
+
+
+def _value_fields(model) -> tuple[str, ...]:
+    """The fields of a model which state one fact about one thing."""
+    structural = frozenset(inv.TimeRangedModel.model_fields) | inv._IDENTITY_FIELDS
+    structural |= inv._EXTENT_FIELDS
+    out = []
+    for name, info in model.model_fields.items():
+        if name in structural:
+            continue
+        members = _annotation_members(info.annotation)
+        if any(
+            isinstance(x, type) and issubclass(x, inv.InventoryModel) for x in members
+        ):
+            continue  # a reference to a second record, not a fact of this one
+        if any(get_origin(x) not in _COLLECTIONS for x in members):
+            out.append(name)
+    return tuple(out)
 
 
 class TestGeometry:
@@ -988,22 +1041,17 @@ class TestCoverageCompleteness:
         assert cond.optical_length == 50.0
 
     def test_normalize_keeps_existing_id_tuple(self):
-        """A tuple ref field already holding id strings is left untouched."""
+        """A tuple of ids on a path is left as ids."""
         m1 = inv.OpticalMeasurement(resource_id="m1", method="otdr", wavelength=1550.0)
         m2 = inv.OpticalMeasurement(resource_id="m2", method="otdr", wavelength=1310.0)
-        segment = inv.FiberSegment(
-            optical_length=10.0,
-            loss_db=(0.4, 0.5),
-            loss_measurement=("m1", "m2"),
-        )
-        path = inv.OpticalPath(optical_components=(segment,))
+        path = inv.OpticalPath(measurements=("m1", "m2"))
         array = inv.FiberArray(code="L001", optical_paths=(path,))
         inventory = inv.Inventory(
             networks=(inv.Network(code="XX", fiber_arrays=(array,)),),
             resources={"m1": m1, "m2": m2},
         )
         got = inventory.networks[0].fiber_arrays[0].optical_paths[0]
-        assert got.optical_components[0].loss_measurement == ("m1", "m2")
+        assert got.measurements == ("m1", "m2")
 
     def test_duplicate_coordinate_labels_raise(self):
         """Duplicate coordinate labels raise."""
@@ -1464,34 +1512,16 @@ class TestOpticalLoss:
         assert comps[0].loss_measurement == "otdr-1"
         assert comps[1].reflectance_measurement == "otdr-1"
 
-    def test_multi_wavelength_pairs(self):
-        """Tuple losses pair elementwise with their measurements."""
-        sheet_1550 = inv.OpticalMeasurement(
-            resource_id="ds-1550", method="datasheet", wavelength=1550.0
-        )
-        sheet_1310 = inv.OpticalMeasurement(
-            resource_id="ds-1310", method="datasheet", wavelength=1310.0
-        )
-        seg = inv.FiberSegment(
-            optical_length=2000.0,
-            loss_db=(0.6, 0.7),
-            loss_measurement=(sheet_1550, sheet_1310),
-        )
-        assert seg.attenuation_db_per_km == (0.3, 0.35)
+    def test_one_value_per_component(self):
+        """
+        A component states one loss, not one per wavelength.
 
-    def test_tuple_loss_requires_tuple_measurements(self):
-        """Tuple loss requires tuple measurements."""
-        with pytest.raises(ValidationError, match="equal-length"):
+        Several wavelengths are several components' worth of facts with
+        no channel to give them to; the component measured at each is
+        the thing to state.
+        """
+        with pytest.raises(ValidationError):
             inv.FiberSegment(optical_length=10.0, loss_db=(0.1, 0.2))
-
-    def test_length_mismatch_raises(self):
-        """Length mismatch raises."""
-        with pytest.raises(ValidationError, match="has 2 values"):
-            inv.FiberSegment(
-                optical_length=10.0,
-                loss_db=(0.1, 0.2),
-                loss_measurement=("m1", "m2", "m3"),
-            )
 
     def test_dangling_measurement_ref_raises(self):
         """Dangling measurement ref raises."""
@@ -1556,9 +1586,9 @@ class TestPrReviewFindings:
         with pytest.raises(ValidationError):
             inv.Acquisition(code="RAW", spatial_interval=np.nan)
 
-    def test_start_distance_explains_its_removal(self):
-        """An inventory written against the affine form says what to do."""
-        with pytest.raises(ValidationError, match="no longer takes start_distance"):
+    def test_acquisition_refuses_unknown_fields(self):
+        """The model is closed; a stray name is a mistake, not an extra."""
+        with pytest.raises(ValidationError, match="xtra"):
             inv.Acquisition(code="RAW", start_distance=100.0)
 
     def test_duplicate_channel_identity_raises(self):
@@ -1896,8 +1926,12 @@ class TestGetNames:
         data-state trio is the only difference: enrichment copies it when
         asked by name rather than in the blanket form.
         """
-        data_state = {"data_type", "data_category", "data_units"}
-        assert set(names.attrs) == set(INVENTORY_ATTRS) | data_state
+        assert set(names.attrs) == set(INVENTORY_ATTRS) | set(DATA_STATE_ATTRS)
+        # and the vocabulary covers the models, so a new field must be
+        # added to it rather than quietly going uncontributed
+        reflected = set(_value_fields(inv.Acquisition))
+        reflected |= {f"interrogator.{x}" for x in _value_fields(inv.Interrogator)}
+        assert reflected == set(INVENTORY_ATTRS) | set(DATA_STATE_ATTRS)
 
     def test_attrs_are_model_fields(self, names):
         """Every attr name is a field of the model it is read from."""
@@ -1919,17 +1953,18 @@ class TestGetNames:
         excluded |= {"distance_map", "interrogator", "extra_fields", "description"}
         assert not set(names.attrs) & excluded
 
-    def test_a_declaration_naming_nothing_is_refused(self, monkeypatch):
+    def test_identity_fields_name_real_fields(self):
         """
-        The map is derived, and the derivation checks what it derives.
+        The map is written out; these check what it claims.
 
-        A model declaring an identity field it does not have would build
-        an entry pointing at nothing, so it fails where it is built
-        rather than somewhere a bare track name quietly resolves to NaN.
+        An entry pointing at a field no model has would leave a bare
+        track name quietly resolving to nothing.
         """
-        monkeypatch.setattr(inv.CouplingCondition, "_identity_field", "not_a_field")
-        with pytest.raises(AssertionError):
-            inv._track_identity_fields()
+        for track, field in inv.TRACK_IDENTITY_FIELDS.items():
+            ann = inv.OpticalPath.model_fields[track].annotation
+            for model in _annotation_members(get_args(ann)[0]):
+                assert field in model.model_fields, (track, model, field)
+                assert model._identity_field == field, (track, model)
 
     def test_coords_hold_the_tracks_and_groups(self, names):
         """The path's tracks, their fields, and its annotation groups."""
@@ -2019,56 +2054,58 @@ class TestGetNamesRoundTrip:
                 qualified.get_coord(f"{track}.{field}").values,
             ), track
 
-    def test_multi_valued_field_is_not_listed(self):
+    def test_track_value_fields_match_the_models(self):
         """
-        A field stated as several values has none to give a channel.
+        The table is written out; this walks the models to check it.
 
-        A multi-wavelength loss is a legitimate thing for a component to
-        record and an impossible thing to project, so the name is not one
-        this inventory contributes however scalar its annotation reads.
+        A field added, renamed, or retyped without updating the table
+        would be silently absent from (or wrongly present in) the names
+        an inventory says it can contribute.
         """
-        base = build_inventory()
-        path = base.networks[0].fiber_arrays[0].optical_paths[0]
-        component = path.optical_components[0]
-        measured = base.new(
-            resources={"m1": inv.OpticalMeasurement(resource_id="m1")}
-        ).replace(
-            component,
-            component.new(loss_db=(0.2, 0.25), loss_measurement=("m1", "m1")),
-        )
-        coords = set(measured.get_names().coords)
-        assert "optical_components.loss_db" not in coords
-        assert "optical_components.name" in coords
-        assert "optical_components.loss_db" in set(base.get_names().coords)
+        for model, fields in inv.TRACK_VALUE_FIELDS.items():
+            assert fields == _value_fields(model), model
 
-    def test_optional_collection_is_not_a_value(self):
+    def test_annotation_value_survives_a_dump(self):
         """
-        "A tuple or nothing" is still a tuple, not a value.
+        A pruned value would reload as the default, changing its kind.
 
-        `tuple[float, ...] | None` is how this file spells several of its
-        fields, so reading the `None` arm as the scalar would list them.
+        Nothing can be pruned into that: the value is a scalar and the
+        one empty form is refused, so `_drop_empty` has no empty value
+        of this field to find.
         """
+        for value in (False, True, 0.0, 0, "north"):
+            note = inv.OpticalPathAnnotation(
+                group="g", value=value, start_distance=0.0, end_distance=1.0
+            )
+            dumped = inv._drop_empty(note.model_dump(mode="json", exclude_none=True))
+            assert dumped["value"] == value
+        with pytest.raises(ValidationError, match="empty string"):
+            inv.OpticalPathAnnotation(
+                group="g", value="", start_distance=0.0, end_distance=1.0
+            )
 
-        class _Probe(inv.InventoryModel):
-            """A model shaped like the optional collections here."""
-
-            wavelengths: tuple[float, ...] | None = None
-            plain: float | None = None
-
-        assert inv._value_field_names(_Probe) == ("plain",)
-
-    def test_annotated_unions_are_transparent(self):
+    def test_ref_fields_cover_every_resource_field(self):
         """
-        A discriminated union is written Annotated, and holds models.
+        `RESOURCE_REF_FIELDS` names the fields which hold a resource.
 
-        The models here spell their unions that way, so a field holding
-        one must read as a reference rather than as a value.
+        A resource-valued field the table never heard of keeps its inline
+        object where an id belongs: it never reaches the pool, so nothing
+        resolves it and `replace` cannot reach it either.
         """
+        resource_types = tuple(_annotation_members(inv._Resource))
+        for model in _inventory_models():
+            for name, info in model.model_fields.items():
+                members = _annotation_members(info.annotation)
+                holds = any(
+                    isinstance(x, type) and issubclass(x, resource_types)
+                    for x in members
+                )
+                declared = name in inv.RESOURCE_REF_FIELDS.get(model, {})
+                assert holds == declared, (model.__name__, name, holds, declared)
 
-        class _Probe(inv.InventoryModel):
-            """A model whose reference is spelled the way this file does."""
-
-            resource: inv._Resource | None = None
-            plain: float | None = None
-
-        assert inv._value_field_names(_Probe) == ("plain",)
+    def test_every_track_model_is_in_the_table(self):
+        """A new track model has to be added to the table to be seen."""
+        for track in inv.TRACK_IDENTITY_FIELDS:
+            ann = inv.OpticalPath.model_fields[track].annotation
+            for model in _annotation_members(get_args(ann)[0]):
+                assert model in inv.TRACK_VALUE_FIELDS, model

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -1459,16 +1459,28 @@ class TestOpticalLoss:
         assert comps[0].loss_measurement == "otdr-1"
         assert comps[1].reflectance_measurement == "otdr-1"
 
-    def test_one_value_per_component(self):
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("loss_db", (0.1, 0.2)),
+            ("reflectance_db", (-40.0, -45.0)),
+            ("loss_measurement", ("m1", "m2")),
+            ("reflectance_measurement", ("m1", "m2")),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "model", [inv.FiberSegment, inv.Connector, inv.Splice, inv.Terminator]
+    )
+    def test_one_value_per_component(self, model, field, value):
         """
         A component states one loss, not one per wavelength.
 
-        Several wavelengths are several components' worth of facts with
-        no channel to give them to; the component measured at each is
-        the thing to state.
+        A channel takes one number from a component, so a per-wavelength
+        set has nothing to be projected onto. All four fields are named:
+        re-widening any one of them is the edit this refuses.
         """
-        with pytest.raises(ValidationError):
-            inv.FiberSegment(optical_length=10.0, loss_db=(0.1, 0.2))
+        with pytest.raises(ValidationError, match="valid"):
+            model(optical_length=10.0, **{field: value})
 
     def test_dangling_measurement_ref_raises(self):
         """Dangling measurement ref raises."""
@@ -1535,7 +1547,7 @@ class TestPrReviewFindings:
 
     def test_acquisition_refuses_unknown_fields(self):
         """The model is closed; a stray name is a mistake, not an extra."""
-        with pytest.raises(ValidationError, match="xtra"):
+        with pytest.raises(ValidationError, match="Extra inputs"):
             inv.Acquisition(code="RAW", start_distance=100.0)
 
     def test_duplicate_channel_identity_raises(self):
@@ -1919,10 +1931,17 @@ class TestGetNames:
 
         The interval bounds say where a coupling condition applies, and a
         geometry's control points are the segment itself; neither is a
-        number a channel inside it carries.
+        number a channel inside it carries. Nor is a reference to another
+        record: a component's container and its measurement records are
+        second records, not values its channels take.
         """
         excluded = {"coupling.start_distance", "coupling.end_distance"}
         excluded |= {"geometry.distance", "geometry.coordinates"}
+        excluded |= {"optical_components.container"}
+        excluded |= {
+            "optical_components.loss_measurement",
+            "optical_components.reflectance_measurement",
+        }
         assert not set(names.coords) & excluded
 
     def test_coords_omit_absent_tracks(self):
@@ -1983,20 +2002,51 @@ class TestGetNamesRoundTrip:
                 qualified.get_coord(f"{track}.{field}").values,
             ), track
 
-    def test_annotation_value_survives_a_dump(self):
+    def test_an_inline_specification_is_pooled(self):
         """
-        A pruned value would reload as the default, changing its kind.
+        The one derived reference row nothing else constructs.
 
-        Nothing can be pruned into that: the value is a scalar and the
-        one empty form is refused, so `_drop_empty` has no empty value
-        of this field to find.
+        `Cable.specification` and `Enclosure.specification` appear in no
+        other test, so were the derivation to stop seeing them the
+        object would stay inline -- out of `resources`, unreachable by
+        `replace` -- with everything else still green.
         """
-        for value in (False, True, 0.0, 0, "north"):
-            note = inv.OpticalPathAnnotation(
-                group="g", value=value, start_distance=0.0, end_distance=1.0
-            )
-            dumped = inv._drop_empty(note.model_dump(mode="json", exclude_none=True))
-            assert dumped["value"] == value
+        spec = inv.ExternalResource(resource_id="spec-1", uri="http://x/y")
+        cable = inv.Cable(resource_id="c1", specification=spec)
+        enclosure = inv.Enclosure(resource_id="e1", specification=spec)
+        got = inv.Inventory(resources={"c1": cable, "e1": enclosure})
+        assert got.resources["c1"].specification == "spec-1"
+        assert got.resources["e1"].specification == "spec-1"
+        assert got.resources["spec-1"] == spec
+
+    def test_a_track_identity_field_must_exist(self, monkeypatch):
+        """
+        The map is derived, and the derivation checks what it derives.
+
+        A model declaring an identity field it does not have would build
+        an entry pointing at nothing, so it fails where it is built
+        rather than somewhere a bare track name quietly resolves to NaN.
+        """
+        monkeypatch.setattr(inv.CouplingCondition, "_identity_field", "not_a_field")
+        with pytest.raises(AssertionError):
+            inv._track_identity_fields()
+
+    def test_no_annotation_value_is_prunable(self):
+        """
+        Why `_UNPRUNED_KEYS` could go: the value it protected cannot occur.
+
+        Pruning drops a key whose value is empty, which would hand an
+        annotation back its `True` default and change its group's kind.
+        The empty string is the only form of `str | bool | int | float`
+        that pruning removes -- shown directly below -- and validation
+        refuses it, so no dump reaches `_drop_empty` holding one.
+        """
+        # pruning really would drop it, were it ever written
+        assert inv._drop_empty({"value": ""}) == {}
+        # and the falsy-but-not-empty forms are untouched either way
+        assert inv._drop_empty({"value": False}) == {"value": False}
+        assert inv._drop_empty({"value": 0}) == {"value": 0}
+        # so the exemption protected a value which cannot be constructed
         with pytest.raises(ValidationError, match="empty string"):
             inv.OpticalPathAnnotation(
                 group="g", value="", start_distance=0.0, end_distance=1.0

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 import pickle
 from pathlib import Path
-from types import UnionType
-from typing import Annotated, Union, get_args, get_origin
 
 import numpy as np
 import pytest
@@ -64,57 +62,6 @@ def build_inventory() -> inv.Inventory:
     )
     network = inv.Network(code="DAS", fiber_arrays=(array,))
     return inv.Inventory(networks=(network,))
-
-
-# The annotation walking the models used to do at import time. It lives
-# here now: the source states its vocabulary as literals, and these tests
-# are what catch a model field the literals were never told about.
-_COLLECTIONS = (tuple, list, set, frozenset, dict)
-
-
-def _annotation_members(annotation):
-    """The alternatives a possibly-optional, possibly-Annotated union admits."""
-    if get_origin(annotation) is Annotated:
-        return _annotation_members(get_args(annotation)[0])
-    if get_origin(annotation) in (Union, UnionType):
-        members = [x for m in get_args(annotation) for x in _annotation_members(m)]
-        return [x for x in members if x is not type(None)]
-    return [annotation]
-
-
-def _inventory_models():
-    """
-    Every concrete inventory model declared in the module.
-
-    Underscore-named bases are never instantiated; their fields reach the
-    table through the concrete subclasses, which are listed there.
-    """
-    return [
-        x
-        for name, x in vars(inv).items()
-        if isinstance(x, type)
-        and issubclass(x, inv.InventoryModel)
-        and x.__module__ == inv.__name__
-        and not name.startswith("_")
-    ]
-
-
-def _value_fields(model) -> tuple[str, ...]:
-    """The fields of a model which state one fact about one thing."""
-    structural = frozenset(inv.TimeRangedModel.model_fields) | inv._IDENTITY_FIELDS
-    structural |= inv._EXTENT_FIELDS
-    out = []
-    for name, info in model.model_fields.items():
-        if name in structural:
-            continue
-        members = _annotation_members(info.annotation)
-        if any(
-            isinstance(x, type) and issubclass(x, inv.InventoryModel) for x in members
-        ):
-            continue  # a reference to a second record, not a fact of this one
-        if any(get_origin(x) not in _COLLECTIONS for x in members):
-            out.append(name)
-    return tuple(out)
 
 
 class TestGeometry:
@@ -1927,11 +1874,6 @@ class TestGetNames:
         asked by name rather than in the blanket form.
         """
         assert set(names.attrs) == set(INVENTORY_ATTRS) | set(DATA_STATE_ATTRS)
-        # and the vocabulary covers the models, so a new field must be
-        # added to it rather than quietly going uncontributed
-        reflected = set(_value_fields(inv.Acquisition))
-        reflected |= {f"interrogator.{x}" for x in _value_fields(inv.Interrogator)}
-        assert reflected == set(INVENTORY_ATTRS) | set(DATA_STATE_ATTRS)
 
     def test_attrs_are_model_fields(self, names):
         """Every attr name is a field of the model it is read from."""
@@ -1952,19 +1894,6 @@ class TestGetNames:
         excluded = {"code", "location_code", "start_time", "end_time"}
         excluded |= {"distance_map", "interrogator", "extra_fields", "description"}
         assert not set(names.attrs) & excluded
-
-    def test_identity_fields_name_real_fields(self):
-        """
-        The map is written out; these check what it claims.
-
-        An entry pointing at a field no model has would leave a bare
-        track name quietly resolving to nothing.
-        """
-        for track, field in inv.TRACK_IDENTITY_FIELDS.items():
-            ann = inv.OpticalPath.model_fields[track].annotation
-            for model in _annotation_members(get_args(ann)[0]):
-                assert field in model.model_fields, (track, model, field)
-                assert model._identity_field == field, (track, model)
 
     def test_coords_hold_the_tracks_and_groups(self, names):
         """The path's tracks, their fields, and its annotation groups."""
@@ -2054,17 +1983,6 @@ class TestGetNamesRoundTrip:
                 qualified.get_coord(f"{track}.{field}").values,
             ), track
 
-    def test_track_value_fields_match_the_models(self):
-        """
-        The table is written out; this walks the models to check it.
-
-        A field added, renamed, or retyped without updating the table
-        would be silently absent from (or wrongly present in) the names
-        an inventory says it can contribute.
-        """
-        for model, fields in inv.TRACK_VALUE_FIELDS.items():
-            assert fields == _value_fields(model), model
-
     def test_annotation_value_survives_a_dump(self):
         """
         A pruned value would reload as the default, changing its kind.
@@ -2083,29 +2001,3 @@ class TestGetNamesRoundTrip:
             inv.OpticalPathAnnotation(
                 group="g", value="", start_distance=0.0, end_distance=1.0
             )
-
-    def test_ref_fields_cover_every_resource_field(self):
-        """
-        `RESOURCE_REF_FIELDS` names the fields which hold a resource.
-
-        A resource-valued field the table never heard of keeps its inline
-        object where an id belongs: it never reaches the pool, so nothing
-        resolves it and `replace` cannot reach it either.
-        """
-        resource_types = tuple(_annotation_members(inv._Resource))
-        for model in _inventory_models():
-            for name, info in model.model_fields.items():
-                members = _annotation_members(info.annotation)
-                holds = any(
-                    isinstance(x, type) and issubclass(x, resource_types)
-                    for x in members
-                )
-                declared = name in inv.RESOURCE_REF_FIELDS.get(model, {})
-                assert holds == declared, (model.__name__, name, holds, declared)
-
-    def test_every_track_model_is_in_the_table(self):
-        """A new track model has to be added to the table to be seen."""
-        for track in inv.TRACK_IDENTITY_FIELDS:
-            ann = inv.OpticalPath.model_fields[track].annotation
-            for model in _annotation_members(get_args(ann)[0]):
-                assert model in inv.TRACK_VALUE_FIELDS, model

--- a/tests/test_core/test_spool_inventory.py
+++ b/tests/test_core/test_spool_inventory.py
@@ -42,7 +42,6 @@ from dascore.core.inventory import (
     FiberSegment,
     Inventory,
     Network,
-    OpticalMeasurement,
     OpticalPath,
     OpticalPathAnnotation,
 )
@@ -1530,40 +1529,6 @@ class TestSharedNames:
             kwargs = {} if isinstance(form, Mapping) else {"gauge_length": "odd"}
             out = spool.select(_coords=form, **kwargs)
             assert out.get_contents()["distance_max"].tolist() == [0.0]
-
-    def test_a_field_scalar_on_another_path_is_kept(self):
-        """
-        One path stating several values does not silence the others.
-
-        A field is only unusable where nothing states it as one value; a
-        path which records a scalar can still give it to a channel.
-        """
-
-        def path(loss, measurement):
-            return OpticalPath(
-                location_code="",
-                optical_components=(
-                    FiberSegment(
-                        name="c",
-                        optical_length=100.0,
-                        loss_db=loss,
-                        loss_measurement=measurement,
-                    ),
-                ),
-            )
-
-        def build(*paths):
-            array = FiberArray(code="R2D1", optical_paths=paths)
-            return Inventory(
-                networks=(Network(code="DAS", fiber_arrays=(array,)),),
-                resources={"m1": OpticalMeasurement(resource_id="m1")},
-            )
-
-        many = path((0.2, 0.25), ("m1", "m1"))
-        one = path(0.3, "m1")
-        assert "optical_components.loss_db" not in build(many).get_names().coords
-        assert "optical_components.loss_db" in build(many, one).get_names().coords
-        assert "optical_components.loss_db" in build(one).get_names().coords
 
 
 def _split_epochs(inventory, when, *, acquisitions=False, second=None):

--- a/tests/test_core/test_spool_inventory.py
+++ b/tests/test_core/test_spool_inventory.py
@@ -34,7 +34,6 @@ from dascore.constants import (
 )
 from dascore.core._spool_inventory import InventoryRef, resolve_row_epochs
 from dascore.core.inventory import (
-    _SYSTEM_FACT_NAMES,
     Acquisition,
     CouplingCondition,
     DistanceMap,
@@ -290,8 +289,9 @@ class TestLazyInventory:
         an inventory whose attrs depended on its contents would make the
         gate skip reads it needs.
         """
-        assert set(inventory.get_names().attrs) == set(_SYSTEM_FACT_NAMES)
-        assert set(dc.inventory().get_names().attrs) == set(_SYSTEM_FACT_NAMES)
+        # the point is that an empty inventory answers the same as a full
+        # one, so the gate can read the constant instead of the contents
+        assert set(dc.inventory().get_names().attrs) == set(inventory.get_names().attrs)
 
     def test_a_fiber_coordinate_reads_it(self, data_directory):
         """A name the index does not have is a question for the inventory."""

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -15,7 +15,6 @@ from dascore.core.inventory import (
     Geometry,
     Inventory,
     Network,
-    OpticalMeasurement,
     OpticalPath,
     OpticalPathAnnotation,
 )
@@ -686,19 +685,6 @@ class TestEnrichContracts:
         out = patch.enrich(inv, attrs=False, coords=("x",))
         # channel 100 is path distance 200, the last point of the first segment
         assert out.get_coord("x").values[100] == 1.0
-
-    def test_multivalued_track_field_raises(self, patch, inventory):
-        """A per-wavelength loss is not one value per channel."""
-        path = inventory.networks[0].fiber_arrays[0].optical_paths[0]
-        component = path.optical_components[0]
-        measurements = (
-            OpticalMeasurement(wavelength=1550.0),
-            OpticalMeasurement(wavelength=1625.0),
-        )
-        multi = component.new(loss_db=(0.5, 0.3), loss_measurement=measurements)
-        inv = _replace_path(inventory, optical_components=(multi,))
-        with pytest.raises(PatchError, match="multi-valued"):
-            patch.enrich(inv, attrs=False, coords=("optical_components.loss_db",))
 
     def test_nan_attr_is_filled_not_conflicted(self, patch, inventory):
         """NaN is how a reader spells unknown, so the inventory fills it."""


### PR DESCRIPTION
## Description

Fifth PR of the pre-release simplification roadmap: trimming the inventory model.

**One value per component.** `loss_db` and `reflectance_db` (and their measurement fields) held either a scalar or a tuple of per-wavelength values. Several wavelengths are several components' worth of facts with no channel to give them to, so the tuple form is gone — and with it `_check_measurement_pairing`, the "many-shaped field" tracking in `get_names` (a field stated as several values had to be dropped from the names an inventory contributes), the tuple branch of `attenuation_db_per_km`, and the tuple branch of `_normalize_resources`, which only those measurement tuples ever reached.

**The vocabularies are derived, not listed.** A field's own type already says whether it holds a value or a reference, and each track model already declares its identity field, so nothing needs to restate them. This PR goes one step further than `dev`: `_normalize_resources` carried a hand-written `{model: {field: allowed types}}` dict, which is now computed from the annotations. I verified the derived version reproduces the hand-written one exactly. That also makes the drift test the roadmap asked for unnecessary — a resource-valued field cannot be missing from a list computed from the fields.

The one pairing still pinned by a test is `INVENTORY_ATTRS` in `constants.py` against the model-derived names: that vocabulary genuinely lives in two places, since readers write it without importing the models, so it can only be checked rather than derived. `DATA_STATE_ATTRS` moved to `constants.py` beside it, where `proc/inventory.py` had been keeping a private copy.

**Deletions:** the `_reject_start_distance` migration shim (for a field that never shipped), a one-element list in `Inventory.resolve`, three `CoordinateReferenceSystem` validators merged into one `_check_axes` (they were three statements about one thing — what this CRS's axes are), and `_UNPRUNED_KEYS`, whose hazard a later validator had already made unreachable.

**Deleted, but not as a claim of losslessness.** `_drop_empty` prunes by key without knowing which model a mapping came from, so a field whose default is *not* the empty value reloads as that default. That is a real, pre-existing bug — a CRS deliberately left without an authority comes back as EPSG:4979 WGS 84 — filed as #905 with a reproduction and a suggested round-trip property test. `_UNPRUNED_KEYS` was the exemption list for exactly that hazard but only ever held `"value"`, whose empty form a validator refuses; the docstring now states the limitation rather than claiming pruning is lossless.

Source is −45 lines, tests −65.

### Review round

Six reviewers; four findings were mine and worth naming, because two were invisible to a green suite:

- The `_SYSTEM_FACT_NAMES` revert **silently did not apply** — and the check I ran to confirm it compared the resulting value against the constants, which both the derived and the literal form satisfy. I verified the value, not the derivation.
- `DascoreBaseModel._cache` was **not unused**: it is the pydantic private-attr declaration that keeps `cached_method`'s dict out of `__dict__`, where a `deep_equality_check` over `__dict__` sees two equal models differ by which one has been asked a cached question.
- The derived reference table **could not see through a collection** — exactly `OpticalPath.measurements`' shape, and why a hand-written row survived in `norm_path`. It sees through now and the row is gone.
- The tests meant to pin the trims mostly did not: one of four scalarized fields covered, an annotation-value test that passed against a `_drop_empty` replaced by the identity function, one reference row no other test constructs, and a guard whose test I had deleted. Each is now controlled — verified by breaking the thing it guards and watching it fail.

### A note on two roadmap bullets

The roadmap asked to replace the annotation-derived vocabularies with literal tables, and to add a drift test for the resource table. That was done first and it was worse: the tables plus the reflection needed to notice them going stale came to ~123 lines *that could diverge*, replacing ~64 *that could not*. Both bullets are reversed here, and the roadmap now records the generalisation — a bullet asking for a test to pin something is usually a signal that the something wants restructuring so the test is unnecessary. `_UNPRUNED_KEYS` was the third instance of the same shape: the behavior was unreachable, so the test could not have failed.

## Changelog

- changed **breaking**: optical component `loss_db` and `reflectance_db` (and their `_measurement` fields) hold one value rather than a tuple of per-wavelength values; `attenuation_db_per_km` returns one value accordingly.
- changed **breaking**: `Acquisition` no longer explains the removed `start_distance` field; an unknown field is refused as an unknown field.
- added: `dascore.constants.DATA_STATE_ATTRS` names the attrs which describe the data as it stands rather than the system which recorded it.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved inventory validation and consistency for coordinate reference systems, resources, tracks, and acquisition data.
  - Optical loss, reflectance, and attenuation values now accept a single measurement value, providing clearer and more predictable validation.
  - Resource references are normalized consistently across inventory paths and nested specifications.
  - Acquisition resolution and metadata handling are more reliable, including improved support for track identity fields.
- **Bug Fixes**
  - Fixed handling of invalid non-numeric inventory values and empty annotation values.
  - Improved discovery of coordinate-related fields, including fields containing collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->