### PR TITLE
Build the development docs from dev instead of master

### DIFF
--- a/.github/workflows/build_deploy_dev_docs.yaml
+++ b/.github/workflows/build_deploy_dev_docs.yaml
@@ -1,12 +1,12 @@
 # This action renders and publishes the development docs whenever
-# new commits are added to the master branch.
+# new commits are added to the dev branch.
 
-name: BuildDeployMasterDocs
+name: BuildDeployDevDocs
 
 on:
-  # Runs on pushes targeting the master branch
+  # Runs on pushes targeting the dev branch
   push:
-    branches: ["master"]
+    branches: ["dev"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -20,18 +20,20 @@ env:
   # Where the test-data cache is restored; pooch reads files from here.
   # Must match the path used in .github/actions/prime-test-data-cache.
   DFS_DATA_DIR: ${{ github.workspace }}/.test_data_cache
+  # The branch quarto uses for the docs' "edit this page" links.
+  DASCORE_DOC_BRANCH: dev
 
-# Allow one concurrent deployment
+# Publish only the newest dev commit. This is a netlify deployment, so it does
+# not share the "pages" group used by the stable docs; grouping them together
+# would let a dev push cancel a release's GitHub Pages deployment.
 concurrency:
-  group: "pages"
+  group: "netlify-dev-docs"
   cancel-in-progress: true
 
 jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/build_deploy_dev_docs.yaml
+++ b/.github/workflows/build_deploy_dev_docs.yaml
@@ -20,8 +20,10 @@ env:
   # Where the test-data cache is restored; pooch reads files from here.
   # Must match the path used in .github/actions/prime-test-data-cache.
   DFS_DATA_DIR: ${{ github.workspace }}/.test_data_cache
-  # The branch quarto uses for the docs' "edit this page" links.
-  DASCORE_DOC_BRANCH: dev
+  # The branch quarto uses for the docs' "edit this page" links. Taken from the
+  # ref rather than hard-coded so a manual run of another branch still links to
+  # the branch it published.
+  DASCORE_DOC_BRANCH: ${{ github.ref_name }}
 
 # Publish only the newest dev commit. This is a netlify deployment, so it does
 # not share the "pages" group used by the stable docs; grouping them together

--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -1,9 +1,8 @@
 name: TestDocBuild
 
 on:
-  push:
-    branches:
-      - dev
+  # Pushes to dev are covered by BuildDeployDevDocs, which builds the same
+  # docs and publishes them, so this only guards labeled pull requests.
   pull_request:
     types: [labeled, synchronize]
 
@@ -18,8 +17,7 @@ env:
 jobs:
   test_build_docs:
     if: |
-      github.event_name == 'push'
-      || (github.event.action == 'labeled' && github.event.label.name == 'documentation')
+      (github.event.action == 'labeled' && github.event.label.name == 'documentation')
       || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'documentation'))
     runs-on: ubuntu-latest
     permissions:

--- a/docs/contributing/general_guidelines.qmd
+++ b/docs/contributing/general_guidelines.qmd
@@ -9,9 +9,7 @@ We create new features or bug fixes in their own branches and merge them into `d
 integration branch; it is merged into `master` at release time. We may switch to a more complex branching model if
 the need arises.
 
-The two documentation sites follow these branches: the [development docs](https://dascore.netlify.app) are rebuilt from
-`dev` on every push, and the [stable docs](https://dascore.org) are rebuilt when a release is published. A push to
-`master` outside of a release does not rebuild either site.
+The two documentation sites follow these branches: the [development docs](https://dascore.netlify.app) are rebuilt from `dev` on every push, and the [stable docs](https://dascore.org) are rebuilt when a release is published. A push to `master` outside of a release does not rebuild either site.
 
 If substantial new features have been added since the last release we will bump the minor version.  If only bug
 fixes/minor changes have been made, only the patch version will be bumped. Like most Python projects, we loosely

--- a/docs/contributing/general_guidelines.qmd
+++ b/docs/contributing/general_guidelines.qmd
@@ -9,6 +9,10 @@ We create new features or bug fixes in their own branches and merge them into `d
 integration branch; it is merged into `master` at release time. We may switch to a more complex branching model if
 the need arises.
 
