### PR TITLE
Add an "Open in JupyterLite" link to the tutorials

### DIFF
--- a/.github/actions/prep_doc_build/action.yml
+++ b/.github/actions/prep_doc_build/action.yml
@@ -1,5 +1,8 @@
 name: "prepare for doc build"
-description: "Installs quarto, renders api docs, prints quarto version"
+description: >
+  Installs quarto, renders api docs, and builds the JupyterLite site the
+  tutorial pages link to. Quarto copies docs/lite into the published site as
+  a project resource, so this must run before `quarto render`/`publish`.
 
 runs:
   using: "composite"
@@ -21,3 +24,25 @@ runs:
       shell: bash
       run: |
         python scripts/build_api_docs.py
+
+    # The notebooks install dascore from a wheel bundled into the JupyterLite
+    # site rather than from PyPI, so the tutorials always run against the same
+    # version the surrounding docs were built from.
+    - name: build dascore wheel for the browser
+      shell: bash
+      run: |
+        python -m pip install build
+        python -m build --wheel
+
+    - name: build tutorial notebooks
+      shell: bash
+      run: |
+        python scripts/build_notebooks.py
+
+    - name: build JupyterLite site
+      shell: bash
+      run: |
+        jupyter lite build \
+          --contents docs/lite_contents \
+          --output-dir docs/lite \
+          --piplite-wheels dist/dascore-*.whl

--- a/.github/workflows/build_deploy_dev_docs.yaml
+++ b/.github/workflows/build_deploy_dev_docs.yaml
@@ -24,6 +24,11 @@ env:
   # ref rather than hard-coded so a manual run of another branch still links to
   # the branch it published.
   DASCORE_DOC_BRANCH: ${{ github.ref_name }}
+  # The dev docs publish to netlify rather than dascore.org, and the tutorial
+  # notebooks link back to the site they were built for. Left unset, they would
+  # point at the released docs, where any page added since the last release
+  # 404s.
+  DASCORE_DOC_SITE_URL: https://dascore.netlify.app
 
 # Publish only the newest dev commit. This is a netlify deployment, so it does
 # not share the "pages" group used by the stable docs; grouping them together

--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -13,6 +13,11 @@ env:
   # Where the test-data cache is restored; pooch reads files from here.
   # Must match the path used in .github/actions/prime-test-data-cache.
   DFS_DATA_DIR: ${{ github.workspace }}/.test_data_cache
+  # A pull request builds dev-based content, so the tutorial notebooks should
+  # link to the dev docs like BuildDeployDevDocs does. Left unset they would
+  # point at the released site, where a page added since the last release 404s
+  # and the preview misleads the reviewer.
+  DASCORE_DOC_SITE_URL: https://dascore.netlify.app
 
 jobs:
   test_build_docs:

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,11 @@ prof/
 .vscode/
 #JetBrains
 .idea/
+
+# JupyterLite site and the notebooks it is built from (see
+# scripts/build_notebooks.py); both are build artifacts.
+docs/lite/
+docs/lite_contents/
+docs/tutorial/lite_tmp_*
+# `jupyter lite build` keeps its incremental-build state here.
+.jupyterlite.doit.db

--- a/docs/contributing/documentation.qmd
+++ b/docs/contributing/documentation.qmd
@@ -141,11 +141,12 @@ Every tutorial page with runnable code carries an "Open in JupyterLite" link, wh
 The `.qmd` files remain the only source; the notebooks are build artifacts. They are produced by rendering each tutorial page to `.ipynb`, rewriting its cross-page links to absolute urls on whichever site is being built, and pointing it at the Pyodide kernel:
 
 ```bash
+python -m build --wheel
 python scripts/build_notebooks.py
 jupyter lite build --contents docs/lite_contents --output-dir docs/lite --piplite-wheels dist/dascore-*.whl
 ```
 
-CI runs both steps in `.github/actions/prep_doc_build`, before quarto renders the site, and quarto copies `docs/lite` into `_site` as a project resource. A tutorial page only gets the link when a notebook exists for it, so a page with no code cells simply does not show one, and rendering the docs without building the notebooks first drops the links rather than producing broken ones.
+CI runs these steps in `.github/actions/prep_doc_build`, before quarto renders the site, and quarto copies `docs/lite` into `_site` as a project resource. A tutorial page only gets the link when a notebook exists for it, so a page with no code cells simply does not show one, and rendering the docs without building the notebooks first drops the links rather than producing broken ones.
 
 The wheel passed to `--piplite-wheels` is bundled into the site and is what the notebooks' first cell installs. That deliberately pins the tutorials to the same DASCore the surrounding docs were built from, rather than whatever is currently on PyPI.
 

--- a/docs/contributing/documentation.qmd
+++ b/docs/contributing/documentation.qmd
@@ -134,6 +134,23 @@ If you need to change the structure of the site, like adding a new section/subse
 Do not modify docs/_quarto.yml because it will be overwritten.
 :::
 
