### PR TITLE
Fingerprint a coordinate by its values, not their spelling

### DIFF
--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-../summary-join/.venv

--- a/.venv
+++ b/.venv
@@ -1,0 +1,1 @@
+../summary-join/.venv

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -184,6 +184,24 @@ def _get_dtype(value, dtype):
     return str(np.dtype(value))
 
 
+def _conformed(value, dtype: np.dtype):
+    """
+    The value as the given dtype, or unchanged where that would lose it.
+
+    Conforming is only ever a change of spelling. A coordinate whose
+    metadata does not fit the dtype it declares — a partial one stating
+    an integer dtype and a fractional start — would otherwise have the
+    difference truncated away, and two coordinates which are not equal
+    would share an identity.
+    """
+    with suppress(TypeError, ValueError, OverflowError):
+        original = np.asarray(value)
+        converted = original.astype(dtype)
+        if converted.astype(original.dtype) == original:
+            return converted
+    return value
+
+
 def _scalar_dtype(dtype: np.dtype, name: str) -> np.dtype:
     """
     The dtype a coordinate's own scalar is conformed to before hashing.
@@ -655,8 +673,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             return ("none", None)
         dtype = np.dtype(self.dtype) if self.dtype else None
         if dtype is not None:
-            with suppress(TypeError, ValueError, OverflowError):
-                value = np.asarray(value).astype(_scalar_dtype(dtype, name))
+            value = _conformed(value, _scalar_dtype(dtype, name))
         return ("scalar", hash_array(np.asarray([value])))
 
     @staticmethod

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -624,11 +624,23 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         _, units = get_factor_and_unit(self.units, simplify=True)
         return self._convert_units(units)
 
-    @staticmethod
-    def _hash_scalar(value) -> tuple[str, str | None]:
-        """Return a dtype-aware scalar hash token."""
+    def _hash_scalar(self, value, name: str = "start") -> tuple[str, str | None]:
+        """
+        Return a dtype-aware scalar hash token.
+
+        The value is first conformed to the coordinate's own dtype, since
+        a fingerprint identifies *values*, not how they were spelled: a
+        range whose start was given as `0` holds the same coordinate as
+        one given `0.0`, and a step of four milliseconds is the step of
+        four million nanoseconds. Without this they would be stored under
+        different identities and never deduplicate.
+        """
         if value is None:
             return ("none", None)
+        dtype = np.dtype(self.dtype) if self.dtype else None
+        if dtype is not None:
+            with suppress(TypeError, ValueError, OverflowError):
+                value = ensure_consistent_dtype(value, name, dtype)
         return ("scalar", hash_array(np.asarray([value])))
 
     @staticmethod
@@ -1419,9 +1431,9 @@ class CoordPartial(BaseCoord):
         return (
             self.shape,
             str(np.dtype(self.dtype)),
-            self._hash_scalar(self.start),
-            self._hash_scalar(self.stop),
-            self._hash_scalar(self.step),
+            self._hash_scalar(self.start, "start"),
+            self._hash_scalar(self.stop, "stop"),
+            self._hash_scalar(self.step, "step"),
         )
 
 
@@ -1562,9 +1574,9 @@ class CoordRange(BaseCoord):
         """Return the scalar payload needed to fingerprint range coords."""
         return (
             self.shape,
-            self._hash_scalar(self.start),
-            self._hash_scalar(self.stop),
-            self._hash_scalar(self.step),
+            self._hash_scalar(self.start, "start"),
+            self._hash_scalar(self.stop, "stop"),
+            self._hash_scalar(self.step, "step"),
         )
 
     def __getitem__(self, item):

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -184,6 +184,22 @@ def _get_dtype(value, dtype):
     return str(np.dtype(value))
 
 
+def _scalar_dtype(dtype: np.dtype, name: str) -> np.dtype:
+    """
+    The dtype a coordinate's own scalar is conformed to before hashing.
+
+    The coordinate's dtype, at its own precision — a coordinate keeping
+    picoseconds must not have them rounded away, or two coordinates a
+    picosecond apart would share an identity. A step is the duration
+    between values, so it takes the matching time unit rather than the
+    time kind itself.
+    """
+    if dtype.kind not in "mM":
+        return dtype
+    unit = np.datetime_data(dtype)[0]
+    return np.dtype(f"timedelta64[{unit}]") if name == "step" else dtype
+
+
 class CoordSummary(DascoreBaseModel):
     """
     A summary for coordinates.
@@ -640,7 +656,7 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
         dtype = np.dtype(self.dtype) if self.dtype else None
         if dtype is not None:
             with suppress(TypeError, ValueError, OverflowError):
-                value = ensure_consistent_dtype(value, name, dtype)
+                value = np.asarray(value).astype(_scalar_dtype(dtype, name))
         return ("scalar", hash_array(np.asarray([value])))
 
     @staticmethod

--- a/dascore/io/index/schema.py
+++ b/dascore/io/index/schema.py
@@ -30,8 +30,13 @@ from collections.abc import Mapping
 from types import MappingProxyType
 from typing import NamedTuple, get_args, get_type_hints
 
