### PR TITLE
Host method namespaces on Inventory and AnnotationSet

### DIFF
--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -54,6 +54,7 @@ from dascore.models import (
 from dascore.utils.intervals import normalize_value, value_kind
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import iterate, to_str, validate_acquisition_key
+from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.tables import parse_cell
 from dascore.utils.time import to_datetime64, to_timedelta64
 
@@ -81,7 +82,7 @@ _VERTEX_KINDS = {"path": 2, "polygon": 3}
 _VERTEX_COLUMNS = ("id", "seq")
 
 # The three parts a stored set spells itself with, and the suffixes each
-# takes. The loader reads these names; `save` writes them, and clears the
+# takes. The loader reads these names; `io.save` writes them, and clears the
 # spellings it supersedes, which is why both need the whole list.
 ATTRS_STEM = "attrs"
 ANNOTATION_STEM = "annotations"
@@ -610,7 +611,7 @@ class _Spelling(NamedTuple):
     end: str | None
 
 
-class AnnotationSet:
+class AnnotationSet(NamespaceOwner):
     """
     An immutable, dataframe-backed set of annotations over patch dimensions.
 
@@ -651,6 +652,8 @@ class AnnotationSet:
     >>> picks[0].region.bounds["distance"]
     (10.0, 80.0)
     """
+
+    _namespace_entry_point_group: ClassVar[str] = "dascore.annotation_namespace"
 
     def __init__(
         self,
@@ -694,103 +697,6 @@ class AnnotationSet:
     def dims(self) -> tuple[str, ...]:
         """The dimensions the annotations are stated in."""
         return self._attrs.dims
-
-    def to_dataframe(self) -> pd.DataFrame:
-        """Return the annotations as a dataframe."""
-        return self._df.copy()
-
-    def to_vertices(self) -> pd.DataFrame:
-        """Return the vertices of every path and polygon as a tidy dataframe."""
-        return self._vertices.copy()
-
-    # --- writing the set out
-
-    def to_csv(self, path=None) -> str:
-        """
-        Return the annotations as CSV text, optionally writing it to a path.
-
-        A bare table states one grain, so a set holding vertices is written
-        with [save](`dascore.core.annotations.AnnotationSet.save`) instead;
-        this is the spelling for a set of regions. The set's dimensions are
-        not part of the table, so reading one back states them again.
-
-        Parameters
-        ----------
-        path
-            Where to write the text, or None to only return it.
-        """
-        if not self._vertices.empty:
-            msg = (
-                "This set holds vertices, which a bare table has no row for. "
-                "Save it as a directory, which states its vertices beside its "
-                "annotations."
-            )
-            raise ParameterError(msg)
-        return _write_table(self._df, path)
-
-    def save(self, path) -> pathlib.Path:
-        """
-        Write the set to a directory, creating it if needed.
-
-        The directory states the set in three parts: what it is and which
-        dimensions it holds, its annotations, and -- where any path or
-        polygon needs them -- its vertices. It reads back through
-        [dascore.annotations](`dascore.annotations`).
-
-        The attributes are written as JSON rather than as YAML, so storing
-        a set needs nothing beyond the standard library; a set authored by
-        hand may spell them in YAML, which reads back the same.
-
-        Writing states the whole directory, so a part this set does not
-        have is removed rather than left behind. A stale vertices table, or
-        the YAML the attributes used to be spelled in, would otherwise sit
-        beside what was written and leave a directory which loaded before
-        the save refusing to load after it.
-
-        Parameters
-        ----------
-        path
-            The directory to write into.
-
-        Returns
-        -------
-        The directory written to, so a save reads straight back.
-        """
-        # Everything is spelled out before the directory is touched: a
-        # table which refuses to be written -- an ambiguous value does --
-        # would otherwise raise with the stale parts already deleted and
-        # the attributes already replaced, leaving half a set behind.
-        # Defaults are dropped from the document, so it says what the set
-        # says; dims has no default, so it is always written, and the
-        # attributes name their own model, which is what the file holds.
-        document = self._attrs.model_dump(mode="json", exclude_defaults=True)
-        annotation_text = _write_table(self._df)
-        vertex_text = None if self._vertices.empty else _write_table(self._vertices)
-        directory = pathlib.Path(path)
-        directory.mkdir(parents=True, exist_ok=True)
-        vertex_table = directory / f"{VERTEX_STEM}{TABLE_SUFFIX}"
-        attrs_file = directory / f"{ATTRS_STEM}{OBJECT_SUFFIXES[0]}"
-        # Only the spellings this format claims: a notes.txt or an
-        # attrs.bak beside them participates in no convention and is not
-        # this function's to delete. The suffix is matched without regard
-        # to case, as the loader matches it.
-        superseded = [
-            x
-            for x in directory.iterdir()
-            if x.stem == ATTRS_STEM
-            and x.suffix.casefold() in OBJECT_SUFFIXES
-            and x != attrs_file
-        ]
-        if vertex_text is None:
-            superseded.append(vertex_table)
-        for stale in superseded:
-            stale.unlink(missing_ok=True)
-        with open(attrs_file, "w") as stream:
-            json.dump(document, stream, indent=2)
-        _write_text(annotation_text, directory / f"{ANNOTATION_STEM}{TABLE_SUFFIX}")
-        if vertex_text is not None:
-            _write_text(vertex_text, vertex_table)
-        return directory
 
     # --- what the set holds
 
@@ -1578,3 +1484,112 @@ def _stated(value) -> bool:
     except (TypeError, ValueError):
         # An array-like cell; it is stated by being there.
         return True
+
+
+def annotation_set_to_dataframe(annotations: AnnotationSet) -> pd.DataFrame:
+    """Return the annotations as a dataframe."""
+    return annotations._df.copy()
+
+
+def annotation_set_to_vertices(annotations: AnnotationSet) -> pd.DataFrame:
+    """Return the vertices of every path and polygon as a tidy dataframe."""
+    return annotations._vertices.copy()
+
+
+def annotation_set_to_csv(annotations: AnnotationSet, path=None) -> str:
+    """
+    Return the annotations as CSV text, optionally writing it to a path.
+
+    Reached as ``annotation_set.io.to_csv``.
+
+    A bare table states one grain, so a set holding vertices is written
+    with [save](`dascore.core.annotations.save_annotation_set`) instead;
+    this is the spelling for a set of regions. The set's dimensions are
+    not part of the table, so reading one back states them again.
+
+    Parameters
+    ----------
+    annotations
+        The set to write.
+    path
+        Where to write the text, or None to only return it.
+    """
+    if not annotations._vertices.empty:
+        msg = (
+            "This set holds vertices, which a bare table has no row for. "
+            "Save it as a directory, which states its vertices beside its "
+            "annotations."
+        )
+        raise ParameterError(msg)
+    return _write_table(annotations._df, path)
+
+
+def save_annotation_set(annotations: AnnotationSet, path) -> pathlib.Path:
+    """
+    Write the set to a directory, creating it if needed.
+
+    Reached as ``annotation_set.io.save``.
+
+    The directory states the set in three parts: what it is and which
+    dimensions it holds, its annotations, and -- where any path or
+    polygon needs them -- its vertices. It reads back through
+    [dascore.annotations](`dascore.annotations`).
+
+    The attributes are written as JSON rather than as YAML, so storing
+    a set needs nothing beyond the standard library; a set authored by
+    hand may spell them in YAML, which reads back the same.
+
+    Writing states the whole directory, so a part this set does not
+    have is removed rather than left behind. A stale vertices table, or
+    the YAML the attributes used to be spelled in, would otherwise sit
+    beside what was written and leave a directory which loaded before
+    the save refusing to load after it.
+
+    Parameters
+    ----------
+    annotations
+        The set to write.
+    path
+        The directory to write into.
+
+    Returns
+    -------
+    The directory written to, so a save reads straight back.
+    """
+    # Everything is spelled out before the directory is touched: a
+    # table which refuses to be written -- an ambiguous value does --
+    # would otherwise raise with the stale parts already deleted and
+    # the attributes already replaced, leaving half a set behind.
+    # Defaults are dropped from the document, so it says what the set
+    # says; dims has no default, so it is always written, and the
+    # attributes name their own model, which is what the file holds.
+    document = annotations._attrs.model_dump(mode="json", exclude_defaults=True)
+    annotation_text = _write_table(annotations._df)
+    vertex_text = (
+        None if annotations._vertices.empty else _write_table(annotations._vertices)
+    )
+    directory = pathlib.Path(path)
+    directory.mkdir(parents=True, exist_ok=True)
+    vertex_table = directory / f"{VERTEX_STEM}{TABLE_SUFFIX}"
+    attrs_file = directory / f"{ATTRS_STEM}{OBJECT_SUFFIXES[0]}"
+    # Only the spellings this format claims: a notes.txt or an
+    # attrs.bak beside them participates in no convention and is not
+    # this function's to delete. The suffix is matched without regard
+    # to case, as the loader matches it.
+    superseded = [
+        x
+        for x in directory.iterdir()
+        if x.stem == ATTRS_STEM
+        and x.suffix.casefold() in OBJECT_SUFFIXES
+        and x != attrs_file
+    ]
+    if vertex_text is None:
+        superseded.append(vertex_table)
+    for stale in superseded:
+        stale.unlink(missing_ok=True)
+    with open(attrs_file, "w") as stream:
+        json.dump(document, stream, indent=2)
+    _write_text(annotation_text, directory / f"{ANNOTATION_STEM}{TABLE_SUFFIX}")
+    if vertex_text is not None:
+        _write_text(vertex_text, vertex_table)
+    return directory

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -1487,16 +1487,58 @@ def _stated(value) -> bool:
 
 
 def annotation_set_to_dataframe(annotations: AnnotationSet) -> pd.DataFrame:
-    """Return the annotations as a dataframe."""
+    """
+    Return the annotations as a dataframe.
+
+    Reached as ``annotation_set.io.to_dataframe``.
+
+    Parameters
+    ----------
+    annotations
+        The set to read.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import dascore as dc
+    >>> frame = pd.DataFrame(
+    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ... )
+    >>> annotations = dc.AnnotationSet(frame, dims=("time", "distance"))
+    >>> list(annotations.io.to_dataframe()["group"])
+    ['event']
+    """
     return annotations._df.copy()
 
 
 def annotation_set_to_vertices(annotations: AnnotationSet) -> pd.DataFrame:
-    """Return the vertices of every path and polygon as a tidy dataframe."""
+    """
+    Return the vertices of every path and polygon as a tidy dataframe.
+
+    Reached as ``annotation_set.io.to_vertices``.
+
+    Parameters
+    ----------
+    annotations
+        The set to read.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import dascore as dc
+    >>> frame = pd.DataFrame(
+    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ... )
+    >>> annotations = dc.AnnotationSet(frame, dims=("time", "distance"))
+    >>> annotations.io.to_vertices().empty  # a region states no vertices
+    True
+    """
     return annotations._vertices.copy()
 
 
-def annotation_set_to_csv(annotations: AnnotationSet, path=None) -> str:
+def annotation_set_to_csv(
+    annotations: AnnotationSet, path: str | pathlib.Path | None = None
+) -> str:
     """
     Return the annotations as CSV text, optionally writing it to a path.
 
@@ -1513,6 +1555,17 @@ def annotation_set_to_csv(annotations: AnnotationSet, path=None) -> str:
         The set to write.
     path
         Where to write the text, or None to only return it.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import dascore as dc
+    >>> frame = pd.DataFrame(
+    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ... )
+    >>> annotations = dc.AnnotationSet(frame, dims=("time", "distance"))
+    >>> "group" in annotations.io.to_csv()
+    True
     """
     if not annotations._vertices.empty:
         msg = (
@@ -1524,7 +1577,9 @@ def annotation_set_to_csv(annotations: AnnotationSet, path=None) -> str:
     return _write_table(annotations._df, path)
 
 
-def save_annotation_set(annotations: AnnotationSet, path) -> pathlib.Path:
+def save_annotation_set(
+    annotations: AnnotationSet, path: str | pathlib.Path
+) -> pathlib.Path:
     """
     Write the set to a directory, creating it if needed.
 
@@ -1555,6 +1610,18 @@ def save_annotation_set(annotations: AnnotationSet, path) -> pathlib.Path:
     Returns
     -------
     The directory written to, so a save reads straight back.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import dascore as dc
+    >>> frame = pd.DataFrame(
+    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ... )
+    >>> annotations = dc.AnnotationSet(frame, dims=("time", "distance"))
+    >>> directory = annotations.io.save("picks")  # doctest: +SKIP
+    >>> dc.annotations(directory) == annotations  # doctest: +SKIP
+    True
     """
     # Everything is spelled out before the directory is touched: a
     # table which refuses to be written -- an ambiguous value does --

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -66,6 +66,7 @@ from dascore.utils.misc import (
     optional_import,
     validate_acquisition_key,
 )
+from dascore.utils.namespace import NamespaceOwner
 
 CouplingType = Literal[
     "conduit",
@@ -1945,13 +1946,17 @@ def _yaml_label(text: str) -> str:
     return f"{text!r}" if short else "the given YAML text"
 
 
-class Inventory(InventoryModel):
+class Inventory(NamespaceOwner, InventoryModel):
     """
     Top-level DASDAE inventory manifest.
 
     Stores document metadata, shareable resources keyed by resource_id, the
     inventory-wide coordinate reference system, and network containers.
     """
+
+    # Annotated as a ClassVar so pydantic leaves it a plain class attribute;
+    # an unannotated underscore name becomes a private attribute instead.
+    _namespace_entry_point_group: ClassVar[str] = "dascore.inventory_namespace"
 
     schema_version: int = Field(
         default=1, description="Version of the inventory manifest envelope."
@@ -2471,26 +2476,6 @@ class Inventory(InventoryModel):
             raise InvalidInventoryError(msg)
         return self.new(networks=tuple(networks))
 
-    def to_yaml(self, path=None) -> str:
-        """
-        Serialize this inventory to YAML, optionally writing to a path.
-
-        A field still holding its default is left out, so the document
-        states what the inventory says rather than every field it has;
-        what is written reloads equal to this inventory.
-        """
-        yaml = optional_import("yaml", required_for="YAML inventory serialization")
-
-        # Everything defaulted is dropped, so the document records which
-        # envelope it was written against even when that is the default.
-        dumped = self.model_dump(mode="json", exclude_defaults=True)
-        data = {"schema_version": self.schema_version} | dumped
-        out = yaml.safe_dump(data, sort_keys=False)
-        if path is not None:
-            with open(path, "w") as fh:
-                fh.write(out)
-        return out
-
     @classmethod
     def from_yaml(cls, text: str) -> Self:
         """
@@ -2547,3 +2532,33 @@ class Inventory(InventoryModel):
             msg = f"{source} holds fields which are not named: {', '.join(named)}."
             raise InvalidInventoryError(msg)
         return cls(**data).check()
+
+
+def inventory_to_yaml(inventory: Inventory, path=None) -> str:
+    """
+    Serialize an inventory to YAML, optionally writing it to a path.
+
+    Reached as ``inventory.io.to_yaml``.
+
+    A field still holding its default is left out, so the document
+    states what the inventory says rather than every field it has;
+    what is written reloads equal to this inventory.
+
+    Parameters
+    ----------
+    inventory
+        The inventory to serialize.
+    path
+        Where to write the text, or None to only return it.
+    """
+    yaml = optional_import("yaml", required_for="YAML inventory serialization")
+
+    # Everything defaulted is dropped, so the document records which
+    # envelope it was written against even when that is the default.
+    dumped = inventory.model_dump(mode="json", exclude_defaults=True)
+    data = {"schema_version": inventory.schema_version} | dumped
+    out = yaml.safe_dump(data, sort_keys=False)
+    if path is not None:
+        with open(path, "w") as fh:
+            fh.write(out)
+    return out

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -18,6 +18,7 @@ import itertools
 from collections.abc import Mapping, Sized
 from contextlib import suppress
 from functools import cache
+from pathlib import Path
 from types import MappingProxyType, UnionType
 from typing import (
     Annotated,
@@ -2534,7 +2535,7 @@ class Inventory(NamespaceOwner, InventoryModel):
         return cls(**data).check()
 
 
-def inventory_to_yaml(inventory: Inventory, path=None) -> str:
+def inventory_to_yaml(inventory: Inventory, path: str | Path | None = None) -> str:
     """
     Serialize an inventory to YAML, optionally writing it to a path.
 
@@ -2550,6 +2551,15 @@ def inventory_to_yaml(inventory: Inventory, path=None) -> str:
         The inventory to serialize.
     path
         Where to write the text, or None to only return it.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> _, inventory = dc.examples.inventory_patch_pair()
+    >>> # Writing YAML needs pyyaml, which is not a core dependency.
+    >>> text = inventory.io.to_yaml()  # doctest: +SKIP
+    >>> dc.inventory(text) == inventory  # doctest: +SKIP
+    True
     """
     yaml = optional_import("yaml", required_for="YAML inventory serialization")
 

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -5,7 +5,7 @@ The authoring format splits an inventory along its natural grain: small
 heterogeneous objects (acquisitions, interrogators, cables) live in YAML or
 JSON files matching the models, while long row-shaped track data lives in
 CSV files a field crew can maintain as a spreadsheet. A directory of these
-files is itself a loadable inventory, and ``to_yaml`` exports the
+files is itself a loadable inventory, and ``io.to_yaml`` exports the
 single-file interchange artifact for shipping beside a data archive.
 
 A table is matched to the model by name: ``<name>.csv`` fills the
@@ -1416,7 +1416,7 @@ def _load_file(path: Path) -> Inventory:
     Load a whole inventory from one serialized document.
 
     The envelope of an authoring directory read on its own terms: same
-    parsers, same errors, so the single-file artifact ``to_yaml`` writes
+    parsers, same errors, so the single-file artifact ``io.to_yaml`` writes
     and the directory it came from fail the same way when they fail.
     """
     return Inventory._from_mapping(_read_object(path), _quote(path))

--- a/dascore/io/__init__.py
+++ b/dascore/io/__init__.py
@@ -18,7 +18,18 @@ from dascore.utils.hdf5 import (
     H5Reader,
     H5Writer,
 )
-from dascore.utils.namespace import PatchNameSpace
+from dascore.core.annotations import (
+    annotation_set_to_csv,
+    annotation_set_to_dataframe,
+    annotation_set_to_vertices,
+    save_annotation_set,
+)
+from dascore.core.inventory import inventory_to_yaml
+from dascore.utils.namespace import (
+    AnnotationNameSpace,
+    InventoryNameSpace,
+    PatchNameSpace,
+)
 from dascore.utils.pd import dataframe_to_patch, patch_to_dataframe
 from dascore.utils.io import (
     xarray_to_patch,
@@ -35,3 +46,18 @@ class PatchIO(PatchNameSpace):
     to_dataframe = patch_to_dataframe
     to_xarray = patch_to_xarray
     to_obspy = patch_to_obspy
+
+
+class InventoryIO(InventoryNameSpace):
+    name = "io"
+
+    to_yaml = inventory_to_yaml
+
+
+class AnnotationIO(AnnotationNameSpace):
+    name = "io"
+
+    to_dataframe = annotation_set_to_dataframe
+    to_vertices = annotation_set_to_vertices
+    to_csv = annotation_set_to_csv
+    save = save_annotation_set

--- a/dascore/plugin_registry/annotation.csv
+++ b/dascore/plugin_registry/annotation.csv
@@ -1,0 +1,1 @@
+package_name,package_url,namespace

--- a/dascore/plugin_registry/inventory.csv
+++ b/dascore/plugin_registry/inventory.csv
@@ -1,0 +1,1 @@
+package_name,package_url,namespace

--- a/dascore/utils/docs.py
+++ b/dascore/utils/docs.py
@@ -131,19 +131,24 @@ def get_plugin_table() -> pd.DataFrame:
     """
     Return a DataFrame of registered third-party plugins.
 
-    Reads all CSV files in the plugin registry, deduplicates on namespace,
-    and sorts alphabetically. Columns are ``namespace``, ``package_name``,
-    and ``package_url``.
+    Reads all CSV files in the plugin registry and sorts alphabetically.
+    Columns are ``host``, ``namespace``, ``package_name`` and
+    ``package_url``. The host is the object the namespace attaches to,
+    taken from the file's name; one package often registers the same
+    namespace on several of them.
     """
     from dascore.utils.namespace import _PLUGIN_REGISTRY_DIR  # noqa: PLC0415
 
-    frames = [pd.read_csv(p) for p in sorted(_PLUGIN_REGISTRY_DIR.glob("*.csv"))]
+    columns = ["host", "namespace", "package_name", "package_url"]
+    frames = []
+    for path in sorted(_PLUGIN_REGISTRY_DIR.glob("*.csv")):
+        frames.append(pd.read_csv(path).assign(host=path.stem))
     if not frames:
-        return pd.DataFrame(columns=["namespace", "package_name", "package_url"])
+        return pd.DataFrame(columns=columns)
     return (
         pd.concat(frames, ignore_index=True)
-        .drop_duplicates(subset="namespace")
-        .sort_values("namespace")[["namespace", "package_name", "package_url"]]
+        .drop_duplicates(subset=["host", "namespace"])
+        .sort_values(["namespace", "host"])[columns]
         .reset_index(drop=True)
     )
 

--- a/dascore/utils/namespace.py
+++ b/dascore/utils/namespace.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import warnings
 from collections import defaultdict
+from contextlib import suppress
 from pathlib import Path
 from threading import RLock
 from typing import ClassVar
@@ -151,10 +152,24 @@ class SpoolNameSpace(_MethodNameSpace):
     entry_point_group: ClassVar[str] = "dascore.spool_namespace"
 
 
+class InventoryNameSpace(_MethodNameSpace):
+    """A namespace for Inventory methods."""
+
+    name: ClassVar[str | None] = None
+    entry_point_group: ClassVar[str] = "dascore.inventory_namespace"
+
+
+class AnnotationNameSpace(_MethodNameSpace):
+    """A namespace for AnnotationSet methods."""
+
+    name: ClassVar[str | None] = None
+    entry_point_group: ClassVar[str] = "dascore.annotation_namespace"
+
+
 class NamespaceOwner:
     """Mixin for classes with lazily-loadable method namespaces."""
 
-    _namespace_entry_point_group: str | None = None
+    _namespace_entry_point_group: ClassVar[str | None] = None
     _namespace_attr_errors: ClassVar[dict[str, str]] = {}
 
     @classmethod
@@ -168,30 +183,41 @@ class NamespaceOwner:
 
     def __getattr__(self, item):
         """Try loading a lazily registered namespace before failing."""
-        # Unknown attribute; try loading the namespaces. Plugin imports must
-        # not run while a lock is held.
-        group = self._namespace_entry_point_group
-        maybe_load_entry_point(group, item)
+        # A private name never names a namespace, and a host which is a
+        # pydantic model keeps its private attributes behind its own
+        # __getattr__, which the namespace search must not stand in front of.
+        if not item.startswith("_"):
+            # Unknown attribute; try loading the namespaces. Plugin imports
+            # must not run while a lock is held.
+            group = self._namespace_entry_point_group
+            maybe_load_entry_point(group, item)
 
-        # Once loaded the registry should be populated.
-        if namespace_type := _MethodNameSpace._get_namespace_type(group, item):
-            with _ATTACHMENT_LOCK:
-                # Another thread may have attached this namespace first; reuse
-                # its instance so all callers share one namespace object.
-                if (instance := self.__dict__.get(item)) is None:
-                    instance = self.__dict__[item] = namespace_type(self)
-            return instance
+            # Once loaded the registry should be populated.
+            if namespace_type := _MethodNameSpace._get_namespace_type(group, item):
+                with _ATTACHMENT_LOCK:
+                    # Another thread may have attached this namespace first;
+                    # reuse its instance so all callers share one object.
+                    if (instance := self.__dict__.get(item)) is None:
+                        instance = self.__dict__[item] = namespace_type(self)
+                return instance
 
-        # Check plugin registry for a known third-party package that provides this.
-        plugin_registry = _load_plugin_registry(self._namespace_entry_point_group)
-        if item in plugin_registry:
-            package_name, package_url = plugin_registry[item]
-            msg = (
-                f"{self.__class__.__name__} has a registered namespace of '{item}' "
-                f"provided by '{package_name}' but it is not installed. "
-                f"Install it from: {package_url}"
-            )
-            raise DASCorePluginError(msg)
+            # Check the registry for a known third-party package providing this.
+            plugin_registry = _load_plugin_registry(group)
+            if item in plugin_registry:
+                package_name, package_url = plugin_registry[item]
+                msg = (
+                    f"{self.__class__.__name__} has a registered namespace of "
+                    f"'{item}' provided by '{package_name}' but it is not "
+                    f"installed. Install it from: {package_url}"
+                )
+                raise DASCorePluginError(msg)
+
+        # The host may resolve names of its own; a pydantic one resolves its
+        # private attributes here. Its failure is not the final word: this
+        # class has a better message for a name neither of them knows.
+        if (parent := getattr(super(), "__getattr__", None)) is not None:
+            with suppress(AttributeError):
+                return parent(item)
 
         # If that fails, see if there is anything specific for this name to raise.
         if item in self._namespace_attr_errors:

--- a/dascore/utils/namespace.py
+++ b/dascore/utils/namespace.py
@@ -173,7 +173,13 @@ class AnnotationNameSpace(_MethodNameSpace):
 
 
 class NamespaceOwner:
-    """Mixin for classes with lazily-loadable method namespaces."""
+    """
+    Mixin for classes with lazily-loadable method namespaces.
+
+    List this before any base which defines its own ``__getattr__``, as a
+    pydantic model does. The one the MRO reaches first is the only one
+    called, so a host which lists this last resolves no namespace at all.
+    """
 
     _namespace_entry_point_group: ClassVar[str | None] = None
     _namespace_attr_errors: ClassVar[dict[str, str]] = {}

--- a/dascore/utils/namespace.py
+++ b/dascore/utils/namespace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import keyword
 import warnings
 from collections import defaultdict
 from contextlib import suppress
@@ -56,6 +57,11 @@ def _check_namespace_name(name) -> None:
     """Refuse a namespace name a host could not hand out."""
     if not isinstance(name, str) or not name.isidentifier():
         msg = f"A namespace name must be a Python identifier, got {name!r}."
+        raise ValueError(msg)
+    if keyword.iskeyword(name):
+        # `host.class` is a syntax error however the namespace registered.
+        # Soft keywords -- match, type -- are legal attribute names and pass.
+        msg = f"A namespace name must not be a Python keyword, got {name!r}."
         raise ValueError(msg)
     if name.startswith("_"):
         # A private name belongs to the host, which resolves its own before

--- a/dascore/utils/namespace.py
+++ b/dascore/utils/namespace.py
@@ -19,11 +19,6 @@ from dascore.utils.plugins import maybe_load_entry_point
 
 _PLUGIN_REGISTRY_DIR = Path(__file__).parent.parent / "plugin_registry"
 
-# Serializes attaching a lazily loaded namespace to its host object. One
-# global lock (rather than one per host) is enough because attachment only
-# constructs a small wrapper around the host.
-_ATTACHMENT_LOCK = RLock()
-
 
 @functools.cache
 def _load_plugin_registry(
@@ -55,6 +50,18 @@ def _load_plugin_registry(
             strict=True,
         )
     )
+
+
+def _check_namespace_name(name) -> None:
+    """Refuse a namespace name a host could not hand out."""
+    if not isinstance(name, str) or not name.isidentifier():
+        msg = f"A namespace name must be a Python identifier, got {name!r}."
+        raise ValueError(msg)
+    if name.startswith("_"):
+        # A private name belongs to the host, which resolves its own before
+        # the namespaces are searched, so one registered here is unreachable.
+        msg = f"A namespace name must be public, got {name!r}."
+        raise ValueError(msg)
 
 
 def _pass_to_host_method(func):
@@ -110,6 +117,7 @@ class _MethodNameSpace(metaclass=_NameSpaceMeta):
                 setattr(cls, key, val)
         # Register all subclasses.
         if cls.name is not None:
+            _check_namespace_name(cls.name)
             with cls._registry_lock:
                 registry = cls._registry[cls.entry_point_group]
                 existing = registry.get(cls.name)
@@ -132,9 +140,7 @@ class _MethodNameSpace(metaclass=_NameSpaceMeta):
 
 @_reinit_after_fork
 def _reinit_namespace_locks():
-    """Install fresh namespace locks; see _reinit_after_fork."""
-    global _ATTACHMENT_LOCK
-    _ATTACHMENT_LOCK = RLock()
+    """Install a fresh registry lock; see _reinit_after_fork."""
     _MethodNameSpace._registry_lock = RLock()
 
 
@@ -183,23 +189,21 @@ class NamespaceOwner:
 
     def __getattr__(self, item):
         """Try loading a lazily registered namespace before failing."""
-        # A private name never names a namespace, and a host which is a
-        # pydantic model keeps its private attributes behind its own
-        # __getattr__, which the namespace search must not stand in front of.
+        # A namespace is never private, so a private name is the host's:
+        # a pydantic one keeps its private attributes behind its own
+        # __getattr__, and looking one up must not import a plugin.
         if not item.startswith("_"):
             # Unknown attribute; try loading the namespaces. Plugin imports
             # must not run while a lock is held.
             group = self._namespace_entry_point_group
             maybe_load_entry_point(group, item)
 
-            # Once loaded the registry should be populated.
+            # Once loaded the registry should be populated. The wrapper is
+            # built per access rather than stored on the host: one kept there
+            # rides into a copy still bound to the object it was built for,
+            # and rebuilding costs a fraction of any call made through it.
             if namespace_type := _MethodNameSpace._get_namespace_type(group, item):
-                with _ATTACHMENT_LOCK:
-                    # Another thread may have attached this namespace first;
-                    # reuse its instance so all callers share one object.
-                    if (instance := self.__dict__.get(item)) is None:
-                        instance = self.__dict__[item] = namespace_type(self)
-                return instance
+                return namespace_type(self)
 
             # Check the registry for a known third-party package providing this.
             plugin_registry = _load_plugin_registry(group)

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -74,7 +74,7 @@ patch = dc.get_example_patch()
 value = patch.my_ext.peak_to_peak()
 ```
 
-The namespace `name` must be a valid Python identifier. If another namespace of the same type already uses that name, DASCore warns when the subclass is defined and the later class wins.
+The namespace `name` must be a public Python identifier -- a leading underscore is refused, since a host resolves its own private names before the namespaces are searched. If another namespace of the same type already uses that name, DASCore warns when the subclass is defined and the later class wins.
 
 ## Packaging an extension plugin
 

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -2,11 +2,11 @@
 title: Extending DASCore
 ---
 
-This page explains how to extend DASCore with `Patch` and `Spool` namespaces. Use it when you want users to write code like `patch.my_plugin.some_method()` or `spool.my_plugin.some_method()` from a separate package.
+This page explains how to extend DASCore's objects with namespaces. Use it when you want users to write code like `patch.my_plugin.some_method()` or `spool.my_plugin.some_method()` from a separate package.
 
 ## When to use a namespace
 
-A namespace is appropriate when you want to group related functionality under a stable access point instead of adding many methods directly to `Patch` or `Spool`. Good candidates include:
+A namespace is appropriate when you want to group related functionality under a stable access point instead of adding many methods directly to a DASCore object. Good candidates include:
 
 - Optional integrations that should live in a separate package.
 - Domain-specific processing that is useful to a subset of users.
@@ -14,11 +14,20 @@ A namespace is appropriate when you want to group related functionality under a 
 
 If you are adding support for a new file format, see [Adding a New Format](new_format.qmd). File formats use `FiberIO` plugins, not method namespaces.
 
-Namespaces and `FiberIO` plugins are the extension points; subclassing `Patch` or `Spool` is not one. There is a single `Spool` class, whose state is the catalog its `__init__` builds, so copying a subclass instance which never ran that `__init__` is refused rather than silently accepted.
+Namespaces and `FiberIO` plugins are the extension points; subclassing a DASCore object is not one. There is a single `Spool` class, whose state is the catalog its `__init__` builds, so copying a subclass instance which never ran that `__init__` is refused rather than silently accepted.
 
 ## The namespace model
 
-DASCore namespaces inherit from either `PatchNameSpace` or `SpoolNameSpace`. Namespace methods receive the parent object, so they look like normal `Patch` or `Spool` methods. Using `patch` or `spool` as the first argument name can make this explicit:
+Four objects host namespaces. Each has its own base class and entry point group, so a namespace named `zug` on a `Patch` and one on a `Spool` are different things:
+
+| Host | Base class | Entry point group | Plugin registry file |
+|---|---|---|---|
+| `Patch` | `PatchNameSpace` | `dascore.patch_namespace` | `patch.csv` |
+| `Spool` | `SpoolNameSpace` | `dascore.spool_namespace` | `spool.csv` |
+| `Inventory` | `InventoryNameSpace` | `dascore.inventory_namespace` | `inventory.csv` |
+| `AnnotationSet` | `AnnotationNameSpace` | `dascore.annotation_namespace` | `annotation.csv` |
+
+All four bases live in `dascore.utils.namespace`. Namespace methods receive the host object, so they look like normal methods on it. Naming the first argument after the host can make this explicit:
 
 ```{python}
 import dascore as dc
@@ -65,7 +74,7 @@ patch = dc.get_example_patch()
 value = patch.my_ext.peak_to_peak()
 ```
 
-The namespace `name` must be a valid Python identifier. If another namespace of the same type already uses that name, DASCore raises an error when the subclass is defined.
+The namespace `name` must be a valid Python identifier. If another namespace of the same type already uses that name, DASCore warns when the subclass is defined and the later class wins.
 
 ## Packaging an extension plugin
 
@@ -106,7 +115,7 @@ After installation, DASCore loads the namespace the first time `patch.my_ext` is
 
 Once your package is published, consider opening a pull request to [DASCore](https://github.com/DASDAE/dascore) to add it to the plugin registry. This lets users see a helpful message pointing to your package when they try to use your namespace without having it installed.
 
-Add a row to `dascore/plugin_registry/patch.csv` (or `spool.csv` for a spool namespace):
+Add a row to the plugin registry file for the host, from the table above -- `dascore/plugin_registry/patch.csv` for a patch namespace:
 
 ```
 package_name,package_url,namespace
@@ -121,12 +130,30 @@ DASCorePluginError: Patch has a registered namespace of 'my_ext' provided by
 https://github.com/yourorg/dascore-extra
 ```
 
-### Spool namespaces
+### The other hosts
 
-Spool namespaces use the same pattern. The only changes are:
+`Spool`, `Inventory` and `AnnotationSet` namespaces use the same pattern. The only changes are the base class and the entry point group, both from the table above. For example, a namespace on an `AnnotationSet`:
 
-- Inherit from `SpoolNameSpace` and write methods against a `Spool`.
-- Register the namespace in the `dascore.spool_namespace` entry point group instead of `dascore.patch_namespace`.
+```{python}
+from dascore.utils.namespace import AnnotationNameSpace
+
+
+class MyAnnotationNamespace(AnnotationNameSpace):
+    """AnnotationSet methods provided by dascore-extra."""
+
+    name = "my_ext"
+
+    def count_groups(annotations) -> int:
+        """Return how many distinct groups the set holds."""
+        return annotations.io.to_dataframe()["group"].nunique()
+```
+
+```default
+[project.entry-points."dascore.annotation_namespace"]
+my_ext = "dascore_extra.annotation_namespace:MyAnnotationNamespace"
+```
+
+DASCore uses this itself: `patch.io`, `inventory.io` and `annotation_set.io` are namespaces registered in exactly this way, defined in `dascore/io/__init__.py`.
 
 ## Array backends
 

--- a/docs/notes/inventory_attachment.qmd
+++ b/docs/notes/inventory_attachment.qmd
@@ -20,7 +20,7 @@ patch, inventory = inventory_patch_pair()
 archive = Path(tempfile.mkdtemp()) / "archive"
 archive.mkdir()
 patch.io.write(archive / "patch.h5", "DASDAE")
-inventory.to_yaml(archive / ".inventory.yaml")
+inventory.io.to_yaml(archive / ".inventory.yaml")
 ```
 
 ## Three moments, at three times
@@ -83,7 +83,7 @@ An inventory is read once and held. There is no modification-time check, and re-
 
 ```{python}
 # Change the file under the running program.
-inventory.new(schema_version=1).to_yaml(archive / ".inventory.yaml")
+inventory.new(schema_version=1).io.to_yaml(archive / ".inventory.yaml")
 
 held = reference._inventory
 _ = spool.select(zone="north")

--- a/docs/recipes/tunnel_inventory.qmd
+++ b/docs/recipes/tunnel_inventory.qmd
@@ -561,16 +561,16 @@ Had the path been edited in place instead, that first assertion would now be fal
 
 # Shipping it
 
-The directory is the authoring format, and it is the right one while a deployment is still being surveyed, because the tracks are spreadsheets. [`Inventory.to_yaml`](`dascore.core.inventory.Inventory.to_yaml`) writes the single-file form to ship beside a data archive, and [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads either back.
+The directory is the authoring format, and it is the right one while a deployment is still being surveyed, because the tracks are spreadsheets. [`Inventory.io.to_yaml`](`dascore.core.inventory.inventory_to_yaml`) writes the single-file form to ship beside a data archive, and [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads either back.
 
 ```{python}
-text = repaired.to_yaml()
+text = repaired.io.to_yaml()
 
 print(f"{len(text.splitlines())} lines of yaml")
 assert dc.inventory(text) == repaired
 ```
 
-Dropping either into the data directory means every spool opened there finds it without being told: the authoring directory as `.inventory/`, or the single file as `.inventory.yaml` or `.inventory.yml`. The suffix states the format rather than decorating it, so a file called plainly `.inventory` is not one of the spellings, and the third one — `.inventory.json` — holds what `model_dump_json` writes rather than what `to_yaml` does.
+Dropping either into the data directory means every spool opened there finds it without being told: the authoring directory as `.inventory/`, or the single file as `.inventory.yaml` or `.inventory.yml`. The suffix states the format rather than decorating it, so a file called plainly `.inventory` is not one of the spellings, and the third one — `.inventory.json` — holds what `model_dump_json` writes rather than what `io.to_yaml` does.
 
 # Where the boundaries fell
 

--- a/docs/supported_plugins.qmd
+++ b/docs/supported_plugins.qmd
@@ -4,7 +4,7 @@ execute:
     warning: false
 ---
 
-Known third-party packages that provide namespaces for DASCore's `Patch` and `Spool` objects.
+Known third-party packages that provide namespaces for DASCore's `Patch`, `Spool`, `Inventory` and `AnnotationSet` objects. The host column names the object a namespace attaches to.
 
 ```{python}
 #| echo: false
@@ -15,5 +15,5 @@ df = get_plugin_table()
 df["package_name"] = df.apply(
     lambda r: f"[{r['package_name']}]({r['package_url']})", axis=1
 )
-print(df[["namespace", "package_name"]].to_markdown(index=False, stralign="center") + "\n: {.striped}")
+print(df[["host", "namespace", "package_name"]].to_markdown(index=False, stralign="center") + "\n: {.striped}")
 ```

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -259,7 +259,7 @@ patch.io.write(data_path / "patch.h5", "DASDAE")
 
 # Either form works: the directory .inventory/, or a serialized file
 # naming its format -- .inventory.yaml, .inventory.yml, or .inventory.json.
-example_inventory.to_yaml(data_path / ".inventory.yaml")
+example_inventory.io.to_yaml(data_path / ".inventory.yaml")
 
 carrying = dc.spool(data_path).update()
 assert carrying.enrich()[0].attrs.gauge_length == 10.0
@@ -279,7 +279,7 @@ old_acquisition = example_inventory.networks[0].fiber_arrays[0].acquisitions[0]
 corrected = example_inventory.replace(
     old_acquisition, old_acquisition.new(gauge_length=12.0)
 )
-corrected.to_yaml(data_path / ".inventory.yaml")
+corrected.io.to_yaml(data_path / ".inventory.yaml")
 
 # The spool which already read it still reports what it read.
 assert carrying.enrich()[0].attrs.gauge_length == 10.0
@@ -293,10 +293,10 @@ assert refreshed.enrich()[0].attrs.gauge_length == 12.0
 
 # Serializing
 
-[`Inventory.to_yaml`](`dascore.core.inventory.Inventory.to_yaml`) writes the single-file interchange form — the artifact to ship beside a data archive — and [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads any of the forms back.
+[`Inventory.io.to_yaml`](`dascore.core.inventory.inventory_to_yaml`) writes the single-file interchange form — the artifact to ship beside a data archive — and [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads any of the forms back.
 
 ```{python}
-text = inventory.to_yaml()
+text = inventory.io.to_yaml()
 assert dc.inventory(text) == inventory
 
 # JSON works everywhere YAML does, and needs no YAML library installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,12 @@ MSEED__V3 = "dascore.io.mseed.core:MSeedV3"
 io = "dascore.io:PatchIO"
 viz = "dascore.viz:VizPatchNameSpace"
 
+[project.entry-points."dascore.inventory_namespace"]
+io = "dascore.io:InventoryIO"
+
+[project.entry-points."dascore.annotation_namespace"]
+io = "dascore.io:AnnotationIO"
+
 
 # --- External tool configuration
 

--- a/tests/test_core/test_annotation_loader.py
+++ b/tests/test_core/test_annotation_loader.py
@@ -96,39 +96,39 @@ class TestRoundTrip:
 
     def test_regions_through_a_directory(self, regions, tmp_path):
         """Bounds, extras and provenance all survive a directory."""
-        regions.save(tmp_path / "picks")
+        regions.io.save(tmp_path / "picks")
         assert dc.annotations(tmp_path / "picks") == regions
 
     def test_regions_through_a_bare_table(self, regions, tmp_path):
         """A set of regions is a table, and its dims are stated again."""
         path = tmp_path / "picks.csv"
-        regions.to_csv(path)
+        regions.io.to_csv(path)
         loaded = dc.annotations(path, dims=DIMS)
-        assert loaded.to_dataframe().equals(regions.to_dataframe())
+        assert loaded.io.to_dataframe().equals(regions.io.to_dataframe())
 
     def test_vertices_and_basis(self, with_vertices, curve, tmp_path):
         """Vertices and the curve they were drawn from both survive."""
-        with_vertices.save(tmp_path / "picks")
+        with_vertices.io.save(tmp_path / "picks")
         loaded = dc.annotations(tmp_path / "picks")
         assert loaded == with_vertices
         assert loaded[1].geometry.basis == curve
 
     def test_extras_keep_their_kind(self, regions, tmp_path):
         """A cell written as a number or a boolean reads back as one."""
-        loaded = dc.annotations(regions.save(tmp_path / "picks"))
+        loaded = dc.annotations(regions.io.save(tmp_path / "picks"))
         assert loaded[0].extra["score"] == 0.9
         assert loaded[0].extra["checked"] is True
         assert loaded[1].extra["checked"] is False
 
     def test_tags_keep_their_shape(self, regions, tmp_path):
         """Tags are one spelling however they arrive."""
-        loaded = dc.annotations(regions.save(tmp_path / "picks"))
+        loaded = dc.annotations(regions.io.save(tmp_path / "picks"))
         assert loaded[0].tags == ("road", "car")
         assert loaded[1].tags == ()
 
     def test_times_keep_their_type(self, regions, tmp_path):
         """A time endpoint reads back as a time, not as its text."""
-        loaded = dc.annotations(regions.save(tmp_path / "picks"))
+        loaded = dc.annotations(regions.io.save(tmp_path / "picks"))
         start, _ = loaded[0].region.bounds["time"]
         assert isinstance(start, np.datetime64)
 
@@ -148,7 +148,7 @@ class TestRoundTrip:
         )
         frame = pd.DataFrame({"id": ["p1"], "geometry": ["path"], "basis": [line]})
         annotations = dc.AnnotationSet(frame, dims=DIMS, vertices=vertices)
-        loaded = dc.annotations(annotations.save(tmp_path / "picks"))
+        loaded = dc.annotations(annotations.io.save(tmp_path / "picks"))
         assert loaded[0].geometry.basis == line
 
     def test_an_unstated_bound(self, tmp_path):
@@ -161,7 +161,7 @@ class TestRoundTrip:
             }
         )
         annotations = dc.AnnotationSet(frame, dims=("distance",))
-        loaded = dc.annotations(annotations.save(tmp_path / "picks"))
+        loaded = dc.annotations(annotations.io.save(tmp_path / "picks"))
         assert loaded == annotations
         assert "distance" not in loaded[1].region.bounds
 
@@ -175,14 +175,14 @@ class TestWhatATableCannotSay:
             {"group": ["a"], "distance": [1.0], "seq": ["third"]},
         )
         annotations = dc.AnnotationSet(frame, dims=("distance",))
-        loaded = dc.annotations(annotations.save(tmp_path / "picks"))
+        loaded = dc.annotations(annotations.io.save(tmp_path / "picks"))
         assert loaded[0].extra["seq"] == "third"
 
     def test_an_empty_cell_is_unset(self, tmp_path):
         """A table cannot tell an empty cell from an empty string."""
         frame = pd.DataFrame({"group": ["", "b"], "distance": [1.0, 2.0]})
         annotations = dc.AnnotationSet(frame, dims=("distance",))
-        assert dc.annotations(annotations.save(tmp_path / "picks")) == annotations
+        assert dc.annotations(annotations.io.save(tmp_path / "picks")) == annotations
         assert annotations[0].group == ""
 
     def test_a_datetime_extra_reads_back_as_text(self, tmp_path):
@@ -197,7 +197,7 @@ class TestWhatATableCannotSay:
             }
         )
         annotations = dc.AnnotationSet(frame, dims=("distance",))
