### PR TITLE
Measure what the lineage ids cost, and fix the tool that measures

### DIFF
--- a/benchmarks/test_patch_benchmarks.py
+++ b/benchmarks/test_patch_benchmarks.py
@@ -9,6 +9,7 @@ import pytest
 import dascore as dc
 from dascore.config import config_context
 from dascore.utils.patch import get_start_stop_step
+from dascore.workflow.processor import _FINGERPRINTS
 
 
 @pytest.fixture(scope="module")
@@ -435,11 +436,15 @@ class TestIdentityOverhead:
     """
     What maintaining the lineage ids costs.
 
-    The cost is a flat charge per operation -- canonicalizing the call and
-    digesting it -- so it is invisible next to real signal processing and
-    plain next to an operation which barely touches the data. Both ends
-    are timed here, because it is the cheap end which decides whether the
+    The charge is per operation -- canonicalizing the call and digesting
+    it -- so it is invisible next to real signal processing and plain
+    next to an operation which barely touches the data. Both ends are
+    timed, because it is the cheap end which decides whether the
     `patch_provenance` knob is worth keeping.
+
+    Repeating one call is the cheap case: `fingerprint_call` memoizes, so
+    the second identical call pays the lookup and not the digest. Real
+    loops vary their arguments, so the uncached case is timed too.
     """
 
     @pytest.fixture(scope="class")
@@ -456,25 +461,65 @@ class TestIdentityOverhead:
         """A mask the fingerprint has to hash, being an array parameter."""
         return np.asarray(example_patch.data) > 0.5
 
+    @pytest.fixture()
+    def ids_disabled(self):
+        """
+        Turn the ids off around a benchmark, not inside it.
+
+        Entering the context builds and validates a whole config, which
+        is not what the control is supposed to be measuring.
+        """
+        with config_context(patch_provenance="disabled"):
+            yield
+
     @pytest.mark.benchmark
     def test_identity_overhead_tiny_patch(self, tiny_patch):
-        """The flat charge, with nothing else in the way."""
+        """The charge on a call which does nothing else, memoized."""
         tiny_patch.transpose()
 
     @pytest.mark.benchmark
-    def test_identity_overhead_tiny_patch_disabled(self, tiny_patch):
-        """The same call with the ids turned off, as the control."""
-        with config_context(patch_provenance="disabled"):
-            tiny_patch.transpose()
+    def test_identity_overhead_tiny_patch_disabled(self, tiny_patch, ids_disabled):
+        """The same call with the ids off, as the control."""
+        tiny_patch.transpose()
+
+    @pytest.mark.benchmark
+    def test_identity_overhead_uncached(self, tiny_patch):
+        """
+        The charge with the memo missed, which is what a real loop pays.
+
+        The cache is cleared rather than the arguments varied, so this
+        times the same call as the memoized benchmark above and the two
+        differ by the digest alone.
+        """
+        _FINGERPRINTS.clear()
+        tiny_patch.transpose()
+
+    @pytest.mark.benchmark
+    def test_identity_overhead_uncached_disabled(self, tiny_patch, ids_disabled):
+        """The control for the uncached charge, clearing included."""
+        _FINGERPRINTS.clear()
+        tiny_patch.transpose()
 
     @pytest.mark.benchmark
     def test_identity_overhead_array_argument(self, example_patch, big_mask):
-        """An array parameter is hashed, which is the one real cost."""
+        """An array parameter is hashed, which is the one unflat cost."""
+        example_patch.where(big_mask)
+
+    @pytest.mark.benchmark
+    def test_identity_overhead_array_argument_disabled(
+        self, example_patch, big_mask, ids_disabled
+    ):
+        """The control: the same call without hashing the mask."""
         example_patch.where(big_mask)
 
     @pytest.mark.benchmark
     def test_identity_overhead_real_work(self, example_patch):
         """Next to actual filtering the charge should not be findable."""
+        example_patch.pass_filter(time=(10, 100))
+
+    @pytest.mark.benchmark
+    def test_identity_overhead_real_work_disabled(self, example_patch, ids_disabled):
+        """The control for real work."""
         example_patch.pass_filter(time=(10, 100))
 
     @pytest.mark.benchmark

--- a/benchmarks/test_patch_benchmarks.py
+++ b/benchmarks/test_patch_benchmarks.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.config import config_context
 from dascore.utils.patch import get_start_stop_step
 
 
@@ -428,3 +429,55 @@ class TestAlignBenchmarks:
         """Benchmark 2D patch with 1D shift coordinate (300 shifts), valid mode."""
         patch = patch_2d_with_1d_shift
         patch.align_to_coord(time="shift_time", mode="valid")
