### PR TITLE
Add the workflow core: a fingerprintable Task and its serializer

### DIFF
--- a/dascore/workflow/__init__.py
+++ b/dascore/workflow/__init__.py
@@ -1,0 +1,18 @@
+"""
+Machinery for describing, identifying and composing DASCore operations.
+
+An operation is a [`Task`](`dascore.workflow.task.Task`): a frozen object
+whose fields are its parameters, which knows its own fingerprint and can be
+written to a document and read back.
+"""
+
+from __future__ import annotations
+
+from dascore.workflow.serialize import (
+    canonical_json,
+    combine_hashes,
+    decode,
+    digest,
+    encode,
+)
+from dascore.workflow.task import Task, intern, make_function_task_class, task

--- a/dascore/workflow/serialize.py
+++ b/dascore/workflow/serialize.py
@@ -1,0 +1,565 @@
+"""
+Canonical encoding, decoding and hashing for workflow objects.
+
+A [`Task`](`dascore.workflow.task.Task`) is identified by a fingerprint: a
+digest of what it is and what it was given. That only works if the same
+parameters always encode to the same bytes, so this module turns arbitrary
+python values into a JSON tree with a fixed shape, then hashes its canonical
+text.
+
+Two modes exist. ``"fingerprint"`` encodes values for hashing: an array
+becomes a digest of its bytes, a parameter left at ``None`` is dropped, and
+values which cannot be reconstructed are named rather than reproduced.
+``"document"`` encodes values for storage: an array becomes a nested list, and
+nothing is dropped, so that reading the document back gives the value again.
+
+Stability rests on four things which do not change between python versions:
+`json`, `repr` of a float, numpy's byte layout, and blake2b. Python's own
+``hash`` is never used -- it is salted per process.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import threading
+import weakref
+from collections.abc import Callable, Iterable, Mapping, Set
+from enum import Enum
+from functools import partial
+from pathlib import PurePath
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+from pint import Quantity
+
+from dascore.exceptions import ParameterError
+from dascore.models.base import DascoreBaseModel
+from dascore.models.registry import TAG_FIELD, get_model_tag, resolve_model_tag
+from dascore.utils.array_api import is_foreign, to_numpy
+
+# The two encoding modes; see the module docstring.
+FINGERPRINT = "fingerprint"
+DOCUMENT = "document"
+
+EncodeMode = Literal["fingerprint", "document"]
+
+# Every tag is a single key starting with "$", which no python identifier and
+# no dascore field name can be, so a tagged value is never mistaken for a
+# plain mapping.
+_ARRAY = "$array"
+_BOOL = "$bool"
+_CALLABLE = "$callable"
+_DATAFRAME = "$dataframe"
+_DATETIME = "$datetime64"
+_DICT = "$dict"
+_ELLIPSIS = "$ellipsis"
+_FLOAT = "$float"
+_MODEL = "$model"
+_OPAQUE = "$opaque"
+_PARTIAL = "$partial"
+_QUANTITY = "$quantity"
+_SLICE = "$slice"
+_TASK = "$task"
+_TIMEDELTA = "$timedelta64"
+
+# The digest size used everywhere: 8 bytes, written as 16 hex characters.
+DIGEST_SIZE = 8
+
+# Digests of arrays already seen, keyed by id. An array passed to the same
+# call in a loop -- a mask given to `where`, an inventory given to `enrich` --
+# is then hashed once rather than once per patch. Entries are dropped when
+# the array is collected, so the cache holds no array alive and cannot grow
+# past what the caller is already holding.
+_ARRAY_DIGESTS: dict[int, str] = {}
+_ARRAY_REFS: dict[int, weakref.ref] = {}
+_ARRAY_LOCK = threading.Lock()
+
+
+def digest(obj: Any, mode: EncodeMode = FINGERPRINT) -> str:
+    """
+    Return a stable 16 character digest of any encodable object.
+
+    Parameters
+    ----------
+    obj
+        The object to hash.
+    mode
+        Either "fingerprint" (the default) or "document"; see the module
+        docstring.
+
+    Examples
+    --------
+    >>> from dascore.workflow.serialize import digest
+    >>> assert digest({"dim": "time"}) == digest({"dim": "time"})
+    >>> assert digest({"dim": "time"}) != digest({"dim": "distance"})
+    """
+    return _digest_bytes(canonical_json(obj, mode=mode).encode("ascii"))
+
+
+def combine_hashes(hashes: Iterable[str]) -> str:
+    """
+    Return one digest standing for an ordered series of digests.
+
+    Order matters: the digests of two patches combined the other way round
+    give a different answer, because which patch came first is part of what
+    was done.
+
+    Examples
+    --------
+    >>> from dascore.workflow.serialize import combine_hashes
+    >>> assert combine_hashes(["a", "b"]) != combine_hashes(["b", "a"])
+    """
+    return digest(list(hashes))
+
+
+def canonical_json(obj: Any, mode: EncodeMode = FINGERPRINT) -> str:
+    """
+    Return the canonical JSON text of an object.
+
+    Keys are sorted, whitespace is stripped and non-ascii characters are
+    escaped, so that equal objects give equal text on any platform.
+    """
+    return json.dumps(
+        encode(obj, mode=mode),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def encode(obj: Any, mode: EncodeMode = FINGERPRINT) -> Any:
+    """
+    Return a JSON-safe tree standing for an object.
+
+    Parameters
+    ----------
+    obj
+        The object to encode.
+    mode
+        Either "fingerprint" (the default) or "document"; see the module
+        docstring.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dascore.workflow.serialize import encode
+    >>> encode(np.arange(3), mode="document")["$array"]["data"]
+    [0, 1, 2]
+    """
+    return _encode_value(obj, mode)
+
+
+def decode(obj: Any) -> Any:
+    """
+    Return the object a document-mode encoding stands for.
+
+    Values which a document cannot carry -- an array reduced to its digest, a
+    function, a dataframe -- raise rather than come back as the tagged
+    mapping which stands for them.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dascore.workflow.serialize import encode, decode
+    >>> decode(encode(np.datetime64("2020-01-01"), mode="document"))
+    np.datetime64('2020-01-01T00:00:00.000000000')
+    """
+    if isinstance(obj, Mapping):
+        return _decode_mapping(obj)
+    if isinstance(obj, list):
+        return [decode(x) for x in obj]
+    return obj
+
+
+def _digest_bytes(data: bytes | memoryview) -> str:
+    """Return the digest of some bytes."""
+    return hashlib.blake2b(data, digest_size=DIGEST_SIZE).hexdigest()
+
+
+def _encode(obj: Any, mode: EncodeMode) -> Any:
+    """Encode anything but the scalars `encode` handles itself."""
+    # Ordered by how specific each check is, not by how common: bool is an
+    # int, np.bool_ is an np.generic, and a Quantity holds an array.
+    if isinstance(obj, bool | np.bool_):
+        return {_BOOL: bool(obj)}
+    if isinstance(obj, float | np.floating):
+        return _encode_float(float(obj))
+    if isinstance(obj, np.datetime64 | np.timedelta64):
+        return _encode_time(obj)
+    if isinstance(obj, np.generic):
+        return _encode_value(obj.item(), mode)
+    if isinstance(obj, Quantity):
+        return _encode_quantity(obj, mode)
+    if isinstance(obj, Enum):
+        return _encode_value(obj.value, mode)
+    if isinstance(obj, PurePath):
+        return obj.as_posix()
+    if isinstance(obj, slice):
+        parts = (obj.start, obj.stop, obj.step)
+        return {_SLICE: [_encode_value(x, mode) for x in parts]}
+    if obj is Ellipsis:
+        return {_ELLIPSIS: True}
+    if _is_task(obj):
+        # Checked before the model branch below, which every task also
+        # answers to: a task carries a version its fields do not show.
+        return {_TASK: obj.fingerprint if mode == FINGERPRINT else obj.to_dict()}
+    if isinstance(obj, DascoreBaseModel):
+        return _encode_model(obj, mode)
+    if isinstance(obj, pd.DataFrame | pd.Series):
+        return _encode_dataframe(obj, mode)
+    if _is_array(obj):
+        return _encode_array(obj, mode)
+    if isinstance(obj, Mapping):
+        return _encode_mapping(obj, mode)
+    if isinstance(obj, Set):
+        return _encode_set(obj, mode)
+    if isinstance(obj, list | tuple):
+        return [_encode_value(x, mode) for x in obj]
+    if isinstance(obj, partial):
+        return _encode_partial(obj, mode)
+    if callable(obj):
+        return _encode_callable(obj)
+    return {_OPAQUE: _spell_type(type(obj))}
+
+
+def _encode_value(obj: Any, mode: EncodeMode) -> Any:
+    """Encode one value, short-circuiting the ones JSON already spells."""
+    # None, strings and ints are much the most common parameter values, and
+    # the check is cheaper than walking the dispatch chain in `_encode`.
+    if obj is None or (isinstance(obj, str | int) and not isinstance(obj, bool)):
+        return obj
+    return _encode(obj, mode)
+
+
+def _encode_float(value: float) -> Any:
+    """Encode a float, tagging the three JSON cannot spell."""
+    if value == value and abs(value) != np.inf:
+        return value
+    if value != value:
+        return {_FLOAT: "nan"}
+    return {_FLOAT: "inf" if value > 0 else "-inf"}
+
+
+def _encode_time(value: np.datetime64 | np.timedelta64) -> Any:
+    """Encode a numpy time as nanoseconds, so the unit it was written in
+    does not change the answer.
+    """
+    tag = _DATETIME if isinstance(value, np.datetime64) else _TIMEDELTA
+    unit = "datetime64[ns]" if tag == _DATETIME else "timedelta64[ns]"
+    return {tag: int(value.astype(unit).astype(np.int64))}
+
+
+def _encode_quantity(value: Quantity, mode: EncodeMode) -> Any:
+    """
+    Encode a quantity as its magnitude and the unit it was written in.
+
+    The unit is not normalized: ``1 m`` and ``100 cm`` are the same length
+    but not the same call, and a task is identified by the call.
+    """
+    return {_QUANTITY: [_encode_value(value.magnitude, mode), f"{value.units:~}"]}
+
+
+def _encode_model(model: DascoreBaseModel, mode: EncodeMode) -> Any:
+    """Encode a dascore model as its tag and its fields."""
+    fields = {name: getattr(model, name) for name in type(model).model_fields}
+    fields.update(model.__pydantic_extra__ or {})
+    # A class no tag can name -- a parametrized generic -- is still spelled
+    # out, so that two of them do not fingerprint alike; a document holding
+    # one refuses to decode rather than rebuilding the wrong class.
+    tag = get_model_tag(type(model)) or _spell_type(type(model))
+    return {_MODEL: {TAG_FIELD: tag, "fields": _encode_mapping(fields, mode)}}
+
+
+def _encode_dataframe(df: pd.DataFrame | pd.Series, mode: EncodeMode) -> Any:
+    """
+    Encode a dataframe as a digest of its values.
+
+    A frame is a parameter to exactly one patch function today
+    (``coords_from_df``) and hashing it is all a fingerprint needs. It has no
+    document form: writing a frame into a pipe file, with its dtypes and its
+    index, is a storage format rather than a parameter encoding.
+    """
+    if mode == DOCUMENT:
+        msg = (
+            "A dataframe parameter cannot be written to a document. Give the "
+            "task the values it needs instead of the frame holding them."
+        )
+        raise ParameterError(msg)
+    hashed = pd.util.hash_pandas_object(df, index=True).to_numpy()
+    return {_DATAFRAME: _digest_bytes(hashed.tobytes())}
+
+
+def _encode_array(array: Any, mode: EncodeMode) -> Any:
+    """Encode an array by its dtype, shape and contents."""
+    original = array
+    array = to_numpy(array) if is_foreign(array) else np.asarray(array)
+    if array.dtype == object:
+        # An object array holds python values, which have no bytes to hash;
+        # each element is encoded on its own terms instead.
+        return [_encode_value(x, mode) for x in array.tolist()]
+    # A big-endian array holds the same values as its little-endian twin, so
+    # the byte order it happens to be stored in is normalized away.
+    array = array.astype(array.dtype.newbyteorder("<"), copy=False)
+    out = {"dtype": array.dtype.str, "shape": list(array.shape)}
+    if mode == DOCUMENT:
+        out["data"] = _encode_value(array.tolist(), mode)
+    else:
+        out["hash"] = _array_digest(array, original)
+    return {_ARRAY: out}
+
+
+def _array_digest(array: np.ndarray, original: Any) -> str:
+    """
+    Return the digest of an array's bytes, hashing each array once.
+
+    The cache is keyed on the array the caller passed rather than on the
+    normalized copy, which is a fresh object every call and would never hit.
+    """
+    key = id(original)
+    with _ARRAY_LOCK:
+        if (out := _ARRAY_DIGESTS.get(key)) is not None:
+            return out
+    # A view, and any datetime array, cannot export a buffer directly, so
+    # the values are copied into a layout numpy can hand out as bytes.
+    out = _digest_bytes(np.ascontiguousarray(array).view(np.uint8).data)
+    _remember_array(key, original, out)
+    return out
+
+
+def _remember_array(key: int, array: np.ndarray, value: str) -> None:
+    """Cache an array's digest for as long as the array itself lives."""
+
+    def _forget(_ref, key=key):
+        with _ARRAY_LOCK:
+            _ARRAY_DIGESTS.pop(key, None)
+            _ARRAY_REFS.pop(key, None)
+
+    # A view of another array, or an array a backend owns, may refuse a weak
+    # reference; the digest is then simply not cached.
+    try:
+        ref = weakref.ref(array, _forget)
+    except TypeError:
+        return
+    with _ARRAY_LOCK:
+        _ARRAY_DIGESTS[key] = value
+        _ARRAY_REFS[key] = ref
+
+
+def _encode_mapping(mapping: Mapping, mode: EncodeMode) -> Any:
+    """
+    Encode a mapping, dropping what a fingerprint should not see.
+
+    A parameter left at None is dropped in fingerprint mode: a call which
+    passes a default explicitly is the same call as one which leaves it out.
+    """
+    if not all(isinstance(key, str) for key in mapping):
+        return _encode_odd_keyed_mapping(mapping, mode)
+    items = mapping.items()
+    if mode == FINGERPRINT:
+        items = [(key, value) for key, value in items if value is not None]
+    return {key: _encode_value(value, mode) for key, value in items}
+
+
+def _encode_odd_keyed_mapping(mapping: Mapping, mode: EncodeMode) -> Any:
+    """Encode a mapping whose keys are not all strings as sorted pairs."""
+    pairs = [
+        [_encode_value(key, mode), _encode_value(value, mode)]
+        for key, value in mapping.items()
+    ]
+    return {_DICT: sorted(pairs, key=_sort_key)}
+
+
+def _encode_set(values: Set, mode: EncodeMode) -> Any:
+    """Encode a set as a sorted list; a set has no order of its own."""
+    return sorted((_encode_value(x, mode) for x in values), key=_sort_key)
+
+
+def _encode_partial(value: partial, mode: EncodeMode) -> Any:
+    """Encode a partial as the function it wraps and what it wraps it with."""
+    return {
+        _PARTIAL: {
+            "func": _encode_value(value.func, mode),
+            "args": [_encode_value(x, mode) for x in value.args],
+            "kwargs": _encode_mapping(value.keywords, mode),
+        }
+    }
+
+
+def _encode_callable(func: Callable) -> Any:
+    """
+    Encode a callable by where it is defined.
+
+    A function which cannot be named -- a lambda, or one defined inside
+    another function -- carries a digest of its source as well, since its
+    path names every one of them alike. Two written on the same line share
+    that source, and so are one parameter as far as a fingerprint is
+    concerned.
+    """
+    module = getattr(func, "__module__", None) or "<unknown>"
+    qualname = getattr(func, "__qualname__", None) or repr(func)
+    out = {"path": f"{module}:{qualname}"}
+    if "<lambda>" in qualname or "<locals>" in qualname:
+        out["source"] = _source_digest(func)
+    return {_CALLABLE: out}
+
+
+def _source_digest(func: Callable) -> str | None:
+    """Return a digest of a function's source, or None if it has none."""
+    try:
+        source = inspect.getsource(func)
+    except (OSError, TypeError):
+        # Defined in a shell, or built in: there is no text to read.
+        return None
+    return _digest_bytes(source.encode("utf8"))
+
+
+def _spell_type(cls: type) -> str:
+    """Spell a class the way an opaque encoding names it."""
+    # Never repr(obj): the default holds the object's address, which changes
+    # from run to run and would make every fingerprint unrepeatable.
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _sort_key(value: Any) -> str:
+    """Return a total order over encoded values."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _is_array(obj: Any) -> bool:
+    """Return True for anything which should encode as an array."""
+    return isinstance(obj, np.ndarray) or is_foreign(obj)
+
+
+def _is_task(obj: Any) -> bool:
+    """Return True if an object is a Task, without importing one."""
+    # Not an isinstance check: task.py imports this module, so naming Task
+    # here is a cycle. Every Task is a DascoreBaseModel and is checked
+    # before this, so only a Task reaches it with a `to_dict`.
+    return hasattr(obj, "fingerprint") and hasattr(obj, "to_dict")
+
+
+def _decode_mapping(obj: Mapping) -> Any:
+    """Decode a mapping, inverting whichever tag it carries."""
+    if len(obj) == 1:
+        key = next(iter(obj))
+        if (decoder := _DECODERS.get(key)) is not None:
+            return decoder(obj[key])
+    return {key: decode(value) for key, value in obj.items()}
+
+
+def _decode_float(value: str) -> float:
+    """Decode one of the floats JSON cannot spell."""
+    return float(value)
+
+
+def _decode_datetime(value: int) -> np.datetime64:
+    """Decode a datetime from its nanoseconds."""
+    return np.datetime64(value, "ns")
+
+
+def _decode_timedelta(value: int) -> np.timedelta64:
+    """Decode a timedelta from its nanoseconds."""
+    return np.timedelta64(value, "ns")
+
+
+def _decode_slice(value: list) -> slice:
+    """Decode a slice from its three parts."""
+    return slice(*(decode(x) for x in value))
+
+
+def _decode_quantity(value: list) -> Quantity:
+    """Decode a quantity from its magnitude and unit."""
+    # dascore.units imports dascore, which imports this module once patch
+    # functions are processors, so the registry is fetched when it is needed.
+    from dascore.units import get_quantity  # noqa: PLC0415
+
+    magnitude, units = decode(value[0]), value[1]
+    # An empty unit spells "no units" to get_quantity, which returns None,
+    # so a dimensionless quantity names its dimensionlessness instead.
+    return magnitude * get_quantity(units or "dimensionless")
+
+
+def _decode_array(value: Mapping) -> np.ndarray:
+    """Decode an array from its dtype, shape and data."""
+    if "data" not in value:
+        msg = (
+            "An array encoded for a fingerprint holds only a digest of its "
+            "values, so the array itself cannot be read back from it."
+        )
+        raise ParameterError(msg)
+    array = np.asarray(decode(value["data"]), dtype=np.dtype(value["dtype"]))
+    return array.reshape(value["shape"])
+
+
+def _decode_model(value: Mapping) -> DascoreBaseModel:
+    """Decode a dascore model from its tag and fields."""
+    cls = resolve_model_tag(value[TAG_FIELD])
+    if cls is None:
+        msg = (
+            f"Nothing registers the {TAG_FIELD} {value[TAG_FIELD]!r}, so the "
+            "model it names cannot be rebuilt."
+        )
+        raise ParameterError(msg)
+    return cls(**{key: decode(val) for key, val in value["fields"].items()})
+
+
+def _decode_task(value: Any) -> Any:
+    """Decode a task from its document."""
+    if not isinstance(value, Mapping):
+        msg = (
+            "A task encoded for a fingerprint holds only its digest, so the "
+            "task itself cannot be read back from it."
+        )
+        raise ParameterError(msg)
+    # Imported here rather than at module scope: task.py imports this module.
+    from dascore.workflow.task import Task  # noqa: PLC0415
+
+    return Task.from_dict(value)
+
+
+def _decode_dict(pairs: list) -> dict:
+    """Decode a mapping whose keys are not strings."""
+    # A key which was a tuple comes back as a list, which cannot be a key
+    # again, so any decoded sequence is made hashable on the way in.
+    return {_hashable(decode(key)): decode(value) for key, value in pairs}
+
+
+def _hashable(value: Any) -> Any:
+    """Return a value which can key a mapping."""
+    return tuple(value) if isinstance(value, list) else value
+
+
+def _refuse(kind: str):
+    """Return a decoder which refuses a value a document cannot carry."""
+
+    def _decoder(value):
+        msg = (
+            f"A {kind} was encoded by name rather than by value, so it cannot "
+            "be rebuilt from a document. Give the task a value it can carry."
+        )
+        raise ParameterError(msg)
+
+    return _decoder
+
+
+_DECODERS: dict[str, Callable[[Any], Any]] = {
+    _ARRAY: _decode_array,
+    _BOOL: bool,
+    _CALLABLE: _refuse("function"),
+    _DATAFRAME: _refuse("dataframe"),
+    _DATETIME: _decode_datetime,
+    _DICT: _decode_dict,
+    _ELLIPSIS: lambda _: Ellipsis,
+    _FLOAT: _decode_float,
+    _MODEL: _decode_model,
+    _OPAQUE: _refuse("value"),
+    _PARTIAL: _refuse("partial"),
+    _QUANTITY: _decode_quantity,
+    _SLICE: _decode_slice,
+    _TASK: _decode_task,
+    _TIMEDELTA: _decode_timedelta,
+}

--- a/dascore/workflow/serialize.py
+++ b/dascore/workflow/serialize.py
@@ -8,23 +8,26 @@ python values into a JSON tree with a fixed shape, then hashes its canonical
 text.
 
 Two modes exist. ``"fingerprint"`` encodes values for hashing: an array
-becomes a digest of its bytes, a parameter left at ``None`` is dropped, and
-values which cannot be reconstructed are named rather than reproduced.
-``"document"`` encodes values for storage: an array becomes a nested list, and
-nothing is dropped, so that reading the document back gives the value again.
+becomes a digest of its bytes and a value left at ``None`` is dropped.
+``"document"`` encodes values for storage: an array becomes a nested list and
+nothing is dropped, so most values read back. A function, a partial, or a
+value with no encoding of its own is named rather than reproduced in either
+mode, and a dataframe has no document form at all; decoding any of them
+raises.
 
-Stability rests on four things which do not change between python versions:
-`json`, `repr` of a float, numpy's byte layout, and blake2b. Python's own
-``hash`` is never used -- it is salted per process.
+Stability rests on `json`, `repr` of a float, numpy's byte layout and blake2b,
+none of which change between python versions, and -- for frames and quantities
+only -- on pandas' object hash and pint's short unit format. Python's own
+``hash`` is never used: it is salted per process.
 """
 
 from __future__ import annotations
 
