### PR TITLE
Apply patch operators in the array backend's own namespace

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -73,6 +73,7 @@ from dascore.models import (
     frozen_dict_serializer,
     frozen_dict_validator,
 )
+from dascore.utils.array_api import array_namespace
 from dascore.utils.docs import compose_docstring
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import (
@@ -702,7 +703,10 @@ class CoordManager(DascoreBaseModel):
             else:
                 msg = f"Cannot broadcast non-empty coord {name} to shape {new}."
                 raise PatchBroadcastError(msg)
-        out = array if array is None else np.broadcast_to(array, target_shape)
+        if array is None:
+            out = None
+        else:
+            out = array_namespace(array).broadcast_to(array, target_shape)
         return self.update_coords(**new_coords), out
 
     def _check_multiple_relative(self, kwargs):

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -703,11 +703,9 @@ class CoordManager(DascoreBaseModel):
             else:
                 msg = f"Cannot broadcast non-empty coord {name} to shape {new}."
                 raise PatchBroadcastError(msg)
-        if array is None:
-            out = None
-        else:
-            out = array_namespace(array).broadcast_to(array, target_shape)
-        return self.update_coords(**new_coords), out
+        if array is not None:
+            array = array_namespace(array).broadcast_to(array, target_shape)
+        return self.update_coords(**new_coords), array
 
     def _check_multiple_relative(self, kwargs):
         """

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -320,7 +320,7 @@ def drop_private_coords(self: PatchType) -> PatchType:
     return self.new(coords=new_coord, dims=new_coord.dims, data=data)
 
 
-@patch_function()
+@patch_function(backend="array_api")
 def make_broadcastable_to(
     self: PatchType,
     shape: tuple[int, ...],

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -182,11 +182,23 @@ def _get_backend_ufunc(ufunc, array):
     return getattr(array_namespace(array), name, None)
 
 
+def _is_python_scalar(value):
+    """Return True for a scalar every array API function accepts."""
+    # Not isinstance; np.float64 subclasses float but is not a python scalar.
+    return type(value) in (int, float, bool)
+
+
+def _is_inexact(array):
+    """Return True if the array holds real or complex floating point values."""
+    xp = array_namespace(array)
+    return xp.isdtype(array.dtype, ("real floating", "complex floating"))
+
+
 def _as_backend(value, template):
     """Put a ufunc operand in the same array namespace as template."""
     # Python scalars are valid operands for any backend, as are arrays which
     # already belong to it.
-    if isinstance(value, int | float | complex | bool) or is_foreign(value):
+    if _is_python_scalar(value) or array_namespace(value) is array_namespace(template):
         return value
     return asarray_like(value, template)
 
@@ -294,8 +306,7 @@ def _apply_binary_ufunc(
         # already have one; that would materialize non-numpy data.
         if (shape := getattr(other, "shape", None)) is None:
             shape = np.asanyarray(other).shape
-        # Scalars broadcast against anything.
-        if not shape or patch.shape == shape:
+        if patch.shape == shape:
             return patch
         if (patch_ndims := patch.ndim) < (array_ndims := len(shape)):
             msg = f"Cannot broadcast patch/array {patch_ndims=} {array_ndims=}"
@@ -630,14 +641,48 @@ def _get_foreign_data(args, kwargs):
     return next((x for x in (*patch_data, *values) if is_foreign(x)), None)
 
 
+def _operand_can_apply(value, data):
+    """Determine if a ufunc operand can be used with the data's namespace."""
+    if _is_python_scalar(value):
+        return True
+    if getattr(value, "dtype", None) is None:
+        return False
+    # Arrays from a third backend can't be mixed with the data's own.
+    if is_foreign(value) and array_namespace(value) is not array_namespace(data):
+        return False
+    return _is_inexact(value)
+
+
 def _backend_can_apply(ufunc, key, args, kwargs, data):
-    """Determine if a ufunc can be applied in the data's own namespace."""
+    """
+    Determine if a ufunc can be applied in the data's own namespace.
+
+    The numpy fallback is always correct, so this only answers yes where
+    the standard is known to agree with numpy. The standard has narrower
+    dtype domains and no value-based promotion, so eg numpy's rint casts
+    integers up to floats while the standard's round leaves them alone.
+    """
     # Only element-wise ufuncs have array API equivalents; reductions and
     # numpy functions (__array_function__) have to use numpy.
     if key not in ((1, 1), (2, 1)):
         return False
-    # Units are implemented with pint, which only wraps numpy arrays.
-    if any(isinstance(x, Quantity | Unit) for x in (*args, *kwargs.values())):
+    # Numpy-only ufunc options (where, casting, dtype) have no equivalent.
+    if kwargs:
+        return False
+    # Units are implemented with pint, which only wraps numpy arrays. A
+    # second patch's units become a quantity while its coords are aligned,
+    # after this runs, so they have to be caught here too.
+    if any(isinstance(x, Quantity | Unit) for x in args):
+        return False
+    patches = [x for x in args if isinstance(x, dc.Patch)]
+    if len(patches) > 1 and any(x.attrs.data_units for x in patches):
+        return False
+    # Integer and boolean data are where the two disagree most, so they use
+    # numpy; patch data are floating point nearly always.
+    if not _is_inexact(data):
+        return False
+    operands = (x.data if isinstance(x, dc.Patch) else x for x in args)
+    if not all(_operand_can_apply(x, data) for x in operands):
         return False
     return _get_backend_ufunc(ufunc, data) is not None
 

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -73,9 +73,9 @@ def _raise_on_out(kwargs):
 
 def _clear_units_if_bool_dtype(patch):
     """Clear the units on the patch if it is a boolean."""
-    if (dtype := getattr(patch, "dtype", None)) is None:
-        return patch
-    if array_namespace(patch.data).isdtype(dtype, "bool"):
+    # Every ufunc and array function path reassembles a patch first.
+    assert hasattr(patch, "dtype"), "can only clear the units of a patch"
+    if array_namespace(patch.data).isdtype(patch.dtype, "bool"):
         return patch.update_attrs(data_units=None)
     return patch
 

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -17,14 +17,40 @@ from dascore.constants import DEFAULT_ATTRS_TO_IGNORE, PatchType
 from dascore.exceptions import ParameterError, PatchBroadcastError, UnitError
 from dascore.models import ArrayLike
 from dascore.units import DimensionalityError, Quantity, Unit, get_quantity
+from dascore.utils.array_api import (
+    array_namespace,
+    asarray_like,
+    backend_name,
+    is_foreign,
+    warn_numpy_fallback,
+)
 from dascore.utils.misc import iterate
 from dascore.utils.patch import (
     _merge_aligned_coords,
     _merge_models,
+    _to_numpy_arg,
     align_patch_coords,
     get_dim_axis_value,
     swap_kwargs_dim_to_axis,
 )
+
+# Numpy ufunc names which the array API standard spells differently.
+UFUNC_NAMES = {
+    "absolute": "abs",
+    "arccos": "acos",
+    "arccosh": "acosh",
+    "arcsin": "asin",
+    "arcsinh": "asinh",
+    "arctan": "atan",
+    "arctan2": "atan2",
+    "arctanh": "atanh",
+    "conjugate": "conj",
+    "invert": "bitwise_invert",
+    "left_shift": "bitwise_left_shift",
+    "power": "pow",
+    "right_shift": "bitwise_right_shift",
+    "rint": "round",
+}
 
 
 def _dummy_accumulate(array, axis=0, dtype=None, out=None):
@@ -47,8 +73,9 @@ def _raise_on_out(kwargs):
 
 def _clear_units_if_bool_dtype(patch):
     """Clear the units on the patch if it is a boolean."""
-    dtype = getattr(patch, "dtype", None)
-    if dtype is not None and np.issubdtype(dtype, np.bool_):
+    if (dtype := getattr(patch, "dtype", None)) is None:
+        return patch
+    if array_namespace(patch.data).isdtype(dtype, "bool"):
         return patch.update_attrs(data_units=None)
     return patch
 
@@ -149,6 +176,37 @@ def convert_bytes_to_strings(data: ArrayLike, original_dtype="") -> np.ndarray:
     return out
 
 
+def _get_backend_ufunc(ufunc, array):
+    """Get the array API equivalent of a numpy ufunc, or None if it has none."""
+    name = UFUNC_NAMES.get(ufunc.__name__, ufunc.__name__)
+    return getattr(array_namespace(array), name, None)
+
+
+def _as_backend(value, template):
+    """Put a ufunc operand in the same array namespace as template."""
+    # Python scalars are valid operands for any backend, as are arrays which
+    # already belong to it.
+    if isinstance(value, int | float | complex | bool) or is_foreign(value):
+        return value
+    return asarray_like(value, template)
+
+
+def _apply_operator(operator, *arrays, **kwargs):
+    """
+    Apply a ufunc to arrays, one of which may not be numpy backed.
+
+    Numpy data are passed to the numpy ufunc, everything else uses the
+    matching function from its own array API namespace.
+    """
+    template = next((x for x in arrays if is_foreign(x)), None)
+    if template is None:
+        return operator(*arrays, **kwargs)
+    func = _get_backend_ufunc(operator, template)
+    assert func is not None, f"{operator.__name__} has no array API equivalent."
+    arrays = tuple(_as_backend(x, template) for x in arrays)
+    return func(*arrays, **kwargs)
+
+
 def _apply_unary_ufunc(operator: np.ufunc, patch, *args, **kwargs):
     """
     Create a patch from a unary ufunc.
@@ -169,7 +227,7 @@ def _apply_unary_ufunc(operator: np.ufunc, patch, *args, **kwargs):
     -----
     We assume the shape of the array won't change.
     """
-    out = operator(patch.data, *args, **kwargs)
+    out = _apply_operator(operator, patch.data, *args, **kwargs)
     return patch.new(data=out)
 
 
@@ -232,20 +290,24 @@ def _apply_binary_ufunc(
         """Deal with broadcasting a patch and an array."""
         # This handles warning from quantity.
         other = other.magnitude if hasattr(other, "magnitude") else other
-        other = np.asanyarray(other)
-        if patch.shape == other.shape:
+        # Only the shape is needed here, so don't convert arrays which
+        # already have one; that would materialize non-numpy data.
+        if (shape := getattr(other, "shape", None)) is None:
+            shape = np.asanyarray(other).shape
+        # Scalars broadcast against anything.
+        if not shape or patch.shape == shape:
             return patch
-        if (patch_ndims := patch.ndim) < (array_ndims := other.ndim):
+        if (patch_ndims := patch.ndim) < (array_ndims := len(shape)):
             msg = f"Cannot broadcast patch/array {patch_ndims=} {array_ndims=}"
             raise PatchBroadcastError(msg)
-        patch = patch.make_broadcastable_to(other.shape)
+        patch = patch.make_broadcastable_to(shape)
         return patch
 
     def _apply_op(array1, array2, operator, reversed=False):
         """Simply apply the operator, account for reversal."""
         if reversed:
             array1, array2 = array2, array1
-        return operator(array1, array2, *args, **kwargs)
+        return _apply_operator(operator, array1, array2, *args, **kwargs)
 
     def _apply_op_units(patch, other, operator, attrs, reversed=False):
         """Apply the operation handling units attached to array."""
@@ -515,8 +577,18 @@ def _reassemble_patch(result, patch, func, args, kwargs):
 def apply_array_func(func, *args, **kwargs):
     """
     Apply an array function.
+
+    Numpy functions have no array API equivalent, so patches from other
+    backends are converted to numpy and the result converted back.
     """
     _raise_on_out(kwargs)
+    if (data := _get_foreign_data(args, kwargs)) is not None:
+        return _numpy_fallback_call(_apply_array_func, func, args, kwargs, data)
+    return _apply_array_func(func, *args, **kwargs)
+
+
+def _apply_array_func(func, *args, **kwargs):
+    """Apply an array function to numpy backed patches."""
     # Only handle functions involving Patches
     patches = _find_patches(args, kwargs)
     assert len(patches), "No patches found in apply_array_func"
@@ -549,6 +621,37 @@ UFUNC_MAP = {
     "reduce": apply_array_func,
     "accumulate": apply_array_func,
 }
+
+
+def _get_foreign_data(args, kwargs):
+    """Return the data of the first non-numpy backed operand, or None."""
+    values = (*args, *kwargs.values())
+    patch_data = (x.data for x in values if isinstance(x, dc.Patch))
+    return next((x for x in (*patch_data, *values) if is_foreign(x)), None)
+
+
+def _backend_can_apply(ufunc, key, args, kwargs, data):
+    """Determine if a ufunc can be applied in the data's own namespace."""
+    # Only element-wise ufuncs have array API equivalents; reductions and
+    # numpy functions (__array_function__) have to use numpy.
+    if key not in ((1, 1), (2, 1)):
+        return False
+    # Units are implemented with pint, which only wraps numpy arrays.
+    if any(isinstance(x, Quantity | Unit) for x in (*args, *kwargs.values())):
+        return False
+    return _get_backend_ufunc(ufunc, data) is not None
+
+
+def _numpy_fallback_call(runner, func, args, kwargs, data):
+    """Apply an operation numpy can perform but the input's backend cannot."""
+    name = getattr(func, "__name__", "operation")
+    warn_numpy_fallback(name, backend_name(data), stacklevel=3)
+    args = tuple(_to_numpy_arg(x) for x in args)
+    kwargs = {i: _to_numpy_arg(v) for i, v in kwargs.items()}
+    out = runner(func, *args, **kwargs)
+    if isinstance(out, dc.Patch):
+        out = out.new(data=asarray_like(out.data, data))
+    return out
 
 
 def apply_ufunc(ufunc, *args, **kwargs):
@@ -597,7 +700,11 @@ def apply_ufunc(ufunc, *args, **kwargs):
             f"supported for use with Patch. Use the patch.data array directly."
         )
         raise ParameterError(msg)
-    out = func(ufunc, *args, **kwargs)
+    data = _get_foreign_data(args, kwargs)
+    if data is None or _backend_can_apply(ufunc, key, args, kwargs, data):
+        out = func(ufunc, *args, **kwargs)
+    else:
+        out = _numpy_fallback_call(func, ufunc, args, kwargs, data)
     return _clear_units_if_bool_dtype(out)
 
 

--- a/dascore/utils/array_api.py
+++ b/dascore/utils/array_api.py
@@ -17,7 +17,7 @@ from typing import Any, TypeGuard
 import array_api_compat.numpy as np_namespace
 import numpy as np
 from array_api_compat import array_namespace as _array_namespace
-from array_api_compat import device, to_device
+from array_api_compat import device, is_array_api_obj, to_device
 
 from dascore.compat import is_array
 from dascore.warnings import NumpyFallbackWarning
@@ -99,7 +99,13 @@ def is_foreign(array: Any) -> bool:
     # protocols from their instances, so exclude types explicitly.
     if is_numpy(array) or isinstance(array, type):
         return False
-    return hasattr(array, "__array_namespace__")
+    # Everything else is only an array if it has a shape; checking here
+    # keeps scalar operands off the slower classification below.
+    if getattr(array, "shape", None) is None:
+        return False
+    # Not just __array_namespace__; backends which don't implement the
+    # standard natively (eg torch, dask) are recognized by their type.
+    return is_array_api_obj(array)
 
 
 def warn_numpy_fallback(name: str, backend: str, stacklevel: int = 3) -> None:

--- a/dascore/utils/array_api.py
+++ b/dascore/utils/array_api.py
@@ -11,6 +11,7 @@ lives in [compat](`dascore.compat`).
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, TypeGuard
 
 import array_api_compat.numpy as np_namespace
@@ -19,14 +20,18 @@ from array_api_compat import array_namespace as _array_namespace
 from array_api_compat import device, to_device
 
 from dascore.compat import is_array
+from dascore.warnings import NumpyFallbackWarning
 
 __all__ = [
     "array_namespace",
     "asarray_like",
     "backend_name",
     "device",
+    "is_foreign",
     "is_numpy",
+    "namespace_name",
     "to_numpy",
+    "warn_numpy_fallback",
 ]
 
 # The key used by patch functions written against the array API standard.
@@ -70,6 +75,55 @@ def is_numpy(array: Any) -> TypeGuard[np.ndarray]:
     return is_array(array) or isinstance(array, np.generic)
 
 
+def is_foreign(array: Any) -> bool:
+    """
+    Return True if the array belongs to a non-numpy array API backend.
+
+    These are the arrays which have to cross the numpy boundary explicitly.
+
+    Parameters
+    ----------
+    array
+        Any object.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dascore.utils.array_api import is_foreign
+    >>>
+    >>> assert not is_foreign(np.array([1, 2]))
+    >>> assert not is_foreign(10)
+    >>> assert not is_foreign(np.float32)  # a dtype, not an array
+    """
+    # Array classes (eg np.float32 used as a dtype) inherit the array
+    # protocols from their instances, so exclude types explicitly.
+    if is_numpy(array) or isinstance(array, type):
+        return False
+    return hasattr(array, "__array_namespace__")
+
+
+def warn_numpy_fallback(name: str, backend: str, stacklevel: int = 3) -> None:
+    """
+    Warn that name has no implementation for the given array backend.
+
+    Parameters
+    ----------
+    name
+        The name of the function which lacks an implementation.
+    backend
+        The name of the array backend of the input data.
+    stacklevel
+        The stack level, as understood by warnings.warn, of the function
+        calling this one.
+    """
+    msg = (
+        f"{name} has no {backend} implementation; the data were converted "
+        "to numpy and the output converted back. Silence this with "
+        "dascore.utils.misc.suppress_warnings(NumpyFallbackWarning)."
+    )
+    warnings.warn(msg, NumpyFallbackWarning, stacklevel=stacklevel + 1)
+
+
 def backend_name(array: Any) -> str:
     """
     Return the name of the array backend which owns array.
@@ -89,15 +143,33 @@ def backend_name(array: Any) -> str:
     >>>
     >>> assert backend_name(np.array([1, 2])) == "numpy"
     """
-    if is_numpy(array):
-        return NUMPY_BACKEND
-    name = array_namespace(array).__name__
     # array_namespace falls back to numpy for array-likes which don't
     # implement the standard; those are numpy's problem as well.
+    if is_numpy(array):
+        return NUMPY_BACKEND
+    return namespace_name(array_namespace(array))
+
+
+def namespace_name(namespace: Any) -> str:
+    """
+    Return the backend name of an array API namespace.
+
+    Parameters
+    ----------
+    namespace
+        An array API namespace module.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dascore.utils.array_api import namespace_name
+    >>>
+    >>> assert namespace_name(np) == "numpy"
+    """
     # array_api_compat wraps incomplete backends in modules named after them
     # (eg array_api_compat.dask.array); native namespaces are named after
     # their own package (eg jax.numpy).
-    name = name.removeprefix("array_api_compat.")
+    name = namespace.__name__.removeprefix("array_api_compat.")
     return name.split(".")[0]
 
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -8,6 +8,7 @@ import sys
 import warnings
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from types import ModuleType
 from typing import Any, Literal, Protocol, cast, overload
 
 import numpy as np
@@ -37,8 +38,11 @@ from dascore.utils.array_api import (
     NUMPY_BACKEND,
     asarray_like,
     backend_name,
+    is_foreign,
     is_numpy,
+    namespace_name,
     to_numpy,
+    warn_numpy_fallback,
 )
 from dascore.utils.attrs import combine_patch_attrs
 from dascore.utils.coordmanager import merge_coord_managers
@@ -57,7 +61,6 @@ from dascore.utils.misc import (
 )
 from dascore.utils.paths import is_memory_uri
 from dascore.utils.time import to_float
-from dascore.warnings import NumpyFallbackWarning
 
 attr_type = dict[str, Any] | str | Sequence[str] | None
 
@@ -236,6 +239,21 @@ class _PatchFunction(Protocol):
     def __call__(self, patch, *args, **kwargs): ...
 
 
+def _resolve_backend(backend) -> str:
+    """
+    Get a backend name from a name, an array API namespace, or an array.
+
+    The namespace and array forms are recommended; they can't be misspelled,
+    and the name of an array library's namespace is not always the name of
+    the library (eg torch, not pytorch).
+    """
+    if isinstance(backend, str):
+        return backend
+    if isinstance(backend, ModuleType):
+        return namespace_name(backend)
+    return backend_name(backend)
+
+
 def _get_backend_name(patch) -> str:
     """Get the name of the array backend which backs a patch's data."""
     data = getattr(patch, "data", None)
@@ -252,19 +270,14 @@ def _to_numpy_arg(obj):
         return obj if is_numpy(obj.data) else obj.new(data=to_numpy(obj.data))
     # Arrays which implement the standard (eg a boolean mask made from the
     # patch data) have to cross the boundary as well.
-    if not is_numpy(obj) and hasattr(obj, "__array_namespace__"):
+    if is_foreign(obj):
         return to_numpy(obj)
     return obj
 
 
 def _numpy_fallback(func, patch, args, kwargs, backend):
     """Run a numpy-only implementation on non-numpy patches."""
-    msg = (
-        f"{func.__name__} has no {backend} implementation; the patch data "
-        "were converted to numpy and the output converted back. Silence this "
-        "with dascore.utils.misc.suppress_warnings(NumpyFallbackWarning)."
-    )
-    warnings.warn(msg, NumpyFallbackWarning, stacklevel=4)
+    warn_numpy_fallback(func.__name__, backend, stacklevel=4)
     args = tuple(_to_numpy_arg(x) for x in args)
     kwargs = {i: _to_numpy_arg(v) for i, v in kwargs.items()}
     numpy_patch = _to_numpy_arg(patch)
@@ -336,8 +349,10 @@ def patch_function(
         [NumpyFallbackWarning](`dascore.warnings.NumpyFallbackWarning`).
         Use "array_api" for functions written against the array API
         standard, which then work with any array backend. Implementations
-        for a specific backend (eg "jax") are added with the ``register``
-        method of the decorated function.
+        for a specific backend are added with the ``register`` method of
+        the decorated function. Both accept a backend name, an array API
+        namespace, or an example array; the last two are recommended since
+        a misspelled name is never matched.
         Only patches passed as arguments are converted for the fallback,
         not patches nested inside other containers.
 
@@ -381,13 +396,14 @@ def patch_function(
     >>>
     >>> # 6. A patch method which works with any array backend, plus a
     >>> # backend-specific implementation.
+    >>> import numpy as np
     >>> from dascore.utils.array_api import array_namespace
     >>> @dc.patch_function(backend="array_api")
     ... def do_portable_thing(patch):
     ...     xp = array_namespace(patch.data)
     ...     return patch.new(data=xp.abs(patch.data))
     >>>
-    >>> @do_portable_thing.register("numpy")
+    >>> @do_portable_thing.register(np)  # or "numpy", or an example array
     ... def _do_numpy_thing(patch):
     ...     ...
 
@@ -417,17 +433,18 @@ def patch_function(
             config = pydantic.ConfigDict(arbitrary_types_allowed=True)
             return pydantic.validate_call(config=config)(function)
 
-        def _register(name: str) -> Callable:
-            """Register an implementation for a named array backend."""
+        def _register(name) -> Callable:
+            """Register an implementation for an array backend."""
+            key = _resolve_backend(name)
 
             def _decorator(function):
-                backends[name] = _maybe_validate(function)
+                backends[key] = _maybe_validate(function)
                 return function
 
             return _decorator
 
         func = _maybe_validate(func)
-        backends = {backend: func}
+        backends = {_resolve_backend(backend): func}
 
         @functools.wraps(func)
         def _func(patch, *args, **kwargs):

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -128,6 +128,38 @@ Spool namespaces use the same pattern. The only changes are:
 - Inherit from `SpoolNameSpace` and write methods against a `Spool`.
 - Register the namespace in the `dascore.spool_namespace` entry point group instead of `dascore.patch_namespace`.
 
+## Array backends
+
+Patch data can be backed by any array library which implements the [array API standard](https://data-apis.org/array-api/latest/), not just NumPy. A patch function declares which one its body was written for:
+
+```{python}
+import dascore as dc
+from dascore.constants import PatchType
+from dascore.utils.array_api import array_namespace
+
+
+@dc.patch_function(backend="array_api")
+def double(patch: PatchType) -> PatchType:
+    xp = array_namespace(patch.data)
+    return patch.new(data=xp.multiply(patch.data, 2))
+```
+
+The default, `"numpy"`, means the function needs NumPy arrays. Patches from another backend are then converted to NumPy, the function is applied, and the output is converted back, which issues a `NumpyFallbackWarning`. Use `"array_api"` when the body only uses functions from the standard, as above, in which case it runs on any backend without conversion.
+
+An implementation for one specific backend is added with `register`, which also works on DASCore's own patch functions from your package:
+
+```{python}
+#| eval: false
+import jax.numpy as jnp
+
+
+@dc.proc.detrend.register(jnp)
+def _jax_detrend(patch, dim="time"):
+    ...
+```
+
+The registration key is the name of the array library's *namespace*, which is not always the name of the library: `torch` rather than `pytorch`, `jax` rather than `jaxlib`. Passing the namespace module, as above, or an example array is therefore recommended over passing the string; a misspelled string registers an implementation which is never called. Note that this only works for libraries which implement the standard. Array-likes which merely support `__array__` are handled by NumPy, and report `"numpy"` as their backend.
+
 ## Related guides
 
 - [Contributing](contributing.qmd)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ test = [
     "aiohttp",
     # A reference array API implementation used to catch numpy-only code.
     "array-api-strict",
+    # An array backend which array-api-compat has to wrap, unlike numpy and
+    # array-api-strict, so backend dispatch is tested against both kinds.
+    "dask[array]",
     "coverage>=7.4,<8",
     "pytest-cov>=4",
     "pre-commit",

--- a/tests/test_utils/conftest.py
+++ b/tests/test_utils/conftest.py
@@ -1,0 +1,41 @@
+"""Fixtures for testing dascore's utilities."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+import dascore as dc
+
+# Array backends dascore is tested against, and how to build one of their
+# arrays. array_api_strict implements the standard natively and rejects any
+# numpy leak; dask does not implement it at all and is only usable through
+# array-api-compat's wrapper. Both are test dependencies, but some
+# environments (eg wasm) install dascore without the test extras.
+BACKENDS = {
+    "array_api_strict": ("array_api_strict", "asarray"),
+    "dask": ("dask.array", "from_array"),
+}
+
+
+@pytest.fixture(params=sorted(BACKENDS), scope="class")
+def backend(request) -> str:
+    """The name of the array backend under test."""
+    module_name, _ = BACKENDS[request.param]
+    pytest.importorskip(module_name)
+    return request.param
+
+
+@pytest.fixture(scope="class")
+def to_backend(backend):
+    """Return a function which moves a patch's data to the backend."""
+    module_name, func_name = BACKENDS[backend]
+    factory = getattr(importlib.import_module(module_name), func_name)
+
+    def _to_backend(patch: dc.Patch) -> dc.Patch:
+        """Return the patch with its data on the array backend."""
+        return patch.new(data=factory(np.asarray(patch.data)))
+
+    return _to_backend

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -25,9 +25,13 @@ from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch import _get_backend_name
 from dascore.warnings import NumpyFallbackWarning
 
-# array_api_strict is a test dependency, but some environments (eg wasm)
-# install dascore without the test extras.
-xps = pytest.importorskip("array_api_strict")
+
+@pytest.fixture(scope="module")
+def xps():
+    """The reference implementation of the array API standard."""
+    # It is a test dependency, but some environments (eg wasm) install
+    # dascore without the test extras.
+    return pytest.importorskip("array_api_strict")
 
 
 @contextmanager
@@ -69,7 +73,7 @@ class TestBackendName:
         """Numpy arrays report the numpy backend."""
         assert backend_name(np.array([1, 2])) == "numpy"
 
-    def test_strict(self):
+    def test_strict(self, xps):
         """Other backends report their top-level package name."""
         assert backend_name(xps.asarray([1, 2])) == "array_api_strict"
 
@@ -81,7 +85,7 @@ class TestIsNumpy:
         """Numpy arrays are numpy arrays."""
         assert is_numpy(np.array([1, 2]))
 
-    def test_not_numpy(self):
+    def test_not_numpy(self, xps):
         """Arrays from other backends are not."""
         assert not is_numpy(xps.asarray([1, 2]))
 
@@ -94,7 +98,7 @@ class TestToNumpy:
         array = np.array([1, 2])
         assert to_numpy(array) is array
 
-    def test_other_backend(self):
+    def test_other_backend(self, xps):
         """Other backends are converted to numpy arrays."""
         out = to_numpy(xps.asarray([1.0, 2.0]))
         assert isinstance(out, np.ndarray)
@@ -111,12 +115,12 @@ class TestToNumpy:
 class TestAsArrayLike:
     """Tests for converting arrays back to another backend."""
 
-    def test_numpy_like(self):
+    def test_numpy_like(self, xps):
         """A numpy template returns a numpy array."""
         out = asarray_like(xps.asarray([1.0, 2.0]), np.array([1.0]))
         assert isinstance(out, np.ndarray)
 
-    def test_other_backend_like(self):
+    def test_other_backend_like(self, xps):
         """A non-numpy template returns that backend's array."""
         out = asarray_like(np.array([1.0, 2.0]), xps.asarray([1.0]))
         assert backend_name(out) == "array_api_strict"
@@ -163,12 +167,12 @@ class TestPatchBackends:
         assert "Patch" in str(backend_patch)
 
 
-def test_suppress_fallback_warning(random_patch):
+def test_suppress_fallback_warning(random_patch, to_backend, backend):
     """The fallback warning can be silenced like any other dascore warning."""
-    patch = random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
+    patch = to_backend(random_patch)
     with suppress_warnings(NumpyFallbackWarning):
         out = patch.detrend("time")
-    assert backend_name(out.data) == "array_api_strict"
+    assert backend_name(out.data) == backend
 
 
 def test_backend_name_of_non_array():
@@ -319,12 +323,12 @@ class TestRegisterBackend:
         patch_func.register("array_api_strict")(_identity)
         assert "array_api_strict" in patch_func.backends
 
-    def test_namespace(self, patch_func):
+    def test_namespace(self, patch_func, xps):
         """It can also be named with the array namespace itself."""
         patch_func.register(xps)(_identity)
         assert "array_api_strict" in patch_func.backends
 
-    def test_array(self, patch_func):
+    def test_array(self, patch_func, xps):
         """Or with an example array."""
         patch_func.register(xps.asarray([1.0]))(_identity)
         assert "array_api_strict" in patch_func.backends

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -38,10 +38,10 @@ def warnings_as_errors():
         yield
 
 
-@pytest.fixture(scope="module")
-def strict_patch(random_patch) -> dc.Patch:
-    """Return a patch whose data are backed by array_api_strict."""
-    return random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
+@pytest.fixture(scope="class")
+def backend_patch(random_patch, to_backend) -> dc.Patch:
+    """Return a patch whose data are on the array backend under test."""
+    return to_backend(random_patch)
 
 
 class _DeviceArray:
@@ -125,42 +125,42 @@ class TestAsArrayLike:
 class TestPatchBackends:
     """Tests for patches backed by a non-numpy array library."""
 
-    def test_patch_keeps_backend(self, strict_patch):
+    def test_patch_keeps_backend(self, backend_patch, backend):
         """Creating a patch does not convert the data to numpy."""
-        assert backend_name(strict_patch.data) == "array_api_strict"
+        assert backend_name(backend_patch.data) == backend
 
-    def test_array_api_function_keeps_backend(self, strict_patch):
+    def test_array_api_function_keeps_backend(self, backend_patch, backend):
         """Functions written against the standard don't warn or convert."""
         with warnings_as_errors():
-            out = strict_patch.transpose()
-        assert backend_name(out.data) == "array_api_strict"
-        assert out.dims == strict_patch.dims[::-1]
+            out = backend_patch.transpose()
+        assert backend_name(out.data) == backend
+        assert out.dims == backend_patch.dims[::-1]
 
-    def test_squeeze_keeps_backend(self, strict_patch):
+    def test_squeeze_keeps_backend(self, backend_patch, backend):
         """Squeeze also works on any backend."""
         with suppress_warnings(NumpyFallbackWarning):
-            patch = strict_patch.select(distance=0, samples=True)
+            patch = backend_patch.select(distance=0, samples=True)
         with warnings_as_errors():
             out = patch.squeeze()
-        assert backend_name(out.data) == "array_api_strict"
+        assert backend_name(out.data) == backend
         assert "distance" not in out.dims
 
-    def test_numpy_only_function_warns(self, strict_patch):
+    def test_numpy_only_function_warns(self, backend_patch, backend):
         """Numpy-only functions warn but preserve the input backend."""
         with pytest.warns(NumpyFallbackWarning, match="detrend"):
-            out = strict_patch.detrend("time")
-        assert backend_name(out.data) == "array_api_strict"
-        assert out.shape == strict_patch.shape
+            out = backend_patch.detrend("time")
+        assert backend_name(out.data) == backend
+        assert out.shape == backend_patch.shape
 
-    def test_to_numpy_array(self, strict_patch):
+    def test_to_numpy_array(self, backend_patch):
         """Patches from any backend convert to numpy arrays."""
-        array = np.asarray(strict_patch)
+        array = np.asarray(backend_patch)
         assert isinstance(array, np.ndarray)
-        assert array.shape == strict_patch.shape
+        assert array.shape == backend_patch.shape
 
-    def test_str(self, strict_patch):
+    def test_str(self, backend_patch):
         """Patches from any backend have a string representation."""
-        assert "Patch" in str(strict_patch)
+        assert "Patch" in str(backend_patch)
 
 
 def test_suppress_fallback_warning(random_patch):
@@ -281,16 +281,16 @@ class TestArrayApiPatchFunctions:
         assert not stale, f"remove the ARRAY_API_CASES entry for: {stale}"
 
     @pytest.mark.parametrize("name", sorted(ARRAY_API_CASES))
-    def test_backend_preserved(self, name, random_patch):
+    def test_backend_preserved(self, name, random_patch, to_backend, backend):
         """The function runs on another backend, unconverted, with no warning."""
         case = ARRAY_API_CASES[name]
         numpy_patch = case.setup(random_patch)
-        patch = numpy_patch.new(data=xps.asarray(np.asarray(numpy_patch.data)))
+        patch = to_backend(numpy_patch)
         with warnings_as_errors():
             out = case.call(patch)
         # A function which returns its input proves nothing about the backend.
         assert out is not patch
-        assert backend_name(out.data) == "array_api_strict"
+        assert backend_name(out.data) == backend
         # The whole patch must match what the numpy implementation returns.
         expected = case.call(numpy_patch)
         array = np.asarray(out.data)

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import importlib
+import pkgutil
+import sys
 import warnings
+from collections.abc import Callable
 from contextlib import contextmanager
+from typing import NamedTuple
 
 import numpy as np
 import pytest
 
 import dascore as dc
 from dascore.utils.array_api import (
+    ARRAY_API_BACKEND,
     asarray_like,
     backend_name,
     is_numpy,
@@ -206,3 +212,118 @@ class TestNonStandardArrayLike:
         with warnings_as_errors():
             out = array_like_patch.transpose()
         assert out.dims == array_like_patch.dims[::-1]
+
+
+def _identity(patch):
+    """Return the patch unchanged."""
+    return patch
+
+
+class _Case(NamedTuple):
+    """How to exercise one patch function on a non-numpy backend."""
+
+    call: Callable
+    setup: Callable = _identity
+
+
+# Every patch function which declares the array API backend needs an entry
+# here, which is also the inventory of what has been converted so far.
+# setup runs on the numpy patch, before it is moved to another backend.
+ARRAY_API_CASES = {
+    "dascore.proc.coords.transpose": _Case(call=lambda patch: patch.transpose()),
+    "dascore.proc.coords.squeeze": _Case(
+        call=lambda patch: patch.squeeze(),
+        setup=lambda patch: patch.select(distance=0, samples=True),
+    ),
+}
+
+
+def _get_patch_functions() -> dict[str, Callable]:
+    """Return every patch function dascore defines, keyed by qualified name."""
+    for module in pkgutil.walk_packages(dc.__path__, "dascore."):
+        importlib.import_module(module.name)
+    out = {}
+    for name, module in list(sys.modules.items()):
+        if not name.startswith("dascore"):
+            continue
+        for obj in vars(module).values():
+            if callable(obj) and isinstance(getattr(obj, "backends", None), dict):
+                out[f"{obj.__module__}.{obj.__qualname__}"] = obj
+    return out
+
+
+PATCH_FUNCTIONS = _get_patch_functions()
+ARRAY_API_FUNCTIONS = {
+    i: v for i, v in PATCH_FUNCTIONS.items() if ARRAY_API_BACKEND in v.backends
+}
+
+
+class TestArrayApiPatchFunctions:
+    """Every patch function which declares the array API must work on it."""
+
+    def test_patch_functions_found(self):
+        """The discovery finds dascore's patch functions."""
+        assert len(PATCH_FUNCTIONS) > 50
+        assert "dascore.proc.detrend.detrend" in PATCH_FUNCTIONS
+
+    def test_every_function_has_a_case(self):
+        """Declaring the array API backend requires proving it works."""
+        missing = sorted(set(ARRAY_API_FUNCTIONS) - set(ARRAY_API_CASES))
+        assert not missing, f"add an ARRAY_API_CASES entry for: {missing}"
+
+    def test_no_stale_cases(self):
+        """Cases for functions which no longer declare the array API."""
+        stale = sorted(set(ARRAY_API_CASES) - set(ARRAY_API_FUNCTIONS))
+        assert not stale, f"remove the ARRAY_API_CASES entry for: {stale}"
+
+    @pytest.mark.parametrize("name", sorted(ARRAY_API_CASES))
+    def test_backend_preserved(self, name, random_patch):
+        """The function runs on another backend, unconverted, with no warning."""
+        case = ARRAY_API_CASES[name]
+        numpy_patch = case.setup(random_patch)
+        patch = numpy_patch.new(data=xps.asarray(np.asarray(numpy_patch.data)))
+        with warnings_as_errors():
+            out = case.call(patch)
+        # A function which returns its input proves nothing about the backend.
+        assert out is not patch
+        assert backend_name(out.data) == "array_api_strict"
+        expected = case.call(numpy_patch)
+        assert np.allclose(np.asarray(out.data), np.asarray(expected.data))
+
+
+class TestRegisterBackend:
+    """Tests for naming the backend an implementation is registered under."""
+
+    @pytest.fixture
+    def patch_func(self):
+        """A patch function with only a numpy implementation."""
+
+        @dc.patch_function()
+        def func(patch):
+            return patch
+
+        return func
+
+    def test_string(self, patch_func):
+        """A backend can be named with a string."""
+        patch_func.register("array_api_strict")(_identity)
+        assert "array_api_strict" in patch_func.backends
+
+    def test_namespace(self, patch_func):
+        """It can also be named with the array namespace itself."""
+        patch_func.register(xps)(_identity)
+        assert "array_api_strict" in patch_func.backends
+
+    def test_array(self, patch_func):
+        """Or with an example array."""
+        patch_func.register(xps.asarray([1.0]))(_identity)
+        assert "array_api_strict" in patch_func.backends
+
+    def test_decorator_argument(self):
+        """The decorator's backend argument accepts the same forms."""
+
+        @dc.patch_function(backend=np)
+        def func(patch):
+            return patch
+
+        assert set(func.backends) == {"numpy"}

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -231,6 +231,10 @@ class _Case(NamedTuple):
 # setup runs on the numpy patch, before it is moved to another backend.
 ARRAY_API_CASES = {
     "dascore.proc.coords.transpose": _Case(call=lambda patch: patch.transpose()),
+    "dascore.proc.coords.make_broadcastable_to": _Case(
+        call=lambda patch: patch.make_broadcastable_to((patch.shape[0], 3)),
+        setup=lambda patch: patch.mean("time"),
+    ),
     "dascore.proc.coords.squeeze": _Case(
         call=lambda patch: patch.squeeze(),
         setup=lambda patch: patch.select(distance=0, samples=True),
@@ -287,8 +291,14 @@ class TestArrayApiPatchFunctions:
         # A function which returns its input proves nothing about the backend.
         assert out is not patch
         assert backend_name(out.data) == "array_api_strict"
+        # The whole patch must match what the numpy implementation returns.
         expected = case.call(numpy_patch)
-        assert np.allclose(np.asarray(out.data), np.asarray(expected.data))
+        array = np.asarray(out.data)
+        assert array.dtype == expected.data.dtype
+        assert out.dims == expected.dims
+        assert out.coords == expected.coords
+        assert out.attrs == expected.attrs
+        assert np.allclose(array, np.asarray(expected.data), equal_nan=True)
 
 
 class TestRegisterBackend:

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -29,11 +29,25 @@ from dascore.utils.array import (
     is_string_byte_serializable_array,
 )
 from dascore.utils.array_api import backend_name
+from dascore.utils.misc import suppress_warnings
 from dascore.warnings import NumpyFallbackWarning
 
 # array_api_strict is a test dependency, but some environments (eg wasm)
 # install dascore without the test extras.
 xps = pytest.importorskip("array_api_strict")
+
+
+class _OtherBackendArray:
+    """An array which claims to belong to a different array API backend."""
+
+    def __init__(self, array):
+        self._array = array
+        self.shape = array.shape
+        self.dtype = array.dtype
+
+    def __array_namespace__(self, api_version=None):
+        """Return a namespace which is not the one under test."""
+        return np
 
 
 @contextmanager
@@ -736,10 +750,26 @@ class TestArrayBackends:
         """A patch whose data are backed by array_api_strict."""
         return random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
 
+    @pytest.fixture(scope="class")
+    def int_numpy_patch(self, random_patch) -> dc.Patch:
+        """A patch with integer data."""
+        data = (np.asarray(random_patch.data) * 10).astype("int32")
+        return random_patch.new(data=data)
+
+    @pytest.fixture(scope="class")
+    def int_patch(self, int_numpy_patch) -> dc.Patch:
+        """A patch with integer data backed by array_api_strict."""
+        return int_numpy_patch.new(data=xps.asarray(np.asarray(int_numpy_patch.data)))
+
     def _assert_matches_numpy(self, out, expected):
-        """The output keeps its backend and agrees with the numpy result."""
+        """The output keeps its backend and matches the patch numpy returns."""
         assert backend_name(out.data) == "array_api_strict"
-        assert np.allclose(np.asarray(out.data), np.asarray(expected.data))
+        array = np.asarray(out.data)
+        assert array.dtype == expected.data.dtype
+        assert out.dims == expected.dims
+        assert out.coords == expected.coords
+        assert out.attrs == expected.attrs
+        assert np.allclose(array, np.asarray(expected.data), equal_nan=True)
 
     def test_scalar_operand(self, strict_patch, random_patch):
         """Operations with python scalars stay on the patch's backend."""
@@ -817,6 +847,56 @@ class TestArrayBackends:
         """Each renamed ufunc exists under both names."""
         assert isinstance(getattr(np, numpy_name), np.ufunc)
         assert hasattr(xps, array_api_name)
+
+    def test_numpy_scalar_operand(self, strict_patch, random_patch):
+        """Numpy scalars are converted; they are not python scalars."""
+        with warnings_as_errors():
+            out = strict_patch + np.float64(1)
+        self._assert_matches_numpy(out, random_patch + np.float64(1))
+
+    def test_sequence_operand_falls_back(self, strict_patch, random_patch):
+        """Sequences have no dtype, and the standard won't promote them."""
+        other = [1] * strict_patch.shape[-1]
+        with pytest.warns(NumpyFallbackWarning):
+            out = strict_patch + other
+        self._assert_matches_numpy(out, random_patch + other)
+
+    def test_ufunc_keyword_falls_back(self, strict_patch, random_patch):
+        """Numpy-only ufunc keywords have no array API equivalent."""
+        where = np.ones(strict_patch.shape, dtype=bool)
+        with pytest.warns(NumpyFallbackWarning):
+            out = np.add(strict_patch, 1, where=where)
+        self._assert_matches_numpy(out, np.add(random_patch, 1, where=where))
+
+    def test_stored_units_fall_back(self, strict_patch, random_patch):
+        """Units stored on a patch become quantities when patches align."""
+        with suppress_warnings(NumpyFallbackWarning):
+            out = strict_patch.set_units("m") * strict_patch.set_units("m")
+        expected = random_patch.set_units("m") * random_patch.set_units("m")
+        self._assert_matches_numpy(out, expected)
+        assert out.attrs.data_units == expected.attrs.data_units
+
+    def test_integer_data_falls_back(self, int_patch, int_numpy_patch):
+        """Numpy and the standard disagree most on integer data."""
+        with pytest.warns(NumpyFallbackWarning):
+            out = np.rint(int_patch)
+        # numpy casts integers up to floats here, the standard does not.
+        expected = np.rint(int_numpy_patch)
+        assert np.asarray(out.data).dtype == expected.data.dtype
+        assert backend_name(out.data) == "array_api_strict"
+
+    def test_broadcast_keeps_backend(self, strict_patch, random_patch):
+        """Broadcasting a patch up to a shape doesn't convert its data."""
+        collapsed = strict_patch.mean("time")
+        with suppress_warnings(NumpyFallbackWarning):
+            out = collapsed.make_broadcastable_to(strict_patch.shape)
+        assert backend_name(out.data) == "array_api_strict"
+        assert out.shape == strict_patch.shape
+
+    def test_other_backend_operand(self, strict_patch):
+        """An array from a third backend is not passed to this one."""
+        other = _OtherBackendArray(np.ones(strict_patch.shape))
+        assert not array_utils._operand_can_apply(other, strict_patch.data)
 
     @pytest.mark.parametrize("ufunc", [np.absolute, np.power, np.arctan2, np.rint])
     def test_renamed_ufunc_values(self, ufunc, strict_patch, random_patch):

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -28,7 +28,7 @@ from dascore.utils.array import (
     hash_array,
     is_string_byte_serializable_array,
 )
-from dascore.utils.array_api import backend_name
+from dascore.utils.array_api import array_namespace, backend_name
 from dascore.utils.misc import suppress_warnings
 from dascore.warnings import NumpyFallbackWarning
 
@@ -746,9 +746,9 @@ class TestArrayBackends:
     """Tests for operators applied to patches backed by other array libraries."""
 
     @pytest.fixture(scope="class")
-    def strict_patch(self, random_patch) -> dc.Patch:
-        """A patch whose data are backed by array_api_strict."""
-        return random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
+    def backend_patch(self, random_patch, to_backend) -> dc.Patch:
+        """A patch whose data are backed by the array backend under test."""
+        return to_backend(random_patch)
 
     @pytest.fixture(scope="class")
     def int_numpy_patch(self, random_patch) -> dc.Patch:
@@ -757,13 +757,13 @@ class TestArrayBackends:
         return random_patch.new(data=data)
 
     @pytest.fixture(scope="class")
-    def int_patch(self, int_numpy_patch) -> dc.Patch:
-        """A patch with integer data backed by array_api_strict."""
-        return int_numpy_patch.new(data=xps.asarray(np.asarray(int_numpy_patch.data)))
+    def int_patch(self, int_numpy_patch, to_backend) -> dc.Patch:
+        """A patch with integer data on the backend under test."""
+        return to_backend(int_numpy_patch)
 
-    def _assert_matches_numpy(self, out, expected):
+    def _assert_matches_numpy(self, out, expected, backend):
         """The output keeps its backend and matches the patch numpy returns."""
-        assert backend_name(out.data) == "array_api_strict"
+        assert backend_name(out.data) == backend
         array = np.asarray(out.data)
         assert array.dtype == expected.data.dtype
         assert out.dims == expected.dims
@@ -771,76 +771,86 @@ class TestArrayBackends:
         assert out.attrs == expected.attrs
         assert np.allclose(array, np.asarray(expected.data), equal_nan=True)
 
-    def test_scalar_operand(self, strict_patch, random_patch):
+    def test_scalar_operand(self, backend_patch, random_patch, backend):
         """Operations with python scalars stay on the patch's backend."""
         with warnings_as_errors():
-            out = strict_patch / 10 + 1
-        self._assert_matches_numpy(out, random_patch / 10 + 1)
+            out = backend_patch / 10 + 1
+        self._assert_matches_numpy(out, random_patch / 10 + 1, backend)
 
-    def test_patch_operand(self, strict_patch, random_patch):
+    def test_patch_operand(self, backend_patch, random_patch, backend):
         """So do operations between two patches."""
         with warnings_as_errors():
-            out = strict_patch * strict_patch
-        self._assert_matches_numpy(out, random_patch * random_patch)
+            out = backend_patch * backend_patch
+        self._assert_matches_numpy(out, random_patch * random_patch, backend)
 
-    def test_reversed_operand(self, strict_patch, random_patch):
+    def test_reversed_operand(self, backend_patch, random_patch, backend):
         """Reversed operators (scalar on the left) also work."""
         with warnings_as_errors():
-            out = 1 - strict_patch
-        self._assert_matches_numpy(out, 1 - random_patch)
+            out = 1 - backend_patch
+        self._assert_matches_numpy(out, 1 - random_patch, backend)
 
-    def test_unary_ufunc(self, strict_patch, random_patch):
+    def test_unary_ufunc(self, backend_patch, random_patch, backend):
         """Unary ufuncs use the backend's own implementation."""
         with warnings_as_errors():
-            out = np.exp(strict_patch)
-        self._assert_matches_numpy(out, np.exp(random_patch))
+            out = np.exp(backend_patch)
+        self._assert_matches_numpy(out, np.exp(random_patch), backend)
 
-    def test_numpy_array_operand(self, strict_patch, random_patch):
+    def test_numpy_array_operand(self, backend_patch, random_patch, backend):
         """A numpy array operand is converted to the patch's backend."""
-        other = np.ones(strict_patch.shape)
+        other = np.ones(backend_patch.shape)
         with warnings_as_errors():
-            out = strict_patch + other
-        self._assert_matches_numpy(out, random_patch + other)
+            out = backend_patch + other
+        self._assert_matches_numpy(out, random_patch + other, backend)
 
-    def test_comparison_clears_units(self, strict_patch):
+    def test_comparison_clears_units(self, backend_patch, backend):
         """Comparisons return bool data, which have no units."""
         with warnings_as_errors():
-            out = strict_patch > 0
-        assert backend_name(out.data) == "array_api_strict"
-        assert xps.isdtype(out.data.dtype, "bool")
+            out = backend_patch > 0
+        assert backend_name(out.data) == backend
+        assert array_namespace(out.data).isdtype(out.data.dtype, "bool")
         assert out.attrs.data_units is None
 
-    def test_dtype_argument(self, strict_patch):
+    def test_dtype_argument(self, backend_patch, backend):
         """A dtype argument is not mistaken for an array from the backend."""
         with pytest.warns(NumpyFallbackWarning):
-            out = strict_patch.add.reduce(dim="time", dtype=np.float32)
-        assert backend_name(out.data) == "array_api_strict"
+            out = backend_patch.add.reduce(dim="time", dtype=np.float32)
+        assert backend_name(out.data) == backend
 
-    def test_reduce_falls_back(self, strict_patch, random_patch):
+    def test_reduce_falls_back(self, backend_patch, random_patch, backend):
         """Reductions have no array API equivalent, so they use numpy."""
         with pytest.warns(NumpyFallbackWarning, match="reduce"):
-            out = strict_patch.add.reduce(dim="time")
-        self._assert_matches_numpy(out, random_patch.add.reduce(dim="time"))
+            out = backend_patch.add.reduce(dim="time")
+        self._assert_matches_numpy(out, random_patch.add.reduce(dim="time"), backend)
 
-    def test_array_function_falls_back(self, strict_patch, random_patch):
+    def test_array_function_falls_back(self, backend_patch, random_patch, backend):
         """So do numpy functions applied to a patch."""
         with pytest.warns(NumpyFallbackWarning, match="mean"):
-            out = np.mean(strict_patch, axis=0)
-        self._assert_matches_numpy(out, np.mean(random_patch, axis=0))
+            out = np.mean(backend_patch, axis=0)
+        self._assert_matches_numpy(out, np.mean(random_patch, axis=0), backend)
 
-    def test_units_fall_back(self, strict_patch, random_patch):
+    def test_units_fall_back(self, backend_patch, random_patch, backend):
         """Units are implemented with pint, which only wraps numpy arrays."""
         with pytest.warns(NumpyFallbackWarning):
-            out = strict_patch * get_quantity("m")
+            out = backend_patch * get_quantity("m")
         expected = random_patch * get_quantity("m")
-        self._assert_matches_numpy(out, expected)
+        self._assert_matches_numpy(out, expected, backend)
         assert out.attrs.data_units == expected.attrs.data_units
 
-    def test_ufunc_without_equivalent_falls_back(self, strict_patch, random_patch):
-        """Ufuncs the standard doesn't define use numpy."""
-        with pytest.warns(NumpyFallbackWarning, match="fmod"):
-            out = np.fmod(strict_patch, 2)
-        self._assert_matches_numpy(out, np.fmod(random_patch, 2))
+    def test_ufunc_outside_the_standard(self, backend_patch, random_patch, backend):
+        """Ufuncs the standard doesn't define still match numpy.
+
+        Whether they need the numpy fallback depends on the backend, since
+        array-api-compat's wrappers expose more than the standard requires.
+        """
+        with suppress_warnings(NumpyFallbackWarning):
+            out = np.fmod(backend_patch, 2)
+        self._assert_matches_numpy(out, np.fmod(random_patch, 2), backend)
+
+    def test_no_equivalent_in_the_standard(self):
+        """A ufunc the standard lacks has no equivalent to look up."""
+        array = xps.asarray([1.0, 2.0])
+        assert array_utils._get_backend_ufunc(np.fmod, array) is None
+        assert array_utils._get_backend_ufunc(np.power, array) is xps.pow
 
     @pytest.mark.parametrize("numpy_name,array_api_name", sorted(UFUNC_NAMES.items()))
     def test_renamed_ufuncs_exist(self, numpy_name, array_api_name):
@@ -848,60 +858,60 @@ class TestArrayBackends:
         assert isinstance(getattr(np, numpy_name), np.ufunc)
         assert hasattr(xps, array_api_name)
 
-    def test_numpy_scalar_operand(self, strict_patch, random_patch):
+    def test_numpy_scalar_operand(self, backend_patch, random_patch, backend):
         """Numpy scalars are converted; they are not python scalars."""
         with warnings_as_errors():
-            out = strict_patch + np.float64(1)
-        self._assert_matches_numpy(out, random_patch + np.float64(1))
+            out = backend_patch + np.float64(1)
+        self._assert_matches_numpy(out, random_patch + np.float64(1), backend)
 
-    def test_sequence_operand_falls_back(self, strict_patch, random_patch):
+    def test_sequence_operand_falls_back(self, backend_patch, random_patch, backend):
         """Sequences have no dtype, and the standard won't promote them."""
-        other = [1] * strict_patch.shape[-1]
+        other = [1] * backend_patch.shape[-1]
         with pytest.warns(NumpyFallbackWarning):
-            out = strict_patch + other
-        self._assert_matches_numpy(out, random_patch + other)
+            out = backend_patch + other
+        self._assert_matches_numpy(out, random_patch + other, backend)
 
-    def test_ufunc_keyword_falls_back(self, strict_patch, random_patch):
+    def test_ufunc_keyword_falls_back(self, backend_patch, random_patch, backend):
         """Numpy-only ufunc keywords have no array API equivalent."""
-        where = np.ones(strict_patch.shape, dtype=bool)
+        where = np.ones(backend_patch.shape, dtype=bool)
         with pytest.warns(NumpyFallbackWarning):
-            out = np.add(strict_patch, 1, where=where)
-        self._assert_matches_numpy(out, np.add(random_patch, 1, where=where))
+            out = np.add(backend_patch, 1, where=where)
+        self._assert_matches_numpy(out, np.add(random_patch, 1, where=where), backend)
 
-    def test_stored_units_fall_back(self, strict_patch, random_patch):
+    def test_stored_units_fall_back(self, backend_patch, random_patch, backend):
         """Units stored on a patch become quantities when patches align."""
         with suppress_warnings(NumpyFallbackWarning):
-            out = strict_patch.set_units("m") * strict_patch.set_units("m")
+            out = backend_patch.set_units("m") * backend_patch.set_units("m")
         expected = random_patch.set_units("m") * random_patch.set_units("m")
-        self._assert_matches_numpy(out, expected)
+        self._assert_matches_numpy(out, expected, backend)
         assert out.attrs.data_units == expected.attrs.data_units
 
-    def test_integer_data_falls_back(self, int_patch, int_numpy_patch):
+    def test_integer_data_falls_back(self, int_patch, int_numpy_patch, backend):
         """Numpy and the standard disagree most on integer data."""
         with pytest.warns(NumpyFallbackWarning):
             out = np.rint(int_patch)
         # numpy casts integers up to floats here, the standard does not.
         expected = np.rint(int_numpy_patch)
         assert np.asarray(out.data).dtype == expected.data.dtype
-        assert backend_name(out.data) == "array_api_strict"
+        assert backend_name(out.data) == backend
 
-    def test_broadcast_keeps_backend(self, strict_patch, random_patch):
+    def test_broadcast_keeps_backend(self, backend_patch, random_patch, backend):
         """Broadcasting a patch up to a shape doesn't convert its data."""
-        collapsed = strict_patch.mean("time")
+        collapsed = backend_patch.mean("time")
         with suppress_warnings(NumpyFallbackWarning):
-            out = collapsed.make_broadcastable_to(strict_patch.shape)
-        assert backend_name(out.data) == "array_api_strict"
-        assert out.shape == strict_patch.shape
+            out = collapsed.make_broadcastable_to(backend_patch.shape)
+        assert backend_name(out.data) == backend
+        assert out.shape == backend_patch.shape
 
-    def test_other_backend_operand(self, strict_patch):
+    def test_other_backend_operand(self, backend_patch, backend):
         """An array from a third backend is not passed to this one."""
-        other = _OtherBackendArray(np.ones(strict_patch.shape))
-        assert not array_utils._operand_can_apply(other, strict_patch.data)
+        other = _OtherBackendArray(np.ones(backend_patch.shape))
+        assert not array_utils._operand_can_apply(other, backend_patch.data)
 
     @pytest.mark.parametrize("ufunc", [np.absolute, np.power, np.arctan2, np.rint])
-    def test_renamed_ufunc_values(self, ufunc, strict_patch, random_patch):
+    def test_renamed_ufunc_values(self, ufunc, backend_patch, random_patch, backend):
         """Renamed ufuncs give the same answer as numpy does."""
         with warnings_as_errors():
-            out = ufunc(strict_patch, 2) if ufunc.nin == 2 else ufunc(strict_patch)
+            out = ufunc(backend_patch, 2) if ufunc.nin == 2 else ufunc(backend_patch)
         expected = ufunc(random_patch, 2) if ufunc.nin == 2 else ufunc(random_patch)
-        self._assert_matches_numpy(out, expected)
+        self._assert_matches_numpy(out, expected, backend)

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -4,6 +4,9 @@ Tests for patch ufuncs.
 
 from __future__ import annotations
 
+import warnings
+from contextlib import contextmanager
+
 import numpy as np
 import pytest
 from pint import DimensionalityError
@@ -15,6 +18,7 @@ from dascore import get_quantity
 from dascore.exceptions import ParameterError, UnitError
 from dascore.units import furlongs, m, s
 from dascore.utils.array import (
+    UFUNC_NAMES,
     PatchUFunc,
     _BoundPatchUFunc,
     apply_array_func,
@@ -24,6 +28,20 @@ from dascore.utils.array import (
     hash_array,
     is_string_byte_serializable_array,
 )
+from dascore.utils.array_api import backend_name
+from dascore.warnings import NumpyFallbackWarning
+
+# array_api_strict is a test dependency, but some environments (eg wasm)
+# install dascore without the test extras.
+xps = pytest.importorskip("array_api_strict")
+
+
+@contextmanager
+def warnings_as_errors():
+    """A context manager which raises rather than warns."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        yield
 
 
 class TestApplyUfunc:
@@ -708,3 +726,102 @@ class TestHashArray:
         """Datetime arrays should hash without special casing at call sites."""
         arr = np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[ns]")
         assert hash_array(arr) == hash_array(arr.copy())
+
+
+class TestArrayBackends:
+    """Tests for operators applied to patches backed by other array libraries."""
+
+    @pytest.fixture(scope="class")
+    def strict_patch(self, random_patch) -> dc.Patch:
+        """A patch whose data are backed by array_api_strict."""
+        return random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
+
+    def _assert_matches_numpy(self, out, expected):
+        """The output keeps its backend and agrees with the numpy result."""
+        assert backend_name(out.data) == "array_api_strict"
+        assert np.allclose(np.asarray(out.data), np.asarray(expected.data))
+
+    def test_scalar_operand(self, strict_patch, random_patch):
+        """Operations with python scalars stay on the patch's backend."""
+        with warnings_as_errors():
+            out = strict_patch / 10 + 1
+        self._assert_matches_numpy(out, random_patch / 10 + 1)
+
+    def test_patch_operand(self, strict_patch, random_patch):
+        """So do operations between two patches."""
+        with warnings_as_errors():
+            out = strict_patch * strict_patch
+        self._assert_matches_numpy(out, random_patch * random_patch)
+
+    def test_reversed_operand(self, strict_patch, random_patch):
+        """Reversed operators (scalar on the left) also work."""
+        with warnings_as_errors():
+            out = 1 - strict_patch
+        self._assert_matches_numpy(out, 1 - random_patch)
+
+    def test_unary_ufunc(self, strict_patch, random_patch):
+        """Unary ufuncs use the backend's own implementation."""
+        with warnings_as_errors():
+            out = np.exp(strict_patch)
+        self._assert_matches_numpy(out, np.exp(random_patch))
+
+    def test_numpy_array_operand(self, strict_patch, random_patch):
+        """A numpy array operand is converted to the patch's backend."""
+        other = np.ones(strict_patch.shape)
+        with warnings_as_errors():
+            out = strict_patch + other
+        self._assert_matches_numpy(out, random_patch + other)
+
+    def test_comparison_clears_units(self, strict_patch):
+        """Comparisons return bool data, which have no units."""
+        with warnings_as_errors():
+            out = strict_patch > 0
+        assert backend_name(out.data) == "array_api_strict"
+        assert xps.isdtype(out.data.dtype, "bool")
+        assert out.attrs.data_units is None
+
+    def test_dtype_argument(self, strict_patch):
+        """A dtype argument is not mistaken for an array from the backend."""
+        with pytest.warns(NumpyFallbackWarning):
+            out = strict_patch.add.reduce(dim="time", dtype=np.float32)
+        assert backend_name(out.data) == "array_api_strict"
+
+    def test_reduce_falls_back(self, strict_patch, random_patch):
+        """Reductions have no array API equivalent, so they use numpy."""
+        with pytest.warns(NumpyFallbackWarning, match="reduce"):
+            out = strict_patch.add.reduce(dim="time")
+        self._assert_matches_numpy(out, random_patch.add.reduce(dim="time"))
+
+    def test_array_function_falls_back(self, strict_patch, random_patch):
+        """So do numpy functions applied to a patch."""
+        with pytest.warns(NumpyFallbackWarning, match="mean"):
+            out = np.mean(strict_patch, axis=0)
+        self._assert_matches_numpy(out, np.mean(random_patch, axis=0))
+
+    def test_units_fall_back(self, strict_patch, random_patch):
+        """Units are implemented with pint, which only wraps numpy arrays."""
+        with pytest.warns(NumpyFallbackWarning):
+            out = strict_patch * get_quantity("m")
+        expected = random_patch * get_quantity("m")
+        self._assert_matches_numpy(out, expected)
+        assert out.attrs.data_units == expected.attrs.data_units
+
+    def test_ufunc_without_equivalent_falls_back(self, strict_patch, random_patch):
+        """Ufuncs the standard doesn't define use numpy."""
+        with pytest.warns(NumpyFallbackWarning, match="fmod"):
+            out = np.fmod(strict_patch, 2)
+        self._assert_matches_numpy(out, np.fmod(random_patch, 2))
+
+    @pytest.mark.parametrize("numpy_name,array_api_name", sorted(UFUNC_NAMES.items()))
+    def test_renamed_ufuncs_exist(self, numpy_name, array_api_name):
+        """Each renamed ufunc exists under both names."""
+        assert isinstance(getattr(np, numpy_name), np.ufunc)
+        assert hasattr(xps, array_api_name)
+
+    @pytest.mark.parametrize("ufunc", [np.absolute, np.power, np.arctan2, np.rint])
+    def test_renamed_ufunc_values(self, ufunc, strict_patch, random_patch):
+        """Renamed ufuncs give the same answer as numpy does."""
+        with warnings_as_errors():
+            out = ufunc(strict_patch, 2) if ufunc.nin == 2 else ufunc(strict_patch)
+        expected = ufunc(random_patch, 2) if ufunc.nin == 2 else ufunc(random_patch)
+        self._assert_matches_numpy(out, expected)

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -32,10 +32,6 @@ from dascore.utils.array_api import array_namespace, backend_name
 from dascore.utils.misc import suppress_warnings
 from dascore.warnings import NumpyFallbackWarning
 
-# array_api_strict is a test dependency, but some environments (eg wasm)
-# install dascore without the test extras.
-xps = pytest.importorskip("array_api_strict")
-
 
 class _OtherBackendArray:
     """An array which claims to belong to a different array API backend."""
@@ -746,6 +742,11 @@ class TestArrayBackends:
     """Tests for operators applied to patches backed by other array libraries."""
 
     @pytest.fixture(scope="class")
+    def xps(self):
+        """The reference implementation of the array API standard."""
+        return pytest.importorskip("array_api_strict")
+
+    @pytest.fixture(scope="class")
     def backend_patch(self, random_patch, to_backend) -> dc.Patch:
         """A patch whose data are backed by the array backend under test."""
         return to_backend(random_patch)
@@ -846,14 +847,14 @@ class TestArrayBackends:
             out = np.fmod(backend_patch, 2)
         self._assert_matches_numpy(out, np.fmod(random_patch, 2), backend)
 
-    def test_no_equivalent_in_the_standard(self):
+    def test_no_equivalent_in_the_standard(self, xps):
         """A ufunc the standard lacks has no equivalent to look up."""
         array = xps.asarray([1.0, 2.0])
         assert array_utils._get_backend_ufunc(np.fmod, array) is None
         assert array_utils._get_backend_ufunc(np.power, array) is xps.pow
 
     @pytest.mark.parametrize("numpy_name,array_api_name", sorted(UFUNC_NAMES.items()))
-    def test_renamed_ufuncs_exist(self, numpy_name, array_api_name):
+    def test_renamed_ufuncs_exist(self, numpy_name, array_api_name, xps):
         """Each renamed ufunc exists under both names."""
         assert isinstance(getattr(np, numpy_name), np.ufunc)
         assert hasattr(xps, array_api_name)


### PR DESCRIPTION
## Description

Second step toward making the `Patch` data path array-backend agnostic, following #908. That PR routed *patch functions* through a backend registry; this one does the operator surface.

Every `Patch` operator — `+`, `*`, `>`, `patch.exp()`, `np.abs(patch)`, `patch.add.reduce(...)` — funnels through `apply_ufunc` with a numpy ufunc object. Applying a numpy ufunc to a non-numpy array silently converts it, so `patch + 1` on a jax-backed patch quietly returned numpy data. Now:

- Numpy ufuncs are resolved to their array API spelling and applied in the data's own namespace. Most names match; the ones that don't are in a small `UFUNC_NAMES` map (`power` → `pow`, `absolute` → `abs`, `arctan2` → `atan2`, `invert` → `bitwise_invert`, …).
- The native path is deliberately narrow. A matching name does not mean a matching operation: `np.rint` casts integers up to floats where the standard's `round` leaves them alone, and numpy's transcendentals accept integers where the standard's reject them. Since the numpy fallback is always correct, the standard is used only where the two are known to agree — floating point data, python scalars or same-kind arrays from the same namespace, no ufunc keywords, no units. Everything else, including all integer and boolean data, uses numpy and converts back.
- The operations numpy alone can do — reductions and accumulations, `__array_function__` calls such as `np.mean(patch)`, operands carrying pint units (whether passed in or stored in `attrs.data_units`), and ufuncs the standard doesn't define such as `np.fmod` — convert to numpy, warn `NumpyFallbackWarning`, and convert the result back to the input backend.
- `_clear_units_if_bool_dtype` uses `xp.isdtype` instead of `np.issubdtype`, which raises on non-numpy dtypes.
- `CoordManager.make_broadcastable_to` broadcasts in the array's own namespace and `Patch.make_broadcastable_to` is written to the standard, so broadcasting a patch no longer converts it. Reading an operand's `shape` no longer materializes it either.

Also in this PR, agreed while reviewing #908:

- `register` and `patch_function(backend=...)` accept an array API namespace or an example array as well as a name: `@detrend.register(jnp)`. The key is the name of a library's *namespace*, which is not always the library's name (`torch`, not `pytorch`), and a misspelled string silently registers an implementation that never runs. The module form can't be misspelled, and is what the docs now recommend.
- A contract test walks the package, finds every patch function declaring `backend="array_api"`, and requires an entry in `ARRAY_API_CASES` exercising it: no warning, backend preserved, same dtype, dims, coords, attrs, and values as the numpy run, and the call must not be a no-op. Declaring the array API backend without proving it now fails CI, and the case table doubles as the running inventory of what has been converted.
- `dask` joins `array-api-strict` as a test dependency and the backend tests run against both. They are the two kinds of backend that exist: one implementing the standard natively, one that array-api-compat has to wrap. That distinction is not cosmetic — it is what the `is_foreign` bug below turned on, and strict alone could never have caught it.
- Two bugs in #908's fallback, both found by review of this PR. `np.float32` passed as a `dtype=` argument was mistaken for array data, since type objects inherit `__array_namespace__` from their instances. And `is_foreign` only recognized arrays exposing `__array_namespace__`, which dask and torch do not — so their patches were classified as numpy and silently computed into numpy arrays. Classification now goes through array-api-compat, which knows those types.

Numpy-backed patches take exactly the path they did before: `_apply_operator` hands them straight to the numpy ufunc, and the patch history is byte for byte what `dev` produces.

## Changelog

- changed: `Patch` operators, `patch.<ufunc>()` methods, and numpy ufuncs applied to a patch now compute in the array backend of the patch data rather than converting it to numpy.
- changed: `Patch.make_broadcastable_to` preserves the array backend of the patch data.
- changed: `dc.patch_function`'s `backend` argument and the `register` method of patch functions accept an array API namespace or an example array in addition to a backend name.
- fixed: a `dtype` argument such as `np.float32` is no longer mistaken for array data when a patch function falls back to numpy.
- fixed: array backends which do not implement the array API standard natively, such as dask and torch, are recognized as non-numpy rather than being silently converted.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for working with patch data across compatible array backends.
  - Operations preserve the selected backend when supported.
  - Automatically converts compatible operands and handles cross-backend operations.
  - Provides NumPy fallback support for unsupported operations, with clear warnings.
  - Improved broadcasting and boolean handling across array implementations.

- **Documentation**
  - Added guidance for configuring array backends and registering backend-specific functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->