### PR TITLE
Tell a spool where its data is missing

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -1631,16 +1631,17 @@ class Spool(NamespaceOwner):
             **kwargs,
         )
 
-    def _report_relation(self, dim: str) -> pd.DataFrame:
+    def _report_relation(self) -> pd.DataFrame:
         """
         Return the relation a gap report reads: the rows the spool presents.
 
         Unlike [`_plan_frames`](`dascore.core.spool.Spool._plan_frames`)
         a plan-backed spool is never collapsed to its members. Chunk
         collapses because re-planning a dimension replaces the plan; a
-        report describes the patches the spool actually holds, so a
-        merged spool has nothing left to report. Samples residuals still
-        adjust the envelopes, since they change what loads.
+        report describes the patches the spool actually holds, so it
+        reads the plan's outputs. Samples residuals still adjust the
+        envelopes, since they change what loads. No dimension is needed:
+        the whole relation is returned and the caller picks its columns.
         """
         base = _ensure_patch_id(self._df.reset_index(drop=True))
         working = base.drop(columns=list(self._drop_columns), errors="ignore")
@@ -1669,11 +1670,13 @@ class Spool(NamespaceOwner):
             The maximum number of samples patches can be spaced and still
             count as contiguous. Same meaning as chunk's `tolerance`.
         group
-            Attributes which separate patches into unrelated partitions; a
-            gap is never reported between two partitions. Defaults to the
-            config option `patch_kind_attrs`. Sampling rate and coordinate
-            structure split partitions too, exactly as they do for
-            `chunk`, so one group value can span several partitions.
+            Attributes which separate patches into unrelated groups; a gap
+            is never reported between two groups. Defaults to the config
+            option `patch_kind_attrs`. Sampling rate and coordinate
+            structure split groups too, exactly as they do for `chunk`,
+            so one attribute value can span several groups. A value
+            nobody recorded conflicts with nothing, so a patch which
+            never stated the attribute joins the group that did.
         missing_dim
             What to do with patches lacking `dim`: "drop" (the default)
             excludes them, "raise" refuses. Chunk defaults to "raise"
@@ -1683,10 +1686,11 @@ class Spool(NamespaceOwner):
         -----
         `{dim}_min` is the last sample before the gap and `{dim}_max` the
         first sample after it, so `gap_size` is their difference — one
-        step wider than the missing extent. Subtract the returned
-        `{dim}_step` column for the extent itself.
+        step wider than the missing extent. Subtract the magnitude of
+        the returned `{dim}_step` for the extent itself; the step keeps
+        the coordinate's sign, which is negative for a descending one.
 
-        `group_id` names the partition each gap belongs to, and is the
+        `group_id` names the group each gap belongs to, and is the
         column to join against
         [`get_coverage`](`dascore.core.spool.Spool.get_coverage`).
 
@@ -1713,7 +1717,7 @@ class Spool(NamespaceOwner):
         >>> assert random_spool().get_gaps().empty
         """
         out = build_gap_frame(
-            self._report_relation(dim),
+            self._report_relation(),
             dim,
             tolerance=tolerance,
             group=group,
@@ -1732,10 +1736,11 @@ class Spool(NamespaceOwner):
         """
         Return a dataframe summarizing how complete the spool is.
 
-        One row per partition, reporting the extent it spans along `dim`
-        and how much of that extent holds data. Patches divide on the
-        group attributes and, exactly as `chunk` divides them, on dims
-        signature, coordinate identity, units, and sampling rate.
+        One row per group of related patches — same kind, dims
+        signature, coordinate identity, units, and sampling rate,
+        exactly as `chunk` groups them before it looks at continuity.
+        Each row reports the extent the group spans along `dim` and how
+        much of that extent holds data.
 
         Parameters
         ----------
@@ -1745,10 +1750,12 @@ class Spool(NamespaceOwner):
             The maximum number of samples patches can be spaced and still
             count as contiguous. Same meaning as chunk's `tolerance`.
         group
-            Attributes which separate patches into unrelated partitions.
-            Defaults to the config option `patch_kind_attrs`; sampling and
-            structural differences split partitions too, so one group
-            value can span several rows.
+            Attributes which separate patches into unrelated groups.
+            Defaults to the config option `patch_kind_attrs`; sampling
+            and structural differences split groups too, so one
+            attribute value can span several rows. A value nobody
+            recorded conflicts with nothing, so a patch which never
+            stated the attribute joins the group that did.
         missing_dim
             What to do with patches lacking `dim`: "drop" (the default)
             excludes them, "raise" refuses.
@@ -1756,17 +1763,18 @@ class Spool(NamespaceOwner):
         Notes
         -----
         `span` is `{dim}_max - {dim}_min`, `gap_total` is the sum of the
-        partition's gaps as
+        group's gaps as
         [`get_gaps`](`dascore.core.spool.Spool.get_gaps`) reports them,
         `covered` is the rest, and `coverage` is `covered / span` (1.0
         when the span is zero, meaning a single sample). `group_id`
         matches the gap frame's, so the two join on it.
 
-        A partition whose step is unknown reports no gaps, and so counts
-        as fully covered. That is what `chunk` would do with it — it
-        would merge the patches — but it means `coverage` of 1.0 there
-        says "nothing chunk would refuse to merge", not "nothing
-        missing".
+        Coverage is measured between patches, from the envelopes the
+        index records; a hole *inside* a patch is not visible here. Nor
+        is one in a group whose step is unknown, which reports no gaps
+        and so counts as fully covered. Both are what `chunk` would
+        make of the data, so a `coverage` of 1.0 says "nothing chunk
+        would refuse to merge", not "nothing missing".
 
         See Also
         --------
