### PR TITLE
Give the JupyterLite link the Jupyter mark and a proper button

### DIFF
--- a/docs/filters/lite_button.lua
+++ b/docs/filters/lite_button.lua
@@ -6,6 +6,20 @@ scripts/build_notebooks.py, so pages without code cells (and renders that
 skipped the notebook build) simply do not get one.
 ]]
 
+--[[
+The Jupyter logo mark, from https://github.com/jupyter/design (BSD-3-Clause),
+flattened out of its Figma export. It is inlined rather than shipped in
+_static because quarto only copies assets it can see referenced from rendered
+markdown, and it never sees the raw html a filter inserts.
+]]
+local JUPYTER_LOGO = [[<svg class="lite-launch-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39 51" aria-hidden="true" focusable="false">
+<path class="jupyter-planet" fill="#767677" transform="translate(31.30 0.31)" d="M 5.89353 2.844C 5.91889 3.43165 5.77085 4.01367 5.46815 4.51645C 5.16545 5.01922 4.72168 5.42015 4.19299 5.66851C 3.6643 5.91688 3.07444 6.00151 2.49805 5.91171C 1.92166 5.8219 1.38463 5.5617 0.954898 5.16401C 0.52517 4.76633 0.222056 4.24903 0.0839037 3.67757C -0.0542483 3.10611 -0.02123 2.50617 0.178781 1.95364C 0.378793 1.4011 0.736809 0.920817 1.20754 0.573538C 1.67826 0.226259 2.24055 0.0275919 2.82326 0.00267229C 3.60389 -0.0307115 4.36573 0.249789 4.94142 0.782551C 5.51711 1.31531 5.85956 2.05676 5.89353 2.844Z"/>
+<path class="jupyter-body" fill="#F37726" transform="translate(1.74 30.98)" d="M 18.2646 7.13411C 10.4145 7.13411 3.55872 4.2576 0 0C 1.32539 3.8204 3.79556 7.13081 7.0686 9.47303C 10.3417 11.8152 14.2557 13.0734 18.269 13.0734C 22.2823 13.0734 26.1963 11.8152 29.4694 9.47303C 32.7424 7.13081 35.2126 3.8204 36.538 0C 32.9705 4.2576 26.1148 7.13411 18.2646 7.13411Z"/>
+<path class="jupyter-body" fill="#F37726" transform="translate(1.73 4.48)" d="M 18.2733 5.93931C 26.1235 5.93931 32.9793 8.81583 36.538 13.0734C 35.2126 9.25303 32.7424 5.94262 29.4694 3.6004C 26.1963 1.25818 22.2823 0 18.269 0C 14.2557 0 10.3417 1.25818 7.0686 3.6004C 3.79556 5.94262 1.32539 9.25303 0 13.0734C 3.56745 8.82463 10.4232 5.93931 18.2733 5.93931Z"/>
+<path class="jupyter-planet" fill="#989798" transform="translate(1.80 42.81)" d="M 7.42789 3.58338C 7.46008 4.3243 7.27355 5.05819 6.89193 5.69213C 6.51031 6.32607 5.95075 6.83156 5.28411 7.1446C 4.61747 7.45763 3.87371 7.56414 3.14702 7.45063C 2.42032 7.33712 1.74336 7.0087 1.20184 6.50695C 0.660328 6.0052 0.27861 5.35268 0.105017 4.63202C -0.0685757 3.91135 -0.0262361 3.15494 0.226675 2.45856C 0.479587 1.76217 0.931697 1.15713 1.52576 0.720033C 2.11983 0.282935 2.82914 0.0334395 3.56389 0.00313344C 4.54667 -0.0374033 5.50529 0.316706 6.22961 0.987835C 6.95393 1.65896 7.38484 2.59235 7.42789 3.58338L 7.42789 3.58338Z"/>
+<path class="jupyter-planet" fill="#6F7070" transform="translate(0.36 5.06)" d="M 2.27471 4.39629C 1.84363 4.41508 1.41671 4.30445 1.04799 4.07843C 0.679268 3.8524 0.385328 3.52114 0.203371 3.12656C 0.0214136 2.73198 -0.0403798 2.29183 0.0258116 1.86181C 0.0920031 1.4318 0.283204 1.03126 0.575213 0.710883C 0.867222 0.39051 1.24691 0.164708 1.66622 0.0620592C 2.08553 -0.0405897 2.52561 -0.0154714 2.93076 0.134235C 3.33591 0.283941 3.68792 0.551505 3.94222 0.90306C 4.19652 1.25462 4.34169 1.67436 4.35935 2.10916C 4.38299 2.69107 4.17678 3.25869 3.78597 3.68746C 3.39516 4.11624 2.85166 4.37116 2.27471 4.39629L 2.27471 4.39629Z"/>
+</svg>]]
+
 --- Return the file's name without its tutorial directory or extension.
 local function tutorial_stem(input)
   return input and input:match("tutorial/([^/]+)%.qmd$")
