### PR TITLE
Set data_type in radians_to_strain

### DIFF
--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -202,6 +202,11 @@ def velocity_to_strain_rate_edgeless(
     return patch.new(data=strain_rate, coords=new_coords, attrs=new_attrs)
 
 
+def _get_strain_data_type(units) -> str:
+    """Get the strain data_type implied by the converted data units."""
+    return "strain_rate" if units.dimensionality.get("[time]") == -1 else "strain"
+
+
 @patch_function()
 def radians_to_strain(
     patch: PatchType,
@@ -227,12 +232,26 @@ def radians_to_strain(
     refractive_index ($n$)
         The refractive index of the cable.
 
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = (
+    ...     dc.get_example_patch()
+    ...     .update_attrs(data_units="rad", gauge_length=10)
+    ...     .radians_to_strain()
+    ... )
+    >>> assert patch.attrs.data_type == "strain"
+
     Notes
     -----
     Equation 3 of @lindsey2020broadband:
     $$
     \epsilon_{xx}(t, x_j) = \frac{\lambda}{4 \pi n L_{g} \zeta} \Delta \Phi
     $$
+
+    The output `data_type` is set from the converted data units; it is
+    "strain_rate" when they are strain per unit time (eg rad/s becomes
+    strain/s) and "strain" otherwise.
     """
     # First get gauge length, using gl passed into function or attached to attrs.
     gl = getattr(patch.attrs, "gauge_length", None)
@@ -263,6 +282,8 @@ def radians_to_strain(
         msg = f"radians to strain failed to convert {data_units} to strain."
         raise UnitError(msg)
     # Build output patch
-    new_attrs = patch.attrs.update(data_units=new_units)
+    new_attrs = patch.attrs.update(
+        data_units=new_units, data_type=_get_strain_data_type(new_units)
+    )
     new_data = patch.data * const * d_factor
     return patch.update(data=new_data, attrs=new_attrs)

--- a/tests/test_transform/test_strain.py
+++ b/tests/test_transform/test_strain.py
@@ -235,6 +235,19 @@ class TestRadianToStrain:
         const = out.data / rad_patch.data
         assert np.allclose(const, expected_const)
 
+    def test_data_type_updated(self, rad_patch):
+        """Phase data should become strain, not stay phase."""
+        patch = rad_patch.update_attrs(data_type="phase")
+        out = patch.radians_to_strain()
+        assert out.attrs.data_type == "strain"
+
+    def test_data_type_rate(self, rad_patch):
+        """Data with a per-time component should become strain_rate."""
+        patch = rad_patch.update_attrs(data_units="rad/s", data_type="phase_rate")
+        out = patch.radians_to_strain()
+        assert out.attrs.data_type == "strain_rate"
+        assert get_quantity(out.attrs.data_units) == get_quantity("strain/s")
+
     def test_no_gauge_length_in_attrs(self, rad_patch):
         """Ensure an empty gauge length raises error."""
         patch = rad_patch.update_attrs(gauge_length=None)


### PR DESCRIPTION
## Description

`Patch.radians_to_strain` converted the data and updated `data_units`, but left `data_type` untouched. A phase patch therefore came out of the conversion labeled `data_type="phase"` with `data_units="strain"`, which is self-contradictory and makes downstream selection on `data_type` wrong.

The output type is now derived from the converted units rather than from the input `data_type`, so it is also correct for patches whose `data_type` was never set:

- `rad` -> `strain`
- `rad/s` -> `strain_rate`

Anything else (an exotic exponent such as `rad/s**2`) stays `strain`; those units do not occur in real phase data, and rejecting them would break conversions that otherwise work.

## Changelog

- fixed: `Patch.radians_to_strain` now sets `data_type` to "strain" (or "strain_rate" for per-time units) instead of leaving the input type in place.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
