### PR TITLE
Give a patch an id for which data it is and what was done to it

### DIFF
--- a/dascore/config.py
+++ b/dascore/config.py
@@ -56,6 +56,14 @@ class DascoreConfig(BaseModel):
         default="standard",
         description="Controls whether DASCore appends processing history to patches.",
     )
+    patch_provenance: Literal["ids", "disabled"] = Field(
+        default="ids",
+        description=(
+            "Controls whether DASCore maintains the patch_id and "
+            "processing_id which say which data a patch is and what was "
+            "done to it."
+        ),
+    )
     sampling_group_tolerance: float = Field(
         default=0.05,
         gt=0,

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -156,7 +156,10 @@ FILE_FORMATTER_METHODS = ("read", "write", "get_format", "scan")
 
 # These attributes are the default to ignore when determine if patches
 # can be merged or broadcast together.
-DEFAULT_ATTRS_TO_IGNORE = ("history", "dims")
+# The ids say where a patch came from and what was done to it, which is
+# never a reason to refuse to combine two patches; the folds decide what
+# the result carries instead.
+DEFAULT_ATTRS_TO_IGNORE = ("history", "dims", "patch_id", "processing_id")
 
 # Large and small np.datetime64[ns] (used when defaults are needed)
 SMALLDT64 = np.datetime64(MININT64 + 5_000_000_000, "ns")

--- a/dascore/core/attrs.py
+++ b/dascore/core/attrs.py
@@ -84,6 +84,22 @@ class PatchAttrs(DascoreBaseModel):
         default_factory=tuple,
         description="A list of processing performed on the patch.",
     )
