### PR TITLE
Reach the error paths with real inputs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import gc
-import os
 import shutil
 import threading
 import warnings
@@ -106,9 +105,10 @@ def pytest_sessionstart(session):
     and to set debug hook to True to avoid showing progress bars,
     except when explicitly being tested.
     """
-    # If running in CI make sure to turn off matplotlib.
-    if os.environ.get("CI", False):
-        matplotlib.use("Agg")
+    # Unconditionally, not only under CI: a test suite which needs a display
+    # on one machine and not another is a suite whose viz tests are untested
+    # locally.
+    matplotlib.use("Agg")
 
     # Test-time debug defaults are applied by fixture to avoid state leakage.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,10 +123,11 @@ def pytest_sessionstart(session):
     and to set debug hook to True to avoid showing progress bars,
     except when explicitly being tested.
     """
-    # Unconditionally, not only under CI: a test suite which needs a display
-    # on one machine and not another is a suite whose viz tests are untested
-    # locally.
-    matplotlib.use("Agg")
+    # Headless everywhere rather than only under CI, so the viz tests run
+    # the same way on a laptop as they do there -- except under --pdb, where
+    # someone is sitting at a breakpoint and may want to look at a figure.
+    if not session.config.getoption("usepdb", False):
+        matplotlib.use("Agg")
 
     # Test-time debug defaults are applied by fixture to avoid state leakage.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import gc
 import shutil
+import sys
 import threading
 import warnings
 from contextlib import contextmanager
@@ -62,6 +63,23 @@ def _link_or_copy(source: Path, dest: Path) -> None:
     except _NO_LINK:
         pass
     shutil.copy2(source, dest)
+
+
+@pytest.fixture
+def hide_module(monkeypatch):
+    """Return a function which makes a module unimportable for one test.
+
+    None in sys.modules is the interpreter's own record of a failed
+    import, so every import of that name raises ImportError -- which is
+    what dascore's optional_import turns into a
+    MissingOptionalDependencyError. Replacing the caller's own
+    optional_import instead only exercises the replacement.
+    """
+
+    def _hide(name: str) -> None:
+        monkeypatch.setitem(sys.modules, name, None)
+
+    return _hide
 
 
 # --- Pytest configuration

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -10,7 +10,6 @@ from functools import partial
 from io import BytesIO
 from types import SimpleNamespace
 from typing import ClassVar
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -632,16 +631,13 @@ class TestCoordFingerprint:
             units="cm",
             dtype="float64",
         )
-        seen = []
-
-        def _fake_convert(value, to_units=None, from_units=None):
-            seen.append((value, to_units, from_units))
-            return value
-
-        with patch("dascore.core.coords.convert_units", _fake_convert):
-            coord.convert_units("m")
-
-        assert seen == [(400.0, "m", coord.units), (100.0, "m", coord.units)]
+        out = coord.convert_units("m")
+        # The null start is left alone rather than converted; the two real
+        # scalars are converted from cm.
+        assert np.isnan(out.start)
+        assert out.stop == 4.0
+        assert out.step == 1.0
+        assert out.units == get_quantity("m")
 
     def test_partial_convert_units_without_existing_units_sets_units_only(self):
         """Unitless partial coords should take units without scalar conversion."""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -27,11 +27,6 @@ class TestGetExamplePatch:
         with pytest.raises(UnknownExampleError, match="No example patch"):
             dc.get_example_patch("NotAnExampleRight????")
 
-    def test_data_file_name(self):
-        """Ensure get_example_spool works on a datafile."""
-        spool = dc.get_example_spool("dispersion_event.h5")
-        assert isinstance(spool, dc.BaseSpool)
-
     def test_get_example_patch_data_file_name(self):
         """Ensure get_example_patch can load file-backed registry entries."""
         patch = dc.get_example_patch("dispersion_event.h5")
@@ -42,46 +37,6 @@ class TestGetExamplePatch:
         """Ensure the registered example patches can all be loaded."""
         patch = dc.get_example_patch(name)
         assert isinstance(patch, dc.Patch)
