### PR TITLE
Give every patch function an operation which says the same call

### DIFF
--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from typing import Any, Literal, Protocol, cast, overload
+from typing import Literal, Protocol, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -28,7 +28,6 @@ from dascore.exceptions import (
     CoordError,
     IncompatiblePatchError,
     ParameterError,
-    PatchAttributeError,
     PatchCoordinateError,
 )
 from dascore.units import convert_units, get_quantity, is_percent
@@ -57,8 +56,8 @@ from dascore.utils.misc import (
 )
 from dascore.utils.paths import is_memory_uri
 from dascore.utils.time import to_float
-
-attr_type = dict[str, Any] | str | Sequence[str] | None
+from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
+from dascore.workflow.processor import PatchOp, register_patch_function
 
 _DimAxisValue = namedtuple("_DimAxisValue", ["dim", "axis", "value"])
 
@@ -157,78 +156,28 @@ def _maybe_add_history_str(attrs, hist_str):
     return attrs.update(history=new_history)
 
 
-def check_patch_coords(
-    patch: PatchType,
-    dims: Sequence[str] | None = None,
-    coords: Sequence[str] | None = None,
-):
-    """
-    Check if a patch object has required coordinates, else raise PatchDimError.
-
-    Parameters
-    ----------
-    patch
-        The input patch
-    dims
-        A tuple of required dimension names.
-    coords
-        A tuple of required coordinate names.
-    """
-    missing = set()
-    if dims is not None:
-        dim_set = set(patch.dims)
-        missing |= set(dims) - dim_set
-    if coords is not None:
-        coord_set = set(patch.coords.coord_map)
-        missing |= set(coords) - coord_set
-    if missing:
-        msg = f"patch is missing required coordinates: {tuple(missing)}"
-        raise PatchCoordinateError(msg)
-    return patch
-
-
-def check_patch_attrs(patch: PatchType, required_attrs: attr_type) -> PatchType:
-    """
-    Check for expected attributes.
-
-    Parameters
-    ----------
-    patch
-        The patch to validate
-    required_attrs
-        The expected attrs. Can be a sequence or mapping. If sequence, only
-        check that attrs exist. If mapping also check that values are equal.
-    """
-    if required_attrs is None:
-        return patch
-    # test that patch attr mapping is equal
-    patch_attrs = patch.attrs
-    if isinstance(required_attrs, Mapping):
-        sub = {i: patch_attrs[i] for i in required_attrs}
-        if sub != dict(required_attrs):
-            msg = f"Patch's attrs {sub} are not required attrs: {required_attrs}"
-            raise PatchAttributeError(msg)
-    else:
-        missing = set(required_attrs) - set(dict(patch.attrs))
-        if missing:
-            msg = f"Patch is missing the following attributes: {missing}"
-            raise PatchAttributeError(msg)
-    return patch
-
-
 class _PatchFunction(Protocol):
     """
     A function wrapped by `patch_function`.
 
-    The decorator attaches references back to the function it wrapped so
-    callers can skip the patch-function machinery when calling it again.
+    The decorator attaches references back to the function it wrapped, so
+    callers can skip the patch-function machinery when calling it again. It
+    also attaches `op`, which builds the operation this function is, and
+    `__version__`, which that operation is declared at.
     """
 
     func: Callable
     raw_function: Callable
+    op: Callable
+    __version__: str
     __wrapped__: Callable
 
     def __call__(self, patch, *args, **kwargs): ...
+
+
+def _op_from_call(patch_func, *args, **kwargs):
+    """Return the operation a call to a patch function is."""
+    return PatchOp.from_call(patch_func, args, kwargs)
 
 
 def _to_numpy_arg(obj):
@@ -277,12 +226,13 @@ def numpy_fallback(name, data, func, args=(), kwargs=None, stacklevel=4):
 
 
 def patch_function(
-    required_dims: tuple[str, ...] | Callable | None = None,
-    required_coords: tuple[str, ...] | None = None,
+    required_dims: str | Sequence[str] | Callable | None = None,
+    required_coords: str | Sequence[str] | None = None,
     required_attrs: attr_type = None,
     history: Literal["full", "method_name", None] = "full",
     validate_call: bool = False,
     data_type: str | None = None,
+    version: str = "1.0",
 ):
     """
     Decorator to mark a function as a patch method.
@@ -290,12 +240,14 @@ def patch_function(
     Parameters
     ----------
     required_dims
-        A tuple of dimensions which must be found in the Patch.
+        A dimension name, or a sequence of them, which must be found in the
+        Patch.
     required_coords
-        A tuple of coordinates which must be found in the Patch.
+        A coordinate name, or a sequence of them, which must be found in the
+        Patch.
     required_attrs
-        A dict of attributes which must be found in the Patch and whose
-        values must be equal to those provided.
+        An attr name, a sequence of them, or a mapping of names to the values
+        the Patch must hold for them.
     history
         Specifies how to track history on Patch.
             Full - Records function name and str version of input arguments.
@@ -309,6 +261,10 @@ def patch_function(
         Controls the output patch's ``data_type`` attr. If None, leave the
         returned patch's ``data_type`` unchanged. Otherwise, set to specified
         value. Use an empty string ("") to clear.
+    version
+        The version of the operation. Bump it when the same arguments should
+        mean a different answer, so that fingerprints recorded against the
+        old behaviour do not name the new one.
 
     Examples
     --------
@@ -355,6 +311,14 @@ def patch_function(
     ... def do_portable_thing(patch):
     ...     xp = array_namespace(patch.data)
     ...     return patch.new(data=xp.abs(patch.data))
+    >>>
+    >>> # 7. Every patch function builds the operation it is with `.op`:
+    >>> # the same call said as a task, which can be compared,
+    >>> # fingerprinted, written to a file and joined into a pipe.
+    >>> patch = dc.get_example_patch()
+    >>> op = dc.proc.normalize.op(dim="time")
+    >>> assert op(patch).equals(patch.normalize(dim="time"))
+    >>> assert op == dc.proc.normalize.op(dim="time")
 
     Notes
     -----
@@ -362,13 +326,20 @@ def patch_function(
       attribute. This may be useful for avoiding calling the patch_func
       machinery multiple times from within another patch function.
 
+    - The decorated function also carries ``op``, which builds the
+      [PatchOp](`dascore.workflow.processor.PatchOp`) a call to it is:
+      ``dc.proc.normalize.op(dim="time")``. The call is bound against the
+      signature, so a positional and a keyword spelling of one call are one
+      operation with one fingerprint.
+
     - If using `PatchType` or `SpoolType` type variables from the
       [constants module](`dascore.constants`), make sure dascore is imported
       as dc at the top of the file where the patch function is defined so
       the forward refs can be resolved properly for type checking.
     """
     # Handled before the wrapper is built so the rest of this function sees
-    # required_dims as the tuple of dimension names it is everywhere else.
+    # required_dims as the dimension names it is everywhere else, not as the
+    # decorated function.
     if callable(required_dims):  # the decorator is used without parens
         return patch_function()(required_dims)
 