+import datetime
 import hashlib
 import inspect
 import json
-import threading
-import weakref
+import warnings
 from collections.abc import Callable, Iterable, Mapping, Set
 from enum import Enum
 from functools import partial
@@ -37,8 +40,9 @@ from pint import Quantity
 
 from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
-from dascore.models.registry import TAG_FIELD, get_model_tag, resolve_model_tag
+from dascore.models.registry import TAG_FIELD, get_model_tag, resolve_tagged_model
 from dascore.utils.array_api import is_foreign, to_numpy
+from dascore.warnings import DASCoreWarning
 
 # The two encoding modes; see the module docstring.
 FINGERPRINT = "fingerprint"
@@ -47,11 +51,15 @@ DOCUMENT = "document"
 EncodeMode = Literal["fingerprint", "document"]
 
 # Every tag is a single key starting with "$", which no python identifier and
-# no dascore field name can be, so a tagged value is never mistaken for a
-# plain mapping.
+# no dascore field name can be. A mapping whose keys come from data rather
+# than from source can still hold one, so `_encode_mapping` writes any
+# mapping with a "$" key as an escaped `$dict` instead; without that a lone
+# {"$datetime64": 0} key would read back, and fingerprint, as a datetime.
 _ARRAY = "$array"
 _BOOL = "$bool"
+_BYTES = "$bytes"
 _CALLABLE = "$callable"
+_COMPLEX = "$complex"
 _DATAFRAME = "$dataframe"
 _DATETIME = "$datetime64"
 _DICT = "$dict"
@@ -67,15 +75,6 @@ _TIMEDELTA = "$timedelta64"
 
 # The digest size used everywhere: 8 bytes, written as 16 hex characters.
 DIGEST_SIZE = 8
-
-# Digests of arrays already seen, keyed by id. An array passed to the same
-# call in a loop -- a mask given to `where`, an inventory given to `enrich` --
-# is then hashed once rather than once per patch. Entries are dropped when
-# the array is collected, so the cache holds no array alive and cannot grow
-# past what the caller is already holding.
-_ARRAY_DIGESTS: dict[int, str] = {}
-_ARRAY_REFS: dict[int, weakref.ref] = {}
-_ARRAY_LOCK = threading.Lock()
 
 
 def digest(obj: Any, mode: EncodeMode = FINGERPRINT) -> str:
@@ -192,6 +191,17 @@ def _encode(obj: Any, mode: EncodeMode) -> Any:
         return _encode_time(obj)
     if isinstance(obj, np.generic):
         return _encode_value(obj.item(), mode)
+    # A pandas Timestamp is a datetime and a Timedelta is a timedelta, so
+    # both are covered here. Without them a time DASCore accepts everywhere
+    # would fall through to the opaque tag and lose its value.
+    if isinstance(obj, datetime.datetime | datetime.date):
+        return _encode_time(_to_datetime64(obj))
+    if isinstance(obj, datetime.timedelta):
+        return _encode_time(np.timedelta64(obj))
+    if isinstance(obj, complex):
+        return {_COMPLEX: [_encode_float(obj.real), _encode_float(obj.imag)]}
+    if isinstance(obj, bytes | bytearray):
+        return {_BYTES: bytes(obj).hex()}
     if isinstance(obj, Quantity):
         return _encode_quantity(obj, mode)
     if isinstance(obj, Enum):
@@ -203,7 +213,7 @@ def _encode(obj: Any, mode: EncodeMode) -> Any:
         return {_SLICE: [_encode_value(x, mode) for x in parts]}
     if obj is Ellipsis:
         return {_ELLIPSIS: True}
-    if _is_task(obj):
+    if isinstance(obj, _task_class()):
         # Checked before the model branch below, which every task also
         # answers to: a task carries a version its fields do not show.
         return {_TASK: obj.fingerprint if mode == FINGERPRINT else obj.to_dict()}
@@ -223,7 +233,7 @@ def _encode(obj: Any, mode: EncodeMode) -> Any:
         return _encode_partial(obj, mode)
     if callable(obj):
         return _encode_callable(obj)
-    return {_OPAQUE: _spell_type(type(obj))}
+    return _encode_opaque(obj)
 
 
 def _encode_value(obj: Any, mode: EncodeMode) -> Any:
@@ -250,7 +260,22 @@ def _encode_time(value: np.datetime64 | np.timedelta64) -> Any:
     """
     tag = _DATETIME if isinstance(value, np.datetime64) else _TIMEDELTA
     unit = "datetime64[ns]" if tag == _DATETIME else "timedelta64[ns]"
-    return {tag: int(value.astype(unit).astype(np.int64))}
+    try:
+        return {tag: int(value.astype(unit).astype(np.int64))}
+    except OverflowError:
+        # DASCore works in nanoseconds throughout, so a time outside that
+        # range is refused here rather than silently truncated.
+        msg = f"{value} cannot be represented in nanoseconds."
+        raise ParameterError(msg) from None
+
+
+def _to_datetime64(value: datetime.datetime | datetime.date) -> np.datetime64:
+    """Return a python date or datetime as a numpy one."""
+    # An aware datetime is moved onto UTC, which is the only zone numpy has;
+    # converting one directly is deprecated and then dropped.
+    if isinstance(value, datetime.datetime) and value.tzinfo is not None:
+        value = value.astimezone(datetime.UTC).replace(tzinfo=None)
+    return np.datetime64(value)
 
 
 def _encode_quantity(value: Quantity, mode: EncodeMode) -> Any:
@@ -263,10 +288,21 @@ def _encode_quantity(value: Quantity, mode: EncodeMode) -> Any:
     return {_QUANTITY: [_encode_value(value.magnitude, mode), f"{value.units:~}"]}
 
 
+def model_values(model: DascoreBaseModel) -> dict[str, Any]:
+    """
+    Return a model's fields and extras, as the objects they are.
+
+    Not model_dump: a dump turns a nested model into a plain mapping, losing
+    which class it was, and its json mode adds a key which is not a field.
+    """
+    out = {name: getattr(model, name) for name in type(model).model_fields}
+    out.update(model.__pydantic_extra__ or {})
+    return out
+
+
 def _encode_model(model: DascoreBaseModel, mode: EncodeMode) -> Any:
     """Encode a dascore model as its tag and its fields."""
-    fields = {name: getattr(model, name) for name in type(model).model_fields}
-    fields.update(model.__pydantic_extra__ or {})
+    fields = model_values(model)
     # A class no tag can name -- a parametrized generic -- is still spelled
     # out, so that two of them do not fingerprint alike; a document holding
     # one refuses to decode rather than rebuilding the wrong class.
@@ -276,12 +312,14 @@ def _encode_model(model: DascoreBaseModel, mode: EncodeMode) -> Any:
 
 def _encode_dataframe(df: pd.DataFrame | pd.Series, mode: EncodeMode) -> Any:
     """
-    Encode a dataframe as a digest of its values.
+    Encode a dataframe as a digest of its labels, dtypes and values.
 
-    A frame is a parameter to exactly one patch function today
-    (``coords_from_df``) and hashing it is all a fingerprint needs. It has no
-    document form: writing a frame into a pipe file, with its dtypes and its
-    index, is a storage format rather than a parameter encoding.
+    The labels are hashed as well as the values because a frame's columns
+    are parameters in their own right: ``coords_from_df`` names the coords
+    it builds after them.
+
+    There is no document form: a frame, with its dtypes and its index, is a
+    storage format rather than a parameter encoding.
     """
     if mode == DOCUMENT:
         msg = (
@@ -289,74 +327,70 @@ def _encode_dataframe(df: pd.DataFrame | pd.Series, mode: EncodeMode) -> Any:
             "task the values it needs instead of the frame holding them."
         )
         raise ParameterError(msg)
-    hashed = pd.util.hash_pandas_object(df, index=True).to_numpy()
-    return {_DATAFRAME: _digest_bytes(hashed.tobytes())}
+    frame = df.to_frame() if isinstance(df, pd.Series) else df
+    values = pd.util.hash_pandas_object(df, index=True).to_numpy()
+    payload = {
+        "columns": [str(x) for x in frame.columns],
+        "dtypes": [str(x) for x in frame.dtypes],
+        "values": _digest_bytes(values.tobytes()),
+    }
+    return {_DATAFRAME: digest(payload)}
 
 
 def _encode_array(array: Any, mode: EncodeMode) -> Any:
     """Encode an array by its dtype, shape and contents."""
-    original = array
+    # hash_array lives in dascore.utils.array, which imports dascore itself,
+    # so naming it at module scope is a cycle; it is the tree's one array
+    # hash and is used rather than repeated.
+    from dascore.utils.array import hash_array  # noqa: PLC0415
+
     array = to_numpy(array) if is_foreign(array) else np.asarray(array)
     if array.dtype == object:
         # An object array holds python values, which have no bytes to hash;
         # each element is encoded on its own terms instead.
-        return [_encode_value(x, mode) for x in array.tolist()]
-    # A big-endian array holds the same values as its little-endian twin, so
-    # the byte order it happens to be stored in is normalized away.
-    array = array.astype(array.dtype.newbyteorder("<"), copy=False)
+        return _encode_value(array.tolist(), mode)
+    array = _normalize_array(array)
     out = {"dtype": array.dtype.str, "shape": list(array.shape)}
     if mode == DOCUMENT:
-        out["data"] = _encode_value(array.tolist(), mode)
+        out["data"] = _encode_value(_array_data(array), mode)
     else:
-        out["hash"] = _array_digest(array, original)
+        out["hash"] = hash_array(array)
     return {_ARRAY: out}
 
 
-def _array_digest(array: np.ndarray, original: Any) -> str:
-    """
-    Return the digest of an array's bytes, hashing each array once.
-
-    The cache is keyed on the array the caller passed rather than on the
-    normalized copy, which is a fresh object every call and would never hit.
-    """
-    key = id(original)
-    with _ARRAY_LOCK:
-        if (out := _ARRAY_DIGESTS.get(key)) is not None:
-            return out
-    # A view, and any datetime array, cannot export a buffer directly, so
-    # the values are copied into a layout numpy can hand out as bytes.
-    out = _digest_bytes(np.ascontiguousarray(array).view(np.uint8).data)
-    _remember_array(key, original, out)
-    return out
+def _normalize_array(array: np.ndarray) -> np.ndarray:
+    """Return the array in the layout its values are hashed and written in."""
+    dtype = array.dtype
+    # Times normalize to nanoseconds for the same reason scalar ones do: the
+    # unit an array of times was built with is not part of its values.
+    if dtype.kind in "Mm":
+        dtype = np.dtype(f"<{dtype.kind}8[ns]")
+    # A big-endian array holds the same values as its little-endian twin, so
+    # the byte order it happens to be stored in is normalized away.
+    elif dtype.byteorder == ">":
+        dtype = dtype.newbyteorder("<")
+    return array.astype(dtype, copy=False)
 
 
-def _remember_array(key: int, array: np.ndarray, value: str) -> None:
-    """Cache an array's digest for as long as the array itself lives."""
-
-    def _forget(_ref, key=key):
-        with _ARRAY_LOCK:
-            _ARRAY_DIGESTS.pop(key, None)
-            _ARRAY_REFS.pop(key, None)
-
-    # A view of another array, or an array a backend owns, may refuse a weak
-    # reference; the digest is then simply not cached.
-    try:
-        ref = weakref.ref(array, _forget)
-    except TypeError:
-        return
-    with _ARRAY_LOCK:
-        _ARRAY_DIGESTS[key] = value
-        _ARRAY_REFS[key] = ref
+def _array_data(array: np.ndarray) -> Any:
+    """Return an array's values in a form a document can hold."""
+    # tolist gives a datetime array back as python datetimes, which lose
+    # their unit; the counts they are stored as do not.
+    if array.dtype.kind in "Mm":
+        return array.view(np.int64).tolist()
+    return array.tolist()
 
 
 def _encode_mapping(mapping: Mapping, mode: EncodeMode) -> Any:
     """
-    Encode a mapping, dropping what a fingerprint should not see.
+    Encode a mapping, dropping every None in fingerprint mode.
 
-    A parameter left at None is dropped in fingerprint mode: a call which
-    passes a default explicitly is the same call as one which leaves it out.
+    A parameter left at its None default is then the same call as one left
+    out. It applies at every depth, so a dict parameter loses its None
+    values too: ``{"time": None, "distance": (1, 2)}`` encodes as
+    ``{"distance": (1, 2)}``.
     """
-    if not all(isinstance(key, str) for key in mapping):
+    if not all(isinstance(key, str) and not key.startswith("$") for key in mapping):
         return _encode_odd_keyed_mapping(mapping, mode)
     items = mapping.items()
     if mode == FINGERPRINT:
@@ -365,7 +399,12 @@ def _encode_mapping(mapping: Mapping, mode: EncodeMode) -> Any:
 
 
 def _encode_odd_keyed_mapping(mapping: Mapping, mode: EncodeMode) -> Any:
