### PR TITLE
Refuse at construction what a stored annotation set cannot read back

### DIFF
--- a/dascore/core/annotation_loader.py
+++ b/dascore/core/annotation_loader.py
@@ -38,7 +38,6 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 import pandas as pd
 from pydantic import ValidationError
 
@@ -52,11 +51,14 @@ from dascore.core.annotations import (
     OBJECT_SUFFIXES,
     RESERVED_COLUMNS,
     TABLE_SUFFIXES,
+    TEXT_DTYPES,
     VERTEX_STEM,
     AnnotationSet,
     _text,
     annotation_set_to_dataframe,
     annotation_set_to_vertices,
+    read_dimension,
+    read_ordinal,
 )
 from dascore.exceptions import InvalidAnnotationError, ParameterError
 from dascore.models.registry import TAG_FIELD
@@ -69,7 +71,6 @@ from dascore.utils.tables import (
     read_parquet_metadata,
     read_table,
 )
-from dascore.utils.time import to_datetime64
 
 # What an attrs file declares itself to be; the model writes its own tag.
 _SET_TAG = "AnnotationSetAttrs"
@@ -167,43 +168,13 @@ def _read_attrs(directory: Path) -> dict[str, Any]:
 
 
 def _read_dimension(series: pd.Series, path: Path) -> pd.Series:
-    """
-    Read a dimension column as the numbers or times its cells state.
-
-    Numbers are tried first because every datetime spelling this writes is
-    an ISO string, which is not a number, while seconds from the epoch are
-    a number a distance column would lose to a date.
-    """
-    stated = series.notna()
-    if not stated.any():
-        return series
-    with suppress(TypeError, ValueError):
-        return pd.to_numeric(series)
-    try:
-        values = to_datetime64(series[stated].to_numpy(dtype=str))
-    except (TypeError, ValueError) as error:
-        msg = (
-            f"The column {series.name!r} of {quote_path(path)} states neither "
-            f"numbers nor times: {error}."
-        )
-        raise ParameterError(msg) from error
-    out = pd.Series(
-        np.datetime64("NaT", "ns"), index=series.index, dtype="datetime64[ns]"
-    )
-    out[stated] = values
-    return out
+    """Read a dimension column as the set reads one, naming the table."""
+    return read_dimension(series, f" of {quote_path(path)}")
 
 
 def _read_ordinal(series: pd.Series, path: Path) -> pd.Series:
-    """Read the vertex order column as the numbers it states."""
-    try:
-        return pd.to_numeric(series)
-    except (TypeError, ValueError) as error:
-        msg = (
-            f"{quote_path(path)} has a non-numeric {_ORDINAL}: {error}. A vertex "
-            "states its place in the order as a number."
-        )
-        raise ParameterError(msg) from error
+    """Read the vertex order column as the set reads one, naming the table."""
+    return read_ordinal(series, f" of {quote_path(path)}")
 
 
 def _read_basis(series: pd.Series, path: Path) -> pd.Series:
@@ -989,6 +960,7 @@ def _load_set(directory: Path, attrs: Mapping, dims, **kwargs) -> AnnotationSet:
     declared, skip = _read_table_dims(table)
     stated = _declared_dims(attrs, dims, directory, declared, table)
     frame = _read_set_table(table, stated, "no annotations", skip=skip)
+    frame = _restore_dtypes(frame, attrs.get("columns"), table)
     # Found as the annotations table is: a set spells each of its parts
     # once, and a `vertices.CSV` beside a `vertices.csv` is two spellings of
     # one part rather than a table nobody reads.
@@ -1008,6 +980,41 @@ def _load_set(directory: Path, attrs: Mapping, dims, **kwargs) -> AnnotationSet:
     return AnnotationSet(frame, dims=stated, vertices=vertices, attrs=attrs, **kwargs)
 
 
+def _restore_dtypes(frame, columns: Mapping | None, path: Path):
+    """
+    Give each column back the dtype the set declares for it.
+
+    A CSV states no types, so a `category` or an `Int64` column comes
+    back as whatever its cells parse as; the declaration beside it is
+    what says which the column holds, and the set checks it on building.
+    Parquet keeps its own types, so the cast changes nothing there. Text
+    is left as it arrived: every spelling of it satisfies the check, and
+    casting would change which spelling a column carries. A declaration
+    which is not one is left for the set's own validation to refuse.
+    """
+    restored = {}
+    for name, spec in (columns or {}).items():
+        dtype = (
+            spec.get("dtype")
+            if isinstance(spec, Mapping)
+            else getattr(spec, "dtype", None)
+        )
+        if frame is None or not dtype or name not in frame.columns:
+            continue
+        with suppress(TypeError):
+            if pd.api.types.pandas_dtype(dtype).name in TEXT_DTYPES:
+                continue
+        try:
+            restored[name] = frame[name].astype(dtype)
+        except (TypeError, ValueError) as error:
+            msg = (
+                f"The column {name!r} of {quote_path(path)} declares the dtype "
+                f"{dtype}, which its cells cannot be read as: {error}."
+            )
+            raise ParameterError(msg) from error
+    return frame.assign(**restored) if restored else frame
+
+
 def _load_file(path: Path, dims, **kwargs) -> AnnotationSet:
     """Load the set a bare table holds."""
     if path.suffix.casefold() not in TABLE_SUFFIXES:
@@ -1021,12 +1028,11 @@ def _load_file(path: Path, dims, **kwargs) -> AnnotationSet:
     # A bare table states no attributes of its own, so a caller may hand it
     # some -- and the dimensions they name are the ones its cells are read
     # in, since nothing can be read before that is known.
