### PR TITLE
Squeeze length one dimensions in Patch.viz.wiggle

### DIFF
--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -24,6 +24,18 @@ def _get_dim_label(patch, dim):
     return dim_str + unit_str
 
 
+def _get_data_label(patch, default=""):
+    """
+    Create a label for the patch data (its type and units).
+
+    Returns default if the patch has neither a data_type nor data_units.
+    """
+    data_type = str(patch.attrs.get("data_type", ""))
+    data_units = get_quantity_str(patch.attrs.data_units) or ""
+    dunits = f" [{data_units}]" if (data_type and data_units) else f"{data_units}"
+    return f"{data_type}{dunits}" or default
+
+
 def _get_cmap(cmap):
     """Return a color map from a colormap or string."""
     if isinstance(cmap, str):  # get color map if a string was passed

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from dascore.constants import DEFAULT_COLORMAPS, PatchType
 from dascore.exceptions import ParameterError
-from dascore.units import get_quantity_str, maybe_convert_percent_to_fraction
+from dascore.units import maybe_convert_percent_to_fraction
 from dascore.utils.gaps import get_gap_edges, is_monotonic_and_finite
 from dascore.utils.misc import tukey_fence
 from dascore.utils.patch import patch_function
@@ -19,6 +19,7 @@ from dascore.utils.plotting import (
     _format_time_axis,
     _get_ax,
     _get_cmap,
+    _get_data_label,
     _get_dim_label,
     _get_extents,
 )
@@ -146,12 +147,9 @@ def _add_colorbar(ax, im, data, patch, log, scale):
     cb = ax.get_figure().colorbar(
         im, ax=ax, fraction=0.05, pad=0.025, extend=extend, extendfrac=0.025
     )
-    data_type = str(patch.attrs.get("data_type", ""))
-    data_units = get_quantity_str(patch.attrs.data_units) or ""
-    dunits = f" [{data_units}]" if (data_type and data_units) else f"{data_units}"
+    label = _get_data_label(patch)
     if log:
-        dunits = f"{dunits} - log_10"
-    label = f"{data_type}{dunits}"
+        label = f"{label} - log_10"
     cb.set_label(label)
 
 

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -82,7 +82,7 @@ def _wiggle_2d(patch, ax, dim, scale, alpha, color, shade):
     if shade:
         _shade(offsets, ax, data_scaled, color, connect_axis_ticks)
     _format_y_axis_ticks(ax, offsets, other_axis_ticks)
-    for dim, x in zip(patch.dims, ["x", "y"]):
+    for dim, x in zip(patch.dims, ["x", "y"], strict=True):
         getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
         # format all dims which have time types.
         if np.issubdtype(patch.get_coord(dim).dtype, np.datetime64):
