### PR TITLE
Keep an annotation value of 1 through serialization

### DIFF
--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -37,6 +37,7 @@ from pydantic import (
     BeforeValidator,
     Field,
     field_validator,
+    model_serializer,
     model_validator,
 )
 from typing_extensions import Self
@@ -696,6 +697,21 @@ class OpticalPathAnnotation(_IntervalModel):
             )
             raise ValueError(msg)
         return value
+
+    @model_serializer(mode="wrap")
+    def _keep_the_value(self, handler, info):
+        """
+        Put back a value which is the default only by ``==``.
+
+        ``exclude_defaults`` compares with ``==``, and ``1 == True``, so a
+        group numbered from one loses every ``1`` on the way out and reloads
+        holding a boolean -- which then mixes kinds with the numbers beside
+        it and is refused. Identity is what "still its default" means here.
+        """
+        out = handler(self)
+        if "value" not in out and self.value is not True:
+            out["value"] = self.value
+        return out
 
 
 # The coordinates a DistanceMap may be written in, in preference order.

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -37,7 +37,6 @@ from pydantic import (
     BeforeValidator,
     Field,
     field_validator,
-    model_serializer,
     model_validator,
 )
 from typing_extensions import Self
@@ -666,6 +665,14 @@ class CouplingCondition(_IntervalModel):
     )
 
 
+def _wanted(field: str, info) -> bool:
+    """Whether a serialization's own include/exclude asked for a field."""
+    if (exclude := getattr(info, "exclude", None)) and field in exclude:
+        return False
+    include = getattr(info, "include", None)
+    return not include or field in include
+
+
 class OpticalPathAnnotation(_IntervalModel):
     """
     Key/value annotation attached to an interval of an optical path.
@@ -698,19 +705,27 @@ class OpticalPathAnnotation(_IntervalModel):
             raise ValueError(msg)
         return value
 
-    @model_serializer(mode="wrap")
-    def _keep_the_value(self, handler, info):
+    def _write_object_type(self, handler, info):
         """
-        Put back a value which is the default only by ``==``.
+        Tag the document as every model does, and keep the value with it.
 
-        ``exclude_defaults`` compares with ``==``, and ``1 == True``, so a
-        group numbered from one loses every ``1`` on the way out and reloads
-        holding a boolean -- which then mixes kinds with the numbers beside
-        it and is refused. Identity is what "still its default" means here.
+        Overridden rather than added beside: pydantic runs one model
+        serializer per class, so a second one here would take the base's
+        place and drop the ``object_type`` every document is dispatched by.
+
+        The value itself needs putting back because ``exclude_defaults``
+        compares with ``==`` and ``1 == True``, the default. A group
+        numbered from one would otherwise lose every ``1`` on the way out
+        and reload holding a boolean, which then mixes kinds with the
+        numbers beside it and is refused. Identity is what "still its
+        default" means for a field admitting both. A caller who asked for
+        the value to be left out is obeyed: this restores what
+        exclude_defaults dropped, not what anyone chose to filter.
         """
-        out = handler(self)
-        if "value" not in out and self.value is not True:
-            out["value"] = self.value
+        out = super()._write_object_type(handler, info)
+        if "value" in out or self.value is True or not _wanted("value", info):
+            return out
+        out["value"] = self.value
         return out
 
 

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -2097,6 +2097,22 @@ class TestSerializationIsLossless:
         # number and is refused as mixing two kinds.
         assert dc.inventory(text) == inventory
 
+    def test_an_annotation_still_names_its_class(self):
+        """Restoring the value must not displace the document's tag."""
+        annotation = inv.OpticalPathAnnotation(
+            start_distance=0.0, end_distance=1.0, group="hole", value=2
+        )
+        dumped = annotation.model_dump(mode="json")
+        assert dumped["object_type"] == "OpticalPathAnnotation"
+
+    def test_a_deliberately_excluded_value_stays_out(self):
+        """What a caller filtered is not what exclude_defaults dropped."""
+        annotation = inv.OpticalPathAnnotation(
+            start_distance=0.0, end_distance=1.0, group="hole", value=2
+        )
+        assert "value" not in annotation.model_dump(mode="json", exclude={"value"})
+        assert "value" not in annotation.model_dump(mode="json", include={"group"})
+
     def test_a_flag_annotation_stays_terse(self):
         """A value which really is the default is still left out."""
         pytest.importorskip("yaml")

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -2073,6 +2073,49 @@ class TestSerializationIsLossless:
         inventory = SAMPLE_INVENTORIES[name]
         assert dc.inventory(inventory.to_yaml()) == inventory
 