-
-    def test_file_backed_examples_use_direct_read(self, monkeypatch):
-        """File-backed examples should not depend on file-spool patch resolution."""
-        patch = dc.get_example_patch()
-
-        def _fetch(_name):
-            return "ignored-path"
-
-        def _read(_path):
-            return [patch]
-
-        def _spool(_path):
-            raise AssertionError("file-backed examples should load via dc.read")
-
-        monkeypatch.setattr(dc_examples, "fetch", _fetch)
-        monkeypatch.setattr(dc_examples.dc, "read", _read)
-        monkeypatch.setattr(dc_examples.dc, "spool", _spool)
-
-        out = dc_examples.example_event_1()
-        assert isinstance(out, dc.Patch)
-
-    def test_file_backed_registry_examples_use_direct_read(self, monkeypatch):
-        """Registry-backed patch examples should load via direct read."""
-        patch = dc.get_example_patch()
-
-        def _fetch(_name):
-            return "ignored-path"
-
-        def _read(_path):
-            return [patch]
-
-        def _spool(_path):
-            raise AssertionError("registry-backed examples should load via dc.read")
-
-        monkeypatch.setattr(dc_examples, "fetch", _fetch)
-        monkeypatch.setattr(dc_examples.dc, "read", _read)
-        monkeypatch.setattr(dc_examples.dc, "spool", _spool)
-
-        out = dc.get_example_patch("dispersion_event.h5")
-        assert isinstance(out, dc.Patch)
 
 
 class TestGetExampleSpool:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -217,6 +217,64 @@ class _MissingOptionalFormatter(FiberIO):
         return False
 
 
+class _ScanBehaviorFormatter(FiberIO):
+    """A reader whose scan misbehaves in whichever way its file name asks.
+
+    Module level, because registration is permanent and keyed by
+    (name, version): a second definition of the same pair inside a test
+    function is ignored and this one keeps answering. It claims only its
+    own suffix, so no other get_format in the process changes.
+
+    The alternative -- patching `scan` on the live terra15 reader -- edits
+    an object every other test in the session shares.
+    """
+
+    name = "_scan_behavior_formatter"
+    version = "1"
+
+    def get_format(self, resource: Path, **kwargs) -> tuple[str, str] | Literal[False]:
+        """Claim only this test's sentinel files."""
+        return (
+            (self.name, self.version)
+            if Path(resource).suffix == ".scanbehavior"
+            else False
+        )
+
+    def scan(self, resource: Path, **kwargs):
+        """Do what the file name says, rather than scanning it."""
+        behavior = Path(resource).stem
+        if behavior == "os_error":
+            raise OSError("Simulated OS issue")
+        if behavior == "remote_cache_error":
+            raise RemoteCacheError("metadata cache blocked")
+        if behavior == "patch_attrs":  # the pre-ScanPayload return type
+            return [dc.PatchAttrs(tag="legacy")]
+        if behavior == "missing_keys":
+            return [{"unexpected": 1}]
+        if behavior == "non_mapping":
+            return ["not a payload"]
+        if behavior == "summary_coords":  # coords collapsed to summaries
+            patch = dc.get_example_patch()
+            return [
+                {
+                    "attrs": patch.attrs,
+                    "coords": patch.coords.to_summary_dict(),
+                    "dims": patch.dims,
+                    "shape": patch.shape,
+                    "dtype": str(patch.data.dtype),
+                }
+            ]
+        msg = f"no scan behavior called {behavior!r}"
+        raise LookupError(msg)
+
+
+def _misbehaving_scan_path(tmp_path, behavior: str) -> Path:
+    """Return a path _ScanBehaviorFormatter will scan in the named way."""
+    path = tmp_path / f"{behavior}.scanbehavior"
+    path.write_text("placeholder")
+    return path
+
+
 class _DependencyErrorFormatter(FiberIO):
     """A formatter whose scan path hits a dependency/compatibility problem."""
 
@@ -1228,110 +1286,50 @@ class TestReloadableSourcePath:
         with pytest.raises(NotImplementedError):
             fio.scan(bad_input)
 