-    stated = _declared_dims(_given_attrs(kwargs), dims, path, declared, path)
-    return AnnotationSet(
-        _read_set_table(path, stated, "no annotations", skip=skip),
-        dims=stated,
-        **kwargs,
-    )
+    given = _given_attrs(kwargs)
+    stated = _declared_dims(given, dims, path, declared, path)
+    frame = _read_set_table(path, stated, "no annotations", skip=skip)
+    columns = kwargs.get("columns") or given.get("columns")
+    return AnnotationSet(_restore_dtypes(frame, columns, path), dims=stated, **kwargs)
 
 
 def _vertex_declaration(path: Path) -> int:

--- a/dascore/core/annotation_loader.py
+++ b/dascore/core/annotation_loader.py
@@ -211,9 +211,13 @@ def _read_cells(
     path: Path,
     ordered: bool = False,
     typed: bool = False,
+    text: Collection[str] = (),
 ) -> pd.DataFrame:
     """
     Read a table's text cells as the values each column holds.
+
+    A column the set declares as text is left as the text it states:
+    "001" read as a number would not be the label it was written as.
 
     Only the vertices are ordered, so only they read ``seq`` as the number
     it is: the annotations table does not reserve that name, and an
@@ -245,6 +249,8 @@ def _read_cells(
             out[name] = _read_ordinal(series, path)
         elif str(name) == "basis":
             out[name] = _read_basis(series, path)
+        elif str(name) in text:
+            out[name] = series
         elif typed:
             # Text in a typed table is text: a cell reading 'true' in a
             # format which has a boolean is the word, not the boolean.
@@ -291,6 +297,7 @@ def _read_set_table(
     what: str,
     ordered: bool = False,
     skip: int = 0,
+    text: Collection[str] = (),
 ) -> pd.DataFrame | None:
     """
     Read one of a set's tables, with its cells typed.
@@ -303,11 +310,11 @@ def _read_set_table(
         frame, _ = read_parquet(path, what=what, empty=True)
         if not len(frame.columns):
             return None
-        return _read_cells(frame, dims, path, ordered=ordered, typed=True)
+        return _read_cells(frame, dims, path, ordered=ordered, typed=True, text=text)
     if _is_blank(path):
         return None
     frame = read_table(path, what=what, skip=skip)
-    return _read_cells(frame, dims, path, ordered=ordered)
+    return _read_cells(frame, dims, path, ordered=ordered, text=text)
 
 
 def _is_parquet(path: Path) -> bool:
@@ -959,8 +966,11 @@ def _load_set(directory: Path, attrs: Mapping, dims, **kwargs) -> AnnotationSet:
         raise ParameterError(msg)
     declared, skip = _read_table_dims(table)
     stated = _declared_dims(attrs, dims, directory, declared, table)
-    frame = _read_set_table(table, stated, "no annotations", skip=skip)
-    frame = _restore_dtypes(frame, attrs.get("columns"), table)
+    columns = attrs.get("columns")
+    frame = _read_set_table(
+        table, stated, "no annotations", skip=skip, text=_text_columns(columns)
+    )
+    frame = _restore_dtypes(frame, columns, table)
     # Found as the annotations table is: a set spells each of its parts
     # once, and a `vertices.CSV` beside a `vertices.csv` is two spellings of
     # one part rather than a table nobody reads.
@@ -993,17 +1003,9 @@ def _restore_dtypes(frame, columns: Mapping | None, path: Path):
     which is not one is left for the set's own validation to refuse.
     """
     restored = {}
-    for name, spec in (columns or {}).items():
-        dtype = (
-            spec.get("dtype")
-            if isinstance(spec, Mapping)
-            else getattr(spec, "dtype", None)
-        )
-        if frame is None or not dtype or name not in frame.columns:
+    for name, dtype in _declared_dtypes(columns).items():
+        if frame is None or name not in frame.columns or _is_text_dtype(dtype):
             continue
-        with suppress(TypeError):
-            if pd.api.types.pandas_dtype(dtype).name in TEXT_DTYPES:
-                continue
         try:
             restored[name] = frame[name].astype(dtype)
         except (TypeError, ValueError) as error:
@@ -1013,6 +1015,36 @@ def _restore_dtypes(frame, columns: Mapping | None, path: Path):
             )
             raise ParameterError(msg) from error
     return frame.assign(**restored) if restored else frame
+
+
+def _declared_dtypes(columns: Mapping | None) -> dict[str, str]:
+    """The dtype each declared column states, where the declaration is one."""
+    out = {}
+    for name, spec in (columns or {}).items():
+        dtype = (
+            spec.get("dtype")
+            if isinstance(spec, Mapping)
+            else getattr(spec, "dtype", None)
+        )
+        if dtype:
+            out[name] = dtype
+    return out
+
+
+def _is_text_dtype(dtype: str) -> bool:
+    """Whether a declared dtype is a spelling of text; an unreadable one is not."""
+    with suppress(TypeError):
+        return pd.api.types.pandas_dtype(dtype).name in TEXT_DTYPES
+    return False
+
+
+def _text_columns(columns: Mapping | None) -> frozenset[str]:
+    """The columns a set declares as text, which a table leaves as it reads them."""
+    return frozenset(
+        name
+        for name, dtype in _declared_dtypes(columns).items()
+        if _is_text_dtype(dtype)
+    )
 
 
 def _load_file(path: Path, dims, **kwargs) -> AnnotationSet:
@@ -1030,8 +1062,14 @@ def _load_file(path: Path, dims, **kwargs) -> AnnotationSet:
     # in, since nothing can be read before that is known.
     given = _given_attrs(kwargs)
     stated = _declared_dims(given, dims, path, declared, path)
-    frame = _read_set_table(path, stated, "no annotations", skip=skip)
-    columns = kwargs.get("columns") or given.get("columns")
+    # An empty mapping is an override which clears the declarations, as
+    # the set reads it, so only an absent one falls back to the attrs.
+    columns = kwargs.get("columns")
+    if columns is None:
+        columns = given.get("columns")
+    frame = _read_set_table(
+        path, stated, "no annotations", skip=skip, text=_text_columns(columns)
+    )
     return AnnotationSet(_restore_dtypes(frame, columns, path), dims=stated, **kwargs)
 
 

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -557,7 +557,8 @@ class AnnotationColumn(_AnnotationModel):
 
     Documenting a column never gates it: an undeclared column is carried
     as an extra just the same. A stated dtype is checked, so a column
-    which says what it holds must hold it.
+    which says what it holds must hold it; a column read back from a CSV,
+    which keeps no types, is given its stated dtype again.
     """
 
     description: str = Field(default="", description="What the column means.")
@@ -731,7 +732,9 @@ class AnnotationSet(NamespaceOwner):
             attrs, dims, creation_info, acquisition_key, history, columns
         )
         frame = _coerce_frame(data, "annotations")