-        loaded = dc.annotations(annotations.save(tmp_path / "picks"))
+        loaded = dc.annotations(annotations.io.save(tmp_path / "picks"))
         assert loaded[0].extra["when"] == "2020-01-01T00:00:00.000000000"
 
     def test_an_ambiguous_value_is_refused_at_the_write(self, tmp_path):
@@ -209,7 +209,7 @@ class TestWhatATableCannotSay:
         )
         annotations = dc.AnnotationSet(frame, dims=("distance",))
         with pytest.raises(ParameterError, match="read back as a boolean"):
-            annotations.save(tmp_path / "picks")
+            annotations.io.save(tmp_path / "picks")
 
     def test_an_unambiguous_value_still_writes(self, tmp_path):
         """Only text a table would read as another kind is refused."""
@@ -217,13 +217,13 @@ class TestWhatATableCannotSay:
             {"group": ["phase"] * 2, "value": ["P", "S"], "distance": [1.0, 2.0]}
         )
         annotations = dc.AnnotationSet(frame, dims=("distance",))
-        assert dc.annotations(annotations.save(tmp_path / "picks")) == annotations
+        assert dc.annotations(annotations.io.save(tmp_path / "picks")) == annotations
 
     def test_a_non_finite_looking_extra_stays_text(self, tmp_path):
         """A cell reading 'nan' is text, not a value which then vanishes."""
         frame = pd.DataFrame({"group": ["a"], "distance": [1.0], "note": ["nan"]})
         annotations = dc.AnnotationSet(frame, dims=("distance",))