+## Runnable tutorials
+
+Each tutorial page carries an "Open in JupyterLite" link, which opens the same content as a live notebook in a [JupyterLite](https://jupyterlite.readthedocs.io) site. DASCore runs there through WebAssembly, so readers need nothing installed.
+
+The `.qmd` files remain the only source; the notebooks are build artifacts. They are produced by rendering each tutorial page to `.ipynb`, rewriting its cross-page links to absolute dascore.org urls, and pointing it at the Pyodide kernel:
+
+```bash
+python scripts/build_notebooks.py
+jupyter lite build --contents docs/lite_contents --output-dir docs/lite --piplite-wheels dist/dascore-*.whl
+```
+
+CI runs both steps in `.github/actions/prep_doc_build`, before quarto renders the site, and quarto copies `docs/lite` into `_site` as a project resource. A tutorial page only gets the link when a notebook exists for it, so a page with no code cells simply does not show one, and rendering the docs without building the notebooks first drops the links rather than producing broken ones.
+
+The wheel passed to `--piplite-wheels` is bundled into the site and is what the notebooks' first cell installs. That deliberately pins the tutorials to the same DASCore the surrounding docs were built from, rather than whatever is currently on PyPI.
+
+Links from a notebook back to other doc pages are absolute, so they need to know which deployment they belong to. `DASCORE_DOC_SITE_URL` sets that base url, like `DASCORE_DOC_BRANCH` sets the "edit this page" branch; it defaults to the released site and the dev workflow points it at netlify. Without it, notebooks built from `dev` would link to pages that have not been released yet.
+
 # Cross references
 
 Cross references provide a means of linking parts of the documentation to the API docs for specific modules, classes, functions, or methods. They work just like normal markdown links except the reference is a dascore object surrounded by backticks like so:

--- a/docs/contributing/documentation.qmd
+++ b/docs/contributing/documentation.qmd
@@ -136,9 +136,9 @@ Do not modify docs/_quarto.yml because it will be overwritten.
 
 ## Runnable tutorials
 
-Each tutorial page carries an "Open in JupyterLite" link, which opens the same content as a live notebook in a [JupyterLite](https://jupyterlite.readthedocs.io) site. DASCore runs there through WebAssembly, so readers need nothing installed.
+Every tutorial page with runnable code carries an "Open in JupyterLite" link, which opens the same content as a live notebook in a [JupyterLite](https://jupyterlite.readthedocs.io) site. DASCore runs there through WebAssembly, so readers need nothing installed.
 
-The `.qmd` files remain the only source; the notebooks are build artifacts. They are produced by rendering each tutorial page to `.ipynb`, rewriting its cross-page links to absolute dascore.org urls, and pointing it at the Pyodide kernel:
+The `.qmd` files remain the only source; the notebooks are build artifacts. They are produced by rendering each tutorial page to `.ipynb`, rewriting its cross-page links to absolute urls on whichever site is being built, and pointing it at the Pyodide kernel:
 
 ```bash
 python scripts/build_notebooks.py

--- a/docs/filters/lite_button.lua
+++ b/docs/filters/lite_button.lua
@@ -1,0 +1,57 @@
+--[[
+Add an "open in JupyterLite" link to the top of each tutorial page.
+
+The link only appears when a notebook was actually built for the page by
+scripts/build_notebooks.py, so pages without code cells (and renders that
+skipped the notebook build) simply do not get one.
+]]
+
+--- Return the file's name without its tutorial directory or extension.
+local function tutorial_stem(input)
+  return input and input:match("tutorial/([^/]+)%.qmd$")
+end
+
+--- Return the docs directory holding a tutorial page.
+local function docs_dir(input)
+  return input and input:match("^(.*)/tutorial/[^/]+%.qmd$")
+end
+
+--- Return true when a file can be opened for reading.
+local function file_exists(path)
+  local handle = io.open(path, "r")
+  if handle == nil then
+    return false
+  end
+  handle:close()
+  return true
+end
+
+function Pandoc(doc)
+  -- Only the html site gets the link; adding raw html to the ipynb render
+  -- would put a stray link inside the notebook the link points at.
+  if not quarto.doc.is_format("html") then
+    return doc
+  end
+  local input = quarto.doc.input_file
+  local stem = tutorial_stem(input)
+  local root = docs_dir(input)
+  if stem == nil or root == nil then
+    return doc
+  end
+  local notebook = root .. "/lite_contents/tutorial/" .. stem .. ".ipynb"
+  if not file_exists(notebook) then
+    return doc
+  end
+  local href = "/lite/lab/index.html?path=tutorial/" .. stem .. ".ipynb"
+  local html = table.concat({
+    '<a class="lite-launch" href="',
+    href,
+    '" target="_blank" rel="noopener" title="',
+    "Runs DASCore in your browser with WebAssembly. Nothing is installed on ",
+    'your computer, and the first load takes a moment.">',
+    "Open in JupyterLite",
+    "</a>",
+  })
+  table.insert(doc.blocks, 1, pandoc.RawBlock("html", html))
+  return doc
+end

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -76,3 +76,23 @@ tbody tr:nth-child(odd) {
     display: block;
     margin-bottom: 10px;
 }
+
+/* Link added to tutorial pages by filters/lite_button.lua, which opens the
+   page as a live notebook in the JupyterLite site. */
+.lite-launch {
+    display: inline-block;
+    margin-bottom: 1.2rem;
+    padding: 0.35rem 0.8rem;
+    border: 1px solid rgb(190, 190, 190);
+    border-radius: 4px;
+    font-size: 0.85rem;
+    text-decoration: none;
+}
+
+.lite-launch::before {
+    content: "▶ ";
+}
+
+.lite-launch:hover {
+    border-color: rgb(120, 120, 120);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,11 @@ docs = [
     "nbformat",
     # quarto's own notebook driver does `from yaml import safe_load`.
     "pyyaml",
+    # The JupyterLite site the tutorial pages link to. jupyter-server is not
+    # used at runtime, but jupyterlite-core requires it to add custom content.
+    "jupyterlite-core",
+    "jupyterlite-pyodide-kernel",
+    "jupyter-server",
 ]
 
 test = [

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -4,10 +4,21 @@
 project:
   type: website
   output-dir: _site
+  # The JupyterLite site is built by scripts/build_notebooks.py plus
+  # `jupyter lite build` (see .github/actions/prep_doc_build); quarto only
+  # copies it. Both directories hold notebooks and prebuilt html, so they are
+  # kept out of the render list -- quarto would otherwise treat them as pages.
+  resources:
+    - lite/**
+  render:
+    - "**/*.qmd"
+    - "!lite/**"
+    - "!lite_contents/**"
 
 filters:
   - quarto
   - filters/fill_links.py
+  - filters/lite_button.lua
 
 execute:
   warning: false

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -6,8 +6,9 @@ project:
   output-dir: _site
   # The JupyterLite site is built by scripts/build_notebooks.py plus
   # `jupyter lite build` (see .github/actions/prep_doc_build); quarto only
-  # copies it. Both directories hold notebooks and prebuilt html, so they are
-  # kept out of the render list -- quarto would otherwise treat them as pages.
+  # copies it. Both directories hold notebooks, and lite/ also holds prebuilt
+  # html, so they are kept out of the render list -- quarto would otherwise
+  # treat them as pages to render.
   resources:
     - lite/**
   render:

--- a/scripts/build_notebooks.py
+++ b/scripts/build_notebooks.py
@@ -1,0 +1,222 @@
+"""
+Render the tutorial pages to notebooks for the JupyterLite site.
+
+The .qmd files stay the source of truth; the notebooks are build artifacts.
+Each page is rendered through quarto (from inside the docs project, so the
+cross-reference filter runs) and then adjusted for a browser kernel:
+
+* links to other doc pages become absolute dascore.org urls, since the site
+  is not around to serve relative ones,
+* the kernelspec points at the Pyodide kernel rather than a local interpreter,
+* a setup cell installing dascore is prepended.
+
+Cells are rendered without executing them; the point of the notebook is that
+the reader runs them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs"
+TUTORIAL_DIR = DOCS / "tutorial"
+
+# Links in the notebooks point back at the rendered site, which differs by
+# deployment: dev publishes to netlify and releases publish to dascore.org.
+# Pointing dev-built notebooks at dascore.org breaks every link to a page that
+# has not been released yet. Set like DASCORE_DOC_BRANCH in the doc workflows.
+# The site is served from the domain root; the `site-path: /docs` in
+# _quarto.yml does not appear in the public urls.
+DEFAULT_SITE_URL = "https://dascore.org"
+
+KERNELSPEC = {
+    "name": "python",
+    "display_name": "Python (Pyodide)",
+    "language": "python",
+}
+
+# Packages the doc examples need that are not dascore install requirements.
+# pyyaml -> inventory serialization, tabulate -> DataFrame.to_markdown,
+# findiff -> velocity_to_strain_rate. IPython ships with the kernel.
+EXTRA_PACKAGES = ("pyyaml", "tabulate", "findiff")
+
+SETUP_SOURCE = f"""\
+# This notebook runs DASCore in your browser through Pyodide; nothing is
+# installed on your computer. Run this cell first, it takes a moment.
+%pip install -q dascore {" ".join(EXTRA_PACKAGES)}
+"""
+
+# Prefix for the transient per-page copies build() renders through quarto.
+TEMP_PREFIX = "lite_tmp_"
+
+# Executable mermaid blocks, which quarto would rasterize through chrome.
+MERMAID_REGEX = re.compile(r"^```\{mermaid\}", re.MULTILINE)
+
+# Matches a markdown link whose target is a .qmd page, with optional anchor.
+LINK_REGEX = re.compile(r"(?<=]\()(?P<target>[^)\s]+\.qmd)(?P<anchor>#[^)\s]*)?(?=\))")
+
+
+def get_site_url() -> str:
+    """Return the base url the notebooks should link back to."""
+    return os.environ.get("DASCORE_DOC_SITE_URL", DEFAULT_SITE_URL).rstrip("/")
+
+
+def qmd_link_to_url(target: str, anchor: str, source: Path, site_url: str) -> str:
+    """Convert a .qmd link target into an absolute url on the docs site."""
+    if target.startswith("/"):
+        # Already site-absolute (the cross-reference filter emits these).
+        path = Path(target)
+    else:
+        # Relative to the directory of the page being rendered.
+        path = (source.parent / target).resolve().relative_to(DOCS.resolve())
+        path = Path("/") / path
+    return f"{site_url}{path.with_suffix('.html').as_posix()}{anchor or ''}"
+
+
+def rewrite_links(cell_source: list[str], source: Path, site_url: str) -> list[str]:
+    """Point every .qmd link in a markdown cell at the published site."""
+
+    def _replace(match: re.Match) -> str:
+        return qmd_link_to_url(match["target"], match["anchor"] or "", source, site_url)
+
+    return [LINK_REGEX.sub(_replace, line) for line in cell_source]
+
+
+def prepare_source(source: Path) -> Path:
+    """Write a notebook-friendly copy of a page beside it, returning its path.
+
+    Executable mermaid blocks are turned into plain fenced blocks. Quarto
+    renders `{mermaid}` to an image through headless chrome, which the notebook
+    build has no use for and CI has no browser for; as a fence the diagram
+    survives as markdown, which JupyterLab renders natively.
+    """
+    text = MERMAID_REGEX.sub("```mermaid", source.read_text())
+    # The copy has to stay inside the quarto project: project mode is what
+    # applies the cross-reference filter, and an excluded (underscore-prefixed)
+    # file renders without it. Build() sweeps any copy a crash leaves behind.
+    prepared = source.parent / f"{TEMP_PREFIX}{source.name}"
+    prepared.write_text(text)
+    return prepared
+
+
+def render_one(source: Path, out_dir: Path) -> Path | None:
+    """Render a single qmd to a notebook, returning its path."""
+    prepared = prepare_source(source)
+    try:
+        relative = prepared.relative_to(DOCS)
+        # Rendering from inside the docs project makes quarto apply the project
+        # filters; without them cross references stay as `dascore.X` aliases.
+        result = subprocess.run(
+            [
+                "quarto",
+                "render",
+                str(relative),
+                "--to",
+                "ipynb",
+                "--no-execute",
+                "--output-dir",
+                str(out_dir),
+            ],
+            cwd=DOCS,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode:
+            # Quarto puts the useful line in stderr; a traceback here would
+            # bury it.
+            sys.exit(f"quarto failed on {source.name}:\n{result.stderr.strip()}")
+    finally:
+        prepared.unlink(missing_ok=True)
+    rendered = out_dir / relative.with_suffix(".ipynb")
+    return rendered if rendered.exists() else None
+
+
+def post_process(notebook_path: Path, source: Path, site_url: str) -> dict | None:
+    """Adjust a rendered notebook for the browser, or None if it has no code."""
+    notebook = json.loads(notebook_path.read_text())
+    cells = notebook.get("cells", [])
+    if not any(cell["cell_type"] == "code" for cell in cells):
+        return None
+    # Non-python executable blocks render as empty code cells; an empty cell
+    # in place of content is worse than no cell at all.
+    cells = [c for c in cells if c["cell_type"] != "code" or "".join(c["source"]).strip()]
+    for cell in cells:
+        if cell["cell_type"] == "markdown":
+            cell["source"] = rewrite_links(cell["source"], source, site_url)
+        elif cell["cell_type"] == "code":
+            # The reader executes these; shipping stale output would be worse
+            # than shipping none, and it keeps the notebooks small.
+            cell["outputs"] = []
+            cell["execution_count"] = None
+    setup = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": SETUP_SOURCE.splitlines(keepends=True),
+    }
+    notebook["cells"] = [setup, *cells]
+    notebook["metadata"]["kernelspec"] = KERNELSPEC
+    return notebook
+
+
+def build(out_dir: Path, site_url: str) -> int:
+    """Render every tutorial page with code into out_dir."""
+    if shutil.which("quarto") is None:
+        sys.exit("quarto is required to build the notebooks but was not found")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # A crashed run can leave a copy behind, and it would then be rendered
+    # into the real site by the next doc build.
+    for stale in TUTORIAL_DIR.glob(f"{TEMP_PREFIX}*"):
+        stale.unlink()
+    written = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for source in sorted(TUTORIAL_DIR.glob("*.qmd")):
+            rendered = render_one(source, tmp_dir)
+            if rendered is None:
+                print(f"  {source.name}: quarto produced no notebook, skipping")  # noqa: T201
+                continue
+            notebook = post_process(rendered, source, site_url)
+            if notebook is None:
+                print(f"  {source.name}: no code cells, skipping")  # noqa: T201
+                continue
+            destination = out_dir / f"{source.stem}.ipynb"
+            destination.write_text(json.dumps(notebook, indent=1) + "\n")
+            print(f"  {source.name} -> {destination.name}")  # noqa: T201
+            written += 1
+    if not written:
+        sys.exit("No notebooks were built; the tutorial directory looks wrong.")
+    print(f"Built {written} notebooks in {out_dir} linking to {site_url}")  # noqa: T201
+    return written
+
+
+def main() -> None:
+    """Parse arguments and build the notebooks."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=ROOT / "docs" / "lite_contents" / "tutorial",
+        help="Directory to write the notebooks into.",
+    )
+    parser.add_argument(
+        "--site-url",
+        default=get_site_url(),
+        help="Base url the notebooks link back to (env DASCORE_DOC_SITE_URL).",
+    )
+    args = parser.parse_args()
+    build(args.out_dir.resolve(), args.site_url.rstrip("/"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_notebooks.py
+++ b/scripts/build_notebooks.py
@@ -148,7 +148,9 @@ def post_process(notebook_path: Path, source: Path, site_url: str) -> dict | Non
         return None
     # Non-python executable blocks render as empty code cells; an empty cell
     # in place of content is worse than no cell at all.
-    cells = [c for c in cells if c["cell_type"] != "code" or "".join(c["source"]).strip()]
+    cells = [
+        c for c in cells if c["cell_type"] != "code" or "".join(c["source"]).strip()
+    ]
     for cell in cells:
         if cell["cell_type"] == "markdown":
             cell["source"] = rewrite_links(cell["source"], source, site_url)
@@ -177,7 +179,8 @@ def build(out_dir: Path, site_url: str) -> int:
     # A crashed run can leave a copy behind, and it would then be rendered
     # into the real site by the next doc build.
     for stale in TUTORIAL_DIR.glob(f"{TEMP_PREFIX}*"):
-        stale.unlink()
+        if stale.is_file():
+            stale.unlink()
     written = 0
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)

--- a/scripts/build_notebooks.py
+++ b/scripts/build_notebooks.py
@@ -144,13 +144,16 @@ def post_process(notebook_path: Path, source: Path, site_url: str) -> dict | Non
     """Adjust a rendered notebook for the browser, or None if it has no code."""
     notebook = json.loads(notebook_path.read_text())
     cells = notebook.get("cells", [])
-    if not any(cell["cell_type"] == "code" for cell in cells):
-        return None
     # Non-python executable blocks render as empty code cells; an empty cell
-    # in place of content is worse than no cell at all.
+    # in place of content is worse than no cell at all. This has to happen
+    # before the check below, or a page whose only code cells are empty
+    # becomes a notebook holding nothing but the setup cell, which the docs
+    # would then advertise as runnable.
     cells = [
         c for c in cells if c["cell_type"] != "code" or "".join(c["source"]).strip()
     ]
+    if not any(cell["cell_type"] == "code" for cell in cells):
+        return None
     for cell in cells:
         if cell["cell_type"] == "markdown":
             cell["source"] = rewrite_links(cell["source"], source, site_url)

--- a/scripts/build_notebooks.py
+++ b/scripts/build_notebooks.py
@@ -5,8 +5,8 @@ The .qmd files stay the source of truth; the notebooks are build artifacts.
 Each page is rendered through quarto (from inside the docs project, so the
 cross-reference filter runs) and then adjusted for a browser kernel:
 
-* links to other doc pages become absolute dascore.org urls, since the site
-  is not around to serve relative ones,
+* links to other doc pages become absolute urls on the site being built, since
+  a notebook is opened outside the site and cannot resolve relative ones,
 * the kernelspec points at the Pyodide kernel rather than a local interpreter,
 * a setup cell installing dascore is prepended.
 
@@ -29,6 +29,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 DOCS = ROOT / "docs"
 TUTORIAL_DIR = DOCS / "tutorial"
+# Not configurable: docs/filters/lite_button.lua looks for the notebooks here,
+# and prep_doc_build hands the same path to `jupyter lite build`.
+OUT_DIR = DOCS / "lite_contents" / "tutorial"
 
 # Links in the notebooks point back at the rendered site, which differs by
 # deployment: dev publishes to netlify and releases publish to dascore.org.
@@ -55,6 +58,8 @@ SETUP_SOURCE = f"""\
 %pip install -q dascore {" ".join(EXTRA_PACKAGES)}
 """
 
+SETUP_CELL_ID = "dascore-setup"
+
 # Prefix for the transient per-page copies build() renders through quarto.
 TEMP_PREFIX = "lite_tmp_"
 
@@ -77,8 +82,10 @@ def qmd_link_to_url(target: str, anchor: str, source: Path, site_url: str) -> st
         path = Path(target)
     else:
         # Relative to the directory of the page being rendered.
-        path = (source.parent / target).resolve().relative_to(DOCS.resolve())
-        path = Path("/") / path
+        resolved = (source.parent / target).resolve()
+        if not resolved.is_relative_to(DOCS.resolve()):
+            sys.exit(f"{source.name}: link target {target!r} escapes {DOCS}")
+        path = Path("/") / resolved.relative_to(DOCS.resolve())
     return f"{site_url}{path.with_suffix('.html').as_posix()}{anchor or ''}"
 
 
@@ -164,25 +171,54 @@ def post_process(notebook_path: Path, source: Path, site_url: str) -> dict | Non
             cell["execution_count"] = None
     setup = {
         "cell_type": "code",
+        # nbformat 4.5 requires an id on every cell; quarto gives the cells it
+        # renders one, so without this the setup cell is the only invalid cell.
+        "id": SETUP_CELL_ID,
         "execution_count": None,
         "metadata": {},
         "outputs": [],
-        "source": SETUP_SOURCE.splitlines(keepends=True),
+        # No trailing newline on the last line, which would render as a blank
+        # line at the bottom of the first cell every reader sees.
+        "source": SETUP_SOURCE.rstrip("\n").splitlines(keepends=True),
     }
     notebook["cells"] = [setup, *cells]
     notebook["metadata"]["kernelspec"] = KERNELSPEC
     return notebook
 
 
+def find_unrewritten_links(notebook: dict) -> list[str]:
+    """Return any .qmd link targets a notebook still carries.
+
+    LINK_REGEX only recognises the plain `](target.qmd)` form, so a titled or
+    angle-bracketed target would pass through and ship a relative link that
+    404s in JupyterLite. Checking the result catches that at build time rather
+    than leaving it for a reader to click.
+    """
+    markdown = [
+        "".join(c["source"]) for c in notebook["cells"] if c["cell_type"] == "markdown"
+    ]
+    return re.findall(r"\]\([^)]*\.qmd[^)]*\)", "\n".join(markdown))
+
+
 def build(out_dir: Path, site_url: str) -> int:
     """Render every tutorial page with code into out_dir."""
     if shutil.which("quarto") is None:
         sys.exit("quarto is required to build the notebooks but was not found")
-    out_dir.mkdir(parents=True, exist_ok=True)
+    # Rebuilt from scratch: a renamed page, or one that loses its last code
+    # cell, would otherwise leave a notebook behind that still gets published
+    # and still gets a launch link, with content the page no longer matches.
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True)
     # A crashed run can leave a copy behind, and it would then be rendered
     # into the real site by the next doc build.
     for stale in TUTORIAL_DIR.glob(f"{TEMP_PREFIX}*"):
-        if stale.is_file():
+        # Quarto leaves a `<stem>_files/` sidecar beside the page, so this has
+        # to remove directories too; skipping them republishes them as a
+        # project resource named after an internal temp file.
+        if stale.is_dir():
+            shutil.rmtree(stale)
+        else:
             stale.unlink()
     written = 0
     with tempfile.TemporaryDirectory() as tmp:
@@ -196,6 +232,11 @@ def build(out_dir: Path, site_url: str) -> int:
             if notebook is None:
                 print(f"  {source.name}: no code cells, skipping")  # noqa: T201
                 continue
+            if leftover := find_unrewritten_links(notebook):
+                sys.exit(
+                    f"{source.name}: these links were not rewritten and would "
+                    f"break in the notebook: {leftover}"
+                )
             destination = out_dir / f"{source.stem}.ipynb"
             destination.write_text(json.dumps(notebook, indent=1) + "\n")
             print(f"  {source.name} -> {destination.name}")  # noqa: T201
@@ -210,18 +251,12 @@ def main() -> None:
     """Parse arguments and build the notebooks."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--out-dir",
-        type=Path,
-        default=ROOT / "docs" / "lite_contents" / "tutorial",
-        help="Directory to write the notebooks into.",
-    )
-    parser.add_argument(
         "--site-url",
         default=get_site_url(),
         help="Base url the notebooks link back to (env DASCORE_DOC_SITE_URL).",
     )
     args = parser.parse_args()
-    build(args.out_dir.resolve(), args.site_url.rstrip("/"))
+    build(OUT_DIR, args.site_url.rstrip("/"))
 
 
 if __name__ == "__main__":

--- a/tests/test_build_notebooks.py
+++ b/tests/test_build_notebooks.py
@@ -178,6 +178,19 @@ class TestPostProcess:
         )
         assert build_notebooks.post_process(path, tutorial_page, site_url) is None
 
+    def test_page_with_only_empty_code_is_skipped(
+        self, build_notebooks, tmp_path, tutorial_page, site_url
+    ):
+        """A page whose only code cells are empty has nothing to run.
+
+        Such a page would otherwise yield a notebook holding just the setup
+        cell, which the tutorial page would then advertise as runnable.
+        """
+        cells = [{"cell_type": "markdown", "source": ["hi\n"]}, _code("  \n")]
+        path = tmp_path / "diagrams.ipynb"
+        path.write_text(json.dumps(_notebook(cells)))
+        assert build_notebooks.post_process(path, tutorial_page, site_url) is None
+
 
 class TestExtraPackages:
     """The browser kernel needs a few packages dascore does not require."""

--- a/tests/test_build_notebooks.py
+++ b/tests/test_build_notebooks.py
@@ -13,9 +13,27 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
+import sys
 from pathlib import Path
 
 import pytest
+
+# Modules a tutorial may import because dascore requires them (or is them).
+_DASCORE_PROVIDED = {
+    "dascore",
+    "h5py",
+    "matplotlib",
+    "numpy",
+    "pandas",
+    "pint",
+    "pooch",
+    "pydantic",
+    "rich",
+    "scipy",
+    "upath",
+    "IPython",
+}
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPT_PATH = _REPO_ROOT / "scripts" / "build_notebooks.py"
@@ -51,6 +69,17 @@ def tutorial_page(build_notebooks):
 def site_url(build_notebooks):
     """The default base url notebooks link back to."""
     return build_notebooks.DEFAULT_SITE_URL
+
+
+@pytest.fixture(scope="module")
+def tutorial_imports(build_notebooks):
+    """Every top-level module imported by a tutorial page's python cells."""
+    modules = set()
+    for page in build_notebooks.TUTORIAL_DIR.glob("*.qmd"):
+        for block in _PYTHON_BLOCK_REGEX.findall(page.read_text()):
+            for name in _IMPORT_REGEX.findall(block):
+                modules.add(name.split(".")[0])
+    return modules
 
 
 class TestQmdLinkToUrl:
@@ -93,20 +122,48 @@ class TestQmdLinkToUrl:
         assert ".qmd" not in out
 
 
-class TestMermaidRegex:
+class TestPrepareSource:
     """Executable mermaid blocks need chrome, so they become plain fences."""
 
-    def test_executable_block_becomes_fence(self, build_notebooks):
-        """```{mermaid} should lose its braces."""
-        text = "intro\n```{mermaid}\ngraph TD;\n```\n"
-        out = build_notebooks.MERMAID_REGEX.sub("```mermaid", text)
-        assert "```mermaid\ngraph TD;" in out
-        assert "{mermaid}" not in out
+    @pytest.fixture()
+    def prepared(self, build_notebooks, tmp_path):
+        """Run prepare_source over a page holding each fence variant."""
+        page = tmp_path / "page.qmd"
+        page.write_text(
+            "intro\n"
+            "```{mermaid}\ngraph TD;\n```\n"
+            "```{python}\nx = 1\n```\n"
+            # Indented, so the line anchor decides whether it is converted.
+            "    ```{mermaid}\nnot a fence\n    ```\n"
+        )
+        out = build_notebooks.prepare_source(page)
+        yield out.read_text(), out, page
+        out.unlink(missing_ok=True)
 
-    def test_indented_python_block_untouched(self, build_notebooks):
+    def test_executable_block_becomes_fence(self, prepared):
+        """```{mermaid} should lose its braces."""
+        text, _, _page = prepared
+        assert "```mermaid\ngraph TD;" in text
+
+    def test_python_block_untouched(self, prepared):
+        """Python fences must still execute, so they keep their braces."""
+        text, _, _page = prepared
+        assert "```{python}\nx = 1" in text
+
+    def test_indented_block_untouched(self, prepared):
         """Only fences at the start of a line are converted."""
-        text = "```{python}\nx = 1\n```\n"
-        assert build_notebooks.MERMAID_REGEX.sub("```mermaid", text) == text
+        text, _, _page = prepared
+        assert "    ```{mermaid}" in text
+
+    def test_copy_sits_beside_the_page(self, build_notebooks, prepared):
+        """The copy must stay in the quarto project to keep the filters.
+
+        Rendered from outside the project, quarto applies no filters and the
+        cross references survive as unresolved aliases.
+        """
+        _text, path, page = prepared
+        assert path.parent == page.parent
+        assert path.name.startswith(build_notebooks.TEMP_PREFIX)
 
 
 def _notebook(cells):
@@ -192,13 +249,50 @@ class TestPostProcess:
         assert build_notebooks.post_process(path, tutorial_page, site_url) is None
 
 
-class TestExtraPackages:
-    """The browser kernel needs a few packages dascore does not require."""
+# Modules a tutorial could import that neither the stdlib nor dascore's
+# requirements provide. Kept as a map so an unaccounted import names the
+# distribution to add to EXTRA_PACKAGES.
+_EXTRA_IMPORTS = {"yaml": "pyyaml", "tabulate": "tabulate", "findiff": "findiff"}
 
-    def test_setup_cell_installs_extras(self, build_notebooks):
-        """Each extra the doc examples import must be in the setup cell."""
-        for package in build_notebooks.EXTRA_PACKAGES:
-            assert package in build_notebooks.SETUP_SOURCE
+_IMPORT_REGEX = re.compile(r"^\s*(?:import|from)\s+([A-Za-z_][\w.]*)", re.MULTILINE)
+# Executable python fences; prose is skipped, or an English sentence opening
+# with "from ..." reads as an import.
+_PYTHON_BLOCK_REGEX = re.compile(r"^```\{python[^}]*\}\n(.*?)^```", re.M | re.S)
+
+
+class TestExtraPackages:
+    """The browser kernel needs packages dascore does not require.
+
+    Note what this can and cannot catch. The three current extras are needed
+    *indirectly* -- dascore optional-imports yaml and findiff, and pandas
+    reaches for tabulate inside `to_markdown` -- so no tutorial imports them by
+    name and nothing here would notice one going missing. That case is covered
+    by running the doc examples under Pyodide in test_wasm.yml, which fails
+    without them. What is left for this file is the case CI would only catch
+    after a reader hits it: a tutorial gaining an import that nobody installs.
+    """
+
+    def test_no_unaccounted_imports(self, build_notebooks, tutorial_imports):
+        """Every module a tutorial imports must be installed in the browser.
+
+        A new import that is neither stdlib, nor supplied by dascore, nor
+        listed in EXTRA_PACKAGES would traceback on the reader's first run.
+        """
+        known = (
+            set(sys.stdlib_module_names)
+            | _DASCORE_PROVIDED
+            | {
+                module
+                for module, distribution in _EXTRA_IMPORTS.items()
+                if distribution in build_notebooks.EXTRA_PACKAGES
+            }
+        )
+        unaccounted = tutorial_imports - known
+        assert not unaccounted, (
+            "these tutorial imports are not installed in the browser; add the "
+            "distribution to EXTRA_PACKAGES in scripts/build_notebooks.py "
+            f"(and to _EXTRA_IMPORTS here if it is new): {sorted(unaccounted)}"
+        )
 
 
 class TestSiteUrl:

--- a/tests/test_build_notebooks.py
+++ b/tests/test_build_notebooks.py
@@ -1,0 +1,211 @@
+"""
+Tests for scripts/build_notebooks.py, which renders the tutorial pages into
+the notebooks the JupyterLite site serves.
+
+The rendering itself needs quarto, so these cover the parts that decide what
+the reader ends up with: where a cross-page link points, and what the notebook
+looks like once it has been adjusted for a browser kernel. Both fail quietly
+when they are wrong -- a bad link 404s and a missed output ships stale data --
+so they are worth pinning.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "build_notebooks.py"
+
+# The sdist ships tests but not scripts/, on the same terms as
+# test_inventory_diagrams.py skipping when the docs tree is absent.
+pytestmark = pytest.mark.skipif(
+    not _SCRIPT_PATH.is_file(), reason="scripts/ is not installed"
+)
+
+
+def _load_module():
+    """Import the build script by path; scripts/ is not a package."""
+    spec = importlib.util.spec_from_file_location("build_notebooks", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def build_notebooks():
+    """The loaded build_notebooks module."""
+    return _load_module()
+
+
+@pytest.fixture()
+def tutorial_page(build_notebooks):
+    """A path standing in for a page in the tutorial directory."""
+    return build_notebooks.DOCS / "tutorial" / "patch.qmd"
+
+
+@pytest.fixture()
+def site_url(build_notebooks):
+    """The default base url notebooks link back to."""
+    return build_notebooks.DEFAULT_SITE_URL
+
+
+class TestQmdLinkToUrl:
+    """Tests for turning .qmd link targets into published urls."""
+
+    def test_site_absolute_link(self, build_notebooks, tutorial_page, site_url):
+        """Links the cross-reference filter emits are already site rooted."""
+        out = build_notebooks.qmd_link_to_url(
+            "/api/dascore/core/patch/Patch.qmd", "", tutorial_page, site_url
+        )
+        assert out == "https://dascore.org/api/dascore/core/patch/Patch.html"
+
+    def test_sibling_link(self, build_notebooks, tutorial_page, site_url):
+        """A bare page name resolves against the page's own directory."""
+        out = build_notebooks.qmd_link_to_url("coords.qmd", "", tutorial_page, site_url)
+        assert out == "https://dascore.org/tutorial/coords.html"
+
+    def test_parent_relative_link(self, build_notebooks, tutorial_page, site_url):
+        """A link out of the tutorial directory keeps its real destination."""
+        out = build_notebooks.qmd_link_to_url(
+            "../notes/patch_attrs.qmd", "", tutorial_page, site_url
+        )
+        assert out == "https://dascore.org/notes/patch_attrs.html"
+
+    def test_anchor_is_kept(self, build_notebooks, tutorial_page, site_url):
+        """An anchor should survive the rewrite."""
+        out = build_notebooks.qmd_link_to_url(
+            "concepts.qmd", "#units", tutorial_page, site_url
+        )
+        assert out == "https://dascore.org/tutorial/concepts.html#units"
+
+    def test_rewrite_links_leaves_other_links_alone(
+        self, build_notebooks, tutorial_page, site_url
+    ):
+        """Only .qmd targets are rewritten."""
+        source = ["see [x](https://example.com/a.html) and [y](coords.qmd)\n"]
+        out = "".join(build_notebooks.rewrite_links(source, tutorial_page, site_url))
+        assert "https://example.com/a.html" in out
+        assert "https://dascore.org/tutorial/coords.html" in out
+        assert ".qmd" not in out
+
+
+class TestMermaidRegex:
+    """Executable mermaid blocks need chrome, so they become plain fences."""
+
+    def test_executable_block_becomes_fence(self, build_notebooks):
+        """```{mermaid} should lose its braces."""
+        text = "intro\n```{mermaid}\ngraph TD;\n```\n"
+        out = build_notebooks.MERMAID_REGEX.sub("```mermaid", text)
+        assert "```mermaid\ngraph TD;" in out
+        assert "{mermaid}" not in out
+
+    def test_indented_python_block_untouched(self, build_notebooks):
+        """Only fences at the start of a line are converted."""
+        text = "```{python}\nx = 1\n```\n"
+        assert build_notebooks.MERMAID_REGEX.sub("```mermaid", text) == text
+
+
+def _notebook(cells):
+    """Build a minimal notebook around some cells."""
+    return {"cells": cells, "metadata": {"kernelspec": {"name": "local"}}}
+
+
+def _code(source, outputs=None):
+    """Build a code cell."""
+    return {
+        "cell_type": "code",
+        "source": [source],
+        "outputs": outputs if outputs is not None else [],
+        "execution_count": 3,
+    }
+
+
+class TestPostProcess:
+    """Tests for adjusting a rendered notebook for the browser."""
+
+    @pytest.fixture()
+    def processed(self, build_notebooks, tmp_path, tutorial_page, site_url):
+        """A notebook run through post_process."""
+        cells = [
+            {"cell_type": "markdown", "source": ["[a](coords.qmd)\n"]},
+            _code("import dascore", outputs=[{"text": "stale"}]),
+            _code("   \n"),
+        ]
+        path = tmp_path / "nb.ipynb"
+        path.write_text(json.dumps(_notebook(cells)))
+        return build_notebooks.post_process(path, tutorial_page, site_url)
+
+    def test_setup_cell_is_first(self, processed):
+        """The reader has to install dascore before anything else runs."""
+        first = "".join(processed["cells"][0]["source"])
+        assert "%pip install" in first
+        assert "dascore" in first
+
+    def test_kernel_points_at_pyodide(self, build_notebooks, processed):
+        """A local interpreter path would not exist in the browser."""
+        assert processed["metadata"]["kernelspec"] == build_notebooks.KERNELSPEC
+
+    def test_outputs_are_dropped(self, processed):
+        """Shipping stale output would misrepresent what the code does."""
+        assert all(not cell.get("outputs") for cell in processed["cells"])
+        code = [c for c in processed["cells"] if c["cell_type"] == "code"]
+        assert all(c["execution_count"] is None for c in code)
+
+    def test_links_are_rewritten(self, processed):
+        """Markdown links should point at the published site."""
+        markdown = [c for c in processed["cells"] if c["cell_type"] == "markdown"]
+        assert "https://dascore.org/tutorial/coords.html" in "".join(
+            markdown[0]["source"]
+        )
+
+    def test_blank_code_cells_are_removed(self, processed):
+        """Non-python blocks render as empty cells, which help nobody."""
+        code = [c for c in processed["cells"] if c["cell_type"] == "code"]
+        # Only the setup cell and the real one survive.
+        assert len(code) == 2
+
+    def test_page_without_code_is_skipped(
+        self, build_notebooks, tmp_path, tutorial_page, site_url
+    ):
+        """A prose-only page should not become a notebook."""
+        path = tmp_path / "prose.ipynb"
+        path.write_text(
+            json.dumps(_notebook([{"cell_type": "markdown", "source": ["hi\n"]}]))
+        )
+        assert build_notebooks.post_process(path, tutorial_page, site_url) is None
+
+
+class TestExtraPackages:
+    """The browser kernel needs a few packages dascore does not require."""
+
+    def test_setup_cell_installs_extras(self, build_notebooks):
+        """Each extra the doc examples import must be in the setup cell."""
+        for package in build_notebooks.EXTRA_PACKAGES:
+            assert package in build_notebooks.SETUP_SOURCE
+
+
+class TestSiteUrl:
+    """The notebooks must link to the deployment they were built for."""
+
+    def test_defaults_to_stable_site(self, build_notebooks, monkeypatch):
+        """Without configuration the released docs are the right target."""
+        monkeypatch.delenv("DASCORE_DOC_SITE_URL", raising=False)
+        assert build_notebooks.get_site_url() == build_notebooks.DEFAULT_SITE_URL
+
+    def test_environment_overrides(self, build_notebooks, monkeypatch):
+        """Dev docs publish elsewhere, so the base url has to be settable."""
+        monkeypatch.setenv("DASCORE_DOC_SITE_URL", "https://dascore.netlify.app/")
+        assert build_notebooks.get_site_url() == "https://dascore.netlify.app"
+
+    def test_links_follow_the_configured_site(
+        self, build_notebooks, tutorial_page
+    ):
+        """A page link should sit under whichever site was requested."""
+        out = build_notebooks.qmd_link_to_url(
+            "coords.qmd", "", tutorial_page, "https://dascore.netlify.app"
+        )
+        assert out == "https://dascore.netlify.app/tutorial/coords.html"

--- a/tests/test_build_notebooks.py
+++ b/tests/test_build_notebooks.py
@@ -201,9 +201,7 @@ class TestSiteUrl:
         monkeypatch.setenv("DASCORE_DOC_SITE_URL", "https://dascore.netlify.app/")
         assert build_notebooks.get_site_url() == "https://dascore.netlify.app"
 
-    def test_links_follow_the_configured_site(
-        self, build_notebooks, tutorial_page
-    ):
+    def test_links_follow_the_configured_site(self, build_notebooks, tutorial_page):
         """A page link should sit under whichever site was requested."""
         out = build_notebooks.qmd_link_to_url(
             "coords.qmd", "", tutorial_page, "https://dascore.netlify.app"


### PR DESCRIPTION
## Description

Adds an "Open in JupyterLite" link to every tutorial page. Following it opens the same content as a live notebook running DASCore through WebAssembly, so a reader can run the tutorial without installing anything. The rendered pages are otherwise unchanged and nothing extra is downloaded until the link is clicked.

Builds on #916, which fixed the CORS problem that made registry downloads impossible from a browser.

### How it fits together

- `scripts/build_notebooks.py` renders each tutorial `.qmd` to `.ipynb` and adjusts it for a browser kernel: cross-page links become absolute urls, the kernelspec points at Pyodide, outputs are stripped, and a setup cell installing dascore is prepended. The `.qmd` files remain the only source; notebooks are build artifacts and are gitignored.
- `jupyter lite build` turns those into a JupyterLite site under `docs/lite`, which quarto copies into `_site` as a project resource. Both lite directories are excluded from the render list — they hold notebooks and prebuilt html that quarto would otherwise try to render as pages. Verified: with the exclusions, quarto's render list drops **exactly** the 27 lite notebooks and nothing else.
- `docs/filters/lite_button.lua` adds the link, but only when a notebook actually exists for that page. So `configuration.qmd` (no code cells) gets no link, and rendering the docs without building the notebooks first drops the links rather than leaving them broken.
- Both steps run in `.github/actions/prep_doc_build`, which is shared by the PR doc-build check and both deploy workflows.

### Verification

Run in real headless Chromium against the built site, driving JupyterLab's "Run All Cells":

| Notebook | Result |
|---|---|
| `visualization.ipynb` | 5/5 cells, 4 plots rendered, 0 errors |
| `patch.ipynb` (largest, 45 code cells) | **45/45 cells, 0 errors** |

That exercises the whole chain: JupyterLite → Pyodide kernel → `%pip install dascore` from the bundled wheel → data fetched from `raw.githubusercontent.com` → matplotlib.

All 102 cross-page links in the generated notebooks were checked against the live site: **102/102 resolve**.

The site CI actually produced was then downloaded and checked, rather than trusting the local build:

- `_site/lite/` present (77 MB) with `lab/index.html`, the notebooks under `lite/files/tutorial/`, and this PR's own wheel bundled at `lite/pypi/dascore-…dev172….whl`
- 10 of 11 tutorial pages carry the link; `configuration.html` (no code cells) correctly carries none
- `lite_contents/` does not leak into the published site
- serving that artifact and running `spool.ipynb` in the browser: **18/18 cells, 0 errors**

### Two things worth a look

**The wheel is bundled deliberately.** `--piplite-wheels` puts the just-built dascore into the site, and that is what the notebooks install. Without it the notebooks would install the last PyPI release, which for docs built from `dev` documents APIs that release does not have.

**Link targets are per-deployment.** Dev docs publish to `dascore.netlify.app` and releases to `dascore.org`. Hardcoding `dascore.org` made 33 of 102 links 404 from a dev build, because they point at pages added since the last release. `DASCORE_DOC_SITE_URL` now sets the base url — same pattern as the existing `DASCORE_DOC_BRANCH` — defaulting to the released site, with the dev and pull-request doc workflows pointing at netlify. All 102 resolve with it set.

### Notes

- The lite site is ~77 MB, almost all of it the JupyterLab bundle. It is static, and Pyodide itself still comes from the jsDelivr CDN.
- `jupyterlite-pyodide-kernel` pins Pyodide 314.0.4 while `test_wasm.yml` pins 314.0.3. Same CPython (3.14) and no observed difference, but they are worth keeping in step.
- Quarto emits one `WARN: Unable to resolve link target: lite/lab/index.html?...` per tutorial page. It cannot verify a resource path at render time; the emitted href is correct (`../lite/lab/index.html`).
- `pytest tests --cov` reports 2 uncovered lines in `dascore/examples.py:661-662` (the `path is None` branch of `spool_to_directory`, which every caller passes explicitly). Pre-existing on dev — this PR touches no file under `dascore/`.

## Changelog

- added: Tutorial pages now have an "Open in JupyterLite" link which runs the page as a live notebook in the browser, with no installation required.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runnable JupyterLite versions of eligible tutorials, including automatic notebook generation and package setup.
  * Added “Open in JupyterLite” links to tutorial pages when an interactive notebook is available.
  * Added configurable tutorial links for development documentation sites.

* **Documentation**
  * Documented how runnable tutorials are generated, built, deployed, and used.

* **Style**
  * Added visual styling for JupyterLite launch links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->