@@ -170,6 +170,10 @@ def wiggle(
     # Create the axis only once the patch is known to be plottable so a
     # rejected call doesn't leak an empty figure.
     ax = _get_ax(ax)
+    # An empty dimension has nothing to draw; the offsets can't be computed
+    # from zero samples so just hand back the empty axis.
+    if 0 in patch.shape:
+        return ax
     if patch.ndim == 1:
         alpha = 1.0 if alpha is None else alpha
         _wiggle_1d(patch, ax, alpha, color, shade)

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -6,10 +6,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from dascore.constants import PatchType
+from dascore.exceptions import ParameterError
 from dascore.utils.patch import patch_function
 from dascore.utils.plotting import (
     _format_time_axis,
     _get_ax,
+    _get_data_label,
     _get_dim_label,
 )
 from dascore.utils.time import dtype_time_like
@@ -27,7 +29,7 @@ def _get_offsets_factor(patch, dim, scale, other_labels):
 
 
 def _shade(offsets, ax, data_scaled, color, wiggle_labels):
-    """Shades the part of the waveforms under the offset line."""
+    """Shades the part of each waveform above its offset line."""
     for i in range(len(offsets)):
         ax.fill_between(
             wiggle_labels,
@@ -50,12 +52,51 @@ def _format_y_axis_ticks(ax, offsets, other_axis_ticks, max_ticks=10):
     plt.locator_params(axis="y", nbins=min_bins)
 
 
+def _wiggle_1d(patch, ax, alpha, color, shade):
+    """Plot a 1D patch as a single trace against its only coordinate."""
+    dim = patch.dims[0]
+    x_values = patch.coords.get_array(dim)
+    ax.plot(x_values, patch.data, color=color, alpha=alpha)
+    if shade:
+        _shade(np.array([0]), ax, patch.data[:, None], color, x_values)
+    ax.set_xlabel(_get_dim_label(patch, dim))
+    ax.set_ylabel(_get_data_label(patch, default="amplitude"))
+    if np.issubdtype(patch.get_coord(dim).dtype, np.datetime64):
+        _format_time_axis(ax, dim, "x")
+    return ax
+
+
+def _wiggle_2d(patch, ax, dim, scale, alpha, color, shade):
+    """Plot each trace of a 2D patch offset from the others."""
+    # After transpose selected dim must be axis 0 and other axis 1
+    patch = patch.transpose(dim, ...)
+    other_dim = next(iter(set(patch.dims) - {dim}))
+    # values for axis which is connected
+    connect_axis_ticks = patch.coords.get_array(dim)
+    # values for y axis (not connected)
+    other_axis_ticks = patch.coords.get_array(other_dim)
+    offsets, data_scaled = _get_offsets_factor(patch, dim, scale, other_axis_ticks)
+    # now plot, add labels, etc.
+    ax.plot(connect_axis_ticks, data_scaled, color=color, alpha=alpha)
+    # shade the part of each wiggle above its offset if desired
+    if shade:
+        _shade(offsets, ax, data_scaled, color, connect_axis_ticks)
+    _format_y_axis_ticks(ax, offsets, other_axis_ticks)
+    for dim, x in zip(patch.dims, ["x", "y"]):
+        getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
+        # format all dims which have time types.
+        if np.issubdtype(patch.get_coord(dim).dtype, np.datetime64):
+            _format_time_axis(ax, dim, x)
+    ax.invert_yaxis()  # invert y so it's consistent with waterfall
+    return ax
+
+
 @patch_function()
 def wiggle(
     patch: PatchType,
     dim: str = "time",
     scale: float = 1,
-    alpha: float = 0.2,
+    alpha: float | None = None,
     color: str = "black",
     shade: bool = False,
     ax: plt.Axes | None = None,
@@ -64,22 +105,30 @@ def wiggle(
     """
     Create a wiggle plot of patch data.
 
+    Length one dimensions are squeezed out first. A patch left with a single
+    dimension (e.g., an OTDR trace stored as ``(time: 1, distance: N)``) is
+    drawn as one line against that dimension, with the data type and units
+    (or "amplitude" if the patch has neither) on the y axis. A patch left with
+    two dimensions is drawn as one wiggle per trace.
+
     Parameters
     ----------
     patch
         The Patch object.
     dim
-        The dimension along which samples are connected.
+        The dimension along which samples are connected. Ignored if only
+        one dimension remains after squeezing.
     scale
         The scale (or gain) of the waveforms. A value of 1 indicates waveform
         centroids are separated by the average total waveform excursion.
     alpha
-        Opacity of the wiggle lines.
+        Opacity of the wiggle lines. Defaults to 0.2 for 2D patches, where
+        neighboring wiggles overlap, and 1.0 for a single trace.
     color
         Color of wiggles
     shade
-        If True, shade all values of each trace which are less than the mean
-        trace value.
+        If True, shade all values of each trace which are greater than the
+        trace offset (zero for a single trace).
     ax
         A matplotlib object, if None ne will be created.
     show
@@ -91,45 +140,42 @@ def wiggle(
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
     >>> _ = patch.viz.wiggle()
+    >>>
+    >>> # A single trace plots as one line
+    >>> trace = patch.select(distance=0, samples=True)
+    >>> _ = trace.viz.wiggle()
     """
+    # A length one dimension has nothing to connect, so drop it rather than
+    # drawing a separate (one-sample) wiggle for every sample along the other.
+    # Only exactly length one dims are dropped; Patch.squeeze can't remove
+    # empty dims and those just plot nothing.
+    squeezable = [x for x in patch.dims if len(patch.get_coord(x)) == 1]
+    if len(squeezable) == patch.ndim:
+        msg = "Cannot make wiggle plot of a Patch with a single sample."
+        raise ParameterError(msg)
+    if squeezable:
+        patch = patch.squeeze(squeezable)
+    if patch.ndim == 2 and dim not in patch.dims:
+        msg = (
+            f"dim {dim!r} is not a dimension of the patch after squeezing "
+            f"length one dimensions; it must be one of {patch.dims}."
+        )
+        raise ParameterError(msg)
+    if patch.ndim > 2:
+        msg = (
+            "Can only make wiggle plot of a 1D or 2D Patch, but after "
+            f"squeezing length one dimensions patch has dims {patch.dims}."
+        )
+        raise ParameterError(msg)
+    # Create the axis only once the patch is known to be plottable so a
+    # rejected call doesn't leak an empty figure.
     ax = _get_ax(ax)
-
-    # Handle 1D patches (issue #462)
-    if len(patch.dims) == 1:
-        plot_dim = patch.dims[0]
-        x_values = patch.coords.get_array(plot_dim)
-        y_values = patch.data
-        ax.plot(x_values, y_values, color=color, alpha=alpha)
-        ax.set_xlabel(_get_dim_label(patch, plot_dim))
-        ax.set_ylabel("amplitude")
-        # Format time axis if applicable
-        if np.issubdtype(patch.get_coord(plot_dim).dtype, np.datetime64):
-            _format_time_axis(ax, plot_dim, "x")
-        if show:
-            plt.show()
-        return ax
-
-    assert len(patch.dims) == 2, "Can only make wiggle plot of 2D Patch"
-    # After transpose selected dim must be axis 0 and other axis 1
-    patch = patch.transpose(dim, ...)
-    other_dim = next(iter(set(patch.dims) - {dim}))
-    # values for axis which is connected
-    connect_axis_ticks = patch.coords.get_array(dim)
-    # values for y axis (not connected)
-    other_axis_ticks = patch.coords.get_array(other_dim)
-    offsets, data_scaled = _get_offsets_factor(patch, dim, scale, other_axis_ticks)
-    # now plot, add labels, etc.
-    ax.plot(connect_axis_ticks, data_scaled, color=color, alpha=alpha)
-    # shade negative part of waveforms if desired
-    if shade:
-        _shade(offsets, ax, data_scaled, color, connect_axis_ticks)
-    _format_y_axis_ticks(ax, offsets, other_axis_ticks)
-    for dim, x in zip(patch.dims, ["x", "y"]):
-        getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
-        # format all dims which have time types.
-        if np.issubdtype(patch.get_coord(dim).dtype, np.datetime64):
-            _format_time_axis(ax, dim, x)
+    if patch.ndim == 1:
+        alpha = 1.0 if alpha is None else alpha
+        _wiggle_1d(patch, ax, alpha, color, shade)
+    else:
+        alpha = 0.2 if alpha is None else alpha
+        _wiggle_2d(patch, ax, dim, scale, alpha, color, shade)
     if show:
         plt.show()
-    ax.invert_yaxis()  # invert y so its consistent with waterfall
     return ax

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.exceptions import ParameterError
 
 
 class TestWiggle:
@@ -70,3 +71,92 @@ class TestWiggle:
         monkeypatch.setattr(plt, "show", lambda: None)
         patch_1d = random_patch.mean("distance", dim_reduce="squeeze")
         patch_1d.viz.wiggle(show=True)
+
+    def test_1d_data_label(self, random_patch):
+        """The y axis of a single trace should show the data type and units."""
+        patch = random_patch.update_attrs(data_type="velocity", data_units="m/s")
+        patch_1d = patch.mean("distance", dim_reduce="squeeze")
+        ylabel = patch_1d.viz.wiggle().get_ylabel()
+        assert ylabel == "velocity [m / s]"
+        # either one alone is used as is.
+        type_only = patch_1d.update_attrs(data_units="")
+        assert type_only.viz.wiggle().get_ylabel() == "velocity"
+        units_only = patch_1d.update_attrs(data_type="")
+        assert units_only.viz.wiggle().get_ylabel() == "m / s"
+        # with neither data type nor units, fall back to a generic label.
+        bare = patch_1d.update_attrs(data_type="", data_units="")
+        assert bare.viz.wiggle().get_ylabel() == "amplitude"
+
+    def test_1d_shade(self, random_patch):
+        """Shading should fill the positive part of a single trace."""
+        patch_1d = random_patch.mean("distance", dim_reduce="squeeze")
+        # Center the trace so it has both signs.
+        centered = patch_1d - np.mean(patch_1d.data)
+        assert np.min(centered.data) < 0 < np.max(centered.data)
+        ax = centered.viz.wiggle(shade=True)
+        assert len(ax.collections) == 1
+        # The fill is clipped to the zero line and never goes below it.
+        verts = np.concatenate([x.vertices for x in ax.collections[0].get_paths()])
+        assert np.all(verts[:, 1] >= 0)
+
+    def test_1d_alpha(self, random_patch):
+        """A single trace is opaque by default, but alpha can still be set."""
+        patch_1d = random_patch.mean("distance", dim_reduce="squeeze")
+        assert patch_1d.viz.wiggle().lines[0].get_alpha() == 1.0
+        assert patch_1d.viz.wiggle(alpha=0.3).lines[0].get_alpha() == 0.3
+        # 2D patches keep the old default so wiggles can overlap.
+        assert random_patch.viz.wiggle().lines[0].get_alpha() == 0.2
+
+    @pytest.mark.parametrize("dim", ["time", "distance"])
+    def test_singleton_dim_squeezed(self, random_patch, dim):
+        """
+        A 2D patch with a length one dimension (e.g., a single OTDR trace
+        stored as (time: 1, distance: N)) should plot as one line along the
+        other dimension rather than one wiggle per sample.
+        """
+        patch = random_patch.select(**{dim: 0, "samples": True})
+        assert len(patch.dims) == 2
+        other_dim = next(iter(set(patch.dims) - {dim}))
+        ax = patch.viz.wiggle()
+        assert len(ax.lines) == 1
+        assert other_dim in ax.get_xlabel().lower()
+        assert len(ax.lines[0].get_xdata()) == len(patch.get_coord(other_dim))
+        # The single trace path is used: opaque line, y axis not inverted.
+        assert ax.lines[0].get_alpha() == 1.0
+        assert not ax.yaxis_inverted()
+
+    def test_3d_with_singleton_dim(self, range_patch_3d):
+        """A 3D patch with one length one dim should plot as a 2D wiggle."""
+        patch = range_patch_3d.select(time=0, samples=True)
+        assert patch.ndim == 3
+        ax = patch.viz.wiggle(dim="distance")
+        assert len(ax.lines) == len(patch.get_coord("smell"))
+        # But the default dim was squeezed away, so say so rather than
+        # complain that "time" isn't a dimension of the (original) patch.
+        with pytest.raises(ParameterError, match="after squeezing"):
+            patch.viz.wiggle()
+
+    def test_empty_dim(self, random_patch):
+        """A patch with an empty dimension plots nothing but shouldn't raise."""
+        patch = random_patch.select(distance=(1e9, None))
+        assert len(patch.get_coord("distance")) == 0
+        assert isinstance(patch.viz.wiggle(), plt.Axes)
+
+    def test_no_figure_on_error(self, random_patch):
+        """A rejected call shouldn't leave an empty figure behind."""
+        patch = random_patch.select(time=0, distance=0, samples=True)
+        plt.close("all")
+        with pytest.raises(ParameterError):
+            patch.viz.wiggle()
+        assert not plt.get_fignums()
+
+    def test_single_sample_raises(self, random_patch):
+        """A patch with a single sample has nothing to plot."""
+        patch = random_patch.select(time=0, distance=0, samples=True)
+        with pytest.raises(ParameterError, match="single sample"):
+            patch.viz.wiggle()
+
+    def test_3d_patch_raises(self, range_patch_3d):
+        """More than two non-trivial dimensions can't be wiggle plotted."""
+        with pytest.raises(ParameterError, match="1D or 2D"):
+            range_patch_3d.viz.wiggle()

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -136,11 +136,18 @@ class TestWiggle:
         with pytest.raises(ParameterError, match="after squeezing"):
             patch.viz.wiggle()
 
-    def test_empty_dim(self, random_patch):
-        """A patch with an empty dimension plots nothing but shouldn't raise."""
-        patch = random_patch.select(distance=(1e9, None))
-        assert len(patch.get_coord("distance")) == 0
-        assert isinstance(patch.viz.wiggle(), plt.Axes)
+    @pytest.mark.parametrize("dim", ["time", "distance"])
+    def test_empty_dim(self, random_patch, dim):
+        """
+        A patch with an empty dimension, whether or not it is the connected
+        one, plots nothing but shouldn't raise.
+        """
+        coord = random_patch.get_coord(dim)
+        patch = random_patch.select(**{dim: (coord.max() + coord.step, None)})
+        assert len(patch.get_coord(dim)) == 0
+        ax = patch.viz.wiggle()
+        assert isinstance(ax, plt.Axes)
+        assert not ax.lines
 
     def test_no_figure_on_error(self, random_patch):
         """A rejected call shouldn't leave an empty figure behind."""


### PR DESCRIPTION
## Description

`Patch.viz.wiggle` did badly on a single trace stored with a length-one dimension, e.g. an OTDR trace read as `(time: 1, distance: 16384)`. The existing 1D special case (#462) only fired for patches that were already 1D, so with the default `dim="time"` the plot connected samples along a one-sample axis and drew 16,384 separate one-point wiggles with 16,384 offsets and y ticks: ~11 s for a plot that showed nothing.

This PR:

- Squeezes length-one dimensions at the start of `wiggle`. A patch left with one dimension is drawn as a single line against that dimension (the OTDR case now takes ~0.2 s); a patch left with two is drawn as before.
- Labels the y axis of a single trace with the data type and units (e.g. `otdr [dB]`), falling back to `amplitude`. The label logic is shared with the waterfall colorbar via a new `_get_data_label` helper in `dascore.utils.plotting`; the colorbar text is unchanged.
- Makes `alpha` default to `None`, resolved to `1.0` for a single trace and the previous `0.2` for overlapping wiggles. `shade` also works for a single trace (fills above zero).
- Raises `ParameterError` (rather than an `AssertionError`) for patches still 3D after squeezing, for single-sample patches, and for a `dim` that was squeezed away, and only creates the figure once the patch is known to be plottable so rejected calls don't leak empty figures. Empty (zero-length) dimensions are left alone, since `Patch.squeeze` can't currently remove them.
- Moves the `invert_yaxis()` call before `plt.show()` for 2D wiggles, so `show=True` now shows the inverted axis that the returned axis already had.

Not changed here: `Patch.squeeze()` on an all-length-one patch raises a `CoordDataError` (it can't build a 0-D patch); `wiggle` guards against that case itself.

## Checklist

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved wiggle plots for single-trace data and patches with singleton dimensions.
  * Added automatic y-axis labels based on data type and units.
  * Added dimension-aware default opacity and improved positive-value shading.

* **Bug Fixes**
  * Added clearer validation for unsupported shapes, empty dimensions, and single-sample data.
  * Standardized colorbar labels across visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->