-        loaded = dc.annotations(annotations.save(tmp_path / "picks"))
+        loaded = dc.annotations(annotations.io.save(tmp_path / "picks"))
         assert loaded[0].extra["note"] == "nan"
 
     def test_an_extra_some_rows_leave_blank(self, tmp_path):
@@ -232,7 +232,7 @@ class TestWhatATableCannotSay:
             {"group": ["a", "b"], "distance": [1.0, 2.0], "note": ["seen", None]}
         )
         annotations = dc.AnnotationSet(frame, dims=("distance",))
-        loaded = dc.annotations(annotations.save(tmp_path / "picks"))
+        loaded = dc.annotations(annotations.io.save(tmp_path / "picks"))
         assert loaded[0].extra["note"] == "seen"
         assert "note" not in loaded[1].extra
 
@@ -240,7 +240,7 @@ class TestWhatATableCannotSay:
         """A cell is read the way its own text states it, as every table is."""
         frame = pd.DataFrame({"group": ["a"], "distance": [1.0], "zip": ["01234"]})
         annotations = dc.AnnotationSet(frame, dims=("distance",))
-        loaded = dc.annotations(annotations.save(tmp_path / "picks"))
+        loaded = dc.annotations(annotations.io.save(tmp_path / "picks"))
         assert loaded[0].extra["zip"] == 1234
 
 
