### PR TITLE
Keep interrogator attrs to facts about the interrogator

### DIFF
--- a/dascore/io/dasvader/__init__.py
+++ b/dascore/io/dasvader/__init__.py
@@ -1,6 +1,11 @@
 """
 This module adds IO support for the files written by the Julia package DASVader:
 https://github.com/marianoarnaiz/DASvader.jl
+
+Interrogator identity
+---------------------
+The file's ``Hostname`` is reported as ``interrogator.name``. It was
+previously reported as ``host_name``, which no longer appears.
 """
 from __future__ import annotations
 

--- a/dascore/io/dasvader/utils.py
+++ b/dascore/io/dasvader/utils.py
@@ -9,7 +9,7 @@ from h5py.h5r import Reference, dereference
 import dascore as dc
 from dascore.core.coords import get_coord
 from dascore.exceptions import DASVaderCompatibilityError
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, drop_blank_attrs
 from dascore.utils.misc import maybe_get_items, unbyte
 
 # Julia DateTime "instant" values (Dates.value) are milliseconds since
@@ -20,7 +20,7 @@ _JULIA_EPOCH_MS = 62135683200000
 
 attrs_map = {
     "GaugeLength": "gauge_length",
-    "Hostname": "host_name",
+    "Hostname": "interrogator.name",
     "PipelineTracker": "pipeline_tracker",
     "PulseRateFreq": "pulse_rate_frequency",
     "SamplingRate": "sampling_rate",
@@ -122,6 +122,7 @@ def _get_attr_dict(atrib) -> dict:
     """Map DASVader attrib values to PatchAttrs fields."""
     attrs = _dataset_to_dict(atrib)
     attrs = maybe_get_items(attrs, attrs_map)
+    drop_blank_attrs(attrs, ("interrogator.name",))
     attrs["data_category"] = "DAS"
     attrs["data_units"] = "nanostrain"
     return attrs

--- a/dascore/io/febus/__init__.py
+++ b/dascore/io/febus/__init__.py
@@ -4,6 +4,15 @@ Support for Febus format.
 This is used by the Febus DAS interrogator.
 
 More info about febus can be found here: https://www.febus-optics.com/en/
+
+Interrogator identity
+---------------------
+A1 files report ``interrogator.name`` from the Source's ``Hostname`` (eg
+"fa1-24090193"). T1 files report it from ``device_name``, plus
+``interrogator.instrument_type`` from ``device``; their
+``interrogator.manufacturer`` and ``interrogator.model`` are asserted by the
+format, not read from the header. The G1 BSL and MTX HDF5 files carry no
+interrogator metadata, so they report none.
 """
 
 from __future__ import annotations

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -11,6 +11,7 @@ import numpy as np
 import dascore as dc
 from dascore.core import get_coord, get_coord_manager
 from dascore.core.coordmanager import CoordManager
+from dascore.io.utils import drop_blank_attrs
 from dascore.utils.io import _normalize_source_patch_keys
 from dascore.utils.misc import (
     _maybe_unpack,
@@ -218,6 +219,11 @@ def _get_febus_attrs(feb: _FebusSlice) -> dict:
     }
     out = maybe_get_items(zone_attrs, attr_mapping, unpack_names=set(attr_mapping))
     out["group"] = feb.group_name
+    # Hostname states the interrogator host; the top-level group is named
+    # for it but is a container key, which a rewrite can rename. Format
+    # detection already requires Hostname on every Source.
+    out.update(maybe_get_items(feb.source.attrs, {"Hostname": "interrogator.name"}))
+    drop_blank_attrs(out, ("interrogator.name",))
     out["source"] = feb.source_name
     out["zone"] = feb.zone_name
     out["schema_version"] = out.get("folog_a1_software_version", "").split(".")[0]

--- a/dascore/io/febus/t1utils.py
+++ b/dascore/io/febus/t1utils.py
@@ -8,8 +8,9 @@ import dascore as dc
 from dascore import get_coord_manager
 from dascore.constants import timeable_types
 from dascore.io.core import make_scan_payload
-from dascore.io.utils import get_exact_coord
+from dascore.io.utils import drop_blank_attrs, get_exact_coord
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import maybe_get_items
 
 _DATA = "Data"
 
@@ -52,7 +53,9 @@ def _get_coords(fi, snap=True) -> dc.CoordManager:
     )
 
 
-# The fixed attrs every Febus T1 file carries.
+# Attrs the format itself fixes. manufacturer and model are asserted by
+# format detection, not read from the header: a file this reader claims
+# is a Febus T1. The header states no maker or model of its own.
 _T1_ATTRS: dict[str, str] = {
     "data_type": "temperature",
     "data_units": "°C",
@@ -61,12 +64,25 @@ _T1_ATTRS: dict[str, str] = {
     "interrogator.model": "T1",
 }
 
+# Root attrs naming the unit: device_name is the host (eg "ft1-24090217"),
+# device the kind of instrument it ran as (eg "DTS").
+_T1_ROOT_ATTRS = {
+    "device_name": "interrogator.name",
+    "device": "interrogator.instrument_type",
+}
+
+
+def _get_t1_attrs(fi: H5Reader) -> dict[str, str]:
+    """Return the fixed T1 attrs plus the interrogator the file names."""
+    named = maybe_get_items(fi.attrs, _T1_ROOT_ATTRS)
+    return _T1_ATTRS | drop_blank_attrs(named, _T1_ROOT_ATTRS.values())
+
 
 def _scan_t1(fi: H5Reader, snap=True):
     """Get the coordinates and attributes for a T1 data patch"""
     coords = _get_coords(fi, snap=snap)
     return make_scan_payload(
-        attrs=_T1_ATTRS,
+        attrs=_get_t1_attrs(fi),
         coords=coords,
         dtype=str(_get_h5_attr(fi, "Temperature").dtype),
     )
@@ -90,5 +106,5 @@ def _get_t1_patch(
         time_slice, distance_slice
     ]  # (n_time, n_dist)
     # Construct the patch
-    attrs = dc.PatchAttrs.from_dict(_T1_ATTRS)
+    attrs = dc.PatchAttrs.from_dict(_get_t1_attrs(fi))
     return dc.Patch(data=temp, coords=coords, dims=coords.dims, attrs=attrs)

--- a/dascore/io/silixah5/__init__.py
+++ b/dascore/io/silixah5/__init__.py
@@ -2,6 +2,15 @@
 IO support for Silixa HDF5 files.
 
 Website: https://silixa.com/
+
+Interrogator identity
+---------------------
+``SystemInfomation.OS.HostName`` is reported as ``interrogator.name`` (eg
+"iDAS20110", "Carina-P52"). No ``interrogator.serial_number`` is set: the
+``Chassis`` and ``Devices<N>`` serials name parts inside the unit -- a PXI
+crate, the cards in its slots -- rather than the interrogator, and these
+files state no serial for the unit itself. Earlier versions reported
+``Devices1.SerialNum`` as ``interrogator.serial_number``.
 """
 
 from .core import SilixaH5V1, SilixaH5V2

