### PR TITLE
Require pandas 3, and convert only the times a row states

### DIFF
--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -1370,7 +1370,13 @@ def _normalize_times(frame: pd.DataFrame, dims: Sequence[str] = ()) -> pd.DataFr
         elif kind == "m" and series.dtype != np.dtype("timedelta64[ns]"):
             changed[name] = to_timedelta64(series)
         elif str(name) in spelled and _states_times(series):
-            changed[name] = to_datetime64(series.astype(str)).where(series.notna())
+            # Only the stated cells are converted, then put back where
+            # they came from: masking the result instead hands every blank
+            # cell to the datetime parser first, and what a blank one reads
+            # as there is up to `astype`.
+            stated = series[series.notna()]
+            times = to_datetime64(stated.astype(str))
+            changed[name] = times.reindex(series.index)
     if not changed:
         return frame
     # Assigned by item rather than by keyword: a column need not be named

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -106,24 +106,6 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-# Copy-on-write is always on from pandas 3, which also deprecates the
-# option: reading it there warns on every access, so settle it by version
-# once and only consult the option on pandas 2.
-_COPY_ON_WRITE_ALWAYS = int(pd.__version__.split(".", maxsplit=1)[0]) >= 3
-
-
-def _copy_public_dataframe(frame: pd.DataFrame) -> pd.DataFrame:
-    """
-    Return a caller-owned view of an internally cached dataframe.
-
-    Copy-on-write makes a shallow copy enough, since the frames detach on
-    the first write. Only the literal True enables it; pandas 2 also
-    accepts "warn", which keeps the old sharing semantics.
-    """
-    copy_on_write = _COPY_ON_WRITE_ALWAYS or pd.options.mode.copy_on_write is True
-    return frame.copy(deep=not copy_on_write)
-
-
 class _InventoryQuery(NamedTuple):
     """How one selection call splits between the index and the inventory."""
 