+
+
+class TestIdentityOverhead:
+    """
+    What maintaining the lineage ids costs.
+
+    The cost is a flat charge per operation -- canonicalizing the call and
+    digesting it -- so it is invisible next to real signal processing and
+    plain next to an operation which barely touches the data. Both ends
+    are timed here, because it is the cheap end which decides whether the
+    `patch_provenance` knob is worth keeping.
+    """
+
+    @pytest.fixture(scope="class")
+    def tiny_patch(self):
+        """The smallest patch worth having: all overhead, no work."""
+        return dc.Patch(
+            data=np.ones((2, 2)),
+            coords={"distance": np.arange(2), "time": np.arange(2)},
+            dims=("distance", "time"),
+        )
+
+    @pytest.fixture(scope="class")
+    def big_mask(self, example_patch):
+        """A mask the fingerprint has to hash, being an array parameter."""
+        return np.asarray(example_patch.data) > 0.5
+
+    @pytest.mark.benchmark
+    def test_identity_overhead_tiny_patch(self, tiny_patch):
+        """The flat charge, with nothing else in the way."""
+        tiny_patch.transpose()
+
+    @pytest.mark.benchmark
+    def test_identity_overhead_tiny_patch_disabled(self, tiny_patch):
+        """The same call with the ids turned off, as the control."""
+        with config_context(patch_provenance="disabled"):
+            tiny_patch.transpose()
+
+    @pytest.mark.benchmark
+    def test_identity_overhead_array_argument(self, example_patch, big_mask):
+        """An array parameter is hashed, which is the one real cost."""
+        example_patch.where(big_mask)
+
+    @pytest.mark.benchmark
+    def test_identity_overhead_real_work(self, example_patch):
+        """Next to actual filtering the charge should not be findable."""
+        example_patch.pass_filter(time=(10, 100))
+
+    @pytest.mark.benchmark
+    def test_processor_fingerprint(self, example_patch):
+        """Building an operation and asking it what it is."""
+        dc.proc.normalize.op(dim="time").fingerprint

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -321,7 +321,7 @@ An operation which hands the patch straight back did nothing, and records nothin
 
 ### What builds a patch, and what operates on one
 
-`new`, `update` and `update_attrs` carry both ids through untouched. They are not operations — they are how a patch function assembles its own result — so stamping there would count every operation twice.
+`new`, `update` and `update_attrs` carry both ids through, unless you name one and set it yourself. They are not operations — they are how a patch function assembles its own result — so stamping there would count every operation twice.
 
 That has a consequence worth knowing: changing data through `new` yourself leaves the ids saying the data is unchanged and the route is the same one.
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -319,6 +319,29 @@ The path is part of the id, so a derived id is not stable across machines. A sto
 
 An operation which hands the patch straight back did nothing, and records nothing. Neither id is part of `Patch.equals`: two patches holding the same data are equal however they were made.
 