-    """Encode a mapping whose keys are not all strings as sorted pairs."""
+    """
+    Encode a mapping as sorted pairs, which any key can survive.
+
+    Used for a mapping whose keys are not all strings, and for one holding a
+    key which would otherwise be read back as a tag.
+    """
     pairs = [
         [_encode_value(key, mode), _encode_value(value, mode)]
         for key, value in mapping.items()
@@ -417,6 +456,23 @@ def _source_digest(func: Callable) -> str | None:
     return _digest_bytes(source.encode("utf8"))
 
 
+def _encode_opaque(obj: Any) -> Any:
+    """
+    Encode a value nothing else describes by naming its class.
+
+    Two values of such a class are indistinguishable, so this warns: a
+    fingerprint which cannot see a parameter's value is a fingerprint two
+    different calls can share.
+    """
+    name = _spell_type(type(obj))
+    msg = (
+        f"A value of type {name} has no encoding of its own, so only its "
+        "type is hashed. Two different values of it share one fingerprint."
+    )
+    warnings.warn(msg, DASCoreWarning, stacklevel=2)
+    return {_OPAQUE: name}
+
+
 def _spell_type(cls: type) -> str:
     """Spell a class the way an opaque encoding names it."""
     # Never repr(obj): the default holds the object's address, which changes
@@ -434,12 +490,13 @@ def _is_array(obj: Any) -> bool:
     return isinstance(obj, np.ndarray) or is_foreign(obj)
 
 
-def _is_task(obj: Any) -> bool:
-    """Return True if an object is a Task, without importing one."""
-    # Not an isinstance check: task.py imports this module, so naming Task
-    # here is a cycle. Every Task is a DascoreBaseModel and is checked
-    # before this, so only a Task reaches it with a `to_dict`.
-    return hasattr(obj, "fingerprint") and hasattr(obj, "to_dict")
+def _task_class() -> type:
+    """Return the Task class, which cannot be named at module scope."""
+    # task.py imports this module, so importing it back is deferred; the
+    # module object is in sys.modules by the time any value is encoded.
+    from dascore.workflow.task import Task  # noqa: PLC0415
+
+    return Task
 
 
 def _decode_mapping(obj: Mapping) -> Any:
@@ -449,11 +506,6 @@ def _decode_mapping(obj: Mapping) -> Any:
         if (decoder := _DECODERS.get(key)) is not None:
             return decoder(obj[key])
     return {key: decode(value) for key, value in obj.items()}
-
-
-def _decode_float(value: str) -> float:
-    """Decode one of the floats JSON cannot spell."""
-    return float(value)
 
 
 def _decode_datetime(value: int) -> np.datetime64:
@@ -491,19 +543,21 @@ def _decode_array(value: Mapping) -> np.ndarray:
             "values, so the array itself cannot be read back from it."
         )
         raise ParameterError(msg)
-    array = np.asarray(decode(value["data"]), dtype=np.dtype(value["dtype"]))
+    dtype = np.dtype(value["dtype"])
+    data = decode(value["data"])
+    # A time array is written as the counts it is stored as, so it is read
+    # back as those before it is given its dtype again.
+    source = np.int64 if dtype.kind in "Mm" else dtype
+    array = np.asarray(data, dtype=source).astype(dtype)
     return array.reshape(value["shape"])
 
 
 def _decode_model(value: Mapping) -> DascoreBaseModel:
     """Decode a dascore model from its tag and fields."""
-    cls = resolve_model_tag(value[TAG_FIELD])
-    if cls is None:
-        msg = (
-            f"Nothing registers the {TAG_FIELD} {value[TAG_FIELD]!r}, so the "
-            "model it names cannot be rebuilt."
-        )
-        raise ParameterError(msg)
+    # resolve_tagged_model rather than a check of its own: a document naming
+    # a class nothing registers fails the same way here as it does for the
+    # task holding it.
+    cls = resolve_tagged_model(value[TAG_FIELD])
     return cls(**{key: decode(val) for key, val in value["fields"].items()})
 
 
