### PR TITLE
Dispatch patch functions on the patch's array backend

### DIFF
--- a/dascore/__init__.py
+++ b/dascore/__init__.py
@@ -1,7 +1,9 @@
 """DASCore - A library for fiber optic sensing."""
 from __future__ import annotations
 
-import warnings
+# Aliased because importing dascore.warnings binds the submodule to the
+# `warnings` name in this namespace, which would shadow the standard library.
+import warnings as std_warnings
 
 from rich import print  # noqa
 
@@ -47,4 +49,4 @@ def __getattr__(name: str):
 
 
 # Ensure warnings are issued only once (per warning/line)
-warnings.filterwarnings("once", category=UserWarning, module=r"dascore\..*")
+std_warnings.filterwarnings("once", category=UserWarning, module=r"dascore\..*")

--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -13,10 +13,11 @@ from typing import TypeGuard
 
 import numpy as np
 from h5py import Dataset as H5Dataset
-from numpy import ndarray  # NOQA
+from numpy import floor, interp, ndarray  # NOQA
 from numpy.random import RandomState
 from rich.progress import Progress  # NOQA
 from scipy.interpolate import interp1d  # NOQA
+from scipy.ndimage import zoom  # NOQA
 from upath import UPath  # NOQA
 
 
@@ -32,7 +33,9 @@ def _lazy_import(module_name: str, attr_name: str):
     return _wrapper
 
 
+decimate = _lazy_import("scipy.signal", "decimate")
 resample = _lazy_import("scipy.signal", "resample")
+resample_poly = _lazy_import("scipy.signal", "resample_poly")
 
 random_state = RandomState(42)
 

--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -13,11 +13,10 @@ from typing import TypeGuard
 
 import numpy as np
 from h5py import Dataset as H5Dataset
-from numpy import floor, interp, ndarray  # NOQA
+from numpy import ndarray  # NOQA
 from numpy.random import RandomState
 from rich.progress import Progress  # NOQA
 from scipy.interpolate import interp1d  # NOQA
-from scipy.ndimage import zoom  # NOQA
 from upath import UPath  # NOQA
 
 
@@ -33,9 +32,7 @@ def _lazy_import(module_name: str, attr_name: str):
     return _wrapper
 
 
-decimate = _lazy_import("scipy.signal", "decimate")
 resample = _lazy_import("scipy.signal", "resample")
-resample_poly = _lazy_import("scipy.signal", "resample_poly")
 
 random_state = RandomState(42)
 

--- a/dascore/compat.py
+++ b/dascore/compat.py
@@ -99,5 +99,5 @@ def is_array(maybe_array) -> TypeGuard[np.ndarray]:
     """
     Determine if an object is a numpy array.
     """
-    # This is here so that we can support other array types in the future.
+    # Support for other array types lives in dascore.utils.array_api.
     return isinstance(maybe_array, np.ndarray)

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -25,6 +25,7 @@ from dascore.utils.array import (
     patch_array_function,
     patch_array_ufunc,
 )
+from dascore.utils.array_api import to_numpy
 from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import check_patch_attrs, check_patch_coords, get_patch_names
@@ -192,7 +193,7 @@ class Patch(NamespaceOwner):
             out = np.empty((), dtype=object)
             out[()] = self
             return out
-        data = np.asarray(self.data)
+        data = to_numpy(self.data)
         out = data.astype(dtype) if dtype is not None else data
         out = out if not copy else np.copy(out)
         return out

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -17,6 +17,7 @@ from dascore.exceptions import (
     PatchCoordinateError,
     PatchError,
 )
+from dascore.utils.array_api import array_namespace
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import get_parent_code_name, iterate
 from dascore.utils.patch import patch_function
