### PR TITLE
Speed up Patch.viz.wiggle for many traces

### DIFF
--- a/benchmarks/test_patch_benchmarks.py
+++ b/benchmarks/test_patch_benchmarks.py
@@ -316,6 +316,12 @@ class TestVisualizationBenchmarks:
         patch = example_patch.select(distance=(0, 100))  # Subset for performance
         patch.viz.wiggle()
 
+    @pytest.mark.usefixtures("cleanup_mpl")
+    @pytest.mark.benchmark
+    def test_wiggle_shade(self, example_patch):
+        """Time a shaded wiggle plot of every trace in the patch."""
+        example_patch.viz.wiggle(shade=True)
+
 
 class TestAggregationBenchmarks:
     """Benchmarks for patch aggregation operations."""

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.collections import LineCollection, PolyCollection
 
 from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
+from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch import patch_function
 from dascore.utils.plotting import (
     _format_time_axis,
@@ -14,51 +17,115 @@ from dascore.utils.plotting import (
     _get_data_label,
     _get_dim_label,
 )
-from dascore.utils.time import dtype_time_like
+from dascore.utils.time import dtype_time_like, is_datetime64
 
 
 def _get_offsets_factor(patch, dim, scale, other_labels):
     """Get the offsets and scale the data."""
     dim_axis = patch.get_axis(dim)
     # get and apply scale_factor. This controls how far apart the wiggles are.
-    diffs = np.max(patch.data, axis=dim_axis) - np.min(patch.data, axis=dim_axis)
-    offsets = (np.median(diffs) * scale) * np.arange(len(other_labels))
+    # NaN samples are skipped so one gap doesn't blank the whole plot.
+    with suppress_warnings(RuntimeWarning):  # all-NaN traces
+        mx = np.nanmax(patch.data, axis=dim_axis)
+        mn = np.nanmin(patch.data, axis=dim_axis)
+        offsets = (np.nanmedian(mx - mn) * scale) * np.arange(len(other_labels))
     # add scale factor to data
     data_scaled = offsets[None, :] + patch.data
     return offsets, data_scaled
 
 
-def _shade(offsets, ax, data_scaled, color, wiggle_labels):
-    """Shades the part of each waveform above its offset line."""
-    for i in range(len(offsets)):
-        ax.fill_between(
-            wiggle_labels,
-            offsets[i],
-            data_scaled[:, i],
-            where=(data_scaled[:, i] > offsets[i]),
-            color=color,
-            alpha=0.6,
-        )
+def _get_plot_values(patch, dim):
+    """
+    Get the values of a coordinate as floats for plotting.
+
+    Datetimes become matplotlib date numbers, which is what xaxis_date (set
+    up later by _format_time_axis) expects, so they can share float arrays
+    with the trace data.
+    """
+    values = patch.coords.get_array(dim)
+    if is_datetime64(values):
+        values = mdates.date2num(values)
+    return values
+
+
+def _plot_traces(ax, x, data_scaled, color, alpha):
+    """
+    Draw each column of data_scaled as a line against x.
+
+    A single LineCollection is much faster to build than one Line2D per
+    trace. Each trace is still rendered as its own path, so overlapping
+    traces darken with alpha like separate lines do. (One NaN separated
+    Line2D would draw faster for very long traces, but Agg composites a
+    path once, so overlaps wouldn't darken.)
+    """
+    n_samples, n_traces = data_scaled.shape
+    segments = np.empty((n_traces, n_samples, 2))
+    segments[:, :, 0] = x[None, :]
+    segments[:, :, 1] = data_scaled.T
+    ax.add_collection(LineCollection(segments, colors=color, alpha=alpha))
+    # Collections don't update the view limits on their own.
+    ax.autoscale_view()
+
+
+def _shade(ax, x, offsets, data_scaled, color):
+    """
+    Shade the part of each trace above its offset line.
+
+    Builds one polygon per trace (rather than calling fill_between for each)
+    with a vertex wherever the trace crosses its offset, like
+    fill_between(interpolate=True), so the shading stops at the crossing
+    rather than at the neighboring sample.
+    """
+    # Height of each sample above its offset; non-finite samples sit on it.
+    d = data_scaled - offsets[None, :]
+    d = np.where(np.isfinite(d), d, np.nan)
+    above = np.fmax(d, 0)
+    d0, d1 = d[:-1], d[1:]
+    x0, x1 = x[:-1, None], x[1:, None]
+    # Between samples add a vertex on the offset at the crossing. Next to a
+    # non-finite sample drop to the offset at the finite one, so gaps aren't
+    # shaded. Elsewhere repeat the next sample (a zero length edge).
+    finite = np.isfinite(d0) & np.isfinite(d1)
+    cross = finite & ((d0 > 0) != (d1 > 0))
+    with np.errstate(invalid="ignore", divide="ignore"):
+        x_mid = np.where(cross, x0 + (x1 - x0) * d0 / (d0 - d1), x1)
+    x_mid = np.where(np.isnan(d1) & np.isfinite(d0), x0, x_mid)
+    y_mid = np.where(cross | ~finite, 0.0, above[1:])
+    n_samples, n_traces = d.shape
+    xs = np.empty((2 * n_samples - 1, n_traces))
+    ys = np.empty_like(xs)
+    xs[0::2], ys[0::2] = x[:, None], above
+    xs[1::2], ys[1::2] = x_mid, y_mid
+    # Assemble the polygons, closing each along its offset line.
+    verts = np.empty((n_traces, 2 * n_samples + 1, 2))
+    verts[:, 1:-1, 0] = xs.T
+    verts[:, 1:-1, 1] = (ys + offsets[None, :]).T
+    verts[:, [0, -1], 0] = x[[0, -1]]
+    verts[:, [0, -1], 1] = offsets[:, None]
+    poly = PolyCollection(verts, facecolors=color, edgecolors="none", alpha=0.6)
+    ax.add_collection(poly)
 
 
 def _format_y_axis_ticks(ax, offsets, other_axis_ticks, max_ticks=10):
-    """Format the Y axis tick labels."""
+    """Put at most max_ticks trace labels on the Y axis."""
     # make sure not printing too many digits on the figure
     if not dtype_time_like(other_axis_ticks):
         other_axis_ticks = np.around(other_axis_ticks, decimals=2)
-    # set the offset
-    ax.set_yticks(offsets, other_axis_ticks)
-    min_bins = min(len(other_axis_ticks), max_ticks)
-    plt.locator_params(axis="y", nbins=min_bins)
+    # Only create the ticks which will be shown; matplotlib builds a Tick
+    # for every location passed to set_yticks, which dominates the run time
+    # with thousands of traces. The step keeps the positions the previous
+    # set-all-then-locator_params(nbins) approach produced.
+    step = max(int(0.99 + len(offsets) / max_ticks), 1)
+    ax.set_yticks(offsets[::step], other_axis_ticks[::step])
 
 
 def _wiggle_1d(patch, ax, alpha, color, shade):
     """Plot a 1D patch as a single trace against its only coordinate."""
     dim = patch.dims[0]
-    x_values = patch.coords.get_array(dim)
+    x_values = _get_plot_values(patch, dim)
     ax.plot(x_values, patch.data, color=color, alpha=alpha)
     if shade:
-        _shade(np.array([0]), ax, patch.data[:, None], color, x_values)
+        _shade(ax, x_values, np.array([0.0]), patch.data[:, None], color)
     ax.set_xlabel(_get_dim_label(patch, dim))
     ax.set_ylabel(_get_data_label(patch, default="amplitude"))
     if np.issubdtype(patch.get_coord(dim).dtype, np.datetime64):
@@ -72,15 +139,15 @@ def _wiggle_2d(patch, ax, dim, scale, alpha, color, shade):
     patch = patch.transpose(dim, ...)
     other_dim = next(iter(set(patch.dims) - {dim}))
     # values for axis which is connected
-    connect_axis_ticks = patch.coords.get_array(dim)
+    connect_axis_values = _get_plot_values(patch, dim)
     # values for y axis (not connected)
     other_axis_ticks = patch.coords.get_array(other_dim)
     offsets, data_scaled = _get_offsets_factor(patch, dim, scale, other_axis_ticks)
     # now plot, add labels, etc.
-    ax.plot(connect_axis_ticks, data_scaled, color=color, alpha=alpha)
+    _plot_traces(ax, connect_axis_values, data_scaled, color, alpha)
     # shade the part of each wiggle above its offset if desired
     if shade:
-        _shade(offsets, ax, data_scaled, color, connect_axis_ticks)
+        _shade(ax, connect_axis_values, offsets, data_scaled, color)
     _format_y_axis_ticks(ax, offsets, other_axis_ticks)
     for dim, x in zip(patch.dims, ["x", "y"], strict=True):
         getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import matplotlib.dates as mdates
+import string
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import LineCollection, PolyCollection
@@ -17,7 +18,7 @@ from dascore.utils.plotting import (
     _get_data_label,
     _get_dim_label,
 )
-from dascore.utils.time import dtype_time_like, is_datetime64
+from dascore.utils.time import dtype_time_like
 
 
 def _get_offsets_factor(patch, dim, scale, other_labels):
@@ -28,24 +29,28 @@ def _get_offsets_factor(patch, dim, scale, other_labels):
     with suppress_warnings(RuntimeWarning):  # all-NaN traces
         mx = np.nanmax(patch.data, axis=dim_axis)
         mn = np.nanmin(patch.data, axis=dim_axis)
-        offsets = (np.nanmedian(mx - mn) * scale) * np.arange(len(other_labels))
+        separation = np.nanmedian(mx - mn) * scale
+    if not np.isfinite(separation):  # no trace has a finite range
+        separation = 0.0
+    offsets = separation * np.arange(len(other_labels))
     # add scale factor to data
     data_scaled = offsets[None, :] + patch.data
     return offsets, data_scaled
 
 
-def _get_plot_values(patch, dim):
+def _get_plot_values(ax, patch, dim):
     """
-    Get the values of a coordinate as floats for plotting.
+    Get the values of a coordinate as floats for the x axis.
 
-    Datetimes become matplotlib date numbers, which is what xaxis_date (set
-    up later by _format_time_axis) expects, so they can share float arrays
-    with the trace data.
+    The conversion is matplotlib's own, the one ax.plot would apply, so
+    datetimes become date numbers (which xaxis_date, set up later by
+    _format_time_axis, expects) and anything else with a registered
+    converter is handled the same way. Floats can then share arrays with
+    the trace data.
     """
     values = patch.coords.get_array(dim)
-    if is_datetime64(values):
-        values = mdates.date2num(values)
-    return values
+    ax.xaxis.update_units(values)
+    return np.asarray(ax.xaxis.convert_units(values), dtype=float)
 
 
 def _plot_traces(ax, x, data_scaled, color, alpha):
@@ -104,6 +109,9 @@ def _shade(ax, x, offsets, data_scaled, color):
     verts[:, [0, -1], 1] = offsets[:, None]
     poly = PolyCollection(verts, facecolors=color, edgecolors="none", alpha=0.6)
     ax.add_collection(poly)
+    # The fill reaches the offset line, which may be outside the data range
+    # the lines were scaled to.
+    ax.autoscale_view()
 
 
 def _format_y_axis_ticks(ax, offsets, other_axis_ticks, max_ticks=10):
@@ -122,7 +130,7 @@ def _format_y_axis_ticks(ax, offsets, other_axis_ticks, max_ticks=10):
 def _wiggle_1d(patch, ax, alpha, color, shade):
     """Plot a 1D patch as a single trace against its only coordinate."""
     dim = patch.dims[0]
-    x_values = _get_plot_values(patch, dim)
+    x_values = _get_plot_values(ax, patch, dim)
     ax.plot(x_values, patch.data, color=color, alpha=alpha)
     if shade:
         _shade(ax, x_values, np.array([0.0]), patch.data[:, None], color)
@@ -139,7 +147,7 @@ def _wiggle_2d(patch, ax, dim, scale, alpha, color, shade):
     patch = patch.transpose(dim, ...)
     other_dim = next(iter(set(patch.dims) - {dim}))
     # values for axis which is connected
-    connect_axis_values = _get_plot_values(patch, dim)
+    connect_axis_values = _get_plot_values(ax, patch, dim)
     # values for y axis (not connected)
     other_axis_ticks = patch.coords.get_array(other_dim)
     offsets, data_scaled = _get_offsets_factor(patch, dim, scale, other_axis_ticks)
@@ -149,11 +157,15 @@ def _wiggle_2d(patch, ax, dim, scale, alpha, color, shade):
     if shade:
         _shade(ax, connect_axis_values, offsets, data_scaled, color)
     _format_y_axis_ticks(ax, offsets, other_axis_ticks)
-    for dim, x in zip(patch.dims, ["x", "y"], strict=True):
-        getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
-        # format all dims which have time types.
-        if np.issubdtype(patch.get_coord(dim).dtype, np.datetime64):
-            _format_time_axis(ax, dim, x)
+    for name, x in zip(patch.dims, ["x", "y"], strict=True):
+        is_time = np.issubdtype(patch.get_coord(name).dtype, np.datetime64)
+        label = string.capwords(name) if is_time else _get_dim_label(patch, name)
+        getattr(ax, f"set_{x}label")(label)
+    # Only the connected (x) axis is a continuous time axis; the y axis
+    # holds trace offsets whose tick labels were set above, and a date
+    # formatter there would overwrite them.
+    if np.issubdtype(patch.get_coord(dim).dtype, np.datetime64):
+        _format_time_axis(ax, dim, "x")
     ax.invert_yaxis()  # invert y so it's consistent with waterfall
     return ax
 

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from matplotlib.collections import LineCollection, PolyCollection
 
 import dascore as dc
 from dascore.exceptions import ParameterError
+
+
+def _get_traces(ax):
+    """Get the segments of the wiggle line collection."""
+    (lines,) = (x for x in ax.collections if isinstance(x, LineCollection))
+    return lines.get_segments()
+
+
+def _get_shade_vertices(ax):
+    """Get the vertices of all shading polygons."""
+    (poly,) = (x for x in ax.collections if isinstance(x, PolyCollection))
+    return poly, np.concatenate([x.vertices for x in poly.get_paths()])
 
 
 class TestWiggle:
@@ -39,10 +53,6 @@ class TestWiggle:
         assert random_patch.dims[0].lower() in ax.get_ylabel().lower()
         assert random_patch.dims[1].lower() in ax.get_xlabel().lower()
         assert isinstance(ax, plt.Axes)
-
-    def test_shading(self, small_patch):
-        """Ensure shading parameter works."""
-        _ = small_patch.viz.wiggle(shade=True)
 
     def test_non_time_axis(self, random_patch):
         """Ensure another dimension works."""
@@ -94,9 +104,8 @@ class TestWiggle:
         centered = patch_1d - np.mean(patch_1d.data)
         assert np.min(centered.data) < 0 < np.max(centered.data)
         ax = centered.viz.wiggle(shade=True)
-        assert len(ax.collections) == 1
+        _, verts = _get_shade_vertices(ax)
         # The fill is clipped to the zero line and never goes below it.
-        verts = np.concatenate([x.vertices for x in ax.collections[0].get_paths()])
         assert np.all(verts[:, 1] >= 0)
 
     def test_1d_alpha(self, random_patch):
@@ -105,7 +114,8 @@ class TestWiggle:
         assert patch_1d.viz.wiggle().lines[0].get_alpha() == 1.0
         assert patch_1d.viz.wiggle(alpha=0.3).lines[0].get_alpha() == 0.3
         # 2D patches keep the old default so wiggles can overlap.
-        assert random_patch.viz.wiggle().lines[0].get_alpha() == 0.2
+        ax = random_patch.viz.wiggle()
+        assert ax.collections[0].get_alpha() == 0.2
 
     @pytest.mark.parametrize("dim", ["time", "distance"])
     def test_singleton_dim_squeezed(self, random_patch, dim):
@@ -130,7 +140,7 @@ class TestWiggle:
         patch = range_patch_3d.select(time=0, samples=True)
         assert patch.ndim == 3
         ax = patch.viz.wiggle(dim="distance")
-        assert len(ax.lines) == len(patch.get_coord("smell"))
+        assert len(_get_traces(ax)) == len(patch.get_coord("smell"))
         # But the default dim was squeezed away, so say so rather than
         # complain that "time" isn't a dimension of the (original) patch.
         with pytest.raises(ParameterError, match="after squeezing"):
@@ -147,7 +157,7 @@ class TestWiggle:
         assert len(patch.get_coord(dim)) == 0
         ax = patch.viz.wiggle()
         assert isinstance(ax, plt.Axes)
-        assert not ax.lines
+        assert not ax.lines and not ax.collections
 
     def test_no_figure_on_error(self, random_patch):
         """A rejected call shouldn't leave an empty figure behind."""
@@ -167,3 +177,91 @@ class TestWiggle:
         """More than two non-trivial dimensions can't be wiggle plotted."""
         with pytest.raises(ParameterError, match="1D or 2D"):
             range_patch_3d.viz.wiggle()
+
+    def test_one_collection_per_patch(self, random_patch):
+        """All traces share one line collection and the view fits them."""
+        ax = random_patch.viz.wiggle()
+        assert not ax.lines
+        traces = _get_traces(ax)
+        assert len(traces) == len(random_patch.get_coord("distance"))
+        # Each trace is plotted against the (numeric) time coordinate.
+        time = mdates.date2num(random_patch.coords.get_array("time"))
+        assert np.allclose(traces[0][:, 0], time)
+        lo, hi = sorted(ax.get_xlim())
+        assert lo <= time.min() and time.max() <= hi
+
+    def test_1d_datetime_axis(self, random_patch):
+        """A single trace against time keeps a date axis."""
+        patch_1d = random_patch.mean("distance", dim_reduce="squeeze")
+        ax = patch_1d.viz.wiggle()
+        time = mdates.date2num(patch_1d.coords.get_array("time"))
+        assert np.allclose(ax.lines[0].get_xdata(), time)
+        assert isinstance(ax.xaxis.get_major_formatter(), mdates.ConciseDateFormatter)
+
+    @pytest.mark.parametrize("n_traces", [2, 10, 11, 300])
+    def test_tick_count(self, random_patch, n_traces):
+        """
+        No more than ten ticks, each on a trace's offset and labeled with
+        that trace's coordinate, matching the old locator_params selection.
+        """
+        patch = random_patch.select(distance=(0, n_traces), samples=True)
+        n_traces = len(patch.get_coord("distance"))
+        ax = patch.viz.wiggle()
+        ticks = ax.get_yticks()
+        assert 0 < len(ticks) <= 10
+        step = max(int(0.99 + n_traces / 10), 1)
+        distance = patch.coords.get_array("distance")
+        labels = [x.get_text() for x in ax.get_yticklabels()]
+        assert labels == [str(x) for x in distance[::step]]
+        # Each trace is data + offset, so recover the offsets of labeled traces.
+        traces = _get_traces(ax)
+        shown = range(0, n_traces, step)
+        offsets = [traces[i][0, 1] - patch.data[i, 0] for i in shown]
+        assert np.allclose(ticks, offsets)
+
+    def test_2d_shade(self, small_patch):
+        """
+        Shading makes one polygon per trace which covers only the part of the
+        trace above its offset.
+        """
+        # Center the traces so each has both signs.
+        patch = small_patch - np.mean(small_patch.data)
+        ax = patch.viz.wiggle(shade=True)
+        poly, verts = _get_shade_vertices(ax)
+        traces = _get_traces(ax)
+        offsets = [x[0, 1] - patch.data[i, 0] for i, x in enumerate(traces)]
+        paths = poly.get_paths()
+        assert len(paths) == len(offsets)
+        for path, offset in zip(paths, offsets, strict=True):
+            assert np.all(path.vertices[:, 1] >= offset - 1e-9)
+            # Some of the polygon is on the offset (clipped) and some above.
+            on_offset = np.isclose(path.vertices[:, 1], offset)
+            assert on_offset.any() and (~on_offset).any()
+
+    def test_shade_crossings(self):
+        """The shading should stop where the trace crosses its offset."""
+        data = np.array([[1.0, -1.0, 1.0, 1.0]]).T  # one trace, 4 samples
+        patch = dc.Patch(
+            data=data,
+            coords={"time": np.arange(4.0), "distance": [0.0]},
+            dims=("time", "distance"),
+        )
+        ax = patch.viz.wiggle(shade=True)
+        poly, verts = _get_shade_vertices(ax)
+        x, y = verts[:, 0], verts[:, 1]
+        area = 0.5 * abs(np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1)))
+        # Two triangles of area 0.25 (crossings at x=0.5, 1.5) and a 1x1 box.
+        assert np.isclose(area, 1.5)
+
+    def test_nan_data(self, small_patch):
+        """NaNs in the data shouldn't break plotting or shading."""
+        data = np.array(small_patch.data)
+        data[2, 10:20] = np.nan
+        data[3, :] = np.nan  # an entirely missing trace
+        patch = small_patch.new(data=data)
+        ax = patch.viz.wiggle(shade=True)
+        traces = _get_traces(ax)
+        assert len(traces) == len(patch.get_coord("distance"))
+        assert np.all(np.isfinite(ax.get_ylim()))
+        _, verts = _get_shade_vertices(ax)
+        assert np.all(np.isfinite(verts))

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -60,6 +60,11 @@ class TestWiggle:
         ax = sub_patch.viz.wiggle(dim="distance")
         assert "Distance [m]" in str(ax.get_xlabel())
         assert "Time" in str(ax.get_ylabel())