@@ -257,7 +239,9 @@ class Spool(NamespaceOwner):
         >>> spool = dc.get_example_spool("random_das")
         >>> df = spool.get_contents()
         """
-        return present_units_columns(_copy_public_dataframe(self._df))
+        # Shallow: copy-on-write is always on from pandas 3, so the
+        # caller's frame detaches from the cached one on its first write.
+        return present_units_columns(self._df.copy(deep=False))
 
     def __len__(self) -> int:
         """Return len of spool."""

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - pytest
   - pytest-timeout
-  - numpy>=2.0
+  - numpy>=2.3.3
   - pydantic>=2.1
   - pip
   - pandas>=3.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy>=2.0
   - pydantic>=2.1
   - pip
-  - pandas>=2.0
+  - pandas>=3.0
   - pooch>=1.3
   - xarray
   - pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ dependencies = [
      # write dascore against.
      "numpy>=2.0",
      "packaging",
-     "pandas>=2.0",
+     # 3.0 is where copy-on-write and the `str` dtype became the only
+     # behavior; dascore is written against those rather than around them.
+     "pandas>=3.0",
      "pooch>=1.3",  # retry_if_failed was added in 1.3
      "pydantic>2.1",
      # An inventory is authored as YAML, so reading one is not optional.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,10 @@ dependencies = [
      "array-api-compat>=1.9",
      "h5py",
      "matplotlib>=3.10",
-     # 2.0 is the first numpy with native array API support; older numpy
-     # works only through array-api-compat shims, which we would rather not
-     # write dascore against.
-     "numpy>=2.0",
+     # 2.0 is the first numpy with native array API support, which is what
+     # dascore is written against; 2.3.3 is the first pandas 3 accepts on
+     # python 3.14, and a floor below what the matrix installs is untested.
+     "numpy>=2.3.3",
      "packaging",
      # 3.0 is where copy-on-write and the `str` dtype became the only
      # behavior; dascore is written against those rather than around them.

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -13,7 +13,7 @@ import pytest
 
 import dascore as dc
 import dascore.utils.patch_assembly as assembly_mod
-from dascore.core.spool import _COPY_ON_WRITE_ALWAYS, BaseSpool, Spool
+from dascore.core.spool import BaseSpool, Spool
 from dascore.examples import ricker_moveout
 from dascore.exceptions import (
     InvalidSpoolError,
@@ -429,19 +429,6 @@ class TestGetContents:
         """Mutating the returned dataframe must not change the spool."""
         df = random_spool.get_contents()
         df["tag"] = "modified"
-        assert (random_spool.get_contents()["tag"] != "modified").all()
-
-    @pytest.mark.parametrize("copy_on_write", [False, True, "warn"])
-    def test_contents_owned_in_every_copy_mode(self, random_spool, copy_on_write):
-        """Ownership holds for each copy-on-write setting pandas 2 allows.
-
-        Notably "warn" is truthy but keeps the old sharing semantics.
-        """
-        if _COPY_ON_WRITE_ALWAYS:
-            pytest.skip("pandas 3 has copy-on-write always on")
-        with pd.option_context("mode.copy_on_write", copy_on_write):
-            df = random_spool.get_contents()
-            df["tag"] = "modified"
         assert (random_spool.get_contents()["tag"] != "modified").all()
 
 


### PR DESCRIPTION
## Description

Two annotation-set tests failed on pandas 2.x, a configuration `pyproject.toml` claimed to support and no CI job ran:

- a column declared `dtype: str` read back as `object`, because pandas 2 has no `str` dtype and `pandas_dtype("str")` resolves to numpy's `<U`;
- a blank cell beside times written as text reached the datetime parser as the literal string `"None"`, because `_normalize_times` masked the *result* of the conversion rather than converting only the cells a row states.

The declared floor was untrue whichever way these were closed. `numpy>=2.0` already forces pandas 2.2.2 or newer, since that is the first numpy-2-compatible pandas, and Python 3.14 — a version the test matrix covers — has no pandas wheel before 2.3.3. pandas 2.2.2 does not even build on 3.13.

So rather than keep a configuration nothing exercises, the floor moves to the release the code is already written against. pandas 3.0 shipped 2026-01-21; Pyodide 314.0.3, which `test_wasm.yml` pins, ships pandas 3.0.2; conda-forge carries 3.0.5; its `requires-python >=3.11` matches ours; it publishes `cp314t` free-threaded wheels, which pandas 2 does not; and no dependency or extra caps pandas below 3. Every CI job already installs it, so the floor is now tested by everything rather than by nothing.

That leaves nothing to guard, so the copy-on-write compatibility branch in `core/spool.py` and the test that skipped itself on pandas 3 both go. `get_contents` copies shallowly outright.

The `str` failure needs no code under the new floor — pandas 3 gives plain text a real `str` dtype, so the existing check is already right. Only the ordering fix remains, and it no longer leans on how `astype` spells a blank.

Checks, all on pandas 3.0.5 with the `[test]` extra alone, matching the min-deps job: the full suite (11583 passed, 350 skipped, 2 xfailed), `pytest dascore --doctest-modules` (195 passed), and `pre-commit run` over the changed files. Before pinning, the full suite was also run green on pandas 2.2.3 to confirm the two fixes were sufficient there and that the pin is a choice rather than a necessity.

`numpy>=2.0` was stale in the same way, and is raised in the same PR. numpy 2.0 has no wheel past Python 3.11, and pandas 3 asks for 2.3.3 or newer on Python 3.14, so the declared floor named a version three of the four supported Pythons could not install. Resolving dascore's runtime dependencies at each matrix Python gives 2.0.0 on 3.11, 2.1.0 on 3.13, and 2.3.3 on 3.14, so 2.3.3 is the lowest true across all of them. What matters for the code is still 2.0, where numpy grew native array API support; the number is higher only because nothing below it is installable. The full suite was run green against numpy 2.3.3 itself, not just against whatever CI resolves.

Still unaddressed, and not part of this PR: `h5py`, `packaging`, `pooch`, `rich`, and `universal-pathlib` declare no floor at all, so `uv --resolution lowest-direct` picks `h5py==2.2.1` from 2014 and fails to build.

## Changelog

- changed **breaking**: DASCore now requires pandas 3.0 or newer.
- changed **breaking**: DASCore now requires numpy 2.3.3 or newer.
- fixed: An annotation set whose dimension column mixes times written as text with blank cells now loads instead of raising on the blanks.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
