### PR TITLE
Require pyyaml, since an inventory is authored as YAML

### DIFF
--- a/dascore/core/annotation_loader.py
+++ b/dascore/core/annotation_loader.py
@@ -40,6 +40,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+import yaml
 from pydantic import ValidationError
 
 from dascore.core.annotations import (
@@ -60,7 +61,7 @@ from dascore.core.annotations import (
 )
 from dascore.exceptions import InvalidAnnotationError, ParameterError
 from dascore.models.registry import TAG_FIELD
-from dascore.utils.misc import iterate, optional_import
+from dascore.utils.misc import iterate
 from dascore.utils.paths import quote_path
 from dascore.utils.tables import (
     parse_cell,
@@ -119,7 +120,6 @@ def _read_object(path: Path) -> dict[str, Any]:
             msg = f"Could not parse JSON from {quote_path(path)}: {error}."
             raise ParameterError(msg) from error
     else:
-        yaml = optional_import("yaml", required_for="YAML annotation storage")
         try:
             data = yaml.safe_load(text)
         except yaml.YAMLError as error:

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -34,6 +34,7 @@ from typing import (
 from uuid import uuid4
 
 import numpy as np
+import yaml
 from pydantic import (
     AfterValidator,
     BeforeValidator,
@@ -64,7 +65,6 @@ from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import (
     check_code,
     is_strictly_monotonic,
-    optional_import,
     validate_acquisition_key,
 )
 from dascore.utils.namespace import NamespaceOwner
@@ -2501,7 +2501,6 @@ class Inventory(NamespaceOwner, InventoryModel):
                 "Load a path with dascore.inventory."
             )
             raise InvalidInventoryError(msg)
-        yaml = optional_import("yaml", required_for="YAML inventory parsing")
         try:
             data = yaml.safe_load(text)
         except yaml.YAMLError as error:
@@ -2554,13 +2553,10 @@ def inventory_to_yaml(inventory: Inventory, path: str | Path | None = None) -> s
     --------
     >>> import dascore as dc
     >>> _, inventory = dc.examples.inventory_patch_pair()
-    >>> # Writing YAML needs pyyaml, which is not a core dependency.
-    >>> text = inventory.io.to_yaml()  # doctest: +SKIP
-    >>> dc.inventory(text) == inventory  # doctest: +SKIP
+    >>> text = inventory.io.to_yaml()
+    >>> dc.inventory(text) == inventory
     True
     """
-    yaml = optional_import("yaml", required_for="YAML inventory serialization")
-
     # Everything defaulted is dropped, so the document records which
     # envelope it was written against even when that is the default.
     dumped = inventory.model_dump(mode="json", exclude_defaults=True)

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 import pandas as pd
+import yaml
 
 from dascore.core.inventory import (
     Acquisition,
@@ -65,7 +66,7 @@ from dascore.exceptions import (
 )
 from dascore.models import InventoryModel, TimeRangedModel
 from dascore.models.registry import TAG_FIELD
-from dascore.utils.misc import check_code, optional_import
+from dascore.utils.misc import check_code
 from dascore.utils.paths import quote_path as _quote
 from dascore.utils.tables import (
     ordered_rows,
@@ -221,7 +222,6 @@ def _read_object(path: Path) -> dict[str, Any]:
             msg = f"Could not parse JSON from {_quote(path)}: {error}."
             raise InvalidInventoryError(msg) from error
     else:
-        yaml = optional_import("yaml", required_for="YAML inventory serialization")
         try:
             data = yaml.safe_load(text)
         except yaml.YAMLError as error:

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -59,11 +59,7 @@ from dascore.core.inventory import (
     _overlapping_epochs,
     _times_equal,
 )
-from dascore.exceptions import (
-    InvalidInventoryError,
-    MissingOptionalDependencyError,
-    ParameterError,
-)
+from dascore.exceptions import InvalidInventoryError, ParameterError
 from dascore.models import InventoryModel, TimeRangedModel
 from dascore.models.registry import TAG_FIELD
 from dascore.utils.misc import check_code
@@ -245,7 +241,7 @@ def _declared_type(path: Path) -> str | None:
     """
     try:
         data = _read_object(path)
-    except (InvalidInventoryError, MissingOptionalDependencyError):
+    except InvalidInventoryError:
         return None
     declared = data.get(TAG_FIELD)
     return declared if isinstance(declared, str) else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dependencies = [
      "pandas>=2.0",
      "pooch>=1.3",  # retry_if_failed was added in 1.3
      "pydantic>2.1",
+     # An inventory is authored as YAML, so reading one is not optional.
+     "pyyaml",
      "rich",
       "typing_extensions>=4.12",
      "universal-pathlib",
@@ -91,8 +93,6 @@ docs = [
     "jupyter-client",
     "nbclient",
     "nbformat",
-    # quarto's own notebook driver does `from yaml import safe_load`.
-    "pyyaml",
     # The JupyterLite site the tutorial pages link to. jupyter-server is not
     # used at runtime, but jupyterlite-core requires it to add custom content.
     "jupyterlite-core",

--- a/tests/test_core/test_annotation_loader.py
+++ b/tests/test_core/test_annotation_loader.py
@@ -9,11 +9,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
-
-try:
-    import yaml
-except ImportError:
-    yaml = None
+import yaml
 
 try:
     import pyarrow
@@ -326,7 +322,6 @@ class TestSavingOverASet:
         assert not (directory / "vertices.csv").exists()
         assert dc.annotations(directory) == regions
 
-    @pytest.mark.skipif(yaml is None, reason="pyyaml is not installed")
     def test_a_hand_authored_yaml_is_superseded(self, tmp_path):
         """Saving a set read from YAML does not leave two attrs files."""
         directory = tmp_path / "picks"
@@ -494,7 +489,6 @@ class TestDeclaringDimensions:
 class TestTheAttrsFile:
     """What a set directory says about itself."""
 
-    @pytest.mark.skipif(yaml is None, reason="pyyaml is not installed")
     def test_yaml_spelling(self, regions, tmp_path):
         """One data model stands behind both spellings; a set may be authored
         in the more readable one.
@@ -528,7 +522,6 @@ class TestTheAttrsFile:
         with pytest.raises(InvalidAnnotationError, match="no mapping"):
             dc.annotations(directory)
 
-    @pytest.mark.skipif(yaml is None, reason="pyyaml is not installed")
     def test_which_does_not_parse(self, regions, tmp_path):
         """Unparseable YAML names the file rather than the parser."""
         directory = regions.io.save(tmp_path / "picks")

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import yaml
 from pydantic import ValidationError
 
 import dascore as dc
@@ -1045,7 +1046,6 @@ class TestInventory:
 
     def test_yaml_roundtrip(self, tmp_path):
         """Yaml roundtrip."""
-        pytest.importorskip("yaml")
         inventory = build_inventory()
         path = tmp_path / "inventory.yaml"
         inventory.io.to_yaml(path)
@@ -1077,7 +1077,6 @@ class TestInventory:
 
     def test_dc_namespace(self, tmp_path):
         """Dc namespace."""
-        pytest.importorskip("yaml")
         assert isinstance(dc.inventory(), inv.Inventory)
         path = tmp_path / "inv.yaml"
         build_inventory().io.to_yaml(path)
@@ -1284,7 +1283,6 @@ class TestResourcePool:
 
     def test_yaml_roundtrip_stays_flat(self, tmp_path):
         """Serialized form holds ids, not inline copies, and round-trips."""
-        pytest.importorskip("yaml")
         cable = inv.Cable(resource_id="cable-01", name="c")
         seg = inv.FiberSegment(optical_length=100.0, container=cable)
         inventory = self._inventory_with(seg)
@@ -1369,7 +1367,6 @@ class TestInternalReviewRegressions:
 
     def test_keyless_dict_resource_adopts_key(self):
         """A dict resource without resource_id adopts its pool key."""
-        pytest.importorskip("yaml")
         inventory = inv.Inventory(
             resources={"cab-1": {"object_type": "Cable", "name": "mycable"}}
         )
@@ -1599,7 +1596,6 @@ class TestCoverageCompleteness:
 
     def test_from_yaml_non_mapping_raises(self):
         """From yaml non mapping raises."""
-        pytest.importorskip("yaml")
         with pytest.raises(InvalidInventoryError, match="mapping"):
             inv.Inventory.from_yaml("- 1\n- 2\n")
 
@@ -1665,7 +1661,6 @@ class TestUniformAttachments:
 
     def test_yaml_omits_empty_fields(self):
         """Empty strings, dicts, and tuples do not serialize."""
-        pytest.importorskip("yaml")
         inventory = build_inventory()
         text = inventory.io.to_yaml()
         assert "description:" not in text
@@ -1675,7 +1670,6 @@ class TestUniformAttachments:
 
     def test_extra_fields_contents_survive(self):
         """User values inside extra_fields are kept verbatim, even empty."""
-        pytest.importorskip("yaml")
         acq = inv.Acquisition(code="RAW", extra_fields={"vendor_flag": ""})
         array = inv.FiberArray(code="L001", acquisitions=(acq,))
         inventory = inv.Inventory(
@@ -1768,7 +1762,6 @@ class TestImmutability:
 
     def test_hash_survives_a_yaml_round_trip(self):
         """Serializing and reloading does not move an inventory's hash."""
-        pytest.importorskip("yaml")
         inventory = self._stocked_inventory()
         loaded = inv.Inventory.from_yaml(inventory.io.to_yaml())
         assert loaded == inventory
@@ -2461,13 +2454,11 @@ class TestSerializationIsLossless:
     @pytest.mark.parametrize("name", sorted(SAMPLE_INVENTORIES))
     def test_round_trip_equals(self, name):
         """Whatever was written comes back, in text and through a file."""
-        pytest.importorskip("yaml")
         inventory = SAMPLE_INVENTORIES[name]
         assert dc.inventory(inventory.io.to_yaml()) == inventory
 
     def test_a_label_value_of_one_survives(self):
         """`1 == True`, and the value's default is True, so it was dropped."""
-        pytest.importorskip("yaml")
         path = inv.OpticalPath(
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
@@ -2507,7 +2498,6 @@ class TestSerializationIsLossless:
 
     def test_a_flag_label_stays_terse(self):
         """A value which really is the default is still left out."""
-        pytest.importorskip("yaml")
         path = inv.OpticalPath(
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
@@ -2526,7 +2516,6 @@ class TestSerializationIsLossless:
 
     def test_round_trip_through_file(self, tmp_path):
         """The writer taking a path writes what the text form holds."""
-        pytest.importorskip("yaml")
         inventory = build_full_inventory()
         path = tmp_path / "inventory.yaml"
         inventory.io.to_yaml(path)
@@ -2534,14 +2523,12 @@ class TestSerializationIsLossless:
 
     def test_blank_crs_fields_survive(self):
         """A frame described by WKT alone must not reload as EPSG:4979."""
-        pytest.importorskip("yaml")
         inventory = SAMPLE_INVENTORIES["blank_crs"]
         crs = dc.inventory(inventory.io.to_yaml()).coordinate_reference_system
         assert (crs.authority, crs.code, crs.name) == ("", "", "")
 
     def test_blank_instrument_type_survives(self):
         """A blanked field with a non-empty default is not a missing one."""
-        pytest.importorskip("yaml")
         inventory = SAMPLE_INVENTORIES["blank_resources"]
         loaded = dc.inventory(inventory.io.to_yaml())
         assert loaded.resources["int-1"].instrument_type == ""
@@ -2552,7 +2539,6 @@ class TestSerializationIsLossless:
         Sweeping the model tree, rather than listing the fields at risk,
         is what catches the next field added with a non-empty default.
         """
-        pytest.importorskip("yaml")
         inventory = build_full_inventory()
         checked = set()
         for model in _walk_models(inventory):
@@ -2577,7 +2563,6 @@ class TestSerializationIsLossless:
 
     def test_defaulted_fields_are_dropped(self):
         """A field still holding its default is left out of the document."""
-        yaml = pytest.importorskip("yaml")
         data = yaml.safe_load(build_inventory().io.to_yaml())
         assert not _empty_keys(data)
         assert "description" not in yaml.safe_dump(data)
@@ -2588,7 +2573,6 @@ class TestSerializationIsLossless:
         Every other defaulted field is dropped, so this is what says which
         envelope a document was written against.
         """
-        yaml = pytest.importorskip("yaml")
         default = inv.Inventory().schema_version
         data = yaml.safe_load(build_inventory().io.to_yaml())
         assert data["schema_version"] == default
@@ -2614,7 +2598,6 @@ class TestLoadingValidates:
 
     def test_invalid_document_raises_on_load(self):
         """A document violating a whole-tree rule fails at its source."""
-        pytest.importorskip("yaml")
         station = inv.Station(code="VA01", coordinates=(1.0, 2.0))
         inventory = inv.Inventory(
             networks=(inv.Network(code="XX", stations=(station,)),)
@@ -2894,13 +2877,11 @@ class TestInventoryNamespaces:
 
     def test_io_namespace(self):
         """The io namespace DASCore registers is reachable."""
-        pytest.importorskip("yaml")
         inventory = build_inventory()
         assert inventory.io.to_yaml() == inv.inventory_to_yaml(inventory)
 
     def test_copy_gets_its_own_binding(self):
         """A copied inventory hands out a namespace bound to the copy."""
-        pytest.importorskip("yaml")
         inventory = build_inventory()
         inventory.io  # a namespace kept on the host would ride along
         other = inventory.model_copy(update={"schema_version": 7})
@@ -2938,7 +2919,6 @@ class TestInventoryNamespaces:
 
     def test_cached_namespace_is_not_state(self):
         """An attached namespace changes neither equality nor a dump."""
-        pytest.importorskip("yaml")
         inventory = build_inventory()
         other = inv.Inventory(**inventory.model_dump())
         inventory.io.to_yaml()

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -15,15 +15,9 @@ from pydantic import ValidationError
 import dascore as dc
 from dascore.core import inventory as inv
 from dascore.core import inventory_loader as loader
-from dascore.exceptions import (
-    InvalidInventoryError,
-    MissingOptionalDependencyError,
-)
+from dascore.exceptions import InvalidInventoryError
 from dascore.models import InventoryModel, TimeRangedModel
 from dascore.models.registry import TAG_FIELD
-
-pytest.importorskip("yaml")
-
 
 # A minimal directory which loads: one acquisition names everything above it.
 PATH_DIRECTORY = {
@@ -598,18 +592,12 @@ class TestOverlookedInput:
         )
         assert not dc.inventory(root).networks
 
-    def test_json_inventory_without_pyyaml(self, tmp_path, monkeypatch):
+    def test_json_inventory_beside_unrelated_yaml(self, tmp_path):
         """A JSON inventory loads past whatever YAML lies beside it.
 
-        PyYAML is optional, and the tests which need it skip without it, so
-        this pins the JSON-only path here rather than leaving it to a
-        minimal install nothing in this file would exercise.
+        The stray file is read, since deciding it declares no object is
+        what reading it is for, and it is then stepped over.
         """
-
-        def no_yaml(name, **kwargs):
-            raise MissingOptionalDependencyError(f"no {name}")
-
-        monkeypatch.setattr(loader, "optional_import", no_yaml)
         root = write_inventory(
             tmp_path / "json_only",
             {
@@ -2296,19 +2284,18 @@ class TestFindInventory:
 class TestLoadSerializedFile:
     """A whole inventory read from one document, not a directory."""
 
-    def test_json_needs_no_yaml(self, tmp_path, monkeypatch):
+    def test_json_is_not_yamls_to_read(self, tmp_path, monkeypatch):
         """The suffix picks the parser, so JSON is not YAML's to read."""
         path = tmp_path / "whole.json"
         path.write_text('{"description": "a JSON inventory"}')
 
-        def _refuse(name, **kwargs):
-            raise MissingOptionalDependencyError(name)
+        def refuse(*args, **kwargs):
+            raise AssertionError("the JSON route parsed YAML")
 
-        # Both bindings, because JSON is legal YAML: a fallback to the
-        # YAML route would parse this file and pass a test which only
-        # watched the loader's own import.
-        monkeypatch.setattr(loader, "optional_import", _refuse)
-        monkeypatch.setattr(inv, "optional_import", _refuse)
+        # JSON is legal YAML, so a fallback to the YAML route would parse
+        # this file and pass a test which only checked the result.
+        monkeypatch.setattr(loader.yaml, "safe_load", refuse)
+        monkeypatch.setattr(inv.yaml, "safe_load", refuse)
         assert dc.inventory(path).description == "a JSON inventory"
 
     def test_a_document_which_does_not_parse(self, tmp_path):


### PR DESCRIPTION
## Description

An inventory's authoring format is a directory of YAML files, and [the tunnel recipe](https://dascore.org/recipes/tunnel_inventory.html) teaches writing one. Reading it back went through `optional_import`, so the format the library documents as its primary one could not be read by a default install. The free-threaded CI job, which installs only `pip install -e .`, is where that surfaces.

`pyyaml` is small and pure python, so it moves to the core dependencies and the YAML paths import it directly. Everything that existed to cope with its absence goes:

- four `optional_import("yaml", ...)` call sites in `inventory.py`, `inventory_loader.py` and `annotation_loader.py`;
- twenty-six `pytest.importorskip("yaml")` guards and three `skipif` markers;
- a `to_yaml` doctest carrying `# doctest: +SKIP` because the dependency might be missing — it now runs.

It also leaves the `docs` extra, which named it separately for quarto's notebook driver; that comes in with the package now.

Net effect is 44 fewer lines and one fewer way for a supported install to be unable to read the documented format.

### Two tests were written around the absence rather than the behaviour

`test_json_inventory_without_pyyaml` asserted that a JSON inventory loads with a stray YAML file beside it. It kept its subject but dropped the monkeypatch, because the premise was wrong: the loader **does** read that file — deciding it declares no object is what `_refuse_stray_objects` reads it for — and the test only passed because a missing parser made stray files unreadable and therefore ignored. Written as "the JSON route never parses YAML" it fails against the real loader.

`test_json_needs_no_yaml` asserted that a whole JSON document is not YAML's to read. Rather than watching an import, it now makes `yaml.safe_load` itself raise, which is the stronger statement: JSON is legal YAML, so a fallback to the YAML route would parse the file and pass a test that only checked the result.

## Changelog

- changed: `pyyaml` is now a required dependency, so an inventory or annotation set authored as YAML can be read by any install.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.