### PR TITLE
Add the annotation models: sets, geometry and curves

### DIFF
--- a/dascore/__init__.py
+++ b/dascore/__init__.py
@@ -11,6 +11,7 @@ from dascore.core.patch import Patch
 from dascore.core.attrs import PatchAttrs
 from dascore.core.summary import PatchSummary
 from dascore.core.spool import BaseSpool, Spool, spool
+from dascore.core.annotations import AnnotationSet
 from dascore.core.inventory import Inventory
 from dascore.core.inventory_loader import inventory
 from dascore.core.coordmanager import get_coord_manager, CoordManager

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -1,0 +1,1229 @@
+"""
+DASCore annotations: labelled geometry over the dimensions of patch data.
+
+An annotation set describes *data* -- picks, events, noisy hours, vehicle
+lines -- in the frame of the patches it was made on. Facts about the fiber
+itself belong to the inventory instead, in optical distance; see
+[dascore.core.inventory](`dascore.core.inventory`).
+
+A set is dataframe-backed, one row per annotation. Columns name the
+dimensions a row constrains: ``<dim>_start``/``<dim>_end`` state a
+half-open range, a bare ``<dim>`` states a point, and a dimension no
+column names is unconstrained. Paths and polygons keep their vertices in
+a second, tidy frame keyed by annotation id, and every row keeps a
+bounding region so table operations work whatever its geometry is.
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Annotated, Any, ClassVar, Literal, NamedTuple
+
+import numpy as np
+import pandas as pd
+from pydantic import (
+    AfterValidator,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    PlainSerializer,
+    TypeAdapter,
+    ValidationError,
+    model_validator,
+)
+from typing_extensions import Self
+
+from dascore.constants import max_lens
+from dascore.core.inventory import CreationInfo
+from dascore.exceptions import ParameterError
+from dascore.models import (
+    DascoreBaseModel,
+    DateTime64,
+    FiniteFloat,
+    FrozenDictType,
+    PositiveFiniteFloat,
+    UnitQuantity,
+)
+from dascore.utils.intervals import normalize_value, value_kind
+from dascore.utils.mapping import FrozenDict
+from dascore.utils.misc import iterate, to_str, validate_acquisition_key
+from dascore.utils.time import to_datetime64, to_timedelta64
+
+# Columns any set may carry, whatever dimensions it declares.
+RESERVED_COLUMNS = (
+    "id",
+    "group",
+    "value",
+    "tags",
+    "parent",
+    "geometry",
+    "basis",
+    "acquisition_key",
+)
+
+# The geometries a row may declare. A region is the default: it is what
+# the dimension columns already state, so a set of boxes names nothing.
+GEOMETRY_KINDS = ("region", "path", "polygon")
+
+# Geometries whose shape lives in the vertices frame rather than in the
+# dimension columns, and the fewest vertices each is a shape with.
+_VERTEX_KINDS = {"path": 2, "polygon": 3}
+
+# The vertices frame's own scaffolding; every other column is a dimension.
+_VERTEX_COLUMNS = ("id", "seq")
+
+# What a range column is spelled with.
+_START, _END = "_start", "_end"
+
+# A moveout is physics, not geometry, so it names the dimensions it relates.
+DISTANCE_DIM, TIME_DIM = "distance", "time"
+
+
+def _annotation_value(value):
+    """Normalize an annotation value so its Python type survives validation."""
+    return normalize_value(value, error=ParameterError)
+
+
+# The value kind decides a group's shape, so it must be exact: a bool is
+# membership and an int is a number, and 1 must not become True.
+AnnotationValue = Annotated[
+    str | bool | int | float, BeforeValidator(_annotation_value)
+]
+
+
+# Spelled as PatchAttrs spells them, so a set and the data it describes
+# state their provenance the same way.
+AcquisitionKey = Annotated[str, AfterValidator(validate_acquisition_key)]
+
+# `iterate` rather than a bare tuple: PatchAttrs.history is `str |
+# tuple[str, ...]`, so copying one straight off a patch may hand over a
+# lone entry, which is a history of one rather than a history of letters.
+History = Annotated[tuple[str, ...], BeforeValidator(lambda x: tuple(iterate(x)))]
+
+
+def _document(value):
+    """Spell a bound or a vertex for a json document."""
+    if isinstance(value, np.datetime64 | np.timedelta64):
+        return to_str(value)
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+# A coordinate may be a time, which json has no type for. Written as the
+# string DASCore writes every datetime as; reading it back as a time again
+# is the loader's job, since it knows what each dimension holds. One
+# serializer rather than two stacked: a python-mode dump is what equality
+# compares and what `new` rebuilds from, so it keeps the values themselves.
+def _serialize_coordinates(value, info):
+    """Write a mapping of coordinates, as a document only in json mode."""
+    if info.mode != "json":
+        return dict(value)
+    return {k: [_document(x) for x in values] for k, values in value.items()}
+
+
+_freeze_map = AfterValidator(lambda x: FrozenDict(x))
+_write_map = PlainSerializer(_serialize_coordinates, return_type=dict)
+
+Bounds = Annotated[Mapping[str, tuple[Any, Any]], _freeze_map, _write_map]
+
+Vertices = Annotated[Mapping[str, tuple[Any, ...]], _freeze_map, _write_map]
+
+
+def _serialize_place(value, info):
+    """Write a mapping of one coordinate per dimension, as `_serialize_coordinates`."""
+    if info.mode != "json":
+        return dict(value)
+    return {k: _document(x) for k, x in value.items()}
+
+
+Point = Annotated[
+    Mapping[str, Any],
+    _freeze_map,
+    PlainSerializer(_serialize_place, return_type=dict),
+]
+
+
+def _interpolate(start, end, fraction):
+    """Walk from one coordinate to another, keeping whatever type it is."""
+    if isinstance(start, np.datetime64):
+        span = (end - start) / np.timedelta64(1, "ns")
+        return start + (span * fraction).astype("timedelta64[ns]")
+    return start + (end - start) * fraction
+
+
+def _tag(name: str):
+    """Return the serialization-only ``object_type`` field of a union member."""
+    return Field(default=name, repr=False)
+
+
+class _AnnotationModel(DascoreBaseModel):
+    """Base for the immutable models an annotation set hands out."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        validate_assignment=True,
+        validate_default=True,
+        arbitrary_types_allowed=True,
+    )
+
+
+# --- Curves ---------------------------------------------------------------
+
+
+class AnnotationBasis(_AnnotationModel):
+    """
+    Base for the curves a path's vertices may be regenerated from.
+
+    A basis is not a geometry: it is the fit the vertices came from, kept
+    so the curve can be redrawn at any resolution. Editing vertices drops
+    it, since they no longer describe the curve.
+
+    Every curve is stated in its dimensions' own coordinates -- a time is a
+    time, a distance is a distance -- so it is anchored without a separate
+    origin and its vertices drop straight into the vertices frame. A curve
+    parameterized in a dimension's raw numbers would put an apex at 1.6e18
+    nanoseconds and a velocity in metres per nanosecond, which nobody can
+    read, write or check.
+    """
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        """The dimensions this curve is stated in."""
+        raise NotImplementedError
+
+    def vertices(self, count: int = 64) -> dict[str, np.ndarray]:
+        """Return ``count`` points along the curve, keyed by dimension."""
+        raise NotImplementedError
+
+    @staticmethod
+    def _fractions(count: int) -> np.ndarray:
+        """Return where along the curve to sample, from one end to the other."""
+        if count < 2:
+            msg = f"A curve needs at least 2 points; got {count}."
+            raise ParameterError(msg)
+        return np.linspace(0.0, 1.0, count)
+
+
+class Line(AnnotationBasis):
+    """
+    A straight line between two points.
+
+    Stated as its endpoints rather than a slope, for two reasons: a slope
+    cannot spell a line of constant time across distance -- an instant, a
+    shot, a trigger -- which is an ordinary thing to annotate; and
+    endpoints are what a person draws when they drag from one place to
+    another.
+    """
+
+    object_type: Literal["Line"] = _tag("Line")
+    start: Point = Field(description="Where the line begins, keyed by dimension.")
+    end: Point = Field(description="Where the line ends, keyed by dimension.")
+
+    @model_validator(mode="after")
+    def _check_points(self) -> Self:
+        """Both ends place the same dimensions, and are not the same place."""
+        if not self.start:
+            msg = "A line states no dimension, so it is nowhere."
+            raise ValueError(msg)
+        if set(self.start) != set(self.end):
+            msg = (
+                f"A line's ends place different dimensions: "
+                f"{sorted(self.start)} and {sorted(self.end)}."
+            )
+            raise ValueError(msg)
+        if all(self.start[x] == self.end[x] for x in self.start):
+            msg = "A line begins and ends in the same place, so it has no length."
+            raise ValueError(msg)
+        return self
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        """The dimensions this line is stated in."""
+        return tuple(self.start)
+
+    def vertices(self, count: int = 64) -> dict[str, np.ndarray]:
+        """Return ``count`` points evenly spaced from one end to the other."""
+        fraction = self._fractions(count)
+        return {
+            dim: _interpolate(self.start[dim], self.end[dim], fraction)
+            for dim in self.start
+        }
+
+
+class Moveout(AnnotationBasis):
+    """
+    The arrival time of a wavefront along the fiber, as a function of distance.
+
+    Physics rather than geometry, so it is pinned to ``distance`` against
+    ``time``. A source sitting ``standoff`` metres off the cable, abreast of
+    fiber distance ``apex_distance``, arrives everywhere at
+
+    ``time = apex_time + (hypot(standoff, distance - apex_distance)
+    - standoff) / velocity``
+
+    which is the hyperbola a point source makes. ``apex_time`` is therefore
+    the earliest arrival and the curve's anchor. A source on the cable has
+    no standoff, and the default of zero leaves the straight V of a wave
+    running both ways at ``velocity``.
+    """
+
+    object_type: Literal["Moveout"] = _tag("Moveout")
+    apex_distance: FiniteFloat = Field(
+        description="Fiber distance the wavefront arrives earliest at, in metres."
+    )
+    apex_time: DateTime64 = Field(description="Time of that earliest arrival.")
+    velocity: PositiveFiniteFloat = Field(
+        description="Speed the wavefront moves along the fiber, in metres/second."
+    )
+    standoff: FiniteFloat = Field(
+        default=0.0,
+        ge=0,
+        description=(
+            "Perpendicular distance from the fiber to the source, in metres. "
+            "Zero is a source on the cable, whose moveout is straight."
+        ),
+    )
+    distance_start: FiniteFloat = Field(
+        description="Fiber distance the curve is drawn from, in metres."
+    )
+    distance_end: FiniteFloat = Field(
+        description="Fiber distance the curve is drawn to, in metres."
+    )
+
+    @model_validator(mode="after")
+    def _check_span(self) -> Self:
+        """A curve with no span draws no vertices."""
+        if not self.distance_end > self.distance_start:
+            msg = (
+                f"Moveout distance_end {self.distance_end} must exceed "
+                f"distance_start {self.distance_start}."
+            )
+            raise ValueError(msg)
+        return self
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        """A moveout relates fiber distance to arrival time, and only those."""
+        return (DISTANCE_DIM, TIME_DIM)
+
+    def vertices(self, count: int = 64) -> dict[str, np.ndarray]:
+        """Return ``count`` arrivals evenly spaced along the fiber."""
+        fraction = self._fractions(count)
+        distance = self.distance_start + fraction * (
+            self.distance_end - self.distance_start
+        )
+        along = np.hypot(self.standoff, distance - self.apex_distance)
+        seconds = (along - self.standoff) / self.velocity
+        return {
+            DISTANCE_DIM: distance,
+            TIME_DIM: self.apex_time + to_timedelta64(seconds),
+        }
+
+
+Basis = Annotated[Line | Moveout, Field(discriminator="object_type")]
+
+
+# --- Geometry -------------------------------------------------------------
+
+
+class Region(_AnnotationModel):
+    """
+    Per-dimension bounds: the box an annotation occupies.
+
+    Each dimension the annotation constrains maps to a half-open
+    ``(start, end)`` pair; equal values are a point, and a dimension the
+    mapping omits is unconstrained. Region subsumes a point, a span and a
+    box, which differ only in how many dimensions they name.
+    """
+
+    object_type: Literal["Region"] = _tag("Region")
+    bounds: Bounds = Field(
+        default_factory=dict, description="Half-open bounds, keyed by dimension."
+    )
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        """The dimensions this region constrains."""
+        return tuple(self.bounds)
+
+    def is_point(self, dim: str) -> bool:
+        """Whether this region is a point, rather than a span, along a dimension."""
+        start, end = self.bounds[dim]
+        return bool(start == end)
+
+
+class _VertexGeometry(_AnnotationModel):
+    """Base for geometries whose shape is a sequence of vertices."""
+
+    region: Region = Field(description="The bounding region of the vertices.")
+    vertices: Vertices = Field(description="Ordered vertex values, keyed by dimension.")
+    basis: Basis | None = Field(
+        default=None, description="The curve these vertices were generated from."
+    )
+
+    # The fewest vertices this geometry is a shape with.
+    _least: ClassVar[int] = 2
+
+    @model_validator(mode="after")
+    def _check_vertices(self) -> Self:
+        """Vertices place every dimension, equally, and enough times."""
+        if not self.vertices:
+            msg = f"A {type(self).__name__} states no dimension, so it is nowhere."
+            raise ValueError(msg)
+        lengths = {len(x) for x in self.vertices.values()}
+        if len(lengths) > 1:
+            msg = (
+                f"The vertices of this {type(self).__name__} differ in length "
+                f"({sorted(lengths)}); every dimension states every point."
+            )
+            raise ValueError(msg)
+        if (count := lengths.pop()) < self._least:
+            msg = (
+                f"A {type(self).__name__} states {count} vertices; it is a "
+                f"shape with at least {self._least}."
+            )
+            raise ValueError(msg)
+        return self
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        """The dimensions the vertices are stated in."""
+        return tuple(self.vertices)
+
+    def __len__(self) -> int:
+        """The number of vertices."""
+        return len(next(iter(self.vertices.values())))
+
+
+class Path(_VertexGeometry):
+    """An open sequence of vertices, e.g. a pick or a vehicle track."""
+
+    object_type: Literal["Path"] = _tag("Path")
+
+
+class Polygon(_VertexGeometry):
+    """
+    A closed sequence of vertices bounding an area.
+
+    Closure is implied rather than written: the last vertex is not the
+    first repeated, so a triangle states three points.
+    """
+
+    object_type: Literal["Polygon"] = _tag("Polygon")
+    _least: ClassVar[int] = 3
+
+
+Geometry = Annotated[Region | Path | Polygon, Field(discriminator="object_type")]
+
+# Reads a basis cell, which a set may state as the model or as its document.
+_BASIS_ADAPTER = TypeAdapter(Basis)
+
+
+# --- The annotation row view ----------------------------------------------
+
+
+class Annotation(_AnnotationModel):
+    """
+    One annotation: a geometry, what it says, and who it belongs to.
+
+    Instances are a view of a row of an
+    [AnnotationSet](`dascore.core.annotations.AnnotationSet`), built on
+    demand rather than held.
+    """
+
+    geometry: Geometry = Field(description="Where this annotation is.")
+    id: str = Field(default="", description="Producer-supplied stable identifier.")
+    group: str = Field(default="", description="Name of the annotated variable.")
+    value: AnnotationValue = Field(
+        default=True, description="Value of the variable over this geometry."
+    )
+    tags: tuple[str, ...] = Field(
+        default=(), description="Free labels; an annotation may carry many."
+    )
+    parent: str = Field(
+        default="", description="Id of the annotation this one belongs to."
+    )
+    acquisition_key: AcquisitionKey = Field(
+        default="",
+        max_length=max_lens["acquisition_key"],
+        description=(
+            "Inventory identity of the data this annotation was made on; the "
+            "set's own where the row names none."
+        ),
+    )
+    extra: FrozenDictType[str, Any] = Field(
+        default_factory=dict, description="Columns the set does not model."
+    )
+
+    @property
+    def region(self) -> Region:
+        """The bounding region, whatever the geometry is."""
+        geometry = self.geometry
+        return geometry if isinstance(geometry, Region) else geometry.region
+
+
+# --- Set attributes -------------------------------------------------------
+
+
+class AnnotationColumn(_AnnotationModel):
+    """
+    What a set says about one of its columns.
+
+    Documenting a column never gates it: an undeclared column is carried
+    as an extra just the same. A stated dtype is checked, so a column
+    which says what it holds must hold it.
+    """
+
+    description: str = Field(default="", description="What the column means.")
+    units: UnitQuantity = Field(default=None, description="Units of the values.")
+    dtype: str = Field(default="", description="Dtype the column must hold, if stated.")
+
+
+class AnnotationSetAttrs(_AnnotationModel):
+    """The attributes of an annotation set: what it describes and how."""
+
+    dims: tuple[str, ...] = Field(
+        description="The patch dimensions annotations are stated in."
+    )
+    creation_info: CreationInfo = Field(
+        default_factory=CreationInfo,
+        description=(
+            "What produced these annotations, and when: a picker "
+            "(author='phasenet', version='2.1', agency_id='INERIS') or a "
+            "person (author='derrick'). Anything further -- a source file, a "
+            "model checkpoint -- goes in its extra_fields."
+        ),
+    )
+    acquisition_key: AcquisitionKey = Field(
+        default="",
+        max_length=max_lens["acquisition_key"],
+        description=(
+            "Inventory identity of the data these annotations were made on, "
+            "spelled network.fiber_array.location.acquisition. The set-level "
+            "default; a row may name its own."
+        ),
+    )
+    history: History = Field(
+        default=(),
+        description=(
+            "Processing performed on the data the annotations were made on. "
+            "Picks made on decimated or filtered data have coordinates which "
+            "only mean anything against that lineage."
+        ),
+    )
+    columns: FrozenDictType[str, AnnotationColumn] = Field(
+        default_factory=dict, description="Documentation for columns, keyed by name."
+    )
+
+    @model_validator(mode="after")
+    def _check_dims(self) -> Self:
+        """A set states which dimensions its annotations live in."""
+        if not self.dims:
+            msg = "An annotation set states at least one dimension."
+            raise ValueError(msg)
+        if len(set(self.dims)) != len(self.dims):
+            msg = f"Annotation dimensions must be unique; got {list(self.dims)}."
+            raise ValueError(msg)
+        for dim in self.dims:
+            for end in (_START, _END):
+                stem = dim[: -len(end)] if dim.endswith(end) else None
+                if stem and stem in self.dims:
+                    msg = (
+                        f"The dimension {dim!r} is spelled like the range column "
+                        f"of {stem!r}, so one column would state both."
+                    )
+                    raise ValueError(msg)
+        if overlap := sorted(set(self.dims) & set(RESERVED_COLUMNS)):
+            msg = (
+                f"The dimension(s) {', '.join(overlap)} name a reserved column; "
+                f"a set may not dimension {', '.join(RESERVED_COLUMNS)}."
+            )
+            raise ValueError(msg)
+        return self
+
+
+# --- The set --------------------------------------------------------------
+
+
+class _Spelling(NamedTuple):
+    """How one dimension is spelled in the frame."""
+
+    dim: str
+    point: str | None  # the bare column, where the dimension is a point
+    start: str | None  # the range columns, where it is a span
+    end: str | None
+
+
+class AnnotationSet:
+    """
+    An immutable, dataframe-backed set of annotations over patch dimensions.
+
+    Parameters
+    ----------
+    data
+        A dataframe, or anything a dataframe can be built from, holding one
+        row per annotation.
+    dims
+        The patch dimensions the annotations are stated in. Required unless
+        ``attrs`` states them.
+    vertices
+        A tidy frame of one row per vertex, with ``id``, ``seq`` and one
+        column per dimension. Required by every path and polygon row.
+    attrs
+        The set's attributes; ``dims`` and the keywords below override it.
+    creation_info
+        What produced the annotations, and when.
+    acquisition_key
+        Inventory identity of the data the annotations were made on. The
+        producer supplies it; ``AnnotationSet.from_patch`` will take it off
+        a patch once the spool integration lands.
+    history
+        Processing performed on that data, in ``PatchAttrs.history``'s shape.
+    columns
+        Documentation for columns, keyed by name.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import dascore as dc
+    >>> frame = pd.DataFrame(
+    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ... )
+    >>> picks = dc.AnnotationSet(frame, dims=("time", "distance"))
+    >>> len(picks), picks[0].group
+    (1, 'event')
+    >>> picks[0].region.bounds["distance"]
+    (10.0, 80.0)
+    """
+
+    def __init__(
+        self,
+        data=None,
+        dims: Sequence[str] | None = None,
+        vertices=None,
+        attrs: AnnotationSetAttrs | Mapping | None = None,
+        creation_info: CreationInfo | Mapping | None = None,
+        acquisition_key: str | None = None,
+        history: Sequence[str] | str | None = None,
+        columns: Mapping | None = None,
+    ):
+        self._attrs = _build_attrs(
+            attrs, dims, creation_info, acquisition_key, history, columns
+        )
+        frame = _coerce_frame(data, "annotations")
+        spellings = _read_spellings(frame, self._attrs.dims)
+        _check_columns(frame, self._attrs)
+        _check_ranges(frame, spellings)
+        _check_values(frame)
+        ids = _check_ids(frame)
+        _check_basis(frame, self._attrs.dims)
+        vertex_frame = _coerce_frame(vertices, "vertices")
+        self._vertices = _check_vertices(vertex_frame, frame, ids, self._attrs.dims)
+        self._df = _fill_vertex_bounds(frame, self._vertices, spellings)
+        # Read again: filling a derived bounding region adds the range
+        # columns a path row had none of, which are bounds like any other.
+        self._spellings = _read_spellings(self._df, self._attrs.dims)
+
+    # --- what the set is
+
+    @property
+    def attrs(self) -> AnnotationSetAttrs:
+        """The set's attributes."""
+        return self._attrs
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        """The dimensions the annotations are stated in."""
+        return self._attrs.dims
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return the annotations as a dataframe."""
+        return self._df.copy()
+
+    def to_vertices(self) -> pd.DataFrame:
+        """Return the vertices of every path and polygon as a tidy dataframe."""
+        return self._vertices.copy()
+
+    # --- what the set holds
+
+    def __len__(self) -> int:
+        """The number of annotations."""
+        return len(self._df)
+
+    def __iter__(self):
+        """Iterate the annotations, building each on demand."""
+        for position in range(len(self._df)):
+            yield self[position]
+
+    def __getitem__(self, position: int) -> Annotation:
+        """Return one annotation by its position."""
+        row = self._df.iloc[position]
+        return Annotation(
+            geometry=self._geometry(row),
+            id=_text(row.get("id")),
+            group=_text(row.get("group")),
+            value=row["value"] if _stated(row.get("value")) else True,
+            tags=_read_tags(row.get("tags")),
+            parent=_text(row.get("parent")),
+            # A set may span acquisitions, so a row naming one overrides
+            # the set-level address rather than sitting beside it.
+            acquisition_key=_text(row.get("acquisition_key"))
+            or self._attrs.acquisition_key,
+            extra=_read_extra(row, self._attrs.dims, self._spellings),
+        )
+
+    def __eq__(self, other) -> bool:
+        """Two sets are equal when their attributes and frames are."""
+        if not isinstance(other, AnnotationSet):
+            return NotImplemented
+        return (
+            self._attrs == other._attrs
+            and self._df.equals(other._df)
+            and self._vertices.equals(other._vertices)
+        )
+
+    def __repr__(self) -> str:
+        """Name the set by what it holds."""
+        dims = ", ".join(self.dims)
+        return f"AnnotationSet({len(self)} annotations, dims=({dims}))"
+
+    __str__ = __repr__
+
+    # --- internals
+
+    def _geometry(self, row) -> Region | Path | Polygon:
+        """Build the geometry a row states."""
+        region = Region(bounds=_read_bounds(row, self._spellings))
+        kind = _text(row.get("geometry")) or "region"
+        if kind == "region":
+            return region
+        vertices = _row_vertices(self._vertices, row["id"], self.dims)
+        model = Path if kind == "path" else Polygon
+        return model(
+            region=region,
+            vertices=vertices,
+            basis=_read_basis(row.get("basis"), self.dims),
+        )
+
+
+def _build_attrs(
+    attrs, dims, creation_info, acquisition_key, history, columns
+) -> AnnotationSetAttrs:
+    """Build the set attributes from an attrs object and its overrides."""
+    stated: dict[str, Any] = {}
+    if attrs is not None:
+        stated = (
+            attrs.model_dump() if isinstance(attrs, AnnotationSetAttrs) else dict(attrs)
+        )
+    overrides = {
+        "dims": tuple(iterate(dims)) if dims is not None else None,
+        "creation_info": creation_info,
+        "acquisition_key": acquisition_key,
+        "history": history,
+        "columns": columns,
+    }
+    stated.update({k: v for k, v in overrides.items() if v is not None})
+    if "dims" not in stated:
+        msg = (
+            "An annotation set states its dimensions; pass dims=... or attrs "
+            "declaring them."
+        )
+        raise ParameterError(msg)
+    return AnnotationSetAttrs(**stated)
+
+
+def _coerce_frame(data, what: str) -> pd.DataFrame:
+    """Return the input as a dataframe, an empty one where nothing was given."""
+    if data is None:
+        return pd.DataFrame()
+    if isinstance(data, pd.DataFrame):
+        frame = data.reset_index(drop=True)
+    else:
+        try:
+            frame = pd.DataFrame(data).reset_index(drop=True)
+        except (ValueError, TypeError) as error:
+            msg = f"Could not read the {what} as a dataframe: {error}."
+            raise ParameterError(msg) from error
+    # Pandas allows a name to repeat, and then getting that column hands
+    # back a frame rather than a column; everything downstream reads one
+    # column per name, so the repeat is refused where it can still be seen.
+    if frame.columns.duplicated().any():
+        repeated = sorted({str(x) for x in frame.columns[frame.columns.duplicated()]})
+        msg = (
+            f"The {what} name {', '.join(repeated)} more than once; one column "
+            "states one thing."
+        )
+        raise ParameterError(msg)
+    return frame
+
+
+def _read_spellings(frame: pd.DataFrame, dims) -> dict[str, _Spelling]:
+    """
+    Return how each dimension is spelled in the frame.
+
+    A dimension is a point where a bare column names it, a span where a
+    start/end pair does, and unconstrained where neither does. Spelling it
+    both ways states one thing twice, which has no answer.
+    """
+    columns = set(frame.columns)
+    out = {}
+    for dim in dims:
+        point = dim if dim in columns else None
+        start = f"{dim}{_START}" if f"{dim}{_START}" in columns else None
+        end = f"{dim}{_END}" if f"{dim}{_END}" in columns else None
+        if point is not None and (start is not None or end is not None):
+            msg = (
+                f"The dimension {dim!r} is spelled both as a point ({dim}) and "
+                f"as a range ({dim}{_START}/{dim}{_END}); it is one or the other."
+            )
+            raise ParameterError(msg)
+        if (start is None) != (end is None):
+            stated = start or end
+            missing = f"{dim}{_END}" if start is not None else f"{dim}{_START}"
+            msg = f"{stated} states half a range; {missing} is not a column."
+            raise ParameterError(msg)
+        out[dim] = _Spelling(dim, point, start, end)
+    return out
+
+
+def _check_columns(frame: pd.DataFrame, attrs: AnnotationSetAttrs) -> None:
+    """
+    Refuse a column which nearly names something, and check stated dtypes.
+
+    An undeclared ``<name>_start``/``<name>_end`` pair is a dimension the
+    set forgot to declare rather than two unrelated extras, and reading it
+    as extras would quietly drop the constraint it states.
+    """
+    known = set(RESERVED_COLUMNS) | set(attrs.dims)
+    known |= {f"{dim}{end}" for dim in attrs.dims for end in (_START, _END)}
+    extras = [str(x) for x in frame.columns if x not in known]
+    stems = {x[: -len(_START)] for x in extras if x.endswith(_START)}
+    stems &= {x[: -len(_END)] for x in extras if x.endswith(_END)}
+    if stems:
+        named = ", ".join(sorted(stems))
+        msg = (
+            f"The column(s) {named} are spelled as a range but name no declared "
+            f"dimension. The set declares {list(attrs.dims)}."
+        )
+        raise ParameterError(msg)
+    for name, column in attrs.columns.items():
+        if not column.dtype or name not in frame.columns:
+            continue
+        actual = frame[name].dtype
+        # Resolved and compared through pandas rather than numpy: an
+        # annotation column may hold an extension dtype -- `str`, which is
+        # what pandas gives plain text, or `category`, or `Int64` -- and
+        # `np.dtype` knows none of them.
+        try:
+            declared = pd.api.types.pandas_dtype(column.dtype)
+        except TypeError as error:
+            msg = f"The column {name!r} declares the dtype {column.dtype!r}: {error}."
+            raise ParameterError(msg) from error
+        # Compared by name rather than by identity: a column documented as
+        # `category` says it is categorical, not which categories it holds,
+        # and the two dtypes are otherwise unequal. Names still tell a
+        # datetime64[ns] from a datetime64[us].
+        if declared.name != actual.name:
+            msg = f"The column {name!r} states dtype {column.dtype} but holds {actual}."
+            raise ParameterError(msg)
+
+
+def _check_ranges(frame: pd.DataFrame, spellings) -> None:
+    """
+    Refuse a range which ends before it starts.
+
+    Checked here rather than where a row is read: an impossible range is
+    structural, so a set holding one does not load at all instead of
+    raising later, on whichever operation happened to touch that row.
+    """
+    for dim, spelling in spellings.items():
+        if spelling.start is None or spelling.end is None:
+            continue
+        start, end = frame[spelling.start], frame[spelling.end]
+        stated = start.notna() & end.notna()
+        half = start.notna() ^ end.notna()
+        if half.any():
+            first = frame.index[half][0]
+            msg = (
+                f"Row {first} states half a {dim} range; a range states both "
+                f"{spelling.start} and {spelling.end}, and neither states an "
+                "unconstrained dimension."
+            )
+            raise ParameterError(msg)
+        if not stated.any():
+            continue
+        try:
+            reversed_rows = stated & (end < start)
+        except TypeError as error:
+            msg = (
+                f"The {dim} range cannot be compared, so nothing can say "
+                f"whether it runs backwards: {error}."
+            )
+            raise ParameterError(msg) from error
+        if reversed_rows.any():
+            first = frame.index[reversed_rows][0]
+            msg = (
+                f"Row {first} states a {dim} range ({start[first]}, {end[first]}) "
+                "which ends before it starts."
+            )
+            raise ParameterError(msg)
+
+
+def _check_values(frame: pd.DataFrame) -> None:
+    """
+    Refuse a group whose values are not all one kind.
+
+    A group's kind decides its shape -- boolean groups state membership and
+    may overlap, others are single valued -- so a group holding both is two
+    variables sharing a name. Overlap itself is not checked here: it only
+    means anything where the set is projected onto a coordinate.
+    """
+    if "value" not in frame.columns:
+        return
+    # Mapped to text first: pandas drops a null grouping key, which would
+    # take every unnamed row out of the check that its group holds one kind.
+    groups = (
+        frame["group"].map(_text)
+        if "group" in frame.columns
+        else pd.Series([""] * len(frame))
+    )
+    for name, index in frame.groupby(groups.values, sort=True).groups.items():
+        values = [x for x in frame.loc[index, "value"] if _stated(x)]
+        kinds = {value_kind(_annotation_value(x)) for x in values}
+        if len(kinds) > 1:
+            msg = (
+                f"The annotation group {str(name)!r} mixes {sorted(kinds)} values; "
+                "a group holds one kind of value."
+            )
+            raise ParameterError(msg)
+
+
+def _check_ids(frame: pd.DataFrame) -> pd.Series:
+    """
+    Check the identity columns and return the id of every row.
+
+    Ids are the producer's: nothing is generated here, so an operation
+    needing identity is available exactly where one was supplied.
+    """
+    if "id" not in frame.columns:
+        ids = pd.Series([""] * len(frame), dtype=object)
+    else:
+        ids = frame["id"].map(_text)
+    stated = ids[ids != ""]
+    if stated.duplicated().any():
+        repeated = sorted(set(stated[stated.duplicated()]))
+        msg = f"The annotation id(s) {', '.join(repeated)} name more than one row."
+        raise ParameterError(msg)
+    kinds = frame["geometry"].map(_text) if "geometry" in frame.columns else None
+    if kinds is not None:
+        if unknown := sorted(set(kinds) - set(GEOMETRY_KINDS) - {""}):
+            msg = (
+                f"The geometry {', '.join(unknown)} is not one of "
+                f"{', '.join(GEOMETRY_KINDS)}."
+            )
+            raise ParameterError(msg)
+        needs_id = kinds.isin(list(_VERTEX_KINDS)) & (ids == "")
+        if needs_id.any():
+            rows = ", ".join(str(x) for x in frame.index[needs_id][:5])
+            msg = (
+                f"Row(s) {rows} state a path or polygon but no id; vertices are "
+                "grouped by id, so one is required."
+            )
+            raise ParameterError(msg)
+    if "basis" in frame.columns:
+        has_basis = frame["basis"].map(_stated)
+        # No geometry column means every row is a region, which is exactly
+        # the case a basis does not belong to.
+        is_vertex = (
+            kinds.isin(list(_VERTEX_KINDS))
+            if kinds is not None
+            else pd.Series(False, index=frame.index)
+        )
+        stray = has_basis & ~is_vertex
+        if stray.any():
+            rows = ", ".join(str(x) for x in frame.index[stray][:5])
+            msg = (
+                f"Row(s) {rows} state a basis but no path or polygon; a basis "
+                "is the curve vertices were generated from."
+            )
+            raise ParameterError(msg)
+    if "parent" in frame.columns:
+        parents = frame["parent"].map(_text)
+        orphans = sorted(set(parents[parents != ""]) - set(stated))
+        if orphans:
+            msg = (
+                f"The parent id(s) {', '.join(orphans)} name no annotation in this set."
+            )
+            raise ParameterError(msg)
+    return ids
+
+
+def _check_vertices(vertices, frame, ids, dims) -> pd.DataFrame:
+    """Check that every vertex geometry has vertices, and only those do."""
+    kinds = frame["geometry"].map(_text) if "geometry" in frame.columns else None
+    wanted = (
+        {}
+        if kinds is None
+        else dict(
+            zip(
+                ids[kinds.isin(list(_VERTEX_KINDS))],
+                kinds[kinds.isin(list(_VERTEX_KINDS))],
+                strict=True,
+            )
+        )
+    )
+    if vertices.empty:
+        if wanted:
+            named = ", ".join(sorted(wanted))
+            msg = f"The path or polygon id(s) {named} state no vertices."
+            raise ParameterError(msg)
+        return pd.DataFrame(columns=[*_VERTEX_COLUMNS, *dims])
+    missing = [x for x in _VERTEX_COLUMNS if x not in vertices.columns]
+    if missing:
+        msg = f"The vertices state no {', '.join(missing)} column."
+        raise ParameterError(msg)
+    vertex_dims = [str(x) for x in vertices.columns if x not in _VERTEX_COLUMNS]
+    if unknown := sorted(set(vertex_dims) - set(dims)):
+        msg = (
+            f"The vertices state the column(s) {', '.join(unknown)}, which name "
+            f"no declared dimension. The set declares {list(dims)}."
+        )
+        raise ParameterError(msg)
+    if not vertex_dims:
+        msg = "The vertices state no dimension column, so they place nothing."
+        raise ParameterError(msg)
+    if vertices["seq"].isnull().any():
+        rows = ", ".join(str(x) for x in vertices.index[vertices["seq"].isnull()][:5])
+        msg = f"Vertex row(s) {rows} state no seq, so they have no place in the order."
+        raise ParameterError(msg)
+    blank = vertices[vertex_dims].isnull().any(axis=1)
+    if blank.any():
+        rows = ", ".join(str(x) for x in vertices.index[blank][:5])
+        msg = (
+            f"Vertex row(s) {rows} leave a dimension empty; a vertex states "
+            "every dimension its frame names."
+        )
+        raise ParameterError(msg)
+    vertex_ids = vertices["id"].map(_text)
+    if stray := sorted(set(vertex_ids) - set(wanted)):
+        msg = (
+            f"The vertex id(s) {', '.join(stray)} name no path or polygon in this set."
+        )
+        raise ParameterError(msg)
+    for name, group in vertices.groupby(vertex_ids.values, sort=True):
+        if group["seq"].duplicated().any():
+            msg = f"The vertices of {str(name)!r} repeat a seq, so they have no order."
+            raise ParameterError(msg)
+        least = _VERTEX_KINDS[wanted[name]]
+        if len(group) < least:
+            msg = (
+                f"The {wanted[name]} {str(name)!r} states {len(group)} vertices; "
+                f"it is a shape with at least {least}."
+            )
+            raise ParameterError(msg)
+    if bare := sorted(set(wanted) - set(vertex_ids)):
+        msg = f"The path or polygon id(s) {', '.join(bare)} state no vertices."
+        raise ParameterError(msg)
+    return vertices.sort_values(["id", "seq"], kind="stable").reset_index(drop=True)
+
+
+def _fill_vertex_bounds(frame, vertices, spellings) -> pd.DataFrame:
+    """
+    Give every path and polygon row the bounding region of its vertices.
+
+    The vertices are the shape and the box is a cache of them, so a row
+    which states one that disagrees is refused rather than quietly
+    corrected. Rows stating none get theirs filled in, which is what lets
+    a table operation treat every geometry alike.
+    """
+    if vertices.empty:
+        return frame
+    out = frame.copy()
+    ids = out["id"].map(_text)
+    for dim, spelling in spellings.items():
+        if dim not in vertices.columns:
+            continue
+        bounds = vertices.groupby(vertices["id"].map(_text))[dim].agg(["min", "max"])
+        if spelling.point is not None:
+            _fill_point_bounds(out, ids, bounds, dim, spelling.point)
+            continue
+        for column, side in ((spelling.start, "min"), (spelling.end, "max")):
+            if column is None:
+                out[f"{dim}{_START if side == 'min' else _END}"] = pd.Series(
+                    ids.map(bounds[side]), index=out.index
+                )
+                continue
+            derived = ids.map(bounds[side])
+            stated = out[column]
+            clash = derived.notna() & stated.notna() & (derived != stated)
+            if clash.any():
+                rows = ", ".join(str(x) for x in out.index[clash][:5])
+                msg = (
+                    f"Row(s) {rows} state a {column} which disagrees with their "
+                    "vertices; a bounding region is derived from them."
+                )
+                raise ParameterError(msg)
+            out[column] = stated.where(derived.isna(), derived)
+    return out
+
+
+def _fill_point_bounds(out, ids, bounds, dim: str, column: str) -> None:
+    """
+    Give a point-spelled dimension the value its vertices sit at.
+
+    A set spelling a dimension as a bare column says every annotation is a
+    point along it, so a path which spans that dimension contradicts the
+    set rather than merely bounding itself oddly.
+    """
+    spanning = bounds["min"] != bounds["max"]
+    if spanning.any():
+        named = ", ".join(str(x) for x in bounds.index[spanning][:5])
+        msg = (
+            f"The path or polygon id(s) {named} span {dim}, which this set "
+            f"spells as a point ({column}); a spanning geometry needs "
+            f"{dim}{_START}/{dim}{_END}."
+        )
+        raise ParameterError(msg)
+    derived = ids.map(bounds["min"])
+    stated = out[column]
+    clash = derived.notna() & stated.notna() & (derived != stated)
+    if clash.any():
+        rows = ", ".join(str(x) for x in out.index[clash][:5])
+        msg = (
+            f"Row(s) {rows} state a {column} which disagrees with their "
+            "vertices; a bounding region is derived from them."
+        )
+        raise ParameterError(msg)
+    out[column] = stated.where(derived.isna(), derived)
+
+
+def _read_bounds(row, spellings) -> dict[str, tuple[Any, Any]]:
+    """Return the half-open bounds a row states, per dimension."""
+    out = {}
+    for dim, spelling in spellings.items():
+        if spelling.point is not None:
+            value = row.get(spelling.point)
+            if _stated(value):
+                out[dim] = (_scalar(value), _scalar(value))
+            continue
+        start = row.get(spelling.start) if spelling.start else None
+        end = row.get(spelling.end) if spelling.end else None
+        if _stated(start) and _stated(end):
+            out[dim] = (_scalar(start), _scalar(end))
+    return out
+
+
+def _row_vertices(vertices, identity, dims) -> dict[str, tuple]:
+    """Return one annotation's vertices, ordered by seq, keyed by dimension."""
+    rows = vertices[vertices["id"].map(_text) == _text(identity)]
+    stated = [x for x in dims if x in rows.columns]
+    return {dim: tuple(_scalar(x) for x in rows[dim]) for dim in stated}
+
+
+def _read_extra(row, dims, spellings) -> dict[str, Any]:
+    """Return the columns a row states which the set does not model."""
+    known = set(RESERVED_COLUMNS)
+    for spelling in spellings.values():
+        known |= {x for x in (spelling.point, spelling.start, spelling.end) if x}
+    known |= set(dims)
+    return {
+        str(k): _freeze(v) for k, v in row.items() if str(k) not in known and _stated(v)
+    }
+
+
+def _freeze(value):
+    """
+    Return a value nothing can change through the set which handed it out.
+
+    A frame cell may hold a list or a dict, and copying a frame does not
+    copy those; an annotation which handed one back would let its holder
+    edit a set which says it is immutable.
+    """
+    if isinstance(value, Mapping):
+        return FrozenDict({k: _freeze(v) for k, v in value.items()})
+    if isinstance(value, list | set | tuple | np.ndarray):
+        return tuple(_freeze(x) for x in value)
+    return _scalar(value)
+
+
+def _check_basis(frame, dims) -> None:
+    """Read every stated curve at load, so a bad one is not found later."""
+    if "basis" not in frame.columns:
+        return
+    for value in frame["basis"]:
+        _read_basis(value, dims)
+
+
+def _read_basis(value, dims):
+    """
+    Return the curve a cell states, which may be the model or its document.
+
+    A set carries a basis so the curve survives a round trip through a
+    frame; the vertices remain the shape, and this is what drew them.
+    """
+    if not _stated(value):
+        return None
+    if isinstance(value, AnnotationBasis):
+        basis = value
+    else:
+        try:
+            basis = _BASIS_ADAPTER.validate_python(value)
+        except ValidationError as error:
+            msg = f"Could not read {value!r} as a curve: {error}."
+            raise ParameterError(msg) from error
+    if foreign := sorted(set(basis.dims) - set(dims)):
+        msg = (
+            f"The curve names the dimension(s) {', '.join(foreign)}, which the "
+            f"set does not declare. It declares {list(dims)}."
+        )
+        raise ParameterError(msg)
+    return basis
+
+
+def _read_tags(value) -> tuple[str, ...]:
+    """Return the tags a cell states, which may be text or a sequence."""
+    if not _stated(value):
+        return ()
+    if isinstance(value, str):
+        return tuple(x.strip() for x in value.split(",") if x.strip())
+    if isinstance(value, Iterable):
+        return tuple(str(x) for x in value)
+    # A lone value is one tag; a cell holding a number is not a mistake,
+    # it is a label which happens to be spelled as one.
+    return (str(value),)
+
+
+def _scalar(value):
+    """
+    Return a cell's value as the plainest thing which still says it.
+
+    Numpy numbers become python ones, so a bound reads as the number it
+    is; datetimes and timedeltas keep their numpy type, which is what
+    makes an endpoint on a time dimension a time rather than an integer.
+    """
+    if isinstance(value, datetime.datetime | datetime.date):
+        return to_datetime64(value)
+    if isinstance(value, pd.Timedelta):
+        return value.to_timedelta64()
+    if isinstance(value, np.generic) and value.dtype.kind not in "mM":
+        return value.item()
+    return value
+
+
+def _text(value) -> str:
+    """Return a cell as text, an unstated one as the empty string."""
+    return str(value) if _stated(value) else ""
+
+
+def _stated(value) -> bool:
+    """Whether a cell states anything at all."""
+    if value is None:
+        return False
+    try:
+        return not bool(pd.isnull(value))
+    except (TypeError, ValueError):
+        # An array-like cell; it is stated by being there.
+        return True

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -1,0 +1,1131 @@
+"""Tests for annotation sets and the models they hand out."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+import dascore as dc
+from dascore.core.annotations import (
+    Annotation,
+    AnnotationBasis,
+    AnnotationSet,
+    AnnotationSetAttrs,
+    Line,
+    Moveout,
+    Path,
+    Polygon,
+    Region,
+)
+from dascore.exceptions import ParameterError
+
+DIMS = ("time", "distance")
+
+TIMES = np.array(
+    ["2020-01-01T00:00:00", "2020-01-01T00:00:01", "2020-01-01T00:00:02"],
+    dtype="datetime64[ns]",
+)
+
+
+@pytest.fixture(scope="module")
+def region_set():
+    """A set of plain regions, the common case."""
+    frame = pd.DataFrame(
+        {
+            "group": ["event", "event", "noisy"],
+            "value": ["car", "truck", True],
+            "distance_start": [10.0, 30.0, 0.0],
+            "distance_end": [80.0, 90.0, 100.0],
+        }
+    )
+    return AnnotationSet(frame, dims=DIMS)
+
+
+@pytest.fixture(scope="module")
+def path_set():
+    """A set holding one path beside one region."""
+    frame = pd.DataFrame(
+        {
+            "id": ["p1", "e1"],
+            "group": ["pick", "pick"],
+            "value": ["car", "truck"],
+            "geometry": ["path", "region"],
+            "distance_start": [np.nan, 10.0],
+            "distance_end": [np.nan, 80.0],
+        }
+    )
+    vertices = pd.DataFrame(
+        {"id": ["p1"] * 3, "seq": [0, 1, 2], "time": TIMES, "distance": [1.0, 5.0, 9.0]}
+    )
+    return AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+
+def _polygon_set(count: int = 3):
+    """Build a set holding one polygon of ``count`` vertices."""
+    frame = pd.DataFrame({"id": ["g1"], "geometry": ["polygon"]})
+    vertices = pd.DataFrame(
+        {
+            "id": ["g1"] * count,
+            "seq": list(range(count)),
+            "distance": [float(x) for x in range(count)],
+        }
+    )
+    return AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+
+class TestConstruction:
+    """A set is built from a frame and the dimensions it is stated in."""
+
+    def test_len_and_iteration(self, region_set):
+        """Every row is one annotation."""
+        assert len(region_set) == 3
+        assert [x.group for x in region_set] == ["event", "event", "noisy"]
+
+    def test_rows_are_annotations(self, region_set):
+        """Indexing builds the row's model."""
+        assert isinstance(region_set[0], Annotation)
+
+    def test_dims_required(self):
+        """A set which names no dimension states nothing about where."""
+        with pytest.raises(ParameterError, match="states its dimensions"):
+            AnnotationSet(pd.DataFrame({"group": ["a"]}))
+
+    def test_dims_from_attrs(self):
+        """Dimensions may come from an attrs object instead of the keyword."""
+        attrs = AnnotationSetAttrs(dims=DIMS)
+        assert AnnotationSet(pd.DataFrame({"group": ["a"]}), attrs=attrs).dims == DIMS
+
+    def test_keyword_overrides_attrs(self):
+        """An explicit keyword wins over what attrs states."""
+        attrs = AnnotationSetAttrs(dims=DIMS, acquisition_key="OLD.A.L.ACQ")
+        out = AnnotationSet(None, attrs=attrs, acquisition_key="NEW.A.L.ACQ")
+        assert out.attrs.acquisition_key == "NEW.A.L.ACQ"
+
+    def test_empty_set(self):
+        """A set with no rows is a set, not an error."""
+        out = AnnotationSet(None, dims=DIMS)
+        assert len(out) == 0
+        assert list(out) == []
+
+    def test_records(self):
+        """Anything a frame can be built from works."""
+        out = AnnotationSet([{"group": "a"}, {"group": "b"}], dims=DIMS)
+        assert len(out) == 2
+
+    def test_unreadable_data(self):
+        """Something which is not tabular says so."""
+        with pytest.raises(ParameterError, match="as a dataframe"):
+            AnnotationSet(object(), dims=DIMS)
+
+    def test_duplicate_columns_refused(self):
+        """Pandas allows a repeated name; every reader here expects one column."""
+        frame = pd.DataFrame([["g", "g", 1]], columns=["group", "group", "value"])
+        with pytest.raises(ParameterError, match="more than once"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_repr_names_contents(self, region_set):
+        """The repr says how many annotations and over which dimensions."""
+        assert "3 annotations" in repr(region_set)
+        assert "time" in repr(region_set)
+
+    def test_equality(self, region_set):
+        """Two sets built the same way are equal."""
+        same = AnnotationSet(region_set.to_dataframe(), attrs=region_set.attrs)
+        assert same == region_set
+        assert region_set != AnnotationSet(None, dims=DIMS)
+
+    def test_not_equal_to_other_types(self, region_set):
+        """A set is not equal to something which is not one."""
+        assert region_set != "not a set"
+
+
+class TestDimensionSpelling:
+    """A dimension is a point, a range, or unconstrained."""
+
+    def test_range_columns(self, region_set):
+        """A start/end pair is a half-open range."""
+        assert region_set[0].region.bounds["distance"] == (10.0, 80.0)
+
+    def test_bare_column_is_a_point(self):
+        """A bare dimension column states a point, which is a zero-width range."""
+        out = AnnotationSet(pd.DataFrame({"distance": [5.0]}), dims=DIMS)
+        assert out[0].region.bounds["distance"] == (5.0, 5.0)
+        assert out[0].region.is_point("distance")
+
+    def test_region_names_its_dims(self, region_set):
+        """A region says which dimensions it constrains."""
+        assert region_set[0].region.dims == ("distance",)
+
+    def test_timedelta_endpoints_keep_their_type(self):
+        """A bound on a lag dimension is a duration, not the integer behind it."""
+        lags = np.array([1, 5], dtype="timedelta64[s]")
+        frame = pd.DataFrame({"time_start": lags[:1], "time_end": lags[1:]})
+        start, end = AnnotationSet(frame, dims=DIMS)[0].region.bounds["time"]
+        assert isinstance(start, np.timedelta64)
+        assert isinstance(end, np.timedelta64)
+
+    def test_unconstrained_dim_absent(self, region_set):
+        """A dimension no column names does not appear in the bounds."""
+        assert "time" not in region_set[0].region.bounds
+
+    def test_unstated_cell_is_unconstrained(self):
+        """A blank cell constrains nothing, even where the column exists."""
+        frame = pd.DataFrame({"distance_start": [np.nan], "distance_end": [np.nan]})
+        assert AnnotationSet(frame, dims=DIMS)[0].region.bounds == {}
+
+    def test_both_spellings_refused(self):
+        """One dimension is spelled one way."""
+        frame = pd.DataFrame({"time": [1], "time_start": [1], "time_end": [2]})
+        with pytest.raises(ParameterError, match="both as a point"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_half_a_range_refused(self):
+        """A start with no end does not bound anything."""
+        with pytest.raises(ParameterError, match="half a range"):
+            AnnotationSet(pd.DataFrame({"time_start": [1]}), dims=DIMS)
+
+    def test_reversed_range_refused(self):
+        """An impossible range is structural, so the set does not load."""
+        frame = pd.DataFrame({"distance_start": [9.0], "distance_end": [1.0]})
+        with pytest.raises(ParameterError, match="ends before it starts"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_reversed_range_names_its_row(self):
+        """The refused row is named, so a long set says which one."""
+        frame = pd.DataFrame({"distance_start": [0.0, 9.0], "distance_end": [1.0, 1.0]})
+        with pytest.raises(ParameterError, match="Row 1"):
+            AnnotationSet(frame, dims=DIMS)
+
+    @pytest.mark.parametrize("side", ["distance_start", "distance_end"])
+    def test_half_a_range_cell_refused(self, side):
+        """A row states both ends or neither; one end bounds nothing."""
+        frame = pd.DataFrame({"distance_start": [np.nan], "distance_end": [np.nan]})
+        frame[side] = [1.0]
+        with pytest.raises(ParameterError, match="half a distance range"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_incomparable_range_refused(self):
+        """A range whose ends cannot be compared says so, not TypeError."""
+        frame = pd.DataFrame({"distance_start": [1.0, "a"], "distance_end": ["b", 2.0]})
+        with pytest.raises(ParameterError, match="cannot be compared"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_datetime_endpoints_keep_their_type(self):
+        """A time bound is a time, not the integer behind it."""
+        frame = pd.DataFrame({"time_start": TIMES[:1], "time_end": TIMES[2:]})
+        start, end = AnnotationSet(frame, dims=DIMS)[0].region.bounds["time"]
+        assert isinstance(start, np.datetime64)
+        assert isinstance(end, np.datetime64)
+
+
+class TestColumns:
+    """Unknown columns carry; near-misses do not."""
+
+    def test_unknown_column_is_an_extra(self):
+        """A column the set does not model rides along with its row."""
+        out = AnnotationSet(pd.DataFrame({"score": [0.9]}), dims=DIMS)
+        assert out[0].extra["score"] == 0.9
+
+    def test_unstated_extra_dropped(self):
+        """A blank extra states nothing, so the row does not carry it."""
+        out = AnnotationSet(pd.DataFrame({"score": [np.nan]}), dims=DIMS)
+        assert "score" not in out[0].extra
+
+    def test_undeclared_range_pair_refused(self):
+        """A range naming no declared dimension is a forgotten dimension."""
+        frame = pd.DataFrame({"depth_start": [1], "depth_end": [2]})
+        with pytest.raises(ParameterError, match="name no declared dimension"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_lone_range_column_is_an_extra(self):
+        """One half of a range names no dimension, so it is just a column."""
+        out = AnnotationSet(pd.DataFrame({"depth_start": [1]}), dims=DIMS)
+        assert out[0].extra["depth_start"] == 1
+
+    def test_declared_column_documents_only(self):
+        """Documenting a column does not gate any other one."""
+        out = AnnotationSet(
+            pd.DataFrame({"score": [0.9], "other": [1]}),
+            dims=DIMS,
+            columns={"score": {"description": "Confidence", "units": "dimensionless"}},
+        )
+        assert out.attrs.columns["score"].description == "Confidence"
+        assert "other" in out[0].extra
+
+    def test_stated_dtype_checked(self):
+        """A column which says what it holds must hold it."""
+        with pytest.raises(ParameterError, match="states dtype"):
+            AnnotationSet(
+                pd.DataFrame({"score": ["high"]}),
+                dims=DIMS,
+                columns={"score": {"dtype": "float64"}},
+            )
+
+    @pytest.mark.parametrize(
+        ("dtype", "values"),
+        [("str", ["a", "b"]), ("category", ["a", "b"]), ("Int64", [1, 2])],
+    )
+    def test_extension_dtypes_declarable(self, dtype, values):
+        """Pandas gives plain text a `str` dtype, which numpy cannot name."""
+        frame = pd.DataFrame({"note": values}).astype(dtype)
+        out = AnnotationSet(frame, dims=DIMS, columns={"note": {"dtype": dtype}})
+        assert len(out) == 2
+
+    def test_category_needs_no_categories(self):
+        """A column documented as categorical says so, not which categories."""
+        frame = pd.DataFrame({"note": ["a", "b"]}).astype("category")
+        assert (
+            len(
+                AnnotationSet(frame, dims=DIMS, columns={"note": {"dtype": "category"}})
+            )
+            == 2
+        )
+
+    def test_datetime_unit_still_distinguished(self):
+        """Comparing by name keeps a nanosecond column from passing as microsecond."""
+        frame = pd.DataFrame({"when": TIMES[:1]})
+        with pytest.raises(ParameterError, match="states dtype"):
+            AnnotationSet(
+                frame, dims=DIMS, columns={"when": {"dtype": "datetime64[us]"}}
+            )
+
+    def test_unreadable_dtype_refused(self):
+        """A dtype naming nothing says so, rather than raising numpy's error."""
+        with pytest.raises(ParameterError, match="declares the dtype"):
+            AnnotationSet(
+                pd.DataFrame({"score": [1.0]}),
+                dims=DIMS,
+                columns={"score": {"dtype": "not-a-dtype"}},
+            )
+
+    def test_stated_dtype_absent_column(self):
+        """Documenting a column the frame lacks is not an error."""
+        out = AnnotationSet(None, dims=DIMS, columns={"score": {"dtype": "float64"}})
+        assert "score" in out.attrs.columns
+
+
+class TestValues:
+    """A group holds one kind of value."""
+
+    def test_mixed_kinds_refused(self):
+        """A boolean and a number in one group are two variables."""
+        frame = pd.DataFrame({"group": ["g", "g"], "value": [True, 3]})
+        with pytest.raises(ParameterError, match="mixes"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_unnamed_group_is_still_a_group(self):
+        """Pandas drops a null grouping key; the unnamed group is checked anyway."""
+        frame = pd.DataFrame({"group": [None, None], "value": [True, 1]})
+        with pytest.raises(ParameterError, match="mixes"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_int_and_float_are_one_kind(self):
+        """Numbers are numbers; the model reads them alike."""
+        frame = pd.DataFrame({"group": ["g", "g"], "value": [1.5, 3]})
+        assert len(AnnotationSet(frame, dims=DIMS)) == 2
+
+    def test_groups_are_independent(self):
+        """Two groups may hold different kinds."""
+        frame = pd.DataFrame({"group": ["a", "b"], "value": [True, "car"]})
+        assert len(AnnotationSet(frame, dims=DIMS)) == 2
+
+    def test_overlap_is_not_checked(self):
+        """Non-overlap only means anything at projection, so it is deferred."""
+        frame = pd.DataFrame(
+            {
+                "group": ["g", "g"],
+                "value": ["a", "b"],
+                "distance_start": [0.0, 5.0],
+                "distance_end": [10.0, 15.0],
+            }
+        )
+        assert len(AnnotationSet(frame, dims=DIMS)) == 2
+
+    def test_value_defaults_to_true(self):
+        """An annotation with no value is a bare flag."""
+        assert AnnotationSet(pd.DataFrame({"group": ["a"]}), dims=DIMS)[0].value is True
+
+    def test_numpy_bool_stays_a_flag(self):
+        """A mask element is membership, not the number one."""
+        frame = pd.DataFrame({"group": ["a"], "value": [np.bool_(True)]})
+        assert AnnotationSet(frame, dims=DIMS)[0].value is True
+
+    def test_non_finite_value_refused(self):
+        """A value which cannot survive a round trip is not a value."""
+        frame = pd.DataFrame({"group": ["a"], "value": [np.inf]})
+        with pytest.raises(ParameterError, match="must be finite"):
+            AnnotationSet(frame, dims=DIMS)
+
+
+class TestTags:
+    """Tags are multi-membership labels."""
+
+    def test_comma_separated_text(self):
+        """A tag cell written as text splits on commas."""
+        out = AnnotationSet(pd.DataFrame({"tags": ["a, b"]}), dims=DIMS)
+        assert out[0].tags == ("a", "b")
+
+    def test_sequence(self):
+        """A cell holding a sequence is taken as it is."""
+        out = AnnotationSet(pd.DataFrame({"tags": [["a", "b"]]}), dims=DIMS)
+        assert out[0].tags == ("a", "b")
+
+    def test_scalar_is_one_tag(self):
+        """A label which happens to be a number is still one label."""
+        assert AnnotationSet(pd.DataFrame({"tags": [5]}), dims=DIMS)[0].tags == ("5",)
+
+    def test_absent(self):
+        """No tags is an empty tuple, not None."""
+        assert AnnotationSet(pd.DataFrame({"group": ["a"]}), dims=DIMS)[0].tags == ()
+
+
+class TestIdentity:
+    """Ids are the producer's, and nothing here invents one."""
+
+    def test_absent_id_is_blank(self, region_set):
+        """A set without ids is fine; identity-needing operations are not."""
+        assert region_set[0].id == ""
+
+    def test_duplicate_ids_refused(self):
+        """An id names one row."""
+        with pytest.raises(ParameterError, match="more than one row"):
+            AnnotationSet(pd.DataFrame({"id": ["a", "a"]}), dims=DIMS)
+
+    def test_blank_ids_may_repeat(self):
+        """Unstated identity is not a clash."""
+        frame = pd.DataFrame({"id": [None, None], "group": ["a", "b"]})
+        assert len(AnnotationSet(frame, dims=DIMS)) == 2
+
+    def test_parent_must_exist(self):
+        """A parent names an annotation of this set."""
+        frame = pd.DataFrame({"id": ["a"], "parent": ["z"]})
+        with pytest.raises(ParameterError, match="name no annotation"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_parent_resolves(self):
+        """A pick group points at its parent by id."""
+        frame = pd.DataFrame({"id": ["a", "b"], "parent": ["", "a"]})
+        assert AnnotationSet(frame, dims=DIMS)[1].parent == "a"
+
+
+class TestAcquisitionKeyColumn:
+    """A set may span acquisitions, so a row may name its own."""
+
+    def test_row_takes_the_set_key(self):
+        """A row naming none is addressed by the set."""
+        out = AnnotationSet(
+            pd.DataFrame({"group": ["a"]}), dims=DIMS, acquisition_key="N.A.L.ACQ"
+        )
+        assert out[0].acquisition_key == "N.A.L.ACQ"
+
+    def test_row_overrides_the_set_key(self):
+        """A row naming one overrides the set-level address."""
+        frame = pd.DataFrame({"acquisition_key": ["N.A.L.OTHER"]})
+        out = AnnotationSet(frame, dims=DIMS, acquisition_key="N.A.L.ACQ")
+        assert out[0].acquisition_key == "N.A.L.OTHER"
+
+    def test_blank_row_key_falls_back(self):
+        """An empty cell states nothing, so the set's key stands."""
+        frame = pd.DataFrame({"acquisition_key": [None]})
+        out = AnnotationSet(frame, dims=DIMS, acquisition_key="N.A.L.ACQ")
+        assert out[0].acquisition_key == "N.A.L.ACQ"
+
+    def test_row_key_validated(self):
+        """A row's key is checked like the set's."""
+        frame = pd.DataFrame({"acquisition_key": ["nope"]})
+        with pytest.raises(ValidationError, match="Invalid acquisition_key"):
+            AnnotationSet(frame, dims=DIMS)[0]
+
+    def test_key_column_is_not_an_extra(self):
+        """The column is modelled, so it does not also ride along as an extra."""
+        frame = pd.DataFrame({"acquisition_key": ["N.A.L.ACQ"]})
+        assert "acquisition_key" not in AnnotationSet(frame, dims=DIMS)[0].extra
+
+
+class TestGeometryKinds:
+    """A row states which geometry it is."""
+
+    def test_default_is_region(self, region_set):
+        """A set naming no geometry is a set of regions."""
+        assert isinstance(region_set[0].geometry, Region)
+
+    def test_unknown_kind_refused(self):
+        """A geometry this format has no meaning for is refused."""
+        with pytest.raises(ParameterError, match="is not one of"):
+            AnnotationSet(pd.DataFrame({"geometry": ["blob"]}), dims=DIMS)
+
+    def test_path_requires_id(self):
+        """Vertices are grouped by id, so a path without one binds to nothing."""
+        with pytest.raises(ParameterError, match="no id"):
+            AnnotationSet(pd.DataFrame({"geometry": ["path"]}), dims=DIMS)
+
+    def test_path_geometry(self, path_set):
+        """A path row builds a Path holding its vertices."""
+        geometry = path_set[0].geometry
+        assert isinstance(geometry, Path)
+        assert len(geometry) == 3
+        assert geometry.vertices["distance"] == (1.0, 5.0, 9.0)
+
+    def test_polygon_geometry(self):
+        """A polygon row builds a Polygon."""
+        assert isinstance(_polygon_set()[0].geometry, Polygon)
+
+    def test_region_beside_a_path(self, path_set):
+        """A set may mix geometries; each row is read as what it says."""
+        assert isinstance(path_set[1].geometry, Region)
+
+    def test_vertex_dims(self, path_set):
+        """The vertices name the dimensions they are stated in."""
+        assert set(path_set[0].geometry.dims) == set(DIMS)
+
+    def test_datetime_vertices_keep_their_type(self, path_set):
+        """A vertex on the time dimension is a time."""
+        assert isinstance(path_set[0].geometry.vertices["time"][0], np.datetime64)
+
+    def test_region_property_for_every_geometry(self, path_set):
+        """Every annotation has a bounding region, whatever its geometry."""
+        assert isinstance(path_set[0].region, Region)
+        assert isinstance(path_set[1].region, Region)
+
+
+class TestVertices:
+    """The vertices frame is checked against the rows which need it."""
+
+    def test_bounds_derived_from_vertices(self, path_set):
+        """A path's bounding region is the box its vertices fill."""
+        assert path_set[0].region.bounds["distance"] == (1.0, 9.0)
+
+    def test_derived_bounds_reach_the_frame(self, path_set):
+        """The derived box is a real column, so table operations see it."""
+        row = path_set.to_dataframe().iloc[0]
+        assert (row["distance_start"], row["distance_end"]) == (1.0, 9.0)
+
+    def test_stated_bounds_must_agree(self):
+        """The vertices are the shape; a box which disagrees is refused."""
+        frame = pd.DataFrame(
+            {
+                "id": ["x"],
+                "geometry": ["path"],
+                "distance_start": [99.0],
+                "distance_end": [100.0],
+            }
+        )
+        vertices = pd.DataFrame(
+            {"id": ["x", "x"], "seq": [0, 1], "distance": [1.0, 2.0]}
+        )
+        with pytest.raises(ParameterError, match="disagrees with their vertices"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_path_spanning_a_point_dimension_refused(self):
+        """A set spelling a dimension as a point holds no geometry spanning it."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"], "distance": [np.nan]})
+        vertices = pd.DataFrame(
+            {"id": ["x", "x"], "seq": [0, 1], "distance": [1.0, 2.0]}
+        )
+        with pytest.raises(ParameterError, match="spells as a point"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_degenerate_path_on_a_point_dimension(self):
+        """Vertices which do not move along a point dimension fill it in."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"], "distance": [np.nan]})
+        vertices = pd.DataFrame(
+            {"id": ["x", "x"], "seq": [0, 1], "distance": [2.0, 2.0]}
+        )
+        out = AnnotationSet(frame, dims=DIMS, vertices=vertices)
+        assert out[0].region.bounds["distance"] == (2.0, 2.0)
+
+    def test_stated_point_must_agree(self):
+        """A stated point which the vertices contradict is refused."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"], "distance": [99.0]})
+        vertices = pd.DataFrame(
+            {"id": ["x", "x"], "seq": [0, 1], "distance": [2.0, 2.0]}
+        )
+        with pytest.raises(ParameterError, match="disagrees with their vertices"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_missing_vertices_refused(self):
+        """A path with no vertices states no shape."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"]})
+        with pytest.raises(ParameterError, match="state no vertices"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_one_path_without_vertices_refused(self):
+        """Every path needs vertices, not just one of them."""
+        frame = pd.DataFrame({"id": ["x", "y"], "geometry": ["path", "path"]})
+        vertices = pd.DataFrame(
+            {"id": ["x", "x"], "seq": [0, 1], "distance": [1.0, 2.0]}
+        )
+        with pytest.raises(ParameterError, match="y state no vertices"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_stray_vertices_refused(self):
+        """Vertices belong to a path or polygon of this set."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["region"]})
+        vertices = pd.DataFrame({"id": ["y"], "seq": [0], "distance": [1.0]})
+        with pytest.raises(ParameterError, match="name no path or polygon"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_scaffolding_columns_required(self):
+        """Vertices are grouped by id and ordered by seq."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"]})
+        vertices = pd.DataFrame({"id": ["x", "x"], "distance": [1.0, 2.0]})
+        with pytest.raises(ParameterError, match="state no seq"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_undeclared_vertex_dim_refused(self):
+        """A vertex column names a declared dimension."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"]})
+        vertices = pd.DataFrame({"id": ["x", "x"], "seq": [0, 1], "depth": [1.0, 2.0]})
+        with pytest.raises(ParameterError, match="name no declared dimension"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_vertices_place_something(self):
+        """Vertices with no dimension column place nothing."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"]})
+        vertices = pd.DataFrame({"id": ["x", "x"], "seq": [0, 1]})
+        with pytest.raises(ParameterError, match="no dimension column"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_blank_seq_refused(self):
+        """A vertex with no seq has no place in the order."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"]})
+        vertices = pd.DataFrame(
+            {"id": ["x", "x"], "seq": [0, None], "distance": [1.0, 2.0]}
+        )
+        with pytest.raises(ParameterError, match="state no seq"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_blank_vertex_dimension_refused(self):
+        """A vertex leaving a dimension empty places nothing there."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"]})
+        vertices = pd.DataFrame(
+            {"id": ["x", "x"], "seq": [0, 1], "distance": [np.nan, 1.0]}
+        )
+        with pytest.raises(ParameterError, match="leave a dimension empty"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_repeated_seq_refused(self):
+        """Two vertices in one place do not say which comes first."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"]})
+        vertices = pd.DataFrame(
+            {"id": ["x", "x"], "seq": [0, 0], "distance": [1.0, 2.0]}
+        )
+        with pytest.raises(ParameterError, match="repeat a seq"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_vertices_ordered_by_seq(self):
+        """Vertices are read in seq order, not the order they were written."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"]})
+        vertices = pd.DataFrame(
+            {"id": ["x", "x"], "seq": [1, 0], "distance": [9.0, 1.0]}
+        )
+        out = AnnotationSet(frame, dims=DIMS, vertices=vertices)
+        assert out[0].geometry.vertices["distance"] == (1.0, 9.0)
+
+    @pytest.mark.parametrize(("kind", "least"), [("path", 2), ("polygon", 3)])
+    def test_too_few_vertices_refused(self, kind, least):
+        """A shape needs enough points to be one."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": [kind]})
+        count = least - 1
+        vertices = pd.DataFrame(
+            {
+                "id": ["x"] * count,
+                "seq": list(range(count)),
+                "distance": [float(x) for x in range(count)],
+            }
+        )
+        with pytest.raises(ParameterError, match="at least"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_to_vertices_round_trips(self, path_set):
+        """The vertices come back out whole: order, coordinates and types."""
+        out = path_set.to_vertices()
+        assert list(out["id"]) == ["p1"] * 3
+        assert list(out["seq"]) == [0, 1, 2]
+        assert list(out["distance"]) == [1.0, 5.0, 9.0]
+        assert out["time"].dtype == np.dtype("datetime64[ns]")
+        assert list(out["time"]) == list(pd.Series(TIMES))
+
+    def test_empty_vertices_frame(self, region_set):
+        """A set with no vertex geometry has an empty vertices frame."""
+        assert region_set.to_vertices().empty
+
+
+class TestFrames:
+    """The frames the set hands back are copies of its own."""
+
+    def test_to_dataframe_is_a_copy(self, region_set):
+        """Mutating what a set handed out does not reach the set."""
+        frame = region_set.to_dataframe()
+        frame.loc[0, "group"] = "changed"
+        assert region_set[0].group == "event"
+
+    def test_to_vertices_is_a_copy(self, path_set):
+        """The same holds for the vertices."""
+        vertices = path_set.to_vertices()
+        vertices.loc[0, "distance"] = 999.0
+        assert path_set[0].geometry.vertices["distance"][0] == 1.0
+
+    def test_extras_are_frozen(self):
+        """A mutable cell cannot be edited through the annotation holding it."""
+        out = AnnotationSet(pd.DataFrame({"note": [[1, 2]]}), dims=DIMS)
+        assert out[0].extra["note"] == (1, 2)
+        with pytest.raises(AttributeError):
+            out[0].extra["note"].append(3)
+
+    def test_nested_extras_are_frozen(self):
+        """Freezing reaches inside a mapping cell too."""
+        out = AnnotationSet(pd.DataFrame({"note": [{"a": [1]}]}), dims=DIMS)
+        with pytest.raises(TypeError):
+            out[0].extra["note"]["a"] = 2
+
+    def test_round_trip(self, region_set):
+        """A set rebuilt from its own frame holds the same annotations."""
+        rebuilt = AnnotationSet(region_set.to_dataframe(), attrs=region_set.attrs)
+        assert [x.group for x in rebuilt] == [x.group for x in region_set]
+        assert rebuilt == region_set
+
+
+class TestAttrs:
+    """What a set says about itself."""
+
+    def test_dims_required(self):
+        """A set states at least one dimension."""
+        with pytest.raises(ValidationError, match="at least one dimension"):
+            AnnotationSetAttrs(dims=())
+
+    def test_dims_unique(self):
+        """A dimension named twice is one dimension."""
+        with pytest.raises(ValidationError, match="must be unique"):
+            AnnotationSetAttrs(dims=("time", "time"))
+
+    def test_dim_may_not_alias_another_dims_range(self):
+        """`distance_start` would be both a point and the start of `distance`."""
+        with pytest.raises(ValidationError, match="spelled like the range column"):
+            AnnotationSetAttrs(dims=("distance", "distance_start"))
+
+    def test_dim_may_not_shadow_a_reserved_column(self):
+        """A dimension named `group` would collide with the group column."""
+        with pytest.raises(ValidationError, match="reserved column"):
+            AnnotationSetAttrs(dims=("group", "time"))
+
+    def test_creation_info_default(self):
+        """A set carries provenance even when nothing was said."""
+        assert AnnotationSetAttrs(dims=DIMS).creation_info.author == ""
+
+    def test_acquisition_key_carries(self):
+        """Provenance is an acquisition key, not a file pointer."""
+        attrs = AnnotationSetAttrs(dims=DIMS, acquisition_key="NET.ARRAY.LOC.ACQ")
+        assert attrs.acquisition_key == "NET.ARRAY.LOC.ACQ"
+
+    def test_acquisition_key_validated(self):
+        """The key is spelled as PatchAttrs spells it, and checked alike."""
+        with pytest.raises(ValidationError, match="Invalid acquisition_key"):
+            AnnotationSetAttrs(dims=DIMS, acquisition_key="nope")
+
+    def test_provenance_defaults_to_unset(self):
+        """Phase 2 cannot know a patch, so the producer supplies these."""
+        attrs = AnnotationSetAttrs(dims=DIMS)
+        assert attrs.acquisition_key == ""
+        assert attrs.history == ()
+
+    def test_history_keeps_the_lineage(self):
+        """Picks made on decimated data only mean anything against that."""
+        attrs = AnnotationSetAttrs(dims=DIMS, history=("decimate(8)", "pass_filter"))
+        assert attrs.history == ("decimate(8)", "pass_filter")
+
+    def test_lone_history_entry(self):
+        """PatchAttrs.history may be one string; that is a history of one."""
+        attrs = AnnotationSetAttrs(dims=DIMS, history="decimate(8)")
+        assert attrs.history == ("decimate(8)",)
+
+    def test_creation_info_identifies_the_producer(self):
+        """A picker names itself the way the inventory names any process."""
+        attrs = AnnotationSetAttrs(
+            dims=DIMS,
+            creation_info={"author": "phasenet", "version": "2.1"},
+        )
+        assert attrs.creation_info.author == "phasenet"
+        assert attrs.creation_info.version == "2.1"
+
+    def test_attrs_are_frozen(self):
+        """Attributes are immutable, like every DASCore model."""
+        with pytest.raises(ValidationError):
+            AnnotationSetAttrs(dims=DIMS).dims = ("other",)
+
+
+class TestBasis:
+    """Curves regenerate vertices; they are not geometries themselves."""
+
+    def test_line_walks_between_its_ends(self):
+        """A line is sampled evenly from one end to the other."""
+        out = Line(start={"distance": 0.0}, end={"distance": 10.0})
+        assert list(out.vertices(3)["distance"]) == [0.0, 5.0, 10.0]
+
+    def test_line_carries_real_coordinates(self):
+        """A time endpoint is a time, so the curve needs no separate origin."""
+        out = Line(
+            start={"distance": 0.0, "time": TIMES[0]},
+            end={"distance": 100.0, "time": TIMES[2]},
+        )
+        drawn = out.vertices(3)
+        assert drawn["time"][0] == TIMES[0]
+        assert drawn["time"][-1] == TIMES[2]
+        assert drawn["time"].dtype == np.dtype("datetime64[ns]")
+
+    def test_line_can_be_an_instant(self):
+        """One time across all distance -- a shot, a trigger -- is a line."""
+        out = Line(
+            start={"distance": 0.0, "time": TIMES[0]},
+            end={"distance": 100.0, "time": TIMES[0]},
+        )
+        assert set(out.vertices(4)["time"]) == {TIMES[0]}
+
+    def test_line_names_its_dims(self):
+        """The endpoints name the dimensions, so nothing states them twice."""
+        out = Line(start={"distance": 0.0}, end={"distance": 1.0})
+        assert out.dims == ("distance",)
+
+    def test_line_ends_must_place_the_same_dims(self):
+        """Two ends in different frames draw no line between them."""
+        with pytest.raises(ValidationError, match="different dimensions"):
+            Line(start={"distance": 0.0}, end={"time": TIMES[0]})
+
+    def test_line_states_somewhere(self):
+        """An endpoint naming no dimension is nowhere."""
+        with pytest.raises(ValidationError, match="states no dimension"):
+            Line(start={}, end={})
+
+    def test_line_of_no_length(self):
+        """A line beginning where it ends is a point."""
+        with pytest.raises(ValidationError, match="no length"):
+            Line(start={"distance": 1.0}, end={"distance": 1.0})
+
+    def test_moveout_apex_is_the_earliest_arrival(self):
+        """The apex anchors the curve, and nothing arrives before it."""
+        out = Moveout(
+            apex_distance=50.0,
+            apex_time=TIMES[0],
+            velocity=3000.0,
+            distance_start=0.0,
+            distance_end=100.0,
+        )
+        drawn = out.vertices(11)
+        assert drawn["time"].min() == TIMES[0]
+        assert drawn["time"][5] == TIMES[0]
+
+    def test_moveout_on_the_cable_is_straight(self):
+        """A source with no standoff runs both ways at its velocity."""
+        out = Moveout(
+            apex_distance=50.0,
+            apex_time=TIMES[0],
+            velocity=3000.0,
+            distance_start=0.0,
+            distance_end=100.0,
+        )
+        seconds = (out.vertices(3)["time"] - TIMES[0]) / np.timedelta64(1, "s")
+        assert np.allclose(seconds, [50 / 3000, 0.0, 50 / 3000])
+
+    def test_standoff_flattens_the_apex(self):
+        """A source off the cable arrives sooner away from the apex."""
+        shared = {
+            "apex_distance": 50.0,
+            "apex_time": TIMES[0],
+            "velocity": 3000.0,
+            "distance_start": 0.0,
+            "distance_end": 100.0,
+        }
+        straight = Moveout(**shared).vertices(3)["time"]
+        curved = Moveout(**shared, standoff=40.0).vertices(3)["time"]
+        assert curved[0] < straight[0]
+        assert curved[1] == straight[1] == TIMES[0]
+
+    def test_moveout_times_are_times(self):
+        """The curve draws in the dimension's own coordinates."""
+        out = Moveout(
+            apex_distance=0.0,
+            apex_time=TIMES[0],
+            velocity=1000.0,
+            distance_start=0.0,
+            distance_end=10.0,
+        )
+        assert out.vertices(2)["time"].dtype == np.dtype("datetime64[ns]")
+
+    def test_moveout_is_pinned_to_its_dims(self):
+        """A moveout is physics, so it relates fiber distance to arrival time."""
+        out = Moveout(
+            apex_distance=0.0,
+            apex_time=TIMES[0],
+            velocity=1000.0,
+            distance_start=0.0,
+            distance_end=1.0,
+        )
+        assert out.dims == ("distance", "time")
+
+    def test_moveout_velocity_positive(self):
+        """A wavefront which does not move has no moveout."""
+        with pytest.raises(ValidationError):
+            Moveout(
+                apex_distance=0.0,
+                apex_time=TIMES[0],
+                velocity=0.0,
+                distance_start=0.0,
+                distance_end=1.0,
+            )
+
+    def test_moveout_standoff_not_negative(self):
+        """A source is off the cable or on it, never behind it."""
+        with pytest.raises(ValidationError):
+            Moveout(
+                apex_distance=0.0,
+                apex_time=TIMES[0],
+                velocity=1.0,
+                standoff=-1.0,
+                distance_start=0.0,
+                distance_end=1.0,
+            )
+
+    def test_moveout_span_must_be_positive(self):
+        """A curve which ends where it starts draws nothing."""
+        with pytest.raises(ValidationError, match="must exceed"):
+            Moveout(
+                apex_distance=0.0,
+                apex_time=TIMES[0],
+                velocity=1.0,
+                distance_start=1.0,
+                distance_end=1.0,
+            )
+
+    @pytest.mark.parametrize("count", [0, 1])
+    def test_too_few_points(self, count):
+        """A curve is drawn from at least two points."""
+        out = Line(start={"distance": 0.0}, end={"distance": 1.0})
+        with pytest.raises(ParameterError, match="at least 2 points"):
+            out.vertices(count)
+
+    def test_base_is_abstract(self):
+        """The base class states the interface and implements none of it."""
+        with pytest.raises(NotImplementedError):
+            AnnotationBasis().vertices()
+
+    def test_base_names_no_dims(self):
+        """A curve says which dimensions it is stated in; the base cannot."""
+        with pytest.raises(NotImplementedError):
+            AnnotationBasis().dims
+
+    def test_carried_by_a_path(self):
+        """A path may keep the curve its vertices came from."""
+        basis = Line(start={"distance": 0.0}, end={"distance": 1.0})
+        out = Path(
+            region=Region(bounds={"distance": (0.0, 1.0)}),
+            vertices={"distance": (0.0, 1.0)},
+            basis=basis,
+        )
+        assert out.basis == basis
+
+    def test_regenerates_what_the_frame_holds(self):
+        """The point of a basis: its output is vertices, not numbers to convert."""
+        basis = Moveout(
+            apex_distance=50.0,
+            apex_time=TIMES[0],
+            velocity=3000.0,
+            standoff=40.0,
+            distance_start=0.0,
+            distance_end=100.0,
+        )
+        drawn = basis.vertices(5)
+        vertices = pd.DataFrame({"id": ["m"] * 5, "seq": range(5), **drawn})
+        frame = pd.DataFrame({"id": ["m"], "geometry": ["path"], "basis": [basis]})
+        out = AnnotationSet(frame, dims=DIMS, vertices=vertices)
+        assert out[0].geometry.vertices["time"] == tuple(drawn["time"])
+
+
+class TestGeometryModels:
+    """A geometry built straight from a document checks itself."""
+
+    def test_no_dimension_refused(self):
+        """Vertices naming no dimension place the geometry nowhere."""
+        with pytest.raises(ValidationError, match="states no dimension"):
+            Path(region=Region(bounds={}), vertices={})
+
+    def test_ragged_vertices_refused(self):
+        """Every dimension states every point, or they pair up wrongly."""
+        with pytest.raises(ValidationError, match="differ in length"):
+            Path(
+                region=Region(bounds={}),
+                vertices={"time": (1, 2, 3), "distance": (1,)},
+            )
+
+    @pytest.mark.parametrize(("model", "least"), [(Path, 2), (Polygon, 3)])
+    def test_too_few_vertices_refused(self, model, least):
+        """A shape needs enough points to be one, however it was built."""
+        with pytest.raises(ValidationError, match="at least"):
+            model(
+                region=Region(bounds={}),
+                vertices={"distance": tuple(range(least - 1))},
+            )
+
+    def test_length_is_the_vertex_count(self):
+        """Every dimension is the same length, so any of them is the count."""
+        out = Path(region=Region(bounds={}), vertices={"distance": (0.0, 1.0, 2.0)})
+        assert len(out) == 3
+
+
+class TestBasisColumn:
+    """A set carries the curve its vertices were drawn from."""
+
+    @staticmethod
+    def _vertices():
+        """Two vertices for the path every test here builds."""
+        return pd.DataFrame({"id": ["x", "x"], "seq": [0, 1], "distance": [0.0, 1.0]})
+
+    def test_basis_as_a_document(self):
+        """A cell holding the curve's document reads back as the model."""
+        document = {
+            "object_type": "Line",
+            "start": {"distance": 0.0},
+            "end": {"distance": 1.0},
+        }
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"], "basis": [document]})
+        out = AnnotationSet(frame, dims=DIMS, vertices=self._vertices())
+        assert isinstance(out[0].geometry.basis, Line)
+
+    def test_basis_as_a_model(self):
+        """A cell holding the model itself is taken as it is."""
+        basis = Moveout(
+            apex_distance=0.0,
+            apex_time=TIMES[0],
+            velocity=2.0,
+            distance_start=0.0,
+            distance_end=1.0,
+        )
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"], "basis": [basis]})
+        out = AnnotationSet(frame, dims=DIMS, vertices=self._vertices())
+        assert out[0].geometry.basis == basis
+
+    def test_no_basis(self):
+        """A path without a curve is simply vertices."""
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"]})
+        out = AnnotationSet(frame, dims=DIMS, vertices=self._vertices())
+        assert out[0].geometry.basis is None
+
+    def test_basis_needs_vertices(self):
+        """A basis regenerates vertices, so a region has no use for one."""
+        frame = pd.DataFrame(
+            {"id": ["x"], "geometry": ["region"], "basis": [{"object_type": "Line"}]}
+        )
+        with pytest.raises(ParameterError, match="no path or polygon"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_unreadable_basis(self):
+        """A cell naming no curve says so, when the set loads."""
+        frame = pd.DataFrame(
+            {"id": ["x"], "geometry": ["path"], "basis": [{"object_type": "Nope"}]}
+        )
+        with pytest.raises(ParameterError, match="as a curve"):
+            AnnotationSet(frame, dims=DIMS, vertices=self._vertices())
+
+    def test_basis_dims_must_be_declared(self):
+        """A curve in an unrelated frame regenerates unrelated vertices."""
+        document = {
+            "object_type": "Line",
+            "start": {"depth": 0.0, "other": 1.0},
+            "end": {"depth": 1.0, "other": 2.0},
+        }
+        frame = pd.DataFrame({"id": ["x"], "geometry": ["path"], "basis": [document]})
+        with pytest.raises(ParameterError, match="does not declare"):
+            AnnotationSet(frame, dims=DIMS, vertices=self._vertices())
+
+    def test_basis_without_a_geometry_column(self):
+        """A frame naming no geometry is all regions, which carry no curve."""
+        frame = pd.DataFrame({"id": ["x"], "basis": [{"object_type": "Line"}]})
+        with pytest.raises(ParameterError, match="no path or polygon"):
+            AnnotationSet(frame, dims=DIMS)
+
+
+class TestSerialization:
+    """The models are documents, like every other DASCore model."""
+
+    @pytest.mark.parametrize(
+        "basis",
+        [
+            Line(start={"distance": 0.0}, end={"distance": 1.0}),
+            Moveout(
+                apex_distance=0.0,
+                apex_time=TIMES[0],
+                velocity=1.0,
+                distance_start=0.0,
+                distance_end=1.0,
+            ),
+        ],
+    )
+    def test_basis_names_its_class(self, basis):
+        """A document says which curve it holds, so the union can dispatch."""
+        assert basis.model_dump(mode="json")["object_type"] == type(basis).__name__
+
+    def test_basis_round_trip(self):
+        """A path rebuilds its basis as the class which wrote it."""
+        basis = Moveout(
+            apex_distance=0.0,
+            apex_time=TIMES[0],
+            velocity=2.0,
+            distance_start=0.0,
+            distance_end=1.0,
+        )
+        path = Path(
+            region=Region(bounds={"distance": (0.0, 1.0)}),
+            vertices={"distance": (0.0, 1.0)},
+            basis=basis,
+        )
+        rebuilt = Path(**path.model_dump(mode="json"))
+        assert isinstance(rebuilt.basis, Moveout)
+        assert rebuilt.basis.velocity == 2.0
+
+    def test_region_round_trip(self):
+        """A region survives a document."""
+        region = Region(bounds={"distance": (0.0, 1.0)})
+        assert Region(**region.model_dump(mode="json")) == region
+
+    def test_datetime_bounds_write_a_document(self):
+        """A time bound has no json type, so it is written as DASCore spells it."""
+        region = Region(bounds={"time": (TIMES[0], TIMES[2])})
+        written = region.model_dump(mode="json")["bounds"]["time"]
+        assert written == [str(TIMES[0]), str(TIMES[2])]
+        assert all(isinstance(x, str) for x in written)
+
+    def test_python_dump_keeps_the_time(self):
+        """A python dump is what equality compares, so it keeps the value."""
+        region = Region(bounds={"time": (TIMES[0], TIMES[2])})
+        kept = region.model_dump()["bounds"]["time"][0]
+        assert isinstance(kept, np.datetime64) and kept == TIMES[0]
+
+    def test_numpy_numbers_write_plainly(self):
+        """A numpy number is written as the number it is."""
+        region = Region(bounds={"distance": (np.float64(1.5), np.float64(2.5))})
+        assert region.model_dump(mode="json")["bounds"]["distance"] == [1.5, 2.5]
+
+    def test_vertices_write_a_document(self):
+        """The same holds for the vertices of a path."""
+        path = Path(region=Region(bounds={}), vertices={"time": (TIMES[0], TIMES[1])})
+        written = path.model_dump(mode="json")["vertices"]["time"]
+        assert written == [str(TIMES[0]), str(TIMES[1])]
+
+    def test_geometry_kinds_are_distinct(self):
+        """A polygon is not a path which happens to close."""
+        assert not isinstance(
+            Polygon(
+                region=Region(bounds={}),
+                vertices={"distance": (0.0, 1.0, 2.0)},
+            ),
+            Path,
+        )
+
+
+class TestTopLevel:
+    """The set is reachable from the top-level namespace."""
+
+    def test_dc_annotation_set(self):
+        """`dc.AnnotationSet` is the in-memory door."""
+        assert dc.AnnotationSet is AnnotationSet


### PR DESCRIPTION
## Description

Phase 2 of the annotations work (follows #911). Adds the models: `AnnotationSet` and the geometry and curve objects it hands out. Models only — the store/loader is phase 3 and the spool integration is phase 4, so there is no `dc.annotations` door and no edit verbs here.

An annotation set describes **data** — picks, events, noisy hours, vehicle lines — in the frame of the patches it was made on. Facts about the fiber belong to the inventory instead, in optical distance.

### The set

`dc.AnnotationSet(frame, dims=...)` is immutable and dataframe-backed: one row per annotation, with `Annotation` models built as a lazy view of a row rather than held. Dimensions are spelled in the columns:

| Spelling | Means |
|---|---|
| `<dim>_start` / `<dim>_end` | a half-open range `[start, end)` |
| bare `<dim>` | a point |
| no column | unconstrained |

Spelling one dimension both ways, stating half a range (as a column pair or in a single row), or a range which ends before it starts are all refused at load — structural validation happens when the set is built, not when a row is later touched.

Unknown columns carry as per-annotation extras. An undeclared `<name>_start`/`<name>_end` **pair** raises instead, since that is a dimension the set forgot to declare rather than two unrelated extras.

### Geometry

`Region` (per-dimension point-or-interval, subsuming point/span/box), `Path` and `Polygon`. Per the decision taken during review, paths and polygons keep their vertices in a **separate tidy frame** keyed by annotation id — `id`, `seq`, and one bare column per dimension — and an `id` is therefore **required** of those rows. Their bounding region is derived from the vertices, so table operations treat every geometry alike; a row stating a box which disagrees with its own vertices is refused rather than quietly corrected.

`Line` and `Moveout` form a tagged union (`object_type`, via the model registry) that a row may carry in a `basis` column, as either the model or its document. A basis is not a geometry: it is the curve the vertices were drawn from, and it can regenerate them at any resolution.

Every curve is stated **in its dimensions' own coordinates** — a time endpoint is a `datetime64`, a distance is metres — so it is anchored without a separate origin, and `basis.vertices(n)` produces values that drop straight into the vertices frame. Parameterizing in a dimension's raw numbers instead would put a moveout apex at 1.6e18 nanoseconds and its velocity in metres per nanosecond.

- **`Line`** is two endpoints rather than a slope and intercept. A slope cannot spell a line of constant time across distance — an instant, a shot, a trigger — which is an ordinary thing to annotate, and endpoints are what a person draws when they drag from one place to another. The endpoints also name the dimensions, so nothing states them twice.
- **`Moveout`** is physics rather than geometry, pinned to `distance` against `time`: `apex_distance`, `apex_time`, `velocity` in m/s, and a `standoff` (perpendicular distance from the fiber to the source) defaulting to zero. `apex_time` is both the earliest arrival and the curve's anchor. A source on the cable has no standoff and leaves the straight V of a wave running both ways at `velocity`; a standoff bends it into the hyperbola a point source makes.

### Reused from phase 1

`value_kind` and `normalize_value` back the value rules: a group holds one kind of value (boolean before int, so `1` never becomes `True`), and a non-finite value is refused. Overlap is deliberately **not** checked — it only means anything where a set is projected onto a coordinate, so it stays deferred.

### Assumptions worth a look

- **`Ellipse` was cut.** The doc named it "day one", but it was filling out a trio: there is no DAS quantity it represents, its `rotation` mixes seconds against metres (so the shape depends on a plot's aspect ratio rather than on the data), and DerZug's ellipse is a screen gesture. A screen gesture belongs with the viz work, not in the data model.
- **`Hyperbola` became `Moveout`.** It was named geometrically but parameterized physically (a `velocity`), drew only one branch, and would have accepted `dims` flipped to time→distance, at which point `velocity` stops meaning velocity.
- **Provenance is three existing concepts, not one free field.** The design doc's `source` ("processing history, default `acquisition_key`") was the union of two ideas and could validate neither, so it is split along the precedents the repo already has: `acquisition_key: str` validated with `validate_acquisition_key` and capped at `max_lens["acquisition_key"]`, exactly as `PatchAttrs` spells it; `history: tuple[str, ...]` in `PatchAttrs.history`'s shape, since picks made on decimated or filtered data have coordinates which only mean something against that lineage; and `creation_info`, the inventory's existing model, identifying what produced the annotations (`author="phasenet", version="2.1", agency_id="INERIS"`, or `author="derrick"` for a person). Anything further — a source file, a model checkpoint — goes in its `extra_fields`. No new concepts.
- A set may span acquisitions, so `acquisition_key` is also a reserved column: a row naming its own overrides the set-level address, and a blank cell falls back to it. Row-level keys are validated the same way.
- The doc's "default `acquisition_key`" is deliberately not implemented here — nothing at the model layer knows a patch. The fields exist, validated, defaulting empty; producers fill them, and phase 4 adds the patch-derived constructor (`AnnotationSet.from_patch(patch, df)`) which stamps both off `patch.attrs`. `split_on` consumes sets and stamps nothing.
- Immutability is enforced where a caller can reach: frames are handed out as copies, models are frozen, and mutable cells are frozen when read into `extra`. A mutable object inside a cell of the frame returned by `to_dataframe()` is still shared with the set's own frame, which pandas cannot copy for us; this is documented rather than worked around.
- Narrative docs are phase 5. The API reference picks up the docstrings automatically, and `build_api_docs.py` runs clean over the new module.

## Changelog

- added: `dascore.AnnotationSet` describes patch data with labelled regions, paths and polygons over patch dimensions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and managing annotation sets with metadata, values, regions, paths, polygons, and curve-based geometries.
  * Added validation for annotation dimensions, identifiers, geometry, values, vertices, and serialized data.
  * Added export options for tabular annotation data and geometry vertices.
  * Made `AnnotationSet` available from the top-level package.
  * Added convenient iteration, indexing, comparison, and representation of annotation sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->