### PR TITLE
Refuse an epoch which reaches outside its container

### DIFF
--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -1040,6 +1040,39 @@ def _overlapping_epochs(items, key) -> list[tuple]:
     return out
 
 
+def _epoch_span(item) -> str:
+    """Name an epoch's range the way an error can show it."""
+    start = "the beginning" if np.isnat(item.start_time) else str(item.start_time)
+    end = "ongoing" if np.isnat(item.end_time) else str(item.end_time)
+    return f"{start} to {end}"
+
+
+def _containment_errors(parent, children, what: str, name) -> list[str]:
+    """
+    Return errors for children whose epoch reaches outside their container.
+
+    A bound a child leaves unset defers to its container rather than
+    reaching past it: an optical path stating no start begins when its
+    fiber array does. A bound it states has to fall inside the range its
+    container states, or the child describes time its container says did
+    not happen -- and since resolution walks down from the container, that
+    is metadata no query can reach.
+    """
+    start, end = parent.start_time, parent.end_time
+    errors = []
+    for child in children:
+        before = not np.isnat(start) and not np.isnat(child.start_time)
+        before = before and child.start_time < start
+        after = not np.isnat(end) and not np.isnat(child.end_time)
+        after = after and child.end_time > end
+        if before or after or not child.overlaps(parent):
+            errors.append(
+                f"{what} {name(child)} is valid {_epoch_span(child)}, outside "
+                f"its container's {_epoch_span(parent)}."
+            )
+    return errors
+
+
 def axis_columns(segment, crs) -> dict[str, int]:
     """
     Return which of a segment's columns name which canonical axis.
@@ -1662,6 +1695,9 @@ class Station(TimeRangedModel):
                 self.channels, lambda x: (x.location_code, x.code)
             )
         ]
+        errors += _containment_errors(
+            self, self.channels, "Channel", lambda x: repr(x.code)
+        )
         if errors:
             msg = f"Station {self.code!r} validation failed:\n" + "\n".join(errors)
             raise InvalidInventoryError(msg)
@@ -1712,6 +1748,12 @@ class FiberArray(TimeRangedModel):
             self.acquisitions, lambda x: (x.location_code, x.code)
         ):
             errors.append(f"Acquisition epochs for {key} overlap in time.")
+        errors += _containment_errors(
+            self, self.optical_paths, "Optical path", lambda x: repr(x.name)
+        )
+        errors += _containment_errors(
+            self, self.acquisitions, "Acquisition", lambda x: repr(x.code)
+        )
         if errors:
             msg = f"Fiber array {self.code!r} validation failed:\n" + "\n".join(errors)
             raise InvalidInventoryError(msg)
@@ -1762,6 +1804,9 @@ class Network(TimeRangedModel):
                 errors.append(
                     f"Duplicate {kind} code {code!r} for overlapping time ranges."
                 )
+            errors += _containment_errors(
+                self, items, kind.capitalize(), lambda x: repr(x.code)
+            )
         if errors:
             msg = f"Network {self.code!r} validation failed:\n" + "\n".join(errors)
             raise InvalidInventoryError(msg)

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -757,6 +757,93 @@ class TestAcquisition:
         assert acq.location_code == ""
 
 
+class TestEpochContainment:
+    """An entry may not describe time its container does not."""
+
+    @staticmethod
+    def _array(array_kwargs, path_kwargs):
+        """A fiber array holding one optical path, each with its own epoch."""
+        path = inv.OpticalPath(
+            name="main",
+            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            **path_kwargs,
+        )
+        return inv.FiberArray(code="L001", optical_paths=(path,), **array_kwargs)
+
+    def test_a_path_starting_before_its_array(self):
+        """The array did not exist then, so nothing can resolve to the path."""
+        array = self._array({"start_time": "2024-01-01"}, {"start_time": "2020-01-01"})
+        with pytest.raises(InvalidInventoryError, match="outside its container"):
+            array.check()
+
+    def test_a_path_ending_after_its_array(self):
+        """The far bound is checked the same way as the near one."""
+        array = self._array(
+            {"start_time": "2024-01-01", "end_time": "2025-01-01"},
+            {"start_time": "2024-06-01", "end_time": "2030-01-01"},
+        )
+        with pytest.raises(InvalidInventoryError, match="outside its container"):
+            array.check()
+
+    def test_a_path_entirely_after_its_array(self):
+        """Neither bound is out of order, and the whole epoch is elsewhere."""
+        array = self._array(
+            {"start_time": "2024-01-01", "end_time": "2025-01-01"},
+            {"start_time": "2026-01-01"},
+        )
+        with pytest.raises(InvalidInventoryError, match="outside its container"):
+            array.check()
+
+    def test_an_unset_bound_defers_to_the_container(self):
+        """A path stating no start begins when its fiber array does."""
+        array = self._array({"start_time": "2024-01-01"}, {})
+        assert array.check() is array
+
+    def test_a_contained_epoch_is_legal(self):
+        """The ordinary case: a path living inside its array's lifetime."""
+        array = self._array(
+            {"start_time": "2024-01-01", "end_time": "2026-01-01"},
+            {"start_time": "2024-06-01", "end_time": "2025-01-01"},
+        )
+        assert array.check() is array
+
+    def test_an_acquisition_outside_its_array(self):
+        """Acquisitions are contained by the same rule as paths."""
+        array = inv.FiberArray(
+            code="L001",
+            start_time="2024-01-01",
+            acquisitions=(inv.Acquisition(code="RAW", start_time="2020-01-01"),),
+        )
+        with pytest.raises(InvalidInventoryError, match="outside its container"):
+            array.check()
+
+    def test_a_fiber_array_outside_its_network(self):
+        """And the rule holds one level up, for what a network contains."""
+        array = inv.FiberArray(code="L001", start_time="2020-01-01")
+        network = inv.Network(code="XX", start_time="2024-01-01", fiber_arrays=(array,))
+        with pytest.raises(InvalidInventoryError, match="outside its container"):
+            network.check()
+
+    def test_a_channel_outside_its_station(self):
+        """Stations contain channels the same way."""
+        station = inv.Station(
+            code="STA1",
+            start_time="2024-01-01",
+            channels=(inv.Channel(code="BHZ", start_time="2020-01-01"),),
+        )
+        with pytest.raises(InvalidInventoryError, match="outside its container"):
+            station.check()
+
+    def test_the_error_names_both_epochs(self):
+        """A reader has to see which range reaches outside which."""
+        array = self._array({"start_time": "2024-01-01"}, {"start_time": "2020-01-01"})
+        with pytest.raises(InvalidInventoryError) as info:
+            array.check()
+        message = str(info.value)
+        assert "2020-01-01" in message and "2024-01-01" in message
+        assert "'main'" in message
+
+
 class TestEpochs:
     """Half-open epoch rules across the tree."""
 