@@ -49,7 +63,8 @@ function Pandoc(doc)
     '" target="_blank" rel="noopener" title="',
     "Runs DASCore in your browser with WebAssembly. Nothing is installed on ",
     'your computer, and the first load takes a moment.">',
-    "Open in JupyterLite",
+    JUPYTER_LOGO,
+    "<span>Open in JupyterLite</span>",
     "</a>",
   })
   table.insert(doc.blocks, 1, pandoc.RawBlock("html", html))

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -79,20 +79,43 @@ tbody tr:nth-child(odd) {
 
 /* Link added to tutorial pages by filters/lite_button.lua, which opens the
    page as a live notebook in the JupyterLite site. */
+/* The "Open in JupyterLite" launcher at the top of runnable tutorials. Greys
+are given as translucent neutrals so one rule serves the light and dark
+themes. */
 .lite-launch {
-    display: inline-block;
-    margin-bottom: 1.2rem;
-    padding: 0.35rem 0.8rem;
-    border: 1px solid rgb(190, 190, 190);
-    border-radius: 4px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55em;
+    margin-bottom: 1.4rem;
+    padding: 0.4rem 0.9rem 0.4rem 0.7rem;
+    border: 1px solid rgba(128, 128, 128, 0.4);
+    border-radius: 999px;
+    background-color: rgba(128, 128, 128, 0.08);
+    /* Without this the label takes the theme's link colour and the button
+    reads as a stray link someone drew a box around. */
+    color: inherit;
     font-size: 0.85rem;
+    font-weight: 500;
+    line-height: 1.25;
+    text-decoration: none;
+    transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.lite-launch:hover,
+.lite-launch:focus-visible {
+    border-color: #f37726;
+    background-color: rgba(243, 119, 38, 0.12);
+    color: inherit;
     text-decoration: none;
 }
 
-.lite-launch::before {
-    content: "▶ ";
+.lite-launch-logo {
+    height: 1.4em;
+    width: auto;
+    flex: none;
 }
 
-.lite-launch:hover {
-    border-color: rgb(120, 120, 120);
+/* The mark's stock planets are mid-grey and sink into the dark theme. */
+body.quarto-dark .lite-launch .jupyter-planet {
+    fill: #c9c9c9;
 }


### PR DESCRIPTION
## Description

The "Open in JupyterLite" link added in #922 rendered as a stray link someone had drawn a box around: the label and its `▶` prefix both took the theme's link colour (blue under yeti, green under darkly) inside a plain grey rectangle.

It now carries the Jupyter logo mark and sits in a neutral pill that inherits the body text colour, with the border and background tinting Jupyter orange on hover and keyboard focus.

Two details worth recording, since both are the kind of thing that fails quietly:

- **The mark is inlined rather than shipped in `docs/_static`.** Quarto only copies assets it can see referenced from rendered markdown, and it never sees the raw html a filter inserts. `_static/logo.svg` is already a 404 on the deployed site for exactly this reason, so an `<img>` would have rendered as a broken image. Inlining also lets `styles.css` lighten the mark's grey planets under the dark theme, where they otherwise sink into the background.
- **Quarto lowercases `viewBox` to `viewbox`** on the way out. That is harmless — the html parser case-corrects attributes in foreign content — but it looks alarming in the generated html, so it is noted here. Verified in a real project render: `getAttribute("viewBox")` returns `0 0 39 51` and the mark draws at the correct aspect ratio.

The logo mark comes from [jupyter/design](https://github.com/jupyter/design) (BSD-3-Clause), flattened out of its Figma `<use>`/`defs` export into five plain paths.

Checked by rendering a minimal quarto project with the filter and screenshotting the result in both themes, plus hover and focus states.

## Changelog

- changed: the tutorials' "Open in JupyterLite" link now carries the Jupyter logo mark and is styled as a button rather than a boxed link.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- No tests: the change is presentational, and its only failure modes are a dim or missing logo. There is no automated visual check for the docs site, so a test here would assert the markup against itself. -->