@@ -408,7 +379,15 @@ def patch_function(
         # matches pydantic naming.
         patch_func.raw_function = getattr(func, "raw_function", func)
         patch_func.__wrapped__ = func
-
+        patch_func.__version__ = version
+        # Registered as it is decorated, so a function is nameable in a
+        # document exactly when its module has been imported. A function
+        # defined inside a call takes no tag; `op` says so if it is asked.
+        register_patch_function(patch_func)
+        # `op` builds the operation a call to this function is. A partial
+        # rather than a lambda so it pickles, and so the wrapper carries no
+        # closure of its own.
+        patch_func.op = functools.partial(_op_from_call, patch_func)
         return patch_func
 
     return _wrapper

--- a/dascore/workflow/__init__.py
+++ b/dascore/workflow/__init__.py
@@ -19,5 +19,12 @@ from dascore.workflow.serialize import (
     encode,
 )
 from dascore.workflow.pipe import Pipe
+from dascore.workflow.processor import (
+    PatchOp,
+    PatchProcessor,
+    fingerprint_call,
+    register_implementation,
+    resolve_patch_function,
+)
 from dascore.workflow.provenance import Provenance, ProvenanceNode, SourceInfo
 from dascore.workflow.task import Task, intern, make_function_task_class, task

--- a/dascore/workflow/checks.py
+++ b/dascore/workflow/checks.py
@@ -1,0 +1,101 @@
+"""
+What an operation requires of a patch before it runs.
+
+A patch function, and a `PatchProcessor` written by hand for one, may say
+which dimensions, coordinates and attributes it needs. Both ask here, so the
+answer is the same however the operation was reached.
+
+These live outside `dascore.utils.patch` because `dascore.workflow.processor`
+is imported while `dascore.utils.patch` is still being imported -- from its
+header, by way of this module -- so importing `dascore.utils.patch` back would
+raise on a partially initialized module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from dascore.constants import PatchType
+from dascore.exceptions import PatchAttributeError, PatchCoordinateError
+from dascore.utils.misc import iterate
+
+# What a required-attrs declaration may be: names, or names against values.
+attr_type = dict[str, Any] | str | Sequence[str] | None
+
+
+def check_patch_coords(
+    patch: PatchType,
+    dims: Sequence[str] | None = None,
+    coords: Sequence[str] | None = None,
+) -> PatchType:
+    """
+    Check that a patch has the required coordinates, else raise.
+
+    Parameters
+    ----------
+    patch
+        The input patch
+    dims
+        A dimension name, or a sequence of them.
+    coords
+        A coordinate name, or a sequence of them.
+
+    Raises
+    ------
+    PatchCoordinateError
+        If the patch is missing any of them.
+    """
+    # Each half is skipped when nothing is declared, which is the common
+    # case: building the patch's dim and coord sets is the whole cost here,
+    # and this runs in front of every patch function.
+    # `iterate` rather than the value itself: a single name is spelled as a
+    # string everywhere else in DASCore, and iterating one gives characters.
+    missing = set()
+    if dims:
+        missing |= set(iterate(dims)) - set(patch.dims)
+    if coords:
+        missing |= set(iterate(coords)) - set(patch.coords.coord_map)
+    if missing:
+        msg = f"patch is missing required coordinates: {tuple(missing)}"
+        raise PatchCoordinateError(msg)
+    return patch
+
+
+def check_patch_attrs(patch: PatchType, required_attrs: attr_type) -> PatchType:
+    """
+    Check for expected attributes.
+
+    Parameters
+    ----------
+    patch
+        The patch to validate
+    required_attrs
+        The expected attrs. Can be a name, a sequence of them, or a mapping.
+        If a mapping, also check that the values are equal.
+
+    Raises
+    ------
+    PatchAttributeError
+        If the patch is missing any of them, or holds a different value.
+    """
+    if required_attrs is None:
+        return patch
+    # test that patch attr mapping is equal
+    held = dict(patch.attrs)
+    wanted = (
+        set(required_attrs)
+        if isinstance(required_attrs, Mapping)
+        else set(iterate(required_attrs))
+    )
+    # Asked before any value is read: an attr the patch does not carry is a
+    # missing attr, not a lookup error from the middle of a comprehension.
+    if missing := wanted - set(held):
+        msg = f"Patch is missing the following attributes: {missing}"
+        raise PatchAttributeError(msg)
+    if isinstance(required_attrs, Mapping):
+        sub = {i: held[i] for i in required_attrs}
+        if sub != dict(required_attrs):
+            msg = f"Patch's attrs {sub} are not required attrs: {required_attrs}"
+            raise PatchAttributeError(msg)
+    return patch

--- a/dascore/workflow/pipe.py
+++ b/dascore/workflow/pipe.py
@@ -409,7 +409,7 @@ class Pipe(DascoreBaseModel):
             )
             raise ParameterError(msg)
         written_tasks = document["tasks"]
-        tasks = {node: Task.from_dict(value) for node, value in written_tasks.items()}
+        tasks = {node: _read_task(node, value) for node, value in written_tasks.items()}
         dependencies = {
             node: tuple(value)
             for node, value in document.get("dependencies", {}).items()
@@ -587,6 +587,21 @@ def _merge(
     return renamed
 
 
+def _read_task(node: str, document: dict[str, Any]) -> Task:
+    """
+    Return the task a node's document describes, saying which node it is.
+
+    A task which names something this process does not have says what to
+    import; without the node it is said of, a pipe of thirty leaves the
+    reader to find which one.
+    """
+    try:
+        return Task.from_dict(document)
+    except ParameterError as error:
+        msg = f"The node {node!r} could not be read: {error}"
+        raise ParameterError(msg) from error
+
+
 def default_key(task: Task) -> str:
     """
     Return the name a task takes in a pipe which does not name it.
@@ -595,8 +610,13 @@ def default_key(task: Task) -> str:
     `decimate`. It says what the node is without saying what it was given,
     so changing a parameter leaves every reference to the node -- in
     `update`, in a mermaid diagram, in a provenance record -- where it was.
+
+    A task which stands for more than one operation says which it is with
+    `node_name`; without that every `PatchOp` in a pipe would be called
+    `patch_op`.
     """
-    return _WORD_BREAK.sub("_", type(task).__name__).lower()
+    name = getattr(task, "node_name", None) or type(task).__name__
+    return _WORD_BREAK.sub("_", name).lower()
 
 
 def unique_key(key: str, taken: Container[str]) -> str:

--- a/dascore/workflow/processor.py
+++ b/dascore/workflow/processor.py
@@ -1,0 +1,587 @@
+"""
+A patch operation, as a task.
+
+Any function decorated with `dascore.patch_function` is one operation, and
+[`PatchOp`](`dascore.workflow.processor.PatchOp`) is that operation said as
+an object: the function's name and the arguments it was given, which can be
+compared, fingerprinted, written to a file and joined into a pipe.
+
+One class stands for every patch function, rather than one class each. What
+identifies an operation is its name and its arguments, and a name is a
+string; manufacturing ninety classes to hold ninety strings buys nothing and
+costs a registry tag, an import and a lookup for each.
+
+[`PatchProcessor`](`dascore.workflow.processor.PatchProcessor`) is the base
+for the few operations which are eventually written out by hand, because
+they want a kernel seam. When one exists, `fn.op(...)` returns it instead:
+one name, one implementation.
+
+An operation is named by a registry tag rather than by where a patch keeps
+it, so a function bound to nothing -- one a user has only just written -- is
+nameable too, and a plugin's `normalize` can never be read as DASCore's.
+
+Examples
+--------
+>>> import dascore as dc
+>>>
+>>> patch = dc.get_example_patch()
+>>> op = dc.proc.normalize.op(dim="time")
+>>> assert op(patch).equals(patch.normalize(dim="time"))
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+import warnings
+from contextlib import suppress
+from functools import cached_property
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from dascore.constants import PatchType
+from dascore.exceptions import ParameterError
+from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
+from dascore.workflow.serialize import digest
+from dascore.workflow.task import Task, _resolve_default
+
+# Stands in for the patch while a call is bound to a signature. The bind
+# only needs something to put in that slot; nothing ever looks at it.
+_PATCH = object()
+
+# The names which have a hand-written class, so `fn.op(...)` can return one.
+# Empty here: the first entries arrive with the first plan/kernel split.
+_IMPLEMENTATIONS: dict[str, type[PatchProcessor]] = {}
+
+# Every patch function, by the tag which names it in a document. Filled by
+# `patch_function` as it decorates, so a function is registered exactly when
+# its module is imported.
+_REGISTERED: dict[str, Any] = {}
+
+# Tags two different functions have claimed; see `_report_collision`.
+_AMBIGUOUS: dict[str, tuple[str, str]] = {}
+
+# DASCore's own patch functions are named bare, a plugin's by its package.
+_DASCORE = "dascore"
+_SEPARATOR = ":"
+
+# `[package:]name`, which is what a package name and a python name make.
+_TAG = re.compile(r"^(?:[A-Za-z_][\w.]*:)?[A-Za-z_]\w*$")
+
+# What `dascore/__init__.py` leaves until something asks for it.
+_DEFERRED_MODULES = ("dascore.viz",)
+
+# Set once the install has been swept looking for an unregistered tag.
+_swept = False
+
+
+class PatchProcessor(Task):
+    """
+    A task which runs on a patch, written out by hand.
+
+    Subclasses declare their parameters as fields and say what a patch has
+    to carry for the operation to mean anything. They exist where an
+    operation wants a seam a whole function does not have -- a kernel to
+    dispatch, a plan to reuse -- and are registered with
+    [`register_implementation`](`dascore.workflow.processor.register_implementation`)
+    so that the patch function's name reaches them.
+    """
+
+    # What the patch must hold. Stated on the class rather than passed to
+    # `run`, because it is a property of the operation and not of the call.
+    required_dims: ClassVar[tuple[str, ...] | str | None] = None
+    required_coords: ClassVar[tuple[str, ...] | str | None] = None
+    required_attrs: ClassVar[attr_type] = None
+    # What the result is, when the operation changes it; None leaves it as
+    # it was, and "" clears it.
+    data_type: ClassVar[str | None] = None
+
+    def check(self, patch: PatchType) -> PatchType:
+        """
+        Refuse a patch which does not carry what the operation needs.
+
+        A subclass which declares `required_dims`, `required_coords` or
+        `required_attrs` has to call this from its own `run`; nothing calls
+        it for you yet. The framework `run` which will call it arrives with
+        the first plan/kernel split.
+
+        Parameters
+        ----------
+        patch
+            The patch to check.
+
+        Returns
+        -------
+        The patch, unchanged, so the call can stand in front of the work.
+
+        Raises
+        ------
+        PatchCoordinateError
+            If a required dimension or coordinate is missing.
+        PatchAttributeError
+            If a required attr is missing, or holds a different value.
+        """
+        check_patch_coords(patch, dims=self.required_dims, coords=self.required_coords)
+        return check_patch_attrs(patch, self.required_attrs)
+
+
+class PatchOp(Task):
+    """
+    Any patch function, as a task.
+
+    Parameters
+    ----------
+    name
+        What the operation is called on a patch. A dotted name walks a
+        namespace, so a plugin's function is `"myplugin.denoise"`.
+    kwargs
+        The arguments the operation was given, bound against its signature,
+        so that two spellings of one call are one mapping.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> from dascore.workflow import PatchOp
+    >>>
+    >>> patch = dc.get_example_patch()
+    >>> op = PatchOp(name="pass_filter", kwargs={"time": (10, 100)})
+    >>> assert op(patch).equals(patch.pass_filter(time=(10, 100)))
+    """
+
+    name: str
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+    # The version the *function* is declared at, not this class's. Held as
+    # a field rather than looked up when asked, so a document reproduces
+    # the fingerprint it recorded even after the function has moved on --
+    # and so the class version stays what every other task's document
+    # machinery compares against.
+    version: str = ""
+    # Where the function was defined when this was written down. Carried so
+    # a document naming a function this process does not have can say what
+    # to import. Informational only: it is in the document and not in the
+    # fingerprint, because moving a function between modules does not make
+    # it a different operation.
+    module: str = ""
+
+    def __init__(self, **data):
+        """
+        Build the operation, refusing one no patch could run.
+
+        Checked here rather than in a validator so that the answer is the
+        `ParameterError` the rest of DASCore raises, rather than the
+        `ValidationError` pydantic wraps one in.
+        """
+        name = data.get("name")
+        if isinstance(name, str):
+            # Bound rather than merely resolved: an argument the signature
+            # rejects is a broken operation, and it is worth saying so
+            # where it was written down rather than when a patch finally
+            # reaches it. The result is kept, so an operation written by
+            # hand carries the same defaults `.op(...)` fills in and the
+            # two are one operation with one fingerprint.
+            function = resolve_patch_function(name, data.get("module"))
+            args, kwargs = _as_call(function, data.get("kwargs") or {})
+            data["kwargs"] = _bind(function, args, kwargs)
+            if not data.get("version"):
+                data["version"] = getattr(function, "__version__", "1.0")
+            if not data.get("module"):
+                data["module"] = getattr(function, "__module__", "")
+        super().__init__(**data)
+
+    @property
+    def node_name(self) -> str:
+        """
+        Return the name this operation takes as a node of a pipe.
+
+        The operation, not the class: every `PatchOp` is a `PatchOp`, so
+        naming nodes after the class would call them all `patch_op`.
+        """
+        return self.name.replace(_SEPARATOR, "_")
+
+    @cached_property
+    def fingerprint(self) -> str:
+        """
+        Return the digest which identifies this operation and its arguments.
+
+        The same digest `fingerprint_call` gives for the call it stands for,
+        because both ask the same function for it.
+        """
+        return self.fingerprint_at(self.version)
+
+    def fingerprint_at(self, version: str) -> str:
+        """
+        Return the fingerprint this operation has.
+
+        The version asked for is this *class's*, which every operation
+        shares and none is identified by; the one which identifies an
+        operation is its own field, and travels in the document with it.
+        """
+        return _fingerprint(self.name, self.version, self.kwargs)
+
+    def run(self, patch: PatchType) -> Any:
+        """Run the operation against a patch."""
+        function = resolve_patch_function(self.name, self.module)
+        args, kwargs = _as_call(function, self.kwargs)
+        # The registered function is the wrapper `patch_function` built,
+        # which is the object `Patch.normalize` is and the one a namespace
+        # hands out bound to its host. So this is the call a user would have
+        # made, and the history it records is the same one.
+        return function(patch, *args, **kwargs)
+
+    @classmethod
+    def from_call(cls, func, args: tuple = (), kwargs: dict | None = None) -> Task:
+        """
+        Return the operation a call to a patch function is.
+
+        Parameters
+        ----------
+        func
+            The patch function, as decorated.
+        args
+            The positional arguments of the call, without the patch.
+        kwargs
+            The keyword arguments of the call.
+
+        Returns
+        -------
+        A `PatchOp`, or an instance of the class registered for this name.
+        """
+        name = op_name(func)
+        implementation = _IMPLEMENTATIONS.get(name)
+        bound = _bind(func, args, kwargs or {})
+        if implementation is not None:
+            return implementation(**bound)
+        return cls(name=name, kwargs=bound)
+
+
+def register_implementation(name: str, cls: type[PatchProcessor]) -> None:
+    """
+    Say that a hand-written class is what a patch function's name means.
+
+    One name has one implementation: after this, `fn.op(...)` returns an
+    instance of `cls` rather than a `PatchOp`, so there is a single code
+    path whether the operation was reached by name or by class.
+
+    Parameters
+    ----------
+    name
+        The patch function's name, as a patch answers to it.
+    cls
+        The class which implements it.
+    """
+    if not issubclass(cls, PatchProcessor):
+        msg = (
+            f"{cls.__name__} is not a PatchProcessor, so it cannot implement {name!r}."
+        )
+        raise ParameterError(msg)
+    _IMPLEMENTATIONS[name] = cls
+
+
+def patch_function_tag(func) -> str | None:
+    """
+    Return the tag which names a patch function in a document.
+
+    DASCore's own are bare, a plugin's are namespaced by the package which
+    declares them -- the rule `dascore.models.registry` uses for a model,
+    and for the same reason: it leaves no way to squat a bare name.
+
+    None means the function cannot be named. One defined inside a call is
+    such a case: nothing can resolve a name which exists only while its
+    enclosing call runs, and two of them sharing one is neither a mistake
+    nor resolvable.
+    """
+    # A callable object carries neither, and is nameless for that reason
+    # rather than for being defined inside a call; both take no tag.
+    if "<locals>" in getattr(func, "__qualname__", ""):
+        return None
+    if not (name := getattr(func, "__name__", "")):
+        return None
+    namespace = getattr(func, "__module__", "").split(".", 1)[0]
+    tag = name if namespace == _DASCORE else f"{namespace}{_SEPARATOR}{name}"
+    return tag if _TAG.match(tag) else None
+
+
+def register_patch_function(func) -> str | None:
+    """Add a patch function to the registry under its derived tag."""
+    tag = patch_function_tag(func)
+    if tag is None:
+        return None
+    existing = _REGISTERED.get(tag)
+    # A module re-imported under the same name replaces its own entry.
+    if existing is not None and _spell(existing) != _spell(func):
+        _report_collision(tag, existing, func)
+        return None
+    _REGISTERED[tag] = func
+    return tag
+
+
+def resolve_patch_function(name: str, module: str | None = None):
+    """
+    Return the patch function a tag names, else say what is missing.
+
+    Nothing a document names is imported to answer this: reading a file
+    would otherwise be a way to run whatever it names. The sweep this does
+    reach for imports what the *install* declares -- DASCore's own deferred
+    modules, and the namespaces plugins register through entry points --
+    which is a fixed set, not one a document chooses.
+
+    Parameters
+    ----------
+    name
+        The tag, as `patch_function_tag` spells one.
+    module
+        Where the function was defined when the document was written, if
+        the document says. Used only to say what to import.
+    """
+    if (found := _REGISTERED.get(name)) is not None:
+        return found
+    if name in _AMBIGUOUS:
+        first, second = _AMBIGUOUS[name]
+        msg = (
+            f"The patch function {name!r} names two functions, {first} and "
+            f"{second}, so which one wrote a document cannot be known."
+        )
+        raise ParameterError(msg)
+    _sweep_patch_functions()
+    if (found := _REGISTERED.get(name)) is not None:
+        return found
+    raise ParameterError(_missing(name, module))
+
+
+def _missing(name: str, module: str | None) -> str:
+    """Return the message a tag nothing registers deserves."""
+    package, _, leaf = name.rpartition(_SEPARATOR)
+    if package == "__main__":
+        return (
+            f"No patch function {leaf!r} is registered in this process. It was "
+            "defined in a script or a notebook session, which nothing can "
+            "import; redefine it here and read again."
+        )
+    if not package:
+        return (
+            f"No patch function {leaf!r} is registered in this process, and "
+            "DASCore defines none by that name."
+        )
+    where = f" It was defined in {module} when this was written --" if module else ""
+    return (
+        f"No patch function {leaf!r} from package {package!r} is registered in "
+        f"this process.{where} import that module (or install {package}) and "
+        "read again."
+    )
+
+
+def _spell(func) -> str:
+    """Spell a function the way a collision message needs to."""
+    module = getattr(func, "__module__", "?")
+    return f"{module}.{getattr(func, '__qualname__', '?')}"
+
+
+def _report_collision(tag: str, existing, new) -> None:
+    """Complain that two different functions want one tag."""
+    msg = (
+        f"Two patch functions claim the tag {tag!r}: {_spell(existing)} and "
+        f"{_spell(new)}. A tag must name one function; rename one of them."
+    )
+    # DASCore's own names are its own to keep unique, and a test pins it.
+    if _SEPARATOR not in tag:
+        raise ParameterError(msg)
+    # Out of tree the collision may be between two packages a user merely
+    # installed, which they cannot fix by renaming, so importing them both
+    # still works. What the tag may not do is quietly resolve to one of
+    # them: a file written by the first would then be read as the second.
+    _AMBIGUOUS[tag] = (_spell(existing), _spell(new))
+    _REGISTERED.pop(tag, None)
+    warnings.warn(f"{msg} Documents naming it can no longer be read.", UserWarning)
+
+
+def _sweep_patch_functions() -> None:
+    """
+    Import what the install says defines patch functions.
+
+    `dascore/__init__.py` leaves `dascore.viz` until something asks for it,
+    and a plugin's namespace is imported when a patch is first asked for
+    one -- and reading a document never asks a patch for anything. Both are
+    declared by the install, so importing them is not the arbitrary import
+    `resolve_patch_function` refuses.
+    """
+    global _swept
+    if _swept:
+        return
+    # Imported here rather than at module scope: this module is imported
+    # while `dascore.utils.patch` is still being imported, by way of the
+    # checks it re-exports, and `dascore` is not built yet at that point.
+    import importlib  # noqa: PLC0415
+
+    from dascore.utils.namespace import _MethodNameSpace  # noqa: PLC0415
+    from dascore.utils.plugins import get_entry_point_loaders  # noqa: PLC0415
+
+    for name in _DEFERRED_MODULES:
+        with suppress(ImportError):
+            importlib.import_module(name)
+    groups: set[str] = set()
+    for kind in _MethodNameSpace.__subclasses__():
+        group = getattr(kind, "entry_point_group", None)
+        if isinstance(group, str) and group:
+            groups.add(group)
+    for group in sorted(groups):
+        for loader in get_entry_point_loaders(group).values():
+            # A plugin which will not import defines nothing to find, and
+            # one unresolved tag is not the place to announce a bad install.
+            with suppress(Exception):
+                loader()
+    _swept = True
+
+
+def op_name(func) -> str:
+    """
+    Return the tag which names a patch function, else raise.
+
+    A function which cannot be named has no operation: an operation is
+    written down by name, and a name nothing can resolve is not one.
+    """
+    if (tag := patch_function_tag(func)) is None:
+        msg = (
+            f"{_spell(func)} cannot be named in a document, so it has no "
+            "operation. A patch function defined inside a call is such a "
+            "case; define it at the top level of a module instead."
+        )
+        raise ParameterError(msg)
+    return tag
+
+
+def fingerprint_call(func, args: tuple = (), kwargs: dict | None = None) -> str:
+    """
+    Return the digest which identifies one call to a patch function.
+
+    The same digest the [`PatchOp`](`dascore.workflow.processor.PatchOp`)
+    for that call carries, so a call made as a method and the same call made
+    as a task are one operation.
+
+    Parameters
+    ----------
+    func
+        The patch function, as decorated.
+    args
+        The positional arguments of the call, without the patch.
+    kwargs
+        The keyword arguments of the call.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> from dascore.workflow import fingerprint_call
+    >>>
+    >>> called = fingerprint_call(dc.proc.normalize, (), {"dim": "time"})
+    >>> assert called == dc.proc.normalize.op(dim="time").fingerprint
+    """
+    name = op_name(func)
+    version = getattr(func, "__version__", "1.0")
+    return _fingerprint(name, version, _bind(func, args, kwargs or {}))
+
+
+def _fingerprint(name: str, version: str, kwargs: dict) -> str:
+    """Return the digest a name, a version and bound arguments make."""
+    # Spelled the way `Task.fingerprint_at` spells one, so a pipe holding a
+    # PatchOp hashes the same whichever built it.
+    return digest(
+        {"task": "dascore:PatchOp", "version": version, "params": {name: kwargs}}
+    )
+
+
+def _signature(func) -> inspect.Signature:
+    """Return the signature of the function inside a patch function."""
+    return inspect.signature(getattr(func, "raw_function", func))
+
+
+def _canonical(value):
+    """
+    Return a value in the one shape a document can give back.
+
+    A document holds a sequence as a list, whichever it was written from,
+    so a call which is not canonicalized here reads back as a different
+    call: its history string says `[10, 100]` where it said `(10, 100)`,
+    and `make_broadcastable_to`, whose shape ends up in a set, stops
+    working entirely.
+    """
+    if isinstance(value, (list, tuple)):
+        return tuple(_canonical(x) for x in value)
+    return value
+
+
+def _check(func, args: tuple, kwargs: dict) -> None:
+    """Refuse a call the function's signature does not accept."""
+    try:
+        _signature(func).bind(_PATCH, *args, **kwargs)
+    except TypeError as error:
+        msg = f"{op_name(func)} cannot be called that way: {error}"
+        raise ParameterError(msg) from error
+
+
+def _bind(func, args: tuple, kwargs: dict) -> dict:
+    """
+    Return the arguments of a call as the one mapping they mean.
+
+    Positional and keyword spellings of one call bind alike, defaults are
+    filled in, the patch is dropped, and a `**kwargs` group is spread back
+    out so that a dimension given as an extra reads as itself.
+    """
+    signature = _signature(func)
+    _check(func, args, kwargs)
+    bound = signature.bind(_PATCH, *args, **kwargs)
+    bound.apply_defaults()
+    # `_resolve_default` rather than a rule of our own: a default spelled
+    # `x=Field(default=3)` means 3, and task.py already says so.
+    out = {key: _resolve_default(value) for key, value in bound.arguments.items()}
+    parameters = list(signature.parameters.values())
+    # The patch is what the operation is given, not part of what it is.
+    out.pop(parameters[0].name, None)
+    for parameter in parameters:
+        if parameter.kind != inspect.Parameter.VAR_KEYWORD:
+            continue
+        extras = out.pop(parameter.name, {})
+        # An extra named for a parameter the signature already has cannot
+        # be told from it once both are one mapping. `append_dims` is the
+        # live shape: its `*empty_dims` cannot be given by name, so
+        # `empty_dims=3` lands in the `**kwargs` group and would overwrite
+        # the group it looks like.
+        if collisions := set(extras) & set(out):
+            msg = (
+                f"{op_name(func)} was given {sorted(collisions)} both as a "
+                "parameter and as an extra, so the call cannot be written "
+                "down as one mapping."
+            )
+            raise ParameterError(msg)
+        out |= extras
+    # Canonicalized last, so that the names a `**kwargs` group carried are
+    # canonicalized too rather than hiding inside the mapping.
+    return {key: _canonical(value) for key, value in out.items()}
+
+
+def _as_call(func, kwargs: dict) -> tuple[tuple, dict]:
+    """
+    Return bound arguments as the call which can be made from them.
+
+    A `*args` group cannot be passed by name, and neither can anything in
+    front of one, so those go back to being positional. The result is bound
+    again, so a mapping which is not a call this function accepts is
+    refused here rather than part-way through running it.
+    """
+    signature = _signature(func)
+    parameters = list(signature.parameters.values())[1:]
+    packs = any(x.kind == inspect.Parameter.VAR_POSITIONAL for x in parameters)
+    args, rest = [], dict(kwargs)
+    for parameter in parameters:
+        positional = parameter.kind == inspect.Parameter.POSITIONAL_ONLY or (
+            packs and parameter.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+        )
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            args.extend(rest.pop(parameter.name, ()))
+        elif positional and parameter.name in rest:
+            args.append(rest.pop(parameter.name))
+        elif positional:
+            # Absent, so everything after it would land in the wrong slot.
+            # `_check` says which name is missing.
+            break
+    _check(func, tuple(args), rest)
+    return tuple(args), rest

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -6,7 +6,7 @@ execute:
 A workflow is processing written down as an object rather than as a script. Its two pieces are a [Task](`dascore.workflow.task.Task`), which is one operation and the parameters it was given, and a [Pipe](`dascore.workflow.pipe.Pipe`), which is several tasks arranged into the shape of one. Both are immutable, both know their own fingerprint, and both can be written to a file and read back, so a processing chain can be compared, stored, shared, and run later against other data.
 
 ::: {.callout-note}
-The workflow module is new, and DASCore's own patch functions do not use it yet. Today you can write tasks of your own; a later release turns every patch function into one.
+The workflow module is new. Every patch function already builds one — see [Patch functions are tasks](#patch-functions-are-tasks) — but DASCore's own processing does not route through it yet.
 :::
 
 # Tasks
@@ -88,6 +88,62 @@ A task is callable, so it can stand anywhere a function of its inputs can:
 
 ```{python}
 scale_number(factor=3)(2)
+```
+
+## Patch functions are tasks
+
+Every function decorated with `dc.patch_function` — which is most, though not all, of DASCore's patch methods — builds the operation a call to it is, with `.op`. The arguments are bound against the function's signature and the defaults filled in, so what comes back says which call was made rather than how it was spelled.
+
+```{python}
+import dascore as dc
+
+patch = dc.get_example_patch()
+normalize = dc.proc.normalize.op("time")
+normalize
+```
+
+That is the operation `patch.normalize("time")` performs, reached the other way round — history and all:
+
+```{python}
+assert normalize(patch).equals(patch.normalize("time"))
+normalize.fingerprint
+```
+
+One class stands for every patch function, not one class each. An operation is a name and some arguments, and a name is a string:
+
+```{python}
+from dascore.workflow import PatchOp
+
+PatchOp(name="pass_filter", kwargs={"time": (10, 100)})
+```
+
+Because it is a task, it composes and it writes itself down:
+
+```{python}
+pipe = dc.proc.detrend.op("time") | normalize
+print(pipe.to_mermaid())
+```
+
+A call has a fingerprint whether or not anyone builds an operation for it. `fingerprint_call` answers for a call written as arguments, and `PatchOp.fingerprint` asks it for the operation built from the same call, so the two agree by construction rather than by test. Nothing is fingerprinted while an ordinary call runs — the decorator does not hash your arguments behind your back:
+
+```{python}
+from dascore.workflow import fingerprint_call
+
+fingerprint_call(dc.proc.normalize, (), {"dim": "time"}) == normalize.fingerprint
+```
+
+An operation is named by a registry tag, not by where a patch keeps it. DASCore's own are bare; anything else is named by the package which defines it, so a plugin's `normalize` can never be read back as DASCore's — and a function you have only just written, bound to nothing, is nameable too:
+
+```{python}
+import dascore.viz
+
+dc.viz.waterfall.op(show=False).name
+```
+
+The document also records which module the function came from. It is informational — what an error message uses to tell you what to import — and deliberately not part of the fingerprint, so moving a function between modules does not make it a different operation:
+
+```{python}
+normalize.to_dict()["params"]["module"]
 ```
 
 # Pipes

--- a/tests/test_workflow/_calls.py
+++ b/tests/test_workflow/_calls.py
@@ -1,0 +1,259 @@
+"""
+One call to every patch function, for comparing the routes to an operation.
+
+`PATCHES` names the patches a call may be made against; `CALLS` holds one
+entry per patch function DASCore defines, so a function added later fails
+`test_every_patch_function_is_covered` until it is given a call here.
+
+The arguments are chosen to do something -- an operation whose arguments the
+example patch is indifferent to compares equal whichever route made it, and
+would not notice an argument being dropped on the way.
+
+Seeded from `scripts/differential_check.py::get_calls`, which picks its
+arguments for the same reason.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from functools import cache
+
+import numpy as np
+import pandas as pd
+
+import dascore as dc
+from dascore.utils.imports import _LazyImport
+
+
+@cache
+def patch_functions() -> tuple:
+    """
+    Return every patch function DASCore defines, each once.
+
+    A private walk rather than a public helper: the only thing which wants
+    the whole list is this suite, and importing every module in the package
+    is not something to hand a user by accident.
+    """
+    # `dascore.viz` is deferred by `dascore/__init__.py`, and its functions
+    # are patch functions like any other.
+    import dascore.viz  # noqa: F401, PLC0415
+
+    seen: set[int] = set()
+    out = []
+    for info in pkgutil.walk_packages(dc.__path__, f"{dc.__name__}."):
+        try:
+            module = importlib.import_module(info.name)
+        except ImportError:  # a module needing something this install lacks
+            continue
+        # A snapshot: calling a function this finds can import a submodule
+        # into the module it came from, which would resize the live view.
+        for value in list(vars(module).values()):
+            # Asked first: touching a lazy proxy performs the import it
+            # exists to defer, and a patch function is never one.
+            if isinstance(value, _LazyImport):
+                continue
+            operation = getattr(value, "op", None)
+            # `is value`, not merely present: `functools.wraps` copies the
+            # wrapped function's `__dict__`, so a decorator around a patch
+            # function inherits its `op` and is not a second one.
+            if operation is None or getattr(operation, "args", (None,))[0] is not value:
+                continue
+            if id(value) not in seen:
+                seen.add(id(value))
+                out.append(value)
+    return tuple(out)
+
+
+@cache
+def get_patch(name: str):
+    """Return the patch a call is made against."""
+    patch = dc.get_example_patch("random_das")
+    if name == "default":
+        return patch
+    if name == "null":
+        return dc.get_example_patch("patch_with_null")
+    if name == "dft":
+        return patch.dft("time")
+    if name == "stft":
+        # The recipe `istft`'s own example uses, which round trips.
+        from dascore.units import second  # noqa: PLC0415
+
+        return dc.get_example_patch("chirp").stft(time=10 * second, overlap=4 * second)
+    if name == "spectrum":
+        # A Fourier coordinate holding real data, which `specplot` draws.
+        return patch.dft("time", real=True).abs()
+    if name == "velocity":
+        return patch.update_attrs(data_type="velocity")
+    if name == "lat_lon":
+        return dc.get_example_patch("random_patch_with_lat_lon")
+    if name == "xyz":
+        return dc.get_example_patch("random_patch_with_xyz")
+    if name == "dispersion":
+        return dc.get_example_patch("dispersion_event")
+    if name == "event":
+        return dc.get_example_patch("example_event_1")
+    if name == "wacky":
+        return dc.get_example_patch("wacky_dim_coords_patch")
+    if name == "collapsed":
+        # Dimensions which carry no coordinate, which is the shape
+        # `make_broadcastable_to` is for.
+        return patch.mean()
+    if name == "shifted":
+        # Each channel carries the time it should be aligned by.
+        small = patch.select(distance=(0, 50))
+        shifts = np.arange(len(small.get_array("distance"))) * np.timedelta64(1, "ms")
+        return small.update_coords(shift_times=("distance", shifts))
+    if name == "inventory":
+        from dascore.examples import inventory_patch_pair  # noqa: PLC0415
+
+        return inventory_patch_pair()[0]
+    msg = f"no example patch called {name!r}"
+    raise LookupError(msg)
+
+
+def _slope_filter():
+    """Return a filter for `slope_filter`, as its docstring builds one."""
+    return np.array([1e3, 2e3, 8e3, 9e3])
+
+
+def _coords_frame():
+    """Return the frame `coords_from_df` reads distances from."""
+    return pd.DataFrame({"distance": [0.0, 100.0, 200.0], "quality": [1.0, 2.0, 3.0]})
+
+
+def _shot():
+    """Return the origin `add_distance_to` measures from."""
+    return pd.Series({"x": 10.0, "y": 10.0, "z": 0.0})
+
+
+class Lazy:
+    """
+    An argument built when a test runs it, not when the catalogue is read.
+
+    `CALLS` is a module-level tuple, so anything spelled out in it is built
+    at import -- which for `enrich`'s inventory means real work during
+    collection, whether or not the test which needs it is selected.
+    """
+
+    def __init__(self, make):
+        self._make = make
+
+    def get(self):
+        """Return the argument."""
+        return self._make()
+
+
+def resolve(args: tuple) -> tuple:
+    """Return a catalogue entry's arguments, built if they were deferred."""
+    return tuple(x.get() if isinstance(x, Lazy) else x for x in args)
+
+
+@cache
+def _inventory():
+    """Return the inventory `enrich` copies metadata from."""
+    from dascore.examples import inventory_patch_pair  # noqa: PLC0415
+
+    return inventory_patch_pair()[1]
+
+
+# (function name, example patch, positional arguments, keyword arguments).
+CALLS: tuple[tuple[str, str, tuple, dict], ...] = (
+    # -- basic, no arguments at all
+    ("abs", "default", (), {}),
+    ("angle", "dft", (), {}),
+    ("conj", "dft", (), {}),
+    ("imag", "dft", (), {}),
+    ("real", "dft", (), {}),
+    ("simplify_units", "default", (), {}),
+    ("drop_private_coords", "default", (), {}),
+    ("istft", "stft", (), {}),
+    # -- one dimension, given positionally where the signature allows it
+    ("normalize", "default", ("time",), {"norm": "l1"}),
+    ("standardize", "default", ("time",), {}),
+    ("detrend", "default", ("time",), {"type": "constant"}),
+    ("demean", "default", (), {"dim": "distance"}),
+    ("demedian", "default", (), {"dim": "distance"}),
+    ("differentiate", "default", ("time",), {"order": 2}),
+    ("integrate", "default", ("time",), {"definite": True}),
+    ("hilbert", "default", ("time",), {}),
+    ("envelope", "default", ("time",), {}),
+    ("dropna", "null", ("time",), {"how": "all"}),
+    ("squeeze", "default", (), {"dim": None}),
+    ("idft", "dft", (), {"dim": "ft_time"}),
+    ("sobel_filter", "default", ("time",), {"mode": "reflect"}),
+    # -- aggregations
+    ("aggregate", "default", (), {"dim": "time", "method": "mean"}),
+    ("all", "default", (), {"dim": "time"}),
+    ("any", "default", (), {"dim": "time"}),
+    ("first", "default", (), {"dim": "time"}),
+    ("last", "default", (), {"dim": "time"}),
+    ("max", "default", (), {"dim": "time"}),
+    ("mean", "default", (), {"dim": "time"}),
+    ("median", "default", (), {"dim": "time"}),
+    ("min", "default", (), {"dim": "time"}),
+    ("std", "default", (), {"dim": "time"}),
+    ("sum", "default", (), {"dim": "time"}),
+    # -- a dimension given as an extra, which the signature does not name
+    ("pass_filter", "default", (), {"time": (10, 100)}),
+    ("notch_filter", "default", (30,), {"time": 100}),
+    ("median_filter", "default", (), {"time": 3, "samples": True}),
+    ("gaussian_filter", "default", (), {"time": 2, "samples": True}),
+    ("savgol_filter", "default", (3,), {"time": 5, "samples": True}),
+    ("slope_filter", "default", (Lazy(_slope_filter),), {}),
+    ("wiener_filter", "default", (), {"time": 5, "samples": True}),
+    ("hampel_filter", "default", (), {"time": 5, "samples": True}),
+    ("select", "default", (), {"distance": (10, 40)}),
+    ("unselect", "default", (), {"distance": (10, 40)}),
+    ("order", "default", (), {"distance": (30, 10, 20), "samples": True}),
+    ("decimate", "default", (), {"time": 2}),
+    ("pad", "default", (), {"time": (2, 3)}),
+    ("roll", "default", (), {"time": 5, "samples": True}),
+    ("taper", "default", (), {"time": 0.05}),
+    ("taper_range", "default", (), {"time": (1, 2, 3, 4), "samples": True}),
+    ("resample", "default", (), {"time": 0.01}),
+    ("interpolate", "default", (), {"distance": np.arange(0, 100, 3.0)}),
+    ("convert_units", "default", (), {"distance": "ft"}),
+    ("set_units", "default", (), {"distance": "m"}),
+    ("rename_coords", "default", (), {"distance": "depth"}),
+    ("update_coords", "default", (), {"distance": np.arange(300) * 2.0}),
+    ("correlate", "default", (), {"distance": 0}),
+    ("correlate_shift", "default", ("time",), {}),
+    ("line_mute", "default", (), {"time": (0.1, 0.2)}),
+    ("whiten", "default", (), {"time": (10, 100)}),
+    ("stalta", "default", (), {"time": (0.1, 0.5)}),
+    ("fbe", "default", (0.5,), {"time": (10, 100)}),
+    ("align_to_coord", "shifted", (), {"time": "shift_times", "mode": "full"}),
+    # -- a *args group
+    ("transpose", "default", ("time", "distance"), {}),
+    ("snap_coords", "wacky", ("time",), {"reverse": True}),
+    ("sort_coords", "default", ("time",), {"reverse": True}),
+    ("flip", "default", ("time",), {"flip_coords": True}),
+    ("drop_coords", "lat_lon", ("latitude",), {}),
+    ("append_dims", "default", ("new_dim",), {}),
+    # -- a plain positional value
+    ("fillna", "null", (0.0,), {}),
+    ("full", "default", (1.0,), {}),
+    ("where", "default", (True,), {"other": 0.0}),
+    ("make_broadcastable_to", "collapsed", ((2, 3),), {}),
+    ("coords_from_df", "default", (Lazy(_coords_frame),), {"extrapolate": True}),
+    ("add_distance_to", "xyz", (Lazy(_shot),), {}),
+    # -- transforms
+    ("dft", "default", ("time",), {"real": True}),
+    ("stft", "default", (), {"time": 1.0}),
+    ("spectrogram", "default", (), {"dim": "time"}),
+    ("velocity_to_strain_rate", "velocity", (), {"step_multiple": 2}),
+    ("velocity_to_strain_rate_edgeless", "velocity", (), {"step_multiple": 2}),
+    ("radians_to_strain", "default", (), {"gauge_length": 10.0}),
+    ("dispersion_phase_shift", "dispersion", (np.arange(100, 1000, 100.0),), {}),
+    ("tau_p", "event", (np.arange(1000, 6000, 500.0),), {}),
+    ("kurtosis", "default", (), {"time": 5, "samples": True}),
+    ("phase_weighted_stack", "default", ("distance",), {"transform_dim": "time"}),
+    ("slope_mute", "default", ((1e3, 2e3),), {}),
+    ("enrich", "inventory", (Lazy(_inventory),), {"attrs": ("gauge_length",)}),
+    # -- the ones which draw rather than return a patch
+    ("waterfall", "default", (), {"show": False}),
+    ("wiggle", "default", (), {"dim": "time"}),
+    ("specplot", "spectrum", (), {"show": False}),
+    ("map_fiber", "xyz", (), {"x": "x", "y": "y", "color": "z"}),
+)

--- a/tests/test_workflow/test_patch_op.py
+++ b/tests/test_workflow/test_patch_op.py
@@ -1,0 +1,803 @@
+"""
+What a patch operation said as a task has to do.
+
+The contracts run over `_calls.CALLS`, which holds one call to every patch
+function DASCore defines, so a function added later is covered without this
+file being edited.
+"""
+
+from __future__ import annotations
+
+import pickle
+import subprocess
+import sys
+from typing import ClassVar
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from pydantic import Field
+
+import dascore as dc
+import dascore.workflow.processor as processor_module
+from dascore.exceptions import ParameterError
+from dascore.models.registry import registered_models
+from dascore.workflow import (
+    PatchOp,
+    PatchProcessor,
+    Pipe,
+    Task,
+    fingerprint_call,
+    register_implementation,
+    resolve_patch_function,
+)
+from dascore.workflow.processor import patch_function_tag, register_patch_function
+
+from ._calls import CALLS, get_patch, patch_functions, resolve
+
+PATCH_FUNCTIONS = patch_functions()
+
+# Named by the function, so a failure says which one.
+IDS = [x[0] for x in CALLS]
+
+# The operations whose arguments the serializer refuses. A frame is data,
+# not a parameter; the serializer says so, and this records which calls in
+# the catalogue land on it.
+_NOT_WRITABLE = {"coords_from_df", "add_distance_to"}
+
+
+def _drawn(axes) -> tuple[int, ...]:
+    """Return how much was drawn on a set of axes, if that is what this is."""
+    parts = ("images", "lines", "collections", "patches", "texts")
+    return tuple(len(getattr(axes, x, ())) for x in parts)
+
+
+def _same_patch(one, other) -> bool:
+    """
+    Whether two results are the same result.
+
+    `Patch.equals` compares data with `np.array_equal`, which reports a NaN
+    as unequal to itself, so a patch carrying one never equals even itself.
+    Several operations here produce NaN legitimately (`dropna`, `stalta`),
+    so the comparison is spelled out.
+
+    An operation which draws returns axes rather than a patch. There is no
+    equality for those, so what was drawn on them is counted -- which at
+    least tells a plot from an empty frame.
+    """
+    if not isinstance(one, dc.Patch):
+        return type(one) is type(other) and _drawn(one) == _drawn(other)
+    data, other_data = np.asarray(one.data), np.asarray(other.data)
+    if data.shape != other_data.shape or data.dtype != other_data.dtype:
+        return False
+    if not np.array_equal(data, other_data, equal_nan=data.dtype.kind == "f"):
+        return False
+    return one.coords == other.coords and one.attrs == other.attrs
+
+
+@dc.patch_function()
+def op_test_scaled(patch, factor=2.0):
+    """Scale a patch, for the contracts which need a function of our own."""
+    return patch.new(data=patch.data * factor)
+
+
+@dc.patch_function()
+def op_test_field_default(patch, value=Field(default=7)):
+    """Take a parameter whose default is spelled as a pydantic Field."""
+    return patch.update_attrs(seen=value)
+
+
+@dc.patch_function()
+def op_test_leading_then_group(patch, first, *rest, flag=False):
+    """Take one named argument, then a group of them."""
+    return patch.update_attrs(seen=f"{first}{rest}{flag}")
+
+
+@dc.patch_function(version="1.0")
+def op_test_versioned(patch, factor=1):
+    """Do nothing, at the version it is declared."""
+    return patch
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """
+    Close whatever the drawing operations opened.
+
+    Several contracts run every catalogued call twice, and four of them
+    draw, so without this the suite holds hundreds of open figures.
+    """
+    yield
+    plt.close("all")
+
+
+@pytest.fixture(scope="module")
+def patch():
+    """A patch for the contracts which need any patch at all."""
+    return dc.get_example_patch("random_das")
+
+
+class TestEveryPatchFunction:
+    """Contracts which hold for all of them."""
+
+    def test_every_patch_function_is_covered(self):
+        """A function added later is not covered until it is given a call."""
+        named = {x[0] for x in CALLS}
+        missing = {x.__name__ for x in PATCH_FUNCTIONS} - named
+        assert not missing, f"no call is catalogued for {sorted(missing)}"
+
+    def test_the_walk_found_them_all(self):
+        """A floor under everything which runs over the catalogue."""
+        assert len(PATCH_FUNCTIONS) >= 89
+
+    @pytest.mark.parametrize("call", CALLS, ids=IDS)
+    def test_the_op_does_what_the_call_did(self, call):
+        """The operation as a task answers as the operation as a call."""
+        name, key, args, kwargs = call
+        args = resolve(args)
+        func = _function(name)
+        target = get_patch(key)
+        assert _same_patch(
+            func(target, *args, **kwargs), func.op(*args, **kwargs)(target)
+        )
+
+    @pytest.mark.parametrize("call", CALLS, ids=IDS)
+    def test_the_history_is_the_same(self, call):
+        """
+        Down to what the patch says was done to it.
+
+        `_same_patch` compares attrs, and history is one, so this is
+        already covered -- said again here because it is the property
+        which catches an operation that skipped the decorator, and it
+        should not quietly go away if that comparison is ever loosened.
+        """
+        name, key, args, kwargs = call
+        args = resolve(args)
+        func = _function(name)
+        target = get_patch(key)
+        direct = func(target, *args, **kwargs)
+        if not isinstance(direct, dc.Patch):
+            pytest.skip(f"{name} does not return a patch")
+        assert func.op(*args, **kwargs)(target).attrs.history == direct.attrs.history
+
+    @pytest.mark.parametrize("call", CALLS, ids=IDS)
+    def test_the_call_fingerprints_alike(self, call):
+        """One call has one fingerprint, whichever route asks for it."""
+        name, _, args, kwargs = call
+        args = resolve(args)
+        func = _function(name)
+        assert (
+            fingerprint_call(func, args, kwargs) == func.op(*args, **kwargs).fingerprint
+        )
+
+    @pytest.mark.parametrize("call", CALLS, ids=IDS)
+    def test_the_op_is_written_down(self, call):
+        """What the operation was given survives being written out."""
+        name, key, args, kwargs = call
+        args = resolve(args)
+        op = _function(name).op(*args, **kwargs)
+        if name in _NOT_WRITABLE:
+            pytest.skip(f"{name} takes an argument no document can hold")
+        read_back = Task.from_dict(op.to_dict())
+        assert read_back == op
+        # Equality is by fingerprint, which does not tell a tuple from the
+        # list a document holds it as, so what the operation *does* is
+        # asserted too.
+        target = get_patch(key)
+        assert _same_patch(op(target), read_back(target))
+
+    @pytest.mark.parametrize("name", sorted(_NOT_WRITABLE))
+    def test_an_operation_a_document_cannot_hold(self, name):
+        """
+        An operation given a frame says so rather than writing half of one.
+
+        The serializer refuses a dataframe parameter, and an operation is
+        not a special case: it is refused where the document is written.
+        """
+        call = next(x for x in CALLS if x[0] == name)
+        op = _function(name).op(*resolve(call[2]), **call[3])
+        with pytest.raises(ParameterError, match="cannot be written"):
+            op.to_dict()
+
+    @pytest.mark.parametrize("call", CALLS, ids=IDS)
+    def test_the_op_pickles(self, call):
+        """A pipe handed to another process carries its operations."""
+        name, _, args, kwargs = call
+        args = resolve(args)
+        op = _function(name).op(*args, **kwargs)
+        assert pickle.loads(pickle.dumps(op)) == op
+
+    @pytest.mark.parametrize("call", CALLS, ids=IDS)
+    def test_the_version_is_the_functions(self, call):
+        """
+        The operation reports the version its function is declared at.
+
+        Not the class's: `PatchOp` stands for every patch function, so its
+        own version says nothing about any of them.
+        """
+        name, _, args, kwargs = call
+        args = resolve(args)
+        func = _function(name)
+        assert _function(name).op(*args, **kwargs).version == func.__version__
+
+
+def _function(name):
+    """Return the patch function a catalogue entry names."""
+    for func in PATCH_FUNCTIONS:
+        if func.__name__ == name:
+            return func
+    msg = f"no patch function called {name!r}"
+    raise LookupError(msg)
+
+
+class TestOneCanonicalCall:
+    """Two spellings of one call are one operation."""
+
+    def test_positional_and_keyword(self):
+        """Which is what binding against the signature is for."""
+        first = dc.proc.normalize.op("time")
+        second = dc.proc.normalize.op(dim="time")
+        assert first.kwargs == second.kwargs == {"dim": "time", "norm": "l2"}
+        assert first.fingerprint == second.fingerprint
+        assert first == second
+
+    def test_a_default_spelled_out(self):
+        """Giving a default explicitly is the same operation as leaving it."""
+        assert dc.proc.normalize.op("time") == dc.proc.normalize.op("time", norm="l2")
+
+    def test_a_star_args_group(self):
+        """A `*args` group is one field holding the tuple it is."""
+        op = dc.proc.transpose.op("time", "distance")
+        assert op.kwargs == {"dims": ("time", "distance")}
+
+    def test_an_extra_is_kept_by_name(self):
+        """A dimension the signature does not name is bound under its own."""
+        op = dc.proc.pass_filter.op(time=(10, 100))
+        assert op.kwargs["time"] == (10, 100)
+        assert op.kwargs["corners"] == 4
+
+    def test_a_keyword_only_parameter(self):
+        """One which cannot be given positionally still binds."""
+        op = dc.transform.dft.op("time", real=True)
+        assert op.kwargs["dim"] == "time"
+        assert op.kwargs["real"] is True
+
+    def test_a_field_default(self):
+        """A default spelled as a pydantic Field is the value it holds."""
+        assert op_test_field_default.op().kwargs == {"value": 7}
+
+    def test_different_arguments_are_different_operations(self):
+        """Two calls which do different things do not share a fingerprint."""
+        assert (
+            dc.proc.decimate.op(time=2).fingerprint
+            != dc.proc.decimate.op(time=3).fingerprint
+        )
+
+
+class TestRefusedAtConstruction:
+    """A broken operation says so where it was written down."""
+
+    def test_an_unknown_dascore_name(self):
+        """A bare tag DASCore does not define is not an operation."""
+        with pytest.raises(ParameterError, match="DASCore defines none"):
+            PatchOp(name="not_a_patch_function")
+
+    def test_an_unknown_package(self):
+        """A tag from a package this process lacks says what to import."""
+        with pytest.raises(ParameterError, match="install nosuchpkg"):
+            PatchOp(name="nosuchpkg:denoise", module="nosuchpkg.filters")
+
+    def test_a_name_from_a_script(self):
+        """Which nothing can import, so it says to redefine it instead."""
+        with pytest.raises(ParameterError, match="script or a notebook"):
+            PatchOp(name="__main__:my_filter")
+
+    def test_a_patch_method_which_is_not_a_patch_function(self):
+        """
+        Only a registered patch function is an operation.
+
+        `get_axis` and `new` are how a patch is used, not operations on
+        one, and a document should not reach into the class through this.
+        """
+        for name in ("get_axis", "new", "update", "dims"):
+            with pytest.raises(ParameterError, match="DASCore defines none"):
+                PatchOp(name=name)
+
+    def test_a_function_defined_inside_a_call(self):
+        """
+        One which exists only while a call runs cannot be named.
+
+        The registry skips it, as the model registry skips a class defined
+        the same way, so `op` says so rather than inventing a tag.
+        """
+
+        @dc.patch_function()
+        def defined_in_here(patch):
+            """Exist only for the length of this test."""
+            return patch
+
+        with pytest.raises(ParameterError, match="cannot be named in a document"):
+            defined_in_here.op()
+
+    def test_an_extra_which_collides_with_a_parameter(self):
+        """
+        A call which cannot be written as one mapping is refused.
+
+        `append_dims(patch, *empty_dims, **dim_kwargs)` is the live shape:
+        `empty_dims` cannot be given by name, so `empty_dims=3` lands in
+        the `**kwargs` group and would overwrite the group it looks like.
+        """
+        with pytest.raises(ParameterError, match="both as a parameter"):
+            dc.proc.append_dims.op("a", empty_dims=3)
+
+    def test_an_argument_the_signature_rejects(self):
+        """An argument the function does not take fails at construction."""
+        with pytest.raises(ParameterError, match="cannot be called that way"):
+            dc.proc.normalize.op(dim="time", not_a_parameter=1)
+
+    def test_an_argument_the_signature_rejects_by_hand(self):
+        """
+        The same, for an operation built without going through a call.
+
+        The required argument is given, so what is refused is the extra
+        rather than the absence, which the test below covers.
+        """
+        with pytest.raises(ParameterError, match="unexpected keyword"):
+            PatchOp(name="normalize", kwargs={"dim": "time", "not_a_parameter": 1})
+
+    def test_a_missing_required_argument(self):
+        """A parameter with no default has to be given."""
+        with pytest.raises(ParameterError, match="cannot be called that way"):
+            dc.proc.normalize.op()
+
+
+class TestCanonicalByHand:
+    """An operation written by hand is the one a call would have built."""
+
+    def test_defaults_are_filled_in(self):
+        """Or the two would be two operations doing one thing."""
+        by_hand = PatchOp(name="normalize", kwargs={"dim": "time"})
+        by_call = dc.proc.normalize.op("time")
+        assert by_hand.kwargs == by_call.kwargs
+        assert by_hand == by_call
+        assert by_hand.fingerprint == by_call.fingerprint
+
+    def test_a_star_args_group_by_hand(self):
+        """Including one whose arguments cannot be passed by name."""
+        assert PatchOp(
+            name="transpose", kwargs={"dims": ("time", "distance")}
+        ) == dc.proc.transpose.op("time", "distance")
+
+
+class TestAPositionalBeforeAStarArgs:
+    """A shape DASCore has none of, which the binding still has to handle."""
+
+    def test_it_binds_and_runs(self, patch):
+        """The leading argument goes back to being positional to run."""
+        op = op_test_leading_then_group.op(1, 2, 3, flag=True)
+        assert op.kwargs == {"first": 1, "rest": (2, 3), "flag": True}
+        direct = op_test_leading_then_group(patch, 1, 2, 3, flag=True)
+        assert op(patch).attrs.seen == direct.attrs.seen
+
+    def test_it_is_refused_without_the_leading_argument(self):
+        """Without it, everything after would land in the wrong slot."""
+        with pytest.raises(ParameterError, match="cannot be called that way"):
+            PatchOp(name="tests:op_test_leading_then_group", kwargs={"rest": (2, 3)})
+
+
+class TestVersions:
+    """What a version bump does, and does not, break."""
+
+    def test_an_operation_carries_the_functions_version(self):
+        """Not this class's, which is the same for every operation."""
+        op = dc.proc.normalize.op("time")
+        assert op.version == dc.proc.normalize.__version__
+        assert op.to_dict()["params"]["version"] == op.version
+
+    def test_a_pipe_reads_back_as_what_was_written(self, monkeypatch):
+        """
+        A document says which version it was written at, so it reads back
+        as the operation it recorded even after the function moved on.
+        """
+        pipe = dc.proc.detrend.op("time") | dc.proc.normalize.op("time")
+        document = pipe.to_dict()
+        monkeypatch.setattr(dc.proc.normalize, "__version__", "2.0")
+        reloaded = Pipe.from_dict(document)
+        assert reloaded.get("normalize").version == "1.0"
+        assert reloaded.fingerprint == document["fingerprint"]
+
+    def test_a_bump_makes_a_new_operation(self, monkeypatch):
+        """Which is what a version is for."""
+        before = dc.proc.normalize.op("time")
+        monkeypatch.setattr(dc.proc.normalize, "__version__", "2.0")
+        after = dc.proc.normalize.op("time")
+        assert after.version == "2.0"
+        assert after.fingerprint != before.fingerprint
+
+
+class TestTags:
+    """What a name is: the tag which names a function, not a patch path."""
+
+    def test_a_dascore_function_is_bare(self):
+        """DASCore's own are unqualified, however a patch reaches them."""
+        assert dc.proc.normalize.op("time").name == "normalize"
+
+    def test_a_deferred_dascore_function_is_bare_too(self):
+        """`viz.waterfall` is a path; the name is `waterfall`."""
+        import dascore.viz  # noqa: F401, PLC0415
+
+        assert dc.viz.waterfall.op(show=False).name == "waterfall"
+
+    def test_our_own_is_namespaced_by_its_package(self):
+        """A function defined here is `tests:name`, not a bare one."""
+        assert op_test_scaled.op().name == "tests:op_test_scaled"
+
+    def test_it_runs_and_round_trips_in_process(self, patch):
+        """Which is the point: a user's function is an operation like any."""
+        op = op_test_scaled.op(factor=3.0)
+        assert np.array_equal(np.asarray(op(patch).data), np.asarray(patch.data) * 3.0)
+        assert Task.from_dict(op.to_dict()) == op
+        assert op.module == "tests.test_workflow.test_patch_op"
+
+    def test_a_plugin_never_resolves_to_dascores(self):
+        """
+        A package's `normalize` is its own, and cannot shadow DASCore's.
+
+        The tag carries the package, so the two cannot collide -- which is
+        what makes the identity check the first round needed unnecessary.
+        """
+
+        def normalize(patch, factor=1):
+            """Share a name with a core patch function."""
+            return patch
+
+        # Declared as a plugin's would be. `__qualname__` too, or the
+        # registry reads it as defined inside this call and skips it.
+        normalize.__module__ = "myplugin.filters"
+        normalize.__qualname__ = "normalize"
+        tagged = dc.patch_function()(normalize)
+        assert patch_function_tag(tagged) == "myplugin:normalize"
+        assert patch_function_tag(dc.proc.normalize) == "normalize"
+        assert resolve_patch_function("normalize") is dc.proc.normalize
+        assert resolve_patch_function("myplugin:normalize") is tagged
+
+    @pytest.mark.concurrency
+    def test_a_deferred_function_resolves_in_a_fresh_process(self):
+        """
+        Nothing has imported `dascore.viz`, and the sweep is what finds it.
+
+        The sweep imports what the install declares; it never imports what
+        a document names.
+        """
+        code = (
+            "import sys, dascore; "
+            "assert 'dascore.viz' not in sys.modules; "
+            "from dascore.workflow import PatchOp; "
+            "op = PatchOp(name='waterfall', kwargs={'show': False}); "
+            "assert op.name == 'waterfall'; "
+            "assert 'dascore.viz' in sys.modules"
+        )
+        subprocess.run(
+            [sys.executable, "-c", code], check=True, timeout=120, capture_output=True
+        )
+
+
+class TestTheRegistry:
+    """Two functions may not claim one tag."""
+
+    @pytest.fixture(autouse=True)
+    def _own_registry(self, monkeypatch):
+        """Work against a copy, so a tag left behind changes nothing."""
+        monkeypatch.setattr(
+            processor_module, "_REGISTERED", dict(processor_module._REGISTERED)
+        )
+        monkeypatch.setattr(processor_module, "_AMBIGUOUS", {})
+
+    def test_a_function_with_no_name(self):
+        """Something callable which is not a function takes no tag."""
+
+        class Callable:
+            """A callable object, which has no `__name__`."""
+
+            __qualname__ = "Callable"
+
+            def __call__(self, patch):
+                """Do nothing."""
+                return patch
+
+        assert patch_function_tag(Callable()) is None
+
+    def test_a_tag_the_sweep_finds(self):
+        """
+        A tag missing until the install has been swept still resolves.
+
+        The fresh-process test covers the real thing; this covers the
+        branch in process, where `dascore.viz` is imported already.
+        """
+
+        def late(patch):
+            """Arrive only once the sweep has run."""
+            return patch
+
+        late.__module__ = "swept.filters"
+        late.__name__ = late.__qualname__ = "late"
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(processor_module, "_swept", False)
+        monkeypatch.setattr(
+            processor_module,
+            "_sweep_patch_functions",
+            lambda: processor_module._REGISTERED.update({"swept:late": late}),
+        )
+        try:
+            assert resolve_patch_function("swept:late") is late
+        finally:
+            monkeypatch.undo()
+
+    def test_two_dascore_functions_may_not_share_a_tag(self):
+        """Ours are ours to keep unique, so the collision is an error."""
+
+        def normalize(patch):
+            """Claim a tag DASCore already uses."""
+            return patch
+
+        normalize.__module__ = "dascore.somewhere"
+        normalize.__qualname__ = "normalize"
+        with pytest.raises(ParameterError, match="claim the tag"):
+            register_patch_function(normalize)
+
+    def test_two_plugins_may_not_resolve_one_tag(self):
+        """
+        A user cannot rename another package's function, so both import.
+
+        What the tag may not do is quietly pick one: a document written by
+        the first would then be read as the second.
+        """
+
+        def denoise(patch):
+            """Claim a tag another package also claims."""
+            return patch
+
+        denoise.__module__ = "pkga.filters"
+        denoise.__qualname__ = "denoise"
+        assert register_patch_function(denoise) == "pkga:denoise"
+
+        def other(patch):
+            """The other package's function of the same name."""
+            return patch
+
+        # `__name__` is what the tag is built from; `__qualname__` is what
+        # says whether it was defined inside a call.
+        other.__module__ = "pkga.elsewhere"
+        other.__name__ = other.__qualname__ = "denoise"
+        with pytest.warns(UserWarning, match="claim the tag"):
+            register_patch_function(other)
+        with pytest.raises(ParameterError, match="names two functions"):
+            resolve_patch_function("pkga:denoise")
+
+    def test_a_module_re_imported_keeps_its_entry(self):
+        """The same function registered twice is not a collision."""
+        tag = register_patch_function(op_test_scaled)
+        assert register_patch_function(op_test_scaled) == tag
+
+
+class TestPipeNodeNames:
+    """A node is named for its operation, not for `PatchOp`."""
+
+    def test_the_nodes_are_named_for_the_operations(self):
+        """Or every node in every pipe would be called `patch_op`."""
+        pipe = dc.proc.detrend.op("time") | dc.proc.normalize.op("time")
+        assert list(pipe.tasks) == ["detrend", "normalize"]
+        assert pipe.get("detrend").name == "detrend"
+
+    def test_the_same_operation_twice(self):
+        """The second copy is numbered, as any repeated task is."""
+        pipe = dc.proc.abs.op() | dc.proc.abs.op()
+        assert list(pipe.tasks) == ["abs", "abs_2"]
+
+    def test_a_namespaced_operation(self):
+        """A package-qualified tag is spelled the way a node name can be."""
+        assert op_test_scaled.op().node_name == "tests_op_test_scaled"
+
+
+class TestDocuments:
+    """A saved pipe names one class, whatever the operation."""
+
+    def test_the_registry_gains_one_tag(self):
+        """
+        One class for every patch function, not one class each.
+
+        `PatchOp` is the whole cost of naming any of them in a document.
+        """
+        tags = {
+            tag
+            for tag, cls in registered_models().items()
+            if isinstance(cls, type) and issubclass(cls, (PatchOp, PatchProcessor))
+        }
+        assert tags == {"PatchOp", "PatchProcessor"}
+
+    def test_the_document_names_the_operation(self):
+        """The name and the arguments are what a document holds."""
+        op = dc.proc.pass_filter.op(time=(10, 100))
+        document = op.to_dict()
+        assert document["object_type"] == "PatchOp"
+        assert document["params"]["name"] == "pass_filter"
+        assert document["params"]["kwargs"]["time"] == [10, 100]
+
+    def test_a_node_which_cannot_be_read_names_itself(self):
+        """
+        A pipe of thirty should not leave the reader hunting for the node.
+
+        The message a missing function gives is worth nothing if it does
+        not say which step of the pipe wanted it.
+        """
+        pipe = dc.proc.detrend.op("time") | dc.proc.normalize.op("time")
+        document = pipe.to_dict()
+        broken = document["tasks"]["normalize"]["params"]
+        broken["name"], broken["module"] = "nosuchpkg:denoise", "nosuchpkg.filters"
+        with pytest.raises(ParameterError, match="node 'normalize' could not be read"):
+            Pipe.from_dict(document)
+
+    def test_a_pipe_of_operations(self, patch):
+        """Which is what the operations are for."""
+        pipe = dc.proc.detrend.op("time") | dc.proc.normalize.op("time")
+        expected = patch.detrend("time").normalize("time")
+        assert _same_patch(pipe(patch), expected)
+        assert Pipe.from_dict(pipe.to_dict()) == pipe
+
+
+class TestFingerprintCall:
+    """The digest a call carries."""
+
+    def test_a_call_is_not_fingerprinted_until_something_reads_it(self, patch):
+        """
+        The decorator does not hash a call's arguments on every call.
+
+        Nothing consumes the answer until patch ids arrive, and taking it
+        eagerly costs a share of every call -- around a fifth of one whose
+        argument is a large array, since hashing it is proportional to its
+        size -- and turns an argument the serializer cannot encode into a
+        failure of a call which otherwise worked.
+        """
+        deep = {}
+        deep["self"] = deep
+
+        @dc.patch_function()
+        def takes_anything(patch, thing=None):
+            """Accept whatever it is given."""
+            return patch
+
+        # Would raise RecursionError if the wrapper hashed its arguments.
+        assert takes_anything(patch, thing=deep) is not None
+
+    def test_the_version_is_part_of_it(self, monkeypatch):
+        """An operation at a new version is a new operation."""
+        before = fingerprint_call(op_test_versioned, (), {})
+        monkeypatch.setattr(op_test_versioned, "__version__", "2.0")
+        assert fingerprint_call(op_test_versioned, (), {}) != before
+
+    def test_the_name_is_part_of_it(self):
+        """Two operations given the same arguments are still two."""
+        assert fingerprint_call(
+            dc.proc.demean, (), {"dim": "time"}
+        ) != fingerprint_call(dc.proc.demedian, (), {"dim": "time"})
+
+    @pytest.mark.parametrize(
+        ("func", "args", "kwargs", "expected"),
+        [
+            ("abs", (), {}, "9a2280cd3ff6dfad"),
+            # With arguments, so that how they are encoded is pinned too
+            # and not only the name and the version.
+            ("pass_filter", (), {"time": (10, 100)}, "f6eddbc14ba34887"),
+            ("transpose", ("time", "distance"), {}, "3678768d58da1f37"),
+        ],
+    )
+    def test_it_is_stable(self, func, args, kwargs, expected):
+        """A fingerprint written down last week names the same call today."""
+        assert fingerprint_call(getattr(dc.proc, func), args, kwargs) == expected
+
+
+class TestImplementations:
+    """One name, one implementation."""
+
+    def test_a_registered_class_is_what_the_name_means(self, patch, monkeypatch):
+        """
+        A hand-written class takes over the name it implements.
+
+        Empty in this PR; the first entry arrives with the first
+        plan/kernel split, and this is what says the routing works.
+        """
+
+        class Doubler(PatchProcessor):
+            """A hand-written stand-in for `normalize`."""
+
+            dim: str = "time"
+            norm: str = "l2"
+
+            def run(self, patch):
+                """Do something a caller could tell apart."""
+                return patch.new(data=patch.data * 2)
+
+        # Through the public hook, against a copy of the table: it is a
+        # module global, and a name left in it would change every test
+        # which runs after this one.
+        table = dict(processor_module._IMPLEMENTATIONS)
+        monkeypatch.setattr(processor_module, "_IMPLEMENTATIONS", table)
+        register_implementation("normalize", Doubler)
+        assert table["normalize"] is Doubler
+        op = dc.proc.normalize.op("time")
+        assert isinstance(op, Doubler)
+        assert np.array_equal(np.asarray(op(patch).data), np.asarray(patch.data) * 2)
+
+    def test_the_table_is_left_as_it_was(self):
+        """The test above puts the table back, or the next one is wrong."""
+        assert "normalize" not in processor_module._IMPLEMENTATIONS
+        assert isinstance(dc.proc.normalize.op("time"), PatchOp)
+
+    def test_registering_something_which_is_not_one(self):
+        """Only a PatchProcessor can implement an operation."""
+        with pytest.raises(ParameterError, match="is not a PatchProcessor"):
+            register_implementation("normalize", dict)
+
+
+class TestPatchProcessor:
+    """The base the hand-written classes derive from."""
+
+    def test_a_missing_dimension_is_refused(self, patch):
+        """A patch which cannot carry the operation is refused by `check`."""
+
+        class NeedsPressure(PatchProcessor):
+            """A processor which wants a dimension the patch lacks."""
+
+            required_dims = ("pressure",)
+
+            def run(self, patch):
+                """Check and hand back."""
+                return self.check(patch)
+
+        with pytest.raises(dc.exceptions.PatchCoordinateError):
+            NeedsPressure()(patch)
+
+    def test_a_present_dimension_passes(self, patch):
+        """A patch which carries it goes through untouched."""
+
+        class NeedsTime(PatchProcessor):
+            """A processor which wants a dimension the patch has."""
+
+            required_dims = "time"
+
+            def run(self, patch):
+                """Check and hand back."""
+                return self.check(patch)
+
+        assert NeedsTime()(patch) is patch
+
+    def test_a_required_coord(self, patch):
+        """A coordinate is checked the same way a dimension is."""
+
+        class NeedsCoord(PatchProcessor):
+            """A processor which wants a coordinate the patch lacks."""
+
+            required_coords = ("no_such_coord",)
+
+            def run(self, patch):
+                """Check and hand back."""
+                return self.check(patch)
+
+        with pytest.raises(dc.exceptions.PatchCoordinateError, match="no_such_coord"):
+            NeedsCoord()(patch)
+
+    def test_a_required_attr(self, patch):
+        """As is an attr, whether named alone or against a value."""
+
+        class NeedsVelocity(PatchProcessor):
+            """A processor which wants a data_type the patch lacks."""
+
+            required_attrs: ClassVar = {"data_type": "velocity"}
+
+            def run(self, patch):
+                """Check and hand back."""
+                return self.check(patch)
+
+        with pytest.raises(dc.exceptions.PatchAttributeError):
+            NeedsVelocity()(patch)
+        assert NeedsVelocity()(patch.update_attrs(data_type="velocity")) is not None


### PR DESCRIPTION
## Description

Fourth PR of the processors series, after #929 (dispatcher rollback), #932 (`Task` and its serializer) and #936 (`Pipe` and provenance). It gives every patch function a fingerprint and an object form, without giving any of them a class.

```python
patch = dc.get_example_patch()

op = dc.proc.normalize.op("time")          # the call, as a task
op(patch).equals(patch.normalize("time"))  # True, history included
op.fingerprint                             # stable, and writable to a file
pipe = dc.proc.detrend.op("time") | op
```

### One class, not eighty-nine

`PatchOp` is any patch function as a task: a `name` and the `kwargs` it was called with.

```python
class PatchOp(Task):
    name: str                  # "pass_filter"; "myplugin.denoise" through a namespace
    kwargs: dict = {}          # the call, bound against the signature
```

What identifies an operation is its name and its arguments, and a name is a string. An earlier revision of this PR synthesized one pydantic model per patch function; that bought a class to hold a string and cost 89 registry tags, ~65 ms of import time, a `get_processor`, a package walk, and a registry sweep to find the classes that lazy modules had not yet defined. All of it is gone. The registry gains exactly two tags — `PatchOp` and `PatchProcessor` — and re-executing DASCore's own module bodies moves 88.6 ms → 94.9 ms, against 157 ms for the class-per-function design.

### Named by a tag, not by a path

An operation is named by a registry tag: bare for DASCore's own (`"normalize"`, `"waterfall"`), and `"mypkg:denoise"` for anything else, derived the way `dascore.models.registry` derives a model's namespace. `patch_function` registers as it decorates, so a function is nameable in a document exactly when its module has been imported.

That is what lets a function bound to nothing — one a user has just written — be an operation at all; a patch path could not name it. It also makes a plugin's `normalize` structurally incapable of being read back as DASCore's. `run` calls the registered wrapper, which is the same object `Patch.normalize` is and the same one a namespace hands out, so history and output are identical by construction rather than by test.

The document also carries `module`, informational only: it is what the error message uses to say what to import, and it is deliberately out of the fingerprint, so moving a function between modules does not make it a different operation.

Resolution imports nothing a document names — that is how a file becomes an exploit. On a miss it sweeps what the *install* declares (DASCore's deferred modules, and the namespace entry-point groups), then says exactly what to do:

```
No patch function 'denoise' from package 'mypkg' is registered in this process.
It was defined in mypkg.filters when this was written -- import that module
(or install mypkg) and read again.
```

`__main__` gets its own wording, and `Pipe.from_dict` prefixes the node it was reading.

`.op(...)` binds the call against the function's signature, so `normalize.op("time")` and `normalize.op(dim="time")` are one operation with one `kwargs` and one fingerprint, defaults are filled in, a `*args` group becomes the tuple it is, and a dimension passed as an extra keeps its own name. A name no patch answers to, or an argument the signature rejects, raises `ParameterError` where the operation is written down rather than when a patch finally reaches it.

A dotted name walks a namespace — `dc.viz.waterfall.op()` is `viz.waterfall` — so a plugin's function needs nothing registered and nothing swept.

### One fingerprint path

`fingerprint_call(func, args, kwargs)` hashes the same canonical arguments against the function's name and version. The `patch_function` wrapper calls it on every call, and `PatchOp.fingerprint` calls it too, so `patch.normalize(dim="time")` and `dc.proc.normalize.op("time")` agree by construction rather than by test. Nothing reads the answer yet; the PR which adds patch ids stamps them from it. It is computed after the call rather than before, so a call the signature rejects still raises what Python raises for it.

`patch_function` gains `version=`, stored on the wrapper as `__version__`. Bump it when the same arguments should mean a different answer.

### The hand-written seam

`PatchProcessor(Task)` stays as a minimal base — `required_dims`, `required_coords`, `required_attrs`, `data_type`, and an annotated `check` — for the few operations later written out by hand because they want a kernel seam. `register_implementation(name, cls)` fills a name→class table, and `fn.op(...)` then returns that class's instance instead of a `PatchOp`: one name, one implementation. The table is empty in this PR; a test with a locally defined class proves the routing.

### Where the checks live

`check_patch_coords`, `check_patch_attrs` and the `attr_type` alias move from `dascore/utils/patch.py` to `dascore/workflow/checks.py`, re-exported from their old home so nothing importing them notices. The move breaks a cycle: `dascore.workflow.processor` is imported while `dascore.utils.patch` is still being imported, from its header, so it cannot import back.

Two fixes came with the move, each with a test: a requirement given as a bare string is one name rather than one name per character (`required_attrs="data_type"` used to report `{'a','e','p','d','y','t','_'}` as missing), and a required-attrs mapping naming an attr the patch lacks raises `PatchAttributeError` rather than `AttributeError` from the middle of the lookup.

### Tests

`tests/test_workflow/_calls.py` holds one call to **every** patch function DASCore defines — 89 of them, seeded from `scripts/differential_check.py::get_calls` — and a private walk which fails the suite if a function added later has no call catalogued. Over that catalogue: the operation answers as the call did, **including `attrs.history`**, and its fingerprint equals `fingerprint_call`'s; each one round trips through a document and through pickle. Plus: both spellings of a call, every parameter kind, the refusals, the namespace route, the registry tag count, and the implementation table.

## Changelog

- added: `dascore.workflow.PatchOp` is any patch function as a task, so an operation can be compared, fingerprinted, written to a file and joined into a pipe.
- added: every function decorated with `dc.patch_function` carries `op`, which builds the `PatchOp` a call to it is.
- added: `dascore.workflow.fingerprint_call` returns the digest which identifies one call to a patch function.
- added: `dascore.workflow.resolve_patch_function` returns the patch function a tag names, and says what to import when nothing registers it.
- added: `dascore.workflow.register_implementation` says which hand-written `PatchProcessor` a patch function's name means.
- added: `dc.patch_function` accepts `version`.
- changed: `check_patch_coords` and `check_patch_attrs` now live in `dascore.workflow.checks`; they are still importable from `dascore.utils.patch`.
- fixed: `check_patch_coords` and `check_patch_attrs` read a single requirement given as a string as one name, rather than one name per character.
- fixed: `check_patch_attrs` raises `PatchAttributeError`, rather than `AttributeError`, when a required attr mapping names an attr the patch does not carry.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