@@ -250,8 +250,8 @@ class TestSavingOverASet:
     def test_a_stale_vertices_table_is_cleared(self, with_vertices, regions, tmp_path):
         """A set without vertices leaves none behind for the next read."""
         directory = tmp_path / "picks"
-        with_vertices.save(directory)
-        regions.save(directory)
+        with_vertices.io.save(directory)
+        regions.io.save(directory)
         assert not (directory / "vertices.csv").exists()
         assert dc.annotations(directory) == regions
 
@@ -263,24 +263,24 @@ class TestSavingOverASet:
         (directory / "attrs.yaml").write_text(yaml.safe_dump({"dims": list(DIMS)}))
         (directory / "annotations.csv").write_text("group,distance\nnoise,1.0\n")
         loaded = dc.annotations(directory)
-        loaded.save(directory)
+        loaded.io.save(directory)
         assert not (directory / "attrs.yaml").exists()
         assert dc.annotations(directory) == loaded
 
     def test_a_file_owing_this_format_nothing_is_left(self, regions, tmp_path):
         """Only the spellings a set claims are cleared."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.bak").write_text("mine")
-        regions.save(directory)
+        regions.io.save(directory)
         assert (directory / "attrs.bak").read_text() == "mine"
 
     def test_a_shouted_suffix_is_read_and_superseded(self, regions, tmp_path):
         """One data model stands behind a suffix however it is spelled."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.json").rename(directory / "attrs.JSON")
         loaded = dc.annotations(directory)
         assert loaded == regions
-        loaded.save(directory)
+        loaded.io.save(directory)
         # One attrs file, whatever it ends up called: a case-insensitive
         # filesystem holds the shouted name and the written one in the
         # same file, so the spelling on disk is the platform's to decide
