### PR TITLE
Split nine operations into what they mean and what they compute

### DIFF
--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
+from contextlib import suppress
 from typing import Any, Literal
 
 import numpy as np
@@ -28,6 +29,10 @@ from dascore.utils.patch import (
     get_dim_axis_value,
     patch_function,
 )
+from dascore.workflow.processor import (
+    PatchProcessor,
+    register_implementation,
+)
 
 # The dtypes which promise, without the values being looked at, that there
 # is no imaginary part: bool, signed and unsigned integers, and floats.
@@ -43,7 +48,18 @@ def _known_real(data) -> bool:
     one. Anything whose dtype cannot be read is treated the same way --
     not known to be real, so the operation runs.
     """
-    return getattr(getattr(data, "dtype", None), "kind", None) in _REAL_KINDS
+    dtype = getattr(data, "dtype", None)
+    if (kind := getattr(dtype, "kind", None)) is not None:
+        return kind in _REAL_KINDS
+    if dtype is None:
+        return False
+    # A backend whose dtypes carry no `kind` -- the standard does not ask
+    # for one -- is asked through its own namespace instead. Without this
+    # every such array reads as "not known to be real", and the operation
+    # runs `real`/`conj` on data the standard forbids them for.
+    with suppress(Exception):
+        return not array_namespace(data).isdtype(dtype, "complex floating")
+    return False
 
 
 def _as_float(data):
@@ -290,7 +306,18 @@ def abs(patch: PatchType) -> PatchType:
     >>> pa = dascore.get_example_patch() # generate example patch
     >>> out = pa.abs() # take absolute value of generated example patch data
     """
-    return patch.new(data=np.abs(patch.data))
+    return Abs()._apply(patch)
+
+
+class Abs(PatchProcessor):
+    """Take the absolute value of the data."""
+
+    def kernel(self, data, meta, out_meta):
+        """Return the magnitude of every sample."""
+        return array_namespace(data).abs(data)
+
+
+register_implementation("abs", Abs)
 
 
 @patch_function()
@@ -307,9 +334,25 @@ def conj(patch: PatchType) -> PatchType:
     >>> dft = pa.dft(None)  # multi-dim dft
     >>> conj = dft.conj()
     """
-    if _known_real(patch.data):  # real data is its own conjugate
-        return patch
-    return patch.new(data=np.conj(patch.data))
+    return Conj()._apply(patch)
+
+
+class Conj(PatchProcessor):
+    """Flip the sign of the imaginary part."""
+
+    def kernel(self, data, meta, out_meta):
+        """
+        Return the conjugate, or the data unchanged.
+
+        Real data is its own conjugate, and handing back the very array
+        which came in is what tells the caller nothing happened.
+        """
+        if _known_real(data):
+            return data
+        return array_namespace(data).conj(data)
+
+
+register_implementation("conj", Conj)
 
 
 @patch_function()
@@ -323,9 +366,20 @@ def real(patch: PatchType) -> PatchType:
     >>> pa = dascore.get_example_patch()
     >>> out = pa.real()
     """
-    if _known_real(patch.data):  # already only a real part
-        return patch
-    return patch.new(data=np.real(patch.data))
+    return Real()._apply(patch)
+
+
+class Real(PatchProcessor):
+    """Keep only the real part of the data."""
+
+    def kernel(self, data, meta, out_meta):
+        """Return the real part, or the data which is already only that."""
+        if _known_real(data):
+            return data
+        return array_namespace(data).real(data)
+
+
+register_implementation("real", Real)
 
 
 @patch_function()
@@ -339,7 +393,28 @@ def imag(patch: PatchType) -> PatchType:
     >>> pa = dascore.get_example_patch()
     >>> out = pa.imag()
     """
-    return patch.new(data=np.imag(patch.data))
+    return Imag()._apply(patch)
+
+
+class Imag(PatchProcessor):
+    """Keep only the imaginary part of the data."""
+
+    def kernel(self, data, meta, out_meta):
+        """
+        Return the imaginary part, which is zero for real data.
+
+        Asked for explicitly rather than through `imag`: numpy answers
+        zero for a real array, and the standard refuses the question, so
+        the answer numpy gives has to be built here to mean the same
+        thing on every backend.
+        """
+        xp = array_namespace(data)
+        if _known_real(data):
+            return xp.zeros_like(data)
+        return xp.imag(data)
+
+
+register_implementation("imag", Imag)
 
 
 @patch_function(data_type="")
@@ -395,8 +470,26 @@ def normalize(
     >>> # Bit normalization (sign only)
     >>> bit_norm = patch.normalize(dim="time", norm="bit")
     """
-    axis = self.get_axis(dim)
-    data = _as_float(self.data)
+    return Normalize(dim=dim, norm=norm)._apply(self)
+
+
+class Normalize(PatchProcessor):
+    """Scale each slice along a dimension by a norm of that slice."""
+
+    dim: str
+    norm: str = "l2"
+
+    def kernel(self, data, meta, out_meta):
+        """Return the data with each slice divided by its norm."""
+        return _normalize_kernel(data, meta.get_axis(self.dim), self.norm)
+
+
+register_implementation("normalize", Normalize)
+
+
+def _normalize_kernel(data, axis: int, norm: str):
+    """Divide each slice along an axis by the norm named."""
+    data = _as_float(data)
     xp = array_namespace(data)
     if norm in {"l1", "l2"}:
         order = int(norm[-1])