-# Version of the index schema, independent of dascore's version.
-INDEX_VERSION = 11
+# Version of the index schema, independent of dascore's version. Bump it
+# when an index written by an older dascore would be read wrongly rather
+# than merely incompletely -- including when what a *stored value* means
+# changes, not only when a column does. 12 canonicalizes the scalars a
+# coordinate's fingerprint is taken over, so identities written by 11 no
+# longer match the ones computed for the same coordinate.
+INDEX_VERSION = 12
 # Identity string so any tool can sanity-check what it opened.
 WHAT_IS_THIS = "dascore_spool_index"
 

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -587,6 +587,16 @@ class TestCoordFingerprint:
         )
         assert coord.to_summary().to_coord().fingerprint() == coord.fingerprint()
 
+    def test_finer_precision_than_nanoseconds_still_differs(self):
+        """Conforming a scalar must not round away what a coordinate keeps."""
+        start = np.datetime64("1969-09-23T15:46:49.660978561024")
+        step = np.timedelta64(1000, "ps")
+        first = get_coord(start=start, stop=start + step * 100, step=step)
+        apart = start + np.timedelta64(1, "ps")
+        second = get_coord(start=apart, stop=apart + step * 100, step=step)
+        assert first != second
+        assert first.fingerprint() != second.fingerprint()
+
     def test_different_values_still_differ(self):
         """Canonicalizing the spelling does not blur real differences."""
         first = get_coord(start=0.0, stop=10.0, step=1.0)

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -587,6 +587,15 @@ class TestCoordFingerprint:
         )
         assert coord.to_summary().to_coord().fingerprint() == coord.fingerprint()
 
+    def test_metadata_which_does_not_fit_its_dtype_still_differs(self):
+        """Conforming is a change of spelling, never a loss of value."""
+        first = CoordPartial(shape=(10,), dtype="int64", start=1.1, stop=11.1, step=1.0)
+        second = CoordPartial(
+            shape=(10,), dtype="int64", start=1.2, stop=11.2, step=1.0
+        )
+        assert first != second
+        assert first.fingerprint() != second.fingerprint()
+
     def test_finer_precision_than_nanoseconds_still_differs(self):
         """Conforming a scalar must not round away what a coordinate keeps."""
         start = np.datetime64("1969-09-23T15:46:49.660978561024")

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -551,7 +551,57 @@ class TestCoordFingerprint:
 
     def test_hash_scalar_none(self):
         """The helper should preserve an explicit None sentinel."""
-        assert BaseCoord._hash_scalar(None) == ("none", None)
+        coord = get_coord(start=0.0, stop=10.0, step=1.0)
+        assert coord._hash_scalar(None) == ("none", None)
+
+    def test_spelling_of_a_scalar_is_not_its_identity(self):
+        """Equal coordinates fingerprint alike however they were written."""
+        as_ints = get_coord(start=0, stop=10, step=1.0)
+        as_floats = get_coord(start=0.0, stop=10.0, step=1.0)
+        assert as_ints == as_floats
+        assert as_ints.fingerprint() == as_floats.fingerprint()
+
+    def test_time_precision_is_not_its_identity(self):
+        """A step of four milliseconds is four million nanoseconds."""
+        t0 = np.datetime64("2020-01-01", "ns")
+        coarse = get_coord(
+            start=t0,
+            stop=t0 + np.timedelta64(400, "ms"),
+            step=np.timedelta64(4, "ms"),
+        )
+        fine = get_coord(
+            start=t0,
+            stop=t0 + np.timedelta64(400_000_000, "ns"),
+            step=np.timedelta64(4_000_000, "ns"),
+        )
+        assert coarse == fine
+        assert coarse.fingerprint() == fine.fingerprint()
+
+    def test_a_summary_round_trip_keeps_the_identity(self):
+        """Describing a coordinate and rebuilding it is the same coordinate."""
+        t0 = np.datetime64("2020-01-01", "ns")
+        coord = get_coord(
+            start=t0,
+            stop=t0 + np.timedelta64(400, "ms"),
+            step=np.timedelta64(4, "ms"),
+        )
+        assert coord.to_summary().to_coord().fingerprint() == coord.fingerprint()
+
+    def test_different_values_still_differ(self):
+        """Canonicalizing the spelling does not blur real differences."""
+        first = get_coord(start=0.0, stop=10.0, step=1.0)
+        assert (
+            first.fingerprint()
+            != get_coord(start=0.0, stop=20.0, step=1.0).fingerprint()
+        )
+        assert (
+            first.fingerprint()
+            != get_coord(start=1.0, stop=11.0, step=1.0).fingerprint()
+        )
+        assert (
+            first.fingerprint()
+            != get_coord(start=0.0, stop=10.0, step=0.5).fingerprint()
+        )
 
     def test_range_equivalent_units_same_fingerprint(self):
         """Equivalent range coords should fingerprint the same after normalization."""

--- a/tests/test_io/test_index/test_index_contract.py
+++ b/tests/test_io/test_index/test_index_contract.py
@@ -16,6 +16,7 @@ import pytest
 
 import dascore as dc
 from dascore.config import config_context
