### PR TITLE
Cancel obsolete PR workflows on close

### DIFF
--- a/.github/workflows/cancel_pr_runs.yml
+++ b/.github/workflows/cancel_pr_runs.yml
@@ -1,0 +1,33 @@
+# Cancel every workflow run that belongs only to a pull request once the pull
+# request closes. This trigger deliberately has no path filter: a PR may start
+# a path-filtered workflow and later revert those files before it is merged.
+name: CancelPRRuns
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cancel:
+    name: Cancel ${{ matrix.workflow }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        workflow:
+          - CheckPRChangelog
+          - CodSpeed
+          - LintCode
+          - TestCode
+          - TestCodeMinDeps
+          - TestDocBuild
+          - TestFreeThreaded
+          - TestWasm
+    concurrency:
+      group: ${{ matrix.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Confirm cancellation
+        run: echo "Canceled obsolete ${{ matrix.workflow }} runs for PR #${{ github.event.pull_request.number }}."

--- a/.github/workflows/cancel_pr_runs.yml
+++ b/.github/workflows/cancel_pr_runs.yml
@@ -30,4 +30,4 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Confirm cancellation
-        run: echo "Canceled obsolete ${{ matrix.workflow }} runs for PR #${{ github.event.pull_request.number }}."
+        run: echo "Canceled obsolete ${{ matrix.workflow }} runs for pull request ${{ github.event.pull_request.number }}."

--- a/.github/workflows/check_pr_changelog.yml
+++ b/.github/workflows/check_pr_changelog.yml
@@ -12,12 +12,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: CheckPRChangelog-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check_pr_changelog:
     runs-on: ubuntu-latest
 
     # only run if CI isn't turned off
-    if: "!contains(github.event.pull_request.labels.*.name, 'no_ci')"
+    if: github.event.pull_request.state == 'open' && !contains(github.event.pull_request.labels.*.name, 'no_ci')
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: LintCode-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint_code:
     runs-on: ubuntu-latest

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -19,6 +19,10 @@ permissions:
   contents: read # required for actions/checkout
   id-token: write # required for OIDC authentication with CodSpeed
 
+concurrency:
+  group: CodSpeed-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # Where the test-data cache is restored; pooch reads files from here.
   # Must match the path used in .github/actions/prime-test-data-cache.
@@ -29,7 +33,8 @@ jobs:
     name: Run benchmarks
     if: >
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'benchmark')
+      (github.event.pull_request.state == 'open' &&
+      contains(github.event.pull_request.labels.*.name, 'benchmark'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: TestDocBuild-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   # Where the test-data cache is restored; pooch reads files from here.
   # Must match the path used in .github/actions/prime-test-data-cache.
@@ -22,8 +26,9 @@ env:
 jobs:
   test_build_docs:
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'documentation')
-      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'documentation'))
+      github.event.pull_request.state == 'open'
+      && ((github.event.action == 'labeled' && github.event.label.name == 'documentation')
+      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'documentation')))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Description

Cancel obsolete pull request workflows when a PR closes so they stop consuming the shared GitHub Actions concurrency pool. A dedicated unfiltered close workflow deliberately shares each PR workflow concurrency key, including path-filtered workflows, while activity-driven checks refuse to restart for closed PRs.

## Changelog

- fixed: Prevent obsolete pull request CI runs from consuming runner capacity after the pull request closes.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated workflow management by canceling outdated runs when pull requests close or receive new changes.
  * Prevented unnecessary checks for closed pull requests.
  * Restricted benchmark checks to open pull requests marked for benchmarking.
  * Reduced duplicate lint, profile, changelog, and documentation build runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->