### PR TITLE
Point each gap question at the other

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -1705,6 +1705,10 @@ class Spool(NamespaceOwner):
         --------
         [`Spool.get_coverage`](`dascore.core.spool.Spool.get_coverage`)
 
+        [`get_gap_edges`](`dascore.utils.gaps.get_gap_edges`) finds the
+        gaps *inside* one patch's coordinate, which is a different
+        question: this method reads the index and never loads data.
+
         Examples
         --------
         >>> import numpy as np
@@ -1779,6 +1783,10 @@ class Spool(NamespaceOwner):
         See Also
         --------
         [`Spool.get_gaps`](`dascore.core.spool.Spool.get_gaps`)
+
+        [`get_gap_edges`](`dascore.utils.gaps.get_gap_edges`) finds the
+        gaps *inside* one patch's coordinate, which is a different
+        question: this method reads the index and never loads data.
 
         Examples
         --------

--- a/dascore/utils/gaps.py
+++ b/dascore/utils/gaps.py
@@ -54,6 +54,12 @@ def get_gap_edges(values, gap_factor: float | None = None):
     -------
     tuple[np.ndarray, np.ndarray]
         Cell edges and a Boolean array marking gaps after each input value.
+
+    See Also
+    --------
+    [`Spool.get_gaps`](`dascore.core.spool.Spool.get_gaps`) answers the
+    other gap question: where whole patches fail to meet, read from the
+    index rather than from a coordinate's values.
     """
     values = _normalize_coord_values(values)
     if len(values) == 1:


### PR DESCRIPTION
## Description

Docs only. DASCore answers two different questions that both use the word "gap", and neither pointed at the other:

- [`Spool.get_gaps`](https://github.com/DASDAE/dascore/pull/956) reads the index to find where whole patches fail to meet.
- `dascore.utils.gaps.get_gap_edges` reads one patch's coordinate values to find breaks for plotting.

A reader who finds one has no way to learn the other exists. This adds a `See Also` entry in each direction, each saying what the *other* one is for rather than just naming it.

Raised by a reviewer on #956 and deferred to keep that PR to one concern.

## Changelog

- none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