-    def test_bad_checksum(self, monkeypatch, terra15_v6_path):
+    def test_bad_checksum(self, tmp_path):
         """Test for when format is identified but can't read part of file #346"""
-        # Monkey patch scan to raise OSError. This simulates observed behavior.
-        fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
-        fiber_io = FiberIO.manager.get_fiberio(format=fname, version=ver)
-
-        def raise_os_error(*args, **kwargs):
-            raise OSError("Simulated OS issue")
-
-        monkeypatch.setattr(fiber_io, "scan", raise_os_error)
-
+        path = _misbehaving_scan_path(tmp_path, "os_error")
         # Ensure scanning doesn't raise and warns
         msg = "Failed to scan"
         with pytest.warns(UserWarning, match=msg):
-            scan = dc.scan(terra15_v6_path)
+            scan = dc.scan(path)
         assert not len(scan)
 
-    def test_remote_cache_error_is_not_swallowed(self, monkeypatch, terra15_v6_path):
+    def test_remote_cache_error_is_not_swallowed(self, tmp_path):
         """Remote cache policy errors during scan should propagate to callers."""
-        fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
-        fiber_io = FiberIO.manager.get_fiberio(format=fname, version=ver)
-
-        def raise_remote_cache_error(*args, **kwargs):
-            raise RemoteCacheError("metadata cache blocked")
-
-        monkeypatch.setattr(fiber_io, "scan", raise_remote_cache_error)
-
+        path = _misbehaving_scan_path(tmp_path, "remote_cache_error")
         with pytest.raises(RemoteCacheError, match="metadata cache blocked"):
-            dc.scan(terra15_v6_path)
+            dc.scan(path)
 
-    def test_scan_legacy_patch_attrs_raises(self, monkeypatch, terra15_v6_path):
+    def test_scan_legacy_patch_attrs_raises(self, tmp_path):
         """FiberIO returning PatchAttrs should now fail loudly."""
-        fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
-        fiber_io = FiberIO.manager.get_fiberio(format=fname, version=ver)
-
-        def return_patch_attrs(*args, **kwargs):
-            return [dc.PatchAttrs(tag="legacy")]
-
-        monkeypatch.setattr(fiber_io, "scan", return_patch_attrs)
-
+        path = _misbehaving_scan_path(tmp_path, "patch_attrs")
         with pytest.raises(ValueError, match=r"PatchAttrs from FiberIO\.scan"):
-            dc.scan(terra15_v6_path)
+            dc.scan(path)
 
-    def test_scan_payloads_legacy_patch_attrs_raises(
-        self, monkeypatch, terra15_v6_path
-    ):
+    def test_scan_payloads_legacy_patch_attrs_raises(self, tmp_path):
         """Raw payload scans should reject legacy summary-only results."""
-        fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
-        fiber_io = FiberIO.manager.get_fiberio(format=fname, version=ver)
-
-        def return_patch_attrs(*args, **kwargs):
-            return [dc.PatchAttrs(tag="legacy")]
-
-        monkeypatch.setattr(fiber_io, "scan", return_patch_attrs)
-
+        path = _misbehaving_scan_path(tmp_path, "patch_attrs")
         with pytest.raises(ValueError, match="no longer accepts PatchAttrs"):
-            dc.scan_payloads(terra15_v6_path)
+            dc.scan_payloads(path)
 
-    def test_scan_payloads_missing_keys_raises(self, monkeypatch, terra15_v6_path):
+    def test_scan_payloads_missing_keys_raises(self, tmp_path):
         """Raw payload scans should validate all required payload keys."""
-        fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
-        fiber_io = FiberIO.manager.get_fiberio(format=fname, version=ver)
-
-        def return_malformed_payload(*args, **kwargs):
-            return [{"unexpected": 1}]
-
-        monkeypatch.setattr(fiber_io, "scan", return_malformed_payload)
-
+        path = _misbehaving_scan_path(tmp_path, "missing_keys")
         with pytest.raises(TypeError, match="missing required keys"):
-            dc.scan_payloads(terra15_v6_path)
+            dc.scan_payloads(path)
 
