### PR TITLE
Let a pandas Series or list index a spool

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -446,12 +446,12 @@ class DataFrameSpool(BaseSpool):
 
     def _as_selector_array(self, item) -> np.ndarray:
         """Convert a Series or list selector to an array which fits the spool."""
-        if isinstance(item, pd.Series):
-            if pd.api.types.is_integer_dtype(item.dtype):
-                # to_numpy(dtype) also unboxes nullable Int64 (NA raises).
-                return item.to_numpy(dtype=np.int64)
-            if not pd.api.types.is_bool_dtype(item.dtype):
-                return item.to_numpy()
+        # Other Series dtypes fall through to the array path and are
+        # rejected there like any non bool/int array.
+        if isinstance(item, pd.Series) and pd.api.types.is_integer_dtype(item):
+            # to_numpy(dtype) also unboxes nullable Int64 (NA raises).
+            return item.to_numpy(dtype=np.int64)
+        if isinstance(item, pd.Series) and pd.api.types.is_bool_dtype(item):
             # A mask is applied by position, so it must be in this spool's
             # order; one built from another spool's contents would otherwise
             # silently select the wrong patches.

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -444,8 +444,33 @@ class DataFrameSpool(BaseSpool):
         self._select_kwargs = {} if select_kwargs is None else select_kwargs
         self._merge_kwargs = {} if merge_kwargs is None else merge_kwargs
 
+    def _as_selector_array(self, item) -> np.ndarray:
+        """Convert a Series or list selector to an array which fits the spool."""
+        if isinstance(item, pd.Series):
+            if not pd.api.types.is_bool_dtype(item.dtype):
+                return item.to_numpy()
+            # A mask is applied by position, so it must be in this spool's
+            # order; one built from another spool's contents would otherwise
+            # silently select the wrong patches.
+            if not item.index.equals(self._df.index):
+                msg = (
+                    "The index of a boolean Series selector must match this "
+                    "spool's get_contents; build the mask from it, or pass a "
+                    "numpy array to select by position."
+                )
+                raise ParameterError(msg)
+            # to_numpy handles nullable boolean dtypes; NA counts as False.
+            return item.to_numpy(dtype=bool, na_value=False)
+        array = np.asarray(item)
+        if array.size == 0:  # an empty list selects nothing
+            array = array.astype(np.int64)
+        return array
+
     def _select_from_array(self, array) -> Self:
         """Create new spool with contents changed from array input."""
+        if array.ndim != 1:
+            msg = f"Spool selectors must be one dimensional, got {array.ndim}D."
+            raise ParameterError(msg)
         if np.issubdtype(array.dtype, np.bool_):  # boolean select
             if len(array) != len(self._df):
                 msg = (
@@ -485,7 +510,7 @@ class DataFrameSpool(BaseSpool):
         elif is_array(item) or isinstance(item, pd.Series | list):
             # An array (or something which converts to one, such as a mask
             # built from get_contents) was passed; use np type selection.
-            return self._select_from_array(np.asarray(item))
+            return self._select_from_array(self._as_selector_array(item))
         else:  # a single index was used, should return a single patch
             out = self._unbox_patch(self._get_patches_from_index(item))
         return out

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -123,8 +123,16 @@ class BaseSpool(NamespaceOwner, abc.ABC):
     }
 
     @abc.abstractmethod
-    def __getitem__(self, item: int | slice | np.ndarray) -> PatchType:
-        """Returns a patch from the spool."""
+    def __getitem__(
+        self, item: int | slice | np.ndarray | pd.Series | list
+    ) -> PatchType | Self:
+        """
+        Return a patch (int index) or a new spool (anything else).
+
+        A slice, an array, a pandas Series, or a list selects patches: with
+        booleans, one per patch, True keeps; with integers, by position.
+        Boolean masks built from `get_contents` line up with the spool.
+        """
 
     @abc.abstractmethod
     def __iter__(self) -> PatchType:
@@ -439,6 +447,12 @@ class DataFrameSpool(BaseSpool):
     def _select_from_array(self, array) -> Self:
         """Create new spool with contents changed from array input."""
         if np.issubdtype(array.dtype, np.bool_):  # boolean select
+            if len(array) != len(self._df):
+                msg = (
+                    f"Boolean selector has {len(array)} values but the spool "
+                    f"has {len(self._df)} patches; it must have one per patch."
+                )
+                raise ParameterError(msg)
             df = self._df[array]
         elif np.issubdtype(array.dtype, np.integer):
             df = self._df.iloc[array]
@@ -468,7 +482,9 @@ class DataFrameSpool(BaseSpool):
                 instruction_df=new_inst,
                 source_df=new_source,
             )
