### PR TITLE
Add the pipe and the two records of provenance

### DIFF
--- a/dascore/core/annotation_loader.py
+++ b/dascore/core/annotation_loader.py
@@ -40,7 +40,6 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-import yaml
 from pydantic import ValidationError
 
 from dascore.core.annotations import (
@@ -61,6 +60,7 @@ from dascore.core.annotations import (
 )
 from dascore.exceptions import InvalidAnnotationError, ParameterError
 from dascore.models.registry import TAG_FIELD
+from dascore.utils.documents import read_document
 from dascore.utils.misc import iterate
 from dascore.utils.paths import quote_path
 from dascore.utils.tables import (
@@ -103,32 +103,18 @@ BLESSED_NAME = ".annotations"
 
 def _read_object(path: Path) -> dict[str, Any]:
     """Parse one YAML or JSON object file into a mapping."""
-    try:
-        text = path.read_text(encoding="utf-8-sig")
-    except (OSError, UnicodeDecodeError) as error:
-        msg = f"Could not read {quote_path(path)}: {error}."
-        raise ParameterError(msg) from error
     # The suffix is casefolded, as the inventory casefolds its own: an
     # attrs.JSON is the file attrs.json would be, and reading it as YAML
     # for its spelling would fail on a document which is not wrong. The
     # stem is not: the part names are exact, as every other name a format
     # reserves is.
-    if path.suffix.casefold() == OBJECT_SUFFIXES[0]:
-        try:
-            data = json.loads(text)
-        except ValueError as error:
-            msg = f"Could not parse JSON from {quote_path(path)}: {error}."
-            raise ParameterError(msg) from error
-    else:
-        try:
-            data = yaml.safe_load(text)
-        except yaml.YAMLError as error:
-            msg = f"Could not parse YAML from {quote_path(path)}: {error}."
-            raise ParameterError(msg) from error
-    if not isinstance(data, Mapping):
-        msg = f"{quote_path(path)} holds no mapping, so it states no attributes."
-        raise ParameterError(msg)
-    return dict(data)
+    is_json = path.suffix.casefold() == OBJECT_SUFFIXES[0]
+    return read_document(
+        path,
+        "json" if is_json else "yaml",
+        error=ParameterError,
+        holds="states no attributes",
+    )
 
 
 def _entries(directory: Path) -> list[Path]:

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -51,6 +51,7 @@ from dascore.models import (
     PositiveFiniteFloat,
     UnitQuantity,
 )
+from dascore.utils.documents import write_document
 from dascore.utils.intervals import normalize_value, value_kind
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import iterate, to_str, validate_acquisition_key
@@ -1879,8 +1880,7 @@ def save_annotation_set(
     # under it -- then leaves the set it was replacing still in the
     # directory, and a reader finds two spellings of one part and says
     # so, rather than finding the set gone.
-    with open(attrs_file, "w") as stream:
-        json.dump(document, stream, indent=2)
+    write_document(document, attrs_file, "json")
     for stem, payload in spelled.items():
         _write_spelled(payload, directory / f"{stem}{suffix}")
     for stale in superseded:

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -34,7 +34,6 @@ from typing import (
 from uuid import uuid4
 
 import numpy as np
-import yaml
 from pydantic import (
     AfterValidator,
     BeforeValidator,
@@ -54,7 +53,11 @@ from dascore.models import (
     TimeRangedModel,
     UnitQuantity,
 )
-from dascore.utils.documents import parse_document, write_document
+from dascore.utils.documents import (
+    dump_document,
+    parse_document,
+    write_text_document,
+)
 from dascore.utils.intervals import (
     clip_intervals,
     interval_masks,
@@ -2542,7 +2545,9 @@ def inventory_to_yaml(inventory: Inventory, path: str | Path | None = None) -> s
 
     A field still holding its default is left out, so the document
     states what the inventory says rather than every field it has;
-    what is written reloads equal to this inventory.
+    what is written reloads equal to this inventory. A path whose
+    directory is not there yet is made, as it is for every document
+    DASCore writes.
 
     Parameters
     ----------
@@ -2563,6 +2568,7 @@ def inventory_to_yaml(inventory: Inventory, path: str | Path | None = None) -> s
     # envelope it was written against even when that is the default.
     dumped = inventory.model_dump(mode="json", exclude_defaults=True)
     data = {"schema_version": inventory.schema_version} | dumped
+    text = dump_document(data, "yaml")
     if path is not None:
-        return write_document(data, path, "yaml").read_text(encoding="utf-8")
-    return yaml.safe_dump(data, sort_keys=False)
+        write_text_document(text, path)
+    return text

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -54,6 +54,7 @@ from dascore.models import (
     TimeRangedModel,
     UnitQuantity,
 )
+from dascore.utils.documents import parse_document, write_document
 from dascore.utils.intervals import (
     clip_intervals,
     interval_masks,
@@ -2501,14 +2502,15 @@ class Inventory(NamespaceOwner, InventoryModel):
                 "Load a path with dascore.inventory."
             )
             raise InvalidInventoryError(msg)
-        try:
-            data = yaml.safe_load(text)
-        except yaml.YAMLError as error:
-            # A document which does not parse is an invalid inventory, and
-            # says so as one: a caller who asked for an inventory should
-            # not have to know which parser was reaching for the file.
-            msg = f"Could not parse YAML from {_yaml_label(text)}: {error}."
-            raise InvalidInventoryError(msg) from error
+        # A document which does not parse is an invalid inventory, and says
+        # so as one: a caller who asked for an inventory should not have to
+        # know which parser was reaching for the text.
+        data = parse_document(
+            text,
+            "yaml",
+            label=_yaml_label(text),
+            error=InvalidInventoryError,
+        )
         return cls._from_mapping(data, _yaml_label(text))
 
     @classmethod
@@ -2561,8 +2563,6 @@ def inventory_to_yaml(inventory: Inventory, path: str | Path | None = None) -> s
     # envelope it was written against even when that is the default.
     dumped = inventory.model_dump(mode="json", exclude_defaults=True)
     data = {"schema_version": inventory.schema_version} | dumped
-    out = yaml.safe_dump(data, sort_keys=False)
     if path is not None:
-        with open(path, "w") as fh:
-            fh.write(out)
-    return out
+        return write_document(data, path, "yaml").read_text(encoding="utf-8")
+    return yaml.safe_dump(data, sort_keys=False)

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import difflib
 import itertools
-import json
 import os
 import re
 from collections import defaultdict
@@ -41,7 +40,6 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 import pandas as pd
-import yaml
 
 from dascore.core.inventory import (
     Acquisition,
@@ -62,6 +60,7 @@ from dascore.core.inventory import (
 from dascore.exceptions import InvalidInventoryError, ParameterError
 from dascore.models import InventoryModel, TimeRangedModel
 from dascore.models.registry import TAG_FIELD
+from dascore.utils.documents import read_document
 from dascore.utils.misc import check_code
 from dascore.utils.paths import quote_path as _quote
 from dascore.utils.tables import (
@@ -206,27 +205,12 @@ def _read_object(path: Path) -> dict[str, Any]:
     Both spellings share one data model, so the suffix picks the parser
     and decides nothing else.
     """
-    try:
-        text = path.read_text()
-    except (OSError, UnicodeDecodeError) as error:
-        msg = f"Could not read {_quote(path)}: {error}."
-        raise InvalidInventoryError(msg) from error
-    if _object_suffix(path) == ".json":
-        try:
-            data = json.loads(text)
-        except ValueError as error:
-            msg = f"Could not parse JSON from {_quote(path)}: {error}."
-            raise InvalidInventoryError(msg) from error
-    else:
-        try:
-            data = yaml.safe_load(text)
-        except yaml.YAMLError as error:
-            msg = f"Could not parse YAML from {_quote(path)}: {error}."
-            raise InvalidInventoryError(msg) from error
-    if not isinstance(data, Mapping):
-        msg = f"{_quote(path)} holds no mapping, so it defines no object."
-        raise InvalidInventoryError(msg)
-    return dict(data)
+    return read_document(
+        path,
+        "json" if _object_suffix(path) == ".json" else "yaml",
+        error=InvalidInventoryError,
+        holds="defines no object",
+    )
 
 
 def _declared_type(path: Path) -> str | None:

--- a/dascore/utils/documents.py
+++ b/dascore/utils/documents.py
@@ -70,6 +70,22 @@ def read_document(
     return dict(document)
 
 
+def dump_document(
+    document: Mapping,
+    file_format: DocumentFormat,
+) -> str:
+    """
+    Return the text a mapping is written as, in the format named.
+
+    Either spelling keeps the order the document states rather than
+    sorting: a document says what it holds, its own order reads better, and
+    a set written twice reads the same both times.
+    """
+    if file_format == "yaml":
+        return yaml.safe_dump(dict(document), sort_keys=False)
+    return json.dumps(document, indent=2)
+
+
 def write_document(
     document: Mapping,
     path: Path,
@@ -81,14 +97,19 @@ def write_document(
     Parent directories are made as needed, so saving into a directory which
     is not there yet works.
     """
+    text = dump_document(document, file_format)
+    return write_text_document(text, path)
+
+
+def write_text_document(text: str, path: Path) -> Path:
+    """
+    Write a document's text to a file and return the path.
+
+    For a caller which already has the text -- because it hands the same
+    string back -- and would otherwise write it and read it again.
+    """
     path = Path(path)
     _maybe_make_parent_directory(path)
-    if file_format == "yaml":
-        # Written in the order the document states rather than sorted: a
-        # document says what it holds, and its own order reads better.
-        text = yaml.safe_dump(dict(document), sort_keys=False)
-    else:
-        text = json.dumps(document, indent=2, sort_keys=True)
     path.write_text(text, encoding="utf-8")
     return path
 

--- a/dascore/utils/documents.py
+++ b/dascore/utils/documents.py
@@ -1,0 +1,109 @@
+"""
+Reading and writing the small YAML-or-JSON documents DASCore stores.
+
+An inventory object, an annotation set's attributes and a saved workflow are
+all one mapping written as either spelling, so they are read the same way:
+the caller decides which parser its own naming rules call for, and this
+turns whatever comes back into a mapping or says why it could not.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from dascore.exceptions import ParameterError
+from dascore.utils.misc import _maybe_make_parent_directory
+from dascore.utils.paths import quote_path
+
+DocumentFormat = Literal["json", "yaml"]
+
+# Read with the BOM stripped: an editor on Windows writes one, and it is not
+# part of the document.
+ENCODING = "utf-8-sig"
+
+
+def read_document(
+    path: Path,
+    file_format: DocumentFormat,
+    *,
+    error: type[Exception] = ParameterError,
+    holds: str = "describes nothing",
+) -> dict[str, Any]:
+    """
+    Return the mapping a document file holds.
+
+    Which parser to use is the caller's to decide, because each format
+    names its files its own way; everything after that is the same.
+
+    Parameters
+    ----------
+    path
+        The file to read.
+    file_format
+        Either "json" or "yaml".
+    error
+        The exception raised for a file which cannot be read, cannot be
+        parsed, or holds something other than a mapping.
+    holds
+        How to finish the sentence "<file> holds no mapping, so it ...".
+    """
+    path = Path(path)
+    try:
+        text = path.read_text(encoding=ENCODING)
+    except (OSError, UnicodeDecodeError) as problem:
+        msg = f"Could not read {quote_path(path)}: {problem}."
+        raise error(msg) from problem
+    document = _parse(text, path, file_format, error=error)
+    if not isinstance(document, Mapping):
+        msg = f"{quote_path(path)} holds no mapping, so it {holds}."
+        raise error(msg)
+    return dict(document)
+
+
+def write_document(
+    document: Mapping,
+    path: Path,
+    file_format: DocumentFormat,
+) -> Path:
+    """
+    Write a mapping to a file, in the format named, and return the path.
+
+    Parent directories are made as needed, so saving into a directory which
+    is not there yet works.
+    """
+    path = Path(path)
+    _maybe_make_parent_directory(path)
+    if file_format == "yaml":
+        # Written in the order the document states rather than sorted: a
+        # document says what it holds, and its own order reads better.
+        text = yaml.safe_dump(dict(document), sort_keys=False)
+    else:
+        text = json.dumps(document, indent=2, sort_keys=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _parse(
+    text: str,
+    path: Path,
+    file_format: DocumentFormat,
+    *,
+    error: type[Exception],
+) -> Any:
+    """Return whatever a document's text holds, naming the file if it cannot."""
+    if file_format == "json":
+        try:
+            return json.loads(text)
+        except ValueError as problem:
+            msg = f"Could not parse JSON from {quote_path(path)}: {problem}."
+            raise error(msg) from problem
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError as problem:
+        msg = f"Could not parse YAML from {quote_path(path)}: {problem}."
+        raise error(msg) from problem

--- a/dascore/utils/documents.py
+++ b/dascore/utils/documents.py
@@ -58,7 +58,12 @@ def read_document(
     except (OSError, UnicodeDecodeError) as problem:
         msg = f"Could not read {quote_path(path)}: {problem}."
         raise error(msg) from problem
-    document = _parse(text, path, file_format, error=error)
+    document = parse_document(
+        text,
+        file_format,
+        label=quote_path(path),
+        error=error,
+    )
     if not isinstance(document, Mapping):
         msg = f"{quote_path(path)} holds no mapping, so it {holds}."
         raise error(msg)
@@ -88,22 +93,36 @@ def write_document(
     return path
 
 
-def _parse(
+def parse_document(
     text: str,
-    path: Path,
     file_format: DocumentFormat,
     *,
-    error: type[Exception],
+    label: str,
+    error: type[Exception] = ParameterError,
 ) -> Any:
-    """Return whatever a document's text holds, naming the file if it cannot."""
+    """
+    Return whatever a document's text holds, naming its source if it cannot.
+
+    Parameters
+    ----------
+    text
+        The document's text.
+    file_format
+        Either "json" or "yaml".
+    label
+        What to call the text in an error: a file's name, or a phrase for
+        text which came from somewhere else.
+    error
+        The exception raised for text which does not parse.
+    """
     if file_format == "json":
         try:
             return json.loads(text)
         except ValueError as problem:
-            msg = f"Could not parse JSON from {quote_path(path)}: {problem}."
+            msg = f"Could not parse JSON from {label}: {problem}."
             raise error(msg) from problem
     try:
         return yaml.safe_load(text)
     except yaml.YAMLError as problem:
-        msg = f"Could not parse YAML from {quote_path(path)}: {problem}."
+        msg = f"Could not parse YAML from {label}: {problem}."
         raise error(msg) from problem

--- a/dascore/utils/documents.py
+++ b/dascore/utils/documents.py
@@ -101,7 +101,7 @@ def write_document(
     return write_text_document(text, path)
 
 
-def write_text_document(text: str, path: Path) -> Path:
+def write_text_document(text: str, path: str | Path) -> Path:
     """
     Write a document's text to a file and return the path.
 

--- a/dascore/workflow/__init__.py
+++ b/dascore/workflow/__init__.py
@@ -3,7 +3,10 @@ Machinery for describing, identifying and composing DASCore operations.
 
 An operation is a [`Task`](`dascore.workflow.task.Task`): a frozen object
 whose fields are its parameters, which knows its own fingerprint and can be
-written to a document and read back.
+written to a document and read back. Several of them joined with ``|`` make
+a [`Pipe`](`dascore.workflow.pipe.Pipe`), which is one operation again, and
+a [`Provenance`](`dascore.workflow.provenance.Provenance`) records a pipe
+and the run which used it.
 """
 
 from __future__ import annotations
@@ -15,4 +18,6 @@ from dascore.workflow.serialize import (
     digest,
     encode,
 )
+from dascore.workflow.pipe import Pipe
+from dascore.workflow.provenance import Provenance, ProvenanceNode, SourceInfo
 from dascore.workflow.task import Task, intern, make_function_task_class, task

--- a/dascore/workflow/pipe.py
+++ b/dascore/workflow/pipe.py
@@ -39,7 +39,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Any
 
-from pydantic import Field, model_validator
+from pydantic import Field, ValidationError, model_validator
 
 from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
@@ -186,6 +186,22 @@ class Pipe(DascoreBaseModel):
         """Return the nodes which take their input from the caller, in order."""
         return self.inputs
 
+    def new(self, **kwargs) -> Pipe:
+        """
+        Return a pipe with some of its fields replaced.
+
+        Not the base model's, which rebuilds from a dump: a dump flattens
+        each task to the fields it holds, losing which class it was, and
+        the pipe it builds back refuses them.
+        """
+        fields: dict[str, Any] = {
+            "tasks": self.tasks,
+            "dependencies": self.dependencies,
+            "inputs": self.inputs,
+            "outputs": self.outputs,
+        }
+        return Pipe(**(fields | kwargs))
+
     def get(self, key: str) -> Task:
         """
         Return the task a node holds.
@@ -223,12 +239,7 @@ class Pipe(DascoreBaseModel):
         """
         tasks = dict(self.tasks)
         tasks[key] = self.get(key).update(**kwargs)
-        return Pipe(
-            tasks=tasks,
-            dependencies=self.dependencies,
-            inputs=self.inputs,
-            outputs=self.outputs,
-        )
+        return self.new(tasks=tasks)
 
     def relabel(self, **names: str) -> Pipe:
         """
@@ -251,7 +262,7 @@ class Pipe(DascoreBaseModel):
             msg = f"Two nodes cannot both be called {sorted(names.values())}."
             raise ParameterError(msg)
         renamed = {node: names.get(node, node) for node in self.tasks}
-        return Pipe(
+        return self.new(
             tasks={renamed[node]: task for node, task in self.tasks.items()},
             dependencies={
                 renamed[node]: tuple(renamed[x] for x in given)
@@ -296,8 +307,12 @@ class Pipe(DascoreBaseModel):
         """
         Check that the pipe describes a graph which can be run.
 
-        Raises `ParameterError` naming what is wrong: an edge from a node
-        which is not there, an output which is not there, or a cycle.
+        Raises `ParameterError` naming what is wrong: an edge or an output
+        which is not one of the tasks, no outputs at all, a set of inputs
+        which is not the set of nodes nothing feeds, a task whose result
+        reaches no output, or a cycle. Building a pipe runs this through a
+        validator, which is pydantic's to wrap: what a caller sees there is
+        a `ValidationError` holding the sentence.
         """
         for node, given in self.dependencies.items():
             for name in (node, *given):
@@ -370,20 +385,34 @@ class Pipe(DascoreBaseModel):
         the check is a guard against an edited file rather than the answer
         to what the pipe is.
         """
+        missing = sorted({"tasks", "inputs", "outputs"} - set(document))
+        if missing:
+            msg = (
+                f"A pipe states its {', '.join(missing)}, and this document "
+                "does not. It describes something else."
+            )
+            raise ParameterError(msg)
         written_tasks = document["tasks"]
         tasks = {node: Task.from_dict(value) for node, value in written_tasks.items()}
         dependencies = {
             node: tuple(value)
             for node, value in document.get("dependencies", {}).items()
         }
-        out = cls(
-            tasks=tasks,
-            dependencies=dependencies,
-            inputs=tuple(document["inputs"]),
-            outputs=tuple(document["outputs"]),
-        )
+        # A graph which cannot be run is a document which does not describe a
+        # pipe, and says so the way every other unreadable document does:
+        # pydantic wraps what `check` raises, which is not a DASCore error.
+        try:
+            out = cls(
+                tasks=tasks,
+                dependencies=dependencies,
+                inputs=tuple(document["inputs"]),
+                outputs=tuple(document["outputs"]),
+            )
+        except ValidationError as problem:
+            msg = f"This document describes a pipe which could not be built: {problem}"
+            raise ParameterError(msg) from problem
         written = document.get("fingerprint")
-        moved_on = holds_another_version(written_tasks)
+        moved_on = holds_another_version(document)
         if written and not moved_on and written != out.fingerprint:
             msg = (
                 f"The document says its fingerprint is {written}, and the "
@@ -447,6 +476,17 @@ def join(left: Any, right: Any) -> Pipe:
         renamed = _merge(pipe, tasks, dependencies)
         inputs.extend(renamed[x] for x in pipe.inputs)
         given.extend(renamed[x] for x in pipe.outputs)
+    waiting = sum(len(pipe.sources()) for pipe in downstream)
+    if len(given) > 1 and waiting > 1:
+        # Every place on the right is given everything from the left, which
+        # is what a fan in means and is not what someone joining two fans
+        # means. There is no one way to pair them, so it is refused where it
+        # is written rather than run as a cross product.
+        msg = (
+            f"A join of {len(given)} results into {waiting} places has no one "
+            "way to pair them. Join them a step at a time."
+        )
+        raise ParameterError(msg)
     outputs: list[str] = []
     for pipe in downstream:
         renamed = _merge(pipe, tasks, dependencies)

--- a/dascore/workflow/pipe.py
+++ b/dascore/workflow/pipe.py
@@ -29,23 +29,18 @@ Examples
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable, Mapping, Sequence
 from functools import cached_property
 from pathlib import Path
 from typing import Any
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.types import FrozenDictType
-from dascore.utils.misc import optional_import
-from dascore.workflow.serialize import digest
+from dascore.workflow.serialize import digest, read_document, write_document
 from dascore.workflow.task import Task
-
-# The suffixes `save` and `load` read as YAML; anything else is JSON.
-YAML_SUFFIXES = frozenset({".yaml", ".yml"})
 
 # What separates a node id from the number which makes it unique, when one
 # task appears in a pipe more than once.
@@ -69,12 +64,17 @@ class Pipe(DascoreBaseModel):
     tasks: FrozenDictType[str, Task]
     # Only a node with inputs appears here; a source has none.
     dependencies: FrozenDictType[str, tuple[str, ...]] = Field(default_factory=dict)
+    # The nodes the caller feeds, in the order they are fed. Written down
+    # rather than read off `tasks`, whose order a document is free to
+    # change: sorting the keys of a saved pipe would otherwise send the
+    # inputs to the wrong branches.
+    inputs: tuple[str, ...] = ()
     output: str
 
-    def __init__(self, **kwargs):
-        """Build a pipe, checking it describes a graph which can be run."""
-        super().__init__(**kwargs)
-        self.check()
+    @model_validator(mode="after")
+    def _check_after_building(self) -> Pipe:
+        """Check every pipe, however it was built."""
+        return self.check()
 
     @cached_property
     def fingerprint(self) -> str:
@@ -87,6 +87,7 @@ class Pipe(DascoreBaseModel):
         payload = {
             "tasks": {node: task.fingerprint for node, task in self.tasks.items()},
             "dependencies": {node: list(x) for node, x in self.dependencies.items()},
+            "inputs": list(self.inputs),
             "output": self.output,
         }
         return digest(payload)
@@ -154,8 +155,8 @@ class Pipe(DascoreBaseModel):
         return list(client.map(self.run, iterable))
 
     def sources(self) -> tuple[str, ...]:
-        """Return the nodes which take their input from the caller."""
-        return tuple(x for x in self.sorted_nodes() if not self.dependencies.get(x))
+        """Return the nodes which take their input from the caller, in order."""
+        return self.inputs
 
     def sorted_nodes(self) -> tuple[str, ...]:
         """
@@ -169,7 +170,10 @@ class Pipe(DascoreBaseModel):
         for node, given in self.dependencies.items():
             for upstream in given:
                 downstream[upstream].append(node)
-        ready = [node for node, count in remaining.items() if not count]
+        # Seeded with the inputs, in their order, so the run order depends
+        # on the pipe rather than on how a document happened to be written.
+        ready = [x for x in self.inputs if not remaining[x]]
+        ready += [x for x, count in remaining.items() if not count and x not in ready]
         out = []
         while ready:
             node = ready.pop(0)
@@ -198,7 +202,26 @@ class Pipe(DascoreBaseModel):
         if self.output not in self.tasks:
             msg = f"The pipe's output {self.output!r} is not one of its tasks."
             raise ParameterError(msg)
-        self.sorted_nodes()
+        fed = {x for x in self.tasks if not self.dependencies.get(x)}
+        if set(self.inputs) != fed:
+            msg = (
+                f"The pipe takes its inputs at {sorted(self.inputs)}, but the "
+                f"nodes with nothing wired into them are {sorted(fed)}."
+            )
+            raise ParameterError(msg)
+        order = self.sorted_nodes()
+        # A task whose output reaches nothing is work the pipe would do and
+        # throw away, which is a pipe built wrong rather than a slow one.
+        reaching = {self.output}
+        for node in reversed(order):
+            if node in reaching:
+                reaching.update(self.dependencies.get(node, ()))
+        if stranded := set(self.tasks) - reaching:
+            msg = (
+                f"Nothing the pipe returns is built from {sorted(stranded)}; "
+                "every task has to feed its output."
+            )
+            raise ParameterError(msg)
         return self
 
     def get_provenance(self, **metadata) -> Any:
@@ -220,6 +243,7 @@ class Pipe(DascoreBaseModel):
         return {
             "tasks": {node: task.to_dict() for node, task in self.tasks.items()},
             "dependencies": {node: list(x) for node, x in self.dependencies.items()},
+            "inputs": list(self.inputs),
             "output": self.output,
             "fingerprint": self.fingerprint,
         }
@@ -234,7 +258,21 @@ class Pipe(DascoreBaseModel):
             node: tuple(value)
             for node, value in document.get("dependencies", {}).items()
         }
-        return cls(tasks=tasks, dependencies=dependencies, output=document["output"])
+        out = cls(
+            tasks=tasks,
+            dependencies=dependencies,
+            inputs=tuple(document["inputs"]),
+            output=document["output"],
+        )
+        # A document says what it holds and what it hashed to; a mismatch
+        # means it was edited, and hiding that would defeat the fingerprint.
+        if (written := document.get("fingerprint")) and written != out.fingerprint:
+            msg = (
+                f"The document says its fingerprint is {written}, and the "
+                f"pipe it describes has {out.fingerprint}."
+            )
+            raise ParameterError(msg)
+        return out
 
     def save(self, path: str | Path) -> Path:
         """
@@ -243,23 +281,20 @@ class Pipe(DascoreBaseModel):
         The suffix picks the format: ``.yaml`` or ``.yml`` write YAML, and
         anything else writes JSON.
         """
-        path = Path(path)
-        path.parent.mkdir(exist_ok=True, parents=True)
-        path.write_text(_dump(self.to_dict(), path), encoding="utf-8")
-        return path
+        return write_document(self.to_dict(), Path(path))
 
     @classmethod
     def load(cls, path: str | Path) -> Pipe:
         """Return the pipe a file holds; see `save`."""
-        path = Path(path)
-        return cls.from_dict(_parse(path.read_text(encoding="utf-8"), path))
+        return cls.from_dict(read_document(Path(path)))
 
     def to_mermaid(self) -> str:
         """
-        Return the pipe as a mermaid flowchart.
+        Return the pipe as the text of a mermaid flowchart.
 
-        Markdown viewers, this project's docs among them, draw one from the
-        text; it is a readable listing on its own besides.
+        Somewhere which draws mermaid -- a markdown viewer, a notebook, a
+        quarto ``{mermaid}`` cell -- turns it into a diagram; on its own it
+        is a readable listing of the tasks and the wires between them.
         """
         lines = ["flowchart TD"]
         names = {node: f"n{index}" for index, node in enumerate(self.sorted_nodes())}
@@ -274,20 +309,31 @@ class Pipe(DascoreBaseModel):
 
 def join(left: Any, right: Any) -> Pipe:
     """Return the pipe which runs one side and then the other."""
-    inputs = [_as_pipe(x) for x in (left if isinstance(left, list | tuple) else [left])]
+    sides = list(left) if isinstance(left, list | tuple) else [left]
+    if not sides:
+        msg = "A pipe cannot be joined to nothing."
+        raise ParameterError(msg)
+    upstream = [_as_pipe(x) for x in sides]
     right = _as_pipe(right)
     tasks: dict[str, Task] = {}
     dependencies: dict[str, tuple[str, ...]] = {}
+    inputs: list[str] = []
     outputs = []
-    for pipe in inputs:
+    for pipe in upstream:
         renamed = _merge(pipe, tasks, dependencies)
+        inputs.extend(renamed[x] for x in pipe.inputs)
         outputs.append(renamed[pipe.output])
     renamed = _merge(right, tasks, dependencies)
-    # The first task of the right hand side takes the left hand sides'
-    # outputs; anything already wired inside it keeps what it had.
+    # Every task the right hand side took its input from now takes the left
+    # hand sides' outputs instead; anything wired inside it keeps what it had.
     for node in right.sources():
         dependencies[renamed[node]] = tuple(outputs)
-    return Pipe(tasks=tasks, dependencies=dependencies, output=renamed[right.output])
+    return Pipe(
+        tasks=tasks,
+        dependencies=dependencies,
+        inputs=tuple(inputs),
+        output=renamed[right.output],
+    )
 
 
 def _as_pipe(value: Any) -> Pipe:
@@ -296,7 +342,7 @@ def _as_pipe(value: Any) -> Pipe:
         return value
     if isinstance(value, Task):
         node = value.fingerprint
-        return Pipe(tasks={node: value}, output=node)
+        return Pipe(tasks={node: value}, inputs=(node,), output=node)
     msg = f"A pipe joins tasks and pipes, not {type(value).__name__}."
     raise ParameterError(msg)
 
@@ -309,22 +355,33 @@ def _merge(
     """
     Copy a pipe's nodes into a graph being built, and say what they became.
 
-    A node is named by its task's fingerprint, so the same task twice in one
-    chain -- ``detrend | detrend`` -- would be one node and would lose a
-    step. The second copy takes a ``#n`` suffix instead.
+    A node which would collide with one already there is renamed; see
+    `unique_name`.
     """
     renamed = {}
     for node in pipe.sorted_nodes():
-        name = node
-        copy = 0
-        while name in tasks:
-            copy += 1
-            name = f"{node}{COPY_SEP}{copy}"
+        name = unique_name(node, tasks)
         renamed[node] = name
         tasks[name] = pipe.tasks[node]
     for node, given in pipe.dependencies.items():
         dependencies[renamed[node]] = tuple(renamed[x] for x in given)
     return renamed
+
+
+def unique_name(fingerprint: str, taken: Mapping[str, Any]) -> str:
+    """
+    Return a node name nothing in a pipe has claimed yet.
+
+    A node is named by its task's fingerprint, so the same task twice in one
+    chain -- ``detrend | detrend`` -- would be one node and would lose a
+    step. The second copy takes a ``#n`` suffix instead.
+    """
+    name = fingerprint
+    copy = 0
+    while name in taken:
+        copy += 1
+        name = f"{fingerprint}{COPY_SEP}{copy}"
+    return name
 
 
 def _source_arguments(node: str, sources: tuple[str, ...], inputs: tuple) -> tuple:
@@ -342,19 +399,3 @@ def _source_arguments(node: str, sources: tuple[str, ...], inputs: tuple) -> tup
         )
         raise ParameterError(msg)
     return (inputs[sources.index(node)],)
-
-
-def _dump(document: Mapping, path: Path) -> str:
-    """Return the text a document is written as, per the path's suffix."""
-    if path.suffix.lower() in YAML_SUFFIXES:
-        yaml = optional_import("yaml", required_for="writing a pipe as YAML")
-        return yaml.safe_dump(document, sort_keys=False)
-    return json.dumps(document, indent=2, sort_keys=True)
-
-
-def _parse(text: str, path: Path) -> Any:
-    """Return the document some text holds, per the path's suffix."""
-    if path.suffix.lower() in YAML_SUFFIXES:
-        yaml = optional_import("yaml", required_for="reading a pipe from YAML")
-        return yaml.safe_load(text)
-    return json.loads(text)

--- a/dascore/workflow/pipe.py
+++ b/dascore/workflow/pipe.py
@@ -7,6 +7,10 @@ fingerprintable and serializable, so a whole processing chain can be
 compared, written to a file, handed to another process, and run later
 against different data.
 
+Running one is deliberately boring: each task is given its inputs, in
+order, once everything feeding it has run. Nothing here schedules, streams
+or fuses; those belong to whatever runs the pipe.
+
 Examples
 --------
 >>> from dascore.workflow import Task
@@ -24,12 +28,13 @@ Examples
 ...         return number * self.value
 >>>
 >>> pipe = PipeAddExample(value=2) | PipeTimesExample(value=3)
->>> assert pipe.run(1) == 9
+>>> assert pipe(1) == 9
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+import re
+from collections.abc import Container, Mapping, Sequence
 from functools import cached_property
 from pathlib import Path
 from typing import Any
@@ -40,25 +45,27 @@ from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.types import FrozenDictType
 from dascore.workflow.serialize import digest, read_workflow, write_workflow
-from dascore.workflow.task import Task
+from dascore.workflow.task import Task, holds_another_version
 
-# What separates a node id from the number which makes it unique, when one
-# task appears in a pipe more than once.
-COPY_SEP = "#"
+# Where a camel cased class name breaks into words: before a capital which
+# follows a lower case letter or digit, and before the last capital of a run
+# of them, so `TrimEdges` and `FFTShift` both read as they are spoken.
+_WORD_BREAK = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
 
 
 class Pipe(DascoreBaseModel):
     """
     A directed acyclic graph of tasks.
 
-    Each node is a task, named by its fingerprint, and each edge says which
+    Each node is a task under a name of its own, and each edge says which
     node's output becomes one of another node's inputs. Inputs are given to
     a task in the order they are listed, so a task taking two of them --
     concatenating two patches, say -- gets them the way it was wired.
 
     Build one with ``|`` rather than by hand: ``first | second`` chains two
-    tasks, ``pipe | third`` extends a chain, and ``(left, right) | merge``
-    feeds two branches into one task.
+    tasks, ``pipe | third`` extends a chain, ``(left, right) | merge`` feeds
+    two branches into one task, and ``split | (left, right)`` fans one out
+    into two results.
     """
 
     tasks: FrozenDictType[str, Task]
@@ -69,7 +76,9 @@ class Pipe(DascoreBaseModel):
     # change: sorting the keys of a saved pipe would otherwise send the
     # inputs to the wrong branches.
     inputs: tuple[str, ...] = ()
-    output: str
+    # The nodes whose results the pipe hands back, in the order it hands
+    # them back. More than one is a pipe which fans out.
+    outputs: tuple[str, ...]
 
     @model_validator(mode="after")
     def _check_after_building(self) -> Pipe:
@@ -81,16 +90,41 @@ class Pipe(DascoreBaseModel):
         """
         Return the digest which identifies this pipe.
 
-        It names every task in the pipe and how they are wired, so two pipes
-        holding the same tasks in a different order are not the same pipe.
+        It is structural rather than nominal: what the pipe is fed and what
+        it hands back, each named by how it is arrived at rather than by
+        what it is called. Every task reaches an output, so folding the
+        outputs folds the whole graph; and no node's name is anywhere in
+        it, so naming a node for the reader leaves the pipe the pipe it was.
         """
+        marks = self._node_marks()
         payload = {
-            "tasks": {node: task.fingerprint for node, task in self.tasks.items()},
-            "dependencies": {node: list(x) for node, x in self.dependencies.items()},
-            "inputs": list(self.inputs),
-            "output": self.output,
+            "inputs": [marks[x] for x in self.inputs],
+            "outputs": [marks[x] for x in self.outputs],
         }
         return digest(payload)
+
+    def _node_marks(self) -> dict[str, str]:
+        """
+        Return a digest for each node of how its value is arrived at.
+
+        A node's mark folds in the task it holds, the marks of whatever
+        feeds it in the order it is fed, and -- for a source -- which of
+        the pipe's inputs it takes. So two nodes share a mark exactly when
+        they compute the same thing from the same place, whatever either of
+        them happens to be called.
+        """
+        seeds = {node: index for index, node in enumerate(self.inputs)}
+        marks: dict[str, str] = {}
+        for node in self.sorted_nodes():
+            given = self.dependencies.get(node, ())
+            marks[node] = digest(
+                [
+                    self.tasks[node].fingerprint,
+                    [marks[x] for x in given],
+                    seeds.get(node),
+                ]
+            )
+        return marks
 
     def __hash__(self) -> int:
         """Hash a pipe the way it compares."""
@@ -106,17 +140,21 @@ class Pipe(DascoreBaseModel):
         """Return how many tasks the pipe holds."""
         return len(self.tasks)
 
-    def __or__(self, other: Task | Pipe) -> Pipe:
-        """Extend this pipe with a task or another pipe."""
+    def __or__(self, other: Task | Pipe | Sequence[Task | Pipe]) -> Pipe:
+        """Extend this pipe with a task, another pipe, or several of them."""
         return join(self, other)
 
-    def __ror__(self, other: Task | Sequence[Task | Pipe]) -> Pipe:
+    def __ror__(self, other: Task | Pipe | Sequence[Task | Pipe]) -> Pipe:
         """Feed a task, or several, into this pipe."""
         return join(other, self)
 
+    def __call__(self, *inputs) -> Any:
+        """Run the pipe; see `run`."""
+        return self.run(*inputs)
+
     def run(self, *inputs) -> Any:
         """
-        Run every task in order and return what the last one gave back.
+        Run every task in order and return what the pipe's outputs gave back.
 
         Parameters
         ----------
@@ -124,7 +162,13 @@ class Pipe(DascoreBaseModel):
             What the pipe's sources are given. A pipe with one source hands
             it all of them. A pipe which branches takes one input per
             branch, in the order they were wired, or a single input which
-            every branch is given.
+            every branch is given. A pipe run with none is a pipe whose
+            sources make their own values.
+
+        Returns
+        -------
+        The result of the pipe's output, or a tuple of them in the order
+        `outputs` lists if it has more than one.
         """
         sources = self.sources()
         results = {}
@@ -135,45 +179,106 @@ class Pipe(DascoreBaseModel):
             else:
                 arguments = _source_arguments(node, sources, inputs)
             results[node] = self.tasks[node].run(*arguments)
-        return results[self.output]
-
-    def map(self, iterable: Iterable, client: Any = None) -> list:
-        """
-        Run the pipe over each item of an iterable.
-
-        Parameters
-        ----------
-        iterable
-            The items to run, each of which is given to the pipe's source.
-        client
-            Something with a ``map`` -- a `ProcessPoolExecutor`, a dask
-            client -- to run them with. The pipe pickles, so a worker in
-            another process can rebuild it.
-        """
-        if client is None:
-            return [self.run(x) for x in iterable]
-        return list(client.map(self.run, iterable))
+        out = tuple(results[x] for x in self.outputs)
+        return out[0] if len(out) == 1 else out
 
     def sources(self) -> tuple[str, ...]:
         """Return the nodes which take their input from the caller, in order."""
         return self.inputs
 
+    def get(self, key: str) -> Task:
+        """
+        Return the task a node holds.
+
+        Examples
+        --------
+        >>> from dascore.workflow import Task
+        >>> class PipeGetExample(Task):
+        ...     '''Add a number.'''
+        ...     value: int = 1
+        ...     def run(self, number):
+        ...         return number + self.value
+        >>> pipe = PipeGetExample(value=1) | PipeGetExample(value=2)
+        >>> assert pipe.get("pipe_get_example").value == 1
+        >>> assert pipe.get("pipe_get_example_2").value == 2
+        """
+        if key not in self.tasks:
+            msg = f"The pipe has no node called {key!r}; it holds {sorted(self.tasks)}."
+            raise ParameterError(msg)
+        return self.tasks[key]
+
+    def update(self, key: str, **kwargs) -> Pipe:
+        """
+        Return a new pipe with one node's parameters changed.
+
+        The wiring is untouched and the node keeps its name; only the task
+        it holds, and therefore the pipe's fingerprint, are new.
+
+        Parameters
+        ----------
+        key
+            Which node to change; see `get`.
+        **kwargs
+            The parameters to change, as `Task.update` takes them.
+        """
+        tasks = dict(self.tasks)
+        tasks[key] = self.get(key).update(**kwargs)
+        return Pipe(
+            tasks=tasks,
+            dependencies=self.dependencies,
+            inputs=self.inputs,
+            outputs=self.outputs,
+        )
+
+    def relabel(self, **names: str) -> Pipe:
+        """
+        Return a new pipe with some of its nodes named differently.
+
+        A node's name is for whoever reads the pipe; the fingerprint is
+        structural, so renaming one gives back an equal pipe.
+
+        Parameters
+        ----------
+        **names
+            Each node's current name against the name to give it.
+        """
+        for key, name in names.items():
+            self.get(key)
+            if name in self.tasks and name not in names:
+                msg = f"The pipe already has a node called {name!r}."
+                raise ParameterError(msg)
+        if len(set(names.values())) != len(names):
+            msg = f"Two nodes cannot both be called {sorted(names.values())}."
+            raise ParameterError(msg)
+        renamed = {node: names.get(node, node) for node in self.tasks}
+        return Pipe(
+            tasks={renamed[node]: task for node, task in self.tasks.items()},
+            dependencies={
+                renamed[node]: tuple(renamed[x] for x in given)
+                for node, given in self.dependencies.items()
+            },
+            inputs=tuple(renamed[x] for x in self.inputs),
+            outputs=tuple(renamed[x] for x in self.outputs),
+        )
+
     def sorted_nodes(self) -> tuple[str, ...]:
         """
         Return the nodes in an order which runs each after its inputs.
 
-        Kahn's algorithm, taking the nodes in the order they were added so
-        that a pipe always runs its tasks the same way round.
+        Kahn's algorithm, seeded with the sources in the order the pipe is
+        fed, so a pipe always runs its tasks the same way round. Which of
+        two independent branches runs first is not part of what a pipe
+        means: tasks are pure, and the fingerprint is built on the shape of
+        the graph rather than on any one walk of it.
         """
         remaining = {node: len(self.dependencies.get(node, ())) for node in self.tasks}
         downstream: dict[str, list[str]] = {node: [] for node in self.tasks}
         for node, given in self.dependencies.items():
             for upstream in given:
                 downstream[upstream].append(node)
-        # Seeded with the inputs, in their order, so the run order depends
-        # on the pipe rather than on how a document happened to be written.
-        ready = [x for x in self.inputs if not remaining[x]]
-        ready += [x for x, count in remaining.items() if not count and x not in ready]
+        # The sources are exactly the nodes with nothing wired into them,
+        # which `check` has already made sure of.
+        ready = list(self.inputs)
         out = []
         while ready:
             node = ready.pop(0)
@@ -199,11 +304,17 @@ class Pipe(DascoreBaseModel):
                 if name not in self.tasks:
                     msg = f"The pipe wires {name!r}, which is not one of its tasks."
                     raise ParameterError(msg)
-        if self.output not in self.tasks:
-            msg = f"The pipe's output {self.output!r} is not one of its tasks."
+        if not self.outputs:
+            msg = "A pipe has to return something; it names no outputs."
             raise ParameterError(msg)
+        for name in self.outputs:
+            if name not in self.tasks:
+                msg = f"The pipe's output {name!r} is not one of its tasks."
+                raise ParameterError(msg)
         fed = {x for x in self.tasks if not self.dependencies.get(x)}
-        if set(self.inputs) != fed:
+        # Compared by count as well as by name: a node listed twice would
+        # be run twice, and would take the place of the source it hides.
+        if set(self.inputs) != fed or len(self.inputs) != len(fed):
             msg = (
                 f"The pipe takes its inputs at {sorted(self.inputs)}, but the "
                 f"nodes with nothing wired into them are {sorted(fed)}."
@@ -212,14 +323,14 @@ class Pipe(DascoreBaseModel):
         order = self.sorted_nodes()
         # A task whose output reaches nothing is work the pipe would do and
         # throw away, which is a pipe built wrong rather than a slow one.
-        reaching = {self.output}
+        reaching = set(self.outputs)
         for node in reversed(order):
             if node in reaching:
                 reaching.update(self.dependencies.get(node, ()))
         if stranded := set(self.tasks) - reaching:
             msg = (
                 f"Nothing the pipe returns is built from {sorted(stranded)}; "
-                "every task has to feed its output."
+                "every task has to feed an output."
             )
             raise ParameterError(msg)
         return self
@@ -244,7 +355,7 @@ class Pipe(DascoreBaseModel):
             "tasks": {node: task.to_dict() for node, task in self.tasks.items()},
             "dependencies": {node: list(x) for node, x in self.dependencies.items()},
             "inputs": list(self.inputs),
-            "output": self.output,
+            "outputs": list(self.outputs),
             "fingerprint": self.fingerprint,
         }
 
@@ -269,13 +380,10 @@ class Pipe(DascoreBaseModel):
             tasks=tasks,
             dependencies=dependencies,
             inputs=tuple(document["inputs"]),
-            output=document["output"],
+            outputs=tuple(document["outputs"]),
         )
         written = document.get("fingerprint")
-        moved_on = any(
-            value.get("version") != type(tasks[node]).__version__
-            for node, value in written_tasks.items()
-        )
+        moved_on = holds_another_version(written_tasks)
         if written and not moved_on and written != out.fingerprint:
             msg = (
                 f"The document says its fingerprint is {written}, and the "
@@ -310,8 +418,11 @@ class Pipe(DascoreBaseModel):
         lines = ["flowchart TD"]
         names = {node: f"n{index}" for index, node in enumerate(self.sorted_nodes())}
         for node, name in names.items():
-            label = type(self.tasks[node]).__name__
-            lines.append(f"    {name}[{label}]")
+            # A name is whatever `relabel` or a document gave the node, so
+            # the quotes which hold the label are escaped rather than left
+            # for a name holding one to break the diagram with.
+            label = node.replace('"', "#quot;")
+            lines.append(f'    {name}["{label}"]')
         for node, given in self.dependencies.items():
             for upstream in given:
                 lines.append(f"    {names[upstream]} --> {names[node]}")
@@ -319,32 +430,47 @@ class Pipe(DascoreBaseModel):
 
 
 def join(left: Any, right: Any) -> Pipe:
-    """Return the pipe which runs one side and then the other."""
-    sides = list(left) if isinstance(left, list | tuple) else [left]
-    if not sides:
-        msg = "A pipe cannot be joined to nothing."
-        raise ParameterError(msg)
-    upstream = [_as_pipe(x) for x in sides]
-    right = _as_pipe(right)
+    """
+    Return the pipe which runs one side and then the other.
+
+    Either side may be several tasks or pipes: on the left they fan in,
+    each feeding what follows, and on the right they fan out, each fed by
+    what came before and each a result of its own.
+    """
+    upstream = [_as_pipe(x) for x in _sides(left)]
+    downstream = [_as_pipe(x) for x in _sides(right)]
     tasks: dict[str, Task] = {}
     dependencies: dict[str, tuple[str, ...]] = {}
     inputs: list[str] = []
-    outputs = []
+    given: list[str] = []
     for pipe in upstream:
         renamed = _merge(pipe, tasks, dependencies)
         inputs.extend(renamed[x] for x in pipe.inputs)
-        outputs.append(renamed[pipe.output])
-    renamed = _merge(right, tasks, dependencies)
-    # Every task the right hand side took its input from now takes the left
-    # hand sides' outputs instead; anything wired inside it keeps what it had.
-    for node in right.sources():
-        dependencies[renamed[node]] = tuple(outputs)
+        given.extend(renamed[x] for x in pipe.outputs)
+    outputs: list[str] = []
+    for pipe in downstream:
+        renamed = _merge(pipe, tasks, dependencies)
+        # Every task the right hand side took its input from now takes the
+        # left hand sides' outputs instead; anything wired inside it keeps
+        # what it had.
+        for node in pipe.sources():
+            dependencies[renamed[node]] = tuple(given)
+        outputs.extend(renamed[x] for x in pipe.outputs)
     return Pipe(
         tasks=tasks,
         dependencies=dependencies,
         inputs=tuple(inputs),
-        output=renamed[right.output],
+        outputs=tuple(outputs),
     )
+
+
+def _sides(value: Any) -> list:
+    """Return one side of a join as the list of tasks or pipes it stands for."""
+    sides = list(value) if isinstance(value, list | tuple) else [value]
+    if not sides:
+        msg = "A pipe cannot be joined to nothing."
+        raise ParameterError(msg)
+    return sides
 
 
 def _as_pipe(value: Any) -> Pipe:
@@ -352,8 +478,8 @@ def _as_pipe(value: Any) -> Pipe:
     if isinstance(value, Pipe):
         return value
     if isinstance(value, Task):
-        node = value.fingerprint
-        return Pipe(tasks={node: value}, inputs=(node,), output=node)
+        node = default_key(value)
+        return Pipe(tasks={node: value}, inputs=(node,), outputs=(node,))
     msg = f"A pipe joins tasks and pipes, not {type(value).__name__}."
     raise ParameterError(msg)
 
@@ -366,12 +492,17 @@ def _merge(
     """
     Copy a pipe's nodes into a graph being built, and say what they became.
 
-    A node which would collide with one already there is renamed; see
-    `unique_name`.
+    A node keeps the name it had, so a name given for the reader survives
+    being joined to something else; one which is taken already is numbered.
     """
     renamed = {}
+    # The names this pipe has still to place are held against as well as
+    # the ones already in the graph: numbering a collision onto a name its
+    # own next node wants would push that node off the name it was given.
+    pending = set(pipe.tasks)
     for node in pipe.sorted_nodes():
-        name = unique_name(node, tasks)
+        pending.discard(node)
+        name = unique_key(node, tasks.keys() | pending)
         renamed[node] = name
         tasks[name] = pipe.tasks[node]
     for node, given in pipe.dependencies.items():
@@ -379,24 +510,40 @@ def _merge(
     return renamed
 
 
-def unique_name(fingerprint: str, taken: Mapping[str, Any]) -> str:
+def default_key(task: Task) -> str:
+    """
+    Return the name a task takes in a pipe which does not name it.
+
+    The class, said the way a variable is spelled: `Decimate` becomes
+    `decimate`. It says what the node is without saying what it was given,
+    so changing a parameter leaves every reference to the node -- in
+    `update`, in a mermaid diagram, in a provenance record -- where it was.
+    """
+    return _WORD_BREAK.sub("_", type(task).__name__).lower()
+
+
+def unique_key(key: str, taken: Container[str]) -> str:
     """
     Return a node name nothing in a pipe has claimed yet.
 
-    A node is named by its task's fingerprint, so the same task twice in one
-    chain -- ``detrend | detrend`` -- would be one node and would lose a
-    step. The second copy takes a ``#n`` suffix instead.
+    Nodes are named for their task, so the same task twice in one chain --
+    ``decimate | decimate`` -- would be one node and would lose a step. The
+    second copy is numbered instead: ``decimate_2``.
     """
-    name = fingerprint
-    copy = 0
-    while name in taken:
+    if key not in taken:
+        return key
+    copy = 2
+    while f"{key}_{copy}" in taken:
         copy += 1
-        name = f"{fingerprint}{COPY_SEP}{copy}"
-    return name
+    return f"{key}_{copy}"
 
 
 def _source_arguments(node: str, sources: tuple[str, ...], inputs: tuple) -> tuple:
     """Return what one source node is given to run."""
+    # Nothing for a pipe run with nothing, whatever shape it is: its
+    # sources make their own values, as a task declared `inputs=0` does.
+    if not inputs:
+        return ()
     if len(sources) == 1:
         return inputs
     # One input for a pipe which branches: every branch gets it, which is

--- a/dascore/workflow/pipe.py
+++ b/dascore/workflow/pipe.py
@@ -1,0 +1,360 @@
+"""
+A pipe: several tasks arranged into the shape of one operation.
+
+A [`Pipe`](`dascore.workflow.pipe.Pipe`) is a directed acyclic graph of
+[`Task`](`dascore.workflow.task.Task`) objects. It is itself immutable,
+fingerprintable and serializable, so a whole processing chain can be
+compared, written to a file, handed to another process, and run later
+against different data.
+
+Examples
+--------
+>>> from dascore.workflow import Task
+>>>
+>>> class PipeAddExample(Task):
+...     '''Add a number.'''
+...     value: int = 1
+...     def run(self, number):
+...         return number + self.value
+>>>
+>>> class PipeTimesExample(Task):
+...     '''Multiply by a number.'''
+...     value: int = 2
+...     def run(self, number):
+...         return number * self.value
+>>>
+>>> pipe = PipeAddExample(value=2) | PipeTimesExample(value=3)
+>>> assert pipe.run(1) == 9
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from functools import cached_property
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from dascore.exceptions import ParameterError
+from dascore.models.base import DascoreBaseModel
+from dascore.models.types import FrozenDictType
+from dascore.utils.misc import optional_import
+from dascore.workflow.serialize import digest
+from dascore.workflow.task import Task
+
+# The suffixes `save` and `load` read as YAML; anything else is JSON.
+YAML_SUFFIXES = frozenset({".yaml", ".yml"})
+
+# What separates a node id from the number which makes it unique, when one
+# task appears in a pipe more than once.
+COPY_SEP = "#"
+
+
+class Pipe(DascoreBaseModel):
+    """
+    A directed acyclic graph of tasks.
+
+    Each node is a task, named by its fingerprint, and each edge says which
+    node's output becomes one of another node's inputs. Inputs are given to
+    a task in the order they are listed, so a task taking two of them --
+    concatenating two patches, say -- gets them the way it was wired.
+
+    Build one with ``|`` rather than by hand: ``first | second`` chains two
+    tasks, ``pipe | third`` extends a chain, and ``(left, right) | merge``
+    feeds two branches into one task.
+    """
+
+    tasks: FrozenDictType[str, Task]
+    # Only a node with inputs appears here; a source has none.
+    dependencies: FrozenDictType[str, tuple[str, ...]] = Field(default_factory=dict)
+    output: str
+
+    def __init__(self, **kwargs):
+        """Build a pipe, checking it describes a graph which can be run."""
+        super().__init__(**kwargs)
+        self.check()
+
+    @cached_property
+    def fingerprint(self) -> str:
+        """
+        Return the digest which identifies this pipe.
+
+        It names every task in the pipe and how they are wired, so two pipes
+        holding the same tasks in a different order are not the same pipe.
+        """
+        payload = {
+            "tasks": {node: task.fingerprint for node, task in self.tasks.items()},
+            "dependencies": {node: list(x) for node, x in self.dependencies.items()},
+            "output": self.output,
+        }
+        return digest(payload)
+
+    def __hash__(self) -> int:
+        """Hash a pipe the way it compares."""
+        return hash(self.fingerprint)
+
+    def __eq__(self, other) -> bool:
+        """Two pipes are equal if they hold the same tasks, wired alike."""
+        if not isinstance(other, Pipe):
+            return NotImplemented
+        return self.fingerprint == other.fingerprint
+
+    def __len__(self) -> int:
+        """Return how many tasks the pipe holds."""
+        return len(self.tasks)
+
+    def __or__(self, other: Task | Pipe) -> Pipe:
+        """Extend this pipe with a task or another pipe."""
+        return join(self, other)
+
+    def __ror__(self, other: Task | Sequence[Task | Pipe]) -> Pipe:
+        """Feed a task, or several, into this pipe."""
+        return join(other, self)
+
+    def run(self, *inputs) -> Any:
+        """
+        Run every task in order and return what the last one gave back.
+
+        Parameters
+        ----------
+        *inputs
+            What the pipe's sources are given. A pipe with one source hands
+            it all of them. A pipe which branches takes one input per
+            branch, in the order they were wired, or a single input which
+            every branch is given.
+        """
+        sources = self.sources()
+        results = {}
+        for node in self.sorted_nodes():
+            given = self.dependencies.get(node, ())
+            if given:
+                arguments = tuple(results[x] for x in given)
+            else:
+                arguments = _source_arguments(node, sources, inputs)
+            results[node] = self.tasks[node].run(*arguments)
+        return results[self.output]
+
+    def map(self, iterable: Iterable, client: Any = None) -> list:
+        """
+        Run the pipe over each item of an iterable.
+
+        Parameters
+        ----------
+        iterable
+            The items to run, each of which is given to the pipe's source.
+        client
+            Something with a ``map`` -- a `ProcessPoolExecutor`, a dask
+            client -- to run them with. The pipe pickles, so a worker in
+            another process can rebuild it.
+        """
+        if client is None:
+            return [self.run(x) for x in iterable]
+        return list(client.map(self.run, iterable))
+
+    def sources(self) -> tuple[str, ...]:
+        """Return the nodes which take their input from the caller."""
+        return tuple(x for x in self.sorted_nodes() if not self.dependencies.get(x))
+
+    def sorted_nodes(self) -> tuple[str, ...]:
+        """
+        Return the nodes in an order which runs each after its inputs.
+
+        Kahn's algorithm, taking the nodes in the order they were added so
+        that a pipe always runs its tasks the same way round.
+        """
+        remaining = {node: len(self.dependencies.get(node, ())) for node in self.tasks}
+        downstream: dict[str, list[str]] = {node: [] for node in self.tasks}
+        for node, given in self.dependencies.items():
+            for upstream in given:
+                downstream[upstream].append(node)
+        ready = [node for node, count in remaining.items() if not count]
+        out = []
+        while ready:
+            node = ready.pop(0)
+            out.append(node)
+            for other in downstream[node]:
+                remaining[other] -= 1
+                if not remaining[other]:
+                    ready.append(other)
+        if len(out) != len(self.tasks):
+            msg = "The pipe's tasks feed into each other in a cycle."
+            raise ParameterError(msg)
+        return tuple(out)
+
+    def check(self) -> Pipe:
+        """
+        Check that the pipe describes a graph which can be run.
+
+        Raises `ParameterError` naming what is wrong: an edge from a node
+        which is not there, an output which is not there, or a cycle.
+        """
+        for node, given in self.dependencies.items():
+            for name in (node, *given):
+                if name not in self.tasks:
+                    msg = f"The pipe wires {name!r}, which is not one of its tasks."
+                    raise ParameterError(msg)
+        if self.output not in self.tasks:
+            msg = f"The pipe's output {self.output!r} is not one of its tasks."
+            raise ParameterError(msg)
+        self.sorted_nodes()
+        return self
+
+    def get_provenance(self, **metadata) -> Any:
+        """
+        Return a record of this pipe and the machine it ran on.
+
+        Parameters
+        ----------
+        **metadata
+            Anything else worth recording alongside it.
+        """
+        # provenance.py imports this module, so it is named where it is used.
+        from dascore.workflow.provenance import Provenance  # noqa: PLC0415
+
+        return Provenance.from_pipe(self, **metadata)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a document which describes this pipe."""
+        return {
+            "tasks": {node: task.to_dict() for node, task in self.tasks.items()},
+            "dependencies": {node: list(x) for node, x in self.dependencies.items()},
+            "output": self.output,
+            "fingerprint": self.fingerprint,
+        }
+
+    @classmethod
+    def from_dict(cls, document: Mapping) -> Pipe:
+        """Return the pipe a document describes."""
+        tasks = {
+            node: Task.from_dict(value) for node, value in document["tasks"].items()
+        }
+        dependencies = {
+            node: tuple(value)
+            for node, value in document.get("dependencies", {}).items()
+        }
+        return cls(tasks=tasks, dependencies=dependencies, output=document["output"])
+
+    def save(self, path: str | Path) -> Path:
+        """
+        Write this pipe to a file.
+
+        The suffix picks the format: ``.yaml`` or ``.yml`` write YAML, and
+        anything else writes JSON.
+        """
+        path = Path(path)
+        path.parent.mkdir(exist_ok=True, parents=True)
+        path.write_text(_dump(self.to_dict(), path), encoding="utf-8")
+        return path
+
+    @classmethod
+    def load(cls, path: str | Path) -> Pipe:
+        """Return the pipe a file holds; see `save`."""
+        path = Path(path)
+        return cls.from_dict(_parse(path.read_text(encoding="utf-8"), path))
+
+    def to_mermaid(self) -> str:
+        """
+        Return the pipe as a mermaid flowchart.
+
+        Markdown viewers, this project's docs among them, draw one from the
+        text; it is a readable listing on its own besides.
+        """
+        lines = ["flowchart TD"]
+        names = {node: f"n{index}" for index, node in enumerate(self.sorted_nodes())}
+        for node, name in names.items():
+            label = type(self.tasks[node]).__name__
+            lines.append(f"    {name}[{label}]")
+        for node, given in self.dependencies.items():
+            for upstream in given:
+                lines.append(f"    {names[upstream]} --> {names[node]}")
+        return "\n".join(lines)
+
+
+def join(left: Any, right: Any) -> Pipe:
+    """Return the pipe which runs one side and then the other."""
+    inputs = [_as_pipe(x) for x in (left if isinstance(left, list | tuple) else [left])]
+    right = _as_pipe(right)
+    tasks: dict[str, Task] = {}
+    dependencies: dict[str, tuple[str, ...]] = {}
+    outputs = []
+    for pipe in inputs:
+        renamed = _merge(pipe, tasks, dependencies)
+        outputs.append(renamed[pipe.output])
+    renamed = _merge(right, tasks, dependencies)
+    # The first task of the right hand side takes the left hand sides'
+    # outputs; anything already wired inside it keeps what it had.
+    for node in right.sources():
+        dependencies[renamed[node]] = tuple(outputs)
+    return Pipe(tasks=tasks, dependencies=dependencies, output=renamed[right.output])
+
+
+def _as_pipe(value: Any) -> Pipe:
+    """Return a task or pipe as a pipe."""
+    if isinstance(value, Pipe):
+        return value
+    if isinstance(value, Task):
+        node = value.fingerprint
+        return Pipe(tasks={node: value}, output=node)
+    msg = f"A pipe joins tasks and pipes, not {type(value).__name__}."
+    raise ParameterError(msg)
+
+
+def _merge(
+    pipe: Pipe,
+    tasks: dict[str, Task],
+    dependencies: dict[str, tuple[str, ...]],
+) -> dict[str, str]:
+    """
+    Copy a pipe's nodes into a graph being built, and say what they became.
+
+    A node is named by its task's fingerprint, so the same task twice in one
+    chain -- ``detrend | detrend`` -- would be one node and would lose a
+    step. The second copy takes a ``#n`` suffix instead.
+    """
+    renamed = {}
+    for node in pipe.sorted_nodes():
+        name = node
+        copy = 0
+        while name in tasks:
+            copy += 1
+            name = f"{node}{COPY_SEP}{copy}"
+        renamed[node] = name
+        tasks[name] = pipe.tasks[node]
+    for node, given in pipe.dependencies.items():
+        dependencies[renamed[node]] = tuple(renamed[x] for x in given)
+    return renamed
+
+
+def _source_arguments(node: str, sources: tuple[str, ...], inputs: tuple) -> tuple:
+    """Return what one source node is given to run."""
+    if len(sources) == 1:
+        return inputs
+    # One input for a pipe which branches: every branch gets it, which is
+    # what a pipe shaped like a diamond means.
+    if len(inputs) == 1:
+        return inputs
+    if len(inputs) != len(sources):
+        msg = (
+            f"The pipe has {len(sources)} sources and was given "
+            f"{len(inputs)} inputs; give it one for each, or one for all."
+        )
+        raise ParameterError(msg)
+    return (inputs[sources.index(node)],)
+
+
+def _dump(document: Mapping, path: Path) -> str:
+    """Return the text a document is written as, per the path's suffix."""
+    if path.suffix.lower() in YAML_SUFFIXES:
+        yaml = optional_import("yaml", required_for="writing a pipe as YAML")
+        return yaml.safe_dump(document, sort_keys=False)
+    return json.dumps(document, indent=2, sort_keys=True)
+
+
+def _parse(text: str, path: Path) -> Any:
+    """Return the document some text holds, per the path's suffix."""
+    if path.suffix.lower() in YAML_SUFFIXES:
+        yaml = optional_import("yaml", required_for="reading a pipe from YAML")
+        return yaml.safe_load(text)
+    return json.loads(text)

--- a/dascore/workflow/pipe.py
+++ b/dascore/workflow/pipe.py
@@ -39,7 +39,7 @@ from pydantic import Field, model_validator
 from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.types import FrozenDictType
-from dascore.workflow.serialize import digest, read_document, write_document
+from dascore.workflow.serialize import digest, read_workflow, write_workflow
 from dascore.workflow.task import Task
 
 # What separates a node id from the number which makes it unique, when one
@@ -278,15 +278,15 @@ class Pipe(DascoreBaseModel):
         """
         Write this pipe to a file.
 
-        The suffix picks the format: ``.yaml`` or ``.yml`` write YAML, and
-        anything else writes JSON.
+        The suffix picks the format; see
+        [`write_workflow`](`dascore.workflow.serialize.write_workflow`).
         """
-        return write_document(self.to_dict(), Path(path))
+        return write_workflow(self.to_dict(), Path(path))
 
     @classmethod
     def load(cls, path: str | Path) -> Pipe:
         """Return the pipe a file holds; see `save`."""
-        return cls.from_dict(read_document(Path(path)))
+        return cls.from_dict(read_workflow(Path(path)))
 
     def to_mermaid(self) -> str:
         """

--- a/dascore/workflow/pipe.py
+++ b/dascore/workflow/pipe.py
@@ -45,7 +45,7 @@ from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.types import FrozenDictType
 from dascore.workflow.serialize import digest, read_workflow, write_workflow
-from dascore.workflow.task import Task, holds_another_version
+from dascore.workflow.task import Task, holds_a_nested_version
 
 # Where a camel cased class name breaks into words: before a capital which
 # follows a lower case letter or digit, and before the last capital of a run
@@ -96,14 +96,34 @@ class Pipe(DascoreBaseModel):
         outputs folds the whole graph; and no node's name is anywhere in
         it, so naming a node for the reader leaves the pipe the pipe it was.
         """
-        marks = self._node_marks()
+        return self.structure(
+            {node: task.fingerprint for node, task in self.tasks.items()}
+        )
+
+    def structure(self, fingerprints: Mapping[str, str]) -> str:
+        """
+        Return the digest this pipe's shape makes of the tasks it is given.
+
+        Parameters
+        ----------
+        fingerprints
+            What to call each node's task, keyed by node. `fingerprint`
+            passes what the tasks say they are; reading a document back
+            passes what they were when it was written.
+        """
+        marks = self._node_marks(fingerprints)
         payload = {
+            # Every node, so that a task run twice is not the same shape as
+            # one run once and used twice: both hand a join the same pair of
+            # marks, and only the count of nodes tells them apart. Sorted,
+            # because it is a tally rather than an order.
+            "nodes": sorted(marks[node] for node in self.tasks),
             "inputs": [marks[x] for x in self.inputs],
             "outputs": [marks[x] for x in self.outputs],
         }
         return digest(payload)
 
-    def _node_marks(self) -> dict[str, str]:
+    def _node_marks(self, fingerprints: Mapping[str, str]) -> dict[str, str]:
         """
         Return a digest for each node of how its value is arrived at.
 
@@ -118,11 +138,7 @@ class Pipe(DascoreBaseModel):
         for node in self.sorted_nodes():
             given = self.dependencies.get(node, ())
             marks[node] = digest(
-                [
-                    self.tasks[node].fingerprint,
-                    [marks[x] for x in given],
-                    seeds.get(node),
-                ]
+                [fingerprints[node], [marks[x] for x in given], seeds.get(node)]
             )
         return marks
 
@@ -412,8 +428,11 @@ class Pipe(DascoreBaseModel):
             msg = f"This document describes a pipe which could not be built: {problem}"
             raise ParameterError(msg) from problem
         written = document.get("fingerprint")
-        moved_on = holds_another_version(document)
-        if written and not moved_on and written != out.fingerprint:
+        # A task holding another task folded it in at the version its class
+        # had then, which cannot be worked out backwards, so that one
+        # version difference is tolerated rather than read as an edit.
+        unknowable = holds_a_nested_version(document)
+        if written and not unknowable and written != out._as_written(written_tasks):
             msg = (
                 f"The document says its fingerprint is {written}, and the "
                 f"pipe it describes has {out.fingerprint}. Something edited "
@@ -421,6 +440,24 @@ class Pipe(DascoreBaseModel):
             )
             raise ParameterError(msg)
         return out
+
+    def _as_written(self, written_tasks: Mapping) -> str:
+        """
+        Return the fingerprint this pipe had when a document recorded it.
+
+        Each task at the version the document names, so a class which has
+        since moved on does not read as a file which was edited -- and an
+        edit is still caught, which it was not while any version difference
+        switched the comparison off.
+        """
+        return self.structure(
+            {
+                node: task.fingerprint_at(
+                    written_tasks[node].get("version", type(task).__version__)
+                )
+                for node, task in self.tasks.items()
+            }
+        )
 
     def save(self, path: str | Path) -> Path:
         """

--- a/dascore/workflow/pipe.py
+++ b/dascore/workflow/pipe.py
@@ -250,10 +250,17 @@ class Pipe(DascoreBaseModel):
 
     @classmethod
     def from_dict(cls, document: Mapping) -> Pipe:
-        """Return the pipe a document describes."""
-        tasks = {
-            node: Task.from_dict(value) for node, value in document["tasks"].items()
-        }
+        """
+        Return the pipe a document describes.
+
+        The fingerprint a document carries is checked against the pipe read
+        out of it, unless a task has moved on to another version since it
+        was written -- which changes the fingerprint by design, and is why
+        the check is a guard against an edited file rather than the answer
+        to what the pipe is.
+        """
+        written_tasks = document["tasks"]
+        tasks = {node: Task.from_dict(value) for node, value in written_tasks.items()}
         dependencies = {
             node: tuple(value)
             for node, value in document.get("dependencies", {}).items()
@@ -264,12 +271,16 @@ class Pipe(DascoreBaseModel):
             inputs=tuple(document["inputs"]),
             output=document["output"],
         )
-        # A document says what it holds and what it hashed to; a mismatch
-        # means it was edited, and hiding that would defeat the fingerprint.
-        if (written := document.get("fingerprint")) and written != out.fingerprint:
+        written = document.get("fingerprint")
+        moved_on = any(
+            value.get("version") != type(tasks[node]).__version__
+            for node, value in written_tasks.items()
+        )
+        if written and not moved_on and written != out.fingerprint:
             msg = (
                 f"The document says its fingerprint is {written}, and the "
-                f"pipe it describes has {out.fingerprint}."
+                f"pipe it describes has {out.fingerprint}. Something edited "
+                "it after it was written."
             )
             raise ParameterError(msg)
         return out

--- a/dascore/workflow/provenance.py
+++ b/dascore/workflow/provenance.py
@@ -29,7 +29,7 @@ from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.types import FrozenDictType
 from dascore.workflow.pipe import Pipe, unique_name
-from dascore.workflow.serialize import read_document, write_document
+from dascore.workflow.serialize import read_workflow, write_workflow
 from dascore.workflow.task import Task
 
 
@@ -336,12 +336,12 @@ class Provenance(DascoreBaseModel):
         """
         Write this record to a file.
 
-        The suffix picks the format, as it does for a pipe: ``.yaml`` or
-        ``.yml`` write YAML, anything else writes JSON.
+        The suffix picks the format, as it does for a pipe; see
+        [`write_workflow`](`dascore.workflow.serialize.write_workflow`).
         """
-        return write_document(self.to_dict(), Path(path))
+        return write_workflow(self.to_dict(), Path(path))
 
     @classmethod
     def load(cls, path: str | Path) -> Provenance:
         """Return the record a file holds; see `save`."""
-        return cls.from_dict(read_document(Path(path)))
+        return cls.from_dict(read_workflow(Path(path)))

--- a/dascore/workflow/provenance.py
+++ b/dascore/workflow/provenance.py
@@ -1,0 +1,315 @@
+"""
+Two records of where data came from.
+
+A [`Provenance`](`dascore.workflow.provenance.Provenance`) is the durable
+one: a pipe, the version of DASCore which ran it, and the machine it ran
+on, written next to the results and read back later.
+
+A [`ProvenanceNode`](`dascore.workflow.provenance.ProvenanceNode`) is the
+live one: one immutable node per step, holding the task which ran and the
+nodes which fed it. A patch carries the node it came out of, so its whole
+history is reachable from it without a store to look anything up in.
+Building the graph as patches are processed is PR 4a's work; this module
+is the graph itself.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+from collections.abc import Iterator, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pydantic import ConfigDict, Field
+
+import dascore as dc
+from dascore.exceptions import ParameterError
+from dascore.models.base import DascoreBaseModel
+from dascore.workflow.pipe import COPY_SEP, Pipe, _dump, _parse
+from dascore.workflow.task import Task
+
+
+class SourceInfo(DascoreBaseModel):
+    """Where a patch was read from."""
+
+    model_config = ConfigDict(frozen=True)
+
+    format: str = ""
+    path: str = ""
+    # What names this patch inside a file holding several.
+    key: str = ""
+
+
+class ProvenanceNode(DascoreBaseModel):
+    """
+    One step of what was done to some data.
+
+    A node holds the task which ran, the nodes which produced its inputs,
+    and the ids the step produced. Nodes are never edited: a further step
+    makes another node which points back at this one, so a graph is shared
+    by everything downstream of it rather than copied.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    # None for a source: nothing was done to it, it was read.
+    task: Task | None = None
+    parents: tuple[ProvenanceNode, ...] = ()
+    # The ids of the inputs, including any whose node is not known.
+    input_pairs: tuple[tuple[str, str], ...] = ()
+    patch_id: str = ""
+    processing_id: str = ""
+    source: SourceInfo | None = None
+    # Which array backend ran the step; an execution detail, recorded here
+    # rather than in the fingerprint, which names the operation.
+    backend: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __hash__(self) -> int:
+        """Hash a node by what it produced and what produced it."""
+        return hash((self.patch_id, self.processing_id, id(self.task)))
+
+    def walk(self) -> Iterator[ProvenanceNode]:
+        """
+        Yield every node behind this one and then this one, each once.
+
+        Oldest first, so a node is always yielded after the nodes which fed
+        it. A graph which narrows -- many files chunked into one patch --
+        shares its ancestors, so a node reached twice is yielded once.
+        """
+        seen: set[int] = set()
+        # Iterative rather than recursive: a long chain of steps is a deep
+        # graph, and python's stack is shallower than a spool loop.
+        stack: list[tuple[ProvenanceNode, bool]] = [(self, False)]
+        while stack:
+            node, expanded = stack.pop()
+            if expanded:
+                yield node
+            elif id(node) not in seen:
+                seen.add(id(node))
+                stack.append((node, True))
+                stack.extend((x, False) for x in reversed(node.parents))
+
+    def steps(self) -> tuple[ProvenanceNode, ...]:
+        """Return the nodes which did something, oldest first."""
+        return tuple(x for x in self.walk() if x.task is not None)
+
+    def sources(self) -> tuple[SourceInfo, ...]:
+        """Return where the data behind this node was read from."""
+        return tuple(x.source for x in self.walk() if x.source is not None)
+
+    def describe(self) -> str:
+        """
+        Return a readable listing of what was done, oldest first.
+
+        A step which took many inputs is written once, with how many, so a
+        patch chunked from sixty files reads as one line rather than sixty.
+        """
+        lines = []
+        for source in self.sources():
+            lines.append(f"read {source.format or 'patch'} {source.path}".rstrip())
+        if len(lines) > 1:
+            lines = [f"read {len(lines)} sources"]
+        for node in self.steps():
+            name = type(node.task).__name__
+            fan_in = (
+                f" over {len(node.parents)} inputs" if len(node.parents) > 1 else ""
+            )
+            lines.append(f"{name}{fan_in}")
+        return "\n".join(lines)
+
+    def to_pipe(self) -> Pipe:
+        """
+        Return a pipe which would do again what this node records.
+
+        The sources are left out: a pipe describes what to do, and is run
+        against whatever data it is given.
+        """
+        steps = self.steps()
+        if not steps:
+            msg = "Nothing was done to this data, so there is no pipe to build."
+            raise ParameterError(msg)
+        names: dict[int, str] = {}
+        tasks: dict[str, Task] = {}
+        dependencies: dict[str, tuple[str, ...]] = {}
+        for node in steps:
+            # steps() keeps only the nodes which hold a task.
+            assert node.task is not None
+            name = _unique_name(node.task.fingerprint, tasks)
+            names[id(node)] = name
+            tasks[name] = node.task
+            given = tuple(names[id(x)] for x in node.parents if x.task is not None)
+            if given and len(given) != len(node.parents):
+                # Every input has to come from somewhere the pipe can name.
+                # A step fed partly by an earlier step and partly by data
+                # read straight from a file is the one shape it cannot say;
+                # a step fed only by sources becomes the pipe's own source.
+                msg = (
+                    f"{type(node.task).__name__} took some of its inputs from "
+                    "earlier steps and some straight from a source, which a "
+                    "pipe has no way to describe."
+                )
+                raise ParameterError(msg)
+            if given:
+                dependencies[name] = given
+        return Pipe(tasks=tasks, dependencies=dependencies, output=names[id(steps[-1])])
+
+    def to_json(self, indent: int | None = 2) -> str:
+        """Return the graph behind this node as JSON text."""
+        return json.dumps(self._to_document(), indent=indent, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, text: str) -> ProvenanceNode:
+        """Return the graph some JSON text holds."""
+        return cls._from_document(json.loads(text))
+
+    def _to_document(self) -> dict[str, Any]:
+        """Return a document holding this node and everything behind it."""
+        # Keyed by identity while it is built, so a node reached twice is
+        # written once and read back as one node again.
+        order: dict[int, int] = {}
+        written: list[dict[str, Any]] = []
+        for node in self.walk():
+            order[id(node)] = len(written)
+            written.append(node._to_entry(order))
+        return {"nodes": written, "output": order[id(self)]}
+
+    def _to_entry(self, order: Mapping[int, int]) -> dict[str, Any]:
+        """Return this node alone, naming its parents by their place."""
+        return {
+            "task": self.task.to_dict() if self.task is not None else None,
+            "parents": [order[id(x)] for x in self.parents],
+            "input_pairs": [list(x) for x in self.input_pairs],
+            "patch_id": self.patch_id,
+            "processing_id": self.processing_id,
+            "source": self.source.model_dump() if self.source is not None else None,
+            "backend": self.backend,
+            "created_at": self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def _from_document(cls, document: Mapping) -> ProvenanceNode:
+        """Return the graph a document describes."""
+        built: list[ProvenanceNode] = []
+        for entry in document["nodes"]:
+            source = entry.get("source")
+            task = entry.get("task")
+            built.append(
+                cls(
+                    task=Task.from_dict(task) if task is not None else None,
+                    parents=tuple(built[x] for x in entry["parents"]),
+                    input_pairs=tuple(tuple(x) for x in entry["input_pairs"]),
+                    patch_id=entry["patch_id"],
+                    processing_id=entry["processing_id"],
+                    source=SourceInfo(**source) if source is not None else None,
+                    backend=entry["backend"],
+                    created_at=datetime.fromisoformat(entry["created_at"]),
+                )
+            )
+        return built[document["output"]]
+
+
+class Provenance(DascoreBaseModel):
+    """
+    A record of a pipe and the run which produced some data.
+
+    This is the durable half: what a file written beside the results holds,
+    and what makes them reproducible when the objects which made them are
+    long gone.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    pipe: Pipe
+    dascore_version: str
+    created_at: datetime
+    python_version: str
+    system_info: Mapping[str, str] = Field(default_factory=dict)
+    metadata: Mapping[str, Any] = Field(default_factory=dict)
+    # The provenance of whatever this run was given, so a chain of runs
+    # reads back as a chain.
+    source_provenance: tuple[Provenance, ...] = ()
+
+    @property
+    def fingerprint(self) -> str:
+        """Return the fingerprint of the pipe this records."""
+        return self.pipe.fingerprint
+
+    def __hash__(self) -> int:
+        """Hash a record by the pipe it holds."""
+        return hash(self.fingerprint)
+
+    @classmethod
+    def from_pipe(cls, pipe: Pipe, **metadata) -> Provenance:
+        """Return a record of a pipe, this version of DASCore, and this host."""
+        return cls(
+            pipe=pipe,
+            dascore_version=dc.__version__,
+            created_at=datetime.now(timezone.utc),
+            python_version=platform.python_version(),
+            system_info={
+                "platform": platform.platform(),
+                "machine": platform.machine(),
+                "processor": platform.processor(),
+            },
+            metadata=metadata,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a document which describes this record."""
+        return {
+            "pipe": self.pipe.to_dict(),
+            "fingerprint": self.fingerprint,
+            "dascore_version": self.dascore_version,
+            "created_at": self.created_at.isoformat(),
+            "python_version": self.python_version,
+            "system_info": dict(self.system_info),
+            "metadata": dict(self.metadata),
+            "source_provenance": [x.to_dict() for x in self.source_provenance],
+        }
+
+    @classmethod
+    def from_dict(cls, document: Mapping) -> Provenance:
+        """Return the record a document describes."""
+        sources = document.get("source_provenance", ())
+        return cls(
+            pipe=Pipe.from_dict(document["pipe"]),
+            dascore_version=document["dascore_version"],
+            created_at=datetime.fromisoformat(document["created_at"]),
+            python_version=document["python_version"],
+            system_info=document.get("system_info", {}),
+            metadata=document.get("metadata", {}),
+            source_provenance=tuple(cls.from_dict(x) for x in sources),
+        )
+
+    def save(self, path: str | Path) -> Path:
+        """
+        Write this record to a file.
+
+        The suffix picks the format, as it does for a pipe: ``.yaml`` or
+        ``.yml`` write YAML, anything else writes JSON.
+        """
+        path = Path(path)
+        path.parent.mkdir(exist_ok=True, parents=True)
+        path.write_text(_dump(self.to_dict(), path), encoding="utf-8")
+        return path
+
+    @classmethod
+    def load(cls, path: str | Path) -> Provenance:
+        """Return the record a file holds; see `save`."""
+        path = Path(path)
+        return cls.from_dict(_parse(path.read_text(encoding="utf-8"), path))
+
+
+def _unique_name(fingerprint: str, taken: Mapping[str, Any]) -> str:
+    """Return a node name which nothing in a pipe has claimed yet."""
+    # The same task twice in one chain is two steps, and two nodes; see
+    # `dascore.workflow.pipe`, which names repeats the same way.
+    name = fingerprint
+    copy = 0
+    while name in taken:
+        copy += 1
+        name = f"{fingerprint}{COPY_SEP}{copy}"
+    return name

--- a/dascore/workflow/provenance.py
+++ b/dascore/workflow/provenance.py
@@ -28,7 +28,7 @@ import dascore as dc
 from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.types import FrozenDictType
-from dascore.workflow.pipe import Pipe, unique_name
+from dascore.workflow.pipe import Pipe, default_key, unique_key
 from dascore.workflow.serialize import read_workflow, write_workflow
 from dascore.workflow.task import Task
 
@@ -167,7 +167,7 @@ class ProvenanceNode(DascoreBaseModel):
         for node in steps:
             # steps() keeps only the nodes which hold a task.
             assert node.task is not None
-            name = unique_name(node.task.fingerprint, tasks)
+            name = unique_key(default_key(node.task), tasks)
             names[id(node)] = name
             tasks[name] = node.task
             given = tuple(names[id(x)] for x in node.parents if x.task is not None)
@@ -201,7 +201,7 @@ class ProvenanceNode(DascoreBaseModel):
             tasks=tasks,
             dependencies=dependencies,
             inputs=tuple(fed),
-            output=names[id(steps[-1])],
+            outputs=(names[id(steps[-1])],),
         )
 
     def to_json(self, indent: int | None = 2) -> str:

--- a/dascore/workflow/provenance.py
+++ b/dascore/workflow/provenance.py
@@ -22,14 +22,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, ValidationError
 
 import dascore as dc
 from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.types import FrozenDictType
+from dascore.utils.documents import parse_document
 from dascore.workflow.pipe import Pipe, default_key, unique_key
-from dascore.workflow.serialize import read_workflow, write_workflow
+from dascore.workflow.serialize import (
+    DOCUMENT,
+    decode,
+    encode,
+    read_workflow,
+    write_workflow,
+)
 from dascore.workflow.task import Task
 
 
@@ -91,7 +98,10 @@ class ProvenanceNode(DascoreBaseModel):
     def _identity(self) -> tuple:
         """Return what makes this node the step it is."""
         task = self.task.fingerprint if self.task is not None else None
-        return (task, self.patch_id, self.processing_id, self.source)
+        # The pairs as well as the ids the step produced: two steps which
+        # ran the same task on different data are not one step, and until
+        # the ids are filled in they are all a node has to say so with.
+        return (task, self.patch_id, self.processing_id, self.source, self.input_pairs)
 
     def walk(self) -> Iterator[ProvenanceNode]:
         """
@@ -149,10 +159,12 @@ class ProvenanceNode(DascoreBaseModel):
         Return a pipe which would do again what this node records.
 
         The sources are left out: a pipe describes what to do, and is run
-        against whatever data it is given. Two shapes have no pipe and
-        raise `ParameterError` rather than returning a pipe which could not
-        run: a graph where nothing was done, and one where a step took its
-        inputs from more places than a pipe can name.
+        against whatever data it is given. A graph a pipe has no way to say
+        raises `ParameterError` rather than giving back a pipe which could
+        not run: one where nothing was done, one where a step was fed both
+        by an earlier step and straight from a source, one where the steps
+        reading from the sources do not each take exactly one input, and
+        any shape left which does not make a graph a pipe would accept.
         """
         steps = self.steps()
         if not steps:
@@ -171,7 +183,11 @@ class ProvenanceNode(DascoreBaseModel):
             names[id(node)] = name
             tasks[name] = node.task
             given = tuple(names[id(x)] for x in node.parents if x.task is not None)
-            if given and len(given) != len(node.parents):
+            # What the step was given, which is what it recorded when a
+            # parent was not tracked: a node holds a pair per input and a
+            # parent only for the ones whose own node is known.
+            taken = len(node.input_pairs) or len(node.parents)
+            if given and len(given) != taken:
                 # Every input has to come from somewhere the pipe can name.
                 # A step fed partly by an earlier step and partly by data
                 # read straight from a file is the one shape it cannot say;
@@ -185,33 +201,46 @@ class ProvenanceNode(DascoreBaseModel):
             if given:
                 dependencies[name] = given
             else:
-                fed[name] = len(node.parents)
-        # A pipe hands one input to each of its sources, so it can describe
-        # one step which took several -- a chunk of many files -- but not two
-        # of them.
-        wide = [name for name, count in fed.items() if count > 1]
-        if len(fed) > 1 and wide:
+                fed[name] = taken
+        # A pipe hands each of its sources one input, so it can describe one
+        # step which took several -- a chunk of many files -- but only when
+        # that step is the only one reading from the sources.
+        if len(fed) > 1 and set(fed.values()) != {1}:
             msg = (
                 "This graph has more than one step reading straight from its "
-                "sources, and one of them took several inputs, which a pipe "
+                "sources, and they do not all take one input, which a pipe "
                 "has no way to describe."
             )
             raise ParameterError(msg)
-        return Pipe(
-            tasks=tasks,
-            dependencies=dependencies,
-            inputs=tuple(fed),
-            outputs=(names[id(steps[-1])],),
-        )
+        # Anything left which does not make a runnable graph -- steps which
+        # never meet, for one -- is this graph having no pipe rather than a
+        # pipe refusing to be built.
+        try:
+            return Pipe(
+                tasks=tasks,
+                dependencies=dependencies,
+                inputs=tuple(fed),
+                outputs=(names[id(steps[-1])],),
+            )
+        except ValidationError as problem:
+            msg = f"This graph does not describe a pipe which could run: {problem}"
+            raise ParameterError(msg) from problem
 
     def to_json(self, indent: int | None = 2) -> str:
         """Return the graph behind this node as JSON text."""
-        return json.dumps(self._to_document(), indent=indent, sort_keys=True)
+        return json.dumps(self._to_document(), indent=indent)
 
     @classmethod
     def from_json(cls, text: str) -> ProvenanceNode:
         """Return the graph some JSON text holds."""
-        return cls._from_document(json.loads(text))
+        # Through the shared parser, so text which does not parse says so
+        # the way every other document in DASCore does rather than raising
+        # whatever the json module happened to raise.
+        document = parse_document(text, "json", label="the provenance text")
+        if not isinstance(document, Mapping) or "nodes" not in document:
+            msg = "This text holds no record of what was done to any data."
+            raise ParameterError(msg)
+        return cls._from_document(document)
 
     def _to_document(self) -> dict[str, Any]:
         """Return a document holding this node and everything behind it."""
@@ -310,13 +339,20 @@ class Provenance(DascoreBaseModel):
         Return a document which describes this record.
 
         Every field is dumped by pydantic, so a field added later is written
-        without this having to be edited; only the two which hold workflow
-        objects are spelled out, since those are named by tag rather than
-        dumped as fields.
+        without this having to be edited. The three which pydantic has no
+        document form for are excluded from that dump rather than written
+        and overwritten: it would raise on a task holding an array, or on a
+        time recorded alongside the run, before reaching the line which
+        replaces what it produced.
         """
-        out = self.model_dump(mode="json")
+        written = {"pipe", "source_provenance", "metadata"}
+        out = self.model_dump(mode="json", exclude=written)
         out["pipe"] = self.pipe.to_dict()
         out["source_provenance"] = [x.to_dict() for x in self.source_provenance]
+        # Through the workflow encoding rather than pydantic's: metadata is
+        # whatever the caller thought worth recording, which is the same
+        # range of values a task's parameters cover.
+        out["metadata"] = encode(dict(self.metadata), mode=DOCUMENT)
         out["fingerprint"] = self.fingerprint
         return out
 
@@ -327,9 +363,13 @@ class Provenance(DascoreBaseModel):
         # Written for a reader, and derived from the pipe, so it is not one
         # of the fields the record is rebuilt from.
         fields.pop("fingerprint", None)
+        if "pipe" not in fields:
+            msg = "A record of a run states the pipe it ran; this document has none."
+            raise ParameterError(msg)
         sources = fields.pop("source_provenance", ())
         fields["pipe"] = Pipe.from_dict(fields["pipe"])
         fields["source_provenance"] = tuple(cls.from_dict(x) for x in sources)
+        fields["metadata"] = decode(fields.get("metadata", {}))
         return cls(**fields)
 
     def save(self, path: str | Path) -> Path:

--- a/dascore/workflow/provenance.py
+++ b/dascore/workflow/provenance.py
@@ -215,14 +215,15 @@ class ProvenanceNode(DascoreBaseModel):
                 dependencies[name] = given
             else:
                 fed[name] = taken
-        # A pipe hands each of its sources one input, so it can describe one
-        # step which took several -- a chunk of many files -- but only when
-        # that step is the only one reading from the sources.
-        if len(fed) > 1 and set(fed.values()) != {1}:
+        # A pipe hands each of its sources the same thing: one input each,
+        # or nothing at all when they make their own values. So it can
+        # describe one step which took several -- a chunk of many files --
+        # only when that step is the only one reading from the sources.
+        if len(fed) > 1 and set(fed.values()) not in ({0}, {1}):
             msg = (
                 "This graph has more than one step reading straight from its "
-                "sources, and they do not all take one input, which a pipe "
-                "has no way to describe."
+                "sources, and they do not all take the same one input, which "
+                "a pipe has no way to describe."
             )
             raise ParameterError(msg)
         # Anything left which does not make a runnable graph -- steps which
@@ -283,22 +284,29 @@ class ProvenanceNode(DascoreBaseModel):
     def _from_document(cls, document: Mapping) -> ProvenanceNode:
         """Return the graph a document describes."""
         built: list[ProvenanceNode] = []
-        for entry in document["nodes"]:
-            source = entry.get("source")
-            task = entry.get("task")
-            built.append(
-                cls(
-                    task=Task.from_dict(task) if task is not None else None,
-                    parents=tuple(built[x] for x in entry["parents"]),
-                    input_pairs=tuple(tuple(x) for x in entry["input_pairs"]),
-                    patch_id=entry["patch_id"],
-                    processing_id=entry["processing_id"],
-                    source=SourceInfo(**source) if source is not None else None,
-                    backend=entry["backend"],
-                    created_at=datetime.fromisoformat(entry["created_at"]),
+        # A node names its parents by where they were written, so a field
+        # which is not there, or a place which is not, is a document
+        # describing no graph rather than an error naming a key.
+        try:
+            for entry in document["nodes"]:
+                source = entry.get("source")
+                task = entry.get("task")
+                built.append(
+                    cls(
+                        task=Task.from_dict(task) if task is not None else None,
+                        parents=tuple(built[x] for x in entry["parents"]),
+                        input_pairs=tuple(tuple(x) for x in entry["input_pairs"]),
+                        patch_id=entry["patch_id"],
+                        processing_id=entry["processing_id"],
+                        source=SourceInfo(**source) if source is not None else None,
+                        backend=entry["backend"],
+                        created_at=datetime.fromisoformat(entry["created_at"]),
+                    )
                 )
-            )
-        return built[document["output"]]
+            return built[document["output"]]
+        except (KeyError, IndexError, TypeError, ValueError) as problem:
+            msg = f"This document describes no graph of what was done: {problem}"
+            raise ParameterError(msg) from problem
 
 
 class Provenance(DascoreBaseModel):

--- a/dascore/workflow/provenance.py
+++ b/dascore/workflow/provenance.py
@@ -8,9 +8,9 @@ on, written next to the results and read back later.
 A [`ProvenanceNode`](`dascore.workflow.provenance.ProvenanceNode`) is the
 live one: one immutable node per step, holding the task which ran and the
 nodes which fed it. A patch carries the node it came out of, so its whole
-history is reachable from it without a store to look anything up in.
-Building the graph as patches are processed is PR 4a's work; this module
-is the graph itself.
+history is reachable from it without a store to look anything up in. This
+module is the graph; building one as patches are processed comes with the
+patch ids, in a later release.
 """
 
 from __future__ import annotations
@@ -27,14 +27,18 @@ from pydantic import ConfigDict, Field
 import dascore as dc
 from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
-from dascore.workflow.pipe import COPY_SEP, Pipe, _dump, _parse
+from dascore.models.types import FrozenDictType
+from dascore.workflow.pipe import Pipe, unique_name
+from dascore.workflow.serialize import read_document, write_document
 from dascore.workflow.task import Task
 
 
 class SourceInfo(DascoreBaseModel):
     """Where a patch was read from."""
 
-    model_config = ConfigDict(frozen=True)
+    # A key which is not a field is a document written against another
+    # version of this class, which is worth an error rather than a shrug.
+    model_config = ConfigDict(extra="forbid")
 
     format: str = ""
     path: str = ""
@@ -52,7 +56,7 @@ class ProvenanceNode(DascoreBaseModel):
     by everything downstream of it rather than copied.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(extra="forbid")
 
     # None for a source: nothing was done to it, it was read.
     task: Task | None = None
@@ -67,9 +71,27 @@ class ProvenanceNode(DascoreBaseModel):
     backend: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
+    def __eq__(self, other) -> bool:
+        """
+        Two nodes are equal when they stand for the same step.
+
+        Compared on what the step was and what it produced rather than by
+        walking the graph behind it: the ids already answer for the whole
+        lineage, and a deep comparison would recurse as far as the data has
+        been processed.
+        """
+        if not isinstance(other, ProvenanceNode):
+            return NotImplemented
+        return self._identity() == other._identity()
+
     def __hash__(self) -> int:
-        """Hash a node by what it produced and what produced it."""
-        return hash((self.patch_id, self.processing_id, id(self.task)))
+        """Hash a node the way it compares."""
+        return hash(self._identity())
+
+    def _identity(self) -> tuple:
+        """Return what makes this node the step it is."""
+        task = self.task.fingerprint if self.task is not None else None
+        return (task, self.patch_id, self.processing_id, self.source)
 
     def walk(self) -> Iterator[ProvenanceNode]:
         """
@@ -104,8 +126,10 @@ class ProvenanceNode(DascoreBaseModel):
         """
         Return a readable listing of what was done, oldest first.
 
-        A step which took many inputs is written once, with how many, so a
-        patch chunked from sixty files reads as one line rather than sixty.
+        Data read from more than one file is one line saying how many
+        rather than a line per file, and a step which took several inputs
+        says how many, so a patch chunked from sixty files reads as two
+        lines rather than sixty-one.
         """
         lines = []
         for source in self.sources():
@@ -125,7 +149,10 @@ class ProvenanceNode(DascoreBaseModel):
         Return a pipe which would do again what this node records.
 
         The sources are left out: a pipe describes what to do, and is run
-        against whatever data it is given.
+        against whatever data it is given. Two shapes have no pipe and
+        raise `ParameterError` rather than returning a pipe which could not
+        run: a graph where nothing was done, and one where a step took its
+        inputs from more places than a pipe can name.
         """
         steps = self.steps()
         if not steps:
@@ -134,10 +161,13 @@ class ProvenanceNode(DascoreBaseModel):
         names: dict[int, str] = {}
         tasks: dict[str, Task] = {}
         dependencies: dict[str, tuple[str, ...]] = {}
+        # The steps which read straight from a source, and how many inputs
+        # each of them took.
+        fed: dict[str, int] = {}
         for node in steps:
             # steps() keeps only the nodes which hold a task.
             assert node.task is not None
-            name = _unique_name(node.task.fingerprint, tasks)
+            name = unique_name(node.task.fingerprint, tasks)
             names[id(node)] = name
             tasks[name] = node.task
             given = tuple(names[id(x)] for x in node.parents if x.task is not None)
@@ -154,7 +184,25 @@ class ProvenanceNode(DascoreBaseModel):
                 raise ParameterError(msg)
             if given:
                 dependencies[name] = given
-        return Pipe(tasks=tasks, dependencies=dependencies, output=names[id(steps[-1])])
+            else:
+                fed[name] = len(node.parents)
+        # A pipe hands one input to each of its sources, so it can describe
+        # one step which took several -- a chunk of many files -- but not two
+        # of them.
+        wide = [name for name, count in fed.items() if count > 1]
+        if len(fed) > 1 and wide:
+            msg = (
+                "This graph has more than one step reading straight from its "
+                "sources, and one of them took several inputs, which a pipe "
+                "has no way to describe."
+            )
+            raise ParameterError(msg)
+        return Pipe(
+            tasks=tasks,
+            dependencies=dependencies,
+            inputs=tuple(fed),
+            output=names[id(steps[-1])],
+        )
 
     def to_json(self, indent: int | None = 2) -> str:
         """Return the graph behind this node as JSON text."""
@@ -220,14 +268,14 @@ class Provenance(DascoreBaseModel):
     long gone.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(extra="forbid")
 
     pipe: Pipe
     dascore_version: str
     created_at: datetime
     python_version: str
-    system_info: Mapping[str, str] = Field(default_factory=dict)
-    metadata: Mapping[str, Any] = Field(default_factory=dict)
+    system_info: FrozenDictType[str, str] = Field(default_factory=dict)
+    metadata: FrozenDictType[str, Any] = Field(default_factory=dict)
     # The provenance of whatever this run was given, so a chain of runs
     # reads back as a chain.
     source_provenance: tuple[Provenance, ...] = ()
@@ -258,31 +306,31 @@ class Provenance(DascoreBaseModel):
         )
 
     def to_dict(self) -> dict[str, Any]:
-        """Return a document which describes this record."""
-        return {
-            "pipe": self.pipe.to_dict(),
-            "fingerprint": self.fingerprint,
-            "dascore_version": self.dascore_version,
-            "created_at": self.created_at.isoformat(),
-            "python_version": self.python_version,
-            "system_info": dict(self.system_info),
-            "metadata": dict(self.metadata),
-            "source_provenance": [x.to_dict() for x in self.source_provenance],
-        }
+        """
+        Return a document which describes this record.
+
+        Every field is dumped by pydantic, so a field added later is written
+        without this having to be edited; only the two which hold workflow
+        objects are spelled out, since those are named by tag rather than
+        dumped as fields.
+        """
+        out = self.model_dump(mode="json")
+        out["pipe"] = self.pipe.to_dict()
+        out["source_provenance"] = [x.to_dict() for x in self.source_provenance]
+        out["fingerprint"] = self.fingerprint
+        return out
 
     @classmethod
     def from_dict(cls, document: Mapping) -> Provenance:
         """Return the record a document describes."""
-        sources = document.get("source_provenance", ())
-        return cls(
-            pipe=Pipe.from_dict(document["pipe"]),
-            dascore_version=document["dascore_version"],
-            created_at=datetime.fromisoformat(document["created_at"]),
-            python_version=document["python_version"],
-            system_info=document.get("system_info", {}),
-            metadata=document.get("metadata", {}),
-            source_provenance=tuple(cls.from_dict(x) for x in sources),
-        )
+        fields = dict(document)
+        # Written for a reader, and derived from the pipe, so it is not one
+        # of the fields the record is rebuilt from.
+        fields.pop("fingerprint", None)
+        sources = fields.pop("source_provenance", ())
+        fields["pipe"] = Pipe.from_dict(fields["pipe"])
+        fields["source_provenance"] = tuple(cls.from_dict(x) for x in sources)
+        return cls(**fields)
 
     def save(self, path: str | Path) -> Path:
         """
@@ -291,25 +339,9 @@ class Provenance(DascoreBaseModel):
         The suffix picks the format, as it does for a pipe: ``.yaml`` or
         ``.yml`` write YAML, anything else writes JSON.
         """
-        path = Path(path)
-        path.parent.mkdir(exist_ok=True, parents=True)
-        path.write_text(_dump(self.to_dict(), path), encoding="utf-8")
-        return path
+        return write_document(self.to_dict(), Path(path))
 
     @classmethod
     def load(cls, path: str | Path) -> Provenance:
         """Return the record a file holds; see `save`."""
-        path = Path(path)
-        return cls.from_dict(_parse(path.read_text(encoding="utf-8"), path))
-
-
-def _unique_name(fingerprint: str, taken: Mapping[str, Any]) -> str:
-    """Return a node name which nothing in a pipe has claimed yet."""
-    # The same task twice in one chain is two steps, and two nodes; see
-    # `dascore.workflow.pipe`, which names repeats the same way.
-    name = fingerprint
-    copy = 0
-    while name in taken:
-        copy += 1
-        name = f"{fingerprint}{COPY_SEP}{copy}"
-    return name
+        return cls.from_dict(read_document(Path(path)))

--- a/dascore/workflow/provenance.py
+++ b/dascore/workflow/provenance.py
@@ -19,6 +19,7 @@ import json
 import platform
 from collections.abc import Iterator, Mapping
 from datetime import datetime, timezone
+from functools import cached_property
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +34,7 @@ from dascore.workflow.pipe import Pipe, default_key, unique_key
 from dascore.workflow.serialize import (
     DOCUMENT,
     decode,
+    digest,
     encode,
     read_workflow,
     write_workflow,
@@ -79,29 +81,40 @@ class ProvenanceNode(DascoreBaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     def __eq__(self, other) -> bool:
-        """
-        Two nodes are equal when they stand for the same step.
-
-        Compared on what the step was and what it produced rather than by
-        walking the graph behind it: the ids already answer for the whole
-        lineage, and a deep comparison would recurse as far as the data has
-        been processed.
-        """
+        """Two nodes are equal when they stand for the same step."""
         if not isinstance(other, ProvenanceNode):
             return NotImplemented
-        return self._identity() == other._identity()
+        return self.mark == other.mark
 
     def __hash__(self) -> int:
         """Hash a node the way it compares."""
-        return hash(self._identity())
+        return hash(self.mark)
 
-    def _identity(self) -> tuple:
-        """Return what makes this node the step it is."""
-        task = self.task.fingerprint if self.task is not None else None
-        # The pairs as well as the ids the step produced: two steps which
-        # ran the same task on different data are not one step, and until
-        # the ids are filled in they are all a node has to say so with.
-        return (task, self.patch_id, self.processing_id, self.source, self.input_pairs)
+    @cached_property
+    def mark(self) -> str:
+        """
+        Return a digest of this step and everything behind it.
+
+        The ids answer for the lineage once something fills them in, and
+        until then they are empty on every node -- so the lineage is folded
+        in as well, and two steps which ran the same task on different data
+        are two steps rather than one which a set would keep only once.
+        Folded rather than compared: it is computed by walking, so a long
+        chain of steps costs one pass and not a recursion per comparison.
+        """
+        marks: dict[int, str] = {}
+        for node in self.walk():
+            marks[id(node)] = digest(
+                [
+                    node.task.fingerprint if node.task is not None else None,
+                    [marks[id(x)] for x in node.parents],
+                    [list(x) for x in node.input_pairs],
+                    node.patch_id,
+                    node.processing_id,
+                    node.source.model_dump() if node.source is not None else None,
+                ]
+            )
+        return marks[id(self)]
 
     def walk(self) -> Iterator[ProvenanceNode]:
         """

--- a/dascore/workflow/serialize.py
+++ b/dascore/workflow/serialize.py
@@ -42,7 +42,8 @@ from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.registry import TAG_FIELD, get_model_tag, resolve_tagged_model
 from dascore.utils.array_api import is_foreign, to_numpy
-from dascore.utils.misc import _maybe_make_parent_directory, optional_import
+from dascore.utils.documents import DocumentFormat, read_document, write_document
+from dascore.utils.paths import quote_path
 from dascore.warnings import DASCoreWarning
 
 # The two encoding modes; see the module docstring.
@@ -77,9 +78,15 @@ _TIMEDELTA = "$timedelta64"
 # The digest size used everywhere: 8 bytes, written as 16 hex characters.
 DIGEST_SIZE = 8
 
-# The suffixes a document is written and read as YAML for; anything else is
-# JSON, which is what a suffix-less path gets.
+# The suffixes a workflow is written and read as, enumerated rather than
+# inferred: a path spelled `.txt` is a caller who meant something this does
+# not do, and picking a format for them would hide it. A path with no
+# suffix at all is JSON.
 YAML_SUFFIXES = frozenset({".yaml", ".yml"})
+JSON_SUFFIXES = frozenset({".json", ""})
+
+# Named when pyyaml is missing, which it may be: it is an optional install.
+_REQUIRED_FOR = "reading and writing a workflow as YAML"
 
 
 def digest(obj: Any, mode: EncodeMode = FINGERPRINT) -> str:
@@ -179,31 +186,42 @@ def decode(obj: Any) -> Any:
     return obj
 
 
-def write_document(document: Mapping, path: Path) -> Path:
+def write_workflow(document: Mapping, path: Path) -> Path:
     """
-    Write a document to a file, in the format its suffix names.
+    Write a workflow document to a file, in the format its suffix names.
 
-    ``.yaml`` and ``.yml`` write YAML; every other suffix writes JSON.
+    ``.yaml`` and ``.yml`` write YAML, ``.json`` and a bare name write
+    JSON, and anything else is refused.
     """
-    path = Path(path)
-    _maybe_make_parent_directory(path)
-    if path.suffix.lower() in YAML_SUFFIXES:
-        yaml = optional_import("yaml", required_for="writing a workflow as YAML")
-        text = yaml.safe_dump(dict(document), sort_keys=False)
-    else:
-        text = json.dumps(document, indent=2, sort_keys=True)
-    path.write_text(text, encoding="utf-8")
-    return path
+    return write_document(
+        document, path, _file_format(path), required_for=_REQUIRED_FOR
+    )
 
 
-def read_document(path: Path) -> Any:
-    """Return the document a file holds; see `write_document`."""
-    path = Path(path)
-    text = path.read_text(encoding="utf-8")
-    if path.suffix.lower() in YAML_SUFFIXES:
-        yaml = optional_import("yaml", required_for="reading a workflow from YAML")
-        return yaml.safe_load(text)
-    return json.loads(text)
+def read_workflow(path: Path) -> Any:
+    """Return the workflow document a file holds; see `write_workflow`."""
+    return read_document(
+        path,
+        _file_format(path),
+        error=ParameterError,
+        holds="describes no workflow",
+        required_for=_REQUIRED_FOR,
+    )
+
+
+def _file_format(path: Path) -> DocumentFormat:
+    """Return the format a path names, refusing a suffix which names none."""
+    suffix = Path(path).suffix.lower()
+    if suffix in YAML_SUFFIXES:
+        return "yaml"
+    if suffix in JSON_SUFFIXES:
+        return "json"
+    msg = (
+        f"{quote_path(Path(path))} has a suffix which names no format. Use "
+        f"one of {sorted(YAML_SUFFIXES | JSON_SUFFIXES - {''})}, or no "
+        "suffix at all."
+    )
+    raise ParameterError(msg)
 
 
 def _digest_bytes(data: bytes | memoryview) -> str:

--- a/dascore/workflow/serialize.py
+++ b/dascore/workflow/serialize.py
@@ -1,5 +1,6 @@
 """
-Canonical encoding, decoding and hashing for workflow objects.
+Canonical encoding, decoding and hashing for workflow objects, and the files
+those documents are written to.
 
 A [`Task`](`dascore.workflow.task.Task`) is identified by a fingerprint: a
 digest of what it is and what it was given. That only works if the same
@@ -13,7 +14,8 @@ becomes a digest of its bytes and a value left at ``None`` is dropped.
 nothing is dropped, so most values read back. A function, a partial, or a
 value with no encoding of its own is named rather than reproduced in either
 mode, and a dataframe has no document form at all; decoding any of them
-raises.
+raises. `write_workflow` and `read_workflow` put a document on disk in the
+format its suffix names, refusing a suffix which names none.
 
 Stability rests on `json`, `repr` of a float, numpy's byte layout and blake2b,
 none of which change between python versions, and -- for frames and quantities
@@ -70,10 +72,12 @@ _FLOAT = "$float"
 _MODEL = "$model"
 _OPAQUE = "$opaque"
 _PARTIAL = "$partial"
-_PIPE = "$pipe"
+PIPE_TAG = "$pipe"
+_PIPE = PIPE_TAG
 _QUANTITY = "$quantity"
 _SLICE = "$slice"
-_TASK = "$task"
+TASK_TAG = "$task"
+_TASK = TASK_TAG
 _TIMEDELTA = "$timedelta64"
 
 # The digest size used everywhere: 8 bytes, written as 16 hex characters.
@@ -85,9 +89,6 @@ DIGEST_SIZE = 8
 # suffix at all is JSON.
 YAML_SUFFIXES = frozenset({".yaml", ".yml"})
 JSON_SUFFIXES = frozenset({".json", ""})
-
-# Named when pyyaml is missing, which it may be: it is an optional install.
-_REQUIRED_FOR = "reading and writing a workflow as YAML"
 
 
 def digest(obj: Any, mode: EncodeMode = FINGERPRINT) -> str:
@@ -194,9 +195,7 @@ def write_workflow(document: Mapping, path: Path) -> Path:
     ``.yaml`` and ``.yml`` write YAML, ``.json`` and a bare name write
     JSON, and anything else is refused.
     """
-    return write_document(
-        document, path, _file_format(path), required_for=_REQUIRED_FOR
-    )
+    return write_document(document, path, _file_format(path))
 
 
 def read_workflow(path: Path) -> Any:
@@ -206,7 +205,6 @@ def read_workflow(path: Path) -> Any:
         _file_format(path),
         error=ParameterError,
         holds="describes no workflow",
-        required_for=_REQUIRED_FOR,
     )
 
 

--- a/dascore/workflow/serialize.py
+++ b/dascore/workflow/serialize.py
@@ -31,7 +31,7 @@ import warnings
 from collections.abc import Callable, Iterable, Mapping, Set
 from enum import Enum
 from functools import partial
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from typing import Any, Literal
 
 import numpy as np
@@ -42,6 +42,7 @@ from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.registry import TAG_FIELD, get_model_tag, resolve_tagged_model
 from dascore.utils.array_api import is_foreign, to_numpy
+from dascore.utils.misc import _maybe_make_parent_directory, optional_import
 from dascore.warnings import DASCoreWarning
 
 # The two encoding modes; see the module docstring.
@@ -75,6 +76,10 @@ _TIMEDELTA = "$timedelta64"
 
 # The digest size used everywhere: 8 bytes, written as 16 hex characters.
 DIGEST_SIZE = 8
+
+# The suffixes a document is written and read as YAML for; anything else is
+# JSON, which is what a suffix-less path gets.
+YAML_SUFFIXES = frozenset({".yaml", ".yml"})
 
 
 def digest(obj: Any, mode: EncodeMode = FINGERPRINT) -> str:
@@ -172,6 +177,33 @@ def decode(obj: Any) -> Any:
     if isinstance(obj, list):
         return [decode(x) for x in obj]
     return obj
+
+
+def write_document(document: Mapping, path: Path) -> Path:
+    """
+    Write a document to a file, in the format its suffix names.
+
+    ``.yaml`` and ``.yml`` write YAML; every other suffix writes JSON.
+    """
+    path = Path(path)
+    _maybe_make_parent_directory(path)
+    if path.suffix.lower() in YAML_SUFFIXES:
+        yaml = optional_import("yaml", required_for="writing a workflow as YAML")
+        text = yaml.safe_dump(dict(document), sort_keys=False)
+    else:
+        text = json.dumps(document, indent=2, sort_keys=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def read_document(path: Path) -> Any:
+    """Return the document a file holds; see `write_document`."""
+    path = Path(path)
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in YAML_SUFFIXES:
+        yaml = optional_import("yaml", required_for="reading a workflow from YAML")
+        return yaml.safe_load(text)
+    return json.loads(text)
 
 
 def _digest_bytes(data: bytes | memoryview) -> str:

--- a/dascore/workflow/serialize.py
+++ b/dascore/workflow/serialize.py
@@ -70,6 +70,7 @@ _FLOAT = "$float"
 _MODEL = "$model"
 _OPAQUE = "$opaque"
 _PARTIAL = "$partial"
+_PIPE = "$pipe"
 _QUANTITY = "$quantity"
 _SLICE = "$slice"
 _TASK = "$task"
@@ -267,6 +268,11 @@ def _encode(obj: Any, mode: EncodeMode) -> Any:
         # Checked before the model branch below, which every task also
         # answers to: a task carries a version its fields do not show.
         return {_TASK: obj.fingerprint if mode == FINGERPRINT else obj.to_dict()}
+    if isinstance(obj, _pipe_class()):
+        # A pipe is one operation too, and says so its own way: dumping its
+        # fields would name the tasks by class rather than by tag, and would
+        # hash a graph by the names of its nodes.
+        return {_PIPE: obj.fingerprint if mode == FINGERPRINT else obj.to_dict()}
     if isinstance(obj, DascoreBaseModel):
         return _encode_model(obj, mode)
     if isinstance(obj, pd.DataFrame | pd.Series):
@@ -571,6 +577,13 @@ def _task_class() -> type:
     return Task
 
 
+def _pipe_class() -> type:
+    """Return the Pipe class; deferred for the reason `_task_class` is."""
+    from dascore.workflow.pipe import Pipe  # noqa: PLC0415
+
+    return Pipe
+
+
 def _decode_mapping(obj: Mapping) -> Any:
     """Decode a mapping, inverting whichever tag it carries."""
     if len(obj) == 1:
@@ -647,6 +660,20 @@ def _decode_task(value: Any) -> Any:
     return Task.from_dict(value)
 
 
+def _decode_pipe(value: Any) -> Any:
+    """Decode a pipe from its document."""
+    if not isinstance(value, Mapping):
+        msg = (
+            "A pipe encoded for a fingerprint holds only its digest, so the "
+            "pipe itself cannot be read back from it."
+        )
+        raise ParameterError(msg)
+    # Imported here rather than at module scope: pipe.py imports this module.
+    from dascore.workflow.pipe import Pipe  # noqa: PLC0415
+
+    return Pipe.from_dict(value)
+
+
 def _decode_dict(pairs: list) -> dict:
     """Decode a mapping whose keys are not strings."""
     # A key which was a tuple comes back as a list, which cannot be a key
@@ -686,6 +713,7 @@ _DECODERS: dict[str, Callable[[Any], Any]] = {
     _MODEL: _decode_model,
     _OPAQUE: _refuse("value"),
     _PARTIAL: _refuse("partial"),
+    _PIPE: _decode_pipe,
     _QUANTITY: _decode_quantity,
     _SLICE: _decode_slice,
     _TASK: _decode_task,

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -49,7 +49,15 @@ from dascore.models.registry import (
 )
 from dascore.utils.misc import suppress_warnings
 from dascore.warnings import DASCoreWarning
-from dascore.workflow.serialize import DOCUMENT, decode, digest, encode, model_values
+from dascore.workflow.serialize import (
+    DOCUMENT,
+    PIPE_TAG,
+    TASK_TAG,
+    decode,
+    digest,
+    encode,
+    model_values,
+)
 
 # The keys a task's document holds beside its parameters.
 _VERSION_KEY = "version"
@@ -69,6 +77,11 @@ class Task(DascoreBaseModel):
     *configured* with is a field. A pipe wires its edges by position for
     the same reason: there is no name to bind them to, and the order the
     inputs are given in is part of what the step did.
+
+    An array given as a parameter is marked read-only in place, as a
+    patch's data is, so that the fingerprint cannot come to describe values
+    the task no longer holds. Nothing is copied, so the array marked is the
+    caller's own: pass a copy of a buffer which is still being written to.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -150,11 +163,9 @@ class Task(DascoreBaseModel):
         """
         Return a document which describes this task.
 
-        The class is named by its registered tag and by nothing else. A
-        module path would be a second answer to the same question, and the
-        wrong one as soon as the class moved -- which a fingerprint
-        deliberately survives -- while the tag already names the package
-        the class came from.
+        The class is named by its registered tag and by nothing else: the
+        tag already names the package, and a module path would go stale as
+        soon as the class moved, which a fingerprint deliberately survives.
         """
         _check_nameable(type(self), self.tag)
         return {
@@ -251,23 +262,45 @@ def _check_nameable(task_class: type[Task], tag: str | None) -> None:
         raise ParameterError(msg)
 
 
-def holds_another_version(document: Any) -> bool:
+def holds_another_version(document: Mapping) -> bool:
     """
     Return True when a document holds a task written at another version.
 
-    Looked for at any depth: a task's parameter can be another task, or a
-    whole pipe, and a version bump down there changes what the document
-    fingerprints to just as much as one at the top.
+    Looked for at any depth a task can nest at: a task's parameter can be
+    another task, or a whole pipe, and a version bump down there changes
+    what the document fingerprints to just as much as one at the top. Only
+    those two nestings are followed, and never a parameter's own contents:
+    a task may legitimately hold a mapping which spells a tag and a version
+    -- a stored attrs document does -- and reading that as a version bump
+    would let a parameter switch off the check for everything around it.
     """
-    if isinstance(document, Mapping):
-        tag, version = document.get(TAG_FIELD), document.get(_VERSION_KEY)
-        model = resolve_model_tag(tag) if isinstance(tag, str) else None
-        if version is not None and getattr(model, "__version__", version) != version:
-            return True
-        return any(holds_another_version(x) for x in document.values())
-    if isinstance(document, list | tuple):
-        return any(holds_another_version(x) for x in document)
-    return False
+    return _task_moved_on(document) or any(
+        holds_another_version(x) for x in _nested_documents(document)
+    )
+
+
+def _task_moved_on(document: Mapping) -> bool:
+    """Return True when a task document names a version its class does not."""
+    tag, version = document.get(TAG_FIELD), document.get(_VERSION_KEY)
+    if version is None or not isinstance(tag, str):
+        return False
+    model = resolve_model_tag(tag)
+    return getattr(model, "__version__", version) != version
+
+
+def _nested_documents(document: Mapping) -> list:
+    """Return the task and pipe documents one document holds directly."""
+    # A pipe writes its nodes under `tasks`; a task writes a nested task or
+    # pipe as the one tagged value the encoding gives it.
+    out = list(document.get("tasks", {}).values())
+    for value in document.get(_PARAMS_KEY, {}).values():
+        if isinstance(value, Mapping) and len(value) == 1:
+            nested = value.get(TASK_TAG, value.get(PIPE_TAG))
+            # A mapping, so a nested value written for a fingerprint -- a
+            # digest rather than a document -- is nothing to walk into.
+            if isinstance(nested, Mapping):
+                out.append(nested)
+    return out
 
 
 def _check_version(task_class: type[Task], version: object) -> None:
@@ -320,10 +353,11 @@ def own_arrays(values: Mapping) -> dict:
     """
     Return parameters with every array in them made read-only.
 
-    A task is immutable and its fingerprint is computed once, so an array a
-    caller keeps writing to would leave the task reporting an id for values
-    it no longer holds. Marking it read-only is what dascore does with a
-    patch's data, and costs no copy.
+    A task is immutable and its fingerprint is cached on first use, so an
+    array a caller kept writing to would leave the task reporting a
+    fingerprint of values it no longer holds. Marking it read-only is what
+    dascore does with a patch's data, and costs no copy -- which means the
+    array marked is the caller's own, not a copy of it.
     """
     return {key: _own(value) for key, value in values.items()}
 
@@ -487,7 +521,8 @@ def make_function_task_class(
     inputs
         How many leading parameters are not made fields. They are what the
         task is given when it runs, such as the patch a patch function
-        operates on.
+        operates on. None by default here, unlike the `task` decorator,
+        which takes one.
     """
     signature = inspect.signature(func)
     # A callable which is not a function -- a class, or an object with a
@@ -539,21 +574,25 @@ def _check_inputs(
     """
     Refuse a count of run time inputs the function could not be given.
 
-    An input is passed positionally, so it has to be a parameter which can
-    be: a keyword only one, or a group, is a parameter the task holds. The
-    failure belongs where the count is written rather than in the call
-    which finds itself missing an argument.
+    An input is passed positionally, so only a positional parameter can be
+    one; a keyword only parameter, or a ``**kwargs`` group, stays with the
+    task. A ``*args`` group takes as many as it is given, so a function
+    which has one can be asked for any number. Refusing here puts the
+    failure where the count is written rather than in the call which finds
+    itself missing an argument.
     """
     positional = (
         inspect.Parameter.POSITIONAL_ONLY,
         inspect.Parameter.POSITIONAL_OR_KEYWORD,
     )
     takeable = [x for x in parameters if x.kind in positional]
-    if not 0 <= inputs <= len(takeable):
+    packs_args = any(x.kind == inspect.Parameter.VAR_POSITIONAL for x in parameters)
+    if inputs < 0 or (inputs > len(takeable) and not packs_args):
         name = getattr(func, "__name__", type(func).__name__)
         msg = (
             f"{name} takes {len(takeable)} arguments which could be an "
-            f"input, and was asked for {inputs}."
+            f"input, and was asked for {inputs}. Spell the count it takes, "
+            "such as inputs=0 for a task which is handed nothing."
         )
         raise ParameterError(msg)
 

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -174,6 +174,19 @@ class Task(DascoreBaseModel):
         """Hash a task the way it compares."""
         return hash(self.fingerprint)
 
+    def __or__(self, other) -> Any:
+        """Return the pipe which runs this task and then what follows it."""
+        # pipe.py imports this module, so it is named where it is used.
+        from dascore.workflow.pipe import join  # noqa: PLC0415
+
+        return join(self, other)
+
+    def __ror__(self, other) -> Any:
+        """Return the pipe which runs what precedes this task and then it."""
+        from dascore.workflow.pipe import join  # noqa: PLC0415
+
+        return join(other, self)
+
     def __reduce__(self):
         """
         Pickle a task by its tag, and its parameters as themselves.

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -563,7 +563,7 @@ def make_function_task_class(
     qualname = getattr(func, "__qualname__", type(func).__qualname__)
     declared = list(signature.parameters.values())
     _check_inputs(func, declared, inputs)
-    parameters = declared[inputs:]
+    parameters = _remaining_parameters(declared, inputs)
     namespace, annotations = _build_fields(parameters)
     positional, keyword = _call_plan(parameters)
     # Declared ClassVar so that pydantic leaves them as class attributes
@@ -628,6 +628,33 @@ def _check_inputs(
             "such as inputs=0 for a task which is handed nothing."
         )
         raise ParameterError(msg)
+
+
+def _remaining_parameters(
+    declared: list[inspect.Parameter], inputs: int
+) -> list[inspect.Parameter]:
+    """
+    Return the parameters left once the run time inputs are taken out.
+
+    Taken off the front one at a time rather than sliced by count: a
+    ``*args`` group absorbs every input which is left, and whatever is
+    declared after it -- a keyword only parameter, a ``**kwargs`` group --
+    is still the task's, which slicing by count would drop.
+    """
+    positional = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    out: list[inspect.Parameter] = []
+    taken = 0
+    for parameter in declared:
+        if taken < inputs and parameter.kind in positional:
+            taken += 1
+        elif taken < inputs and parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            taken = inputs
+        else:
+            out.append(parameter)
+    return out
 
 
 def _call_plan(

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -120,13 +120,30 @@ class Task(DascoreBaseModel):
         within a package nor a faster kernel makes an operation a different
         operation.
         """
+        return self.fingerprint_at(self.__version__)
+
+    def fingerprint_at(self, version: str) -> str:
+        """
+        Return the fingerprint this task has at a stated version.
+
+        For reading a document back: the version is part of what a task is,
+        so a document written before its class moved on records a
+        fingerprint this task no longer has. Asking for it at the version
+        the document names says what it was, which is how an edited file
+        can still be told from an old one.
+
+        Parameters
+        ----------
+        version
+            The version to compute it at, as `__version__` spells one.
+        """
         # The parameters go in as the objects they are: `digest` encodes
         # what it is given, and encoding them here as well would put every
         # tagged value -- an array, a time, a quantity -- through the
         # escape which exists for a mapping that spells a tag itself.
         payload = {
             "task": _qualified_tag(type(self)),
-            _VERSION_KEY: self.__version__,
+            _VERSION_KEY: version,
             _PARAMS_KEY: self._params(),
         }
         return digest(payload)
@@ -262,20 +279,36 @@ def _check_nameable(task_class: type[Task], tag: str | None) -> None:
         raise ParameterError(msg)
 
 
-def holds_another_version(document: Mapping) -> bool:
+def holds_a_nested_version(document: Mapping) -> bool:
     """
-    Return True when a document holds a task written at another version.
+    Return True when a task or pipe a document holds as a *parameter* was
+    written at another version.
 
-    Looked for at any depth a task can nest at: a task's parameter can be
-    another task, or a whole pipe, and a version bump down there changes
-    what the document fingerprints to just as much as one at the top. Only
-    those two nestings are followed, and never a parameter's own contents:
-    a task may legitimately hold a mapping which spells a tag and a version
-    -- a stored attrs document does -- and reading that as a version bump
-    would let a parameter switch off the check for everything around it.
+    The tasks a pipe is made of are not looked at: their fingerprints can
+    be recomputed at the version the document records, which says exactly
+    what they were. A nested one cannot, because the task holding it
+    fingerprints it at the version its class has now -- so a bump down
+    there is the one version difference which still cannot be told from an
+    edit, and is tolerated rather than reported as one.
+    """
+    return any(
+        _holds_another_version(nested)
+        for task in document.get("tasks", {}).values()
+        for nested in _nested_documents(task)
+    )
+
+
+def _holds_another_version(document: Mapping) -> bool:
+    """
+    Return True when a task document, or one it holds, moved on.
+
+    Only a nested task or pipe is followed, never a parameter's own
+    contents: a task may legitimately hold a mapping which spells a tag and
+    a version -- a stored attrs document does -- and reading that as a
+    version bump would let a parameter speak for the tasks around it.
     """
     return _task_moved_on(document) or any(
-        holds_another_version(x) for x in _nested_documents(document)
+        _holds_another_version(x) for x in _nested_documents(document)
     )
 
 

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -52,7 +52,6 @@ from dascore.workflow.serialize import DOCUMENT, decode, digest, encode, model_v
 
 # The keys a task's document holds beside its parameters.
 _VERSION_KEY = "version"
-_CODE_PATH_KEY = "code_path"
 _PARAMS_KEY = "params"
 
 
@@ -128,16 +127,16 @@ class Task(DascoreBaseModel):
         """
         Return a document which describes this task.
 
-        The document names the class by its registered tag, never by an
-        import path; `code_path` is written only so a human, or an error
-        message, can find the class the tag stands for.
+        The class is named by its registered tag and by nothing else. A
+        module path would be a second answer to the same question, and the
+        wrong one as soon as the class moved -- which a fingerprint
+        deliberately survives -- while the tag already names the package
+        the class came from.
         """
-        cls = type(self)
-        _check_nameable(cls, self.tag)
+        _check_nameable(type(self), self.tag)
         return {
             TAG_FIELD: self.tag,
             _VERSION_KEY: self.__version__,
-            _CODE_PATH_KEY: f"{cls.__module__}:{cls.__qualname__}",
             _PARAMS_KEY: encode(self._params(), mode=DOCUMENT),
         }
 

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -30,13 +30,14 @@ from __future__ import annotations
 import inspect
 import warnings
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import cached_property
 from typing import Any, ClassVar, Self
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 from pydantic.fields import FieldInfo
 
+from dascore.compat import array, is_array_like
 from dascore.exceptions import ParameterError
 from dascore.models.base import DascoreBaseModel
 from dascore.models.registry import (
@@ -65,6 +66,12 @@ class Task(DascoreBaseModel):
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _own_the_arrays(cls, data: Any) -> Any:
+        """Take ownership of any array a task was handed."""
+        return own_arrays(data) if isinstance(data, dict) else data
 
     # Bumped by a subclass whenever the same parameters should mean a
     # different answer, so that old fingerprints do not name the new
@@ -274,6 +281,36 @@ def intern(task: Task) -> Task:
     return task
 
 
+def own_arrays(values: Mapping) -> dict:
+    """
+    Return parameters with every array in them made read-only.
+
+    A task is immutable and its fingerprint is computed once, so an array a
+    caller keeps writing to would leave the task reporting an id for values
+    it no longer holds. Marking it read-only is what dascore does with a
+    patch's data, and costs no copy.
+    """
+    return {key: _own(value) for key, value in values.items()}
+
+
+def _own(value: Any) -> Any:
+    """Return one parameter value with the arrays inside it made read-only."""
+    # Only array-likes: `array` would turn anything else, a string or a
+    # tuple of bounds, into an array of its own.
+    if is_array_like(value):
+        return array(value)
+    # Arrays reach a task inside a sequence as well -- a pair of masks, a
+    # mapping of them -- and a container is walked rather than rebuilt when
+    # it holds none.
+    if isinstance(value, list | tuple):
+        owned = [_own(x) for x in value]
+        return type(value)(owned) if owned != list(value) else value
+    if isinstance(value, Mapping):
+        owned = {key: _own(x) for key, x in value.items()}
+        return owned if owned != dict(value) else value
+    return value
+
+
 def _qualified_tag(cls: type) -> str:
     """Return the tag naming a class, always with its namespace."""
     # DASCore's own models register bare, so that a hand written file says
@@ -326,7 +363,9 @@ class FunctionTask(Task):
         for name, parameter in cls._signature.parameters.items():
             if parameter.kind == inspect.Parameter.VAR_KEYWORD:
                 values |= values.pop(name, {})
-        return cls.model_construct(**values)
+        # model_construct skips validation, and with it the validator which
+        # takes ownership of an array, so it is done here instead.
+        return cls.model_construct(**own_arrays(values))
 
     def _call_args(self) -> tuple:
         """Return the arguments this task passes positionally."""

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -95,10 +95,14 @@ class Task(DascoreBaseModel):
         within a package nor a faster kernel makes an operation a different
         operation.
         """
+        # The parameters go in as the objects they are: `digest` encodes
+        # what it is given, and encoding them here as well would put every
+        # tagged value -- an array, a time, a quantity -- through the
+        # escape which exists for a mapping that spells a tag itself.
         payload = {
             "task": _qualified_tag(type(self)),
             _VERSION_KEY: self.__version__,
-            _PARAMS_KEY: encode(self._params()),
+            _PARAMS_KEY: self._params(),
         }
         return digest(payload)
 

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -63,6 +63,12 @@ class Task(DascoreBaseModel):
     Subclasses declare their parameters as fields and implement `run`. Every
     instance is frozen, so a task can be shared, cached and reused; changing
     one means making another with `update`.
+
+    What `run` takes is what the task is given when it runs, positionally
+    and in the order its parameters are declared; everything the task was
+    *configured* with is a field. A pipe wires its edges by position for
+    the same reason: there is no name to bind them to, and the order the
+    inputs are given in is part of what the step did.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -116,6 +122,16 @@ class Task(DascoreBaseModel):
         """Execute the task. Subclasses must implement this."""
         msg = f"{type(self).__name__} does not implement run."
         raise NotImplementedError(msg)
+
+    def __call__(self, *args, **kwargs) -> Any:
+        """
+        Run the task; see `run`.
+
+        Defined rather than aliased so that a subclass's own `run` is the
+        one called, and so a task can stand anywhere a function of its
+        inputs can -- `spool.map(task)`, most of all.
+        """
+        return self.run(*args, **kwargs)
 
     def update(self, **kwargs) -> Self:
         """
@@ -233,6 +249,25 @@ def _check_nameable(task_class: type[Task], tag: str | None) -> None:
             "its package claims."
         )
         raise ParameterError(msg)
+
+
+def holds_another_version(document: Any) -> bool:
+    """
+    Return True when a document holds a task written at another version.
+
+    Looked for at any depth: a task's parameter can be another task, or a
+    whole pipe, and a version bump down there changes what the document
+    fingerprints to just as much as one at the top.
+    """
+    if isinstance(document, Mapping):
+        tag, version = document.get(TAG_FIELD), document.get(_VERSION_KEY)
+        model = resolve_model_tag(tag) if isinstance(tag, str) else None
+        if version is not None and getattr(model, "__version__", version) != version:
+            return True
+        return any(holds_another_version(x) for x in document.values())
+    if isinstance(document, list | tuple):
+        return any(holds_another_version(x) for x in document)
+    return False
 
 
 def _check_version(task_class: type[Task], version: object) -> None:
@@ -385,12 +420,12 @@ class FunctionTask(Task):
         return out
 
 
-def task(func: Callable | None = None, *, version: str = "1.0") -> Any:
+def task(func: Callable | None = None, *, version: str = "1.0", inputs: int = 1) -> Any:
     """
     Turn a function into a `Task` subclass.
 
-    The function's parameters become the task's fields, and calling `run`
-    calls the function with them.
+    The function's parameters become the task's fields, except the first
+    `inputs` of them, which are what the task is given when it runs.
 
     Parameters
     ----------
@@ -398,22 +433,35 @@ def task(func: Callable | None = None, *, version: str = "1.0") -> Any:
         The function to convert.
     version
         The version of the new task class.
+    inputs
+        How many of the function's leading positional parameters are run
+        time inputs rather than parameters. One by default, which is what a
+        step of a pipe takes; zero makes a task which is fed nothing and is
+        a source of its own.
 
     Examples
     --------
     >>> from dascore.workflow import task
     >>>
     >>> @task
-    ... def add_example(a, b=1):
-    ...     '''Add two numbers.'''
-    ...     return a + b
+    ... def scale_number_example(number, factor=1):
+    ...     '''Scale a number.'''
+    ...     return number * factor
     >>>
-    >>> assert add_example(a=1, b=2).run() == 3
-    >>> assert add_example(a=1).run() == 2
+    >>> assert scale_number_example(factor=2).run(3) == 6
+    >>> # A pipe step is a task of one input, so `|` works on them.
+    >>> assert (scale_number_example(factor=2) | scale_number_example(factor=3))(1) == 6
+    >>>
+    >>> @task(inputs=0)
+    ... def source_number_example(value=1):
+    ...     '''Make a number out of nothing.'''
+    ...     return value
+    >>>
+    >>> assert source_number_example(value=2).run() == 2
     """
 
     def decorator(function: Callable) -> type[Task]:
-        return make_function_task_class(function, version=version)
+        return make_function_task_class(function, version=version, inputs=inputs)
 
     return decorator if func is None else decorator(func)
 
@@ -422,7 +470,7 @@ def make_function_task_class(
     func: Callable,
     base: type[Task] = Task,
     version: str = "1.0",
-    skip_first: bool = False,
+    inputs: int = 0,
 ) -> type[Task]:
     """
     Return a `Task` subclass whose fields are a function's parameters.
@@ -436,8 +484,8 @@ def make_function_task_class(
         `PatchProcessor` rather than from `Task` itself.
     version
         The version of the new class.
-    skip_first
-        If True the first parameter is not made a field. It is the input the
+    inputs
+        How many leading parameters are not made fields. They are what the
         task is given when it runs, such as the patch a patch function
         operates on.
     """
@@ -445,7 +493,9 @@ def make_function_task_class(
     # A callable which is not a function -- a class, or an object with a
     # __call__ -- is named by its own class instead.
     qualname = getattr(func, "__qualname__", type(func).__qualname__)
-    parameters = list(signature.parameters.values())[1 if skip_first else 0 :]
+    declared = list(signature.parameters.values())
+    _check_inputs(func, declared, inputs)
+    parameters = declared[inputs:]
     namespace, annotations = _build_fields(parameters)
     positional, keyword = _call_plan(parameters)
     # Declared ClassVar so that pydantic leaves them as class attributes
@@ -481,6 +531,31 @@ def make_function_task_class(
     # the function, and the attribute it hides is not part of a task's API.
     with suppress_warnings(UserWarning, message="Field name .* shadows an attribute"):
         return type(name, (FunctionTask, base), namespace)
+
+
+def _check_inputs(
+    func: Callable, parameters: list[inspect.Parameter], inputs: int
+) -> None:
+    """
+    Refuse a count of run time inputs the function could not be given.
+
+    An input is passed positionally, so it has to be a parameter which can
+    be: a keyword only one, or a group, is a parameter the task holds. The
+    failure belongs where the count is written rather than in the call
+    which finds itself missing an argument.
+    """
+    positional = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    takeable = [x for x in parameters if x.kind in positional]
+    if not 0 <= inputs <= len(takeable):
+        name = getattr(func, "__name__", type(func).__name__)
+        msg = (
+            f"{name} takes {len(takeable)} arguments which could be an "
+            f"input, and was asked for {inputs}."
+        )
+        raise ParameterError(msg)
 
 
 def _call_plan(

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -184,11 +184,15 @@ print(diamond.to_mermaid())
 
 A pipe can be written to JSON or YAML — `.yaml` and `.yml` write YAML, `.json` or a bare name write JSON, and any other suffix is refused rather than guessed at — and read back into the same pipe. It names each task by its registered tag rather than by an import path, so reading a pipe never imports whatever a file happens to name. The other side of that is that a task class has to live at module level, under a name no other class in its package claims, and that whatever defines it has to be imported before the pipe is loaded.
 
+<!--
+`execute: false` keeps the chunk below out of the generated doc tests
+(scripts/generate_doc_code_tests.py), which run a page's chunks inside a
+function, where a task class is a local one and no document could name it.
+Quarto ignores the option and still runs the chunk at build time.
+-->
+
 ```{python}
 #| execute: false
-#  Not mirrored into the generated doc tests: those run a page's chunks
-#  inside a function, where a task class is a local one and no document
-#  could name it. Quarto still runs this at build time.
 import tempfile
 from pathlib import Path
 

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -1,0 +1,177 @@
+---
+title: Workflow
+execute:
+  warning: false
+---
+A workflow is processing written down as an object rather than as a script. Its two pieces are a [Task](`dascore.workflow.task.Task`), which is one operation and the parameters it was given, and a [Pipe](`dascore.workflow.pipe.Pipe`), which is several tasks arranged into the shape of one. Both are immutable, both know their own fingerprint, and both can be written to a file and read back, so a processing chain can be compared, stored, shared, and run later against other data.
+
+::: {.callout-note}
+The workflow module is new, and DASCore's own patch functions do not use it yet. Today you can write tasks of your own; a later release turns every patch function into one.
+:::
+
+# Tasks
+
+A task is a frozen model whose fields are the parameters of the operation, plus a `run` which does it.
+
+```{python}
+from dascore.workflow import Task
+
+
+class Scale(Task):
+    """Multiply data by a factor."""
+
+    factor: float = 1.0
+
+    def run(self, patch):
+        """Scale a patch."""
+        return patch.update(data=patch.data * self.factor)
+
+
+task = Scale(factor=2)
+task
+```
+
+Because the parameters are the object, two tasks which would do the same thing are the same task:
+
+```{python}
+assert Scale(factor=2) == Scale(factor=2)
+assert Scale(factor=2) != Scale(factor=3)
+```
+
+## Fingerprints
+
+Every task has a `fingerprint`: a short digest of which task it is, which version of it, and what it was given. The same call gives the same fingerprint in another process, on another machine, and in a later release.
+
+```{python}
+Scale(factor=2).fingerprint
+```
+
+The fingerprint names the class and its parameters, not the module the class lives in nor the source of its body. Moving `Scale` between modules does not change it; changing what the same parameters *mean* should, which is what `__version__` is for:
+
+```{python}
+class Scale(Task):
+    """Multiply data by a factor, differently."""
+
+    __version__ = "2.0"
+    factor: float = 1.0
+
+    def run(self, patch):
+        """Scale a patch."""
+        return patch.update(data=patch.data * self.factor)
+
+
+Scale(factor=2).fingerprint
+```
+
+## Tasks from functions
+
+A function can become a task class without being rewritten. The decorator reads its signature and makes each parameter a field.
+
+```{python}
+from dascore.workflow import task
+
+
+@task
+def add(first, second=1):
+    """Add two numbers."""
+    return first + second
+
+
+add(first=1, second=2).run()
+```
+
+# Pipes
+
+Tasks joined with `|` make a pipe, which runs them in order.
+
+```{python}
+from dascore.workflow import Task
+
+
+class Add(Task):
+    """Add a number."""
+
+    value: int = 1
+
+    def run(self, number):
+        """Add to a number."""
+        return number + self.value
+
+
+class Times(Task):
+    """Multiply by a number."""
+
+    value: int = 2
+
+    def run(self, number):
+        """Multiply a number."""
+        return number * self.value
+
+
+pipe = Add(value=2) | Times(value=3)
+pipe.run(1)
+```
+
+A pipe is a graph rather than a list, so several branches can feed one task. Each branch gets the input, and the task which joins them is given their outputs in the order they were wired.
+
+```{python}
+class Join(Task):
+    """Add up everything it is given."""
+
+    def run(self, *numbers):
+        """Add up numbers."""
+        return sum(numbers)
+
+
+branched = (Add(value=1), Times(value=5)) | Join()
+branched.run(10)
+```
+
+`map` runs the pipe over many inputs, optionally with something else's workers:
+
+```{python}
+pipe.map([1, 2, 3])
+```
+
+A pipe has a fingerprint of its own, which covers both the tasks and how they are wired, and it draws itself:
+
+```{python}
+print(branched.to_mermaid())
+```
+
+## Saving and loading
+
+A pipe can be written to JSON or YAML — the suffix decides — and read back into the same pipe. It names each task by its registered tag rather than by an import path, so reading a pipe never imports whatever a file happens to name.
+
+```python
+pipe.save("run.yaml")
+same = Pipe.load("run.yaml")
+assert same == pipe
+```
+
+# Provenance
+
+A [Provenance](`dascore.workflow.provenance.Provenance`) records a pipe together with the run which used it: the version of DASCore, the python, and the machine. It is the durable record — the thing worth writing next to results.
+
+```{python}
+provenance = pipe.get_provenance(operator="a tutorial")
+provenance.dascore_version, provenance.fingerprint
+```
+
+Alongside it is a [ProvenanceNode](`dascore.workflow.provenance.ProvenanceNode`), the live record: one immutable node per step, each pointing back at the nodes which fed it. A graph starts wide, at the files data was read from, and narrows as data is merged. `describe` reads it back as a listing, and `to_pipe` turns it into something runnable again.
+
+```{python}
+from dascore.workflow import ProvenanceNode, SourceInfo
+
+source = ProvenanceNode(source=SourceInfo(format="DASDAE", path="/data/patch.h5"))
+first = ProvenanceNode(task=Add(value=2), parents=(source,))
+second = ProvenanceNode(task=Times(value=3), parents=(first,))
+
+print(second.describe())
+```
+
+```{python}
+second.to_pipe().run(1)
+```
+
+Building that graph as patches are processed comes in a later release, along with the two ids — `patch_id` for which data, `processing_id` for what was done — which the nodes carry.

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -31,6 +31,8 @@ task = Scale(factor=2)
 task
 ```
 
+Because the parameters are the object, a task holds its parameters for good: an array given to one is marked read-only in place, so a task cannot come to report a fingerprint of values it no longer holds. Nothing is copied, so pass a copy of a buffer you are still writing to.
+
 Because the parameters are the object, two tasks which would do the same thing are the same task:
 
 ```{python}
@@ -40,7 +42,7 @@ assert Scale(factor=2) != Scale(factor=3)
 
 ## Fingerprints
 
-Every task has a `fingerprint`: a short digest of which task it is, which version of it, and what it was given. The same call gives the same fingerprint in another process, on another machine, and in a later release.
+Every task has a `fingerprint`: a short digest of which task it is, which version of it, and what it was given. The same call gives the same fingerprint in another process, on another machine, and in a later release, barring a change in how pandas or pint hash their own objects.
 
 ```{python}
 Scale(factor=2).fingerprint
@@ -65,7 +67,7 @@ Scale(factor=2).fingerprint
 
 ## Tasks from functions
 
-A function can become a task class without being rewritten. The decorator reads its signature and makes its parameters fields.
+A function can become a task class without being rewritten. The decorator reads its signature: the first parameter is what the task is given when it runs, and the rest become its fields.
 
 ```{python}
 from dascore.workflow import task
@@ -80,7 +82,7 @@ def scale_number(number, factor=1):
 scale_number(factor=3).run(2)
 ```
 
-The first parameter is what the task is *given* when it runs; the rest are its parameters. `inputs=` says how many leading parameters are inputs — `inputs=0` makes a task which is handed nothing and produces a value of its own, and `inputs=2` one which takes a pair.
+`inputs=` says how many leading parameters are inputs — `inputs=0` makes a task which is handed nothing and produces a value of its own, and `inputs=2` one which takes a pair. A function which packs its arguments (`def merge(*patches)`) can be asked for any number, which is what a task joining two branches needs.
 
 A task is callable, so it can stand anywhere a function of its inputs can:
 

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -141,7 +141,7 @@ print(branched.to_mermaid())
 
 ## Saving and loading
 
-A pipe can be written to JSON or YAML — the suffix decides — and read back into the same pipe. It names each task by its registered tag rather than by an import path, so reading a pipe never imports whatever a file happens to name.
+A pipe can be written to JSON or YAML — `.yaml` and `.yml` write YAML, `.json` or a bare name write JSON, and any other suffix is refused rather than guessed at — and read back into the same pipe. It names each task by its registered tag rather than by an import path, so reading a pipe never imports whatever a file happens to name.
 
 ```{python}
 import tempfile

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -182,9 +182,13 @@ print(diamond.to_mermaid())
 
 ## Saving and loading
 
-A pipe can be written to JSON or YAML — `.yaml` and `.yml` write YAML, `.json` or a bare name write JSON, and any other suffix is refused rather than guessed at — and read back into the same pipe. It names each task by its registered tag rather than by an import path, so reading a pipe never imports whatever a file happens to name.
+A pipe can be written to JSON or YAML — `.yaml` and `.yml` write YAML, `.json` or a bare name write JSON, and any other suffix is refused rather than guessed at — and read back into the same pipe. It names each task by its registered tag rather than by an import path, so reading a pipe never imports whatever a file happens to name. The other side of that is that a task class has to live at module level, under a name no other class in its package claims, and that whatever defines it has to be imported before the pipe is loaded.
 
 ```{python}
+#| execute: false
+#  Not mirrored into the generated doc tests: those run a page's chunks
+#  inside a function, where a task class is a local one and no document
+#  could name it. Quarto still runs this at build time.
 import tempfile
 from pathlib import Path
 

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -65,19 +65,27 @@ Scale(factor=2).fingerprint
 
 ## Tasks from functions
 
-A function can become a task class without being rewritten. The decorator reads its signature and makes each parameter a field.
+A function can become a task class without being rewritten. The decorator reads its signature and makes its parameters fields.
 
 ```{python}
 from dascore.workflow import task
 
 
 @task
-def add_numbers(first, second=1):
-    """Add two numbers."""
-    return first + second
+def scale_number(number, factor=1):
+    """Scale a number."""
+    return number * factor
 
 
-add_numbers(first=1, second=2).run()
+scale_number(factor=3).run(2)
+```
+
+The first parameter is what the task is *given* when it runs; the rest are its parameters. `inputs=` says how many leading parameters are inputs — `inputs=0` makes a task which is handed nothing and produces a value of its own, and `inputs=2` one which takes a pair.
+
+A task is callable, so it can stand anywhere a function of its inputs can:
+
+```{python}
+scale_number(factor=3)(2)
 ```
 
 # Pipes
@@ -109,7 +117,7 @@ class TimesValue(Task):
 
 
 pipe = AddValue(value=2) | TimesValue(value=3)
-pipe.run(1)
+pipe(1)
 ```
 
 A pipe is a graph rather than a list, so several branches can feed one task. Each branch gets the input, and the task which joins them is given their outputs in the order they were wired.
@@ -124,19 +132,52 @@ class JoinValues(Task):
 
 
 branched = (AddValue(value=1), TimesValue(value=5)) | JoinValues()
-branched.run(10)
+branched(10)
 ```
 
-`map` runs the pipe over many inputs, optionally with something else's workers:
+`|` works the same way round: a tuple on the right fans out, and a pipe which fans out returns one result per branch.
 
 ```{python}
-pipe.map([1, 2, 3])
+fanned = AddValue(value=1) | (TimesValue(value=2), TimesValue(value=3))
+fanned(10)
 ```
 
-A pipe has a fingerprint of its own, covering the tasks, how they are wired, and the order its branches are fed. It also writes itself out as a mermaid flowchart, which anywhere that draws mermaid turns into a diagram:
+Putting the two together makes a diamond — one input, two branches, joined again:
 
 ```{python}
-print(branched.to_mermaid())
+diamond = AddValue(value=1) | (TimesValue(value=2), TimesValue(value=3)) | JoinValues()
+diamond(10)
+```
+
+DASCore does not schedule or stream: running a pipe gives each task its inputs, in order, and nothing else. Running one over many patches is a loop, `spool.map`, or whatever else already does that work:
+
+```{python}
+[pipe(x) for x in [1, 2, 3]]
+```
+
+## Nodes
+
+Each task in a pipe is a node under a name of its own, taken from the class and numbered when the same task appears twice. Names are for reading and for referring to a node — `get` reads one, `update` changes its parameters and gives back a new pipe, and `relabel` gives it a name of your own.
+
+```{python}
+print(list(diamond.tasks))
+diamond.update("times_value", value=10)(10)
+```
+
+```{python}
+diamond.get("times_value_2")
+```
+
+A pipe has a fingerprint of its own, covering the tasks, how they are wired, the order its branches are fed and the order it returns its results. It is structural rather than nominal, so renaming a node leaves the pipe the pipe it was:
+
+```{python}
+assert diamond.relabel(times_value="left").fingerprint == diamond.fingerprint
+```
+
+A pipe also writes itself out as a mermaid flowchart, which anywhere that draws mermaid turns into a diagram:
+
+```{python}
+print(diamond.to_mermaid())
 ```
 
 ## Saving and loading

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -46,7 +46,7 @@ Every task has a `fingerprint`: a short digest of which task it is, which versio
 Scale(factor=2).fingerprint
 ```
 
-The fingerprint names the class and its parameters, not the module the class lives in nor the source of its body. Moving `Scale` between modules does not change it; changing what the same parameters *mean* should, which is what `__version__` is for:
+The fingerprint names the package, the class and its parameters, not the module inside the package nor the source of the body. Moving `Scale` to another module of the same package does not change it; changing what the same parameters *mean* should, which is what `__version__` is for:
 
 ```{python}
 class Scale(Task):
@@ -72,12 +72,12 @@ from dascore.workflow import task
 
 
 @task
-def add(first, second=1):
+def add_numbers(first, second=1):
     """Add two numbers."""
     return first + second
 
 
-add(first=1, second=2).run()
+add_numbers(first=1, second=2).run()
 ```
 
 # Pipes
@@ -88,7 +88,7 @@ Tasks joined with `|` make a pipe, which runs them in order.
 from dascore.workflow import Task
 
 
-class Add(Task):
+class AddValue(Task):
     """Add a number."""
 
     value: int = 1
@@ -98,7 +98,7 @@ class Add(Task):
         return number + self.value
 
 
-class Times(Task):
+class TimesValue(Task):
     """Multiply by a number."""
 
     value: int = 2
@@ -108,14 +108,14 @@ class Times(Task):
         return number * self.value
 
 
-pipe = Add(value=2) | Times(value=3)
+pipe = AddValue(value=2) | TimesValue(value=3)
 pipe.run(1)
 ```
 
 A pipe is a graph rather than a list, so several branches can feed one task. Each branch gets the input, and the task which joins them is given their outputs in the order they were wired.
 
 ```{python}
-class Join(Task):
+class JoinValues(Task):
     """Add up everything it is given."""
 
     def run(self, *numbers):
@@ -123,7 +123,7 @@ class Join(Task):
         return sum(numbers)
 
 
-branched = (Add(value=1), Times(value=5)) | Join()
+branched = (AddValue(value=1), TimesValue(value=5)) | JoinValues()
 branched.run(10)
 ```
 
@@ -133,7 +133,7 @@ branched.run(10)
 pipe.map([1, 2, 3])
 ```
 
-A pipe has a fingerprint of its own, which covers both the tasks and how they are wired, and it draws itself:
+A pipe has a fingerprint of its own, covering the tasks, how they are wired, and the order its branches are fed. It also writes itself out as a mermaid flowchart, which anywhere that draws mermaid turns into a diagram:
 
 ```{python}
 print(branched.to_mermaid())
@@ -143,10 +143,16 @@ print(branched.to_mermaid())
 
 A pipe can be written to JSON or YAML — the suffix decides — and read back into the same pipe. It names each task by its registered tag rather than by an import path, so reading a pipe never imports whatever a file happens to name.
 
-```python
-pipe.save("run.yaml")
-same = Pipe.load("run.yaml")
-assert same == pipe
+```{python}
+import tempfile
+from pathlib import Path
+
+from dascore.workflow import Pipe
+
+path = Path(tempfile.mkdtemp()) / "run.yaml"
+pipe.save(path)
+assert Pipe.load(path) == pipe
+print(path.read_text()[:120])
 ```
 
 # Provenance
@@ -164,8 +170,8 @@ Alongside it is a [ProvenanceNode](`dascore.workflow.provenance.ProvenanceNode`)
 from dascore.workflow import ProvenanceNode, SourceInfo
 
 source = ProvenanceNode(source=SourceInfo(format="DASDAE", path="/data/patch.h5"))
-first = ProvenanceNode(task=Add(value=2), parents=(source,))
-second = ProvenanceNode(task=Times(value=3), parents=(first,))
+first = ProvenanceNode(task=AddValue(value=2), parents=(source,))
+second = ProvenanceNode(task=TimesValue(value=3), parents=(first,))
 
 print(second.describe())
 ```

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -121,6 +121,9 @@ website:
         - text: Transformations
           href: tutorial/transformations.qmd
 
+        - text: Workflow
+          href: tutorial/workflow.qmd
+
         - text: Visualization
           href: tutorial/visualization.qmd
 

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -18,6 +18,7 @@ from dascore.core import inventory_loader as loader
 from dascore.exceptions import InvalidInventoryError
 from dascore.models import InventoryModel, TimeRangedModel
 from dascore.models.registry import TAG_FIELD
+from dascore.utils import documents
 
 # A minimal directory which loads: one acquisition names everything above it.
 PATH_DIRECTORY = {
@@ -2293,9 +2294,9 @@ class TestLoadSerializedFile:
             raise AssertionError("the JSON route parsed YAML")
 
         # JSON is legal YAML, so a fallback to the YAML route would parse
-        # this file and pass a test which only checked the result.
-        monkeypatch.setattr(loader.yaml, "safe_load", refuse)
-        monkeypatch.setattr(inv.yaml, "safe_load", refuse)
+        # this file and pass a test which only checked the result. The one
+        # binding there is to watch is the shared reader's.
+        monkeypatch.setattr(documents.yaml, "safe_load", refuse)
         assert dc.inventory(path).description == "a JSON inventory"
 
     def test_a_document_which_does_not_parse(self, tmp_path):

--- a/tests/test_workflow/test_pipe.py
+++ b/tests/test_workflow/test_pipe.py
@@ -492,6 +492,30 @@ class TestFingerprint:
         assert swapped.fingerprint != branched.fingerprint
         assert swapped.run(10, 20) != branched.run(10, 20)
 
+    def test_a_task_run_twice(self, chain):
+        """
+        Running a task twice is not the same shape as running it once.
+
+        Both hand what follows the same pair of results, so only how many
+        nodes there are tells them apart -- and a task run twice is two
+        steps whatever its results look like.
+        """
+        add, times, join = AddTask(value=1), TimesTask(value=2), JoinTask()
+        twice = Pipe(
+            tasks={"a": add, "t": times, "t2": times, "j": join},
+            dependencies={"t": ("a",), "t2": ("a",), "j": ("t", "t2")},
+            inputs=("a",),
+            outputs=("j",),
+        )
+        once = Pipe(
+            tasks={"a": add, "t": times, "j": join},
+            dependencies={"t": ("a",), "j": ("t", "t")},
+            inputs=("a",),
+            outputs=("j",),
+        )
+        assert twice.run(1) == once.run(1)
+        assert twice.fingerprint != once.fingerprint
+
     def test_node_names_do_not_matter(self, branched):
         """A pipe whose nodes are named differently is the same pipe."""
         names = {node: f"node_{index}" for index, node in enumerate(branched.tasks)}
@@ -769,6 +793,22 @@ class TestDocuments:
         assert document["fingerprint"] != moved.fingerprint
         with suppress_warnings(DASCoreWarning, message="The document holds"):
             assert Pipe.from_dict(document).run(1) == 6
+
+    def test_an_edit_is_caught_after_a_version_moved_on(self, monkeypatch):
+        """
+        A version bump does not switch the check on edits off.
+
+        The fingerprint is recomputed at the version the document names,
+        which says what it was; a task whose parameters were changed since
+        then still does not add up.
+        """
+        pipe = VersionedTask(value=2) | AddTask(value=3)
+        document = pipe.to_dict()
+        monkeypatch.setattr(VersionedTask, "__version__", "2.0")
+        document["tasks"]["add_task"]["params"]["value"] = 99
+        with suppress_warnings(DASCoreWarning, message="The document holds"):
+            with pytest.raises(ParameterError, match="edited it"):
+                Pipe.from_dict(document)
 
     def test_nested_version_moved_on(self, monkeypatch):
         """A version bump inside a nested pipe is a version bump."""

--- a/tests/test_workflow/test_pipe.py
+++ b/tests/test_workflow/test_pipe.py
@@ -1,0 +1,244 @@
+"""Tests for pipes: tasks arranged into the shape of one operation."""
+
+from __future__ import annotations
+
+import pickle
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from dascore.exceptions import ParameterError
+from dascore.workflow import Pipe, Task
+
+
+class AddTask(Task):
+    """Add a number to what it is given."""
+
+    value: int = 1
+
+    def run(self, number):
+        """Add to a number."""
+        return number + self.value
+
+
+class TimesTask(Task):
+    """Multiply what it is given by a number."""
+
+    value: int = 2
+
+    def run(self, number):
+        """Multiply a number."""
+        return number * self.value
+
+
+class JoinTask(Task):
+    """Add up everything it is given."""
+
+    def run(self, *numbers):
+        """Add up numbers."""
+        return sum(numbers)
+
+
+@pytest.fixture
+def chain():
+    """A pipe of two tasks, one after the other."""
+    return AddTask(value=2) | TimesTask(value=3)
+
+
+@pytest.fixture
+def branched():
+    """A pipe whose two branches feed one task."""
+    return (AddTask(value=1), TimesTask(value=5)) | JoinTask()
+
+
+class TestBuilding:
+    """Tests for putting a pipe together."""
+
+    def test_two_tasks(self, chain):
+        """Two tasks joined make a pipe of two."""
+        assert isinstance(chain, Pipe)
+        assert len(chain) == 2
+
+    def test_extend_a_pipe(self, chain):
+        """A pipe takes another task on the end."""
+        assert len(chain | AddTask(value=7)) == 3
+
+    def test_prepend_a_task(self, chain):
+        """A task in front of a pipe runs first."""
+        pipe = AddTask(value=7) | chain
+        assert pipe.run(0) == (0 + 7 + 2) * 3
+
+    def test_join_two_pipes(self, chain):
+        """Two pipes joined run one after the other."""
+        pipe = chain | (AddTask(value=1) | TimesTask(value=2))
+        assert len(pipe) == 4
+
+    def test_repeated_task(self):
+        """The same task twice is two steps, not one."""
+        pipe = AddTask(value=1) | AddTask(value=1)
+        assert len(pipe) == 2
+        assert pipe.run(0) == 2
+
+    def test_repeated_task_names(self):
+        """The second copy of a task is named apart from the first."""
+        pipe = AddTask(value=1) | AddTask(value=1)
+        first, second = pipe.sorted_nodes()
+        assert second.startswith(first) and second != first
+
+    def test_branches_into_a_pipe(self, chain):
+        """Two tasks can feed a pipe rather than a single task."""
+        pipe = (AddTask(value=1), AddTask(value=2)) | (JoinTask() | TimesTask(value=2))
+        assert pipe.run(1) == ((1 + 1) + (1 + 2)) * 2
+
+    def test_joining_something_else(self):
+        """A pipe joins tasks and pipes, and says so otherwise."""
+        with pytest.raises(ParameterError, match="not str"):
+            AddTask() | "not a task"
+
+
+class TestRunning:
+    """Tests for running a pipe."""
+
+    def test_order(self, chain):
+        """The tasks run in the order they were joined."""
+        assert chain.run(1) == (1 + 2) * 3
+
+    def test_branches_share_one_input(self, branched):
+        """A pipe which branches gives one input to every branch."""
+        assert branched.run(10) == (10 + 1) + (10 * 5)
+
+    def test_branches_take_one_input_each(self, branched):
+        """A pipe which branches takes an input per branch."""
+        assert branched.run(10, 20) == (10 + 1) + (20 * 5)
+
+    def test_wrong_number_of_inputs(self, branched):
+        """A pipe says when it was given inputs it cannot place."""
+        with pytest.raises(ParameterError, match="one for each"):
+            branched.run(1, 2, 3)
+
+    def test_map(self, chain):
+        """A pipe runs over an iterable."""
+        assert chain.map([1, 2]) == [chain.run(1), chain.run(2)]
+
+    def test_map_with_a_client(self, chain):
+        """A pipe runs over an iterable with something else's workers."""
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            assert chain.map([1, 2], client=pool) == [chain.run(1), chain.run(2)]
+
+
+class TestFingerprint:
+    """Tests for what identifies a pipe."""
+
+    def test_same_pipe(self, chain):
+        """The same pipe built twice fingerprints alike."""
+        assert chain.fingerprint == (AddTask(value=2) | TimesTask(value=3)).fingerprint
+
+    def test_parameters_matter(self, chain):
+        """A pipe holding another task is another pipe."""
+        assert chain.fingerprint != (AddTask(value=3) | TimesTask(value=3)).fingerprint
+
+    def test_order_matters(self):
+        """The same tasks the other way round are another pipe."""
+        first = AddTask(value=2) | TimesTask(value=3)
+        second = TimesTask(value=3) | AddTask(value=2)
+        assert first.fingerprint != second.fingerprint
+
+    def test_equality(self, chain):
+        """Two pipes are equal when they hold the same tasks, wired alike."""
+        assert chain == AddTask(value=2) | TimesTask(value=3)
+        assert chain != AddTask(value=2) | TimesTask(value=4)
+
+    def test_not_a_pipe(self, chain):
+        """Comparison with something else is left to the something else."""
+        assert chain.__eq__("a pipe") is NotImplemented
+
+    def test_hashes_with_equality(self, chain):
+        """Equal pipes land in the same place in a set."""
+        assert len({chain, AddTask(value=2) | TimesTask(value=3)}) == 1
+
+
+class TestValidation:
+    """Tests for the checks a pipe makes on itself."""
+
+    def test_missing_task(self):
+        """A pipe cannot wire a node it does not hold."""
+        node = AddTask().fingerprint
+        with pytest.raises(ParameterError, match="not one of its tasks"):
+            Pipe(
+                tasks={node: AddTask()},
+                dependencies={node: ("nowhere",)},
+                output=node,
+            )
+
+    def test_missing_output(self):
+        """A pipe's output has to be one of its tasks."""
+        node = AddTask().fingerprint
+        with pytest.raises(ParameterError, match="output"):
+            Pipe(tasks={node: AddTask()}, output="nowhere")
+
+    def test_cycle(self):
+        """Tasks which feed each other in a circle are refused."""
+        first, second = AddTask(value=1), AddTask(value=2)
+        one, two = first.fingerprint, second.fingerprint
+        with pytest.raises(ParameterError, match="cycle"):
+            Pipe(
+                tasks={one: first, two: second},
+                dependencies={one: (two,), two: (one,)},
+                output=one,
+            )
+
+    def test_check_returns_the_pipe(self, chain):
+        """Checking a good pipe hands it back."""
+        assert chain.check() is chain
+
+
+class TestDocuments:
+    """Tests for writing a pipe down and reading it back."""
+
+    def test_round_trip(self, chain):
+        """A pipe rebuilt from its document is the same pipe."""
+        assert Pipe.from_dict(chain.to_dict()) == chain
+
+    def test_branched_round_trip(self, branched):
+        """A pipe which branches keeps its shape."""
+        rebuilt = Pipe.from_dict(branched.to_dict())
+        assert rebuilt == branched
+        assert rebuilt.run(10) == branched.run(10)
+
+    @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml", "pipe.yml", "pipe"])
+    def test_save_and_load(self, chain, tmp_path, name):
+        """A pipe read back from a file is the same pipe."""
+        path = chain.save(tmp_path / name)
+        assert Pipe.load(path) == chain
+
+    def test_save_makes_the_directory(self, chain, tmp_path):
+        """Saving into a directory which is not there makes it."""
+        path = chain.save(tmp_path / "nested" / "deeper" / "pipe.json")
+        assert path.exists()
+
+    def test_pickle(self, chain):
+        """A pipe survives a pickle, tasks and all."""
+        assert pickle.loads(pickle.dumps(chain)) == chain
+
+
+class TestMermaid:
+    """Tests for drawing a pipe."""
+
+    def test_lists_every_task(self, branched):
+        """Every task in the pipe is drawn."""
+        text = branched.to_mermaid()
+        for name in ["AddTask", "TimesTask", "JoinTask"]:
+            assert name in text
+
+    def test_draws_every_edge(self, branched):
+        """Every wire in the pipe is drawn."""
+        assert text_edges(branched.to_mermaid()) == 2
+
+    def test_chain_edges(self, chain):
+        """A chain of two tasks is one edge."""
+        assert text_edges(chain.to_mermaid()) == 1
+
+
+def text_edges(text: str) -> int:
+    """Return how many edges a mermaid flowchart holds."""
+    return sum("-->" in line for line in text.splitlines())

--- a/tests/test_workflow/test_pipe.py
+++ b/tests/test_workflow/test_pipe.py
@@ -288,6 +288,32 @@ class TestDocuments:
         assert not text.lstrip().startswith("{")
         assert "tasks:" in text
 
+    def test_unknown_suffix_refused(self, chain, tmp_path):
+        """A suffix which names no format is refused, not guessed at."""
+        with pytest.raises(ParameterError, match="names no format"):
+            chain.save(tmp_path / "pipe.txt")
+
+    def test_unparsable_file(self, chain, tmp_path):
+        """A file which does not parse names itself in the error."""
+        path = tmp_path / "pipe.json"
+        path.write_text("{not json at all")
+        with pytest.raises(ParameterError, match="Could not parse JSON"):
+            Pipe.load(path)
+
+    def test_unparsable_yaml(self, chain, tmp_path):
+        """A YAML file which does not parse says so as YAML."""
+        path = tmp_path / "pipe.yaml"
+        path.write_text("tasks: [unclosed")
+        with pytest.raises(ParameterError, match="Could not parse YAML"):
+            Pipe.load(path)
+
+    def test_file_holding_no_document(self, chain, tmp_path):
+        """A file holding something other than a document is refused."""
+        path = tmp_path / "pipe.json"
+        path.write_text("[1, 2, 3]")
+        with pytest.raises(ParameterError, match="describes no workflow"):
+            Pipe.load(path)
+
     def test_edited_document_refused(self, chain, tmp_path):
         """A document whose fingerprint disagrees with it is refused."""
         document = chain.to_dict()

--- a/tests/test_workflow/test_pipe.py
+++ b/tests/test_workflow/test_pipe.py
@@ -9,6 +9,8 @@ import pytest
 from pydantic import ValidationError
 
 from dascore.exceptions import ParameterError
+from dascore.utils.misc import suppress_warnings
+from dascore.warnings import DASCoreWarning
 from dascore.workflow import Pipe, Task
 
 
@@ -318,8 +320,21 @@ class TestDocuments:
         """A document whose fingerprint disagrees with it is refused."""
         document = chain.to_dict()
         document["fingerprint"] = "0" * 16
-        with pytest.raises(ParameterError, match="fingerprint"):
+        with pytest.raises(ParameterError, match="edited it"):
             Pipe.from_dict(document)
+
+    def test_document_written_by_another_version(self, chain):
+        """
+        A pipe written before a task changed version still loads.
+
+        The version is what makes a fingerprint differ on purpose, so a
+        stored pipe must not be read as an edited one for having one.
+        """
+        document = chain.to_dict()
+        for value in document["tasks"].values():
+            value["version"] = "0.5"
+        with suppress_warnings(DASCoreWarning, message="The document holds"):
+            assert Pipe.from_dict(document).run(1) == chain.run(1)
 
     def test_save_makes_the_directory(self, chain, tmp_path):
         """Saving into a directory which is not there makes it."""

--- a/tests/test_workflow/test_pipe.py
+++ b/tests/test_workflow/test_pipe.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pickle
-from concurrent.futures import ThreadPoolExecutor
+from typing import ClassVar
 
 import pytest
 from pydantic import ValidationError
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 from dascore.exceptions import ParameterError
 from dascore.utils.misc import suppress_warnings
 from dascore.warnings import DASCoreWarning
-from dascore.workflow import Pipe, Task
+from dascore.workflow import Pipe, Task, decode, encode
 
 
 class AddTask(Task):
@@ -42,6 +42,55 @@ class JoinTask(Task):
         return sum(numbers)
 
 
+class PortedTask(Task):
+    """
+    A task from another package, carrying declarations of its own.
+
+    Stands for what derzug's ported tasks look like: a subclass which adds
+    class level declarations a pipe knows nothing about, and which has to
+    round trip through the tag registry all the same.
+    """
+
+    inputs_ports: ClassVar[tuple[str, ...]] = ("left", "right")
+    output_ports: ClassVar[tuple[str, ...]] = ("result",)
+
+    value: int = 1
+
+    def run(self, number):
+        """Add to a number."""
+        return number + self.value
+
+
+class VersionedTask(Task):
+    """A task whose version a test moves on after writing a document."""
+
+    value: int = 1
+
+    def run(self, number):
+        """Add to a number."""
+        return number + self.value
+
+
+class ConstantTask(Task):
+    """Make a number out of nothing; a source of its own."""
+
+    value: int = 0
+
+    def run(self):
+        """Return the number."""
+        return self.value
+
+
+class NestedPipeTask(Task):
+    """A task which holds a whole pipe as one of its parameters."""
+
+    inner: Pipe
+
+    def run(self, number):
+        """Run the pipe this task holds."""
+        return self.inner.run(number)
+
+
 @pytest.fixture
 def chain():
     """A pipe of two tasks, one after the other."""
@@ -52,6 +101,18 @@ def chain():
 def branched():
     """A pipe whose two branches feed one task."""
     return (AddTask(value=1), TimesTask(value=5)) | JoinTask()
+
+
+@pytest.fixture
+def fanned():
+    """A pipe which splits into two results and merges neither."""
+    return AddTask(value=1) | (TimesTask(value=2), TimesTask(value=3))
+
+
+@pytest.fixture
+def diamond():
+    """A pipe which splits into two branches and joins them again."""
+    return AddTask(value=1) | (TimesTask(value=2), TimesTask(value=3)) | JoinTask()
 
 
 class TestBuilding:
@@ -82,12 +143,6 @@ class TestBuilding:
         assert len(pipe) == 2
         assert pipe.run(0) == 2
 
-    def test_repeated_task_names(self):
-        """The second copy of a task is named apart from the first."""
-        pipe = AddTask(value=1) | AddTask(value=1)
-        first, second = pipe.sorted_nodes()
-        assert second.startswith(first) and second != first
-
     def test_branches_into_a_pipe(self, chain):
         """Two tasks can feed a pipe rather than a single task."""
         pipe = (AddTask(value=1), AddTask(value=2)) | (JoinTask() | TimesTask(value=2))
@@ -103,6 +158,148 @@ class TestBuilding:
         with pytest.raises(ParameterError, match="joined to nothing"):
             () | JoinTask()
 
+    def test_joining_to_nothing(self):
+        """A pipe cannot fan out into an empty list of branches."""
+        with pytest.raises(ParameterError, match="joined to nothing"):
+            AddTask() | ()
+
+
+class TestNodeKeys:
+    """Tests for what a pipe calls its nodes."""
+
+    def test_named_for_the_task(self, chain):
+        """A node is named for its task, said the way a variable is."""
+        assert set(chain.tasks) == {"add_task", "times_task"}
+
+    def test_repeated_task_numbered(self):
+        """The second copy of a task is numbered rather than merged."""
+        pipe = AddTask(value=1) | AddTask(value=2)
+        assert list(pipe.tasks) == ["add_task", "add_task_2"]
+
+    def test_key_ignores_parameters(self):
+        """Two pipes differing only in a parameter name their nodes alike."""
+        first = AddTask(value=1) | TimesTask(value=2)
+        second = AddTask(value=9) | TimesTask(value=2)
+        assert list(first.tasks) == list(second.tasks)
+
+    def test_relabel(self, chain):
+        """A node can be given a name of the caller's own."""
+        renamed = chain.relabel(add_task="offset")
+        assert set(renamed.tasks) == {"offset", "times_task"}
+        assert renamed.run(1) == chain.run(1)
+
+    def test_relabel_keeps_the_fingerprint(self, diamond):
+        """A name is for the reader; the pipe is what it always was."""
+        renamed = diamond.relabel(
+            add_task="start", times_task="left", times_task_2="right"
+        )
+        assert renamed.fingerprint == diamond.fingerprint
+        assert renamed == diamond
+
+    def test_relabel_survives_a_join(self, chain):
+        """A name given to a node outlives being joined to something else."""
+        pipe = chain.relabel(add_task="offset") | AddTask(value=1)
+        assert "offset" in pipe.tasks
+
+    def test_join_keeps_a_pipes_own_names(self):
+        """A collision does not push a later node off the name it was given."""
+        left = (AddTask(value=1) | TimesTask(value=1)).relabel(add_task="shared")
+        right = (AddTask(value=2) | AddTask(value=3)).relabel(
+            add_task="shared", add_task_2="shared_2"
+        )
+        joined = left | right
+        # `shared` is taken, so right's own `shared` is numbered past the
+        # name its second node holds rather than onto it.
+        assert "shared_2" in joined.tasks
+        assert joined.get("shared_2") == AddTask(value=3)
+
+    def test_relabel_unknown_node(self, chain):
+        """Renaming a node which is not there says so."""
+        with pytest.raises(ParameterError, match="no node called"):
+            chain.relabel(nowhere="somewhere")
+
+    def test_relabel_onto_a_taken_name(self, chain):
+        """A name another node holds is refused."""
+        with pytest.raises(ParameterError, match="already has a node"):
+            chain.relabel(add_task="times_task")
+
+    def test_relabel_two_nodes_alike(self, chain):
+        """Two nodes cannot be given the same name."""
+        with pytest.raises(ParameterError, match="cannot both be called"):
+            chain.relabel(add_task="same", times_task="same")
+
+    def test_relabel_tied_nodes(self):
+        """
+        Two nodes nothing tells apart but their downstream still relabel.
+
+        `p` and `q` hold the same task and are fed by the same source, so
+        only what they feed sets them apart. Naming them the other way
+        round must leave the pipe the pipe it was.
+        """
+        base = Pipe(
+            tasks={
+                "src": AddTask(value=0),
+                "p": AddTask(value=1),
+                "q": AddTask(value=1),
+                "left": TimesTask(value=2),
+                "right": TimesTask(value=3),
+            },
+            dependencies={
+                "p": ("src",),
+                "q": ("src",),
+                "left": ("p",),
+                "right": ("q",),
+            },
+            inputs=("src",),
+            outputs=("left", "right"),
+        )
+        renamed = base.relabel(p="zz", q="aa")
+        assert renamed.fingerprint == base.fingerprint
+        assert renamed.run(1) == base.run(1)
+
+    def test_relabel_swap(self, chain):
+        """Two nodes can trade names, which nothing else claims."""
+        swapped = chain.relabel(add_task="times_task", times_task="add_task")
+        assert swapped.fingerprint == chain.fingerprint
+        assert swapped.get("times_task") == AddTask(value=2)
+
+
+class TestGetAndUpdate:
+    """Tests for reading and changing one node of a pipe."""
+
+    def test_get(self, chain):
+        """A node hands back the task it holds."""
+        assert chain.get("add_task") == AddTask(value=2)
+
+    def test_get_unknown(self, chain):
+        """Asking for a node which is not there names the ones which are."""
+        with pytest.raises(ParameterError, match="no node called"):
+            chain.get("nowhere")
+
+    def test_update(self, chain):
+        """Changing a parameter gives back another pipe."""
+        updated = chain.update("add_task", value=10)
+        assert updated.get("add_task") == AddTask(value=10)
+        assert updated.run(1) == (1 + 10) * 3
+        # The pipe it came from is untouched.
+        assert chain.get("add_task") == AddTask(value=2)
+
+    def test_update_changes_the_fingerprint(self, chain):
+        """A pipe holding another task is another pipe."""
+        assert chain.update("add_task", value=10).fingerprint != chain.fingerprint
+
+    def test_update_keeps_the_wiring(self, diamond):
+        """Only the task changes; the graph around it stays."""
+        updated = diamond.update("times_task", value=7)
+        assert updated.dependencies == diamond.dependencies
+        assert updated.inputs == diamond.inputs
+        assert updated.outputs == diamond.outputs
+
+    def test_update_unknown(self, chain):
+        """Changing a node which is not there says so."""
+        with pytest.raises(ParameterError, match="no node called"):
+            chain.update("nowhere", value=1)
+
 
 class TestRunning:
     """Tests for running a pipe."""
@@ -110,6 +307,10 @@ class TestRunning:
     def test_order(self, chain):
         """The tasks run in the order they were joined."""
         assert chain.run(1) == (1 + 2) * 3
+
+    def test_calling_runs(self, chain):
+        """Calling a pipe runs it, so a pipe can stand for a function."""
+        assert chain(1) == chain.run(1)
 
     def test_branches_share_one_input(self, branched):
         """A pipe which branches gives one input to every branch."""
@@ -124,39 +325,78 @@ class TestRunning:
         with pytest.raises(ParameterError, match="one for each"):
             branched.run(1, 2, 3)
 
-    def test_runs_after_its_inputs(self):
+    def test_runs_after_its_inputs(self, branched):
         """A task runs after whatever feeds it, however the pipe is held."""
-        pipe = (AddTask(value=1), TimesTask(value=5)) | JoinTask()
-        order = pipe.sorted_nodes()
-        for node, given in pipe.dependencies.items():
+        order = branched.sorted_nodes()
+        for node, given in branched.dependencies.items():
             for upstream in given:
                 assert order.index(upstream) < order.index(node)
 
-    def test_map(self, chain):
-        """A pipe runs over an iterable."""
-        assert chain.map([1, 2]) == [chain.run(1), chain.run(2)]
 
-    def test_map_uses_the_client(self, chain):
-        """A client, when given one, is what runs the pipe."""
+class TestSources:
+    """Tests for a pipe whose sources make their own values."""
 
-        class Recorder:
-            """Something with a map, which says it was the one used."""
+    def test_a_pipe_of_sources(self):
+        """Several tasks which take nothing can still feed one which does."""
+        pipe = (ConstantTask(value=1), ConstantTask(value=2)) | JoinTask()
+        assert pipe.run() == 3
 
-            used = False
+    def test_one_source_which_takes_nothing(self):
+        """A single source is handed nothing when the pipe is given nothing."""
+        assert (ConstantTask(value=4) | TimesTask(value=2)).run() == 8
 
-            def map(self, func, iterable):
-                """Run the pipe, and remember having done so."""
-                Recorder.used = True
-                return [func(x) for x in iterable]
 
-        assert chain.map([1, 2], client=Recorder()) == [chain.run(1), chain.run(2)]
-        assert Recorder.used
+class TestOutputs:
+    """Tests for a pipe which returns more than one thing."""
 
-    @pytest.mark.concurrency
-    def test_map_with_a_thread_pool(self, chain):
-        """A pipe runs over an iterable with another thread's workers."""
-        with ThreadPoolExecutor(max_workers=2) as pool:
-            assert chain.map([1, 2], client=pool) == [chain.run(1), chain.run(2)]
+    def test_one_output_is_not_a_tuple(self, chain):
+        """A pipe with a single output hands back the value itself."""
+        assert chain.run(1) == 9
+
+    def test_fan_out_returns_a_tuple(self, fanned):
+        """A fan out with nothing merging it returns one result per output."""
+        assert fanned.outputs == ("times_task", "times_task_2")
+        assert fanned.run(1) == ((1 + 1) * 2, (1 + 1) * 3)
+
+    def test_diamond_merges(self, diamond):
+        """A fan out joined again is one result."""
+        assert diamond.outputs == ("join_task",)
+        assert diamond.run(1) == (1 + 1) * 2 + (1 + 1) * 3
+
+    def test_diamond_matches_a_hand_built_pipe(self, diamond):
+        """A diamond built with `|` is the pipe it would be built by hand."""
+        add, left, right = AddTask(value=1), TimesTask(value=2), TimesTask(value=3)
+        by_hand = Pipe(
+            tasks={"a": add, "l": left, "r": right, "j": JoinTask()},
+            dependencies={"l": ("a",), "r": ("a",), "j": ("l", "r")},
+            inputs=("a",),
+            outputs=("j",),
+        )
+        assert by_hand.fingerprint == diamond.fingerprint
+        assert by_hand.run(1) == diamond.run(1)
+
+    def test_output_order_matters(self, fanned):
+        """Which result comes first is part of what a pipe is."""
+        swapped = Pipe(
+            tasks=fanned.tasks,
+            dependencies=fanned.dependencies,
+            inputs=fanned.inputs,
+            outputs=fanned.outputs[::-1],
+        )
+        assert swapped.fingerprint != fanned.fingerprint
+        assert swapped.run(1) == fanned.run(1)[::-1]
+
+    def test_fan_out_of_pipes(self):
+        """The branches of a fan out can be pipes of their own."""
+        pipe = AddTask(value=1) | (
+            TimesTask(value=2) | AddTask(value=1),
+            TimesTask(value=3),
+        )
+        assert pipe.run(1) == ((1 + 1) * 2 + 1, (1 + 1) * 3)
+
+    def test_fan_in_of_a_fan_out(self, fanned):
+        """A pipe of two outputs feeds them, in order, into what follows."""
+        assert (fanned | JoinTask()).run(1) == (1 + 1) * 2 + (1 + 1) * 3
 
 
 class TestFingerprint:
@@ -181,7 +421,7 @@ class TestFingerprint:
         chained = AddTask(value=1) | TimesTask(value=5) | JoinTask()
         branched = (AddTask(value=1), TimesTask(value=5)) | JoinTask()
         assert set(chained.tasks.values()) == set(branched.tasks.values())
-        assert chained.output.split("#")[0] == branched.output.split("#")[0]
+        assert set(chained.tasks) == set(branched.tasks)
         assert chained.fingerprint != branched.fingerprint
 
     def test_input_order_matters(self, branched):
@@ -190,10 +430,25 @@ class TestFingerprint:
             tasks=branched.tasks,
             dependencies=branched.dependencies,
             inputs=branched.inputs[::-1],
-            output=branched.output,
+            outputs=branched.outputs,
         )
         assert swapped.fingerprint != branched.fingerprint
         assert swapped.run(10, 20) != branched.run(10, 20)
+
+    def test_node_names_do_not_matter(self, branched):
+        """A pipe whose nodes are named differently is the same pipe."""
+        names = {node: f"node_{index}" for index, node in enumerate(branched.tasks)}
+        assert branched.relabel(**names).fingerprint == branched.fingerprint
+
+    def test_task_order_does_not_matter(self, branched):
+        """A document is free to list the tasks in any order it likes."""
+        shuffled = Pipe(
+            tasks=dict(reversed(list(branched.tasks.items()))),
+            dependencies=branched.dependencies,
+            inputs=branched.inputs,
+            outputs=branched.outputs,
+        )
+        assert shuffled.fingerprint == branched.fingerprint
 
     def test_equality(self, chain):
         """Two pipes are equal when they hold the same tasks, wired alike."""
@@ -214,40 +469,54 @@ class TestValidation:
 
     def test_missing_task(self):
         """A pipe cannot wire a node it does not hold."""
-        node = AddTask().fingerprint
         with pytest.raises(ValidationError, match="not one of its tasks"):
             Pipe(
-                tasks={node: AddTask()},
-                dependencies={node: ("nowhere",)},
-                output=node,
+                tasks={"add": AddTask()},
+                dependencies={"add": ("nowhere",)},
+                outputs=("add",),
             )
 
     def test_missing_output(self):
         """A pipe's output has to be one of its tasks."""
-        node = AddTask().fingerprint
         with pytest.raises(ValidationError, match="output"):
-            Pipe(tasks={node: AddTask()}, output="nowhere")
+            Pipe(tasks={"add": AddTask()}, inputs=("add",), outputs=("nowhere",))
+
+    def test_no_outputs(self):
+        """A pipe which returns nothing is a pipe built wrong."""
+        with pytest.raises(ValidationError, match="has to return something"):
+            Pipe(tasks={"add": AddTask()}, inputs=("add",), outputs=())
 
     def test_cycle(self):
         """Tasks which feed each other in a circle are refused."""
-        first, second = AddTask(value=1), AddTask(value=2)
-        one, two = first.fingerprint, second.fingerprint
         with pytest.raises(ValidationError, match="cycle"):
             Pipe(
-                tasks={one: first, two: second},
-                dependencies={one: (two,), two: (one,)},
-                output=one,
+                tasks={"one": AddTask(value=1), "two": AddTask(value=2)},
+                dependencies={"one": ("two",), "two": ("one",)},
+                outputs=("one",),
             )
 
     def test_stranded_task(self, chain):
         """A task whose output reaches nothing is a pipe built wrong."""
-        stranded = AddTask(value=99)
         with pytest.raises(ValidationError, match="every task has to feed"):
             Pipe(
-                tasks=dict(chain.tasks) | {stranded.fingerprint: stranded},
+                tasks=dict(chain.tasks) | {"stranded": AddTask(value=99)},
                 dependencies=chain.dependencies,
-                inputs=(*chain.inputs, stranded.fingerprint),
-                output=chain.output,
+                inputs=(*chain.inputs, "stranded"),
+                outputs=chain.outputs,
+            )
+
+    def test_a_second_output_is_not_stranded(self, fanned):
+        """A task reaching any output is a task which feeds the pipe."""
+        assert set(fanned.tasks) == {"add_task", "times_task", "times_task_2"}
+
+    def test_repeated_input(self, chain):
+        """A node cannot be fed twice; it would hide one of the sources."""
+        with pytest.raises(ValidationError, match="nothing wired into them"):
+            Pipe(
+                tasks=chain.tasks,
+                dependencies=chain.dependencies,
+                inputs=(*chain.inputs, *chain.inputs),
+                outputs=chain.outputs,
             )
 
     def test_inputs_must_be_the_unfed_nodes(self, chain):
@@ -256,8 +525,8 @@ class TestValidation:
             Pipe(
                 tasks=chain.tasks,
                 dependencies=chain.dependencies,
-                inputs=(chain.output,),
-                output=chain.output,
+                inputs=chain.outputs,
+                outputs=chain.outputs,
             )
 
 
@@ -283,6 +552,60 @@ class TestDocuments:
         # Run as well as compared: a document is free to write the tasks in
         # another order, and the answer must not depend on which order.
         assert loaded.run(10, 20) == branched.run(10, 20)
+
+    @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml"])
+    def test_source_order_survives_a_round_trip(self, branched, tmp_path, name):
+        """The branch fed first is still the one fed first after loading."""
+        loaded = Pipe.load(branched.save(tmp_path / name))
+        assert loaded.sources() == branched.sources()
+        # Which is what makes the first input reach the first branch.
+        assert loaded.run(10, 20) == branched.run(10, 20)
+
+    @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml"])
+    def test_output_order_survives_a_round_trip(self, fanned, tmp_path, name):
+        """A pipe of two results returns them in the order it was written."""
+        loaded = Pipe.load(fanned.save(tmp_path / name))
+        assert loaded.outputs == fanned.outputs
+        assert loaded.run(1) == fanned.run(1)
+
+    def test_nested_pipe_field(self, chain):
+        """A pipe held as a task's parameter is written as a pipe."""
+        task = NestedPipeTask(inner=chain)
+        document = task.to_dict()
+        assert set(document["params"]["inner"]) == {"$pipe"}
+        rebuilt = Task.from_dict(document)
+        assert rebuilt == task
+        assert rebuilt.run(1) == chain.run(1)
+
+    def test_nested_pipe_in_a_pipe(self, chain):
+        """A task holding a pipe round trips inside a pipe of its own."""
+        pipe = NestedPipeTask(inner=chain) | AddTask(value=1)
+        assert Pipe.from_dict(pipe.to_dict()) == pipe
+
+    def test_nested_pipe_fingerprint_cannot_decode(self, chain):
+        """A pipe hashed for a fingerprint cannot be read back."""
+        with pytest.raises(ParameterError, match="cannot be read back"):
+            decode(encode(chain))
+
+    def test_nested_pipe_fingerprint(self, chain):
+        """A task holding a pipe is identified by the pipe it holds."""
+        first = NestedPipeTask(inner=chain)
+        second = NestedPipeTask(inner=chain.update("add_task", value=99))
+        assert first.fingerprint != second.fingerprint
+
+    def test_task_from_another_package(self):
+        """A task declared elsewhere round trips under its own namespace."""
+        task = PortedTask(value=3)
+        assert task.tag == "tests:PortedTask"
+        assert Task.from_dict(task.to_dict()) == task
+
+    def test_pipe_of_tasks_from_another_package(self):
+        """A pipe of such tasks is written and read back the same way."""
+        pipe = PortedTask(value=1) | PortedTask(value=2)
+        rebuilt = Pipe.from_dict(pipe.to_dict())
+        assert rebuilt == pipe
+        assert rebuilt.get("ported_task_2").value == 2
+        assert rebuilt.run(1) == 4
 
     def test_yaml_is_yaml(self, chain, tmp_path):
         """A pipe saved as YAML is written as YAML, not as JSON."""
@@ -323,18 +646,31 @@ class TestDocuments:
         with pytest.raises(ParameterError, match="edited it"):
             Pipe.from_dict(document)
 
-    def test_document_written_by_another_version(self, chain):
+    def test_document_written_by_another_version(self, monkeypatch):
         """
         A pipe written before a task changed version still loads.
 
         The version is what makes a fingerprint differ on purpose, so a
         stored pipe must not be read as an edited one for having one.
         """
-        document = chain.to_dict()
-        for value in document["tasks"].values():
-            value["version"] = "0.5"
+        pipe = VersionedTask(value=2) | AddTask(value=3)
+        document = pipe.to_dict()
+        monkeypatch.setattr(VersionedTask, "__version__", "2.0")
+        # Which really is a document whose stored fingerprint no longer
+        # matches the pipe it describes.
+        moved = VersionedTask(value=2) | AddTask(value=3)
+        assert document["fingerprint"] != moved.fingerprint
         with suppress_warnings(DASCoreWarning, message="The document holds"):
-            assert Pipe.from_dict(document).run(1) == chain.run(1)
+            assert Pipe.from_dict(document).run(1) == 6
+
+    def test_nested_version_moved_on(self, monkeypatch):
+        """A version bump inside a nested pipe is a version bump."""
+        inner = VersionedTask(value=2) | AddTask(value=3)
+        pipe = NestedPipeTask(inner=inner) | AddTask(value=1)
+        document = pipe.to_dict()
+        monkeypatch.setattr(VersionedTask, "__version__", "2.0")
+        with suppress_warnings(DASCoreWarning, message="The document holds"):
+            assert Pipe.from_dict(document).run(1) == 7
 
     def test_save_makes_the_directory(self, chain, tmp_path):
         """Saving into a directory which is not there makes it."""
@@ -345,15 +681,19 @@ class TestDocuments:
         """A pipe survives a pickle, tasks and all."""
         assert pickle.loads(pickle.dumps(chain)) == chain
 
+    def test_pickle_a_fan_out(self, fanned):
+        """A pipe of several results keeps them through a pickle."""
+        assert pickle.loads(pickle.dumps(fanned)).outputs == fanned.outputs
+
 
 class TestMermaid:
     """Tests for drawing a pipe."""
 
     def test_lists_every_task(self, branched):
-        """Every task in the pipe is drawn."""
+        """Every node in the pipe is drawn, under the name it holds."""
         text = branched.to_mermaid()
-        for name in ["AddTask", "TimesTask", "JoinTask"]:
-            assert name in text
+        for name in branched.tasks:
+            assert f'"{name}"' in text
 
     def test_draws_every_edge(self, branched):
         """Every wire in the pipe is drawn."""
@@ -362,6 +702,18 @@ class TestMermaid:
     def test_chain_edges(self, chain):
         """A chain of two tasks is one edge."""
         assert text_edges(chain.to_mermaid()) == 1
+
+    def test_escapes_a_quoted_name(self, chain):
+        """A name holding a quote does not break the label around it."""
+        text = chain.relabel(add_task='a "name"').to_mermaid()
+        assert '["a #quot;name#quot;"]' in text
+
+    def test_shows_both_leaves(self, fanned):
+        """A fan out draws the two results it ends in."""
+        text = fanned.to_mermaid()
+        for name in fanned.outputs:
+            assert f'"{name}"' in text
+        assert text_edges(text) == 2
 
 
 def text_edges(text: str) -> int:

--- a/tests/test_workflow/test_pipe.py
+++ b/tests/test_workflow/test_pipe.py
@@ -6,7 +6,7 @@ import pickle
 from typing import ClassVar
 
 import pytest
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 
 from dascore.exceptions import ParameterError
 from dascore.utils.misc import suppress_warnings
@@ -42,6 +42,14 @@ class JoinTask(Task):
         return sum(numbers)
 
 
+class SubtractTask(Task):
+    """Subtract what it is given second from what it is given first."""
+
+    def run(self, first, second):
+        """Subtract one number from another."""
+        return first - second
+
+
 class PortedTask(Task):
     """
     A task from another package, carrying declarations of its own.
@@ -69,6 +77,16 @@ class VersionedTask(Task):
     def run(self, number):
         """Add to a number."""
         return number + self.value
+
+
+class CarryingTask(Task):
+    """A task holding a mapping which looks like a document of its own."""
+
+    meta: dict = Field(default_factory=dict)
+
+    def run(self, number):
+        """Hand back what it was given."""
+        return number
 
 
 class ConstantTask(Task):
@@ -112,6 +130,18 @@ def chain():
 def branched():
     """A pipe whose two branches feed one task."""
     return (AddTask(value=1), TimesTask(value=5)) | JoinTask()
+
+
+@pytest.fixture
+def crossed():
+    """
+    A pipe fed by two branches, in an order nothing else would pick.
+
+    Its nodes are named so that sorting them gives the other order, and the
+    task joining them tells its inputs apart, so the pipe answers
+    differently if either the wiring or the source order is lost.
+    """
+    return (TimesTask(value=5), AddTask(value=1)) | SubtractTask()
 
 
 @pytest.fixture
@@ -168,6 +198,13 @@ class TestBuilding:
         """A pipe cannot be fed by an empty list of branches."""
         with pytest.raises(ParameterError, match="joined to nothing"):
             () | JoinTask()
+
+    def test_joining_two_fans(self):
+        """Several results into several places have no one pairing."""
+        with pytest.raises(ParameterError, match="one way to pair them"):
+            (AddTask(value=1) | (TimesTask(value=2), TimesTask(value=3))) | (
+                (AddTask(value=1), AddTask(value=2)) | JoinTask()
+            )
 
     def test_joining_to_nothing(self):
         """A pipe cannot fan out into an empty list of branches."""
@@ -239,13 +276,14 @@ class TestNodeKeys:
         with pytest.raises(ParameterError, match="cannot both be called"):
             chain.relabel(add_task="same", times_task="same")
 
-    def test_relabel_tied_nodes(self):
+    def test_relabel_nodes_holding_one_task(self):
         """
-        Two nodes nothing tells apart but their downstream still relabel.
+        Two nodes holding the same task, fed alike, still relabel freely.
 
-        `p` and `q` hold the same task and are fed by the same source, so
-        only what they feed sets them apart. Naming them the other way
-        round must leave the pipe the pipe it was.
+        This is the shape an order-based fingerprint has to break a tie in,
+        and where it would reach for the node's name to do it. Marking a
+        node by what feeds it has no tie to break, so renaming these two --
+        in an order which sorts the other way -- leaves the pipe alone.
         """
         base = Pipe(
             tasks={
@@ -306,6 +344,12 @@ class TestGetAndUpdate:
         assert updated.inputs == diamond.inputs
         assert updated.outputs == diamond.outputs
 
+    def test_new(self, chain, fanned):
+        """A field can be replaced without going through a dump."""
+        swapped = fanned.new(outputs=fanned.outputs[::-1])
+        assert swapped.outputs == fanned.outputs[::-1]
+        assert swapped.run(1) == fanned.run(1)[::-1]
+
     def test_update_unknown(self, chain):
         """Changing a node which is not there says so."""
         with pytest.raises(ParameterError, match="no node called"):
@@ -330,6 +374,12 @@ class TestRunning:
     def test_branches_take_one_input_each(self, branched):
         """A pipe which branches takes an input per branch."""
         assert branched.run(10, 20) == (10 + 1) + (20 * 5)
+
+    def test_fan_in_order(self, crossed):
+        """A task is given its inputs the way they were wired."""
+        # Wired (times, add): 10 * 5 - (20 + 1). The other way round it is
+        # 21 - 50, so a pipe which loses the order cannot answer this.
+        assert crossed.run(10, 20) == 29
 
     def test_wrong_number_of_inputs(self, branched):
         """A pipe says when it was given inputs it cannot place."""
@@ -359,10 +409,6 @@ class TestSources:
 
 class TestOutputs:
     """Tests for a pipe which returns more than one thing."""
-
-    def test_one_output_is_not_a_tuple(self, chain):
-        """A pipe with a single output hands back the value itself."""
-        assert chain.run(1) == 9
 
     def test_fan_out_returns_a_tuple(self, fanned):
         """A fan out with nothing merging it returns one result per output."""
@@ -516,9 +562,16 @@ class TestValidation:
                 outputs=chain.outputs,
             )
 
-    def test_a_second_output_is_not_stranded(self, fanned):
-        """A task reaching any output is a task which feeds the pipe."""
-        assert set(fanned.tasks) == {"add_task", "times_task", "times_task_2"}
+    def test_a_task_reaching_a_later_output(self):
+        """A task is fed when it reaches any output, not only the first."""
+        # `times_task_2` reaches only the second result, so a check which
+        # looked at one output would call it stranded and refuse to build.
+        pipe = AddTask(value=1) | (
+            TimesTask(value=2),
+            TimesTask(value=3) | AddTask(value=5),
+        )
+        assert "times_task_2" in pipe.tasks
+        assert pipe.run(1) == ((1 + 1) * 2, (1 + 1) * 3 + 5)
 
     def test_repeated_input(self, chain):
         """A node cannot be fed twice; it would hide one of the sources."""
@@ -567,12 +620,25 @@ class TestDocuments:
         assert loaded.run(10, 20) == branched.run(10, 20)
 
     @pytest.mark.parametrize("yaml_path", ["pipe.json", "pipe.yaml"], indirect=True)
-    def test_source_order_survives_a_round_trip(self, branched, yaml_path):
+    def test_source_order_survives_a_round_trip(self, crossed, yaml_path):
         """The branch fed first is still the one fed first after loading."""
-        loaded = Pipe.load(branched.save(yaml_path))
-        assert loaded.sources() == branched.sources()
-        # Which is what makes the first input reach the first branch.
-        assert loaded.run(10, 20) == branched.run(10, 20)
+        loaded = Pipe.load(crossed.save(yaml_path))
+        assert loaded.sources() == crossed.sources()
+        assert loaded.run(10, 20) == 29
+
+    def test_source_order_survives_a_reordered_document(self, crossed):
+        """
+        A document is free to list the tasks in any order it likes.
+
+        Which is why the sources are a field of their own: read off the
+        tasks instead, this document would hand each branch the other
+        branch's input and answer 89.
+        """
+        document = crossed.to_dict()
+        document["tasks"] = dict(reversed(list(document["tasks"].items())))
+        loaded = Pipe.from_dict(document)
+        assert loaded.sources() == crossed.sources()
+        assert loaded.run(10, 20) == 29
 
     @pytest.mark.parametrize("yaml_path", ["pipe.json", "pipe.yaml"], indirect=True)
     def test_output_order_survives_a_round_trip(self, fanned, yaml_path):
@@ -653,6 +719,32 @@ class TestDocuments:
         path.write_text("[1, 2, 3]")
         with pytest.raises(ParameterError, match="describes no workflow"):
             Pipe.load(path)
+
+    def test_document_of_something_else(self):
+        """A document which is not a pipe says so rather than raising a KeyError."""
+        with pytest.raises(ParameterError, match="describes something else"):
+            Pipe.from_dict({"object_type": "Inventory"})
+
+    def test_document_holding_a_graph_which_cannot_run(self, chain):
+        """A wire a document lost is an unreadable document, not a bad model."""
+        document = chain.to_dict()
+        document["dependencies"] = {"times_task": ["nowhere"]}
+        with pytest.raises(ParameterError, match="could not be built"):
+            Pipe.from_dict(document)
+
+    def test_a_parameter_cannot_fake_a_version(self):
+        """
+        A parameter which spells a tag and a version is still a parameter.
+
+        Read as a version bump it would switch off the check that the
+        document has not been edited, for every task in the pipe.
+        """
+        faked = {"object_type": VersionedTask(value=1).tag, "version": "0.5"}
+        pipe = CarryingTask(meta=faked) | AddTask(value=1)
+        document = pipe.to_dict()
+        document["tasks"]["add_task"]["params"]["value"] = 99
+        with pytest.raises(ParameterError, match="edited it"):
+            Pipe.from_dict(document)
 
     def test_edited_document_refused(self, chain, tmp_path):
         """A document whose fingerprint disagrees with it is refused."""

--- a/tests/test_workflow/test_pipe.py
+++ b/tests/test_workflow/test_pipe.py
@@ -92,6 +92,17 @@ class NestedPipeTask(Task):
 
 
 @pytest.fixture
+def yaml_path(request, tmp_path):
+    """A path to save to, skipped when its format needs a missing pyyaml."""
+    name = request.param
+    if name.endswith((".yaml", ".yml")):
+        # pyyaml is an optional install, and the free-threaded build is one
+        # place it is not there.
+        pytest.importorskip("yaml")
+    return tmp_path / name
+
+
+@pytest.fixture
 def chain():
     """A pipe of two tasks, one after the other."""
     return AddTask(value=2) | TimesTask(value=3)
@@ -543,28 +554,30 @@ class TestDocuments:
         assert rebuilt == branched
         assert rebuilt.run(10) == branched.run(10)
 
-    @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml", "pipe.yml", "pipe"])
-    def test_save_and_load(self, branched, tmp_path, name):
+    @pytest.mark.parametrize(
+        "yaml_path", ["pipe.json", "pipe.yaml", "pipe.yml", "pipe"], indirect=True
+    )
+    def test_save_and_load(self, branched, yaml_path):
         """A pipe read back from a file is the same pipe, and runs alike."""
-        path = branched.save(tmp_path / name)
+        path = branched.save(yaml_path)
         loaded = Pipe.load(path)
         assert loaded == branched
         # Run as well as compared: a document is free to write the tasks in
         # another order, and the answer must not depend on which order.
         assert loaded.run(10, 20) == branched.run(10, 20)
 
-    @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml"])
-    def test_source_order_survives_a_round_trip(self, branched, tmp_path, name):
+    @pytest.mark.parametrize("yaml_path", ["pipe.json", "pipe.yaml"], indirect=True)
+    def test_source_order_survives_a_round_trip(self, branched, yaml_path):
         """The branch fed first is still the one fed first after loading."""
-        loaded = Pipe.load(branched.save(tmp_path / name))
+        loaded = Pipe.load(branched.save(yaml_path))
         assert loaded.sources() == branched.sources()
         # Which is what makes the first input reach the first branch.
         assert loaded.run(10, 20) == branched.run(10, 20)
 
-    @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml"])
-    def test_output_order_survives_a_round_trip(self, fanned, tmp_path, name):
+    @pytest.mark.parametrize("yaml_path", ["pipe.json", "pipe.yaml"], indirect=True)
+    def test_output_order_survives_a_round_trip(self, fanned, yaml_path):
         """A pipe of two results returns them in the order it was written."""
-        loaded = Pipe.load(fanned.save(tmp_path / name))
+        loaded = Pipe.load(fanned.save(yaml_path))
         assert loaded.outputs == fanned.outputs
         assert loaded.run(1) == fanned.run(1)
 
@@ -609,6 +622,7 @@ class TestDocuments:
 
     def test_yaml_is_yaml(self, chain, tmp_path):
         """A pipe saved as YAML is written as YAML, not as JSON."""
+        pytest.importorskip("yaml")
         text = chain.save(tmp_path / "pipe.yaml").read_text()
         assert not text.lstrip().startswith("{")
         assert "tasks:" in text
@@ -627,6 +641,7 @@ class TestDocuments:
 
     def test_unparsable_yaml(self, chain, tmp_path):
         """A YAML file which does not parse says so as YAML."""
+        pytest.importorskip("yaml")
         path = tmp_path / "pipe.yaml"
         path.write_text("tasks: [unclosed")
         with pytest.raises(ParameterError, match="Could not parse YAML"):

--- a/tests/test_workflow/test_pipe.py
+++ b/tests/test_workflow/test_pipe.py
@@ -110,17 +110,6 @@ class NestedPipeTask(Task):
 
 
 @pytest.fixture
-def yaml_path(request, tmp_path):
-    """A path to save to, skipped when its format needs a missing pyyaml."""
-    name = request.param
-    if name.endswith((".yaml", ".yml")):
-        # pyyaml is an optional install, and the free-threaded build is one
-        # place it is not there.
-        pytest.importorskip("yaml")
-    return tmp_path / name
-
-
-@pytest.fixture
 def chain():
     """A pipe of two tasks, one after the other."""
     return AddTask(value=2) | TimesTask(value=3)
@@ -631,22 +620,20 @@ class TestDocuments:
         assert rebuilt == branched
         assert rebuilt.run(10) == branched.run(10)
 
-    @pytest.mark.parametrize(
-        "yaml_path", ["pipe.json", "pipe.yaml", "pipe.yml", "pipe"], indirect=True
-    )
-    def test_save_and_load(self, branched, yaml_path):
+    @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml", "pipe.yml", "pipe"])
+    def test_save_and_load(self, branched, tmp_path, name):
         """A pipe read back from a file is the same pipe, and runs alike."""
-        path = branched.save(yaml_path)
+        path = branched.save(tmp_path / name)
         loaded = Pipe.load(path)
         assert loaded == branched
         # Run as well as compared: a document is free to write the tasks in
         # another order, and the answer must not depend on which order.
         assert loaded.run(10, 20) == branched.run(10, 20)
 
-    @pytest.mark.parametrize("yaml_path", ["pipe.json", "pipe.yaml"], indirect=True)
-    def test_source_order_survives_a_round_trip(self, crossed, yaml_path):
+    @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml"])
+    def test_source_order_survives_a_round_trip(self, crossed, tmp_path, name):
         """The branch fed first is still the one fed first after loading."""
-        loaded = Pipe.load(crossed.save(yaml_path))
+        loaded = Pipe.load(crossed.save(tmp_path / name))
         assert loaded.sources() == crossed.sources()
         assert loaded.run(10, 20) == 29
 
@@ -664,10 +651,10 @@ class TestDocuments:
         assert loaded.sources() == crossed.sources()
         assert loaded.run(10, 20) == 29
 
-    @pytest.mark.parametrize("yaml_path", ["pipe.json", "pipe.yaml"], indirect=True)
-    def test_output_order_survives_a_round_trip(self, fanned, yaml_path):
+    @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml"])
+    def test_output_order_survives_a_round_trip(self, fanned, tmp_path, name):
         """A pipe of two results returns them in the order it was written."""
-        loaded = Pipe.load(fanned.save(yaml_path))
+        loaded = Pipe.load(fanned.save(tmp_path / name))
         assert loaded.outputs == fanned.outputs
         assert loaded.run(1) == fanned.run(1)
 
@@ -712,7 +699,6 @@ class TestDocuments:
 
     def test_yaml_is_yaml(self, chain, tmp_path):
         """A pipe saved as YAML is written as YAML, not as JSON."""
-        pytest.importorskip("yaml")
         text = chain.save(tmp_path / "pipe.yaml").read_text()
         assert not text.lstrip().startswith("{")
         assert "tasks:" in text
@@ -731,7 +717,6 @@ class TestDocuments:
 
     def test_unparsable_yaml(self, chain, tmp_path):
         """A YAML file which does not parse says so as YAML."""
-        pytest.importorskip("yaml")
         path = tmp_path / "pipe.yaml"
         path.write_text("tasks: [unclosed")
         with pytest.raises(ParameterError, match="Could not parse YAML"):

--- a/tests/test_workflow/test_pipe.py
+++ b/tests/test_workflow/test_pipe.py
@@ -6,6 +6,7 @@ import pickle
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from pydantic import ValidationError
 
 from dascore.exceptions import ParameterError
 from dascore.workflow import Pipe, Task
@@ -95,6 +96,11 @@ class TestBuilding:
         with pytest.raises(ParameterError, match="not str"):
             AddTask() | "not a task"
 
+    def test_joining_nothing(self):
+        """A pipe cannot be fed by an empty list of branches."""
+        with pytest.raises(ParameterError, match="joined to nothing"):
+            () | JoinTask()
+
 
 class TestRunning:
     """Tests for running a pipe."""
@@ -116,12 +122,37 @@ class TestRunning:
         with pytest.raises(ParameterError, match="one for each"):
             branched.run(1, 2, 3)
 
+    def test_runs_after_its_inputs(self):
+        """A task runs after whatever feeds it, however the pipe is held."""
+        pipe = (AddTask(value=1), TimesTask(value=5)) | JoinTask()
+        order = pipe.sorted_nodes()
+        for node, given in pipe.dependencies.items():
+            for upstream in given:
+                assert order.index(upstream) < order.index(node)
+
     def test_map(self, chain):
         """A pipe runs over an iterable."""
         assert chain.map([1, 2]) == [chain.run(1), chain.run(2)]
 
-    def test_map_with_a_client(self, chain):
-        """A pipe runs over an iterable with something else's workers."""
+    def test_map_uses_the_client(self, chain):
+        """A client, when given one, is what runs the pipe."""
+
+        class Recorder:
+            """Something with a map, which says it was the one used."""
+
+            used = False
+
+            def map(self, func, iterable):
+                """Run the pipe, and remember having done so."""
+                Recorder.used = True
+                return [func(x) for x in iterable]
+
+        assert chain.map([1, 2], client=Recorder()) == [chain.run(1), chain.run(2)]
+        assert Recorder.used
+
+    @pytest.mark.concurrency
+    def test_map_with_a_thread_pool(self, chain):
+        """A pipe runs over an iterable with another thread's workers."""
         with ThreadPoolExecutor(max_workers=2) as pool:
             assert chain.map([1, 2], client=pool) == [chain.run(1), chain.run(2)]
 
@@ -143,6 +174,25 @@ class TestFingerprint:
         second = TimesTask(value=3) | AddTask(value=2)
         assert first.fingerprint != second.fingerprint
 
+    def test_wiring_matters(self):
+        """The same tasks wired differently are different pipes."""
+        chained = AddTask(value=1) | TimesTask(value=5) | JoinTask()
+        branched = (AddTask(value=1), TimesTask(value=5)) | JoinTask()
+        assert set(chained.tasks.values()) == set(branched.tasks.values())
+        assert chained.output.split("#")[0] == branched.output.split("#")[0]
+        assert chained.fingerprint != branched.fingerprint
+
+    def test_input_order_matters(self, branched):
+        """Which branch is fed first is part of what a pipe is."""
+        swapped = Pipe(
+            tasks=branched.tasks,
+            dependencies=branched.dependencies,
+            inputs=branched.inputs[::-1],
+            output=branched.output,
+        )
+        assert swapped.fingerprint != branched.fingerprint
+        assert swapped.run(10, 20) != branched.run(10, 20)
+
     def test_equality(self, chain):
         """Two pipes are equal when they hold the same tasks, wired alike."""
         assert chain == AddTask(value=2) | TimesTask(value=3)
@@ -163,7 +213,7 @@ class TestValidation:
     def test_missing_task(self):
         """A pipe cannot wire a node it does not hold."""
         node = AddTask().fingerprint
-        with pytest.raises(ParameterError, match="not one of its tasks"):
+        with pytest.raises(ValidationError, match="not one of its tasks"):
             Pipe(
                 tasks={node: AddTask()},
                 dependencies={node: ("nowhere",)},
@@ -173,23 +223,40 @@ class TestValidation:
     def test_missing_output(self):
         """A pipe's output has to be one of its tasks."""
         node = AddTask().fingerprint
-        with pytest.raises(ParameterError, match="output"):
+        with pytest.raises(ValidationError, match="output"):
             Pipe(tasks={node: AddTask()}, output="nowhere")
 
     def test_cycle(self):
         """Tasks which feed each other in a circle are refused."""
         first, second = AddTask(value=1), AddTask(value=2)
         one, two = first.fingerprint, second.fingerprint
-        with pytest.raises(ParameterError, match="cycle"):
+        with pytest.raises(ValidationError, match="cycle"):
             Pipe(
                 tasks={one: first, two: second},
                 dependencies={one: (two,), two: (one,)},
                 output=one,
             )
 
-    def test_check_returns_the_pipe(self, chain):
-        """Checking a good pipe hands it back."""
-        assert chain.check() is chain
+    def test_stranded_task(self, chain):
+        """A task whose output reaches nothing is a pipe built wrong."""
+        stranded = AddTask(value=99)
+        with pytest.raises(ValidationError, match="every task has to feed"):
+            Pipe(
+                tasks=dict(chain.tasks) | {stranded.fingerprint: stranded},
+                dependencies=chain.dependencies,
+                inputs=(*chain.inputs, stranded.fingerprint),
+                output=chain.output,
+            )
+
+    def test_inputs_must_be_the_unfed_nodes(self, chain):
+        """A pipe's inputs are exactly the nodes nothing is wired into."""
+        with pytest.raises(ValidationError, match="nothing wired into them"):
+            Pipe(
+                tasks=chain.tasks,
+                dependencies=chain.dependencies,
+                inputs=(chain.output,),
+                output=chain.output,
+            )
 
 
 class TestDocuments:
@@ -206,10 +273,27 @@ class TestDocuments:
         assert rebuilt.run(10) == branched.run(10)
 
     @pytest.mark.parametrize("name", ["pipe.json", "pipe.yaml", "pipe.yml", "pipe"])
-    def test_save_and_load(self, chain, tmp_path, name):
-        """A pipe read back from a file is the same pipe."""
-        path = chain.save(tmp_path / name)
-        assert Pipe.load(path) == chain
+    def test_save_and_load(self, branched, tmp_path, name):
+        """A pipe read back from a file is the same pipe, and runs alike."""
+        path = branched.save(tmp_path / name)
+        loaded = Pipe.load(path)
+        assert loaded == branched
+        # Run as well as compared: a document is free to write the tasks in
+        # another order, and the answer must not depend on which order.
+        assert loaded.run(10, 20) == branched.run(10, 20)
+
+    def test_yaml_is_yaml(self, chain, tmp_path):
+        """A pipe saved as YAML is written as YAML, not as JSON."""
+        text = chain.save(tmp_path / "pipe.yaml").read_text()
+        assert not text.lstrip().startswith("{")
+        assert "tasks:" in text
+
+    def test_edited_document_refused(self, chain, tmp_path):
+        """A document whose fingerprint disagrees with it is refused."""
+        document = chain.to_dict()
+        document["fingerprint"] = "0" * 16
+        with pytest.raises(ParameterError, match="fingerprint"):
+            Pipe.from_dict(document)
 
     def test_save_makes_the_directory(self, chain, tmp_path):
         """Saving into a directory which is not there makes it."""

--- a/tests/test_workflow/test_provenance.py
+++ b/tests/test_workflow/test_provenance.py
@@ -29,11 +29,19 @@ class MergeTask(Task):
         return sum(numbers)
 
 
+class LaterTask(Task):
+    """A step which runs after another, and is named differently."""
+
+    def run(self, number):
+        """Double a number."""
+        return number * 2
+
+
 @pytest.fixture
 def source_node():
     """A node standing for a patch read from a file."""
     return ProvenanceNode(
-        source=SourceInfo(format="DASDAE", path="/data/first.h5"),
+        source=SourceInfo(format="DASDAE", path="/data/first.h5", key="patch_2"),
         patch_id="first",
     )
 
@@ -49,11 +57,12 @@ def chain(source_node):
         processing_id="one",
     )
     return ProvenanceNode(
-        task=StepTask(value=2),
+        task=LaterTask(),
         parents=(first,),
         input_pairs=(("first", "one"),),
         patch_id="first",
         processing_id="two",
+        backend="numpy",
     )
 
 
@@ -94,7 +103,10 @@ class TestWalk:
 
     def test_steps(self, chain):
         """The steps are the nodes which did something, oldest first."""
-        assert [x.task.value for x in chain.steps()] == [1, 2]
+        assert [type(x.task).__name__ for x in chain.steps()] == [
+            "StepTask",
+            "LaterTask",
+        ]
 
     def test_sources(self, merged):
         """The sources are where the data was read from."""
@@ -114,7 +126,7 @@ class TestDescribe:
 
     def test_lists_the_steps(self, chain):
         """Every step is named, oldest first."""
-        assert chain.describe().splitlines()[1:] == ["StepTask", "StepTask"]
+        assert chain.describe().splitlines()[1:] == ["StepTask", "LaterTask"]
 
     def test_names_the_source(self, chain):
         """The file the data came from is the first line."""
@@ -136,7 +148,7 @@ class TestToPipe:
         """A chain of steps becomes a pipe of the same tasks."""
         pipe = chain.to_pipe()
         assert len(pipe) == 2
-        assert pipe.run(0) == 3
+        assert pipe.run(0) == 2
 
     def test_sources_become_the_pipes_input(self, merged):
         """A step fed only by files takes its inputs from the caller."""
@@ -154,6 +166,15 @@ class TestToPipe:
         """A patch which was only read has no pipe."""
         with pytest.raises(ParameterError, match="no pipe"):
             source_node.to_pipe()
+
+    def test_two_wide_sources_refused(self, source_node):
+        """Two steps reading straight from files cannot both be fed."""
+        others = [ProvenanceNode(source=SourceInfo(path=f"/{x}.h5")) for x in "abc"]
+        first = ProvenanceNode(task=MergeTask(), parents=(source_node, others[0]))
+        second = ProvenanceNode(task=MergeTask(), parents=tuple(others[1:]))
+        both = ProvenanceNode(task=MergeTask(), parents=(first, second))
+        with pytest.raises(ParameterError, match="no way to describe"):
+            both.to_pipe()
 
     def test_mixed_inputs_refused(self, source_node):
         """A step fed by a step and a file at once cannot be described."""
@@ -197,15 +218,40 @@ class TestNodeDocuments:
         """A graph of one source, with no steps, still round trips."""
         rebuilt = ProvenanceNode.from_json(source_node.to_json())
         assert rebuilt.source == source_node.source
+        assert rebuilt.source.key == "patch_2"
+
+    def test_everything_a_node_holds_round_trips(self, chain):
+        """Every field a node holds survives the trip."""
+        rebuilt = ProvenanceNode.from_json(chain.to_json())
+        for name in type(chain).model_fields:
+            if name != "parents":
+                assert getattr(rebuilt, name) == getattr(chain, name)
 
     def test_pickle(self, chain):
         """A graph survives a pickle."""
         rebuilt = pickle.loads(pickle.dumps(chain))
         assert rebuilt.to_pipe() == chain.to_pipe()
 
-    def test_hashable(self, chain):
-        """A node can be put in a set."""
-        assert len({chain, chain}) == 1
+    def test_equal_after_a_round_trip(self, chain):
+        """A node read back is the step it was, and hashes as one."""
+        rebuilt = ProvenanceNode.from_json(chain.to_json())
+        assert rebuilt == chain
+        assert len({rebuilt, chain}) == 1
+
+    def test_different_steps_differ(self, chain, source_node):
+        """Two nodes standing for different steps are not each other."""
+        other = ProvenanceNode(
+            task=StepTask(value=99),
+            parents=(source_node,),
+            patch_id=chain.patch_id,
+            processing_id=chain.processing_id,
+        )
+        assert other != chain
+        assert len({other, chain}) == 2
+
+    def test_not_a_node(self, chain):
+        """Comparison with something else is left to the something else."""
+        assert chain.__eq__("a node") is NotImplemented
 
 
 class TestProvenance:
@@ -248,6 +294,17 @@ class TestProvenance:
         rebuilt = Provenance.from_dict(document)
         assert rebuilt.source_provenance[0].fingerprint == provenance.fingerprint
 
-    def test_hashable(self, provenance):
-        """A record can be put in a set."""
-        assert len({provenance, provenance}) == 1
+    def test_hashed_by_its_pipe(self, provenance, chain):
+        """Two records of one pipe land in the same place in a dict."""
+        again = Provenance.from_pipe(chain.to_pipe(), operator="someone else")
+        assert hash(again) == hash(provenance)
+
+    def test_metadata_cannot_be_edited(self, provenance):
+        """A durable record is durable: nothing about it can be changed."""
+        with pytest.raises(TypeError):
+            provenance.metadata["sneaked"] = 1
+
+    def test_new_fields_are_written(self, provenance):
+        """Every field the record holds reaches its document."""
+        written = set(provenance.to_dict())
+        assert set(type(provenance).model_fields) <= written

--- a/tests/test_workflow/test_provenance.py
+++ b/tests/test_workflow/test_provenance.py
@@ -30,6 +30,16 @@ class MergeTask(Task):
         return sum(numbers)
 
 
+class SourceTask(Task):
+    """A step which made a number out of nothing."""
+
+    value: int = 1
+
+    def run(self):
+        """Return the number."""
+        return self.value
+
+
 class ArrayTask(Task):
     """A step parametrized by an array, which a document has to carry."""
 
@@ -308,8 +318,20 @@ class TestToPipeRefusals:
             task=StepTask(value=2), parents=(ProvenanceNode(), ProvenanceNode())
         )
         merged = ProvenanceNode(task=StepTask(value=3), parents=(made, chunked))
-        with pytest.raises(ParameterError, match="do not all take one input"):
+        with pytest.raises(ParameterError, match="the same one input"):
             merged.to_pipe()
+
+    def test_sources_which_make_their_own_values(self):
+        """
+        Steps which took nothing have a pipe, which is run with nothing.
+
+        A pipe hands each of its sources the same thing, and nothing is as
+        good as one input each -- which is the shape `Pipe` already runs.
+        """
+        first = ProvenanceNode(task=SourceTask(value=1))
+        second = ProvenanceNode(task=SourceTask(value=2))
+        merged = ProvenanceNode(task=MergeTask(), parents=(first, second))
+        assert merged.to_pipe().run() == 3
 
     def test_an_input_whose_node_was_not_kept(self):
         """A step is fed from more places than the pipe can name."""
@@ -362,6 +384,16 @@ class TestProvenanceNodeDocuments:
         """Which says so as a workflow document does, naming what it read."""
         with pytest.raises(ParameterError, match="Could not parse JSON"):
             ProvenanceNode.from_json("{not json at all")
+
+    def test_a_node_missing_a_field(self):
+        """A document which parses but is not a graph says so."""
+        with pytest.raises(ParameterError, match="no graph of what was done"):
+            ProvenanceNode.from_json('{"nodes": [{}], "output": 0}')
+
+    def test_an_output_which_is_not_there(self):
+        """Nor is one whose result names a node it did not write."""
+        with pytest.raises(ParameterError, match="no graph of what was done"):
+            ProvenanceNode.from_json('{"nodes": [], "output": 3}')
 
     def test_text_holding_something_else(self):
         """A document which is not a graph is refused, not indexed into."""

--- a/tests/test_workflow/test_provenance.py
+++ b/tests/test_workflow/test_provenance.py
@@ -259,6 +259,36 @@ class TestNodeDocuments:
         assert chain.__eq__("a node") is NotImplemented
 
 
+class TestNodeIdentity:
+    """Tests for when two nodes stand for the same step."""
+
+    def test_the_same_step_on_different_data(self):
+        """Two nodes reading different files are two steps, not one."""
+        first = ProvenanceNode(source=SourceInfo(path="/first.h5"))
+        second = ProvenanceNode(source=SourceInfo(path="/second.h5"))
+        left = ProvenanceNode(task=StepTask(value=1), parents=(first,))
+        right = ProvenanceNode(task=StepTask(value=1), parents=(second,))
+        assert left != right
+        assert len({left, right}) == 2
+
+    def test_the_same_step_on_the_same_data(self):
+        """A graph rebuilt from the same lineage holds the same steps."""
+        source = ProvenanceNode(source=SourceInfo(path="/first.h5"))
+        left = ProvenanceNode(task=StepTask(value=1), parents=(source,))
+        right = ProvenanceNode(task=StepTask(value=1), parents=(source,))
+        assert left == right
+        assert len({left, right}) == 1
+
+    def test_a_step_further_back(self):
+        """Two nodes differ when anything behind them does."""
+        source = ProvenanceNode(source=SourceInfo(path="/first.h5"))
+        left = ProvenanceNode(task=StepTask(value=1), parents=(source,))
+        right = ProvenanceNode(task=StepTask(value=2), parents=(source,))
+        after_left = ProvenanceNode(task=LaterTask(), parents=(left,))
+        after_right = ProvenanceNode(task=LaterTask(), parents=(right,))
+        assert after_left != after_right
+
+
 class TestToPipeRefusals:
     """Tests for the graphs which have no pipe."""
 

--- a/tests/test_workflow/test_provenance.py
+++ b/tests/test_workflow/test_provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pickle
 
+import numpy as np
 import pytest
 
 import dascore as dc
@@ -27,6 +28,16 @@ class MergeTask(Task):
     def run(self, *numbers):
         """Add up numbers."""
         return sum(numbers)
+
+
+class ArrayTask(Task):
+    """A step parametrized by an array, which a document has to carry."""
+
+    weights: object = None
+
+    def run(self, number):
+        """Hand back what it was given."""
+        return number
 
 
 class LaterTask(Task):
@@ -208,12 +219,6 @@ class TestNodeDocuments:
         rebuilt = ProvenanceNode.from_json(merged.to_json())
         assert len(list(rebuilt.walk())) == 4
 
-    def test_ids_kept(self, chain):
-        """The ids a step produced survive the trip."""
-        rebuilt = ProvenanceNode.from_json(chain.to_json())
-        assert rebuilt.patch_id == chain.patch_id
-        assert rebuilt.input_pairs == chain.input_pairs
-
     def test_source_node_round_trip(self, source_node):
         """A graph of one source, with no steps, still round trips."""
         rebuilt = ProvenanceNode.from_json(source_node.to_json())
@@ -252,6 +257,86 @@ class TestNodeDocuments:
     def test_not_a_node(self, chain):
         """Comparison with something else is left to the something else."""
         assert chain.__eq__("a node") is NotImplemented
+
+
+class TestToPipeRefusals:
+    """Tests for the graphs which have no pipe."""
+
+    def test_steps_which_never_meet(self):
+        """Two chains joined by a step which recorded no task have no pipe."""
+        source = ProvenanceNode()
+        left = ProvenanceNode(task=StepTask(value=2), parents=(source,))
+        right = ProvenanceNode(task=StepTask(value=3), parents=(source,))
+        joined = ProvenanceNode(parents=(left, right))
+        with pytest.raises(ParameterError, match="could run"):
+            joined.to_pipe()
+
+    def test_sources_read_by_steps_of_different_widths(self):
+        """A pipe hands each source one input, so it cannot say this."""
+        made = ProvenanceNode(task=StepTask(value=9))
+        chunked = ProvenanceNode(
+            task=StepTask(value=2), parents=(ProvenanceNode(), ProvenanceNode())
+        )
+        merged = ProvenanceNode(task=StepTask(value=3), parents=(made, chunked))
+        with pytest.raises(ParameterError, match="do not all take one input"):
+            merged.to_pipe()
+
+    def test_an_input_whose_node_was_not_kept(self):
+        """A step is fed from more places than the pipe can name."""
+        source = ProvenanceNode()
+        earlier = ProvenanceNode(task=StepTask(value=2), parents=(source,))
+        node = ProvenanceNode(
+            task=StepTask(value=3),
+            parents=(earlier,),
+            input_pairs=(("one", ""), ("two", "")),
+        )
+        with pytest.raises(ParameterError, match="straight from a source"):
+            node.to_pipe()
+
+
+class TestProvenanceDocuments:
+    """Tests for what a record of a run can be written with."""
+
+    def test_a_task_holding_an_array(self):
+        """
+        A record writes its pipe the way a pipe does.
+
+        Dumped by pydantic instead it would raise on an array parameter --
+        which the pipes most worth recording hold -- before reaching the
+        line that replaces what it produced.
+        """
+        pipe = ArrayTask(weights=np.arange(3.0)) | ArrayTask(weights=np.ones(2))
+        rebuilt = Provenance.from_dict(pipe.get_provenance().to_dict())
+        assert rebuilt.pipe == pipe
+
+    def test_metadata_a_document_has_no_shape_for(self):
+        """Metadata is whatever was worth recording, and comes back as it."""
+        when = np.datetime64("2020-01-01")
+        record = Provenance.from_pipe(
+            StepTask(value=1) | StepTask(value=2), when=when, run=3
+        )
+        rebuilt = Provenance.from_dict(record.to_dict())
+        assert rebuilt.metadata["when"] == when
+        assert rebuilt.metadata["run"] == 3
+
+    def test_document_of_something_else(self):
+        """A document which records no run says so."""
+        with pytest.raises(ParameterError, match="states the pipe it ran"):
+            Provenance.from_dict({"dascore_version": "1.0"})
+
+
+class TestProvenanceNodeDocuments:
+    """Tests for reading a graph back from text which may not hold one."""
+
+    def test_text_which_does_not_parse(self):
+        """Which says so as a workflow document does, naming what it read."""
+        with pytest.raises(ParameterError, match="Could not parse JSON"):
+            ProvenanceNode.from_json("{not json at all")
+
+    def test_text_holding_something_else(self):
+        """A document which is not a graph is refused, not indexed into."""
+        with pytest.raises(ParameterError, match="no record of what was done"):
+            ProvenanceNode.from_json('{"tasks": {}}')
 
 
 class TestProvenance:

--- a/tests/test_workflow/test_provenance.py
+++ b/tests/test_workflow/test_provenance.py
@@ -1,0 +1,253 @@
+"""Tests for the two records of where data came from."""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+import dascore as dc
+from dascore.exceptions import ParameterError
+from dascore.workflow import Provenance, ProvenanceNode, SourceInfo, Task
+
+
+class StepTask(Task):
+    """A step which changes a number."""
+
+    value: int = 1
+
+    def run(self, number):
+        """Add to a number."""
+        return number + self.value
+
+
+class MergeTask(Task):
+    """A step which takes several numbers."""
+
+    def run(self, *numbers):
+        """Add up numbers."""
+        return sum(numbers)
+
+
+@pytest.fixture
+def source_node():
+    """A node standing for a patch read from a file."""
+    return ProvenanceNode(
+        source=SourceInfo(format="DASDAE", path="/data/first.h5"),
+        patch_id="first",
+    )
+
+
+@pytest.fixture
+def chain(source_node):
+    """Two steps run one after the other on one source."""
+    first = ProvenanceNode(
+        task=StepTask(value=1),
+        parents=(source_node,),
+        input_pairs=(("first", ""),),
+        patch_id="first",
+        processing_id="one",
+    )
+    return ProvenanceNode(
+        task=StepTask(value=2),
+        parents=(first,),
+        input_pairs=(("first", "one"),),
+        patch_id="first",
+        processing_id="two",
+    )
+
+
+@pytest.fixture
+def merged(source_node):
+    """One step over patches read from three files."""
+    others = [
+        ProvenanceNode(source=SourceInfo(path=f"/data/{x}.h5"), patch_id=x)
+        for x in ("second", "third")
+    ]
+    return ProvenanceNode(
+        task=MergeTask(),
+        parents=(source_node, *others),
+        patch_id="merged",
+        processing_id="three",
+    )
+
+
+class TestWalk:
+    """Tests for reading a graph."""
+
+    def test_walk_reaches_everything(self, chain):
+        """Every node behind one is reachable from it."""
+        assert len(list(chain.walk())) == 3
+
+    def test_walk_is_oldest_first(self, chain):
+        """A node is walked after the nodes which fed it."""
+        walked = list(chain.walk())
+        assert walked[0].source is not None
+        assert walked[-1] is chain
+
+    def test_walk_yields_each_node_once(self, source_node):
+        """A node two branches share is walked once."""
+        left = ProvenanceNode(task=StepTask(value=1), parents=(source_node,))
+        right = ProvenanceNode(task=StepTask(value=2), parents=(source_node,))
+        merged = ProvenanceNode(task=MergeTask(), parents=(left, right))
+        assert len(list(merged.walk())) == 4
+
+    def test_steps(self, chain):
+        """The steps are the nodes which did something, oldest first."""
+        assert [x.task.value for x in chain.steps()] == [1, 2]
+
+    def test_sources(self, merged):
+        """The sources are where the data was read from."""
+        assert [x.path for x in merged.sources()] == [
+            "/data/first.h5",
+            "/data/second.h5",
+            "/data/third.h5",
+        ]
+
+    def test_a_source_has_no_steps(self, source_node):
+        """Nothing was done to a patch which was only read."""
+        assert source_node.steps() == ()
+
+
+class TestDescribe:
+    """Tests for the readable listing which replaces a history string."""
+
+    def test_lists_the_steps(self, chain):
+        """Every step is named, oldest first."""
+        assert chain.describe().splitlines()[1:] == ["StepTask", "StepTask"]
+
+    def test_names_the_source(self, chain):
+        """The file the data came from is the first line."""
+        assert chain.describe().splitlines()[0] == "read DASDAE /data/first.h5"
+
+    def test_collapses_many_sources(self, merged):
+        """A patch built from many files does not list them all."""
+        assert merged.describe().splitlines()[0] == "read 3 sources"
+
+    def test_says_how_wide_a_step_was(self, merged):
+        """A step over several inputs says how many."""
+        assert "MergeTask over 3 inputs" in merged.describe()
+
+
+class TestToPipe:
+    """Tests for turning a graph back into something runnable."""
+
+    def test_chain(self, chain):
+        """A chain of steps becomes a pipe of the same tasks."""
+        pipe = chain.to_pipe()
+        assert len(pipe) == 2
+        assert pipe.run(0) == 3
+
+    def test_sources_become_the_pipes_input(self, merged):
+        """A step fed only by files takes its inputs from the caller."""
+        pipe = merged.to_pipe()
+        assert len(pipe) == 1
+        assert pipe.run(1, 2, 3) == 6
+
+    def test_repeated_task(self, source_node):
+        """The same task twice stays two steps."""
+        first = ProvenanceNode(task=StepTask(value=1), parents=(source_node,))
+        second = ProvenanceNode(task=StepTask(value=1), parents=(first,))
+        assert len(second.to_pipe()) == 2
+
+    def test_nothing_was_done(self, source_node):
+        """A patch which was only read has no pipe."""
+        with pytest.raises(ParameterError, match="no pipe"):
+            source_node.to_pipe()
+
+    def test_mixed_inputs_refused(self, source_node):
+        """A step fed by a step and a file at once cannot be described."""
+        step = ProvenanceNode(task=StepTask(value=1), parents=(source_node,))
+        other = ProvenanceNode(source=SourceInfo(path="/data/other.h5"))
+        mixed = ProvenanceNode(task=MergeTask(), parents=(step, other))
+        with pytest.raises(ParameterError, match="no way to describe"):
+            mixed.to_pipe()
+
+
+class TestNodeDocuments:
+    """Tests for writing a graph down and reading it back."""
+
+    def test_round_trip(self, chain):
+        """A graph read back holds the same steps."""
+        rebuilt = ProvenanceNode.from_json(chain.to_json())
+        assert rebuilt.to_pipe() == chain.to_pipe()
+        assert rebuilt.processing_id == chain.processing_id
+
+    def test_shape_kept(self, merged):
+        """A graph read back has the shape it was written with."""
+        rebuilt = ProvenanceNode.from_json(merged.to_json())
+        assert len(rebuilt.parents) == 3
+        assert [x.path for x in rebuilt.sources()] == [x.path for x in merged.sources()]
+
+    def test_shared_node_stays_shared(self, source_node):
+        """A node two branches share is written once and read back once."""
+        left = ProvenanceNode(task=StepTask(value=1), parents=(source_node,))
+        right = ProvenanceNode(task=StepTask(value=2), parents=(source_node,))
+        merged = ProvenanceNode(task=MergeTask(), parents=(left, right))
+        rebuilt = ProvenanceNode.from_json(merged.to_json())
+        assert len(list(rebuilt.walk())) == 4
+
+    def test_ids_kept(self, chain):
+        """The ids a step produced survive the trip."""
+        rebuilt = ProvenanceNode.from_json(chain.to_json())
+        assert rebuilt.patch_id == chain.patch_id
+        assert rebuilt.input_pairs == chain.input_pairs
+
+    def test_source_node_round_trip(self, source_node):
+        """A graph of one source, with no steps, still round trips."""
+        rebuilt = ProvenanceNode.from_json(source_node.to_json())
+        assert rebuilt.source == source_node.source
+
+    def test_pickle(self, chain):
+        """A graph survives a pickle."""
+        rebuilt = pickle.loads(pickle.dumps(chain))
+        assert rebuilt.to_pipe() == chain.to_pipe()
+
+    def test_hashable(self, chain):
+        """A node can be put in a set."""
+        assert len({chain, chain}) == 1
+
+
+class TestProvenance:
+    """Tests for the durable record of a run."""
+
+    @pytest.fixture
+    def provenance(self, chain):
+        """A record of the pipe a graph describes."""
+        return chain.to_pipe().get_provenance(operator="a test")
+
+    def test_records_the_pipe(self, provenance, chain):
+        """The record holds the pipe it was made from."""
+        assert provenance.pipe == chain.to_pipe()
+
+    def test_fingerprint_is_the_pipes(self, provenance):
+        """A record is identified by the pipe it holds."""
+        assert provenance.fingerprint == provenance.pipe.fingerprint
+
+    def test_records_the_run(self, provenance):
+        """The record says which DASCore and which machine ran it."""
+        assert provenance.dascore_version == dc.__version__
+        assert provenance.python_version
+        assert "platform" in provenance.system_info
+
+    def test_metadata(self, provenance):
+        """Anything else worth recording is kept."""
+        assert provenance.metadata["operator"] == "a test"
+
+    @pytest.mark.parametrize("name", ["run.json", "run.yaml"])
+    def test_save_and_load(self, provenance, tmp_path, name):
+        """A record read back from a file describes the same run."""
+        rebuilt = Provenance.load(provenance.save(tmp_path / name))
+        assert rebuilt.pipe == provenance.pipe
+        assert rebuilt.created_at == provenance.created_at
+        assert rebuilt.metadata == provenance.metadata
+
+    def test_source_provenance(self, provenance):
+        """A record of a run over another run's results holds both."""
+        document = provenance.to_dict() | {"source_provenance": [provenance.to_dict()]}
+        rebuilt = Provenance.from_dict(document)
+        assert rebuilt.source_provenance[0].fingerprint == provenance.fingerprint
+
+    def test_hashable(self, provenance):
+        """A record can be put in a set."""
+        assert len({provenance, provenance}) == 1

--- a/tests/test_workflow/test_provenance.py
+++ b/tests/test_workflow/test_provenance.py
@@ -283,6 +283,9 @@ class TestProvenance:
     @pytest.mark.parametrize("name", ["run.json", "run.yaml"])
     def test_save_and_load(self, provenance, tmp_path, name):
         """A record read back from a file describes the same run."""
+        if name.endswith(".yaml"):
+            # pyyaml is an optional install.
+            pytest.importorskip("yaml")
         rebuilt = Provenance.load(provenance.save(tmp_path / name))
         assert rebuilt.pipe == provenance.pipe
         assert rebuilt.created_at == provenance.created_at

--- a/tests/test_workflow/test_provenance.py
+++ b/tests/test_workflow/test_provenance.py
@@ -430,9 +430,6 @@ class TestProvenance:
     @pytest.mark.parametrize("name", ["run.json", "run.yaml"])
     def test_save_and_load(self, provenance, tmp_path, name):
         """A record read back from a file describes the same run."""
-        if name.endswith(".yaml"):
-            # pyyaml is an optional install.
-            pytest.importorskip("yaml")
         rebuilt = Provenance.load(provenance.save(tmp_path / name))
         assert rebuilt.pipe == provenance.pipe
         assert rebuilt.created_at == provenance.created_at

--- a/tests/test_workflow/test_task.py
+++ b/tests/test_workflow/test_task.py
@@ -124,6 +124,17 @@ class TestFingerprint:
         """
         assert ScaleTask(factor=2).fingerprint == "761d418c84549e16"
 
+    def test_hard_coded_with_tagged_values(self):
+        """
+        A parameter the serializer tags is pinned as well.
+
+        The plain values above go through the encoding unchanged, so they
+        cannot see a change in how a tagged one -- an array, a time -- is
+        written; this pins that half.
+        """
+        task_ = TimedValueTask(when=np.datetime64("2020-01-01"), where=np.arange(3))
+        assert task_.fingerprint == "53791ea82cf3fe6d"
+
     def test_params_matter(self):
         """Two different calls are two different tasks."""
         assert ScaleTask(factor=2).fingerprint != ScaleTask(factor=3).fingerprint

--- a/tests/test_workflow/test_task.py
+++ b/tests/test_workflow/test_task.py
@@ -226,6 +226,52 @@ class TestEquality:
         assert hash(first) == hash(TimedValueTask(when=np.arange(3)))
 
 
+class TestOwnedParameters:
+    """Tests for a task taking ownership of the arrays it is given."""
+
+    def test_array_is_read_only(self):
+        """An array handed to a task cannot be written to afterwards."""
+        values = np.arange(3)
+        TimedValueTask(when=values)
+        with pytest.raises(ValueError, match="read-only"):
+            values[0] = 99
+
+    def test_fingerprint_cannot_go_stale(self):
+        """So the id a task reports still describes what it holds."""
+        values = np.arange(3)
+        task_ = TimedValueTask(when=values)
+        with pytest.raises(ValueError, match="read-only"):
+            values[0] = 99
+        assert task_.fingerprint == TimedValueTask(when=values).fingerprint
+
+    def test_array_inside_a_sequence(self):
+        """An array reaches a task inside a container too."""
+        values = np.arange(3)
+        TimedValueTask(when=[values, "something else"])
+        with pytest.raises(ValueError, match="read-only"):
+            values[0] = 99
+
+    def test_array_inside_a_mapping(self):
+        """A mapping of arrays is walked as well."""
+        values = np.arange(3)
+        TimedValueTask(when={"mask": values})
+        with pytest.raises(ValueError, match="read-only"):
+            values[0] = 99
+
+    def test_other_values_are_left_alone(self):
+        """Nothing which is not an array is touched on the way in."""
+        task_ = TimedValueTask(when=(1, 2), where="time")
+        assert task_.when == (1, 2)
+        assert task_.where == "time"
+
+    def test_from_call_owns_them_too(self):
+        """The call path skips validation, and takes ownership anyway."""
+        values = np.arange(3)
+        add_numbers._from_call((values,), {})
+        with pytest.raises(ValueError, match="read-only"):
+            values[0] = 99
+
+
 class TestUpdate:
     """Tests for making one task from another."""
 

--- a/tests/test_workflow/test_task.py
+++ b/tests/test_workflow/test_task.py
@@ -59,16 +59,16 @@ class TimedValueTask(Task):
     where: object = None
 
 
-@task
+@task(inputs=0)
 def add_numbers(first, second=1):
     """Add two numbers."""
     return first + second
 
 
 @task(version="2.0")
-def multiply_numbers(first, second=2):
-    """Multiply two numbers."""
-    return first * second
+def multiply_numbers(number, factor=2):
+    """Multiply a number by a factor."""
+    return number * factor
 
 
 def every_kind(positional, /, normal=1, *rest, named=2, **extra):
@@ -87,7 +87,7 @@ def skips_first(given, /, normal=1, *rest, named=2, **extra):
 
 
 EveryKind = make_function_task_class(every_kind)
-SkipsFirst = make_function_task_class(skips_first, skip_first=True)
+SkipsFirst = make_function_task_class(skips_first, inputs=1)
 WithFieldDefault = make_function_task_class(with_field_default)
 
 
@@ -445,6 +445,14 @@ class TestRun:
         """A subclass runs what it implements."""
         assert ScaleTask(factor=2).run(3) == 6
 
+    def test_calling_runs(self):
+        """Calling a task runs it, so a task can stand for a function."""
+        assert ScaleTask(factor=2)(3) == 6
+
+    def test_calling_a_function_task(self):
+        """Calling reaches the subclass's own run, not the base class's."""
+        assert multiply_numbers(factor=3)(2) == 6
+
 
 class TestFunctionTasks:
     """Tests for the task a function makes."""
@@ -473,7 +481,7 @@ class TestFunctionTasks:
     def test_version(self):
         """The decorator's version reaches the class."""
         assert multiply_numbers.__version__ == "2.0"
-        assert multiply_numbers(first=2).run() == 4
+        assert multiply_numbers(factor=2).run(2) == 4
 
     def test_extra_input_passed_first(self):
         """Arguments given to run are passed before the stored ones."""
@@ -577,16 +585,74 @@ class TestTaskDecorator:
         """The decorator works without parentheses."""
 
         @task
-        def bare(value=1):
+        def bare(number, value=1):
             """A task made without parentheses."""
+            return number + value
+
+        assert bare(value=2).run(1) == 3
+
+    def test_one_input_by_default(self):
+        """The first parameter is what the task is given when it runs."""
+
+        @task
+        def scaled(number, factor=2):
+            """Scale a number."""
+            return number * factor
+
+        assert "number" not in scaled.model_fields
+        assert scaled(factor=3).run(2) == 6
+
+    def test_no_inputs(self):
+        """A task of no inputs takes everything as a parameter."""
+
+        @task(inputs=0)
+        def constant(value=1):
+            """Make a number out of nothing."""
             return value
 
-        assert bare(value=2).run() == 2
+        assert constant(value=2).run() == 2
+
+    def test_more_inputs_than_arguments(self):
+        """A count of inputs the function could not be given is refused."""
+        with pytest.raises(ParameterError, match="was asked for 2"):
+
+            @task(inputs=2)
+            def too_few(number):
+                """Take one argument, and be asked for two."""
+                return number
+
+    def test_inputs_cannot_be_negative(self):
+        """A negative count would make a parameter out of nothing."""
+        with pytest.raises(ParameterError, match="was asked for -1"):
+
+            @task(inputs=-1)
+            def negative(number):
+                """Take one argument, and be asked for less than none."""
+                return number
+
+    def test_keyword_only_is_not_an_input(self):
+        """An input is passed positionally, so a keyword only one is not."""
+        with pytest.raises(ParameterError, match="was asked for 2"):
+
+            @task(inputs=2)
+            def keyword_only(number, *, named=1):
+                """Take an argument which cannot be passed by position."""
+                return number + named
+
+    def test_several_inputs(self):
+        """A task can be given more than one input."""
+
+        @task(inputs=2)
+        def combined(first, second, factor=1):
+            """Combine two numbers."""
+            return (first + second) * factor
+
+        assert combined(factor=2).run(1, 2) == 6
 
     def test_with_version(self):
         """The decorator works with arguments."""
 
-        @task(version="3.0")
+        @task(version="3.0", inputs=0)
         def versioned(value=1):
             """A task made with a version."""
             return value

--- a/tests/test_workflow/test_task.py
+++ b/tests/test_workflow/test_task.py
@@ -260,12 +260,10 @@ class TestDocuments:
         document = ScaleTask(factor=2).to_dict()
         assert document["object_type"] == "tests:ScaleTask"
 
-    def test_code_path_is_a_hint(self):
-        """The import hint is written but does not change the fingerprint."""
+    def test_names_the_class_once(self):
+        """A document names the class by its tag and by nothing else."""
         document = ScaleTask(factor=2).to_dict()
-        assert "code_path" in document
-        document["code_path"] = "somewhere:else"
-        assert _fingerprint_of(document) == ScaleTask(factor=2).fingerprint
+        assert set(document) == {"object_type", "version", "params"}
 
     def test_local_class_refused(self):
         """A task class defined in a function cannot be written down."""

--- a/tests/test_workflow/test_task.py
+++ b/tests/test_workflow/test_task.py
@@ -666,6 +666,33 @@ class TestTaskDecorator:
         # two sources are handed one input each, and the join both results.
         assert ((merged(), merged()) | merged()).run(1, 2) == 3
 
+    def test_a_parameter_after_a_group(self):
+        """
+        What is declared after a `*args` group is still the task's.
+
+        The group absorbs the inputs; taking the inputs off by counting
+        parameters would walk past it and drop everything behind.
+        """
+
+        @task(inputs=2)
+        def scaled_sum(*numbers, scale=1):
+            """Add numbers and scale the total."""
+            return sum(numbers) * scale
+
+        assert "scale" in scaled_sum.model_fields
+        assert scaled_sum(scale=10).run(1, 2) == 30
+        assert scaled_sum().run(1, 2) == 3
+
+    def test_a_kwargs_group_after_a_group(self):
+        """A `**kwargs` group behind a `*args` group still takes extras."""
+
+        @task(inputs=1)
+        def collected(*numbers, **extra):
+            """Take numbers and whatever else."""
+            return (sum(numbers), extra)
+
+        assert collected(other=1).run(2) == (2, {"other": 1})
+
     def test_several_inputs(self):
         """A task can be given more than one input."""
 

--- a/tests/test_workflow/test_task.py
+++ b/tests/test_workflow/test_task.py
@@ -132,7 +132,11 @@ class TestFingerprint:
         cannot see a change in how a tagged one -- an array, a time -- is
         written; this pins that half.
         """
-        task_ = TimedValueTask(when=np.datetime64("2020-01-01"), where=np.arange(3))
+        # The dtype is spelled out: `arange` gives int32 where a C long is
+        # 32 bits -- WebAssembly, for one -- and the digest names the dtype.
+        task_ = TimedValueTask(
+            when=np.datetime64("2020-01-01"), where=np.arange(3, dtype="int64")
+        )
         assert task_.fingerprint == "53791ea82cf3fe6d"
 
     def test_params_matter(self):

--- a/tests/test_workflow/test_task.py
+++ b/tests/test_workflow/test_task.py
@@ -234,19 +234,29 @@ class TestOwnedParameters:
     """Tests for a task taking ownership of the arrays it is given."""
 
     def test_array_is_read_only(self):
-        """An array handed to a task cannot be written to afterwards."""
+        """
+        An array handed to a task cannot be written to afterwards.
+
+        Which is what keeps the fingerprint from going stale: it is cached
+        on first use, so an array a caller kept writing to would leave the
+        task naming values it no longer holds.
+        """
         values = np.arange(3)
         TimedValueTask(when=values)
         with pytest.raises(ValueError, match="read-only"):
             values[0] = 99
 
-    def test_fingerprint_cannot_go_stale(self):
-        """So the id a task reports still describes what it holds."""
+    def test_the_callers_array_is_the_one_frozen(self):
+        """
+        Nothing is copied, so the caller's own array is what is marked.
+
+        Stated as a test because it is the cost of the policy rather than a
+        detail of it: a caller who keeps writing to a buffer it passed as a
+        parameter finds out at the write, not at the call.
+        """
         values = np.arange(3)
-        task_ = TimedValueTask(when=values)
-        with pytest.raises(ValueError, match="read-only"):
-            values[0] = 99
-        assert task_.fingerprint == TimedValueTask(when=values).fingerprint
+        TimedValueTask(when=values)
+        assert values.flags.writeable is False
 
     def test_array_inside_a_sequence(self):
         """An array reaches a task inside a container too."""
@@ -642,6 +652,19 @@ class TestTaskDecorator:
             def keyword_only(number, *, named=1):
                 """Take an argument which cannot be passed by position."""
                 return number + named
+
+    def test_a_group_takes_any_number_of_inputs(self):
+        """A function which packs its arguments can be asked for any count."""
+
+        @task(inputs=2)
+        def merged(*numbers):
+            """Add up whatever it is given."""
+            return sum(numbers)
+
+        assert merged().run(1, 2) == 3
+        # Which is what lets a decorated function join two branches: the
+        # two sources are handed one input each, and the join both results.
+        assert ((merged(), merged()) | merged()).run(1, 2) == 3
 
     def test_several_inputs(self):
         """A task can be given more than one input."""


### PR DESCRIPTION
## Description

Third PR of the processors series, after #929 (dispatcher rollback) and #932 (the `Task` and its serializer). It adds the other two workflow objects: a `Pipe`, which is several tasks arranged into the shape of one, and the two records of where data came from. Nothing in DASCore uses them yet; `PatchProcessor` is next, and the patch ids which fill the provenance graph come with it.

### Pipe

A pipe is a directed acyclic graph of tasks, built with `|`, which reads the same way round:

```python
pipe = Detrend(dim="time") | PassFilter(time=(1, 10))            # a chain
merged = (Detrend(dim="time"), Taper(time=0.05)) | Correlate()   # two branches into one
split = Raw() | (StrainRate(), Velocity())                       # one into two results
diamond = Raw() | (StrainRate(), Velocity()) | Combine()         # and back again
pipe(patch)                                                      # a pipe is callable
```

It is a task-like object in its own right: immutable, hashable, callable, with a fingerprint covering the tasks, the wiring, the order its branches are fed and the order it returns its results. It writes itself to JSON or YAML (the suffix decides) and reads back through the tag registry, so loading a pipe never imports whatever a file happens to name; it pickles; and `to_mermaid` writes it out as a flowchart.

A pipe holding several outputs returns a tuple in the order `outputs` lists, and one output returns the value itself. That is what lets a canvas with several sinks — derzug's export target — leave as one pipe rather than several.

Running a pipe is deliberately boring: each task is given its inputs, in order, once everything feeding it has run, and nothing else. DASCore composes patch operations; it does not schedule or stream. Running one over an archive is a loop, `spool.map`, Dask or Ray — which is why there is no `Pipe.map`.

### Naming the nodes

Each task in a pipe is a node under a name taken from its class and numbered when the same task appears twice: `decimate`, `decimate_2`. The name is what `get`, `update`, `relabel`, a mermaid diagram and a provenance record refer to, so it deliberately says nothing about the parameters — changing one leaves every reference where it was.

```python
pipe.get("trim_edges")                 # the task a node holds
pipe.update("decimate", factor=5)      # a new pipe, a new fingerprint
pipe.relabel(decimate="coarse")        # a new pipe, the same fingerprint
```

The fingerprint is **structural**, not nominal: the task fingerprints and the wires between them as positions in a canonical topological order. The order comes from the sources, the shape of the graph and the outputs, never from what a node is called, so renaming a node — or reading back a document whose parser sorted the task keys — gives the pipe it always was.

### One way to read and write a document

The workflow's save and load do not add a convention. `dascore/utils/documents.py` now holds `read_document`, `write_document` and `parse_document`, and the three formats which store a mapping as YAML or JSON all go through them:

| was | now |
|---|---|
| `annotation_loader._read_object` | `read_document(..., error=ParameterError, holds="states no attributes")` |
| `inventory_loader._read_object` | `read_document(..., error=InvalidInventoryError, holds="defines no object")` |
| `AnnotationSet.save`'s `json.dump` | `write_document(document, attrs_file, "json")` |
| `Inventory.to_yaml`'s `open(path, "w")` | `write_document(data, path, "yaml")` |
| `Inventory.from_yaml`'s parse-and-wrap | `parse_document(text, "yaml", label=...)` |
| `Pipe.save` / `Provenance.save` / their loads | the same three |

A caller hands it the format its own naming rules picked — the inventory's compound suffixes, the annotation set's exact part names, the workflow's enumerated ones — along with the exception it wants raised and how to finish the sentence about a file which holds no mapping. Three things follow: every document is read as `utf-8-sig` rather than through the locale's encoding, so a file written on Windows reads the same everywhere; every writer makes its parent directory, as only some did; and a workflow path whose suffix names no format is refused rather than quietly written as JSON.

`DascoreConfig` is the obvious next resident — it has no file form at all today — but a config file needs a discovery rule, so it is left for its own PR.

Two shape rules are worth stating. Inputs are given to a task **in the order they were wired**, because a synthesized task's `run` is `run(*args)` and has no parameter names to bind to. And the nodes the caller feeds are recorded explicitly, as `inputs`, rather than read off the task ordering — a document is free to write the tasks in any order, and sorting them must not change which branch gets which input.

### Provenance

`Provenance` is the durable record: a pipe, the DASCore version, the python, the machine, free-form metadata, and the provenance of whatever the run was given. It is what belongs beside results, and it saves and loads like a pipe.

`ProvenanceNode` is the live half: one immutable node per step, holding the task which ran and the nodes which fed it. A graph starts wide, at the files data was read from, and narrows as data is merged; appending is O(1) and splits share their ancestors. It offers `walk` (oldest first, each node once), `steps`, `sources`, `describe` — the readable listing which replaces `attrs.history` — `to_pipe`, and a JSON round trip which keeps a shared node shared.

Also here: `Task.__or__`/`__ror__`, `Task.__call__`, `@task(inputs=N)` — how many of a function's leading parameters are what the task is *given* rather than what it *is*, one by default so a decorated function is a pipe step — a `$pipe` encoding so a pipe held as a task's parameter is written as a pipe rather than as a bag of fields, `docs/tutorial/workflow.qmd`, and its entry in the docs sidebar.

### Owned parameters

A task is immutable and fingerprints itself once, so an array a caller kept writing to would leave the task reporting an id for values it no longer held — the same staleness the review removed the array-digest cache for, one level up. Array parameters now go through `dascore.compat.array`, which marks them read-only in place, exactly as a patch's data is marked: no copy, and mutation raises in the caller rather than going quiet. Containers are walked; nothing which is not an array is touched.

## Changelog

- none



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added composable workflow pipelines with branching, joining, execution, inspection, and Mermaid visualization.
  * Added durable provenance tracking, lineage inspection, workflow reconstruction, and run metadata.
  * Added JSON/YAML workflow persistence with validation and fingerprint checks.
  * Enhanced tasks with callable composition, configurable inputs, fingerprints, and safe array handling.
  * Added Parquet support for annotation tables, annotation collections, dimension metadata, and provenance-aware merging.
* **Improvements**
  * Standardized JSON/YAML document reading and writing with clearer errors and automatic directory creation.
* **Documentation**
  * Added a comprehensive workflow tutorial covering composition, execution, serialization, and provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->