-        frame = _normalize_blanks(_normalize_times(frame, self._attrs.dims))
+        # Blanks first: a blank cell beside times written as text is unset,
+        # not a word the time column holds.
+        frame = _normalize_times(_normalize_blanks(frame), self._attrs.dims)
         spellings = _read_spellings(frame, self._attrs.dims)
         _check_columns(frame, self._attrs)
         _check_ranges(frame, spellings)
@@ -740,7 +743,7 @@ class AnnotationSet(NamespaceOwner):
         ids = _check_ids(frame)
         frame = _normalize_tags(_normalize_basis(frame, self._attrs.dims))
         vertex_frame = _normalize_times(
-            _coerce_frame(vertices, "vertices"), self._attrs.dims
+            _normalize_blanks(_coerce_frame(vertices, "vertices")), self._attrs.dims
         )
         self._vertices = _check_vertices(vertex_frame, frame, ids, self._attrs.dims)
         self._df = _fill_vertex_bounds(frame, self._vertices, spellings)
@@ -888,6 +891,14 @@ def _coerce_frame(data, what: str) -> pd.DataFrame:
             "states one thing."
         )
         raise ParameterError(msg)
+    # A table names a column by a string, so any other name would come
+    # back from a saved set as the string it was written as.
+    if odd := [repr(x) for x in frame.columns if not isinstance(x, str)][:5]:
+        msg = (
+            f"The {what} name the column(s) {', '.join(odd)} by something other "
+            "than a string, which is what a table names a column by."
+        )
+        raise ParameterError(msg)
     return frame
 
 
@@ -956,7 +967,7 @@ def _check_columns(frame: pd.DataFrame, attrs: AnnotationSetAttrs) -> None:
         # Compared by name rather than by identity: a column documented as
         # `category` says it is categorical, not which categories it holds,
         # and the two dtypes are otherwise unequal.
-        if declared.name != actual.name:
+        if not _dtype_matches(declared, frame[name]):
             # A time is held at nanoseconds whatever it arrived as, so
             # another unit is not a column this set could ever hold, and
             # saying it "holds datetime64[ns]" reads as a mistake the
@@ -969,6 +980,28 @@ def _check_columns(frame: pd.DataFrame, attrs: AnnotationSetAttrs) -> None:
                 raise ParameterError(msg)
             msg = f"The column {name!r} states dtype {column.dtype} but holds {actual}."
             raise ParameterError(msg)
+
+
+TEXT_DTYPES = frozenset({"object", "str", "string"})
+
+
+def _dtype_matches(declared, series: pd.Series) -> bool:
+    """
+    Whether a column holds its declared dtype, however pandas spells text.
+
+    Text has several spellings -- `object`, `str`, `string` -- and which
+    one a column gets depends on the pandas version and on what wrote it,
+    so a declaration of any of them is a declaration of text. An `object`
+    column may hold anything, so it is text only if its cells are.
+    """
+    actual = series.dtype
+    if declared.name == actual.name:
+        return True
+    if declared.name not in TEXT_DTYPES or actual.name not in TEXT_DTYPES:
+        return False
+    return actual.name != "object" or all(
+        isinstance(x, str) for x in series if _stated(x)
+    )
 
 
 def _check_ranges(frame: pd.DataFrame, spellings) -> None:
@@ -1183,6 +1216,7 @@ def _check_vertices(vertices, frame, ids, dims) -> pd.DataFrame:
         rows = ", ".join(str(x) for x in vertices.index[vertices["seq"].isnull()][:5])
         msg = f"Vertex row(s) {rows} state no seq, so they have no place in the order."
         raise ParameterError(msg)
+    vertices = vertices.assign(seq=read_ordinal(vertices["seq"]))
     blank = vertices[vertex_dims].isnull().any(axis=1)
     if blank.any():
         rows = ", ".join(str(x) for x in vertices.index[blank][:5])
@@ -1348,53 +1382,98 @@ def _normalize_basis(frame, dims) -> pd.DataFrame:
     return frame.assign(basis=pd.Series(read, index=frame.index, dtype=object))
 
 