@@ -307,7 +307,7 @@ class TestTheDoor:
 
     def test_a_directory_refuses_what_it_states(self, regions, tmp_path):
         """A directory holds its own attributes and vertices."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         with pytest.raises(InvalidAnnotationError, match="a set directory"):
             dc.annotations(directory, attrs={"dims": DIMS})
         with pytest.raises(InvalidAnnotationError, match="a set directory"):
@@ -345,7 +345,7 @@ class TestTheDoor:
     def test_a_set_of_none(self, tmp_path):
         """A set of no annotations writes an empty table and reads back."""
         empty = dc.annotations(dims=DIMS)
-        assert dc.annotations(empty.save(tmp_path / "picks")) == empty
+        assert dc.annotations(empty.io.save(tmp_path / "picks")) == empty
 
 
 class TestDeclaringDimensions:
@@ -353,18 +353,18 @@ class TestDeclaringDimensions:
 
     def test_stated_by_the_attrs(self, regions, tmp_path):
         """A directory states its own dimensions."""
-        assert dc.annotations(regions.save(tmp_path / "picks")).dims == DIMS
+        assert dc.annotations(regions.io.save(tmp_path / "picks")).dims == DIMS
 
     def test_stated_by_the_caller(self, regions, tmp_path):
         """A bare table has the caller state them."""
         path = tmp_path / "picks.csv"
-        regions.to_csv(path)
+        regions.io.to_csv(path)
         assert dc.annotations(path, dims=DIMS).dims == DIMS
 
     def test_stated_by_neither(self, regions, tmp_path):
         """A source stating none fails saying how to state them."""
         path = tmp_path / "picks.csv"
-        regions.to_csv(path)
+        regions.io.to_csv(path)
         with pytest.raises(InvalidAnnotationError, match="states no dimensions"):
             dc.annotations(path)
 
@@ -397,13 +397,13 @@ class TestDeclaringDimensions:
         """Reading the cells against other dimensions would type them
         differently and build a set which is not the one stored.
         """
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         with pytest.raises(InvalidAnnotationError, match="its own dimensions"):
             dc.annotations(directory, dims=("time", "distance"))
 
     def test_a_directory_which_states_none_takes_them(self, regions, tmp_path):
         """Where a directory states none, the caller's are the only ones."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.json").unlink()
         assert dc.annotations(directory, dims=("time", "distance")).dims == (
             "time",
@@ -419,7 +419,7 @@ class TestTheAttrsFile:
         """One data model stands behind both spellings; a set may be authored
         in the more readable one.
         """
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         document = json.loads((directory / "attrs.json").read_text())
         (directory / "attrs.yaml").write_text(yaml.safe_dump(document))
         (directory / "attrs.json").unlink()
@@ -427,14 +427,14 @@ class TestTheAttrsFile:
 
     def test_two_spellings(self, regions, tmp_path):
         """A set spells each of its parts once."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.yml").write_text("{}")
         with pytest.raises(InvalidAnnotationError, match="more than once"):
             dc.annotations(directory)
 
     def test_the_wrong_object(self, regions, tmp_path):
         """A file declaring another model is a misfiled object."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.json").write_text(
             '{"object_type": "Inventory", "dims": ["time"]}'
         )
@@ -443,7 +443,7 @@ class TestTheAttrsFile:
 
     def test_which_is_not_a_mapping(self, regions, tmp_path):
         """A document stating a list defines no attributes."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.json").write_text('["distance", "time"]')
         with pytest.raises(InvalidAnnotationError, match="no mapping"):
             dc.annotations(directory)
@@ -451,7 +451,7 @@ class TestTheAttrsFile:
     @pytest.mark.skipif(yaml is None, reason="pyyaml is not installed")
     def test_which_does_not_parse(self, regions, tmp_path):
         """Unparseable YAML names the file rather than the parser."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.json").unlink()
         (directory / "attrs.yaml").write_text("dims: [\n")
         with pytest.raises(InvalidAnnotationError, match="Could not parse YAML"):
@@ -459,21 +459,21 @@ class TestTheAttrsFile:
 
     def test_bad_json(self, regions, tmp_path):
         """Unparseable JSON names the file too."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.json").write_text("{")
         with pytest.raises(InvalidAnnotationError, match="Could not parse JSON"):
             dc.annotations(directory)
 
     def test_which_cannot_be_read(self, regions, tmp_path):
         """A file which does not decode names itself, not the codec."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.json").write_bytes(b'{"dims": ["\xff\xfe"]}')
         with pytest.raises(InvalidAnnotationError, match="Could not read"):
             dc.annotations(directory)
 
     def test_no_attrs_file(self, regions, tmp_path):
         """A directory without one is read on the caller's dimensions."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "attrs.json").unlink()
         assert dc.annotations(directory, dims=DIMS).dims == DIMS
 
@@ -490,21 +490,21 @@ class TestTheTables:
 
     def test_a_table_which_cannot_be_read(self, regions, tmp_path):
         """A table which does not decode is the table reader's to name."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "annotations.csv").write_bytes(b"group\n\xff\xfe\n")
         with pytest.raises(InvalidAnnotationError, match="Could not read"):
             dc.annotations(directory)
 
     def test_a_stray_table(self, regions, tmp_path):
         """A near-miss on the convention raises rather than being skipped."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         (directory / "vertexes.csv").write_text("id,seq\n")
         with pytest.raises(InvalidAnnotationError, match=r"vertexes\.csv"):
             dc.annotations(directory)
 
     def test_a_basis_which_is_not_json(self, with_vertices, tmp_path):
         """A stored basis is what its curve dumps."""
-        directory = with_vertices.save(tmp_path / "picks")
+        directory = with_vertices.io.save(tmp_path / "picks")
         table = directory / "annotations.csv"
         table.write_text(table.read_text().replace('"{""object_type', '"{oops'))
         with pytest.raises(InvalidAnnotationError, match="not a JSON document"):
@@ -512,7 +512,7 @@ class TestTheTables:
 
     def test_a_basis_which_is_not_a_curve(self, with_vertices, tmp_path):
         """A document which parses but names no curve is still refused."""
-        directory = with_vertices.save(tmp_path / "picks")
+        directory = with_vertices.io.save(tmp_path / "picks")
         table = directory / "annotations.csv"
         original = table.read_text()
         start = original.index('"{""object_type')
@@ -525,7 +525,7 @@ class TestTheTables:
 
     def test_a_non_numeric_seq(self, with_vertices, tmp_path):
         """A vertex states its place in the order as a number."""
-        directory = with_vertices.save(tmp_path / "picks")
+        directory = with_vertices.io.save(tmp_path / "picks")
         table = directory / "vertices.csv"
         table.write_text(table.read_text().replace("p1,0,", "p1,first,"))
         with pytest.raises(InvalidAnnotationError, match="non-numeric seq"):
@@ -533,7 +533,7 @@ class TestTheTables:
 
     def test_a_dimension_which_is_neither(self, regions, tmp_path):
         """A dimension column holds numbers or times, and says so."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         table = directory / "annotations.csv"
         table.write_text(table.read_text().replace("120.0", "far"))
         with pytest.raises(InvalidAnnotationError, match="neither numbers nor times"):
@@ -556,7 +556,7 @@ class TestTheTables:
             }
         )
         annotations = dc.AnnotationSet(frame, dims=("time",))
-        loaded = dc.annotations(annotations.save(tmp_path / "picks"))
+        loaded = dc.annotations(annotations.io.save(tmp_path / "picks"))
         assert loaded == annotations
         assert isinstance(loaded[0].region.bounds["time"][0], np.datetime64)
 
@@ -577,7 +577,7 @@ class TestTheTables:
         """The frame and the geometry built from it say the same thing."""
         frame = pd.DataFrame({"time_start": ["2020-01-01"], "time_end": ["2020-01-02"]})
         out = dc.AnnotationSet(frame, dims=("time",))
-        held = out.to_dataframe()["time_start"][0]
+        held = out.io.to_dataframe()["time_start"][0]
         assert isinstance(held, pd.Timestamp | np.datetime64)
         assert out[0].region.bounds["time"][0] == np.datetime64("2020-01-01")
 
@@ -588,12 +588,12 @@ class TestTheTables:
             {"id": ["1", "1"], "seq": [0, 1], "distance": [1.0, 2.0]}
         )
         annotations = dc.AnnotationSet(frame, dims=("distance",), vertices=vertices)
-        loaded = dc.annotations(annotations.save(tmp_path / "picks"))
+        loaded = dc.annotations(annotations.io.save(tmp_path / "picks"))
         assert loaded[0].id == "1"
         # The frame too, not only the model: Annotation.id is typed str, so
         # it would coerce an int back and hide the damage.
-        assert loaded.to_dataframe()["id"][0] == "1"
-        assert loaded.to_vertices()["id"][0] == "1"
+        assert loaded.io.to_dataframe()["id"][0] == "1"
+        assert loaded.io.to_vertices()["id"][0] == "1"
         assert loaded == annotations
 
 
@@ -602,44 +602,44 @@ class TestWriting:
 
     def test_to_csv_returns_text(self, regions):
         """The text comes back whether or not it is written."""
-        text = regions.to_csv()
+        text = regions.io.to_csv()
         assert text.splitlines()[0].startswith("id,group,tags")
 
     def test_to_csv_refuses_vertices(self, with_vertices):
         """A bare table states one grain."""
         with pytest.raises(ParameterError, match="holds vertices"):
-            with_vertices.to_csv()
+            with_vertices.io.to_csv()
 
     def test_save_makes_the_directory(self, regions, tmp_path):
         """Saving into a directory which is not there makes it."""
-        directory = regions.save(tmp_path / "deep" / "picks")
+        directory = regions.io.save(tmp_path / "deep" / "picks")
         assert directory.is_dir()
 
     def test_save_writes_no_empty_vertices(self, regions, tmp_path):
         """A set without vertices states no vertices table."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         assert not (directory / "vertices.csv").exists()
 
     def test_save_writes_what_it_holds(self, with_vertices, tmp_path):
         """A set with vertices states all three parts."""
-        directory = with_vertices.save(tmp_path / "picks")
+        directory = with_vertices.io.save(tmp_path / "picks")
         written = {x.name for x in directory.iterdir()}
         assert written == {"attrs.json", "annotations.csv", "vertices.csv"}
 
     def test_save_over_itself(self, regions, tmp_path):
         """Saving twice into one directory rewrites it."""
-        regions.save(tmp_path / "picks")
-        assert dc.annotations(regions.save(tmp_path / "picks")) == regions
+        regions.io.save(tmp_path / "picks")
+        assert dc.annotations(regions.io.save(tmp_path / "picks")) == regions
 
     def test_times_are_written_unambiguously(self, regions, tmp_path):
         """A time is written the way DASCore writes every datetime."""
-        text = regions.to_csv()
+        text = regions.io.to_csv()
         assert "2020-01-01T00:00:10.000000000" in text
 
     def test_a_nested_extra_is_written_as_its_document(self, tmp_path):
         """A cell a table has no column shape for is written as text."""
         frame = pd.DataFrame({"group": ["a"], "distance": [1.0], "meta": [{"n": 1}]})
-        text = dc.AnnotationSet(frame, dims=("distance",)).to_csv()
+        text = dc.AnnotationSet(frame, dims=("distance",)).io.to_csv()
         assert '{""n"": 1}' in text
 
     def test_an_extra_json_cannot_spell(self, tmp_path):
@@ -647,11 +647,11 @@ class TestWriting:
         than dying as a circular reference.
         """
         frame = pd.DataFrame({"group": ["a"], "distance": [1.0], "meta": [{"s": {1}}]})
-        text = dc.AnnotationSet(frame, dims=("distance",)).to_csv()
+        text = dc.AnnotationSet(frame, dims=("distance",)).io.to_csv()
         assert '{""s"": ""1""}' in text
 
     def test_the_attrs_name_their_model(self, regions, tmp_path):
         """The document says what it holds, as every stored object does."""
-        directory = regions.save(tmp_path / "picks")
+        directory = regions.io.save(tmp_path / "picks")
         text = (directory / "attrs.json").read_text()
         assert '"object_type": "AnnotationSetAttrs"' in text

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -20,6 +20,7 @@ from dascore.core.annotations import (
     Region,
 )
 from dascore.exceptions import ParameterError
+from dascore.utils.namespace import AnnotationNameSpace
 
 DIMS = ("time", "distance")
 
@@ -132,7 +133,7 @@ class TestConstruction:
 
     def test_equality(self, region_set):
         """Two sets built the same way are equal."""
-        same = AnnotationSet(region_set.to_dataframe(), attrs=region_set.attrs)
+        same = AnnotationSet(region_set.io.to_dataframe(), attrs=region_set.attrs)
         assert same == region_set
         assert region_set != AnnotationSet(None, dims=DIMS)
 
@@ -299,7 +300,7 @@ class TestColumns:
         out = AnnotationSet(
             frame, dims=DIMS, columns={"when": {"dtype": "datetime64[ns]"}}
         )
-        assert out.to_dataframe()["when"].dtype == np.dtype("datetime64[ns]")
+        assert out.io.to_dataframe()["when"].dtype == np.dtype("datetime64[ns]")
 
     def test_unreadable_dtype_refused(self):
         """A dtype naming nothing says so, rather than raising numpy's error."""
@@ -393,7 +394,7 @@ class TestTags:
     def test_a_padded_tag_is_held_stripped(self):
         """Tags are held as they read back, so padding does not survive."""
         out = AnnotationSet(pd.DataFrame({"tags": [(" a", "b ")]}), dims=DIMS)
-        assert out.to_dataframe()["tags"][0] == ("a", "b")
+        assert out.io.to_dataframe()["tags"][0] == ("a", "b")
 
     def test_an_empty_tag_is_no_tag(self):
         """A tag holding nothing cannot be written down, so it is not held."""
@@ -525,7 +526,7 @@ class TestVertices:
 
     def test_derived_bounds_reach_the_frame(self, path_set):
         """The derived box is a real column, so table operations see it."""
-        row = path_set.to_dataframe().iloc[0]
+        row = path_set.io.to_dataframe().iloc[0]
         assert (row["distance_start"], row["distance_end"]) == (1.0, 9.0)
 
     def test_stated_bounds_must_agree(self):