### PR DESCRIPTION
## Description

Closes #917.

An inventory is a tree of time-ranged entities — network → fiber array → acquisitions and optical paths, station → channels — and each states its own epoch. `check()` verified that epochs sharing an identity do not *overlap* each other, but nothing verified that a child's epoch fell inside its parent's, so this passed:

```python
path  = OpticalPath(start_time="2020-01-01", ...)
array = FiberArray(code="L001", start_time="2024-01-01", optical_paths=(path,))
array.check()   # accepted
```

The array did not exist in 2020, so that path describes fiber during years its own container says were not happening. It is not only untidy: resolution walks down from the container, so an entry outside its parent's range is metadata no query can reach. It reads as valid and behaves as absent, which is the worst of both.

Each container now checks what it holds — networks their fiber arrays and stations, arrays their paths and acquisitions, stations their channels — and the error names both ranges and the child, since knowing which one reaches outside which is the whole of the fix.

### The rule, and why it is this one

**A bound the child leaves unset defers to its container rather than reaching past it.** An optical path stating no start begins when its fiber array does. This matters more than it looks: almost every inventory is written with the range stated on the array and the paths running with it — the tunnel recipe and the tutorial both do — so the strict reading, where an unset start means "since the beginning of time" and therefore always violates a bounded parent, would refuse nearly every document in existence, including our own examples.

**A bound the child does state has to fall inside the one its container states.** That covers a path starting before its array, one ending after it, and one whose epoch lies wholly elsewhere — the last through `overlaps`, which already carries the half-open semantics, so an epoch beginning exactly when its container ends is outside rather than touching.

### This is a tightening

Documents which load today can start being refused. That is the point, but it is worth saying plainly: the ones affected are exactly those with entries no query could reach, so nothing that *worked* stops working. I would rather have it in before inventories are widespread than after.

The existing suite needed no changes, which is the evidence that the deferring rule is the right one.

## Changelog

- changed: `Inventory.check` now refuses an epoch which reaches outside its container's — an optical path or acquisition outside its fiber array's lifetime, a fiber array or station outside its network's, a channel outside its station's. A bound the child leaves unset defers to its container, so an inventory which states its range at one level only is unaffected.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