-        elif is_array(item):  # An array was passed use np type selection.
+        elif is_array(item) or isinstance(item, pd.Series | list):
+            # An array (or something which converts to one, such as a mask
+            # built from get_contents) was passed; use np type selection.
             return self._select_from_array(np.asarray(item))
         else:  # a single index was used, should return a single patch
             out = self._unbox_patch(self._get_patches_from_index(item))

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -447,6 +447,9 @@ class DataFrameSpool(BaseSpool):
     def _as_selector_array(self, item) -> np.ndarray:
         """Convert a Series or list selector to an array which fits the spool."""
         if isinstance(item, pd.Series):
+            if pd.api.types.is_integer_dtype(item.dtype):
+                # to_numpy(dtype) also unboxes nullable Int64 (NA raises).
+                return item.to_numpy(dtype=np.int64)
             if not pd.api.types.is_bool_dtype(item.dtype):
                 return item.to_numpy()
             # A mask is applied by position, so it must be in this spool's

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -449,8 +449,10 @@ class DataFrameSpool(BaseSpool):
         # Other Series dtypes fall through to the array path and are
         # rejected there like any non bool/int array.
         if isinstance(item, pd.Series) and pd.api.types.is_integer_dtype(item):
-            # to_numpy(dtype) also unboxes nullable Int64 (NA raises).
-            return item.to_numpy(dtype=np.int64)
+            # Keep the Series' own integer width: nullable Int64/UInt64 unbox
+            # to it (NA raises) and unsigned values can't wrap negative.
+            dtype = getattr(item.dtype, "numpy_dtype", item.dtype)
+            return item.to_numpy(dtype=dtype)
         if isinstance(item, pd.Series) and pd.api.types.is_bool_dtype(item):
             # A mask is applied by position, so it must be in this spool's
             # order; one built from another spool's contents would otherwise

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -132,6 +132,19 @@ index_array = np.array([2, 0])
 new = spool[index_array]
 ```
 
+A pandas Series or a list works the same way. Since the rows of [`get_contents`](`dascore.core.spool.Spool.get_contents`) line up with the patches, a filter on that dataframe is a boolean selector for the spool:
+
+```{python}
+import dascore as dc
+
+spool = dc.get_example_spool("diverse_das")
+df = spool.get_contents()
+
+# Keep the patches whose tag is "some_tag" (the same as a select).
+new = spool[df["tag"] == "some_tag"]
+assert len(new) == (df["tag"] == "some_tag").sum()
+```
+
 # get_contents
 
 The [`get_contents`](`dascore.core.spool.BaseSpool.get_contents`) method returns a dataframe listing the spool contents. This method may not be supported on all spools, especially those interfacing with large remote resources.

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -132,7 +132,7 @@ index_array = np.array([2, 0])
 new = spool[index_array]
 ```
 