@@ -420,8 +513,7 @@ def normalize(
     # A zero divisor means there is nothing but zeros and nulls to scale, so
     # divide those by one; the zeros stay zero and the nulls stay null.
     one = xp.asarray(1, dtype=divisor.dtype)
-    new_data = data / xp.where(divisor == 0, one, divisor)
-    return self.new(data=new_data)
+    return data / xp.where(divisor == 0, one, divisor)
 
 
 @patch_function(data_type="")
@@ -460,12 +552,24 @@ def standardize(
     standardized_distance = patch.standardize('distance')
     ```
     """
-    axis = self.get_axis(dim)
-    data = _as_float(self.data)
-    mean = nan_reduce("mean", data, axis=axis, keepdims=True)
-    std = nan_reduce("std", data, axis=axis, keepdims=True)
-    new_data = (data - mean) / std
-    return self.new(data=new_data)
+    return Standardize(dim=dim)._apply(self)
+
+
+class Standardize(PatchProcessor):
+    """Remove the mean and scale to unit variance along a dimension."""
+
+    dim: str
+
+    def kernel(self, data, meta, out_meta):
+        """Return the data centred and scaled along its dimension."""
+        axis = meta.get_axis(self.dim)
+        data = _as_float(data)
+        mean = nan_reduce("mean", data, axis=axis, keepdims=True)
+        std = nan_reduce("std", data, axis=axis, keepdims=True)
+        return (data - mean) / std
+
+
+register_implementation("standardize", Standardize)
 
 
 # This is left here to not break compatibility. It also forces `apply_ufunc`
@@ -987,13 +1091,19 @@ def demean(patch, dim: str = "time"):
     >>> plt.show()  # doctest: +SKIP
     >>> plt.close(fig)
     """
-    axis = patch.get_axis(dim)
-    data = _as_float(patch.data)
+    return Demean(dim=dim)._apply(patch)
 
-    # Compute mean along axis, keep dims for broadcasting
-    mea = nan_reduce("mean", data, axis=axis, keepdims=True)
 
-    new_data = data - mea
+class Demean(PatchProcessor):
+    """Remove the mean along a dimension."""
 
-    # Return a new patch with updated data
-    return patch.new(data=new_data)
+    dim: str = "time"
+
+    def kernel(self, data, meta, out_meta):
+        """Return the data with the mean of each slice taken out."""
+        data = _as_float(data)
+        mean = nan_reduce("mean", data, axis=meta.get_axis(self.dim), keepdims=True)
+        return data - mean
+
+
+register_implementation("demean", Demean)

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 import numpy as np
 import pandas as pd
+from pydantic import ConfigDict
 from scipy.interpolate import interp1d
 
 import dascore as dc
@@ -21,6 +23,10 @@ from dascore.utils.array_api import array_namespace
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import get_parent_code_name, iterate
 from dascore.utils.patch import patch_function
+from dascore.workflow.processor import (
+    PatchProcessor,
+    register_implementation,
+)
 
 
 @patch_function()
@@ -231,8 +237,31 @@ def rename_coords(self: PatchType, **kwargs) -> PatchType:
     >>> pa2 = pa.rename_coords(distance='fragrance')
     >>> assert 'fragrance' in pa2.dims
     """
-    new_coord = self.coords.rename_coord(**kwargs)
-    return self.new(coords=new_coord, dims=new_coord.dims, attrs=self.attrs)
+    return RenameCoords(**kwargs)._apply(self)
+
+
+class RenameCoords(PatchProcessor):
+    """
+    Give coordinates other names.
+
+    No kernel: the data are what they were, and only what they are
+    called changes. A processor which defines no kernel says exactly
+    that, and `_apply` hands the array through untouched.
+    """
+
+    # The renames arrive as whatever the caller named them, so the fields
+    # cannot be known in advance; `model_values` folds the extras back
+    # into the parameters, so the fingerprint and the document still hold
+    # every one of them.
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    def derive_meta(self, meta):
+        """Return the coordinates under their new names."""
+        coords = meta.coords.rename_coord(**self._params())
+        return meta.update(coords=coords)
+
+
+register_implementation("rename_coords", RenameCoords)
 
 
 @patch_function()
@@ -742,25 +771,44 @@ def transpose(self: PatchType, *dims: str) -> PatchType:
     >>> # Set distance as the first dimension.
     >>> out = pa.transpose("distance", ...)
     """
-    dims = tuple(dims)
-    old_dims = self.coords.dims
-    # Filter out ellipsis from dims to validate
-    dims_to_check = [d for d in dims if d is not ...]
-    # Check for invalid dimensions
-    if invalid_dims := set(dims_to_check) - set(old_dims):
-        invalid_list = sorted(invalid_dims)
-        valid_list = sorted(old_dims)
-        msg = f"Dimension(s) {invalid_list} not found in Patch dimensions: {valid_list}"
-        raise ParameterError(msg)
-    new_coord = self.coords.transpose(*dims)
-    # No-op transpose; the coord manager returned self, so reuse this patch.
-    if new_coord is self.coords:
-        return self
-    new_dims = new_coord.dims
-    axes = tuple(old_dims.index(x) for x in new_dims)
-    xp = array_namespace(self.data)
-    new_data = xp.permute_dims(self.data, axes)
-    return self.new(data=new_data, coords=new_coord)
+    return Transpose(dims=tuple(dims))._apply(self)
+
+
+class Transpose(PatchProcessor):
+    """Put the dimensions of a patch into another order."""
+
+    # Typed loosely because `...` is a legal element: `transpose(...,
+    # "distance")` means "distance last, the rest as they were".
+    dims: tuple[Any, ...] = ()
+
+    def derive_meta(self, meta):
+        """
+        Return the coordinates in their new order.
+
+        The coord manager hands back the very object it was given when
+        the order asked for is the order already held, and that is what
+        tells `_apply` the operation did nothing.
+        """
+        old_dims = meta.coords.dims
+        named = [x for x in self.dims if x is not ...]
+        if invalid := set(named) - set(old_dims):
+            msg = (
+                f"Dimension(s) {sorted(invalid)} not found in Patch "
+                f"dimensions: {sorted(old_dims)}"
+            )
+            raise ParameterError(msg)
+        coords = meta.coords.transpose(*self.dims)
+        return meta if coords is meta.coords else meta.update(coords=coords)
+
+    def kernel(self, data, meta, out_meta):
+        """Return the data with its axes permuted to the new order."""
+        if out_meta is meta:
+            return data
+        axes = tuple(meta.dims.index(x) for x in out_meta.dims)
+        return array_namespace(data).permute_dims(data, axes)
+
+
+register_implementation("transpose", Transpose)
 
 
 @patch_function(history=None)

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -187,6 +187,9 @@ class _PatchFunction(Protocol):
     func: Callable
     raw_function: Callable
     op: Callable
+    # What the decorator was told, so a registered processor can be held
+    # to the same requirements rather than declaring its own in parallel.
+    _declared: dict
     __version__: str
     __wrapped__: Callable
 
@@ -438,6 +441,17 @@ def patch_function(
         patch_func.raw_function = getattr(func, "raw_function", func)
         patch_func.__wrapped__ = func
         patch_func.__version__ = version
+        # What the decorator was told, kept where a registered processor
+        # can find it. `register_implementation` reconciles the two, so
+        # the class and the decorator cannot drift apart in silence.
+        patch_func._declared = {
+            "required_dims": required_dims,
+            "required_coords": required_coords,
+            "required_attrs": required_attrs,
+            "data_type": data_type,
+            "history": history,
+            "validate_call": validate_call,
+        }
         # Registered as it is decorated, so a function is nameable in a
         # document exactly when its module has been imported. A function
         # defined inside a call takes no tag; `op` says so if it is asked.

--- a/dascore/workflow/__init__.py
+++ b/dascore/workflow/__init__.py
@@ -25,11 +25,13 @@ from dascore.workflow.identity import (
     new_patch_id,
     source_patch_id,
 )
+from dascore.workflow.meta import PatchMeta
 from dascore.workflow.processor import (
     PatchOp,
     PatchProcessor,
     fingerprint_call,
     register_implementation,
+    register_kernel,
     resolve_patch_function,
 )
 from dascore.workflow.task import Task, intern, make_function_task_class, task

--- a/dascore/workflow/meta.py
+++ b/dascore/workflow/meta.py
@@ -1,0 +1,106 @@
+"""
+What a patch is, apart from its values.
+
+A [`PatchProcessor`](`dascore.workflow.processor.PatchProcessor`) is split
+in two: a metadata step which decides what the result's coordinates and
+attributes are, and a kernel which does the arithmetic. `PatchMeta` is
+what the metadata step works on, and the reason the two halves can be
+told apart -- the metadata step never sees an array, and the kernel never
+sees a coordinate.
+
+That separation is what makes an operation fusible: something which wants
+to compile a chain of them can ask each one what it does to the metadata
+without touching, or even holding, the data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dascore.core.attrs import PatchAttrs
+    from dascore.core.coordmanager import CoordManager
+
+# A dataclass rather than a model, and annotations which are never
+# evaluated: `dascore.core.coordmanager` is still being imported when this
+# module is, so naming `CoordManager` at runtime would raise. It also
+# saves revalidating a coord manager on every operation.
+
+
+@dataclass(frozen=True, slots=True)
+class PatchMeta:
+    """
+    Everything a patch carries except its data.
+
+    Parameters
+    ----------
+    coords
+        The coordinates, which carry the dimensions and the shape too.
+    attrs
+        The patch's attributes.
+    dtype
+        What the data are. Held separately because a kernel may promote --
+        `normalize` divides, so integers come back as floats -- and the
+        metadata cannot always say in advance what it will be.
+    backend
+        Which array library the data belong to, as
+        [`backend_name`](`dascore.utils.array_api.backend_name`) spells
+        it. This is how a kernel is chosen without looking at an array.
+    """
+
+    coords: CoordManager
+    attrs: PatchAttrs
+    dtype: Any
+    backend: str = "numpy"
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        """The dimension names, in order."""
+        return self.coords.dims
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """The shape the data have."""
+        return self.coords.shape
+
+    @property
+    def ndim(self) -> int:
+        """How many dimensions the patch has."""
+        return len(self.coords.dims)
+
+    def get_axis(self, dim: str) -> int:
+        """Return the axis a dimension name refers to."""
+        return self.coords.get_axis(dim)
+
+    @classmethod
+    def from_patch(cls, patch) -> PatchMeta:
+        """Return what a patch is, apart from its values."""
+        # Imported here rather than at module scope, for the reason the
+        # header gives: this module is imported mid-way through
+        # `dascore.core`.
+        from dascore.utils.array_api import backend_name  # noqa: PLC0415
+
+        data = patch.data
+        return cls(
+            coords=patch.coords,
+            attrs=patch.attrs,
+            dtype=data.dtype,
+            backend=backend_name(data),
+        )
+
+    def update(self, **kwargs) -> PatchMeta:
+        """Return metadata with some of it changed."""
+        return replace(self, **kwargs)
+
+    def to_patch(self, data):
+        """
+        Return the patch this metadata and some data make.
+
+        The coords check the data's shape on the way in, so a kernel
+        which returned the wrong shape is refused here rather than
+        somewhere later and stranger.
+        """
+        import dascore as dc  # noqa: PLC0415
+
+        return dc.Patch(data=data, coords=self.coords, attrs=self.attrs)

--- a/dascore/workflow/meta.py
+++ b/dascore/workflow/meta.py
@@ -53,6 +53,11 @@ class PatchMeta:
     attrs: PatchAttrs
     dtype: Any
     backend: str = "numpy"
+    # What to build the result with. A patch function used to go through
+    # `patch.new`, which builds `self.__class__`, so a subclass survived
+    # its own operations; naming `Patch` here would quietly take that
+    # away. None means whatever `dascore.Patch` is.
+    patch_type: Any = None
 
     @property
     def dims(self) -> tuple[str, ...]:
@@ -87,6 +92,7 @@ class PatchMeta:
             attrs=patch.attrs,
             dtype=data.dtype,
             backend=backend_name(data),
+            patch_type=type(patch),
         )
 
     def update(self, **kwargs) -> PatchMeta:
@@ -103,4 +109,5 @@ class PatchMeta:
         """
         import dascore as dc  # noqa: PLC0415
 
-        return dc.Patch(data=data, coords=self.coords, attrs=self.attrs)
+        patch_type = self.patch_type or dc.Patch
+        return patch_type(data=data, coords=self.coords, attrs=self.attrs)

--- a/dascore/workflow/processor.py
+++ b/dascore/workflow/processor.py
@@ -31,6 +31,7 @@ Examples
 
 from __future__ import annotations
 
+import functools
 import inspect
 import re
 import warnings
@@ -39,15 +40,16 @@ from contextlib import suppress
 from functools import cached_property, lru_cache
 from typing import Any, ClassVar
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
 from dascore.utils.misc import suppress_warnings
 from dascore.warnings import DASCoreWarning
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
+from dascore.workflow.meta import PatchMeta
 from dascore.workflow.serialize import digest
-from dascore.workflow.task import Task, _resolve_default
+from dascore.workflow.task import _VERSION_KEY, Task, _resolve_default
 
 # Stands in for the patch while a call is bound to a signature. The bind
 # only needs something to put in that slot; nothing ever looks at it.
@@ -96,6 +98,11 @@ class PatchProcessor(Task):
     so that the patch function's name reaches them.
     """
 
+    # Everything `patch_function` is given, so that a processor is a whole
+    # description of its operation rather than half of one. Something
+    # reading a chain of these -- to fuse them, to compile them -- has the
+    # decorator nowhere in reach, and needs all of it.
+    #
     # What the patch must hold. Stated on the class rather than passed to
     # `run`, because it is a property of the operation and not of the call.
     required_dims: ClassVar[tuple[str, ...] | str | None] = None
@@ -104,15 +111,36 @@ class PatchProcessor(Task):
     # What the result is, when the operation changes it; None leaves it as
     # it was, and "" clears it.
     data_type: ClassVar[str | None] = None
+    # How the call is written into the patch's history, or None for an
+    # operation which records nothing. `transpose` is the live case.
+    history: ClassVar[str | None] = "full"
+    # Whether the function's arguments are checked by pydantic on the way
+    # in. A processor validates its own fields, so this is here to be
+    # reconciled with the decorator rather than acted on.
+    validate_call: ClassVar[bool] = False
+
+    # The registry tag this class implements, set by
+    # `register_implementation`. Empty until it is registered.
+    _patch_function: ClassVar[str] = ""
+    # Kernels registered for a particular array backend, by
+    # `register_kernel`. Looked up in `__dict__` per class, never
+    # inherited wholesale, so a subclass does not silently answer for its
+    # parent's backends.
+    _kernels: ClassVar[dict[str, Any]] = {}
 
     def check(self, patch: PatchType) -> PatchType:
         """
         Refuse a patch which does not carry what the operation needs.
 
-        A subclass which declares `required_dims`, `required_coords` or
-        `required_attrs` has to call this from its own `run`; nothing calls
-        it for you yet. The framework `run` which will call it arrives with
-        the first plan/kernel split.
+        The framework does not call this, and deliberately: a registered
+        processor is reached through its patch function, whose decorator
+        has already run the same checks from its own declaration of them.
+        Running them again from the class's declaration would mean two
+        sources of truth which can disagree in silence.
+        `register_implementation` reconciles the two instead, at import.
+
+        It is still here for a hand-written `run` which does not go
+        through a patch function, which has nothing else to call.
 
         Parameters
         ----------
@@ -132,6 +160,151 @@ class PatchProcessor(Task):
         """
         check_patch_coords(patch, dims=self.required_dims, coords=self.required_coords)
         return check_patch_attrs(patch, self.required_attrs)
+
+    # --- the surface a PatchOp has -----------------------------------
+    #
+    # A registered processor stands where a `PatchOp` would, so it answers
+    # the same questions. Every contract parametrised over all the patch
+    # functions -- the fingerprint, the document, the pickle -- then keeps
+    # passing without knowing which of the two it got.
+
+    @property
+    def name(self) -> str:
+        """Return the registry tag of the operation this implements."""
+        return self._patch_function
+
+    @property
+    def kwargs(self) -> dict:
+        """Return the arguments the operation was given."""
+        return self._params()
+
+    # The function's version, read once when the operation is built. A
+    # `PatchOp` keeps it as a field for the same reason: an operation is
+    # what it was when it was written down, so a later bump of the
+    # function must not reach back and change what an existing one
+    # fingerprints as.
+    _captured_version: str = PrivateAttr(default="")
+
+    def model_post_init(self, context) -> None:
+        """Record the version the function was at when this was built."""
+        function = _REGISTERED.get(self._patch_function)
+        version = getattr(function, "__version__", self.__version__)
+        object.__setattr__(self, "_captured_version", version)
+
+    @property
+    def version(self) -> str:
+        """
+        Return the version the operation is declared at.
+
+        The patch function's, not this class's. Registration pins the two
+        equal, so they can only part when the function is bumped -- and a
+        bump has to reach the fingerprint, which is the whole reason a
+        version exists.
+        """
+        return self._captured_version or self.__version__
+
+    def to_dict(self) -> dict:
+        """
+        Return a document which describes this operation.
+
+        The version written down is the function's, so the document
+        fingerprints as it did when it was written even after the
+        function has moved on.
+        """
+        return super().to_dict() | {_VERSION_KEY: self.version}
+
+    @property
+    def node_name(self) -> str:
+        """Return the name this operation goes by where a task is labelled."""
+        return self.name.replace(_SEPARATOR, "_")
+
+    def fingerprint_at(self, version: str) -> str:
+        """
+        Return the digest which identifies this operation and its arguments.
+
+        Spelled as the `PatchOp` for the same call would spell it, not as
+        this class. Registering a hand-written implementation is meant to
+        be invisible from outside: were the class name to reach the
+        digest, every `processing_id` ever recorded for the operation
+        would stop matching, and every stored document with it.
+        """
+        return _fingerprint(self.name, self.version, self.kwargs)
+
+    def run(self, patch: PatchType) -> Any:
+        """
+        Run the operation against a patch.
+
+        Through the patch function, not straight into `_apply`: the
+        function's decorator is what writes the history and stamps the
+        ids, and a processor reached by `.op(...)` has to come out the
+        same as one reached by calling the method.
+        """
+        function = resolve_patch_function(self.name)
+        args, kwargs = _as_call(function, self.kwargs)
+        return function(patch, *args, **kwargs)
+
+    # --- the seam ----------------------------------------------------
+
+    def derive_meta(self, meta: PatchMeta) -> PatchMeta:
+        """
+        Return what the result's metadata is.
+
+        Never sees an array, which is what lets something fuse a chain of
+        operations without holding any data. The default says the
+        operation changes nothing: right for anything elementwise.
+        """
+        return meta
+
+    def plan_kernel(self, meta: PatchMeta, out_meta: PatchMeta):
+        """
+        Return the array function this call is, or None to touch no data.
+
+        Both metadata objects are given because a kernel often needs the
+        difference between them -- `transpose` wants the permutation which
+        takes the old dimension order to the new.
+
+        The default finds a kernel registered for the data's backend, and
+        failing that the class's own `kernel`, which is written to the
+        array API standard and so runs on any of them. A class with no
+        kernel at all is a metadata-only operation and gets None.
+        """
+        if (found := _resolve_kernel(type(self), meta.backend)) is None:
+            return None
+        return functools.partial(found, self, meta=meta, out_meta=out_meta)
+
+    def reconcile(self, data, meta: PatchMeta) -> PatchMeta:
+        """
+        Return the metadata the data actually turned out to have.
+
+        Defining this says the operation cannot be fused: it is the one
+        step which has to see both halves at once. The default only
+        carries the data's dtype back, since a kernel may promote.
+        """
+        dtype = getattr(data, "dtype", meta.dtype)
+        return meta if dtype == meta.dtype else meta.update(dtype=dtype)
+
+    def _apply(self, patch: PatchType) -> PatchType:
+        """
+        Run the operation, metadata first and then the data.
+
+        This is what a patch function's body calls. It does none of the
+        ceremony around an operation -- the checks, the history, the
+        lineage ids -- because the patch function's decorator is still
+        wrapped around this call and is already doing all of it. Doing it
+        here as well would count every operation twice.
+        """
+        meta = PatchMeta.from_patch(patch)
+        out_meta = self.derive_meta(meta)
+        kernel = self.plan_kernel(meta, out_meta)
+        data = patch.data if kernel is None else kernel(patch.data)
+        # An operation which changed neither half did nothing, and hands
+        # back the patch it was given rather than an equal one. The
+        # decorator reads that as nothing having happened, so no history
+        # is written and no id advances -- which is what `conj` on real
+        # data and a transpose into the order already held both mean.
+        if data is patch.data and out_meta is meta:
+            return patch
+        return self.reconcile(data, out_meta).to_patch(data)
 
 
 class PatchOp(Task):
@@ -263,6 +436,48 @@ class PatchOp(Task):
         return cls(name=name, kwargs=bound)
 
 
+def register_kernel(cls: type[PatchProcessor], backend: str):
+    """
+    Say that a function is how an operation runs on one array backend.
+
+    Used as a decorator. The kernel takes the processor, the data, and
+    both metadata objects, and returns an array.
+
+    Parameters
+    ----------
+    cls
+        The processor the kernel belongs to.
+    backend
+        The backend it is for, as
+        [`backend_name`](`dascore.utils.array_api.backend_name`) spells
+        it -- "numpy", "cupy", "dask".
+    """
+
+    def decorate(func):
+        """Record the kernel against the class and hand it back."""
+        # Written into this class's own dict, not a ClassVar it shares
+        # with its parent, so registering for a subclass cannot answer
+        # for the class it derives from.
+        cls._kernels = {**cls.__dict__.get("_kernels", {}), backend: func}
+        return func
+
+    return decorate
+
+
+def _resolve_kernel(cls: type[PatchProcessor], backend: str):
+    """
+    Return the kernel a class runs for one backend, or None if it has none.
+
+    A kernel registered for the backend wins; failing that the class's own
+    `kernel`, which is written to the array API standard and so runs on
+    any of them. A class which defines neither is metadata-only.
+    """
+    for klass in cls.__mro__:
+        if (found := klass.__dict__.get("_kernels", {}).get(backend)) is not None:
+            return found
+    return getattr(cls, "kernel", None)
+
+
 def register_implementation(name: str, cls: type[PatchProcessor]) -> None:
     """
     Say that a hand-written class is what a patch function's name means.
@@ -283,7 +498,73 @@ def register_implementation(name: str, cls: type[PatchProcessor]) -> None:
             f"{cls.__name__} is not a PatchProcessor, so it cannot implement {name!r}."
         )
         raise ParameterError(msg)
+    function = resolve_patch_function(name)
+    _reconcile(name, cls, function)
+    _check_fields(name, cls, function)
+    cls._patch_function = name
     _IMPLEMENTATIONS[name] = cls
+
+
+def _reconcile(name: str, cls: type[PatchProcessor], function) -> None:
+    """
+    Make the class and the decorator say the same thing, or refuse both.
+
+    A processor states what its operation requires so that something
+    reading a chain of them has the whole story without the decorator in
+    reach. That leaves two places saying it, and two places which say it
+    differently are worse than one -- so a class which states a
+    requirement must state the one the decorator did, and a class which
+    states none takes the decorator's.
+    """
+    declared = getattr(function, "_declared", {})
+    for field, value in declared.items():
+        stated = getattr(cls, field, None)
+        default = getattr(PatchProcessor, field, None)
+        if stated == default:
+            setattr(cls, field, value)
+            continue
+        if stated != value:
+            msg = (
+                f"{cls.__name__} says {field}={stated!r} and {name!r} says "
+                f"{value!r}. A processor and its patch function have to "
+                "agree about what the operation requires."
+            )
+            raise ParameterError(msg)
+    if (version := getattr(function, "__version__", None)) != cls.__version__:
+        msg = (
+            f"{cls.__name__} is version {cls.__version__!r} and {name!r} is "
+            f"{version!r}. They fingerprint as one operation, so one version."
+        )
+        raise ParameterError(msg)
+
+
+def _check_fields(name: str, cls: type[PatchProcessor], function) -> None:
+    """
+    Refuse a class which could not be built from a call to its function.
+
+    Caught here rather than where someone calls the patch function: the
+    class is built with the call's bound arguments, so a mismatch is a
+    pydantic complaint about a name the caller never typed, arriving at
+    the wrong moment and pointing at the wrong thing.
+    """
+    parameters = list(_signature(function).parameters.values())[1:]
+    fields = set(cls.model_fields)
+    takes_extras = cls.model_config.get("extra") == "allow"
+    for parameter in parameters:
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            if not takes_extras:
+                msg = (
+                    f"{name!r} takes **{parameter.name}, so {cls.__name__} has "
+                    'to accept them: set model_config extra="allow".'
+                )
+                raise ParameterError(msg)
+            continue
+        if parameter.name not in fields:
+            msg = (
+                f"{name!r} takes {parameter.name!r} and {cls.__name__} has no "
+                "such field, so a call could not be written down as one."
+            )
+            raise ParameterError(msg)
 
 
 def patch_function_tag(func) -> str | None:

--- a/dascore/workflow/processor.py
+++ b/dascore/workflow/processor.py
@@ -302,6 +302,13 @@ class PatchProcessor(Task):
         # decorator reads that as nothing having happened, so no history
         # is written and no id advances -- which is what `conj` on real
         # data and a transpose into the order already held both mean.
+        #
+        # A kernel says "nothing to do" by handing its argument back, so
+        # a kernel must not write into that argument and return it: the
+        # result would be a change nothing records. Patch data is marked
+        # read-only where the backend allows it, but not every array-like
+        # can promise that, so this is a contract rather than a guard --
+        # checking it would mean hashing the data on every operation.
         if data is patch.data and out_meta is meta:
             return patch
         return self.reconcile(data, out_meta).to_patch(data)
@@ -472,10 +479,16 @@ def _resolve_kernel(cls: type[PatchProcessor], backend: str):
     `kernel`, which is written to the array API standard and so runs on
     any of them. A class which defines neither is metadata-only.
     """
+    # One class at a time, both questions asked of it before moving up:
+    # a subclass which wrote its own `kernel` means it, and a backend
+    # kernel registered against its parent must not answer for it.
     for klass in cls.__mro__:
-        if (found := klass.__dict__.get("_kernels", {}).get(backend)) is not None:
+        contents = klass.__dict__
+        if (found := contents.get("_kernels", {}).get(backend)) is not None:
             return found
-    return getattr(cls, "kernel", None)
+        if (generic := contents.get("kernel")) is not None:
+            return generic
+    return None
 
 
 def register_implementation(name: str, cls: type[PatchProcessor]) -> None:
@@ -518,9 +531,16 @@ def _reconcile(name: str, cls: type[PatchProcessor], function) -> None:
     """
     declared = getattr(function, "_declared", {})
     for field, value in declared.items():
+        # Asked of the class's own dict, not of `getattr`: a class which
+        # states the base default on purpose has still stated it, and
+        # silently overwriting that would make the check a formality.
+        declares = any(
+            field in klass.__dict__
+            for klass in cls.__mro__[:-1]
+            if klass is not PatchProcessor
+        )
         stated = getattr(cls, field, None)
-        default = getattr(PatchProcessor, field, None)
-        if stated == default:
+        if not declares:
             setattr(cls, field, value)
             continue
         if stated != value:

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -209,7 +209,16 @@ class Task(DascoreBaseModel):
         params = {
             key: decode(value) for key, value in document.get(_PARAMS_KEY, {}).items()
         }
-        return task_class(**params)
+        out = task_class(**params)
+        # A processor keeps the version privately rather than as a
+        # parameter, so that `kwargs` stays the call and nothing else.
+        # The document's version still has to reach it, or a document
+        # written before a bump would fingerprint as one written after.
+        if (version := document.get(_VERSION_KEY)) and hasattr(
+            out, "_captured_version"
+        ):
+            object.__setattr__(out, "_captured_version", version)
+        return out
 
     def save(self, path: str | Path) -> Path:
         """

--- a/dascore/workflow/task.py
+++ b/dascore/workflow/task.py
@@ -174,7 +174,14 @@ class Task(DascoreBaseModel):
         ...     factor: float = 1.0
         >>> assert ScaleExample().update(factor=2.0).factor == 2.0
         """
-        return type(self)(**{**self._params(), **kwargs})
+        out = type(self)(**{**self._params(), **kwargs})
+        # Changing an argument does not change which version the
+        # operation was written at; see `__reduce__`.
+        if (version := getattr(self, "_captured_version", "")) and hasattr(
+            out, "_captured_version"
+        ):
+            object.__setattr__(out, "_captured_version", version)
+        return out
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -269,13 +276,21 @@ class Task(DascoreBaseModel):
         carries an array as bytes rather than as a list of numbers.
         """
         _check_nameable(type(self), self.tag)
-        return (_rebuild, (self.tag, self._params()))
+        # The captured version travels too. A processor keeps it privately
+        # rather than as a parameter, and an operation which came back
+        # from a document says which version it was written at; rebuilding
+        # it must not quietly re-read whatever the function is now.
+        version = getattr(self, "_captured_version", "")
+        return (_rebuild, (self.tag, self._params(), version))
 
 
-def _rebuild(tag: str, params: dict[str, Any]) -> Task:
+def _rebuild(tag: str, params: dict[str, Any], version: str = "") -> Task:
     """Return the task a tag and its parameters name; see `Task.__reduce__`."""
     task_class = resolve_tagged_model(tag)
-    return task_class(**params)
+    out = task_class(**params)
+    if version and hasattr(out, "_captured_version"):
+        object.__setattr__(out, "_captured_version", version)
+    return out
 
 
 def _check_nameable(task_class: type[Task], tag: str | None) -> None:

--- a/docs/contributing/extending_dascore.qmd
+++ b/docs/contributing/extending_dascore.qmd
@@ -175,6 +175,27 @@ Most of DASCore's patch functions are still written against NumPy, and make no p
 
 Array-likes which merely support `__array__`, rather than implementing the standard, are handled by NumPy and report `"numpy"` as their backend.
 
+### Supplying a kernel for your own backend
+
+A handful of operations are written out by hand as a [PatchProcessor](`dascore.workflow.processor.PatchProcessor`), splitting what the operation *means* from what it *computes*: `derive_meta` works out the result's coordinates and never sees an array, and `kernel` does the arithmetic and never sees a coordinate. Where one exists, a package which brings its own arrays can say how that operation runs on them, without touching DASCore:
+
+```{python}
+import numpy as np
+
+from dascore.proc.basic import Abs
+from dascore.workflow import register_kernel
+
+
+@register_kernel(Abs, "mybackend")
+def _abs_mybackend(processor, data, meta, out_meta):
+    """How `abs` runs on mybackend's arrays."""
+    return np.abs(data)
+```
+
+The kernel is chosen by the backend the data report, so nothing else about the operation changes — `patch.abs()` reaches it, and the name, arguments and fingerprint are what they always were. An operation with no registered kernel for a backend falls back to the class's own `kernel`, which is written to the standard.
+
+Only a few operations have a processor today; the rest are plain functions, and adding one is a deliberate act rather than something every patch function needs.
+
 ## Related guides
 
 - [Contributing](contributing.qmd)

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -144,8 +144,28 @@ dc.viz.waterfall.op(show=False).name
 The document also records which module the function came from. It is informational — what an error message uses to tell you what to import — and deliberately not part of the fingerprint, so moving a function between modules does not make it a different operation:
 
 ```{python}
-normalize.to_dict()["params"]["module"]
+dc.proc.detrend.op("time").to_dict()["params"]["module"]
 ```
+
+## Operations written out by hand
+
+A few operations are not `PatchOp` at all. Where an operation wants a seam — a kernel another array library can supply, a metadata step something can read without touching the data — it is written as a [PatchProcessor](`dascore.workflow.processor.PatchProcessor`) instead, and the patch function delegates to it.
+
+```{python}
+type(normalize)
+```
+
+It is the same operation either way: the same name, the same arguments, and the same fingerprint, so an id recorded before the class existed still matches. What the class adds is that the two halves can be asked for separately — `derive_meta` says what happens to the coordinates and never sees an array, `kernel` does the arithmetic and never sees a coordinate.
+
+```{python}
+from dascore.workflow import PatchMeta
+
+meta = PatchMeta.from_patch(patch)
+# What normalizing does to the metadata: nothing, which is why it fuses.
+normalize.derive_meta(meta) is meta
+```
+
+`register_kernel` is how a package which brings its own arrays says how one of them runs; nothing else about the operation changes.
 
 ## Saving and loading
 

--- a/scripts/differential_check.py
+++ b/scripts/differential_check.py
@@ -35,12 +35,34 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 import warnings
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
 import dascore as dc
+
+# How hard to work at timing a call. A microsecond-scale call is repeated
+# until it has run for _TIMING_BUDGET so the reading means something; a
+# slow one stops at _TIMING_MIN_ROUNDS so the sweep stays quick.
+_TIMING_MIN_ROUNDS = 3
+_TIMING_MAX_ROUNDS = 200
+_TIMING_BUDGET = 0.002
+# Timings below this are noise on any machine, so they are not reported
+# however far they appear to have moved.
+_TIMING_FLOOR = 50e-6
+# How far a single call can read out with nothing changed at all. Measured
+# by running this script with --ref HEAD, which compares a checkout against
+# itself: the totals landed within 10% and individual calls within 35%.
+_TIMING_NOISE = 0.35
+# How many times each leg is run. Two is enough to stop the leg which
+# happened to go first from looking slow.
+_TIMING_PASSES = 3
+
+# Keys a dump carries which are not calls.
+_BOOKKEEPING = {"_timing", "_dascore_path"}
 
 
 # Data covering the dtypes patch data can hold and the values which
@@ -106,6 +128,11 @@ MATRIX_CALLS = {
     "min": lambda patch: patch.min("time"),
     "mul": lambda patch: patch * 2,
     "norm_bit": lambda patch: patch.normalize("time", norm="bit"),
+    "norm_l2_distance": lambda patch: patch.normalize("distance", norm="l2"),
+    "demean_distance": lambda patch: patch.demean("distance"),
+    "rename": lambda patch: patch.rename_coords(time="t"),
+    "transpose_noop": lambda patch: patch.transpose(*patch.dims),
+    "transpose_ell": lambda patch: patch.transpose(..., "distance"),
     "norm_l1": lambda patch: patch.normalize("time", norm="l1"),
     "norm_l2": lambda patch: patch.normalize("time", norm="l2"),
     "norm_max": lambda patch: patch.normalize("time", norm="max"),
@@ -160,6 +187,13 @@ def get_calls() -> dict:
     int_patch = patch.new(data=(np.asarray(patch.data) * 10).astype("int32"))
     bool_patch = patch.new(data=np.asarray(patch.data) > 0.5)
     collapsed = patch.mean("time")
+    # A patch which states a data_type, so that clearing it is visible.
+    # Every other patch here already carries "", where a processor which
+    # forgot to clear it would read the same as one which cleared it.
+    typed = patch.update_attrs(data_type="strain_rate")
+    with_nondim = patch.update_coords(
+        quality=("distance", np.arange(patch.shape[0], dtype="float64"))
+    )
     return {
         # The inputs themselves, so a difference in the examples cannot
         # masquerade as a difference in the functions.
@@ -241,8 +275,33 @@ def get_calls() -> dict:
         "pad_no_expand": lambda: patch.pad(time=2, samples=True, expand_coords=False),
         "pad_fill": lambda: patch.pad(time=1, samples=True, constant_values=1.0),
         "pad_two_dims": lambda: patch.pad(time=1, distance=2, samples=True),
+        # data_type is cleared by these; only a typed input can show it
+        "norm_typed": lambda: typed.normalize("time"),
+        "standardize_typed": lambda: typed.standardize("time"),
+        "abs_typed": lambda: typed.abs(),
+        "conj_typed": lambda: typed.conj(),
+        # the other axis, the other dtypes, and the default argument
+        "norm_l2_distance": lambda: patch.normalize("distance", norm="l2"),
+        "norm_complex_l2": lambda: dft_patch.normalize("ft_time", norm="l2"),
+        "norm_units": lambda: patch.update_attrs(data_units="m/s").normalize("time"),
+        "standardize_distance": lambda: patch.standardize("distance"),
+        "standardize_complex": lambda: dft_patch.standardize("ft_time"),
+        "demean_distance": lambda: patch.demean("distance"),
+        "demean_complex": lambda: dft_patch.demean("ft_time"),
+        "abs_complex": lambda: dft_patch.abs(),
+        # the messages, which a rewrite can change without changing a number
+        "norm_bad": lambda: patch.normalize("time", norm="nope"),
+        "transpose_bad_dim": lambda: patch.transpose("nope"),
+        "rename_missing": lambda: patch.rename_coords(nope="x"),
         # coords
         "transpose": lambda: patch.transpose(),
+        # The no-op and ellipsis branches, which nothing else here reaches.
+        # `transpose_noop` must keep handing back the patch it was given.
+        "transpose_noop": lambda: patch.transpose(*patch.dims),
+        "transpose_ell_last": lambda: patch.transpose(..., "distance"),
+        "transpose_ell_first": lambda: patch.transpose("distance", ...),
+        "rename_coords": lambda: patch.rename_coords(distance="depth"),
+        "rename_nondim": lambda: with_nondim.rename_coords(quality="grade"),
         "transpose_named": lambda: patch.transpose("time", "distance"),
         "squeeze": lambda: patch.select(distance=0, samples=True).squeeze(),
         "broadcast": lambda: collapsed.make_broadcastable_to((collapsed.shape[0], 3)),
@@ -284,22 +343,80 @@ def _hash(array) -> str:
 def dump(path: Path) -> None:
     """Write the fingerprint of every call to path."""
     warnings.simplefilter("ignore")
-    out = {}
-    for name, call in (get_calls() | get_matrix_calls()).items():
+    calls = get_calls() | get_matrix_calls()
+    # Hashed before anything runs, so a call which writes into its own
+    # argument can be told from one which does not. Nothing else here
+    # would notice: every digest is taken from the call's own result.
+    inputs_before = _input_digests(calls)
+    out, timing = {}, {}
+    for name, call in calls.items():
         try:
-            out[name] = digest(call())
+            seconds, patch = _timed(call)
+            out[name] = digest(patch)
+            timing[name] = seconds
         except Exception as error:
             out[name] = {"error": f"{type(error).__name__}: {error}"}
+    inputs_after = _input_digests(calls)
+    for name, before in inputs_before.items():
+        if inputs_after.get(name) != before:
+            out[name] = {"error": "the call changed the patch it was given"}
     # Recorded so the caller can prove which dascore was measured.
     out["_dascore_path"] = str(Path(dc.__file__).parent)
+    out["_timing"] = timing
     path.write_text(json.dumps(out, indent=1, sort_keys=True))
 
 
-def compare(before: dict, after: dict) -> list[str]:
-    """Return a report of the calls whose results differ."""
+def _timed(call) -> tuple[float, Any]:
+    """
+    Return how long a call took, and what it returned.
+
+    Best of several, and enough of them to be worth reading: a call which
+    takes a microsecond gets repeated until it has run for a few
+    milliseconds, so the answer is about the code rather than about when
+    the scheduler happened to look away. A slow call is measured a few
+    times and left alone. The last result is the one fingerprinted; they
+    are all the same call, so any of them would do.
+    """
+    best, patch, spent, rounds = None, None, 0.0, 0
+    while rounds < _TIMING_MAX_ROUNDS and (
+        rounds < _TIMING_MIN_ROUNDS or spent < _TIMING_BUDGET
+    ):
+        start = time.perf_counter()
+        patch = call()
+        elapsed = time.perf_counter() - start
+        best = elapsed if best is None else min(best, elapsed)
+        spent += elapsed
+        rounds += 1
+    return best, patch
+
+
+def _input_digests(calls) -> dict:
+    """Return a fingerprint of the patches the calls close over."""
+    seen = {}
+    for name, call in calls.items():
+        for value in getattr(call, "__closure__", None) or ():
+            contents = value.cell_contents
+            if isinstance(contents, dc.Patch):
+                seen[f"_input_of/{name}"] = _hash(np.asarray(contents.data))
+                break
+    return seen
+
+
+def compare(before: dict, after: dict, fields: set[str] | None = None) -> list[str]:
+    """
+    Return a report of the calls whose results differ.
+
+    `fields` restricts the comparison to part of a fingerprint. Comparing
+    against a ref far enough back that the attrs schema itself changed --
+    master, at the time of writing -- otherwise reports every call as a
+    difference and so reports nothing; the numbers are still worth
+    checking there, and this is how.
+    """
     report = []
-    for name in sorted(set(before) | set(after)):
-        old, new = before.get(name), after.get(name)
+    # Timing is not a result; it is reported on its own and never compared.
+    names = (set(before) | set(after)) - _BOOKKEEPING
+    for name in sorted(names):
+        old, new = _select(before.get(name), fields), _select(after.get(name), fields)
         if old == new:
             continue
         if old is None or new is None:
@@ -312,6 +429,59 @@ def compare(before: dict, after: dict) -> list[str]:
             for i in fields
         )
     return report
+
+
+def _select(fingerprint: dict | None, fields: set[str] | None) -> dict | None:
+    """Return the part of a fingerprint being compared."""
+    if fingerprint is None or fields is None:
+        return fingerprint
+    # An error is never dropped: a call which raised on one side and not
+    # the other is a difference whatever fields were asked for.
+    kept = {i: v for i, v in fingerprint.items() if i in fields or i == "error"}
+    return kept
+
+
+def report_timing(before: dict, after: dict, slowest: int = 15) -> list[str]:
+    """
+    Return what the change cost, call by call.
+
+    Best-of readings on one machine, so this is a guide rather than a
+    benchmark: it says which calls moved, not by exactly how much.
+    """
+    old, new = before.get("_timing", {}), after.get("_timing", {})
+    shared = sorted(set(old) & set(new))
+    if not shared:
+        return []
+    rows = [
+        (new[i] / old[i], old[i], new[i], i)
+        for i in shared
+        # A call too quick to time is not evidence of anything; reporting
+        # it just fills the list with whichever ones the scheduler noticed.
+        if old[i] >= _TIMING_FLOOR and new[i] >= _TIMING_FLOOR
+    ]
+    rows.sort(reverse=True)
+    total_old = sum(old[i] for i in shared)
+    total_new = sum(new[i] for i in shared)
+    out = [
+        f"timing over {len(shared)} calls: "
+        f"{total_old * 1e3:.1f} ms before, {total_new * 1e3:.1f} ms after "
+        f"({(total_new / total_old - 1) * 100:+.1f}%)",
+        "  the two legs are separate processes, so a single call can read "
+        f"{_TIMING_NOISE:.0%} out either way;",
+        "  the total is the number to trust, and benchmarks/ is where a "
+        "single operation gets measured properly.",
+    ]
+    moved = [x for x in rows if x[0] >= 1 + _TIMING_NOISE or x[0] <= 1 - _TIMING_NOISE]
+    if not moved:
+        out.append(f"  no call moved by more than {_TIMING_NOISE:.0%}.")
+        return out
+    out.append(f"  calls which moved more than {_TIMING_NOISE:.0%}:")
+    out.extend(
+        f"    {name:34} {before_s * 1e6:9.1f} us -> {after_s * 1e6:9.1f} us "
+        f"({(ratio - 1) * 100:+6.1f}%)"
+        for ratio, before_s, after_s, name in moved[:slowest]
+    )
+    return out
 
 
 def _dump_at(worktree: Path, out_path: Path) -> dict:
@@ -338,7 +508,7 @@ def check_dascore_path(used: str, worktree: Path) -> None:
         raise RuntimeError(msg)
 
 
-def main(ref: str) -> int:
+def main(ref: str, fields: set[str] | None = None, strict: bool = False) -> int:
     """Compare the working tree against a git ref."""
     repo = Path(__file__).resolve().parent.parent
     with tempfile.TemporaryDirectory() as temp:
@@ -357,8 +527,19 @@ def main(ref: str) -> int:
             msg = f"could not check out {ref!r}: {error.stderr.strip()}"
             raise SystemExit(msg) from error
         try:
+            # Alternated, and more than once: run one leg after the other
+            # and the first pays for a cold cache and a CPU which has not
+            # yet ramped, which reads as the second being faster. Taking
+            # the best of each pass per call takes most of that out.
             before = _dump_at(worktree, temp / "before.json")
             after = _dump_at(repo, temp / "after.json")
+            for index in range(_TIMING_PASSES - 1):
+                after = _merge_timing(
+                    after, _dump_at(repo, temp / f"after{index}.json")
+                )
+                before = _merge_timing(
+                    before, _dump_at(worktree, temp / f"before{index}.json")
+                )
         finally:
             subprocess.run(
                 ["git", "worktree", "remove", "--force", str(worktree)],
@@ -366,22 +547,66 @@ def main(ref: str) -> int:
                 check=False,
                 capture_output=True,
             )
-    if report := compare(before, after):
-        print(f"{len(before)} calls compared against {ref}; some differ:\n")  # noqa
+    # Timing is reported whatever the verdict: a change which alters no
+    # value can still cost, and that is worth seeing on a passing run.
+    counted = len(before) - len(_BOOKKEEPING & set(before))
+    if timing := report_timing(before, after):
+        print("\n".join(timing), end="\n\n")  # noqa
+    if strict and (raised := _raised(before) | _raised(after)):
+        print(f"calls which raised on one side or both: {sorted(raised)}")  # noqa
+        return 1
+    if report := compare(before, after, fields):
+        print(f"{counted} calls compared against {ref}; some differ:\n")  # noqa
         print("\n".join(report))  # noqa
         return 1
-    print(f"{len(before)} calls compared against {ref}; all identical.")  # noqa
+    print(f"{counted} calls compared against {ref}; all identical.")  # noqa
     return 0
+
+
+def _merge_timing(kept: dict, other: dict) -> dict:
+    """Return one dump holding the best timing of two runs of the same code."""
+    best = dict(kept.get("_timing", {}))
+    for name, seconds in other.get("_timing", {}).items():
+        best[name] = min(seconds, best.get(name, seconds))
+    return kept | {"_timing": best}
+
+
+def _raised(dumped: dict) -> set[str]:
+    """Return the names of calls which recorded an error.
+
+    An error is stored as its message and compared like any other field,
+    so a call which fails the same way on both sides reads as a pass.
+    `--strict` is how to notice that the check is not checking anything.
+    """
+    return {
+        i
+        for i, v in dumped.items()
+        if i not in _BOOKKEEPING and isinstance(v, dict) and "error" in v
+    }
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--ref", help="The git ref to compare against.")
     parser.add_argument("--dump", help="Write fingerprints here and exit.")
+    parser.add_argument(
+        "--fields",
+        help=(
+            "Comma separated fingerprint fields to compare, e.g. "
+            "'dtype,shape,dims,data_hash,coords'. Use when the ref is far "
+            "enough back that the attrs schema itself changed."
+        ),
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail if any call raised, even where both sides raised alike.",
+    )
     args = parser.parse_args()
     if args.dump:
         dump(Path(args.dump))
     elif not args.ref:
         parser.error("--ref is required; it names the checkout to compare against.")
     else:
-        sys.exit(main(args.ref))
+        chosen = {i.strip() for i in args.fields.split(",")} if args.fields else None
+        sys.exit(main(args.ref, chosen, args.strict))

--- a/scripts/differential_check.py
+++ b/scripts/differential_check.py
@@ -391,14 +391,26 @@ def _timed(call) -> tuple[float, Any]:
 
 
 def _input_digests(calls) -> dict:
-    """Return a fingerprint of the patches the calls close over."""
+    """
+    Return a fingerprint of every patch the calls were given.
+
+    Both ways a call can be holding one: `get_calls` closes over its
+    patches, and `get_matrix_calls` passes them as default arguments.
+    Reading only the closures left the matrix half unchecked, which is
+    the half carrying the dtypes and the special values -- so a call
+    which wrote into one of those would have gone unnoticed.
+
+    Every patch found is digested, not just the first: a call given two
+    of them can spoil either.
+    """
     seen = {}
     for name, call in calls.items():
-        for value in getattr(call, "__closure__", None) or ():
-            contents = value.cell_contents
-            if isinstance(contents, dc.Patch):
-                seen[f"_input_of/{name}"] = _hash(np.asarray(contents.data))
-                break
+        held = [x.cell_contents for x in getattr(call, "__closure__", None) or ()]
+        held.extend(getattr(call, "__defaults__", None) or ())
+        held.extend((getattr(call, "__kwdefaults__", None) or {}).values())
+        patches = [x for x in held if isinstance(x, dc.Patch)]
+        for index, patch in enumerate(patches):
+            seen[f"_input_of/{name}/{index}"] = _hash(np.asarray(patch.data))
     return seen
 
 

--- a/tests/test_utils/test_array_api.py
+++ b/tests/test_utils/test_array_api.py
@@ -205,6 +205,12 @@ def _identity(patch):
     return patch
 
 
+def _make_complex(patch):
+    """Return the patch with complex data, so a conjugate means something."""
+    data = np.asarray(patch.data)
+    return patch.new(data=(data + 1j * data[::-1]).astype("complex128"))
+
+
 class _Case(NamedTuple):
     """How to exercise one patch function on a non-numpy backend."""
 
@@ -218,6 +224,19 @@ class _Case(NamedTuple):
 # setup runs on the numpy patch, before it is moved to another backend.
 ARRAY_API_CASES = {
     "dascore.proc.coords.transpose": _Case(call=lambda patch: patch.transpose()),
+    "dascore.proc.coords.rename_coords": _Case(
+        call=lambda patch: patch.rename_coords(time="t")
+    ),
+    "dascore.proc.basic.abs": _Case(call=lambda patch: patch.abs()),
+    # conj and real hand a real patch straight back, which says nothing
+    # about the backend, so they are given something to actually do.
+    "dascore.proc.basic.conj": _Case(
+        call=lambda patch: patch.conj(), setup=_make_complex
+    ),
+    "dascore.proc.basic.imag": _Case(call=lambda patch: patch.imag()),
+    "dascore.proc.basic.real": _Case(
+        call=lambda patch: patch.real(), setup=_make_complex
+    ),
     "dascore.proc.aggregate.all": _Case(call=lambda patch: patch.all("time")),
     "dascore.proc.aggregate.any": _Case(call=lambda patch: patch.any("time")),
     "dascore.proc.aggregate.max": _Case(call=lambda patch: patch.max("time")),

--- a/tests/test_workflow/test_patch_op.py
+++ b/tests/test_workflow/test_patch_op.py
@@ -356,8 +356,8 @@ class TestCanonicalByHand:
 
     def test_defaults_are_filled_in(self):
         """Or the two would be two operations doing one thing."""
-        by_hand = PatchOp(name="normalize", kwargs={"dim": "time"})
-        by_call = dc.proc.normalize.op("time")
+        by_hand = PatchOp(name="detrend", kwargs={"dim": "time"})
+        by_call = dc.proc.detrend.op("time")
         assert by_hand.kwargs == by_call.kwargs
         assert by_hand == by_call
         assert by_hand.fingerprint == by_call.fingerprint
@@ -365,8 +365,8 @@ class TestCanonicalByHand:
     def test_a_star_args_group_by_hand(self):
         """Including one whose arguments cannot be passed by name."""
         assert PatchOp(
-            name="transpose", kwargs={"dims": ("time", "distance")}
-        ) == dc.proc.transpose.op("time", "distance")
+            name="flip", kwargs={"dims": ("time",), "flip_coords": True}
+        ) == dc.proc.flip.op("time")
 
 
 class TestAPositionalBeforeAStarArgs:
@@ -390,9 +390,14 @@ class TestVersions:
 
     def test_an_operation_carries_the_functions_version(self):
         """Not this class's, which is the same for every operation."""
-        op = dc.proc.normalize.op("time")
-        assert op.version == dc.proc.normalize.__version__
+        op = dc.proc.detrend.op("time")
+        assert op.version == dc.proc.detrend.__version__
         assert op.to_dict()["params"]["version"] == op.version
+        # A processor keeps its version out of the parameters, so that
+        # `kwargs` stays the call; the document still records it.
+        implemented = dc.proc.normalize.op("time")
+        assert implemented.version == dc.proc.normalize.__version__
+        assert implemented.to_dict()["version"] == implemented.version
 
     def test_a_document_reads_back_as_what_was_written(self, monkeypatch):
         """
@@ -607,7 +612,23 @@ class TestDocuments:
             for tag, cls in registered_models().items()
             if isinstance(cls, type) and issubclass(cls, (PatchOp, PatchProcessor))
         }
-        assert tags == {"PatchOp", "PatchProcessor"}
+        # Spelled out rather than counted, so that a class added without
+        # a reason to is noticed. The module argues against a class per
+        # patch function; these are the exceptions it names -- the ones
+        # wanting a kernel seam.
+        assert tags == {
+            "PatchOp",
+            "PatchProcessor",
+            "Abs",
+            "Conj",
+            "Demean",
+            "Imag",
+            "Normalize",
+            "Real",
+            "RenameCoords",
+            "Standardize",
+            "Transpose",
+        }
 
     def test_the_document_names_the_operation(self):
         """The name and the arguments are what a document holds."""
@@ -619,7 +640,7 @@ class TestDocuments:
 
     def test_a_document_which_cannot_be_read_says_what_to_import(self):
         """The message is worth nothing if it does not name the function."""
-        document = dc.proc.normalize.op("time").to_dict()
+        document = dc.proc.detrend.op("time").to_dict()
         broken = document["params"]
         broken["name"], broken["module"] = "nosuchpkg:denoise", "nosuchpkg.filters"
         with pytest.raises(ParameterError, match="nosuchpkg"):
@@ -742,8 +763,8 @@ class TestImplementations:
 
     def test_the_table_is_left_as_it_was(self):
         """The test above puts the table back, or the next one is wrong."""
-        assert "normalize" not in processor_module._IMPLEMENTATIONS
-        assert isinstance(dc.proc.normalize.op("time"), PatchOp)
+        assert "detrend" not in processor_module._IMPLEMENTATIONS
+        assert isinstance(dc.proc.detrend.op("time"), PatchOp)
 
     def test_registering_something_which_is_not_one(self):
         """Only a PatchProcessor can implement an operation."""

--- a/tests/test_workflow/test_patch_op.py
+++ b/tests/test_workflow/test_patch_op.py
@@ -22,6 +22,7 @@ import dascore as dc
 import dascore.workflow.processor as processor_module
 from dascore.exceptions import ParameterError
 from dascore.models.registry import registered_models
+from dascore.proc.basic import Normalize
 from dascore.units import get_quantity
 from dascore.workflow import (
     PatchOp,
@@ -752,8 +753,9 @@ class TestImplementations:
         """
         A hand-written class takes over the name it implements.
 
-        Empty in this PR; the first entry arrives with the first
-        plan/kernel split, and this is what says the routing works.
+        The table already holds the operations which were split into a
+        plan and a kernel; this says the routing which reaches them is
+        the same routing anything else would get.
         """
 
         class Doubler(PatchProcessor):
@@ -781,6 +783,11 @@ class TestImplementations:
         """The test above puts the table back, or the next one is wrong."""
         assert "detrend" not in processor_module._IMPLEMENTATIONS
         assert isinstance(dc.proc.detrend.op("time"), PatchOp)
+        # Stated positively too: were the test above to stop working on a
+        # copy of the table, it would leave its stand-in registered under
+        # a name which already has an implementation, and the absence of
+        # `detrend` would not notice.
+        assert processor_module._IMPLEMENTATIONS["normalize"] is Normalize
 
     def test_registering_something_which_is_not_one(self):
         """Only a PatchProcessor can implement an operation."""

--- a/tests/test_workflow/test_patch_op.py
+++ b/tests/test_workflow/test_patch_op.py
@@ -362,6 +362,22 @@ class TestCanonicalByHand:
         assert by_hand == by_call
         assert by_hand.fingerprint == by_call.fingerprint
 
+    def test_a_name_with_an_implementation(self):
+        """
+        A hand-built `PatchOp` for an implemented name is the same
+        operation, and says so where it counts.
+
+        It is not the same *object*: `.op(...)` gives the class which
+        implements the name, and equality asks for one type. The
+        fingerprint is what provenance is written from, and that agrees,
+        so an id recorded either way still matches.
+        """
+        by_hand = PatchOp(name="normalize", kwargs={"dim": "time", "norm": "l2"})
+        by_call = dc.proc.normalize.op("time")
+        assert by_hand.fingerprint == by_call.fingerprint
+        assert by_hand.kwargs == by_call.kwargs
+        assert type(by_hand) is not type(by_call)
+
     def test_a_star_args_group_by_hand(self):
         """Including one whose arguments cannot be passed by name."""
         assert PatchOp(

--- a/tests/test_workflow/test_processor_seam.py
+++ b/tests/test_workflow/test_processor_seam.py
@@ -62,6 +62,23 @@ class TestPatchMeta:
         """The metadata and some data make a patch again."""
         assert meta.to_patch(patch.data).equals(patch)
 
+    def test_a_patch_subclass_survives(self, patch):
+        """
+        An operation on a subclass gives back that subclass.
+
+        A patch function used to build its result with `patch.new`, which
+        constructs `self.__class__`; naming `Patch` in the metadata would
+        have taken a subclass's own behaviour away from it silently.
+        """
+
+        class _Sub(dc.Patch):
+            """A patch which is more than a patch."""
+
+        sub = _Sub(data=patch.data, coords=patch.coords, dims=patch.dims)
+        assert type(sub.abs()) is _Sub
+        assert type(sub.transpose()) is _Sub
+        assert type(sub.rename_coords(distance="depth")) is _Sub
+
     def test_data_of_the_wrong_shape(self, meta, patch):
         """The coords check the data on the way in, so this cannot pass."""
         with pytest.raises(CoordDataError, match="doesnt match the coordinate"):

--- a/tests/test_workflow/test_processor_seam.py
+++ b/tests/test_workflow/test_processor_seam.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
-from dascore.exceptions import ParameterError
+from dascore.exceptions import CoordDataError, ParameterError
 from dascore.proc.basic import Abs, Normalize, _known_real
 from dascore.workflow import PatchMeta, PatchProcessor, Task, register_kernel
 from dascore.workflow.processor import (
@@ -64,7 +64,7 @@ class TestPatchMeta:
 
     def test_data_of_the_wrong_shape(self, meta, patch):
         """The coords check the data on the way in, so this cannot pass."""
-        with pytest.raises(Exception, match="shape|match|size"):
+        with pytest.raises(CoordDataError, match="doesnt match the coordinate"):
             meta.to_patch(np.asarray(patch.data)[:2])
 
 

--- a/tests/test_workflow/test_processor_seam.py
+++ b/tests/test_workflow/test_processor_seam.py
@@ -1,0 +1,281 @@
+"""
+Tests for the plan/kernel seam.
+
+The nine converted operations exercise it from above, and the parity
+check proves they still answer what they answered. What is here is the
+seam itself: what a processor is allowed to leave out, what it is refused
+for getting wrong, and how a kernel for another array backend is found.
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import numpy as np
+import pytest
+
+import dascore as dc
+from dascore.exceptions import ParameterError
+from dascore.proc.basic import Abs, Normalize, _known_real
+from dascore.workflow import PatchMeta, PatchProcessor, Task, register_kernel
+from dascore.workflow.processor import (
+    _resolve_kernel,
+    register_implementation,
+)
+
+
+@pytest.fixture(scope="module")
+def patch():
+    """A patch to operate on."""
+    return dc.get_example_patch()
+
+
+@pytest.fixture(scope="module")
+def meta(patch):
+    """What that patch is, apart from its values."""
+    return PatchMeta.from_patch(patch)
+
+
+class TestPatchMeta:
+    """A patch with the values taken out."""
+
+    def test_it_carries_the_shape_without_the_data(self, meta, patch):
+        """Which is what lets something plan an operation without one."""
+        assert meta.dims == patch.dims
+        assert meta.shape == patch.shape
+        assert meta.ndim == len(patch.dims)
+        assert meta.dtype == patch.data.dtype
+        assert meta.backend == "numpy"
+
+    def test_an_axis_by_name(self, meta, patch):
+        """A kernel wants an axis; the caller said a dimension."""
+        assert meta.get_axis("time") == patch.dims.index("time")
+
+    def test_update_leaves_the_rest(self, meta):
+        """Changing one part of the metadata changes only that part."""
+        other = meta.update(dtype="float32")
+        assert other.dtype == "float32"
+        assert other.coords is meta.coords
+        assert other.attrs is meta.attrs
+
+    def test_back_to_a_patch(self, meta, patch):
+        """The metadata and some data make a patch again."""
+        assert meta.to_patch(patch.data).equals(patch)
+
+    def test_data_of_the_wrong_shape(self, meta, patch):
+        """The coords check the data on the way in, so this cannot pass."""
+        with pytest.raises(Exception, match="shape|match|size"):
+            meta.to_patch(np.asarray(patch.data)[:2])
+
+
+class TestKernelResolution:
+    """Which function actually runs, and for which backend."""
+
+    def test_a_registered_kernel_wins_for_its_backend(self, patch):
+        """Which is the whole point of registering one."""
+
+        class Doubling(PatchProcessor):
+            """A processor whose generic kernel does nothing."""
+
+            def kernel(self, data, meta, out_meta):
+                """Hand the data back unchanged."""
+                return data
+
+        @register_kernel(Doubling, "numpy")
+        def _double(processor, data, meta, out_meta):
+            """Double it, so the two can be told apart."""
+            return data * 2
+
+        assert _resolve_kernel(Doubling, "numpy") is _double
+        out = Doubling()._apply(patch)
+        assert np.array_equal(np.asarray(out.data), np.asarray(patch.data) * 2)
+
+    def test_another_backend_falls_back_to_the_generic(self):
+        """A kernel written to the standard runs wherever it is asked to."""
+
+        class Generic(PatchProcessor):
+            """A processor with only a generic kernel."""
+
+            def kernel(self, data, meta, out_meta):
+                """Do nothing, visibly."""
+                return data
+
+        @register_kernel(Generic, "cupy")
+        def _never(processor, data, meta, out_meta):
+            """Registered for a backend nothing here uses."""
+            raise AssertionError("the cupy kernel should not have been chosen")
+
+        assert _resolve_kernel(Generic, "numpy") is Generic.__dict__["kernel"]
+
+    def test_a_subclass_kernel_beats_a_parents_backend_kernel(self):
+        """
+        Or a parent could answer for an operation it does not implement.
+
+        A subclass which wrote its own kernel means it; a kernel
+        registered against the class it derives from is about the
+        parent's operation, not this one.
+        """
+
+        class Parent(PatchProcessor):
+            """The class the kernel is registered against."""
+
+        @register_kernel(Parent, "numpy")
+        def _parent_kernel(processor, data, meta, out_meta):
+            """What the parent does on numpy."""
+            return data
+
+        class Child(Parent):
+            """A subclass which computes something else entirely."""
+
+            def kernel(self, data, meta, out_meta):
+                """The child's own arithmetic."""
+                return data
+
+        assert _resolve_kernel(Parent, "numpy") is _parent_kernel
+        assert _resolve_kernel(Child, "numpy") is Child.__dict__["kernel"]
+
+    def test_no_kernel_at_all_is_metadata_only(self):
+        """A processor which touches no data says so by defining none."""
+
+        class MetadataOnly(PatchProcessor):
+            """A processor with nothing to compute."""
+
+        assert _resolve_kernel(MetadataOnly, "numpy") is None
+
+    def test_a_metadata_only_processor_passes_the_data_through(self, patch):
+        """And hands back the very patch, since nothing changed."""
+
+        class Nothing(PatchProcessor):
+            """A processor which does nothing at all."""
+
+        assert Nothing()._apply(patch) is patch
+
+
+class TestRegistrationRefuses:
+    """What a class is turned away for, at import rather than at use."""
+
+    def test_something_which_is_not_a_processor(self):
+        """Only a PatchProcessor can implement an operation."""
+        with pytest.raises(ParameterError, match="is not a PatchProcessor"):
+            register_implementation("detrend", dict)
+
+    def test_a_class_which_disagrees_about_a_requirement(self):
+        """Two places saying it differently is worse than one saying it."""
+
+        class Disagrees(PatchProcessor):
+            """Claims a history the function does not declare."""
+
+            dim: str = "time"
+            type: str = "linear"
+            history = None
+
+        with pytest.raises(ParameterError, match="have to agree"):
+            register_implementation("detrend", Disagrees)
+
+    def test_a_class_at_another_version(self):
+        """They fingerprint as one operation, so they are one version."""
+
+        class Bumped(PatchProcessor):
+            """Says it is a version its function is not."""
+
+            __version__ = "9.9"
+            dim: str = "time"
+            type: str = "linear"
+
+        with pytest.raises(ParameterError, match="one version"):
+            register_implementation("detrend", Bumped)
+
+    def test_a_class_missing_a_parameter(self):
+        """A call could not be written down as one."""
+
+        class Missing(PatchProcessor):
+            """Has no field for the dimension detrend takes."""
+
+        with pytest.raises(ParameterError, match="no such field"):
+            register_implementation("detrend", Missing)
+
+    def test_a_class_which_cannot_take_the_extras(self):
+        """A function with **kwargs needs a class which accepts them."""
+
+        class Strict(PatchProcessor):
+            """Forbids extras, so the renames could not reach it."""
+
+        with pytest.raises(ParameterError, match='extra="allow"'):
+            register_implementation("update_coords", Strict)
+
+
+class TestTheVersionTravels:
+    """An operation is what it was when it was written down."""
+
+    def test_through_a_document(self, monkeypatch):
+        """A document says which version wrote it, and that is what it is."""
+        op = dc.proc.normalize.op("time")
+        document = op.to_dict()
+        monkeypatch.setattr(dc.proc.normalize, "__version__", "2.0")
+        assert Task.from_dict(document).version == "1.0"
+        # A newly built one does see the bump; that is what a version is for.
+        assert dc.proc.normalize.op("time").version == "2.0"
+
+    def test_through_a_pickle(self, monkeypatch):
+        """Rebuilding in another process must not re-read the function."""
+        restored = Task.from_dict(dc.proc.normalize.op("time").to_dict())
+        monkeypatch.setattr(dc.proc.normalize, "__version__", "2.0")
+        assert pickle.loads(pickle.dumps(restored)).version == "1.0"
+
+    def test_through_an_update(self, monkeypatch):
+        """Changing an argument is not changing which version it is."""
+        restored = Task.from_dict(dc.proc.normalize.op("time").to_dict())
+        monkeypatch.setattr(dc.proc.normalize, "__version__", "2.0")
+        assert restored.update(norm="l1").version == "1.0"
+
+
+class TestKnownReal:
+    """
+    Whether a dtype alone says the data has no imaginary part.
+
+    The question is asked of every `real`, `conj` and `imag`, and the
+    answer decides whether the operation runs at all. A numpy dtype says
+    so with `kind`; the standard does not ask a dtype for one, so a
+    backend which omits it has to be asked another way.
+    """
+
+    def test_something_which_is_not_an_array(self):
+        """No dtype at all says nothing, so the operation runs."""
+        assert _known_real(object()) is False
+
+    def test_a_dtype_no_namespace_will_answer_for(self):
+        """
+        A dtype with no `kind`, belonging to nothing which can be asked.
+
+        Not known to be real, so the operation runs -- which is the same
+        answer an object array gets, and for the same reason.
+        """
+
+        class _Dtype:
+            """A dtype which says nothing about what it holds."""
+
+        class _Array:
+            """An array-like whose namespace cannot be found."""
+
+            dtype = _Dtype()
+
+        assert _known_real(_Array()) is False
+
+
+class TestTheSeamIsInvisible:
+    """Registering a class must not move anything already recorded."""
+
+    def test_the_fingerprint_is_the_operations(self, patch):
+        """Not the class's, or every processing_id would stop matching."""
+        by_hand = dc.workflow.PatchOp(
+            name="normalize", kwargs={"dim": "time", "norm": "l2"}
+        )
+        assert Normalize(dim="time", norm="l2").fingerprint == by_hand.fingerprint
+
+    def test_an_operation_answers_what_a_patch_op_answers(self):
+        """So a contract written over all of them does not have to care."""
+        op = Abs()
+        assert op.name == "abs"
+        assert op.node_name == "abs"
+        assert op.kwargs == {}
+        assert op.version == dc.proc.abs.__version__


### PR DESCRIPTION
## Description

PR 6 of the processors plan: the first kernel splits. A patch function used to do two things in one body — work out which axis it wanted and what the coordinates became, and do the arithmetic. Nothing could ask it the first without running the second, which is why nothing could register an array backend for a single operation, and why nothing could fuse a chain of them without holding the data.

Nine operations are now split: `abs`, `real`, `imag`, `conj`, `normalize`, `standardize`, `demean`, `transpose`, `rename_coords`.

### The seam

`PatchMeta` (`dascore/workflow/meta.py`) is a patch with the values taken out — coords, attrs, dtype, and which array backend the data belong to. A processor's `derive_meta` sees only that and never an array; its `kernel` sees only the array and never a coordinate. A class which defines no kernel is metadata-only and the data pass through untouched, which is what `rename_coords` is. `register_kernel(Normalize, "cupy")` is how another package says how an operation runs on its arrays — and it reaches `patch.normalize(...)`, not just the operation object.

It is a frozen dataclass rather than a model on purpose: `dascore.core.coordmanager` is still being imported when `workflow/processor.py` runs, so annotations which are never evaluated are what let this module name a `CoordManager` at all.

### Delegation is in the function body, not the decorator

`normalize`'s body is now `return Normalize(dim=dim, norm=norm)._apply(self)`. The `patch_function` wrapper is **untouched**, so the checks, `data_type`, the history string and the lineage stamp are unchanged by construction rather than by care.

The alternative — having the wrapper consult `_IMPLEMENTATIONS` — would have put a signature bind (~10 µs) and a model construction (~5 µs) on every one of the ~90 patch functions so that nine could dispatch, and would have built the operation twice on the `.op()` route which already had one. Third-party replacement of a whole implementation class still wants that, and stays available as an additive follow-up; nothing here is wasted if it lands.

### A processor is a whole operation

It answers everything a `PatchOp` answers — `name`, `kwargs`, `version`, `node_name` — and **fingerprints as one**. The class name never reaches the digest: were it to, every `processing_id` ever recorded for these nine would stop matching, and every stored document with them.

It carries all seven `@patch_function` parameters rather than the four it had, because something reading a chain of processors to fuse them has the decorator nowhere in reach. `register_implementation` reconciles the two at import and refuses a class which disagrees with its function about any of them.

## Verification

**Parity is the gate.** `scripts/differential_check.py` hashes every result exactly and reports **870 calls identical** against the branch point, re-run after every conversion.

Ninety-five of those calls are new, added in the first commit *before* anything was converted, because the harness only checks what it lists and the two functions this PR changes most were the least listed: `rename_coords` was not there at all, `transpose`'s no-op short circuit and its ellipsis forms were never called, and every `normalize`/`standardize` call ran on a patch whose `data_type` was already empty — so clearing it could not be told from forgetting to.

Three things the harness could not see also went in: a call which writes into the patch it was given (inputs are hashed again afterwards), a call which raises the same way on both sides and so reads as a pass (`--strict`), and timing.

- `pytest tests` — 12,498 passed.
- `pytest dascore --doctest-modules` — 204 passed.
- `tests/test_utils/test_array_api.py` — the nine run on `array_api_strict` and `dask` with no numpy fallback.

### What parity could not catch, the strict backend did

`_known_real` read `dtype.kind`. An `array_api_strict` dtype has no `kind`, so every such array read as "not known to be real", and `real`, `conj` and `imag` ran on data the standard forbids them for. Numpy accepts all three, so a numpy-only parity check is structurally blind to it. It asks the namespace through `isdtype` now, and `imag` builds the zeros numpy would have returned.

### Timing

Reported on every harness run, passing or not. The two legs are separate processes, so they are alternated and each call keeps its best of three passes — that takes the total from reading 34% out on *identical code* to about 6%. A single call can still read 35% out and the report says so rather than implying a precision it does not have; `benchmarks/` is where one operation gets measured properly.

- **master → dev: 405 ms → 326 ms** over 865 calls, about 20% faster.
- **This PR: +1.3% aggregate**, no call outside the noise band.

### The master baseline

`--fields` exists because the attrs schema itself changed between master and dev: without it, 773 of 775 calls "differ" in `attrs` and the leg says nothing. Comparing the numbers alone leaves **exactly one real difference in 212 commits** — `matrix/bool/conj`, `int8` → `bool`, from the `_known_real` short circuit. Recorded in `.scratch/parity-baselines.md`.

## Review

Codex CLI review found five; four were real and are fixed:

- **Kernel resolution walked the MRO wrongly** — every ancestor's registered kernels were consulted before a subclass's own `kernel`, so a parent's backend kernel could answer for a subclass which had written a different operation.
- **A restored version did not survive pickling or `update`** — an operation written at `1.0` came back fingerprinting as `2.0`. It travels with both now; a freshly built one still tracks a bump.
- **Reconciliation could not tell an omitted declaration from one equal to the base default**, so a class stating `history="full"` against a function declaring `None` was overwritten rather than refused.
- **Equality regressed and I had masked it.** A hand-built `PatchOp` naming an implemented operation has the same fingerprint and arguments but a different type. I had moved the canonical-by-hand tests onto unconverted functions; a test now states the real behaviour.

The fifth — a kernel which mutates its argument in place and returns it would bypass everything — is documented as a contract in `_apply` rather than guarded, since checking means hashing the data on every operation.

## Deferred

- **`angle`**, deliberately. `np.angle` and `atan2(imag, real)` are bit-identical on numpy in every case tried, so the risk is entirely in the portable three-branch rewrite — and `make_arrays()` has no complex array containing a zero, an inf or a nan, so that surface is untested. It gets its own PR once those arrays land.
- **scipy-backed ops** (`pass_filter`, `median_filter`, `savgol_filter`, `sobel_filter`, `detrend`, `taper`) — scipy is numpy-only, so there is no portable kernel to write until there is a backend to justify one.
- **A plan cache** keyed on the fingerprint and the metadata, so `plan_kernel` runs once per spool rather than once per patch. This PR buys the seam, not the speed.

## Changelog

- added: patch operations can be split into a metadata step and an array kernel, and another package can register a kernel for its own array backend with `register_kernel`.
- added: `PatchMeta` describes a patch without its data, for code which decides what an operation does to the metadata without touching the values.
- fixed: `real`, `conj` and `imag` no longer fail on array backends whose dtypes carry no numpy `kind`.
- fixed: an operation restored from a document keeps the version it was written at through pickling and `update`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for array backends across common operations, including absolute value, conjugation, real/imaginary extraction, normalization, standardization, and demeaning.
  * Added reliable coordinate renaming and dimension transposition with validation and no-op handling.
  * Complex and real-valued data now produce backend-compatible results while preserving existing NaN and zero-value behavior.

* **Documentation**
  * Added guidance for extending operations with backend-specific implementations and updated workflow examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->