@@ -711,7 +712,7 @@ def order(
     return patch.new(data=data, coords=new_coords)
 
 
-@patch_function(history=None)
+@patch_function(history=None, backend="array_api")
 def transpose(self: PatchType, *dims: str) -> PatchType:
     """
     Transpose the data array to any dimension order desired.
@@ -753,7 +754,8 @@ def transpose(self: PatchType, *dims: str) -> PatchType:
         return self
     new_dims = new_coord.dims
     axes = tuple(old_dims.index(x) for x in new_dims)
-    new_data = np.transpose(self.data, axes)
+    xp = array_namespace(self.data)
+    new_data = xp.permute_dims(self.data, axes)
     return self.new(data=new_data, coords=new_coord)
 
 
@@ -823,7 +825,7 @@ def append_dims(patch: PatchType, *empty_dims, **dim_kwargs) -> PatchType:
     return patch.update(data=data, coords=coords)
 
 
-@patch_function()
+@patch_function(backend="array_api")
 def squeeze(self: PatchType, dim=None) -> PatchType:
     """
     Return a new object with len one dimensions flattened.
@@ -853,10 +855,11 @@ def squeeze(self: PatchType, dim=None) -> PatchType:
     if coords is self.coords:
         return self
     if dim is None:
-        axes = None
+        axes = tuple(i for i, x in enumerate(self.shape) if x == 1)
     else:
         axes = tuple(self.get_axis(x) for x in iterate(dim))
-    data = np.squeeze(self.data, axis=axes)
+    xp = array_namespace(self.data)
+    data = xp.squeeze(self.data, axis=axes)
     return self.new(data=data, coords=coords)
 
 

--- a/dascore/utils/array_api.py
+++ b/dascore/utils/array_api.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any, TypeGuard
 
 import numpy as np
-from array_api_compat import array_namespace, device
+from array_api_compat import array_namespace, device, to_device
 
 __all__ = [
     "array_namespace",
@@ -82,13 +82,14 @@ def to_numpy(array: Any) -> np.ndarray:
     >>>
     >>> assert isinstance(to_numpy(np.array([1, 2])), np.ndarray)
     """
-    # asarray returns numpy arrays unchanged. Most other backends implement
-    # __array__, but some (eg device arrays) raise rather than silently
-    # moving data, so fall back to the dlpack protocol for those.
+    # asarray returns numpy arrays unchanged and handles any backend which
+    # implements __array__.
     try:
         return np.asarray(array)
     except (TypeError, ValueError, RuntimeError):
-        return np.from_dlpack(array)
+        # Arrays which live on another device (eg a gpu) refuse implicit
+        # conversion, so they must be copied to the host first.
+        return np.asarray(to_device(array, "cpu"))
 
 
 def asarray_like(array: Any, like: Any) -> Any:

--- a/dascore/utils/array_api.py
+++ b/dascore/utils/array_api.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 from typing import Any, TypeGuard
 
+import array_api_compat.numpy as np_namespace
 import numpy as np
-from array_api_compat import array_namespace, device, to_device
+from array_api_compat import array_namespace as _array_namespace
+from array_api_compat import device, to_device
 
 __all__ = [
     "array_namespace",
@@ -28,6 +30,33 @@ ARRAY_API_BACKEND = "array_api"
 
 # The key used by patch functions which require numpy arrays.
 NUMPY_BACKEND = "numpy"
+
+
+def array_namespace(*arrays: Any) -> Any:
+    """
+    Return the array API namespace shared by arrays.
+
+    Array-likes which don't implement the standard, but which numpy can
+    consume through ``__array__``, get the numpy namespace; numpy code is
+    what has always handled them.
+
+    Parameters
+    ----------
+    *arrays
+        One or more arrays.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dascore.utils.array_api import array_namespace
+    >>>
+    >>> xp = array_namespace(np.array([1, 2]))
+    >>> assert xp.sum(np.array([1, 2])) == 3
+    """
+    try:
+        return _array_namespace(*arrays)
+    except TypeError:
+        return np_namespace
 
 
 def is_numpy(array: Any) -> TypeGuard[np.ndarray]:
@@ -59,6 +88,8 @@ def backend_name(array: Any) -> str:
     if is_numpy(array):
         return NUMPY_BACKEND
     name = array_namespace(array).__name__
+    # array_namespace falls back to numpy for array-likes which don't
+    # implement the standard; those are numpy's problem as well.
     # array_api_compat wraps incomplete backends in modules named after them
     # (eg array_api_compat.dask.array); native namespaces are named after
     # their own package (eg jax.numpy).

--- a/dascore/utils/array_api.py
+++ b/dascore/utils/array_api.py
@@ -60,9 +60,9 @@ def array_namespace(*arrays: Any) -> Any:
 
 
 def is_numpy(array: Any) -> TypeGuard[np.ndarray]:
-    """Return True if the array is a numpy array."""
-    # Not array_api_compat.is_numpy_array; this is called by every patch
-    # function and the isinstance check is several times faster.
+    """Return True if the array is a numpy array or scalar."""
+    # Unlike compat.is_array numpy scalars count, and unlike
+    # array_api_compat.is_numpy_array this is fast enough for every call.
     return isinstance(array, np.ndarray | np.generic)
 
 

--- a/dascore/utils/array_api.py
+++ b/dascore/utils/array_api.py
@@ -1,0 +1,116 @@
+"""
+Utilities for working with the Python array API standard.
+
+DASCore patch data can be backed by any array library which implements the
+[array API standard](https://data-apis.org/array-api/latest/). This module
+holds the small set of helpers needed to write backend-agnostic code and to
+cross the boundary back to numpy when a numpy-only implementation is used.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypeGuard
+
+import numpy as np
+from array_api_compat import array_namespace, device
+
+__all__ = [
+    "array_namespace",
+    "asarray_like",
+    "backend_name",
+    "device",
+    "is_numpy",
+    "to_numpy",
+]
+
+# The key used by patch functions written against the array API standard.
+ARRAY_API_BACKEND = "array_api"
+
+# The key used by patch functions which require numpy arrays.
+NUMPY_BACKEND = "numpy"
+
+
+def is_numpy(array: Any) -> TypeGuard[np.ndarray]:
+    """Return True if the array is a numpy array."""
+    # Not array_api_compat.is_numpy_array; this is called by every patch
+    # function and the isinstance check is several times faster.
+    return isinstance(array, np.ndarray | np.generic)
+
+
+def backend_name(array: Any) -> str:
+    """
+    Return the name of the array backend which owns array.
+
+    The name is the top-level package of the array's namespace, so
+    numpy arrays return "numpy", jax arrays "jax", dask arrays "dask", etc.
+
+    Parameters
+    ----------
+    array
+        Any array which implements the array API standard.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dascore.utils.array_api import backend_name
+    >>>
+    >>> assert backend_name(np.array([1, 2])) == "numpy"
+    """
+    if is_numpy(array):
+        return NUMPY_BACKEND
+    name = array_namespace(array).__name__
+    # array_api_compat wraps incomplete backends in modules named after them
+    # (eg array_api_compat.dask.array); native namespaces are named after
+    # their own package (eg jax.numpy).
+    name = name.removeprefix("array_api_compat.")
+    return name.split(".")[0]
+
+
+def to_numpy(array: Any) -> np.ndarray:
+    """
+    Convert an array from any backend to a numpy array.
+
+    Parameters
+    ----------
+    array
+        Any array which implements the array API standard.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dascore.utils.array_api import to_numpy
+    >>>
+    >>> assert isinstance(to_numpy(np.array([1, 2])), np.ndarray)
+    """
+    # asarray returns numpy arrays unchanged. Most other backends implement
+    # __array__, but some (eg device arrays) raise rather than silently
+    # moving data, so fall back to the dlpack protocol for those.
+    try:
+        return np.asarray(array)
+    except (TypeError, ValueError, RuntimeError):
+        return np.from_dlpack(array)
+
+
+def asarray_like(array: Any, like: Any) -> Any:
+    """
+    Return array converted to the backend and device of like.
+
+    Parameters
+    ----------
+    array
+        The array to convert.
+    like
+        An array whose backend and device the output should match.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dascore.utils.array_api import asarray_like
+    >>>
+    >>> out = asarray_like(np.array([1, 2]), np.array([3.0]))
+    >>> assert isinstance(out, np.ndarray)
+    """
+    if is_numpy(like):
+        return np.asarray(array)
+    xp = array_namespace(like)
+    return xp.asarray(array, device=device(like))

--- a/dascore/utils/array_api.py
+++ b/dascore/utils/array_api.py
@@ -5,6 +5,8 @@ DASCore patch data can be backed by any array library which implements the
 [array API standard](https://data-apis.org/array-api/latest/). This module
 holds the small set of helpers needed to write backend-agnostic code and to
 cross the boundary back to numpy when a numpy-only implementation is used.
+Which array-likes are accepted as patch data is a separate question, and
+lives in [compat](`dascore.compat`).
 """
 
 from __future__ import annotations
@@ -15,6 +17,8 @@ import array_api_compat.numpy as np_namespace
 import numpy as np
 from array_api_compat import array_namespace as _array_namespace
 from array_api_compat import device, to_device
+
+from dascore.compat import is_array
 
 __all__ = [
     "array_namespace",
@@ -61,9 +65,9 @@ def array_namespace(*arrays: Any) -> Any:
 
 def is_numpy(array: Any) -> TypeGuard[np.ndarray]:
     """Return True if the array is a numpy array or scalar."""
-    # Unlike compat.is_array numpy scalars count, and unlike
-    # array_api_compat.is_numpy_array this is fast enough for every call.
-    return isinstance(array, np.ndarray | np.generic)
+    # Numpy scalars are excluded by is_array but count here; they carry
+    # __array_namespace__, so they must not be treated as foreign arrays.
+    return is_array(array) or isinstance(array, np.generic)
 
 
 def backend_name(array: Any) -> str:

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -32,6 +32,14 @@ from dascore.exceptions import (
     PatchCoordinateError,
 )
 from dascore.units import convert_units, get_quantity, is_percent
+from dascore.utils.array_api import (
+    ARRAY_API_BACKEND,
+    NUMPY_BACKEND,
+    asarray_like,
+    backend_name,
+    is_numpy,
+    to_numpy,
+)
 from dascore.utils.attrs import combine_patch_attrs
 from dascore.utils.coordmanager import merge_coord_managers
 from dascore.utils.deprecate import deprecate
@@ -49,6 +57,7 @@ from dascore.utils.misc import (
 )
 from dascore.utils.paths import is_memory_uri
 from dascore.utils.time import to_float
+from dascore.warnings import NumpyFallbackWarning
 
 attr_type = dict[str, Any] | str | Sequence[str] | None
 
@@ -214,13 +223,67 @@ class _PatchFunction(Protocol):
 
     The decorator attaches references back to the function it wrapped so
     callers can skip the patch-function machinery when calling it again.
+    It also attaches the backend registry, which maps the name of an array
+    backend to the implementation used for patches backed by it.
     """
 
     func: Callable
     raw_function: Callable
+    backends: dict[str, Callable]
+    register: Callable[[str], Callable]
     __wrapped__: Callable
 
     def __call__(self, patch, *args, **kwargs): ...
+
+
+def _get_backend_name(patch) -> str:
+    """Get the name of the array backend which backs a patch's data."""
+    data = getattr(patch, "data", None)
+    # Anything which doesn't carry array data uses the numpy path, where
+    # it gets the same error it would have gotten before dispatch existed.
+    if data is None or is_numpy(data):
+        return NUMPY_BACKEND
+    return backend_name(data)
+
+
+def _to_numpy_patch(obj):
+    """Convert a patch's data to numpy, leaving everything else alone."""
+    if not isinstance(obj, dc.Patch) or is_numpy(obj.data):
+        return obj
+    return obj.new(data=to_numpy(obj.data))
+
+
+def _numpy_fallback(func, patch, args, kwargs, backend):
+    """Run a numpy-only implementation on non-numpy patches."""
+    msg = (
+        f"{func.__name__} has no {backend} implementation; the patch data "
+        "were converted to numpy and the output converted back. Silence this "
+        "with dascore.utils.misc.suppress_warnings(NumpyFallbackWarning)."
+    )
+    warnings.warn(msg, NumpyFallbackWarning, stacklevel=4)
+    data = patch.data
+    args = tuple(_to_numpy_patch(x) for x in args)
+    kwargs = {i: _to_numpy_patch(v) for i, v in kwargs.items()}
+    out = func(_to_numpy_patch(patch), *args, **kwargs)
+    # Only patches carry data back to the original backend.
+    if isinstance(out, dc.Patch):
+        out = out.new(data=asarray_like(out.data, data))
+    return out
+
+
+def _dispatch_backend(backends, patch, args, kwargs):
+    """Call the implementation which best matches the patch's array backend."""
+    name = _get_backend_name(patch)
+    for key in (name, ARRAY_API_BACKEND, NUMPY_BACKEND):
+        if (func := backends.get(key)) is not None:
+            break
+    else:
+        keys = sorted(backends)
+        msg = f"No implementation for {name} arrays. Registered backends: {keys}"
+        raise NotImplementedError(msg)
+    if key == NUMPY_BACKEND and name != NUMPY_BACKEND:
+        return _numpy_fallback(func, patch, args, kwargs, name)
+    return func(patch, *args, **kwargs)
 
 
 def patch_function(
@@ -230,6 +293,7 @@ def patch_function(
     history: Literal["full", "method_name", None] = "full",
     validate_call: bool = False,
     data_type: str | None = None,
+    backend: str = NUMPY_BACKEND,
 ):
     """
     Decorator to mark a function as a patch method.
@@ -256,6 +320,16 @@ def patch_function(
         Controls the output patch's ``data_type`` attr. If None, leave the
         returned patch's ``data_type`` unchanged. Otherwise, set to specified
         value. Use an empty string ("") to clear.
+    backend
+        The name of the array backend the decorated function supports.
+        The default, "numpy", means the function requires numpy arrays;
+        patches backed by another array library are converted to numpy and
+        the output converted back, which issues a
+        [NumpyFallbackWarning](`dascore.warnings.NumpyFallbackWarning`).
+        Use "array_api" for functions written against the array API
+        standard, which then work with any array backend. Implementations
+        for a specific backend (eg "jax") are added with the ``register``
+        method of the decorated function.
 
     Examples
     --------
@@ -294,6 +368,18 @@ def patch_function(
     >>> @dc.patch_function(data_type="")
     ... def do_unknown_quantity(patch):
     ...     ...
+    >>>
+    >>> # 6. A patch method which works with any array backend, plus a
+    >>> # backend-specific implementation.
+    >>> from dascore.utils.array_api import array_namespace
+    >>> @dc.patch_function(backend="array_api")
+    ... def do_portable_thing(patch):
+    ...     xp = array_namespace(patch.data)
+    ...     return patch.new(data=xp.abs(patch.data))
+    >>>
+    >>> @do_portable_thing.register("numpy")
+    ... def _do_numpy_thing(patch):
+    ...     ...
 
     Notes
     -----
@@ -312,9 +398,24 @@ def patch_function(
         return patch_function()(required_dims)
 
     def _wrapper(func):
-        if validate_call:
+        def _maybe_validate(function):
+            """Apply pydantic validation to each backend implementation."""
+            if not validate_call:
+                return function
             config = pydantic.ConfigDict(arbitrary_types_allowed=True)
-            func = pydantic.validate_call(config=config)(func)
+            return pydantic.validate_call(config=config)(function)
+
+        def _register(name: str) -> Callable:
+            """Register an implementation for a named array backend."""
+
+            def _decorator(function):
+                backends[name] = _maybe_validate(function)
+                return function
+
+            return _decorator
+
+        func = _maybe_validate(func)
+        backends = {backend: func}
 
         @functools.wraps(func)
         def _func(patch, *args, **kwargs):
@@ -324,7 +425,7 @@ def patch_function(
                 coords=required_coords,
             )
             check_patch_attrs(patch, required_attrs)
-            out = func(patch, *args, **kwargs)
+            out = _dispatch_backend(backends, patch, args, kwargs)
             attr_updates = {}
             if data_type is not None:
                 attr_updates["data_type"] = data_type
@@ -347,6 +448,8 @@ def patch_function(
         # matches pydantic naming.
         patch_func.raw_function = getattr(func, "raw_function", func)
         patch_func.__wrapped__ = func
+        patch_func.backends = backends
+        patch_func.register = _register
 
         return patch_func
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -246,11 +246,15 @@ def _get_backend_name(patch) -> str:
     return backend_name(data)
 
 
-def _to_numpy_patch(obj):
-    """Convert a patch's data to numpy, leaving everything else alone."""
-    if not isinstance(obj, dc.Patch) or is_numpy(obj.data):
-        return obj
-    return obj.new(data=to_numpy(obj.data))
+def _to_numpy_arg(obj):
+    """Convert patches and non-numpy arrays to numpy, leaving the rest alone."""
+    if isinstance(obj, dc.Patch):
+        return obj if is_numpy(obj.data) else obj.new(data=to_numpy(obj.data))
+    # Arrays which implement the standard (eg a boolean mask made from the
+    # patch data) have to cross the boundary as well.
+    if not is_numpy(obj) and hasattr(obj, "__array_namespace__"):
+        return to_numpy(obj)
+    return obj
 
 
 def _numpy_fallback(func, patch, args, kwargs, backend):
@@ -261,13 +265,17 @@ def _numpy_fallback(func, patch, args, kwargs, backend):
         "with dascore.utils.misc.suppress_warnings(NumpyFallbackWarning)."
     )
     warnings.warn(msg, NumpyFallbackWarning, stacklevel=4)
-    data = patch.data
-    args = tuple(_to_numpy_patch(x) for x in args)
-    kwargs = {i: _to_numpy_patch(v) for i, v in kwargs.items()}
-    out = func(_to_numpy_patch(patch), *args, **kwargs)
+    args = tuple(_to_numpy_arg(x) for x in args)
+    kwargs = {i: _to_numpy_arg(v) for i, v in kwargs.items()}
+    numpy_patch = _to_numpy_arg(patch)
+    out = func(numpy_patch, *args, **kwargs)
+    # The function did nothing, so neither should the conversion. This keeps
+    # the identity check the patch function machinery uses for history.
+    if out is numpy_patch:
+        return patch
     # Only patches carry data back to the original backend.
     if isinstance(out, dc.Patch):
-        out = out.new(data=asarray_like(out.data, data))
+        out = out.new(data=asarray_like(out.data, patch.data))
     return out
 
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -330,6 +330,8 @@ def patch_function(
         standard, which then work with any array backend. Implementations
         for a specific backend (eg "jax") are added with the ``register``
         method of the decorated function.
+        Only patches passed as arguments are converted for the fallback,
+        not patches nested inside other containers.
 
     Examples
     --------
@@ -385,7 +387,9 @@ def patch_function(
     -----
     - The original function can still be accessed with the raw_function
       attribute. This may be useful for avoiding calling the patch_func
-      machinery multiple times from within another patch function.
+      machinery multiple times from within another patch function. It skips
+      backend dispatch as well, so it should only be used on data the
+      calling function has already put on the right backend.
 
     - If using `PatchType` or `SpoolType` type variables from the
       [constants module](`dascore.constants`), make sure dascore is imported

--- a/dascore/warnings.py
+++ b/dascore/warnings.py
@@ -1,0 +1,18 @@
+"""Custom dascore warnings."""
+
+from __future__ import annotations
+
+
+class DASCoreWarning(UserWarning):
+    """Base class for dascore warnings."""
+
+
+class NumpyFallbackWarning(DASCoreWarning):
+    """
+    Raised when a patch function converts non-numpy data to numpy.
+
+    Patch functions which have no implementation for the array backend of
+    the input patch fall back to their numpy implementation. The data are
+    converted to numpy, the function is applied, then the output data are
+    converted back to the original backend.
+    """

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - pytest
   - pytest-timeout
-  - numpy>=1.24
+  - numpy>=2.0
   - pydantic>=2.1
   - pip
   - pandas>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ dependencies = [
      "array-api-compat>=1.9",
      "h5py",
      "matplotlib>=3.10",
-     "numpy>=2.0",  # array API standard support (isdtype, permute_dims, ...)
+     # 2.0 is the first numpy with native array API support; older numpy
+     # works only through array-api-compat shims, which we would rather not
+     # write dascore against.
+     "numpy>=2.0",
      "packaging",
      "pandas>=2.0",
      "pooch>=1.3",  # retry_if_failed was added in 1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,11 @@ keywords = ["geophysics", "distributed-acoustic-sensing"]
 # --- Dependencies
 
 dependencies = [
+     # Provides array_namespace and friends for array-API backed code.
+     "array-api-compat>=1.9",
      "h5py",
      "matplotlib>=3.10",
-     "numpy>=1.24",
+     "numpy>=2.0",  # array API standard support (isdtype, permute_dims, ...)
      "packaging",
      "pandas>=2.0",
      "pooch>=1.3",  # retry_if_failed was added in 1.3
@@ -89,6 +91,8 @@ docs = [
 
 test = [
     "aiohttp",
+    # A reference array API implementation used to catch numpy-only code.
+    "array-api-strict",
     "coverage>=7.4,<8",
     "pytest-cov>=4",
     "pre-commit",

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -168,3 +168,41 @@ def test_suppress_fallback_warning(random_patch):
 def test_backend_name_of_non_array():
     """Objects which don't carry array data dispatch to numpy."""
     assert _get_backend_name(object()) == "numpy"
+
+
+class _ArrayLike:
+    """An array-like which numpy can consume but which isn't standard."""
+
+    def __init__(self, array):
+        self._array = array
+        self.shape = array.shape
+        self.dtype = array.dtype
+
+    def __array__(self, dtype=None, copy=None):
+        return self._array
+
+
+class TestNonStandardArrayLike:
+    """Tests for patch data which doesn't implement the array API."""
+
+    @pytest.fixture(scope="class")
+    def array_like_patch(self, random_patch) -> dc.Patch:
+        """A patch whose data only implement __array__."""
+        data = _ArrayLike(np.asarray(random_patch.data))
+        return random_patch.new(data=data)
+
+    def test_namespace_is_numpy(self, array_like_patch):
+        """Such arrays are handled by numpy, so they report numpy."""
+        assert backend_name(array_like_patch.data) == "numpy"
+
+    def test_numpy_function(self, array_like_patch):
+        """Numpy-only functions work as they did before dispatch existed."""
+        with warnings_as_errors():
+            out = array_like_patch.detrend("time")
+        assert isinstance(out.data, np.ndarray)
+
+    def test_array_api_function(self, array_like_patch):
+        """So do functions written against the standard."""
+        with warnings_as_errors():
+            out = array_like_patch.transpose()
+        assert out.dims == array_like_patch.dims[::-1]

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -38,8 +38,8 @@ def strict_patch(random_patch) -> dc.Patch:
     return random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
 
 
-class _DLPackOnly:
-    """An array-like which can only be converted to numpy through dlpack."""
+class _DeviceArray:
+    """An array-like which must be moved to the host to become numpy."""
 
     def __init__(self, array):
         self._array = array
@@ -50,11 +50,10 @@ class _DLPackOnly:
         msg = "Implicit conversion to a numpy array is not allowed."
         raise TypeError(msg)
 
-    def __dlpack__(self, **kwargs):
-        return self._array.__dlpack__(**kwargs)
-
-    def __dlpack_device__(self):
-        return self._array.__dlpack_device__()
+    def to_device(self, device, stream=None):
+        """Return the host array, like cupy's asnumpy does."""
+        assert device == "cpu"
+        return self._array
 
 
 class TestBackendName:
@@ -95,10 +94,10 @@ class TestToNumpy:
         assert isinstance(out, np.ndarray)
         assert np.allclose(out, [1.0, 2.0])
 
-    def test_dlpack_fallback(self):
-        """Arrays which refuse implicit conversion go through dlpack."""
+    def test_device_array(self):
+        """Arrays which refuse implicit conversion are moved to the host."""
         array = np.array([1.0, 2.0])
-        out = to_numpy(_DLPackOnly(array))
+        out = to_numpy(_DeviceArray(array))
         assert isinstance(out, np.ndarray)
         assert np.allclose(out, array)
 

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -1,0 +1,171 @@
+"""Tests for array API utilities and array backend support."""
+
+from __future__ import annotations
+
+import warnings
+from contextlib import contextmanager
+
+import numpy as np
+import pytest
+
+import dascore as dc
+from dascore.utils.array_api import (
+    asarray_like,
+    backend_name,
+    is_numpy,
+    to_numpy,
+)
+from dascore.utils.misc import suppress_warnings
+from dascore.utils.patch import _get_backend_name
+from dascore.warnings import NumpyFallbackWarning
+
+# array_api_strict is a test dependency, but some environments (eg wasm)
+# install dascore without the test extras.
+xps = pytest.importorskip("array_api_strict")
+
+
+@contextmanager
+def warnings_as_errors():
+    """A context manager which raises rather than warns."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        yield
+
+
+@pytest.fixture(scope="module")
+def strict_patch(random_patch) -> dc.Patch:
+    """Return a patch whose data are backed by array_api_strict."""
+    return random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
+
+
+class _DLPackOnly:
+    """An array-like which can only be converted to numpy through dlpack."""
+
+    def __init__(self, array):
+        self._array = array
+        self.shape = array.shape
+        self.dtype = array.dtype
+
+    def __array__(self, dtype=None, copy=None):
+        msg = "Implicit conversion to a numpy array is not allowed."
+        raise TypeError(msg)
+
+    def __dlpack__(self, **kwargs):
+        return self._array.__dlpack__(**kwargs)
+
+    def __dlpack_device__(self):
+        return self._array.__dlpack_device__()
+
+
+class TestBackendName:
+    """Tests for getting the name of an array's backend."""
+
+    def test_numpy(self):
+        """Numpy arrays report the numpy backend."""
+        assert backend_name(np.array([1, 2])) == "numpy"
+
+    def test_strict(self):
+        """Other backends report their top-level package name."""
+        assert backend_name(xps.asarray([1, 2])) == "array_api_strict"
+
+
+class TestIsNumpy:
+    """Tests for detecting numpy arrays."""
+
+    def test_numpy(self):
+        """Numpy arrays are numpy arrays."""
+        assert is_numpy(np.array([1, 2]))
+
+    def test_not_numpy(self):
+        """Arrays from other backends are not."""
+        assert not is_numpy(xps.asarray([1, 2]))
+
+
+class TestToNumpy:
+    """Tests for converting arrays to numpy."""
+
+    def test_numpy_returns_same_array(self):
+        """Numpy arrays are returned without a copy."""
+        array = np.array([1, 2])
+        assert to_numpy(array) is array
+
+    def test_other_backend(self):
+        """Other backends are converted to numpy arrays."""
+        out = to_numpy(xps.asarray([1.0, 2.0]))
+        assert isinstance(out, np.ndarray)
+        assert np.allclose(out, [1.0, 2.0])
+
+    def test_dlpack_fallback(self):
+        """Arrays which refuse implicit conversion go through dlpack."""
+        array = np.array([1.0, 2.0])
+        out = to_numpy(_DLPackOnly(array))
+        assert isinstance(out, np.ndarray)
+        assert np.allclose(out, array)
+
+
+class TestAsArrayLike:
+    """Tests for converting arrays back to another backend."""
+
+    def test_numpy_like(self):
+        """A numpy template returns a numpy array."""
+        out = asarray_like(xps.asarray([1.0, 2.0]), np.array([1.0]))
+        assert isinstance(out, np.ndarray)
+
+    def test_other_backend_like(self):
+        """A non-numpy template returns that backend's array."""
+        out = asarray_like(np.array([1.0, 2.0]), xps.asarray([1.0]))
+        assert backend_name(out) == "array_api_strict"
+
+
+class TestPatchBackends:
+    """Tests for patches backed by a non-numpy array library."""
+
+    def test_patch_keeps_backend(self, strict_patch):
+        """Creating a patch does not convert the data to numpy."""
+        assert backend_name(strict_patch.data) == "array_api_strict"
+
+    def test_array_api_function_keeps_backend(self, strict_patch):
+        """Functions written against the standard don't warn or convert."""
+        with warnings_as_errors():
+            out = strict_patch.transpose()
+        assert backend_name(out.data) == "array_api_strict"
+        assert out.dims == strict_patch.dims[::-1]
+
+    def test_squeeze_keeps_backend(self, strict_patch):
+        """Squeeze also works on any backend."""
+        with suppress_warnings(NumpyFallbackWarning):
+            patch = strict_patch.select(distance=0, samples=True)
+        with warnings_as_errors():
+            out = patch.squeeze()
+        assert backend_name(out.data) == "array_api_strict"
+        assert "distance" not in out.dims
+
+    def test_numpy_only_function_warns(self, strict_patch):
+        """Numpy-only functions warn but preserve the input backend."""
+        with pytest.warns(NumpyFallbackWarning, match="detrend"):
+            out = strict_patch.detrend("time")
+        assert backend_name(out.data) == "array_api_strict"
+        assert out.shape == strict_patch.shape
+
+    def test_to_numpy_array(self, strict_patch):
+        """Patches from any backend convert to numpy arrays."""
+        array = np.asarray(strict_patch)
+        assert isinstance(array, np.ndarray)
+        assert array.shape == strict_patch.shape
+
+    def test_str(self, strict_patch):
+        """Patches from any backend have a string representation."""
+        assert "Patch" in str(strict_patch)
+
+
+def test_suppress_fallback_warning(random_patch):
+    """The fallback warning can be silenced like any other dascore warning."""
+    patch = random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
+    with suppress_warnings(NumpyFallbackWarning):
+        out = patch.detrend("time")
+    assert backend_name(out.data) == "array_api_strict"
+
+
+def test_backend_name_of_non_array():
+    """Objects which don't carry array data dispatch to numpy."""
+    assert _get_backend_name(object()) == "numpy"

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -1334,6 +1334,32 @@ class TestBackendDispatch:
         assert out.attrs.data_type == "strain"
         assert "set_strain" in out.attrs.history[-1]
 
+    def test_array_arguments_converted(self, strict_patch):
+        """Arrays passed as arguments are converted for the fallback."""
+        types = []
+
+        @dc.patch_function()
+        def uses_array(patch, condition):
+            types.append(type(condition))
+            return patch.new(data=np.where(condition, patch.data, 0))
+
+        condition = strict_patch.data > 0
+        with pytest.warns(NumpyFallbackWarning):
+            out = uses_array(strict_patch, condition)
+        assert types == [np.ndarray]
+        assert backend_name(out.data) == "array_api_strict"
+
+    def test_unchanged_patch_returned(self, strict_patch):
+        """A function which returns its input returns the original patch."""
+
+        @dc.patch_function()
+        def do_nothing(patch):
+            return patch
+
+        with pytest.warns(NumpyFallbackWarning):
+            out = do_nothing(strict_patch)
+        assert out is strict_patch
+
     def test_registered_function_validated(self, strict_patch):
         """Registered implementations get the same call validation."""
 

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Annotated, Literal, get_type_hints
 
 import numpy as np
@@ -21,6 +22,7 @@ from dascore.exceptions import (
     PatchCoordinateError,
 )
 from dascore.units import percent
+from dascore.utils.array_api import backend_name
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch import (
     _force_patch_merge,
@@ -39,6 +41,7 @@ from dascore.utils.patch import (
     stack_patches,
     swap_kwargs_dim_to_axis,
 )
+from dascore.warnings import NumpyFallbackWarning
 
 
 @dc.patch_function(required_dims=("time", "distance"))
@@ -1193,3 +1196,154 @@ class TestDottedPatchNames:
         assert "DAS.R2D1..RAW" in name
         patch.io.write(tmp_path / f"{name}.h5", "dasdae")
         assert get_patch_names(dc.spool(tmp_path).update()).iloc[0] == name
+
+
+class TestBackendDispatch:
+    """Tests for dispatching patch functions on the patch's array backend."""
+
+    @pytest.fixture
+    def numpy_func(self):
+        """A patch function which only supports numpy."""
+
+        @dc.patch_function()
+        def numpy_only(patch, calls=None):
+            if calls is not None:
+                calls.append(backend_name(patch.data))
+            return patch.new(data=patch.data * 2)
+
+        return numpy_only
+
+    @pytest.fixture
+    def strict_patch(self, random_patch):
+        """A patch backed by the array_api_strict library."""
+        xps = pytest.importorskip("array_api_strict")
+        return random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
+
+    def test_default_backend(self, numpy_func):
+        """By default a patch function declares only a numpy implementation."""
+        assert set(numpy_func.backends) == {"numpy"}
+        assert numpy_func.backends["numpy"] is numpy_func.raw_function
+
+    def test_numpy_patch_not_converted(self, numpy_func, random_patch):
+        """Numpy patches use the numpy implementation directly."""
+        calls = []
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            out = numpy_func(random_patch, calls=calls)
+        assert calls == ["numpy"]
+        assert isinstance(out.data, np.ndarray)
+
+    def test_fallback_converts_and_restores(self, numpy_func, strict_patch):
+        """Other backends are converted to numpy then converted back."""
+        calls = []
+        with pytest.warns(NumpyFallbackWarning, match="numpy_only"):
+            out = numpy_func(strict_patch, calls=calls)
+        assert calls == ["numpy"]
+        assert backend_name(out.data) == "array_api_strict"
+
+    def test_registered_backend_used(self, numpy_func, strict_patch):
+        """A registered implementation takes precedence over the fallback."""
+
+        @numpy_func.register("array_api_strict")
+        def _strict(patch, calls=None):
+            calls.append("registered")
+            return patch
+
+        calls = []
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            numpy_func(strict_patch, calls=calls)
+        assert calls == ["registered"]
+
+    def test_array_api_used_for_unknown_backend(self, strict_patch):
+        """Array API implementations serve backends with no exact match."""
+        calls = []
+
+        @dc.patch_function(backend="array_api")
+        def array_api_func(patch):
+            calls.append(backend_name(patch.data))
+            return patch
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            array_api_func(strict_patch)
+        assert calls == ["array_api_strict"]
+
+    def test_exact_backend_beats_array_api(self, random_patch):
+        """An exact backend match wins over the generic implementation."""
+        calls = []
+
+        @dc.patch_function(backend="array_api")
+        def func(patch):
+            calls.append("array_api")
+            return patch
+
+        @func.register("numpy")
+        def _numpy_func(patch):
+            calls.append("numpy")
+            return patch
+
+        func(random_patch)
+        assert calls == ["numpy"]
+
+    def test_no_implementation_raises(self, random_patch):
+        """A patch with no usable implementation raises."""
+
+        @dc.patch_function(backend="jax")
+        def jax_only(patch):
+            return patch
+
+        with pytest.raises(NotImplementedError, match="numpy"):
+            jax_only(random_patch)
+
+    def test_patch_arguments_converted(self, strict_patch):
+        """Patches passed as arguments are also converted for the fallback."""
+        backends = []
+
+        @dc.patch_function()
+        def two_patches(patch, other, key=None):
+            backends.append(
+                (backend_name(patch.data), backend_name(other.data), key.dims)
+            )
+            return patch
+
+        with pytest.warns(NumpyFallbackWarning):
+            two_patches(strict_patch, strict_patch, key=strict_patch)
+        assert backends == [("numpy", "numpy", strict_patch.dims)]
+
+    def test_non_patch_output(self, strict_patch):
+        """Functions which don't return a patch are left alone."""
+
+        @dc.patch_function()
+        def get_shape(patch):
+            return patch.shape
+
+        with pytest.warns(NumpyFallbackWarning):
+            out = get_shape(strict_patch)
+        assert out == strict_patch.shape
+
+    def test_history_and_data_type_added(self, strict_patch):
+        """The fallback path keeps the normal patch function machinery."""
+
+        @dc.patch_function(data_type="strain")
+        def set_strain(patch):
+            return patch.new(data=patch.data)
+
+        with pytest.warns(NumpyFallbackWarning):
+            out = set_strain(strict_patch)
+        assert out.attrs.data_type == "strain"
+        assert "set_strain" in out.attrs.history[-1]
+
+    def test_registered_function_validated(self, strict_patch):
+        """Registered implementations get the same call validation."""
+
+        @dc.patch_function(validate_call=True)
+        def needs_int(patch, value: int = 1):
+            return patch
+
+        @needs_int.register("array_api_strict")
+        def _strict_needs_int(patch, value: int = 1):
+            return patch
+
+        with pytest.raises(pydantic.ValidationError):
+            needs_int(strict_patch, value="not_an_int")


### PR DESCRIPTION
## Description

First step toward making DASCore's `Patch` data path array-backend agnostic. This PR adds the machinery only; almost all patch functions keep their current numpy implementations.

`Patch` data has always been allowed to be any array-like (`dascore.compat.array` never forced numpy), but every patch function assumed numpy, so non-numpy data were silently converted somewhere in the middle and the output backend was whatever numpy happened to return. This makes that explicit:

- `dascore/utils/array_api.py` holds `array_namespace` (re-exported from `array-api-compat`) plus the numpy-boundary helpers: `backend_name`, `is_numpy`, `to_numpy` (`__array__` with a dlpack fallback), and `asarray_like`.
- `patch_function` takes a `backend` keyword, defaulting to `"numpy"`, and attaches a `backends` registry (`{backend_name: implementation}`) plus a `register` method. Dispatch prefers an exact backend match, then `"array_api"`, then `"numpy"`. Using the `"numpy"` implementation for a non-numpy patch converts every `Patch` argument to numpy, warns `NumpyFallbackWarning`, then converts the output back to the input backend and device (only when the output is a patch). Validation, the history string, and `data_type` are untouched and run once around whichever implementation is chosen.
- `dascore/warnings.py` is a new module for warning classes, mirroring `dascore/exceptions.py`.
- `transpose` and `squeeze` are written against the standard as the first two conversions; `Patch.__array__` now goes through `to_numpy` rather than assuming `__array__` exists.

Nothing changes for numpy patches: they take the same code path they always did, with no warning and no conversion. `patch_function` keeps every existing calling form; `backends`/`register` are additive, so third-party patch functions need no change.

Follow-on PRs (planned): operator/ufunc dispatch in `utils/array.py`, then `proc/basic.py` + `proc/aggregate.py`, then the coord/transform data paths. Functions that stay numpy-only (scipy, numba, and pandas backed) are exactly the ones the fallback covers.

The numpy floor moves to 2.0, matched in `environment.yml`. `array-api-compat` can shim older numpy, but 2.0 is the first version with native array API support and writing dascore against the shims instead is not worth it. `array-api-compat` becomes a runtime dependency and `array-api-strict` a test dependency, used as a conformance oracle so numpy leaks show up as a changed output backend.

Known limits of the fallback, both documented on the decorator: only patches passed as arguments are converted (not patches nested in containers), and `raw_function`/`func` skip dispatch along with the rest of the patch function machinery.

## Changelog

- added: `dascore.warnings.NumpyFallbackWarning` is issued when a patch function converts non-numpy patch data to numpy and back.
- added: `dc.patch_function` accepts a `backend` argument and exposes a `backends` registry so patch functions can provide implementations for specific array backends.
- changed: `Patch.transpose` and `Patch.squeeze` are written against the Python array API standard, so they preserve the array backend of the patch data.
- changed **breaking**: DASCore now requires numpy 2.0 or greater.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing patches with multiple array backends and devices.
  * Added automatic conversion between supported array formats while preserving the original backend when possible.
  * Added clear warnings when operations fall back to NumPy.
  * Improved transpose and squeeze operations for broader array compatibility.

* **Bug Fixes**
  * Improved handling of array conversion, including device-resident and non-standard array objects.

* **Compatibility**
  * Updated support requirements for NumPy 2.0 and modern array API standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->