### PR TITLE
Supersede push runs by branch, not run id

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,9 @@ on:
 permissions:
   contents: read
 
+# Supersede the previous run: by pull request, or by branch for pushes.
 concurrency:
-  group: LintCode-${{ github.event.pull_request.number || github.run_id }}
+  group: LintCode-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -19,8 +19,9 @@ permissions:
   contents: read # required for actions/checkout
   id-token: write # required for OIDC authentication with CodSpeed
 
+# Supersede the previous run: by pull request, or by branch for pushes.
 concurrency:
-  group: CodSpeed-${{ github.event.pull_request.number || github.run_id }}
+  group: CodSpeed-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -29,9 +29,9 @@ env:
   # Must match the path used in .github/actions/prime-test-data-cache.
   DFS_DATA_DIR: ${{ github.workspace }}/.test_data_cache
 
-# Cancel previous runs when this one starts.
+# Supersede the previous run: by pull request, or by branch for pushes.
 concurrency:
-  group: TestCodeMinDeps-${{ github.event.pull_request.number || github.run_id }}
+  group: TestCodeMinDeps-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -34,9 +34,9 @@ env:
   MPLBACKEND: Agg
   QT_QPA_PLATFORM: offscreen
 
-# Cancel previous runs when this one starts.
+# Supersede the previous run: by pull request, or by branch for pushes.
 concurrency:
-  group: TestCode-${{ github.event.pull_request.number || github.run_id }}
+  group: TestCode-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test_free_threaded.yml
+++ b/.github/workflows/test_free_threaded.yml
@@ -21,8 +21,9 @@ on:
 permissions:
   contents: read
 
+# Supersede the previous run: by pull request, or by branch for pushes.
 concurrency:
-  group: TestFreeThreaded-${{ github.event.pull_request.number || github.run_id }}
+  group: TestFreeThreaded-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test_wasm.yml
+++ b/.github/workflows/test_wasm.yml
@@ -26,8 +26,9 @@ on:
       - '.github/actions/**/*.yml'
       - '.github/scripts/**'
 
+# Supersede the previous run: by pull request, or by branch for pushes.
 concurrency:
-  group: TestWasm-${{ github.event.pull_request.number || github.run_id }}
+  group: TestWasm-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Both jobs must exercise the same Pyodide release so their results are


### PR DESCRIPTION
## Description

Every test workflow's concurrency group falls back to `github.run_id` when there is no pull request number:

```yaml
group: TestCode-${{ github.event.pull_request.number || github.run_id }}
```

`run_id` is unique per run, so on a push the group never collides and `cancel-in-progress` has nothing to cancel. Consecutive pushes to `dev` therefore each keep a full matrix alive. This morning three dev pushes (08:57, 08:58, 09:14) were running simultaneously — `TestCode` alone is 14 jobs (`setup` + `conda_env` + 3 OS × 3 Python + 3 `network_tests`), so that is ~42 jobs for one branch against the org's 20-concurrent-job cap. Queued jobs peaked at 84 and PR CI stalled behind it.

Switching the fallback to `github.ref` puts all pushes to a branch in one group, so a new commit on `dev` supersedes the in-flight run for the previous one. Pull requests are unaffected: they still group by `pull_request.number` and never reach the fallback. `master` and `dev` group separately, since `github.ref` differs.

Six workflows carried the same fallback: `runtests.yml`, `run_min_dep_tests.yml`, `lint.yml`, `profile.yml`, `test_free_threaded.yml`, `test_wasm.yml`.

Trade-off worth stating: a rapid series of merges to `dev` now leaves intermediate commits untested, since only the newest push keeps its run. That is the usual reason to group by branch, and it is what the fallback already does for pull requests.

Two related contributors to the same pile-up are left alone here and can be handled separately:

- `CancelPRRuns` is an 8-job matrix of `echo` statements, so it queues behind the very backlog it exists to drain (jobs sat queued for over an hour this morning).
- `network_tests` adds 3 jobs to every `TestCode` run and is subject to the known stall in #784.

## Changelog

- none (CI only)

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).