### PR TITLE
Run the documentation examples in the WebAssembly suite

### DIFF
--- a/.github/workflows/test_wasm.yml
+++ b/.github/workflows/test_wasm.yml
@@ -16,6 +16,10 @@ on:
     paths:
       - 'dascore/**'
       - 'tests/**'
+      # The suite now runs the documentation examples, so a change to a qmd
+      # page or to the generator can break this workflow on its own.
+      - 'docs/**'
+      - 'scripts/generate_doc_code_tests.py'
       - 'scripts/test_wasm.mjs'
       - 'pyproject.toml'
       - '.github/workflows/test_wasm.yml'
@@ -102,10 +106,20 @@ jobs:
           python -m pip install "pyodide-build==$PYODIDE_BUILD_VERSION"
           pyodide xbuildenv install "$PYODIDE_VERSION"
           pyodide venv .venv-pyodide
-          .venv-pyodide/bin/pip install dist/*.whl pytest
+          # findiff, pyyaml, tabulate and ipython are not dascore requirements,
+          # but the documentation examples import them, so the doc tests below
+          # cannot run without them.
+          .venv-pyodide/bin/pip install dist/*.whl pytest \
+            findiff pyyaml tabulate ipython
 
       - name: prepare test data cache
         uses: ./.github/actions/prime-test-data-cache
+
+      # The documentation examples are what a reader actually runs when they
+      # open a tutorial in the browser, so they belong in the wasm suite. The
+      # generated modules land under tests/, so the run below picks them up.
+      - name: generate qmd docs tests
+        run: python scripts/generate_doc_code_tests.py
 
       - name: Run test suite in WebAssembly
         run: >


### PR DESCRIPTION
## Description

The `test_wasm_suite` job builds the wheel and runs `tests` under a Pyodide virtual environment, but it never generates the documentation-example tests, so those have never run under WebAssembly. They are exactly the code a reader executes when they open a tutorial in the browser, which makes them the examples most worth covering there.

This generates them alongside the rest of the suite. The generated modules land under `tests/`, so the existing run picks them up — the same arrangement `runtests.yml` already uses.

It also installs `findiff`, `pyyaml`, `tabulate` and `ipython` into the Pyodide venv. These are not dascore requirements, but the doc examples import them.

### Verification

Run locally in a real Pyodide venv (`pyodide-build 0.37.0`, xbuildenv 314.0.3), matching what CI does:

| | Result |
|---|---|
| with the four packages | **31 passed** |
| without them (control) | **9 failed, 22 passed** |

The control is there to show the four additions are load-bearing rather than guessed. The modules that fail without them are `test_inventory_attachment`, `test_velocity_to_strain_rate`, `test_tunnel_inventory`, `test_supported_formats`, `test_supported_plugins`, `tutorial/test_file_io`, `tutorial/test_inventory`, `tutorial/test_patch`, and `tutorial/test_spool`.

`docs/**` and the generator are added to the workflow's path filter, since a qmd change can now break this workflow on its own.

## Changelog

- none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Documentation examples are now automatically generated and validated in the WebAssembly test suite.
  * WebAssembly testing also runs when documentation or documentation-test generation changes, helping detect broken examples earlier.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->