### PR TITLE
Judge inventory selection by what enrichment will yield

### DIFF
--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -26,6 +26,7 @@ import pandas as pd
 from pydantic import ValidationError
 
 import dascore as dc
+from dascore.constants import INVENTORY_ATTRS
 from dascore.core.coords import BaseCoord, get_coord
 from dascore.core.inventory import (
     DISTANCE_MAP_AXES,
@@ -45,14 +46,20 @@ from dascore.exceptions import (
     PatchError,
     UnresolvedPatchError,
 )
+from dascore.models import values_equal
 from dascore.units import get_quantity_str
+from dascore.utils.attrs import validate_conflict
 from dascore.utils.intervals import interval_masks, value_kind
-from dascore.utils.misc import iterate
+from dascore.utils.misc import iterate, validate_acquisition_key
+from dascore.utils.time import to_datetime64
 
 # One vocabulary for both fiber verbs. What the quiet option leaves
 # behind still differs -- enrich leaves the patch as it was, conform
 # removes it -- but that is the verb's business rather than the value's.
 VALID_ON_UNRESOLVED = ("raise", "warn", "ignore")
+
+# What `Patch.enrich` does about a named attr the inventory leaves unset.
+VALID_ON_MISSING = ("raise", "warn", "ignore", "null")
 
 # Written once because both fiber verbs refuse for it, and two spellings
 # would let them start explaining the same refusal differently.
@@ -193,11 +200,12 @@ def combine_inventories(first, second) -> tuple:
     """
     Return the (inventory, enrich kwargs) a union of two spools carries.
 
-    The two halves carry over independently: an inventory attached to one
-    operand still describes the patches it came with, and so does the
-    enrichment set up from it — which is why attaching the same inventory
-    to the other operand cannot turn a working union into an error. Two
-    operands answering either question differently have no single answer.
+    An inventory and its enrichment are spool-wide state, so the union
+    carries whichever either operand has and applies it to every patch
+    it yields -- including the other operand's, as attaching and
+    enriching the union would. Attaching the same inventory to both
+    operands therefore cannot turn a working union into an error, while
+    two operands carrying different ones have no single answer.
     """
     # At call time only; importing Spool at module top would be circular.
     from dascore.core.spool import Spool  # noqa: PLC0415
@@ -245,10 +253,18 @@ def normalize_enrich_kwargs(kwargs) -> dict:
         raise ParameterError(msg)
     bound = signature.bind_partial(**kwargs)
     bound.apply_defaults()
-    # Refused on this call rather than on whichever patch is pulled first.
+    # Refused on this call rather than on whichever patch is pulled first;
+    # selection reads the policies and the key too, so none can wait.
+    arguments = bound.arguments
     validate_enrich_selection(
-        bound.arguments.get("attrs", False), bound.arguments.get("coords", False)
+        arguments.get("attrs", False), arguments.get("coords", False)
     )
+    validate_conflict(arguments.get("conflict", "keep_first"))
+    if (on_missing := arguments.get("on_missing", "raise")) not in VALID_ON_MISSING:
+        msg = f"on_missing must be one of {VALID_ON_MISSING}, got {on_missing!r}."
+        raise ParameterError(msg)
+    if key := arguments.get("acquisition_key"):
+        validate_acquisition_key(key)
     # A collection of names means what it holds, not which container holds it.
     return {
         name: tuple(value) if isinstance(value, list) else value
@@ -257,10 +273,32 @@ def normalize_enrich_kwargs(kwargs) -> dict:
     }
 
 
+# Facts the patch's own coordinates already state: the time coordinate has
+# the sample rate and the distance coordinate the channel spacing, and
+# decimating changes both. Nothing should be redundant between coords and
+# attrs, so a blanket request leaves these alone; naming one restores the
+# as-acquired value.
+COORD_REDUNDANT_ATTRS = ("sample_rate", "spatial_interval")
+
+# Attrs describing the data as it now stands rather than the system which
+# recorded it. Processing functions maintain them, so blanket enrichment
+# leaves them alone; naming one explicitly restores the as-acquired value.
+DATA_STATE_ATTRS = ("data_type", "data_category", "data_units")
+
+
+def enriched_attr_names(attrs) -> frozenset[str]:
+    """Return the attr names `Patch.enrich` may write for an `attrs` argument."""
+    if attrs is False:
+        return frozenset()
+    if attrs is True:
+        return frozenset(INVENTORY_ATTRS) - set(COORD_REDUNDANT_ATTRS)
+    return frozenset(iterate(attrs))
+
+
 # --- planning-frame helpers -------------------------------------------
 
 
-def resolution_columns(frame: pd.DataFrame) -> list | None:
+def resolution_columns(frame: pd.DataFrame, enrich_kwargs=None) -> list | None:
     """
     Return the columns a relation resolves against an inventory with.
 
@@ -269,12 +307,38 @@ def resolution_columns(frame: pd.DataFrame) -> list | None:
     `acquisition_key` has no identity to offer, and one whose time axis
     is not physical — lag times from a correlation, say — has no
     instants, which is the same thing `Patch.enrich` refuses to guess at.
+
+    Pending enrichment can supply both: its `acquisition_key` names the
+    entry for rows stating none, and its `time` the instant for rows
+    without instants of their own, so such rows resolve here as the
+    patches will on extraction. A dated row keeps its own instants and a
+    stated key stands, though `Patch.enrich` refuses either beside the
+    pending argument: the refusal is extraction's to make.
     """
-    columns = [frame.get(x) for x in ("acquisition_key", "time_min", "time_max")]
-    physical = all(column is not None for column in columns) and all(
-        np.issubdtype(column.dtype, np.datetime64) for column in columns[1:]
+    key, start, end = (
+        frame.get(x) for x in ("acquisition_key", "time_min", "time_max")
     )
-    return columns if physical else None
+    enrich_kwargs = enrich_kwargs or {}
+    if override := enrich_kwargs.get("acquisition_key"):
+        # A relation no row states the key in has no column for it.
+        if key is None:
+            key = pd.Series(override, index=frame.index, dtype=object)
+        else:
+            key = key.where(~_unstated(key), override)
+    if key is None:
+        return None
+    physical = all(column is not None for column in (start, end)) and all(
+        np.issubdtype(column.dtype, np.datetime64) for column in (start, end)
+    )
+    when = enrich_kwargs.get("time")
+    if when is None:
+        return [key, start, end] if physical else None
+    # A row without instants is NaT beside physical rows, and the whole
+    # column is something else when no row has them.
+    stamp = pd.Series(to_datetime64(when), index=frame.index)
+    if physical:
+        return [key, start.fillna(stamp), end.fillna(stamp)]
+    return [key, stamp, stamp]
 
 
 def _first_few(items, limit: int = 5) -> str:
@@ -410,12 +474,14 @@ def check_stampable(name: str, rows: pd.DataFrame) -> None:
     called `output_id` would replace the column binding each output to
     its members, and one called `time_min` an envelope. Overwriting a
     carried attr is fine and is how re-splitting restamps; these are not
-    attrs.
+    attrs. `acquisition_key` is one, but it is the identity every later
+    resolution goes by, and a label value is not a valid one.
     """
     envelopes = {
         x for x in rows.columns if x.rsplit("_", 1)[-1] in {"min", "max", "step"}
     }
-    if name not in {"output_id", "dims", *envelopes} and not name.startswith("_"):
+    structural = {"output_id", "dims", "acquisition_key", *envelopes}
+    if name not in structural and not name.startswith("_"):
         return
     msg = (
         f"{name!r} is how the spool itself describes a patch, so stamping "
@@ -480,6 +546,37 @@ def match_resolved(values, name: str, selector, units=None) -> np.ndarray:
     stated = ~_unstated(values)
     if stated.any():
         out[stated] = evaluate_attr_predicate(values[stated], name, selector, units)
+    return out
+
+
+def effective_matches(
+    stated, by_index, answers, by_inventory, headers=None, conflict=None, resolved=None
+) -> np.ndarray:
+    """
+    Combine the index's verdict with the inventory's the way extraction will.
+
+    An unstated row holds whatever the inventory answers, so its verdict
+    is the inventory's. A stated row keeps the index's verdict unless a
+    pending enrichment rewrites the name: under `keep_first` the
+    inventory's answer replaces the header where it has one, and under
+    `drop` a header disagreeing with the answer comes out blank, which
+    nothing selects. `resolved` is given when `on_missing="null"` is
+    pending on a named attr: a resolved row the inventory has no answer
+    for then comes out blank too. `conflict` is None when nothing rewrites.
+    """
+    out = np.where(stated, by_index, by_inventory)
+    if conflict is None:
+        return out
+    rewritten = stated & ~_unstated(answers)
+    if conflict == "keep_first":
+        out[rewritten] = by_inventory[rewritten]
+    else:
+        assert conflict == "drop" and headers is not None
+        for row in np.flatnonzero(rewritten):
+            if not values_equal(headers[row], answers[row]):
+                out[row] = False
+    if resolved is not None:
+        out[stated & resolved & _unstated(answers)] = False
     return out
 
 

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -1153,9 +1153,10 @@ def _track_identity_fields() -> Mapping[str, str]:
 
 
 # Names a label group may not take: a group becomes a patch coordinate
-# at enrichment, where it would shadow one of these.
+# at enrichment, where it would shadow one of these, and a stamped attr
+# at expansion, where it would replace the patch's identity.
 RESERVED_GROUP_NAMES = frozenset(
-    {"time", "distance", "channel", "instrument_distance"}
+    {"time", "distance", "channel", "instrument_distance", "acquisition_key"}
     | {"optical_components", "geometry", "coupling", "labels"}
     | set(VALID_COORDINATE_LABELS)
 )

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -43,6 +43,8 @@ from dascore.core._spool_inventory import (
     check_stampable,
     combine_inventories,
     drops_samples,
+    effective_matches,
+    enriched_attr_names,
     get_attr_values,
     glob_filter,
     match_resolved,
@@ -318,7 +320,10 @@ class Spool(NamespaceOwner):
         metadata: file-backed patches stay unloaded, in-memory patches
         are shared (not copied), and the same source appearing in both
         spools keeps a single entry. Selections on the inputs carry over
-        by row membership.
+        by row membership. An attached inventory, and any enrichment set
+        up from it, is spool-wide state: the union carries whichever
+        operand has one and applies it to every patch it yields, as
+        attaching and enriching the union would; two different ones raise.
 
         Examples
         --------
@@ -710,15 +715,27 @@ class Spool(NamespaceOwner):
         """
         Keep the rows whose inventory-backed values match.
 
-        Precedence is per row: a row which states the name is judged by
-        the index, exactly as it would be without an inventory, and only
-        the rows leaving it unstated are resolved. A spool whose headers
-        state everything therefore never touches the inventory, and one
-        which states nothing resolves once per epoch rather than per row.
-        A row the inventory has no answer for is not selected, as a patch
-        lacking the attr entirely is not. Straddling is decided against
-        the row as it now stands, so a range which has already trimmed a
-        row inside one epoch leaves it resolvable.
+        Precedence is per row, and is the precedence extraction applies.
+        A row which states the name is judged by the index, exactly as it
+        would be without an inventory, and only the rows leaving it
+        unstated are resolved. A spool whose headers state everything
+        therefore touches the inventory only when enrichment will rewrite
+        the name, and one which states nothing resolves once per epoch
+        rather than per row. A row the inventory has no answer for is not
+        selected, as a patch lacking the attr entirely is not. Straddling
+        is decided against the row as it now stands, so a range which has
+        already trimmed a row inside one epoch leaves it resolvable.
+
+        Pending enrichment changes what a stated row comes out holding,
+        so stated rows are resolved too where it would write the name:
+        `conflict="keep_first"` makes the inventory's answer the row's
+        value, `conflict="drop"` leaves a disagreeing row with none, and
+        `on_missing="null"` on named attrs blanks a resolved row the
+        inventory cannot answer. A row extraction refuses rather than
+        rewrites -- a disagreeing header under `conflict="raise"`, a dated
+        row under a pending `time`, a stated key disagreeing with a
+        pending `acquisition_key` -- is judged as it stands; the refusal
+        is extraction's to make.
         """
         ids = np.asarray(self._catalog.ordered_ids(), dtype=np.int64)
         if not len(ids):
@@ -727,10 +744,21 @@ class Spool(NamespaceOwner):
         known = set(backend.attr_names())
         contexts = None
         mask = np.ones(len(ids), dtype=bool)
+        # How pending enrichment rewrites a stated header, if at all; the
+        # `raise` policy refuses rather than rewrites, and `on_missing`
+        # applies to named attrs only.
+        pending = self._enrich_kwargs or {}
+        conflict = pending.get("conflict")
+        rewritten = frozenset()
+        if conflict is not None and conflict != "raise":
+            rewritten = enriched_attr_names(pending["attrs"])
+        nulls_missing = (
+            pending.get("on_missing") == "null" and pending.get("attrs") is not True
+        )
         for name, selector in query.items():
             # Which rows state the name is asked of the index rather than
             # read off the relation, so a spool whose headers state it
-            # everywhere is never realized: the index alone answers.
+            # everywhere is realized only when enrichment will rewrite it.
             stated = np.isin(ids, list(backend.attr_stated_ids(name, patch_ids=ids)))
             # A name no patch states is asked about rather than tried: the
             # index rejects it and the inventory answers for every row, and
@@ -746,16 +774,23 @@ class Spool(NamespaceOwner):
                 else np.empty(0, dtype=np.int64)
             )
             matched = np.isin(ids, index_ids)
-            if not stated.all():
+            # A stated row is resolved too when enrichment will rewrite it.
+            rewriting = name in rewritten
+            if not stated.all() or rewriting:
                 if contexts is None:
                     contexts = self._row_contexts(ids)
-                matched[~stated] = match_resolved(
-                    get_attr_values(
-                        self._resolved_inventory(), contexts[~stated], name
-                    ),
-                    name,
-                    selector,
-                    backend.attr_units(name),
+                answers = get_attr_values(self._resolved_inventory(), contexts, name)
+                resolved = None
+                if rewriting and nulls_missing:
+                    resolved = np.array([x is not None for x in contexts], dtype=bool)
+                matched = effective_matches(
+                    stated,
+                    matched,
+                    answers,
+                    match_resolved(answers, name, selector, backend.attr_units(name)),
+                    self._row_headers(ids, name) if rewriting else None,
+                    conflict if rewriting else None,
+                    resolved,
                 )
             mask &= matched
         return self._new_from_catalog(self._catalog.restrict(mask, ids=ids))
@@ -765,25 +800,42 @@ class Spool(NamespaceOwner):
         Resolve each presented row to its inventory context, or to None.
 
         This is where the relation is realized, which is why it is only
-        reached for a name the index does not state for every row.
+        reached for a name some row leaves unstated or pending enrichment
+        will rewrite. Rows resolve as extraction will, so pending
+        enrichment's own `acquisition_key` and `time` each stand in where
+        a row has none of its own.
         """
-        out = np.full(len(ids), None, dtype=object)
         df = self._df
-        columns = resolution_columns(df)
+        columns = resolution_columns(df, self._enrich_kwargs)
         if columns is None:
-            return out
-        # Aligned by id rather than by position: the relation is realized
-        # by a route of its own and need not present every row the id list
-        # does, and a row it leaves out is one nothing was resolved for.
-        resolved = dict(
-            zip(
-                df["_patch_id"].to_numpy(),
-                resolve_contexts(self._resolved_inventory(), *columns),
-                strict=True,
-            )
+            return np.full(len(ids), None, dtype=object)
+        return self._aligned(
+            ids, df, resolve_contexts(self._resolved_inventory(), *columns)
         )
+
+    def _row_headers(self, ids, name: str) -> np.ndarray:
+        """Each presented row's own value of a name, or None where unstated."""
+        df = self._df
+        values = (
+            df[name].to_numpy(dtype=object)
+            if name in df.columns
+            else np.full(len(df), None, dtype=object)
+        )
+        return self._aligned(ids, df, values)
+
+    @staticmethod
+    def _aligned(ids, df, values) -> np.ndarray:
+        """
+        Order per-relation-row values by the presented ids.
+
+        Aligned by id rather than by position: the relation is realized
+        by a route of its own and need not present every row the id list
+        does, and a row it leaves out is one nothing was resolved for.
+        """
+        by_id = dict(zip(df["_patch_id"].to_numpy(), values, strict=True))
+        out = np.full(len(ids), None, dtype=object)
         for position, patch_id in enumerate(ids):
-            out[position] = resolved.get(patch_id)
+            out[position] = by_id.get(patch_id)
         return out
 
     def attach_inventory(self, inventory=None) -> Self:
@@ -959,10 +1011,11 @@ class Spool(NamespaceOwner):
             Held and passed to
             [`Patch.enrich`](`dascore.proc.inventory.enrich`) for each
             extracted patch. The names accepted are read from its
-            signature, so the two cannot disagree, and only the names are
-            checked at this point — the values each patch's own enrichment
-            checks as it is extracted. Calling `enrich` again replaces
-            these rather than adding to them. They are:
+            signature, so the two cannot disagree. The names, the policies
+            and the shape of an `acquisition_key` are checked now — the
+            rest each patch's own enrichment checks as it is extracted.
+            Calling `enrich` again replaces these rather than adding to
+            them. They are:
 
         Other Parameters
         ----------------
@@ -998,6 +1051,8 @@ class Spool(NamespaceOwner):
         new = self.__class__(self)
         new._enrich_kwargs = enrich_kwargs
         new._on_unresolved = on_unresolved
+        # What this enrichment leaves unresolved is worth saying once more.
+        new._warned_unresolved = False
         return new
 
     def expand_by(
@@ -1096,7 +1151,7 @@ class Spool(NamespaceOwner):
 
     def _plan_contexts(self, working) -> np.ndarray:
         """Resolve each row of a planning frame to its inventory context."""
-        columns = resolution_columns(working)
+        columns = resolution_columns(working, self._enrich_kwargs)
         if columns is None:
             return np.full(len(working), None, dtype=object)
         return resolve_contexts(self._resolved_inventory(), *columns)
@@ -1130,7 +1185,8 @@ class Spool(NamespaceOwner):
         ----------
         on_unresolved
             What to do with a patch the inventory does not describe — one
-            carrying no `acquisition_key`, one carrying a key the
+            carrying no `acquisition_key` (and given none by a pending
+            `enrich`), one carrying a key the
             inventory does not resolve to exactly one entry, one reaching
             outside every matching epoch, or one with no instants to
             resolve at because its time axis is not physical. A patch is
@@ -1172,7 +1228,7 @@ class Spool(NamespaceOwner):
         # either is the same patch as the row beside it; the messages
         # below name files from one while judging the other.
         assert (source_rows["_patch_id"].to_numpy() == working["_patch_id"]).all()
-        columns = resolution_columns(working)
+        columns = resolution_columns(working, new._enrich_kwargs)
         epochs = (
             [NO_EPOCHS] * len(working)
             if columns is None

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -16,6 +16,9 @@ from dascore.constants import (
     enrich_on_missing_description,
 )
 from dascore.core._spool_inventory import (
+    COORD_REDUNDANT_ATTRS,
+    DATA_STATE_ATTRS,
+    VALID_ON_MISSING,
     attr_owner,
     get_coord_values,
     get_interrogator,
@@ -45,20 +48,7 @@ from dascore.utils.misc import iterate, validate_acquisition_key, warn_or_raise
 from dascore.utils.patch import patch_function
 from dascore.utils.time import to_datetime64
 
-# Attrs describing the data as it now stands rather than the system which
-# recorded it. Processing functions maintain them, so blanket enrichment
-# leaves them alone; naming one explicitly restores the as-acquired value.
-_DATA_STATE_ATTRS = ("data_type", "data_category", "data_units")
-
-# Facts the patch's own coordinates already state: the time coordinate has
-# the sample rate and the distance coordinate the channel spacing, and
-# decimating changes both. Nothing should be redundant between coords and
-# attrs, so a blanket request leaves these alone; naming one restores the
-# as-acquired value.
-_COORD_REDUNDANT_ATTRS = ("sample_rate", "spatial_interval")
-
 OnMissing = Literal["raise", "warn", "ignore", "null"]
-_VALID_ON_MISSING = get_args(OnMissing)
 
 
 def _get_acquisition_key(patch, acquisition_key) -> str:
@@ -163,9 +153,9 @@ def _get_attr_values(inventory, context, attrs, on_missing) -> dict:
         return {}
     system = _get_system_attrs(inventory, context)
     if attrs is True:
-        return {i: v for i, v in system.items() if i not in _COORD_REDUNDANT_ATTRS}
+        return {i: v for i, v in system.items() if i not in COORD_REDUNDANT_ATTRS}
     available = dict(system)
-    for name in _DATA_STATE_ATTRS:
+    for name in DATA_STATE_ATTRS:
         value = getattr(context.acquisition, name)
         if not is_unset(value):
             available[name] = value
@@ -468,8 +458,8 @@ def enrich(
     ... )
     """
     validate_conflict(conflict)
-    if on_missing not in _VALID_ON_MISSING:
-        msg = f"on_missing must be one of {_VALID_ON_MISSING}, got {on_missing!r}."
+    if on_missing not in VALID_ON_MISSING:
+        msg = f"on_missing must be one of {VALID_ON_MISSING}, got {on_missing!r}."
         raise ParameterError(msg)
     validate_enrich_selection(attrs, coords)
     source_id = _get_acquisition_key(patch, acquisition_key)

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -597,6 +597,24 @@ class TestPathTracks:
         with pytest.raises(InvalidInventoryError, match="one kind of value"):
             path.check()
 
+    def test_acquisition_key_is_a_reserved_group(self):
+        """A group becomes a stamped attr at expansion, and the key is the
+        patch's identity rather than a thing a label may say.
+        """
+        path = inv.OpticalPath(
+            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            labels=(
+                inv.OpticalPathLabel(
+                    start_distance=0.0,
+                    end_distance=10.0,
+                    group="acquisition_key",
+                    value="bad",
+                ),
+            ),
+        )
+        with pytest.raises(InvalidInventoryError, match="reserved name"):
+            path.check()
+
     def test_numeric_label_group(self):
         """Numeric groups are single valued but otherwise ordinary."""
         path = inv.OpticalPath(

--- a/tests/test_core/test_spool_inventory.py
+++ b/tests/test_core/test_spool_inventory.py
@@ -32,7 +32,7 @@ from dascore.constants import (
     enrich_coords_description,
     enrich_on_missing_description,
 )
-from dascore.core._spool_inventory import InventoryRef, resolve_row_epochs
+from dascore.core._spool_inventory import InventoryRef, is_unset, resolve_row_epochs
 from dascore.core.inventory import (
     _SYSTEM_FACT_NAMES,
     Acquisition,
@@ -652,6 +652,20 @@ class TestOnUnresolved:
             list(second.attach_inventory(inventory).enrich())
         assert len(caught) == 2
 
+    def test_a_new_attachment_says_it_again(self, patch, inventory):
+        """The warning is per spool, and a re-attached or re-enriched spool is
+        a new one: a different inventory covers a different part of it.
+        """
+        stranger = dc.spool([patch.update_attrs(acquisition_key="XX.A1..RAW")])
+        spool = stranger.attach_inventory(inventory).enrich()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("default")
+            list(spool)
+            list(spool)
+            list(spool.attach_inventory(inventory).enrich())
+            list(spool.enrich(on_unresolved="warn"))
+        assert len(caught) == 3
+
     def test_ignore_is_silent(self, mixed, inventory):
         """The same, without saying so."""
         with warnings.catch_warnings():
@@ -691,13 +705,14 @@ class TestOnUnresolved:
             spool[0]
 
     def test_malformed_explicit_id_is_not_swallowed(self, patch, inventory):
-        """A caller getting the argument wrong is not the inventory's silence."""
-        bare = dc.spool(patch.update_attrs(acquisition_key=""))
-        spool = bare.attach_inventory(inventory).enrich(
-            acquisition_key="broken", on_unresolved="ignore"
+        """A caller getting the argument wrong is not the inventory's silence,
+        and is settled before any patch is pulled or selected.
+        """
+        bare = dc.spool(patch.update_attrs(acquisition_key="")).attach_inventory(
+            inventory
         )
         with pytest.raises(ValueError, match="Invalid acquisition_key"):
-            spool[0]
+            bare.enrich(acquisition_key="broken", on_unresolved="ignore")
 
     def test_bad_policy_raises(self, patch, inventory):
         """An unknown policy names no behavior."""
@@ -729,12 +744,11 @@ class TestOnUnresolved:
         long_key = "DAS." + "A" * 70 + "..RAW"
         with pytest.raises(InvalidInventoryError, match="characters"):
             inventory.resolve(long_key)
-        bare = dc.spool(patch.update_attrs(acquisition_key=""))
-        spool = bare.attach_inventory(inventory).enrich(
-            acquisition_key=long_key, on_unresolved="ignore"
+        bare = dc.spool(patch.update_attrs(acquisition_key="")).attach_inventory(
+            inventory
         )
         with pytest.raises(InvalidInventoryError, match="characters"):
-            spool[0]
+            bare.enrich(acquisition_key=long_key, on_unresolved="ignore")
 
 
 class TestInventoryQueryError:
@@ -1161,6 +1175,201 @@ class TestInventorySelect:
         for selector in (10.0 * meters, (5.0 * meters, 15.0 * meters), [10.0 * meters]):
             out = sorted(spool.select(gauge_length=selector).get_contents()["tag"])
             assert out == ["blank", "stated"], selector
+
+
+class TestSelectSeesPendingEnrichment:
+    """
+    Selection judges the patch extraction will yield, not only the header.
+
+    `enrich` defaults to `conflict="keep_first"`, under which the inventory
+    rewrites a stated header; a selection which read the header would keep
+    a patch that comes out not matching it.
+    """
+
+    @pytest.fixture(scope="class")
+    def disagreeing(self, patch, inventory):
+        """Two patches stating gauge lengths; the inventory contradicts one."""
+        return dc.spool(
+            [
+                patch.update_attrs(tag="wrong", gauge_length=20.0),
+                patch.update_attrs(tag="right", gauge_length=10.0),
+            ]
+        ).attach_inventory(inventory)
+
+    @pytest.fixture(scope="class")
+    def two_epochs(self, patch, inventory):
+        """The acquisition split at the patch's first sample; gauge 12 after."""
+        when = patch.get_coord("time").min()
+        return _split_epochs(
+            inventory, when, acquisitions=True, second={"gauge_length": 12.0}
+        )
+
+    def test_keep_first_judges_by_the_inventory(self, disagreeing):
+        """The inventory's value is what comes out, so it is what is matched."""
+        spool = disagreeing.enrich(coords=False)
+        assert len(spool.select(gauge_length=20.0)) == 0
+        selected = spool.select(gauge_length=10.0)
+        assert sorted(selected.get_contents()["tag"]) == ["right", "wrong"]
+        assert all(x.attrs.gauge_length == 10.0 for x in selected)
+        assert len(spool.unselect(gauge_length=10.0)) == 0
+
+    def test_drop_leaves_a_disagreeing_row_unselectable(self, disagreeing):
+        """A dropped attr is no value at all, which no selector matches."""
+        spool = disagreeing.enrich(coords=False, conflict="drop")
+        assert len(spool.select(gauge_length=20.0)) == 0
+        # An agreeing header is not a conflict, and stays selectable.
+        assert spool.select(gauge_length=10.0).get_contents()["tag"].tolist() == [
+            "right"
+        ]
+        assert spool.unselect(gauge_length=10.0).get_contents()["tag"].tolist() == [
+            "wrong"
+        ]
+
+    def test_raise_keeps_the_header(self, disagreeing):
+        """`raise` refuses the patch on extraction rather than rewriting it."""
+        spool = disagreeing.enrich(coords=False, conflict="raise")
+        wrong = spool.select(gauge_length=20.0)
+        assert wrong.get_contents()["tag"].tolist() == ["wrong"]
+        assert spool.select(gauge_length=10.0).get_contents()["tag"].tolist() == [
+            "right"
+        ]
+        with pytest.raises(PatchError, match="inventory says"):
+            wrong[0]
+
+    @pytest.mark.parametrize("attrs", [("pulse_width",), False])
+    def test_a_name_enrichment_leaves_alone_keeps_the_header(self, disagreeing, attrs):
+        """Only the attrs enrichment writes change hands."""
+        spool = disagreeing.enrich(attrs=attrs, coords=False)
+        selected = spool.select(gauge_length=20.0)
+        assert selected.get_contents()["tag"].tolist() == ["wrong"]
+        assert selected[0].attrs.gauge_length == 20.0
+
+    def test_without_enrichment_the_header_stands(self, disagreeing):
+        """Attaching alone rewrites nothing, so nothing changes hands."""
+        selected = disagreeing.select(gauge_length=20.0)
+        assert selected.get_contents()["tag"].tolist() == ["wrong"]
+
+    @pytest.mark.parametrize("conflict", ["keep_first", "drop"])
+    def test_null_on_missing_blanks_a_stated_header(self, patch, inventory, conflict):
+        """
+        `on_missing="null"` answers with a missing marker, which disagrees
+        with a stated header: `keep_first` writes the marker over it and
+        `drop` removes it, and either way the row is not selected by what
+        it stated.
+        """
+        stated = dc.spool(patch.update_attrs(pulse_rate=1.25))
+        spool = stated.attach_inventory(inventory)
+        assert len(spool.select(pulse_rate=1.25)) == 1
+        nulled = spool.enrich(
+            attrs=("pulse_rate",), coords=False, on_missing="null", conflict=conflict
+        )
+        assert len(nulled.select(pulse_rate=1.25)) == 0
+        assert len(nulled.unselect(pulse_rate=1.25)) == 1
+        assert is_unset(dict(nulled[0].attrs).get("pulse_rate"))
+        # A blanket request never blanks anything.
+        blanket = spool.enrich(coords=False, on_missing="null", conflict=conflict)
+        assert len(blanket.select(pulse_rate=1.25)) == 1
+
+    @pytest.mark.parametrize(
+        "bad", [{"conflict": "keep_last"}, {"on_missing": "blank"}]
+    )
+    def test_a_bad_policy_is_refused_at_once(self, patch, inventory, bad):
+        """Selection reads the policies, so a typo cannot wait for extraction."""
+        with pytest.raises(ParameterError, match="must be one of"):
+            dc.spool(patch).attach_inventory(inventory).enrich(**bad)
+
+    @pytest.mark.parametrize("with_a_stated_row", [False, True])
+    def test_the_enrichment_key_resolves_a_bare_row(
+        self, patch, inventory, with_a_stated_row
+    ):
+        """
+        A row stating no key resolves by the one enrichment will use.
+
+        Both with and without a neighbour stating its own key: a relation
+        no row states the key in has no column for it at all.
+        """
+        patches = [patch.update_attrs(acquisition_key="", tag="bare")]
+        if with_a_stated_row:
+            patches.append(patch.update_attrs(tag="keyed"))
+        bare = dc.spool(patches)
+        spool = bare.attach_inventory(inventory).enrich(
+            acquisition_key=patch.attrs.acquisition_key
+        )
+        selected = spool.select(gauge_length=10.0)
+        assert len(selected) == len(patches)
+        assert all(x.attrs.gauge_length == 10.0 for x in selected)
+        # Attached alone, the bare row names no entry and is not selected.
+        attached = bare.attach_inventory(inventory).select(gauge_length=10.0)
+        assert attached.get_contents()["tag"].tolist() == (
+            ["keyed"] if with_a_stated_row else []
+        )
+
+    def test_a_stated_key_disagreeing_with_the_enrichment_key_stands(
+        self, patch, inventory
+    ):
+        """
+        Extraction refuses the disagreement rather than resolving either
+        key, so the row is judged by the key it states.
+        """
+        stranger = patch.update_attrs(acquisition_key="XX.A1..RAW", tag="stranger")
+        bare = patch.update_attrs(acquisition_key="", tag="bare")
+        spool = dc.spool([bare, stranger]).attach_inventory(inventory)
+        spool = spool.enrich(acquisition_key=patch.attrs.acquisition_key)
+        assert spool.select(gauge_length=10.0).get_contents()["tag"].tolist() == [
+            "bare"
+        ]
+        with pytest.raises(PatchError, match="disagree"):
+            spool.select(tag="stranger")[0]
+
+    def test_the_enrichment_key_reaches_the_fiber_too(self, patch, inventory):
+        """
+        Channel selection, expansion and conformance resolve rows the same
+        way, so a bare row pending enrichment has a fiber to place on.
+        """
+        bare = dc.spool(patch.update_attrs(acquisition_key=""))
+        spool = bare.attach_inventory(inventory).enrich(
+            acquisition_key=patch.attrs.acquisition_key
+        )
+        assert len(spool.select(zone="north")) == 1
+        assert len(spool.expand_by("zone")) == 2
+        assert len(spool.conform_to_inventory(on_unresolved="raise")) == 1
+        attached = bare.attach_inventory(inventory)
+        assert len(attached.select(zone="north")) == 0
+        with pytest.raises(UnresolvedPatchError):
+            attached.conform_to_inventory(on_unresolved="raise")
+
+    def test_the_enrichment_time_resolves_a_lag_time_row(self, patch, two_epochs):
+        """A row without instants resolves at the instant enrichment will use."""
+        when = patch.get_coord("time").min()
+        lags = patch.get_coord("time").values - when
+        spool = dc.spool(patch.update_coords(time=lags)).attach_inventory(two_epochs)
+        assert len(spool.select(gauge_length=12.0)) == 0
+        before = spool.enrich(time=when - dc.to_timedelta64(1), coords=False)
+        assert len(before.select(gauge_length=12.0)) == 0
+        assert before.select(gauge_length=10.0)[0].attrs.gauge_length == 10.0
+        after = spool.enrich(time=when, coords=False)
+        assert len(after.select(gauge_length=10.0)) == 0
+        assert after.select(gauge_length=12.0)[0].attrs.gauge_length == 12.0
+
+    def test_a_dated_row_beside_a_lag_time_row_keeps_its_own_instants(
+        self, patch, two_epochs
+    ):
+        """
+        The pending time is for rows without instants; a dated row resolves
+        at its own, as it stands, and extraction is what refuses it.
+        """
+        when = patch.get_coord("time").min()
+        lags = patch.get_coord("time").values - when
+        lag = patch.update_coords(time=lags).update_attrs(tag="lag")
+        spool = dc.spool([patch, lag]).attach_inventory(two_epochs)
+        enriched = spool.enrich(time=when - dc.to_timedelta64(1), coords=False)
+        tags = enriched.select(gauge_length=10.0).get_contents()["tag"].tolist()
+        assert tags == ["lag"]
+        tags = enriched.select(gauge_length=12.0).get_contents()["tag"].tolist()
+        assert tags == ["random"]
+        assert enriched.select(tag="lag")[0].attrs.gauge_length == 10.0
+        with pytest.raises(PatchError, match="time coordinate"):
+            enriched.select(tag="random")[0]
 
 
 class TestInventoryUnselect:
@@ -3090,6 +3299,31 @@ class TestChannelSelectContracts:
             spool.expand_by("output_id")
         # Splitting on it is still legal; only recording the value is not.
         assert len(spool.expand_by("output_id", stamp=False)) == 1
+
+    def test_a_stamp_cannot_replace_the_acquisition_key(self, patch, inventory):
+        """
+        The key is the identity every later resolution goes by, and a
+        label value is not a valid one; stamping it would give a spool
+        whose contents look fine and whose patches cannot be built.
+        """
+        path = inventory.networks[0].fiber_arrays[0].optical_paths[0]
+        clash = inventory.replace(
+            path,
+            path.new(
+                labels=(
+                    OpticalPathLabel(
+                        start_distance=100.0,
+                        end_distance=400.0,
+                        group="acquisition_key",
+                        value="bad",
+                    ),
+                )
+            ),
+        )
+        spool = dc.spool(patch).attach_inventory(clash)
+        with pytest.raises(InvalidSpoolQueryError, match="overwrite"):
+            spool.expand_by("acquisition_key")
+        assert len(spool.expand_by("acquisition_key", stamp=False)) == 1
 
     def test_a_no_op_channel_selector_does_not_veto_a_flag(self, patch, inventory):
         """


### PR DESCRIPTION
## Description

Three composition bugs from the inventory review in `.scratch/dev_review`, all in how a spool with an attached inventory answers questions about the patches it will yield.

**Selection disagreed with extraction.** `Spool.enrich` defaults to `conflict="keep_first"`, under which the inventory's value replaces a stated header on extraction, while `Spool.select` judged a stated row by its header. With a patch stating `gauge_length=20` and an inventory stating `10`, `attach_inventory(...).enrich(coords=False).select(gauge_length=20)` kept one patch which then came out with `gauge_length == 10`, and `select(gauge_length=10)` was empty. Selection now applies the precedence extraction will: where pending enrichment writes the name, `keep_first` judges by the inventory's answer, `drop` leaves a disagreeing row unselectable, and `on_missing="null"` on a named attr blanks a row the inventory cannot answer. Rows also resolve with enrichment's own `acquisition_key` and `time`, so a bare or lag-time row pending enrichment is selectable by what it will come out holding; `expand_by` and `conform_to_inventory` resolve the same way. A row extraction refuses rather than rewrites — a disagreeing header under `conflict="raise"`, a dated row under a pending `time`, a stated key disagreeing with the pending one — is judged as it stands. `unselect` follows, since it takes the complement of the same verdict.

Because selection now reads the policies, `Spool.enrich` checks `conflict`, `on_missing` and the shape of `acquisition_key` when called, rather than on the first patch pulled. One consequence worth knowing: a spool with `enrich()` pending now reads its inventory on `select(gauge_length=...)` even when every header states the value, since the inventory's value is what the patch will carry (7→31 ms on 400 in-memory patches).

**A stamp could replace the patch's identity.** Nothing stopped a label group named `acquisition_key`; `expand_by` stamped its value over the attr every later resolution goes by, giving a spool whose `get_contents()` looked fine and whose patches failed validation on load. `expand_by` now refuses to stamp it (as it already refused `output_id` and the envelopes), and `Inventory.check()` reserves the name.

**The unresolved warning stayed silenced.** `_warned_unresolved` rode along through `attach_inventory` and `enrich`, so after one spool warned, attaching a different inventory and hitting the same condition said nothing. Both now reset it.

The union "leak" the review also named — an enriched spool plus a plain one enriching the plain operand's patches — is the tested, intended behavior (`TestSpoolUnion`): an inventory is spool-wide state, as attaching to the union would be. Only the `combine_inventories` and `Spool.__add__` docstrings changed, to say so rather than describe the halves as independent.

Also folds the two enrichment attr tuples into `dascore/core/_spool_inventory.py` so `enriched_attr_names` and `Patch.enrich` read one definition.

## Changelog

- fixed: `Spool.select` and `Spool.unselect` judge a row by the value pending enrichment will give it, so a selected spool no longer yields patches which do not satisfy the selector.
- changed: `Spool.enrich` refuses an unknown `conflict` or `on_missing` value, or a malformed `acquisition_key`, when called rather than when the first patch is pulled.
- fixed: `Spool.expand_by` refuses to stamp a label group named `acquisition_key`, and `Inventory.check` reserves the name.
- fixed: a spool warns again about patches its inventory does not describe after `enrich` changes what it enriches with.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