+        # The y ticks label traces by their time, not a date axis of offsets.
+        ax.figure.canvas.draw()
+        labels = [x.get_text() for x in ax.get_yticklabels()]
+        times = sub_patch.coords.get_array("time")
+        assert labels[0] == str(times[0])
 
     def test_show(self, random_patch, monkeypatch):
         """Ensure show path is callable."""
@@ -227,7 +232,7 @@ class TestWiggle:
         # Center the traces so each has both signs.
         patch = small_patch - np.mean(small_patch.data)
         ax = patch.viz.wiggle(shade=True)
-        poly, verts = _get_shade_vertices(ax)
+        poly, _ = _get_shade_vertices(ax)
         traces = _get_traces(ax)
         offsets = [x[0, 1] - patch.data[i, 0] for i, x in enumerate(traces)]
         paths = poly.get_paths()
@@ -247,7 +252,7 @@ class TestWiggle:
             dims=("time", "distance"),
         )
         ax = patch.viz.wiggle(shade=True)
-        poly, verts = _get_shade_vertices(ax)
+        _, verts = _get_shade_vertices(ax)
         x, y = verts[:, 0], verts[:, 1]
         area = 0.5 * abs(np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1)))
         # Two triangles of area 0.25 (crossings at x=0.5, 1.5) and a 1x1 box.
