### PR TITLE
Let a spool find a patch by the id it carries

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -1967,13 +1967,20 @@ class Spool(NamespaceOwner):
             # synthetic per-catalog identities (memory:// paths, ids) and
             # backend provenance (format/version) are not content; equal
             # spools must compare equal without them, and column order
-            # (a construction artifact) must not matter. Coordinate def
-            # keys are representation artifacts too: a residual-trimmed
+            # (a construction artifact) must not matter. A patch's own
+            # lineage ids go too: a plan's outputs state none (a merged
+            # patch folds its members' rather than inheriting one), so
+            # keeping them would make a view unequal to its own
+            # materialization over a column neither describes it by.
+            # Coordinate def keys are representation artifacts too: a
+            # residual-trimmed
             # view cannot know its trimmed fingerprint without loading,
             # and data values are never compared here anyway.
             drop = [
                 "source_path",
                 "_patch_id",
+                "patch_id",
+                "processing_id",
                 "source_patch_key",
                 "source_format",
                 "source_version",

--- a/dascore/core/summary.py
+++ b/dascore/core/summary.py
@@ -12,6 +12,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 from pydantic import ConfigDict, Field, SerializeAsAny, model_validator
+from upath import UPath
 
 import dascore as dc
 from dascore.constants import path_types
@@ -154,6 +155,33 @@ def _normalize_source_patch_key(
     return attrs, normalized
 
 
+def _upath_from_dump(value) -> UPath | None:
+    """
+    Return the path a dumped `UPath` describes, or None if it is not one.
+
+    A remote `UPath` does not survive `model_dump` as a path: it comes
+    back as its parts. Without this a summary round-tripped through a
+    dump -- which is what `new` does -- would lose its source path, and
+    then its format and version with it, because a summary with nothing
+    to reload from states no reload metadata.
+
+    A local path dumps as itself, so this is only ever reached by a
+    remote one.
+    """
+    if not isinstance(value, Mapping) or "path" not in value:
+        return None
+    protocol = value.get("protocol") or ""
+    options = value.get("storage_options") or {}
+    try:
+        if not protocol:
+            return UPath(value["path"])
+        return UPath(value["path"], protocol=protocol, **options)
+    except Exception:
+        # A mapping which is not a path is simply not one; the caller
+        # drops the source metadata as it would for any other value.
+        return None
+
+
 def _build_patch_summary_payload(
     *,
     attrs: PatchAttrs,
@@ -175,6 +203,8 @@ def _build_patch_summary_payload(
         normalized_source_path = ""
     elif is_pathlike(source_path):
         normalized_source_path = coerce_to_upath(source_path)
+    elif (restored := _upath_from_dump(source_path)) is not None:
+        normalized_source_path = restored
     else:
         normalized_source_path = ""
     normalized_source_format = "" if source_format in (None, "") else str(source_format)
@@ -250,13 +280,13 @@ class PatchSummary(DascoreBaseModel):
         """
         Create a summary from a loaded patch.
 
-        The lineage ids are dropped. A summary describes what data a file
-        holds, and the index does not store an id -- so a summary which
-        carried one would make scanning a file and reading it disagree
-        about the same data, for a field neither of them indexes.
+        The lineage ids are carried, not dropped: the index stores them,
+        so a summary which left them behind would be the one thing which
+        made scanning a patch and reading it disagree about which data it
+        is.
         """
         return cls(
-            attrs=patch.attrs.drop("patch_id", "processing_id"),
+            attrs=patch.attrs,
             coords=patch.coords.to_summary_dict(),
             dims=patch.dims,
             shape=patch.shape,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -87,7 +87,6 @@ from dascore.utils.remote_io import (
 )
 from dascore.workflow.identity import (
     ids_enabled,
-    patch_id_of,
     source_patch_id,
 )
 
@@ -1231,7 +1230,11 @@ def _canonical_path(path) -> str:
     if not is_local_path(text):
         return text
     try:
-        return str(Path(text).resolve())
+        # `coerce_to_local_path` rather than `Path`: a local file may be
+        # spelled as a `file://` URI, which `Path` would read as a
+        # relative directory called `file:` and resolve against the
+        # working directory.
+        return str(coerce_to_local_path(text).resolve())
     except Exception:
         # A path the filesystem will not answer for is still a path, and
         # a spelling nothing can canonicalize is better than none.
@@ -1589,9 +1592,17 @@ def _iter_scan_results(
     *,
     snap: bool | None = None,
     payloads: bool = False,
-) -> Generator[tuple[ScanPayload | PatchSummary, dict[str, Any]], None, None]:
-    """Yield raw scan results with dispatcher-owned source information."""
+) -> Generator[tuple[ScanPayload | PatchSummary, dict[str, Any], int], None, None]:
+    """
+    Yield raw scan results with dispatcher-owned source information.
+
+    Each result is tagged with the index of the input it came from, which
+    is the only thing that tells a file's second patch apart from the same
+    file scanned twice: both spell one source path and, for a format which
+    names no patch within a file, one key.
+    """
     output_count = 0
+    input_index = -1
     fiber_io_hint: dict[str, FiberIO] = {}
     # A dict for keeping track of missing optional dependencies.
     missing_optional_deps = defaultdict(lambda: 0)
@@ -1619,6 +1630,7 @@ def _iter_scan_results(
     try:
         with remote_cache_scope("metadata"):
             for patch_source in tracker:
+                input_index += 1
                 # Normalize direct patch inputs to summary objects.
                 if isinstance(patch_source, dc.Patch):
                     if payloads:
@@ -1640,7 +1652,7 @@ def _iter_scan_results(
                             ),
                         )
                     output_count += 1
-                    yield result, source_info
+                    yield result, source_info, input_index
                     continue
                 with IOResourceManager(patch_source) as man:
                     try:
@@ -1705,7 +1717,7 @@ def _iter_scan_results(
                     }
                     for result in source:
                         output_count += 1
-                        yield result, source_info
+                        yield result, source_info, input_index
     # Ensure ctl + c exists scan.
     except KeyboardInterrupt:
         getattr(progress, "stop", lambda: None)()
@@ -1769,7 +1781,7 @@ def scan_payloads(
         snap=snap,
         payloads=True,
     )
-    for result, source_info in iterator:
+    for result, source_info, _ in iterator:
         _validate_scan_payload(result, require_coord_manager=True)
         # dict() erases a TypedDict's value types; the validation above has
         # already raised unless every key holds what ScanPayload declares.
@@ -1842,12 +1854,16 @@ def scan(
         timestamp=timestamp,
         progress=progress,
     )
-    for result, source_info in iterator:
+    inputs = []
+    for result, source_info, input_index in iterator:
         out.append(_scan_result_to_summary(result, **source_info))
-    return _stamp_summary_ids(out)
+        inputs.append(input_index)
+    return _stamp_summary_ids(out, inputs)
 
 
-def _stamp_summary_ids(summaries: list[PatchSummary]) -> list[PatchSummary]:
+def _stamp_summary_ids(
+    summaries: list[PatchSummary], inputs: list[int]
+) -> list[PatchSummary]:
     """
     Say which data each scanned patch is, without reading any of it.
 
@@ -1860,28 +1876,49 @@ def _stamp_summary_ids(summaries: list[PatchSummary]) -> list[PatchSummary]:
     A source is stat-ed once however many patches it holds, and one which
     names no path is left alone -- an id derived from the format alone
     would make every such summary the same datum.
+
+    Parameters
+    ----------
+    summaries
+        What the scan produced.
+    inputs
+        Which scan input each summary came from. Ordinals count within
+        one input, so a file's second patch and the same file scanned
+        twice are told apart -- they are otherwise identical, both
+        spelling one path and, absent a key, one key.
     """
     if not ids_enabled():
         return summaries
     identities: dict[str, tuple[str, int | None, int | None]] = {}
-    ordinals: dict[str, int] = {}
     out = []
-    for summary in summaries:
+    ordinals: dict[tuple[int, str], int] = {}
+    for index, summary in enumerate(summaries):
         attrs = summary.attrs
         source = str(summary.source_path or "")
-        # The ordinal counts within a source, as the reader's own position
-        # does; a file's second patch is not every source's second patch.
-        ordinal = ordinals.get(source, 0)
-        ordinals[source] = ordinal + 1
-        if patch_id_of(attrs) or not source:
+        # Keyed by the input as well as the source: the ordinal is the
+        # reader's own position within one reading of one file, so
+        # scanning a file twice reads the same data twice rather than
+        # making the second copy that file's second patch.
+        key = (inputs[index], source)
+        ordinal = ordinals.get(key, 0)
+        ordinals[key] = ordinal + 1
+        # The marker, not the field: a patch pickled to a file carries the
+        # id it was minted with in some other process, and reading it back
+        # derives one from the file. Only a format which says it stored an
+        # id -- which is what the marker says -- is believed here, so the
+        # two routes cannot disagree.
+        if not source:
             out.append(summary)
+            continue
+        if stored := attrs.get(STORED_PATCH_ID, ""):
+            out.append(_summary_with_id(summary, attrs, stored))
             continue
         if (identity := identities.get(source)) is None:
             identity = identities[source] = source_identity(summary.source_path)
         path, size_bytes, mtime_ns = identity
-        if not path:
-            out.append(summary)
-            continue
+        # A summary which names a source names a path: `source` is that
+        # path, and canonicalizing one never empties it.
+        assert path, f"{source!r} named a source but no path"
         patch_id = source_patch_id(
             summary.source_format,
             summary.source_version,
@@ -1890,12 +1927,21 @@ def _stamp_summary_ids(summaries: list[PatchSummary]) -> list[PatchSummary]:
             size_bytes,
             mtime_ns,
         )
-        # `model_copy` rather than `new`: nothing here needs revalidating,
-        # and a scan of a large archive would pay for it once per patch.
-        out.append(
-            summary.model_copy(update={"attrs": attrs.update(patch_id=patch_id)})
-        )
+        out.append(_summary_with_id(summary, attrs, patch_id))
     return out
+
+
+def _summary_with_id(summary: PatchSummary, attrs, patch_id: str) -> PatchSummary:
+    """
+    Return a summary which says which data it is.
+
+    `model_copy` rather than `new`: nothing here needs revalidating, and a
+    scan of a large archive would pay for it once per patch. The marker a
+    reader left is consumed rather than carried, as it is when a patch is
+    read.
+    """
+    updated = attrs.update(patch_id=patch_id).drop(STORED_PATCH_ID)
+    return summary.model_copy(update={"attrs": updated})
 
 
 def get_format(

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -85,7 +85,11 @@ from dascore.utils.remote_io import (
     remote_cache_scope,
     suppress_gc_pause_warning,
 )
-from dascore.workflow.identity import ids_enabled, source_patch_id
+from dascore.workflow.identity import (
+    ids_enabled,
+    patch_id_of,
+    source_patch_id,
+)
 
 # What the scan dispatchers accept: one resource or patch, or an
 # iterable of them (`_iterate_scan_inputs` flattens its input with
@@ -1201,14 +1205,50 @@ def _source_path_string(source) -> str:
     if isinstance(source, IOResourceManager):
         source = source.source
     if isinstance(source, str | Path | UPath):
-        return str(source)
+        return _canonical_path(source)
     for attribute in ("_dascore_source_path", "name", "filename"):
         if value := getattr(source, attribute, ""):
             # A file object opened on a descriptor names an int, which is
             # not a path and is not the same one twice.
             if isinstance(value, str | Path | UPath):
-                return str(value)
+                return _canonical_path(value)
     return ""
+
+
+def _canonical_path(path) -> str:
+    """
+    Return the one spelling of a path an id is derived from.
+
+    A local path resolves, so a relative spelling, an absolute one and the
+    one a spool absolutizes out of its index all name a single datum --
+    which is what lets a patch scanned through a spool and the same patch
+    read straight off disk agree about which data they are.
+
+    A URI is left alone: it is already absolute, and resolving one would
+    only mangle it.
+    """
+    text = str(path)
+    if not is_local_path(text):
+        return text
+    try:
+        return str(Path(text).resolve())
+    except Exception:
+        # A path the filesystem will not answer for is still a path, and
+        # a spelling nothing can canonicalize is better than none.
+        return text
+
+
+def source_identity(source) -> tuple[str, int | None, int | None]:
+    """
+    Return what a source is: its canonical path, its size and its mtime.
+
+    The three fields of a derived id which come from the source rather
+    than from the reader; see
+    [`source_patch_id`](`dascore.workflow.identity.source_patch_id`).
+    """
+    if not (path := _source_path_string(source)):
+        return "", None, None
+    return path, *_source_stats(path)
 
 
 def _stamp_source_ids(
@@ -1245,13 +1285,9 @@ def _stamp_source_ids(
     """
     # A FiberIO is free to hand back whatever its format means; only a
     # spool of patches has ids to stamp.
-    path = _source_path_string(source)
+    path, size_bytes, mtime_ns = source_identity(source)
     if not path or not isinstance(spool, Spool) or not ids_enabled():
         return spool
-    # Stat-ed by the path rather than by the source, so a file read
-    # through a handle or a manager is stat-ed at all, and is stat-ed the
-    # same way reading it by name would be.
-    size_bytes, mtime_ns = _source_stats(path)
     # The key the caller asked for stands in for a patch's own only when
     # it named exactly this patch: a key naming several says which patches
     # were wanted, not which one any of them is.
@@ -1808,6 +1844,57 @@ def scan(
     )
     for result, source_info in iterator:
         out.append(_scan_result_to_summary(result, **source_info))
+    return _stamp_summary_ids(out)
+
+
+def _stamp_summary_ids(summaries: list[PatchSummary]) -> list[PatchSummary]:
+    """
+    Say which data each scanned patch is, without reading any of it.
+
+    The same id `read` stamps, derived the same way from the same fields,
+    so a patch found through a spool's index and the same patch read
+    straight off disk agree about which data they are. A summary whose
+    attrs already name an id keeps it: a format which stores one has
+    already answered the question.
+
+    A source is stat-ed once however many patches it holds, and one which
+    names no path is left alone -- an id derived from the format alone
+    would make every such summary the same datum.
+    """
+    if not ids_enabled():
+        return summaries
+    identities: dict[str, tuple[str, int | None, int | None]] = {}
+    ordinals: dict[str, int] = {}
+    out = []
+    for summary in summaries:
+        attrs = summary.attrs
+        source = str(summary.source_path or "")
+        # The ordinal counts within a source, as the reader's own position
+        # does; a file's second patch is not every source's second patch.
+        ordinal = ordinals.get(source, 0)
+        ordinals[source] = ordinal + 1
+        if patch_id_of(attrs) or not source:
+            out.append(summary)
+            continue
+        if (identity := identities.get(source)) is None:
+            identity = identities[source] = source_identity(summary.source_path)
+        path, size_bytes, mtime_ns = identity
+        if not path:
+            out.append(summary)
+            continue
+        patch_id = source_patch_id(
+            summary.source_format,
+            summary.source_version,
+            path,
+            summary.source_patch_key or ordinal,
+            size_bytes,
+            mtime_ns,
+        )
+        # `model_copy` rather than `new`: nothing here needs revalidating,
+        # and a scan of a large archive would pay for it once per patch.
+        out.append(
+            summary.model_copy(update={"attrs": attrs.update(patch_id=patch_id)})
+        )
     return out
 
 

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -389,6 +389,11 @@ def _get_scan_payload_from_group(group, legacy: bool = True, snap=True):
     else:
         coords = _get_coords(group, dims, {}, snap=snap)
         attr_info = out
+    # Marked here as it is when the patch is read: an id the file carries
+    # is the one which survived the round trip, and `scan` prefers it to
+    # the one it would derive only when a format says it stored one.
+    if stored := attr_info.get("patch_id", ""):
+        attr_info[STORED_PATCH_ID] = stored
     # Data shape/dtype come from the stored data node without loading the array.
     data_node = group.get("data")
     dtype = str(data_node.dtype) if data_node is not None else ""

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -45,6 +45,7 @@ from dascore.io.index.schema import (
     INDEX_VERSION,
     INDEXES,
     KIND_STORAGE,
+    SPOOL_EARLY_RENAMES,
     TABLE_CONSTRAINTS,
     TABLES,
     WHAT_IS_THIS,
@@ -838,6 +839,10 @@ class SQLiteIndexBackend:
         df = self._fetch_df(sql, params)
         df, attr_columns = self._flatten(df, attr_meta)
         df = self._pivot_coords(df)
+        # Renamed before the attrs land, not after: `patch_id` names a
+        # row here and a datum on a patch, and the attr must find the
+        # public spelling free rather than collide with the row's.
+        df = df.rename(columns=dict(SPOOL_EARLY_RENAMES))
         df = self._apply_attr_columns(df, attr_columns)
         if residuals:
             # Residuals only ever come from attr predicates, so they must
@@ -860,7 +865,7 @@ class SQLiteIndexBackend:
         if residuals:
             # regex residuals need string values; realize the relation
             df = self.query(queries, order_by=order_by, patch_ids=patch_ids)
-            return [int(x) for x in df["patch_id"]]
+            return [int(x) for x in df["_patch_id"]]
         return [int(x) for x in self._fetch_df(sql, params)["patch_id"]]
 
     def count(self, query=None, patch_ids=None) -> int:

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -153,6 +153,10 @@ def _classic_dtypes(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+# The attr a moved source can no longer vouch for; see `_forget_lineage`.
+_LINEAGE_ATTR = "patch_id"
+
+
 class SQLiteIndexBackend:
     """
     The index backend: persists the schema and answers flat-relation queries.
@@ -806,6 +810,37 @@ class SQLiteIndexBackend:
                         f"WHERE source_id IN ({marks}))",
                         (*values, *chunk),
                     )
+            self._forget_lineage(list(ids.values()))
+
+    def _forget_lineage(self, source_ids: list[int]) -> None:
+        """
+        Clear the indexed `patch_id` of sources which have moved.
+
+        A derived id names the path it was derived from, so a moved
+        source's stored id is the id of where it used to be: selecting by
+        it would hand back a patch which no longer carries it. Cleared
+        rather than recomputed, because telling a derived id from one a
+        format stored means reading rows this path exists to avoid
+        reading; a rescan fills them back in.
+
+        A missing id is a missed lookup. A stale one is a wrong answer.
+        """
+        columns = [column for _, column in self._attr_kinds(_LINEAGE_ATTR)]
+        if not columns or not source_ids:
+            return
+        assignments = ", ".join(f"{quote(col)} = NULL" for col in columns)
+        for chunk, marks in self._iter_in_batches(source_ids):
+            self._execute(
+                f"UPDATE attrs SET {assignments} WHERE patch_id IN "
+                f"(SELECT patch_id FROM patches WHERE source_id IN ({marks}))",
+                chunk,
+            )
+
+    def _attr_kinds(self, name: str) -> list[tuple[str, str]]:
+        """Return the (kind, column) pairs an attr name is stored under."""
+        meta = self._attr_meta()
+        rows = meta[meta["attr_name"] == name]
+        return list(zip(rows["value_kind"], rows["column_name"], strict=True))
 
     # --- queries -----------------------------------------------------
 

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -41,7 +41,7 @@ from dascore.io.index.query import (
     Query,
     resolve_query,
 )
-from dascore.io.index.schema import SPOOL_PRIVATE_RENAMES
+from dascore.io.index.schema import SPOOL_LATE_RENAMES
 from dascore.utils.misc import (
     _canonical_range,
     _CanonicalRange,
@@ -935,9 +935,10 @@ class PatchCatalog:
                 # id membership presents in its own (window/array) order
                 position = {pid: i for i, pid in enumerate(self._ids)}
                 df = df.sort_values(
-                    "patch_id", key=lambda s: s.map(position), kind="stable"
+                    "_patch_id", key=lambda s: s.map(position), kind="stable"
                 ).reset_index(drop=True)
-            df = df.rename(columns=dict(SPOOL_PRIVATE_RENAMES))
+            # The early ones are already done; see SPOOL_EARLY_RENAMES.
+            df = df.rename(columns=dict(SPOOL_LATE_RENAMES))
             # SQL identifies overlapping source patches. Expose the selected
             # envelopes, matching spool.get_contents() and the exact trim
             # applied when each patch is materialized. Each pass copies the

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -45,7 +45,11 @@ _SANITIZE_RE = re.compile(r"[^a-z0-9_]+")
 # Attrs handled structurally or intentionally excluded from the index.
 # The ids are not indexed until the schema version which adds columns for
 # them; an index is for finding data, and an id is not a search term.
-_SKIPPED_ATTRS = frozenset({"history", "dims", "coords", "patch_id", "processing_id"})
+# Attrs which are structure rather than metadata, and are never indexed.
+# The two lineage ids are not here: they are ordinary strings, one per
+# patch, and indexing them is what lets a spool find a patch by the id it
+# carries rather than by loading every patch to look.
+_SKIPPED_ATTRS = frozenset({"history", "dims", "coords"})
 
 
 @dataclass(frozen=True)

--- a/dascore/io/index/ingest.py
+++ b/dascore/io/index/ingest.py
@@ -46,10 +46,16 @@ _SANITIZE_RE = re.compile(r"[^a-z0-9_]+")
 # The ids are not indexed until the schema version which adds columns for
 # them; an index is for finding data, and an id is not a search term.
 # Attrs which are structure rather than metadata, and are never indexed.
-# The two lineage ids are not here: they are ordinary strings, one per
-# patch, and indexing them is what lets a spool find a patch by the id it
-# carries rather than by loading every patch to look.
-_SKIPPED_ATTRS = frozenset({"history", "dims", "coords"})
+# `patch_id` is not here: it is an ordinary string, one per patch, and
+# indexing it is what lets a spool find a patch by the id it carries
+# rather than by loading every patch to look.
+#
+# `processing_id` is. It advances on every operation, and a spool applies
+# operations as it loads -- a residual trim is a real `select` on the
+# patch -- so what the index recorded is not what the patch which comes
+# back carries. `patch_id` survives those same operations by definition,
+# which is what makes it, and not this, the one worth indexing.
+_SKIPPED_ATTRS = frozenset({"history", "dims", "coords", "processing_id"})
 
 
 @dataclass(frozen=True)
@@ -290,15 +296,31 @@ def _extract_attrs(summary: PatchSummary) -> dict[str, TypedValue]:
     return out
 
 
+# What a directory name may never claim to be. A path says where data is
+# kept, which is how renaming a directory corrects metadata; it does not
+# get to say which data it is, or a directory called `patch_id=x` would
+# rewrite the lineage of everything under it.
+_UNCLAIMABLE_BY_PATH = frozenset({"patch_id"})
+
+
 def hive_path_attrs(rel_posix: str, warn: bool = True) -> dict[str, str]:
     """
     Return the indexable hive-style path attrs for a stored relative path.
 
     Applies the same name rules as file attrs: structural/underscore
     names are dropped silently, reserved column collisions warn and drop.
+    A name only the data itself may state is dropped with a warning too.
     """
     out = {}
     for name, value in parse_hive_path_attrs(rel_posix).items():
+        if name in _UNCLAIMABLE_BY_PATH:
+            if warn:
+                msg = (
+                    f"Ignoring hive-style path key {name!r} in {rel_posix!r}; "
+                    "a path says where data is kept, not which data it is."
+                )
+                warnings.warn(msg, UserWarning, stacklevel=2)
+            continue
         status = _attr_name_status(name)
         if status == "reserved" and warn:
             msg = (

--- a/dascore/io/index/schema.py
+++ b/dascore/io/index/schema.py
@@ -264,7 +264,8 @@ RESERVED_ATTR_COLUMNS = frozenset(
         # storage tables. `patch_id` is deliberately absent: the row id it
         # names here is renamed private (SPOOL_EARLY_RENAMES) before attr
         # columns are applied, so a patch's own `patch_id` claims the
-        # public spelling rather than colliding with it.
+        # public spelling rather than colliding with it. A path may still
+        # not claim it; see `_UNCLAIMABLE_BY_PATH`.
         "source_id",
         "source_patch_key",
         "source_path",

--- a/dascore/io/index/schema.py
+++ b/dascore/io/index/schema.py
@@ -31,7 +31,7 @@ from types import MappingProxyType
 from typing import NamedTuple, get_args, get_type_hints
 
 # Version of the index schema, independent of dascore's version.
-INDEX_VERSION = 10
+INDEX_VERSION = 11
 # Identity string so any tool can sanity-check what it opened.
 WHAT_IS_THIS = "dascore_spool_index"
 
@@ -261,8 +261,10 @@ TABLE_CONSTRAINTS = MappingProxyType(
 # not indexed; ingest warns about them.
 RESERVED_ATTR_COLUMNS = frozenset(
     {
-        # storage tables
-        "patch_id",
+        # storage tables. `patch_id` is deliberately absent: the row id it
+        # names here is renamed private (SPOOL_EARLY_RENAMES) before attr
+        # columns are applied, so a patch's own `patch_id` claims the
+        # public spelling rather than colliding with it.
         "source_id",
         "source_patch_key",
         "source_path",
@@ -319,7 +321,12 @@ RESERVED_ATTR_COLUMNS = frozenset(
 # grouping and conflict policing both compare all non-private columns, so
 # a public `dtype` would raise CoordMergeError on every merge of patches
 # with differing element types.
-SPOOL_PRIVATE_RENAMES = MappingProxyType({"patch_id": "_patch_id", "dtype": "_dtype"})
+# `patch_id` is the one of these an attr also legitimately claims: it
+# names a row in this schema and a datum on a patch. It is renamed in the
+# backend, before attr columns land, so the attr finds the public spelling
+# free; the rest are renamed where the spool relation is built.
+SPOOL_EARLY_RENAMES = MappingProxyType({"patch_id": "_patch_id"})
+SPOOL_LATE_RENAMES = MappingProxyType({"dtype": "_dtype"})
 
 # Explicit secondary indexes. Every other access path is covered by a
 # PRIMARY KEY or UNIQUE autoindex above — patch_coords(patch_id,

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -48,8 +48,17 @@ from dascore.utils.pd import get_interval_columns
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float, to_timedelta64
 
 # Columns which never participate in conflict policing and never carry to
-# outputs: source bookkeeping (outputs are not file rows).
-_SOURCE_COLUMNS = ("source_path", "source_format", "source_version", "source_patch_key")
+# outputs: source bookkeeping (outputs are not file rows) and the two
+# lineage ids, which every patch states differently and a merged patch
+# folds from its members rather than inheriting from any one of them.
+_SOURCE_COLUMNS = (
+    "source_path",
+    "source_format",
+    "source_version",
+    "source_patch_key",
+    "patch_id",
+    "processing_id",
+)
 # The default continuity tolerance; looser values warn when they force
 # merges (#662).
 _DEFAULT_TOLERANCE = 1.5
@@ -1018,7 +1027,7 @@ def build_chunk_plan(
         # and make the plan row disagree with the patch it assembles
         # (which spool equality compares). Uniform partitions (the
         # common case) resolve in one shot; mixed ones resolve per
-        # output below. Carried privately (see SPOOL_PRIVATE_RENAMES)
+        # output below. Carried privately (see SPOOL_EARLY_RENAMES)
         # because a size-based chunk needs it.
         dtype_all = sorted_df["_dtype"].to_numpy()
         kdtypes = dtype_all[keep_row]

--- a/docs/notes/spool_index.qmd
+++ b/docs/notes/spool_index.qmd
@@ -65,7 +65,11 @@ SQLite permits concurrent readers and serializes writers. Initialization and upd
 
 ## The flat relation
 
-Spool-facing operations consume the tables through one flat relation: a dataframe with one row per patch carrying `{dim}_min/max/step` envelopes, private structural columns (`_patch_id`, `_{name}_def_key` coordinate identities, and `_{name}_units` original unit spellings, presented publicly as `{name}_units` by `get_contents` and normalized per dimensionality by the chunk planner before partitioning), the `dims` signature, and one column per attribute. Attrs and coords are independent namespaces, so an attr may share a name with a coordinate envelope column (e.g. an attr `channel_step` alongside a `channel` coordinate); in that rare genuine collision the envelope column owns the flat name, the attr column is omitted with a warning, and the attr remains queryable through the `_attrs` namespace. The chunk planner and selection both operate on this relation (see the [Spool Chunking](spool_chunking.qmd) and [Spool Selection](spool_selection.qmd) notes). The cell below runs against the real catalog so this description cannot silently drift.
+Spool-facing operations consume the tables through one flat relation: a dataframe with one row per patch carrying `{dim}_min/max/step` envelopes, private structural columns (`_patch_id`, `_{name}_def_key` coordinate identities, and `_{name}_units` original unit spellings, presented publicly as `{name}_units` by `get_contents` and normalized per dimensionality by the chunk planner before partitioning), the `dims` signature, and one column per attribute. Attrs and coords are independent namespaces, so an attr may share a name with a coordinate envelope column (e.g. an attr `channel_step` alongside a `channel` coordinate); in that rare genuine collision the envelope column owns the flat name, the attr column is omitted with a warning, and the attr remains queryable through the `_attrs` namespace. The chunk planner and selection both operate on this relation (see the [Spool Chunking](spool_chunking.qmd) and [Spool Selection](spool_selection.qmd) notes).
+
+A patch's own `patch_id` and `processing_id` are ordinary indexed attrs, so a patch can be found by the id it carries without loading anything. `patch_id` is the one name the storage schema and a patch both claim — a row id there, a datum here — so the row's is renamed `_patch_id` before attr columns are applied and the patch's keeps the public spelling. Neither id takes part in chunk's merge compatibility: every patch states a different one, and a merged patch folds its members' ids rather than inheriting any one of them.
+
+The cell below runs against the real catalog so this description cannot silently drift.
 
 ```{python}
 import dascore as dc
@@ -75,6 +79,7 @@ catalog = PatchCatalog.from_patches(list(dc.get_example_spool("random_das")))
 df = catalog.to_df()
 required = {
     "_patch_id",
+    "patch_id",
     "_time_def_key",
     "_time_units",
     "dims",

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -299,7 +299,7 @@ other = patch.decimate(time=2).pass_filter(time=(1, 10))
 assert other.attrs.processing_id != one.attrs.processing_id
 ```
 
-A patch read from a file derives its `patch_id` from what it was read from — the format and version, the path, which patch it is within the file, and the file's size and modification time — so two processes reading the same file agree on which data it is:
+A patch read from a file derives its `patch_id` from what it was read from — the format and version, the path, which patch it is within the file, and the file's size and modification time — so two processes reading the same file agree on which data it is, and so does scanning it without reading it at all:
 
 ```{python}
 import tempfile
@@ -312,6 +312,8 @@ assert dc.read(path)[0].attrs.patch_id == dc.read(path)[0].attrs.patch_id
 ```
 
 Those fields are the ones the spool index already keeps, and they are the ones it already uses to decide whether a file changed: data written over a path is a new datum rather than the old one wearing its id. The price is the other way round — the same bytes copied to a second path, or re-fetched over the first, are a new datum too. A missed match is the safe failure; two different data claiming to be one is not.
+
+Both ids are indexed by the spool, so a spool hands back the patch an id names without loading anything to look for it — see [Finding a patch by its id](spool.qmd#finding-a-patch-by-its-id).
 
 The path is part of the id, so a derived id is not stable across machines. A stored one is: DASDAE writes both ids into the file, and a patch read back from it keeps the id it was written with rather than deriving a new one. A patch built in memory names no source, so its `patch_id` is minted, and stable only within the process which built it.
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -313,7 +313,7 @@ assert dc.read(path)[0].attrs.patch_id == dc.read(path)[0].attrs.patch_id
 
 Those fields are the ones the spool index already keeps, and they are the ones it already uses to decide whether a file changed: data written over a path is a new datum rather than the old one wearing its id. The price is the other way round — the same bytes copied to a second path, or re-fetched over the first, are a new datum too. A missed match is the safe failure; two different data claiming to be one is not.
 
-Both ids are indexed by the spool, so a spool hands back the patch an id names without loading anything to look for it — see [Finding a patch by its id](spool.qmd#finding-a-patch-by-its-id).
+`patch_id` is indexed by the spool, so a spool hands back the patch an id names without loading anything to look for it — see [Finding a patch by its id](spool.qmd#finding-a-patch-by-its-id). `processing_id` is not: it advances on every operation, including the ones a spool runs as it loads.
 
 The path is part of the id, so a derived id is not stable across machines. A stored one is: DASDAE writes both ids into the file, and a patch read back from it keeps the id it was written with rather than deriving a new one. A patch built in memory names no source, so its `patch_id` is minted, and stable only within the process which built it.
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -244,7 +244,7 @@ subspool = spool.select(tag='some*')
 
 ## Finding a patch by its id
 
-The two ids a patch carries — `patch_id` for which data it is, `processing_id` for what was done to it, both described in [Patch identity](patch.qmd#patch-identity) — are indexed like any other attribute. A spool can therefore hand back the patch an id names without loading anything to look for it, which is how a result written down somewhere else finds its way back to the data it came from.
+`patch_id` — which data a patch is, described in [Patch identity](patch.qmd#patch-identity) — is indexed like any other attribute. A spool can therefore hand back the patch an id names without loading anything to look for it, which is how a result written down somewhere else finds its way back to the data it came from.
 
 ```{python}
 import dascore as dc
@@ -258,6 +258,10 @@ assert found[0].attrs.patch_id == wanted
 ```
 
 An id is the same on every read of the same file, so one written down today still names the same data next year — see [Patch identity](patch.qmd#patch-identity) for what an id is derived from and when it changes.
+
+Two things do not carry an id. `processing_id` is not indexed at all: it advances whenever an operation runs, and a spool runs one as it loads, so what the index recorded would not be what came back. And a spool whose patches are built rather than read — a chunked one, most of all — has no `patch_id` column, because a merged patch folds its members' ids rather than inheriting any one of them; selecting by id there says the spool has no such attribute rather than quietly matching nothing.
+
+An id names a path, so an archive which is moved and re-indexed keeps the ids it was indexed with while the patches it loads derive new ones. Delete the index and rebuild it after moving an archive.
 
 # unselect
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -261,7 +261,7 @@ An id is the same on every read of the same file, so one written down today stil
 
 Two things do not carry an id. `processing_id` is not indexed at all: it advances whenever an operation runs, and a spool runs one as it loads, so what the index recorded would not be what came back. And a spool whose patches are built rather than read — a chunked one, most of all — has no `patch_id` column, because a merged patch folds its members' ids rather than inheriting any one of them; selecting by id there says the spool has no such attribute rather than quietly matching nothing.
 
-An id names a path, so an archive which is moved and re-indexed keeps the ids it was indexed with while the patches it loads derive new ones. Delete the index and rebuild it after moving an archive.
+An id names a path, so a file which moves — including the directory rename that attaches metadata to an archive — is no longer the row the index derived an id for. The index clears the id rather than keeping a stale one, so a moved source has an empty `patch_id` until the archive is scanned again; the patches themselves still carry theirs.
 
 # unselect
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -242,6 +242,23 @@ subspool = spool.select(acquisition_key={'DAS2.R2D1..RAW', 'DAS3.R2D1..RAW'})
 subspool = spool.select(tag='some*')
 ```
 
+## Finding a patch by its id
+
+The two ids a patch carries — `patch_id` for which data it is, `processing_id` for what was done to it, both described in [Patch identity](patch.qmd#patch-identity) — are indexed like any other attribute. A spool can therefore hand back the patch an id names without loading anything to look for it, which is how a result written down somewhere else finds its way back to the data it came from.
+
+```{python}
+import dascore as dc
+spool = dc.get_example_spool()
+
+wanted = spool.get_contents()["patch_id"].iloc[1]
+found = spool.select(patch_id=wanted)
+
+assert len(found) == 1
+assert found[0].attrs.patch_id == wanted
+```
+
+An id is the same on every read of the same file, so one written down today still names the same data next year — see [Patch identity](patch.qmd#patch-identity) for what an id is derived from and when it changes.
+
 # unselect
 
 [`unselect`](`dascore.core.spool.Spool.unselect`) is the complement of `select`: it returns the patches the same selection would have removed. Each keyword means what it means in `select`, so this is how to name what a spool does *not* want without spelling out the rest of the archive.

--- a/tests/test_io/test_index/test_index_contract.py
+++ b/tests/test_io/test_index/test_index_contract.py
@@ -643,6 +643,34 @@ class TestLineageIds:
         # stopped claiming to know without looking.
         assert moved[0].attrs.patch_id
 
+    def test_a_path_may_not_claim_the_lineage(self, tmp_path):
+        """
+        A directory name says where data is kept, not which data it is.
+
+        Hive-style path keys become ordinary attrs and override what a
+        file states, which is how a rename corrects metadata. Letting one
+        claim `patch_id` would rewrite the lineage of everything beneath
+        it -- on the loaded patch, not merely in the index.
+        """
+        directory = tmp_path / "patch_id=bogus"
+        directory.mkdir()
+        with config_context(patch_provenance="disabled"):
+            dc.get_example_patch().io.write(directory / "x.h5", "dasdae")
+        with pytest.warns(UserWarning, match="not which data it is"):
+            spool = dc.spool(tmp_path).update()
+        assert spool.get_contents()["patch_id"].iloc[0] != "bogus"
+        assert spool[0].attrs.patch_id != "bogus"
+
+    def test_a_rename_when_no_id_was_indexed(self, tmp_path):
+        """An archive indexed with the ids off has none to forget."""
+        with config_context(patch_provenance="disabled"):
+            dc.get_example_patch().io.write(tmp_path / "x.h5", "dasdae")
+            spool = dc.spool(tmp_path).update()
+            assert "patch_id" not in spool.get_contents().columns
+            (tmp_path / "x.h5").rename(tmp_path / "tag=renamed.h5")
+            moved = dc.spool(tmp_path).update()
+        assert len(moved) == 1
+
     def test_chunk_still_merges_across_ids(self, written_spool):
         """Every patch states a different id; none of them blocks a merge."""
         assert len(set(written_spool.get_contents()["patch_id"])) == 3

--- a/tests/test_io/test_index/test_index_contract.py
+++ b/tests/test_io/test_index/test_index_contract.py
@@ -591,12 +591,24 @@ class TestLineageIds:
         assert len(selected) == 1
         assert selected[0].attrs.patch_id == wanted
 
-    def test_selecting_by_processing_id(self, tmp_path):
-        """What was done is queryable the same way which data is."""
+    def test_what_was_done_is_not_indexed(self, tmp_path):
+        """
+        `processing_id` advances whenever an operation runs, and a spool
+        runs one as it loads: a residual trim is a real `select` on the
+        patch. What the index recorded would not be what came back, so it
+        is not recorded. `patch_id` survives those same operations, which
+        is what makes it the one worth indexing.
+        """
         patch = dc.get_example_patch().pass_filter(time=(1, 10))
         patch.io.write(tmp_path / "filtered.h5", "dasdae")
         spool = dc.spool(tmp_path).update()
-        assert len(spool.select(processing_id=patch.attrs.processing_id)) == 1
+        assert "processing_id" not in spool.get_contents().columns
+
+    def test_a_trim_keeps_the_id_it_says_it_keeps(self, written_spool):
+        """The index and the patch which loads must not disagree."""
+        trimmed = written_spool.select(time=(10, 20), samples=True)
+        indexed = trimmed.get_contents()["patch_id"].iloc[0]
+        assert trimmed[0].attrs.patch_id == indexed
 
     def test_a_memory_spool_too(self):
         """A summary carries the ids, so a patch never written is findable."""

--- a/tests/test_io/test_index/test_index_contract.py
+++ b/tests/test_io/test_index/test_index_contract.py
@@ -621,6 +621,28 @@ class TestLineageIds:
         """An id which names nothing selects nothing, rather than raising."""
         assert len(written_spool.select(patch_id="0" * 16)) == 0
 
+    def test_a_renamed_source_forgets_its_id(self, tmp_path):
+        """
+        A derived id names the path it came from.
+
+        Renaming a file is how metadata is attached to an archive, and
+        the index rewrites the path without re-reading the file. The id
+        the row held is the id of where it used to be, so it is cleared
+        rather than left to select a patch which no longer carries it.
+        """
+        with config_context(patch_provenance="disabled"):
+            dc.get_example_patch().io.write(tmp_path / "x.h5", "dasdae")
+        spool = dc.spool(tmp_path).update()
+        stale = spool.get_contents()["patch_id"].iloc[0]
+        assert stale
+        (tmp_path / "x.h5").rename(tmp_path / "tag=renamed.h5")
+        moved = dc.spool(tmp_path).update()
+        assert moved.get_contents()["patch_id"].iloc[0] == ""
+        assert len(moved.select(patch_id=stale)) == 0
+        # The patch itself still says which data it is; only the index
+        # stopped claiming to know without looking.
+        assert moved[0].attrs.patch_id
+
     def test_chunk_still_merges_across_ids(self, written_spool):
         """Every patch states a different id; none of them blocks a merge."""
         assert len(set(written_spool.get_contents()["patch_id"])) == 3

--- a/tests/test_io/test_index/test_index_contract.py
+++ b/tests/test_io/test_index/test_index_contract.py
@@ -15,6 +15,7 @@ import pandas as pd
 import pytest
 
 import dascore as dc
+from dascore.config import config_context
 from dascore.core.summary import PatchSummary
 from dascore.exceptions import UnitError
 from dascore.io.index.backend import get_backend
@@ -557,3 +558,58 @@ class TestCoordPivot:
         df = backend.query(Query(attrs={"tag": "corr"}))
         assert df["lag_time_min"].notna().all()
         assert "frequency_min" not in df.columns or df["frequency_min"].isna().all()
+
+
+class TestLineageIds:
+    """A patch can be found by the id it carries, without loading it."""
+
+    @pytest.fixture
+    def written_spool(self, tmp_path):
+        """Three patches on disk, each its own datum."""
+        with config_context(patch_provenance="disabled"):
+            for index, patch in enumerate(dc.get_example_spool("random_das")):
+                patch.io.write(tmp_path / f"{index}.h5", "dasdae")
+        return dc.spool(tmp_path).update()
+
+    def test_the_two_ids_are_different_columns(self, written_spool):
+        """The row's id is private; the patch's owns the public name."""
+        df = written_spool.get_contents()
+        assert {"_patch_id", "patch_id"}.issubset(df.columns)
+        assert df["_patch_id"].tolist() != df["patch_id"].tolist()
+
+    def test_scanning_and_reading_agree(self, tmp_path):
+        """Or an id found in the index would not name the patch it loads."""
+        path = tmp_path / "one.h5"
+        with config_context(patch_provenance="disabled"):
+            dc.get_example_patch().io.write(path, "dasdae")
+        assert dc.scan(path)[0].attrs.patch_id == dc.read(path)[0].attrs.patch_id
+
+    def test_selecting_by_id_finds_that_patch(self, written_spool):
+        """Which is what indexing the id is for."""
+        wanted = written_spool.get_contents()["patch_id"].iloc[1]
+        selected = written_spool.select(patch_id=wanted)
+        assert len(selected) == 1
+        assert selected[0].attrs.patch_id == wanted
+
+    def test_selecting_by_processing_id(self, tmp_path):
+        """What was done is queryable the same way which data is."""
+        patch = dc.get_example_patch().pass_filter(time=(1, 10))
+        patch.io.write(tmp_path / "filtered.h5", "dasdae")
+        spool = dc.spool(tmp_path).update()
+        assert len(spool.select(processing_id=patch.attrs.processing_id)) == 1
+
+    def test_a_memory_spool_too(self):
+        """A summary carries the ids, so a patch never written is findable."""
+        patches = list(dc.get_example_spool("random_das"))
+        spool = dc.spool(patches)
+        wanted = patches[1].attrs.patch_id
+        assert spool.select(patch_id=wanted)[0].attrs.patch_id == wanted
+
+    def test_an_id_no_patch_carries(self, written_spool):
+        """An id which names nothing selects nothing, rather than raising."""
+        assert len(written_spool.select(patch_id="0" * 16)) == 0
+
+    def test_chunk_still_merges_across_ids(self, written_spool):
+        """Every patch states a different id; none of them blocks a merge."""
+        assert len(set(written_spool.get_contents()["patch_id"])) == 3
+        assert len(written_spool.chunk(time=None)) == 1

--- a/tests/test_io/test_index/test_index_edge_cases.py
+++ b/tests/test_io/test_index/test_index_edge_cases.py
@@ -928,12 +928,12 @@ class TestIngestEdges:
         assert "source_id" not in records[0].patches[0].attrs
 
     @pytest.mark.parametrize("name", ["patch_id", "processing_id"])
-    def test_the_ids_are_skipped_silently(self, name):
+    def test_the_ids_are_indexed_silently(self, name):
         """
-        Every patch carries them, so a warning would fire on every patch.
+        An id is a search term: it is how a result finds its data again.
 
-        They are not indexed: an index is for finding data, and an id is
-        not a search term.
+        Every patch carries one, so a reserved-name warning would fire on
+        every patch; indexing them is quiet.
         """
         summary = PatchSummary(
             attrs={name: "0123456789abcdef", "tag": "x"},
@@ -956,7 +956,7 @@ class TestIngestEdges:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             records = s2r([summary])
-        assert name not in records[0].patches[0].attrs
+        assert records[0].patches[0].attrs[name].value == "0123456789abcdef"
 
     @pytest.mark.parametrize("name", ["shape", "n_dims", "sample_count_total"])
     def test_dropped_columns_stay_reserved(self, random_patch, name):

--- a/tests/test_io/test_index/test_index_edge_cases.py
+++ b/tests/test_io/test_index/test_index_edge_cases.py
@@ -927,7 +927,7 @@ class TestIngestEdges:
             records = s2r([summary])
         assert "source_id" not in records[0].patches[0].attrs
 
-    @pytest.mark.parametrize("name", ["patch_id", "processing_id"])
+    @pytest.mark.parametrize("name", ["patch_id"])
     def test_the_ids_are_indexed_silently(self, name):
         """
         An id is a search term: it is how a result finds its data again.

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -1831,6 +1831,50 @@ class TestConvertAttrUnits:
         assert "gauge_length" not in out
 
 
+class TestSummaryRoundTrip:
+    """What a summary keeps when it is rebuilt from itself."""
+
+    @pytest.fixture
+    def remote_summary(self, random_patch):
+        """A summary naming a source on a filesystem which is not local."""
+        return random_patch.summary.new(
+            source_path=UPath("memory://archive/one.h5"),
+            source_format="DASDAE",
+            source_version="1",
+        )
+
+    def test_a_remote_path_survives(self, remote_summary):
+        """
+        A remote path does not survive `model_dump` as a path.
+
+        It comes back as its parts, and a summary which cannot read those
+        back drops the path -- and then the format and version with it,
+        because a summary with nothing to reload from states no reload
+        metadata. Every `new` on a remote-backed summary went that way.
+        """
+        rebuilt = remote_summary.new(attrs=remote_summary.attrs.update(tag="x"))
+        assert str(rebuilt.source_path) == "memory://archive/one.h5"
+        assert rebuilt.source_format == "DASDAE"
+        assert rebuilt.source_version == "1"
+        assert rebuilt.attrs.tag == "x"
+
+    @pytest.mark.parametrize("path", ["one.h5", "/tmp/one.h5"])
+    def test_a_local_path_survives_too(self, random_patch, path):
+        """Local paths dump as themselves; this is the control."""
+        summary = random_patch.summary.new(source_path=path, source_format="DASDAE")
+        rebuilt = summary.new(dtype="float32")
+        assert str(rebuilt.source_path) == str(summary.source_path)
+        assert rebuilt.source_format == "DASDAE"
+
+    def test_a_mapping_which_is_not_a_path(self, random_patch):
+        """Something else shaped like one is not one, and is dropped."""
+        summary = random_patch.summary.new(
+            source_path={"not": "a path"}, source_format="DASDAE"
+        )
+        assert str(summary.source_path) == ""
+        assert summary.source_format == ""
+
+
 class TestSourceIds:
     """The id a patch gets from the file it was read out of."""
 
@@ -1933,6 +1977,14 @@ class TestSourceIds:
         (tmp_path / ".cache").mkdir()
         (tmp_path / ".cache" / "member.h5").write_bytes(b"much more data")
         assert _source_stats(tmp_path) == before
+
+    def test_one_file_spelled_two_ways(self, terra15_path):
+        """A relative and an absolute spelling name one datum."""
+        relative = os.path.relpath(terra15_path)
+        assert (
+            dc.read(relative)[0].attrs.patch_id
+            == dc.read(terra15_path)[0].attrs.patch_id
+        )
 
     def test_a_source_which_will_not_answer(self):
         """Nothing said is better than fields which pretend to be equal."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -33,6 +33,7 @@ from dascore.exceptions import (
 from dascore.io.core import (
     STORED_PATCH_ID,
     FiberIO,
+    _canonical_path,
     _FiberIOManager,
     _get_missing_install_name,
     _get_reloadable_source_path,
@@ -1866,6 +1867,22 @@ class TestSummaryRoundTrip:
         assert str(rebuilt.source_path) == str(summary.source_path)
         assert rebuilt.source_format == "DASDAE"
 
+    def test_a_mapping_naming_no_filesystem(self, random_patch):
+        """The parts of a local path, which is the form with no protocol."""
+        dumped = {"path": "/tmp/one.h5", "protocol": "", "storage_options": {}}
+        summary = random_patch.summary.new(
+            source_path=dumped, source_format="DASDAE", source_version="1"
+        )
+        assert str(summary.source_path) == "/tmp/one.h5"
+        assert summary.source_format == "DASDAE"
+
+    def test_a_mapping_naming_no_such_filesystem(self, random_patch):
+        """A protocol nothing implements is not a path either."""
+        dumped = {"path": "/one.h5", "protocol": "nosuchfs", "storage_options": {}}
+        summary = random_patch.summary.new(source_path=dumped, source_format="DASDAE")
+        assert str(summary.source_path) == ""
+        assert summary.source_format == ""
+
     def test_a_mapping_which_is_not_a_path(self, random_patch):
         """Something else shaped like one is not one, and is dropped."""
         summary = random_patch.summary.new(
@@ -1985,6 +2002,16 @@ class TestSourceIds:
             dc.read(relative)[0].attrs.patch_id
             == dc.read(terra15_path)[0].attrs.patch_id
         )
+
+    def test_a_path_which_cannot_be_canonicalized(self):
+        """A spelling nothing can resolve is still the spelling given."""
+        unresolvable = "one\x00two.h5"
+        assert _canonical_path(unresolvable) == unresolvable
+
+    def test_scanning_with_the_ids_disabled(self, terra15_path):
+        """The config which turns the ids off turns scanning off too."""
+        with config_context(patch_provenance="disabled"):
+            assert dc.scan(terra15_path)[0].attrs.patch_id == ""
 
     def test_a_source_which_will_not_answer(self):
         """Nothing said is better than fields which pretend to be equal."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -30,6 +30,7 @@ from dascore.exceptions import (
     RemoteCacheError,
     UnknownFiberFormatError,
 )
+from dascore.io import core as io_core
 from dascore.io.core import (
     STORED_PATCH_ID,
     FiberIO,
@@ -1997,18 +1998,31 @@ class TestSourceIds:
         (tmp_path / ".cache" / "member.h5").write_bytes(b"much more data")
         assert _source_stats(tmp_path) == before
 
-    def test_one_file_spelled_two_ways(self, terra15_path):
-        """A relative and an absolute spelling name one datum."""
-        relative = os.path.relpath(terra15_path)
-        assert (
-            dc.read(relative)[0].attrs.patch_id
-            == dc.read(terra15_path)[0].attrs.patch_id
-        )
+    def test_one_file_spelled_two_ways(self, terra15_path, monkeypatch):
+        """
+        A relative and an absolute spelling name one datum.
 
-    def test_a_path_which_cannot_be_canonicalized(self):
-        """A spelling nothing can resolve is still the spelling given."""
-        unresolvable = "one\x00two.h5"
-        assert _canonical_path(unresolvable) == unresolvable
+        The relative one is made by moving to the file's own directory:
+        `relpath` refuses to answer across windows drives, and where the
+        test data is cached is not this test's business.
+        """
+        absolute = dc.read(terra15_path)[0].attrs.patch_id
+        monkeypatch.chdir(Path(terra15_path).parent)
+        assert dc.read(Path(terra15_path).name)[0].attrs.patch_id == absolute
+
+    def test_a_path_which_cannot_be_canonicalized(self, monkeypatch):
+        """
+        A spelling nothing can resolve is still the spelling given.
+
+        Forced rather than found: which strings a filesystem refuses is
+        the filesystem's business, and differs by platform and python.
+        """
+
+        def _refuse(_):
+            raise OSError("no")
+
+        monkeypatch.setattr(io_core, "coerce_to_local_path", _refuse)
+        assert _canonical_path("one.h5") == "one.h5"
 
     def test_scanning_with_the_ids_disabled(self, terra15_path):
         """The config which turns the ids off turns scanning off too."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -1873,7 +1873,9 @@ class TestSummaryRoundTrip:
         summary = random_patch.summary.new(
             source_path=dumped, source_format="DASDAE", source_version="1"
         )
-        assert str(summary.source_path) == "/tmp/one.h5"
+        # Compared as paths, not as text: windows spells this one with
+        # backslashes, and what matters is that it is the same path.
+        assert summary.source_path == UPath("/tmp/one.h5")
         assert summary.source_format == "DASDAE"
 
     def test_a_mapping_naming_no_such_filesystem(self, random_patch):

--- a/tests/test_io/test_sintela/test_protobuf.py
+++ b/tests/test_io/test_sintela/test_protobuf.py
@@ -90,6 +90,19 @@ def _payload_to_summary(payload):
     return _scan_payload_to_summary(payload)
 
 
+def _without_ids(summary):
+    """
+    Return a summary with the lineage ids cleared.
+
+    A FiberIO is not where an id is decided: `dc.read` and `dc.scan` stamp
+    one between them, so a patch built straight off a reader carries the
+    one minted for any in-memory patch and a scan payload carries none.
+    Comparing the two at this level would compare that, not the metadata.
+    """
+    attrs = summary.attrs.update(patch_id="", processing_id="")
+    return summary.model_copy(update={"attrs": attrs})
+
+
 @cache
 def _get_test_proto_messages():
     """Build local protobuf classes for Sintela synthetic test payloads."""
@@ -352,7 +365,7 @@ class TestSintelaProtobuf:
         """Scan metadata should match the loaded patch summary."""
         summary = _payload_to_summary(fiber_io.scan(sintela_protobuf_path)[0])
         patch_summary = fiber_io.read(sintela_protobuf_path)[0].summary
-        assert summary == patch_summary
+        assert _without_ids(summary) == _without_ids(patch_summary)
 
     def test_ts_read_promotes_selected_meta_attrs(
         self, fiber_io, write_sintela_file, ts_records
@@ -429,7 +442,8 @@ class TestSintelaProtobuf:
         """Band scan should exercise the metadata-only summary path."""
         path = write_sintela_file("band.pb", band_records)
         scan_summary = _payload_to_summary(fiber_io.scan(path)[0])
-        assert scan_summary == fiber_io.read(path)[0].summary
+        read_summary = fiber_io.read(path)[0].summary
+        assert _without_ids(scan_summary) == _without_ids(read_summary)
 
     def test_fft_scan_matches_read_summary(
         self, fiber_io, write_sintela_file, complex_fft_records
@@ -437,7 +451,8 @@ class TestSintelaProtobuf:
         """FFT scan should exercise the metadata-only summary path."""
         path = write_sintela_file("fft.pb", complex_fft_records)
         scan_summary = _payload_to_summary(fiber_io.scan(path)[0])
-        assert scan_summary == fiber_io.read(path)[0].summary
+        read_summary = fiber_io.read(path)[0].summary
+        assert _without_ids(scan_summary) == _without_ids(read_summary)
 
     def test_complex_fft_not_labeled_power_spectral_density(
         self, fiber_io, write_sintela_file, complex_fft_records, fft_records

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -367,14 +367,15 @@ class TestTheRulesOnRealPatches:
             assert made.attrs.patch_id == ""
             assert made.normalize("time").attrs.processing_id == ""
 
-    def test_a_summary_does_not_carry_them(self, patch):
+    def test_a_summary_carries_them(self, patch):
         """
-        An index does not store an id, so a summary holding one would make
-        scanning a file and reading it disagree about the same data.
+        The index stores them, so a summary which left them behind would
+        make scanning a patch and reading it disagree about which data it
+        is -- and would leave the spool nothing to find a patch by.
         """
         summary = patch.summary
-        assert summary.attrs.patch_id == ""
-        assert summary.attrs.processing_id == ""
+        assert summary.attrs.patch_id == patch.attrs.patch_id
+        assert summary.attrs.processing_id == patch.attrs.processing_id
 
 
 class TestTheAwkwardCases:


### PR DESCRIPTION
## Description

Follow-up to #944, which made `patch_id` mean something. This makes it *findable*: a spool now hands back the patch an id names without loading anything to look for it.

```python
wanted = spool.get_contents()["patch_id"].iloc[1]
spool.select(patch_id=wanted)      # exactly that patch
```

That is the whole feature. The rest of this is what it took.

### One derivation site

`dc.scan` now derives the id the same way `dc.read` stamps it, both through `source_patch_id` and both from the same `source_identity(source)` — so a patch found through an index and the same patch read straight off disk cannot disagree about which data they are. Ingest stores a string and derives nothing.

Local paths are canonicalized before hashing, so `dc.read("rel.h5")`, `dc.read("/abs/rel.h5")` and the absolutized path a spool hands its resolver all name one datum. URIs pass through untouched. This is a behavior change against #944, where the id followed whatever spelling the caller used.

`PatchSummary.from_patch` used to drop both ids, and its docstring said why: *"the index does not store an id"*. This PR makes that premise false, so the drop goes with it — leaving it in place is now the one thing that would make scanning a patch and reading it disagree.

### Freeing the name

`patch_id` is the one name the storage schema and a patch both legitimately claim: a row id there, a datum here. `SPOOL_PRIVATE_RENAMES` already decoupled DB names from relation names, so nothing new is renamed — the existing rename just moves *earlier*, into `backend.query` between the coord pivot and the attr columns, so the attr finds the public spelling free. It splits into `SPOOL_EARLY_RENAMES` (`patch_id`, contested) and `SPOOL_LATE_RENAMES` (`dtype`, not); moving both early breaks the backend's documented `dtype` contract for no gain.

With the name free, both ids come out of `_SKIPPED_ATTRS` and `patch_id` out of `RESERVED_ATTR_COLUMNS`, and they index as ordinary string attrs. `select` needed no new machinery — which was the point of making them attrs rather than structural columns, since **no structural column is selectable** (`spool.select(source_path=...)` raises today).

### Keeping chunk working

A public per-patch-unique column would join chunk's merge-compatibility comparison and make chunk refuse every merge. Both ids go into `_SOURCE_COLUMNS` in the chunk planner — never conflict-policed, never carried to outputs — which is also correct on the merits: a merged patch folds its members' ids rather than inheriting any one of them.

Spool equality strips both for the reason it already strips `source_path` and `_patch_id`: a plan's outputs state no id, so keeping them would make a view unequal to its own materialization.

### Cost

1.7% on a 200-file local directory scan (538 ms → 529 ms with ids off), from one extra `stat` per source — a source is stat-ed once however many patches it holds. Scanning a remote archive pays one metadata request per source, the same trade #944 already accepted at read.

`INDEX_VERSION` 10 → 11; existing indices rebuild.

### Why only `patch_id`

`processing_id` is deliberately **not** indexed. It advances on every operation, and a spool runs one as it loads — a residual trim is a real `select` on the patch — so the index would record a value the returned patch no longer carries. Confirmed: after `spool.select(time=(10, 20), samples=True)`, the indexed `processing_id` and `spool[0].attrs.processing_id` differ. `patch_id` survives those same operations by definition, which is exactly what makes it the one worth indexing, and there is a test pinning that.

### A bug this turned up

Carrying the ids on a summary is what first called `PatchSummary.new()` on a remote-backed summary, and it does not survive: `model_dump()` serializes a remote `UPath` to its parts, revalidation cannot read those back as a path, and `_build_patch_summary_payload`'s "coherent reload information" rule then blanks `source_format` and `source_version` too. So `summary.new(...)` on anything not on a local filesystem silently returned a summary with no source identity. This is pre-existing and independent of the ids — a dumped path is now read back as one, with tests covering the remote case, the local control, and a mapping which merely looks like one.

### Review findings, and what came of them

A Codex CLI review raised six. Four were real and are fixed here, each with a test:

- **`file://` URIs were mangled.** `is_local_path("file:///tmp/x")` is true but `Path(...).resolve()` reads `file:` as a relative directory, so scan and read derived different ids for one file. Canonicalization goes through `coerce_to_local_path` now.
- **Scan ordinals accumulated across inputs.** `dc.scan([p, p])` gave the same file two different ids. Ordinals are now keyed by scan input as well as source — the only thing that tells a file's second patch apart from the same file scanned twice, since both spell one path and, absent a key, one key.
- **Scan trusted any `patch_id` in a format's attrs**, while read trusts only the explicit stored-id marker. A pickled patch carries the id minted in whatever process pickled it, so scanning a `.pkl` indexed that while reading derived another. Scan now requires the same marker, and DASDAE's scan sets it as its reader already did.
- **A hive path could claim the lineage.** With `patch_id` un-reserved, a directory named `patch_id=bogus/` rewrote the id of everything under it — on the loaded patch, not just in the index. A path says where data is kept, not which data it is; that name is now refused from a path with a warning.

One more was real and is fixed, though not the way the review suggested. **A moved source kept a stale id** — and the case that matters is not moving a whole archive but the directory rename that attaches metadata to one, which the indexer deliberately handles without re-reading files. Confirmed: after a rename, `select(patch_id=X)` returned a patch which no longer carried `X` — the exact failure this PR exists to prevent. Recomputing the id there is possible (it is a pure function of columns the index already holds) but means telling a derived id from a stored one, which needs reads that `move_sources` exists to avoid, and it sits on a path benchmarked at 34× for large renames. So the index **clears** the id of a moved source instead: a missed lookup rather than a wrong answer, filled back in by the next real scan. Recomputing it cheaply is a good follow-up, with the benchmark that path deserves.

One is accepted and documented rather than fixed:

- **A plan's output rows carry no id**, so a chunked spool — and a union of an already-trimmed view — has no `patch_id` column and selecting by id there raises rather than matching nothing. For chunk that is correct: a merged patch folds its members' ids rather than inheriting one, and a null column would claim these patches have no id when they do. For the union it is a genuine gap; closing it means re-attaching the member's id for single-member unmodified outputs, a conditional in the plan-assembly hot path.

## Changelog

- added: `spool.select(patch_id=...)` finds a patch by the id it carries, without loading it.
- changed: `dc.scan` derives a patch's `patch_id` the same way `dc.read` does, so scanning a file and reading it agree about which data it holds.
- fixed: `PatchSummary.new` no longer loses the source path, format, and version of a summary whose data lives on a remote filesystem.
- changed: a source which moves has its indexed `patch_id` cleared rather than kept, since a derived id names the path it came from. Scan the archive again to fill it back in.
- changed: a derived `patch_id` is now taken from a local path's canonical spelling, so relative and absolute spellings of one file name one datum. The spool index version is bumped, so existing indices rebuild.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