+from dascore.core.coords import get_coord
 from dascore.core.summary import PatchSummary
 from dascore.exceptions import UnitError
 from dascore.io.index.backend import get_backend
@@ -678,3 +679,54 @@ class TestLineageIds:
         """Every patch states a different id; none of them blocks a merge."""
         assert len(set(written_spool.get_contents()["patch_id"])) == 3
         assert len(written_spool.chunk(time=None)) == 1
+
+
+class TestCoordDefinitionDedup:
+    """One coordinate is stored once, however its values were written."""
+
+    def _definitions(self, spool, name):
+        """The def keys stored for one coordinate name."""
+        sql = (
+            "SELECT cd.def_key FROM patch_coords pc "
+            "JOIN coord_defs cd ON cd.coord_def_id = pc.coord_def_id "
+            "WHERE pc.coord_name = ?"
+        )
+        frame = spool._catalog.backend._fetch_df(sql, [name])
+        return frame["def_key"].tolist()
+
+    def test_scalar_spelling_shares_one_definition(self):
+        """A range written with an int start is the one written with a float."""
+        base = dc.get_example_patch()
+        n = base.shape[base.get_axis("distance")]
+        as_ints = base.update_coords(distance=get_coord(start=0, stop=n, step=1.0))
+        as_floats = base.update_coords(
+            distance=get_coord(start=0.0, stop=float(n), step=1.0)
+        )
+        keys = self._definitions(dc.spool([as_ints, as_floats]), "distance")
+        assert len(keys) == 2
+        assert len(set(keys)) == 1
+
+    def test_time_precision_shares_one_definition(self):
+        """A step in milliseconds is the same step in nanoseconds."""
+        t0 = np.datetime64("2020-01-01", "ns")
+        data = np.random.default_rng(0).random((2, 100))
+        coarse = get_coord(
+            start=t0, stop=t0 + np.timedelta64(400, "ms"), step=np.timedelta64(4, "ms")
+        )
+        fine = get_coord(
+            start=t0,
+            stop=t0 + np.timedelta64(400_000_000, "ns"),
+            step=np.timedelta64(4_000_000, "ns"),
+        )
+        distance = get_coord(values=np.array([0.0, 1.0]))
+        patches = [
+            dc.Patch(
+                data=data,
+                coords={"distance": distance, "time": x},
+                dims=("distance", "time"),
+            )
+            for x in (coarse, fine)
+        ]
+        keys = self._definitions(dc.spool(patches), "time")
+        assert len(keys) == 2
+        assert len(set(keys)) == 1


### PR DESCRIPTION
## Description

Closes #978.

A coordinate's fingerprint was taken over its scalars as they were handed in, so how a value was *written* changed its identity:

```python
a = get_coord(start=0,   stop=10,   step=1.0)   # int start, float64 dtype
b = get_coord(start=0.0, stop=10.0, step=1.0)
a == b                              # True
np.array_equal(a.values, b.values)  # True
a.fingerprint() == b.fingerprint()  # False   <-- two identities
```

and likewise a step of `4 ms` against `4_000_000 ns`. The index stores that fingerprint as a coordinate's `def_key`, so equal coordinates were written as two definitions rather than deduplicating, and an identity match between them missed. It also meant a summary round trip changed the identity, since `CoordSummary` conforms its values while `CoordRange` did not.

The scalars are now conformed to the coordinate's own dtype before hashing, using the same `ensure_consistent_dtype` a summary uses. The values a coordinate *stores* are untouched — this is a change to what is hashed, not to what is held, which is why the datetime precision behaviour in the ProdML writer is unaffected.

### Index version

Identities written by index version 11 no longer match the ones computed for the same coordinate, so `INDEX_VERSION` moves to 12. A directory index is a disposable cache and rebuilds itself on open (`DBDirectoryIndexer` already handles `InvalidIndexVersionError` that way, covered by `test_old_index_version_rebuilds`); any other index is refused with a message saying to delete and rebuild.

I chose this over conforming the scalars at construction, which fixes the same two cases but changes the values a `CoordRange` holds — that broke four tests around sub-nanosecond and out-of-range datetimes in the ProdML writer, for no gain in identity.

### Tests

- `TestCoordFingerprint` gains the two equalities above, a summary round trip, and a check that genuinely different coordinates still differ.
- `TestCoordDefinitionDedup` shows the index-level effect: two patches whose coordinate is written differently now share one `coord_defs` row.

## Changelog

- fixed: a coordinate's identity no longer depends on how its values were written, so equal coordinates written with different scalar types or time precisions deduplicate in the index and match each other.
- changed: the spool index version moved to 12; a directory index rebuilds itself on open and any other must be deleted and rebuilt.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordinate identity handling so equivalent numeric, datetime, and timedelta values are recognized consistently.
  * Prevented duplicate coordinate definitions caused by differences in scalar type or time precision.
  * Improved handling of missing coordinate values in fingerprinting.

* **Maintenance**
  * Updated the index format version to reflect the corrected coordinate identity behavior. Existing indexes may need to be rebuilt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->