+### What builds a patch, and what operates on one
+
+`new`, `update` and `update_attrs` carry both ids through untouched. They are not operations — they are how a patch function assembles its own result — so stamping there would count every operation twice.
+
+That has a consequence worth knowing: changing data through `new` yourself leaves the ids saying the data is unchanged and the route is the same one.
+
+```{python}
+doubled = patch.new(data=patch.data * 2)
+
+# It says it is the same data by the same route, because nothing told it otherwise.
+assert doubled.attrs.patch_id == patch.attrs.patch_id
+assert doubled.attrs.processing_id == patch.attrs.processing_id
+```
+
+The ids describe what DASCore was asked to do. Work done through [patch functions](processing.qmd) is described; work done by reaching past them is not. Building a patch from arrays rather than from another patch is the honest case, and mints a new `patch_id`:
+
+```{python}
+import numpy as np
+
+built = dc.Patch(data=np.asarray(patch.data), coords=patch.coords, dims=patch.dims)
+assert built.attrs.patch_id != patch.attrs.patch_id
+```
+
 Set `patch_provenance="disabled"` to stop maintaining them:
 
 ```{python}

--- a/scripts/differential_check.py
+++ b/scripts/differential_check.py
@@ -259,8 +259,14 @@ def digest(patch) -> dict:
         name: _hash(patch.get_array(name)) for name in sorted(patch.coords.coord_map)
     }
     # History holds the repr of the arguments, which says nothing about the
-    # answer, so it is left out.
-    attrs = patch.attrs.model_dump(exclude={"history", "coords"})
+    # answer, so it is left out. The lineage ids go with it, and for a
+    # sharper reason: this compares a patch against one built by other
+    # code, and `patch_id` is minted per patch for anything not read from
+    # a file while `processing_id` names the route rather than the result.
+    # Left in, every patch would differ and the check would say nothing.
+    attrs = patch.attrs.model_dump(
+        exclude={"history", "coords", "patch_id", "processing_id"}
+    )
     return {
         "dtype": str(data.dtype),
         "shape": list(data.shape),

--- a/scripts/differential_check.py
+++ b/scripts/differential_check.py
@@ -259,14 +259,13 @@ def digest(patch) -> dict:
         name: _hash(patch.get_array(name)) for name in sorted(patch.coords.coord_map)
     }
     # History holds the repr of the arguments, which says nothing about the
-    # answer, so it is left out. The lineage ids go with it, and for a
-    # sharper reason: this compares a patch against one built by other
-    # code, and `patch_id` is minted per patch for anything not read from
-    # a file while `processing_id` names the route rather than the result.
-    # Left in, every patch would differ and the check would say nothing.
-    attrs = patch.attrs.model_dump(
-        exclude={"history", "coords", "patch_id", "processing_id"}
-    )
+    # answer, so it is left out. `patch_id` goes with it for a harder
+    # reason: this dumps in two processes, and a patch not read from a
+    # file mints one, so every patch would differ and the check would say
+    # nothing. `processing_id` stays -- it is a digest of the route, the
+    # same in both processes, so it catches a call which stopped being
+    # stamped or started fingerprinting its arguments differently.
+    attrs = patch.attrs.model_dump(exclude={"history", "coords", "patch_id"})
     return {
         "dtype": str(data.dtype),
         "shape": list(data.shape),

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -272,6 +272,36 @@ class TestTheRulesOnRealPatches:
         first = dc.get_example_patch("random_das")
         assert first.attrs.patch_id != dc.get_example_patch("random_das").attrs.patch_id
 
+    @pytest.mark.parametrize(
+        "builder",
+        [
+            lambda p: p.new(data=p.data),
+            lambda p: p.new(data=np.asarray(p.data) * 2),
+            lambda p: p.update(data=np.asarray(p.data) * 2),
+            lambda p: p.update_attrs(tag="rebuilt"),
+        ],
+    )
+    def test_building_a_patch_is_not_operating_on_one(self, patch, builder):
+        """
+        `new` and `update` carry both ids through untouched.
+
+        They are how a patch function assembles its own result, so
+        stamping here would count every operation twice. The cost is that
+        changing data through `new` yourself leaves the ids saying it did
+        not change -- documented in the patch tutorial, and pinned here
+        because it is a policy rather than an accident.
+        """
+        out = builder(patch)
+        assert out.attrs.patch_id == patch.attrs.patch_id
+        assert out.attrs.processing_id == patch.attrs.processing_id
+
+    def test_a_patch_built_from_arrays_is_new_data(self, patch):
+        """Naming no source, it is not the same data as anything else."""
+        built = dc.Patch(
+            data=np.asarray(patch.data), coords=patch.coords, dims=patch.dims
+        )
+        assert built.attrs.patch_id != patch.attrs.patch_id
+
     def test_an_operation_advances_what_was_done(self, patch):
         """Which is what the id is for."""
         out = patch.normalize("time")

--- a/tests/test_workflow/test_identity.py
+++ b/tests/test_workflow/test_identity.py
@@ -291,9 +291,13 @@ class TestTheRulesOnRealPatches:
         not change -- documented in the patch tutorial, and pinned here
         because it is a policy rather than an accident.
         """
-        out = builder(patch)
-        assert out.attrs.patch_id == patch.attrs.patch_id
-        assert out.attrs.processing_id == patch.attrs.processing_id
+        # Operated on first: an unprocessed patch states no route, so
+        # preserving it would be satisfied by dropping it.
+        processed = patch.abs()
+        assert processed.attrs.processing_id != NOTHING_DONE
+        out = builder(processed)
+        assert out.attrs.patch_id == processed.attrs.patch_id
+        assert out.attrs.processing_id == processed.attrs.processing_id
 
     def test_a_patch_built_from_arrays_is_new_data(self, patch):
         """Naming no source, it is not the same data as anything else."""


### PR DESCRIPTION
## Description

PR 5 of the processors plan: the harness, the benchmarks, and the knob decision the 4a timing table was supposed to make. No behaviour changes — this is the measuring step, plus one live bug in the measuring tool.

### The differential harness was blind to itself

`scripts/differential_check.py` proves a refactor changed no values by digesting every patch and comparing against a pre-change reference. Its digest excluded `history` and `coords` but not `patch_id`, which is minted per patch for anything not read from a file. Since the harness dumps in two processes, two identical patches digested differently:

```
identical example patches differ in: ['attrs']
  attr keys differing: ['patch_id']
