### PR TITLE
Name a mapped callable without assuming it is a function

### DIFF
--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -815,6 +815,21 @@ def cached_method(func):
     return wrapper
 
 
+def _callable_name(func) -> str:
+    """
+    Return a human-readable name for a callable's progress label.
+
+    A `functools.partial` is named for the function it wraps. A callable
+    object and a `Task` have no `__name__`; a `Task` standing for more than
+    one operation names itself with `node_name` (see `pipe.default_key`),
+    and anything else falls back to its class name.
+    """
+    while isinstance(func, functools.partial):
+        func = func.func
+    name = getattr(func, "__name__", None) or getattr(func, "node_name", None)
+    return name or type(func).__name__
+
+
 class _MapFuncWrapper:
     """A class for unwrapping spools to base applies."""
 
@@ -835,7 +850,7 @@ class _MapFuncWrapper:
             # displays the progress bar. A huge hack, maybe there is a better
             # way? See #265.
             if not getattr(spool, "_no_progress", False):
-                desc = f"Applying {self._func.__name__} to spool"
+                desc = f"Applying {_callable_name(self._func)} to spool"
                 iterable = track(spool, desc, self._progress)
             return [self._func(x, **self._kwargs) for x in iterable]
 
@@ -869,8 +884,8 @@ def _spool_map(
     # accepted or refused depending on how much data there was.
     validate_progress_level(progress)
     # no client; simple for loop.
-    desc = f"Applying {func.__name__} to spool"
     if client is None:
+        desc = f"Applying {_callable_name(func)} to spool"
         return [func(patch, **kwargs) for patch in track(spool, desc, progress)]
     # Now things get interesting. We need to split the spool here
     # so that patches don't get serialized.

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import functools
 import shutil
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
@@ -32,6 +33,13 @@ from dascore.utils.time import to_datetime64, to_timedelta64
 def _gigo(garbage):
     """Dummy func which can be serialized."""
     return garbage
+
+
+class _CallableObject:
+    """A callable object, which has no `__name__`."""
+
+    def __call__(self, patch):
+        return patch
 
 
 class _SerialClient:
@@ -737,6 +745,16 @@ class TestMap:
         except (PermissionError, OSError, RuntimeError) as exc:
             pytest.skip(f"ProcessPoolExecutor unavailable: {exc}")
 
+    @pytest.fixture(params=["partial", "callable_object", "patch_op"])
+    def nameless_callable(self, request):
+        """A callable with no `__name__`, of each kind DASCore makes."""
+        callables = {
+            "partial": functools.partial(_gigo),
+            "callable_object": _CallableObject(),
+            "patch_op": dc.proc.abs.op(),
+        }
+        return callables[request.param]
+
     def test_simple(self, random_spool):
         """Simplest case for mapping a function on all patches."""
         out = list(random_spool.map(lambda x: x))
@@ -767,6 +785,16 @@ class TestMap:
         out = list(random_spool.map(_gigo, client=proc_client))
         assert len(out) == len(random_spool)
         assert dc.spool(out) == random_spool
+
+    def test_callable_without_name(self, random_spool, nameless_callable):
+        """A callable with no `__name__` can be mapped."""
+        out = list(random_spool.map(nameless_callable))
+        assert len(out) == len(random_spool)
+
+    def test_callable_without_name_client(self, random_spool, nameless_callable):
+        """A client maps a nameless callable; the worker builds the label."""
+        out = list(random_spool.map(nameless_callable, client=_SerialClient()))
+        assert len(out) == len(random_spool)
 
     def test_map_docstring(self, random_spool):
         """Ensure the docstring examples work."""

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import os
 import threading
 import time
@@ -18,6 +19,7 @@ from upath import UPath
 import dascore as dc
 from dascore.exceptions import MissingOptionalDependencyError, ParameterError
 from dascore.utils.misc import (
+    _callable_name,
     _get_install_name,
     _iter_filesystem,
     _locked,
@@ -713,6 +715,36 @@ class TestToObjectArray:
         assert isinstance(out, np.ndarray)
 
 
+def _dim_count(patch, value=1):
+    """Return the dimension count plus value; named, unlike a lambda."""
+    return len(patch.dims) + value
+
+
+class TestCallableName:
+    """Tests for naming a callable for a progress label."""
+
+    def test_function(self):
+        """A plain function is named by `__name__`."""
+        assert _callable_name(iterate) == "iterate"
+
+    def test_partial(self):
+        """A partial has no `__name__`; it is named for what it wraps."""
+        assert _callable_name(functools.partial(iterate, 1)) == "iterate"
+
+    def test_callable_object(self):
+        """A callable object is named for its class."""
+
+        class Doubler:
+            def __call__(self, patch):
+                return patch * 2
+
+        assert _callable_name(Doubler()) == "Doubler"
+
+    def test_node_name(self):
+        """An object with `node_name` is named for its operation, not its class."""
+        assert _callable_name(dc.proc.abs.op()) == "abs"
+
+
 class TestSpoolMap:
     """Tests for the private spool mapping helper."""
 
@@ -726,7 +758,15 @@ class TestSpoolMap:
         )
         assert out == [3, 3, 3]
 
-    def test_with_client(self, random_spool, monkeypatch):
+    @pytest.mark.parametrize(
+        "func, label",
+        [
+            (lambda patch, value=1: len(patch.dims) + value, "<lambda>"),
+            (functools.partial(_dim_count), "_dim_count"),
+        ],
+        ids=["function", "partial"],
+    )
+    def test_with_client(self, random_spool, monkeypatch, func, label):
         """A client should receive split spools and flatten mapped outputs."""
         seen = []
 
@@ -742,13 +782,13 @@ class TestSpoolMap:
         monkeypatch.setattr("dascore.utils.misc.os.cpu_count", lambda: 2)
         out = _spool_map(
             random_spool[:4],
-            lambda patch, value=1: len(patch.dims) + value,
+            func,
             client=DummyClient(),
             size=None,
             progress="standard",
         )
         assert out == [3, 3, 3]
-        assert seen == ["Applying <lambda> to spool"]
+        assert seen == [f"Applying {label} to spool"]
 
     def test_empty_spool_with_client(self):
         """An empty spool asks for no work rather than a split size of zero."""


### PR DESCRIPTION
## Description

`Spool.map(func)` built its progress bar label from `func.__name__`, so it raised `AttributeError` for any callable which is not a plain function. On `dev`:

```python
import functools, dascore as dc

sp = dc.get_example_spool()
list(sp.map(functools.partial(dc.proc.abs)))  # AttributeError: 'functools.partial' object has no attribute '__name__'
list(sp.map(dc.proc.abs.op()))                # AttributeError: 'PatchOp' object has no attribute '__name__'
```

A `functools.partial` is the ordinary user-facing case, and it is broken today at either call site: the no-client loop in `_spool_map` and the worker label in `_MapFuncWrapper.__call__`. It also made a promise in merged code false — `Task.__call__`'s docstring says a task "can stand anywhere a function of its inputs can -- `spool.map(task)`, most of all", which it could not.

The fix is a small private helper, `dascore.utils.misc._callable_name`, used at both sites. It names a `functools.partial` for the function it wraps (so the bar says `Applying abs to spool`, not `Applying partial to spool`), lets an object which stands for more than one operation name itself with `node_name` (a `PatchOp` says `abs`), and falls back to the class name for anything else. Nothing but the progress label reads a name off the mapped callable.

The label in `_spool_map` also moved inside the `client is None` branch; on the client path it was computed and never read.

Assumptions and things deliberately not done:

- The repo now has several small "name a callable" helpers with different contracts — `pipe.default_key` (node name for a pipe node, snake-cased), `utils.patch._func_name` (falls back to `str(func)` because a history string wants the full repr), and two in `workflow/task.py`. Unifying them would change how pipe nodes and history strings are named, which is not a bug fix; it is left for a follow-up.
- `Task` was not given a `__name__` property. The bug is that the progress bar assumed every callable is a function, which `functools.partial` proves wrong independently of the workflow module.

## Changelog

- fixed: `Spool.map` no longer raises `AttributeError` for a callable without a `__name__`, such as a `functools.partial`, a callable object or a `Task`. The progress label now names a partial for the function it wraps.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress reporting for partial functions, callable objects, tasks, and other functions without standard names.
  * Fixed mapping operations so nameless callables work reliably in both direct and serial-client execution.
  * Progress descriptions now display clearer, more consistent callable names, including for lambda and partial functions.
* **Tests**
  * Added coverage for callable naming and mapping behavior across supported execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->