+The two documentation sites follow these branches: the [development docs](https://dascore.netlify.app) are rebuilt from
+`dev` on every push, and the [stable docs](https://dascore.org) are rebuilt when a release is published. A push to
+`master` outside of a release does not rebuild either site.
+
 If substantial new features have been added since the last release we will bump the minor version.  If only bug
 fixes/minor changes have been made, only the patch version will be bumped. Like most Python projects, we loosely
 follow [semantic versioning](https://semver.org/), meaning we will not bump the major version until DASCore

--- a/scripts/_qmd_builder.py
+++ b/scripts/_qmd_builder.py
@@ -88,12 +88,21 @@ def _get_dascore_title():
     return f"DASCore ({vstr})"
 
 
+def _get_repo_branch():
+    """Get the branch the docs' "edit this page" links should point to."""
+    return os.environ.get("DASCORE_DOC_BRANCH", "master")
+
+
 def create_quarto_qmd():
     """Create the _quarto.yml file."""
     temp = get_template("_quarto.yml")
     version_str = _get_dascore_title()
     api_toc_tree = build_amp_toc_tree()
-    out = temp.render(dascore_version_str=version_str, api_toc_tree=api_toc_tree)
+    out = temp.render(
+        dascore_version_str=version_str,
+        api_toc_tree=api_toc_tree,
+        repo_branch=_get_repo_branch(),
+    )
     path = Path(__file__).parent.parent / "docs" / "_quarto.yml"
     with path.open("w") as fi:
         fi.write(out)

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -31,7 +31,7 @@ website:
   image: "_static/logo.png"
   favicon: "_static/logo.png"
   repo-subdir: docs
-  repo-branch: master
+  repo-branch: {{ repo_branch }}
   repo-actions: [edit]
   page-navigation: true
 

--- a/scripts/test_qmd_builder.py
+++ b/scripts/test_qmd_builder.py
@@ -30,3 +30,19 @@ class TestGetDascoreTitle:
         monkeypatch.setattr(_qmd_builder.dc, "__version__", "0.1.16.dev19+gabc123")
 
         assert _qmd_builder._get_dascore_title() == "DASCore (0.1.16)"
+
+
+class TestGetRepoBranch:
+    """Tests for the branch used by the docs' edit links."""
+
+    def test_default_branch(self, monkeypatch):
+        """Builds which don't set the branch point at master."""
+        monkeypatch.delenv("DASCORE_DOC_BRANCH", raising=False)
+
+        assert _qmd_builder._get_repo_branch() == "master"
+
+    def test_branch_override(self, monkeypatch):
+        """The dev doc build points edit links at dev."""
+        monkeypatch.setenv("DASCORE_DOC_BRANCH", "dev")
+
+        assert _qmd_builder._get_repo_branch() == "dev"


### PR DESCRIPTION
## Description

The netlify site is advertised as DASCore's [development documentation](https://dascore.netlify.app), but it was rebuilt by `BuildDeployMasterDocs` on pushes to `master`. Since `master` only moves at release time, that site tracked the last release rather than ongoing work (`dev` is currently ~150 commits ahead).

This publishes it from `dev` instead. Changes:

- `build_deploy_master_docs.yaml` → `build_deploy_dev_docs.yaml` (`BuildDeployDevDocs`), triggered by pushes to `dev`.
- Dropped the job's `environment: github-pages`. This is load-bearing, not cleanup: that environment's deployment branch policy allows only `main`, `master`, and `v*` tags, so a `dev`-triggered job would be rejected before it ran. The job never touches GitHub Pages, and `NETLIFY_AUTH_TOKEN` is a repository-level secret, so nothing is lost.
- Gave the workflow its own concurrency group (`netlify-dev-docs`). It previously shared the `pages` group with `BuildDeployStableDocs`, which sets `cancel-in-progress: true`; frequent dev pushes could otherwise cancel a release's Pages deployment.
- The quarto `repo-branch` setting (the "edit this page" links) is now templated from `DASCORE_DOC_BRANCH`, mirroring the existing `DASCORE_DOC_VERSION` pattern. It defaults to `master`, so stable, local, and release builds are unchanged; the dev workflow sets it from `github.ref_name`.
- `TestDocBuild` drops its push-to-`dev` trigger. The deploy workflow now builds the same docs on every dev push, and two ~30 minute builds per push is waste. The label-gated pull request path is unchanged.
- Documented the branch/site relationship in the branching section of the contributing guidelines.

API source links in the rendered docs already follow `$GITHUB_REF` at runtime, so they point at `dev` on a dev build with no change needed.

After this, a push to `master` outside of a release rebuilds neither site; the stable docs still come from `release: published`.

## Changelog

- changed: the development documentation site is now built from the `dev` branch instead of `master`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Development and stable documentation branch behavior is now documented.
  * Generated documentation links use the branch being built, improving navigation for development docs.

* **Chores**
  * Development documentation now builds and publishes from the `dev` branch.
  * Documentation build checks are limited to relevant documentation pull requests.

* **Tests**
  * Added coverage for default and development documentation branch selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->