### PR TITLE
Name an oversized CSV cell as an inventory error

### DIFF
--- a/dascore/utils/tables.py
+++ b/dascore/utils/tables.py
@@ -65,7 +65,10 @@ def read_table(path: Path, what: str = "nothing") -> pd.DataFrame:
                 # object beside the frame pandas builds would cost several
                 # times what the frame itself does.
                 _check_widths(reader, header, path)
-    except (OSError, UnicodeDecodeError) as read_error:
+    # csv.Error too: a cell longer than csv.field_size_limit stops the
+    # header scan, and without this it would leave this function as a bare
+    # _csv.Error rather than as whatever the caller's format raises.
+    except (OSError, UnicodeDecodeError, csv.Error) as read_error:
         msg = f"Could not read {quote_path(path)}: {read_error}."
         raise ParameterError(msg) from read_error
     if not header:

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import os
 import tempfile
 from pathlib import Path
@@ -1584,6 +1585,21 @@ class TestUnreadableTables:
         """A file which cannot be read at all says which one it was."""
         root = write_inventory(tmp_path / "binary", {**MINIMAL, **TRACKS})
         (root / "fiber_arrays/DAS.L001/path/coupling.csv").write_bytes(b"\xff\xfe\x00")
+        with pytest.raises(InvalidInventoryError, match="Could not read"):
+            dc.inventory(root)
+
+    def test_a_table_with_an_oversized_cell(self, tmp_path):
+        """A cell the csv module refuses to scan is an unreadable table.
+
+        Pandas would read it, but the header and row-width scan runs first
+        and stops; what matters is that it stops as an inventory error
+        rather than as a bare _csv.Error out of the standard library.
+        """
+        root = write_inventory(tmp_path / "wide", {**MINIMAL, **TRACKS})
+        cell = "x" * (csv.field_size_limit() + 1)
+        (root / "fiber_arrays/DAS.L001/path/coupling.csv").write_text(
+            f"start_distance,end_distance,coupling_type,description\n0,340,conduit,{cell}\n"
+        )
         with pytest.raises(InvalidInventoryError, match="Could not read"):
             dc.inventory(root)
 

--- a/tests/test_utils/test_tables.py
+++ b/tests/test_utils/test_tables.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import csv
+
 import pandas as pd
 import pytest
 
@@ -79,6 +81,13 @@ class TestReadTable:
         """An unreadable file raises the caller's error, not OSError."""
         with pytest.raises(ParameterError, match="Could not read"):
             read_table(tmp_path / "absent.csv")
+
+    def test_oversized_cell_refused(self, tmp_path):
+        """A cell past the csv module's limit stops the scan, not the caller."""
+        limit = csv.field_size_limit()
+        path = _write(tmp_path, "a,b\n" + "x" * (limit + 1) + ",2\n")
+        with pytest.raises(ParameterError, match="field larger than field limit"):
+            read_table(path)
 
 
 class TestRowCells:


### PR DESCRIPTION
## Description

Follow-up to a review comment on #911, which was deliberately deferred there because that PR was a pure refactor and this behavior predates it on `dev`.

`read_table` builds a `csv.reader` to check the header and the row widths before handing the file to pandas. A cell longer than `csv.field_size_limit()` (131072 by default) stops that scan with `_csv.Error`, which the handler did not catch. The error therefore left the function as a standard library exception rather than as the caller's own, and `dc.inventory(path)` escaped its contract that anything malformed raises `InvalidInventoryError`:

```python
>>> dc.inventory(root)
_csv.Error: field larger than field limit (131072)
```

`csv.Error` now joins `OSError` and `UnicodeDecodeError` in that handler, so the loader's boundary in `_load_table` translates it like any other unreadable table.

Refusing rather than raising the limit is deliberate: pandas has no such limit and would read the file, but the csv scan exists only to check the header and row widths, and raising a process-wide limit to accommodate a pathological cell trades a clear error for unbounded memory. The inventory format is meant to be hand-authored spreadsheets, where a single cell over 128 KB is not a thing to accept quietly.

Two tests, one at each level: `read_table` raises `ParameterError`, and `dc.inventory` on a directory holding such a table raises `InvalidInventoryError`. Both were confirmed to fail without the one-line change.

## Changelog

- fixed: An inventory table with a cell larger than the CSV field size limit now raises `InvalidInventoryError` rather than a bare `_csv.Error`.