@@ -549,12 +603,14 @@ def _refuse(kind: str):
 _DECODERS: dict[str, Callable[[Any], Any]] = {
     _ARRAY: _decode_array,
     _BOOL: bool,
+    _BYTES: bytes.fromhex,
     _CALLABLE: _refuse("function"),
+    _COMPLEX: lambda pair: complex(*(decode(x) for x in pair)),
     _DATAFRAME: _refuse("dataframe"),
     _DATETIME: _decode_datetime,
     _DICT: _decode_dict,
     _ELLIPSIS: lambda _: Ellipsis,
-    _FLOAT: _decode_float,
+    _FLOAT: float,
     _MODEL: _decode_model,
     _OPAQUE: _refuse("value"),
     _PARTIAL: _refuse("partial"),

--- a/dascore/workflow/serialize.py
+++ b/dascore/workflow/serialize.py
@@ -261,12 +261,17 @@ def _encode_time(value: np.datetime64 | np.timedelta64) -> Any:
     tag = _DATETIME if isinstance(value, np.datetime64) else _TIMEDELTA
     unit = "datetime64[ns]" if tag == _DATETIME else "timedelta64[ns]"
     try:
-        return {tag: int(value.astype(unit).astype(np.int64))}
+        out = value.astype(unit)
     except OverflowError:
-        # DASCore works in nanoseconds throughout, so a time outside that
-        # range is refused here rather than silently truncated.
+        out = None
+    # DASCore works in nanoseconds throughout, and a time outside that range
+    # wraps silently -- to a value centuries away -- on some numpy versions
+    # and raises on others. Either way it is refused rather than hashed as
+    # whatever it wrapped to, which is checked by converting it back.
+    if out is None or (not np.isnat(value) and out.astype(value.dtype) != value):
         msg = f"{value} cannot be represented in nanoseconds."
-        raise ParameterError(msg) from None
+        raise ParameterError(msg)
+    return {tag: int(out.astype(np.int64))}
 
 
 def _to_datetime64(value: datetime.datetime | datetime.date) -> np.datetime64:
@@ -364,12 +369,29 @@ def _normalize_array(array: np.ndarray) -> np.ndarray:
     # Times normalize to nanoseconds for the same reason scalar ones do: the
     # unit an array of times was built with is not part of its values.
     if dtype.kind in "Mm":
-        dtype = np.dtype(f"<{dtype.kind}8[ns]")
+        return _times_as_nanoseconds(array)
     # A big-endian array holds the same values as its little-endian twin, so
     # the byte order it happens to be stored in is normalized away.
     elif dtype.byteorder == ">":
         dtype = dtype.newbyteorder("<")
     return array.astype(dtype, copy=False)
+
+
+def _times_as_nanoseconds(array: np.ndarray) -> np.ndarray:
+    """Return an array of times as nanoseconds, refusing any which wrap."""
+    # An out of range time raises on some numpy versions and wraps silently
+    # -- to a value centuries away -- on others, so both are refused; see
+    # `_encode_time`.
+    try:
+        out = array.astype(np.dtype(f"<{array.dtype.kind}8[ns]"))
+        kept = ~np.isnat(array)
+        wrapped = not np.array_equal(out[kept].astype(array.dtype), array[kept])
+    except OverflowError:
+        wrapped = True
+    if wrapped:
+        msg = "Some times in the array cannot be represented in nanoseconds."
+        raise ParameterError(msg)
+    return out
 
 
 def _array_data(array: np.ndarray) -> Any:

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -11,25 +11,27 @@ Examples
 --------
 >>> from dascore.workflow import Task
 >>>
->>> class AddNumber(Task):
+>>> class AddNumberExample(Task):
 ...     '''Add a number to what it is given.'''
 ...     value: int = 1
 ...
 ...     def run(self, number):
 ...         return number + self.value
 >>>
->>> task = AddNumber(value=2)
+>>> task = AddNumberExample(value=2)
 >>> assert task.run(1) == 3
 >>> # The same task, however it was built, has the same fingerprint.
->>> assert task.fingerprint == AddNumber(value=2).fingerprint
->>> assert task.fingerprint != AddNumber(value=3).fingerprint
+>>> assert task.fingerprint == AddNumberExample(value=2).fingerprint
+>>> assert task.fingerprint != AddNumberExample(value=3).fingerprint
 """
 
 from __future__ import annotations
 
 import inspect
+import warnings
+import weakref
 from collections.abc import Callable
-from functools import cached_property, lru_cache
+from functools import cached_property
 from typing import Any, ClassVar, Self
 
 from pydantic import ConfigDict
@@ -41,14 +43,12 @@ from dascore.models.registry import (
     NAMESPACE_SEP,
     TAG_FIELD,
     get_model_tag,
+    resolve_model_tag,
     resolve_tagged_model,
 )
 from dascore.utils.misc import suppress_warnings
-from dascore.workflow.serialize import DOCUMENT, decode, digest, encode
-
-# How many distinct tasks `intern` keeps. Enough that a long spool loop
-# reuses its tasks, small enough that it cannot become a leak.
-INTERN_SIZE = 4096
+from dascore.warnings import DASCoreWarning
+from dascore.workflow.serialize import DOCUMENT, decode, digest, encode, model_values
 
 # The keys a task's document holds beside its parameters.
 _VERSION_KEY = "version"
@@ -88,11 +88,12 @@ class Task(DascoreBaseModel):
         """
         Return the digest which identifies this task and its parameters.
 
-        The fingerprint names the class, its version and its parameters. It
-        deliberately does not name the module the class lives in, nor the
-        source of its body, nor the backend which will run it: DASCore moves
-        its own code around, and neither a move nor a faster kernel makes an
-        operation a different operation.
+        The fingerprint names the top level package, the class name, the
+        version and the parameters. It deliberately leaves out the submodule
+        the class lives in, the source of its body, and the backend which
+        will run it: DASCore moves its own code around, and neither a move
+        within a package nor a faster kernel makes an operation a different
+        operation.
         """
         payload = {
             "task": _qualified_tag(type(self)),
@@ -113,9 +114,9 @@ class Task(DascoreBaseModel):
         Examples
         --------
         >>> from dascore.workflow import Task
-        >>> class Scale(Task):
+        >>> class ScaleExample(Task):
         ...     factor: float = 1.0
-        >>> assert Scale().update(factor=2.0).factor == 2.0
+        >>> assert ScaleExample().update(factor=2.0).factor == 2.0
         """
         return type(self)(**{**self._params(), **kwargs})
 
@@ -128,6 +129,7 @@ class Task(DascoreBaseModel):
         message, can find the class the tag stands for.
         """
         cls = type(self)
+        _check_nameable(cls, self.tag)
         return {
             TAG_FIELD: self.tag,
             _VERSION_KEY: self.__version__,
@@ -145,10 +147,11 @@ class Task(DascoreBaseModel):
         not a reason to import whatever it names.
         """
         tag = document.get(TAG_FIELD)
-        task_class = resolve_tagged_model(tag, default=None)
+        task_class = resolve_tagged_model(tag)
         if not issubclass(task_class, Task):
             msg = f"The tag {tag!r} names {task_class.__name__}, which is not a Task."
             raise ParameterError(msg)
+        _check_version(task_class, document.get(_VERSION_KEY))
         params = {
             key: decode(value) for key, value in document.get(_PARAMS_KEY, {}).items()
         }
@@ -156,12 +159,7 @@ class Task(DascoreBaseModel):
 
     def _params(self) -> dict[str, Any]:
         """Return this task's parameters, as the objects they are."""
-        # Not model_dump: a dump turns a nested model into a plain mapping,
-        # losing which class it was, and its json mode adds a key which is
-        # not a parameter.
-        out = {name: getattr(self, name) for name in type(self).model_fields}
-        out.update(self.__pydantic_extra__ or {})
-        return out
+        return model_values(self)
 
     def __eq__(self, other) -> bool:
         """Two tasks are equal if they are the same task, given the same."""
@@ -178,24 +176,61 @@ class Task(DascoreBaseModel):
 
     def __reduce__(self):
         """
-        Pickle a task by its document rather than by its class.
+        Pickle a task by its tag, and its parameters as themselves.
 
         A task class synthesized from a function is not reachable at any
         attribute path, so the default pickling cannot find it again in
-        another process; its tag can.
+        another process; its tag can. The parameters are left to pickle,
+        which carries values a document cannot -- a function, a frame -- and
+        carries an array as bytes rather than as a list of numbers.
         """
-        return (from_dict, (self.to_dict(),))
+        _check_nameable(type(self), self.tag)
+        return (_rebuild, (self.tag, self._params()))
 
 
-def from_dict(document: dict[str, Any]) -> Task:
-    """Return the task a document describes; see `Task.from_dict`."""
-    return Task.from_dict(document)
+def _rebuild(tag: str, params: dict[str, Any]) -> Task:
+    """Return the task a tag and its parameters name; see `Task.__reduce__`."""
+    task_class = resolve_tagged_model(tag)
+    return task_class(**params)
 
 
-@lru_cache(maxsize=INTERN_SIZE)
-def _intern(task: Task) -> Task:
-    """Return the first task seen which equals this one."""
-    return task
+def _check_nameable(task_class: type[Task], tag: str | None) -> None:
+    """
+    Refuse to write down a task whose class nothing could look up.
+
+    A class defined inside a function is not registered, and one whose tag
+    two classes claim is struck from the registry. Either way the failure
+    belongs where the task is written, not in whoever reads it later.
+    """
+    if resolve_model_tag(tag or "") is not task_class:
+        msg = (
+            f"{task_class.__qualname__} is not registered under the tag "
+            f"{tag!r}, so nothing could read it back. A task class has to "
+            "be defined at module level, under a name no other class in "
+            "its package claims."
+        )
+        raise ParameterError(msg)
+
+
+def _check_version(task_class: type[Task], version: object) -> None:
+    """Say so when a document was written by another version of a task."""
+    # Not an error: an old pipe should still load and run. The version has
+    # already done its work by changing the fingerprint, and refusing the
+    # document would only hide what it was.
+    if version is not None and version != task_class.__version__:
+        msg = (
+            f"The document holds {task_class.__name__} version {version!r}, "
+            f"and this one is {task_class.__version__!r}. It will not "
+            "fingerprint the way it did when it was written."
+        )
+        warnings.warn(msg, DASCoreWarning, stacklevel=3)
+
+
+# The canonical instance of each task, held only while something else holds
+# it: interning is for sharing one object, not for keeping it alive. A task's
+# parameters can be as big as an array, so a cache which retained them would
+# hold that memory long after the caller dropped it.
+_INTERNED: weakref.WeakValueDictionary[str, Task] = weakref.WeakValueDictionary()
 
 
 def intern(task: Task) -> Task:
@@ -209,11 +244,18 @@ def intern(task: Task) -> Task:
     Examples
     --------
     >>> from dascore.workflow import Task, intern
-    >>> class Scale(Task):
+    >>> class ScaleExample(Task):
     ...     factor: float = 1.0
-    >>> assert intern(Scale()) is intern(Scale())
+    >>> assert intern(ScaleExample()) is intern(ScaleExample())
     """
-    return _intern(task)
+    existing = _INTERNED.get(task.fingerprint)
+    # Two classes can only share a fingerprint if neither could be named in
+    # a document, in which case they are left as the separate objects they
+    # are rather than one standing in for the other.
+    if existing is not None and type(existing) is type(task):
+        return existing
+    _INTERNED[task.fingerprint] = task
+    return task
 
 
 def _qualified_tag(cls: type) -> str:
@@ -259,7 +301,9 @@ class FunctionTask(Task):
         function itself is what checks its own arguments.
         """
         bound = cls._signature.bind_partial(*args, **kwargs)
-        bound.apply_defaults()
+        # Not apply_defaults: model_construct fills a missing field from the
+        # class default, which pydantic copies. Binding the function's own
+        # default object instead would share a mutable one between tasks.
         values = dict(bound.arguments)
         # A **kwargs group arrives as one mapping and is spread back out,
         # which is how validation would have attached those names.
@@ -305,12 +349,12 @@ def task(func: Callable | None = None, *, version: str = "1.0") -> Any:
     >>> from dascore.workflow import task
     >>>
     >>> @task
-    ... def add(a, b=1):
+    ... def add_example(a, b=1):
     ...     '''Add two numbers.'''
     ...     return a + b
     >>>
-    >>> assert add(a=1, b=2).run() == 3
-    >>> assert add(a=1).run() == 2
+    >>> assert add_example(a=1, b=2).run() == 3
+    >>> assert add_example(a=1).run() == 2
     """
 
     def decorator(function: Callable) -> type[Task]:

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -1,0 +1,463 @@
+"""
+The immutable, fingerprintable unit of work DASCore's workflows are built of.
+
+A [`Task`](`dascore.workflow.task.Task`) is a frozen pydantic model whose
+fields are the parameters of one operation. Because the parameters are the
+object, a task can be compared, hashed, written to a file and read back, and
+identified by a fingerprint: a digest of which task it is, which version of
+it, and what it was given.
+
+Examples
+--------
+>>> from dascore.workflow import Task
+>>>
+>>> class AddNumber(Task):
+...     '''Add a number to what it is given.'''
+...     value: int = 1
+...
+...     def run(self, number):
+...         return number + self.value
+>>>
+>>> task = AddNumber(value=2)
+>>> assert task.run(1) == 3
+>>> # The same task, however it was built, has the same fingerprint.
+>>> assert task.fingerprint == AddNumber(value=2).fingerprint
+>>> assert task.fingerprint != AddNumber(value=3).fingerprint
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from functools import cached_property, lru_cache
+from typing import Any, ClassVar, Self
+
+from pydantic import ConfigDict
+from pydantic.fields import FieldInfo
+
+from dascore.exceptions import ParameterError
+from dascore.models.base import DascoreBaseModel
+from dascore.models.registry import (
+    NAMESPACE_SEP,
+    TAG_FIELD,
+    get_model_tag,
+    resolve_tagged_model,
+)
+from dascore.utils.misc import suppress_warnings
+from dascore.workflow.serialize import DOCUMENT, decode, digest, encode
+
+# How many distinct tasks `intern` keeps. Enough that a long spool loop
+# reuses its tasks, small enough that it cannot become a leak.
+INTERN_SIZE = 4096
+
+# The keys a task's document holds beside its parameters.
+_VERSION_KEY = "version"
+_CODE_PATH_KEY = "code_path"
+_PARAMS_KEY = "params"
+
+
+class Task(DascoreBaseModel):
+    """
+    Base class for a fingerprintable, serializable operation.
+
+    Subclasses declare their parameters as fields and implement `run`. Every
+    instance is frozen, so a task can be shared, cached and reused; changing
+    one means making another with `update`.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    # Bumped by a subclass whenever the same parameters should mean a
+    # different answer, so that old fingerprints do not name the new
+    # behaviour. It is a ClassVar rather than a field: the version belongs to
+    # the class, not to the call.
+    __version__: ClassVar[str] = "1.0"
+
+    @property
+    def tag(self) -> str | None:
+        """
+        Return the registered name of this task's class.
+
+        None means the class cannot be named in a document, which a
+        parametrized generic cannot; see `dascore.models.registry`.
+        """
+        return get_model_tag(type(self))
+
+    @cached_property
+    def fingerprint(self) -> str:
+        """
+        Return the digest which identifies this task and its parameters.
+
+        The fingerprint names the class, its version and its parameters. It
+        deliberately does not name the module the class lives in, nor the
+        source of its body, nor the backend which will run it: DASCore moves
+        its own code around, and neither a move nor a faster kernel makes an
+        operation a different operation.
+        """
+        payload = {
+            "task": _qualified_tag(type(self)),
+            _VERSION_KEY: self.__version__,
+            _PARAMS_KEY: encode(self._params()),
+        }
+        return digest(payload)
+
+    def run(self, *args, **kwargs) -> Any:
+        """Execute the task. Subclasses must implement this."""
+        msg = f"{type(self).__name__} does not implement run."
+        raise NotImplementedError(msg)
+
+    def update(self, **kwargs) -> Self:
+        """
+        Return a new task with some parameters changed.
+
+        Examples
+        --------
+        >>> from dascore.workflow import Task
+        >>> class Scale(Task):
+        ...     factor: float = 1.0
+        >>> assert Scale().update(factor=2.0).factor == 2.0
+        """
+        return type(self)(**{**self._params(), **kwargs})
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return a document which describes this task.
+
+        The document names the class by its registered tag, never by an
+        import path; `code_path` is written only so a human, or an error
+        message, can find the class the tag stands for.
+        """
+        cls = type(self)
+        return {
+            TAG_FIELD: self.tag,
+            _VERSION_KEY: self.__version__,
+            _CODE_PATH_KEY: f"{cls.__module__}:{cls.__qualname__}",
+            _PARAMS_KEY: encode(self._params(), mode=DOCUMENT),
+        }
+
+    @classmethod
+    def from_dict(cls, document: dict[str, Any]) -> Task:
+        """
+        Return the task a document describes.
+
+        The tag is resolved through the model registry alone. A tag nothing
+        registers raises rather than being imported: reading a document is
+        not a reason to import whatever it names.
+        """
+        tag = document.get(TAG_FIELD)
+        task_class = resolve_tagged_model(tag, default=None)
+        if not issubclass(task_class, Task):
+            msg = f"The tag {tag!r} names {task_class.__name__}, which is not a Task."
+            raise ParameterError(msg)
+        params = {
+            key: decode(value) for key, value in document.get(_PARAMS_KEY, {}).items()
+        }
+        return task_class(**params)
+
+    def _params(self) -> dict[str, Any]:
+        """Return this task's parameters, as the objects they are."""
+        # Not model_dump: a dump turns a nested model into a plain mapping,
+        # losing which class it was, and its json mode adds a key which is
+        # not a parameter.
+        out = {name: getattr(self, name) for name in type(self).model_fields}
+        out.update(self.__pydantic_extra__ or {})
+        return out
+
+    def __eq__(self, other) -> bool:
+        """Two tasks are equal if they are the same task, given the same."""
+        # Not the base model's field comparison, which does not look at the
+        # class: Hilbert(dim="time") and Envelope(dim="time") hold the same
+        # fields and are not the same operation.
+        if not isinstance(other, Task):
+            return NotImplemented
+        return type(self) is type(other) and self.fingerprint == other.fingerprint
+
+    def __hash__(self) -> int:
+        """Hash a task the way it compares."""
+        return hash(self.fingerprint)
+
+    def __reduce__(self):
+        """
+        Pickle a task by its document rather than by its class.
+
+        A task class synthesized from a function is not reachable at any
+        attribute path, so the default pickling cannot find it again in
+        another process; its tag can.
+        """
+        return (from_dict, (self.to_dict(),))
+
+
+def from_dict(document: dict[str, Any]) -> Task:
+    """Return the task a document describes; see `Task.from_dict`."""
+    return Task.from_dict(document)
+
+
+@lru_cache(maxsize=INTERN_SIZE)
+def _intern(task: Task) -> Task:
+    """Return the first task seen which equals this one."""
+    return task
+
+
+def intern(task: Task) -> Task:
+    """
+    Return one shared instance for every task which equals the given one.
+
+    A patch function called in a loop builds an equal task every call.
+    Interning them means the provenance of a thousand patches holds one task
+    object rather than a thousand copies of it.
+
+    Examples
+    --------
+    >>> from dascore.workflow import Task, intern
+    >>> class Scale(Task):
+    ...     factor: float = 1.0
+    >>> assert intern(Scale()) is intern(Scale())
+    """
+    return _intern(task)
+
+
+def _qualified_tag(cls: type) -> str:
+    """Return the tag naming a class, always with its namespace."""
+    # DASCore's own models register bare, so that a hand written file says
+    # `object_type: Cable`. A fingerprint is not read by hand and is
+    # compared against other packages' tasks, so it always names the
+    # package the class came from.
+    namespace = cls.__module__.split(".", 1)[0]
+    return f"{namespace}{NAMESPACE_SEP}{cls.__name__}"
+
+
+class FunctionTask(Task):
+    """
+    The behaviour a task synthesized from a function has.
+
+    Kept apart from `make_function_task_class` so that the methods are
+    ordinary, testable functions rather than closures built per class, and
+    so that a synthesized class can be recognized by what it derives from.
+    """
+
+    # How the wrapped function is called: which fields go positionally --
+    # with a flag for the one standing for a *args group, which is splatted
+    # -- and which go by name. Worked out once, when the class is made.
+    _original_function: ClassVar[Callable]
+    _signature: ClassVar[inspect.Signature]
+    _positional_names: ClassVar[tuple[tuple[str, bool], ...]]
+    _keyword_names: ClassVar[tuple[str, ...]]
+
+    def run(self, *args) -> Any:
+        """Call the wrapped function with any inputs and this task's fields."""
+        return self._original_function(*args, *self._call_args(), **self._call_kwargs())
+
+    @classmethod
+    def _from_call(cls, args: tuple, kwargs: dict) -> Self:
+        """
+        Return the task standing for one call of the wrapped function.
+
+        The arguments are the ones the function was given, minus any input
+        it is handed at run time, exactly as `_call_args` gives them back.
+
+        Binding rather than validating: this runs on every call, and the
+        function itself is what checks its own arguments.
+        """
+        bound = cls._signature.bind_partial(*args, **kwargs)
+        bound.apply_defaults()
+        values = dict(bound.arguments)
+        # A **kwargs group arrives as one mapping and is spread back out,
+        # which is how validation would have attached those names.
+        for name, parameter in cls._signature.parameters.items():
+            if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+                values |= values.pop(name, {})
+        return cls.model_construct(**values)
+
+    def _call_args(self) -> tuple:
+        """Return the arguments this task passes positionally."""
+        out = []
+        for name, packed in self._positional_names:
+            value = getattr(self, name)
+            if packed:
+                out.extend(value)
+            else:
+                out.append(value)
+        return tuple(out)
+
+    def _call_kwargs(self) -> dict:
+        """Return the arguments this task passes by name."""
+        out = {name: getattr(self, name) for name in self._keyword_names}
+        out.update(self.__pydantic_extra__ or {})
+        return out
+
+
+def task(func: Callable | None = None, *, version: str = "1.0") -> Any:
+    """
+    Turn a function into a `Task` subclass.
+
+    The function's parameters become the task's fields, and calling `run`
+    calls the function with them.
+
+    Parameters
+    ----------
+    func
+        The function to convert.
+    version
+        The version of the new task class.
+
+    Examples
+    --------
+    >>> from dascore.workflow import task
+    >>>
+    >>> @task
+    ... def add(a, b=1):
+    ...     '''Add two numbers.'''
+    ...     return a + b
+    >>>
+    >>> assert add(a=1, b=2).run() == 3
+    >>> assert add(a=1).run() == 2
+    """
+
+    def decorator(function: Callable) -> type[Task]:
+        return make_function_task_class(function, version=version)
+
+    return decorator if func is None else decorator(func)
+
+
+def make_function_task_class(
+    func: Callable,
+    base: type[Task] = Task,
+    version: str = "1.0",
+    skip_first: bool = False,
+) -> type[Task]:
+    """
+    Return a `Task` subclass whose fields are a function's parameters.
+
+    Parameters
+    ----------
+    func
+        The function the class stands for.
+    base
+        The class to derive from; a patch function derives from
+        `PatchProcessor` rather than from `Task` itself.
+    version
+        The version of the new class.
+    skip_first
+        If True the first parameter is not made a field. It is the input the
+        task is given when it runs, such as the patch a patch function
+        operates on.
+    """
+    signature = inspect.signature(func)
+    # A callable which is not a function -- a class, or an object with a
+    # __call__ -- is named by its own class instead.
+    qualname = getattr(func, "__qualname__", type(func).__qualname__)
+    parameters = list(signature.parameters.values())[1 if skip_first else 0 :]
+    namespace, annotations = _build_fields(parameters)
+    positional, keyword = _call_plan(parameters)
+    # Declared ClassVar so that pydantic leaves them as class attributes
+    # rather than making private, per-instance ones of them.
+    annotations |= {
+        "_original_function": ClassVar[Callable],
+        "_signature": ClassVar[inspect.Signature],
+        "_positional_names": ClassVar[tuple[tuple[str, bool], ...]],
+        "_keyword_names": ClassVar[tuple[str, ...]],
+    }
+    namespace |= {
+        "__annotations__": annotations,
+        "__doc__": func.__doc__,
+        "__module__": func.__module__,
+        # Set here rather than after the class is built: the registry reads
+        # both while `__init_subclass__` runs.
+        "__qualname__": f"{qualname}.processor",
+        "__version__": version,
+        # A bare function in a class body is a method, and would be handed
+        # the task as its first argument.
+        "_original_function": staticmethod(func),
+        # The signature the task's own parameters make, which is the one an
+        # incoming call is bound against; the input a patch function is
+        # given is not one of them.
+        "_signature": signature.replace(parameters=parameters),
+        "_positional_names": positional,
+        "_keyword_names": keyword,
+        "model_config": _build_config(base, parameters),
+    }
+    name = _camel_case(getattr(func, "__name__", type(func).__name__))
+    # A field named for a BaseModel attribute -- `copy`, `json`, `schema` --
+    # shadows it. That is what the caller asked for: the field is named by
+    # the function, and the attribute it hides is not part of a task's API.
+    with suppress_warnings(UserWarning, message="Field name .* shadows an attribute"):
+        return type(name, (FunctionTask, base), namespace)
+
+
+def _call_plan(
+    parameters: list[inspect.Parameter],
+) -> tuple[tuple[tuple[str, bool], ...], tuple[str, ...]]:
+    """
+    Return which fields are passed positionally and which by name.
+
+    Everything which can go by name does, which keeps a call readable and
+    lets a function reorder its keyword parameters without changing what a
+    stored task means.
+    """
+    kinds = {x.kind for x in parameters}
+    # Nothing can be passed by name before a *args group without landing in
+    # the group instead.
+    packs_args = inspect.Parameter.VAR_POSITIONAL in kinds
+    positional, keyword = [], []
+    for parameter in parameters:
+        kind = parameter.kind
+        if kind == inspect.Parameter.VAR_KEYWORD:
+            # Its values are extras rather than a field, and are spread out
+            # by `_call_kwargs`.
+            continue
+        if kind == inspect.Parameter.VAR_POSITIONAL:
+            positional.append((parameter.name, True))
+        elif kind == inspect.Parameter.POSITIONAL_ONLY or (
+            kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and packs_args
+        ):
+            positional.append((parameter.name, False))
+        else:
+            keyword.append(parameter.name)
+    return tuple(positional), tuple(keyword)
+
+
+def _build_fields(
+    parameters: list[inspect.Parameter],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return the namespace and annotations a function's parameters make."""
+    namespace: dict[str, Any] = {}
+    annotations: dict[str, Any] = {}
+    for parameter in parameters:
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            # The extras a **kwargs group collects are not fields; the class
+            # is configured to keep them instead.
+            continue
+        # Every field is typed Any: the function validates its own
+        # arguments, and a patch function's annotations name forward
+        # references (PatchType) which pydantic cannot resolve here.
+        annotations[parameter.name] = Any
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            namespace[parameter.name] = ()
+        elif parameter.default is not inspect.Parameter.empty:
+            namespace[parameter.name] = _resolve_default(parameter.default)
+    return namespace, annotations
+
+
+def _resolve_default(default: Any) -> Any:
+    """Return the value a parameter defaults to."""
+    # A function which spells its default `x=Field(default=3)` means 3; the
+    # FieldInfo itself would otherwise become the default value.
+    if isinstance(default, FieldInfo):
+        return default.get_default(call_default_factory=True)
+    return default
+
+
+def _build_config(base: type[Task], parameters: list[inspect.Parameter]) -> ConfigDict:
+    """Return the model config a function's parameters call for."""
+    kinds = {x.kind for x in parameters}
+    packs_kwargs = inspect.Parameter.VAR_KEYWORD in kinds
+    # A function taking **kwargs is called with names its signature does not
+    # list -- `patch.pad(time=(2, 3))` -- so its task has to keep them.
+    return ConfigDict(
+        **(base.model_config | {"extra": "allow" if packs_kwargs else "forbid"})
+    )
+
+
+def _camel_case(name: str) -> str:
+    """Return the class name a function name makes."""
+    return "".join(part.title() for part in name.split("_"))

--- a/tests/test_workflow/test_serialize.py
+++ b/tests/test_workflow/test_serialize.py
@@ -1,0 +1,434 @@
+"""Tests for the canonical workflow serializer."""
+
+from __future__ import annotations
+
+import gc
+from enum import Enum
+from functools import partial
+from pathlib import Path, PureWindowsPath
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import dascore as dc
+from dascore.exceptions import ParameterError
+from dascore.workflow import serialize
+from dascore.workflow.serialize import (
+    DOCUMENT,
+    canonical_json,
+    combine_hashes,
+    decode,
+    digest,
+    encode,
+)
+
+
+def round_trip(value):
+    """Encode a value as a document and read it back."""
+    return decode(encode(value, mode=DOCUMENT))
+
+
+class Color(Enum):
+    """An enum whose members stand for strings."""
+
+    red = "red"
+    blue = "blue"
+
+
+class TestDigest:
+    """Tests for the digest itself."""
+
+    def test_length(self):
+        """The digest is 8 bytes written as hex."""
+        assert len(digest("something")) == 16
+
+    def test_stable(self):
+        """Equal values digest alike, whatever built them."""
+        assert digest({"dim": "time"}) == digest({"dim": "" + "time"})
+
+    def test_hard_coded(self):
+        """
+        The digest of a fixed value never changes.
+
+        A stored id is only useful if the same call gives the same answer in
+        a later release, so this pins the whole chain: the encoding, the
+        canonical text, and blake2b.
+        """
+        assert digest({"a": 1, "b": [1.5, "x"]}) == "3cdfb6194bc1acd6"
+
+    def test_key_order_ignored(self):
+        """A mapping digests the same however it was built."""
+        assert digest({"a": 1, "b": 2}) == digest({"b": 2, "a": 1})
+
+    def test_combine_hashes_ordered(self):
+        """Combining digests keeps the order they were given in."""
+        assert combine_hashes(["a", "b"]) != combine_hashes(["b", "a"])
+
+    def test_combine_hashes_repeats(self):
+        """A digest repeated is not the same as a digest given once."""
+        assert combine_hashes(["a", "a"]) != combine_hashes(["a"])
+
+
+class TestCanonicalJson:
+    """Tests for the canonical text a digest is taken of."""
+
+    def test_sorted_and_tight(self):
+        """Keys are sorted and no whitespace is written."""
+        assert canonical_json({"b": 1, "a": 2}) == '{"a":2,"b":1}'
+
+    def test_ascii_only(self):
+        """Non-ascii characters are escaped rather than written."""
+        assert canonical_json("é") == '"\\u00e9"'
+
+
+class TestScalars:
+    """Tests for values JSON nearly spells itself."""
+
+    def test_bool_is_not_int(self):
+        """True and 1 are equal in python and are not the same parameter."""
+        assert digest(True) != digest(1)
+        assert digest(False) != digest(0)
+
+    def test_bool_round_trip(self):
+        """A bool comes back a bool."""
+        assert round_trip(True) is True
+
+    def test_numpy_bool(self):
+        """A numpy bool is the same parameter as a python one."""
+        assert digest(np.bool_(True)) == digest(True)
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_floats(self, value):
+        """The floats JSON cannot spell are still encodable."""
+        out = round_trip(value)
+        assert (out != out and value != value) or out == value
+
+    def test_non_finite_floats_differ(self):
+        """The three of them are three different values."""
+        digests = {digest(x) for x in [float("nan"), float("inf"), float("-inf")]}
+        assert len(digests) == 3
+
+    def test_numpy_scalars(self):
+        """A numpy scalar is the same parameter as the python value."""
+        assert digest(np.int64(3)) == digest(3)
+        assert digest(np.float64(1.5)) == digest(1.5)
+
+    def test_none(self):
+        """None encodes as itself."""
+        assert encode(None) is None
+
+    def test_enum_by_value(self):
+        """An enum member stands for its value."""
+        assert digest(Color.red) == digest("red")
+        assert digest(Color.red) != digest(Color.blue)
+
+
+class TestTimes:
+    """Tests for numpy's time types."""
+
+    def test_unit_normalized(self):
+        """The unit a time was written in does not change its digest."""
+        day = np.datetime64("2020-01-01")
+        nanosecond = np.datetime64("2020-01-01T00:00:00.000000000")
+        assert digest(day) == digest(nanosecond)
+
+    def test_datetime_round_trip(self):
+        """A datetime comes back as itself."""
+        value = np.datetime64("2020-01-01T00:00:01")
+        assert round_trip(value) == value
+
+    def test_timedelta_round_trip(self):
+        """A timedelta comes back as itself."""
+        value = np.timedelta64(5, "s")
+        assert round_trip(value) == value
+
+    def test_datetime_is_not_timedelta(self):
+        """Two times with the same count are two different values."""
+        assert digest(np.datetime64(10, "ns")) != digest(np.timedelta64(10, "ns"))
+
+
+class TestArrays:
+    """Tests for array parameters."""
+
+    @pytest.fixture
+    def array(self):
+        """A small array of known values."""
+        return np.arange(6).reshape(2, 3)
+
+    def test_values_matter(self, array):
+        """Two arrays with different values digest differently."""
+        assert digest(array) != digest(array + 1)
+
+    def test_shape_matters(self, array):
+        """The same values in another shape are another array."""
+        assert digest(array) != digest(array.reshape(3, 2))
+
+    def test_dtype_matters(self, array):
+        """The same values in another dtype are another array."""
+        assert digest(array) != digest(array.astype(np.float64))
+
+    def test_endianness_ignored(self, array):
+        """The byte order an array is stored in is not part of its value."""
+        swapped = array.astype(array.dtype.newbyteorder(">"))
+        assert digest(array) == digest(swapped)
+
+    def test_non_contiguous(self, array):
+        """A view digests as the values it presents."""
+        assert digest(array[:, ::2]) == digest(np.ascontiguousarray(array[:, ::2]))
+
+    def test_object_array(self):
+        """An object array holds python values, and encodes as them."""
+        array = np.array([1, "a", None], dtype=object)
+        assert encode(array) == [1, "a", None]
+
+    def test_round_trip(self, array):
+        """A document holds an array's values, not its digest."""
+        out = round_trip(array)
+        assert np.array_equal(out, array)
+        assert out.dtype == array.dtype
+
+    def test_fingerprint_cannot_round_trip(self, array):
+        """An array reduced to a digest refuses to come back."""
+        with pytest.raises(ParameterError, match="cannot be read back"):
+            decode(encode(array))
+
+    def test_foreign_array_matches_numpy(self, array):
+        """An array from another backend digests as its values."""
+        strict = pytest.importorskip("array_api_strict")
+        foreign = strict.asarray(np.asarray(array, dtype=np.float64))
+        assert digest(foreign) == digest(array.astype(np.float64))
+
+    def test_repeat_operand_cached(self, array, monkeypatch):
+        """An array given twice is hashed once."""
+        calls = []
+        original = np.ascontiguousarray
+
+        def _counted(value, *args, **kwargs):
+            calls.append(value)
+            return original(value, *args, **kwargs)
+
+        monkeypatch.setattr(np, "ascontiguousarray", _counted)
+        assert digest(array) == digest(array)
+        assert len(calls) == 1
+
+    def test_cache_released(self, array):
+        """The cache holds no array alive once its owner drops it."""
+        held = np.arange(4)
+        digest(held)
+        key = id(held)
+        assert key in serialize._ARRAY_DIGESTS
+        del held
+        gc.collect()
+        assert key not in serialize._ARRAY_DIGESTS
+
+    def test_unweakreferenceable_array(self, monkeypatch):
+        """An array which refuses a weak reference is still hashed."""
+
+        def _refuse(*args, **kwargs):
+            raise TypeError("cannot weakly reference this")
+
+        monkeypatch.setattr(serialize.weakref, "ref", _refuse)
+        array = np.arange(3) + 100
+        assert digest(array) == digest(np.arange(3) + 100)
+
+
+class TestCollections:
+    """Tests for the containers a parameter may be."""
+
+    def test_tuple_and_list_alike(self):
+        """A tuple and a list of the same values are the same parameter."""
+        assert digest([1, 2]) == digest((1, 2))
+
+    def test_order_matters(self):
+        """A sequence keeps the order it was given in."""
+        assert digest([1, 2]) != digest([2, 1])
+
+    def test_set_sorted(self):
+        """A set has no order, so its encoding is sorted."""
+        assert digest({1, 2, 3}) == digest({3, 2, 1})
+        assert encode({3, 1, 2}) == [1, 2, 3]
+
+    def test_frozenset(self):
+        """A frozenset is a set."""
+        assert digest(frozenset({1, 2})) == digest({1, 2})
+
+    def test_nested(self):
+        """Containers nest."""
+        assert digest({"a": [1, {"b": (2,)}]}) == digest({"a": [1, {"b": [2]}]})
+
+    def test_none_dropped_from_fingerprint(self):
+        """A parameter left at None is the same call as one left out."""
+        assert digest({"a": 1, "b": None}) == digest({"a": 1})
+
+    def test_none_kept_in_document(self):
+        """A document keeps what it was given, so it can give it back."""
+        assert round_trip({"a": 1, "b": None}) == {"a": 1, "b": None}
+
+    def test_non_string_keys(self):
+        """A mapping keyed by something other than strings round trips."""
+        value = {(1, 2): "x", 3: "y"}
+        assert round_trip(value) == value
+
+    def test_non_string_keys_sorted(self):
+        """Such a mapping digests the same however it was built."""
+        assert digest({1: "a", 2: "b"}) == digest({2: "b", 1: "a"})
+
+
+class TestPaths:
+    """Tests for path parameters."""
+
+    def test_posix_string(self):
+        """A path encodes as its posix spelling."""
+        assert encode(Path("/a/b")) == "/a/b"
+
+    def test_windows_separator_normalized(self):
+        """A windows path digests as the same path written for posix."""
+        assert digest(PureWindowsPath(r"a\b")) == digest("a/b")
+
+
+class TestQuantities:
+    """Tests for pint quantities."""
+
+    def test_round_trip(self):
+        """A quantity comes back as itself."""
+        value = dc.get_quantity("10 m")
+        assert round_trip(value) == value
+
+    def test_dimensionless_round_trip(self):
+        """A quantity with no units comes back as itself."""
+        value = dc.get_quantity("2.5")
+        assert round_trip(value) == value
+
+    def test_unit_not_normalized(self):
+        """The same length written two ways is not the same call."""
+        assert digest(dc.get_quantity("1 m")) != digest(dc.get_quantity("100 cm"))
+
+    def test_array_magnitude(self):
+        """A quantity over an array round trips too."""
+        value = np.arange(3) * dc.get_quantity("m/s")
+        out = round_trip(value)
+        assert np.array_equal(out.magnitude, value.magnitude)
+        assert out.units == value.units
+
+
+class TestOddballs:
+    """Tests for the values which have no natural encoding."""
+
+    def test_slice(self):
+        """A slice round trips, holes and all."""
+        assert round_trip(slice(1, None, 2)) == slice(1, None, 2)
+
+    def test_slice_values_matter(self):
+        """Two different slices are two different parameters."""
+        assert digest(slice(1, 2)) != digest(slice(1, 3))
+
+    def test_ellipsis(self):
+        """An ellipsis round trips."""
+        assert round_trip(...) is ...
+
+    def test_named_callable(self):
+        """A function is encoded by where it is defined."""
+        assert encode(np.mean) == {"$callable": {"path": "numpy:mean"}}
+
+    def test_callable_cannot_round_trip(self):
+        """A document does not import whatever it names."""
+        with pytest.raises(ParameterError, match="cannot be rebuilt"):
+            decode(encode(np.mean, mode=DOCUMENT))
+
+    def test_lambdas_differ_by_source(self):
+        """Two lambdas which do different things are different parameters."""
+        first = lambda x: x  # noqa: E731
+        second = lambda x: x + 1  # noqa: E731
+        assert digest(first) != digest(second)
+
+    def test_named_callable_has_no_source(self):
+        """A function which can be found by name is not hashed by source."""
+        assert "source" not in encode(np.sin)["$callable"]
+
+    def test_sourceless_callable(self):
+        """A callable whose source cannot be read is still encodable."""
+        # Built by eval, so there is no file holding the text of it.
+        assert isinstance(digest(eval("lambda x: x")), str)
+
+    def test_partial(self):
+        """A partial is what it wraps and what it wraps it with."""
+        value = partial(np.mean, axis=0)
+        assert digest(value) != digest(partial(np.mean, axis=1))
+        assert digest(value) != digest(np.mean)
+
+    def test_partial_round_trip_refused(self):
+        """A partial holds a function, so a document cannot carry it."""
+        with pytest.raises(ParameterError, match="cannot be rebuilt"):
+            decode(encode(partial(np.mean, axis=0), mode=DOCUMENT))
+
+    def test_opaque_value(self):
+        """A value nothing else describes is named by its class."""
+        assert encode(object()) == {"$opaque": "builtins.object"}
+
+    def test_opaque_holds_no_address(self):
+        """An address changes every run and would never digest alike."""
+        assert "0x" not in canonical_json(object())
+
+    def test_opaque_cannot_round_trip(self):
+        """A value encoded by name only cannot be rebuilt."""
+        with pytest.raises(ParameterError, match="cannot be rebuilt"):
+            decode(encode(object()))
+
+    def test_plain_value_decodes_to_itself(self):
+        """Anything untagged decodes to what it already is."""
+        assert decode([1, {"a": "b"}]) == [1, {"a": "b"}]
+
+
+class TestModels:
+    """Tests for dascore models as parameters."""
+
+    def test_fields_matter(self):
+        """Two models holding different values digest differently."""
+        assert digest(dc.PatchAttrs(tag="a")) != digest(dc.PatchAttrs(tag="b"))
+
+    def test_class_matters(self):
+        """Two classes holding the same fields are not the same value."""
+        model = dc.PatchAttrs(tag="a")
+        assert digest(model) != digest({"tag": "a"})
+
+    def test_round_trip(self):
+        """A model comes back as itself."""
+        model = dc.PatchAttrs(tag="a", station="wow")
+        assert round_trip(model) == model
+
+    def test_extra_fields_included(self):
+        """A model's extras are part of what it holds."""
+        assert digest(dc.PatchAttrs(my_extra=1)) != digest(dc.PatchAttrs())
+
+    def test_unknown_tag_refused(self):
+        """A document naming no known model refuses to decode."""
+        document = {"$model": {"object_type": "NotAModelAnyoneHas", "fields": {}}}
+        with pytest.raises(ParameterError, match="Nothing registers"):
+            decode(document)
+
+
+class TestDataFrames:
+    """Tests for dataframe parameters."""
+
+    @pytest.fixture
+    def df(self):
+        """A small dataframe."""
+        return pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+
+    def test_values_matter(self, df):
+        """Two frames holding different values digest differently."""
+        assert digest(df) != digest(df.assign(a=[1, 3]))
+
+    def test_equal_frames_agree(self, df):
+        """Two frames holding the same values digest alike."""
+        assert digest(df) == digest(df.copy())
+
+    def test_series(self, df):
+        """A series is a frame's column."""
+        assert isinstance(digest(df["a"]), str)
+
+    def test_no_document_form(self, df):
+        """A frame cannot be written into a document."""
+        with pytest.raises(ParameterError, match="cannot be written"):
+            encode(df, mode=DOCUMENT)

--- a/tests/test_workflow/test_serialize.py
+++ b/tests/test_workflow/test_serialize.py
@@ -192,10 +192,27 @@ class TestPythonTimes:
         """A pandas timedelta is the same span as numpy's."""
         assert digest(pd.Timedelta("5s")) == digest(np.timedelta64(5, "s"))
 
-    def test_out_of_range_time(self):
-        """A time nanoseconds cannot hold is refused, not truncated."""
+    @pytest.mark.parametrize("value", ["1500-01-01", "2300-01-01"])
+    def test_out_of_range_time(self, value):
+        """
+        A time nanoseconds cannot hold is refused.
+
+        Numpy wraps such a time silently on some versions and raises on
+        others, so hashing whatever it wrapped to would make two centuries
+        apart the same parameter.
+        """
         with pytest.raises(ParameterError, match="nanoseconds"):
-            digest(np.datetime64("1500-01-01"))
+            digest(np.datetime64(value))
+
+    def test_sub_nanosecond_time(self):
+        """A span too fine for nanoseconds is refused, not truncated."""
+        with pytest.raises(ParameterError, match="nanoseconds"):
+            digest(np.timedelta64(5, "ps"))
+
+    def test_not_a_time_round_trips(self):
+        """A missing time is a value like any other."""
+        assert np.isnat(round_trip(np.datetime64("NaT", "s")))
+        assert np.isnat(round_trip(np.timedelta64("NaT", "s")))
 
 
 class TestNumbersAndBytes:
@@ -288,6 +305,18 @@ class TestArrays:
         """An array of times digests as the instants it holds."""
         seconds = np.array([1, 2], dtype="datetime64[s]")
         assert digest(seconds) == digest(seconds.astype("datetime64[ns]"))
+
+    def test_time_array_with_missing_values(self):
+        """An array of times may hold missing ones."""
+        times = np.array(["2020-01-01", "NaT"], dtype="datetime64[s]")
+        out = round_trip(times)
+        assert out[0] == times[0] and np.isnat(out[1])
+
+    def test_out_of_range_time_array(self):
+        """An array holding a time nanoseconds cannot hold is refused."""
+        times = np.array(["1500-01-01"], dtype="datetime64[s]")
+        with pytest.raises(ParameterError, match="nanoseconds"):
+            digest(times)
 
     def test_zero_dimensional_object_array(self):
         """A zero dimensional object array holds one value, not none."""

--- a/tests/test_workflow/test_serialize.py
+++ b/tests/test_workflow/test_serialize.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import gc
+import datetime
 from enum import Enum
 from functools import partial
 from pathlib import Path, PureWindowsPath
@@ -12,8 +12,9 @@ import pandas as pd
 import pytest
 
 import dascore as dc
-from dascore.exceptions import ParameterError
-from dascore.workflow import serialize
+from dascore.exceptions import InvalidModelTagError, ParameterError
+from dascore.utils.misc import suppress_warnings
+from dascore.warnings import DASCoreWarning
 from dascore.workflow.serialize import (
     DOCUMENT,
     canonical_json,
@@ -29,6 +30,14 @@ def round_trip(value):
     return decode(encode(value, mode=DOCUMENT))
 
 
+def _normalized(dtype):
+    """Return the dtype an array of this one is stored and read back as."""
+    # Times are normalized to nanoseconds, as scalar ones are.
+    kind = np.dtype(dtype).kind
+    names = {"M": "datetime64[ns]", "m": "timedelta64[ns]"}
+    return names.get(kind, dtype)
+
+
 class Color(Enum):
     """An enum whose members stand for strings."""
 
@@ -39,14 +48,6 @@ class Color(Enum):
 class TestDigest:
     """Tests for the digest itself."""
 
-    def test_length(self):
-        """The digest is 8 bytes written as hex."""
-        assert len(digest("something")) == 16
-
-    def test_stable(self):
-        """Equal values digest alike, whatever built them."""
-        assert digest({"dim": "time"}) == digest({"dim": "" + "time"})
-
     def test_hard_coded(self):
         """
         The digest of a fixed value never changes.
@@ -56,6 +57,11 @@ class TestDigest:
         canonical text, and blake2b.
         """
         assert digest({"a": 1, "b": [1.5, "x"]}) == "3cdfb6194bc1acd6"
+
+    def test_mode_matters(self):
+        """The two modes encode an array differently, so they digest so."""
+        array = np.arange(3)
+        assert digest(array) != digest(array, mode=DOCUMENT)
 
     def test_key_order_ignored(self):
         """A mapping digests the same however it was built."""
@@ -148,6 +154,78 @@ class TestTimes:
         assert digest(np.datetime64(10, "ns")) != digest(np.timedelta64(10, "ns"))
 
 
+class TestPythonTimes:
+    """Tests for the times which are not numpy's."""
+
+    def test_datetime(self):
+        """A python datetime is the instant it names."""
+        value = datetime.datetime(2020, 1, 1, 0, 0, 1)
+        assert digest(value) == digest(np.datetime64("2020-01-01T00:00:01"))
+        assert round_trip(value) == np.datetime64(value)
+
+    def test_datetime_values_matter(self):
+        """Two different datetimes are two different parameters."""
+        first = datetime.datetime(2020, 1, 1)
+        assert digest(first) != digest(datetime.datetime(1999, 5, 5))
+
+    def test_aware_datetime_moved_to_utc(self):
+        """A datetime carrying a zone is the instant it stands for."""
+        zone = datetime.timezone(datetime.timedelta(hours=2))
+        aware = datetime.datetime(2020, 1, 1, 2, tzinfo=zone)
+        assert digest(aware) == digest(np.datetime64("2020-01-01T00:00:00"))
+
+    def test_date(self):
+        """A bare date is midnight on that day."""
+        assert digest(datetime.date(2020, 1, 1)) == digest(np.datetime64("2020-01-01"))
+
+    def test_timestamp(self):
+        """A pandas timestamp is the same instant as numpy's."""
+        assert digest(pd.Timestamp("2020-01-01")) == digest(np.datetime64("2020-01-01"))
+
+    def test_timedelta(self):
+        """A python timedelta is the span it names."""
+        value = datetime.timedelta(seconds=5)
+        assert digest(value) == digest(np.timedelta64(5, "s"))
+        assert round_trip(value) == np.timedelta64(5, "s")
+
+    def test_pandas_timedelta(self):
+        """A pandas timedelta is the same span as numpy's."""
+        assert digest(pd.Timedelta("5s")) == digest(np.timedelta64(5, "s"))
+
+    def test_out_of_range_time(self):
+        """A time nanoseconds cannot hold is refused, not truncated."""
+        with pytest.raises(ParameterError, match="nanoseconds"):
+            digest(np.datetime64("1500-01-01"))
+
+
+class TestNumbersAndBytes:
+    """Tests for the values JSON has no spelling for."""
+
+    def test_complex_round_trip(self):
+        """A complex number comes back as itself."""
+        assert round_trip(complex(1.5, -2)) == complex(1.5, -2)
+
+    def test_complex_values_matter(self):
+        """The two halves of a complex number both count."""
+        assert digest(complex(1, 2)) != digest(complex(2, 1))
+
+    def test_complex_is_not_a_pair(self):
+        """A complex number is not the tuple of its parts."""
+        assert digest(complex(1, 2)) != digest((1.0, 2.0))
+
+    def test_bytes_round_trip(self):
+        """Bytes come back as themselves."""
+        assert round_trip(b"\x00\xff") == b"\x00\xff"
+
+    def test_bytes_values_matter(self):
+        """Two different byte strings are two different parameters."""
+        assert digest(b"a") != digest(b"b")
+
+    def test_bytes_is_not_a_string(self):
+        """Bytes are not the string which spells them."""
+        assert digest(b"a") != digest("a")
+
+
 class TestArrays:
     """Tests for array parameters."""
 
@@ -188,6 +266,33 @@ class TestArrays:
         assert np.array_equal(out, array)
         assert out.dtype == array.dtype
 
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "int64",
+            "float64",
+            "bool",
+            "datetime64[s]",
+            "timedelta64[s]",
+            "complex128",
+            "<U3",
+        ],
+    )
+    def test_round_trip_every_dtype(self, dtype):
+        """A document holds an array's values whatever they are."""
+        original = np.arange(3).astype(dtype)
+        out = round_trip(original)
+        assert np.array_equal(out, original.astype(_normalized(dtype)))
+
+    def test_time_array_unit_normalized(self):
+        """An array of times digests as the instants it holds."""
+        seconds = np.array([1, 2], dtype="datetime64[s]")
+        assert digest(seconds) == digest(seconds.astype("datetime64[ns]"))
+
+    def test_zero_dimensional_object_array(self):
+        """A zero dimensional object array holds one value, not none."""
+        assert encode(np.array("a", dtype=object)) == "a"
+
     def test_fingerprint_cannot_round_trip(self, array):
         """An array reduced to a digest refuses to come back."""
         with pytest.raises(ParameterError, match="cannot be read back"):
@@ -198,39 +303,6 @@ class TestArrays:
         strict = pytest.importorskip("array_api_strict")
         foreign = strict.asarray(np.asarray(array, dtype=np.float64))
         assert digest(foreign) == digest(array.astype(np.float64))
-
-    def test_repeat_operand_cached(self, array, monkeypatch):
-        """An array given twice is hashed once."""
-        calls = []
-        original = np.ascontiguousarray
-
-        def _counted(value, *args, **kwargs):
-            calls.append(value)
-            return original(value, *args, **kwargs)
-
-        monkeypatch.setattr(np, "ascontiguousarray", _counted)
-        assert digest(array) == digest(array)
-        assert len(calls) == 1
-
-    def test_cache_released(self, array):
-        """The cache holds no array alive once its owner drops it."""
-        held = np.arange(4)
-        digest(held)
-        key = id(held)
-        assert key in serialize._ARRAY_DIGESTS
-        del held
-        gc.collect()
-        assert key not in serialize._ARRAY_DIGESTS
-
-    def test_unweakreferenceable_array(self, monkeypatch):
-        """An array which refuses a weak reference is still hashed."""
-
-        def _refuse(*args, **kwargs):
-            raise TypeError("cannot weakly reference this")
-
-        monkeypatch.setattr(serialize.weakref, "ref", _refuse)
-        array = np.arange(3) + 100
-        assert digest(array) == digest(np.arange(3) + 100)
 
 
 class TestCollections:
@@ -246,8 +318,10 @@ class TestCollections:
 
     def test_set_sorted(self):
         """A set has no order, so its encoding is sorted."""
-        assert digest({1, 2, 3}) == digest({3, 2, 1})
-        assert encode({3, 1, 2}) == [1, 2, 3]
+        # Strings, whose sets do not iterate in sorted order by luck the way
+        # a set of small ints does.
+        assert digest({"b", "a", "c"}) == digest({"c", "a", "b"})
+        assert encode({"c", "a", "b"}) == ["a", "b", "c"]
 
     def test_frozenset(self):
         """A frozenset is a set."""
@@ -264,6 +338,17 @@ class TestCollections:
     def test_none_kept_in_document(self):
         """A document keeps what it was given, so it can give it back."""
         assert round_trip({"a": 1, "b": None}) == {"a": 1, "b": None}
+
+    def test_tag_shaped_key_is_not_a_tag(self):
+        """A mapping which spells a tag is not read back as one."""
+        spoof = {"$datetime64": 5}
+        assert digest(spoof) != digest(np.datetime64(5, "ns"))
+        assert round_trip(spoof) == spoof
+
+    def test_tag_shaped_key_survives_nesting(self):
+        """The escape holds for the tag the escape itself uses."""
+        spoof = {"$dict": [["a", 1]]}
+        assert round_trip(spoof) == spoof
 
     def test_non_string_keys(self):
         """A mapping keyed by something other than strings round trips."""
@@ -302,7 +387,9 @@ class TestQuantities:
 
     def test_unit_not_normalized(self):
         """The same length written two ways is not the same call."""
-        assert digest(dc.get_quantity("1 m")) != digest(dc.get_quantity("100 cm"))
+        # Magnitudes which survive a conversion unchanged, so the units are
+        # the only thing left to tell the two apart.
+        assert digest(dc.get_quantity("1.0 m")) != digest(dc.get_quantity("1.0 km"))
 
     def test_array_magnitude(self):
         """A quantity over an array round trips too."""
@@ -364,15 +451,25 @@ class TestOddballs:
 
     def test_opaque_value(self):
         """A value nothing else describes is named by its class."""
-        assert encode(object()) == {"$opaque": "builtins.object"}
+        with suppress_warnings(DASCoreWarning):
+            assert encode(object()) == {"$opaque": "builtins.object"}
+
+    def test_opaque_warns(self):
+        """Reducing a value to its type name is said out loud."""
+        with pytest.warns(DASCoreWarning, match="only its type is hashed"):
+            digest(object())
 
     def test_opaque_holds_no_address(self):
         """An address changes every run and would never digest alike."""
-        assert "0x" not in canonical_json(object())
+        with suppress_warnings(DASCoreWarning):
+            assert "0x" not in canonical_json(object())
 
     def test_opaque_cannot_round_trip(self):
         """A value encoded by name only cannot be rebuilt."""
-        with pytest.raises(ParameterError, match="cannot be rebuilt"):
+        with (
+            suppress_warnings(DASCoreWarning),
+            pytest.raises(ParameterError, match="cannot be rebuilt"),
+        ):
             decode(encode(object()))
 
     def test_plain_value_decodes_to_itself(self):
@@ -404,7 +501,7 @@ class TestModels:
     def test_unknown_tag_refused(self):
         """A document naming no known model refuses to decode."""
         document = {"$model": {"object_type": "NotAModelAnyoneHas", "fields": {}}}
-        with pytest.raises(ParameterError, match="Nothing registers"):
+        with pytest.raises(InvalidModelTagError, match="Nothing registers"):
             decode(document)
 
 
@@ -424,9 +521,17 @@ class TestDataFrames:
         """Two frames holding the same values digest alike."""
         assert digest(df) == digest(df.copy())
 
+    def test_column_names_matter(self, df):
+        """Two frames holding the same numbers under other names differ."""
+        assert digest(df) != digest(df.rename(columns={"a": "z"}))
+
+    def test_dtypes_matter(self, df):
+        """A column read as floats is not the same column read as ints."""
+        assert digest(df) != digest(df.assign(a=df["a"].astype(float)))
+
     def test_series(self, df):
-        """A series is a frame's column."""
-        assert isinstance(digest(df["a"]), str)
+        """A series digests by its values, like the frame it came from."""
+        assert digest(df["a"]) != digest(df["a"] + 1)
 
     def test_no_document_form(self, df):
         """A frame cannot be written into a document."""

--- a/tests/test_workflow/test_task.py
+++ b/tests/test_workflow/test_task.py
@@ -1,0 +1,474 @@
+"""Tests for the Task base class and the tasks a function makes."""
+
+from __future__ import annotations
+
+import json
+import pickle
+from concurrent.futures import ProcessPoolExecutor
+
+import numpy as np
+import pytest
+from pydantic import Field, ValidationError
+
+import dascore as dc
+from dascore.exceptions import InvalidModelTagError, ParameterError
+from dascore.utils.misc import suppress_warnings
+from dascore.workflow import (
+    Task,
+    decode,
+    encode,
+    intern,
+    make_function_task_class,
+    task,
+)
+
+
+class Scale(Task):
+    """Multiply what it is given by a factor."""
+
+    factor: float = 1.0
+
+    def run(self, value):
+        """Scale a value."""
+        return value * self.factor
+
+
+class Shift(Task):
+    """Add an offset to what it is given."""
+
+    offset: float = 0.0
+
+
+class VersionedScale(Scale):
+    """The same parameters, said to mean something else."""
+
+    __version__ = "2.0"
+
+
+class TupleTask(Task):
+    """A task with a field which declares itself a tuple."""
+
+    values: tuple[int, ...] = ()
+
+
+class TimedTask(Task):
+    """A task parametrized by the values a fingerprint has to normalize."""
+
+    when: object = None
+    where: object = None
+
+
+@task
+def add(first, second=1):
+    """Add two numbers."""
+    return first + second
+
+
+@task(version="2.0")
+def multiply(first, second=2):
+    """Multiply two numbers."""
+    return first * second
+
+
+def every_kind(positional, /, normal=1, *rest, named=2, **extra):
+    """Take one of every kind of parameter python has."""
+    return (positional, normal, rest, named, extra)
+
+
+def with_field_default(value=Field(default=7)):
+    """Spell a default the way a pydantic model would."""
+    return value
+
+
+EveryKind = make_function_task_class(every_kind)
+WithFieldDefault = make_function_task_class(with_field_default)
+
+
+def _task_class(name, module):
+    """Return a task class which believes it lives in a given module."""
+    namespace = {"__annotations__": {"factor": float}, "__module__": module}
+    return type(name, (Task,), namespace)
+
+
+def _fingerprint_of(document):
+    """Rebuild a task from its document and return its fingerprint."""
+    return Task.from_dict(document).fingerprint
+
+
+class TestFingerprint:
+    """Tests for what a task's fingerprint answers to."""
+
+    def test_stable_across_constructions(self):
+        """The same task built twice fingerprints alike."""
+        assert Scale(factor=2).fingerprint == Scale(factor=2).fingerprint
+
+    def test_hard_coded(self):
+        """
+        A fingerprint does not drift between releases.
+
+        Stored ids depend on this: the same call has to give the same answer
+        after a refactor, so the value is pinned rather than merely stable
+        within one run.
+        """
+        assert Scale(factor=2).fingerprint == "7a9e5fd2be41f9d4"
+
+    def test_params_matter(self):
+        """Two different calls are two different tasks."""
+        assert Scale(factor=2).fingerprint != Scale(factor=3).fingerprint
+
+    def test_default_is_a_value(self):
+        """Passing a default explicitly is the same call as leaving it out."""
+        assert Scale(factor=1.0).fingerprint == Scale().fingerprint
+
+    def test_class_matters(self):
+        """Two classes holding the same fields are two tasks."""
+        assert Scale(factor=1).fingerprint != Shift(offset=1).fingerprint
+
+    def test_version_matters(self):
+        """A version bump says the same call means something else."""
+        assert Scale(factor=2).fingerprint != VersionedScale(factor=2).fingerprint
+
+    def test_survives_a_move(self):
+        """Moving a class between modules does not rename it."""
+        # Both live in one package under one name, which is exactly the
+        # collision the registry warns about; here it is the point.
+        with suppress_warnings(UserWarning, message="Two models claim"):
+            first = _task_class("MovedScale", "tests.first_home")
+            second = _task_class("MovedScale", "tests.second_home")
+        assert first(factor=2).fingerprint == second(factor=2).fingerprint
+
+    def test_namespaced(self):
+        """A task outside dascore fingerprints under its own namespace."""
+        inside = _task_class("NamespacedScale", "tests.tasks")
+        outside = _task_class("NamespacedScale", "someplugin.tasks")
+        assert inside(factor=2).fingerprint != outside(factor=2).fingerprint
+
+    def test_cached(self):
+        """The fingerprint is computed once per instance."""
+        task_ = Scale(factor=2)
+        assert task_.fingerprint is task_.fingerprint
+
+    def test_time_units_normalized(self):
+        """A parameter's fingerprint goes through the serializer."""
+        day = TimedTask(when=np.datetime64("2020-01-01"))
+        nanosecond = TimedTask(when=np.datetime64("2020-01-01T00:00:00.000000000"))
+        assert day.fingerprint == nanosecond.fingerprint
+
+    def test_none_parameters_dropped(self):
+        """A parameter left at None is the same call as one left out."""
+        assert TimedTask(when=None).fingerprint == TimedTask().fingerprint
+
+    def test_array_parameter(self):
+        """An array parameter is hashed by its values."""
+        first = TimedTask(when=np.arange(3))
+        assert first.fingerprint != TimedTask(when=np.arange(4)).fingerprint
+        assert first.fingerprint == TimedTask(when=np.arange(3)).fingerprint
+
+    def test_nested_task_parameter(self):
+        """A task given to a task is part of its parameters."""
+        first = TimedTask(when=Scale(factor=2))
+        assert first.fingerprint != TimedTask(when=Scale(factor=3)).fingerprint
+        assert first.fingerprint == TimedTask(when=Scale(factor=2)).fingerprint
+
+
+class TestEquality:
+    """Tests for how tasks compare."""
+
+    def test_equal_tasks(self):
+        """Two tasks with the same parameters are the same task."""
+        assert Scale(factor=2) == Scale(factor=2)
+
+    def test_different_params(self):
+        """Two calls of one task are not each other."""
+        assert Scale(factor=2) != Scale(factor=3)
+
+    def test_different_classes(self):
+        """Two classes holding the same field values are not equal."""
+        assert Scale(factor=1) != VersionedScale(factor=1)
+
+    def test_not_a_task(self):
+        """Something which is not a task is not equal to one."""
+        assert Scale(factor=1) != "Scale(factor=1)"
+
+    def test_hashes_with_equality(self):
+        """Equal tasks land in the same place in a set."""
+        assert len({Scale(factor=2), Scale(factor=2)}) == 1
+        assert len({Scale(factor=2), Scale(factor=3)}) == 2
+
+    def test_hashable_with_array_params(self):
+        """A task holding an array is still hashable."""
+        assert hash(TimedTask(when=np.arange(3))) is not None
+
+
+class TestUpdate:
+    """Tests for making one task from another."""
+
+    def test_returns_new_task(self):
+        """Updating leaves the original alone."""
+        first = Scale(factor=2)
+        second = first.update(factor=3)
+        assert first.factor == 2
+        assert second.factor == 3
+
+    def test_validates(self):
+        """An update goes through validation."""
+        with pytest.raises(ValidationError):
+            Scale(factor=2).update(factor="not a number")
+
+    def test_unknown_parameter(self):
+        """A task refuses a parameter it does not have."""
+        with pytest.raises(ValidationError):
+            Scale(factor=2).update(not_a_field=1)
+
+
+class TestDocuments:
+    """Tests for writing a task down and reading it back."""
+
+    def test_round_trip(self):
+        """A task rebuilt from its document is the same task."""
+        original = Scale(factor=2)
+        assert Task.from_dict(original.to_dict()) == original
+
+    def test_names_the_class_by_tag(self):
+        """A document names a registered tag, not an import path."""
+        document = Scale(factor=2).to_dict()
+        assert document["object_type"] == "tests:Scale"
+
+    def test_code_path_is_a_hint(self):
+        """The import hint is written but does not change the fingerprint."""
+        document = Scale(factor=2).to_dict()
+        assert "code_path" in document
+        document["code_path"] = "somewhere:else"
+        assert _fingerprint_of(document) == Scale(factor=2).fingerprint
+
+    def test_unknown_tag_raises(self):
+        """A tag nothing registers is an error, not an import."""
+        document = Scale(factor=2).to_dict()
+        document["object_type"] = "NotATaskAnyoneHas"
+        with pytest.raises(InvalidModelTagError):
+            Task.from_dict(document)
+
+    def test_tag_naming_another_model(self):
+        """A tag which names something other than a task is refused."""
+        document = Scale(factor=2).to_dict()
+        document["object_type"] = "PatchAttrs"
+        with pytest.raises(ParameterError, match="not a Task"):
+            Task.from_dict(document)
+
+    def test_nested_task_round_trip(self):
+        """A task given to a task comes back as itself."""
+        original = TimedTask(when=Scale(factor=2))
+        assert Task.from_dict(original.to_dict()).when == Scale(factor=2)
+
+    def test_nested_task_fingerprint_cannot_decode(self):
+        """A nested task hashed for a fingerprint cannot be read back."""
+        encoded = encode(Scale(factor=2))
+        with pytest.raises(ParameterError, match="cannot be read back"):
+            decode(encoded)
+
+    def test_declared_tuple_field(self):
+        """A JSON list comes back a tuple where the field says tuple."""
+        original = TupleTask(values=(1, 2))
+        assert Task.from_dict(original.to_dict()).values == (1, 2)
+
+    def test_undeclared_sequence_stays_a_list(self):
+        """A field which promises nothing gets the list a document holds."""
+        assert Task.from_dict(TimedTask(when=(1, 2)).to_dict()).when == [1, 2]
+
+    def test_time_parameter_round_trip(self):
+        """A parameter the serializer tags comes back as itself."""
+        original = TimedTask(when=np.datetime64("2020-01-01"), where=slice(1, 2))
+        rebuilt = Task.from_dict(original.to_dict())
+        assert rebuilt.when == original.when
+        assert rebuilt.where == original.where
+
+    def test_document_is_json_safe(self):
+        """A document holds only what JSON can write."""
+        document = TimedTask(when=np.arange(3)).to_dict()
+        assert json.loads(json.dumps(document)) == document
+
+
+class TestPickle:
+    """Tests for moving a task between processes."""
+
+    def test_round_trip(self):
+        """A task survives a pickle."""
+        original = Scale(factor=2)
+        assert pickle.loads(pickle.dumps(original)) == original
+
+    def test_synthesized_class(self):
+        """A class no attribute path names still pickles, by its tag."""
+        original = add(first=1, second=2)
+        assert pickle.loads(pickle.dumps(original)) == original
+
+    def test_across_processes(self):
+        """A task rebuilt in another process fingerprints the same."""
+        original = Scale(factor=2)
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            out = pool.submit(_fingerprint_of, original.to_dict()).result()
+        assert out == original.fingerprint
+
+
+class TestIntern:
+    """Tests for sharing one instance of a task."""
+
+    def test_returns_one_instance(self):
+        """Equal tasks intern to one object."""
+        assert intern(Scale(factor=2)) is intern(Scale(factor=2))
+
+    def test_keeps_them_apart(self):
+        """Tasks which are not equal keep their own instances."""
+        assert intern(Scale(factor=2)) is not intern(Scale(factor=3))
+
+    def test_first_wins(self):
+        """The instance which arrived first is the one handed back."""
+        first = Scale(factor=4)
+        assert intern(first) is first
+        assert intern(Scale(factor=4)) is first
+
+
+class TestRun:
+    """Tests for running a task."""
+
+    def test_base_class_has_no_body(self):
+        """A task which does not implement run says so."""
+        with pytest.raises(NotImplementedError, match="does not implement run"):
+            Shift(offset=1).run(1)
+
+    def test_subclass_body(self):
+        """A subclass runs what it implements."""
+        assert Scale(factor=2).run(3) == 6
+
+
+class TestFunctionTasks:
+    """Tests for the task a function makes."""
+
+    def test_class_name(self):
+        """The class is named for the function, in camel case."""
+        assert make_function_task_class(every_kind).__name__ == "EveryKind"
+
+    def test_docstring_kept(self):
+        """The class carries the function's docstring."""
+        assert add.__doc__ == "Add two numbers."
+
+    def test_runs_the_function(self):
+        """Running the task calls the function with its fields."""
+        assert add(first=1, second=2).run() == 3
+
+    def test_defaults(self):
+        """A parameter's default becomes the field's default."""
+        assert add(first=1).run() == 2
+
+    def test_required_parameter(self):
+        """A parameter with no default is required."""
+        with pytest.raises(ValidationError):
+            add()
+
+    def test_version(self):
+        """The decorator's version reaches the class."""
+        assert multiply.__version__ == "2.0"
+        assert multiply(first=2).run() == 4
+
+    def test_extra_input_passed_first(self):
+        """Arguments given to run are passed before the stored ones."""
+        double = make_function_task_class(every_kind, skip_first=True)
+        assert double(normal=5).run("given")[0] == "given"
+
+    def test_field_default_resolved(self):
+        """A default spelled as a pydantic Field is the value it holds."""
+        assert WithFieldDefault().value == 7
+
+    def test_all_parameter_kinds(self):
+        """Every kind of parameter survives the trip through a task."""
+        instance = EveryKind(
+            positional="p",
+            normal=5,
+            rest=(1, 2),
+            named=9,
+            an_extra="e",
+        )
+        assert instance.run() == ("p", 5, (1, 2), 9, {"an_extra": "e"})
+
+    def test_extras_allowed_only_with_kwargs(self):
+        """A function without **kwargs makes a task which refuses extras."""
+        with pytest.raises(ValidationError):
+            add(first=1, not_a_parameter=2)
+
+    def test_from_call_matches_construction(self):
+        """A task built from a call equals the task built by hand."""
+        from_call = EveryKind._from_call(("p", 5, 1, 2), {"named": 9, "an_extra": "e"})
+        by_hand = EveryKind(
+            positional="p", normal=5, rest=(1, 2), named=9, an_extra="e"
+        )
+        assert from_call.fingerprint == by_hand.fingerprint
+
+    def test_from_call_applies_defaults(self):
+        """A call which leaves a parameter out still records its value."""
+        assert (
+            add._from_call((1,), {}).fingerprint == add(first=1, second=1).fingerprint
+        )
+
+    def test_from_call_skips_first(self):
+        """The input a task is given is not one of its parameters."""
+        cls = make_function_task_class(every_kind, skip_first=True)
+        assert "positional" not in cls.model_fields
+        # The arguments are the ones left after the input, as _call_args
+        # gives them back.
+        assert cls._from_call((5,), {}).normal == 5
+
+    def test_shadowing_field_name(self):
+        """A parameter named for a model attribute is still a field."""
+
+        def shadowing(copy=True):
+            """Take a parameter named after BaseModel.copy."""
+            return copy
+
+        cls = make_function_task_class(shadowing)
+        assert cls().run() is True
+
+    def test_defined_in_a_function_is_not_registered(self):
+        """A class which only exists inside a call cannot be named."""
+
+        def local(value=1):
+            """A function defined inside a test."""
+            return value
+
+        cls = make_function_task_class(local)
+        with pytest.raises(InvalidModelTagError):
+            Task.from_dict(cls().to_dict())
+
+
+class TestTaskDecorator:
+    """Tests for the decorator spelling."""
+
+    def test_bare(self):
+        """The decorator works without parentheses."""
+
+        @task
+        def bare(value=1):
+            """A task made without parentheses."""
+            return value
+
+        assert bare(value=2).run() == 2
+
+    def test_with_version(self):
+        """The decorator works with arguments."""
+
+        @task(version="3.0")
+        def versioned(value=1):
+            """A task made with a version."""
+            return value
+
+        assert versioned.__version__ == "3.0"
+
+
+class TestTag:
+    """Tests for what names a task."""
+
+    def test_dascore_tags_are_bare(self):
+        """A model registers under a bare name inside dascore."""
+        assert dc.PatchAttrs().model_dump(mode="json")["object_type"] == "PatchAttrs"
+
+    def test_task_tag(self):
+        """A task outside dascore is namespaced by its package."""
+        assert Scale(factor=1).tag == "tests:Scale"

--- a/tests/test_workflow/test_task.py
+++ b/tests/test_workflow/test_task.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
 import pickle
 from concurrent.futures import ProcessPoolExecutor
 
@@ -10,9 +11,9 @@ import numpy as np
 import pytest
 from pydantic import Field, ValidationError
 
-import dascore as dc
 from dascore.exceptions import InvalidModelTagError, ParameterError
 from dascore.utils.misc import suppress_warnings
+from dascore.warnings import DASCoreWarning
 from dascore.workflow import (
     Task,
     decode,
@@ -23,7 +24,7 @@ from dascore.workflow import (
 )
 
 
-class Scale(Task):
+class ScaleTask(Task):
     """Multiply what it is given by a factor."""
 
     factor: float = 1.0
@@ -33,25 +34,25 @@ class Scale(Task):
         return value * self.factor
 
 
-class Shift(Task):
+class ShiftTask(Task):
     """Add an offset to what it is given."""
 
     offset: float = 0.0
 
 
-class VersionedScale(Scale):
+class VersionedScaleTask(ScaleTask):
     """The same parameters, said to mean something else."""
 
     __version__ = "2.0"
 
 
-class TupleTask(Task):
+class TupleFieldTask(Task):
     """A task with a field which declares itself a tuple."""
 
     values: tuple[int, ...] = ()
 
 
-class TimedTask(Task):
+class TimedValueTask(Task):
     """A task parametrized by the values a fingerprint has to normalize."""
 
     when: object = None
@@ -59,13 +60,13 @@ class TimedTask(Task):
 
 
 @task
-def add(first, second=1):
+def add_numbers(first, second=1):
     """Add two numbers."""
     return first + second
 
 
 @task(version="2.0")
-def multiply(first, second=2):
+def multiply_numbers(first, second=2):
     """Multiply two numbers."""
     return first * second
 
@@ -80,7 +81,13 @@ def with_field_default(value=Field(default=7)):
     return value
 
 
+def skips_first(given, /, normal=1, *rest, named=2, **extra):
+    """Take an input at run time, then one of every other kind."""
+    return (given, normal, rest, named, extra)
+
+
 EveryKind = make_function_task_class(every_kind)
+SkipsFirst = make_function_task_class(skips_first, skip_first=True)
 WithFieldDefault = make_function_task_class(with_field_default)
 
 
@@ -95,12 +102,17 @@ def _fingerprint_of(document):
     return Task.from_dict(document).fingerprint
 
 
+def _fingerprint(task_):
+    """Return a task's fingerprint; run in another process."""
+    return task_.fingerprint
+
+
 class TestFingerprint:
     """Tests for what a task's fingerprint answers to."""
 
     def test_stable_across_constructions(self):
         """The same task built twice fingerprints alike."""
-        assert Scale(factor=2).fingerprint == Scale(factor=2).fingerprint
+        assert ScaleTask(factor=2).fingerprint == ScaleTask(factor=2).fingerprint
 
     def test_hard_coded(self):
         """
@@ -110,65 +122,67 @@ class TestFingerprint:
         after a refactor, so the value is pinned rather than merely stable
         within one run.
         """
-        assert Scale(factor=2).fingerprint == "7a9e5fd2be41f9d4"
+        assert ScaleTask(factor=2).fingerprint == "761d418c84549e16"
 
     def test_params_matter(self):
         """Two different calls are two different tasks."""
-        assert Scale(factor=2).fingerprint != Scale(factor=3).fingerprint
+        assert ScaleTask(factor=2).fingerprint != ScaleTask(factor=3).fingerprint
 
     def test_default_is_a_value(self):
         """Passing a default explicitly is the same call as leaving it out."""
-        assert Scale(factor=1.0).fingerprint == Scale().fingerprint
+        assert ScaleTask(factor=1.0).fingerprint == ScaleTask().fingerprint
 
     def test_class_matters(self):
         """Two classes holding the same fields are two tasks."""
-        assert Scale(factor=1).fingerprint != Shift(offset=1).fingerprint
+        assert ScaleTask(factor=1).fingerprint != ShiftTask(offset=1).fingerprint
 
     def test_version_matters(self):
         """A version bump says the same call means something else."""
-        assert Scale(factor=2).fingerprint != VersionedScale(factor=2).fingerprint
+        assert (
+            ScaleTask(factor=2).fingerprint != VersionedScaleTask(factor=2).fingerprint
+        )
 
     def test_survives_a_move(self):
         """Moving a class between modules does not rename it."""
         # Both live in one package under one name, which is exactly the
         # collision the registry warns about; here it is the point.
         with suppress_warnings(UserWarning, message="Two models claim"):
-            first = _task_class("MovedScale", "tests.first_home")
-            second = _task_class("MovedScale", "tests.second_home")
+            first = _task_class("MovedScaleTask", "tests.first_home")
+            second = _task_class("MovedScaleTask", "tests.second_home")
         assert first(factor=2).fingerprint == second(factor=2).fingerprint
 
     def test_namespaced(self):
         """A task outside dascore fingerprints under its own namespace."""
-        inside = _task_class("NamespacedScale", "tests.tasks")
-        outside = _task_class("NamespacedScale", "someplugin.tasks")
+        inside = _task_class("NamespacedScaleTask", "tests.tasks")
+        outside = _task_class("NamespacedScaleTask", "someplugin.tasks")
         assert inside(factor=2).fingerprint != outside(factor=2).fingerprint
 
     def test_cached(self):
         """The fingerprint is computed once per instance."""
-        task_ = Scale(factor=2)
+        task_ = ScaleTask(factor=2)
         assert task_.fingerprint is task_.fingerprint
 
     def test_time_units_normalized(self):
         """A parameter's fingerprint goes through the serializer."""
-        day = TimedTask(when=np.datetime64("2020-01-01"))
-        nanosecond = TimedTask(when=np.datetime64("2020-01-01T00:00:00.000000000"))
+        day = TimedValueTask(when=np.datetime64("2020-01-01"))
+        nanosecond = TimedValueTask(when=np.datetime64("2020-01-01T00:00:00.000000000"))
         assert day.fingerprint == nanosecond.fingerprint
 
     def test_none_parameters_dropped(self):
         """A parameter left at None is the same call as one left out."""
-        assert TimedTask(when=None).fingerprint == TimedTask().fingerprint
+        assert TimedValueTask(when=None).fingerprint == TimedValueTask().fingerprint
 
     def test_array_parameter(self):
         """An array parameter is hashed by its values."""
-        first = TimedTask(when=np.arange(3))
-        assert first.fingerprint != TimedTask(when=np.arange(4)).fingerprint
-        assert first.fingerprint == TimedTask(when=np.arange(3)).fingerprint
+        first = TimedValueTask(when=np.arange(3))
+        assert first.fingerprint != TimedValueTask(when=np.arange(4)).fingerprint
+        assert first.fingerprint == TimedValueTask(when=np.arange(3)).fingerprint
 
     def test_nested_task_parameter(self):
         """A task given to a task is part of its parameters."""
-        first = TimedTask(when=Scale(factor=2))
-        assert first.fingerprint != TimedTask(when=Scale(factor=3)).fingerprint
-        assert first.fingerprint == TimedTask(when=Scale(factor=2)).fingerprint
+        first = TimedValueTask(when=ScaleTask(factor=2))
+        assert first.fingerprint != TimedValueTask(when=ScaleTask(factor=3)).fingerprint
+        assert first.fingerprint == TimedValueTask(when=ScaleTask(factor=2)).fingerprint
 
 
 class TestEquality:
@@ -176,28 +190,29 @@ class TestEquality:
 
     def test_equal_tasks(self):
         """Two tasks with the same parameters are the same task."""
-        assert Scale(factor=2) == Scale(factor=2)
+        assert ScaleTask(factor=2) == ScaleTask(factor=2)
 
     def test_different_params(self):
         """Two calls of one task are not each other."""
-        assert Scale(factor=2) != Scale(factor=3)
+        assert ScaleTask(factor=2) != ScaleTask(factor=3)
 
     def test_different_classes(self):
         """Two classes holding the same field values are not equal."""
-        assert Scale(factor=1) != VersionedScale(factor=1)
+        assert ScaleTask(factor=1) != VersionedScaleTask(factor=1)
 
     def test_not_a_task(self):
-        """Something which is not a task is not equal to one."""
-        assert Scale(factor=1) != "Scale(factor=1)"
+        """Comparison with something else is left to the something else."""
+        assert ScaleTask(factor=1).__eq__("ScaleTask(factor=1)") is (NotImplemented)
 
     def test_hashes_with_equality(self):
         """Equal tasks land in the same place in a set."""
-        assert len({Scale(factor=2), Scale(factor=2)}) == 1
-        assert len({Scale(factor=2), Scale(factor=3)}) == 2
+        assert len({ScaleTask(factor=2), ScaleTask(factor=2)}) == 1
+        assert len({ScaleTask(factor=2), ScaleTask(factor=3)}) == 2
 
     def test_hashable_with_array_params(self):
-        """A task holding an array is still hashable."""
-        assert hash(TimedTask(when=np.arange(3))) is not None
+        """A task holding an array hashes, where its fields alone could not."""
+        first = TimedValueTask(when=np.arange(3))
+        assert hash(first) == hash(TimedValueTask(when=np.arange(3)))
 
 
 class TestUpdate:
@@ -205,7 +220,7 @@ class TestUpdate:
 
     def test_returns_new_task(self):
         """Updating leaves the original alone."""
-        first = Scale(factor=2)
+        first = ScaleTask(factor=2)
         second = first.update(factor=3)
         assert first.factor == 2
         assert second.factor == 3
@@ -213,12 +228,12 @@ class TestUpdate:
     def test_validates(self):
         """An update goes through validation."""
         with pytest.raises(ValidationError):
-            Scale(factor=2).update(factor="not a number")
+            ScaleTask(factor=2).update(factor="not a number")
 
     def test_unknown_parameter(self):
         """A task refuses a parameter it does not have."""
         with pytest.raises(ValidationError):
-            Scale(factor=2).update(not_a_field=1)
+            ScaleTask(factor=2).update(not_a_field=1)
 
 
 class TestDocuments:
@@ -226,65 +241,82 @@ class TestDocuments:
 
     def test_round_trip(self):
         """A task rebuilt from its document is the same task."""
-        original = Scale(factor=2)
+        original = ScaleTask(factor=2)
         assert Task.from_dict(original.to_dict()) == original
 
     def test_names_the_class_by_tag(self):
         """A document names a registered tag, not an import path."""
-        document = Scale(factor=2).to_dict()
-        assert document["object_type"] == "tests:Scale"
+        document = ScaleTask(factor=2).to_dict()
+        assert document["object_type"] == "tests:ScaleTask"
 
     def test_code_path_is_a_hint(self):
         """The import hint is written but does not change the fingerprint."""
-        document = Scale(factor=2).to_dict()
+        document = ScaleTask(factor=2).to_dict()
         assert "code_path" in document
         document["code_path"] = "somewhere:else"
-        assert _fingerprint_of(document) == Scale(factor=2).fingerprint
+        assert _fingerprint_of(document) == ScaleTask(factor=2).fingerprint
+
+    def test_local_class_refused(self):
+        """A task class defined in a function cannot be written down."""
+
+        def local(value=1):
+            """A function defined inside a test."""
+            return value
+
+        with pytest.raises(ParameterError, match="module level"):
+            make_function_task_class(local)().to_dict()
+
+    def test_version_change_warns(self):
+        """Reading a document written by another version says so."""
+        document = ScaleTask(factor=2).to_dict()
+        document["version"] = "0.5"
+        with pytest.warns(DASCoreWarning, match="version"):
+            Task.from_dict(document)
 
     def test_unknown_tag_raises(self):
         """A tag nothing registers is an error, not an import."""
-        document = Scale(factor=2).to_dict()
+        document = ScaleTask(factor=2).to_dict()
         document["object_type"] = "NotATaskAnyoneHas"
         with pytest.raises(InvalidModelTagError):
             Task.from_dict(document)
 
     def test_tag_naming_another_model(self):
         """A tag which names something other than a task is refused."""
-        document = Scale(factor=2).to_dict()
+        document = ScaleTask(factor=2).to_dict()
         document["object_type"] = "PatchAttrs"
         with pytest.raises(ParameterError, match="not a Task"):
             Task.from_dict(document)
 
     def test_nested_task_round_trip(self):
         """A task given to a task comes back as itself."""
-        original = TimedTask(when=Scale(factor=2))
-        assert Task.from_dict(original.to_dict()).when == Scale(factor=2)
+        original = TimedValueTask(when=ScaleTask(factor=2))
+        assert Task.from_dict(original.to_dict()).when == ScaleTask(factor=2)
 
     def test_nested_task_fingerprint_cannot_decode(self):
         """A nested task hashed for a fingerprint cannot be read back."""
-        encoded = encode(Scale(factor=2))
+        encoded = encode(ScaleTask(factor=2))
         with pytest.raises(ParameterError, match="cannot be read back"):
             decode(encoded)
 
     def test_declared_tuple_field(self):
         """A JSON list comes back a tuple where the field says tuple."""
-        original = TupleTask(values=(1, 2))
+        original = TupleFieldTask(values=(1, 2))
         assert Task.from_dict(original.to_dict()).values == (1, 2)
 
     def test_undeclared_sequence_stays_a_list(self):
         """A field which promises nothing gets the list a document holds."""
-        assert Task.from_dict(TimedTask(when=(1, 2)).to_dict()).when == [1, 2]
+        assert Task.from_dict(TimedValueTask(when=(1, 2)).to_dict()).when == [1, 2]
 
     def test_time_parameter_round_trip(self):
         """A parameter the serializer tags comes back as itself."""
-        original = TimedTask(when=np.datetime64("2020-01-01"), where=slice(1, 2))
+        original = TimedValueTask(when=np.datetime64("2020-01-01"), where=slice(1, 2))
         rebuilt = Task.from_dict(original.to_dict())
         assert rebuilt.when == original.when
         assert rebuilt.where == original.where
 
     def test_document_is_json_safe(self):
         """A document holds only what JSON can write."""
-        document = TimedTask(when=np.arange(3)).to_dict()
+        document = TimedValueTask(when=np.arange(3)).to_dict()
         assert json.loads(json.dumps(document)) == document
 
 
@@ -293,20 +325,39 @@ class TestPickle:
 
     def test_round_trip(self):
         """A task survives a pickle."""
-        original = Scale(factor=2)
+        original = ScaleTask(factor=2)
         assert pickle.loads(pickle.dumps(original)) == original
 
     def test_synthesized_class(self):
         """A class no attribute path names still pickles, by its tag."""
-        original = add(first=1, second=2)
+        original = add_numbers(first=1, second=2)
         assert pickle.loads(pickle.dumps(original)) == original
 
+    @pytest.mark.concurrency
     def test_across_processes(self):
-        """A task rebuilt in another process fingerprints the same."""
-        original = Scale(factor=2)
-        with ProcessPoolExecutor(max_workers=1) as pool:
-            out = pool.submit(_fingerprint_of, original.to_dict()).result()
+        """A task pickled into another process fingerprints the same."""
+        original = ScaleTask(factor=2)
+        # Spawn rather than the platform default: the task has to survive
+        # being rebuilt in an interpreter which shares nothing with this one.
+        context = multiprocessing.get_context("spawn")
+        with ProcessPoolExecutor(max_workers=1, mp_context=context) as pool:
+            out = pool.submit(_fingerprint, original).result()
         assert out == original.fingerprint
+
+    def test_callable_parameter(self):
+        """A parameter a document cannot hold still pickles."""
+        original = add_numbers(first=1, second=np.mean)
+        assert pickle.loads(pickle.dumps(original)) == original
+
+    def test_local_class_refused(self):
+        """A class no document could name says so when it is pickled."""
+
+        def local(value=1):
+            """A function defined inside a test."""
+            return value
+
+        with pytest.raises(ParameterError, match="module level"):
+            pickle.dumps(make_function_task_class(local)())
 
 
 class TestIntern:
@@ -314,17 +365,17 @@ class TestIntern:
 
     def test_returns_one_instance(self):
         """Equal tasks intern to one object."""
-        assert intern(Scale(factor=2)) is intern(Scale(factor=2))
+        assert intern(ScaleTask(factor=2)) is intern(ScaleTask(factor=2))
 
     def test_keeps_them_apart(self):
         """Tasks which are not equal keep their own instances."""
-        assert intern(Scale(factor=2)) is not intern(Scale(factor=3))
+        assert intern(ScaleTask(factor=2)) is not intern(ScaleTask(factor=3))
 
     def test_first_wins(self):
         """The instance which arrived first is the one handed back."""
-        first = Scale(factor=4)
+        first = ScaleTask(factor=4)
         assert intern(first) is first
-        assert intern(Scale(factor=4)) is first
+        assert intern(ScaleTask(factor=4)) is first
 
 
 class TestRun:
@@ -333,11 +384,11 @@ class TestRun:
     def test_base_class_has_no_body(self):
         """A task which does not implement run says so."""
         with pytest.raises(NotImplementedError, match="does not implement run"):
-            Shift(offset=1).run(1)
+            ShiftTask(offset=1).run(1)
 
     def test_subclass_body(self):
         """A subclass runs what it implements."""
-        assert Scale(factor=2).run(3) == 6
+        assert ScaleTask(factor=2).run(3) == 6
 
 
 class TestFunctionTasks:
@@ -345,38 +396,54 @@ class TestFunctionTasks:
 
     def test_class_name(self):
         """The class is named for the function, in camel case."""
-        assert make_function_task_class(every_kind).__name__ == "EveryKind"
+        assert EveryKind.__name__ == "EveryKind"
 
     def test_docstring_kept(self):
         """The class carries the function's docstring."""
-        assert add.__doc__ == "Add two numbers."
+        assert add_numbers.__doc__ == "Add two numbers."
 
     def test_runs_the_function(self):
         """Running the task calls the function with its fields."""
-        assert add(first=1, second=2).run() == 3
+        assert add_numbers(first=1, second=2).run() == 3
 
     def test_defaults(self):
         """A parameter's default becomes the field's default."""
-        assert add(first=1).run() == 2
+        assert add_numbers(first=1).run() == 2
 
     def test_required_parameter(self):
         """A parameter with no default is required."""
         with pytest.raises(ValidationError):
-            add()
+            add_numbers()
 
     def test_version(self):
         """The decorator's version reaches the class."""
-        assert multiply.__version__ == "2.0"
-        assert multiply(first=2).run() == 4
+        assert multiply_numbers.__version__ == "2.0"
+        assert multiply_numbers(first=2).run() == 4
 
     def test_extra_input_passed_first(self):
         """Arguments given to run are passed before the stored ones."""
-        double = make_function_task_class(every_kind, skip_first=True)
-        assert double(normal=5).run("given")[0] == "given"
+        assert SkipsFirst(normal=5).run("given")[0] == "given"
 
     def test_field_default_resolved(self):
         """A default spelled as a pydantic Field is the value it holds."""
         assert WithFieldDefault().value == 7
+
+    def test_call_plan(self):
+        """Only what cannot go by name is passed positionally."""
+        # `positional` is positional-only, and `normal` precedes the *args
+        # group, so both have to be passed in order; the rest go by name.
+        assert EveryKind._positional_names == (
+            ("positional", False),
+            ("normal", False),
+            ("rest", True),
+        )
+        assert EveryKind._keyword_names == ("named",)
+
+    def test_keyword_parameters_passed_by_name(self):
+        """A parameter which can go by name does, whatever its position."""
+        cls = make_function_task_class(lambda first=1, second=2: (first, second))
+        assert cls._positional_names == ()
+        assert cls._keyword_names == ("first", "second")
 
     def test_all_parameter_kinds(self):
         """Every kind of parameter survives the trip through a task."""
@@ -389,10 +456,18 @@ class TestFunctionTasks:
         )
         assert instance.run() == ("p", 5, (1, 2), 9, {"an_extra": "e"})
 
+    def test_extras_are_parameters(self):
+        """What a **kwargs group collects is part of the task."""
+        first = EveryKind(positional="p", an_extra=1)
+        assert first.fingerprint != EveryKind(positional="p", an_extra=2).fingerprint
+        assert first.fingerprint != EveryKind(positional="p").fingerprint
+        assert Task.from_dict(first.to_dict()) == first
+        assert pickle.loads(pickle.dumps(first)) == first
+
     def test_extras_allowed_only_with_kwargs(self):
         """A function without **kwargs makes a task which refuses extras."""
         with pytest.raises(ValidationError):
-            add(first=1, not_a_parameter=2)
+            add_numbers(first=1, not_a_parameter=2)
 
     def test_from_call_matches_construction(self):
         """A task built from a call equals the task built by hand."""
@@ -402,15 +477,28 @@ class TestFunctionTasks:
         )
         assert from_call.fingerprint == by_hand.fingerprint
 