-def _states_times(series: pd.Series) -> bool:
-    """Whether every cell a column states is a datetime written as text."""
-    stated = [x for x in series if _stated(x)]
-    return bool(stated) and all(
-        isinstance(x, str) and _DATETIME_TEXT.match(x) for x in stated
+def read_dimension(series: pd.Series, where: str = "") -> pd.Series:
+    """
+    Read a dimension column as the numbers or times its cells state.
+
+    Numbers are tried first because every datetime spelling this writes is
+    an ISO string, which is not a number, while seconds from the epoch are
+    a number a distance column would lose to a date. Times arriving at
+    another resolution are held at nanoseconds, the resolution DASCore
+    keeps them at, and a column holding neither numbers nor times is
+    refused: a dimension is a coordinate, and the set's own store would
+    refuse to read it back. `where` names the source in the refusal.
+    """
+    kind = getattr(series.dtype, "kind", "")
+    if kind in "iuf":
+        return series
+    if kind == "M":
+        return (
+            series
+            if series.dtype == np.dtype("datetime64[ns]")
+            else to_datetime64(series)
+        )
+    if kind == "m":
+        return (
+            series
+            if series.dtype == np.dtype("timedelta64[ns]")
+            else to_timedelta64(series)
+        )
+    stated = np.array([_stated(x) for x in series], dtype=bool)
+    if not stated.any():
+        return series
+    cells = series[stated]
+    if kind != "b" and not any(isinstance(x, bool) for x in cells):
+        with suppress(TypeError, ValueError):
+            return pd.to_numeric(series)
+        try:
+            values = to_datetime64(cells.to_numpy(dtype=str))
+        except (TypeError, ValueError) as error:
+            msg = (
+                f"The column {series.name!r}{where} states neither numbers nor "
+                f"times: {error}."
+            )
+            raise ParameterError(msg) from error
+        out = pd.Series(
+            np.datetime64("NaT", "ns"), index=series.index, dtype="datetime64[ns]"
+        )
+        out[stated] = values
+        return out
+    msg = (
+        f"The column {series.name!r}{where} holds {cells.iloc[0]!r}, where a "
+        "dimension holds numbers or times."
     )
+    raise ParameterError(msg)
+
+
+def read_ordinal(series: pd.Series, where: str = "") -> pd.Series:
+    """Read the vertex order column as the numbers it states."""
+    try:
+        return pd.to_numeric(series)
+    except (TypeError, ValueError) as error:
+        msg = (
+            f"The vertices{where} state a non-numeric {_VERTEX_COLUMNS[1]}: "
+            f"{error}. A vertex states its place in the order as a number."
+        )
+        raise ParameterError(msg) from error
 
 
 def _normalize_times(frame: pd.DataFrame, dims: Sequence[str] = ()) -> pd.DataFrame:
     """
-    Hold every time at nanoseconds, the resolution DASCore keeps them at.
+    Hold every time at nanoseconds, and read each dimension column.
 
     A column arriving at another resolution states the same times, but
     everything which reads one back -- a stored table, a coordinate, a
     curve -- states them at DASCore's, so a set which kept both spellings
-    would differ from itself over nothing.
-
-    A dimension column holding times as *text* is read as times for the
-    same reason: the geometry a row builds reads that spelling back, so a
-    frame which kept the text would disagree with the region built from
-    it about what the row says.
+    would differ from itself over nothing. A dimension column is read as
+    the numbers or times it states, text included, for the same reason:
+    the geometry a row builds reads that spelling back, so a frame which
+    kept the text would disagree with the region built from it.
     """
     spelled = {x for dim in dims for x in (dim, f"{dim}{_START}", f"{dim}{_END}")}
     changed = {}
     for name in frame.columns:
         series = frame[name]
         kind = getattr(series.dtype, "kind", "")
-        if kind == "M" and series.dtype != np.dtype("datetime64[ns]"):
+        if name in spelled:
+            read = read_dimension(series)
+            if read is not series:
+                changed[name] = read
+        elif kind == "M" and series.dtype != np.dtype("datetime64[ns]"):
             changed[name] = to_datetime64(series)
         elif kind == "m" and series.dtype != np.dtype("timedelta64[ns]"):
             changed[name] = to_timedelta64(series)
-        elif str(name) in spelled and _states_times(series):
-            # Only the stated cells are converted, then put back where
-            # they came from: masking the result instead hands every blank
-            # cell to the datetime parser first, and what a blank one reads
-            # as there is up to `astype`.
-            stated = series[series.notna()]
-            times = to_datetime64(stated.astype(str))
-            changed[name] = times.reindex(series.index)
-    if not changed:
-        return frame
-    # Assigned by item rather than by keyword: a column need not be named
-    # anything a keyword can spell.
-    out = frame.copy()
-    for name, series in changed.items():
-        out[name] = series
-    return out
+    return frame.assign(**changed) if changed else frame
 
 
 def _normalize_tags(frame) -> pd.DataFrame:
@@ -1439,7 +1518,9 @@ def _normalize_blanks(frame: pd.DataFrame) -> pd.DataFrame:
         series = frame[name]
         if getattr(series.dtype, "kind", "") not in "OTU":
             continue
-        blank = series.map(lambda x: isinstance(x, str) and not x)
+        # Not `Series.map`: on a categorical column it returns a categorical,
+        # which pandas 3 refuses to reduce with `any`.
+        blank = np.array([isinstance(x, str) and not x for x in series], dtype=bool)
         if blank.any():
             changed[name] = series.where(~blank, None)
     # An all-blank value column is how a membership-only set is spelled,

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -1413,7 +1413,7 @@ def read_dimension(series: pd.Series, where: str = "") -> pd.Series:
     if not stated.any():
         return series
     cells = series[stated]
-    if kind != "b" and not any(isinstance(x, bool) for x in cells):
+    if kind != "b" and not any(_is_bool(x) for x in cells):
         with suppress(TypeError, ValueError):
             return pd.to_numeric(series)
         try:
@@ -1438,14 +1438,24 @@ def read_dimension(series: pd.Series, where: str = "") -> pd.Series:
 
 def read_ordinal(series: pd.Series, where: str = "") -> pd.Series:
     """Read the vertex order column as the numbers it states."""
-    try:
-        return pd.to_numeric(series)
-    except (TypeError, ValueError) as error:
-        msg = (
-            f"The vertices{where} state a non-numeric {_VERTEX_COLUMNS[1]}: "
-            f"{error}. A vertex states its place in the order as a number."
-        )
-        raise ParameterError(msg) from error
+    # Refused before `to_numeric`, which would count a truth value as 1 or 0.
+    if getattr(series.dtype, "kind", "") == "b" or any(_is_bool(x) for x in series):
+        error = "it holds truth values"
+    else:
+        try:
+            return pd.to_numeric(series)
+        except (TypeError, ValueError) as exc:
+            error = str(exc)
+    msg = (
+        f"The vertices{where} state a non-numeric {_VERTEX_COLUMNS[1]}: "
+        f"{error}. A vertex states its place in the order as a number."
+    )
+    raise ParameterError(msg)
+
+
+def _is_bool(value) -> bool:
+    """Whether a cell is a truth value, numpy's included."""
+    return isinstance(value, bool | np.bool_)
 
 
 def _normalize_times(frame: pd.DataFrame, dims: Sequence[str] = ()) -> pd.DataFrame:

--- a/tests/test_core/test_annotation_loader.py
+++ b/tests/test_core/test_annotation_loader.py
@@ -283,6 +283,36 @@ class TestDeclaredDtypes:
         assert loaded[0].extra["n"] == "a"
         assert "n" not in loaded[1].extra
 
+    def test_a_declared_text_column_keeps_its_text(self, tmp_path):
+        """A cell a table would read as a number, a truth value or a date
+        stays the text it was written as when the column is declared text.
+        """
+        frame = pd.DataFrame(
+            {
+                "distance_start": [0.0, 1.0, 2.0],
+                "distance_end": [1.0, 2.0, 3.0],
+                "label": ["001", "true", "2020-01-01"],
+            }
+        )
+        columns = {"label": {"dtype": "str"}}
+        built = dc.AnnotationSet(frame, dims=("distance",), columns=columns)
+        loaded = dc.annotations(built.io.save(tmp_path / "set"))
+        assert [x.extra["label"] for x in loaded] == ["001", "true", "2020-01-01"]
+        assert loaded == built
+        # A bare table handed the declaration reads the same way.
+        path = tmp_path / "set.csv"
+        built.io.to_csv(path)
+        bare = dc.annotations(path, dims=("distance",), columns=columns)
+        assert [x.extra["label"] for x in bare] == ["001", "true", "2020-01-01"]
+
+    def test_an_empty_columns_override_restores_nothing(self, typed, tmp_path):
+        """`columns={}` clears the declarations, so nothing is restored from them."""
+        path = tmp_path / "typed.csv"
+        typed.io.to_csv(path)
+        loaded = dc.annotations(path, dims=("distance",), attrs=typed.attrs, columns={})
+        assert not loaded.attrs.columns
+        assert loaded.io.to_dataframe()["count"].dtype.name != "Int64"
+
     def test_a_declaration_which_is_not_one(self, tmp_path):
         """A column spec which is no mapping is refused as a bad attrs file."""
         frame = pd.DataFrame({"distance_start": [0.0], "distance_end": [1.0], "n": [1]})

--- a/tests/test_core/test_annotation_loader.py
+++ b/tests/test_core/test_annotation_loader.py
@@ -313,6 +313,19 @@ class TestDeclaredDtypes:
         assert not loaded.attrs.columns
         assert loaded.io.to_dataframe()["count"].dtype.name != "Int64"
 
+    def test_an_unreadable_declared_dtype(self, tmp_path):
+        """A dtype naming nothing is refused on reload as it is on building."""
+        frame = pd.DataFrame({"distance_start": [0.0], "distance_end": [1.0], "n": [1]})
+        directory = dc.AnnotationSet(frame, dims=("distance",)).io.save(
+            tmp_path / "set"
+        )
+        attrs_path = directory / "attrs.json"
+        document = json.loads(attrs_path.read_text())
+        document["columns"] = {"n": {"dtype": "not-a-dtype"}}
+        attrs_path.write_text(json.dumps(document))
+        with pytest.raises(InvalidAnnotationError, match="cannot be read as"):
+            dc.annotations(directory)
+
     def test_a_declaration_which_is_not_one(self, tmp_path):
         """A column spec which is no mapping is refused as a bad attrs file."""
         frame = pd.DataFrame({"distance_start": [0.0], "distance_end": [1.0], "n": [1]})

--- a/tests/test_core/test_annotation_loader.py
+++ b/tests/test_core/test_annotation_loader.py
@@ -233,6 +233,85 @@ class TestRoundTrip:
         assert "distance" not in loaded[1].region.bounds
 
 
+class TestDeclaredDtypes:
+    """A CSV states no types; the declaration beside it gives them back."""
+
+    @pytest.fixture
+    def typed(self):
+        """A set declaring a categorical and a nullable integer column."""
+        frame = pd.DataFrame(
+            {
+                "distance_start": [0.0, 1.0],
+                "distance_end": [1.0, 2.0],
+                "kind": pd.Series(["a", "b"], dtype="category"),
+                "count": pd.Series([1, None], dtype="Int64"),
+            }
+        )
+        columns = {"kind": {"dtype": "category"}, "count": {"dtype": "Int64"}}
+        return dc.AnnotationSet(frame, dims=("distance",), columns=columns)
+
+    def test_declared_dtypes_survive_a_csv(self, typed, tmp_path):
+        """The loaded set holds what the saved one declared, and equals it."""
+        loaded = dc.annotations(typed.io.save(tmp_path / "typed"))
+        frame = loaded.io.to_dataframe()
+        assert frame["kind"].dtype.name == "category"
+        assert frame["count"].dtype.name == "Int64"
+        assert loaded == typed
+
+    def test_declared_dtypes_survive_parquet(self, typed, tmp_path):
+        """Parquet keeps the types itself; the declaration then changes nothing."""
+        pytest.importorskip("pyarrow")
+        loaded = dc.annotations(typed.io.save(tmp_path / "typed", format="parquet"))
+        assert loaded == typed
+
+    def test_a_bare_table_given_its_declarations(self, typed, tmp_path):
+        """A CSV states no attrs; a caller handing it the columns gets them back."""
+        path = tmp_path / "typed.csv"
+        typed.io.to_csv(path)
+        loaded = dc.annotations(path, dims=("distance",), columns=typed.attrs.columns)
+        assert loaded.io.to_dataframe()["count"].dtype.name == "Int64"
+
+    def test_a_declared_text_dtype_keeps_blank_cells_unset(self, tmp_path):
+        """Text is not cast on reload, so a blank stays a blank, not the word 'nan'."""
+        frame = pd.DataFrame(
+            {"distance_start": [0.0, 1.0], "distance_end": [1.0, 2.0], "n": ["a", None]}
+        )
+        built = dc.AnnotationSet(
+            frame, dims=("distance",), columns={"n": {"dtype": "str"}}
+        )
+        loaded = dc.annotations(built.io.save(tmp_path / "set"))
+        assert loaded[0].extra["n"] == "a"
+        assert "n" not in loaded[1].extra
+
+    def test_a_declaration_which_is_not_one(self, tmp_path):
+        """A column spec which is no mapping is refused as a bad attrs file."""
+        frame = pd.DataFrame({"distance_start": [0.0], "distance_end": [1.0], "n": [1]})
+        directory = dc.AnnotationSet(frame, dims=("distance",)).io.save(
+            tmp_path / "set"
+        )
+        attrs_path = directory / "attrs.json"
+        document = json.loads(attrs_path.read_text())
+        document["columns"] = {"n": None}
+        attrs_path.write_text(json.dumps(document))
+        with pytest.raises(InvalidAnnotationError):
+            dc.annotations(directory)
+
+    def test_a_declaration_the_cells_cannot_hold(self, tmp_path):
+        """A declaration edited to something the column is not says so."""
+        frame = pd.DataFrame(
+            {"distance_start": [0.0], "distance_end": [1.0], "n": ["x"]}
+        )
+        directory = dc.AnnotationSet(frame, dims=("distance",)).io.save(
+            tmp_path / "set"
+        )
+        attrs_path = directory / "attrs.json"
+        document = json.loads(attrs_path.read_text())
+        document["columns"] = {"n": {"dtype": "Int64"}}
+        attrs_path.write_text(json.dumps(document))
+        with pytest.raises(InvalidAnnotationError, match="cannot be read as"):
+            dc.annotations(directory)
+
+
 class TestWhatATableCannotSay:
     """A CSV has no types, and these are the corners where that shows."""
 
@@ -687,13 +766,14 @@ class TestTheTables:
         assert loaded == annotations
         assert isinstance(loaded[0].region.bounds["time"][0], np.datetime64)
 
-    def test_a_dimension_some_rows_leave_blank(self):
+    @pytest.mark.parametrize("blank", [None, ""])
+    def test_a_dimension_some_rows_leave_blank(self, blank):
         """Times as text beside empty cells read as times and as unset."""
         frame = pd.DataFrame(
             {
                 "group": ["a", "b"],
-                "time_start": ["2020-01-01", None],
-                "time_end": ["2020-01-02", None],
+                "time_start": ["2020-01-01", blank],
+                "time_end": ["2020-01-02", blank],
             }
         )
         out = dc.AnnotationSet(frame, dims=("time",))

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -209,9 +209,46 @@ class TestDimensionSpelling:
 
     def test_incomparable_range_refused(self):
         """A range whose ends cannot be compared says so, not TypeError."""
-        frame = pd.DataFrame({"distance_start": [1.0, "a"], "distance_end": ["b", 2.0]})
+        when = np.datetime64("2020-01-01", "ns")
+        frame = pd.DataFrame({"distance_start": [1.0], "distance_end": [when]})
         with pytest.raises(ParameterError, match="cannot be compared"):
             AnnotationSet(frame, dims=DIMS)
+
+    @pytest.mark.parametrize("spelling", ["distance", "distance_start"])
+    def test_text_in_a_dimension_refused(self, spelling):
+        """A dimension is a coordinate, so a word is no place on it."""
+        frame = pd.DataFrame({spelling: ["alpha"]})
+        if spelling != "distance":
+            frame["distance_end"] = ["omega"]
+        with pytest.raises(ParameterError, match="neither numbers nor times"):
+            AnnotationSet(frame, dims=DIMS)
+
+    def test_numeric_text_in_a_dimension_is_read_as_numbers(self):
+        """Read as a stored table reads it, so the two cannot disagree."""
+        frame = pd.DataFrame(
+            {"distance_start": ["1.5", None], "distance_end": ["2", None]}
+        )
+        out = AnnotationSet(frame, dims=DIMS)
+        assert out[0].region.bounds["distance"] == (1.5, 2.0)
+        assert "distance" not in out[1].region.bounds
+
+    @pytest.mark.parametrize(
+        "text", ["2020-01-01 10:00:00", "2020-01-01T10:00:00Z", "2020-01-01T10:00:00"]
+    )
+    def test_time_text_in_any_spelling_is_a_time(self, text):
+        """What `to_csv` writes and `read_csv` hands back is a time here too."""
+        out = AnnotationSet(pd.DataFrame({"time": [text]}), dims=DIMS)
+        assert out[0].region.bounds["time"][0] == np.datetime64("2020-01-01T10:00:00")
+
+    def test_a_malformed_date_is_refused_not_a_value_error(self):
+        """Shaped like a date without being one is text, and said to be."""
+        with pytest.raises(ParameterError, match="neither numbers nor times"):
+            AnnotationSet(pd.DataFrame({"time": ["2020-13-45"]}), dims=DIMS)
+
+    def test_a_boolean_dimension_refused(self):
+        """A truth value is no place on an axis, and a table reads it as a word."""
+        with pytest.raises(ParameterError, match="numbers or times"):
+            AnnotationSet(pd.DataFrame({"distance": [True]}), dims=DIMS)
 
     def test_datetime_endpoints_keep_their_type(self):
         """A time bound is a time, not the integer behind it."""
@@ -284,6 +321,54 @@ class TestColumns:
         frame = pd.DataFrame({"note": values}).astype(dtype)
         out = AnnotationSet(frame, dims=DIMS, columns={"note": {"dtype": dtype}})
         assert len(out) == 2
+
+    @pytest.mark.parametrize("declared", ["str", "string", "object"])
+    def test_a_text_dtype_matches_any_text_spelling(self, declared):
+        """
+        Pandas spells text as `object`, `str` or `string` depending on its
+        version and on what built the column; a declaration of any of them
+        is a declaration of text.
+        """
+        for frame in (
+            pd.DataFrame({"note": pd.Series(["a"], dtype=object)}),
+            pd.DataFrame({"note": pd.Series(["a"], dtype="string")}),
+        ):
+            out = AnnotationSet(frame, dims=DIMS, columns={"note": {"dtype": declared}})
+            assert len(out) == 1
+        with pytest.raises(ParameterError, match="states dtype"):
+            AnnotationSet(
+                pd.DataFrame({"note": [1.0]}),
+                dims=DIMS,
+                columns={"note": {"dtype": declared}},
+            )
+
+    def test_an_object_column_is_text_only_if_its_cells_are(self):
+        """`object` may hold anything, so a text declaration reads its cells."""
+        frame = pd.DataFrame({"note": pd.Series(["a", {"x": 1}], dtype=object)})
+        with pytest.raises(ParameterError, match="states dtype"):
+            AnnotationSet(frame, dims=DIMS, columns={"note": {"dtype": "string"}})
+        # Declared as what it is, an object column holding anything is fine.
+        out = AnnotationSet(frame, dims=DIMS, columns={"note": {"dtype": "object"}})
+        assert len(out) == 2
+
+    def test_a_categorical_column_builds(self):
+        """A categorical extra is carried like any other, blank cells and all."""
+        frame = pd.DataFrame(
+            {
+                "distance_start": [0.0, 1.0],
+                "distance_end": [1.0, 2.0],
+                "note": pd.Series(["a", ""], dtype="category"),
+            }
+        )
+        out = AnnotationSet(frame, dims=DIMS)
+        assert out[0].extra["note"] == "a"
+        assert "note" not in out[1].extra
+
+    def test_a_column_named_by_something_other_than_a_string(self):
+        """A table names a column by a string, so a set does too."""
+        frame = pd.DataFrame({"distance_start": [0.0], "distance_end": [1.0], 1: ["x"]})
+        with pytest.raises(ParameterError, match="other than a string"):
+            AnnotationSet(frame, dims=DIMS)
 
     def test_category_needs_no_categories(self):
         """A column documented as categorical says so, not which categories."""
@@ -539,6 +624,44 @@ class TestGeometryKinds:
 
 class TestVertices:
     """The vertices frame is checked against the rows which need it."""
+
+    def test_seq_is_read_as_a_number(self):
+        """Text ordinals order '10' before '2'; a vertex states a number."""
+        frame = pd.DataFrame({"id": ["p1"], "geometry": ["path"]})
+        vertices = pd.DataFrame(
+            {"id": ["p1"] * 3, "seq": ["10", "2", "1"], "distance": [3.0, 2.0, 1.0]}
+        )
+        out = AnnotationSet(frame, dims=DIMS, vertices=vertices)
+        vertices = out.io.to_vertices()
+        assert vertices["seq"].tolist() == [1, 2, 10]
+        assert vertices["distance"].tolist() == [1.0, 2.0, 3.0]
+
+    def test_non_numeric_seq_refused(self):
+        """What the loader refuses to read, the set refuses to hold."""
+        frame = pd.DataFrame({"id": ["p1"], "geometry": ["path"]})
+        vertices = pd.DataFrame(
+            {"id": ["p1"] * 2, "seq": ["first", "second"], "distance": [1.0, 2.0]}
+        )
+        with pytest.raises(ParameterError, match="non-numeric seq"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_text_in_a_vertex_dimension_refused(self):
+        """A vertex places a shape, so its dimensions are numbers or times too."""
+        frame = pd.DataFrame({"id": ["p1"], "geometry": ["path"]})
+        vertices = pd.DataFrame(
+            {"id": ["p1"] * 2, "seq": [0, 1], "distance": ["here", "there"]}
+        )
+        with pytest.raises(ParameterError, match="neither numbers nor times"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
+
+    def test_a_blank_seq_is_no_seq(self):
+        """The empty string is how a table spells an unset cell, here too."""
+        frame = pd.DataFrame({"id": ["p1"], "geometry": ["path"]})
+        vertices = pd.DataFrame(
+            {"id": ["p1"] * 2, "seq": ["", "1"], "distance": [1.0, 2.0]}
+        )
+        with pytest.raises(ParameterError, match="state no seq"):
+            AnnotationSet(frame, dims=DIMS, vertices=vertices)
 
     def test_bounds_derived_from_vertices(self, path_set):
         """A path's bounding region is the box its vertices fill."""

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -245,10 +245,15 @@ class TestDimensionSpelling:
         with pytest.raises(ParameterError, match="neither numbers nor times"):
             AnnotationSet(pd.DataFrame({"time": ["2020-13-45"]}), dims=DIMS)
 
-    def test_a_boolean_dimension_refused(self):
-        """A truth value is no place on an axis, and a table reads it as a word."""
+    @pytest.mark.parametrize(
+        "values",
+        [[True], pd.array([True, None], dtype="boolean"), [np.True_, None]],
+    )
+    def test_a_boolean_dimension_refused(self, values):
+        """A truth value is no place on an axis, numpy's and a nullable one too."""
+        frame = pd.DataFrame({"distance": pd.Series(values, dtype=object)})
         with pytest.raises(ParameterError, match="numbers or times"):
-            AnnotationSet(pd.DataFrame({"distance": [True]}), dims=DIMS)
+            AnnotationSet(frame, dims=DIMS)
 
     def test_datetime_endpoints_keep_their_type(self):
         """A time bound is a time, not the integer behind it."""
@@ -636,11 +641,20 @@ class TestVertices:
         assert vertices["seq"].tolist() == [1, 2, 10]
         assert vertices["distance"].tolist() == [1.0, 2.0, 3.0]
 
-    def test_non_numeric_seq_refused(self):
-        """What the loader refuses to read, the set refuses to hold."""
+    @pytest.mark.parametrize(
+        "seq", [["first", "second"], [True, False], [np.True_, np.False_]]
+    )
+    def test_non_numeric_seq_refused(self, seq):
+        """What the loader refuses to read, the set refuses to hold -- a truth
+        value included, which `to_numeric` would otherwise count as 1 or 0.
+        """
         frame = pd.DataFrame({"id": ["p1"], "geometry": ["path"]})
         vertices = pd.DataFrame(
-            {"id": ["p1"] * 2, "seq": ["first", "second"], "distance": [1.0, 2.0]}
+            {
+                "id": ["p1"] * 2,
+                "seq": pd.Series(seq, dtype=object),
+                "distance": [1.0, 2.0],
+            }
         )
         with pytest.raises(ParameterError, match="non-numeric seq"):
             AnnotationSet(frame, dims=DIMS, vertices=vertices)

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -356,6 +356,14 @@ class TestColumns:
         out = AnnotationSet(frame, dims=DIMS, columns={"note": {"dtype": "object"}})
         assert len(out) == 2
 
+    def test_an_extra_holding_timedeltas_is_held_at_nanoseconds(self):
+        """Every time is held at DASCore's resolution, an extra's too."""
+        frame = pd.DataFrame({"lag": np.array([1, 5], dtype="timedelta64[s]")})
+        out = AnnotationSet(frame, dims=DIMS)
+        held = out.io.to_dataframe()["lag"]
+        assert held.dtype == np.dtype("timedelta64[ns]")
+        assert held.iloc[0] == np.timedelta64(1, "s")
+
     def test_a_categorical_column_builds(self):
         """A categorical extra is carried like any other, blank cells and all."""
         frame = pd.DataFrame(


### PR DESCRIPTION
## Description

The annotation round-trip findings from the inventory review in `.scratch/dev_review`: an `AnnotationSet` accepted several things its own `io.save` → `dc.annotations` reload then refused or silently changed, which breaks the round-trip promise the store makes.

**One reader for dimension cells.** The constructor kept its own half-reader for a dimension column (times as ISO text only), while the loader had another (numbers, then times in any spelling). The two now share `read_dimension`: numbers first, then times in any spelling `to_datetime64` reads — including the space-separated form `to_csv` writes — else refused with "states neither numbers nor times". So text in a dimension column is refused when the set is built rather than on reload, numeric text is read as the number the loader would read, a malformed date is a `ParameterError` rather than a leaked `ValueError`, and booleans or other non-coordinate objects are refused. The vertex `seq` column is read the same way through a shared `read_ordinal`, so `"10"` no longer sorts before `"2"` and a non-numeric one is refused up front. Blank cells are read as unset *before* times are, for the vertices too, so `""` beside times written as text is a blank rather than a word.

**Column names are strings.** A CSV header can only be a string, so a column named `1` came back as `"1"` and the reloaded set compared unequal; it is refused now.

**Declared dtypes survive a CSV.** A set declaring `category` or `Int64` columns saved fine and then failed to reload (`"states dtype category but holds object"`), because the CSV kept no types and the loader never applied the declaration beside it. The loader gives each column back its declared dtype — for a directory and for a bare table handed `columns=` — except text, which is left as it arrived: pandas spells text three ways (`object`, `str`, `string`) depending on version and origin, any of them satisfies a text declaration (an `object` column only if its cells are text), and casting would change which spelling a column carries, so a reloaded set would compare unequal over nothing.

**pandas 3:** `_normalize_blanks` used `Series.map(...).any()`, which pandas 3 keeps categorical and refuses to reduce, so any categorical column crashed the constructor with a `TypeError`.

Not covered here, noted for later: a `"category"` declaration carries no categories, so ordered or unobserved categories do not survive a CSV (parquet keeps them); collection-level column declarations are not restored on a flat reload.

## Changelog

- fixed: `AnnotationSet` reads a dimension column as its stored table does — numbers, then times in any spelling — and refuses text, booleans, a non-numeric vertex `seq`, or a column not named by a string when it is built, rather than saving a set its own reload refuses.
- fixed: `dc.annotations` restores a column's declared dtype when reading a CSV, so a set declaring `category` or `Int64` columns reloads equal to itself; a text declaration is satisfied by any pandas spelling of text.
- fixed: `AnnotationSet` accepts a categorical column on pandas 3, and reads a blank cell beside times written as text as unset.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added robust parsing for numeric, datetime, and timedelta annotation dimensions.
  * Added validation and conversion for vertex sequence values.
  * Restored declared column data types when loading annotation data, including categorical and nullable integer types.

* **Bug Fixes**
  * Improved handling of blank values and text columns.
  * Added clearer validation for invalid dates, dimensions, vertex sequences, and column names.
  * Preserved consistent data types across supported annotation loading methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->