@@ -1783,7 +1791,7 @@ class Spool(NamespaceOwner):
         >>> assert (random_spool().get_coverage()["coverage"] == 1).all()
         """
         out = build_coverage_frame(
-            self._report_relation(dim),
+            self._report_relation(),
             dim,
             tolerance=tolerance,
             group=group,

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -76,6 +76,8 @@ from dascore.utils.chunk_plan import (
     _combined_dtype,
     _ensure_patch_id,
     build_chunk_plan,
+    build_coverage_frame,
+    build_gap_frame,
     build_subdivision_plan,
     samples_adjusted_envelopes,
     subdivision_pieces,
@@ -1628,6 +1630,166 @@ class Spool(NamespaceOwner):
             missing_dim=missing_dim,
             **kwargs,
         )
+
+    def _report_relation(self, dim: str) -> pd.DataFrame:
+        """
+        Return the relation a gap report reads: the rows the spool presents.
+
+        Unlike [`_plan_frames`](`dascore.core.spool.Spool._plan_frames`)
+        a plan-backed spool is never collapsed to its members. Chunk
+        collapses because re-planning a dimension replaces the plan; a
+        report describes the patches the spool actually holds, so a
+        merged spool has nothing left to report. Samples residuals still
+        adjust the envelopes, since they change what loads.
+        """
+        base = _ensure_patch_id(self._df.reset_index(drop=True))
+        working = base.drop(columns=list(self._drop_columns), errors="ignore")
+        return samples_adjusted_envelopes(working, self._catalog.residuals)
+
+    def get_gaps(
+        self,
+        dim: str = "time",
+        *,
+        tolerance: float = 1.5,
+        group: str | Sequence[str] | None = None,
+        missing_dim: Literal["raise", "drop"] = "drop",
+    ) -> pd.DataFrame:
+        """
+        Return a dataframe with one row per gap along a dimension.
+
+        Gaps are found with the rules
+        [`chunk`](`dascore.Spool.chunk`) merges by, so every row is
+        exactly a boundary that `chunk` would refuse to close.
+
+        Parameters
+        ----------
+        dim
+            The dimension to look for gaps along.
+        tolerance
+            The maximum number of samples patches can be spaced and still
+            count as contiguous. Same meaning as chunk's `tolerance`.
+        group
+            Attributes which separate patches into unrelated partitions; a
+            gap is never reported between two partitions. Defaults to the
+            config option `patch_kind_attrs`. Sampling rate and coordinate
+            structure split partitions too, exactly as they do for
+            `chunk`, so one group value can span several partitions.
+        missing_dim
+            What to do with patches lacking `dim`: "drop" (the default)
+            excludes them, "raise" refuses. Chunk defaults to "raise"
+            because it must produce those patches; a report need not.
+
+        Notes
+        -----
+        `{dim}_min` is the last sample before the gap and `{dim}_max` the
+        first sample after it, so `gap_size` is their difference — one
+        step wider than the missing extent. Subtract the returned
+        `{dim}_step` column for the extent itself.
+
+        `group_id` names the partition each gap belongs to, and is the
+        column to join against
+        [`get_coverage`](`dascore.core.spool.Spool.get_coverage`).
+
+        Overlapping and fully-nested patches never open a gap: each
+        boundary is measured against the furthest point reached so far,
+        not the previous row.
+
+        Patches whose step is unknown report no gaps, since the tolerance
+        has no sample to scale.
+
+        See Also
+        --------
+        [`Spool.get_coverage`](`dascore.core.spool.Spool.get_coverage`)
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from dascore.examples import random_spool
+        >>>
+        >>> spool = random_spool(time_gap=np.timedelta64(1, "s"), length=3)
+        >>> gaps = spool.get_gaps()
+        >>> assert len(gaps) == 2
+        >>> # A contiguous spool has none.
+        >>> assert random_spool().get_gaps().empty
+        """
+        out = build_gap_frame(
+            self._report_relation(dim),
+            dim,
+            tolerance=tolerance,
+            group=group,
+            missing_dim=missing_dim,
+        )
+        return present_units_columns(out)
+
+    def get_coverage(
+        self,
+        dim: str = "time",
+        *,
+        tolerance: float = 1.5,
+        group: str | Sequence[str] | None = None,
+        missing_dim: Literal["raise", "drop"] = "drop",
+    ) -> pd.DataFrame:
+        """
+        Return a dataframe summarizing how complete the spool is.
+
+        One row per partition, reporting the extent it spans along `dim`
+        and how much of that extent holds data. Patches divide on the
+        group attributes and, exactly as `chunk` divides them, on dims
+        signature, coordinate identity, units, and sampling rate.
+
+        Parameters
+        ----------
+        dim
+            The dimension to measure along.
+        tolerance
+            The maximum number of samples patches can be spaced and still
+            count as contiguous. Same meaning as chunk's `tolerance`.
+        group
+            Attributes which separate patches into unrelated partitions.
+            Defaults to the config option `patch_kind_attrs`; sampling and
+            structural differences split partitions too, so one group
+            value can span several rows.
+        missing_dim
+            What to do with patches lacking `dim`: "drop" (the default)
+            excludes them, "raise" refuses.
+
+        Notes
+        -----
+        `span` is `{dim}_max - {dim}_min`, `gap_total` is the sum of the
+        partition's gaps as
+        [`get_gaps`](`dascore.core.spool.Spool.get_gaps`) reports them,
+        `covered` is the rest, and `coverage` is `covered / span` (1.0
+        when the span is zero, meaning a single sample). `group_id`
+        matches the gap frame's, so the two join on it.
+
+        A partition whose step is unknown reports no gaps, and so counts
+        as fully covered. That is what `chunk` would do with it — it
+        would merge the patches — but it means `coverage` of 1.0 there
+        says "nothing chunk would refuse to merge", not "nothing
+        missing".
+
+        See Also
+        --------
+        [`Spool.get_gaps`](`dascore.core.spool.Spool.get_gaps`)
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from dascore.examples import random_spool
+        >>>
+        >>> spool = random_spool(time_gap=np.timedelta64(1, "s"), length=3)
+        >>> coverage = spool.get_coverage()
+        >>> assert (coverage["coverage"] < 1).all()
+        >>> assert (random_spool().get_coverage()["coverage"] == 1).all()
+        """
+        out = build_coverage_frame(
+            self._report_relation(dim),
+            dim,
+            tolerance=tolerance,
+            group=group,
+            missing_dim=missing_dim,
+        )
+        return present_units_columns(out)
 
     @compose_docstring(conflict_desc=attr_conflict_description)
     def chunk(

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -313,7 +313,11 @@ def _gap_boundaries(start, stop, step, tolerance):
     reach = np.empty_like(stops)
     reach[:1] = stops[:1]
     np.maximum.accumulate(stops[:-1], out=reach[1:])
-    has_gap = starts > reach + steps * tolerance
+    # Measure the distance from the reach rather than comparing against
+    # `reach + step * tolerance`: a float margin promotes that sum, and
+    # an integer coordinate past 2**53 rounds both endpoints together,
+    # hiding the gap. The distance itself is small enough to compare.
+    has_gap = (starts - reach) > steps * tolerance
     has_gap[:1] = False
     return order, reach, has_gap
 

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -45,7 +45,7 @@ from dascore.units import (
 from dascore.utils.attrs import known_only, validate_conflict
 from dascore.utils.chunk import get_intervals
 from dascore.utils.misc import get_middle_value, is_range
-from dascore.utils.pd import get_interval_columns
+from dascore.utils.pd import get_dim_names_from_columns, get_interval_columns
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float, to_timedelta64
 
 # Columns which never participate in conflict policing and never carry to
@@ -289,19 +289,41 @@ def _sampling_group(step: pd.Series, tolerance: float) -> pd.Series:
     return pd.Series(labels, index=step.index)
 
 
-def _continuity_group(start, stop, step, tolerance) -> pd.Series:
-    """Label maximal near-contiguous runs (spec 2.4)."""
-    args = np.argsort(start.to_numpy())
-    start_sorted = start.iloc[args]
-    stop_sorted = stop.iloc[args]
+def _gap_boundaries(start, stop, step, tolerance):
+    """
+    Locate the discontinuities in one partition cell (spec 2.4).
+
+    Returns `(order, reach, has_gap)` over the start-ordered rows.
+    `reach` is the furthest stop seen *before* each row, so an
+    overlapping or fully-nested row can never open a gap behind it, and
+    `has_gap` marks each row whose start clears that reach by more than
+    `tolerance` steps. The first row has nothing behind it, and a row
+    whose step is unknown compares False, so neither reports a gap.
+
+    Arrays rather than a frame, and an explicit first-row mask rather
+    than `shift`, whose NaN fill would upcast integer envelopes to
+    float — `reach` is a reported value, not just a comparand.
+    """
+    order = np.argsort(start.to_numpy())
+    starts = start.to_numpy()[order]
+    stops = stop.to_numpy()[order]
     # envelopes are value-ordered regardless of coordinate orientation,
     # so the continuity margin uses the step magnitude
-    step_sorted = step.iloc[args].abs()
-    stop_cum_max = stop_sorted.cummax()
-    end_markers = stop_cum_max.shift() + step_sorted * tolerance
-    has_gap = start_sorted > end_markers
-    group = has_gap.astype(np.int64).cumsum()
-    return group[start.index]
+    steps = np.abs(step.to_numpy()[order])
+    reach = np.empty_like(stops)
+    reach[:1] = stops[:1]
+    np.maximum.accumulate(stops[:-1], out=reach[1:])
+    has_gap = starts > reach + steps * tolerance
+    has_gap[:1] = False
+    return order, reach, has_gap
+
+
+def _continuity_group(start, stop, step, tolerance) -> pd.Series:
+    """Label maximal near-contiguous runs (spec 2.4)."""
+    order, _, has_gap = _gap_boundaries(start, stop, step, tolerance)
+    out = pd.Series(0, index=start.index, dtype=np.int64)
+    out.iloc[order] = np.cumsum(has_gap)
+    return out
 
 
 def _normalize_chunk_units(df: pd.DataFrame, name: str) -> pd.DataFrame:
@@ -376,24 +398,73 @@ def _normalize_chunk_units(df: pd.DataFrame, name: str) -> pd.DataFrame:
     return df
 
 
-def _partition(
-    df, name, group_attrs, tolerance, sampling_tolerance
-) -> tuple[pd.Series, bool]:
-    """
-    Return (partition labels, forced_merge): rows sharing a label may
-    combine (spec 2).
+def _validate_missing_dim(missing_dim) -> None:
+    """Reject a missing_dim value that is neither policy."""
+    if missing_dim not in ("raise", "drop"):
+        msg = f"missing_dim must be 'raise' or 'drop', got {missing_dim!r}"
+        raise ParameterError(msg)
 