@@ -667,7 +668,7 @@ class TestVertices:
 
     def test_to_vertices_round_trips(self, path_set):
         """The vertices come back out whole: order, coordinates and types."""
-        out = path_set.to_vertices()
+        out = path_set.io.to_vertices()
         assert list(out["id"]) == ["p1"] * 3
         assert list(out["seq"]) == [0, 1, 2]
         assert list(out["distance"]) == [1.0, 5.0, 9.0]
@@ -676,7 +677,7 @@ class TestVertices:
 
     def test_empty_vertices_frame(self, region_set):
         """A set with no vertex geometry has an empty vertices frame."""
-        assert region_set.to_vertices().empty
+        assert region_set.io.to_vertices().empty
 
 
 class TestFrames:
@@ -684,13 +685,13 @@ class TestFrames:
 
     def test_to_dataframe_is_a_copy(self, region_set):
         """Mutating what a set handed out does not reach the set."""
-        frame = region_set.to_dataframe()
+        frame = region_set.io.to_dataframe()
         frame.loc[0, "group"] = "changed"
         assert region_set[0].group == "event"
 
     def test_to_vertices_is_a_copy(self, path_set):
         """The same holds for the vertices."""
-        vertices = path_set.to_vertices()
+        vertices = path_set.io.to_vertices()
         vertices.loc[0, "distance"] = 999.0
         assert path_set[0].geometry.vertices["distance"][0] == 1.0
 
@@ -709,7 +710,7 @@ class TestFrames:
 
     def test_round_trip(self, region_set):
         """A set rebuilt from its own frame holds the same annotations."""
-        rebuilt = AnnotationSet(region_set.to_dataframe(), attrs=region_set.attrs)
+        rebuilt = AnnotationSet(region_set.io.to_dataframe(), attrs=region_set.attrs)
         assert [x.group for x in rebuilt] == [x.group for x in region_set]
         assert rebuilt == region_set
 
@@ -1202,3 +1203,34 @@ class TestTopLevel:
     def test_dc_annotation_set(self):
         """`dc.AnnotationSet` is the in-memory door."""
         assert dc.AnnotationSet is AnnotationSet
+
+
+class TestAnnotationNamespaces:
+    """A set hosts method namespaces, as a patch and a spool do."""
+
+    def test_io_namespace(self, region_set):
+        """The io namespace DASCore registers is reachable."""
+        assert region_set.io.to_dataframe().equals(region_set.io.to_dataframe())
+        assert len(region_set.io.to_dataframe()) == len(region_set)
+
+    def test_namespace_is_cached(self, region_set):
+        """Repeated access returns one namespace object."""
+        assert region_set.io is region_set.io
+
+    def test_local_namespace_attaches(self, region_set):
+        """A namespace defined without an entry point still attaches."""
+
+        class _Local(AnnotationNameSpace):
+            name = "some_local_namespace"
+
+            def group_count(annotations) -> int:  # noqa: N805
+                """Return how many distinct groups the set holds."""
+                return annotations.io.to_dataframe()["group"].nunique()
+
+        assert region_set.some_local_namespace.group_count() == 2
+
+    def test_unknown_attr_raises(self, region_set):
+        """A name no namespace claims raises DASCore's message."""
+        msg = "AnnotationSet has no attribute 'nope'"
+        with pytest.raises(AttributeError, match=msg):
+            region_set.nope

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import copy
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -1215,12 +1213,6 @@ class TestAnnotationNamespaces:
         frame = region_set.io.to_dataframe()
         assert len(frame) == len(region_set)
         assert list(frame["group"]) == [x.group for x in region_set]
-
-    def test_copy_gets_its_own_binding(self, region_set):
-        """A copied set hands out a namespace bound to the copy."""
-        region_set.io  # a namespace kept on the host would ride along
-        other = copy.copy(region_set)
-        assert other.io._obj is other
 
     def test_local_namespace_attaches(self, region_set):
         """A namespace defined without an entry point still attaches."""

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import copy
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -1210,12 +1212,15 @@ class TestAnnotationNamespaces:
 
     def test_io_namespace(self, region_set):
         """The io namespace DASCore registers is reachable."""
-        assert region_set.io.to_dataframe().equals(region_set.io.to_dataframe())
-        assert len(region_set.io.to_dataframe()) == len(region_set)
+        frame = region_set.io.to_dataframe()
+        assert len(frame) == len(region_set)
+        assert list(frame["group"]) == [x.group for x in region_set]
 
-    def test_namespace_is_cached(self, region_set):
-        """Repeated access returns one namespace object."""
-        assert region_set.io is region_set.io
+    def test_copy_gets_its_own_binding(self, region_set):
+        """A copied set hands out a namespace bound to the copy."""
+        region_set.io  # a namespace kept on the host would ride along
+        other = copy.copy(region_set)
+        assert other.io._obj is other
 
     def test_local_namespace_attaches(self, region_set):
         """A namespace defined without an entry point still attaches."""

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -2898,10 +2898,13 @@ class TestInventoryNamespaces:
         inventory = build_inventory()
         assert inventory.io.to_yaml() == inv.inventory_to_yaml(inventory)
 
-    def test_namespace_is_cached(self):
-        """Repeated access returns one namespace object."""
+    def test_copy_gets_its_own_binding(self):
+        """A copied inventory hands out a namespace bound to the copy."""
+        pytest.importorskip("yaml")
         inventory = build_inventory()
-        assert inventory.io is inventory.io
+        inventory.io  # a namespace kept on the host would ride along
+        other = inventory.model_copy(update={"schema_version": 7})
+        assert other.io.to_yaml().startswith("schema_version: 7")
 
     def test_local_namespace_attaches(self):
         """A namespace defined without an entry point still attaches."""

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -18,6 +18,7 @@ from dascore.core import inventory as inv
 from dascore.exceptions import InvalidInventoryError
 from dascore.models import InventoryModel, values_equal
 from dascore.utils.mapping import FrozenDict
+from dascore.utils.namespace import InventoryNameSpace
 
 
 def build_inventory() -> inv.Inventory:
@@ -1047,7 +1048,7 @@ class TestInventory:
         pytest.importorskip("yaml")
         inventory = build_inventory()
         path = tmp_path / "inventory.yaml"
-        inventory.to_yaml(path)
+        inventory.io.to_yaml(path)
         loaded = dc.inventory(path)
         assert loaded.model_dump(mode="json") == inventory.model_dump(mode="json")
 
@@ -1079,7 +1080,7 @@ class TestInventory:
         pytest.importorskip("yaml")
         assert isinstance(dc.inventory(), inv.Inventory)
         path = tmp_path / "inv.yaml"
-        build_inventory().to_yaml(path)
+        build_inventory().io.to_yaml(path)
         assert isinstance(dc.inventory(path), inv.Inventory)
 
     def test_crs_vocabulary_enforced(self):
@@ -1287,7 +1288,7 @@ class TestResourcePool:
         cable = inv.Cable(resource_id="cable-01", name="c")
         seg = inv.FiberSegment(optical_length=100.0, container=cable)
         inventory = self._inventory_with(seg)
-        text = inventory.to_yaml()
+        text = inventory.io.to_yaml()
         assert text.count("cable-01") >= 2
         loaded = inv.Inventory.from_yaml(text)
         assert loaded.model_dump(mode="json") == inventory.model_dump(mode="json")
@@ -1373,7 +1374,7 @@ class TestInternalReviewRegressions:
             resources={"cab-1": {"object_type": "Cable", "name": "mycable"}}
         )
         assert inventory.get_resource("cab-1").resource_id == "cab-1"
-        loaded = inv.Inventory.from_yaml(inventory.to_yaml())
+        loaded = inv.Inventory.from_yaml(inventory.io.to_yaml())
         assert loaded.model_dump(mode="json") == inventory.model_dump(mode="json")
 
     def test_duplicate_array_codes_raise(self):
@@ -1666,7 +1667,7 @@ class TestUniformAttachments:
         """Empty strings, dicts, and tuples do not serialize."""
         pytest.importorskip("yaml")
         inventory = build_inventory()
-        text = inventory.to_yaml()
+        text = inventory.io.to_yaml()
         assert "description:" not in text
         assert "extra_fields:" not in text
         loaded = inv.Inventory.from_yaml(text)
@@ -1680,7 +1681,7 @@ class TestUniformAttachments:
         inventory = inv.Inventory(
             networks=(inv.Network(code="DAS", fiber_arrays=(array,)),)
         )
-        loaded = inv.Inventory.from_yaml(inventory.to_yaml())
+        loaded = inv.Inventory.from_yaml(inventory.io.to_yaml())
         got = loaded.networks[0].fiber_arrays[0].acquisitions[0]
         assert got.extra_fields == {"vendor_flag": ""}
 
@@ -1769,7 +1770,7 @@ class TestImmutability:
         """Serializing and reloading does not move an inventory's hash."""
         pytest.importorskip("yaml")
         inventory = self._stocked_inventory()
-        loaded = inv.Inventory.from_yaml(inventory.to_yaml())
+        loaded = inv.Inventory.from_yaml(inventory.io.to_yaml())
         assert loaded == inventory
         assert hash(loaded) == hash(inventory)
 
@@ -2462,7 +2463,7 @@ class TestSerializationIsLossless:
         """Whatever was written comes back, in text and through a file."""
         pytest.importorskip("yaml")
         inventory = SAMPLE_INVENTORIES[name]
-        assert dc.inventory(inventory.to_yaml()) == inventory
+        assert dc.inventory(inventory.io.to_yaml()) == inventory
 
     def test_an_annotation_value_of_one_survives(self):
         """`1 == True`, and the value's default is True, so it was dropped."""
@@ -2482,7 +2483,7 @@ class TestSerializationIsLossless:
         inventory = inv.Inventory(
             networks=(inv.Network(code="XX", fiber_arrays=(array,)),)
         )
-        text = inventory.to_yaml()
+        text = inventory.io.to_yaml()
         assert "value: 1" in text
         # Without the value, the group reloads holding a boolean beside a
         # number and is refused as mixing two kinds.
@@ -2519,7 +2520,7 @@ class TestSerializationIsLossless:
         inventory = inv.Inventory(
             networks=(inv.Network(code="XX", fiber_arrays=(array,)),)
         )
-        text = inventory.to_yaml()
+        text = inventory.io.to_yaml()
         assert "value:" not in text
         assert dc.inventory(text) == inventory
 
@@ -2528,21 +2529,21 @@ class TestSerializationIsLossless:
         pytest.importorskip("yaml")
         inventory = build_full_inventory()
         path = tmp_path / "inventory.yaml"
-        inventory.to_yaml(path)
+        inventory.io.to_yaml(path)
         assert dc.inventory(path) == inventory
 
     def test_blank_crs_fields_survive(self):
         """A frame described by WKT alone must not reload as EPSG:4979."""
         pytest.importorskip("yaml")
         inventory = SAMPLE_INVENTORIES["blank_crs"]
-        crs = dc.inventory(inventory.to_yaml()).coordinate_reference_system
+        crs = dc.inventory(inventory.io.to_yaml()).coordinate_reference_system
         assert (crs.authority, crs.code, crs.name) == ("", "", "")
 
     def test_blank_instrument_type_survives(self):
         """A blanked field with a non-empty default is not a missing one."""
         pytest.importorskip("yaml")
         inventory = SAMPLE_INVENTORIES["blank_resources"]
-        loaded = dc.inventory(inventory.to_yaml())
+        loaded = dc.inventory(inventory.io.to_yaml())
         assert loaded.resources["int-1"].instrument_type == ""
 
     def test_every_blankable_field_survives(self):
@@ -2566,7 +2567,7 @@ class TestSerializationIsLossless:
                     continue  # a field a validator refuses to blank
                 # Outside the catch: an inventory valid here but not once it
                 # has been written is a document the pruning damaged.
-                loaded = dc.inventory(candidate.to_yaml())
+                loaded = dc.inventory(candidate.io.to_yaml())
                 assert loaded == candidate, f"{type(model).__name__}.{name} was lost"
                 checked.add((type(model).__name__, name))
         # The fields the reported bug was found in must be among those swept.
@@ -2577,7 +2578,7 @@ class TestSerializationIsLossless:
     def test_defaulted_fields_are_dropped(self):
         """A field still holding its default is left out of the document."""
         yaml = pytest.importorskip("yaml")
-        data = yaml.safe_load(build_inventory().to_yaml())
+        data = yaml.safe_load(build_inventory().io.to_yaml())
         assert not _empty_keys(data)
         assert "description" not in yaml.safe_dump(data)
 
@@ -2589,10 +2590,10 @@ class TestSerializationIsLossless:
         """
         yaml = pytest.importorskip("yaml")
         default = inv.Inventory().schema_version
-        data = yaml.safe_load(build_inventory().to_yaml())
+        data = yaml.safe_load(build_inventory().io.to_yaml())
         assert data["schema_version"] == default
         other = inv.Inventory(schema_version=default + 1)
-        assert dc.inventory(other.to_yaml()).schema_version == default + 1
+        assert dc.inventory(other.io.to_yaml()).schema_version == default + 1
 
     def test_empty_annotation_value_is_rejected(self):
         """An empty value would have to survive serialization to mean anything.