-    def test_scan_payloads_non_mapping_raises(self, monkeypatch, terra15_v6_path):
+    def test_scan_payloads_non_mapping_raises(self, tmp_path):
         """Raw payload scans should reject unsupported result types."""
-        fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
-        fiber_io = FiberIO.manager.get_fiberio(format=fname, version=ver)
-
-        def return_non_mapping(*args, **kwargs):
-            return ["not a payload"]
-
-        monkeypatch.setattr(fiber_io, "scan", return_non_mapping)
-
+        path = _misbehaving_scan_path(tmp_path, "non_mapping")
         with pytest.raises(TypeError, match="must return ScanPayload mappings"):
-            dc.scan_payloads(terra15_v6_path)
+            dc.scan_payloads(path)
 
-    def test_scan_payloads_requires_coord_manager(self, monkeypatch, terra15_v6_path):
+    def test_scan_payloads_requires_coord_manager(self, tmp_path):
         """Raw payload scans should reject collapsed coordinate summaries."""
-        fname, ver = FiberIO.manager._get_format(path=terra15_v6_path)
-        fiber_io = FiberIO.manager.get_fiberio(format=fname, version=ver)
-        patch = dc.get_example_patch()
-        payload = {
-            "attrs": patch.attrs,
-            "coords": patch.coords.to_summary_dict(),
-            "dims": patch.dims,
-            "shape": patch.shape,
-            "dtype": str(patch.data.dtype),
-        }
-
-        def return_summary_coords(*args, **kwargs):
-            return [payload]
-
-        monkeypatch.setattr(fiber_io, "scan", return_summary_coords)
-
+        path = _misbehaving_scan_path(tmp_path, "summary_coords")
         with pytest.raises(TypeError, match="must be a CoordManager"):
