### PR TITLE
Read every segment of a TDMS file, along time

### DIFF
--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -334,7 +334,9 @@ def _get_data(tdms_file, lead_in_length=28):
             # Rotate the axes to [samples, nch]
             raw_last_chunk = np.rollaxis(raw_last_chunk, 1)
             data_node = np.append(data_node, raw_last_chunk, axis=0)
-            return data_node, channel_length
+        # Outside the branch: a decimated segment whose chunks all happen to
+        # be full has nothing left over, and still has its data.
+        return data_node, channel_length
 
     fileinfo, attrs = _get_fileinfo(tdms_file)
 

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -173,6 +173,48 @@ def _get_distance_coord(attr):
     return d_coord
 
 
+def _iter_segment_bounds(tdms_file, fileinfo, lead_in_length=28):
+    """
+    Yield the (data start, data end) byte offsets of each segment in the file.
+
+    A TDMS file is a sequence of segments, each with its own lead-in naming
+    where the next one begins; the first segment's offsets are the ones
+    already read into fileinfo. Leaves the file position at the last lead-in
+    it had to read, so callers which care must restore it.
+    """
+    rdo = int(fileinfo["raw_data_offset"])
+    nso = int(fileinfo["next_segment_offset"])
+    file_size = fileinfo["file_size"]
+    while True:
+        yield rdo, nso
+        if nso >= file_size:
+            return
+        tdms_file.seek(nso + 12, 0)
+        # Unsigned, as the lead-in reader above also reads them: TDMS writes
+        # all ones for a file it never got to close, meaning the segment runs
+        # to the end of the file, and clamping is what says so.
+        (next_seg_nso, next_seg_rdo) = struct.unpack("<QQ", tdms_file.read(2 * 8))
+        start = nso + lead_in_length
+        rdo = min(file_size, start + next_seg_rdo)
+        # Each segment starts a whole lead-in past the one before it, so this
+        # climbs to file_size and the walk always ends.
+        nso = min(file_size, start + next_seg_nso)
+
+
+def _get_sample_count(tdms_file, fileinfo, lead_in_length=28):
+    """Return how many samples per channel the whole file holds."""
+    itemsize = np.dtype(fileinfo["data_type"]).itemsize
+    per_sample = fileinfo["n_channels"] * itemsize
+    position = tdms_file.tell()
+    try:
+        bounds = list(_iter_segment_bounds(tdms_file, fileinfo, lead_in_length))
+    finally:
+        tdms_file.seek(position, 0)
+    # Counting bytes to the end of the file instead would count every
+    # segment's lead-in and metadata as data.
+    return sum((nso - rdo) // per_sample for rdo, nso in bounds)
+
+
 def _get_all_attrs(tdms_file, lead_in_length=28):
     """Return all the attributes which can be fetched from attributes."""
     # read lead-in information into fileinfo
@@ -227,13 +269,9 @@ def _get_all_attrs(tdms_file, lead_in_length=28):
     fileinfo["data_type"] = TDS_DATA_TYPE.get(struct.unpack("<i", tdms_file.read(4))[0])
     if fileinfo["data_type"] not in ("int16", "float32"):
         raise Exception(f"Unsupported TDMS data type: {fileinfo['data_type']}")
-    # get number of samples by dividing amount of unread data by the
-    # size of data per channel
-    numofsamples = (
-        (fileinfo["file_size"] - fileinfo["raw_data_offset"])
-        / n_channels
-        / np.dtype(fileinfo["data_type"]).itemsize
-    )
+    # Add up what each segment holds, which for a one-segment file is the
+    # whole file after the header.
+    numofsamples = _get_sample_count(tdms_file, fileinfo, lead_in_length)
     t_coord = _get_time_coord(out, numofsamples)
     out["coords"] = {"time": t_coord, "distance": d_coord}
     return out, fileinfo
@@ -302,31 +340,19 @@ def _get_data(tdms_file, lead_in_length=28):
 
     # map file contents to a variable dmap
     dmap = mmap.mmap(tdms_file.fileno(), 0, access=mmap.ACCESS_READ)
-    # rdo: the start of the data in the file
-    rdo = int(fileinfo["raw_data_offset"])
     # nch: number of channels
     nch = int(fileinfo["n_channels"])
 
-    # nso: the beginning of the segment that comes next after the data
-    nso = fileinfo["next_segment_offset"]
-    # seg1_length: length of recording indicated as raw_data in metadata for
-    # each channel in bytes
-
-    flag = 0
-    while flag == 0:
-        cdata_node, cchannel_length = get_segment_data(fileinfo, nch, dmap, nso, rdo)
-        if fileinfo["file_size"] == nso:
-            flag = 1
+    data_node = None
+    channel_length = 0
+    for rdo, nso in _iter_segment_bounds(tdms_file, fileinfo, lead_in_length):
+        segment, seg_length = get_segment_data(fileinfo, nch, dmap, nso, rdo)
+        # A segment holds every channel for a stretch of time, so segments
+        # stack along time, which is the first axis of (samples, channels).
+        if data_node is None:
+            data_node = segment
         else:
-            tdms_file.seek(nso + 12, 0)
-            (next_seg_nso, next_seg_rdo) = struct.unpack("<qq", tdms_file.read(2 * 8))
-            rdo = min(fileinfo["file_size"], nso + lead_in_length + next_seg_rdo)
-            nso = min(fileinfo["file_size"], nso + lead_in_length + next_seg_nso)
-        try:
-            data_node = np.append(data_node, cdata_node, axis=1)
-            channel_length += cchannel_length
-        except NameError:
-            data_node = cdata_node
-            channel_length = cchannel_length
+            data_node = np.append(data_node, segment, axis=0)
+        channel_length += seg_length
 
     return data_node, channel_length, attrs

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import io
 import struct
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -115,9 +116,79 @@ class TestTDMSUtils:
         monkeypatch.setattr(tdms_utils, "_get_fileinfo", lambda _: (fileinfo, attrs))
         monkeypatch.setattr(tdms_utils.mmap, "mmap", lambda *args, **kwargs: data)
         out_data, channel_length, out_attrs = tdms_utils._get_data(fake)
-        assert out_data.shape == (3, 2)
+        # Three samples on one channel from each of the two segments.
+        assert out_data.shape == (6, 1)
         assert channel_length == 6
         assert out_attrs == attrs
+
+
+class TestMultiSegment:
+    """A TDMS file can hold several segments, each a stretch of time."""
+
+    @pytest.fixture(scope="class")
+    def two_segment_path(self, tmp_path_factory):
+        """The example file's segment, written twice.
+
+        Appending segments is how a TDMS file grows, and this example
+        declares its segment length exactly, so the second copy reads as a
+        second segment. sample_tdms_file_v4713.tdms cannot stand in for it:
+        its lead-in claims 146 MB for a 1 MB file, so anything after it is
+        read as part of the first segment.
+        """
+        raw = Path(fetch("iDAS005_tdms_example.626.tdms")).read_bytes()
+        path = tmp_path_factory.mktemp("tdms_multi_segment") / "two_segment.tdms"
+        path.write_bytes(raw + raw)
+        return path
+
+    def test_segments_stack_along_time(self, two_segment_path):
+        """Both segments are read, and they stack along time, not distance."""
+        with open(two_segment_path, "rb") as fi:
+            data, channel_length, _ = tdms_utils._get_data(fi)
+        assert data.shape == (2000, 1152)
+        assert channel_length == 2000
+        # One segment written twice, so the halves are the same samples.
+        assert np.array_equal(data[:1000], data[1000:])
+
+    def test_read(self, two_segment_path):
+        """A multi-segment file reads as one patch holding every segment."""
+        patch = dc.spool(two_segment_path)[0]
+        single = dc.spool(fetch("iDAS005_tdms_example.626.tdms"))[0]
+        assert patch.shape == (2000, 1152)
+        assert np.array_equal(patch.data[:1000], single.data)
+        assert len(patch.get_coord("time")) == 2000
+
+    def test_unclosed_last_segment_runs_to_the_end_of_the_file(self):
+        """All ones for a segment's length means the rest of the file.
+
+        TDMS writes that when a file was never closed -- the recording was
+        cut short -- and the offsets are unsigned, so reading them as signed
+        would make the last segment a backwards one.
+        """
+        fileinfo = {
+            "raw_data_offset": 28,
+            "next_segment_offset": 40,
+            "file_size": 200,
+            "n_channels": 1,
+            "data_type": "float32",
+        }
+        buffer = bytearray(200)
+        buffer[52:68] = struct.pack("<QQ", 0xFFFFFFFFFFFFFFFF, 0)
+        fake = _FakeTDMSFile(bytes(buffer))
+        bounds = list(tdms_utils._iter_segment_bounds(fake, fileinfo))
+        assert bounds == [(28, 40), (68, 200)]
+        assert tdms_utils._get_sample_count(fake, fileinfo) == 3 + 33
+
+    def test_scan_agrees_with_read(self, two_segment_path):
+        """Counting bytes to the end of the file would over-count the time.
+
+        A scan never reads the data, so nothing else would catch it saying
+        the file covers more time than it holds.
+        """
+        summary = dc.scan(two_segment_path)[0]
+        time = dc.spool(two_segment_path)[0].get_coord("time")
+        assert summary.coords["time"].len == 2000
+        assert summary.coords["time"].min == time.min()
+        assert summary.coords["time"].max == time.max()
 
 
 class TestTDMSInterrogator:

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -121,6 +121,26 @@ class TestTDMSUtils:
         assert channel_length == 6
         assert out_attrs == attrs
 
+    def test_get_data_decimated_whole_chunks(self, monkeypatch):
+        """A decimated segment whose chunks are all full still has its data."""
+        fileinfo = {
+            "decimated": True,
+            "chunk_size": 2,
+            "data_type": "float32",
+            "file_size": 8,
+            "raw_data_offset": 0,
+            "n_channels": 1,
+            "next_segment_offset": 8,
+        }
+        attrs = {"tag": "example"}
+        data = np.array([1.0, 2.0], dtype=np.float32).tobytes()
+        fake = _FakeTDMSFile(data)
+        monkeypatch.setattr(tdms_utils, "_get_fileinfo", lambda _: (fileinfo, attrs))
+        monkeypatch.setattr(tdms_utils.mmap, "mmap", lambda *args, **kwargs: data)
+        out_data, channel_length, _ = tdms_utils._get_data(fake)
+        assert out_data.shape == (2, 1)
+        assert channel_length == 2
+
 
 class TestMultiSegment:
     """A TDMS file can hold several segments, each a stretch of time."""


### PR DESCRIPTION
## Description

Fixes #974: every TDMS file with more than one segment fails to read today.

A TDMS file is a sequence of segments — a 28-byte lead-in, metadata, then raw data for a stretch of time across every channel — and appending segments is how one grows while it records. DASCore read only the first segment correctly, for two independent reasons:

- **The segments were stacked along the wrong axis.** `_get_data` appended each following segment with `np.append(..., axis=1)`, the channel axis, while a segment is `(samples, channels)` and the sample count the same function returns is summed along axis 0. Two 1000-sample segments on 1152 channels came back as `(1000, 2304)` with a stated length of 2000 — a shape and a length that contradict each other.
- **The time coordinate counted the wrong bytes.** The sample count was everything from the end of the *first* header to the end of the file, divided by bytes per sample, so every later segment's lead-in and metadata counted as data: 2027 samples where the file holds 2000. `scan()` goes through that same code and never reads the data, so an index built from these files records a time range the file does not have — the failure is silent there, not loud.

Together: `CoordDataError: Data array has a shape of (1000, 2304) which doesnt match the coordinate manager shape of (2027, 1152)`.

Both numbers now come from one walk over the segments (`_iter_segment_bounds`), so the data and the coordinate cannot disagree about how many samples the file holds. The walk reads the following lead-ins' offsets unsigned, the way the first lead-in is already read: TDMS writes all ones for a segment in a file it never got to close, and clamping that to the file size is what says "runs to the end of the file". Reading them signed made the last segment of such a file a backwards one.

### The test file

`iDAS005_tdms_example.626.tdms` written twice. Its lead-in declares its segment length exactly (2,365,412 + the 28-byte lead-in is the file's 2,365,440 bytes), and each copy carries a full `TDSm` lead-in and metadata, so the copy reads as a genuine second segment. `sample_tdms_file_v4713.tdms` cannot stand in for it: its lead-in claims 146 MB for a 1 MB file, so anything appended to it is read as part of the first segment.

The assertions that catch the old bug are the shape and the two halves being equal; `channel_length == 2000` passed with the bug present, and is kept because it is the number the two axes disagreed about.

### Not fixed here

- Later segments may declare their own object list, data type, chunk size, or interleaving. This reader has always assumed every segment matches the first, and still does; no test file exercises it. Worth its own issue if a file in the wild turns up.

A second bug came out of review and is fixed in the same PR: `get_segment_data` returned its data from inside the "there is a partial chunk left" branch, so a decimated segment whose length is an exact multiple of the chunk size returned `None` and the caller failed unpacking it. Only decimated files reach it.

### Verified

- `pytest tests -m "not network" -n logical --cov dascore`: 12,466 passed, only the known case-insensitive-filesystem line in `annotations.py` missing on Linux. `-m network`: 118 passed. `dascore/io/tdms/utils.py` and `core.py` at 100%.
- Both example files read the same as before the change, single-segment (`(1000, 1152)` and `(216, 2432)`), and the doubled file now reads `(2000, 1152)` with `scan` and `read` agreeing on the time range.
- Codex review saved under `.scratch/`; it found the signed/unsigned bug above, which is fixed here.

## Changelog

- fixed: TDMS files with more than one segment read every segment, in time order, and `scan` reports the time they actually cover.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