@@ -2618,7 +2619,7 @@ class TestLoadingValidates:
         inventory = inv.Inventory(
             networks=(inv.Network(code="XX", stations=(station,)),)
         )
-        text = inventory.to_yaml()
+        text = inventory.io.to_yaml()
         with pytest.raises(InvalidInventoryError, match="coordinate values"):
             inv.Inventory.from_yaml(text)
         with pytest.raises(InvalidInventoryError, match="coordinate values"):
@@ -2886,3 +2887,58 @@ class TestGetNamesRoundTrip:
             plain: float | None = None
 
         assert inv._value_field_names(_Probe) == ("plain",)
+
+
+class TestInventoryNamespaces:
+    """An inventory hosts method namespaces, as a patch and a spool do."""
+
+    def test_io_namespace(self):
+        """The io namespace DASCore registers is reachable."""
+        pytest.importorskip("yaml")
+        inventory = build_inventory()
+        assert inventory.io.to_yaml() == inv.inventory_to_yaml(inventory)
+
+    def test_namespace_is_cached(self):
+        """Repeated access returns one namespace object."""
+        inventory = build_inventory()
+        assert inventory.io is inventory.io
+
+    def test_local_namespace_attaches(self):
+        """A namespace defined without an entry point still attaches."""
+
+        class _Local(InventoryNameSpace):
+            name = "some_local_namespace"
+
+            def network_count(inventory) -> int:  # noqa: N805
+                """Return how many networks the inventory holds."""
+                return len(inventory.networks)
+
+        inventory = build_inventory()
+        assert inventory.some_local_namespace.network_count() == len(inventory.networks)
+
+    def test_unknown_attr_raises(self):
+        """A name no namespace claims raises DASCore's message."""
+        inventory = build_inventory()
+        with pytest.raises(AttributeError, match="Inventory has no attribute 'nope'"):
+            inventory.nope
+
+    def test_private_attrs_still_resolve(self):
+        """The namespace search does not stand in front of pydantic's own."""
+        # _cache is a private attribute pydantic resolves in __getattr__,
+        # which the namespace search would otherwise answer first.
+        assert build_inventory()._cache == {}
+
+    def test_unknown_private_attr_raises(self):
+        """A private name neither pydantic nor a namespace knows still fails."""
+        with pytest.raises(AttributeError, match="_not_a_field"):
+            build_inventory()._not_a_field
+
+    def test_cached_namespace_is_not_state(self):
+        """An attached namespace changes neither equality nor a dump."""
+        pytest.importorskip("yaml")
+        inventory = build_inventory()
+        other = inv.Inventory(**inventory.model_dump())
+        inventory.io.to_yaml()
+        assert inventory == other
+        assert hash(inventory) == hash(other)
+        assert inventory.model_dump(mode="json") == other.model_dump(mode="json")

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -981,7 +981,7 @@ class TestFactory:
     def test_yaml_file_still_works(self, tmp_path):
         """A file keeps going to the single-file reader."""
         path = tmp_path / "inv.yaml"
-        dc.inventory().to_yaml(path)
+        dc.inventory().io.to_yaml(path)
         assert isinstance(dc.inventory(path), inv.Inventory)
 
     def test_directory_which_holds_no_inventory(self, tmp_path):
@@ -2156,7 +2156,7 @@ class TestFindInventory:
     def test_the_file_form(self, tmp_path):
         """A serialized inventory beside the data it describes."""
         found = tmp_path / f"{loader.BLESSED_NAME}.yaml"
-        found.write_text(dc.inventory().to_yaml())
+        found.write_text(dc.inventory().io.to_yaml())
         assert loader.carries_inventory(tmp_path)
         assert loader.find_inventory(tmp_path) == found
         assert isinstance(dc.inventory(loader.find_inventory(tmp_path)), inv.Inventory)
@@ -2170,7 +2170,7 @@ class TestFindInventory:
 
     def test_the_visible_name_is_not_it(self, tmp_path):
         """`inventory.yaml` is the envelope of the authoring format."""
-        (tmp_path / "inventory.yaml").write_text(dc.inventory().to_yaml())
+        (tmp_path / "inventory.yaml").write_text(dc.inventory().io.to_yaml())
         assert not loader.carries_inventory(tmp_path)
         assert loader.find_inventory(tmp_path) is None
 
@@ -2293,7 +2293,7 @@ class TestLoadSerializedFile:
         """What `to_yaml` writes is what this reads."""
         original = dc.inventory(write_inventory(tmp_path / "authored", MINIMAL))
         path = tmp_path / "whole.yaml"
-        original.to_yaml(path)
+        original.io.to_yaml(path)
         assert dc.inventory(path) == original
 
 
@@ -2303,7 +2303,7 @@ class TestOneLoadingDoor:
     def test_text_and_file_agree(self, tmp_path):
         """The same document loads the same from either side of the door."""
         original = dc.inventory(write_inventory(tmp_path / "authored", MINIMAL))
-        text = original.to_yaml()
+        text = original.io.to_yaml()
         path = tmp_path / "whole.yaml"
         path.write_text(text)
         assert dc.inventory(text) == dc.inventory(path) == original
@@ -2311,7 +2311,7 @@ class TestOneLoadingDoor:
     def test_from_yaml_refuses_a_path(self, tmp_path):
         """The text reader says so rather than letting the parser fail."""
         path = tmp_path / "whole.yaml"
-        path.write_text(dc.inventory().to_yaml())
+        path.write_text(dc.inventory().io.to_yaml())
         with pytest.raises(InvalidInventoryError, match="reads YAML text"):
             inv.Inventory.from_yaml(path)
 

--- a/tests/test_core/test_spool_inventory.py
+++ b/tests/test_core/test_spool_inventory.py
@@ -200,7 +200,7 @@ def data_directory(tmp_path_factory, patch, inventory):
     """A directory of data which carries the inventory describing it."""
     path = tmp_path_factory.mktemp("blessed")
     dc.write(patch, path / "patch.h5", "dasdae")
-    inventory.to_yaml(path / f"{BLESSED_NAME}.yaml")
+    inventory.io.to_yaml(path / f"{BLESSED_NAME}.yaml")
     return path
 
 
@@ -246,7 +246,7 @@ class TestBlessedInventory:
     def test_a_visible_inventory_is_not_attached(self, tmp_path, patch, inventory):
         """`inventory.yaml` names the envelope, not a spool's inventory."""
         dc.write(patch, tmp_path / "patch.h5", "dasdae")
-        inventory.to_yaml(tmp_path / "inventory.yaml")
+        inventory.io.to_yaml(tmp_path / "inventory.yaml")
         assert dc.spool(tmp_path).update()._inventory is None
 
     def test_in_memory_spools_carry_none(self, patch):
@@ -256,7 +256,7 @@ class TestBlessedInventory:
     def test_a_file_spool_carries_none(self, tmp_path, patch, inventory):
         """A file is not a directory, whatever lies beside it."""
         dc.write(patch, tmp_path / "patch.h5", "dasdae")
-        inventory.to_yaml(tmp_path / f"{BLESSED_NAME}.yaml")
+        inventory.io.to_yaml(tmp_path / f"{BLESSED_NAME}.yaml")
         assert dc.spool(tmp_path / "patch.h5")._inventory is None
 
 
@@ -362,10 +362,10 @@ class TestLazyInventory:
     ):
         """An inventory is an input, not a cache: it is read once."""
         dc.write(patch, tmp_path / "patch.h5", "dasdae")
-        inventory.to_yaml(tmp_path / f"{BLESSED_NAME}.yaml")
+        inventory.io.to_yaml(tmp_path / f"{BLESSED_NAME}.yaml")
         spool = dc.spool(tmp_path).update()
         assert spool.enrich()[0].attrs.gauge_length == 10.0