-            dc.scan_payloads(terra15_v6_path)
+            dc.scan_payloads(path)
 
     @pytest.mark.parametrize(
         ("key", "value"),

--- a/tests/test_io/test_mseed/test_mseed.py
+++ b/tests/test_io/test_mseed/test_mseed.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 
 import dascore as dc
-import dascore.io.mseed.core as mseed_core
 from dascore.exceptions import MissingOptionalDependencyError
 from dascore.io.mseed import utils as mseed_utils
 from dascore.io.mseed.core import MSeedV2
@@ -184,13 +183,9 @@ class TestMiniSeedGetFormat:
         """DASCore can detect MiniSEED files through plugin discovery."""
         assert dc.get_format(mseed_v3_path) == ("MSEED", "3")
 
-    def test_get_format_without_pymseed(self, tmp_path, monkeypatch):
+    def test_get_format_without_pymseed(self, tmp_path, hide_module):
         """MiniSEED headers can be detected without PyMseed installed."""
-
-        def _optional_import(*args, **kwargs):
-            raise MissingOptionalDependencyError("missing")
-
-        monkeypatch.setattr(mseed_core, "optional_import", _optional_import)
+        hide_module("pymseed")
         v2_path = _write_mseed_v2_header(tmp_path / "test_v2.mseed")
         v3_path = tmp_path / "test_v3.mseed"
         v3_path.write_bytes(b"MS\x03" + bytes(45))
@@ -493,13 +488,9 @@ class TestMiniSeedScan:
         assert payload["shape"] == (1, 10)
         assert payload["dtype"] == "int32"
 
-    def test_missing_pymseed_raises(self, mseed_v3_path, monkeypatch):
+    def test_missing_pymseed_raises(self, mseed_v3_path, hide_module):
         """Explicit MiniSEED reads require PyMseed."""
-
-        def _optional_import(*args, **kwargs):
-            raise MissingOptionalDependencyError("missing")
-
-        monkeypatch.setattr(mseed_core, "optional_import", _optional_import)
+        hide_module("pymseed")
         with pytest.raises(MissingOptionalDependencyError):
             dc.read(mseed_v3_path, file_format="MSEED", file_version="3")
 

--- a/tests/test_io/test_netcdf/test_netcdf.py
+++ b/tests/test_io/test_netcdf/test_netcdf.py
@@ -303,88 +303,16 @@ class TestNetCDFCoreHelpers:
         assert out["chunksizes"] == (10, 20)
 
     def test_read_returns_empty_spool_for_empty_filtered_patch(
-        self, minimal_cf_netcdf_path, monkeypatch
+        self, minimal_cf_netcdf_path
     ):
-        """Read should return an empty spool after filtering removes all data."""
+        """A selection which keeps no samples reads as an empty spool.
 
-        class FakeDataArray:
-            def __init__(self):
-                self.data = np.ones((1, 1))
-
-                def _make_coord(dims, vals):
-                    return type("Coord", (), {"dims": dims, "values": vals})()
-
-                self.coords = {
-                    "distance": _make_coord(("distance",), np.array([0])),
-                    "time": _make_coord(("time",), np.array([0])),
-                }
-                self.attrs = {}
-                self.dims = ("distance", "time")
-                self.shape = self.data.shape
-
-            def load(self):
-                return self
-
-        class FakeDataset:
-            def __init__(self):
-                self.data_vars = {"data": FakeDataArray()}
-                self.attrs = {}
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                return False
-
-            def get(self, name):
-                return self.data_vars["data"]
-
-            def __getitem__(self, item):
-                return self.data_vars[item]
-
-        formatter = netcdf_core.NetCDFCFV18()
-        fake_xarray = type(
-            "FakeXarray",
-            (),
-            {"open_dataset": staticmethod(lambda *args, **kwargs: FakeDataset())},
-        )
-        empty_patch = dc.Patch(
-            data=np.empty((0, 0)),
-            coords=dc.get_coord_manager(
-                coords={"distance": np.array([]), "time": np.array([])},
-                dims=("distance", "time"),
-            ),
-            dims=("distance", "time"),
-            attrs={"tag": "empty"},
-        )
-
-        def _optional_import(name, on_missing="raise"):
-            if name == "xarray":
-                return fake_xarray
-            if name == "netCDF4":
-                return object()
-            return None
-
-        monkeypatch.setattr(netcdf_core, "optional_import", _optional_import)
-        monkeypatch.setattr(
-            netcdf_core,
-            "xarray_to_patch",
-            lambda data_array: dc.Patch(
-                data=data_array.data,
-                coords=dc.get_coord_manager(
-                    coords={
-                        name: (coord.dims, coord.values)
-                        for name, coord in data_array.coords.items()
-                    },
-                    dims=data_array.dims,
-                ),
-                dims=data_array.dims,
-                attrs=dict(data_array.attrs),
-            ),
-        )
-        monkeypatch.setattr(dc.Patch, "select", lambda self, **kwargs: empty_patch)
-
-        spool = formatter.read(minimal_cf_netcdf_path, time=(0, 1))
+        A window past the end of the file is what empties the patch; the
+        fake xarray pipeline this replaces reached the same two lines by
+        making Patch.select return an empty patch to every caller.
+        """
+        # The file's time axis runs 0-9, so this window keeps nothing.
+        spool = netcdf_core.NetCDFCFV18().read(minimal_cf_netcdf_path, time=(100, 200))
         assert len(spool) == 0
 
     def test_write_uses_xarray_dataset_path(self, example_patch, tmp_path, monkeypatch):
@@ -552,18 +480,10 @@ class TestNetCDFIO:
         assert _cached_file_count() == 0, "read should stream, not download"
 
     def test_get_format_without_xarray_import(
-        self, minimal_cf_netcdf_path, monkeypatch
+        self, minimal_cf_netcdf_path, hide_module
     ):
         """Format detection should not depend on xarray being importable."""
-        original_import_module = importlib.import_module
-
-        def _import_module(name, package=None):
-            if name == "xarray":
-                raise ImportError("xarray disabled for test")
-            return original_import_module(name, package)
-
-        monkeypatch.setattr(importlib, "import_module", _import_module)
-
+        hide_module("xarray")
         assert dc.get_format(minimal_cf_netcdf_path) == ("NETCDF_CF", "1.8")
 
 

--- a/tests/test_viz/conftest.py
+++ b/tests/test_viz/conftest.py
@@ -11,3 +11,16 @@ def close_figures():
     """Close all figures after each test."""
     yield
     plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def shown(monkeypatch) -> list:
+    """Record what `show=True` shows, rather than trying to show it.
+
+    Agg makes the backend headless; this is what keeps `plt.show()` from
+    warning that the canvas is non-interactive, and it gives a test asking
+    whether `show=True` reached the call something to assert.
+    """
+    calls = []
+    monkeypatch.setattr(plt, "show", lambda *args, **kwargs: calls.append(kwargs))
+    return calls

--- a/tests/test_viz/conftest.py
+++ b/tests/test_viz/conftest.py
@@ -20,6 +20,10 @@ def shown(monkeypatch) -> list:
     Agg makes the backend headless; this is what keeps `plt.show()` from
     warning that the canvas is non-interactive, and it gives a test asking
     whether `show=True` reached the call something to assert.
+
+    It records rather than forwarding even under --pdb: a real show on an
+    interactive backend blocks until the window is closed, once per viz
+    test. At a breakpoint, `plt.gcf().show()` displays the figure in hand.
     """
     calls = []
     monkeypatch.setattr(plt, "show", lambda *args, **kwargs: calls.append(kwargs))

--- a/tests/test_viz/test_inventory_viz.py
+++ b/tests/test_viz/test_inventory_viz.py
@@ -449,10 +449,8 @@ class TestPath:
         with pytest.raises(ParameterError, match="has no length"):
             path(inventory)
 
-    def test_color_override_and_figsize(self, site, monkeypatch):
+    def test_color_override_and_figsize(self, site, shown):
         """color= reaches the renderer, figsize the figure, show plt.show."""
-        called = []
-        monkeypatch.setattr(plt, "show", lambda: called.append(True))
         ax = path(
             site,
             "DAS.L1.00",
@@ -462,7 +460,7 @@ class TestPath:
             figsize=(4, 3),
             show=True,
         )
-        assert called
+        assert shown
         assert tuple(ax.get_figure().get_size_inches()) == (4.0, 3.0)
         assert np.allclose(_boxes(ax)[0].get_facecolors()[0][:3], [0, 0, 0])
 
@@ -1032,12 +1030,10 @@ class TestMap:
         ax = map_path(tunnel, x="x", y="z", color="section", time="2024-07-01")
         assert "borehole" in _legend_labels(ax)
 
-    def test_show(self, site, monkeypatch):
+    def test_show(self, site, shown):
         """Show calls plt.show."""
-        called = []
-        monkeypatch.setattr(plt, "show", lambda: called.append(True))
         map_path(site, show=True)
-        assert called
+        assert shown
 
 
 class TestTimeline:
@@ -1186,13 +1182,11 @@ class TestTimeline:
         with pytest.raises(ParameterError, match="nothing with a time epoch"):
             timeline(empty)
 
-    def test_ax_and_show(self, site, monkeypatch):
+    def test_ax_and_show(self, site, shown):
         """A given ax is drawn on; show calls plt.show."""
-        called = []
-        monkeypatch.setattr(plt, "show", lambda: called.append(True))
         _, ax = plt.subplots()
         assert timeline(site, ax=ax, show=True) is ax
-        assert called
+        assert shown
 
     def test_tunnel_repair(self, tunnel):
         """The tunnel's path lane holds two epochs split at the repair."""

--- a/tests/test_viz/test_lanes.py
+++ b/tests/test_viz/test_lanes.py
@@ -258,13 +258,11 @@ class TestLayout:
         ax = plot_lanes(kinds_frame, lane="lane", value="value")
         assert sorted(_texts(ax)) == ["1", "2", "a", "b"]
 
-    def test_x_label_and_show(self, monkeypatch):
+    def test_x_label_and_show(self, shown):
         """x_label is applied and show calls plt.show."""
-        called = []
-        monkeypatch.setattr(plt, "show", lambda: called.append(True))
         ax = plot_lanes({"start": [0.0], "end": [1.0]}, x_label="Time", show=True)
         assert ax.get_xlabel() == "Time"
-        assert called
+        assert shown
 
 
 class TestColors:

--- a/tests/test_viz/test_map_fiber.py
+++ b/tests/test_viz/test_map_fiber.py
@@ -111,10 +111,10 @@ class TestPlotMap:
         ax = new.viz.map_fiber("latitude", "longitude")
         check_label_units(new, ax, ["latitude", "longitude"])
 
-    def test_show(self, random_patch, monkeypatch):
+    def test_show(self, random_patch, shown):
         """Ensure show path is callable."""
-        monkeypatch.setattr(plt, "show", lambda: None)
         random_patch.viz.map_fiber(show=True)
+        assert shown
 
 
 class TestMapFiberErrors:

--- a/tests/test_viz/test_specplot.py
+++ b/tests/test_viz/test_specplot.py
@@ -103,7 +103,7 @@ def test_specplot_log_distance_axis_uses_symlog(random_patch):
     assert ax.get_xscale() == "symlog" or ax.get_yscale() == "symlog"
 
 
-def test_show(random_patch, monkeypatch):
+def test_show(random_patch, shown):
     """Ensure show path is callable."""
-    monkeypatch.setattr(plt, "show", lambda: None)
     random_patch.dft("distance").abs().viz.specplot(show=True)
+    assert shown

--- a/tests/test_viz/test_spectrogram.py
+++ b/tests/test_viz/test_spectrogram.py
@@ -78,11 +78,13 @@ class TestPlotSpectrogram:
         axis = patch.viz.spectrogram(dim="time")
         assert isinstance(axis, plt.Axes)
 
-    def test_show(self, random_patch, monkeypatch):
+    def test_show(self, random_patch, shown):
         """Ensure show path is callable."""
-        monkeypatch.setattr(plt, "show", lambda: None)
         axis = random_patch.viz.spectrogram(dim="time", show=True)
         assert isinstance(axis, plt.Axes)
+        axis = random_patch.viz.spectrogram(dim="time", show=True)
+        assert isinstance(axis, plt.Axes)
+        assert shown
 
     @staticmethod
     def _image_shape(axis):

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -289,10 +289,10 @@ class TestWaterfall:
         ax = timedelta_patch.viz.waterfall()
         assert ax is not None
 
-    def test_show(self, random_patch, monkeypatch):
+    def test_show(self, random_patch, shown):
         """Ensure show path is callable."""
-        monkeypatch.setattr(plt, "show", lambda: None)
         random_patch.viz.waterfall(show=True)
+        assert shown
 
     def test_log(self, random_patch):
         """Ensure log is callable."""

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -66,10 +66,10 @@ class TestWiggle:
         times = sub_patch.coords.get_array("time")
         assert labels[0] == str(times[0])
 
-    def test_show(self, random_patch, monkeypatch):
+    def test_show(self, random_patch, shown):
         """Ensure show path is callable."""
-        monkeypatch.setattr(plt, "show", lambda: None)
         random_patch.viz.wiggle(show=True)
+        assert shown
 
     def test_1d_patch(self, random_patch):
         """Test that wiggle works with 1D patches (issue #462)."""
@@ -81,11 +81,11 @@ class TestWiggle:
         # The remaining dimension should be on the x-axis
         assert patch_1d.dims[0].lower() in ax.get_xlabel().lower()
 
-    def test_1d_patch_show(self, random_patch, monkeypatch):
+    def test_1d_patch_show(self, random_patch, shown):
         """Test that show works with 1D patches (issue #462)."""
-        monkeypatch.setattr(plt, "show", lambda: None)
         patch_1d = random_patch.mean("distance", dim_reduce="squeeze")
         patch_1d.viz.wiggle(show=True)
+        assert shown
 
     def test_1d_data_label(self, random_patch):
         """The y axis of a single trace should show the data type and units."""


### PR DESCRIPTION
## Description

PR C of the test-suite reformation, and the first tranche of it. **Based on #976** — they both edit `test_io_core.py` and `test_netcdf.py`, so this is stacked; I will rebase onto `dev` once that merges. Review #976 first.

The suite reaches into dascore to make things go wrong: it replaces a module's own `optional_import` with one that raises, patches `scan` on the live registered terra15 reader, swaps `dc.read` and `dc.spool` process-wide, and builds a fake xarray to reach two lines. Each of those tests the stand-in as much as the code. This replaces the ones where a real input reaches the same place.

**`plt.show` (10 sites → 1 fixture).** Ten viz tests patched `plt.show` to a no-op, and the six which wanted to know it was called each wrote their own recorder. One autouse fixture in the viz conftest collects the calls: a test which cares asserts `shown`, one which does not says nothing. `matplotlib.use("Agg")` is now unconditional rather than CI-only — it is the independent guarantee that no test needs a display, and a suite which needs one on your laptop but not in CI has viz tests nobody runs locally.

**Missing optional dependencies (3 sites → 1 fixture).** `None` in `sys.modules` is the interpreter's own record of a failed import, so `hide_module("pymseed")` makes the real `optional_import` raise the real `MissingOptionalDependencyError`. What the old tests asserted was that their own replacement raised.

**A reader which misbehaves (7 sites → 1 module-level FiberIO).** Seven tests patched `scan` on the terra15 instance every other test in the session shares, to watch `dc.scan` react to a reader that raises `OSError`, raises `RemoteCacheError`, or returns the wrong type. A `FiberIO` which claims only a `.scanbehavior` suffix does whatever its file name asks. Module level, because registration is permanent and keyed by `(name, version)`: a class defined inside a test function is silently ignored and the first one keeps answering.

**A real empty selection (1 site).** The netcdf empty-spool test built a fake xarray, a fake dataset, a fake data array, and a `Patch.select` which returned an empty patch to every caller in the process, to reach the two lines that say "a selection which keeps nothing is an empty spool". Reading the real file with a window past the end of its time axis reaches them.

**The last `unittest.mock`.** `grep -rn "unittest.mock\|mock.patch\|MagicMock" tests` is now empty. The one use replaced `convert_units` with a recorder to prove a null `start` was never passed to it; converting a partial coord from cm to metres and looking at the result says the same thing.

Mock sites: **195 → 168** (the plan's regex). Three tests are deleted rather than converted, each a statement about wiring rather than about a result: two proving file-backed examples take the `dc.read` path by making `dc.spool` raise, and one of a pair of identical `test_data_file_name` tests.

### Verified

- Full suite serial and under `-n logical --dist loadfile`: 9,500 passed, 115 skipped, 2 xfailed; network 40; coverage 100% but `annotations.py:2284`, the case-insensitive-filesystem line macOS and Windows cover.
- Each converted test was checked to still reach what it reached: the netcdf window empties the patch on the real file, `sys.modules[name] = None` produces the real `MissingOptionalDependencyError`, and the sentinel reader's six behaviors each raise what the patched `scan` raised.

### Still to do in this series

The plan's remaining PR C work, none of it started here:

- The `fake_dist_info` and `processor_registry_snapshot` fixtures (~16 sites), which need `functools.cache` clearing on both sides to avoid leaking a fake loader into the registry.
- The rest of the replace-with-real-inputs list: `_updated_after` on a missing remote path, a real `sqlite3.IntegrityError` from a duplicate source row, a real DASDAE file with a bogus `source_version`, garbage after index 0 in a DASDAE coord, `func.__signature__ = "bogus"`, and the `test_misc.py` remote-filesystem triples.
- The three dead source branches (`_redact_remote_resource`'s tuple protocol, DASDAE's three 0-d ndarray copies, MiniSEED's unreachable `struct.unpack` guard) and the side fixes. Two of the three TDMS items the plan listed here are already done, in #975.
- ~55 sites the plan keeps as-is: injected `OSError` from `_walk`, the timeout-skip helpers' signal fakes, numpy-version-gated array checks, and the negative-call laziness guards.

## Changelog

none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for coordinate conversion, file-backed and registry-backed examples, scan outcomes, optional dependencies, and NetCDF filtering.
  * Added validation for malformed data, remote cache errors, missing payloads, and unavailable visualization dependencies.
  * Improved visualization tests to verify display behavior without opening windows.
  * Standardized headless plotting behavior during test runs and added reusable test fixtures for simulated environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->