-A pandas Series or a list works the same way. Since the rows of [`get_contents`](`dascore.core.spool.Spool.get_contents`) line up with the patches, a filter on that dataframe is a boolean selector for the spool:
+A pandas Series or a list works the same way. Since the rows of [`get_contents`](`dascore.core.spool.BaseSpool.get_contents`) line up with the patches, a filter on that dataframe is a boolean selector for the spool:
 
 ```{python}
 import dascore as dc

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -346,6 +346,33 @@ class TestSpoolBoolArraySelect:
         with pytest.raises(ParameterError, match="one per patch"):
             random_spool[mask]
 
+    def test_series_from_other_spool_raises(self, diverse_spool):
+        """A mask built from a different spool's contents must not be applied."""
+        mask = diverse_spool.get_contents()["tag"] == "some_tag"
+        reversed_spool = diverse_spool[::-1]
+        with pytest.raises(ParameterError, match="match this spool"):
+            reversed_spool[mask]
+        # but by position it is allowed, and the caller owns the alignment.
+        assert len(reversed_spool[mask.to_numpy()]) == mask.sum()
+
+    def test_nullable_bool_series(self, diverse_spool):
+        """Missing values in a nullable boolean mask count as False."""
+        df = diverse_spool.get_contents()
+        mask = (df["tag"] == "some_tag").astype("boolean")
+        mask.iloc[0] = pd.NA
+        out = diverse_spool[mask]
+        assert len(out) == mask.fillna(False).sum()
+
+    def test_empty_list(self, random_spool):
+        """An empty list selects no patches."""
+        assert len(random_spool[[]]) == 0
+
+    def test_two_dimensional_raises(self, random_spool):
+        """Selectors must be one dimensional."""
+        mask = np.ones((len(random_spool), 1), dtype=np.bool_)
+        with pytest.raises(ParameterError, match="one dimensional"):
+            random_spool[mask]
+
 
 class TestSpoolIntArraySelect:
     """Tests for selecting patches using an integer array."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -416,6 +416,13 @@ class TestSpoolIntArraySelect:
         assert random_spool[indices] == expected
         assert random_spool[pd.Series(indices)] == expected
         assert random_spool[pd.Series(indices, dtype="Int64")] == expected
+        assert random_spool[pd.Series(indices, dtype="UInt64")] == expected
+
+    def test_unsigned_out_of_bounds_raises(self, random_spool):
+        """A huge unsigned index must not wrap around to a valid position."""
+        series = pd.Series([2**63 + 1], dtype="UInt64")
+        with pytest.raises(IndexError):
+            random_spool[series]
 
 
 class TestSpoolIterable:

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -409,6 +409,7 @@ class TestSpoolIntArraySelect:
         expected = random_spool[np.array(indices)]
         assert random_spool[indices] == expected
         assert random_spool[pd.Series(indices)] == expected
+        assert random_spool[pd.Series(indices, dtype="Int64")] == expected
 
 
 class TestSpoolIterable:

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -323,6 +323,29 @@ class TestSpoolBoolArraySelect:
         df2 = random_spool.get_contents()[bool_array]
         assert df1.equals(df2)
 
+    def test_bool_series_from_contents(self, diverse_spool):
+        """A mask built from get_contents should select like a select."""
+        df = diverse_spool.get_contents()
+        mask = df["tag"] == "some_tag"
+        assert 0 < mask.sum() < len(mask)
+        out = diverse_spool[mask]
+        expected = diverse_spool.select(tag="some_tag")
+        assert len(out) == len(expected) == mask.sum()
+        for patch, expected_patch in zip(out, expected, strict=True):
+            assert patch.equals(expected_patch)
+
+    def test_bool_list(self, random_spool):
+        """A list of bools should work like a bool array."""
+        mask = [i != 1 for i in range(len(random_spool))]
+        out = random_spool[mask]
+        assert out == random_spool[np.array(mask)]
+
+    def test_wrong_length_raises(self, random_spool):
+        """A mask which doesn't have one value per patch is an error."""
+        mask = np.ones(len(random_spool) + 1, dtype=np.bool_)
+        with pytest.raises(ParameterError, match="one per patch"):
+            random_spool[mask]
+
 
 class TestSpoolIntArraySelect:
     """Tests for selecting patches using an integer array."""
@@ -352,6 +375,13 @@ class TestSpoolIntArraySelect:
         out = random_spool[array]
         assert out[0] == random_spool[-1]
         assert out[-1] == random_spool[0]
+
+    def test_int_series_and_list(self, random_spool):
+        """A pandas Series or list of ints should select by position."""
+        indices = [len(random_spool) - 1, 0]
+        expected = random_spool[np.array(indices)]
+        assert random_spool[indices] == expected
+        assert random_spool[pd.Series(indices)] == expected
 
 
 class TestSpoolIterable:

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -396,6 +396,12 @@ class TestSpoolIntArraySelect:
         with pytest.raises(ValueError, match="Only bool or int dtypes"):
             random_spool[array]
 
+    def test_bad_series_type(self, random_spool):
+        """A Series which is neither bool nor int raises the same way."""
+        series = pd.Series(np.arange(len(random_spool)) + 0.01)
+        with pytest.raises(ValueError, match="Only bool or int dtypes"):
+            random_spool[series]
+
     def test_rearrange(self, random_spool):
         """Ensure patch order can be changed."""
         array = np.array([len(random_spool) - 1, 0])


### PR DESCRIPTION
## Description

The rows of `Spool.get_contents()` line up with the patches in the spool, so filtering that dataframe and using the result as a boolean selector is the natural thing to do:

```python
df = spool.get_contents()
sub = spool[df["tag"] == "DAS_LF"]
```

It didn't work: `Spool.__getitem__` only recognised NumPy arrays, so a pandas Series fell through to the single-index path and raised `ValueError: The truth value of a Series is ambiguous`. Users had to know to call `.to_numpy()` first.

This PR:

- accepts a pandas Series or a list wherever an array is accepted, with the same semantics (booleans keep one patch per `True`; integers select by position);
- raises a clear `ParameterError` when a boolean selector does not have one value per patch, rather than pandas' `Item wrong length` error;
- documents the pattern in the spool tutorial (new example after the array examples) and in the `__getitem__` docstring.

Tests cover a boolean Series built from `get_contents` (checked against the equivalent `select`), boolean lists, integer Series/lists, and the wrong-length error.

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting spool contents with slices, lists, NumPy arrays, and pandas Series.
  * Boolean selectors support nullable values, treating missing values as false.
  * Selections can return matching patches or filtered sub-spools.
  * Integer selectors support standard, nullable, and unsigned integer types.

* **Bug Fixes**
  * Added validation for selector dimensions, mask lengths, data types, and index alignment.

* **Documentation**
  * Added examples showing boolean and index-based spool filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->