+    def test_mutable_default_not_shared(self):
+        """A task does not hold the function's own default object."""
+
+        def mutable(value=[]):
+            """Take a mutable default, as a careless caller might."""
+            return value
+
+        cls = make_function_task_class(mutable)
+        first = cls._from_call((), {})
+        first.value.append("changed")
+        assert cls._from_call((), {}).value == []
+
     def test_from_call_applies_defaults(self):
         """A call which leaves a parameter out still records its value."""
         assert (
-            add._from_call((1,), {}).fingerprint == add(first=1, second=1).fingerprint
+            add_numbers._from_call((1,), {}).fingerprint
+            == add_numbers(first=1, second=1).fingerprint
         )
 
     def test_from_call_skips_first(self):
         """The input a task is given is not one of its parameters."""
-        cls = make_function_task_class(every_kind, skip_first=True)
+        cls = SkipsFirst
         assert "positional" not in cls.model_fields
         # The arguments are the ones left after the input, as _call_args
         # gives them back.
@@ -425,17 +513,6 @@ class TestFunctionTasks:
 
         cls = make_function_task_class(shadowing)
         assert cls().run() is True
-
-    def test_defined_in_a_function_is_not_registered(self):
-        """A class which only exists inside a call cannot be named."""
-
-        def local(value=1):
-            """A function defined inside a test."""
-            return value
-
-        cls = make_function_task_class(local)
-        with pytest.raises(InvalidModelTagError):
-            Task.from_dict(cls().to_dict())
 
 
 class TestTaskDecorator:
