### PR TITLE
Remove the per-function array backend dispatcher

### DIFF
--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -43,9 +43,10 @@ def aggregate(
     Notes
     -----
     Whether an aggregation can be applied by the patch's own array backend
-    depends on the method, so this function always uses numpy. The
-    shortcuts, such as [`Patch.mean`](`dascore.proc.aggregate.mean`), do
-    not; use those to keep the data on their backend.
+    depends on the method, so this function makes no promise about the
+    backend of its output. The shortcuts, such as
+    [`Patch.mean`](`dascore.proc.aggregate.mean`), do keep the data on their
+    backend; use those where one fits.
 
     Parameters
     ----------
@@ -86,7 +87,7 @@ def aggregate(
     return _apply_aggregator(patch, dim, func, dim_reduce)
 
 
-@patch_function(backend="array_api")
+@patch_function()
 @compose_docstring(params=AGG_DOC_STR, notes=AGG_NOTES)
 def min(
     patch: PatchType,
@@ -114,7 +115,7 @@ def min(
     return aggregate.func(patch, dim=dim, method=np.nanmin, dim_reduce=dim_reduce)
 
 
-@patch_function(backend="array_api")
+@patch_function()
 @compose_docstring(params=AGG_DOC_STR, notes=AGG_NOTES)
 def max(
     patch: PatchType,
@@ -142,7 +143,7 @@ def max(
     return aggregate.func(patch, dim=dim, method=np.nanmax, dim_reduce=dim_reduce)
 
 
-@patch_function(backend="array_api")
+@patch_function()
 @compose_docstring(params=AGG_DOC_STR, notes=AGG_NOTES)
 def mean(
     patch: PatchType,
@@ -189,7 +190,7 @@ def median(
     return aggregate.func(patch, dim=dim, method=np.nanmedian, dim_reduce=dim_reduce)
 
 
-@patch_function(backend="array_api")
+@patch_function()
 @compose_docstring(params=AGG_DOC_STR, notes=AGG_NOTES)
 def std(
     patch: PatchType,
@@ -248,7 +249,7 @@ def last(
     return aggregate.func(patch, dim=dim, method=func, dim_reduce=dim_reduce)
 
 
-@patch_function(backend="array_api")
+@patch_function()
 @compose_docstring(params=AGG_DOC_STR, notes=AGG_NOTES)
 def sum(
     patch: PatchType,
@@ -267,7 +268,7 @@ def sum(
     return aggregate.func(patch, dim=dim, method=np.nansum, dim_reduce=dim_reduce)
 
 
-@patch_function(data_type="", backend="array_api")
+@patch_function(data_type="")
 @compose_docstring(params=AGG_DOC_STR, notes=AGG_NOTES)
 def any(
     patch: PatchType,
@@ -286,7 +287,7 @@ def any(
     return aggregate.func(patch, dim=dim, method=np.any, dim_reduce=dim_reduce)
 
 
-@patch_function(data_type="", backend="array_api")
+@patch_function(data_type="")
 @compose_docstring(params=AGG_DOC_STR, notes=AGG_NOTES)
 def all(
     patch: PatchType,

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -44,7 +44,7 @@ def aggregate(
     -----
     Whether an aggregation can be applied by the patch's own array backend
     depends on the method, so this function makes no promise about the
-    backend of its output. The shortcuts, such as
+    backend of its output. Most shortcuts, such as
     [`Patch.mean`](`dascore.proc.aggregate.mean`), do keep the data on their
     backend; use those where one fits.
 

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -327,7 +327,7 @@ def angle(patch: PatchType) -> PatchType:
     return patch.new(data=np.angle(patch.data))
 
 
-@patch_function(data_type="", backend="array_api")
+@patch_function(data_type="")
 def normalize(
     self: PatchType,
     dim: str,
@@ -395,7 +395,7 @@ def normalize(
     return self.new(data=new_data)
 
 
-@patch_function(data_type="", backend="array_api")
+@patch_function(data_type="")
 def standardize(
     self: PatchType,
     dim: str,
@@ -903,7 +903,7 @@ def demedian(patch, dim: str = "time"):
     return patch.new(data=new_data)
 
 
-@patch_function(backend="array_api")
+@patch_function()
 def demean(patch, dim: str = "time"):
     """
     Remove the mean along a given dimension of a DASCore patch.

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -320,7 +320,7 @@ def drop_private_coords(self: PatchType) -> PatchType:
     return self.new(coords=new_coord, dims=new_coord.dims, data=data)
 
 
-@patch_function(backend="array_api")
+@patch_function()
 def make_broadcastable_to(
     self: PatchType,
     shape: tuple[int, ...],
@@ -712,7 +712,7 @@ def order(
     return patch.new(data=data, coords=new_coords)
 
 
-@patch_function(history=None, backend="array_api")
+@patch_function(history=None)
 def transpose(self: PatchType, *dims: str) -> PatchType:
     """
     Transpose the data array to any dimension order desired.
@@ -825,7 +825,7 @@ def append_dims(patch: PatchType, *empty_dims, **dim_kwargs) -> PatchType:
     return patch.update(data=data, coords=coords)
 
 
-@patch_function(backend="array_api")
+@patch_function()
 def squeeze(self: PatchType, dim=None) -> PatchType:
     """
     Return a new object with len one dimensions flattened.

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -483,16 +483,15 @@ def _apply_reduction(func, data, axis):
 
     nan_reduce handles the dtypes the standard cannot reduce.
     """
-    if is_numpy(data):
-        return func(data, axis=axis)
-    if (name := NAN_REDUCTIONS.get(func)) is not None:
-        return nan_reduce(name, data, axis=axis)
-    if (name := REDUCTIONS.get(func)) is not None:
-        return getattr(array_namespace(data), name)(data, axis=axis)
-    # An aggregation the standard has no name for, eg a median or a callable
-    # the caller passed to aggregate. Numpy applies it to whatever it can
-    # make of the array, which is what it did before dascore knew about
-    # other backends; the backend of the result is numpy's business.
+    if not is_numpy(data):
+        if (name := NAN_REDUCTIONS.get(func)) is not None:
+            return nan_reduce(name, data, axis=axis)
+        if (name := REDUCTIONS.get(func)) is not None:
+            return getattr(array_namespace(data), name)(data, axis=axis)
+    # Numpy data, or an aggregation the standard has no name for: a median, or
+    # a callable passed to aggregate. It gets the array as-is, exactly as
+    # before dascore knew about other backends, and decides the output's
+    # backend.
     return func(data, axis=axis)
 
 

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -487,9 +487,13 @@ def _apply_reduction(func, data, axis):
         return func(data, axis=axis)
     if (name := NAN_REDUCTIONS.get(func)) is not None:
         return nan_reduce(name, data, axis=axis)
-    # Only the shortcuts get here with data from another backend, and they
-    # all name a reduction dascore knows; aggregate itself is numpy backed.
-    return getattr(array_namespace(data), REDUCTIONS[func])(data, axis=axis)
+    if (name := REDUCTIONS.get(func)) is not None:
+        return getattr(array_namespace(data), name)(data, axis=axis)
+    # An aggregation the standard has no name for, eg a median or a callable
+    # the caller passed to aggregate. Numpy applies it to whatever it can
+    # make of the array, which is what it did before dascore knew about
+    # other backends; the backend of the result is numpy's business.
+    return func(data, axis=axis)
 
 
 def _apply_aggregator(patch, dim, func, dim_reduce="empty"):

--- a/dascore/utils/array_api.py
+++ b/dascore/utils/array_api.py
@@ -36,10 +36,7 @@ __all__ = [
     "warn_numpy_fallback",
 ]
 
-# The key used by patch functions written against the array API standard.
-ARRAY_API_BACKEND = "array_api"
-
-# The key used by patch functions which require numpy arrays.
+# The name reported for numpy arrays, and for array-likes numpy handles.
 NUMPY_BACKEND = "numpy"
 
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -270,11 +270,6 @@ def numpy_fallback(name, data, func, args=(), kwargs=None, stacklevel=4):
     converted = tuple(_to_numpy_arg(x) for x in args)
     kwargs = {i: _to_numpy_arg(v) for i, v in (kwargs or {}).items()}
     out = func(*converted, **kwargs)
-    # A function which returned one of its inputs unchanged returns the
-    # original, so callers still see the no-op they would have seen.
-    for original, numpy_arg in zip(args, converted, strict=True):
-        if out is numpy_arg:
-            return original
     # Only patches carry data back to the original backend.
     if isinstance(out, dc.Patch):
         out = out.new(data=asarray_like(out.data, data))

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -8,7 +8,6 @@ import sys
 import warnings
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from types import ModuleType
 from typing import Any, Literal, Protocol, cast, overload
 
 import numpy as np
@@ -34,13 +33,10 @@ from dascore.exceptions import (
 )
 from dascore.units import convert_units, get_quantity, is_percent
 from dascore.utils.array_api import (
-    ARRAY_API_BACKEND,
-    NUMPY_BACKEND,
     asarray_like,
     backend_name,
     is_foreign,
     is_numpy,
-    namespace_name,
     to_numpy,
     warn_numpy_fallback,
 )
@@ -226,42 +222,13 @@ class _PatchFunction(Protocol):
 
     The decorator attaches references back to the function it wrapped so
     callers can skip the patch-function machinery when calling it again.
-    It also attaches the backend registry, which maps the name of an array
-    backend to the implementation used for patches backed by it.
     """
 
     func: Callable
     raw_function: Callable
-    backends: dict[str, Callable]
-    register: Callable[[str], Callable]
     __wrapped__: Callable
 
     def __call__(self, patch, *args, **kwargs): ...
-
-
-def _resolve_backend(backend) -> str:
-    """
-    Get a backend name from a name, an array API namespace, or an array.
-
-    The namespace and array forms are recommended; they can't be misspelled,
-    and the name of an array library's namespace is not always the name of
-    the library (eg torch, not pytorch).
-    """
-    if isinstance(backend, str):
-        return backend
-    if isinstance(backend, ModuleType):
-        return namespace_name(backend)
-    return backend_name(backend)
-
-
-def _get_backend_name(patch) -> str:
-    """Get the name of the array backend which backs a patch's data."""
-    data = getattr(patch, "data", None)
-    # Anything which doesn't carry array data uses the numpy path, where
-    # it gets the same error it would have gotten before dispatch existed.
-    if data is None or is_numpy(data):
-        return NUMPY_BACKEND
-    return backend_name(data)
 
 
 def _to_numpy_arg(obj):
@@ -314,21 +281,6 @@ def numpy_fallback(name, data, func, args=(), kwargs=None, stacklevel=4):
     return out
 
 
-def _dispatch_backend(backends, patch, args, kwargs):
-    """Call the implementation which best matches the patch's array backend."""
-    name = _get_backend_name(patch)
-    for key in (name, ARRAY_API_BACKEND, NUMPY_BACKEND):
-        if (func := backends.get(key)) is not None:
-            break
-    else:
-        keys = sorted(backends)
-        msg = f"No implementation for {name} arrays. Registered backends: {keys}"
-        raise NotImplementedError(msg)
-    if key == NUMPY_BACKEND and name != NUMPY_BACKEND:
-        return numpy_fallback(func.__name__, patch.data, func, (patch, *args), kwargs)
-    return func(patch, *args, **kwargs)
-
-
 def patch_function(
     required_dims: tuple[str, ...] | Callable | None = None,
     required_coords: tuple[str, ...] | None = None,
@@ -336,7 +288,6 @@ def patch_function(
     history: Literal["full", "method_name", None] = "full",
     validate_call: bool = False,
     data_type: str | None = None,
-    backend: str = NUMPY_BACKEND,
 ):
     """
     Decorator to mark a function as a patch method.
@@ -363,20 +314,6 @@ def patch_function(
         Controls the output patch's ``data_type`` attr. If None, leave the
         returned patch's ``data_type`` unchanged. Otherwise, set to specified
         value. Use an empty string ("") to clear.
-    backend
-        The name of the array backend the decorated function supports.
-        The default, "numpy", means the function requires numpy arrays;
-        patches backed by another array library are converted to numpy and
-        the output converted back, which issues a
-        [NumpyFallbackWarning](`dascore.warnings.NumpyFallbackWarning`).
-        Use "array_api" for functions written against the array API
-        standard, which then work with any array backend. Implementations
-        for a specific backend are added with the ``register`` method of
-        the decorated function. Both accept a backend name, an array API
-        namespace, or an example array; the last two are recommended since
-        a misspelled name is never matched.
-        Only patches passed as arguments are converted for the fallback,
-        not patches nested inside other containers.
 
     Examples
     --------
@@ -416,26 +353,19 @@ def patch_function(
     ... def do_unknown_quantity(patch):
     ...     ...
     >>>
-    >>> # 6. A patch method which works with any array backend, plus a
-    >>> # backend-specific implementation.
-    >>> import numpy as np
+    >>> # 6. A patch method whose body is written to the array API standard,
+    >>> # so it runs on any array backend rather than only on numpy.
     >>> from dascore.utils.array_api import array_namespace
-    >>> @dc.patch_function(backend="array_api")
+    >>> @dc.patch_function()
     ... def do_portable_thing(patch):
     ...     xp = array_namespace(patch.data)
     ...     return patch.new(data=xp.abs(patch.data))
-    >>>
-    >>> @do_portable_thing.register(np)  # or "numpy", or an example array
-    ... def _do_numpy_thing(patch):
-    ...     ...
 
     Notes
     -----
     - The original function can still be accessed with the raw_function
       attribute. This may be useful for avoiding calling the patch_func
-      machinery multiple times from within another patch function. It skips
-      backend dispatch as well, so it should only be used on data the
-      calling function has already put on the right backend.
+      machinery multiple times from within another patch function.
 
     - If using `PatchType` or `SpoolType` type variables from the
       [constants module](`dascore.constants`), make sure dascore is imported
@@ -448,25 +378,9 @@ def patch_function(
         return patch_function()(required_dims)
 
     def _wrapper(func):
-        def _maybe_validate(function):
-            """Apply pydantic validation to each backend implementation."""
-            if not validate_call:
-                return function
+        if validate_call:
             config = pydantic.ConfigDict(arbitrary_types_allowed=True)
-            return pydantic.validate_call(config=config)(function)
-
-        def _register(name) -> Callable:
-            """Register an implementation for an array backend."""
-            key = _resolve_backend(name)
-
-            def _decorator(function):
-                backends[key] = _maybe_validate(function)
-                return function
-
-            return _decorator
-
-        func = _maybe_validate(func)
-        backends = {_resolve_backend(backend): func}
+            func = pydantic.validate_call(config=config)(func)
 
         @functools.wraps(func)
         def _func(patch, *args, **kwargs):
@@ -476,7 +390,7 @@ def patch_function(
                 coords=required_coords,
             )
             check_patch_attrs(patch, required_attrs)
-            out = _dispatch_backend(backends, patch, args, kwargs)
+            out = func(patch, *args, **kwargs)
             attr_updates = {}
             if data_type is not None:
                 attr_updates["data_type"] = data_type
@@ -499,8 +413,6 @@ def patch_function(
         # matches pydantic naming.
         patch_func.raw_function = getattr(func, "raw_function", func)
         patch_func.__wrapped__ = func
-        patch_func.backends = backends
-        patch_func.register = _register
 
         return patch_func
 

--- a/dascore/warnings.py
+++ b/dascore/warnings.py
@@ -9,10 +9,9 @@ class DASCoreWarning(UserWarning):
 
 class NumpyFallbackWarning(DASCoreWarning):
     """
-    Raised when an operation converts non-numpy data to numpy.
+    Issued when an operation converts non-numpy data to numpy.
 
-    Ufuncs, numpy functions and reductions which the array API standard
-    cannot express are applied by numpy: the data are converted to numpy,
-    the operation is applied, then the output data are converted back to
-    the original backend.
+    Some ufuncs, all numpy functions, and reductions of dtypes the standard
+    excludes are applied by numpy: the data are converted, the operation
+    applied, and the output converted back to the original backend.
     """

--- a/dascore/warnings.py
+++ b/dascore/warnings.py
@@ -9,10 +9,10 @@ class DASCoreWarning(UserWarning):
 
 class NumpyFallbackWarning(DASCoreWarning):
     """
-    Raised when a patch function converts non-numpy data to numpy.
+    Raised when an operation converts non-numpy data to numpy.
 
-    Patch functions which have no implementation for the array backend of
-    the input patch fall back to their numpy implementation. The data are
-    converted to numpy, the function is applied, then the output data are
-    converted back to the original backend.
+    Ufuncs, numpy functions and reductions which the array API standard
+    cannot express are applied by numpy: the data are converted to numpy,
+    the operation is applied, then the output data are converted back to
+    the original backend.
     """

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -130,7 +130,7 @@ Spool namespaces use the same pattern. The only changes are:
 
 ## Array backends
 
-Patch data can be backed by any array library which implements the [array API standard](https://data-apis.org/array-api/latest/), not just NumPy. A patch function declares which one its body was written for:
+Patch data can be backed by any array library which implements the [array API standard](https://data-apis.org/array-api/latest/), not just NumPy. A patch function receives the patch exactly as it was given, so its body decides which backends it supports. Getting the namespace from the data, rather than reaching for NumPy, is what makes a function work on all of them:
 
 ```{python}
 import dascore as dc
@@ -138,27 +138,15 @@ from dascore.constants import PatchType
 from dascore.utils.array_api import array_namespace
 
 
-@dc.patch_function(backend="array_api")
+@dc.patch_function()
 def double(patch: PatchType) -> PatchType:
     xp = array_namespace(patch.data)
     return patch.new(data=xp.multiply(patch.data, 2))
 ```
 
-The default, `"numpy"`, means the function needs NumPy arrays. Patches from another backend are then converted to NumPy, the function is applied, and the output is converted back, which issues a `NumpyFallbackWarning`. Use `"array_api"` when the body only uses functions from the standard, as above, in which case it runs on any backend without conversion.
+Most of DASCore's patch functions are still written against NumPy, and make no promise about data from another backend: depending on the body they may raise, or quietly return a NumPy-backed patch. Operators and NumPy functions applied to a patch (`patch * 2`, `np.sqrt(patch)`, `np.mean(patch)`) are the exception: they stay in the array's own namespace when the standard can express them, and otherwise convert to NumPy and back, which issues a `NumpyFallbackWarning`.
 
-An implementation for one specific backend is added with `register`, which also works on DASCore's own patch functions from your package:
-
-```{python}
-#| eval: false
-import jax.numpy as jnp
-
-
-@dc.proc.detrend.register(jnp)
-def _jax_detrend(patch, dim="time"):
-    ...
-```
-
-The registration key is the name of the array library's *namespace*, which is not always the name of the library: `torch` rather than `pytorch`, `jax` rather than `jaxlib`. Passing the namespace module, as above, or an example array is therefore recommended over passing the string; a misspelled string registers an implementation which is never called. Note that this only works for libraries which implement the standard. Array-likes which merely support `__array__` are handled by NumPy, and report `"numpy"` as their backend.
+Array-likes which merely support `__array__`, rather than implementing the standard, are handled by NumPy and report `"numpy"` as their backend.
 
 ## Related guides
 

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -144,7 +144,7 @@ def double(patch: PatchType) -> PatchType:
     return patch.new(data=xp.multiply(patch.data, 2))
 ```
 
-Most of DASCore's patch functions are still written against NumPy, and make no promise about data from another backend: depending on the body they may raise, or quietly return a NumPy-backed patch. Operators and NumPy functions applied to a patch (`patch * 2`, `np.sqrt(patch)`, `np.mean(patch)`) are the exception: they stay in the array's own namespace when the standard can express them, and otherwise convert to NumPy and back, which issues a `NumpyFallbackWarning`.
+Most of DASCore's patch functions are still written against NumPy, and make no promise about data from another backend: depending on the body they may raise, or quietly return a NumPy-backed patch. Operators and ufuncs (`patch * 2`, `np.sqrt(patch)`) always work: they stay in the array's own namespace when the standard can express them, and otherwise convert to NumPy and back, which issues a `NumpyFallbackWarning`. NumPy functions such as `np.mean(patch)`, and reductions of dtypes the standard excludes, always take that second path.
 
 Array-likes which merely support `__array__`, rather than implementing the standard, are handled by NumPy and report `"numpy"` as their backend.
 

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -144,9 +144,9 @@ class TestPatchBackends:
         assert backend_name(out.data) == backend
         assert "distance" not in out.dims
 
-    def test_numpy_only_function_leaves_the_backend_alone(self, backend_patch):
-        """Numpy-only functions neither convert the data nor warn about it."""
-        # What the body makes of a foreign array is the body's business.
+    def test_numpy_only_function_does_not_warn(self, backend_patch):
+        """Nothing converts or warns for a numpy-only function; its body decides."""
+        # detrend hands the array to scipy, which gives numpy data back.
         with warnings_as_errors():
             out = backend_patch.detrend("time")
         assert out.shape == backend_patch.shape
@@ -213,9 +213,8 @@ class _Case(NamedTuple):
 
 
 # The patch functions whose bodies are written to the array API standard, and
-# so run on any backend. It is a hand-kept inventory rather than something
-# discovered from the functions; nothing on a patch function declares which
-# backends its body supports.
+# so run on any backend. Nothing on a patch function declares that, so this
+# inventory is hand-kept: add an entry when you convert one.
 # setup runs on the numpy patch, before it is moved to another backend.
 ARRAY_API_CASES = {
     "dascore.proc.coords.transpose": _Case(call=lambda patch: patch.transpose()),
@@ -245,7 +244,7 @@ ARRAY_API_CASES = {
 
 
 class TestArrayApiPatchFunctions:
-    """Every patch function written to the standard must work on it."""
+    """The patch functions listed as written to the standard must work on it."""
 
     @pytest.mark.parametrize("name", sorted(ARRAY_API_CASES))
     def test_backend_preserved(self, name, random_patch, to_backend, backend):

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
-import pkgutil
-import sys
 import warnings
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -15,7 +12,6 @@ import pytest
 
 import dascore as dc
 from dascore.utils.array_api import (
-    ARRAY_API_BACKEND,
     asarray_like,
     backend_name,
     can_nan_reduce,
@@ -24,8 +20,6 @@ from dascore.utils.array_api import (
     to_numpy,
 )
 from dascore.utils.misc import suppress_warnings
-from dascore.utils.patch import _get_backend_name
-from dascore.warnings import NumpyFallbackWarning
 
 
 @pytest.fixture(scope="module")
@@ -144,18 +138,17 @@ class TestPatchBackends:
 
     def test_squeeze_keeps_backend(self, backend_patch, backend):
         """Squeeze also works on any backend."""
-        with suppress_warnings(NumpyFallbackWarning):
-            patch = backend_patch.select(distance=0, samples=True)
+        patch = backend_patch.select(distance=0, samples=True)
         with warnings_as_errors():
             out = patch.squeeze()
         assert backend_name(out.data) == backend
         assert "distance" not in out.dims
 
-    def test_numpy_only_function_warns(self, backend_patch, backend):
-        """Numpy-only functions warn but preserve the input backend."""
-        with pytest.warns(NumpyFallbackWarning, match="detrend"):
+    def test_numpy_only_function_leaves_the_backend_alone(self, backend_patch):
+        """Numpy-only functions neither convert the data nor warn about it."""
+        # What the body makes of a foreign array is the body's business.
+        with warnings_as_errors():
             out = backend_patch.detrend("time")
-        assert backend_name(out.data) == backend
         assert out.shape == backend_patch.shape
 
     def test_to_numpy_array(self, backend_patch):
@@ -167,19 +160,6 @@ class TestPatchBackends:
     def test_str(self, backend_patch):
         """Patches from any backend have a string representation."""
         assert "Patch" in str(backend_patch)
-
-
-def test_suppress_fallback_warning(random_patch, to_backend, backend):
-    """The fallback warning can be silenced like any other dascore warning."""
-    patch = to_backend(random_patch)
-    with suppress_warnings(NumpyFallbackWarning):
-        out = patch.detrend("time")
-    assert backend_name(out.data) == backend
-
-
-def test_backend_name_of_non_array():
-    """Objects which don't carry array data dispatch to numpy."""
-    assert _get_backend_name(object()) == "numpy"
 
 
 class _ArrayLike:
@@ -208,7 +188,7 @@ class TestNonStandardArrayLike:
         assert backend_name(array_like_patch.data) == "numpy"
 
     def test_numpy_function(self, array_like_patch):
-        """Numpy-only functions work as they did before dispatch existed."""
+        """Numpy-only functions handle them, since numpy consumes them."""
         with warnings_as_errors():
             out = array_like_patch.detrend("time")
         assert isinstance(out.data, np.ndarray)
@@ -232,8 +212,10 @@ class _Case(NamedTuple):
     setup: Callable = _identity
 
 
-# Every patch function which declares the array API backend needs an entry
-# here, which is also the inventory of what has been converted so far.
+# The patch functions whose bodies are written to the array API standard, and
+# so run on any backend. It is a hand-kept inventory rather than something
+# discovered from the functions; nothing on a patch function declares which
+# backends its body supports.
 # setup runs on the numpy patch, before it is moved to another backend.
 ARRAY_API_CASES = {
     "dascore.proc.coords.transpose": _Case(call=lambda patch: patch.transpose()),
@@ -262,43 +244,8 @@ ARRAY_API_CASES = {
 }
 
 
-def _get_patch_functions() -> dict[str, Callable]:
-    """Return every patch function dascore defines, keyed by qualified name."""
-    for module in pkgutil.walk_packages(dc.__path__, "dascore."):
-        importlib.import_module(module.name)
-    out = {}
-    for name, module in list(sys.modules.items()):
-        if not name.startswith("dascore"):
-            continue
-        for obj in vars(module).values():
-            if callable(obj) and isinstance(getattr(obj, "backends", None), dict):
-                out[f"{obj.__module__}.{obj.__qualname__}"] = obj
-    return out
-
-
-PATCH_FUNCTIONS = _get_patch_functions()
-ARRAY_API_FUNCTIONS = {
-    i: v for i, v in PATCH_FUNCTIONS.items() if ARRAY_API_BACKEND in v.backends
-}
-
-
 class TestArrayApiPatchFunctions:
-    """Every patch function which declares the array API must work on it."""
-
-    def test_patch_functions_found(self):
-        """The discovery finds dascore's patch functions."""
-        assert len(PATCH_FUNCTIONS) > 50
-        assert "dascore.proc.detrend.detrend" in PATCH_FUNCTIONS
-
-    def test_every_function_has_a_case(self):
-        """Declaring the array API backend requires proving it works."""
-        missing = sorted(set(ARRAY_API_FUNCTIONS) - set(ARRAY_API_CASES))
-        assert not missing, f"add an ARRAY_API_CASES entry for: {missing}"
-
-    def test_no_stale_cases(self):
-        """Cases for functions which no longer declare the array API."""
-        stale = sorted(set(ARRAY_API_CASES) - set(ARRAY_API_FUNCTIONS))
-        assert not stale, f"remove the ARRAY_API_CASES entry for: {stale}"
+    """Every patch function written to the standard must work on it."""
 
     @pytest.mark.parametrize("name", sorted(ARRAY_API_CASES))
     def test_backend_preserved(self, name, random_patch, to_backend, backend):
@@ -319,44 +266,6 @@ class TestArrayApiPatchFunctions:
         assert out.coords == expected.coords
         assert out.attrs == expected.attrs
         assert np.allclose(array, np.asarray(expected.data), equal_nan=True)
-
-
-class TestRegisterBackend:
-    """Tests for naming the backend an implementation is registered under."""
-
-    @pytest.fixture
-    def patch_func(self):
-        """A patch function with only a numpy implementation."""
-
-        @dc.patch_function()
-        def func(patch):
-            return patch
-
-        return func
-
-    def test_string(self, patch_func):
-        """A backend can be named with a string."""
-        patch_func.register("array_api_strict")(_identity)
-        assert "array_api_strict" in patch_func.backends
-
-    def test_namespace(self, patch_func, xps):
-        """It can also be named with the array namespace itself."""
-        patch_func.register(xps)(_identity)
-        assert "array_api_strict" in patch_func.backends
-
-    def test_array(self, patch_func, xps):
-        """Or with an example array."""
-        patch_func.register(xps.asarray([1.0]))(_identity)
-        assert "array_api_strict" in patch_func.backends
-
-    def test_decorator_argument(self):
-        """The decorator's backend argument accepts the same forms."""
-
-        @dc.patch_function(backend=np)
-        def func(patch):
-            return patch
-
-        assert set(func.backends) == {"numpy"}
 
 
 class TestNanReduce:

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -864,16 +864,15 @@ class TestArrayBackends:
             out = patch.min("time")
         self._assert_matches_numpy(out, numpy_patch.min("time"), backend)
 
-    def test_multi_dimension_fallback_warns_once(
-        self, backend_patch, random_patch, backend
-    ):
-        """The patch crosses to numpy once, not once per dimension."""
-        # aggregate is numpy backed, so its dispatcher does the conversion.
-        with pytest.warns(NumpyFallbackWarning) as warnings_raised:
-            out = backend_patch.aggregate(dim=None, method="median")
-        assert len(warnings_raised) == 1
+    def test_aggregation_the_standard_lacks(self, backend_patch, random_patch):
+        """An aggregation with no name in the standard is left to numpy."""
+        # aggregate promises nothing about the backend of its output, so
+        # only the values have to survive.
+        out = backend_patch.aggregate(dim=None, method="median")
         expected = random_patch.aggregate(dim=None, method="median")
-        self._assert_matches_numpy(out, expected, backend)
+        assert out.dims == expected.dims
+        assert out.coords == expected.coords
+        assert np.allclose(np.asarray(out.data), np.asarray(expected.data))
 
     @pytest.mark.parametrize("dtype", ["int32", "bool"])
     @pytest.mark.parametrize(

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -852,6 +852,16 @@ class TestArrayBackends:
             out = np.fmod(backend_patch, 2)
         self._assert_matches_numpy(out, np.fmod(random_patch, 2), backend)
 
+    def test_foreign_array_operand_converted(
+        self, backend_patch, random_patch, backend
+    ):
+        """An operand which is a bare array from the backend crosses too."""
+        array = np.asarray(random_patch.data) + 1
+        other = to_backend_array(backend_patch, array)
+        with suppress_warnings(NumpyFallbackWarning):
+            out = np.fmod(backend_patch, other)
+        self._assert_matches_numpy(out, np.fmod(random_patch, array), backend)
+
     def test_reduction_dtype_without_equivalent(
         self, backend_patch, random_patch, backend
     ):
@@ -865,14 +875,17 @@ class TestArrayBackends:
         self._assert_matches_numpy(out, numpy_patch.min("time"), backend)
 
     def test_aggregation_the_standard_lacks(self, backend_patch, random_patch):
-        """An aggregation with no name in the standard is left to numpy."""
+        """An aggregation with no name in the standard goes straight to the func."""
         # aggregate promises nothing about the backend of its output, so
-        # only the values have to survive.
+        # everything but the backend has to survive.
         out = backend_patch.aggregate(dim=None, method="median")
         expected = random_patch.aggregate(dim=None, method="median")
+        array = np.asarray(out.data)
+        assert array.dtype == expected.data.dtype
         assert out.dims == expected.dims
         assert out.coords == expected.coords
-        assert np.allclose(np.asarray(out.data), np.asarray(expected.data))
+        assert out.attrs == expected.attrs
+        assert np.allclose(array, np.asarray(expected.data))
 
     @pytest.mark.parametrize("dtype", ["int32", "bool"])
     @pytest.mark.parametrize(

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import Annotated, Literal, get_type_hints
 
 import numpy as np
@@ -22,7 +21,6 @@ from dascore.exceptions import (
     PatchCoordinateError,
 )
 from dascore.units import percent
-from dascore.utils.array_api import backend_name
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch import (
     _force_patch_merge,
@@ -41,7 +39,6 @@ from dascore.utils.patch import (
     stack_patches,
     swap_kwargs_dim_to_axis,
 )
-from dascore.warnings import NumpyFallbackWarning
 
 
 @dc.patch_function(required_dims=("time", "distance"))
@@ -1196,180 +1193,3 @@ class TestDottedPatchNames:
         assert "DAS.R2D1..RAW" in name
         patch.io.write(tmp_path / f"{name}.h5", "dasdae")
         assert get_patch_names(dc.spool(tmp_path).update()).iloc[0] == name
-
-
-class TestBackendDispatch:
-    """Tests for dispatching patch functions on the patch's array backend."""
-
-    @pytest.fixture
-    def numpy_func(self):
-        """A patch function which only supports numpy."""
-
-        @dc.patch_function()
-        def numpy_only(patch, calls=None):
-            if calls is not None:
-                calls.append(backend_name(patch.data))
-            return patch.new(data=patch.data * 2)
-
-        return numpy_only
-
-    @pytest.fixture
-    def strict_patch(self, random_patch):
-        """A patch backed by the array_api_strict library."""
-        xps = pytest.importorskip("array_api_strict")
-        return random_patch.new(data=xps.asarray(np.asarray(random_patch.data)))
-
-    def test_default_backend(self, numpy_func):
-        """By default a patch function declares only a numpy implementation."""
-        assert set(numpy_func.backends) == {"numpy"}
-        assert numpy_func.backends["numpy"] is numpy_func.raw_function
-
-    def test_numpy_patch_not_converted(self, numpy_func, random_patch):
-        """Numpy patches use the numpy implementation directly."""
-        calls = []
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            out = numpy_func(random_patch, calls=calls)
-        assert calls == ["numpy"]
-        assert isinstance(out.data, np.ndarray)
-
-    def test_fallback_converts_and_restores(self, numpy_func, strict_patch):
-        """Other backends are converted to numpy then converted back."""
-        calls = []
-        with pytest.warns(NumpyFallbackWarning, match="numpy_only"):
-            out = numpy_func(strict_patch, calls=calls)
-        assert calls == ["numpy"]
-        assert backend_name(out.data) == "array_api_strict"
-
-    def test_registered_backend_used(self, numpy_func, strict_patch):
-        """A registered implementation takes precedence over the fallback."""
-
-        @numpy_func.register("array_api_strict")
-        def _strict(patch, calls=None):
-            calls.append("registered")
-            return patch
-
-        calls = []
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            numpy_func(strict_patch, calls=calls)
-        assert calls == ["registered"]
-
-    def test_array_api_used_for_unknown_backend(self, strict_patch):
-        """Array API implementations serve backends with no exact match."""
-        calls = []
-
-        @dc.patch_function(backend="array_api")
-        def array_api_func(patch):
-            calls.append(backend_name(patch.data))
-            return patch
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            array_api_func(strict_patch)
-        assert calls == ["array_api_strict"]
-
-    def test_exact_backend_beats_array_api(self, random_patch):
-        """An exact backend match wins over the generic implementation."""
-        calls = []
-
-        @dc.patch_function(backend="array_api")
-        def func(patch):
-            calls.append("array_api")
-            return patch
-
-        @func.register("numpy")
-        def _numpy_func(patch):
-            calls.append("numpy")
-            return patch
-
-        func(random_patch)
-        assert calls == ["numpy"]
-
-    def test_no_implementation_raises(self, random_patch):
-        """A patch with no usable implementation raises."""
-
-        @dc.patch_function(backend="jax")
-        def jax_only(patch):
-            return patch
-
-        with pytest.raises(NotImplementedError, match="numpy"):
-            jax_only(random_patch)
-
-    def test_patch_arguments_converted(self, strict_patch):
-        """Patches passed as arguments are also converted for the fallback."""
-        backends = []
-
-        @dc.patch_function()
-        def two_patches(patch, other, key=None):
-            backends.append(
-                (backend_name(patch.data), backend_name(other.data), key.dims)
-            )
-            return patch
-
-        with pytest.warns(NumpyFallbackWarning):
-            two_patches(strict_patch, strict_patch, key=strict_patch)
-        assert backends == [("numpy", "numpy", strict_patch.dims)]
-
-    def test_non_patch_output(self, strict_patch):
-        """Functions which don't return a patch are left alone."""
-
-        @dc.patch_function()
-        def get_shape(patch):
-            return patch.shape
-
-        with pytest.warns(NumpyFallbackWarning):
-            out = get_shape(strict_patch)
-        assert out == strict_patch.shape
-
-    def test_history_and_data_type_added(self, strict_patch):
-        """The fallback path keeps the normal patch function machinery."""
-
-        @dc.patch_function(data_type="strain")
-        def set_strain(patch):
-            return patch.new(data=patch.data)
-
-        with pytest.warns(NumpyFallbackWarning):
-            out = set_strain(strict_patch)
-        assert out.attrs.data_type == "strain"
-        assert "set_strain" in out.attrs.history[-1]
-
-    def test_array_arguments_converted(self, strict_patch):
-        """Arrays passed as arguments are converted for the fallback."""
-        types = []
-
-        @dc.patch_function()
-        def uses_array(patch, condition):
-            types.append(type(condition))
-            return patch.new(data=np.where(condition, patch.data, 0))
-
-        condition = strict_patch.data > 0
-        with pytest.warns(NumpyFallbackWarning):
-            out = uses_array(strict_patch, condition)
-        assert types == [np.ndarray]
-        assert backend_name(out.data) == "array_api_strict"
-
-    def test_unchanged_patch_returned(self, strict_patch):
-        """A function which returns its input returns the original patch."""
-
-        @dc.patch_function()
-        def do_nothing(patch):
-            return patch
-
-        with pytest.warns(NumpyFallbackWarning):
-            out = do_nothing(strict_patch)
-        assert out is strict_patch
-
-    def test_registered_function_validated(self, strict_patch):
-        """Registered implementations get the same call validation."""
-
-        @dc.patch_function(validate_call=True)
-        def needs_int(patch, value: int = 1):
-            return patch
-
-        @needs_int.register("array_api_strict")
-        def _strict_needs_int(patch, value: int = 1):
-            return patch
-
-        with pytest.raises(pydantic.ValidationError):
-            needs_int(strict_patch, value="not_an_int")


### PR DESCRIPTION
## Description

First PR of the processors series. It removes the per-patch-function backend dispatcher that #908 added, so that dispatch can be reintroduced later at the kernel level of a split processor class rather than around a whole patch function.

Dispatching a whole function turned out to be the wrong seam. A patch function is a body plus metadata bookkeeping; the part another array backend can actually implement is the array-to-array kernel inside it, not the metadata work around it. Keeping a registry on every patch function also committed DASCore to a fallback promise — convert to NumPy, run, convert back, warn — for roughly 65 NumPy-only functions whose round trips nobody had verified. Rather than carry that promise through the rest of the series, it is withdrawn here and the seam left clean.

Removed:

- `patch_function(backend=...)`, and the `backends` dict and `register` method the decorator attached to every wrapped function.
- `_dispatch_backend`, `_resolve_backend` and `_get_backend_name` in `dascore/utils/patch.py`.
- The declared-backend gate and the `_get_patch_functions` sweep in `tests/test_utils/test_array_api.py`, and `TestBackendDispatch` in `tests/test_utils/test_patch_utils.py`.
- `ARRAY_API_BACKEND`, which was only ever a registry key.

Kept:

- Everything else in `dascore/utils/array_api.py`.
- #909 and #915. Operators, NumPy functions and reductions applied to a patch still run in the array's own namespace, and still fall back to NumPy with a `NumpyFallbackWarning` where the standard cannot express them. `numpy_fallback` stays where it is because that path uses it.
- The `xp`-portable function bodies. They no longer *declare* anything, but they still work on any backend, and `ARRAY_API_CASES` still proves it for each of them.

After this PR a NumPy-only patch function makes no promise about data from another backend, exactly as before #908: depending on the body it may raise, or quietly hand back NumPy's answer. Foreign-backed data keeps working through operators, NumPy functions and reductions.

`patch_function` is now byte-for-byte identical to its text at `7b18d1ca~1`, the commit before #908.

Supersedes #921, which can be closed.

## Changelog

- none

## Decisions made

Where the plan under-specified something, or disagreed with the code:

1. **`docs/contributing/testing.qmd` is untouched.** The plan lists a "declares backend" paragraph there for removal. `dev` has no such paragraph — it exists only on the unmerged #921 branch.

2. **`ARRAY_API_CASES` and `test_backend_preserved` are kept.** The plan names "the declared-backend gate" and "the `_get_patch_functions` sweep" for removal. Both read `func.backends`, so both had to go. `test_backend_preserved` does not read it — it is a plain table of calls, and it is the only thing proving the portable bodies the plan says to keep still run on another backend. It stays, re-keyed as a hand-maintained inventory. PR 6 re-keys it onto processors with an `array_api` kernel.

3. **`ARRAY_API_BACKEND` is deleted rather than kept.** The plan says to keep `array_api.py`'s helpers. This is not a helper but the dispatcher's registry key, and nothing reads it once the dispatcher is gone. A constant whose docstring describes a mechanism that no longer exists seemed worse than deleting it; PR 6 can reintroduce it as a `kernels` key.

4. **`_apply_reduction` needed a NumPy branch.** `aggregate` was NumPy-backed and relied on the dispatcher converting foreign data before `_apply_aggregator` ran — the guarantee behind the comment "aggregate itself is numpy backed". Without it, `patch.aggregate(method="median")` on a foreign array raised `KeyError: <function nanmedian>` from the bare `REDUCTIONS[func]` subscript. It now falls through to `func(data, axis=axis)`, which is what the call did before #908. `test_multi_dimension_fallback_warns_once` asserted the dispatcher's once-per-patch conversion and no longer had a referent; it is replaced by `test_aggregation_the_standard_lacks`, which checks values, dims and coords.

5. **Docstring example 6 of `patch_function` is rewritten here, not in PR 3.** It used `backend="array_api"` and `.register`, both removed by this PR, so `--doctest-modules` would fail otherwise. It now shows only the portable body.

6. **The plan's "NumPy-only patch functions error on [foreign data] as on master" overstates it.** Measured on `array_api_strict` and `dask`: `detrend` and `pass_filter` do not raise, they return a NumPy-backed patch through `__array__`. That is master's behaviour, so the rollback is faithful; the docs and the replacement test describe what actually happens rather than the plan's wording.

All eight aggregation methods were checked on both test backends against the NumPy answer:

| method | array_api_strict | dask |
|---|---|---|
| mean, min, max, sum, std | backend kept, values match | backend kept, values match |
| median, first, last | NumPy output, values match | dask output, values match |

Values are unchanged everywhere. Only the output backend changes, and only for the three methods the standard cannot name — the withdrawn fallback promise.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified array operation handling and backend behavior.
  * Aggregation shortcuts now better preserve the data’s native backend where supported.
  * Standard reductions use the active array backend, with unsupported operations handled through reliable fallback behavior.
  * Common patch operations retain their existing functionality without requiring explicit backend selection.

* **Documentation**
  * Clarified backend preservation, NumPy fallback behavior, and requirements for multi-library array support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->