```

Every patch would have reported a difference, which means the check would have said nothing at all — for exactly the PRs (0, 3, 4a, 5) the plan says to run it against. `patch_id` joins `history` in the exclusion.

`processing_id` deliberately does **not**. It is a digest of the route rather than a minted value, and it is identical in both processes (verified), so keeping it lets the harness catch a call which stopped being stamped or started canonicalizing its arguments differently — regressions the data hash alone would miss. `775 calls compared against origin/dev; all identical.`

### Benchmarks

`TestIdentityOverhead` in `benchmarks/test_patch_benchmarks.py`, on CodSpeed:

- `test_identity_overhead_tiny_patch` — the charge on a call which does nothing else.
- `test_identity_overhead_uncached` — the same call with the memo cleared, which is what a loop over varying arguments pays.
- `test_identity_overhead_array_argument` — `where` with a big mask, the one place the charge is not flat, because an array parameter is hashed.
- `test_identity_overhead_real_work` — `pass_filter`, where the charge should not be findable.
- `test_processor_fingerprint` — building an operation and asking what it is.

Each of the four overhead benchmarks has a `_disabled` twin. The control turns the ids off in a *fixture*, not inside the timed body: entering `config_context` builds and validates a whole config, which is not what a control should be measuring.

The plan also asked for `test_provenance_graph_overhead`. There is no graph — it was cut on 2026-08-20 — so that one simply does not exist.

### The knob decision

Measured on this branch, best-of-7, ids on vs `patch_provenance="disabled"`, with the config context outside the timed region:

| call | off | on | delta |
|---|---|---|---|
| `tiny.transpose()` (memo hit) | 34.8 µs | 88.3 µs | **+153%** |
| `tiny.transpose()` (memo missed) | 35.1 µs | 112.1 µs | **+219%** |
| `tiny.abs()` | 55.2 µs | 88.6 µs | **+61%** |
| `Patch(...)` construction | 15.4 µs | 27.1 µs | **+76%** |
| `patch.abs()` | 244 µs | 286 µs | +17% |
| `patch.where(big mask)` | 2250 µs | 2991 µs | **+33%** |
| `patch.normalize("time")` | 3237 µs | 3291 µs | +2% |
| `patch.pass_filter(time)` | 11.6 ms | 11.7 ms | +1% |
| `patch.select(time=…)` | 86 µs | 85 µs | — |
| `spool.chunk(time=None)` | 32.8 ms | 35.4 ms | +8% |

The charge is roughly 53 µs to canonicalize a call and look up its digest, and 77 µs when the digest actually has to be computed — `fingerprint_call` memoizes, so repeating one call is the cheap case and a loop over varying arguments is not. Either way it is invisible next to a pass filter (+1%) and more than doubles a transpose on a two-by-two patch. `where` is the exception to flatness: its array argument is hashed, so the charge scales with the mask and the memo cannot help.

**So `patch_provenance` stays.** The plan said to remove whichever knobs the table made unnecessary; the table says none of them are. `select` costing nothing is the no-op short-circuit from #943 handing the patch straight back.

### `Patch.new` / `update` policy

The plan asked for a paragraph, and writing it turned up a footgun worth stating plainly: `new`, `update` and `update_attrs` carry both ids through unless you name one and set it yourself — they are how a patch function assembles its own result, so stamping there would count every operation twice. The consequence is that changing data through `new` yourself leaves the ids claiming the data did not change:

```python
doubled = patch.new(data=patch.data * 2)
assert doubled.attrs.patch_id == patch.attrs.patch_id          # same data, it says
assert doubled.attrs.processing_id == patch.attrs.processing_id  # same route, it says
```

Documented in the patch tutorial under "What builds a patch, and what operates on one", and pinned by tests, because it is a policy rather than an accident. Building from arrays rather than from another patch is the honest case and mints a new `patch_id`.

## A note on the red checks

This branch is merged up to `dev`, and **`dev` is currently red for reasons unrelated to this PR**. Verified by running `origin/dev` on its own in a detached worktree — identical counts and names:

- `tests/test_viz/test_inventory_viz.py` — 61 errors
- `tests/test_viz/test_lanes.py::TestLayout::test_default_labels` and `TestColors::test_boolean_lane` — 2 failures
- the `dascore/viz/_lanes.py::plot_lanes` doctest

It looks like a crossed merge: #950 made label membership mean *no value* and now refuses `value=True`, while the lanes and inventory-viz work still constructs labels that way. Both were green on their own.

Excluding that one file, this branch is `12,247 passed`. Nothing here touches viz.

## Changelog

- fixed: `scripts/differential_check.py` no longer reports a difference for every patch; `patch_id` is excluded from its digest, as `history` already was.
- added: benchmarks for what maintaining the lineage ids costs, and for fingerprinting an operation.
- added: the patch tutorial says what `Patch.new` and `Patch.update` do to the lineage ids, and what that means if you change data through them.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