-        _replace_acquisition(inventory, gauge_length=2.0).to_yaml(
+        _replace_acquisition(inventory, gauge_length=2.0).io.to_yaml(
             tmp_path / f"{BLESSED_NAME}.yaml"
         )
         assert spool.enrich()[0].attrs.gauge_length == 10.0
@@ -407,7 +407,7 @@ class TestLazyInventory:
         spool = dc.spool(tmp_path).update()
         with pytest.raises(InvalidInventoryError):
             spool.enrich()[0]
-        inventory.to_yaml(tmp_path / f"{BLESSED_NAME}.yaml")
+        inventory.io.to_yaml(tmp_path / f"{BLESSED_NAME}.yaml")
         assert spool.enrich()[0].attrs.gauge_length == 10.0
 
     def test_a_lazily_attached_spool_pickles(self, data_directory):
@@ -440,7 +440,7 @@ class TestAttachInventoryPath:
     def test_a_file_path(self, tmp_path, patch, inventory):
         """The serialized artifact shipped beside an archive."""
         path = tmp_path / "somewhere.yaml"
-        inventory.to_yaml(path)
+        inventory.io.to_yaml(path)
         spool = dc.spool(patch).attach_inventory(path)
         assert spool.enrich()[0].attrs.gauge_length == 10.0
 
@@ -460,7 +460,7 @@ class TestAttachInventoryPath:
     def test_a_path_is_read_lazily(self, tmp_path, patch, inventory):
         """As the blessed name is, and for the same reason."""
         path = tmp_path / "somewhere.yaml"
-        inventory.to_yaml(path)
+        inventory.io.to_yaml(path)
         spool = dc.spool(patch).attach_inventory(path)
         assert spool._inventory._inventory is None
 
@@ -480,7 +480,7 @@ class TestAttachInventoryPath:
     def test_a_named_file_of_any_suffix(self, tmp_path, patch, inventory):
         """A path is a path; only the blessed name insists on a spelling."""
         path = tmp_path / "inventory.txt"
-        path.write_text(inventory.to_yaml())
+        path.write_text(inventory.io.to_yaml())
         spool = dc.spool(patch).attach_inventory(path)
         assert spool.enrich()[0].attrs.gauge_length == 10.0
 
@@ -494,7 +494,7 @@ class TestAttachInventoryPath:
 
     def test_a_path_is_anchored_when_it_is_attached(self, tmp_path, patch, inventory):
         """The read comes later, possibly from another directory entirely."""
-        inventory.to_yaml(tmp_path / "somewhere.yaml")
+        inventory.io.to_yaml(tmp_path / "somewhere.yaml")
         here = os.getcwd()
         os.chdir(tmp_path)
         try:
@@ -506,7 +506,7 @@ class TestAttachInventoryPath:
     def test_conform_uses_an_attached_path(self, tmp_path, patch, inventory):
         """A lazily attached path is read by the eager verb too."""
         path = tmp_path / "somewhere.yaml"
-        inventory.to_yaml(path)
+        inventory.io.to_yaml(path)
         assert len(dc.spool(patch).attach_inventory(path).conform_to_inventory()) == 1
 
     @pytest.mark.parametrize("verb", ["enrich", "conform_to_inventory"])
@@ -551,7 +551,7 @@ class TestLazyInventoryEquality:
             root = tmp_path / name
             root.mkdir()
             dc.write(patch, root / "patch.h5", "dasdae")
-            inventory.to_yaml(root / f"{BLESSED_NAME}.yaml")
+            inventory.io.to_yaml(root / f"{BLESSED_NAME}.yaml")
             spools.append(dc.spool(root).update())
         assert spools[0] != spools[1]
         assert all(x._inventory._inventory is None for x in spools)
@@ -608,7 +608,7 @@ class TestLazyInventoryEquality:
             root.mkdir()
             dc.write(patch, root / "patch.h5", "dasdae")
         (broken / f"{BLESSED_NAME}.yaml").write_text("this: [is not: yaml\n")
-        inventory.to_yaml(whole / f"{BLESSED_NAME}.yaml")
+        inventory.io.to_yaml(whole / f"{BLESSED_NAME}.yaml")
         assert dc.spool(broken).update() not in [dc.spool(whole).update()]
 
 

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -131,11 +131,17 @@ class TestGetPluginTable:
         assert "zug" in df["namespace"].values
         assert "derzug" in df["package_name"].values
 
+    def test_one_row_per_host(self):
+        """A namespace registered on two hosts keeps a row for each."""
+        df = get_plugin_table()
+        hosts = set(df.loc[df["namespace"] == "zug", "host"])
+        assert hosts == {"patch", "spool"}
+
     def test_empty_registry_returns_empty_dataframe(self, monkeypatch, tmp_path):
         """An empty registry directory returns a DataFrame with the correct columns."""
         monkeypatch.setattr(ns_module, "_PLUGIN_REGISTRY_DIR", tmp_path)
         df = get_plugin_table()
-        assert list(df.columns) == ["namespace", "package_name", "package_url"]
+        assert list(df.columns) == ["host", "namespace", "package_name", "package_url"]
         assert df.empty
 
 

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -134,8 +134,9 @@ class TestGetPluginTable:
     def test_one_row_per_host(self):
         """A namespace registered on two hosts keeps a row for each."""
         df = get_plugin_table()
-        hosts = set(df.loc[df["namespace"] == "zug", "host"])
-        assert hosts == {"patch", "spool"}
+        rows = df[df["namespace"] == "zug"]
+        assert set(rows["host"]) == {"patch", "spool"}
+        assert len(rows) == 2
 
     def test_empty_registry_returns_empty_dataframe(self, monkeypatch, tmp_path):
         """An empty registry directory returns a DataFrame with the correct columns."""

--- a/tests/test_utils/test_namespace.py
+++ b/tests/test_utils/test_namespace.py
@@ -227,6 +227,21 @@ class TestNamespace:
             class _Private(ParentClassNamespace):
                 name = "_hidden"
 
+    def test_keyword_name_refused(self):
+        """A keyword is an identifier, but `host.class` will not parse."""
+        with pytest.raises(ValueError, match="must not be a Python keyword"):
+
+            class _Keyword(ParentClassNamespace):
+                name = "class"
+
+    def test_soft_keyword_name_allowed(self):
+        """A soft keyword is a legal attribute name, so it is not refused."""
+
+        class _Soft(ParentClassNamespace):
+            name = "match"
+
+        assert ParentClass().match.__class__ is _Soft
+
     def test_non_identifier_name_refused(self):
         """A name which is not an identifier is refused, as the docs say."""
         with pytest.raises(ValueError, match="must be a Python identifier"):

--- a/tests/test_utils/test_namespace.py
+++ b/tests/test_utils/test_namespace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from typing import ClassVar
 
 import pandas as pd
@@ -86,10 +87,12 @@ class TestNamespace:
         bob = inst.bob
         assert isinstance(bob, ParentClassNamespace)
 
-    def test_discoverable_is_cached(self):
-        """The same namespace instance should be returned on repeated access."""
+    def test_copy_gets_its_own_binding(self):
+        """A copy of a host hands out a namespace bound to the copy."""
         inst = ParentClass()
-        assert inst.bob is inst.bob
+        inst.bob  # a namespace kept on the host would ride along
+        other = copy.copy(inst)
+        assert other.bob.return_self() is other
 
     def test_parent_type_bound(self):
         """Ensure the parent type is bound the instances."""
@@ -217,6 +220,20 @@ class TestNamespace:
         out = CooperativeBase._registry["dascore.cooperative_test"]
         assert out["cooperative"] is CooperativeNamespace
 
+    def test_private_name_refused(self):
+        """A private namespace name a host could never hand out is refused."""
+        with pytest.raises(ValueError, match="must be public"):
+
+            class _Private(ParentClassNamespace):
+                name = "_hidden"
+
+    def test_non_identifier_name_refused(self):
+        """A name which is not an identifier is refused, as the docs say."""
+        with pytest.raises(ValueError, match="must be a Python identifier"):
+
+            class _Spaced(ParentClassNamespace):
+                name = "not an identifier"
+
     def test_custom_attr_error_message(self):
         """Ensure _namespace_attr_errors messages are raised verbatim."""
         inst = ParentClass()
@@ -242,15 +259,19 @@ class TestHostWithGetattr:
         inst = GetattrParent()
         assert inst._private == "host"
 
-    def test_underscore_namespace_does_not_shadow_host(self):
-        """A namespace named with a leading underscore is never reached."""
-
-        class _Shadow(ParentClassNamespace):
-            name = "_private"
-
+    def test_private_lookup_loads_no_plugin(self, monkeypatch):
+        """Resolving a private name must not import a plugin to find it."""
+        loaded = []
+        monkeypatch.setattr(
+            ns_module,
+            "maybe_load_entry_point",
+            lambda group, name: loaded.append(name),
+        )
         inst = GetattrParent()
         assert inst._private == "host"
-        assert _Shadow.name in ParentClass.get_registered_namespaces()
+        assert not loaded
+        assert inst.from_host == "host"
+        assert loaded == ["from_host"]
 
     def test_default_message_survives_host_getattr(self):
         """A name neither knows still raises this class's message."""
@@ -345,12 +366,11 @@ class TestNamespaceConcurrency:
     """Lazy namespace attachment must be safe under concurrent first use."""
 
     @pytest.mark.concurrency
-    def test_one_instance_per_host(self, run_in_threads):
-        """Concurrent first access on one object returns a single namespace."""
+    def test_one_host_per_instance(self, run_in_threads):
+        """Concurrent first access on one object binds every namespace to it."""
         inst = ParentClass()
         results = run_in_threads(lambda _: inst.bob)
-        assert len({id(x) for x in results}) == 1
-        assert results[0] is inst.bob
+        assert [x.return_self() for x in results] == [inst] * len(results)
 
     @pytest.mark.concurrency
     def test_distinct_hosts_get_own_namespace(self, run_in_threads):
@@ -378,16 +398,12 @@ class TestNamespaceConcurrency:
         assert set(registered) == {f"ns_{i}" for i in range(4)}
 
     def test_fork_handler_replaces_held_locks(self):
-        """Locks held at fork time are replaced so the child cannot deadlock."""
-        old_attachment = ns_module._ATTACHMENT_LOCK
+        """A lock held at fork time is replaced so the child cannot deadlock."""
         old_registry = _MethodNameSpace._registry_lock
         try:
-            with old_attachment, old_registry:
+            with old_registry:
                 ns_module._reinit_namespace_locks()
-                new_attachment = ns_module._ATTACHMENT_LOCK
                 new_registry = _MethodNameSpace._registry_lock
-            assert new_attachment is not old_attachment
             assert new_registry is not old_registry
         finally:
-            ns_module._ATTACHMENT_LOCK = old_attachment
             _MethodNameSpace._registry_lock = old_registry

--- a/tests/test_utils/test_namespace.py
+++ b/tests/test_utils/test_namespace.py
@@ -7,11 +7,16 @@ from typing import ClassVar
 import pandas as pd
 import pytest
 
+import dascore as dc
 import dascore.utils.namespace as ns_module
 from dascore.exceptions import DASCorePluginError
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.namespace import (
+    AnnotationNameSpace,
+    InventoryNameSpace,
     NamespaceOwner,
+    PatchNameSpace,
+    SpoolNameSpace,
     _load_plugin_registry,
     _MethodNameSpace,
 )
@@ -34,6 +39,22 @@ class ParentClassNamespace(_MethodNameSpace):
     """A test child class."""
 
     entry_point_group = "dascore.ParentClass"
+
+
+class _HostGetattr:
+    """A base which resolves names of its own, as a pydantic model does."""
+
+    def __getattr__(self, item):
+        """Answer a few names this base owns."""
+        if item in {"from_host", "_private"}:
+            return "host"
+        raise AttributeError(item)
+
+
+class GetattrParent(NamespaceOwner, _HostGetattr):
+    """A host whose base resolves names the namespace search does not."""
+
+    _namespace_entry_point_group = "dascore.ParentClass"
 
 
 class Namespace1(ParentClassNamespace):
@@ -201,6 +222,66 @@ class TestNamespace:
         inst = ParentClass()
         with pytest.raises(AttributeError, match="test_error emitted"):
             inst.test_error
+
+
+class TestHostWithGetattr:
+    """A host which already resolves names of its own keeps doing so."""
+
+    def test_host_getattr_still_resolves(self):
+        """The host's own __getattr__ answers a name no namespace claims."""
+        inst = GetattrParent()
+        assert inst.from_host == "host"
+
+    def test_namespace_still_resolves(self):
+        """A namespace is found even though the host would answer anything."""
+        inst = GetattrParent()
+        assert isinstance(inst.bob, ParentClassNamespace)
+
+    def test_private_name_skips_namespace_search(self):
+        """A private name goes to the host rather than the namespace search."""
+        inst = GetattrParent()
+        assert inst._private == "host"
+
+    def test_underscore_namespace_does_not_shadow_host(self):
+        """A namespace named with a leading underscore is never reached."""
+
+        class _Shadow(ParentClassNamespace):
+            name = "_private"
+
+        inst = GetattrParent()
+        assert inst._private == "host"
+        assert _Shadow.name in ParentClass.get_registered_namespaces()
+
+    def test_default_message_survives_host_getattr(self):
+        """A name neither knows still raises this class's message."""
+        inst = GetattrParent()
+        with pytest.raises(AttributeError, match="has no attribute 'unknown'"):
+            inst.unknown
+
+
+class TestRegisteredHosts:
+    """The namespace bases DASCore ships, and the hosts which own them."""
+
+    hosts: ClassVar[dict] = {
+        dc.Patch: (PatchNameSpace, "dascore.patch_namespace"),
+        dc.Spool: (SpoolNameSpace, "dascore.spool_namespace"),
+        dc.Inventory: (InventoryNameSpace, "dascore.inventory_namespace"),
+        dc.AnnotationSet: (AnnotationNameSpace, "dascore.annotation_namespace"),
+    }
+
+    @pytest.mark.parametrize("host", list(hosts))
+    def test_group_matches_base(self, host):
+        """Each host names the group its namespace base registers into."""
+        base, group = self.hosts[host]
+        assert host._namespace_entry_point_group == group
+        assert base.entry_point_group == group
+
+    @pytest.mark.parametrize("host", list(hosts))
+    def test_registry_file_stem(self, host):
+        """Each group's plugin registry file is the one the docs name."""
+        _, group = self.hosts[host]
+        stem = group.split(".")[-1].replace("_namespace", "")
+        assert (ns_module._PLUGIN_REGISTRY_DIR / f"{stem}.csv").exists()
 
 
 class TestPluginRegistry:


### PR DESCRIPTION
## Description

`Patch` and `Spool` let an external package attach methods through an entry point: define a subclass of `PatchNameSpace`/`SpoolNameSpace`, register it under `dascore.patch_namespace`, and users reach it as `patch.my_ext.some_method()`. `Inventory` and `AnnotationSet` are now first-class DASCore objects with the same need and no way to do it.

This makes both of them namespace hosts. The machinery in `dascore/utils/namespace.py` was already host-agnostic, so each new host is a base class, an entry point group and a plugin registry file:

| Host | Base class | Entry point group | Registry file |
|---|---|---|---|
| `Patch` | `PatchNameSpace` | `dascore.patch_namespace` | `patch.csv` |
| `Spool` | `SpoolNameSpace` | `dascore.spool_namespace` | `spool.csv` |
| `Inventory` | `InventoryNameSpace` | `dascore.inventory_namespace` | `inventory.csv` |
| `AnnotationSet` | `AnnotationNameSpace` | `dascore.annotation_namespace` | `annotation.csv` |

Their io methods move onto an `io` namespace so all four objects group io the same way, matching `patch.io.write`. `Inventory.from_yaml` stays a classmethod: reading is `dc.inventory`'s job, as `dc.spool` is for a patch, and a namespace passes the host instance rather than the class.

Three things fell out of the work:

**`NamespaceOwner.__getattr__` had to compose rather than take over.** `Inventory` is a pydantic model, and pydantic resolves private attributes in its own `__getattr__`. With the mixin winning the MRO, every private read died -- `inventory._cache` is the test that pins it. A private name now skips the namespace search entirely, and a public name no namespace claims falls through to the next `__getattr__` in the MRO before this class's message.

**Namespace wrappers are built per access rather than kept on the host.** A wrapper memoized in `__dict__` rides into a copy of the host still bound to the object it was built for: after touching `inventory.io`, `inventory.model_copy(update={"schema_version": 7}).io.to_yaml()` serialized the original. Rebuilding costs ~0.6 us against a namespace call which costs tens of microseconds, so the memo -- and the lock which guarded it -- are gone.

**A namespace name is checked when it registers.** A private one could never be handed out, since a host resolves its own private names first; a non-identifier is what the docs already claimed was refused. Both now raise where the class is defined instead of registering something unreachable.

`get_plugin_table` also gains a `host` column and dedupes on `(host, namespace)`. With four hosts a bare namespace name no longer says what it extends, and `derzug` registers `zug` on two of them.

## Changelog

- added: `Inventory` and `AnnotationSet` host method namespaces, registered through the `dascore.inventory_namespace` and `dascore.annotation_namespace` entry point groups.
- changed **breaking**: `Inventory.to_yaml` is now `Inventory.io.to_yaml`.
- changed **breaking**: `AnnotationSet.to_dataframe`, `to_vertices`, `to_csv` and `save` are now reached through `AnnotationSet.io`.
- changed **breaking**: a namespace `name` which is private or not a Python identifier now raises where the namespace class is defined.
- changed: a namespace is built each time it is accessed, so one reached through a copy of its host is bound to that copy.
- changed: the supported plugins table names the host each namespace attaches to.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `.io` interfaces for Inventory and AnnotationSet serialization and conversion.
  - Added host-specific namespaces and extensible plugins for inventories and annotations.
  - Namespace access now works consistently with copied objects and local extensions.
- **Breaking Changes**
  - Use `inventory.io.to_yaml()` and `annotations.io` methods instead of direct serialization methods.
- **Documentation**
  - Updated tutorials, recipes, extension guidance, and supported-plugin listings.
- **Improvements**
  - Plugin listings now show host objects and clarify duplicate registrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->