@@ -465,10 +542,6 @@ class TestTaskDecorator:
 class TestTag:
     """Tests for what names a task."""
 
-    def test_dascore_tags_are_bare(self):
-        """A model registers under a bare name inside dascore."""
-        assert dc.PatchAttrs().model_dump(mode="json")["object_type"] == "PatchAttrs"
-
     def test_task_tag(self):
         """A task outside dascore is namespaced by its package."""
-        assert Scale(factor=1).tag == "tests:Scale"
+        assert ScaleTask(factor=1).tag == "tests:ScaleTask"


### PR DESCRIPTION
## Description

Second PR of the processors series (after #929), and the first to add anything. It lands the core of `dascore.workflow`: a `Task`, and the canonical serializer a task's fingerprint is taken with. Nothing else in DASCore uses either yet; `Pipe` and `Provenance` follow in the next PR, and `PatchProcessor` in the one after.

A `Task` is a frozen pydantic model whose fields are the parameters of one operation. Because the parameters *are* the object, a task can be compared, hashed, put in a set, written to a document, read back, pickled across processes, and identified by a fingerprint:

```python
class Normalize(Task):
    dim: str = "time"
    norm: str = "l2"

    def run(self, patch):
        ...

task = Normalize(dim="time")
task.fingerprint          # 'c0ffee...' -- the same 16 hex characters in any process
task == Normalize(dim="time")
Task.from_dict(task.to_dict()) == task
```

The fingerprint names three things and nothing else: the class, spelled `package:ClassName`; its `__version__`; and its parameters, canonically encoded. It deliberately does not name the module the class lives in, the source of its body, or the backend which will run it. Moving `Normalize` between modules, or giving it a faster kernel, does not make it a different operation; changing what the same parameters mean does, and that is what a version bump says.

### What is here

- `dascore/workflow/serialize.py` — `encode`, `decode`, `canonical_json`, `digest`, `combine_hashes`. One digest everywhere: `blake2b(digest_size=8)`, written as 16 hex characters. Two modes: `"fingerprint"` encodes for hashing (an array becomes a digest of its bytes, a value left at `None` is dropped), `"document"` encodes for storage (an array becomes a nested list, nothing is dropped, and most values read back — a function, a partial, a dataframe or an opaque value cannot, and say so).
- `dascore/workflow/task.py` — `Task`, `FunctionTask`, `make_function_task_class`, the `@task` decorator, and `intern`.
- `dascore/workflow/__init__.py`, `tests/test_workflow/{test_serialize,test_task}.py`.

Stability rests on `json`, `repr` of a float, numpy's byte layout and blake2b, all of which are committed-stable across Python versions — and, for frames and quantities only, on pandas' object hash and pint's short unit format. Python's own `hash` is never used: it is salted per process. A hard-coded digest and a hard-coded task fingerprint are pinned in the tests, so a change to any link in that chain fails rather than silently renaming every stored id.

### The encoding, briefly

`bool` is tagged so `True` is not `1`; `NaN` and the infinities are tagged, since JSON cannot spell them; every time normalizes to nanoseconds — numpy's, python's, and pandas' alike — so neither the unit nor the type a time was written as changes the answer; arrays normalize to little-endian, so byte order does not either; a `Quantity` keeps the unit it was written in, because `1 m` and `100 cm` are the same length but not the same call; a path is its POSIX spelling; a set is sorted; `complex` and `bytes` have tags of their own; a callable is named by `module:qualname`, plus a digest of its source when it is a lambda or defined inside a function. A mapping which itself holds a `"$"` key is written in an escaped form, so a user dict can never be mistaken for a tag.

Arrays are always hashed in full — correctness over speed — through `hash_array`, which is the tree's one array hash. A value with no encoding of its own is named by its class, never by its `repr` (which would hold an address), and warns: a fingerprint that cannot see a parameter's value is one two different calls can share.

### Tasks from functions

`make_function_task_class(func)` builds a `Task` subclass whose fields are the function's parameters; `@task` is the decorator spelling of it. Every kind of parameter python has is handled: positional-only, `*args` (a tuple field), keyword-only, `**kwargs` (extras, via `extra="allow"`), and defaults spelled as `Field(default=...)`. `skip_first=True` leaves the first parameter out, which is how PR 3 will make a processor out of a patch function whose first parameter is the patch. How the wrapped function is called back is worked out once, when the class is made, rather than by inspecting the signature on every call.

## Changelog

- none

## Review response

Five independent reviewers (correctness, test vacuity, blast radius, redundancy, prose) read the diff. Every finding below was reproduced before it was fixed, and the fix verified after. The Codex leg could not run: the CLI is over its usage limit until Aug 20.

Fixed, in rough order of severity:

- **The array digest cache went stale on in-place mutation** — flagged independently by all five reviewers. `digest(a)`, `a[0] = 1`, `digest(a)` returned the same value, so the reused-mask-in-a-loop pattern the cache existed to speed up was exactly the pattern it broke. The cache is gone, and `hash_array` (`dascore/utils/array.py`) now does the hashing through a deferred import, so the tree has one array hash rather than two. The plan asked for the cache; it can come back keyed on something safe once there is a caller and a benchmark to justify it.
- **Values with no encoding collapsed onto their type name.** `datetime.datetime`, `pd.Timestamp`, `datetime.timedelta`, `pd.Timedelta`, `complex` and `bytes` all fell through to `$opaque`, so every `select(time=(t1, t2))` written with python datetimes — idiomatic DASCore — shared one fingerprint. All six now encode properly, and the remaining `$opaque` fallback warns rather than silently reducing a value to its class.
- **A dataframe hashed its values but not its column labels**, so `coords_from_df` — the one caller — built differently *named* coords under one fingerprint. Labels and dtypes are now part of the digest.
- **A mapping could spoof a tag.** `{"$datetime64": 0}` as a user dict encoded byte-identically to a real `datetime64`, and came back as one. Any mapping holding a `"$"` key is now written in the escaped `$dict` form, which round trips and cannot collide.
- **`__reduce__` was weaker than pydantic's own pickling.** Routing through the document meant a task holding a callable pickled fine and failed on *load*, in the child process, and a 1e6-element array param took ~77× longer. Pickling now carries the class by tag and the parameters as themselves, so pickle handles what a document cannot.
- **A task no reader could resolve wrote a document anyway** — a class defined inside a function, or one whose tag two classes claim. Both now raise where the task is written, naming the cause, rather than failing later in whoever reads it.
- **`_from_call` shared the wrapped function's mutable default object** between every task built from it. Dropping `apply_defaults()` lets pydantic supply (and copy) the default instead.
- **Document-mode arrays were lossy** for non-nanosecond `datetime64`/`timedelta64` and `complex` dtypes, and a 0-d object array crashed with a bare `TypeError`. Time arrays now normalize to nanoseconds like scalar times do, and are written as the counts they are stored as.
- **`intern` retained tasks strongly**, pinning any array parameter for the life of the process. It is a `WeakValueDictionary` now: interning shares one object, it does not keep it alive.
- **Doctest and test classes squatted generic registry tags.** A `Scale(Task)` defined in a doctest registers in the bare `dascore` namespace, where a later collision *raises* at import. The examples and test classes now use distinctive names.
- Smaller: `_is_task` duck-typing replaced with a deferred `isinstance` (`BaseCoord` was one attribute away from being mistaken for a task); `_decode_model` now fails through `resolve_tagged_model`, the same way `Task.from_dict` does; `from_dict` warns when a document names another version of the task; a time outside the nanosecond range raises `ParameterError` rather than `OverflowError`.

Test changes from the vacuity review: assertions that could not fail are gone or strengthened (`hash(...) is not None`, `isinstance(digest(...), str)`, a set of small ints that was already sorted, a quantity comparison that passed for the wrong reason), the cross-process test now really pickles a task through a spawned interpreter, and new tests cover the call plan, extras, `mode`, and mutable defaults.

Not acted on, deliberately:

- **The 64-bit digest.** `blake2b(digest_size=8)` is what the plan specifies everywhere, and equality rides on it. Worth revisiting as a series-wide decision rather than here.
- **Two fingerprint systems.** `BaseCoord.fingerprint` (sha256, unit-normalized, persisted in the index) and `Task.fingerprint` (blake2b-8, unit-preserving) now coexist and answer differently for the same coord. Which is canonical is a design question for a later PR.
- **Synthesized class names could collide at import** (`_camel_case(func.__name__)` ignores the module). The plan handles this with a uniqueness test over dascore in PR 3, where the first synthesized classes appear.

## Decisions made

Where the plan under-specified something:

1. **A `Patch` operand has no encoding yet.** The plan encodes one as its `{patch_id, processing_id}` pair. Those attributes arrive in PR 4a; encoding a patch before they exist would mean inventing a second answer and then replacing it. A patch currently encodes as an opaque value, and PR 4a adds the pair.

2. **A dataframe has no document form.** It is hashed with `hash_pandas_object` for a fingerprint, as the plan says. Writing one into a saved pipe, with its dtypes and its index, is a storage format rather than a parameter encoding, so `encode(df, mode="document")` raises.

3. **`decode` refuses what a document cannot carry**: a callable, a `functools.partial` (which holds one), a dataframe, an opaque value, and an array or task which was encoded for a fingerprint rather than for a document. Each raises `ParameterError` naming what happened, rather than handing back the tagged mapping that stands for it — and, in the callable's case, rather than importing whatever a document names, which the model registry refuses to do for exactly the same reason.

4. **A task's document carries its `version`, and reading one does not check it.** A stored pipe from an older release should still load and run; the version already did its work by changing the fingerprint.

5. **`_from_call(args, kwargs)` takes the arguments after the input.** With `skip_first=True` the first parameter is the patch, which is not one of the task's parameters, so the call and `_call_args` agree on what the arguments are.

6. **`Task.tag` may be None.** It is whatever the model registry calls the class, and the registry cannot name a parametrized generic. Such a task still fingerprints (it is spelled out by hand there); its document simply cannot be read back.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