--- a/dascore/io/silixah5/utils.py
+++ b/dascore/io/silixah5/utils.py
@@ -38,10 +38,20 @@ _ATTR_MAP = {
 # A file may carry the host name but leave it empty.
 _BLANKABLE_ATTRS = ("interrogator.name",)
 
+# Read for metadata but not required to claim the format: a file which omits
+# HostName is still a Silixa file. Kept out of the fingerprints below so that
+# changing what is extracted cannot change which files the reader accepts.
+_OPTIONAL_ATTRS = frozenset({"SystemInfomation.OS.HostName"})
+
+# The detection fingerprints. Devices1.SerialNum is named here rather than in
+# _ATTR_MAP: it is no longer read (it names a card, not the interrogator) but
+# is still required to claim a file, so detection is unchanged.
+_FINGERPRINT_EXTRAS = frozenset({"SystemInfomation.Devices1.SerialNum"})
+
 # The header states these units in the key; patch attrs use seconds.
 _PULSE_WIDTH_UNITS = "ns"
 
-_EXPECTED_ATTRS = set(_ATTR_MAP)
+_EXPECTED_ATTRS = (frozenset(_ATTR_MAP) - _OPTIONAL_ATTRS) | _FINGERPRINT_EXTRAS
 
 
 def _get_version_string(resource, version):
@@ -151,7 +161,9 @@ _CARINA_ATTR_MAP = {k: v for k, v in _ATTR_MAP.items() if k != "Tags"} | {
     "StartTime": "start_time_us",
     "Samplerate": "sample_rate",
 }
-_CARINA_EXPECTED_ATTRS = set(_CARINA_ATTR_MAP)
+_CARINA_EXPECTED_ATTRS = (
+    frozenset(_CARINA_ATTR_MAP) - _OPTIONAL_ATTRS
+) | _FINGERPRINT_EXTRAS
 
 
 def _get_carina_version_string(resource, version):

--- a/dascore/io/silixah5/utils.py
+++ b/dascore/io/silixah5/utils.py
@@ -6,7 +6,12 @@ import pandas as pd
 import dascore as dc
 from dascore.core import get_coord, get_coord_manager
 from dascore.exceptions import InvalidFiberFileError
-from dascore.io.utils import build_patches, convert_attr_units, get_attr_names
+from dascore.io.utils import (
+    build_patches,
+    convert_attr_units,
+    drop_blank_attrs,
+    get_attr_names,
+)
 from dascore.utils.misc import maybe_get_items
 
 _ATTR_MAP = {
@@ -24,8 +29,14 @@ _ATTR_MAP = {
     "StartPosition[m]": "start_position",
     "SpatialResolution[m]": "spatial_resolution",
     # oops, they spelled information "infomation"
-    "SystemInfomation.Devices1.SerialNum": "interrogator.serial_number",
+    # HostName names the unit ("iDAS20110", "Carina-P52"). The Chassis and
+    # Devices<N> entries name COTS parts inside it, so their serials are not
+    # the interrogator's; these files state no interrogator serial.
+    "SystemInfomation.OS.HostName": "interrogator.name",
 }
+
+# A file may carry the host name but leave it empty.
+_BLANKABLE_ATTRS = ("interrogator.name",)
 
 # The header states these units in the key; patch attrs use seconds.
 _PULSE_WIDTH_UNITS = "ns"
@@ -89,6 +100,7 @@ def _get_attr_dict(resource):
     """Get the attribute map."""
     ds = resource["Acoustic"]
     attrs_dict = maybe_get_items(ds.attrs, _ATTR_MAP)
+    drop_blank_attrs(attrs_dict, _BLANKABLE_ATTRS)
     convert_attr_units(attrs_dict, "pulse_width", "s", from_units=_PULSE_WIDTH_UNITS)
     coords = _get_coords(attrs_dict, ds.shape)
     return attrs_dict, coords
@@ -214,6 +226,7 @@ def _get_carina_attrs_and_coords(resource):
     attrs_dict = maybe_get_items(
         resource.attrs, _CARINA_ATTR_MAP, unpack_names=set(_CARINA_ATTR_MAP)
     )
+    drop_blank_attrs(attrs_dict, _BLANKABLE_ATTRS)
     convert_attr_units(attrs_dict, "pulse_width", "s", from_units=_PULSE_WIDTH_UNITS)
     n_time, n_columns = resource[_CARINA_DATA_NAME].shape
     time_coord = _get_carina_time_coord(attrs_dict, n_time)

--- a/dascore/io/tdms/__init__.py
+++ b/dascore/io/tdms/__init__.py
@@ -1,5 +1,12 @@
 """
 Module for reading and writing TDMS fiber data recorded by Silixa.
+
+Interrogator identity
+---------------------
+``SystemInfomation.OS.HostName`` is reported as ``interrogator.name`` (eg
+"iDAS005"). No ``interrogator.serial_number`` is set, for the reasons given
+in :mod:`dascore.io.silixah5`. Earlier versions reported
+``Devices0.SerialNum`` as ``interrogator.serial_number``.
 """
 from __future__ import annotations
 from .core import TDMSFormatterV4713

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coords import get_coord
-from dascore.io.utils import get_attr_names
+from dascore.io.utils import drop_blank_attrs, get_attr_names
 from dascore.utils.misc import get_buffer_size
 from dascore.utils.time import to_datetime64, to_timedelta64
 
@@ -209,7 +209,11 @@ def _get_all_attrs(tdms_file, lead_in_length=28):
     out["data_type"] = "strain_rate"
     out["data_units"] = ""
     out["dims"] = "time,distance"
-    out["interrogator.serial_number"] = out.get("SystemInfomation.Devices0.SerialNum")
+    # HostName names the unit ("iDAS005"). The Chassis and Devices<N>
+    # serials name COTS parts inside it, not the interrogator. Silixa's
+    # HDF5 reader keys off the same attr.
+    out["interrogator.name"] = out.get("SystemInfomation.OS.HostName")
+    drop_blank_attrs(out, ("interrogator.name",))
     # Rename some attributes to preferred names
     d_coord = _get_distance_coord(out)
     fileinfo["end_of_properties_offset"] = tdms_file.tell()

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 import numpy as np
@@ -81,6 +81,29 @@ def convert_attr_units(attrs: dict, name: str, to_units: str, from_units="") -> 
         )
         warnings.warn(msg, UserWarning, stacklevel=2)
         attrs.pop(name)
+    return attrs
+
+
+def drop_blank_attrs(attrs: dict, names: Iterable[str]) -> dict:
+    """
+    Drop the named attrs whose value is blank, in place.
+
+    A field the vendor left empty, or omitted, states nothing. Keeping it
+    turns "the file does not say" into a value downstream code can match
+    on, so the parse boundary drops it rather than passing the blank along.
+
+    Parameters
+    ----------
+    attrs
+        The parsed attrs, modified in place and returned.
+    names
+        The attrs to drop when blank. A name is blank when it is missing,
+        None, or a string of only whitespace.
+    """
+    for name in names:
+        value = attrs.get(name)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            attrs.pop(name, None)
     return attrs
 
 

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -49,7 +49,10 @@ MODERN_DASVADER = _ModernDASVaderValues()
 
 
 def _write_modern_dasvader_file(
-    path: Path, data_name: str = "data", include_attrib: bool = True
+    path: Path,
+    data_name: str = "data",
+    include_attrib: bool = True,
+    host_name: str | None = None,
 ) -> Path:
     """Write a readable DASVader file with named datasets and references."""
     tp_dtype = np.dtype([("hi", "<f8"), ("lo", "<f8")])
@@ -111,7 +114,7 @@ def _write_modern_dasvader_file(
             )
             host = fi.create_dataset(
                 "Hostname",
-                data=MODERN_DASVADER.host_name,
+                data=(MODERN_DASVADER.host_name if host_name is None else host_name),
                 dtype=h5py.string_dtype(encoding="utf-8"),
             )
             tracker = fi.create_dataset(
@@ -258,7 +261,8 @@ class TestDASVader:
         summary = scanned[0]
         assert summary.source_format == "DASVader"
         assert summary.attrs.gauge_length == MODERN_DASVADER.gauge_length
-        assert summary.attrs.host_name == MODERN_DASVADER.host_name
+        interrogator_name = dict(summary.attrs)["interrogator.name"]
+        assert interrogator_name == MODERN_DASVADER.host_name
         assert summary.attrs.pipeline_tracker == MODERN_DASVADER.pipeline_tracker
         assert summary.attrs.pulse_rate_frequency == MODERN_DASVADER.pulse_rate_freq
         time_summary = summary.get_coord_summary("time")
@@ -271,6 +275,13 @@ class TestDASVader:
         )[0]
         assert patch.dims == ("distance", "time")
         assert patch.attrs.gauge_length == MODERN_DASVADER.gauge_length
+        assert dict(patch.attrs)["interrogator.name"] == MODERN_DASVADER.host_name
+
+    def test_blank_host_name_dropped(self, tmp_path):
+        """An empty Hostname is not passed off as an interrogator name."""
+        path = _write_modern_dasvader_file(tmp_path / "blank.jld2", host_name="   ")
+        assert "interrogator.name" not in dict(dc.scan(path)[0].attrs)
+        assert "interrogator.name" not in dict(dc.read(path)[0].attrs)
 
     def test_modern_file_out_of_range_read_is_empty(self, dasvader_modern_path):
         """Out-of-range selections should return an empty spool."""

--- a/tests/test_io/test_febus/test_febusa1.py
+++ b/tests/test_io/test_febus/test_febusa1.py
@@ -2,6 +2,8 @@
 Febus specific tests.
 """
 
+import shutil
+
 import h5py
 import numpy as np
 import pytest
@@ -10,6 +12,7 @@ import dascore as dc
 from dascore.io.febus import Febus2
 from dascore.io.febus.a1utils import _flatten_febus_info
 from dascore.utils.downloader import fetch
+from dascore.utils.misc import unbyte
 from dascore.utils.time import to_float
 
 
@@ -90,3 +93,47 @@ class TestFebus:
         """A non-matching source_patch_key should filter out Febus patches."""
         out = dc.read(febus_path, source_patch_key="not-a-real-febus-patch")
         assert len(out) == 0
+
+
+class TestFebusA1Interrogator:
+    """A1 Source attrs name the interrogator which wrote the file."""
+
+    @pytest.fixture(scope="class", params=["febus_1.h5", "febus_2.h5"])
+    def a1_path(self, request):
+        """Paths to A1 files of both schema versions."""
+        return fetch(request.param)
+
+    def test_interrogator_name_is_hostname(self, a1_path):
+        """The name is the Hostname the Source states."""
+        with h5py.File(a1_path, "r") as f:
+            hostname = _flatten_febus_info(f)[0].source.attrs["Hostname"]
+        attrs = dict(dc.scan(a1_path)[0].attrs)
+        assert attrs["interrogator.name"] == unbyte(hostname)
+
+    def test_hostname_wins_over_group_name(self, a1_path, tmp_path):
+        """A renamed container group does not rename the interrogator."""
+        path = tmp_path / "renamed_group.h5"
+        shutil.copy2(a1_path, path)
+        with h5py.File(path, "r+") as f:
+            group_name = next(iter(f))
+            hostname = unbyte(f[f"{group_name}/Source1"].attrs["Hostname"])
+            f.move(group_name, "container-alias")
+        attrs = dict(dc.scan(path)[0].attrs)
+        assert attrs["group"] == "container-alias"
+        assert attrs["interrogator.name"] == hostname
+
+    def test_blank_hostname_dropped(self, a1_path, tmp_path):
+        """An empty Hostname is not passed off as a name."""
+        path = tmp_path / "blank_hostname.h5"
+        shutil.copy2(a1_path, path)
+        with h5py.File(path, "r+") as f:
+            group_name = next(iter(f))
+            for node in (f[group_name]["Source1"], f[group_name]["Source1"]["Zone1"]):
+                node.attrs["Hostname"] = b"  "
+        assert "interrogator.name" not in dict(dc.scan(path)[0].attrs)
+
+    def test_scan_and_read_agree(self, a1_path):
+        """A read states the same interrogator a scan does."""
+        scanned = dict(dc.scan(a1_path)[0].attrs)
+        read = dict(Febus2().read(a1_path)[0].attrs)
+        assert scanned["interrogator.name"] == read["interrogator.name"]

--- a/tests/test_io/test_febus/test_febust1.py
+++ b/tests/test_io/test_febus/test_febust1.py
@@ -2,13 +2,18 @@
 FEBUS T1 DTS specific tests.
 """
 
+import shutil
+
+import h5py
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
+import dascore as dc
 from dascore.core.coords import CoordMonotonicArray
 from dascore.io.febus import FebusT1V1
 from dascore.utils.downloader import fetch
+from dascore.utils.misc import unbyte
 
 
 class TestFebusT1:
@@ -60,3 +65,54 @@ class TestFebusT1:
         time = t1_single_reading_patch.get_coord("time")
         assert isinstance(time, CoordMonotonicArray)
         assert time.min() == time.max()
+
+
+class TestFebusT1Interrogator:
+    """T1 root attrs name the unit and the kind of instrument it ran as."""
+
+    parser = FebusT1V1()
+
+    @pytest.fixture(
+        scope="class", params=["febus_dts.h5", "febus_dts_single_reading.h5"]
+    )
+    def t1_file(self, request):
+        """Paths to both T1 test files."""
+        return fetch(request.param)
+
+    def test_interrogator_from_root_attrs(self, t1_file):
+        """Name and instrument_type come from the file, not a constant."""
+        with h5py.File(t1_file, "r") as f:
+            device_name = unbyte(f.attrs["device_name"])
+            device = unbyte(f.attrs["device"])
+        attrs = dict(dc.scan(t1_file)[0].attrs)
+        assert attrs["interrogator.name"] == device_name
+        assert attrs["interrogator.instrument_type"] == device
+
+    def test_format_constants_still_set(self, t1_file):
+        """
+        Manufacturer and model come from the format, not the header.
+
+        T1 files state no maker or model, so these are what claiming the
+        format asserts rather than facts read out of the file.
+        """
+        attrs = dict(dc.scan(t1_file)[0].attrs)
+        assert attrs["interrogator.manufacturer"] == "FEBUS"
+        assert attrs["interrogator.model"] == "T1"
+
+    def test_scan_and_read_agree(self, t1_file):
+        """A read states the same interrogator a scan does."""
+        scanned = dict(dc.scan(t1_file)[0].attrs)
+        read = dict(self.parser.read(t1_file)[0].attrs)
+        keys = [x for x in scanned if x.startswith("interrogator.")]
+        assert keys
+        assert all(scanned[x] == read[x] for x in keys)
+
+    def test_blank_root_attrs_dropped(self, t1_file, tmp_path):
+        """An empty device_name is not passed off as a name."""
+        path = tmp_path / "blank_device.h5"
+        shutil.copy2(t1_file, path)
+        with h5py.File(path, "r+") as f:
+            f.attrs["device_name"] = b"   "
+        attrs = dict(dc.scan(path)[0].attrs)
+        assert "interrogator.name" not in attrs
+        assert attrs["interrogator.model"] == "T1"

--- a/tests/test_io/test_silixah5/test_silixa_interrogator.py
+++ b/tests/test_io/test_silixah5/test_silixa_interrogator.py
@@ -65,6 +65,16 @@ class TestSilixaInterrogator:
         patch = dc.spool(silixa_path)[0]
         assert dict(patch.attrs)["interrogator.name"] == scanned["interrogator.name"]
 
+    def test_detection_survives_missing_host_name(self, silixa_path, tmp_path):
+        """A file which omits HostName is still claimed, just unnamed."""
+        path = tmp_path / "no_host.h5"
+        shutil.copy2(silixa_path, path)
+        with h5py.File(path, "r+") as f:
+            node = f["Acoustic"] if "Acoustic" in f else f
+            del node.attrs["SystemInfomation.OS.HostName"]
+        assert dc.get_format(path)[0] == "Silixa_H5"
+        assert "interrogator.name" not in dict(dc.scan(path)[0].attrs)
+
     def test_blank_host_name_dropped(self, silixa_path, tmp_path):
         """An empty HostName is not passed off as a name."""
         path = tmp_path / "blank_host.h5"

--- a/tests/test_io/test_silixah5/test_silixa_interrogator.py
+++ b/tests/test_io/test_silixah5/test_silixa_interrogator.py
@@ -1,0 +1,76 @@
+"""The interrogator a Silixa file names, and the components it does not."""
+
+import shutil
+
+import h5py
+import pytest
+
+import dascore as dc
+from dascore.utils.downloader import fetch
+
+# Serials the file states for parts inside the unit rather than for the
+# unit: an NI timing card, a GPIB card, an ADLINK PXI crate. None is the
+# interrogator's, so none may be read as one.
+_COMPONENT_SERIAL_ATTRS = (
+    "SystemInfomation.Chassis.SerialNum",
+    "SystemInfomation.Devices0.SerialNum",
+    "SystemInfomation.Devices1.SerialNum",
+    "SystemInfomation.ProcessingUnit.FPGA1.SerialNum",
+)
+
+
+@pytest.fixture(scope="module", params=["silixa_h5_1.hdf5", "silixa_h5_ingv_1.h5"])
+def silixa_path(request):
+    """Paths to the Acoustic and Carina variants."""
+    return fetch(request.param)
+
+
+def _host_name(path):
+    """Read the host name from wherever the variant keeps its attrs."""
+    with h5py.File(path, "r") as f:
+        attrs = f["Acoustic"].attrs if "Acoustic" in f else f.attrs
+        value = attrs["SystemInfomation.OS.HostName"]
+    return value.decode() if isinstance(value, bytes) else str(value)
+
+
+class TestSilixaInterrogator:
+    """Both Silixa variants name the interrogator by its host name."""
+
+    def test_name_is_host_name(self, silixa_path):
+        """HostName is the only field naming the unit itself."""
+        attrs = dict(dc.scan(silixa_path)[0].attrs)
+        assert attrs["interrogator.name"] == _host_name(silixa_path)
+
+    def test_no_component_serial_as_interrogator(self, silixa_path):
+        """No card or crate serial is passed off as the interrogator's."""
+        with h5py.File(silixa_path, "r") as f:
+            raw = f["Acoustic"].attrs if "Acoustic" in f else f.attrs
+            serials = {
+                v.decode() if isinstance(v, bytes) else str(v)
+                for k in _COMPONENT_SERIAL_ATTRS
+                if (v := raw.get(k)) is not None
+            }
+        attrs = dict(dc.scan(silixa_path)[0].attrs)
+        stated = {v for k, v in attrs.items() if k.startswith("interrogator.")}
+        assert not (stated & (serials - {""}))
+
+    def test_no_serial_claimed(self, silixa_path):
+        """These files state no interrogator serial, so the reader sets none."""
+        attrs = dict(dc.scan(silixa_path)[0].attrs)
+        assert "interrogator.serial_number" not in attrs
+
+    def test_scan_and_read_agree(self, silixa_path):
+        """A read states the same interrogator a scan does."""
+        scanned = dict(dc.scan(silixa_path)[0].attrs)
+        patch = dc.spool(silixa_path)[0]
+        assert dict(patch.attrs)["interrogator.name"] == scanned["interrogator.name"]
+
+    def test_blank_host_name_dropped(self, silixa_path, tmp_path):
+        """An empty HostName is not passed off as a name."""
+        path = tmp_path / "blank_host.h5"
+        shutil.copy2(silixa_path, path)
+        with h5py.File(path, "r+") as f:
+            is_acoustic = "Acoustic" in f
+            node = f["Acoustic"] if is_acoustic else f
+            node.attrs["SystemInfomation.OS.HostName"] = b""
+        assert "interrogator.name" not in dict(dc.scan(path)[0].attrs)

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -9,8 +9,11 @@ import struct
 import numpy as np
 import pytest
 
+import dascore as dc
+from dascore.io.silixah5.utils import _ATTR_MAP as _SILIXA_ATTR_MAP
 from dascore.io.tdms import utils as tdms_utils
 from dascore.io.tdms.utils import parse_time_stamp, type_not_supported
+from dascore.utils.downloader import fetch
 
 
 class _FakeTDMSFile(io.BytesIO):
@@ -115,3 +118,55 @@ class TestTDMSUtils:
         assert out_data.shape == (3, 2)
         assert channel_length == 6
         assert out_attrs == attrs
+
+
+class TestTDMSInterrogator:
+    """A TDMS file names the interrogator by its host name."""
+
+    @pytest.fixture(
+        scope="class",
+        params=["sample_tdms_file_v4713.tdms", "iDAS005_tdms_example.626.tdms"],
+    )
+    def tdms_path(self, request):
+        """Paths to each TDMS test file."""
+        return fetch(request.param)
+
+    @pytest.fixture(scope="class")
+    def tdms_attrs(self, tdms_path):
+        """Attrs read back from a TDMS file."""
+        return dict(dc.spool(tdms_path)[0].attrs)
+
+    @pytest.fixture(scope="class")
+    def raw_host_name(self, tdms_path):
+        """The HostName property as the TDMS header states it."""
+        with open(tdms_path, "rb") as fi:
+            header, _ = tdms_utils._get_all_attrs(fi)
+        return header["SystemInfomation.OS.HostName"]
+
+    def test_name_is_host_name(self, tdms_attrs, raw_host_name):
+        """The name is exactly the HostName property, eg "iDAS005"."""
+        assert raw_host_name
+        assert tdms_attrs["interrogator.name"] == raw_host_name
+
+    def test_no_component_serial_as_interrogator(self, tdms_attrs, tdms_path):
+        """No card or crate serial is passed off as the interrogator's."""
+        with open(tdms_path, "rb") as fi:
+            header, _ = tdms_utils._get_all_attrs(fi)
+        serials = {
+            v
+            for k, v in header.items()
+            if k.startswith("SystemInfomation.") and k.endswith(".SerialNum") and v
+        }
+        stated = {v for k, v in tdms_attrs.items() if k.startswith("interrogator.")}
+        assert serials
+        assert not (stated & serials)
+
+    def test_no_serial_claimed(self, tdms_attrs):
+        """The Devices and Chassis serials name parts, not the interrogator."""
+        assert "interrogator.serial_number" not in tdms_attrs
+
+    def test_agrees_with_silixa_h5(self, tdms_attrs, raw_host_name):
+        """Both Silixa readers key the interrogator off the same attr."""
+        key = "SystemInfomation.OS.HostName"
+        assert _SILIXA_ATTR_MAP[key] == "interrogator.name"
+        assert tdms_attrs["interrogator.name"] == raw_host_name


### PR DESCRIPTION
## Description

Readers fill the dotted `interrogator.*` slots from `dascore.constants.INVENTORY_ATTRS`, and those values now flow into an inventory that `spool.select` and `patch.enrich` resolve against. That raises the bar on what may go in one: a slot holding the wrong thing is worse than an empty slot, because downstream code will match on it.

This applies one rule across the readers that were getting it wrong — **an `interrogator.*` slot may only carry what the file states about the interrogator itself**, not about a component inside it, and not something inferred from a filename.

### Filling slots

Three readers had the interrogator named in the file and emitted nothing, or emitted it under a vendor spelling:

| Reader | Was | Now |
|---|---|---|
| `febus` (A1) | `group='fa1-24090193'` only | `interrogator.name` from `Source/@Hostname` |
| `FEBUS_T1` | manufacturer/model constants only | `+ interrogator.name` from `device_name`, `interrogator.instrument_type` from `device` |
| `DASVader` | `host_name='fa1-19004'` | `interrogator.name` (same Febus A1 identity, standard spelling) |

A1 reads `Source/@Hostname` rather than the top-level group name: the group is named for the host, but it is a container key a rewrite can rename, and format detection already requires `Hostname` on every Source.

### Retracting slots

`silixah5` and `tdms` were both putting a component's serial into `interrogator.serial_number`:

- `silixah5` used `SystemInfomation.Devices1.SerialNum`. That slot holds a GPIB card in `silixa_h5_1` (`031A2C6F`) and a 3985 in `silixa_h5_ingv_1` (`L334NC1006`) — the value was not stable in meaning between files.
- `tdms` used `Devices0.SerialNum`, consistently the NI 6682/6683 timing card.

`Devices<N>` are cards in PXI slots and `Chassis` is the ADLINK crate holding them; none is the interrogator. The field that names the unit is `SystemInfomation.OS.HostName` — `iDAS20110`, `iDAS14030`, `iDAS005`, `Carina-P52`. Both readers now key off it, and neither claims a serial, because these files state none.

### Also

`dascore.io.utils.drop_blank_attrs` drops a named attr the vendor left empty, so a blank header field is absent rather than present-and-blank.

### Deliberately out of scope

- **ProdML.** Nothing in the standard `Acquisition` namespace identifies the interrogator — `AcquisitionId`/`uuid` name the acquisition, `FacilityId` is `TBD`/`Empty` in all five test files, and `ServiceCompanyName`/`VendorCode` are the operator and a free-text software string. The serials live under `Acquisition/Custom`, which is the vendor extension point: Silixa nests `SystemInformation/…` there, OptaSense writes flat `Unit Serial Number` attrs. Reading it would make a standard's reader vendor-sniff. Worth noting GDR hits the same wall and solves it by layering DAS-RCN v1.10 over PRODML v2.2 purely to add an `Interrogator` group.
- **Febus G1 (`.bsl`/`.mtx`).** The DSS HDF5 files carry no device metadata at all — root attrs are acquisition parameters only — so the BSL and MTX readers stay empty rather than parsing the filename. The G1 CSV reader's existing filename-derived `interrogator.name` is left as-is; removing it is a separate call.
- `FEBUS_T1`'s `interrogator.manufacturer`/`model` stay hardcoded. The header states no maker or model; these are what claiming the format asserts. Now said so in a comment and the test docstring.
- `dashdf5`, `gdr`, and `sintela_protobuf` slot fixes; the `software_version`/`firmware_version` slots; any `PatchAttrs` or `INVENTORY_ATTRS` change.

### Net effect on test files

`silixa_h5_1` and `sample_tdms_file_v4713` lose a wrong serial; `silixa_h5_ingv_1` and `iDAS005` gain a correct interrogator name; the three A1 files, both T1 files, and the DASVader file gain a correct interrogator name.

### Review

Reviewed with the Codex CLI before opening (two rounds) and by the Codex GitHub connector after. Both connector findings are addressed in 185034f2: the Silixa detection fingerprint is decoupled from the extraction map so `HostName` is optional metadata rather than a detection requirement, and the renamed/removed attrs are recorded in the affected readers' module docstrings.

## Changelog

- added: The Febus A1 and Febus T1 readers now report `interrogator.name`, and Febus T1 also reports `interrogator.instrument_type`.
- changed **breaking**: The DASVader reader reports the interrogator host as `interrogator.name` rather than `host_name`.
- changed: The Silixa HDF5 and TDMS readers report `interrogator.name` from the unit's host name, and no longer report a PXI card's serial as `interrogator.serial_number`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