-    Components: kind labels (`_kind_codes` over the group attrs), dims
-    signature, structural def keys of non-chunked coords, sampling group,
-    and continuity group. Continuity
-    is evaluated *within* each other-component cell so unrelated patches
-    can never bridge a gap. `forced_merge` is True when a loosened
-    tolerance merged patches the default would have kept apart (#662);
-    the caller owns warning about it.
+
+def _prepare_relation(
+    df: pd.DataFrame,
+    name: str,
+    missing_dim: str,
+    dim_label: str = "chunk dimension",
+    operation: str = "chunking",
+) -> pd.DataFrame:
     """
-    _start, _stop, step = get_interval_columns(df, name)
-    kind = _kind_codes(df, [x for x in group_attrs if x in df.columns])
-    cols: list = [kind]
+    Ready a flat relation for planning or reporting along ``name``.
+
+    Attaches patch ids, re-spells compatible units, then applies the
+    `missing_dim` policy. Missing envelopes, and patches carrying the
+    name only as a non-dimensional coordinate (spec 7 / D2), both count
+    as missing: envelope presence is not enough, because auxiliary
+    coordinates index their envelopes too but their patches cannot be
+    trimmed or merged *along* the name.
+
+    `dim_label` and `operation` word the error for the caller; a typo in
+    `missing_dim` raises here rather than silently taking the drop
+    branch, which would truncate exactly the report the user asked for.
+    """
+    _validate_missing_dim(missing_dim)
+    min_name, max_name = f"{name}_min", f"{name}_max"
+    df = _ensure_patch_id(df)
+    df = _normalize_chunk_units(df, name)
+    null_rows = pd.isnull(df[min_name]) | pd.isnull(df[max_name])
+    if "dims" in df.columns:
+        dim_lists = df["dims"].fillna("").astype(str).str.split(",")
+        not_a_dim = ~dim_lists.map(lambda dims: name in dims)
+    else:
+        not_a_dim = pd.Series(False, index=df.index)
+    unusable = null_rows | not_a_dim
+    if not unusable.any():
+        return df
+    if missing_dim == "raise":
+        bad = df.loc[unusable, "_patch_id"].tolist()
+        rides = int((not_a_dim & ~null_rows).sum())
+        detail = (
+            f" ({rides} of them carry {name!r} only as a non-dimensional "
+            f"coordinate; {operation} is defined on dimensions)"
+            if rides
+            else ""
+        )
+        msg = (
+            f"{int(unusable.sum())} patch(es) lack the {dim_label} "
+            f"{name!r}{detail} (patch ids {bad[:5]}...). Pass "
+            "missing_dim='drop' to exclude them."
+        )
+        raise ChunkError(msg)
+    return df[~unusable]
+
+
+def _cell_columns(df, name) -> list[str]:
+    """
+    Return the structural columns whose values decide a cell.
+
+    The kind attrs decide it too, but through `_kind_codes` rather than
+    their own values, so they are not listed here.
+    """
+    cols = []
     if "dims" in df.columns:
         cols.append("dims")
     # Structural identity: def keys of non-chunked *dimensions* only
@@ -409,10 +480,43 @@ def _partition(
     # coordinates either.
     if (unit_col := f"_{name}_units") in df.columns:
         cols.append(unit_col)
-    cols = [df[x] if isinstance(x, str) else x for x in cols]
-    base = df.groupby(cols, dropna=False, sort=False).ngroup()
+    # A name repeated in `group` would repeat the column, and a frame
+    # with duplicate labels cannot be grouped or sorted.
+    return list(dict.fromkeys(cols))
+
+
+def _cell_labels(df, name, group_attrs, sampling_tolerance) -> pd.Series:
+    """
+    Label the cells a partition's continuity runs live inside (spec 2).
+
+    A cell holds the rows which could combine if only their envelopes
+    lined up: the same kind, dims signature, structural def keys of the
+    non-chunked dimensions, chunk-dim units, and sampling group.
+    Continuity is then evaluated *within* a cell, so unrelated patches
+    can never bridge (or fabricate) a gap.
+    """
+    _start, _stop, step = get_interval_columns(df, name)
+    kind = _kind_codes(df, [x for x in group_attrs if x in df.columns])
+    keys = [kind, *(df[x] for x in _cell_columns(df, name))]
+    base = df.groupby(keys, dropna=False, sort=False).ngroup()
     samp = _sampling_group(step, sampling_tolerance)
-    cell = base.astype(str) + "_" + samp.astype(str)
+    return base.astype(str) + "_" + samp.astype(str)
+
+
+def _partition(
+    df, name, group_attrs, tolerance, sampling_tolerance
+) -> tuple[pd.Series, bool]:
+    """
+    Return (partition labels, forced_merge): rows sharing a label may
+    combine (spec 2).
+
+    A partition is a continuity run within a cell (see
+    [`_cell_labels`](`dascore.utils.chunk_plan._cell_labels`)).
+    `forced_merge` is True when a loosened tolerance merged patches the
+    default would have kept apart (#662); the caller owns warning about
+    it.
+    """
+    cell = _cell_labels(df, name, group_attrs, sampling_tolerance)
     cont = pd.Series(0, index=df.index, dtype=np.int64)
     forced_merge = False
     for _, index in df.groupby(cell, sort=False).groups.items():
@@ -921,6 +1025,248 @@ def _uniform_dtype_str(value, cache: dict[str, str]) -> str:
     return cache[key]
 
 
+_REPORT_COLUMNS = ("span", "gap_total", "gap_size", "covered", "coverage", "group_id")
+
+
+def _report_dim_columns(df: pd.DataFrame, name: str, carried) -> tuple[str, str, str]:
+    """
+    Return the envelope columns of `name`, checked for a usable report.
+
+    `get_interval_columns` words its error for chunking, and a carried
+    attr sharing a computed column's name would overwrite the statistic
+    rather than fail, so both are policed here instead.
+    """
+    columns = (f"{name}_min", f"{name}_max", f"{name}_step")
+    if missing := set(columns) - set(df.columns):
+        dims = get_dim_names_from_columns(df)
+        msg = (
+            f"Cannot report on {name!r}: no {sorted(missing)} in the "
+            f"relation. Valid dimensions or columns are {dims}."
+        )
+        raise ParameterError(msg)
+    if collide := sorted(set(carried) & set(_REPORT_COLUMNS)):
+        msg = (
+            f"Cannot group a report by {collide}: the name(s) collide with "
+            "the columns the report computes."
+        )
+        raise ParameterError(msg)
+    return columns
+
+
+def _report_preamble(df, name, group, missing_dim):
+    """
+    Resolve what both reports need before they can differ.
+
+    Returns the prepared relation, its carried columns, and the
+    envelope column names -- kept in one place so the two reports
+    cannot drift apart in how they group, validate, or label.
+    """
+    group_attrs = _resolve_group_attrs(group, set(df.columns))
+    names = _report_dim_columns(df, name, group_attrs)
+    df = _prepare_relation(df, name, missing_dim, "dimension", "gap reporting")
+    return df, group_attrs, _gap_carried_columns(df, name, group_attrs), names
+
+
+def _gap_carried_columns(df: pd.DataFrame, name: str, group_attrs) -> list[str]:
+    """
+    Return the cell columns a report shows, in a stable order.
+
+    Def keys are opaque structural identity, so they partition a report
+    without appearing in it; `group_id` tells cells apart instead. The
+    dimension's units are kept: they name what the reported magnitudes
+    are in, and `present_units_columns` makes them public at the spool
+    boundary. The kind attrs are shown by value, which is why they are
+    listed here rather than reached through `_kind_codes`.
+    """
+    private = set(_dim_def_key_columns(df, name))
+    cols = [x for x in group_attrs if x in df.columns]
+    cols += [x for x in _cell_columns(df, name) if x not in private]
+    return list(dict.fromkeys(cols))
+
+
+def _stated(sub: pd.DataFrame, column: str) -> pd.Series:
+    """
+    Return the one value a cell states for a column, as a length-1 slice.
+
+    Kind matching lets a row which never recorded an attr share a cell
+    with one that did, so the first row is not always the one that
+    knows. Slicing the column (rather than taking the value) keeps the
+    frame's dtype. Falls back to the first row when nobody recorded it.
+    """
+    known = known_only(sub[column])
+    index = known.first_valid_index()
+    return sub[column].iloc[:1] if index is None else sub[column].loc[[index]]
+
+
+def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance: float):
+    """
+    Yield `(cell rows, gaps in that cell)` for every cell in `df`.
+
+    Cells come in the order partitions do (spec 8) — by envelope min,
+    then smallest patch id — so a report never depends on the order the
+    relation happened to arrive in. Each cell's ordinal rides on its
+    gaps as `group_id`, which is the only thing that always tells two
+    cells apart: sampling group and structural def keys partition
+    without being shown.
+    """
+    min_name, max_name, step_name = _dim_columns(df, name)
+    carried = _gap_carried_columns(df, name, group_attrs)
+    cells = _cell_labels(
+        df, name, group_attrs, dc.get_config().sampling_group_tolerance
+    )
+    grouped = df.groupby(cells, sort=False)
+    order = grouped.agg(_min=(min_name, "min"), _pid=("_patch_id", "min")).sort_values(
+        ["_min", "_pid"], kind="stable"
+    )
+    groups = grouped.groups
+    for group_id, label in enumerate(order.index):
+        sub = df.loc[groups[label]]
+        start, stop, step = get_interval_columns(sub, name)
+        row_order, reach, has_gap = _gap_boundaries(start, stop, step, tolerance)
+        found = np.flatnonzero(has_gap)
+        # the row opening each gap states the step, signed as the
+        # coordinate is -- only the continuity margin needs a magnitude
+        starts = start.to_numpy()[row_order][found]
+        gaps = pd.DataFrame(
+            {
+                min_name: reach[found],
+                max_name: starts,
+                step_name: step.to_numpy()[row_order][found],
+                "gap_size": starts - reach[found],
+                "group_id": np.full(len(found), group_id, dtype=np.int64),
+            }
+            | {x: _stated(sub, x).repeat(len(found)).to_numpy() for x in carried}
+        )
+        yield group_id, sub, gaps
+
+
+def _empty_report(columns: dict) -> pd.DataFrame:
+    """
+    Build a report frame with no rows but the right columns and dtypes.
+
+    Callers pass empty slices of relation columns, or expressions over
+    them, so a caller which sums or groups an empty report gets the
+    dtypes the same relation would give populated. Purely computed
+    columns (`coverage`, `group_id`) pass a bare typed Series instead.
+    """
+    return pd.DataFrame({k: v.iloc[:0] for k, v in columns.items()})
+
+
+def build_gap_frame(
+    df: pd.DataFrame,
+    name: str,
+    *,
+    tolerance: float = _DEFAULT_TOLERANCE,
+    group: str | Sequence[str] | None = None,
+    missing_dim: Literal["raise", "drop"] = "drop",
+) -> pd.DataFrame:
+    """
+    Report every discontinuity along ``name`` in a flat patch relation.
+
+    One row per gap, over the same cells and the same continuity rule
+    [`build_chunk_plan`](`dascore.utils.chunk_plan.build_chunk_plan`)
+    uses, so a gap here is exactly a boundary chunk refuses to merge.
+    `{name}_min` is the last sample before the gap and `{name}_max` the
+    first sample after it, so `gap_size` is their difference.
+    """
+    df, group_attrs, carried, names = _report_preamble(df, name, group, missing_dim)
+    min_name, max_name, step_name = names
+    columns = [min_name, max_name, step_name, "gap_size", "group_id", *carried]
+    # Contiguous cells are dropped rather than concatenated: their empty
+    # frames carry object-dtype attr columns, which would widen the
+    # dtypes of the gappy cells they are concatenated with.
+    frames = [x for _, _, x in _cell_gaps(df, name, group_attrs, tolerance) if len(x)]
+    if not frames:
+        return _empty_report(
+            {
+                min_name: df[min_name],
+                max_name: df[max_name],
+                step_name: df[step_name],
+                "gap_size": df[max_name] - df[min_name],
+                "group_id": pd.Series(dtype=np.int64),
+            }
+            | {x: df[x] for x in carried},
+        )[columns]
+    out = pd.concat(frames, ignore_index=True)
+    return out[columns].sort_values(["group_id", min_name]).reset_index(drop=True)
+
+
+def build_coverage_frame(
+    df: pd.DataFrame,
+    name: str,
+    *,
+    tolerance: float = _DEFAULT_TOLERANCE,
+    group: str | Sequence[str] | None = None,
+    missing_dim: Literal["raise", "drop"] = "drop",
+) -> pd.DataFrame:
+    """
+    Summarize how much of each cell's span along ``name`` holds data.
+
+    One row per cell, over the same cells
+    [`build_gap_frame`](`dascore.utils.chunk_plan.build_gap_frame`)
+    reports in and sharing its `group_id`: `span` is the cell's full
+    extent, `gap_total` the sum of its gaps, `covered` the rest, and
+    `coverage` their ratio.
+    """
+    df, group_attrs, carried, names = _report_preamble(df, name, group, missing_dim)
+    min_name, max_name, step_name = names
+    columns = [
+        min_name,
+        max_name,
+        step_name,
+        "span",
+        "gap_total",
+        "covered",
+        "coverage",
+        "group_id",
+        *carried,
+    ]
+    rows = []
+    for group_id, sub, gaps in _cell_gaps(df, name, group_attrs, tolerance):
+        low, high = sub[min_name].min(), sub[max_name].max()
+        span = high - low
+        # Sum through the span itself when there are no gaps, so a
+        # contiguous cell's total is a zero of the span's own dtype.
+        gap_total = gaps["gap_size"].sum() if len(gaps) else span - span
+        rows.append(
+            {
+                min_name: low,
+                max_name: high,
+                # D7: one step everywhere in a cell, as chunk advertises.
+                step_name: get_middle_value(sub[step_name].to_numpy()),
+                "span": span,
+                "gap_total": gap_total,
+                "group_id": group_id,
+            }
+            | {x: _stated(sub, x).iloc[0] for x in carried}
+        )
+    if not rows:
+        span = df[max_name] - df[min_name]
+        return _empty_report(
+            {
+                min_name: df[min_name],
+                max_name: df[max_name],
+                step_name: df[step_name],
+                "span": span,
+                "gap_total": span,
+                "covered": span,
+                "coverage": pd.Series(dtype=float),
+                "group_id": pd.Series(dtype=np.int64),
+            }
+            | {x: df[x] for x in carried},
+        )[columns]
+    out = pd.DataFrame(rows)
+    out["covered"] = out["span"] - out["gap_total"]
+    # A zero span is a single sample, which is wholly covered; dividing
+    # would make it NaN and read as "unknown" rather than "all there".
+    covered = np.asarray(to_float(out["covered"]), dtype=float)
+    total = np.asarray(to_float(out["span"]), dtype=float)
+    out["coverage"] = np.divide(
+        covered, total, out=np.ones_like(total), where=total != 0
+    )
+    return out[columns].reset_index(drop=True)
+
+
 def build_chunk_plan(
     df: pd.DataFrame,
     *,
@@ -968,10 +1314,7 @@ def build_chunk_plan(
         if value <= zero:
             msg = "Chunk value must be greater than 0."
             raise ParameterError(msg)
-    if missing_dim not in ("raise", "drop"):
-        msg = f"missing_dim must be 'raise' or 'drop', got {missing_dim!r}"
-        raise ParameterError(msg)
-
+    _validate_missing_dim(missing_dim)
     min_name, max_name = f"{name}_min", f"{name}_max"
     if min_name not in df.columns and not df.empty:
         msg = f"No patch in the spool has a {name!r} dimension to chunk."
@@ -992,37 +1335,7 @@ def build_chunk_plan(
     if df.empty:
         outputs = pd.DataFrame(columns=[min_name, max_name, "output_id"])
         return ChunkPlan(outputs, empty_members, name, value, params)
-    df = _ensure_patch_id(df)
-    df = _normalize_chunk_units(df, name)
-    # Missing chunk-dim envelopes, and patches carrying the name only as
-    # a non-dimensional coordinate (spec 7 / D2): chunking is defined on
-    # dimensions, so both fall under missing_dim. Envelope presence is
-    # not enough — auxiliary coordinates index their envelopes too, but
-    # their patches cannot be trimmed or merged *along* the name.
-    null_rows = pd.isnull(df[min_name]) | pd.isnull(df[max_name])
-    if "dims" in df.columns:
-        dim_lists = df["dims"].fillna("").astype(str).str.split(",")
-        not_a_dim = ~dim_lists.map(lambda dims: name in dims)
-    else:
-        not_a_dim = pd.Series(False, index=df.index)
-    unusable = null_rows | not_a_dim
-    if unusable.any():
-        if missing_dim == "raise":
-            bad = df.loc[unusable, "_patch_id"].tolist()
-            rides = int((not_a_dim & ~null_rows).sum())
-            detail = (
-                f" ({rides} of them carry {name!r} only as a non-dimensional "
-                "coordinate; chunking is defined on dimensions)"
-                if rides
-                else ""
-            )
-            msg = (
-                f"{int(unusable.sum())} patch(es) lack the chunk dimension "
-                f"{name!r}{detail} (patch ids {bad[:5]}...). Pass "
-                "missing_dim='drop' to exclude them."
-            )
-            raise ChunkError(msg)
-        df = df[~unusable]
+    df = _prepare_relation(df, name, missing_dim)
     if df.empty:
         outputs = pd.DataFrame(columns=[min_name, max_name, "output_id"])
         return ChunkPlan(outputs, empty_members, name, value, params)

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -291,7 +291,7 @@ def _sampling_group(step: pd.Series, tolerance: float) -> pd.Series:
 
 def _gap_boundaries(start, stop, step, tolerance):
     """
-    Locate the discontinuities in one partition cell (spec 2.4).
+    Locate the discontinuities in one cell (spec 2.4).
 
     Returns `(order, reach, has_gap)` over the start-ordered rows.
     `reach` is the furthest stop seen *before* each row, so an
@@ -317,7 +317,13 @@ def _gap_boundaries(start, stop, step, tolerance):
     # `reach + step * tolerance`: a float margin promotes that sum, and
     # an integer coordinate past 2**53 rounds both endpoints together,
     # hiding the gap. The distance itself is small enough to compare.
-    has_gap = (starts - reach) > steps * tolerance
+    # Only rows past the reach are measured — a row which starts at or
+    # before it cannot open a gap, and subtracting there would wrap an
+    # unsigned envelope into an enormous phantom one.
+    has_gap = np.zeros(len(starts), dtype=bool)
+    ahead = starts > reach
+    if ahead.any():
+        has_gap[ahead] = (starts[ahead] - reach[ahead]) > steps[ahead] * tolerance
     has_gap[:1] = False
     return order, reach, has_gap
 
@@ -1037,8 +1043,10 @@ def _report_dim_columns(df: pd.DataFrame, name: str, carried) -> tuple[str, str,
     Return the envelope columns of `name`, checked for a usable report.
 
     `get_interval_columns` words its error for chunking, and a carried
-    attr sharing a computed column's name would overwrite the statistic
-    rather than fail, so both are policed here instead.
+    attr sharing an emitted column's name would overwrite it rather than
+    fail, so both are policed here instead. The envelope columns count
+    as emitted: grouping by one would leave the frame two columns of
+    that name, which no longer answers to `frame[name]` as a series.
     """
     columns = (f"{name}_min", f"{name}_max", f"{name}_step")
     if missing := set(columns) - set(df.columns):
@@ -1048,10 +1056,11 @@ def _report_dim_columns(df: pd.DataFrame, name: str, carried) -> tuple[str, str,
             f"relation. Valid dimensions or columns are {dims}."
         )
         raise ParameterError(msg)
-    if collide := sorted(set(carried) & set(_REPORT_COLUMNS)):
+    emitted = set(_REPORT_COLUMNS) | set(columns)
+    if collide := sorted(set(carried) & emitted):
         msg = (
             f"Cannot group a report by {collide}: the name(s) collide with "
-            "the columns the report computes."
+            "the columns the report emits."
         )
         raise ParameterError(msg)
     return columns
@@ -1106,12 +1115,13 @@ def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance: float):
     """
     Yield `(cell rows, gaps in that cell)` for every cell in `df`.
 
-    Cells come in the order partitions do (spec 8) — by envelope min,
-    then smallest patch id — so a report never depends on the order the
-    relation happened to arrive in. Each cell's ordinal rides on its
-    gaps as `group_id`, which is the only thing that always tells two
-    cells apart: sampling group and structural def keys partition
-    without being shown.
+    Cells come in envelope-min order, as partitions do (spec 8), and
+    ties break on what the cell states rather than on a patch id, which
+    is positional — so a report never depends on the order the relation
+    happened to arrive in. Each cell's ordinal rides on its gaps as
+    `group_id`, which is the only thing that always tells two cells
+    apart: sampling group and structural def keys partition without
+    being shown.
     """
     min_name, max_name, step_name = _dim_columns(df, name)
     carried = _gap_carried_columns(df, name, group_attrs)
@@ -1119,11 +1129,16 @@ def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance: float):
         df, name, group_attrs, dc.get_config().sampling_group_tolerance
     )
     grouped = df.groupby(cells, sort=False)
-    order = grouped.agg(_min=(min_name, "min"), _pid=("_patch_id", "min")).sort_values(
-        ["_min", "_pid"], kind="stable"
-    )
     groups = grouped.groups
-    for group_id, label in enumerate(order.index):
+    mins = grouped[min_name].min()
+    stated = {
+        label: tuple(_stated(df.loc[index], x).iloc[0] for x in carried)
+        for label, index in groups.items()
+    }
+    order = sorted(
+        groups, key=lambda label: (mins[label], [str(x) for x in stated[label]])
+    )
+    for group_id, label in enumerate(order):
         sub = df.loc[groups[label]]
         start, stop, step = get_interval_columns(sub, name)
         row_order, reach, has_gap = _gap_boundaries(start, stop, step, tolerance)

--- a/docs/notes/spool_chunking.qmd
+++ b/docs/notes/spool_chunking.qmd
@@ -36,6 +36,8 @@ Patches may only combine when they agree on all of:
 3. **Sampling** — step magnitudes within the relative tolerance `config.sampling_group_tolerance` (default 5%) of the group's smallest member, with matching orientation (ascending never merges with descending; contiguous descending patches merge with each other).
 4. **Continuity** — patches within `tolerance` samples of each other, evaluated within each group so unrelated patches can never bridge a gap.
 
+[`Spool.get_gaps`](`dascore.core.spool.Spool.get_gaps`) and [`Spool.get_coverage`](`dascore.core.spool.Spool.get_coverage`) read this same partition: a `get_coverage` row is one cell of criteria 1-3, and a `get_gaps` row is a boundary criterion 4 declines to close. So the counts tie — merging yields one patch per coverage row plus one per gap reported. The reports read the rows a spool presents rather than a plan's members, so merging a spool and then reporting on it finds nothing left to close.
+
 ```{python}
 import numpy as np
 
@@ -47,8 +49,12 @@ source = "XX2.R2D1..RAW"
 p3, p4 = p1.update_attrs(acquisition_key=source), p2.update_attrs(acquisition_key=source)
 
 # Two data sources, each with two contiguous patches: two outputs, no error.
-merged = dc.spool([p1, p2, p3, p4]).chunk(time=None)
+spool = dc.spool([p1, p2, p3, p4])
+merged = spool.chunk(time=None)
 assert len(merged) == 2
+
+# The reports partition the same way, so the counts tie.
+assert len(merged) == len(spool.get_gaps()) + len(spool.get_coverage())
 ```
 
 Remaining (non-group, non-dimensional) attributes must hold no *conflicting* values within a partition, policed by `conflict`: `"raise"` (default), `"drop"`, or `"keep_first"`. A missing value (null or `""`) is an attribute nobody recorded, so it conflicts with nothing and the output carries the known value; only two differing known values are a conflict. History and the ids are never policed — the output carries the first member's — but merging members whose histories differ (processed beside unprocessed data) warns.

--- a/docs/notes/spool_chunking.qmd
+++ b/docs/notes/spool_chunking.qmd
@@ -36,7 +36,7 @@ Patches may only combine when they agree on all of:
 3. **Sampling** — step magnitudes within the relative tolerance `config.sampling_group_tolerance` (default 5%) of the group's smallest member, with matching orientation (ascending never merges with descending; contiguous descending patches merge with each other).
 4. **Continuity** — patches within `tolerance` samples of each other, evaluated within each group so unrelated patches can never bridge a gap.
 
-[`Spool.get_gaps`](`dascore.core.spool.Spool.get_gaps`) and [`Spool.get_coverage`](`dascore.core.spool.Spool.get_coverage`) read this same partition: a `get_coverage` row is one cell of criteria 1-3, and a `get_gaps` row is a boundary criterion 4 declines to close. So the counts tie — merging yields one patch per coverage row plus one per gap reported. The reports read the rows a spool presents rather than a plan's members, so merging a spool and then reporting on it finds nothing left to close.
+[`Spool.get_gaps`](`dascore.core.spool.Spool.get_gaps`) and [`Spool.get_coverage`](`dascore.core.spool.Spool.get_coverage`) read this same partition: a `get_coverage` row is one cell of criteria 1-3, and a `get_gaps` row is a boundary criterion 4 declines to close. So on a spool of unplanned patches the counts tie — merging yields one patch per coverage row plus one per gap reported. The reports read the rows a spool presents rather than a plan's members, so a spool that has already been chunked reports on the patches it now holds, and re-chunking it need not reproduce those counts.
 
 ```{python}
 import numpy as np

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -311,6 +311,34 @@ size_chunked = spool.chunk(time=1 * megabytes)
 
 A data size measures the data array only; coordinates, attrs, and any copies made later during processing are extra, so the patch as a whole is somewhat larger. The sample count is rounded down, so the patch's data never exceeds the requested size, and `MB` is 10^6^ bytes while `MiB` is 2^20^. `overlap` accepts the same forms.
 
+# get_gaps
+
+Merging tells you what a spool *has*; [`get_gaps`](`dascore.core.spool.Spool.get_gaps`) tells you what it is missing. It applies the same rules `chunk` merges by, so every row it returns is a boundary `chunk` refuses to close.
+
+```{python}
+import numpy as np
+from dascore.examples import random_spool
+
+# Three patches separated by one second holes.
+gappy = random_spool(time_gap=np.timedelta64(1, "s"), length=3)
+
+gappy.get_gaps()
+```
+
+`time_min` is the last sample before the gap and `time_max` the first sample after it, so `gap_size` is one step wider than the extent actually missing; subtract the `time_step` column for the extent itself. Overlapping patches are never a gap, and neither is a hole smaller than `tolerance` samples — the same `tolerance` `chunk` takes, so widening it here predicts exactly which merges will succeed.
+
+Pass another dimension to ask about it instead; `time` is only the default.
+
+# get_coverage
+
+[`get_coverage`](`dascore.core.spool.Spool.get_coverage`) summarizes the same partitions, one row each, which is the quicker way to see whether an archive is worth loading at all.
+
+```{python}
+gappy.get_coverage()
+```
+
+`gap_total` is the sum of that partition's `get_gaps` rows, `span` is the extent it covers end to end, and `coverage` is the fraction of that span holding data. Patches divide into partitions the way `chunk` divides them — on the group attributes, but also on sampling rate and coordinate structure — so a single tag can span several rows. `group_id` names the partition in both frames, which is how a gap is traced back to the row that counts it.
+
 # concatenate
 Similar to `chunk`, [`Spool.concatenate`](`dascore.Spool.concatenate`) is used to combine patches together. However, `concatenate` doesn't account for coordinate values along the concatenation axis, and can even be used to create new patch dimensions. Like `chunk`, it produces a lazy, plan-backed result.
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -325,19 +325,19 @@ gappy = random_spool(time_gap=np.timedelta64(1, "s"), length=3)
 gappy.get_gaps()
 ```
 
-`time_min` is the last sample before the gap and `time_max` the first sample after it, so `gap_size` is one step wider than the extent actually missing; subtract the `time_step` column for the extent itself. Overlapping patches are never a gap, and neither is a hole smaller than `tolerance` samples — the same `tolerance` `chunk` takes, so widening it here predicts exactly which merges will succeed.
+`time_min` is the last sample before the gap and `time_max` the first sample after it, so `gap_size` is one step wider than the extent actually missing; subtract the magnitude of the `time_step` column for the extent itself. Overlapping patches are never a gap, and neither is a hole the `tolerance` covers — a boundary is a gap once it exceeds `tolerance` samples, so at the default 1.5 a single missing sample already counts. It is the same `tolerance` `chunk` takes, so widening it here predicts exactly which merges will succeed.
 
 Pass another dimension to ask about it instead; `time` is only the default.
 
 # get_coverage
 
-[`get_coverage`](`dascore.core.spool.Spool.get_coverage`) summarizes the same partitions, one row each, which is the quicker way to see whether an archive is worth loading at all.
+[`get_coverage`](`dascore.core.spool.Spool.get_coverage`) summarizes the same groups, one row each, which is the quicker way to see whether an archive is worth loading at all.
 
 ```{python}
 gappy.get_coverage()
 ```
 
-`gap_total` is the sum of that partition's `get_gaps` rows, `span` is the extent it covers end to end, and `coverage` is the fraction of that span holding data. Patches divide into partitions the way `chunk` divides them — on the group attributes, but also on sampling rate and coordinate structure — so a single tag can span several rows. `group_id` names the partition in both frames, which is how a gap is traced back to the row that counts it.
+`gap_total` is the sum of that group's `get_gaps` rows, `span` is the extent it covers end to end, and `coverage` is the fraction of that span the patches cover. It is measured between patches, from the index's envelopes, so a hole *inside* a patch does not show up. Patches divide into groups the way `chunk` divides them — on the kind attributes, but also on sampling rate and coordinate structure — so a single tag can span several rows. `group_id` names the group in both frames, which is how a gap is traced back to the row that counts it.
 
 # concatenate
 Similar to `chunk`, [`Spool.concatenate`](`dascore.Spool.concatenate`) is used to combine patches together. However, `concatenate` doesn't account for coordinate values along the concatenation axis, and can even be used to create new patch dimensions. Like `chunk`, it produces a lazy, plan-backed result.

--- a/tests/test_core/test_spool_gaps.py
+++ b/tests/test_core/test_spool_gaps.py
@@ -129,11 +129,40 @@ class TestGetGaps:
         """A report describes the patches the spool holds, not their sources."""
         merged = gappy_spool.concatenate(time=None)
         assert len(merged) == 1
-        # concatenate closed the holes, so there is nothing left to report
+        # concatenate ignores the coordinate values, so the holes are
+        # inside the one patch it made and no boundary is left to report
         assert merged.get_gaps().empty
         assert merged.get_coverage()["coverage"].iloc[0] == 1
         # and the report agrees with rebuilding the spool from its patches
         assert merged.get_gaps().equals(dc.spool(list(merged)).get_gaps())
+
+    def test_chunk_keeps_the_gaps_it_cannot_close(self, gappy_spool):
+        """Merging does not close a real hole, so the report still sees it."""
+        chunked = gappy_spool.chunk(time=...)
+        assert len(chunked) == len(gappy_spool)
+        assert len(chunked.get_gaps()) == len(gappy_spool.get_gaps())
+
+    def test_samples_selection_is_measured(self, gappy_spool):
+        """A samples window trims the envelopes the report reads."""
+        trimmed = gappy_spool.select(time=(0, 200), samples=True)
+        out = trimmed.get_gaps()
+        assert len(out) == len(gappy_spool.get_gaps())
+        # the trim shortened each patch, so the holes are wider than the
+        # untrimmed spool's
+        assert (out["gap_size"] > gappy_spool.get_gaps()["gap_size"]).all()
+
+    def test_group_id_ignores_construction_order(self):
+        """A group keeps its id however the spool was assembled."""
+        early, late = random_spool(tag="a"), random_spool(tag="b")
+        expected = {"a": 0, "b": 1}
+        for patches in ([*early, *late], [*late, *early]):
+            out = dc.spool(patches).get_coverage()
+            assert dict(zip(out["tag"], out["group_id"])) == expected
+
+    def test_group_colliding_with_emitted_column(self, gappy_spool):
+        """Grouping by a column the report emits is refused."""
+        with pytest.raises(ParameterError, match="collide"):
+            gappy_spool.get_gaps(group="time_step")
 
     def test_units_are_presented(self, gappy_spool):
         """The report says what unit its magnitudes are in."""

--- a/tests/test_core/test_spool_gaps.py
+++ b/tests/test_core/test_spool_gaps.py
@@ -1,0 +1,214 @@
+"""
+Tests for reporting where a spool's data is missing.
+
+Gaps are found with the rules chunk merges by, so the two must agree:
+every gap is a boundary chunk refuses to close, and nothing else is.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import dascore as dc
+from dascore.examples import random_spool
+from dascore.exceptions import ChunkError, ParameterError
+
+ONE_SECOND = np.timedelta64(1, "s")
+
+
+@pytest.fixture(scope="module")
+def gappy_spool():
+    """Four patches separated by one second holes."""
+    return random_spool(time_gap=ONE_SECOND, length=4)
+
+
+@pytest.fixture(scope="module")
+def overlapping_spool():
+    """Four patches which overlap by 10 ms."""
+    return random_spool(time_gap=-np.timedelta64(10, "ms"), length=4)
+
+
+@pytest.fixture(scope="module")
+def distance_tiled_spool():
+    """Two patches adjacent in distance, with a hole between them."""
+    patch = dc.get_example_patch()
+    step = patch.get_coord("distance").step
+    shifted = patch.update_coords(
+        distance_min=patch.get_coord("distance").max() + step * 20
+    )
+    return dc.spool([patch, shifted])
+
+
+class TestGetGaps:
+    """Spool.get_gaps."""
+
+    def test_contiguous_spool_has_none(self):
+        """A spool with no holes reports no gaps."""
+        out = random_spool().get_gaps()
+        assert out.empty
+        assert {"time_min", "time_max", "time_step", "gap_size"} <= set(out.columns)
+
+    def test_gap_per_hole(self, gappy_spool):
+        """Each hole is one row, sized from the samples bracketing it."""
+        out = gappy_spool.get_gaps()
+        assert len(out) == len(gappy_spool) - 1
+        # the bracketing convention makes gap_size one step wider than
+        # the extent actually missing
+        missing = out["gap_size"] - out["time_step"]
+        assert (missing == ONE_SECOND).all()
+
+    def test_bracketing_samples_are_real(self, gappy_spool):
+        """The reported bounds are samples the spool actually holds."""
+        contents = gappy_spool.get_contents()
+        out = gappy_spool.get_gaps()
+        assert set(out["time_min"]).issubset(set(contents["time_max"]))
+        assert set(out["time_max"]).issubset(set(contents["time_min"]))
+
+    def test_overlaps_are_not_gaps(self, overlapping_spool):
+        """Overlapping patches leave nothing missing."""
+        assert overlapping_spool.get_gaps().empty
+
+    def test_agrees_with_chunk(self, gappy_spool, overlapping_spool):
+        """Merging leaves one patch per group, plus one per gap it can't close."""
+        for spool in (gappy_spool, overlapping_spool):
+            merged = spool.chunk(time=...)
+            assert len(merged) == len(spool.get_gaps()) + len(spool.get_coverage())
+
+    def test_tolerance_closes_gap(self, gappy_spool):
+        """A tolerance wide enough to span the hole reports no gap."""
+        step = gappy_spool.get_contents()["time_step"].iloc[0]
+        samples = ONE_SECOND / step
+        assert gappy_spool.get_gaps(tolerance=samples + 2).empty
+
+    def test_groups_never_bridge(self):
+        """Two unrelated groups are not a gap in each other."""
+        early = random_spool(tag="early")
+        late = random_spool(time_min=np.datetime64("2030-01-01"), tag="late")
+        spool = dc.spool([*early, *late])
+        # collapsing the groups puts a decade-wide hole between them ...
+        assert len(spool.get_gaps(group=[])) == 1
+        # ... which the tags keep apart
+        assert spool.get_gaps().empty
+        assert len(spool.get_coverage()) == 2
+
+    def test_other_dimension(self, distance_tiled_spool):
+        """The dimension really is a parameter, not just time."""
+        assert distance_tiled_spool.get_gaps().empty
+        out = distance_tiled_spool.get_gaps("distance")
+        assert len(out) == 1
+        assert out["distance_max"].iloc[0] > out["distance_min"].iloc[0]
+
+    def test_respects_select(self, gappy_spool):
+        """Gaps are reported for the spool as currently selected."""
+        contents = gappy_spool.get_contents()
+        trimmed = gappy_spool.select(
+            time=(None, contents["time_max"].iloc[1]),
+        )
+        assert len(trimmed.get_gaps()) == 1
+
+    def test_missing_dim_dropped(self, spool_with_non_coords):
+        """Patches without the dimension are excluded, the rest reported."""
+        contents = spool_with_non_coords.get_contents()
+        assert contents["time_min"].isna().any(), "fixture has no dimensionless patch"
+        out = spool_with_non_coords.get_coverage()
+        # the patches which do have time are still measured ...
+        assert len(out) == 1
+        assert out["time_max"].iloc[0] == contents["time_max"].max()
+        assert spool_with_non_coords.get_gaps().empty
+        # ... and the dropped ones can be made an error instead
+        with pytest.raises(ChunkError, match="lack the dimension"):
+            spool_with_non_coords.get_gaps(missing_dim="raise")
+
+    def test_bad_missing_dim_raises(self, gappy_spool):
+        """A typo in missing_dim raises rather than silently dropping."""
+        with pytest.raises(ParameterError, match="missing_dim"):
+            gappy_spool.get_gaps(missing_dim="rasie")
+
+    def test_plan_backed_spool(self, gappy_spool):
+        """A report describes the patches the spool holds, not their sources."""
+        merged = gappy_spool.concatenate(time=None)
+        assert len(merged) == 1
+        # concatenate closed the holes, so there is nothing left to report
+        assert merged.get_gaps().empty
+        assert merged.get_coverage()["coverage"].iloc[0] == 1
+        # and the report agrees with rebuilding the spool from its patches
+        assert merged.get_gaps().equals(dc.spool(list(merged)).get_gaps())
+
+    def test_units_are_presented(self, gappy_spool):
+        """The report says what unit its magnitudes are in."""
+        out = gappy_spool.get_gaps()
+        assert "time_units" in out.columns
+        assert "_time_units" not in out.columns
+
+    def test_unknown_dim_raises(self, gappy_spool):
+        """An unknown dimension names the ones which exist."""
+        with pytest.raises(ParameterError, match="Cannot report on"):
+            gappy_spool.get_gaps("not_a_dim")
+
+
+class TestGetCoverage:
+    """Spool.get_coverage."""
+
+    def test_contiguous_is_complete(self):
+        """A spool with no holes is fully covered."""
+        out = random_spool().get_coverage()
+        assert len(out) == 1
+        assert out["coverage"].iloc[0] == 1
+
+    def test_incomplete_with_gaps(self, gappy_spool):
+        """Holes lower the coverage below one."""
+        assert (gappy_spool.get_coverage()["coverage"] < 1).all()
+
+    def test_totals_match_gap_frame(self, gappy_spool):
+        """gap_total is the sum of the rows get_gaps reports."""
+        out = gappy_spool.get_coverage()
+        assert out["gap_total"].iloc[0] == gappy_spool.get_gaps()["gap_size"].sum()
+        assert out["covered"].iloc[0] == out["span"].iloc[0] - out["gap_total"].iloc[0]
+
+    def test_span_matches_contents(self, gappy_spool):
+        """The span reaches from the first sample to the last."""
+        contents = gappy_spool.get_contents()
+        out = gappy_spool.get_coverage()
+        assert out["time_min"].iloc[0] == contents["time_min"].min()
+        assert out["time_max"].iloc[0] == contents["time_max"].max()
+
+    def test_row_per_group(self, diverse_spool):
+        """Each group gets its own row, keyed by group_id."""
+        out = diverse_spool.get_coverage()
+        assert len(out) > 1
+        assert out["group_id"].is_unique
+        # every gap belongs to a group the coverage frame names
+        assert set(diverse_spool.get_gaps()["group_id"]) <= set(out["group_id"])
+
+    def test_group_id_joins_the_frames(self, diverse_spool):
+        """gap_total is the sum of that group's own gap rows."""
+        coverage = diverse_spool.get_coverage().set_index("group_id")
+        summed = diverse_spool.get_gaps().groupby("group_id")["gap_size"].sum()
+        for group_id, total in summed.items():
+            assert coverage.loc[group_id, "gap_total"] == total
+
+    def test_cells_are_distinguishable(self):
+        """Two cells alike in every shown attribute still get separate ids."""
+        patch = dc.get_example_patch()
+        moved = patch.update_coords(
+            distance_min=patch.get_coord("distance").max() + 1000
+        )
+        out = dc.spool([patch, moved]).get_coverage()
+        assert len(out) == 2
+        assert out["group_id"].is_unique
+
+    def test_empty_spool(self):
+        """An empty spool reports the schema a populated one would."""
+        empty = dc.spool([])
+        assert empty.get_gaps().empty
+        out = empty.get_coverage()
+        assert out.empty
+        expected = {"time_min", "time_max", "span", "gap_total", "covered", "coverage"}
+        assert expected <= set(out.columns)
+        # the measured columns keep their dtypes, so summing an empty
+        # report works. String attrs come from the catalog's own empty
+        # relation, which is where their dtype is decided.
+        populated = random_spool().get_coverage()
+        measured = ["time_min", "time_max", "span", "gap_total", "covered", "coverage"]
+        assert out[measured].dtypes.to_dict() == populated[measured].dtypes.to_dict()

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -835,8 +835,9 @@ class TestBuildGapFrame:
         # the two rows are 15 samples apart, so one group would report a gap
         assert len(build_gap_frame(df, "time", group=[])) == 1
         assert build_gap_frame(df, "time", group="station").empty
-        coverage = build_gap_frame(df, "time", group="station")
-        assert coverage.empty
+        # the hole became the boundary between two cells, not a gap
+        coverage = build_coverage_frame(df, "time", group="station")
+        assert len(coverage) == 2
 
     def test_negative_step(self, contiguous_df, gapy_df):
         """A descending coordinate is measured by its step's magnitude.

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -918,6 +918,54 @@ class TestBuildGapFrame:
         assert set(out["group_id"]) == {0, 1}
         assert build_coverage_frame(df, "time")["group_id"].is_unique
 
+    def test_unsigned_overlap_is_not_a_gap(self):
+        """An overlap on an unsigned envelope must not wrap into a gap."""
+        df = pd.DataFrame(
+            {
+                "x_min": np.array([100, 50], dtype=np.uint64),
+                "x_max": np.array([200, 150], dtype=np.uint64),
+                "x_step": np.array([1, 1], dtype=np.uint64),
+            }
+        )
+        assert build_gap_frame(df, "x").empty
+        # and the shared kernel keeps chunk merging them
+        assert len(build_chunk_plan(df, x=None).outputs) == 1
+
+    def test_group_id_ignores_row_order(self):
+        """Two cells sharing an envelope keep their ids when rows move."""
+        t0 = np.datetime64("2020-01-01", "ns")
+        step = np.timedelta64(1, "s")
+        df = pd.DataFrame(
+            {
+                "time_min": [t0, t0],
+                "time_max": [t0 + step * 9, t0 + step * 9],
+                "time_step": [step, step],
+                "station": ["a", "b"],
+            }
+        )
+        expected = {"a": 0, "b": 1}
+        for order in ([0, 1], [1, 0]):
+            out = build_coverage_frame(
+                df.iloc[order].reset_index(drop=True), "time", group="station"
+            )
+            assert dict(zip(out["station"], out["group_id"])) == expected
+
+    def test_coverage_states_one_step(self, gapy_df):
+        """The coverage row advertises the cell's step, as chunk does."""
+        out = build_coverage_frame(gapy_df, "time")
+        assert out["time_step"].iloc[0] == gapy_df["time_step"].iloc[0]
+
+    def test_mixed_cells_keep_attr_dtypes(self, gapy_df, contiguous_df):
+        """A contiguous cell beside a gappy one must not widen dtypes."""
+        gappy = gapy_df.assign(station="a")
+        # a second cell with no gaps at all
+        whole = contiguous_df.iloc[:1].assign(station="b")
+        df = pd.concat([gappy, whole], ignore_index=True)
+        df["station"] = df["station"].astype(str)
+        out = build_gap_frame(df, "time", group="station")
+        assert set(out["station"]) == {"a"}
+        assert out["station"].dtype == df["station"].dtype
+
     def test_repeated_group_name(self, contiguous_df_two_stations):
         """A name repeated in `group` is not a duplicate column."""
         out = build_gap_frame(contiguous_df_two_stations, "time", group=["station"] * 2)
@@ -933,6 +981,11 @@ class TestBuildGapFrame:
         df = contiguous_df.assign(span=1.0)
         with pytest.raises(ParameterError, match="collide"):
             build_coverage_frame(df, "time", group="span")
+
+    def test_group_colliding_with_dim_column(self, contiguous_df):
+        """Grouping by an envelope column would emit it twice."""
+        with pytest.raises(ParameterError, match="collide"):
+            build_gap_frame(contiguous_df, "time", group="time_step")
 
     def test_bad_missing_dim_raises(self, contiguous_df):
         """A typo in missing_dim raises rather than silently dropping."""

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -884,6 +884,30 @@ class TestBuildGapFrame:
         assert out["tag"].tolist() == ["sta1"]
         assert build_coverage_frame(df, "time")["tag"].tolist() == ["sta1"]
 
+    def test_integer_dimension_beyond_float_precision(self):
+        """A gap survives an integer coordinate too large for float64.
+
+        Past 2**53 a float margin makes `reach + step * tolerance` and
+        the next start round to the same value, so the gap disappears.
+        """
+        base = 10**18
+        df = pd.DataFrame(
+            {
+                "x_min": [base, base + 10],
+                "x_max": [base + 8, base + 18],
+                "x_step": [1, 1],
+            }
+        )
+        # the start clears the reach by 2 samples, over the 1.5 tolerance
+        out = build_gap_frame(df, "x")
+        assert len(out) == 1
+        assert out["gap_size"].iloc[0] == 2
+        # and chunk agrees the two rows cannot merge
+        assert len(build_chunk_plan(df, x=None).outputs) == 2
+        # one sample of separation is still under the tolerance
+        close = df.assign(x_min=[base, base + 9])
+        assert build_gap_frame(close, "x").empty
+
     def test_group_id_separates_cells(self, contiguous_df):
         """Cells invisible in the carried columns are still told apart."""
         # same envelopes, different sampling rate: one cell each

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -14,6 +14,8 @@ from dascore.utils.chunk import get_intervals
 from dascore.utils.chunk_plan import (
     _normalize_chunk_units,
     build_chunk_plan,
+    build_coverage_frame,
+    build_gap_frame,
     build_subdivision_plan,
     subdivision_pieces,
 )
@@ -43,6 +45,21 @@ def contiguous_sr_spaced_df(contiguous_df):
     out = contiguous_df.copy()
     out["time_max"] = out["time_max"] - sr
     return out
+
+
+@pytest.fixture()
+def gapy_df(contiguous_df):
+    """Create a dataframe with gaps of 15 samples."""
+    df = contiguous_df.copy()
+    df["time_max"] -= df["time_step"] * 15
+    return df
+
+
+@pytest.fixture()
+def gapy_df_unordered(gapy_df):
+    """Create a dataframe with gaps that is not sorted by starttime."""
+    inds = np.random.RandomState(42).permutation(gapy_df.index)
+    return gapy_df.loc[inds].reset_index(drop=True)
 
 
 @pytest.fixture()
@@ -244,19 +261,6 @@ class TestChunkPlanDF:
 
 class TestChunkPlanToMerge:
     """Merge-mode planning on raw dataframes."""
-
-    @pytest.fixture()
-    def gapy_df(self, contiguous_df):
-        """Create a dataframe with gaps."""
-        df = contiguous_df.copy()
-        df["time_max"] -= df["time_step"] * 15
-        return df
-
-    @pytest.fixture()
-    def gapy_df_unordered(self, gapy_df):
-        """Create a dataframe with gaps that is not sorted by starttime."""
-        inds = np.random.RandomState(42).permutation(gapy_df.index)
-        return gapy_df.loc[inds].reset_index(drop=True)
 
     def test_chunk_can_merge(self, contiguous_df):
         """Ensure chunk can be used to merge unspecified segment lengths."""
@@ -739,3 +743,219 @@ class TestSnappedCutExactness:
             # it opens starts at the next one.
             assert pieces[1][0] > on_grid
             assert pieces[1][0] >= cut
+
+
+class TestBuildGapFrame:
+    """Gap reporting on raw dataframes."""
+
+    @pytest.fixture()
+    def nested_then_later_df(self, contiguous_df):
+        """A wide row, a row nested inside it, then a later adjacent row."""
+        step = contiguous_df["time_step"].iloc[0]
+        wide_min = contiguous_df["time_min"].iloc[0]
+        wide_max = wide_min + step * 100
+        return pd.DataFrame(
+            {
+                "time_min": [wide_min, wide_min + step * 10, wide_max + step],
+                "time_max": [wide_max, wide_min + step * 20, wide_max + step * 10],
+                "time_step": [step] * 3,
+                "distance_min": 0,
+                "distance_max": 10,
+                "distance_step": 1,
+            }
+        )
+
+    def test_contiguous_has_no_gaps(self, contiguous_df):
+        """A contiguous relation reports nothing, but keeps its schema."""
+        out = build_gap_frame(contiguous_df, "time")
+        assert out.empty
+        gappy = contiguous_df.assign(
+            time_max=contiguous_df["time_max"] - contiguous_df["time_step"] * 15
+        )
+        populated = build_gap_frame(gappy, "time")
+        assert not populated.empty
+        # an empty report must be summable and groupable like a real one
+        assert out.dtypes.to_dict() == populated.dtypes.to_dict()
+
+    def test_gap_count_and_size(self, gapy_df):
+        """Each 15 sample hole is one row, bracketed by the samples around it."""
+        out = build_gap_frame(gapy_df, "time")
+        assert len(out) == len(gapy_df) - 1
+        expected = gapy_df["time_step"].iloc[0] * 15
+        assert (out["gap_size"] == expected).all()
+        # the bracketing samples are real values from the relation
+        assert set(out["time_min"]).issubset(set(gapy_df["time_max"]))
+        assert set(out["time_max"]).issubset(set(gapy_df["time_min"]))
+
+    def test_gaps_match_merge_partitions(self, gapy_df):
+        """Gaps are exactly the boundaries a merge refuses to close."""
+        merged = build_chunk_plan(gapy_df, time=None).outputs
+        assert len(merged) == len(build_gap_frame(gapy_df, "time")) + 1
+
+    def test_unordered_input(self, gapy_df, gapy_df_unordered):
+        """Row order in the relation does not change the report."""
+        out = build_gap_frame(gapy_df_unordered, "time")
+        assert out.equals(build_gap_frame(gapy_df, "time"))
+
+    def test_overlaps_report_no_gap(self, contiguous_df):
+        """Overlapping rows are contiguous, so nothing is missing."""
+        df = contiguous_df.copy()
+        df["time_max"] += df["time_step"] * 5
+        assert build_gap_frame(df, "time").empty
+
+    def test_nested_row_reports_no_gap(self, nested_then_later_df):
+        """A row swallowed by an earlier one cannot open a gap behind it.
+
+        The later row starts one step after the *wide* row ends, so a
+        boundary measured against the previous row's stop (rather than
+        the running max) would fabricate an 80 sample gap.
+        """
+        assert build_gap_frame(nested_then_later_df, "time").empty
+
+    def test_sub_tolerance_gap_ignored(self, contiguous_df):
+        """A hole under the tolerance is not a gap."""
+        df = contiguous_df.copy()
+        df["time_max"] -= df["time_step"]
+        assert build_gap_frame(df, "time").empty
+        # ... but tightening the tolerance finds it
+        assert len(build_gap_frame(df, "time", tolerance=0.5)) == len(df) - 1
+
+    def test_unknown_step_reports_no_gap(self, gapy_df):
+        """With no step the tolerance has no sample to scale, so no gaps."""
+        df = gapy_df.assign(time_step=np.timedelta64("NaT", "ns"))
+        assert build_gap_frame(df, "time").empty
+
+    def test_groups_never_bridge(self, gapy_df):
+        """A gap is never reported between two unrelated groups."""
+        first, second = gapy_df.iloc[:1], gapy_df.iloc[1:2]
+        df = pd.concat(
+            [first.assign(station="sta1"), second.assign(station="sta2")],
+            ignore_index=True,
+        )
+        # the two rows are 15 samples apart, so one group would report a gap
+        assert len(build_gap_frame(df, "time", group=[])) == 1
+        assert build_gap_frame(df, "time", group="station").empty
+        coverage = build_gap_frame(df, "time", group="station")
+        assert coverage.empty
+
+    def test_negative_step(self, contiguous_df, gapy_df):
+        """A descending coordinate is measured by its step's magnitude.
+
+        A signed margin would run backwards and turn every adjacent
+        boundary into a gap.
+        """
+        adjacent = contiguous_df.assign(time_step=-contiguous_df["time_step"])
+        assert build_gap_frame(adjacent, "time").empty
+        # real holes are still found ...
+        flipped = gapy_df.assign(time_step=-gapy_df["time_step"])
+        out = build_gap_frame(flipped, "time")
+        assert len(out) == len(build_gap_frame(gapy_df, "time"))
+        # ... and the reported step keeps the coordinate's own sign
+        assert (out["time_step"] == flipped["time_step"].iloc[0]).all()
+
+    def test_integer_dimension_keeps_precision(self):
+        """An integer envelope is not rounded through float on the way out."""
+        base = 10**18
+        df = pd.DataFrame(
+            {
+                "x_min": [base + 1, base + 1001],
+                "x_max": [base + 8, base + 1008],
+                "x_step": [1, 1],
+            }
+        )
+        out = build_gap_frame(df, "x")
+        assert out["x_min"].iloc[0] == base + 8
+        assert out["gap_size"].iloc[0] == 993
+        assert out["x_min"].dtype == df["x_min"].dtype
+
+    def test_cell_states_its_known_value(self, gapy_df):
+        """A cell reports the attr its members know, not the first row's.
+
+        Kind matching admits a row which never recorded an attr into the
+        cell of one that did, so the first row is not always the one
+        that knows.
+        """
+        df = gapy_df.iloc[:2].copy()
+        df["tag"] = ["", "sta1"]
+        # kind matching keeps them one cell, so the hole is a real gap
+        out = build_gap_frame(df, "time")
+        assert len(out) == 1
+        assert out["tag"].tolist() == ["sta1"]
+        assert build_coverage_frame(df, "time")["tag"].tolist() == ["sta1"]
+
+    def test_group_id_separates_cells(self, contiguous_df):
+        """Cells invisible in the carried columns are still told apart."""
+        # same envelopes, different sampling rate: one cell each
+        other = contiguous_df.assign(time_step=contiguous_df["time_step"] * 10)
+        df = pd.concat([contiguous_df, other], ignore_index=True)
+        df["time_max"] -= df["time_step"] * 15
+        out = build_gap_frame(df, "time")
+        assert set(out["group_id"]) == {0, 1}
+        assert build_coverage_frame(df, "time")["group_id"].is_unique
+
+    def test_repeated_group_name(self, contiguous_df_two_stations):
+        """A name repeated in `group` is not a duplicate column."""
+        out = build_gap_frame(contiguous_df_two_stations, "time", group=["station"] * 2)
+        assert list(out.columns) == list(out.columns.unique())
+
+    def test_bad_dim_raises(self, contiguous_df):
+        """An unknown dimension names the ones which are known."""
+        with pytest.raises(ParameterError, match="Cannot report on"):
+            build_gap_frame(contiguous_df, "not_a_dim")
+
+    def test_group_colliding_with_report_column(self, contiguous_df):
+        """A group attr cannot quietly overwrite a computed statistic."""
+        df = contiguous_df.assign(span=1.0)
+        with pytest.raises(ParameterError, match="collide"):
+            build_coverage_frame(df, "time", group="span")
+
+    def test_bad_missing_dim_raises(self, contiguous_df):
+        """A typo in missing_dim raises rather than silently dropping."""
+        with pytest.raises(ParameterError, match="missing_dim"):
+            build_gap_frame(contiguous_df, "time", missing_dim="rasie")
+
+
+class TestBuildCoverageFrame:
+    """Coverage summaries on raw dataframes."""
+
+    def test_contiguous_is_fully_covered(self, contiguous_df):
+        """No gaps means nothing is missing."""
+        out = build_coverage_frame(contiguous_df, "time")
+        assert len(out) == 1
+        assert out["coverage"].iloc[0] == 1
+        assert out["gap_total"].iloc[0] == to_timedelta64(0)
+        assert out["span"].iloc[0] == (
+            contiguous_df["time_max"].max() - contiguous_df["time_min"].min()
+        )
+
+    def test_totals_telescope(self, gapy_df):
+        """gap_total is exactly the gap frame's own sum, and covered the rest."""
+        gaps = build_gap_frame(gapy_df, "time")
+        out = build_coverage_frame(gapy_df, "time")
+        assert out["gap_total"].iloc[0] == gaps["gap_size"].sum()
+        assert out["covered"].iloc[0] == out["span"].iloc[0] - out["gap_total"].iloc[0]
+        # covered really is the extent the patches themselves occupy
+        occupied = (gapy_df["time_max"] - gapy_df["time_min"]).sum()
+        assert out["covered"].iloc[0] == occupied
+
+    def test_empty_keeps_schema(self, gapy_df):
+        """An empty relation reports the dtypes a populated one would."""
+        out = build_coverage_frame(gapy_df.iloc[:0], "time")
+        assert out.empty
+        assert (
+            out.dtypes.to_dict()
+            == build_coverage_frame(gapy_df, "time").dtypes.to_dict()
+        )
+
+    def test_single_sample_span(self, contiguous_df):
+        """A zero length span is one sample, and it is wholly covered."""
+        df = contiguous_df.iloc[:1].copy()
+        df["time_max"] = df["time_min"]
+        assert build_coverage_frame(df, "time")["coverage"].iloc[0] == 1
+
+    def test_row_per_cell(self, contiguous_df_two_stations):
+        """Each cell gets exactly one row, keyed by group_id."""
+        out = build_coverage_frame(contiguous_df_two_stations, "time", group="station")
+        assert len(out) == 2
+        assert sorted(out["group_id"]) == [0, 1]
+        assert set(out["station"]) == {"sta1", "sta2"}


### PR DESCRIPTION
## Description

Adds two read-only reporting methods to `Spool`, in the spirit of obsplus's [`WaveBank.get_gaps_df`](https://github.com/niosh-mining/obsplus/blob/f2772d0c930f365534eeaba08c5a43216ffb826a/src/obsplus/bank/wavebank.py#L428) / `get_uptime_df`, but generalized so the dimension is a parameter — a DAS spool can be discontinuous along any dimension, not just time.

```python
spool.get_gaps(dim="time", *, tolerance=1.5, group=None, missing_dim="drop")
spool.get_coverage(dim="time", *, tolerance=1.5, group=None, missing_dim="drop")
```

```
>>> random_spool(time_gap=np.timedelta64(1, "s"), length=3).get_gaps()
                 time_min             time_max  time_step        gap_size  group_id     tag
0 2020-01-03 00:00:07.996  2020-01-03 00:00:09   0:00:00.004  0:00:01.004         0  random
1 2020-01-03 00:00:16.996  2020-01-03 00:00:18   0:00:00.004  0:00:01.004         0  random
```

Today the only way to answer "where is my data missing?" is to chunk and count the patches that come back, or hand-diff `time_max` against the next `time_min`.

**The rules are chunk's rules.** Both methods read the same partition and the same continuity test `chunk` merges by, so a gap is exactly a boundary `chunk` refuses to close, and `tolerance` means what it means on `chunk`. That tie is asserted in `docs/notes/spool_chunking.qmd` and in the tests: merging yields one patch per coverage row plus one per gap.

**Conventions.** `{dim}_min` is the last sample before the gap and `{dim}_max` the first after, so `gap_size` is one step wider than the missing extent (subtract the returned `{dim}_step`). Overlapping and fully-nested patches never open a gap — each boundary is measured against the furthest point reached so far. The arithmetic telescopes exactly: `gap_total` is the sum of that partition's `get_gaps` rows, `covered = span - gap_total`, and the two frames join on `group_id`.

`missing_dim` defaults to `"drop"` here rather than `chunk`'s `"raise"`: a report on a mixed spool should not be an error. Both are documented.

### Shared kernel

Rather than a second definition of "gap", `_continuity_group`'s boundary test is extracted as `_gap_boundaries` and rewritten on numpy — an explicit first-row mask instead of a `shift` whose NaN fill upcast integer envelopes to float. That silently reported a gap of `1024.0` where the truth was `993`, and made empty and populated frames disagree on dtype. Fixing it also makes chunk's continuity kernel **~4.8x faster** than dev's baseline with byte-identical output (451.8 µs -> 93.8 µs per 20-row cell). `_cell_labels`, `_prepare_relation`, and `_validate_missing_dim` are extracted alongside it; `chunk`'s behavior and error messages are otherwise unchanged.

### Known limits

- The gaps-plus-coverage count identity holds for merge mode, not sized chunking or `keep_partial`; the docs limit the claim to merging.
- A partition whose step is unknown reports no gaps and so counts as fully covered — what `chunk` would do with it, documented on `get_coverage`.
- `_sampling_group` rejects pandas nullable `Int64` envelope columns. Pre-existing, affects `chunk` identically, and dascore catalogs do not produce such columns; not addressed here.

## Changelog

- added: `Spool.get_gaps` reports every discontinuity along a dimension.
- added: `Spool.get_coverage` summarizes how much of a spool's span along a dimension holds data.
- fixed: chunking a dimension with integer envelopes no longer rounds the continuity test through float.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Spool.get_gaps()` to identify discontinuities in partitioned data.
  * Added `Spool.get_coverage()` to summarize spans, gaps, and coverage ratios.
  * Reports support dimensions, tolerances, grouping, and missing-dimension handling.
  * Results preserve units and provide group-level details.

* **Documentation**
  * Added usage guidance and examples for gap and coverage reporting.

* **Tests**
  * Added coverage for contiguous, overlapping, grouped, tolerance-adjusted, empty, and invalid data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->