+    def test_an_annotation_value_of_one_survives(self):
+        """`1 == True`, and the value's default is True, so it was dropped."""
+        pytest.importorskip("yaml")
+        path = inv.OpticalPath(
+            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            annotations=(
+                inv.OpticalPathAnnotation(
+                    start_distance=0.0, end_distance=10.0, group="hole", value=1
+                ),
+                inv.OpticalPathAnnotation(
+                    start_distance=20.0, end_distance=30.0, group="hole", value=2
+                ),
+            ),
+        )
+        array = inv.FiberArray(code="L001", optical_paths=(path,))
+        inventory = inv.Inventory(
+            networks=(inv.Network(code="XX", fiber_arrays=(array,)),)
+        )
+        text = inventory.to_yaml()
+        assert "value: 1" in text
+        # Without the value, the group reloads holding a boolean beside a
+        # number and is refused as mixing two kinds.
+        assert dc.inventory(text) == inventory
+
+    def test_a_flag_annotation_stays_terse(self):
+        """A value which really is the default is still left out."""
+        pytest.importorskip("yaml")
+        path = inv.OpticalPath(
+            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            annotations=(
+                inv.OpticalPathAnnotation(
+                    start_distance=0.0, end_distance=10.0, group="noisy"
+                ),
+            ),
+        )
+        array = inv.FiberArray(code="L001", optical_paths=(path,))
+        inventory = inv.Inventory(
+            networks=(inv.Network(code="XX", fiber_arrays=(array,)),)
+        )
+        text = inventory.to_yaml()
+        assert "value:" not in text
+        assert dc.inventory(text) == inventory
+
     def test_round_trip_through_file(self, tmp_path):
         """The writer taking a path writes what the text form holds."""
         pytest.importorskip("yaml")


### PR DESCRIPTION
## Description

`tests/test_autogenerated_doccode/recipes/test_tunnel_inventory.py` has been failing on `dev` since the tunnel recipe merged in #901, which also means `TestDocBuild` is red for anything branched from it. The cause is not in the recipe.

`OpticalPathAnnotation.value` defaults to `True`, so a bare flag — `noisy` over an interval — needs no value written. `Inventory.to_yaml` leaves out any field still holding its default. But `1 == True` in Python, and pydantic's `exclude_defaults` compares with `==`, so an annotation whose value is the number `1` is dropped as though it were the flag default:

```python
annotation = OpticalPathAnnotation(start_distance=0.0, end_distance=10.0, group="borehole", value=1)
# ...in an inventory:
text = inventory.to_yaml()          # no `value:` line for this annotation
dc.inventory(text)                  # InvalidInventoryError: group 'borehole'
                                    # mixes ['boolean', 'numeric'] values
```

Reloading gives the annotation `True`, the group then holds a boolean beside the numbers next to it, and the group-holds-one-kind rule refuses the whole document. Any group numbered from one — boreholes 1, 2, 3, which is what the recipe writes — cannot survive a round trip.

Identity, not equality, is what "still its default" means for a field whose type admits both `bool` and `int`, so a wrap serializer puts the value back unless it is `True` itself. A flag annotation still writes no value, so documents which use the default stay as terse as they were.

This is the same shape as the existing fix for the `object_type` tag in `dascore/models/base.py`, which `exclude_defaults` also drops and which is also put back by a wrap serializer.

## Changelog

- fixed: an optical path annotation whose value is the number `1` is no longer dropped when an inventory is serialized, which had made any annotation group numbered from one fail to reload.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serialization of optical path annotations so numeric values, including `1`, are preserved correctly.
  * Ensured annotation type information survives YAML round trips.
  * Maintained support for explicit field inclusion and exclusion during serialization.
  * Default-valued boolean fields continue to be omitted when appropriate.

* **Tests**
  * Added regression coverage for annotation serialization, filtering, round trips, and invalid mixed value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->