@@ -265,3 +270,17 @@ class TestWiggle:
         assert np.all(np.isfinite(ax.get_ylim()))
         _, verts = _get_shade_vertices(ax)
         assert np.all(np.isfinite(verts))
+
+    def test_all_nan_data(self, small_patch):
+        """A patch with no finite data should still produce a plot."""
+        patch = small_patch.new(data=np.full(small_patch.shape, np.nan))
+        ax = patch.viz.wiggle(shade=True)
+        assert np.all(np.isfinite(ax.get_yticks()))
+        assert np.all(np.isfinite(ax.get_ylim()))
+
+    def test_1d_shade_includes_baseline(self, random_patch):
+        """Shading an all-positive trace must keep the zero line in view."""
+        patch_1d = random_patch.mean("distance", dim_reduce="squeeze")
+        patch = patch_1d + 10  # everything well above zero
+        ax = patch.viz.wiggle(shade=True)
+        assert min(ax.get_ylim()) <= 0


### PR DESCRIPTION
## Description

Follow-up to #945. `Patch.viz.wiggle` got slow with many traces, and profiling showed why: for a 2000-trace patch, 3.3 of 4.6 s went into `set_yticks` building a `Tick` for every trace before `locator_params` hid all but ten, and the rest into one `Line2D` per trace (plus one `fill_between` per trace when shading).