+    patch_id: str = Field(
+        default="",
+        description=(
+            "Identifies which data this is. It survives every operation "
+            "which does not change what the data is of, and changes only "
+            "when data from more than one source is combined."
+        ),
+    )
+    processing_id: str = Field(
+        default="",
+        description=(
+            "Identifies what was done to the data. It advances on every "
+            "operation, so two patches which took the same route from the "
+            "same source carry the same value and two which did not, do not."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -180,7 +180,9 @@ class Patch(NamespaceOwner):
         return apply_ufunc(np.mod, other, self)
 
     def __neg__(self):
-        return self.update(data=-self.data)
+        # Through the ufunc, not `update`: `-patch` and `np.negative(patch)`
+        # are one operation, and `update` records nothing.
+        return apply_ufunc(np.negative, self)
 
     # Numpy Compatibility things
     __array_ufunc__ = patch_array_ufunc

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -30,6 +30,7 @@ from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import check_patch_attrs, check_patch_coords, get_patch_names
 from dascore.utils.time import to_float
+from dascore.workflow.identity import with_data_id
 
 
 class Patch(NamespaceOwner):
@@ -102,6 +103,9 @@ class Patch(NamespaceOwner):
         shape = data.shape
         coords = get_coord_manager(coords, dims=dims, shape=shape)
         attrs = dc.PatchAttrs.from_dict(attrs)
+        # Data which names no source still says which data it is, so that
+        # everything downstream has something to carry forward.
+        attrs = with_data_id(attrs)
         self._coords = coords
         self._attrs = attrs
         self._data = array(self.coords.validate_data(data))

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -30,7 +30,7 @@ from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import check_patch_attrs, check_patch_coords, get_patch_names
 from dascore.utils.time import to_float
-from dascore.workflow.identity import with_data_id
+from dascore.workflow.identity import with_patch_id
 
 
 class Patch(NamespaceOwner):
@@ -105,7 +105,7 @@ class Patch(NamespaceOwner):
         attrs = dc.PatchAttrs.from_dict(attrs)
         # Data which names no source still says which data it is, so that
         # everything downstream has something to carry forward.
-        attrs = with_data_id(attrs)
+        attrs = with_patch_id(attrs)
         self._coords = coords
         self._attrs = attrs
         self._data = array(self.coords.validate_data(data))

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -245,9 +245,16 @@ class PatchSummary(DascoreBaseModel):
 
     @classmethod
     def from_patch(cls, patch: dc.Patch) -> PatchSummary:
-        """Create a summary from a loaded patch."""
+        """
+        Create a summary from a loaded patch.
+
+        The lineage ids are dropped. A summary describes what data a file
+        holds, and the index does not store an id -- so a summary which
+        carried one would make scanning a file and reading it disagree
+        about the same data, for a field neither of them indexes.
+        """
         return cls(
-            attrs=patch.attrs,
+            attrs=patch.attrs.drop("patch_id", "processing_id"),
             coords=patch.coords.to_summary_dict(),
             dims=patch.dims,
             shape=patch.shape,

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -90,6 +90,12 @@ def _save_attrs_and_dims(patch, patch_group):
     # copy attrs to group attrs
     # TODO will need to test if objects are serializable
     attr_dict = patch.attrs.model_dump(exclude_unset=True)
+    # Not written yet. An older DASCore reading a file which carries them
+    # treats them as ordinary attrs, and then refuses to merge two patches
+    # whose ids differ -- which is every pair. Persisting them is for the
+    # format version which knows to fold them instead.
+    attr_dict.pop("patch_id", None)
+    attr_dict.pop("processing_id", None)
     for i, v in attr_dict.items():
         encoded, attr_type = _encode_attr_value(i, v)
         patch_group.attrs[f"{_ATTR_PREFIX}{i}"] = encoded

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -43,7 +43,9 @@ from dascore.utils.time import to_datetime64, to_int, to_timedelta64
 _SANITIZE_RE = re.compile(r"[^a-z0-9_]+")
 
 # Attrs handled structurally or intentionally excluded from the index.
-_SKIPPED_ATTRS = frozenset({"history", "dims", "coords"})
+# The ids are not indexed until the schema version which adds columns for
+# them; an index is for finding data, and an id is not a search term.
+_SKIPPED_ATTRS = frozenset({"history", "dims", "coords", "patch_id", "processing_id"})
 
 
 @dataclass(frozen=True)

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -137,6 +137,11 @@ def update_attrs(self: PatchType, **attrs) -> PatchType:
     )
 
 
+# Which data a patch is and what was done to it are not part of what it
+# *is*: two patches holding the same data are equal however they were made.
+_LINEAGE = {"patch_id", "processing_id"}
+
+
 def equals(self: PatchType, other: Any, only_required_attrs=True, close=False) -> bool:
     """
     Determine if the current patch equals another.
@@ -178,16 +183,14 @@ def equals(self: PatchType, other: Any, only_required_attrs=True, close=False) -
     if only_required_attrs:  # only include default fields
         # The ids are not part of what a patch *is*: two patches with the
         # same data, coords and attrs are equal however they were made.
-        attrs_to_compare = set(PatchAttrs.model_fields) - {
-            "history",
-            "patch_id",
-            "processing_id",
-        }
+        attrs_to_compare = set(PatchAttrs.model_fields) - {"history"} - _LINEAGE
         attrs1 = self.attrs.model_dump(include=attrs_to_compare)
         attrs2 = other.attrs.model_dump(include=attrs_to_compare)
     else:
-        attrs1 = self.attrs.model_dump()
-        attrs2 = other.attrs.model_dump()
+        # The ids are excluded here too: comparing every attr is about
+        # the user's attrs, not about where the data came from.
+        attrs1 = self.attrs.model_dump(exclude=_LINEAGE)
+        attrs2 = other.attrs.model_dump(exclude=_LINEAGE)
     if set(attrs1) != set(attrs2):  # attrs don't have same keys; not equal
         return False
     if attrs1 != attrs2:

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -176,7 +176,13 @@ def equals(self: PatchType, other: Any, only_required_attrs=True, close=False) -
     if not self.coords == other.coords:
         return False
     if only_required_attrs:  # only include default fields
-        attrs_to_compare = set(PatchAttrs.model_fields) - {"history"}
+        # The ids are not part of what a patch *is*: two patches with the
+        # same data, coords and attrs are equal however they were made.
+        attrs_to_compare = set(PatchAttrs.model_fields) - {
+            "history",
+            "patch_id",
+            "processing_id",
+        }
         attrs1 = self.attrs.model_dump(include=attrs_to_compare)
         attrs2 = other.attrs.model_dump(include=attrs_to_compare)
     else:

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -34,6 +34,8 @@ from dascore.utils.patch import (
     numpy_fallback,
     swap_kwargs_dim_to_axis,
 )
+from dascore.workflow.builtin import ArrayFunc, Ufunc
+from dascore.workflow.identity import stamp_combination
 
 # Numpy reductions which skip nans, and the name they are known by in
 # dascore.utils.array_api.nan_reduce.
@@ -254,7 +256,15 @@ def _apply_unary_ufunc(operator: np.ufunc, patch, *args, **kwargs):
     We assume the shape of the array won't change.
     """
     out = _apply_operator(operator, patch.data, *args, **kwargs)
-    return patch.new(data=out)
+    # As for the binary case: a ufunc has no patch function to name it, so
+    # `np.abs(patch)` would otherwise record that nothing happened.
+    task = Ufunc(
+        name=getattr(operator, "__name__", str(operator)),
+        operands=tuple(args),
+        kwargs=_without_patch_values(kwargs),
+    )
+    attrs = stamp_combination(patch.attrs, [patch.attrs], task.fingerprint)
+    return patch.new(data=out, attrs=attrs)
 
 
 def _apply_binary_ufunc(
@@ -369,6 +379,9 @@ def _apply_binary_ufunc(
         patch, other = other, patch
         reversed = True
 
+    # Taken before the operands are aligned and possibly replaced below:
+    # what went in is what decides which data comes out.
+    members = [x.attrs for x in (patch, other) if isinstance(x, dc.Patch)]
     if patch_count > 1:
         patch, other, coords, attrs = _get_coords_attrs_from_patches(patch, other)
     else:
@@ -379,6 +392,16 @@ def _apply_binary_ufunc(
         new_data, attrs = _apply_op_units(patch, other, operator, attrs, reversed)
     else:
         new_data = _apply_op(patch.data, other, operator, reversed)
+    # A ufunc is not a patch function, so nothing else names it. Without
+    # this, `patch + 1` and `patch - (-1)` produce the same data and the
+    # same id, though they are different operations.
+    task = Ufunc(
+        name=getattr(operator, "__name__", str(operator)),
+        reversed=reversed,
+        operands=() if other_is_patch else (other,),
+        kwargs=kwargs,
+    )
+    attrs = stamp_combination(attrs, members, task.fingerprint)
     new = patch.new(data=new_data, coords=coords, attrs=attrs)
     return new
 
@@ -657,7 +680,23 @@ def _apply_array_func(func, *args, **kwargs):
     patch = _reassemble_patch(
         result, first_patch, func, converted_args, converted_kwargs
     )
-    return _clear_units_if_bool_dtype(patch)
+    # An array function is not a patch function either, so nothing else
+    # names it: without this `np.mean(patch, axis=0)` leaves the ids where
+    # they were and claims nothing was done.
+    task = ArrayFunc(
+        name=getattr(func, "__name__", str(func)),
+        kwargs=_without_patch_values(converted_kwargs),
+    )
+    attrs = stamp_combination(patch.attrs, [x.attrs for x in patches], task.fingerprint)
+    return _clear_units_if_bool_dtype(patch.new(attrs=attrs))
+
+
+def _without_patch_values(kwargs):
+    """Return kwargs with any patch replaced: it is an input, not a parameter."""
+    return {
+        key: "$patch" if isinstance(value, dc.Patch) else value
+        for key, value in kwargs.items()
+    }
 
 
 # Mapping of ufunc dispatches. Keys are method name or num input/num output.

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -25,7 +25,7 @@ from dascore.utils.array_api import (
     is_numpy,
     nan_reduce,
 )
-from dascore.utils.misc import iterate
+from dascore.utils.misc import iterate, suppress_warnings
 from dascore.utils.patch import (
     _merge_aligned_coords,
     _merge_models,
@@ -34,8 +34,10 @@ from dascore.utils.patch import (
     numpy_fallback,
     swap_kwargs_dim_to_axis,
 )
+from dascore.warnings import DASCoreWarning
 from dascore.workflow.builtin import ArrayFunc, Ufunc
 from dascore.workflow.identity import ids_enabled, stamp_combination
+from dascore.workflow.processor import _PATCH_ARGUMENT
 
 # Numpy reductions which skip nans, and the name they are known by in
 # dascore.utils.array_api.nan_reduce.
@@ -407,7 +409,7 @@ def _apply_binary_ufunc(
             operands=_without_patch_values((*rest, *args)),
             kwargs=_without_patch_values(kwargs),
         )
-        attrs = stamp_combination(attrs, members, task.fingerprint)
+        attrs = stamp_combination(attrs, members, _fingerprint_of(task))
     new = patch.new(data=new_data, coords=coords, attrs=attrs)
     return new
 
@@ -698,7 +700,7 @@ def _apply_array_func(func, *args, **kwargs):
             kwargs=_without_patch_values(converted_kwargs),
         )
         attrs = stamp_combination(
-            patch.attrs, [x.attrs for x in patches], task.fingerprint
+            patch.attrs, [x.attrs for x in patches], _fingerprint_of(task)
         )
         patch = patch.new(attrs=attrs)
     return _clear_units_if_bool_dtype(patch)
@@ -718,6 +720,20 @@ def _array_func_name(func) -> str:
     return f"{owner}.{name}" if owner else name
 
 
+def _fingerprint_of(task) -> str:
+    """
+    Return a task's fingerprint without complaining about the patch marker.
+
+    The marker is a singleton, so hashing it by its type -- which is what
+    the warning is about -- loses nothing. The warning is worth hearing
+    for a value where it would.
+    """
+    with suppress_warnings(
+        DASCoreWarning, message="A value of type .* has no encoding"
+    ):
+        return task.fingerprint
+
+
 def _without_patch_values(values):
     """
     Return arguments with anything the fingerprint should not hold replaced.
@@ -730,7 +746,7 @@ def _without_patch_values(values):
 
     def _plain(value):
         if isinstance(value, dc.Patch):
-            return "$patch"
+            return _PATCH_ARGUMENT
         if isinstance(value, np.dtype):
             return str(value)
         return value

--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import functools
 import hashlib
 import inspect
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 import numpy as np
@@ -35,7 +35,7 @@ from dascore.utils.patch import (
     swap_kwargs_dim_to_axis,
 )
 from dascore.workflow.builtin import ArrayFunc, Ufunc
-from dascore.workflow.identity import stamp_combination
+from dascore.workflow.identity import ids_enabled, stamp_combination
 
 # Numpy reductions which skip nans, and the name they are known by in
 # dascore.utils.array_api.nan_reduce.
@@ -394,14 +394,20 @@ def _apply_binary_ufunc(
         new_data = _apply_op(patch.data, other, operator, reversed)
     # A ufunc is not a patch function, so nothing else names it. Without
     # this, `patch + 1` and `patch - (-1)` produce the same data and the
-    # same id, though they are different operations.
-    task = Ufunc(
-        name=getattr(operator, "__name__", str(operator)),
-        reversed=reversed,
-        operands=() if other_is_patch else (other,),
-        kwargs=kwargs,
-    )
-    attrs = stamp_combination(attrs, members, task.fingerprint)
+    # same id, though they are different operations. Guarded, so that a
+    # process which has turned the ids off does not hash operands for a
+    # value nothing will read.
+    if ids_enabled():
+        rest = () if other_is_patch else (other,)
+        task = Ufunc(
+            name=getattr(operator, "__name__", str(operator)),
+            reversed=reversed,
+            # `args` reaches the operator too, so two calls which differ
+            # only in those are two operations.
+            operands=_without_patch_values((*rest, *args)),
+            kwargs=_without_patch_values(kwargs),
+        )
+        attrs = stamp_combination(attrs, members, task.fingerprint)
     new = patch.new(data=new_data, coords=coords, attrs=attrs)
     return new
 
@@ -683,20 +689,55 @@ def _apply_array_func(func, *args, **kwargs):
     # An array function is not a patch function either, so nothing else
     # names it: without this `np.mean(patch, axis=0)` leaves the ids where
     # they were and claims nothing was done.
-    task = ArrayFunc(
-        name=getattr(func, "__name__", str(func)),
-        kwargs=_without_patch_values(converted_kwargs),
-    )
-    attrs = stamp_combination(patch.attrs, [x.attrs for x in patches], task.fingerprint)
-    return _clear_units_if_bool_dtype(patch.new(attrs=attrs))
+    if ids_enabled():
+        task = ArrayFunc(
+            name=_array_func_name(func),
+            # The positional arguments say which reduction it was:
+            # `np.mean(patch, 0)` and `np.mean(patch, 1)` are two.
+            args=_without_patch_values(converted_args),
+            kwargs=_without_patch_values(converted_kwargs),
+        )
+        attrs = stamp_combination(
+            patch.attrs, [x.attrs for x in patches], task.fingerprint
+        )
+        patch = patch.new(attrs=attrs)
+    return _clear_units_if_bool_dtype(patch)
 
 
-def _without_patch_values(kwargs):
-    """Return kwargs with any patch replaced: it is an input, not a parameter."""
-    return {
-        key: "$patch" if isinstance(value, dc.Patch) else value
-        for key, value in kwargs.items()
-    }
+def _array_func_name(func) -> str:
+    """
+    Return the name an array function is recorded under.
+
+    A ufunc method arrives here as the bound `np.add.reduce`, whose
+    `__name__` is only "reduce" -- so `np.add.reduce` and
+    `np.multiply.reduce` would be one operation without the ufunc it
+    belongs to.
+    """
+    name = getattr(func, "__name__", str(func))
+    owner = getattr(getattr(func, "__self__", None), "__name__", None)
+    return f"{owner}.{name}" if owner else name
+
+
+def _without_patch_values(values):
+    """
+    Return arguments with anything the fingerprint should not hold replaced.
+
+    A patch is an *input*, not a parameter -- which one it was is said by
+    the ids folded from the operands. A numpy dtype has no encoding of its
+    own, so it is spelled out rather than hashed by its class, which would
+    give every dtype one fingerprint and warn on every call.
+    """
+
+    def _plain(value):
+        if isinstance(value, dc.Patch):
+            return "$patch"
+        if isinstance(value, np.dtype):
+            return str(value)
+        return value
+
+    if isinstance(values, Mapping):
+        return {key: _plain(value) for key, value in values.items()}
+    return tuple(_plain(x) for x in values)
 
 
 # Mapping of ufunc dispatches. Keys are method name or num input/num output.

--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -19,6 +19,7 @@ from dascore.utils.misc import (
     _dict_list_diffs,
     iterate,
 )
+from dascore.workflow.identity import _ID_FIELDS, fold_ids
 
 _VALID_CONFLICT_VALUES = ("drop", "raise", "keep_first")
 
@@ -71,6 +72,13 @@ def combine_patch_attrs(
             _drop_private_keys(_to_patch_attrs(x).model_dump(exclude_defaults=True))
             for x in mod_list
         ]
+        # Taken out before anything compares them: two patches which are
+        # different data, or which were processed differently, are exactly
+        # what a merge is for, so an id must never make one raise. The fold
+        # below decides what the result carries instead.
+        model_dicts = [
+            {i: v for i, v in x.items() if i not in _ID_FIELDS} for x in model_dicts
+        ]
         # drop attributes specified.
         if drop := set(iterate(drop_attrs)):
             model_dicts = [
@@ -121,10 +129,11 @@ def combine_patch_attrs(
         return [final_dict]
 
     mod_dict_list = _get_model_dict_list(model_list)
+    ids = fold_ids([_to_patch_attrs(x) for x in model_list])
     mod_dict_list = _handle_other_attrs(mod_dict_list)
     first = model_list[0]
     first_class = (
         _to_patch_attrs(first).__class__ if not isinstance(first, dict) else dict
     )
     cls = first_class if first_class is not dict else dc.PatchAttrs
-    return cls(**mod_dict_list[0])
+    return cls(**{**mod_dict_list[0], **ids})

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -136,6 +136,9 @@ def attrs_to_text(attrs) -> Text:
     attrs = dc.PatchAttrs.from_dict(attrs).model_dump(exclude_defaults=True)
     # pop coords and dims since they show up in other places.
     attrs.pop("coords", None), attrs.pop("dims", None)
+    # The lineage ids are not metadata a reader is looking at a patch to
+    # read; they would put a line of hex on every patch anyone prints.
+    attrs.pop("patch_id", None), attrs.pop("processing_id", None)
     txt = Text("➤ ") + Text("Attributes", style=dascore_styles["dc_yellow"])
     txt += Text("\n")
     for name, attr in dict(attrs).items():

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -57,7 +57,12 @@ from dascore.utils.misc import (
 from dascore.utils.paths import is_memory_uri
 from dascore.utils.time import to_float
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
-from dascore.workflow.processor import PatchOp, register_patch_function
+from dascore.workflow.identity import advance, ids_enabled
+from dascore.workflow.processor import (
+    PatchOp,
+    fingerprint_call,
+    register_patch_function,
+)
 
 _DimAxisValue = namedtuple("_DimAxisValue", ["dim", "axis", "value"])
 
@@ -366,6 +371,24 @@ def patch_function(
                     patch, func, *args, _history=history, **kwargs
                 )
                 attrs = _maybe_add_history_str(out.attrs, hist_str)
+                # What was done, folded into what the input carried, into
+                # the same attrs object the history went into: an operation
+                # should cost one new patch, not one per thing it stamps.
+                #
+                # Only when something new came back: an operation which
+                # handed the patch straight through did nothing, and nothing
+                # is what it records.
+                if ids_enabled():
+                    fingerprint = fingerprint_call(patch_func, args, kwargs)
+                    attrs = attrs.update(
+                        processing_id=advance(patch.attrs.processing_id, fingerprint),
+                        # Carried from the input rather than left to
+                        # whatever the body returned: filtering data does
+                        # not make it other data, and a function building
+                        # its result from scratch would otherwise mint a
+                        # new id and claim it had.
+                        patch_id=patch.attrs.patch_id,
+                    )
                 if attrs is not out.attrs:
                     out = out.update(attrs=attrs)
             if attr_updates and hasattr(out, "attrs"):

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -56,8 +56,13 @@ from dascore.utils.misc import (
 )
 from dascore.utils.paths import is_memory_uri
 from dascore.utils.time import to_float
+from dascore.workflow.builtin import Concatenate, Stack
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
-from dascore.workflow.identity import advance, ids_enabled
+from dascore.workflow.identity import (
+    advance,
+    ids_enabled,
+    stamp_combination,
+)
 from dascore.workflow.processor import (
     PatchOp,
     fingerprint_call,
@@ -1508,6 +1513,16 @@ def concatenate_patches(
     for patch_list in yield_sub_sequences(patches, val):
         ar = get_output_array(patch_list, dims.index(dim), new_dim)
         attrs = _maybe_add_history_str(patch_list[0].attrs, "concatenate")
+        # Which data this now is: every member which went in, in order.
+        # Taking the first patch's id would claim the result was only the
+        # first source.
+        attrs = stamp_combination(
+            attrs,
+            [x.attrs for x in patch_list],
+            Concatenate.from_kwargs(
+                check_behavior=check_behavior, **kwargs
+            ).fingerprint,
+        )
         coords = _get_new_coords(patch_list, dim, new_dim)
         out.append(dc.Patch(data=ar, attrs=attrs, coords=coords, dims=dims))
     return out
@@ -1546,6 +1561,7 @@ def stack_patches(
         msg = f"Dimension {dim_vary} is not in first patch."
         raise PatchCoordinateError(msg)
 
+    kept = []
     for p in patches:
         # check dimensions of patch compared to init_patch
         dims_ok = check_dims(init_patch, p, check_behavior)
@@ -1553,9 +1569,17 @@ def stack_patches(
         # actually do the stacking of data
         if dims_ok and coords_ok:
             stack_arr = stack_arr + p.data
+            kept.append(p.attrs)
 
     # create attributes for the stack with adjusted history
     stack_attrs = _maybe_add_history_str(init_patch.attrs, "stack")
+    # The kept members only: one dropped for being incompatible did not
+    # contribute its data, so it is not part of what this data is.
+    stack_attrs = stamp_combination(
+        stack_attrs,
+        kept,
+        Stack(dim_vary=dim_vary, check_behavior=check_behavior).fingerprint,
+    )
 
     # create coords array for the stack
     stack_coords = init_patch.coords

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -60,10 +60,10 @@ from dascore.workflow.builtin import Concatenate, Stack
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
 from dascore.workflow.identity import (
     advance,
-    data_id_of,
-    fold_data_ids,
+    fold_patch_ids,
     fold_processing_ids,
     ids_enabled,
+    patch_id_of,
     processing_id_of,
     stamp_combination,
 )
@@ -213,7 +213,7 @@ def _stamp(patch, attrs, patch_func, args, kwargs):
         # returned: filtering data does not make it other data, and a
         # function building its result from scratch would otherwise mint a
         # new id and claim it had.
-        patch_id=fold_data_ids([data_id_of(x) for x in members]),
+        patch_id=fold_patch_ids([patch_id_of(x) for x in members]),
         processing_id=advance(
             fold_processing_ids([processing_id_of(x) for x in members]), fingerprint
         ),

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -60,7 +60,11 @@ from dascore.workflow.builtin import Concatenate, Stack
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
 from dascore.workflow.identity import (
     advance,
+    data_id_of,
+    fold_data_ids,
+    fold_processing_ids,
     ids_enabled,
+    processing_id_of,
     stamp_combination,
 )
 from dascore.workflow.processor import (
@@ -183,6 +187,37 @@ class _PatchFunction(Protocol):
     __wrapped__: Callable
 
     def __call__(self, patch, *args, **kwargs): ...
+
+
+def _stamp(patch, attrs, patch_func, args, kwargs):
+    """
+    Return attrs saying which data this is and what was just done to it.
+
+    Every patch given to the call counts towards which data the result is
+    -- `where(cond_patch, other_patch)` uses all three -- so their ids are
+    folded rather than the first one being copied across. The ids are read
+    with `getattr`, because attrs unpickled from before these fields
+    existed have neither.
+    """
+    members = [patch.attrs]
+    members += [x.attrs for x in (*args, *kwargs.values()) if isinstance(x, dc.Patch)]
+    try:
+        fingerprint = fingerprint_call(patch_func, args, kwargs)
+    except Exception:
+        # Provenance is metadata about the work, not the work. An argument
+        # the serializer cannot encode is a reason to say nothing about
+        # this call, never a reason to fail a call which otherwise worked.
+        return attrs
+    return attrs.update(
+        # Carried from the inputs rather than from whatever the body
+        # returned: filtering data does not make it other data, and a
+        # function building its result from scratch would otherwise mint a
+        # new id and claim it had.
+        patch_id=fold_data_ids([data_id_of(x) for x in members]),
+        processing_id=advance(
+            fold_processing_ids([processing_id_of(x) for x in members]), fingerprint
+        ),
+    )
 
 
 def _op_from_call(patch_func, *args, **kwargs):
@@ -384,16 +419,7 @@ def patch_function(
                 # handed the patch straight through did nothing, and nothing
                 # is what it records.
                 if ids_enabled():
-                    fingerprint = fingerprint_call(patch_func, args, kwargs)
-                    attrs = attrs.update(
-                        processing_id=advance(patch.attrs.processing_id, fingerprint),
-                        # Carried from the input rather than left to
-                        # whatever the body returned: filtering data does
-                        # not make it other data, and a function building
-                        # its result from scratch would otherwise mint a
-                        # new id and claim it had.
-                        patch_id=patch.attrs.patch_id,
-                    )
+                    attrs = _stamp(patch, attrs, patch_func, args, kwargs)
                 if attrs is not out.attrs:
                     out = out.update(attrs=attrs)
             if attr_updates and hasattr(out, "attrs"):

--- a/dascore/workflow/__init__.py
+++ b/dascore/workflow/__init__.py
@@ -21,10 +21,10 @@ from dascore.workflow.serialize import (
 from dascore.workflow.builtin import ArrayFunc, Concatenate, Stack, Ufunc
 from dascore.workflow.identity import (
     advance,
-    fold_data_ids,
+    fold_patch_ids,
     fold_processing_ids,
-    new_data_id,
-    source_data_id,
+    new_patch_id,
+    source_patch_id,
 )
 from dascore.workflow.pipe import Pipe
 from dascore.workflow.processor import (

--- a/dascore/workflow/__init__.py
+++ b/dascore/workflow/__init__.py
@@ -18,6 +18,14 @@ from dascore.workflow.serialize import (
     digest,
     encode,
 )
+from dascore.workflow.builtin import ArrayFunc, Concatenate, Stack, Ufunc
+from dascore.workflow.identity import (
+    advance,
+    fold_data_ids,
+    fold_processing_ids,
+    new_data_id,
+    source_data_id,
+)
 from dascore.workflow.pipe import Pipe
 from dascore.workflow.processor import (
     PatchOp,

--- a/dascore/workflow/builtin.py
+++ b/dascore/workflow/builtin.py
@@ -1,0 +1,121 @@
+"""
+The operations DASCore performs which are not patch functions.
+
+Concatenating, stacking and applying a ufunc are things done to patches,
+but none of them is written as a `@patch_function`, so none has an `op`.
+They still have to be named and fingerprinted, because they are what
+advances a patch's `processing_id` -- hence one small `Task` each.
+
+Anything which *is* a patch function needs nothing here:
+[`PatchOp`](`dascore.workflow.processor.PatchOp`) already names it, which
+is why there is no `Select` in this module.
+
+Examples
+--------
+>>> import numpy as np
+>>> from dascore.workflow.builtin import Ufunc
+>>>
+>>> added = Ufunc(name="add")
+>>> assert added.fingerprint != Ufunc(name="subtract").fingerprint
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from dascore.workflow.task import Task
+
+
+class Concatenate(Task):
+    """
+    Putting patches end to end along a dimension.
+
+    Parameters
+    ----------
+    arguments
+        The dimensions concatenated along and how much of each, in the
+        order they were given: `(("time", None),)`.
+    check_behavior
+        What was done about patches which did not fit.
+
+    Notes
+    -----
+    The arguments are pairs rather than a mapping because here the
+    dimension is the *key* and `None` is its documented value, meaning
+    "all of it". The canonical serializer drops a `None` mapping value --
+    deliberately, so a parameter left at its default is the same call as
+    one left out -- which would make concatenating along time and along
+    distance one fingerprint. A pair keeps both halves.
+    """
+
+    arguments: tuple[tuple[str, Any], ...] = ()
+    check_behavior: str | None = "warn"
+
+    @classmethod
+    def from_kwargs(cls, check_behavior: str | None = "warn", **kwargs) -> Concatenate:
+        """Return the task a call to `concatenate_patches` is."""
+        return cls(arguments=tuple(kwargs.items()), check_behavior=check_behavior)
+
+
+class Stack(Task):
+    """
+    Adding patches together.
+
+    Parameters
+    ----------
+    dim_vary
+        The dimension whose values were allowed to differ, if any.
+    check_behavior
+        What was done about patches which did not fit.
+    """
+
+    dim_vary: str | None = None
+    check_behavior: str | None = "warn"
+
+
+class Ufunc(Task):
+    """
+    A numpy ufunc applied to a patch.
+
+    Parameters
+    ----------
+    name
+        The ufunc's name, as numpy spells it: `"add"`, `"multiply"`.
+    method
+        Which way it was applied -- `"__call__"`, `"reduce"`,
+        `"accumulate"` -- since a reduction is not the operation the plain
+        call is.
+    reversed
+        Whether the patch was the right operand, so that `1 - patch` is
+        not recorded as `patch - 1`.
+    operands
+        What the other operands were, for the ones which are not patches.
+        A patch operand is not written here: it is a parent, and the ids
+        already say so.
+    kwargs
+        Whatever else the call carried.
+    """
+
+    name: str
+    method: str = "__call__"
+    reversed: bool = False
+    operands: tuple[Any, ...] = ()
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
+class ArrayFunc(Task):
+    """
+    A numpy array function applied to a patch.
+
+    Parameters
+    ----------
+    name
+        The function's name, as numpy spells it: `"mean"`, `"concatenate"`.
+    kwargs
+        Whatever the call carried, minus the patches themselves.
+    """
+
+    name: str
+    kwargs: dict[str, Any] = Field(default_factory=dict)

--- a/dascore/workflow/builtin.py
+++ b/dascore/workflow/builtin.py
@@ -113,9 +113,12 @@ class ArrayFunc(Task):
     ----------
     name
         The function's name, as numpy spells it: `"mean"`, `"concatenate"`.
+    args
+        The positional arguments, which for a reduction say which axis.
     kwargs
         Whatever the call carried, minus the patches themselves.
     """
 
     name: str
+    args: tuple[Any, ...] = ()
     kwargs: dict[str, Any] = Field(default_factory=dict)

--- a/dascore/workflow/identity.py
+++ b/dascore/workflow/identity.py
@@ -59,9 +59,11 @@ def fold_ids(attrs_list) -> dict[str, Any]:
     kept = list(attrs_list)
     if not kept:
         return {}
+    # `getattr`, for the reason `with_data_id` gives: attrs unpickled from
+    # before these fields existed have neither.
     return {
-        "patch_id": fold_data_ids([x.patch_id for x in kept]),
-        "processing_id": fold_processing_ids([x.processing_id for x in kept]),
+        "patch_id": fold_data_ids([data_id_of(x) for x in kept]),
+        "processing_id": fold_processing_ids([processing_id_of(x) for x in kept]),
     }
 
 
@@ -89,6 +91,16 @@ def stamp_combination(attrs, members, fingerprint: str):
         patch_id=folded["patch_id"],
         processing_id=advance(folded["processing_id"], fingerprint),
     )
+
+
+def data_id_of(attrs) -> str:
+    """Return which data some attrs say they are, or nothing if they cannot."""
+    return getattr(attrs, "patch_id", NOTHING_DONE) or NOTHING_DONE
+
+
+def processing_id_of(attrs) -> str:
+    """Return what some attrs say was done, or nothing if they cannot."""
+    return getattr(attrs, "processing_id", NOTHING_DONE) or NOTHING_DONE
 
 
 def ids_enabled() -> bool:

--- a/dascore/workflow/identity.py
+++ b/dascore/workflow/identity.py
@@ -1,0 +1,135 @@
+"""
+What a patch is, and what was done to it.
+
+Two ids answer two different questions, and they move independently:
+
+`patch_id` says **which data**. It survives every operation which does not
+change what the data is *of* -- filtering, decimating, transposing, changing
+units -- and changes only when data from more than one source is combined.
+
+`processing_id` says **what was done**. It advances on every operation, by
+folding the operation's fingerprint into the id the input carried, so that
+two patches which took the same route from the same source arrive at the
+same id and two which did not, do not.
+
+Neither is a random number after the first: they are digests of what came
+before, so the same data processed the same way gives the same pair on
+another machine, in another process, next year.
+
+Examples
+--------
+>>> from dascore.workflow.identity import advance, fold_data_ids
+>>>
+>>> # What was done: the operation folds into what came before.
+>>> first = advance("", "0123456789abcdef")
+>>> assert advance(first, "0123456789abcdef") != first
+>>>
+>>> # Which data: combining two sources makes a new answer.
+>>> assert fold_data_ids(["a", "b"]) != fold_data_ids(["b", "a"])
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from uuid import uuid4
+
+from dascore.workflow.serialize import digest
+
+# What a patch carries before anything has been done to it. Not a digest:
+# an empty string is the identity element of `advance`, and reads as "this
+# is how the data arrived" rather than as an operation which did nothing.
+NOTHING_DONE = ""
+
+
+def new_data_id() -> str:
+    """
+    Return an id for data which names no source.
+
+    A random one, because there is nothing to derive it from: a patch built
+    in memory from an array is not the same data as anything else, and
+    saying so is more honest than hashing the values and claiming two
+    coincidentally equal arrays are one datum.
+    """
+    return uuid4().hex
+
+
+def source_data_id(format_name: str, path: str, key: object = None) -> str:
+    """
+    Return the id of data read from a file.
+
+    Derived rather than random, so reading the same file twice -- in two
+    processes, on two days -- gives the same answer and the ids in a
+    result can be traced back to what they came from.
+
+    Parameters
+    ----------
+    format_name
+        The format the reader was using.
+    path
+        The resolved path or URI the data came from.
+    key
+        What names this patch within the file, when a file holds more than
+        one. The reader's own key if it has one, else the ordinal.
+
+    Notes
+    -----
+    An id derived this way is stable for a given archive laid out the same
+    way; it is not stable across hosts, because the path is part of it. A
+    format which stores an id -- DASDAE does -- keeps that one instead, and
+    those are stable everywhere.
+    """
+    return digest({"format": format_name, "path": path, "key": key})
+
+
+def advance(processing_id: str, fingerprint: str) -> str:
+    """
+    Return the processing id an operation leads to.
+
+    Parameters
+    ----------
+    processing_id
+        What the input carried.
+    fingerprint
+        The operation's fingerprint; see
+        [`fingerprint_call`](`dascore.workflow.processor.fingerprint_call`).
+    """
+    return digest({"prev": processing_id, "task": fingerprint})
+
+
+def fold_data_ids(data_ids: Sequence[str]) -> str:
+    """
+    Return the data id of a patch combined from several.
+
+    Ordered, and not deduplicated: how many patches went in and in what
+    order is part of what the data *is*, so stacking a patch with itself is
+    not the same datum as the patch alone.
+
+    A single id folds to itself, so an operation which combines one patch
+    with nothing leaves the id where it was.
+    """
+    ids = tuple(data_ids)
+    if len(ids) == 1:
+        return ids[0]
+    return digest({"members": list(ids)})
+
+
+def fold_processing_ids(processing_ids: Iterable[str]) -> str:
+    """
+    Return the processing id which several inputs agree on.
+
+    When every input took the same route, that route is the answer: a
+    chunk of sixty windows of one file has one history, not sixty.
+
+    When they did not, the answer is a digest of the distinct routes in
+    the order they were first seen -- so combining differently processed
+    data says so, and says it the same way every time.
+    """
+    seen: list[str] = []
+    for processing_id in processing_ids:
+        if processing_id not in seen:
+            seen.append(processing_id)
+    if not seen:
+        return NOTHING_DONE
+    if len(seen) == 1:
+        return seen[0]
+    return digest({"routes": seen})

--- a/dascore/workflow/identity.py
+++ b/dascore/workflow/identity.py
@@ -31,14 +31,61 @@ Examples
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
+from typing import Any
 from uuid import uuid4
 
-from dascore.workflow.serialize import digest
+from dascore.workflow.serialize import combine_hashes, digest
 
 # What a patch carries before anything has been done to it. Not a digest:
 # an empty string is the identity element of `advance`, and reads as "this
 # is how the data arrived" rather than as an operation which did nothing.
 NOTHING_DONE = ""
+
+
+# The attrs which say which data a patch is and what was done to it. They
+# are folded rather than compared wherever patches are combined.
+_ID_FIELDS = ("patch_id", "processing_id")
+
+
+def fold_ids(attrs_list) -> dict[str, Any]:
+    """
+    Return the ids a patch combined from several inherits.
+
+    Kept members only: a merge which dropped an incompatible patch did not
+    use its data, so its id is not part of what this data is.
+    """
+    if not ids_enabled():
+        return {}
+    kept = list(attrs_list)
+    if not kept:
+        return {}
+    return {
+        "patch_id": fold_data_ids([x.patch_id for x in kept]),
+        "processing_id": fold_processing_ids([x.processing_id for x in kept]),
+    }
+
+
+def ids_enabled() -> bool:
+    """Whether this process is keeping track of what a patch is."""
+    # Imported here rather than at module scope: `dascore.config` is not
+    # built while the workflow package is being imported.
+    from dascore import get_config  # noqa: PLC0415
+
+    return get_config().patch_provenance != "disabled"
+
+
+def with_data_id(attrs):
+    """
+    Return attrs which name which data they belong to.
+
+    Minted rather than derived when there is nothing to derive one from: a
+    patch built in memory is not the same data as anything else. A reader
+    which knows better -- one whose file stores an id, or which can derive
+    one from the path -- stamps over this.
+    """
+    if attrs.patch_id or not ids_enabled():
+        return attrs
+    return attrs.update(patch_id=new_data_id())
 
 
 def new_data_id() -> str:
@@ -93,7 +140,10 @@ def advance(processing_id: str, fingerprint: str) -> str:
         The operation's fingerprint; see
         [`fingerprint_call`](`dascore.workflow.processor.fingerprint_call`).
     """
-    return digest({"prev": processing_id, "task": fingerprint})
+    # `combine_hashes` rather than a digest of a mapping: both halves are
+    # already digests, and this is what it is for -- an ordered series of
+    # them, where the order is part of the answer.
+    return combine_hashes([processing_id, fingerprint])
 
 
 def fold_data_ids(data_ids: Sequence[str]) -> str:
@@ -110,7 +160,7 @@ def fold_data_ids(data_ids: Sequence[str]) -> str:
     ids = tuple(data_ids)
     if len(ids) == 1:
         return ids[0]
-    return digest({"members": list(ids)})
+    return combine_hashes(ids)
 
 
 def fold_processing_ids(processing_ids: Iterable[str]) -> str:
@@ -132,4 +182,4 @@ def fold_processing_ids(processing_ids: Iterable[str]) -> str:
         return NOTHING_DONE
     if len(seen) == 1:
         return seen[0]
-    return digest({"routes": seen})
+    return combine_hashes(seen)

--- a/dascore/workflow/identity.py
+++ b/dascore/workflow/identity.py
@@ -65,6 +65,32 @@ def fold_ids(attrs_list) -> dict[str, Any]:
     }
 
 
+def stamp_combination(attrs, members, fingerprint: str):
+    """
+    Return the ids a patch made from several members carries.
+
+    Parameters
+    ----------
+    attrs
+        The attrs the result is being built with.
+    members
+        The attrs of the patches which actually went into it -- the kept
+        ones. A member which was dropped for being incompatible did not
+        contribute its data, so it is not part of what this data is.
+    fingerprint
+        The fingerprint of the operation which combined them.
+    """
+    if not ids_enabled():
+        return attrs
+    folded = fold_ids(members)
+    if not folded:
+        return attrs
+    return attrs.update(
+        patch_id=folded["patch_id"],
+        processing_id=advance(folded["processing_id"], fingerprint),
+    )
+
+
 def ids_enabled() -> bool:
     """Whether this process is keeping track of what a patch is."""
     # Imported here rather than at module scope: `dascore.config` is not
@@ -83,7 +109,10 @@ def with_data_id(attrs):
     which knows better -- one whose file stores an id, or which can derive
     one from the path -- stamps over this.
     """
-    if attrs.patch_id or not ids_enabled():
+    # `getattr`, not attribute access: a `PatchAttrs` unpickled from before
+    # these fields existed has neither, and `PatchAttrs.from_dict` hands an
+    # instance back untouched rather than revalidating it into one.
+    if getattr(attrs, "patch_id", None) or not ids_enabled():
         return attrs
     return attrs.update(patch_id=new_data_id())
 
@@ -160,6 +189,11 @@ def fold_data_ids(data_ids: Sequence[str]) -> str:
     ids = tuple(data_ids)
     if len(ids) == 1:
         return ids[0]
+    # Data which never said which data it was does not acquire an identity
+    # by being combined: folding a pile of empty strings would give every
+    # such combination one deterministic id, and they are not one datum.
+    if not any(ids):
+        return NOTHING_DONE
     return combine_hashes(ids)
 
 

--- a/dascore/workflow/identity.py
+++ b/dascore/workflow/identity.py
@@ -13,19 +13,22 @@ two patches which took the same route from the same source arrive at the
 same id and two which did not, do not.
 
 Neither is a random number after the first: they are digests of what came
-before, so the same data processed the same way gives the same pair on
-another machine, in another process, next year.
+before, so the same data processed the same way gives the same
+`processing_id` on another machine, in another process, next year. That
+holds for `patch_id` too once a patch read from a file derives its id from
+the source; until then one is minted for each patch built in memory, and
+is stable only within the process which built it.
 
 Examples
 --------
->>> from dascore.workflow.identity import advance, fold_data_ids
+>>> from dascore.workflow.identity import advance, fold_patch_ids
 >>>
 >>> # What was done: the operation folds into what came before.
 >>> first = advance("", "0123456789abcdef")
 >>> assert advance(first, "0123456789abcdef") != first
 >>>
 >>> # Which data: combining two sources makes a new answer.
->>> assert fold_data_ids(["a", "b"]) != fold_data_ids(["b", "a"])
+>>> assert fold_patch_ids(["a", "b"]) != fold_patch_ids(["b", "a"])
 """
 
 from __future__ import annotations
@@ -59,10 +62,10 @@ def fold_ids(attrs_list) -> dict[str, Any]:
     kept = list(attrs_list)
     if not kept:
         return {}
-    # `getattr`, for the reason `with_data_id` gives: attrs unpickled from
+    # `getattr`, for the reason `with_patch_id` gives: attrs unpickled from
     # before these fields existed have neither.
     return {
-        "patch_id": fold_data_ids([data_id_of(x) for x in kept]),
+        "patch_id": fold_patch_ids([patch_id_of(x) for x in kept]),
         "processing_id": fold_processing_ids([processing_id_of(x) for x in kept]),
     }
 
@@ -93,7 +96,7 @@ def stamp_combination(attrs, members, fingerprint: str):
     )
 
 
-def data_id_of(attrs) -> str:
+def patch_id_of(attrs) -> str:
     """Return which data some attrs say they are, or nothing if they cannot."""
     return getattr(attrs, "patch_id", NOTHING_DONE) or NOTHING_DONE
 
@@ -112,7 +115,7 @@ def ids_enabled() -> bool:
     return get_config().patch_provenance != "disabled"
 
 
-def with_data_id(attrs):
+def with_patch_id(attrs):
     """
     Return attrs which name which data they belong to.
 
@@ -126,10 +129,10 @@ def with_data_id(attrs):
     # instance back untouched rather than revalidating it into one.
     if getattr(attrs, "patch_id", None) or not ids_enabled():
         return attrs
-    return attrs.update(patch_id=new_data_id())
+    return attrs.update(patch_id=new_patch_id())
 
 
-def new_data_id() -> str:
+def new_patch_id() -> str:
     """
     Return an id for data which names no source.
 
@@ -141,7 +144,7 @@ def new_data_id() -> str:
     return uuid4().hex
 
 
-def source_data_id(format_name: str, path: str, key: object = None) -> str:
+def source_patch_id(format_name: str, path: str, key: object = None) -> str:
     """
     Return the id of data read from a file.
 
@@ -187,9 +190,9 @@ def advance(processing_id: str, fingerprint: str) -> str:
     return combine_hashes([processing_id, fingerprint])
 
 
-def fold_data_ids(data_ids: Sequence[str]) -> str:
+def fold_patch_ids(patch_ids: Sequence[str]) -> str:
     """
-    Return the data id of a patch combined from several.
+    Return the patch id of a patch combined from several.
 
     Ordered, and not deduplicated: how many patches went in and in what
     order is part of what the data *is*, so stacking a patch with itself is
@@ -198,7 +201,7 @@ def fold_data_ids(data_ids: Sequence[str]) -> str:
     A single id folds to itself, so an operation which combines one patch
     with nothing leaves the id where it was.
     """
-    ids = tuple(data_ids)
+    ids = tuple(patch_ids)
     if len(ids) == 1:
         return ids[0]
     # Data which never said which data it was does not acquire an identity

--- a/dascore/workflow/processor.py
+++ b/dascore/workflow/processor.py
@@ -573,6 +573,10 @@ def _as_key(value, budget: int = _KEY_LIMIT):
     # its base and encode differently, which is the trap this exists for.
     if type(value) not in _KEYABLE:
         raise TypeError(value)
+    if type(value) is float:
+        # `0.0 == -0.0` and the two hash alike, while the encoder keeps
+        # the sign; `repr` tells them apart, and NaN from NaN.
+        return (float, repr(value))
     return (type(value), value)
 
 
@@ -589,7 +593,11 @@ def _call_name(func) -> str:
     """
     if (tag := patch_function_tag(func)) is not None:
         return tag
-    return _spell(func)
+    # Where it was written, and *which* one: a factory making patch
+    # functions gives every one of them the same module and qualname, and
+    # two closures over different values are two operations. The identity
+    # is process-local, which is honest -- so is the function.
+    return f"{_spell(func)}#{id(func):x}"
 
 
 def _fingerprint(name: str, version: str, kwargs: dict) -> str:

--- a/dascore/workflow/processor.py
+++ b/dascore/workflow/processor.py
@@ -523,8 +523,24 @@ _KEYABLE = (str, bytes, int, float, bool, type(None))
 # it saves.
 _KEY_LIMIT = 32
 
-# Stands for a patch handed to an operation as an argument.
-_PATCH_ARGUMENT = "$patch"
+
+class _PatchArgument:
+    """
+    Stands for a patch handed to an operation as an argument.
+
+    A class rather than a string: a caller is free to pass the string
+    `"$patch"`, and a marker it could be mistaken for would make that call
+    and a call with an actual patch one operation.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self):
+        """Say what it is, which is what the digest records."""
+        return "<patch argument>"
+
+
+_PATCH_ARGUMENT = _PatchArgument()
 
 
 def _without_patches(kwargs: dict) -> dict:

--- a/dascore/workflow/processor.py
+++ b/dascore/workflow/processor.py
@@ -34,8 +34,9 @@ from __future__ import annotations
 import inspect
 import re
 import warnings
+from collections.abc import Mapping
 from contextlib import suppress
-from functools import cached_property
+from functools import cache, cached_property
 from typing import Any, ClassVar
 
 from pydantic import Field
@@ -74,6 +75,11 @@ _DEFERRED_MODULES = ("dascore.viz",)
 
 # Set once the install has been swept looking for an unregistered tag.
 _swept = False
+
+# Fingerprints of calls already made, so a loop over a spool pays for the
+# digest of one call rather than of every one.
+_FINGERPRINTS: dict[Any, str] = {}
+_FINGERPRINT_LIMIT = 4096
 
 
 class PatchProcessor(Task):
@@ -475,9 +481,58 @@ def fingerprint_call(func, args: tuple = (), kwargs: dict | None = None) -> str:
     >>> called = fingerprint_call(dc.proc.normalize, (), {"dim": "time"})
     >>> assert called == dc.proc.normalize.op(dim="time").fingerprint
     """
-    name = op_name(func)
     version = getattr(func, "__version__", "1.0")
-    return _fingerprint(name, version, _bind(func, args, kwargs or {}))
+    name = _call_name(func)
+    bound = _bind(func, args, kwargs or {})
+    # Answered from the cache when the same call has been made before,
+    # which in a loop over a spool is every call after the first. Hashing
+    # the bound arguments costs a few microseconds; the digest of their
+    # canonical JSON costs several times that.
+    try:
+        key = (name, version, _as_key(bound))
+    except TypeError:
+        # Something unhashable -- an array argument, most often. Its
+        # digest is the honest cost of saying which array it was.
+        return _fingerprint(name, version, bound)
+    if (found := _FINGERPRINTS.get(key)) is None:
+        found = _fingerprint(name, version, bound)
+        # Bounded, and simply stops growing rather than evicting: the
+        # entries are one small string each, and a process which has made
+        # four thousand distinct calls is not one this is hot for.
+        if len(_FINGERPRINTS) < _FINGERPRINT_LIMIT:
+            _FINGERPRINTS[key] = found
+    return found
+
+
+def _as_key(value):
+    """
+    Return a hashable stand-in for a value, which two values cannot share.
+
+    The type is part of it: `1`, `1.0` and `True` are equal and hash alike
+    in Python, and they are not the same argument.
+    """
+    if isinstance(value, Mapping):
+        return (dict, tuple((k, _as_key(v)) for k, v in value.items()))
+    if isinstance(value, (list, tuple)):
+        return (type(value), tuple(_as_key(x) for x in value))
+    hash(value)  # TypeError here is the caller's signal to not cache
+    return (type(value), value)
+
+
+def _call_name(func) -> str:
+    """
+    Return the name a call is fingerprinted under.
+
+    The registry tag when the function has one. When it does not -- a patch
+    function defined inside another call -- something was still done to the
+    patch, and a `processing_id` which did not move would claim it was not.
+    So the call is named by where it was written instead: enough to tell it
+    from another operation, and honestly not resolvable, which is why
+    `op_name` still refuses it and no `PatchOp` can be built.
+    """
+    if (tag := patch_function_tag(func)) is not None:
+        return tag
+    return _spell(func)
 
 
 def _fingerprint(name: str, version: str, kwargs: dict) -> str:
@@ -489,9 +544,24 @@ def _fingerprint(name: str, version: str, kwargs: dict) -> str:
     )
 
 
+@cache
+def _signature_of(func) -> inspect.Signature:
+    """Return a function's signature, worked out once."""
+    return inspect.signature(func)
+
+
 def _signature(func) -> inspect.Signature:
-    """Return the signature of the function inside a patch function."""
-    return inspect.signature(getattr(func, "raw_function", func))
+    """
+    Return the signature of the function inside a patch function.
+
+    Cached on the function: `inspect.signature` is not cheap, a signature
+    cannot change, and every call which is fingerprinted asks for one.
+    """
+    inner = getattr(func, "raw_function", func)
+    try:
+        return _signature_of(inner)
+    except TypeError:  # something unhashable; ask the slow way
+        return inspect.signature(inner)
 
 
 def _canonical(value):

--- a/dascore/workflow/processor.py
+++ b/dascore/workflow/processor.py
@@ -36,7 +36,7 @@ import re
 import warnings
 from collections.abc import Mapping
 from contextlib import suppress
-from functools import cache, cached_property
+from functools import cached_property, lru_cache
 from typing import Any, ClassVar
 
 from pydantic import Field
@@ -491,7 +491,13 @@ def fingerprint_call(func, args: tuple = (), kwargs: dict | None = None) -> str:
     # the bound arguments costs a few microseconds; the digest of their
     # canonical JSON costs several times that.
     try:
-        key = (name, version, _as_key(bound))
+        # The function itself is in the key, not just its name. For one
+        # which has no tag the name ends in `id(func)`, and CPython reuses
+        # an address once the function is collected -- so a factory making
+        # one patch function per call could hand a later one the earlier
+        # one's fingerprint. Holding the function here makes the key exact
+        # and keeps the address from being reused underneath it.
+        key = (func, name, version, _as_key(bound))
     except TypeError:
         # Something unhashable -- an array argument, most often. Its
         # digest is the honest cost of saying which array it was.
@@ -620,7 +626,10 @@ def _fingerprint(name: str, version: str, kwargs: dict) -> str:
         )
 
 
-@cache
+# Bounded, and it holds function references: a process which builds patch
+# functions in a loop should not keep every one of them, and the closures
+# they captured, alive for its lifetime.
+@lru_cache(maxsize=2048)
 def _signature_of(func) -> inspect.Signature:
     """Return a function's signature, worked out once."""
     return inspect.signature(func)

--- a/dascore/workflow/processor.py
+++ b/dascore/workflow/processor.py
@@ -43,6 +43,8 @@ from pydantic import Field
 
 from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
+from dascore.utils.misc import suppress_warnings
+from dascore.warnings import DASCoreWarning
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
 from dascore.workflow.serialize import digest
 from dascore.workflow.task import Task, _resolve_default
@@ -483,7 +485,7 @@ def fingerprint_call(func, args: tuple = (), kwargs: dict | None = None) -> str:
     """
     version = getattr(func, "__version__", "1.0")
     name = _call_name(func)
-    bound = _bind(func, args, kwargs or {})
+    bound = _without_patches(_bind(func, args, kwargs or {}))
     # Answered from the cache when the same call has been made before,
     # which in a loop over a spool is every call after the first. Hashing
     # the bound arguments costs a few microseconds; the digest of their
@@ -504,18 +506,73 @@ def fingerprint_call(func, args: tuple = (), kwargs: dict | None = None) -> str:
     return found
 
 
-def _as_key(value):
-    """
-    Return a hashable stand-in for a value, which two values cannot share.
+# The only leaves a cache key may be built from. The rule is not "hashable":
+# it is "two of these are the same argument exactly when Python says they are
+# equal". A pint quantity fails that -- `1 * m == 100 * cm` and the two hash
+# alike, while the serializer encodes them differently -- so caching on it
+# would give one call two answers depending on what ran first.
+_KEYABLE = (str, bytes, int, float, bool, type(None))
 
-    The type is part of it: `1`, `1.0` and `True` are equal and hash alike
-    in Python, and they are not the same argument.
+# Beyond this many elements, working the key out costs more than the digest
+# it saves.
+_KEY_LIMIT = 32
+
+# Stands for a patch handed to an operation as an argument.
+_PATCH_ARGUMENT = "$patch"
+
+
+def _without_patches(kwargs: dict) -> dict:
+    """
+    Return the bound arguments with any patch replaced by a marker.
+
+    A patch given as an argument is not a *parameter* of the operation, it
+    is another input to it: `where(cond_patch)` is the same operation
+    whichever patch it was handed, and which one it was is said by the ids
+    folded from the operands. Encoding it here would also hash a whole
+    patch on every call, and warn that it has no encoding of its own.
+    """
+    # Imported here rather than at module scope: this module is imported
+    # while `dascore.utils.patch` is still being imported.
+    import dascore as dc  # noqa: PLC0415
+
+    if not any(isinstance(x, dc.Patch) for x in kwargs.values()):
+        return kwargs
+    return {
+        key: _PATCH_ARGUMENT if isinstance(value, dc.Patch) else value
+        for key, value in kwargs.items()
+    }
+
+
+def _as_key(value, budget: int = _KEY_LIMIT):
+    """
+    Return a hashable stand-in a different value cannot share.
+
+    Raises `TypeError` for anything it cannot key safely or cheaply, which
+    is the caller's signal to compute the digest instead of caching it.
     """
     if isinstance(value, Mapping):
-        return (dict, tuple((k, _as_key(v)) for k, v in value.items()))
+        if len(value) > budget:
+            raise TypeError(value)
+        # The keys are typed too: `{1: "x"}` and `{True: "x"}` are equal
+        # mappings to Python and different calls to the serializer.
+        return (
+            dict,
+            tuple(
+                (_as_key(k, budget - len(value)), _as_key(v, budget - len(value)))
+                for k, v in value.items()
+            ),
+        )
     if isinstance(value, (list, tuple)):
-        return (type(value), tuple(_as_key(x) for x in value))
-    hash(value)  # TypeError here is the caller's signal to not cache
+        if len(value) > budget:
+            raise TypeError(value)
+        return (
+            type(value),
+            tuple(_as_key(x, budget - len(value)) for x in value),
+        )
+    # `type(value) in`, not `isinstance`: a subclass may compare equal to
+    # its base and encode differently, which is the trap this exists for.
+    if type(value) not in _KEYABLE:
+        raise TypeError(value)
     return (type(value), value)
 
 
@@ -536,12 +593,23 @@ def _call_name(func) -> str:
 
 
 def _fingerprint(name: str, version: str, kwargs: dict) -> str:
-    """Return the digest a name, a version and bound arguments make."""
+    """
+    Return the digest a name, a version and bound arguments make.
+
+    The serializer's warning about a value it has no encoding for is
+    suppressed. It is worth hearing when a *task* is being written to a
+    document, which is what it was written for; here it would fire on
+    every ordinary call carrying, say, a numpy dtype, and hashing such a
+    value by its type is all an id needs of it.
+    """
     # Spelled the way `Task.fingerprint_at` spells one, so a pipe holding a
     # PatchOp hashes the same whichever built it.
-    return digest(
-        {"task": "dascore:PatchOp", "version": version, "params": {name: kwargs}}
-    )
+    with suppress_warnings(
+        DASCoreWarning, message="A value of type .* has no encoding"
+    ):
+        return digest(
+            {"task": "dascore:PatchOp", "version": version, "params": {name: kwargs}}
+        )
 
 
 @cache

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -267,6 +267,49 @@ assert out.attrs.history == old_history
 
 `Patch.attrs` only stores non-coordinate metadata. This includes things like the acquisition key, data units, and observing-system fields such as `gauge_length` or `pulse_width`.
 
+### Patch identity
+
+Two ids answer two different questions, and they move independently.
+
+`patch_id` says **which data** this is. It survives every operation which does not change what the data is *of* — filtering, decimating, transposing, changing units — and changes only when data from more than one source is combined.
+
+`processing_id` says **what was done**. It advances on every operation, by folding that operation's fingerprint into the id the input carried.
+
+```{python}
+import dascore as dc
+
+patch = dc.get_example_patch()
+filtered = patch.pass_filter(time=(1, 10))
+
+# Same data, so the same patch_id.
+assert filtered.attrs.patch_id == patch.attrs.patch_id
+# Something was done to it, so a new processing_id.
+assert filtered.attrs.processing_id != patch.attrs.processing_id
+```
+
+Neither is a random number after the first, so the same data processed the same way arrives at the same pair — in another process, on another machine, next year:
+
+```{python}
+one = patch.pass_filter(time=(1, 10)).decimate(time=2)
+two = patch.pass_filter(time=(1, 10)).decimate(time=2)
+assert one.attrs.processing_id == two.attrs.processing_id
+
+# And a different route is a different answer, order included.
+other = patch.decimate(time=2).pass_filter(time=(1, 10))
+assert other.attrs.processing_id != one.attrs.processing_id
+```
+
+An operation which hands the patch straight back did nothing, and records nothing. Neither id is part of `Patch.equals`: two patches holding the same data are equal however they were made.
+
+Set `patch_provenance="disabled"` to stop maintaining them:
+
+```{python}
+with config_context(patch_provenance="disabled"):
+    plain = dc.Patch(data=patch.data, coords=patch.coords, dims=patch.dims)
+
+assert plain.attrs.patch_id == ""
+```
+
 ## Summary
 
 `Patch.summary` provides a read-only combined view of:

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -287,7 +287,7 @@ assert filtered.attrs.patch_id == patch.attrs.patch_id
 assert filtered.attrs.processing_id != patch.attrs.processing_id
 ```
 
-Neither is a random number after the first, so the same data processed the same way arrives at the same pair — in another process, on another machine, next year:
+Neither is a random number after the first, so the same data processed the same way arrives at the same `processing_id` — in another process, on another machine, next year:
 
 ```{python}
 one = patch.pass_filter(time=(1, 10)).decimate(time=2)
@@ -298,6 +298,8 @@ assert one.attrs.processing_id == two.attrs.processing_id
 other = patch.decimate(time=2).pass_filter(time=(1, 10))
 assert other.attrs.processing_id != one.attrs.processing_id
 ```
+
+That reproducibility is `processing_id`'s today. `patch_id` is minted fresh for each patch built in memory, so two processes reading the same file currently give it two different answers; it becomes reproducible everywhere once patches read from a file derive their id from what they were read from, which is the next piece of this work.
 
 An operation which hands the patch straight back did nothing, and records nothing. Neither id is part of `Patch.equals`: two patches holding the same data are equal however they were made.
 

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -315,6 +315,11 @@ class TestScanDASDAE:
         # what data a file holds, and files do not carry them yet.
         managed = {"history", "patch_id", "processing_id"}
         common_keys = set(info1) & set(info2) - managed
+        # Asserted, not merely ignored: the ids are deliberately not
+        # written, because an older DASCore reading a file which carried
+        # them refuses to merge any two patches.
+        assert not info1.get("patch_id")
+        assert not info1.get("processing_id")
         for key in common_keys:
             assert info1[key] == info2[key]
 

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -310,7 +310,11 @@ class TestScanDASDAE:
         """Ensure scanning returns expected values."""
         info1 = dc.scan(written_dascore_v1_random)[0].attrs.model_dump()
         info2 = random_patch.attrs.model_dump()
-        common_keys = set(info1) & set(info2) - {"history"}
+        # The lineage ids are excluded for the same reason history is:
+        # they say where a patch came from and what was done to it, not
+        # what data a file holds, and files do not carry them yet.
+        managed = {"history", "patch_id", "processing_id"}
+        common_keys = set(info1) & set(info2) - managed
         for key in common_keys:
             assert info1[key] == info2[key]
 

--- a/tests/test_io/test_index/test_index_edge_cases.py
+++ b/tests/test_io/test_index/test_index_edge_cases.py
@@ -16,6 +16,7 @@ import re
 import sqlite3
 import sys
 import threading
+import warnings
 import warnings as warnings_mod
 from typing import Any
 
@@ -896,9 +897,16 @@ class TestIngestEdges:
         assert typed_value(np.array([1.0, 2.0]) * get_quantity("m")) is None
 
     def test_reserved_attr_name_warns(self):
-        """An attr named patch_id is skipped with a warning."""
+        """
+        An attr named for a structural column is skipped with a warning.
+
+        It used to be spelled with `patch_id`, which is now a field of
+        `PatchAttrs` in its own right -- a first-class id rather than a
+        user attr which happens to collide -- and is skipped silently.
+        `source_id` is still only a column, so it still warns.
+        """
         summary = PatchSummary(
-            attrs={"patch_id": 5, "tag": "x"},
+            attrs={"source_id": 5, "tag": "x"},
             coords={
                 "distance": {
                     "dtype": "float64",
@@ -917,7 +925,38 @@ class TestIngestEdges:
         )
         with pytest.warns(UserWarning, match="reserved attr name"):
             records = s2r([summary])
-        assert "patch_id" not in records[0].patches[0].attrs
+        assert "source_id" not in records[0].patches[0].attrs
+
+    @pytest.mark.parametrize("name", ["patch_id", "processing_id"])
+    def test_the_ids_are_skipped_silently(self, name):
+        """
+        Every patch carries them, so a warning would fire on every patch.
+
+        They are not indexed: an index is for finding data, and an id is
+        not a search term.
+        """
+        summary = PatchSummary(
+            attrs={name: "0123456789abcdef", "tag": "x"},
+            coords={
+                "distance": {
+                    "dtype": "float64",
+                    "min": 0.0,
+                    "max": 1.0,
+                    "dims": ("distance",),
+                    "len": 2,
+                }
+            },
+            dims=("distance",),
+            shape=(2,),
+            dtype="float32",
+            source_path="a.h5",
+            source_format="DASDAE",
+            source_version="1",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            records = s2r([summary])
+        assert name not in records[0].patches[0].attrs
 
     @pytest.mark.parametrize("name", ["shape", "n_dims", "sample_count_total"])
     def test_dropped_columns_stay_reserved(self, random_patch, name):

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -730,7 +730,7 @@ class TestWhere:
         # Check that attributes are preserved (except the ones the
         # decorator maintains: history, and the ids which say what was
         # done to the data).
-        managed = {"history", "processing_id", "patch_id"}
+        managed = {"history", "processing_id"}
         assert result.attrs.model_dump(exclude=managed) == (
             random_patch.attrs.model_dump(exclude=managed)
         )

--- a/tests/test_proc/test_basic.py
+++ b/tests/test_proc/test_basic.py
@@ -727,10 +727,13 @@ class TestWhere:
         # Check that dimensions are preserved
         assert result.dims == random_patch.dims
 
-        # Check that attributes are preserved (except history)
-        assert result.attrs.model_dump(
-            exclude={"history"}
-        ) == random_patch.attrs.model_dump(exclude={"history"})
+        # Check that attributes are preserved (except the ones the
+        # decorator maintains: history, and the ids which say what was
+        # done to the data).
+        managed = {"history", "processing_id", "patch_id"}
+        assert result.attrs.model_dump(exclude=managed) == (
+            random_patch.attrs.model_dump(exclude=managed)
+        )
 
     def test_where_non_boolean_condition_raises(self, random_patch):
         """Test that non-boolean condition raises ValueError."""

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -249,10 +249,18 @@ class TestConflicts:
         assert out.attrs.gauge_length == 10.0
 
     def test_re_enrich_is_a_refresh(self, patch, inventory):
-        """Enriching twice is not an error and changes nothing."""
+        """
+        Enriching twice is not an error and changes nothing.
+
+        Nothing but what the decorator maintains, that is: doing it twice
+        is two operations, so `processing_id` says so even though every
+        attr it copied is the one it copied the first time.
+        """
         once = patch.enrich(inventory, coords=False)
         twice = once.enrich(inventory, coords=False)
-        assert dict(twice.attrs.drop("history")) == dict(once.attrs.drop("history"))
+        managed = ("history", "processing_id")
+        assert dict(twice.attrs.drop(*managed)) == dict(once.attrs.drop(*managed))
+        assert twice.attrs.processing_id != once.attrs.processing_id
 
     def test_bad_conflicts_raises(self, patch, inventory):
         """The flag shares chunking's vocabulary and its validation."""

--- a/tests/test_proc/test_wiener.py
+++ b/tests/test_proc/test_wiener.py
@@ -151,7 +151,7 @@ class TestWienerFilter:
 
         # Remove what the patch_function decorator maintains: history, and
         # the ids which say what was done to the data.
-        for managed in ("history", "processing_id", "patch_id"):
+        for managed in ("history", "processing_id"):
             original_attrs.pop(managed, None)
             result_attrs.pop(managed, None)
 

--- a/tests/test_proc/test_wiener.py
+++ b/tests/test_proc/test_wiener.py
@@ -149,9 +149,11 @@ class TestWienerFilter:
         original_attrs = dict(noisy_patch.attrs)
         result_attrs = dict(result.attrs)
 
-        # Remove history from comparison as it gets updated by patch_function decorator
-        original_attrs.pop("history", None)
-        result_attrs.pop("history", None)
+        # Remove what the patch_function decorator maintains: history, and
+        # the ids which say what was done to the data.
+        for managed in ("history", "processing_id", "patch_id"):
+            original_attrs.pop(managed, None)
+            result_attrs.pop(managed, None)
 
         assert result_attrs == original_attrs
 

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -688,7 +688,11 @@ class TestApplyArrayFunc:
         assert isinstance(result, dc.Patch)
         assert result.shape == random_patch.shape
         assert result.coords.equals(random_patch.coords)  # coords should be preserved
-        assert result.attrs == random_patch.attrs  # attrs should be preserved
+        # attrs should be preserved, apart from the id which says an array
+        # function was applied -- which is the one thing that did happen.
+        managed = ("processing_id",)
+        assert result.attrs.drop(*managed) == random_patch.attrs.drop(*managed)
+        assert result.attrs.processing_id != random_patch.attrs.processing_id
         assert np.allclose(result.data, np.abs(random_patch.data) + 1)
 
 

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -638,3 +638,16 @@ class TestWhatTheReviewsFound:
 
         first, second = make(2), make(3)
         assert first(patch).attrs.processing_id != second(patch).attrs.processing_id
+
+    def test_a_dtype_argument_is_spelled_out(self, patch):
+        """
+        The serializer has no encoding for a `np.dtype`.
+
+        Hashed by its class it would give every dtype one fingerprint and
+        warn on every call, so it is recorded as its string instead.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            single = np.mean(patch, axis=0, dtype=np.dtype("float32"))
+            double = np.mean(patch, axis=0, dtype=np.dtype("float64"))
+        assert single.attrs.processing_id != double.attrs.processing_id

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -21,13 +21,13 @@ from dascore.workflow.builtin import ArrayFunc, Concatenate, Stack, Ufunc
 from dascore.workflow.identity import (
     NOTHING_DONE,
     advance,
-    data_id_of,
-    fold_data_ids,
     fold_ids,
+    fold_patch_ids,
     fold_processing_ids,
-    new_data_id,
+    new_patch_id,
+    patch_id_of,
     processing_id_of,
-    source_data_id,
+    source_patch_id,
     stamp_combination,
 )
 from dascore.workflow.processor import _PATCH_ARGUMENT, _as_key, _signature
@@ -38,11 +38,11 @@ class TestNewDataId:
 
     def test_each_is_its_own(self):
         """Two arrays are two data, however alike they look."""
-        assert new_data_id() != new_data_id()
+        assert new_patch_id() != new_patch_id()
 
     def test_it_is_a_hex_string(self):
         """The same shape as every other id, so nothing can tell them apart."""
-        made = new_data_id()
+        made = new_patch_id()
         assert isinstance(made, str)
         assert int(made, 16) >= 0
 
@@ -52,8 +52,8 @@ class TestSourceDataId:
 
     def test_it_is_derived(self):
         """Reading the same file twice is reading the same data."""
-        first = source_data_id("DASDAE", "/data/one.h5", 0)
-        assert first == source_data_id("DASDAE", "/data/one.h5", 0)
+        first = source_patch_id("DASDAE", "/data/one.h5", 0)
+        assert first == source_patch_id("DASDAE", "/data/one.h5", 0)
 
     @pytest.mark.parametrize(
         ("format_name", "path", "key"),
@@ -66,12 +66,12 @@ class TestSourceDataId:
     )
     def test_every_part_counts(self, format_name, path, key):
         """The format, the path and the key each name different data."""
-        base = source_data_id("DASDAE", "/data/one.h5", 0)
-        assert source_data_id(format_name, path, key) != base
+        base = source_patch_id("DASDAE", "/data/one.h5", 0)
+        assert source_patch_id(format_name, path, key) != base
 
     def test_a_key_may_be_anything_encodable(self):
         """A reader names its patches however it likes."""
-        assert source_data_id("X", "/a", "channel-3") != source_data_id("X", "/a", 3)
+        assert source_patch_id("X", "/a", "channel-3") != source_patch_id("X", "/a", 3)
 
 
 class TestAdvance:
@@ -111,23 +111,23 @@ class TestFoldDataIds:
 
     def test_one_folds_to_itself(self):
         """Combining a patch with nothing leaves the id where it was."""
-        assert fold_data_ids(["only"]) == "only"
+        assert fold_patch_ids(["only"]) == "only"
 
     def test_order_is_part_of_it(self):
         """Concatenating a before b is not concatenating b before a."""
-        assert fold_data_ids(["a", "b"]) != fold_data_ids(["b", "a"])
+        assert fold_patch_ids(["a", "b"]) != fold_patch_ids(["b", "a"])
 
     def test_repeats_are_part_of_it(self):
         """Stacking a patch with itself is not the patch."""
-        assert fold_data_ids(["a", "a"]) != fold_data_ids(["a"])
+        assert fold_patch_ids(["a", "a"]) != fold_patch_ids(["a"])
 
     def test_it_is_derived(self):
         """So the same combination gives the same answer twice."""
-        assert fold_data_ids(["a", "b"]) == fold_data_ids(["a", "b"])
+        assert fold_patch_ids(["a", "b"]) == fold_patch_ids(["a", "b"])
 
     def test_it_takes_any_sequence(self):
         """Callers hold their members in whatever they hold them in."""
-        assert fold_data_ids(("a", "b")) == fold_data_ids(["a", "b"])
+        assert fold_patch_ids(("a", "b")) == fold_patch_ids(["a", "b"])
 
 
 class TestFoldProcessingIds:
@@ -323,7 +323,7 @@ class TestTheRulesOnRealPatches:
         """Two sources make a third answer, not either of the two."""
         other = patch.update_attrs(patch_id="other")
         merged = dc.utils.attrs.combine_patch_attrs([patch.attrs, other.attrs])
-        assert merged.patch_id == fold_data_ids([patch.attrs.patch_id, "other"])
+        assert merged.patch_id == fold_patch_ids([patch.attrs.patch_id, "other"])
         # Spelled out, because `not in {...}` is also true of the empty
         # string, which is what dropping the fold entirely would leave.
         assert merged.patch_id
@@ -442,7 +442,7 @@ class TestOperationsWhichAreNotPatchFunctions:
     def test_two_patches_fold(self, patch):
         """Adding two patches is data from two sources."""
         other = patch.update_attrs(patch_id="other")
-        assert (patch + other).attrs.patch_id == fold_data_ids(
+        assert (patch + other).attrs.patch_id == fold_patch_ids(
             [patch.attrs.patch_id, "other"]
         )
 
@@ -582,7 +582,7 @@ class TestWhatTheReviewsFound:
         held.pop("patch_id"), held.pop("processing_id")
         legacy = dc.PatchAttrs.model_construct(**held)
         made = dc.Patch(data=patch.data, coords=patch.coords, dims=patch.dims)
-        assert data_id_of(legacy) == NOTHING_DONE
+        assert patch_id_of(legacy) == NOTHING_DONE
         assert processing_id_of(legacy) == NOTHING_DONE
         # The fold reads them without raising, and says the result is data
         # from two places even though one of them could not say which.

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -20,10 +20,12 @@ from dascore.workflow.builtin import ArrayFunc, Concatenate, Stack, Ufunc
 from dascore.workflow.identity import (
     NOTHING_DONE,
     advance,
+    data_id_of,
     fold_data_ids,
     fold_ids,
     fold_processing_ids,
     new_data_id,
+    processing_id_of,
     source_data_id,
     stamp_combination,
 )
@@ -526,3 +528,113 @@ class TestCombinationEdges:
         """
         with pytest.raises(TypeError):
             _as_key(value)
+
+
+class TestWhatTheReviewsFound:
+    """Cases the first round of this PR got wrong."""
+
+    @pytest.fixture(scope="class")
+    def patch(self):
+        """A patch to operate on."""
+        return dc.get_example_patch("random_das")
+
+    def test_every_patch_argument_counts(self, patch):
+        """
+        `where(cond, other)` uses all of them, so all of them fold.
+
+        Copying the primary patch's id would say a result built from three
+        sources was only the first.
+        """
+        one = patch.new(data=patch.data > 0.5).update_attrs(patch_id="a")
+        two = patch.new(data=patch.data < 0.5).update_attrs(patch_id="b")
+        assert patch.where(one, 0.0).attrs.patch_id != (
+            patch.where(two, 0.0).attrs.patch_id
+        )
+
+    def test_provenance_never_fails_a_call(self, patch):
+        """
+        It is metadata about the work, not the work.
+
+        A self-referential argument cannot be encoded; that is a reason to
+        say nothing about the call, not to fail one which otherwise worked.
+        """
+        loop: dict = {}
+        loop["self"] = loop
+
+        @dc.patch_function()
+        def takes_anything(patch, thing=None):
+            """Accept whatever it is given."""
+            return patch.new(data=patch.data)
+
+        out = takes_anything(patch, thing=loop)
+        assert out.attrs.processing_id == patch.attrs.processing_id
+
+    def test_attrs_from_before_these_fields(self, patch):
+        """
+        An old pickle restores a `PatchAttrs` which has neither.
+
+        It must still be usable: unpickling bypasses the constructor, so
+        nothing fills the defaults in.
+        """
+        bare = dc.PatchAttrs()
+        held = dict(bare.model_dump())
+        held.pop("patch_id"), held.pop("processing_id")
+        legacy = dc.PatchAttrs.model_construct(**held)
+        made = dc.Patch(data=patch.data, coords=patch.coords, dims=patch.dims)
+        assert data_id_of(legacy) == NOTHING_DONE
+        assert processing_id_of(legacy) == NOTHING_DONE
+        # The fold reads them without raising, and says the result is data
+        # from two places even though one of them could not say which.
+        folded = fold_ids([legacy, made.attrs])["patch_id"]
+        assert folded and folded != made.attrs.patch_id
+
+    def test_equality_ignores_the_ids_either_way(self, patch):
+        """Both spellings of `equals`, not just the default."""
+        other = patch.update_attrs(patch_id="x", processing_id="y")
+        assert patch.equals(other)
+        assert patch.equals(other, only_required_attrs=False)
+
+    @pytest.mark.parametrize(
+        ("first", "second"),
+        [
+            pytest.param(0.0, -0.0, id="signed zero"),
+            pytest.param(1, True, id="int and bool"),
+            pytest.param(1, 1.0, id="int and float"),
+        ],
+    )
+    def test_the_cache_cannot_confuse_two_arguments(self, first, second):
+        """
+        Python calls these equal; the serializer does not.
+
+        Caching on one would give a call two answers depending on which
+        ran first, which is the one thing an id must never do.
+        """
+        assert _as_key(first) != _as_key(second)
+
+    def test_a_quantity_is_never_cached(self):
+        """`1 * m == 100 * cm` and the two hash alike; they encode apart."""
+        from dascore.units import m  # noqa: PLC0415
+
+        with pytest.raises(TypeError):
+            _as_key(1 * m)
+
+    def test_two_closures_are_two_operations(self, patch):
+        """
+        A factory gives every function it makes one module and qualname.
+
+        Naming them by where they were written alone would make
+        `make(2)` and `make(3)` one operation.
+        """
+
+        def make(factor):
+            """Return a patch function which scales by a fixed amount."""
+
+            @dc.patch_function()
+            def scale(patch):
+                """Scale by whatever this closure captured."""
+                return patch.new(data=patch.data * factor)
+
+            return scale
+
+        first, second = make(2), make(3)
+        assert first(patch).attrs.processing_id != second(patch).attrs.processing_id

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -8,7 +8,9 @@ applied live beside the things which apply them.
 from __future__ import annotations
 
 import pickle
+import warnings
 
+import numpy as np
 import pytest
 
 import dascore as dc
@@ -23,8 +25,9 @@ from dascore.workflow.identity import (
     fold_processing_ids,
     new_data_id,
     source_data_id,
+    stamp_combination,
 )
-from dascore.workflow.processor import _signature
+from dascore.workflow.processor import _as_key, _signature
 
 
 class TestNewDataId:
@@ -262,11 +265,19 @@ class TestTheRulesOnRealPatches:
         """
         Even one which builds its result from scratch.
 
-        `fbe` does; without the wrapper carrying the id across, it would
-        mint a new one and claim the data had changed.
+        Without the wrapper carrying the id across from the input, a body
+        which returns a patch it built itself would mint a fresh one and
+        claim the data had changed.
         """
-        out = patch.fbe(0.5, time=(10, 100))
-        assert out.attrs.patch_id == patch.attrs.patch_id
+
+        @dc.patch_function()
+        def rebuilds(patch):
+            """Return a patch built from nothing but the data."""
+            return dc.Patch(data=patch.data, coords=patch.coords, dims=patch.dims)
+
+        assert rebuilds(patch).attrs.patch_id == patch.attrs.patch_id
+        # And a real one which does the same thing.
+        assert patch.fbe(0.5, time=(10, 100)).attrs.patch_id == patch.attrs.patch_id
 
     def test_the_same_route_gives_the_same_id(self, patch):
         """So two patches processed alike can be told to be alike."""
@@ -309,6 +320,10 @@ class TestTheRulesOnRealPatches:
         """Two sources make a third answer, not either of the two."""
         other = patch.update_attrs(patch_id="other")
         merged = dc.utils.attrs.combine_patch_attrs([patch.attrs, other.attrs])
+        assert merged.patch_id == fold_data_ids([patch.attrs.patch_id, "other"])
+        # Spelled out, because `not in {...}` is also true of the empty
+        # string, which is what dropping the fold entirely would leave.
+        assert merged.patch_id
         assert merged.patch_id not in {patch.attrs.patch_id, "other"}
 
     def test_combining_patches_keeps_a_common_route(self, patch):
@@ -387,3 +402,127 @@ class TestTheAwkwardCases:
                 return patch
 
         assert _signature(Unhashable()) is not None
+
+
+class TestOperationsWhichAreNotPatchFunctions:
+    """Concatenating, stacking and ufuncs still have to say what they did."""
+
+    @pytest.fixture(scope="class")
+    def patch(self):
+        """A patch to operate on."""
+        return dc.get_example_patch("random_das")
+
+    @pytest.fixture(scope="class")
+    def spool(self):
+        """A spool whose patches are different data."""
+        return dc.get_example_spool()
+
+    def test_arithmetic_says_which_operation(self, patch):
+        """
+        `patch + 1` and `patch - (-1)` give the same data and are not the
+        same operation; without the `Ufunc` task they shared an id.
+        """
+        made = {
+            (patch * 2).attrs.processing_id,
+            (patch * 3).attrs.processing_id,
+            (patch + 5).attrs.processing_id,
+            (patch - 7).attrs.processing_id,
+            (patch + 1).attrs.processing_id,
+            (patch - (-1)).attrs.processing_id,
+        }
+        assert len(made) == 6
+
+    def test_arithmetic_leaves_which_data_alone(self, patch):
+        """Scaling data does not make it other data."""
+        assert (patch * 2).attrs.patch_id == patch.attrs.patch_id
+
+    def test_two_patches_fold(self, patch):
+        """Adding two patches is data from two sources."""
+        other = patch.update_attrs(patch_id="other")
+        assert (patch + other).attrs.patch_id == fold_data_ids(
+            [patch.attrs.patch_id, "other"]
+        )
+
+    def test_a_unary_ufunc_says_which_one(self, patch):
+        """`np.abs` is not `np.sqrt`."""
+        assert np.abs(patch).attrs.processing_id != patch.attrs.processing_id
+        assert np.abs(patch).attrs.processing_id != (
+            np.sqrt(np.abs(patch)).attrs.processing_id
+        )
+
+    def test_an_array_function_says_which_one(self, patch):
+        """And what it was given."""
+        first = np.mean(patch, axis=0).attrs.processing_id
+        assert first != patch.attrs.processing_id
+        assert first != np.mean(patch, axis=1).attrs.processing_id
+
+    def test_a_patch_argument_is_an_input_not_a_parameter(self, patch):
+        """
+        Which patch was handed in is said by the ids, not the fingerprint.
+
+        Encoding it would hash a whole patch on every call, and warn that
+        a patch has no encoding of its own.
+        """
+        one = patch.new(data=patch.data > 0.5)
+        two = patch.new(data=patch.data < 0.5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            first = patch.where(one, 0.0)
+        assert first.attrs.processing_id == patch.where(two, 0.0).attrs.processing_id
+
+    def test_concatenating_folds_which_data(self, spool):
+        """Taking the first patch's id would claim it was the only source."""
+        members = {x.attrs.patch_id for x in spool}
+        merged = spool.chunk(time=None)[0]
+        assert merged.attrs.patch_id not in members
+        assert merged.attrs.patch_id
+
+    def test_stacking_folds_which_data(self, spool):
+        """As does adding them together."""
+        members = {x.attrs.patch_id for x in spool}
+        stacked = spool.stack(dim_vary="time")
+        assert stacked.attrs.patch_id not in members
+        assert stacked.attrs.processing_id != NOTHING_DONE
+
+    def test_the_raw_function_bypass_is_not_recorded(self, patch):
+        """
+        A body which calls `.raw_function` skips the wrapper, so nothing
+        is stamped -- which is what those bypasses are for, and worth
+        pinning so a refactor which removes one is a visible change.
+        """
+        wrapped = dc.proc.normalize(patch, "time")
+        raw = dc.proc.normalize.raw_function(patch, "time")
+        assert wrapped.attrs.processing_id != raw.attrs.processing_id
+        assert raw.attrs.processing_id == patch.attrs.processing_id
+
+
+class TestCombinationEdges:
+    """The branches a combination reaches only in odd cases."""
+
+    def test_disabled_leaves_a_combination_alone(self):
+        """A process not keeping ids does not stamp one on a merge."""
+        patch = dc.get_example_patch()
+        with dc.config_context(patch_provenance="disabled"):
+            out = stamp_combination(patch.attrs, [patch.attrs], "abc")
+        assert out is patch.attrs
+
+    def test_no_members_leaves_a_combination_alone(self):
+        """Nothing went in, so there is nothing to fold."""
+        patch = dc.get_example_patch()
+        assert stamp_combination(patch.attrs, [], "abc") is patch.attrs
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param([0] * 64, id="a long sequence"),
+            pytest.param({str(x): x for x in range(64)}, id="a big mapping"),
+        ],
+    )
+    def test_a_big_argument_is_not_worth_keying(self, value):
+        """
+        Working the key out would cost more than the digest it saves.
+
+        `TypeError` is how `_as_key` says "do not cache this".
+        """
+        with pytest.raises(TypeError):
+            _as_key(value)

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -7,18 +7,24 @@ applied live beside the things which apply them.
 
 from __future__ import annotations
 
+import pickle
+
 import pytest
 
+import dascore as dc
+from dascore.exceptions import ParameterError
 from dascore.workflow import Task
 from dascore.workflow.builtin import ArrayFunc, Concatenate, Stack, Ufunc
 from dascore.workflow.identity import (
     NOTHING_DONE,
     advance,
     fold_data_ids,
+    fold_ids,
     fold_processing_ids,
     new_data_id,
     source_data_id,
 )
+from dascore.workflow.processor import _signature
 
 
 class TestNewDataId:
@@ -223,3 +229,161 @@ class TestBuiltinTasks:
     def test_they_are_written_down(self, task):
         """A provenance record holds them, so they have to survive one."""
         assert Task.from_dict(task.to_dict()) == task
+
+
+class TestTheRulesOnRealPatches:
+    """The rules, where they are actually applied."""
+
+    @pytest.fixture(scope="class")
+    def patch(self):
+        """A patch to operate on."""
+        return dc.get_example_patch("random_das")
+
+    def test_data_arrives_with_an_id(self, patch):
+        """Everything downstream needs something to carry forward."""
+        assert patch.attrs.patch_id
+        assert patch.attrs.processing_id == NOTHING_DONE
+
+    def test_two_patches_are_two_data(self):
+        """Nothing derives an id from values, so nothing claims they are one."""
+        first = dc.get_example_patch("random_das")
+        assert first.attrs.patch_id != dc.get_example_patch("random_das").attrs.patch_id
+
+    def test_an_operation_advances_what_was_done(self, patch):
+        """Which is what the id is for."""
+        out = patch.normalize("time")
+        assert out.attrs.processing_id != patch.attrs.processing_id
+
+    def test_an_operation_leaves_which_data_alone(self, patch):
+        """Filtering data does not make it other data."""
+        assert patch.normalize("time").attrs.patch_id == patch.attrs.patch_id
+
+    def test_a_function_which_rebuilds_still_leaves_it_alone(self, patch):
+        """
+        Even one which builds its result from scratch.
+
+        `fbe` does; without the wrapper carrying the id across, it would
+        mint a new one and claim the data had changed.
+        """
+        out = patch.fbe(0.5, time=(10, 100))
+        assert out.attrs.patch_id == patch.attrs.patch_id
+
+    def test_the_same_route_gives_the_same_id(self, patch):
+        """So two patches processed alike can be told to be alike."""
+        first = patch.normalize("time").decimate(time=2)
+        second = patch.normalize("time").decimate(time=2)
+        assert first.attrs.processing_id == second.attrs.processing_id
+
+    def test_a_different_route_does_not(self, patch):
+        """Order included."""
+        forward = patch.normalize("time").decimate(time=2)
+        backward = patch.decimate(time=2).normalize("time")
+        assert forward.attrs.processing_id != backward.attrs.processing_id
+
+    def test_different_arguments_are_a_different_route(self, patch):
+        """The operation's fingerprint is what distinguishes them."""
+        assert patch.normalize("time").attrs.processing_id != (
+            patch.normalize("distance").attrs.processing_id
+        )
+
+    def test_a_no_op_records_nothing(self, patch):
+        """
+        An operation which handed the patch straight back did nothing.
+
+        `select` with no bounds is the live case: it returns the patch it
+        was given, and a `processing_id` which moved would say otherwise.
+        """
+        assert patch.select(time=None).attrs.processing_id == patch.attrs.processing_id
+
+    def test_the_ids_are_not_part_of_equality(self, patch):
+        """Two patches with the same data are equal however they were made."""
+        assert patch.equals(patch.update_attrs(patch_id="x", processing_id="y"))
+
+    def test_a_raw_constructor_keeps_what_it_was_given(self, patch):
+        """You edited it; that is on you."""
+        made = patch.update_attrs(patch_id="kept", processing_id="also")
+        assert made.attrs.patch_id == "kept"
+        assert made.new(data=made.data).attrs.patch_id == "kept"
+
+    def test_combining_patches_folds_which_data(self, patch):
+        """Two sources make a third answer, not either of the two."""
+        other = patch.update_attrs(patch_id="other")
+        merged = dc.utils.attrs.combine_patch_attrs([patch.attrs, other.attrs])
+        assert merged.patch_id not in {patch.attrs.patch_id, "other"}
+
+    def test_combining_patches_keeps_a_common_route(self, patch):
+        """Windows of one file have one history, not one each."""
+        first = patch.normalize("time")
+        merged = dc.utils.attrs.combine_patch_attrs([first.attrs, first.attrs])
+        assert merged.processing_id == first.attrs.processing_id
+
+    def test_the_ids_survive_a_pickle(self, patch):
+        """A patch handed to another process is the same data."""
+        out = patch.normalize("time")
+        assert pickle.loads(pickle.dumps(out)).attrs.patch_id == out.attrs.patch_id
+        assert pickle.loads(pickle.dumps(out)).attrs.processing_id == (
+            out.attrs.processing_id
+        )
+
+    def test_they_can_be_turned_off(self, patch):
+        """A process which does not want them does not pay for them."""
+        with dc.config_context(patch_provenance="disabled"):
+            made = dc.Patch(data=patch.data, coords=patch.coords, dims=patch.dims)
+            assert made.attrs.patch_id == ""
+            assert made.normalize("time").attrs.processing_id == ""
+
+    def test_a_summary_does_not_carry_them(self, patch):
+        """
+        An index does not store an id, so a summary holding one would make
+        scanning a file and reading it disagree about the same data.
+        """
+        summary = patch.summary
+        assert summary.attrs.patch_id == ""
+        assert summary.attrs.processing_id == ""
+
+
+class TestTheAwkwardCases:
+    """The branches the ordinary path never reaches."""
+
+    def test_no_members_folds_to_nothing(self):
+        """A fold given nothing has nothing to say."""
+        assert fold_ids([]) == {}
+
+    def test_disabled_folds_to_nothing(self):
+        """A process which is not keeping ids does not invent them."""
+        patch = dc.get_example_patch()
+        with dc.config_context(patch_provenance="disabled"):
+            assert fold_ids([patch.attrs, patch.attrs]) == {}
+
+    def test_a_function_defined_inside_a_call_is_still_named(self):
+        """
+        It cannot be named in a document, but it still did something.
+
+        A `processing_id` which did not move would say it had not.
+        """
+        patch = dc.get_example_patch()
+
+        @dc.patch_function()
+        def only_here(patch):
+            """Exist only for the length of this test."""
+            return patch.new(data=patch.data + 1)
+
+        out = only_here(patch)
+        assert out.attrs.processing_id != patch.attrs.processing_id
+        # Named by where it was written, which is honestly not resolvable.
+        with pytest.raises(ParameterError, match="cannot be named"):
+            only_here.op()
+
+    def test_a_callable_which_cannot_be_hashed(self):
+        """Its signature is asked for the slow way rather than cached."""
+
+        class Unhashable:
+            """A callable which refuses to be a dict key."""
+
+            __hash__ = None
+
+            def __call__(self, patch, factor=1):
+                """Do nothing."""
+                return patch
+
+        assert _signature(Unhashable()) is not None

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -7,6 +7,7 @@ applied live beside the things which apply them.
 
 from __future__ import annotations
 
+import gc
 import pickle
 import warnings
 
@@ -651,3 +652,30 @@ class TestWhatTheReviewsFound:
             single = np.mean(patch, axis=0, dtype=np.dtype("float32"))
             double = np.mean(patch, axis=0, dtype=np.dtype("float64"))
         assert single.attrs.processing_id != double.attrs.processing_id
+
+    def test_a_collected_closure_does_not_lend_its_id(self):
+        """
+        An unnameable function is named partly by `id(func)`, and CPython
+        reuses an address once the function is collected. The one before
+        must not hand its fingerprint to the one after.
+
+        Written this way deliberately: holding both alive at once, as the
+        test above does, cannot reach the case.
+        """
+        patch = dc.get_example_patch()
+
+        def make(factor):
+            """Return a patch function which scales by a fixed amount."""
+
+            @dc.patch_function()
+            def scale(patch):
+                """Scale by whatever this closure captured."""
+                return patch.new(data=patch.data * factor)
+
+            return scale
+
+        first = make(2)
+        first_id = first(patch).attrs.processing_id
+        del first
+        gc.collect()
+        assert make(3)(patch).attrs.processing_id != first_id

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -1,0 +1,225 @@
+"""
+Tests for the two ids a patch carries.
+
+These cover the rules themselves; the tests which pin where they are
+applied live beside the things which apply them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dascore.workflow import Task
+from dascore.workflow.builtin import ArrayFunc, Concatenate, Stack, Ufunc
+from dascore.workflow.identity import (
+    NOTHING_DONE,
+    advance,
+    fold_data_ids,
+    fold_processing_ids,
+    new_data_id,
+    source_data_id,
+)
+
+
+class TestNewDataId:
+    """Data which names no source."""
+
+    def test_each_is_its_own(self):
+        """Two arrays are two data, however alike they look."""
+        assert new_data_id() != new_data_id()
+
+    def test_it_is_a_hex_string(self):
+        """The same shape as every other id, so nothing can tell them apart."""
+        made = new_data_id()
+        assert isinstance(made, str)
+        assert int(made, 16) >= 0
+
+
+class TestSourceDataId:
+    """Data read from a file."""
+
+    def test_it_is_derived(self):
+        """Reading the same file twice is reading the same data."""
+        first = source_data_id("DASDAE", "/data/one.h5", 0)
+        assert first == source_data_id("DASDAE", "/data/one.h5", 0)
+
+    @pytest.mark.parametrize(
+        ("format_name", "path", "key"),
+        [
+            ("TERRA15", "/data/one.h5", 0),
+            ("DASDAE", "/data/two.h5", 0),
+            ("DASDAE", "/data/one.h5", 1),
+            ("DASDAE", "/data/one.h5", None),
+        ],
+    )
+    def test_every_part_counts(self, format_name, path, key):
+        """The format, the path and the key each name different data."""
+        base = source_data_id("DASDAE", "/data/one.h5", 0)
+        assert source_data_id(format_name, path, key) != base
+
+    def test_a_key_may_be_anything_encodable(self):
+        """A reader names its patches however it likes."""
+        assert source_data_id("X", "/a", "channel-3") != source_data_id("X", "/a", 3)
+
+
+class TestAdvance:
+    """What was done."""
+
+    def test_nothing_done_is_the_starting_point(self):
+        """Data which arrived and has not been touched says so."""
+        assert NOTHING_DONE == ""
+
+    def test_an_operation_moves_it(self):
+        """Which is the whole point of the id."""
+        assert advance(NOTHING_DONE, "0123456789abcdef") != NOTHING_DONE
+
+    def test_the_same_route_gives_the_same_answer(self):
+        """So two patches processed alike can be told to be alike."""
+        once = advance(NOTHING_DONE, "aaaa")
+        assert advance(once, "bbbb") == advance(advance(NOTHING_DONE, "aaaa"), "bbbb")
+
+    def test_order_matters(self):
+        """Filtering then decimating is not decimating then filtering."""
+        first = advance(advance(NOTHING_DONE, "aaaa"), "bbbb")
+        second = advance(advance(NOTHING_DONE, "bbbb"), "aaaa")
+        assert first != second
+
+    def test_doing_it_twice_is_not_doing_it_once(self):
+        """A fold of a fold, so a repeated operation is two operations."""
+        once = advance(NOTHING_DONE, "aaaa")
+        assert advance(once, "aaaa") != once
+
+    def test_a_different_operation_is_a_different_answer(self):
+        """The fingerprint is what distinguishes them."""
+        assert advance(NOTHING_DONE, "aaaa") != advance(NOTHING_DONE, "bbbb")
+
+
+class TestFoldDataIds:
+    """Which data, when there was more than one."""
+
+    def test_one_folds_to_itself(self):
+        """Combining a patch with nothing leaves the id where it was."""
+        assert fold_data_ids(["only"]) == "only"
+
+    def test_order_is_part_of_it(self):
+        """Concatenating a before b is not concatenating b before a."""
+        assert fold_data_ids(["a", "b"]) != fold_data_ids(["b", "a"])
+
+    def test_repeats_are_part_of_it(self):
+        """Stacking a patch with itself is not the patch."""
+        assert fold_data_ids(["a", "a"]) != fold_data_ids(["a"])
+
+    def test_it_is_derived(self):
+        """So the same combination gives the same answer twice."""
+        assert fold_data_ids(["a", "b"]) == fold_data_ids(["a", "b"])
+
+    def test_it_takes_any_sequence(self):
+        """Callers hold their members in whatever they hold them in."""
+        assert fold_data_ids(("a", "b")) == fold_data_ids(["a", "b"])
+
+
+class TestFoldProcessingIds:
+    """What was done, when the inputs disagree."""
+
+    def test_a_common_route_survives(self):
+        """Sixty windows of one file have one history, not sixty."""
+        assert fold_processing_ids(["x", "x", "x"]) == "x"
+
+    def test_distinct_routes_fold(self):
+        """Combining differently processed data says so."""
+        folded = fold_processing_ids(["x", "y"])
+        assert folded not in {"x", "y"}
+
+    def test_the_fold_is_stable(self):
+        """And says it the same way every time."""
+        assert fold_processing_ids(["x", "y"]) == fold_processing_ids(["x", "y"])
+
+    def test_first_seen_order(self):
+        """Two orders of the same routes are two answers."""
+        assert fold_processing_ids(["x", "y"]) != fold_processing_ids(["y", "x"])
+
+    def test_repeats_do_not_count(self):
+        """It is the distinct routes which matter, not how many took each."""
+        assert fold_processing_ids(["x", "y", "x"]) == fold_processing_ids(["x", "y"])
+
+    def test_nothing_folds_to_nothing_done(self):
+        """An operation given no inputs has nothing to carry forward."""
+        assert fold_processing_ids([]) == NOTHING_DONE
+
+    def test_untouched_inputs_stay_untouched(self):
+        """Reading two files and putting them together is not processing."""
+        assert fold_processing_ids([NOTHING_DONE, NOTHING_DONE]) == NOTHING_DONE
+
+
+class TestBuiltinTasks:
+    """The operations which are not patch functions still have names."""
+
+    def test_a_ufunc_names_which_one(self):
+        """Adding is not subtracting."""
+        assert Ufunc(name="add").fingerprint != Ufunc(name="subtract").fingerprint
+
+    def test_a_ufunc_names_how_it_was_applied(self):
+        """A reduction is not the plain call."""
+        plain = Ufunc(name="add")
+        assert Ufunc(name="add", method="reduce").fingerprint != plain.fingerprint
+
+    def test_a_reversed_ufunc_is_its_own_operation(self):
+        """`1 - patch` is not `patch - 1`."""
+        forward = Ufunc(name="subtract")
+        assert Ufunc(name="subtract", reversed=True).fingerprint != forward.fingerprint
+
+    def test_a_ufunc_names_its_other_operands(self):
+        """Multiplying by two is not multiplying by three."""
+        assert Ufunc(name="multiply", operands=(2,)).fingerprint != (
+            Ufunc(name="multiply", operands=(3,)).fingerprint
+        )
+
+    def test_concatenate_names_what_it_was_given(self):
+        """
+        Concatenating along time is not concatenating along distance.
+
+        `time=None` is the documented call, and the serializer drops a
+        `None` mapping value, so holding the call as a mapping would make
+        these one operation. They are held as pairs for that reason.
+        """
+        assert Concatenate.from_kwargs(time=None).fingerprint != (
+            Concatenate.from_kwargs(distance=None).fingerprint
+        )
+
+    def test_concatenate_names_how_much(self):
+        """And the size, when one was given."""
+        assert Concatenate.from_kwargs(time=None).fingerprint != (
+            Concatenate.from_kwargs(time=10).fingerprint
+        )
+
+    def test_concatenate_keeps_the_order_it_was_given(self):
+        """Two dimensions given the other way round is another call."""
+        first = Concatenate.from_kwargs(time=None, distance=2)
+        assert (
+            first.fingerprint
+            != Concatenate.from_kwargs(distance=2, time=None).fingerprint
+        )
+
+    def test_stack_names_the_varying_dimension(self):
+        """Which is the only thing which makes two stacks differ."""
+        assert Stack(dim_vary="time").fingerprint != Stack().fingerprint
+
+    def test_an_array_func_names_which_one(self):
+        """And what it was given."""
+        assert ArrayFunc(name="mean", kwargs={"axis": 0}).fingerprint != (
+            ArrayFunc(name="mean").fingerprint
+        )
+
+    @pytest.mark.parametrize(
+        "task",
+        [
+            Concatenate.from_kwargs(time=None),
+            Stack(dim_vary="time"),
+            Ufunc(name="add", operands=(2,)),
+            ArrayFunc(name="mean", kwargs={"axis": 0}),
+        ],
+        ids=["concatenate", "stack", "ufunc", "array_func"],
+    )
+    def test_they_are_written_down(self, task):
+        """A provenance record holds them, so they have to survive one."""
+        assert Task.from_dict(task.to_dict()) == task

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -7,7 +7,6 @@ applied live beside the things which apply them.
 
 from __future__ import annotations
 
-import gc
 import pickle
 import warnings
 
@@ -15,8 +14,9 @@ import numpy as np
 import pytest
 
 import dascore as dc
+import dascore.workflow.processor as processor_module
 from dascore.exceptions import ParameterError
-from dascore.workflow import Task
+from dascore.workflow import Task, fingerprint_call
 from dascore.workflow.builtin import ArrayFunc, Concatenate, Stack, Ufunc
 from dascore.workflow.identity import (
     NOTHING_DONE,
@@ -30,7 +30,7 @@ from dascore.workflow.identity import (
     source_data_id,
     stamp_combination,
 )
-from dascore.workflow.processor import _as_key, _signature
+from dascore.workflow.processor import _PATCH_ARGUMENT, _as_key, _signature
 
 
 class TestNewDataId:
@@ -653,29 +653,39 @@ class TestWhatTheReviewsFound:
             double = np.mean(patch, axis=0, dtype=np.dtype("float64"))
         assert single.attrs.processing_id != double.attrs.processing_id
 
-    def test_a_collected_closure_does_not_lend_its_id(self):
+    def test_the_cache_holds_the_function_it_named(self):
         """
         An unnameable function is named partly by `id(func)`, and CPython
-        reuses an address once the function is collected. The one before
-        must not hand its fingerprint to the one after.
+        reuses an address once the function is collected -- so a cache
+        entry outliving its function could hand a later one the earlier
+        one's fingerprint.
 
-        Written this way deliberately: holding both alive at once, as the
-        test above does, cannot reach the case.
+        Asserted on the mechanism rather than by trying to collect one:
+        the key holds the function, which is exactly what stops it being
+        collected, so a test which deleted it and looked for a collision
+        would pass whether or not the fix were there.
         """
         patch = dc.get_example_patch()
 
-        def make(factor):
-            """Return a patch function which scales by a fixed amount."""
+        @dc.patch_function()
+        def unnameable(patch):
+            """Be defined inside a call, so it takes no tag."""
+            return patch.new(data=patch.data)
 
-            @dc.patch_function()
-            def scale(patch):
-                """Scale by whatever this closure captured."""
-                return patch.new(data=patch.data * factor)
+        unnameable(patch)
+        held = [k[0] for k in processor_module._FINGERPRINTS]
+        assert any(x is unnameable for x in held)
 
-            return scale
+    def test_a_patch_argument_is_not_the_string_that_stands_for_it(self):
+        """
+        A caller may pass the marker's own spelling as an ordinary value.
 
-        first = make(2)
-        first_id = first(patch).attrs.processing_id
-        del first
-        gc.collect()
-        assert make(3)(patch).attrs.processing_id != first_id
+        If the marker were that string the two calls would be one
+        operation, though their operands are entirely different.
+        """
+        patch = dc.get_example_patch()
+        assert fingerprint_call(dc.proc.where, (patch,), {}) != (
+            fingerprint_call(dc.proc.where, ("$patch",), {})
+        )
+        # It says what it is, which is what the digest records of it.
+        assert "patch argument" in repr(_PATCH_ARGUMENT)

--- a/tests/test_workflow/test_patch_op.py
+++ b/tests/test_workflow/test_patch_op.py
@@ -22,6 +22,7 @@ import dascore as dc
 import dascore.workflow.processor as processor_module
 from dascore.exceptions import ParameterError
 from dascore.models.registry import registered_models
+from dascore.units import get_quantity
 from dascore.workflow import (
     PatchOp,
     PatchProcessor,
@@ -680,6 +681,27 @@ class TestFingerprintCall:
         assert fingerprint_call(
             dc.proc.demean, (), {"dim": "time"}
         ) != fingerprint_call(dc.proc.demedian, (), {"dim": "time"})
+
+    def test_equal_quantities_are_two_calls(self):
+        """
+        A pint quantity is not a cache key.
+
+        `1 * m` and `100 * cm` are equal and hash alike, while the
+        serializer encodes them differently. Were the cache keyed on them,
+        whichever call ran second would be handed the first one's answer,
+        and the same call would fingerprint differently depending on what
+        a process happened to do before it.
+        """
+        one_meter, hundred_cm = get_quantity("1 m"), get_quantity("100 cm")
+        # The trap itself: equal to Python, and the same hash.
+        assert one_meter == hundred_cm
+        assert hash(one_meter) == hash(hundred_cm)
+        first = fingerprint_call(dc.proc.select, (), {"distance": one_meter})
+        second = fingerprint_call(dc.proc.select, (), {"distance": hundred_cm})
+        assert first != second
+        # And whichever ran first, both still answer for themselves.
+        assert fingerprint_call(dc.proc.select, (), {"distance": one_meter}) == first
+        assert fingerprint_call(dc.proc.select, (), {"distance": hundred_cm}) == second
 
     @pytest.mark.parametrize(
         ("func", "args", "kwargs", "expected"),


### PR DESCRIPTION
## Description

Fifth PR of the processors series, after #929, #932, #936 and #940. It gives a patch two ids: one saying **which data** it is, one saying **what was done** to it.

```python
patch = dc.get_example_patch()
filtered = patch.pass_filter(time=(1, 10))

filtered.attrs.patch_id == patch.attrs.patch_id       # True — same data
filtered.attrs.processing_id != patch.attrs.processing_id  # True — something was done
```

`patch_id` survives every operation which does not change what the data is *of* — filtering, decimating, transposing, changing units — and changes only when data from more than one source is combined. `processing_id` advances on every operation, by folding that call's fingerprint (the `fingerprint_call` from #940) into the id the input carried.

Neither is a random number after the first. Both are digests of what came before, so the same data processed the same way arrives at the same pair in another process, on another machine, next year — and two patches which took different routes say so, order included.

### The rules

`dascore/workflow/identity.py` holds them, as pure functions with their own tests:

- **`advance(processing_id, fingerprint)`** — a fold, so doing an operation twice is not doing it once, and `filter→decimate` is not `decimate→filter`.
- **`fold_patch_ids`** — ordered and *not* deduplicated. How many patches went in and in what order is part of what the data is, so stacking a patch with itself is not the patch.
- **`fold_processing_ids`** — a common route survives (sixty windows of one file have one history, not sixty); distinct routes fold in first-seen order.
- **`NOTHING_DONE`** is `""`, not a digest: it is the identity element of `advance` and reads as "this is how the data arrived".

### Where they are applied

The `patch_function` wrapper stamps both, in the same attrs update history already makes, so an operation still costs one new patch rather than one per thing it stamps. Two details are load-bearing:

- It carries `patch_id` across from the **input**, not from whatever the body returned. `fbe` builds its result from scratch; without this it would mint a fresh id and claim the data had changed.
- A call which hands the patch straight back (`out is patch`) records nothing. `patch.select(time=None)` is the live case — it returns its input, and an id which moved would say otherwise.

Combining patches **folds instead of comparing**. `combine_patch_attrs` strips both ids before the conflict check: two patches which are different data, or which were processed differently, are exactly what a merge is *for*, so an id must never be the thing that makes one raise.

Neither id joins `Patch.equals`, `DEFAULT_ATTRS_TO_IGNORE`, the index, or a `PatchSummary`. A summary carrying one would make scanning a file and reading it disagree about the same data, for a field the index does not store.

`patch_provenance="disabled"` turns the whole thing off.

### What it costs

The wrapper now fingerprints every call. Measured against `dev` at `e13caaa4`:

| call | dev | with ids | delta |
|---|---|---|---|
| `abs()` | 257 µs | 291 µs | +13% |
| `normalize("time")` | 3402 µs | 3570 µs | +5% |
| `pass_filter` | 10.9 ms | 11.4 ms | +4% |
| `select(time=…)` (no-op) | 84.7 µs | 86.8 µs | +2% |
| `transpose()` (no-op) | 32.7 µs | 86.9 µs | **+166%** |
| `where(big mask)` | 2169 µs | 2928 µs | +35% |
| `spool[0]` | 0.4 µs | 0.5 µs | — |
| `spool.chunk(time=None)` | 49.4 ms | 48.8 ms | — |

Real work is unaffected; the cost is a flat ~40–55 µs per call, which only shows on operations that were already nearly free. Two things already went in to reduce it, both of which the design plan anticipated:

- **A bounded cache in front of `fingerprint_call`** (4096 entries, keyed on the bound arguments with their types, so `1`/`1.0`/`True` cannot share an entry; skipped when an argument is unhashable). In a loop over a spool every call after the first is a hit.
- **`inspect.signature` cached per function** — it is not cheap, a signature cannot change, and every fingerprinted call wanted one.

`where(big mask)` is the honest floor: saying *which* array was used means hashing it, and that is proportional to its size.

### Operations which are not patch functions

Concatenating, stacking and applying a numpy ufunc are things done to patches, but none is written as a `@patch_function`, so none has a `PatchOp` to name it. Each gets a small `Task` in `dascore/workflow/builtin.py`, and each site folds the ids of the members which **actually went in** — a patch dropped for being incompatible did not contribute its data, so it is not part of what this data is.

Without it, a patch made from two sources kept the first one's id and claimed to be only that; and `patch + 1` and `patch - (-1)` produced the same data with the same id, though they are different operations.

`Concatenate` holds its arguments as ordered pairs rather than a mapping. `spool.concatenate(time=None)` is the documented call, and the canonical serializer drops a `None` mapping value — deliberately, so a parameter left at its default is the same call as one left out — which would make concatenating along time and along distance one fingerprint.

A patch handed to an operation as an argument (`where(cond_patch)`) is another *input*, not a parameter: it is not encoded into the fingerprint, because the ids folded from the operands already say which patch it was.

### Scope

The design plan bundles the in-memory provenance **graph** into this step. It is not here, and that is deliberate: the ids are a complete, coherent unit at ~1000 lines, and the graph is a separate object model (nodes, `describe`, `to_pipe`, JSON) which would roughly triple the diff — past the plan's own "≲1500 lines" guidance and past what is reviewable in one pass. The graph is next, and the `patch_provenance` knob is already spelled to grow a `"graph"` level.

Also deferred to the graph PR, and worth being plain about because it limits what the ids currently promise:

- **Source ids are not wired.** `source_patch_id` exists and is tested, but nothing calls it, so a patch read from disk mints a fresh `patch_id` like any other. `processing_id` *is* reproducible across processes — the same data processed the same way gives the same value anywhere. `patch_id` is not yet: it identifies which data a patch is *within a process*, and reading one file twice gives two ids. Wiring `dc.read`/`dc.scan` is the next PR.
- **Files do not carry the ids.** DASDAE would happily write them, but an older DASCore reading such a file treats them as ordinary attrs and then refuses to merge any two patches, because their ids differ. Persisting them belongs with the format version which knows to fold them.

## Changelog

- added: `PatchAttrs.patch_id` says which data a patch is; `PatchAttrs.processing_id` says what was done to it. Both are derived, so the same data processed the same way gives the same pair anywhere.
- added: `dascore.workflow.identity` holds the rules which maintain them.
- added: the `patch_provenance` config option, which turns them off.
- changed: `Patch.equals`, patch summaries, the index and a printed patch all ignore the two ids.
- fixed: `fingerprint_call` no longer warns for an argument the serializer has no encoding of its own for, which fired on ordinary calls such as `patch.update_coords(time=coord)`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added patch provenance tracking with data and processing identifiers.
  * Provenance records operations and combines identifiers when patches are merged.
  * Added configuration to disable provenance tracking.
  * Extended workflow support for arithmetic, array functions, concatenation, and stacking.

* **Improvements**
  * Provenance identifiers no longer affect equality, summaries, display, or indexing.
  * Added deterministic identifiers for reproducible processing histories.

* **Documentation**
  * Added a Patch identity tutorial section explaining provenance behavior and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
