### PR TITLE
Say on the pull request which lines are not covered

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -178,9 +178,10 @@ jobs:
     env:
       # Whether this run has a pull request to comment on, and something
       # trustworthy to say. A push has no pull request; a fork's token is
-      # read-only, as test_doc_build.yml also has to allow for; and a failed
-      # test cell leaves a hole in the combined data.
-      can_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.test_code.result == 'success' }}
+      # read-only, as test_doc_build.yml also has to allow for, and so is
+      # Dependabot's even though its branch is in this repository; and a
+      # failed test cell leaves a hole in the combined data.
+      can_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && needs.test_code.result == 'success' }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -258,9 +259,14 @@ jobs:
           table=$(coverage report --format=markdown --show-missing --skip-covered)
           # A comment past 65,536 characters is refused, which would turn a
           # coverage problem into a workflow error. The log has every line.
-          rows=$(printf '%s\n' "$table" | tail -n +3 | wc -l)
+          # Sliced in bash rather than piped through head: the runner's shell
+          # sets pipefail, so head closing the pipe early on a large table
+          # would kill this step with SIGPIPE -- in exactly the case the cap
+          # is here for.
+          mapfile -t lines <<< "$table"
+          rows=$(( ${#lines[@]} - 2 ))  # less the header and its underline
           if [ "$rows" -gt 40 ]; then
-            table=$(printf '%s\n' "$table" | head -n 42)
+            table=$(printf '%s\n' "${lines[@]:0:42}")
             table="${table}"$'\n\n'"…and $((rows - 40)) more files; the job log lists them all."
           fi
           if [ "${#table}" -gt 60000 ]; then

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -170,6 +170,18 @@ jobs:
     # failed; do not wait on network_tests, which is allowed to fail.
     if: ${{ !cancelled() && (github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')) }}
 
+    permissions:
+      contents: read
+      # Needed to leave the missing-lines comment on the pull request.
+      pull-requests: write
+
+    env:
+      # Whether this run has a pull request to comment on, and something
+      # trustworthy to say. A push has no pull request; a fork's token is
+      # read-only, as test_doc_build.yml also has to allow for; and a failed
+      # test cell leaves a hole in the combined data.
+      can_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.test_code.result == 'success' }}
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -208,7 +220,105 @@ jobs:
           name: combined_tests
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      # Last, so the report is uploaded whether or not this passes.
+      # The comment says on the pull request what the log says here. It is
+      # skipped when a test cell failed: cells upload their data even when
+      # they fail, so a failed one leaves a hole in the combine and the
+      # missing lines would name code that is covered. The failing cell is
+      # the signal then.
+      - name: read the coverage back
+        id: coverage
+        if: ${{ env.can_comment == 'true' }}
+        shell: bash
+        run: |
+          # The command the gate itself runs, so the two cannot disagree.
+          # It exits 2 below the threshold; anything else is a real failure.
+          set +e
+          coverage report --fail-under=100 > /dev/null
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "complete=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          elif [ "$status" -ne 2 ]; then
+            echo "coverage report exited $status" >&2
+            exit "$status"
+          fi
+          echo "complete=false" >> "$GITHUB_OUTPUT"
+          # How bad it is, for the line which shows before the table is
+          # expanded. From the same data the table is built from.
+          coverage json -q -o coverage.json
+          summary=$(python -c "
+          import json
+          data = json.load(open('coverage.json'))
+          lines = data['totals']['missing_lines']
+          files = sum(1 for x in data['files'].values() if x['summary']['missing_lines'])
+          print(f\"{lines} line{'' if lines == 1 else 's'} in \"
+                f\"{files} file{'' if files == 1 else 's'}\")
+          ")
+          table=$(coverage report --format=markdown --show-missing --skip-covered)
+          # A comment past 65,536 characters is refused, which would turn a
+          # coverage problem into a workflow error. The log has every line.
+          rows=$(printf '%s\n' "$table" | tail -n +3 | wc -l)
+          if [ "$rows" -gt 40 ]; then
+            table=$(printf '%s\n' "$table" | head -n 42)
+            table="${table}"$'\n\n'"…and $((rows - 40)) more files; the job log lists them all."
+          fi
+          if [ "${#table}" -gt 60000 ]; then
+            table="${table:0:60000}"$'\n\n'"…truncated; the job log lists them all."
+          fi
+          # The table is folded away: what a reviewer needs at a glance is
+          # that coverage is short and by how much. The blank line after
+          # </summary> is what lets the table inside parse as markdown.
+          {
+            echo "body<<COVERAGE_REPORT_EOF"
+            echo "❌ **Coverage is not complete** — $summary."
+            echo
+            echo "<details>"
+            echo "<summary>Which lines</summary>"
+            echo
+            printf '%s\n' "$table"
+            echo
+            echo "</details>"
+            echo
+            echo "<sub>Every test cell's data, combined. This comment is updated"
+            echo "on re-run and deleted when coverage returns to 100%.</sub>"
+            echo "<!-- coverage-gate -->"
+            echo "COVERAGE_REPORT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # The marker is hidden rather than the first line of the body, so the
+      # wording above can change without orphaning the comment it wrote.
+      - name: find the coverage comment
+        id: fc
+        if: ${{ env.can_comment == 'true' }}
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad  # v4.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- coverage-gate -->'
+
+      - name: say which lines are missing
+        if: ${{ env.can_comment == 'true' && steps.coverage.outputs.complete == 'false' }}
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9  # v5.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.coverage.outputs.body }}
+          edit-mode: replace
+
+      # Withdrawn rather than edited to say all is well: a pull request at
+      # 100% should carry no coverage comment at all.
+      - name: withdraw the comment once coverage is complete
+        if: ${{ env.can_comment == 'true' && steps.coverage.outputs.complete == 'true' && steps.fc.outputs.comment-id != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ steps.fc.outputs.comment-id }}
+        run: gh api -X DELETE "repos/{owner}/{repo}/issues/comments/$COMMENT_ID"
+
+      # Last, so the report is uploaded and the comment written whether or
+      # not this passes.
       - name: require full coverage
         shell: bash
         run: coverage report --fail-under=100


### PR DESCRIPTION
## Description

`coverage_gate` combines every test cell's data and fails the run below 100%, but the lines it is failing over live only in that job's log — behind a run, a job, and a scroll. Codecov says it separately, and says it differently.

The gate now says it where the review happens. The comment leads with what a reviewer needs at a glance, and folds the detail away under it:

> ❌ **Coverage is not complete** — 1 line in 1 file.
>
> <details><summary>Which lines</summary>
>
> | Name | Stmts | Miss | Cover | Missing |
> |---|--:|--:|--:|--:|
> | dascore/utils/misc.py | 615 | 1 | 99% | 1487 |
>
> </details>

The blank line after `</summary>` is load-bearing — without it GitHub renders the table as raw pipes. Both spellings were checked through GitHub's own `/markdown` API. The count in the headline comes from `coverage json`, the same data the table is built from, so the two cannot disagree.

The comment carries a hidden `<!-- coverage-gate -->` marker, so a re-run on the same PR **edits that comment** rather than adding another, and a run which finds 100% **deletes it** — a pull request at 100% should carry no coverage comment at all. The marker is hidden rather than being the visible first line (as the doc-link comment's is), so the wording can change later without orphaning old comments.

No new dependency: this is the same pinned `peter-evans/find-comment` + `create-or-update-comment` pair `test_doc_build.yml` already uses, and the delete goes through `gh api` the way `remove_review_label.yml` removes a label.

### Three things stop it saying something untrue

- **A push has no pull request** to comment on. The gate still fails there.
- **A fork's token is read-only**, so the write would 403. Skipped there, exactly as the doc-link comment is skipped; the fork PR still gets the red check and the log.
- **A failed test cell still uploads its partial data** (`if: !cancelled()` on the upload), so its share of the combine is missing and covered lines look uncovered. When any cell failed, nothing is posted — the failing cell is the signal. A stale comment is left alone in that case, because that run does not know the true state; the next clean run updates or deletes it.

### Two details worth reviewing

**Where "complete" comes from.** `coverage report --fail-under=100` — the same command the gate itself runs, so the comment and the gate cannot disagree. It exits **2** below the threshold and 1 on a real failure, so a crash is not silently reported as "coverage is short".

**The table is capped** at 40 files and 60,000 characters. The API refuses a comment past 65,536, which would turn a coverage problem into a workflow error. Measured against a deliberately partial data set (one test file's worth of coverage, 193 files with misses): 10,825 characters and a "…and 153 more files" line.

### Verified

Locally: the body rendered from a real partial data file, `--fail-under=100` exits 2 as expected, and `pre-commit` passes including actionlint and zizmor (every value the `run:` block touches arrives through `env:`).

On this PR, all four states were exercised with scratch commits (since removed, so the branch is the one commit):

| State | Result |
|---|---|
| 1. Green matrix at 100% | No comment posted. `coverage_gate` green. |
| 2. One planted uncovered line | Comment appears: ❌ "1 line in 1 file", `dascore/utils/misc.py` — `1487` in the dropdown. `coverage_gate` red, `codecov/project` red. |
| 3. A commit changing *which* lines are missing | **The same comment** (id 5378513959) edited in place — `updated_at` moves, the count stays 1, body now `1487-1488, 1493`. |
| 4. Both reverted | Comment deleted (0 remaining). `coverage_gate` green. |

The delete returned no 403, so `pull-requests: write` alone is enough for `DELETE /issues/comments/{id}` on a pull request — `issues: write` is not needed.

## Changelog

none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