Changes:

- **Ticks**: only the ≤10 ticks that will be shown are created, at the same positions the old `locator_params(nbins=10)` path selected. The old call also used `plt.locator_params`, which acts on the *current* axes rather than the `ax` passed in, so plotting into a subplot piled every trace label onto the y axis.
- **Lines**: all traces go into one `LineCollection` instead of N `Line2D`s. Each trace is still its own path, so overlapping traces darken with `alpha` exactly as before (a single NaN-separated `Line2D` would draw faster for very long traces but Agg composites a path once, so overlaps wouldn't darken; rejected for that reason).
- **Shading**: one `PolyCollection` with one polygon per trace, with a vertex wherever the trace crosses its offset, like `fill_between(interpolate=True)`. The old per-trace `fill_between(where=...)` also stroked an edge around every filled region, so near-zero-area regions showed up as thick dark bars along each baseline; the new shading fills area only.
- **NaNs**: offsets are computed with `nanmax`/`nanmin`/`nanmedian`, so a NaN sample no longer turns every offset into NaN and fails on `Axis limits cannot be NaN`. Gaps are not shaded.

Timings (build = `wiggle()` call, draw = `savefig` to PNG, Agg):

| shape (traces × samples) | master build / draw | this PR build / draw |
|---|---|---|
| 300 × 2000 | 0.21 / 0.32 s | 0.03 / 0.32 s |
| 300 × 2000, shade | 0.57 / 0.76 s | 0.08 / 0.38 s |
| 2000 × 2000 | 1.56 / 0.72 s | 0.10 / 1.07 s |
| 300 × 20000 | 0.44 / 1.67 s | 0.12 / 2.76 s |
| 300 × 20000, shade | 1.21 / 5.88 s | 0.67 / 3.23 s |

Build time drops 4–15×; draw time is lower with shading and similar or somewhat higher without, because Agg doesn't apply path simplification to collection paths. Overall this is a clear win for many traces and roughly a wash for a few very long ones.

Artifacts change: the 2D plot's traces are now in `ax.collections` (a `LineCollection`) rather than `ax.lines`; the 1D path is unchanged.

## Benchmarks

The suite's two wiggle benchmarks (`benchmarks/test_patch_benchmarks.py`), run with `pytest --codspeed` locally on the same benchmark file for both refs. `test_wiggle` is the existing 100-trace unshaded benchmark; `test_wiggle_shade` is added here and draws all 300 traces of the example patch with shading.

| benchmark (best of N) | master `34a418a2` | this PR `d1bcc2e0` | speed-up |
|---|---|---|---|
| `test_wiggle` | 84.4 ms | 32.7 ms | 2.6× |
| `test_wiggle_shade` | 529.3 ms | 88.5 ms | 6.0× |

The PR carries the `benchmark` label so CodSpeed reports its own comparison.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wiggle plots now support datetime-based coordinates.
  * Improved shaded 2D wiggle visualizations, including crossings and gaps.
  * Plot rendering better handles missing or entirely empty traces.
  * Y-axis labels and limits are more consistently managed for large trace sets.

* **Bug Fixes**
  * Improved handling of NaN values and trace offsets in wiggle plots.

* **Tests**
  * Expanded coverage for datetime axes, shading, labels, limits, crossings, and missing data.
  * Added performance benchmarking for shaded wiggle visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
