### PR TITLE
Make a missing attr value a value where patches are partitioned

### DIFF
--- a/dascore/config.py
+++ b/dascore/config.py
@@ -93,11 +93,13 @@ class DascoreConfig(BaseModel):
             "holding conflicting values for any of these are never "
             "combined: operators and ufuncs raise, concatenate and stack "
             "skip them, and chunk puts them in separate outputs (its "
-            "per-call `group` argument overrides this default). A missing "
-            "or empty value conflicts with nothing, which is why the legacy "
-            "`network` and `station` can stay: archives which predate "
-            "`acquisition_key` partition by them and everything else "
-            "ignores them."
+            "per-call `group` argument overrides this default). Operators "
+            "and ufuncs read a missing or empty value as a wildcard which "
+            "matches anything; the operations which partition a collection "
+            "read it as a value, equal to another missing value and nothing "
+            "else. The legacy `network` and `station` can stay because a "
+            "name no patch in a spool states is ignored, and an archive "
+            "which predates `acquisition_key` states them throughout."
         ),
     )
 

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -224,11 +224,13 @@ same units as the specified dimension, or have units attached.
 attr_conflict_description = """
 Indicates how to handle attributes which hold conflicting values across
 the patches being combined (eg data_type, data_units, custom attrs). A
-missing value (None, NaN, "") conflicts with nothing: the known value is
-carried. History and the ids are never compared. If "raise" (default)
-raise an [AttributeMergeError](`dascore.exceptions.AttributeMergeError`)
-for conflicting known values. If "drop", omit the conflicting attributes
-from the output. If "keep_first", keep the first known value of each.
+missing value (None, NaN, "") is a value like any other: it equals
+another missing one and nothing else, so a patch which never stated an
+attribute conflicts with one which did. History and the ids are never
+compared. If "raise" (default) raise an
+[AttributeMergeError](`dascore.exceptions.AttributeMergeError`) for
+conflicting values. If "drop", omit the conflicting attributes from the
+output. If "keep_first", keep the first patch's value of each.
 """
 
 

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -1734,8 +1734,8 @@ class Spool(NamespaceOwner):
             option `patch_kind_attrs`. Sampling rate and coordinate
             structure split groups too, exactly as they do for `chunk`,
             so one attribute value can span several groups. A value
-            nobody recorded conflicts with nothing, so a patch which
-            never stated the attribute joins the group that did.
+            nobody recorded is a value of its own, so a patch which never
+            stated the attribute is not grouped with one which did.
         missing_dim
             What to do with patches lacking `dim`: "drop" (the default)
             excludes them, "raise" refuses. Chunk defaults to "raise"
@@ -1817,8 +1817,8 @@ class Spool(NamespaceOwner):
             Defaults to the config option `patch_kind_attrs`; sampling
             and structural differences split groups too, so one
             attribute value can span several rows. A value nobody
-            recorded conflicts with nothing, so a patch which never
-            stated the attribute joins the group that did.
+            recorded is a value of its own, so a patch which never
+            stated the attribute is not grouped with one which did.
         missing_dim
             What to do with patches lacking `dim`: "drop" (the default)
             excludes them, "raise" refuses.
@@ -1902,8 +1902,10 @@ class Spool(NamespaceOwner):
         group
             Attributes which partition patches into separate outputs:
             conflicting values are never an error, the patches simply land
-            in different outputs, and a missing value (null or "") joins the
-            one group consistent with it. Defaults to the config option
+            in different outputs. A missing value (null or "") is a value
+            like any other, so patches which never stated an attribute are
+            grouped together and apart from those which did. Defaults to
+            the config option
             `patch_kind_attrs`; unlike the default, explicitly passed names
             must exist on at least one patch. Dimensions and coordinate
             identities always partition implicitly.

--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -1229,22 +1229,6 @@ class SQLiteIndexBackend:
         df = self._fetch_df("SELECT DISTINCT coord_name FROM patch_coords")
         return set(df["coord_name"])
 
-    def attr_units_map(self, kind: str = "num") -> dict[str, str | None]:
-        """
-        Return the canonical units the index stores each attr of one kind in.
-
-        Units belong to an (attr name, value kind) pair, and only numbers
-        carry any, so the default asks about the numeric kind; an attr the
-        index holds in that kind without units maps to None, and one it
-        does not hold in that kind is absent. One read of the metadata.
-        """
-        rows = self._attr_meta()
-        rows = rows[rows["value_kind"] == kind]
-        return {
-            str(name): _normalize_unit(unit)
-            for name, unit in zip(rows["attr_name"], rows["units"], strict=True)
-        }
-
     def attr_units(self, name: str) -> dict[str, str | None]:
         """Return the canonical units the index stores one attr's kinds in."""
         rows = self._attr_meta()

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -17,7 +17,7 @@ syncer, and views never write.
 from __future__ import annotations
 
 import secrets
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 
 import numpy as np
 import pandas as pd
@@ -41,7 +41,6 @@ from dascore.io.index.ingest import (
     typed_value,
 )
 from dascore.units import get_quantity
-from dascore.utils.attrs import _is_missing
 from dascore.utils.chunk_plan import (
     _SOURCE_COLUMNS,
     _concatenated_steps,
@@ -486,8 +485,6 @@ class PlanResolver(PatchResolver):
         origin_path=None,
         stamped: tuple[str, ...] = (),
         lossy: bool = False,
-        attr_units: Mapping[str, str | None] | None = None,
-        coord_names: Iterable[str] = (),
     ):
         if "output_id" not in member_rows.columns:
             msg = "member_rows must carry an output_id column."
@@ -500,20 +497,10 @@ class PlanResolver(PatchResolver):
         self.merge_kwargs = dict(merge_kwargs)
         self.parent_residuals = tuple(parent_residuals)
         self.mode = mode
-        # The kind rule which produced the plan decides assembly too,
-        # whatever the config says by the time a patch is asked for.
-        self.kind_attrs = dc.get_config().patch_kind_attrs
         # informational only: the directory/file the plan derived from
         self.origin_path = origin_path
         # attrs the outputs state about themselves rather than inherit
         self.stamped = tuple(stamped)
-        # the units the index stores each numeric attr column in (None for
-        # a plain number), resolved at planning so a row's magnitude can
-        # be turned back into the attr it came from
-        self.attr_units = dict(attr_units or {})
-        # every coordinate the parent index knows, so a row's envelope
-        # columns are told from attrs which merely look like one
-        self.coord_names = frozenset(coord_names)
         # Whether the outputs leave samples of their sources out. A lossy
         # plan must never be collapsed: its members do not cover their
         # sources, so re-planning over them would load back what it
@@ -594,11 +581,6 @@ class PlanResolver(PatchResolver):
 
     def resolve(self, row: Mapping, **trim) -> dc.Patch:
         """Assemble the output patch a plan row describes."""
-        with dc.config_context(patch_kind_attrs=self.kind_attrs):
-            return self._resolve(row, **trim)
-
-    def _resolve(self, row: Mapping, **trim) -> dc.Patch:
-        """Assemble under the plan's own kind rule."""
         output_id = int(_row_source_patch_key(row))
         members = self.member_rows[self.member_rows["output_id"] == output_id]
         assert len(members), "no plan members found for output row"
@@ -633,67 +615,13 @@ class PlanResolver(PatchResolver):
         an operation which does know says so -- `Spool.expand_by`
         recording which value each patch was split on -- and it keeps
         the patch which comes out agreeing with the row `get_contents`
-        shows for it.
+        shows for it. Nothing else needs filling: the members of an
+        output agree on every attr the row carries, so the assembled
+        patch already states what the row does.
         """
-        if self.stamped:
-            patch = patch.update_attrs(**{x: row[x] for x in self.stamped})
-        # A row carries its partition's known attr values; the members
-        # which survived into this output may lack some (a missing value
-        # matches, and overlap removal may keep the member which lacked
-        # it). Fill them so the patch agrees with the row.
-        attrs = patch.attrs
-        # every public attr column the row carries, extras included; the
-        # coordinate envelope columns and the row's own bookkeeping are not attrs
-        # the row may carry an envelope for a coordinate the assembled patch
-        # no longer has, so every coordinate the index knows has its envelope
-        # columns set aside; only the patch's own coordinate names are
-        # reserved outright — an attr may share its name with a coordinate
-        # some other patch has
-        own = set(patch.coords.coord_map) | set(patch.dims) | {self.dim}
-        coords = own | self.coord_names
-        envelope = {f"{x}_{y}" for x in coords for y in ("min", "max", "step", "units")}
-        skip = {*_SOURCE_COLUMNS, *own, *envelope, "dims", "output_id"}
-        names = {x for x in row if not x.startswith("_") and x not in skip}
-        # A number in a row may be a quantity the index stored as a base-SI
-        # magnitude with its units kept in the attr metadata resolved at
-        # planning; a number whose units the plan does not know is left
-        # alone rather than stamped as a bare magnitude.
-        fill = {}
-        for x in names:
-            value = row[x]
-            if _is_missing(value) or not _is_missing(attrs.get(x)):
-                continue
-            if _is_number(value):
-                if x not in self.attr_units:
-                    continue
-                if units := self.attr_units[x]:
-                    value = value * get_quantity(units)
-            fill[x] = value
-        if fill:
-            patch = patch.new(attrs=attrs.update(**fill))
-        return patch
-
-
-def _plan_attr_units(parent, outputs: pd.DataFrame) -> dict[str, str | None]:
-    """
-    The units the parent index stores each public numeric output column in.
-
-    One read of the index's attr metadata for the numeric kind, the only
-    kind which carries units: None marks a plain number, and a column the
-    index never held as a number is absent, so `_stamp` leaves a number
-    it cannot account for alone.
-    """
-    if parent is None:
-        return {}
-    known = parent.backend.attr_units_map()
-    return {x: known[x] for x in outputs.columns if x in known}
-
-
-def _is_number(value) -> bool:
-    """True for a numeric scalar other than a bool."""
-    return isinstance(value, int | float | np.number) and not isinstance(
-        value, bool | np.bool_
-    )
+        if not self.stamped:
+            return patch
+        return patch.update_attrs(**{x: row[x] for x in self.stamped})
 
 
 def _trimmed_dims(residuals, coord_dims_map: Mapping) -> frozenset[str]:
@@ -822,8 +750,6 @@ def derived_catalog(
         origin_path=origin_path,
         stamped=stamped,
         lossy=lossy,
-        attr_units=_plan_attr_units(parent, plan.outputs),
-        coord_names=() if parent is None else parent.backend.coord_names(),
     )
     backend = get_backend(":memory:")
     # residual selections trim at load; identity claims (def keys) for

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -615,9 +615,10 @@ class PlanResolver(PatchResolver):
         an operation which does know says so -- `Spool.expand_by`
         recording which value each patch was split on -- and it keeps
         the patch which comes out agreeing with the row `get_contents`
-        shows for it. Nothing else needs filling: the members of an
-        output agree on every attr the row carries, so the assembled
-        patch already states what the row does.
+        shows for it. Nothing else needs filling: under every `conflict`
+        policy the row and the assembled patch reach the same values --
+        the members agree, or both take the first member's, or both
+        carry nothing.
         """
         if not self.stamped:
             return patch

--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -141,10 +141,10 @@ def _is_missing(value) -> bool:
     """
     True for an attr nobody recorded: None, NaN/NaT, or an empty string.
 
-    The one spelling of "missing": every rule which compares attrs
-    normalizes to it first, so a patch which never stated an attr, one
-    which stated null, and one which stated "" are the same patch as far
-    as kind, the merge conflict policy, and units are concerned.
+    A patch which never stated an attr, one which stated null, and one
+    which stated "" compare equal everywhere. Kind and the merge conflict
+    policy reach that through this function; `known_only` spells the same
+    predicate for frames and `get_quantity` for units.
     """
     return value is None or (np.ndim(value) == 0 and (pd.isnull(value) or value == ""))
 

--- a/dascore/utils/attrs.py
+++ b/dascore/utils/attrs.py
@@ -85,23 +85,25 @@ def combine_patch_attrs(
 
     def _handle_other_attrs(mod_dict_list):
         """
-        Fold the attrs: a missing value never conflicts, known ones must agree.
+        Fold the attrs: the members' values must agree, missing included.
 
-        Attrs are scalars, and an empty one (None, NaN, "") is an attr
-        nobody recorded rather than a recorded emptiness, so it is
-        satisfied by whatever another member knows. Only two differing
-        known values are a conflict, handled per `conflict`.
+        Attrs are scalars, and an empty one (None, NaN, "") is a value
+        like any other: it equals another empty one and nothing else. A
+        merge combines a collection, which needs one value per attr, so
+        differing values are a conflict handled per `conflict`.
         """
         keys = list(dict.fromkeys(key for model in mod_dict_list for key in model))
         out, conflicts = {}, []
         for key in keys:
-            known = [x[key] for x in mod_dict_list if not _is_missing(x.get(key))]
-            if not known:
-                continue
-            first = known[0]
-            agree = all(_values_equal(first, x) for x in known[1:])
+            values = [
+                None if _is_missing(value) else value
+                for value in (x.get(key) for x in mod_dict_list)
+            ]
+            first = values[0]
+            agree = all(_values_equal(first, x) for x in values[1:])
             if agree or conflict == "keep_first":
-                out[key] = first
+                if first is not None:
+                    out[key] = first
             else:
                 conflicts.append(key)
         if conflicts and conflict == "raise":
@@ -139,8 +141,10 @@ def _is_missing(value) -> bool:
     """
     True for an attr nobody recorded: None, NaN/NaT, or an empty string.
 
-    The one spelling of "missing" for every rule which lets a missing
-    value match a known one (kind, the merge conflict policy, units).
+    The one spelling of "missing": every rule which compares attrs
+    normalizes to it first, so a patch which never stated an attr, one
+    which stated null, and one which stated "" are the same patch as far
+    as kind, the merge conflict policy, and units are concerned.
     """
     return value is None or (np.ndim(value) == 0 and (pd.isnull(value) or value == ""))
 

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -107,47 +107,21 @@ class ChunkPlan:
 
 def _kind_codes(df: pd.DataFrame, names: Sequence[str]) -> pd.Series:
     """
-    Label each row by kind: rows sharing a label hold no conflicting values.
+    Label each row by kind: rows sharing a label hold equal values.
 
-    A missing (null or "") value conflicts with nothing, so rows are
-    gathered into runs the way `_KindRun` admits patches: a row joins the
-    one run it conflicts with nothing in, and the run takes on the values
-    the row knows. Fully specified rows seed the runs; the rest are taken
-    in a canonical order (so the labels are deterministic and independent
-    of row order), and a row consistent with *several* runs — an unlabelled
-    file between two acquisitions — starts a run of its own rather than
-    guessing. Rows spelled identically always share a label.
+    A plan partitions a whole relation at once, which needs an
+    equivalence relation, so kind values are compared for equality: a
+    missing value (null or "") is a value like any other, equal to
+    another missing one and nothing else. `known_only` is what makes the
+    two spellings one value.
     """
+    # a name repeated in `group` says nothing twice, and a frame with
+    # duplicate labels cannot be grouped
+    names = list(dict.fromkeys(names))
     if not names or df.empty:
         return pd.Series(0, index=df.index, dtype=np.int64)
-    values = known_only(df[list(names)].astype(object))
-    values = values.where(values.notna(), None)
-    rows = [tuple(x) for x in values.itertuples(index=False, name=None)]
-    order = sorted(
-        range(len(rows)), key=lambda i: (None in rows[i], [str(x) for x in rows[i]])
-    )
-    runs: list[tuple] = []  # the accumulated kind of each label
-    seeded: dict[tuple, int] = {}  # the label a spelling started
-    out = np.empty(len(rows), dtype=np.int64)
-    for i in order:
-        row = rows[i]
-        if (label := seeded.get(row)) is None:
-            candidates = [
-                j
-                for j, run in enumerate(runs)
-                if all(a is None or b is None or a == b for a, b in zip(row, run))
-            ]
-            if len(candidates) == 1:
-                (label,) = candidates
-                runs[label] = tuple(
-                    a if a is not None else b for a, b in zip(runs[label], row)
-                )
-            else:
-                label = len(runs)
-                runs.append(row)
-            seeded[row] = label
-        out[i] = label
-    return pd.Series(out, index=df.index)
+    values = known_only(df[names].astype(object))
+    return values.groupby(names, dropna=False, sort=False).ngroup()
 
 
 def _resolve_group_attrs(group, columns) -> tuple[str, ...]:
@@ -918,15 +892,16 @@ def _carried_columns(
     Resolve every partition's carried columns at once (spec 2.5/6.4).
 
     Dims and def keys are single-valued by construction. Public attrs
-    must hold no conflicting *known* values per partition, policed by
-    `conflict`: a missing value (null or "") is an attr nobody recorded,
-    so it conflicts with nothing and the partition carries the known
-    value. Returns a mapping of column -> one carried value per
-    partition (null where a partition does not carry the column), in the
-    order columns ride onto outputs. A conflict raises for the first
-    active partition (in output order) and its first conflicting column,
-    exactly as per-partition policing did; partitions which produced no
-    outputs (`active` False) are never policed.
+    must hold equal values per partition, policed by `conflict`: a
+    missing value (null or "") is a value like any other, equal to
+    another missing one and nothing else, so a member which never
+    recorded an attr conflicts with one which did. Returns a mapping of
+    column -> one carried value per partition (null where a partition
+    does not carry the column), in the order columns ride onto outputs.
+    A conflict raises for the first active partition (in output order)
+    and its first conflicting column, exactly as per-partition policing
+    did; partitions which produced no outputs (`active` False) are never
+    policed.
     """
     n_parts = len(seg_starts)
     first = sorted_df.iloc[seg_starts].reset_index(drop=True)
@@ -956,7 +931,7 @@ def _carried_columns(
         # were never policed (their values may not even be hashable),
         # and their carried values are never published.
         rows = active[codes]
-        # "" is a value nobody recorded, like null; neither conflicts.
+        # "" and null are one missing value, which is a value like any other.
         known = known_only(sorted_df.loc[rows, policed])
         grouped = known.groupby(codes[rows], sort=True)
         part_index = grouped.size().index.to_numpy()
@@ -965,13 +940,16 @@ def _carried_columns(
         # TypeError here. Per-partition policing raised it too, though
         # partition-major rather than at aggregation; such values are
         # outside the relation's contract, so the eager error is fine.
-        nunique[part_index] = grouped.nunique(dropna=True).to_numpy()
-        # no conflict: at most one distinct known value
+        # dropna=False: a member which recorded nothing is a distinct value.
+        nunique[part_index] = grouped.nunique(dropna=False).to_numpy()
+        # no conflict: exactly one distinct value
         single = nunique <= 1
         conflicted = ~single & active[:, None]
-        # the first known value of each partition, null where none
+        # The first *row* of each partition (sorted_df carries a fresh
+        # RangeIndex, so seg_starts are its labels), not `grouped.first()`,
+        # which skips nulls and would resurrect the old first-known rule.
         firsts = pd.DataFrame(index=range(n_parts), columns=policed, dtype=object)
-        firsts.loc[part_index] = grouped.first().to_numpy()
+        firsts.loc[part_index] = known.loc[seg_starts[part_index]].to_numpy()
         # Dims are a partition key and group attrs never conflict within
         # one, so neither reaches the conflict policy here.
         raising = conflicted & (owned | (conflict == "raise"))
@@ -986,7 +964,7 @@ def _carried_columns(
             raise CoordMergeError(msg)
         keep_first = conflict == "keep_first"
         for index, col in enumerate(policed):
-            # keep_first carries the first known value; drop omits the
+            # keep_first carries the first member's value; drop omits the
             # column for that partition (null after assembly).
             keeps = single[:, index] | (conflicted[:, index] & keep_first)
             if not (keeps & active).any():
@@ -1104,14 +1082,12 @@ def _stated(sub: pd.DataFrame, column: str) -> pd.Series:
     """
     Return the one value a cell states for a column, as a length-1 slice.
 
-    Kind matching lets a row which never recorded an attr share a cell
-    with one that did, so the first row is not always the one that
-    knows. Slicing the column (rather than taking the value) keeps the
-    frame's dtype. Falls back to the first row when nobody recorded it.
+    Every row of a cell states the same value -- the kind attrs and the
+    other cell columns are what the cell is -- so the first row speaks
+    for it. Slicing the column (rather than taking the value) keeps the
+    frame's dtype.
     """
-    known = known_only(sub[column])
-    index = known.first_valid_index()
-    return sub[column].iloc[:1] if index is None else sub[column].loc[[index]]
+    return sub[column].iloc[:1]
 
 
 def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance: float):
@@ -1686,24 +1662,26 @@ def build_concat_plan(
         # centimetres plan together and members convert on loading; only
         # numbers are stored per spelling, so only they convert
         df = _normalize_numeric_units(df, name)
-    # The concatenated dimension's units partition like kind: a patch whose
-    # coordinate has values but no units cannot join one whose has units
-    # (the values would be mixed), while a patch with no values along the
-    # dimension (an aggregated coordinate) joins whichever it meets.
-    kind_names = list(names)
+    # How the concatenated dimension is spelled partitions too: a patch
+    # whose coordinate has values but no units cannot join one whose has
+    # them (the values would be mixed), and values of one kind concatenate
+    # while a datetime and a number sharing a name (and a unit) do not.
+    # This is about coordinates, not attrs, so a patch with no values
+    # along the dimension is not a spelling of its own: it states nothing
+    # which could clash, and assembly fills its placeholders from the
+    # members which do state values (`_joinable`). It joins them when they
+    # spell the dimension one way, and stays out when they do not -- which
+    # binds nothing and so needs no accumulating.
+    spelling = pd.Series("", index=df.index, dtype=object)
     if unit_col in df.columns:
         units = df[unit_col].fillna("unitless").astype(object)
         if has_envelope:
             units = units.where(df[min_name].notna(), "")
-        df = df.assign(_concat_units=units.where(along, ""))
-        kind_names.append("_concat_units")
+        spelling = spelling.str.cat(units.where(along, ""))
     if has_envelope:
-        # values of one kind concatenate; a datetime and a number sharing a
-        # name (and a unit) do not, and a row with no values joins either
         family = df[min_name].map(_value_family)
-        df = df.assign(_concat_family=family.where(along, ""))
-        kind_names.append("_concat_family")
-    keys: list = [_kind_codes(df, kind_names)]
+        spelling = spelling.str.cat(family.where(along, ""), sep="|")
+    keys: list = [_kind_codes(df, list(names))]
     if "dims" in df.columns:
         keys.append(df["dims"])
     for dim_key in _dim_def_key_columns(df, name):
@@ -1720,8 +1698,14 @@ def build_concat_plan(
             env = pd.Series(["env:" + "|".join(map(str, x)) for x in spelled])
             key = key.where(key.notna(), env)
         keys.append(key)
-    labels = df.groupby(keys, dropna=False, sort=False).ngroup().to_numpy()
-    df = df.drop(columns=["_concat_units", "_concat_family"], errors="ignore")
+    # Everything a row states about itself; the dimension's spelling then
+    # splits these further, the value-less rows following the stated ones.
+    base = df.groupby(keys, dropna=False, sort=False).ngroup()
+    stated = spelling.where(spelling.str.strip("|") != "")
+    by_base = stated.groupby(base, sort=False)
+    lone = by_base.transform("nunique") == 1
+    spelling = spelling.mask(stated.isna() & lone, by_base.transform("first"))
+    labels = df.groupby([base, spelling], dropna=False, sort=False).ngroup().to_numpy()
     # Order: partitions in order of first appearance, rows within one the
     # way the data run along the dimension (ascending by start, descending
     # by stop), then cut into runs of `count`. A partition without a known
@@ -1777,23 +1761,21 @@ def build_concat_plan(
         sorted_df = sorted_df.assign(**blank)
     by_output = sorted_df.groupby(codes, sort=True)
     if has_envelope:
-        # a member with no values along the dimension (an aggregated
-        # coordinate) has a null envelope, which the output's skips
-        # An output whose members state values of more than one kind has no
-        # envelope the two could share. Labels are the awkward pair: they
-        # have no missing value, so a member which states none cannot join
-        # them either, and such an output claims nothing.
+        # A member with no values along the dimension (an aggregated
+        # coordinate) has a null envelope, which the output's skips.
+        # Labels are the awkward pair: they have no missing value, so a
+        # member which states none cannot join them, and such an output
+        # claims nothing until assembly refuses it.
         families = sorted_df[min_name].map(_value_family)
         by_family = families.replace("", np.nan).groupby(codes, sort=True)
-        mixed = (by_family.nunique(dropna=True) > 1).to_numpy()
         text = (by_family.first() == "text").fillna(False).to_numpy()
         blank = (families == "").groupby(codes, sort=True).any().to_numpy()
-        undecided = pd.Series(mixed | (text & blank))
+        undecided = pd.Series(text & blank)
         data[min_name] = by_output[min_name].min().where(~undecided).to_numpy()
         data[max_name] = by_output[max_name].max().where(~undecided).to_numpy()
         if unit_col in sorted_df.columns:
             # a member with no values along the dimension states no unit;
-            # the output speaks the first unit any member states, which is
+            # the output speaks the unit its stated members share, which is
             # what assembly joins in
             known = known_only(sorted_df[[unit_col]])[unit_col]
             data[unit_col] = known.groupby(codes, sort=True).first().to_numpy()

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -1743,6 +1743,16 @@ def build_concat_plan(
     policed_df = sorted_df.assign(**blanked)
     carried = _carried_columns(policed_df, codes, seg_starts, name, conflict, active)
     data: dict[str, Any] = {k: v.reset_index(drop=True) for k, v in carried.items()}
+    if "data_units" in sorted_df.columns:
+        # Data units scale the data, so assembly converts every member to
+        # the first units any member states rather than letting a loosened
+        # policy splice differently scaled samples (`concatenate_planned`).
+        # The row has to say the same, or it would describe kilometre-scaled
+        # samples by a first member's silence -- or, under `drop`, not at all.
+        first_stated = known_only(sorted_df[["data_units"]])["data_units"]
+        first_stated = first_stated.groupby(codes, sort=True).first()
+        if first_stated.notna().any():
+            data["data_units"] = first_stated.reset_index(drop=True)
     if has_envelope and not along.all():
         # rows gaining the dimension have no values along it; what their
         # column holds belongs to a coordinate the new dimension replaces
@@ -1825,9 +1835,10 @@ def build_concat_plan(
             first[i] if uniform[i] else _combined_dtype(all_dtypes.iloc[a : a + n])
             for i, (a, n) in enumerate(zip(seg_starts, sizes))
         ]
-        if conflict == "keep_first" and "data_units" in sorted_df.columns:
-            # keeping one spelling of the data units converts the members
-            # stated otherwise, which floats an integer array
+        if conflict != "raise" and "data_units" in sorted_df.columns:
+            # settling on one spelling of the data units converts the members
+            # stated otherwise, which floats an integer array; `drop` reaches
+            # the same conversion, since units are reconciled either way
             stated = known_only(sorted_df[["data_units"]])["data_units"]
             converts = stated.groupby(codes, sort=True).nunique(dropna=True) > 1
             combined = [

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -115,9 +115,7 @@ def _kind_codes(df: pd.DataFrame, names: Sequence[str]) -> pd.Series:
     another missing one and nothing else. `known_only` is what makes the
     two spellings one value.
     """
-    # a name repeated in `group` says nothing twice, and a frame with
-    # duplicate labels cannot be grouped
-    names = list(dict.fromkeys(names))
+    names = list(names)
     if not names or df.empty:
         return pd.Series(0, index=df.index, dtype=np.int64)
     values = known_only(df[names].astype(object))
@@ -126,6 +124,9 @@ def _kind_codes(df: pd.DataFrame, names: Sequence[str]) -> pd.Series:
 
 def _resolve_group_attrs(group, columns) -> tuple[str, ...]:
     """Resolve the group attrs: per-call > config; explicit names must exist."""
+    # A name repeated says nothing twice; deduping here keeps it out of the
+    # recorded params as well as out of the groupby, which cannot take
+    # duplicate labels.
     if group is not None:
         group = (group,) if isinstance(group, str) else tuple(group)
         if missing := [x for x in group if x not in columns]:
@@ -133,9 +134,10 @@ def _resolve_group_attrs(group, columns) -> tuple[str, ...]:
                 f"group attribute(s) {missing} do not exist on any patch in the spool."
             )
             raise InvalidSpoolQueryError(msg)
-        return group
+        return tuple(dict.fromkeys(group))
     # Config (and default) names are best-effort.
-    return tuple(x for x in dc.get_config().patch_kind_attrs if x in columns)
+    names = (x for x in dc.get_config().patch_kind_attrs if x in columns)
+    return tuple(dict.fromkeys(names))
 
 
 def samples_adjusted_envelopes(
@@ -945,11 +947,13 @@ def _carried_columns(
         # no conflict: exactly one distinct value
         single = nunique <= 1
         conflicted = ~single & active[:, None]
-        # The first *row* of each partition (sorted_df carries a fresh
-        # RangeIndex, so seg_starts are its labels), not `grouped.first()`,
-        # which skips nulls and would resurrect the old first-known rule.
+        # The first *row* of each partition, not `grouped.first()`, which
+        # skips nulls and would resurrect the old first-known rule. Only
+        # active partitions: `known_only` on the rest could meet an
+        # unhashable value, as the comment above says.
         firsts = pd.DataFrame(index=range(n_parts), columns=policed, dtype=object)
-        firsts.loc[part_index] = known.loc[seg_starts[part_index]].to_numpy()
+        stated = known_only(first.loc[part_index, policed])
+        firsts.loc[part_index] = stated.to_numpy()
         # Dims are a partition key and group attrs never conflict within
         # one, so neither reaches the conflict policy here.
         raising = conflicted & (owned | (conflict == "raise"))
@@ -1078,18 +1082,6 @@ def _gap_carried_columns(df: pd.DataFrame, name: str, group_attrs) -> list[str]:
     return list(dict.fromkeys(cols))
 
 
-def _stated(sub: pd.DataFrame, column: str) -> pd.Series:
-    """
-    Return the one value a cell states for a column, as a length-1 slice.
-
-    Every row of a cell states the same value -- the kind attrs and the
-    other cell columns are what the cell is -- so the first row speaks
-    for it. Slicing the column (rather than taking the value) keeps the
-    frame's dtype.
-    """
-    return sub[column].iloc[:1]
-
-
 def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance: float):
     """
     Yield `(cell rows, gaps in that cell)` for every cell in `df`.
@@ -1111,7 +1103,7 @@ def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance: float):
     groups = grouped.groups
     mins = grouped[min_name].min()
     stated = {
-        label: tuple(_stated(df.loc[index], x).iloc[0] for x in carried)
+        label: tuple(df.loc[index, x].iloc[0] for x in carried)
         for label, index in groups.items()
     }
     order = sorted(
@@ -1133,7 +1125,7 @@ def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance: float):
                 "gap_size": starts - reach[found],
                 "group_id": np.full(len(found), group_id, dtype=np.int64),
             }
-            | {x: _stated(sub, x).repeat(len(found)).to_numpy() for x in carried}
+            | {x: sub[x].iloc[:1].repeat(len(found)).to_numpy() for x in carried}
         )
         yield group_id, sub, gaps
 
@@ -1236,7 +1228,7 @@ def build_coverage_frame(
                 "gap_total": gap_total,
                 "group_id": group_id,
             }
-            | {x: _stated(sub, x).iloc[0] for x in carried}
+            | {x: sub[x].iloc[0] for x in carried}
         )
     if not rows:
         span = df[max_name] - df[min_name]
@@ -1580,18 +1572,20 @@ def build_concat_plan(
     """
     Build a plan concatenating patches in order (`Spool.concatenate`).
 
-    Partitions as a chunk plan does — kind (the config's attrs, a missing
-    value matching anything), dimensions, the identity of every other
-    dimension, and the concatenated dimension's units (a patch with no
-    values along it joins any) — and then groups
-    each partition's rows by the requested count in the order of the
-    dimension (ascending or descending as the data run; given order when
-    the rows have no envelope), with no sampling tolerance, no gap test,
-    and no overlap removal. Patches which cannot be concatenated together
-    land in separate outputs, never in an error. Remaining attributes must
-    hold no conflicting known values within an output, policed by
-    `conflict` exactly as a chunk plan polices them; non-dimensional
-    coordinates are checked when the output is assembled.
+    Partitions as a chunk plan does — kind (the config's attrs, compared
+    for equality, so a missing value is a value), dimensions, the identity
+    of every other dimension, and how the concatenated dimension is
+    spelled (its units and value kind; a patch with no values along it
+    states neither, so it follows the one spelling the others share and
+    forms its own group when they state two) — and then groups each
+    partition's rows by the requested count in the order of the dimension
+    (ascending or descending as the data run; given order when the rows
+    have no envelope), with no sampling tolerance, no gap test, and no
+    overlap removal. Patches which cannot be concatenated together land in
+    separate outputs, never in an error. Remaining attributes must hold
+    equal values within an output, policed by `conflict` exactly as a
+    chunk plan polices them; non-dimensional coordinates are checked when
+    the output is assembled.
 
     Parameters
     ----------
@@ -1662,16 +1656,12 @@ def build_concat_plan(
         # centimetres plan together and members convert on loading; only
         # numbers are stored per spelling, so only they convert
         df = _normalize_numeric_units(df, name)
-    # How the concatenated dimension is spelled partitions too: a patch
-    # whose coordinate has values but no units cannot join one whose has
-    # them (the values would be mixed), and values of one kind concatenate
-    # while a datetime and a number sharing a name (and a unit) do not.
-    # This is about coordinates, not attrs, so a patch with no values
-    # along the dimension is not a spelling of its own: it states nothing
-    # which could clash, and assembly fills its placeholders from the
-    # members which do state values (`_joinable`). It joins them when they
-    # spell the dimension one way, and stays out when they do not -- which
-    # binds nothing and so needs no accumulating.
+    # The concatenated dimension's spelling partitions too: values with no
+    # units cannot join values with units (they would be mixed), and a
+    # datetime cannot join a number sharing its name and unit. A row with
+    # no values along the dimension states no spelling; it follows the one
+    # spelling the stated rows share (assembly fills its placeholders from
+    # them, see `_joinable`) and forms its own group when they state two.
     spelling = pd.Series("", index=df.index, dtype=object)
     if unit_col in df.columns:
         units = df[unit_col].fillna("unitless").astype(object)

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -1664,7 +1664,9 @@ def build_concat_plan(
     # them, see `_joinable`) and forms its own group when they state two.
     spelling = pd.Series("", index=df.index, dtype=object)
     if unit_col in df.columns:
-        units = df[unit_col].fillna("unitless").astype(object)
+        # `known_only` first: a coordinate stated with no units spells that
+        # null or "", and the two are one statement here as everywhere else.
+        units = known_only(df[unit_col]).fillna("unitless").astype(object)
         if has_envelope:
             units = units.where(df[min_name].notna(), "")
         spelling = spelling.str.cat(units.where(along, ""))

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -68,7 +68,6 @@ from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_co
 from dascore.workflow.identity import (
     _ID_FIELDS,
     advance,
-    fold_ids,
     fold_patch_ids,
     fold_processing_ids,
     ids_enabled,
@@ -1273,13 +1272,6 @@ def _kind_value(value):
     return None if _is_missing(value) else value
 
 
-def _kind_values_equal(value1, value2, strict: bool) -> bool:
-    """Compare two kind values; a missing one is a wildcard unless strict."""
-    if not strict and (value1 is None or value2 is None):
-        return True
-    return _values_equal(value1, value2)
-
-
 def check_kind(
     patch1, patch2, check_behavior: WARN_LEVELS = "raise", *, strict: bool = False
 ) -> bool:
@@ -1291,16 +1283,13 @@ def check_kind(
     the remaining attributes never enter. Patches of different kinds are
     never combined, whatever their coordinates.
 
-    How a missing value compares depends on how many patches the
-    operation combines. An operation with two operands -- an operator, a
-    ufunc, [`Patch.where`](`dascore.Patch.where`) -- has one answer to
-    give, so a missing value is a wildcard which matches anything and the
-    result carries the union of what the two knew. An operation which
-    combines a *collection* -- concatenate, stack, and the spool
-    operations -- must partition its patches instead, which a wildcard
-    cannot do consistently (`"a"` would match `""` would match `"b"`, yet
-    `"a"` and `"b"` conflict), so it passes `strict` and a missing value
-    is a value: it equals another missing value and nothing else.
+    Two-operand callers -- operators, ufuncs,
+    [`Patch.where`](`dascore.Patch.where`) -- leave `strict` False: a
+    missing value is a wildcard matching anything, and the result carries
+    the union of what the two knew. Callers combining a *collection* --
+    concatenate, stack, the spool operations -- pass `strict`, because a
+    wildcard is not transitive (`"a"` matches `""` matches `"b"`, yet
+    `"a"` and `"b"` conflict) and a partition needs it to be.
 
     Parameters
     ----------
@@ -1331,18 +1320,14 @@ def check_kind(
     """
     validate_warn_level(check_behavior)
     kind1, kind2 = get_patch_kind(patch1), get_patch_kind(patch2)
-    return _check_kinds(kind1, kind2, check_behavior, strict=strict)
 
+    def _equal(value1, value2) -> bool:
+        """A missing value is a wildcard unless the caller is strict."""
+        if not strict and (value1 is None or value2 is None):
+            return True
+        return _values_equal(value1, value2)
 
-def _check_kinds(
-    kind1: Mapping, kind2: Mapping, check_behavior, strict: bool = False
-) -> bool:
-    """Compare two kind mappings, warning or raising per check_behavior."""
-    diffs = {
-        x: (kind1[x], kind2[x])
-        for x in kind1
-        if not _kind_values_equal(kind1[x], kind2[x], strict)
-    }
+    diffs = {x: (kind1[x], kind2[x]) for x in kind1 if not _equal(kind1[x], kind2[x])}
     if not diffs:
         return True
     msg = (
@@ -1378,11 +1363,6 @@ def check_data_units(patch1, patch2, check_behavior: WARN_LEVELS = "raise") -> b
     validate_warn_level(check_behavior)
     units1 = get_quantity(patch1.attrs.data_units)
     units2 = get_quantity(patch2.attrs.data_units)
-    return _data_units_agree(units1, units2, check_behavior)
-
-
-def _data_units_agree(units1, units2, check_behavior) -> bool:
-    """Different units disagree; no units is a unit like any other."""
     if units1 == units2:
         return True
     msg = (
@@ -1533,22 +1513,24 @@ def _merge_models(attrs1, attrs2):
     """
     if attrs1 == attrs2:
         return attrs1
+    # keep_first gives the first patch's value for everything, folds the
+    # ids, and keeps the history and the attrs subclass; the data units of
+    # the output are decided by the operation from each operand's own, so
+    # the first's stand here whether or not it has any.
+    merged = combine_patch_attrs([attrs1, attrs2], conflict="keep_first")
+    # It does not fill, though, which is the one thing two operands do:
+    # what the first left empty the second supplies.
     dump1 = attrs1.model_dump(exclude_defaults=True)
-    dump2 = attrs2.model_dump(exclude_defaults=True)
     fill = {
         key: value
-        for key, value in dump2.items()
-        if key not in _ID_FIELDS
+        for key, value in attrs2.model_dump(exclude_defaults=True).items()
+        if key not in _ID_FIELDS  # fold_ids returns {} when ids are disabled
         and key not in ("history", "data_units")
         and not key.startswith("_")
         and not _is_missing(value)
         and _is_missing(dump1.get(key))
     }
-    # The ids fold as they do for any combination; the data units of the
-    # output are decided by the operation from each operand's own, so the
-    # first's must stand whether or not it has any.
-    merged = attrs1.update(**fill) if fill else attrs1
-    return merged.update(**fold_ids([attrs1, attrs2]))
+    return merged.update(**fill) if fill else merged
 
 
 def merge_compatible_coords_attrs(
@@ -1910,13 +1892,22 @@ def concatenate_planned(
         )
         raise CoordMergeError(msg)
     attrs = combine_patch_attrs([x.attrs for x in patches], conflict=conflict)
-    if (kept := attrs.data_units) is not None:
-        # keep_first keeps one spelling of the data units; the data must
-        # then say the same thing, so members stated otherwise convert
+    # Data units scale the data rather than labelling it, so they are
+    # reconciled rather than policed by `conflict` (the plan says the same,
+    # see `_carried_columns`): the output speaks the first units any member
+    # states and the rest convert to them. Letting a unitless first member
+    # stand would splice metre- and kilometre-scaled samples into one array.
+    units = (x.attrs.data_units for x in patches)
+    stated = [x for x in units if not _is_missing(x)]
+    if stated:
+        kept = stated[0]
         patches = [
-            x if x.attrs.data_units in (None, kept) else x.convert_units(kept)
+            x
+            if _is_missing(x.attrs.data_units) or x.attrs.data_units == kept
+            else x.convert_units(kept)
             for x in patches
         ]
+        attrs = attrs.update(data_units=kept)
     task = Concatenate(
         arguments=((dim, count),), check_behavior=None, conflict=conflict
     )

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -66,7 +66,9 @@ from dascore.utils.time import to_float
 from dascore.workflow.builtin import Concatenate, Stack
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
 from dascore.workflow.identity import (
+    _ID_FIELDS,
     advance,
+    fold_ids,
     fold_patch_ids,
     fold_processing_ids,
     ids_enabled,
@@ -1228,9 +1230,10 @@ def get_patch_kind(patch: PatchType | dc.PatchAttrs) -> FrozenDict:
 
     The attribute names come from the config option `patch_kind_attrs`.
     A name the patch lacks, or holds a null or empty string for, maps to
-    None, which conflicts with nothing: an attribute left at its empty
-    default is the same as no attribute, which is also how spool metadata
-    records it.
+    None: an attribute left at its empty default is the same as no
+    attribute, which is also how spool metadata records it.
+    [`check_kind`](`dascore.utils.patch.check_kind`) decides what None
+    then compares equal to.
 
     Parameters
     ----------
@@ -1244,7 +1247,7 @@ def get_patch_kind(patch: PatchType | dc.PatchAttrs) -> FrozenDict:
     >>> patch = dc.get_example_patch()
     >>> kind = get_patch_kind(patch)
     >>> assert kind["tag"] == patch.attrs.tag
-    >>> assert kind["acquisition_key"] is None  # not set, so matches any
+    >>> assert kind["acquisition_key"] is None  # not set
     """
     attrs = patch.attrs if isinstance(patch, dc.Patch) else patch
     names = get_config().patch_kind_attrs
@@ -1256,52 +1259,34 @@ def _kind_value(value):
     return None if _is_missing(value) else value
 
 
-def _kind_values_equal(value1, value2) -> bool:
-    """True unless both values are known and differ."""
-    if value1 is None or value2 is None:
+def _kind_values_equal(value1, value2, strict: bool) -> bool:
+    """Compare two kind values; a missing one is a wildcard unless strict."""
+    if not strict and (value1 is None or value2 is None):
         return True
     return _values_equal(value1, value2)
 
 
-class _KindRun:
-    """
-    The kind a run of combined patches has settled on so far.
-
-    A missing value matches anything, so "same kind" is not transitive;
-    a run resolves that by accumulating: a value any admitted patch knows
-    binds the patches after it, so the run never holds two values for
-    one attribute. Callers admit a patch only once it has passed every
-    other gate, so a patch rejected for its coordinates binds nothing.
-    """
-
-    def __init__(self):
-        self.kind: dict = {}
-
-    def admits(self, kind: Mapping, check_behavior: WARN_LEVELS) -> bool:
-        """Return True if `kind` conflicts with nothing admitted so far."""
-        return not self.kind or _check_kinds(self.kind, kind, check_behavior)
-
-    def add(self, kind: Mapping) -> None:
-        """Admit a kind, filling values the run was missing."""
-        if not self.kind:
-            self.kind = dict(kind)
-        else:
-            self.kind = {
-                x: (self.kind[x] if self.kind[x] is not None else kind[x])
-                for x in self.kind
-            }
-
-
-def check_kind(patch1, patch2, check_behavior: WARN_LEVELS = "raise") -> bool:
+def check_kind(
+    patch1, patch2, check_behavior: WARN_LEVELS = "raise", *, strict: bool = False
+) -> bool:
     """
     Return True if two patches are the same kind.
 
     Kind is decided by the attributes named in the config option
     `patch_kind_attrs` and nothing else: coordinates, units, history, and
-    the remaining attributes never enter. Two patches are the same kind
-    unless they hold conflicting values for one of these attributes; a
-    missing or empty value conflicts with nothing. Patches of different
-    kinds are never combined, whatever their coordinates.
+    the remaining attributes never enter. Patches of different kinds are
+    never combined, whatever their coordinates.
+
+    How a missing value compares depends on how many patches the
+    operation combines. An operation with two operands -- an operator, a
+    ufunc, [`Patch.where`](`dascore.Patch.where`) -- has one answer to
+    give, so a missing value is a wildcard which matches anything and the
+    result carries the union of what the two knew. An operation which
+    combines a *collection* -- concatenate, stack, and the spool
+    operations -- must partition its patches instead, which a wildcard
+    cannot do consistently (`"a"` would match `""` would match `"b"`, yet
+    `"a"` and `"b"` conflict), so it passes `strict` and a missing value
+    is a value: it equals another missing value and nothing else.
 
     Parameters
     ----------
@@ -1313,6 +1298,8 @@ def check_kind(patch1, patch2, check_behavior: WARN_LEVELS = "raise") -> bool:
         What to do when the kinds differ: 'raise' (default) raises
         [`IncompatiblePatchError`](`dascore.exceptions.IncompatiblePatchError`),
         'warn' warns and returns False, 'ignore' returns False quietly.
+    strict
+        If True, a missing value equals only another missing value.
 
     Examples
     --------
@@ -1322,20 +1309,25 @@ def check_kind(patch1, patch2, check_behavior: WARN_LEVELS = "raise") -> bool:
     >>> assert check_kind(patch, patch.pass_filter(time=(None, 10)))
     >>> other = patch.update_attrs(tag="other")
     >>> assert not check_kind(patch, other, check_behavior="ignore")
-    >>> # An unset attribute matches any value.
-    >>> assert check_kind(patch, patch.update_attrs(acquisition_key="A.B.C.D"))
+    >>> # An unset attribute matches any value for a two-patch operation,
+    >>> keyed = patch.update_attrs(acquisition_key="A.B.C.D")
+    >>> assert check_kind(patch, keyed)
+    >>> # but is a value of its own where patches are partitioned.
+    >>> assert not check_kind(patch, keyed, check_behavior="ignore", strict=True)
     """
     validate_warn_level(check_behavior)
     kind1, kind2 = get_patch_kind(patch1), get_patch_kind(patch2)
-    return _check_kinds(kind1, kind2, check_behavior)
+    return _check_kinds(kind1, kind2, check_behavior, strict=strict)
 
 
-def _check_kinds(kind1: Mapping, kind2: Mapping, check_behavior) -> bool:
+def _check_kinds(
+    kind1: Mapping, kind2: Mapping, check_behavior, strict: bool = False
+) -> bool:
     """Compare two kind mappings, warning or raising per check_behavior."""
     diffs = {
         x: (kind1[x], kind2[x])
         for x in kind1
-        if not _kind_values_equal(kind1[x], kind2[x])
+        if not _kind_values_equal(kind1[x], kind2[x], strict)
     }
     if not diffs:
         return True
@@ -1348,22 +1340,15 @@ def _check_kinds(kind1: Mapping, kind2: Mapping, check_behavior) -> bool:
     return False
 
 
-def _with_kind(attrs: dc.PatchAttrs, kind: Mapping) -> dc.PatchAttrs:
-    """Fill the attrs' missing kind values from a run's accumulated kind."""
-    fill = {
-        x: y for x, y in kind.items() if y is not None and _is_missing(attrs.get(x))
-    }
-    return attrs.update(**fill) if fill else attrs
-
-
 def check_data_units(patch1, patch2, check_behavior: WARN_LEVELS = "raise") -> bool:
     """
-    Return True unless the patches hold known, different data units.
+    Return True unless the patches hold different data units.
 
-    Splicing or summing data demands one unit: a patch without units
-    adopts the other's, but metres beside kilometres are not converted
-    for the caller — convert with
-    [`Patch.convert_units`](`dascore.Patch.convert_units`) first.
+    Splicing or summing data demands one unit, and none is converted for
+    the caller: metres beside kilometres, or beside a patch with no units
+    at all, must be reconciled first with
+    [`Patch.convert_units`](`dascore.Patch.convert_units`) or
+    [`Patch.set_units`](`dascore.Patch.set_units`).
 
     Parameters
     ----------
@@ -1382,24 +1367,16 @@ def check_data_units(patch1, patch2, check_behavior: WARN_LEVELS = "raise") -> b
     return _data_units_agree(units1, units2, check_behavior)
 
 
-def _data_units_agree(known, units, check_behavior) -> bool:
-    """Known, different units disagree; a missing one agrees with anything."""
-    if known is None or units is None or known == units:
+def _data_units_agree(units1, units2, check_behavior) -> bool:
+    """Different units disagree; no units is a unit like any other."""
+    if units1 == units2:
         return True
     msg = (
-        f"Patches are not compatible: data units differ ({known} and {units}); "
+        f"Patches are not compatible: data units differ ({units1} and {units2}); "
         "convert one with Patch.convert_units first."
     )
     warn_or_raise(msg, exception=IncompatiblePatchError, behavior=check_behavior)
     return False
-
-
-def _with_data_units(attrs: dc.PatchAttrs, members: Sequence[dc.PatchAttrs]):
-    """Fill missing data units from the first member which knows them."""
-    if not _is_missing(attrs.data_units):
-        return attrs
-    known = next((x.data_units for x in members if not _is_missing(x.data_units)), None)
-    return attrs.update(data_units=known) if known is not None else attrs
 
 
 def check_dims(
@@ -1536,15 +1513,28 @@ def _merge_models(attrs1, attrs2):
 
     The caller has already checked kind; nothing here refuses a merge. An
     attribute the first leaves empty takes the second's value, so the
-    result's kind is the union of the two.
+    result's kind is the union of the two. This is the two-operand fold,
+    not `combine_patch_attrs`, which combines a collection and so treats
+    a missing value as a value rather than as something to fill.
     """
     if attrs1 == attrs2:
         return attrs1
-    merged = combine_patch_attrs([attrs1, attrs2], conflict="keep_first")
-    # keep_first folds over set values only, so a first patch without
-    # units would inherit the second's. The operation decides the units
-    # of its output from each operand's own, so the first's must stand.
-    return merged.update(data_units=attrs1.data_units)
+    dump1 = attrs1.model_dump(exclude_defaults=True)
+    dump2 = attrs2.model_dump(exclude_defaults=True)
+    fill = {
+        key: value
+        for key, value in dump2.items()
+        if key not in _ID_FIELDS
+        and key not in ("history", "data_units")
+        and not key.startswith("_")
+        and not _is_missing(value)
+        and _is_missing(dump1.get(key))
+    }
+    # The ids fold as they do for any combination; the data units of the
+    # output are decided by the operation from each operand's own, so the
+    # first's must stand whether or not it has any.
+    merged = attrs1.update(**fill) if fill else attrs1
+    return merged.update(**fold_ids([attrs1, attrs2]))
 
 
 def merge_compatible_coords_attrs(
@@ -1641,10 +1631,10 @@ def concatenate_patches(
 
     Only patches compatible with the first patch are concatenated together:
     the same kind (see [`check_kind`](`dascore.utils.patch.check_kind`);
-    a value any kept patch holds binds the patches after it), the same
-    dimensions, and equal coordinates other than the concatenated one. The
-    output carries the first patch's attributes, with kind values the first
-    patch lacks filled from the others.
+    compared strictly, so a missing value equals only another missing
+    value), the same data units, the same dimensions, and equal
+    coordinates other than the concatenated one. The output carries the
+    first patch's attributes.
 
     Parameters
     ----------
@@ -1702,16 +1692,11 @@ def concatenate_patches(
         patches = list(x.drop_private_coords() for x in patches)
         first_patch = patches[0]
         compat_patches = []
-        # Different kinds are skipped before anything else is asked of them;
-        # a patch binds the run's kind only once its coordinates pass too.
-        run = _KindRun()
-        # the units the run has settled on: the first admitted member's known ones
-        units_run = None
         first_dims = first_patch.dims
-        # Get patches compatible with first.
+        # Get patches compatible with first. Kind is compared strictly:
+        # this combines a collection, so a missing value is a value.
         for p in patches:
-            kind = get_patch_kind(p)
-            kind_ok = run.admits(kind, check_behavior)
+            kind_ok = check_kind(first_patch, p, check_behavior, strict=True)
             if kind_ok and p.dims != first_dims:
                 # a same-kind patch with other dimensions is never skipped
                 msg = "Cannot concatenate patches with different dimensions."
@@ -1724,11 +1709,7 @@ def concatenate_patches(
                 ignore_dim_eq_shape=False,
                 riders_vary=True,
             )
-            units = get_quantity(p.attrs.data_units)
-            units_ok = coords_ok and _data_units_agree(units_run, units, check_behavior)
-            if units_ok:
-                run.add(kind)
-                units_run = units_run if units_run is not None else units
+            if coords_ok and check_data_units(first_patch, p, check_behavior):
                 compat_patches.append(p)
         return compat_patches
 
@@ -1737,12 +1718,8 @@ def concatenate_patches(
     fingerprint = Concatenate.from_kwargs(check_behavior=check_behavior, **kwargs)
     out = []
     for patch_list in yield_sub_sequences(patches, val):
-        # An output's kind is the union over its own members only.
-        run = _KindRun()
-        for p in patch_list:
-            run.add(get_patch_kind(p))
-        attrs = _with_kind(patch_list[0].attrs, run.kind)
-        attrs = _with_data_units(attrs, [x.attrs for x in patch_list])
+        # The members agree on kind and units, so the first states them.
+        attrs = patch_list[0].attrs
         out.append(_concatenate_group(patch_list, dim, attrs, fingerprint.fingerprint))
     return out
 
@@ -1874,8 +1851,7 @@ def concatenate_planned(
     A concat plan (`dascore.utils.chunk_plan.build_concat_plan`) has
     already decided kind, dimensions, and the dimensions' identities, so
     none of that is asked again. The attrs fold as a merge folds them
-    (`combine_patch_attrs`, a missing value matching anything and known
-    conflicts policed by `conflict`).
+    (`combine_patch_attrs`, differing values policed by `conflict`).
 
     Coordinates are not policed by `conflict`; they are reconciled or
     refused. A coordinate riding `dim` is joined along it, provided every
@@ -1940,10 +1916,10 @@ def stack_patches(
     Stack (add) all patches compatible with first patch together.
 
     Compatible means the same kind (see
-    [`check_kind`](`dascore.utils.patch.check_kind`); a value any kept
-    patch holds binds the patches after it), the same dimensions, and equal
-    coordinates other than `dim_vary`. The output carries the first patch's
-    attributes, with kind values the first patch lacks filled from the others.
+    [`check_kind`](`dascore.utils.patch.check_kind`); compared strictly,
+    so a missing value equals only another missing value), the same data
+    units, the same dimensions, and equal coordinates other than
+    `dim_vary`. The output carries the first patch's attributes.
 
     Parameters
     ----------
@@ -1972,26 +1948,20 @@ def stack_patches(
         raise PatchCoordinateError(msg)
 
     kept = []
-    run, units_run = _KindRun(), None
     for p in patches:
-        # check kind, then dimensions and coords of patch against init_patch;
-        # a patch binds the run's kind only once everything passes.
-        kind = get_patch_kind(p)
-        kind_ok = run.admits(kind, check_behavior)
+        # check kind, then dimensions and coords of patch against init_patch.
+        # Kind is compared strictly: a collection is being combined, so a
+        # missing value is a value.
+        kind_ok = check_kind(init_patch, p, check_behavior, strict=True)
         dims_ok = kind_ok and check_dims(init_patch, p, check_behavior)
         coords_ok = dims_ok and check_coords(init_patch, p, check_behavior, dim_vary)
-        units = get_quantity(p.attrs.data_units)
-        units_ok = coords_ok and _data_units_agree(units_run, units, check_behavior)
         # actually do the stacking of data
-        if units_ok:
-            run.add(kind)
-            units_run = units_run if units_run is not None else units
+        if coords_ok and check_data_units(init_patch, p, check_behavior):
             stack_arr = stack_arr + p.data
             kept.append(p.attrs)
 
     # create attributes for the stack with adjusted history
-    stack_attrs = _with_data_units(_with_kind(init_patch.attrs, run.kind), kept)
-    stack_attrs = _maybe_add_history_str(stack_attrs, "stack")
+    stack_attrs = _maybe_add_history_str(init_patch.attrs, "stack")
     # The kept members only: one dropped for being incompatible did not
     # contribute its data, so it is not part of what this data is.
     stack_attrs = stamp_combination(

--- a/dascore/viz/spool.py
+++ b/dascore/viz/spool.py
@@ -111,8 +111,9 @@ def _lane_names(report: pd.DataFrame, dim: str) -> list[str]:
     telling = [x for x in stated if report[x].astype(str).nunique() > 1]
     described = []
     for _, row in report.iterrows():
-        # An attr nobody recorded is left out rather than shown as a
-        # blank, which would read as a value the group states.
+        # A group which recorded nothing is left blank here and named by
+        # its ordinal below; the blank is a value it states, but drawing
+        # it as an empty label would read as a rendering gap.
         stated_values = (str(row[x]) for x in telling if pd.notnull(row[x]))
         parts = [x for x in stated_values if x]
         described.append(" · ".join(parts))

--- a/docs/notes/patch_compatibility.qmd
+++ b/docs/notes/patch_compatibility.qmd
@@ -6,9 +6,9 @@ Several operations combine patches: the arithmetic operators and ufuncs (`patch1
 
 ## Kind
 
-The kind of a patch is the set of values it holds for the attributes named by the config option `patch_kind_attrs`. By default these are `acquisition_key`, `data_category`, and `tag` (plus the legacy `network` and `station`, which only archives predating `acquisition_key` still carry). Two patches are the same kind unless they hold *conflicting* values for one of these: a value that is missing — the attribute is absent, null, or left at its empty default `""` — conflicts with nothing. So a hand-built patch with no `acquisition_key` combines with one that has it, a reader that stamps `network=""` agrees with a patch carrying no `network` at all (which is also how spool metadata records such attributes), and the result of combining carries the union of the known values.
+The kind of a patch is the set of values it holds for the attributes named by the config option `patch_kind_attrs`. By default these are `acquisition_key`, `data_category`, and `tag` (plus the legacy `network` and `station`, which only archives predating `acquisition_key` still carry). Two patches are the same kind when they hold the same values for these attributes. A value that is missing — the attribute is absent, null, or left at its empty default `""` — is one value however it is spelled, so a reader that stamps `network=""` agrees with a patch carrying no `network` at all, which is also how spool metadata records such attributes.
 
-Kind attributes are categorical labels — strings naming an acquisition, a category, a tag — not quantities; the spool index partitions on them as stored text, so a quantity named as a kind attribute is not supported. Kind is decided from attributes alone. Coordinates, data units, history, the patch and processing ids, and every attribute outside the configured names never enter: a filtered patch is the same kind as its raw source, and so is a copy with different units or a different time range. Attributes are scalars, and the missing-value rule is the same everywhere: an attribute nobody recorded (absent, null, or `""`) is satisfied by whatever another patch knows. `data_type` is deliberately *not* a kind attribute: processing rewrites it (`standardize` clears it, `envelope` sets it), so it would separate a patch from its own derivatives — `vel / vel.envelope("time")` must work — while the acquisition key, category, and tag already keep unrelated data apart.
+Kind attributes are categorical labels — strings naming an acquisition, a category, a tag — not quantities; the spool index partitions on them as stored text, so a quantity named as a kind attribute is not supported. Kind is decided from attributes alone. Coordinates, data units, history, the patch and processing ids, and every attribute outside the configured names never enter: a filtered patch is the same kind as its raw source, and so is a copy with different units or a different time range. `data_type` is deliberately *not* a kind attribute: processing rewrites it (`standardize` clears it, `envelope` sets it), so it would separate a patch from its own derivatives — `vel / vel.envelope("time")` must work — while the acquisition key, category, and tag already keep unrelated data apart.
 
 ```{python}
 import dascore as dc
@@ -20,16 +20,44 @@ assert tuple(get_patch_kind(patch)) == dc.get_config().patch_kind_attrs
 processed = patch.pass_filter(time=(None, 10)).set_units("m/s")
 assert check_kind(patch, processed)
 assert not check_kind(patch, patch.update_attrs(tag="other"), check_behavior="ignore")
-
-# A missing value matches; the result carries the known one.
-keyed = patch.update_attrs(acquisition_key="DAS.R2D1..RAW")
-assert check_kind(patch, keyed)
-assert (patch + keyed).attrs.acquisition_key == "DAS.R2D1..RAW"
 ```
 
 [`check_kind`](`dascore.utils.patch.check_kind`) implements this test for patches, and every combining operation applies it before looking at coordinates; the spool operations apply the same rule to their metadata, so a plan decided without loading data agrees with the patches it later assembles.
 
-Because a missing value matches anything, "same kind" is not transitive — `"a"` matches `""` matches `"b"`, yet `"a"` conflicts with `"b"` — and operations that combine more than two patches resolve this in two ways. `concatenate_patches` and `stack` run through their patches in order with an *accumulated* kind: a value any kept patch knows binds the patches after it, so a run never ends up holding two values for one attribute. `Spool.chunk` and `Spool.concatenate` must partition a whole spool at once, so they gather patches into the same kind of runs in a canonical order: fully specified patches seed the runs, and each remaining patch joins the one run it conflicts with nothing in (the run taking on the values it knows), starts its own when none fits, or — when *several* runs would accept it, an unlabelled file between two acquisitions — starts its own rather than guessing. That keeps plans deterministic and independent of row order.
+### A missing value, and how many patches are being combined
+
+How a missing value compares depends on how many patches the operation combines, because the two cases are asking different questions.
+
+An operation with **two operands** — an operator, a ufunc, [`Patch.where`](`dascore.Patch.where`) — must produce one patch, and it has one answer available: a missing value is a wildcard which matches anything, and the result carries the union of what the two patches knew. This is the same rule the data units follow, where a unitless operand takes the other's units.
+
+An operation which combines a **collection** — `concatenate`, `stack`, and the spool operations — is not answering "do these two go together?" but "which of these go together?". That is a partition, and partitioning needs the comparison to be transitive. A wildcard is not: `"a"` would match `""` would match `"b"`, yet `"a"` and `"b"` conflict, so the answer would depend on which patch was looked at first. These operations therefore read a missing value as a *value*: it equals another missing value and nothing else. Partitioning is then just grouping by the kind attributes, and the result never depends on the order the patches arrived in.
+
+```{python}
+keyed = patch.update_attrs(acquisition_key="DAS.R2D1..RAW")
+
+# Two operands: the unset key is a wildcard and the result carries the key.
+assert check_kind(patch, keyed)
+assert (patch + keyed).attrs.acquisition_key == "DAS.R2D1..RAW"
+
+# A collection: not stating a key is its own kind, so these do not merge.
+assert not check_kind(patch, keyed, check_behavior="ignore", strict=True)
+assert len(dc.spool([patch, keyed]).chunk(time=None)) == 2
+```
+
+To fold such patches together, say what they have in common rather than leaving a spool operation to guess it. Stating the value is the direct way; `group=` alone is not enough, since an attribute outside the group is still policed by `conflict` (see rule 3), so a spool operation which should ignore one needs both.
+
+```{python}
+stated = dc.spool([patch, keyed]).map(
+    lambda x: x.update_attrs(acquisition_key="DAS.R2D1..RAW")
+)
+assert len(dc.spool(stated).chunk(time=None)) == 1
+
+# or say that the key neither partitions nor has to agree
+merged = dc.spool([patch, keyed]).chunk(
+    time=None, group=("tag",), conflict="keep_first"
+)
+assert len(merged) == 1
+```
 
 ## Rule 1: different kinds never combine
 
@@ -70,7 +98,7 @@ assert out.attrs.data_type == "velocity"
 Only once the kind matches do coordinates matter, and each operation has its own fit:
 
 - **Operators, ufuncs, and `where`** broadcast. A dimension only one patch has is appended to the other as length one; a dimension both have is aligned on the intersection of its coordinate values, so the result covers only where both patches have data. Sharing a dimension but none of its values is a conflict and raises a [`PatchCoordinateError`](`dascore.exceptions.PatchCoordinateError`) — an empty result is never what was meant, and it would propagate silently.
-- **`concatenate`** requires the same dimensions and equal coordinates except along the concatenated dimension; **`stack`** the same, except along `dim_vary`, which must still have the same shape. `Spool.concatenate` partitions a spool's metadata as `chunk` does — kind, dimensions, the identity of every other dimension, and the concatenated dimension's units (a patch with no values along it joins either) — so patches which differ on those land in separate outputs, then joins each partition's patches in the order of the dimension (when its step is known; irregular values, labels, and a new dimension keep spool order), contiguous or not; like `chunk`, it polices the remaining *attributes* with `conflict`. Coordinates are not policed by it: one riding the concatenated dimension is joined along it, and any other must agree between the members or the output raises when it loads — a patch never quietly loses a coordinate its catalog row describes. A selection still to be applied when the patches load leaves their coordinate identities undecided, so such patches stay in separate outputs; load them (`dc.spool(list(spool))`) to concatenate what the selection reconciles. Where the index knows a coordinate only by a summary — no fingerprint of its values — two patches whose summaries agree plan together and are settled when the output loads: equal values concatenate, different ones raise rather than being mixed.
+- **`concatenate`** requires the same dimensions and equal coordinates except along the concatenated dimension; **`stack`** the same, except along `dim_vary`, which must still have the same shape. `Spool.concatenate` partitions a spool's metadata as `chunk` does — kind, dimensions, the identity of every other dimension, and the concatenated dimension's units and value kind (a patch with no values along it states neither, so it follows the one spelling the others state, and stays out when they state two) — so patches which differ on those land in separate outputs, then joins each partition's patches in the order of the dimension (when its step is known; irregular values, labels, and a new dimension keep spool order), contiguous or not; like `chunk`, it polices the remaining *attributes* with `conflict`. Coordinates are not policed by it: one riding the concatenated dimension is joined along it, and any other must agree between the members or the output raises when it loads — a patch never quietly loses a coordinate its catalog row describes. A selection still to be applied when the patches load leaves their coordinate identities undecided, so such patches stay in separate outputs; load them (`dc.spool(list(spool))`) to concatenate what the selection reconciles. Where the index knows a coordinate only by a summary — no fingerprint of its values — two patches whose summaries agree plan together and are settled when the output loads: equal values concatenate, different ones raise rather than being mixed.
 - **`chunk`** partitions further by structure (the dimensions tuple, the coordinate identity of every non-chunked dimension, the chunked dimension's units), sampling interval, and continuity; see [Spool Chunking](spool_chunking.qmd).
 
 ```{python}
@@ -91,8 +119,8 @@ with pytest.raises(PatchCoordinateError, match="share no values"):
 Attributes outside the kind — `data_units`, `history`, the ids, and any custom attribute — never decide whether patches combine. They are folded instead:
 
 - **Operators and ufuncs**: data units take part in the arithmetic, so metres times seconds gives metre-seconds and metres plus seconds raises a [`UnitError`](`dascore.exceptions.UnitError`); convertible units are converted to the first patch's. An operand without units — a patch with no `data_units`, an array, or a scalar — conflicts with nothing, just like a missing kind value: it is dimensionless where that works (metres times it is metres, it divided by metres is 1/metres) and takes the other operand's units where the operation needs equal units (metres plus it is metres; comparisons likewise). Offset units such as `degC` cannot be scaled, so a patch in them accepts only sums, differences, extrema, and comparisons: beside a unitless operand, which counts as a difference of so many degrees, it may be added to or taken from the temperature but the temperature not from it (`temp - 1` is Celsius, `1 - temp` raises); beside another temperature, a difference is a delta (`delta_degC`), extrema and comparisons work, and a sum is refused; beside a difference (`delta_degC`, or anything convertible to it), a sum or a difference is a temperature. Anything else asks you to convert to kelvin first. Every other attribute keeps the first patch's value, and attributes only the second patch has are added. History and the ids follow the [patch identity rules](../tutorial/patch.qmd#patch-identity).
-- **`concatenate` and `stack`**: the output carries the first patch's attributes, with kind values and data units it lacks filled from the others, and its history with the operation's own entry appended. Splicing or summing data demands one unit, and units are not converted for you: a patch whose known data units differ from the first's is skipped (or raises) by `concatenate_patches` and `stack`, and is a conflict for `Spool.concatenate` and `chunk`, policed by `conflict` — convert it first.
-- **`chunk`**: attributes must hold no conflicting known values within a partition, policed by its `conflict` argument (`"raise"` by default, `"drop"`, or `"keep_first"`); a missing value conflicts with nothing and the output carries the known one, exactly as for kind.
+- **`concatenate` and `stack`**: the output carries the first patch's attributes, and its history with the operation's own entry appended. Splicing or summing data demands one unit, and units are not converted for you: a patch whose data units differ from the first's — a patch with no units included — is skipped (or raises) by `concatenate_patches` and `stack`, and is a conflict for `Spool.concatenate` and `chunk`, policed by `conflict`. Convert with [`Patch.convert_units`](`dascore.Patch.convert_units`), or state the units with [`Patch.set_units`](`dascore.Patch.set_units`), first.
+- **`chunk`**: attributes must hold equal values within a partition, policed by its `conflict` argument (`"raise"` by default, `"drop"`, or `"keep_first"`); a missing value is a value here too, exactly as for kind, so a patch which never recorded an attribute conflicts with one which did. `"keep_first"` keeps the first patch's value, stated or not.
 - **History** is never compared by any operation — processing differing between members is what combining is for — and the output carries the first patch's (plus the combining operation's own entry, where it records one). Operations which splice members side by side along a dimension (`chunk`'s merge and `concatenate`) warn when the histories differ, since a raw patch merged beside a filtered one is usually a mistake; elementwise operations do not, since a residual is exactly filtered minus raw.
 
 ```{python}

--- a/docs/notes/patch_compatibility.qmd
+++ b/docs/notes/patch_compatibility.qmd
@@ -6,7 +6,7 @@ Several operations combine patches: the arithmetic operators and ufuncs (`patch1
 
 ## Kind
 
-The kind of a patch is the set of values it holds for the attributes named by the config option `patch_kind_attrs`. By default these are `acquisition_key`, `data_category`, and `tag` (plus the legacy `network` and `station`, which only archives predating `acquisition_key` still carry). Two patches are the same kind when they hold the same values for these attributes. A value that is missing — the attribute is absent, null, or left at its empty default `""` — is one value however it is spelled, so a reader that stamps `network=""` agrees with a patch carrying no `network` at all, which is also how spool metadata records such attributes.
+The kind of a patch is the set of values it holds for the attributes named by the config option `patch_kind_attrs`. By default these are `acquisition_key`, `data_category`, and `tag` (plus the legacy `network` and `station`, which only archives predating `acquisition_key` still carry). Two patches are the same kind when they hold the same values for these attributes — with one wrinkle for missing values, below, which turns on how many patches are being combined. A value that is missing — the attribute is absent, null, or left at its empty default `""` — is one value however it is spelled, so a reader that stamps `network=""` agrees with a patch carrying no `network` at all, which is also how spool metadata records such attributes.
 
 Kind attributes are categorical labels — strings naming an acquisition, a category, a tag — not quantities; the spool index partitions on them as stored text, so a quantity named as a kind attribute is not supported. Kind is decided from attributes alone. Coordinates, data units, history, the patch and processing ids, and every attribute outside the configured names never enter: a filtered patch is the same kind as its raw source, and so is a copy with different units or a different time range. `data_type` is deliberately *not* a kind attribute: processing rewrites it (`standardize` clears it, `envelope` sets it), so it would separate a patch from its own derivatives — `vel / vel.envelope("time")` must work — while the acquisition key, category, and tag already keep unrelated data apart.
 
@@ -22,11 +22,9 @@ assert check_kind(patch, processed)
 assert not check_kind(patch, patch.update_attrs(tag="other"), check_behavior="ignore")
 ```
 
-[`check_kind`](`dascore.utils.patch.check_kind`) implements this test for patches, and every combining operation applies it before looking at coordinates; the spool operations apply the same rule to their metadata, so a plan decided without loading data agrees with the patches it later assembles.
+[`check_kind`](`dascore.utils.patch.check_kind`) implements this test for patches (the next section covers how it compares a missing value), and every combining operation applies it before looking at coordinates; the spool operations apply the same rule to their metadata, so a plan decided without loading data agrees with the patches it later assembles.
 
 ### A missing value, and how many patches are being combined
-
-How a missing value compares depends on how many patches the operation combines, because the two cases are asking different questions.
 
 An operation with **two operands** — an operator, a ufunc, [`Patch.where`](`dascore.Patch.where`) — must produce one patch, and it has one answer available: a missing value is a wildcard which matches anything, and the result carries the union of what the two patches knew. This is the same rule the data units follow, where a unitless operand takes the other's units.
 

--- a/docs/notes/spool_chunking.qmd
+++ b/docs/notes/spool_chunking.qmd
@@ -31,7 +31,7 @@ Plans are deterministic: the same spool produces the same plan regardless of met
 
 Patches may only combine when they agree on all of:
 
-1. **Kind** — the config option `patch_kind_attrs` by default (conventional categorical identity: acquisition key, data category, and tag; see [Patch Compatibility](patch_compatibility.qmd)), overridden per call with `group=`. Conflicting values are never an error; the patches simply land in separate outputs. A missing value conflicts with nothing: a patch lacking one joins the single kind consistent with it (which takes on the values the patch knows), or stays apart when several would accept it. Explicitly passed names must exist somewhere in the spool; config names are best-effort.
+1. **Kind** — the config option `patch_kind_attrs` by default (conventional categorical identity: acquisition key, data category, and tag; see [Patch Compatibility](patch_compatibility.qmd)), overridden per call with `group=`. Differing values are never an error; the patches simply land in separate outputs. A missing value is a value: patches which never recorded an attribute partition together, and apart from those which did. Explicitly passed names must exist somewhere in the spool; config names are best-effort.
 2. **Structure** — the dimensions tuple, the coordinate identity of every non-chunked dimension, and the chunked dimension's units (a metre patch can never plan into one output with a seconds patch, or a unitful with a unitless one; compatible spellings such as metres and feet are normalized to one unit per dimensionality before partitioning, so they plan together, and assembly converts each member to the first member's units).
 3. **Sampling** — step magnitudes within the relative tolerance `config.sampling_group_tolerance` (default 5%) of the group's smallest member, with matching orientation (ascending never merges with descending; contiguous descending patches merge with each other).
 4. **Continuity** — patches within `tolerance` samples of each other, evaluated within each group so unrelated patches can never bridge a gap.
@@ -57,11 +57,17 @@ assert len(merged) == 2
 assert len(merged) == len(spool.get_gaps()) + len(spool.get_coverage())
 ```
 
-Remaining (non-group, non-dimensional) attributes must hold no *conflicting* values within a partition, policed by `conflict`: `"raise"` (default), `"drop"`, or `"keep_first"`. A missing value (null or `""`) is an attribute nobody recorded, so it conflicts with nothing and the output carries the known value; only two differing known values are a conflict. History and the ids are never policed — the output carries the first member's — but merging members whose histories differ (processed beside unprocessed data) warns.
+Remaining (non-group, non-dimensional) attributes must hold *equal* values within a partition, policed by `conflict`: `"raise"` (default), `"drop"`, or `"keep_first"`. A missing value (null or `""`) is a value like any other — an attribute one member recorded and another did not is a conflict, since the output can only state one thing. `"keep_first"` states what the first member did, stated or not; `"drop"` leaves the attribute out. History and the ids are never policed — the output carries the first member's — but merging members whose histories differ (processed beside unprocessed data) warns.
 
 ```{python}
+import pytest
+from dascore.exceptions import CoordMergeError
+
 typed = p1.update_attrs(data_type="velocity")
-merged = dc.spool([typed, p2]).chunk(time=None)
+with pytest.raises(CoordMergeError, match="data_type"):
+    dc.spool([typed, p2]).chunk(time=None)
+
+merged = dc.spool([typed, p2]).chunk(time=None, conflict="keep_first")
 assert len(merged) == 1
 assert merged.get_contents()["data_type"].iloc[0] == "velocity"
 assert merged[0].attrs.data_type == "velocity"
@@ -139,7 +145,7 @@ assert isinstance(patch.get_coord("time"), CoordRange)
 # A gap forced together by a loose tolerance warns, and with
 # snap_coords=False the output keeps the exact segmented coordinate.
 gap_start = time.max() + 3 * time.step
-p_gap = dc.get_example_patch(time_min=gap_start)
+p_gap = dc.get_example_patch(time_min=gap_start, acquisition_key="XX1.R2D1..RAW")
 with pytest.warns(UserWarning, match="force merging"):
     forced = dc.spool([p1, p_gap]).chunk(
         time=None, tolerance=5, snap_coords=False

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -47,7 +47,7 @@ with config_context(patch_history="disabled"):
     ...
 ```
 
-Which patches may be combined is configurable too: `patch_kind_attrs` names the attributes that decide whether two patches are the same kind (patches with conflicting values for any of them are never combined; a missing value conflicts with nothing). See the [Patch Compatibility](../notes/patch_compatibility.qmd) note.
+Which patches may be combined is configurable too: `patch_kind_attrs` names the attributes that decide whether two patches are the same kind (patches with differing values for any of them are never combined; a missing value is a wildcard for operators and a value of its own where patches are partitioned). See the [Patch Compatibility](../notes/patch_compatibility.qmd) note.
 
 ```python
 with config_context(patch_kind_attrs=("acquisition_key",)):

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -507,71 +507,61 @@ class TestChunkMerge:
         assert time_max <= time_tup[1]
         assert (time_max + time_step) > time_tup[1]
 
-    def test_missing_attr_merges_and_carries(self):
-        """A member lacking an attr merges; the output carries the known value."""
+    def test_missing_attr_is_a_conflict(self):
+        """A member lacking an attr conflicts with one which states it."""
         p1 = dc.get_example_patch().update_attrs(data_type="velocity")
         time = p1.get_coord("time")
         p2 = dc.get_example_patch(time_min=time.max() + time.step)
         assert p2.attrs.data_type == ""
-        out = dc.spool([p1, p2]).chunk(time=None)
+        with pytest.raises(CoordMergeError, match="data_type"):
+            dc.spool([p1, p2]).chunk(time=None)
+        out = dc.spool([p1, p2]).chunk(time=None, conflict="drop")
         assert len(out) == 1
-        assert out.get_contents()["data_type"].iloc[0] == "velocity"
-        assert out[0].attrs.data_type == "velocity"
+        assert out[0].attrs.data_type == ""
 
     def test_surviving_member_takes_the_rows_attrs(self):
         """Whichever duplicate survives overlap removal, patch and row agree."""
         p1 = dc.get_example_patch().update_attrs(foo="a", data_type="velocity")
         p2 = dc.get_example_patch()  # same span, knows neither
-        for patches in ([p1, p2], [p2, p1]):
-            out = dc.spool(patches).chunk(time=None)
-            assert len(out) == 1
-            row = out.get_contents().iloc[0]
-            assert row["foo"] == "a" and row["data_type"] == "velocity"
-            assert out[0].attrs.foo == "a"
-            assert out[0].attrs.data_type == "velocity"
+        with pytest.raises(CoordMergeError, match=r"foo|data_type"):
+            dc.spool([p1, p2]).chunk(time=None)
+        # keep_first takes the first member's values, stated or not, and
+        # the assembled patch says exactly what its row does.
+        out = dc.spool([p1, p2]).chunk(time=None, conflict="keep_first")
+        assert len(out) == 1
+        assert out.get_contents().iloc[0]["foo"] == "a"
+        assert out[0].attrs.foo == "a"
+        # the other order keeps the first member's silence
+        out = dc.spool([p2, p1]).chunk(time=None, conflict="keep_first")
+        assert len(out) == 1
+        assert pd.isnull(out.get_contents().iloc[0].get("foo"))
+        assert out[0].attrs.get("foo") is None
 
-    def test_attr_held_in_two_kinds_takes_the_numeric_units(self):
-        """An attr stored as text in one patch and a quantity in another."""
-        p1 = dc.get_example_patch().update_attrs(foo=2 * dc.get_quantity("m"))
-        p2 = dc.get_example_patch(time_min=p1.get_coord("time").max()).update_attrs(
-            foo="text"
-        )
-        spool = dc.spool([p1, p2])
-        assert spool._catalog.backend.attr_units_map()["foo"] == "m"
-        assert "foo" not in spool._catalog.backend.attr_units_map(kind="bool")
-        # the quantity member dropped by overlap removal still stamps metres
-        dup = dc.get_example_patch()
-        out = dc.spool([dup, p1]).chunk(time=None)
-        assert out[0].attrs.foo == 2 * dc.get_quantity("m")
-
-    def test_attr_named_like_another_patches_coordinate(self):
-        """An attr is not suppressed because some other patch has such a coordinate."""
-        p1 = dc.get_example_patch().update_attrs(latitude="north")
-        p2 = dc.get_example_patch()
+    def test_attrs_named_like_coordinates_survive_a_chunk(self):
+        """Attrs which look like coordinate metadata are still attrs."""
+        extra = {
+            "latitude": "north",  # a coordinate some other patch has
+            "foo_min": "a",  # an envelope pair with no foo coordinate
+            "foo_max": "b",
+            "time_zone": "UTC",  # a name prefixed by a real dimension
+            "gauge": 10 * dc.get_quantity("m"),  # a quantity
+            "shots": 7,  # a plain number
+        }
+        p1 = dc.get_example_patch().update_attrs(**extra)
         time = p1.get_coord("time")
+        p2 = dc.get_example_patch(time_min=time.max() + time.step)
+        p2 = p2.update_attrs(**extra)
         n = p1.shape[p1.get_axis("distance")]
+        # a patch which holds latitude as a coordinate rather than an attr
         elsewhere = dc.get_example_patch(
             time_min=time.max() + 10 * time.step, tag="other"
         ).update_coords(latitude=("distance", np.arange(n, dtype=float)))
         out = dc.spool([p2, p1, elsewhere]).chunk(time=None)
-        first = out.select(tag="random")[0]
-        assert first.attrs.latitude == "north"
-
-    def test_attr_pair_named_like_an_envelope_is_stamped(self):
-        """foo_min and foo_max attrs, with no foo coordinate, are attrs."""
-        p1 = dc.get_example_patch().update_attrs(foo_min="a", foo_max="b")
-        p2 = dc.get_example_patch()
-        out = dc.spool([p2, p1]).chunk(time=None)
-        assert out[0].attrs.foo_min == "a"
-        assert out[0].attrs.foo_max == "b"
-
-    def test_attr_named_like_a_coordinate_is_stamped(self):
-        """An attr such as time_zone is not coordinate metadata."""
-        p1 = dc.get_example_patch().update_attrs(time_zone="UTC")
-        p2 = dc.get_example_patch()
-        out = dc.spool([p2, p1]).chunk(time=None)
-        assert out.get_contents()["time_zone"].iloc[0] == "UTC"
-        assert out[0].attrs.time_zone == "UTC"
+        merged = out.select(tag="random")[0]
+        row = out.get_contents().set_index("tag").loc["random"]
+        for name, value in extra.items():
+            assert merged.attrs.get(name) == value
+        assert row["time_zone"] == "UTC"
 
     def test_dropped_coordinate_envelope_is_not_an_attr(self):
         """A coordinate only one member has leaves no stray attrs behind."""
@@ -584,17 +574,6 @@ class TestChunkMerge:
         patch = out[0]
         assert patch.attrs.get("latitude_min") is None
         assert patch.attrs.get("latitude_max") is None
-
-    def test_numeric_attrs_are_stamped_with_their_units(self):
-        """A number comes back a number; a quantity comes back with its units."""
-        p1 = dc.get_example_patch().update_attrs(
-            gauge=10 * dc.get_quantity("m"), shots=7
-        )
-        p2 = dc.get_example_patch()
-        for patches in ([p1, p2], [p2, p1]):
-            patch = dc.spool(patches).chunk(time=None)[0]
-            assert patch.attrs.gauge == 10 * dc.get_quantity("m")
-            assert patch.attrs.shots == 7
 
     def test_history_warns_not_raises(self):
         """Differing histories merge with a warning, carrying the first's."""

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -523,7 +523,7 @@ class TestChunkMerge:
         """Whichever duplicate survives overlap removal, patch and row agree."""
         p1 = dc.get_example_patch().update_attrs(foo="a", data_type="velocity")
         p2 = dc.get_example_patch()  # same span, knows neither
-        with pytest.raises(CoordMergeError, match=r"foo|data_type"):
+        with pytest.raises(CoordMergeError, match=r"\bfoo\b|\bdata_type\b"):
             dc.spool([p1, p2]).chunk(time=None)
         # keep_first takes the first member's values, stated or not, and
         # the assembled patch says exactly what its row does.
@@ -537,31 +537,50 @@ class TestChunkMerge:
         assert pd.isnull(out.get_contents().iloc[0].get("foo"))
         assert out[0].attrs.get("foo") is None
 
-    def test_attrs_named_like_coordinates_survive_a_chunk(self):
-        """Attrs which look like coordinate metadata are still attrs."""
-        extra = {
-            "latitude": "north",  # a coordinate some other patch has
+    def test_attrs_named_like_coordinates_are_policed_as_attrs(self):
+        """Attrs which look like coordinate metadata are policed by `conflict`.
+
+        A column a coordinate owns is refused whatever `conflict` says,
+        so keeping the first value is what proves these are read as
+        ordinary attrs rather than as the envelope of some coordinate.
+        """
+        # values differ, so only the conflict policy can decide them
+        first = {
+            "latitude": "north",  # a coordinate another patch has
             "foo_min": "a",  # an envelope pair with no foo coordinate
             "foo_max": "b",
             "time_zone": "UTC",  # a name prefixed by a real dimension
             "gauge": 10 * dc.get_quantity("m"),  # a quantity
             "shots": 7,  # a plain number
         }
-        p1 = dc.get_example_patch().update_attrs(**extra)
+        second = {
+            "latitude": "south",
+            "foo_min": "c",
+            "foo_max": "d",
+            "time_zone": "MST",
+            "gauge": 20 * dc.get_quantity("m"),
+            "shots": 9,
+        }
+        p1 = dc.get_example_patch().update_attrs(**first)
         time = p1.get_coord("time")
         p2 = dc.get_example_patch(time_min=time.max() + time.step)
-        p2 = p2.update_attrs(**extra)
+        p2 = p2.update_attrs(**second)
         n = p1.shape[p1.get_axis("distance")]
         # a patch which holds latitude as a coordinate rather than an attr
         elsewhere = dc.get_example_patch(
             time_min=time.max() + 10 * time.step, tag="other"
         ).update_coords(latitude=("distance", np.arange(n, dtype=float)))
-        out = dc.spool([p2, p1, elsewhere]).chunk(time=None)
+        spool = dc.spool([p1, p2, elsewhere])
+        # they are attrs, so they conflict rather than being coordinate metadata
+        with pytest.raises(CoordMergeError, match=r"latitude|foo_min|time_zone"):
+            spool.chunk(time=None)
+        out = spool.chunk(time=None, conflict="keep_first")
         merged = out.select(tag="random")[0]
         row = out.get_contents().set_index("tag").loc["random"]
-        for name, value in extra.items():
+        for name, value in first.items():
             assert merged.attrs.get(name) == value
-        assert row["time_zone"] == "UTC"
+            assert name in row or name == "gauge"
+        assert row["time_zone"] == "UTC" and row["latitude"] == "north"
 
     def test_dropped_coordinate_envelope_is_not_an_attr(self):
         """A coordinate only one member has leaves no stray attrs behind."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -1198,12 +1198,6 @@ class TestConcatenatePartitions:
         for pair_ in ([metres, km], [metres, bare]):
             with pytest.raises(CoordMergeError, match="data_units"):
                 dc.spool(pair_).concatenate(time=None)
-        dropped = dc.spool([metres, km]).concatenate(time=None, conflict="drop")
-        assert len(dropped) == 1
-        assert dropped[0].attrs.data_units is None
-        assert (
-            dc.get_quantity(dropped.get_contents().get("data_units", [None])[0]) is None
-        )
         # equal units are one output, and the row says what the patch does
         out = dc.spool([metres, other.set_units("m")]).concatenate(time=None)
         assert len(out) == 1
@@ -1211,6 +1205,24 @@ class TestConcatenatePartitions:
         assert dc.get_quantity(out.get_contents()["data_units"].iloc[0]) == (
             dc.get_quantity("m")
         )
+
+    def test_members_convert_to_the_units_the_output_declares(self, pair):
+        """A loosened policy must never splice differently scaled samples."""
+        first, other = pair
+        bare, km = first.set_units(None), other.set_units("km")
+        metres = other.set_units("m")
+        n = first.shape[first.get_axis("time")]
+        for conflict in ("keep_first", "drop"):
+            out = dc.spool([bare, km]).concatenate(time=None, conflict=conflict)
+            assert len(out) == 1
+            patch = out[0]
+            # the output declares the units its samples are in ...
+            assert dc.get_quantity(patch.attrs.data_units) == dc.get_quantity("km")
+            # ... and the unitless member's samples are left as they were
+            assert np.allclose(patch.data[:, :n], bare.data)
+        # a member stated otherwise is rescaled, not spliced in raw
+        out = dc.spool([km, metres]).concatenate(time=None, conflict="keep_first")
+        assert np.allclose(out[0].data[:, n:], metres.data / 1000)
 
     def test_different_dims_partition(self, pair):
         """Other dimensions are another partition, not an error."""
@@ -1275,6 +1287,19 @@ class TestConcatenatePartitions:
         loaded = dc.spool(list(selected)).concatenate(time=None)
         assert len(loaded) == 1
         assert loaded[0].shape[1] == 2 * base.shape[1]
+
+    def test_assembly_does_not_read_the_kind_config(self, pair):
+        """A plan decides kind; assembly must not re-read the config later."""
+        first, other = pair
+        other = other.update_attrs(tag="other")
+        with dc.config_context(patch_kind_attrs=("acquisition_key",)):
+            # tag is not kind here, so these are one output
+            out = dc.spool([first, other]).concatenate(time=None, conflict="keep_first")
+            assert len(out) == 1
+        # the config that built the plan is gone; the patch is still the
+        # one the plan described, and its row still agrees
+        assert out[0].shape[1] == 2 * first.shape[1]
+        assert out[0].attrs.tag == out.get_contents()["tag"].iloc[0]
 
     def test_positional_check_behavior_still_works(self, pair):
         """The deprecated argument keeps its old positional slot."""
@@ -1829,11 +1854,11 @@ class TestConcatenatePartitions:
     def test_replanning_after_a_drop_keeps_the_drop(self, pair):
         """Concatenating again along the same dimension does not resurrect metadata."""
         first, other = pair
-        metres, km = first.set_units("m"), other.set_units("km")
-        dropped = dc.spool([metres, km]).concatenate(time=None, conflict="drop")
+        a, b = first.update_attrs(foo="a"), other.update_attrs(foo="b")
+        dropped = dc.spool([a, b]).concatenate(time=None, conflict="drop")
         again = dropped.concatenate(time=None)
         assert len(again) == 1
-        assert again[0].attrs.data_units is None
+        assert again[0].attrs.get("foo") is None
 
     def test_conflict_policy_is_part_of_the_identity(self, pair):
         """Drop and keep_first give different patches, so different ids."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -1224,6 +1224,30 @@ class TestConcatenatePartitions:
         out = dc.spool([km, metres]).concatenate(time=None, conflict="keep_first")
         assert np.allclose(out[0].data[:, n:], metres.data / 1000)
 
+    def test_rows_state_the_reconciled_units(self, pair):
+        """The row must declare the units assembly converts the members to."""
+        first, other = pair
+        bare, km = first.set_units(None), other.set_units("km")
+        for conflict in ("keep_first", "drop"):
+            out = dc.spool([bare, km]).concatenate(time=None, conflict=conflict)
+            row_units = out.get_contents()["data_units"].iloc[0]
+            assert dc.get_quantity(row_units) == dc.get_quantity("km")
+            assert dc.get_quantity(out[0].attrs.data_units) == dc.get_quantity(
+                row_units
+            )
+
+    def test_rows_state_the_dtype_the_conversion_produces(self, pair):
+        """Converting an integer member floats it under every loosened policy."""
+        first, other = pair
+        km = first.new(data=first.data.astype("int32")).set_units("km")
+        metres = other.new(data=other.data.astype("int32")).set_units("m")
+        for conflict in ("keep_first", "drop"):
+            out = dc.spool([km, metres]).concatenate(time=None, conflict=conflict)
+            contents = out.get_contents()
+            assert out[0].data.dtype.kind == "f"
+            if "_dtype" in contents.columns:  # the relation may not state one
+                assert np.dtype(contents["_dtype"].iloc[0]) == out[0].data.dtype
+
     def test_different_dims_partition(self, pair):
         """Other dimensions are another partition, not an error."""
         first, other = pair

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -1184,39 +1184,38 @@ class TestConcatenatePartitions:
         # ... spells None, as it does for chunk
         assert len(dc.spool(pair).concatenate(time=...)) == 1
 
-    def test_missing_kind_value_filled_in_rows_and_patch(self, pair):
-        """A member lacking the key matches, and the output carries the key."""
+    def test_missing_kind_value_is_its_own_output(self, pair):
+        """A member lacking the key is another kind; rows and patches agree."""
         first, other = pair
         other = other.update_attrs(acquisition_key="XX.R2D1..RAW")
         out = dc.spool([first, other]).concatenate(time=None)
-        assert len(out) == 1
-        assert out.get_contents()["acquisition_key"].iloc[0] == "XX.R2D1..RAW"
-        assert out[0].attrs.acquisition_key == "XX.R2D1..RAW"
-        assert out[0].shape[1] == 2 * first.shape[1]
+        assert len(out) == 2
+        keys = out.get_contents()["acquisition_key"].fillna("")
+        assert sorted(keys) == ["", "XX.R2D1..RAW"]
+        for patch, key in zip(out, keys):
+            assert patch.attrs.acquisition_key == key
+            assert patch.shape == first.shape
 
     def test_data_units_policed_by_conflict(self, pair):
-        """Known, different units conflict as in chunk; a missing one matches."""
+        """Differing units conflict as in chunk; no units is a unit."""
         first, other = pair
         metres, km = first.set_units("m"), other.set_units("km")
-        with pytest.raises(CoordMergeError, match="data_units"):
-            dc.spool([metres, km]).concatenate(time=None)
+        bare = other.set_units(None)
+        for pair_ in ([metres, km], [metres, bare]):
+            with pytest.raises(CoordMergeError, match="data_units"):
+                dc.spool(pair_).concatenate(time=None)
         dropped = dc.spool([metres, km]).concatenate(time=None, conflict="drop")
         assert len(dropped) == 1
         assert dropped[0].attrs.data_units is None
         assert (
             dc.get_quantity(dropped.get_contents().get("data_units", [None])[0]) is None
         )
-        bare = first.set_units(None)
-        out = dc.spool([bare, km]).concatenate(time=None)
+        # equal units are one output, and the row says what the patch does
+        out = dc.spool([metres, other.set_units("m")]).concatenate(time=None)
         assert len(out) == 1
-        assert dc.get_quantity(out[0].attrs.data_units) == dc.get_quantity("km")
-        # a missing unit never hides a conflict between two known ones
-        time = other.get_coord("time")
-        third = first.update_coords(time_min=time.max() + time.step).set_units("m")
-        with pytest.raises(CoordMergeError, match="data_units"):
-            dc.spool([bare, km, third]).concatenate(time=None)
+        assert dc.get_quantity(out[0].attrs.data_units) == dc.get_quantity("m")
         assert dc.get_quantity(out.get_contents()["data_units"].iloc[0]) == (
-            dc.get_quantity("km")
+            dc.get_quantity("m")
         )
 
     def test_different_dims_partition(self, pair):
@@ -1261,14 +1260,6 @@ class TestConcatenatePartitions:
         expected = {(first.attrs.tag, 2 * first.shape[1]), ("other", first.shape[1])}
         assert kinds == expected
 
-    def test_each_output_carries_its_own_members(self, pair):
-        """A value known only in another output is not borrowed."""
-        first, other = pair
-        blank, tagged = first.update_attrs(tag=""), other.update_attrs(tag="a")
-        out = dc.spool([blank, tagged]).concatenate(time=1)
-        assert [p.attrs.tag for p in out] == ["", "a"]
-        assert list(out.get_contents()["tag"].fillna("")) == ["", "a"]
-
     def test_order_follows_the_dimension(self, pair):
         """Within a partition, patches join in order of the dimension."""
         first, other = pair
@@ -1290,17 +1281,6 @@ class TestConcatenatePartitions:
         loaded = dc.spool(list(selected)).concatenate(time=None)
         assert len(loaded) == 1
         assert loaded[0].shape[1] == 2 * base.shape[1]
-
-    def test_plan_keeps_its_kind_rule(self, pair):
-        """A plan made under one kind rule assembles under it later."""
-        first, other = pair
-        other = other.update_attrs(tag="other")
-        # with tag out of the kind, it is an ordinary attr the policy folds
-        with dc.config_context(patch_kind_attrs=("acquisition_key",)):
-            out = dc.spool([first, other]).concatenate(time=None, conflict="keep_first")
-            assert len(out) == 1
-        assert out[0].shape[1] == 2 * first.shape[1]
-        assert out[0].attrs.tag == first.attrs.tag
 
     def test_positional_check_behavior_still_works(self, pair):
         """The deprecated argument keeps its old positional slot."""

--- a/tests/test_io/test_index/test_plan.py
+++ b/tests/test_io/test_index/test_plan.py
@@ -801,6 +801,18 @@ class TestConcatPlan:
             == 3
         )
 
+    def test_empty_and_null_coordinate_units_are_one_spelling(self, trio):
+        """A coordinate stated with no units spells that null or ""."""
+        p1, p2, _ = trio
+        df = _flat([p1, p2])
+        col = "_time_units"
+        assert col in df.columns
+        df = df.copy()
+        df.loc[df.index[0], col] = ""
+        df.loc[df.index[1], col] = None
+        plan = build_concat_plan(df, time=None)
+        assert len(plan.outputs) == 1
+
     def test_relation_without_step_or_dtype(self, trio):
         """An envelope without a step, or rows without a dtype, still plan."""
         df = _flat(trio).drop(columns=["time_step"])

--- a/tests/test_io/test_index/test_plan.py
+++ b/tests/test_io/test_index/test_plan.py
@@ -201,47 +201,47 @@ class TestConflict:
     def conflicted_patches(self):
         """Two contiguous patches with conflicting known values of an attr."""
         t0 = np.datetime64("2020-01-01", "ns")
-        p1 = dc.get_example_patch(time_min=t0).update_attrs(data_units="ft/s")
+        p1 = dc.get_example_patch(time_min=t0).update_attrs(data_type="velocity")
         time = p1.get_coord("time")
         p2 = dc.get_example_patch(time_min=time.max() + time.step)
-        p2 = p2.update_attrs(data_units="m/s")
+        p2 = p2.update_attrs(data_type="strain_rate")
         return [p1, p2]
 
     def test_raise(self, conflicted_patches):
         """Conflicting known values raise by default."""
-        with pytest.raises(CoordMergeError, match="data_units"):
+        with pytest.raises(CoordMergeError, match="data_type"):
             build_chunk_plan(_flat(conflicted_patches), time=None)
 
     def test_missing_value_is_a_conflict(self, conflicted_patches):
         """A member lacking the attr conflicts with one which has it."""
         p1, p2 = conflicted_patches
-        df = _flat([p1.update_attrs(data_units=None), p2])
-        with pytest.raises(CoordMergeError, match="data_units"):
+        df = _flat([p1.update_attrs(data_type=""), p2])
+        with pytest.raises(CoordMergeError, match="data_type"):
             build_chunk_plan(df, time=None)
         plan = build_chunk_plan(df, time=None, conflict="drop")
         assert len(plan.outputs) == 1
-        assert "data_units" not in plan.outputs.columns
+        assert "data_type" not in plan.outputs.columns
 
     def test_keep_first(self, conflicted_patches):
         """keep_first carries the first member's value."""
         df = _flat(conflicted_patches)
         plan = build_chunk_plan(df, time=None, conflict="keep_first")
         first_id = df.sort_values("time_min")["_patch_id"].iloc[0]
-        expected = df.loc[df["_patch_id"] == first_id, "data_units"].iloc[0]
-        assert plan.outputs["data_units"].iloc[0] == expected
+        expected = df.loc[df["_patch_id"] == first_id, "data_type"].iloc[0]
+        assert plan.outputs["data_type"].iloc[0] == expected
 
     def test_keep_first_means_the_first_member(self, conflicted_patches):
         """keep_first takes the first member's value even where it states none."""
         p1, p2 = conflicted_patches
-        df = _flat([p1.update_attrs(data_units=None), p2])
+        df = _flat([p1.update_attrs(data_type=""), p2])
         plan = build_chunk_plan(df, time=None, conflict="keep_first")
         assert len(plan.outputs) == 1
-        assert pd.isnull(plan.outputs["data_units"].iloc[0])
+        assert pd.isnull(plan.outputs["data_type"].iloc[0])
 
     def test_drop(self, conflicted_patches):
         """Drop omits the conflicting attr from outputs."""
         plan = build_chunk_plan(_flat(conflicted_patches), time=None, conflict="drop")
-        assert "data_units" not in plan.outputs.columns
+        assert "data_type" not in plan.outputs.columns
 
 
 class TestGroupParameter:

--- a/tests/test_io/test_index/test_plan.py
+++ b/tests/test_io/test_index/test_plan.py
@@ -754,7 +754,11 @@ class TestConcatPlan:
             build_concat_plan(mixed, time=None)
         plan = build_concat_plan(mixed, time=None, conflict="drop")
         assert len(plan.outputs) == 1
-        assert "data_units" not in plan.outputs.columns
+        # dropping the conflict still leaves the row stating the units the
+        # members are converted to, which is what the patch will hold
+        assert dc.get_quantity(plan.outputs["data_units"].iloc[0]) == dc.get_quantity(
+            "km"
+        )
 
     def test_new_dimension_is_described(self, trio):
         """An output along a new dimension names it, claiming no envelope."""

--- a/tests/test_io/test_index/test_plan.py
+++ b/tests/test_io/test_index/test_plan.py
@@ -122,9 +122,10 @@ class TestMergePlan:
         )
         for col in ("acquisition_key", "tag"):
             src, out = merged[f"{col}_src"], merged[f"{col}_out"]
-            # a member missing the value matches any output value
-            equal = (src == out) | src.isnull() | (src == "")
-            assert equal.all()
+            # the members of an output state exactly what it does; the
+            # missing value is the one spelled two ways
+            missing = (src.isnull() | (src == "")) & (out.isnull() | (out == ""))
+            assert ((src == out) | missing).all()
 
     def test_gap_splits_partition(self):
         """A gap larger than tolerance yields separate outputs."""
@@ -211,16 +212,15 @@ class TestConflict:
         with pytest.raises(CoordMergeError, match="data_units"):
             build_chunk_plan(_flat(conflicted_patches), time=None)
 
-    def test_missing_value_is_not_a_conflict(self, conflicted_patches):
-        """A member lacking the attr merges; the output carries the known value."""
+    def test_missing_value_is_a_conflict(self, conflicted_patches):
+        """A member lacking the attr conflicts with one which has it."""
         p1, p2 = conflicted_patches
         df = _flat([p1.update_attrs(data_units=None), p2])
-        plan = build_chunk_plan(df, time=None)
-        assert len(plan.outputs) == 1
-        assert plan.outputs["data_units"].iloc[0] == "m / s"
-        # the same for drop, which only omits real conflicts
+        with pytest.raises(CoordMergeError, match="data_units"):
+            build_chunk_plan(df, time=None)
         plan = build_chunk_plan(df, time=None, conflict="drop")
-        assert plan.outputs["data_units"].iloc[0] == "m / s"
+        assert len(plan.outputs) == 1
+        assert "data_units" not in plan.outputs.columns
 
     def test_keep_first(self, conflicted_patches):
         """keep_first carries the first member's value."""
@@ -230,21 +230,13 @@ class TestConflict:
         expected = df.loc[df["_patch_id"] == first_id, "data_units"].iloc[0]
         assert plan.outputs["data_units"].iloc[0] == expected
 
-    def test_keep_first_known(self, conflicted_patches):
-        """keep_first skips a first member which lacks the value."""
+    def test_keep_first_means_the_first_member(self, conflicted_patches):
+        """keep_first takes the first member's value even where it states none."""
         p1, p2 = conflicted_patches
-        third = p2.update_coords(
-            time_min=p2.get_coord("time").max() + p2.get_coord("time").step
-        )
-        df = _flat(
-            [
-                p1.update_attrs(data_units=None),
-                p2,
-                third.update_attrs(data_units="ft/s"),
-            ]
-        )
+        df = _flat([p1.update_attrs(data_units=None), p2])
         plan = build_chunk_plan(df, time=None, conflict="keep_first")
-        assert plan.outputs["data_units"].iloc[0] == "m / s"
+        assert len(plan.outputs) == 1
+        assert pd.isnull(plan.outputs["data_units"].iloc[0])
 
     def test_drop(self, conflicted_patches):
         """Drop omits the conflicting attr from outputs."""
@@ -267,32 +259,17 @@ class TestGroupParameter:
         p4 = p2.update_attrs(acquisition_key="XX2.R2D1..RAW")
         return _flat([p1, p2, p3, p4])
 
-    def test_missing_value_joins_the_one_candidate(self, two_source_flat):
-        """A row lacking a kind value joins the only kind consistent with it."""
+    def test_missing_value_is_its_own_kind(self, two_source_flat):
+        """A row lacking a kind value is not the kind of one which states it."""
         df = two_source_flat
-        # Remove one acquisition entirely; the un-keyed row is unambiguous.
         one = df[df["acquisition_key"] == "XX1.R2D1..RAW"].copy()
         one.loc[one.index[-1], "acquisition_key"] = ""
         plan = build_chunk_plan(one, time=None)
-        assert len(plan.outputs) == 1
-        # The output carries the known value, not the first member's "".
-        assert plan.outputs["acquisition_key"].iloc[0] == "XX1.R2D1..RAW"
+        assert len(plan.outputs) == 2
+        keys = sorted(plan.outputs["acquisition_key"].fillna(""))
+        assert keys == ["", "XX1.R2D1..RAW"]
 
-    def test_complementary_partial_kinds_combine(self, two_source_flat):
-        """Rows knowing different attrs, none conflicting, are one kind."""
-        df = two_source_flat[
-            two_source_flat["acquisition_key"] == "XX1.R2D1..RAW"
-        ].copy()
-        # first row knows only the tag, second only the key
-        df.loc[df.index[0], "acquisition_key"] = ""
-        df.loc[df.index[1], "tag"] = ""
-        plan = build_chunk_plan(df, time=None)
-        assert len(plan.outputs) == 1
-        out = plan.outputs.iloc[0]
-        assert out["acquisition_key"] == "XX1.R2D1..RAW"
-        assert out["tag"] == "random"
-
-    def test_identical_ambiguous_rows_share_a_kind(self):
+    def test_un_keyed_rows_are_one_kind(self):
         """Un-keyed rows beside two acquisitions stay together, apart from both."""
         t0 = np.datetime64("2020-01-01", "ns")
         p1 = dc.get_example_patch(time_min=t0)
@@ -308,13 +285,12 @@ class TestGroupParameter:
         keys = sorted(plan.outputs["acquisition_key"].fillna(""))
         assert keys == ["", "XX1.R2D1..RAW", "XX2.R2D1..RAW"]
 
-    def test_missing_value_with_two_candidates_stays_apart(self, two_source_flat):
-        """With conflicting candidates a missing value joins neither."""
+    def test_missing_spellings_are_one_kind(self, two_source_flat):
+        """Null and "" spell one missing value, so they are one kind."""
         df = two_source_flat.copy()
-        df.loc[df.index[0], "acquisition_key"] = ""
+        df["acquisition_key"] = ["", None, "", None]
         plan = build_chunk_plan(df, time=None)
-        # un-keyed first patch alone, the rest of XX1, and XX2
-        assert len(plan.outputs) == 3
+        assert len(plan.outputs) == 1
 
     def test_source_partitions(self, two_source_flat):
         """Different data sources produce separate outputs, no error."""
@@ -409,9 +385,9 @@ class TestChunkPlanAccessor:
         plan = spool.chunk_plan(time=None)
         assert set(plan.members["output_id"]) == set(plan.outputs["output_id"])
         # Three un-keyed patches and three keyed ones cover the same span
-        # with the same tag; a missing key matches, so they are one kind and
-        # overlap removal keeps one copy of each span.
-        assert len(plan.members) == len(spool) - 3
+        # with the same tag, but a missing key is a kind of its own, so the
+        # two sets partition apart and nothing is deduplicated as an overlap.
+        assert len(plan.members) == len(spool)
         assert set(plan.members["_patch_id"]) <= set(spool._df["_patch_id"])
         # The plan rows and the assembled patches agree on the key.
         out = spool.chunk(time=None)
@@ -763,18 +739,17 @@ class TestConcatPlan:
         assert plan.outputs["time_min"].iloc[0] == p1.get_coord("time").min()
         assert plan.outputs["time_max"].iloc[0] == p2.get_coord("time").max()
 
-    def test_missing_matches_for_kind_and_units(self, trio):
-        """A missing kind value or unit matches, and the output carries the known."""
+    def test_missing_kind_value_partitions(self, trio):
+        """A missing kind value is a kind of its own; units are policed."""
         p1, p2, _ = trio
         keyed = p2.update_attrs(acquisition_key="XX.R2D1..RAW").set_units("m")
         plan = build_concat_plan(_flat([p1, keyed]), time=None)
-        assert len(plan.outputs) == 1
-        assert plan.outputs["acquisition_key"].iloc[0] == "XX.R2D1..RAW"
-        assert dc.get_quantity(plan.outputs["data_units"].iloc[0]) == dc.get_quantity(
-            "m"
-        )
-        # known, different units conflict, policed as a chunk plan polices them
-        mixed = _flat([p1.set_units("km"), keyed])
+        assert len(plan.outputs) == 2
+        keys = sorted(plan.outputs["acquisition_key"].fillna(""))
+        assert keys == ["", "XX.R2D1..RAW"]
+        # different units conflict, policed as a chunk plan polices them
+        same_kind = p1.update_attrs(acquisition_key="XX.R2D1..RAW")
+        mixed = _flat([same_kind.set_units("km"), keyed])
         with pytest.raises(CoordMergeError, match="data_units"):
             build_concat_plan(mixed, time=None)
         plan = build_concat_plan(mixed, time=None, conflict="drop")
@@ -810,10 +785,16 @@ class TestConcatPlan:
         bare = shifted.update_coords(distance=unitless)
         assert len(build_concat_plan(_flat([p1, bare]), distance=None).outputs) == 2
         assert len(build_concat_plan(_flat([p1, shifted]), distance=None).outputs) == 1
-        # a patch with no values along the dimension joins whichever it meets
+        # a patch with no values along the dimension states nothing which
+        # could clash, so it follows the one spelling the others state
         collapsed = p1.mean("distance")
         assert (
             len(build_concat_plan(_flat([p1, collapsed]), distance=None).outputs) == 1
+        )
+        # but not when they state two, which would be a guess
+        assert (
+            len(build_concat_plan(_flat([p1, bare, collapsed]), distance=None).outputs)
+            == 3
         )
 
     def test_relation_without_step_or_dtype(self, trio):

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -18,7 +18,6 @@ from dascore.io.index.planned import (
     _aux_coord_info,
     _coord_record_from_row,
     _ns,
-    _plan_attr_units,
     _stated_units,
     collapse_working_df,
     derived_catalog,
@@ -398,11 +397,3 @@ class TestStatedUnits:
     def test_stated_units_pass_through(self):
         """A real spelling survives as a string."""
         assert _stated_units("ft") == "ft"
-
-
-class TestNumericAttrUnits:
-    """The attr units a plan resolves for stamping."""
-
-    def test_no_parent_knows_nothing(self):
-        """Without a parent index there are no attr units to resolve."""
-        assert _plan_attr_units(None, pd.DataFrame({"foo": [1.0]})) == {}

--- a/tests/test_utils/test_attrs_utils.py
+++ b/tests/test_utils/test_attrs_utils.py
@@ -7,10 +7,9 @@ from collections.abc import Mapping
 import numpy as np
 import pytest
 
-import dascore as dc
 from dascore import PatchAttrs
 from dascore.exceptions import ParameterError
-from dascore.utils.attrs import combine_patch_attrs
+from dascore.utils.attrs import _is_missing, combine_patch_attrs
 
 
 class TestMergeAttrs:
@@ -44,35 +43,41 @@ class TestMergeAttrs:
         with pytest.raises(Exception, match="hold conflicting values"):
             combine_patch_attrs([pa1, pa2, pa3])
 
-    def test_missing_matches(self):
-        """An attr nobody recorded conflicts with nothing; the known value carries."""
-        pa1 = PatchAttrs(data_type="velocity", data_units=None, gauge=10.0)
-        pa2 = PatchAttrs(data_type="", data_units="m/s", gauge=np.nan)
+    def test_missing_is_a_value(self):
+        """An attr one member never recorded conflicts with one which did."""
+        pa1 = PatchAttrs(data_type="velocity", gauge=10.0)
+        pa2 = PatchAttrs(data_type="", gauge=np.nan)
         for order in ([pa1, pa2], [pa2, pa1]):
-            out = combine_patch_attrs(order)  # conflict="raise" does not raise
-            assert out.data_type == "velocity"
-            assert dc.get_quantity(out.data_units) == dc.get_quantity("m/s")
-            assert out.gauge == 10.0
+            with pytest.raises(Exception, match="hold conflicting values"):
+                combine_patch_attrs(order)
+
+    def test_missing_spellings_are_one_value(self):
+        """None, NaN, and "" are the same value, so they never conflict."""
+        attrs = [PatchAttrs(foo=""), PatchAttrs(foo=None), PatchAttrs(foo=np.nan)]
+        assert combine_patch_attrs(attrs).get("foo") is None
 
     def test_all_missing_is_omitted(self):
         """An attr nobody knows is left out rather than carried as ""."""
         out = combine_patch_attrs([PatchAttrs(foo=""), PatchAttrs(foo="")])
         assert out.get("foo") is None
 
-    def test_drop_keeps_known_beside_missing(self):
-        """Drop only omits attrs whose known values conflict."""
+    def test_drop_omits_missing_beside_known(self):
+        """Drop omits an attr one member left empty, like any other conflict."""
         pa1 = PatchAttrs(data_type="velocity", foo="a")
         pa2 = PatchAttrs(data_type="", foo="b")
         out = combine_patch_attrs([pa1, pa2], conflict="drop")
-        assert out.data_type == "velocity"
+        # data_type is a declared field, so dropping it leaves its default.
+        assert _is_missing(out.get("data_type"))
         assert out.get("foo") is None
 
-    def test_keep_first_means_first_known(self):
-        """keep_first skips a first member which lacks the value."""
+    def test_keep_first_means_the_first_member(self):
+        """keep_first keeps the first member's value, empty or not."""
         pa1 = PatchAttrs(foo="", bar=None)
         pa2 = PatchAttrs(foo="x", bar=1)
-        pa3 = PatchAttrs(foo="y", bar=2)
-        out = combine_patch_attrs([pa1, pa2, pa3], conflict="keep_first")
+        out = combine_patch_attrs([pa1, pa2], conflict="keep_first")
+        assert out.get("foo") is None
+        assert out.get("bar") is None
+        out = combine_patch_attrs([pa2, pa1], conflict="keep_first")
         assert out.foo == "x"
         assert out.bar == 1
 

--- a/tests/test_utils/test_attrs_utils.py
+++ b/tests/test_utils/test_attrs_utils.py
@@ -9,7 +9,7 @@ import pytest
 
 from dascore import PatchAttrs
 from dascore.exceptions import ParameterError
-from dascore.utils.attrs import _is_missing, combine_patch_attrs
+from dascore.utils.attrs import combine_patch_attrs
 
 
 class TestMergeAttrs:
@@ -67,7 +67,7 @@ class TestMergeAttrs:
         pa2 = PatchAttrs(data_type="", foo="b")
         out = combine_patch_attrs([pa1, pa2], conflict="drop")
         # data_type is a declared field, so dropping it leaves its default.
-        assert _is_missing(out.get("data_type"))
+        assert out.get("data_type") == ""
         assert out.get("foo") is None
 
     def test_keep_first_means_the_first_member(self):

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -838,20 +838,17 @@ class TestBuildGapFrame:
         assert out["gap_size"].iloc[0] == 993
         assert out["x_min"].dtype == df["x_min"].dtype
 
-    def test_cell_states_its_known_value(self, gapy_df):
-        """A cell reports the attr its members know, not the first row's.
+    def test_rows_of_different_kinds_are_different_cells(self, gapy_df):
+        """A row which never recorded an attr is not the kind of one which did.
 
-        Kind matching admits a row which never recorded an attr into the
-        cell of one that did, so the first row is not always the one
-        that knows.
+        The two are unrelated, so the hole between them is not a gap: a
+        report never bridges cells.
         """
         df = gapy_df.iloc[:2].copy()
         df["tag"] = ["", "sta1"]
-        # kind matching keeps them one cell, so the hole is a real gap
-        out = build_gap_frame(df, "time")
-        assert len(out) == 1
-        assert out["tag"].tolist() == ["sta1"]
-        assert build_coverage_frame(df, "time")["tag"].tolist() == ["sta1"]
+        assert len(build_gap_frame(df, "time")) == 0
+        coverage = build_coverage_frame(df, "time")
+        assert sorted(coverage["tag"].fillna("")) == ["", "sta1"]
 
     def test_integer_dimension_beyond_float_precision(self):
         """A gap survives an integer coordinate too large for float64.

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -566,7 +566,7 @@ class TestCheckKind:
             assert check_kind(pa1, pa1.update_attrs(tag="other"))
 
     def test_missing_attr_matches_anything(self, random_patch):
-        """A missing value conflicts with nothing; only known values can."""
+        """For two operands a missing value is a wildcard; known ones can clash."""
         with config_context(patch_kind_attrs=("foo",)):
             assert get_patch_kind(random_patch)["foo"] is None
             assert check_kind(random_patch, random_patch.new())
@@ -576,6 +576,18 @@ class TestCheckKind:
                     random_patch.update_attrs(foo="a"),
                     random_patch.update_attrs(foo="b"),
                 )
+
+    def test_strict_makes_missing_a_value(self, random_patch):
+        """Where patches are partitioned a missing value equals only a missing one."""
+        with config_context(patch_kind_attrs=("foo",)):
+            known = random_patch.update_attrs(foo="a")
+            # Two patches which never recorded it are still the same kind.
+            assert check_kind(random_patch, random_patch.new(), strict=True)
+            assert not check_kind(
+                random_patch, known, check_behavior="ignore", strict=True
+            )
+            with pytest.raises(IncompatiblePatchError, match="'foo'"):
+                check_kind(random_patch, known, strict=True)
 
     def test_data_type_is_not_kind(self, random_patch):
         """Processing changes data_type, so it must not gate arithmetic."""
@@ -590,6 +602,8 @@ class TestCheckKind:
         legacy = random_patch.update_attrs(network="", station="")
         assert get_patch_kind(legacy)["network"] is None
         assert check_kind(legacy, random_patch)
+        # The two spell one missing value, so they match even strictly.
+        assert check_kind(legacy, random_patch, strict=True)
 
     def test_array_valued_kind_attr(self, random_patch):
         """Array-valued kind attrs compare as a whole rather than raising."""
@@ -609,13 +623,14 @@ class TestCheckKind:
 class TestCheckDataUnits:
     """Tests for the data-units gate shared by concatenate and stack."""
 
-    def test_missing_agrees_known_differ(self, random_patch):
-        """A missing unit agrees with anything; known, different units do not."""
+    def test_only_equal_units_agree(self, random_patch):
+        """Units must be equal; no units is a unit like any other."""
         bare, metres, km = (random_patch.set_units(x) for x in (None, "m", "km"))
-        assert check_data_units(bare, metres)
+        assert check_data_units(bare, bare.new())
         assert check_data_units(metres, metres.set_units("meter"))
-        with pytest.raises(IncompatiblePatchError, match="data units differ"):
-            check_data_units(metres, km)
+        for other in (bare, km):
+            with pytest.raises(IncompatiblePatchError, match="data units differ"):
+                check_data_units(metres, other)
         with pytest.warns(UserWarning, match="convert_units"):
             assert not check_data_units(metres, km, check_behavior="warn")
 
@@ -738,55 +753,35 @@ class TestConcatenate:
                 [random_patch, other], time=None, check_behavior="raise"
             )
 
-    def test_kind_accumulates(self, random_patch):
-        """A value a kept patch knows binds the patches after it."""
+    def test_missing_kind_value_is_another_kind(self, random_patch):
+        """A patch which never stated a kind attr is not the kind which did."""
         blank = random_patch.update_attrs(tag="")
-        a, b = random_patch.update_attrs(tag="a"), random_patch.update_attrs(tag="b")
-        with pytest.warns(UserWarning, match="'tag': \\('a', 'b'\\)"):
-            out = concatenate_patches([blank, a, b], time=None)
-        assert out[0].shape[1] == 2 * random_patch.shape[1]
-        assert out[0].attrs.tag == "a"
-
-    def test_rejected_patch_binds_nothing(self, random_patch):
-        """A patch dropped for its coordinates must not set the run's kind."""
-        blank = random_patch.update_attrs(tag="")
-        bad = random_patch.update_attrs(tag="a").update_coords(distance_min=5)
-        good = random_patch.update_attrs(tag="b")
-        with pytest.warns(UserWarning, match="not equal"):
-            out = concatenate_patches([blank, bad, good], time=None)
-        assert out[0].shape[1] == 2 * random_patch.shape[1]
-        assert out[0].attrs.tag == "b"
+        a = random_patch.update_attrs(tag="a")
+        with pytest.warns(UserWarning, match="not the same kind"):
+            out = concatenate_patches([blank, a], time=None)
+        assert len(out) == 1
+        assert out[0].shape == random_patch.shape
+        assert out[0].attrs.tag == ""
+        # NaN is the same missing value, and just as much a value.
+        with config_context(patch_kind_attrs=("foo",)):
+            nan = random_patch.update_attrs(foo=np.nan)
+            known = random_patch.update_attrs(foo="a")
+            with pytest.warns(UserWarning, match="not the same kind"):
+                out = concatenate_patches([nan, known], time=None)
+            assert out[0].shape == random_patch.shape
 
     def test_dims_mismatch_raises_even_after_rejections(self, random_patch):
         """Different dimensions raise whatever was rejected before them."""
-        blank = random_patch.update_attrs(tag="")
-        bad = random_patch.update_attrs(tag="a").update_coords(distance_min=5)
-        odd = random_patch.update_attrs(tag="b").rename_coords(time="money")
+        bad = random_patch.update_coords(distance_min=5)
+        odd = random_patch.rename_coords(time="money")
         with pytest.warns(UserWarning, match="not equal"):
             with pytest.raises(PatchCoordinateError, match="different dimensions"):
-                concatenate_patches([blank, bad, odd], time=None)
+                concatenate_patches([random_patch, bad, odd], time=None)
         # another kind with other dimensions is merely skipped
         other_kind = random_patch.update_attrs(tag="z").rename_coords(time="money")
         with pytest.warns(UserWarning, match="not the same kind"):
             out = concatenate_patches([random_patch, other_kind], time=None)
         assert len(out) == 1
-
-    def test_kind_is_per_output(self, random_patch):
-        """Each output's kind comes from its own members only."""
-        blank = random_patch.update_attrs(tag="")
-        a = random_patch.update_attrs(tag="a")
-        out = concatenate_patches([blank, a], time=1)
-        assert [x.attrs.tag for x in out] == ["", "a"]
-
-    def test_nan_kind_value_is_filled(self, random_patch):
-        """A NaN kind value is missing and takes the known value."""
-        with config_context(patch_kind_attrs=("foo",)):
-            nan, known = (
-                random_patch.update_attrs(foo=np.nan),
-                random_patch.update_attrs(foo="a"),
-            )
-            out = concatenate_patches([nan, known], time=None)
-            assert out[0].attrs.foo == "a"
 
     def test_different_kind_skipped_before_dims(self, random_patch):
         """A different-kind patch is skipped whatever its dimensions."""
@@ -798,25 +793,15 @@ class TestConcatenate:
         assert len(out) == 1
         assert out[0].shape == random_patch.shape
 
-    def test_missing_units_adopt_the_known(self, random_patch):
-        """A patch without units concatenates and the output takes the known units."""
+    def test_missing_units_are_not_spliced_into_known(self, random_patch):
+        """A patch without units is not spliced onto one which has them."""
         other = random_patch.set_units("m/s").update_attrs(
             history=random_patch.attrs.history
         )
-        with suppress_warnings(action="error"):
-            out = concatenate_patches([random_patch, other], time=None)
-        assert out[0].shape[1] == 2 * random_patch.shape[1]
-        assert dc.get_quantity(out[0].attrs.data_units) == dc.get_quantity("m/s")
-
-    def test_units_bind_to_the_first_known(self, random_patch):
-        """After a unitless first patch, the first known units set the bar."""
-        bare = random_patch.set_units(None)
-        metres = random_patch.set_units("m").update_attrs(history=bare.attrs.history)
-        km = random_patch.set_units("km").update_attrs(history=bare.attrs.history)
         with pytest.warns(UserWarning, match="data units differ"):
-            out = concatenate_patches([bare, metres, km], time=None)
-        assert out[0].shape[1] == 2 * random_patch.shape[1]
-        assert dc.get_quantity(out[0].attrs.data_units) == dc.get_quantity("m")
+            out = concatenate_patches([random_patch, other], time=None)
+        assert out[0].shape == random_patch.shape
+        assert out[0].attrs.data_units is None
 
     def test_different_units_are_not_spliced(self, random_patch):
         """Known, different data units are skipped or raise, never mixed."""
@@ -1092,29 +1077,26 @@ class TestStackPatches:
             stack_patches([random_patch, other], check_behavior="raise")
 
     def test_different_units_are_not_summed(self, random_patch):
-        """Stacking metres onto kilometres is refused; a unitless patch adopts."""
+        """Only patches whose units are equal are summed; no units is a unit."""
         metres = random_patch.set_units("m")
         km = random_patch.set_units("km")
-        with pytest.warns(UserWarning, match="data units differ"):
-            out = stack_patches([metres, km])
-        assert np.allclose(out.data, metres.data)
         bare = random_patch.set_units(None)
-        out = stack_patches([bare, metres])
+        for others in ([km], [bare], [bare, km]):
+            with pytest.warns(UserWarning, match="data units differ"):
+                out = stack_patches([metres, *others])
+            assert np.allclose(out.data, metres.data)
+        out = stack_patches([metres, metres.set_units("meter")])
         assert np.allclose(out.data, 2 * metres.data)
         assert dc.get_quantity(out.attrs.data_units) == dc.get_quantity("m")
-        with pytest.warns(UserWarning, match="data units differ"):
-            out = stack_patches([bare, metres, km])
-        assert np.allclose(out.data, 2 * metres.data)
 
-    def test_rejected_patch_binds_nothing(self, random_patch):
-        """A patch dropped for its coordinates must not set the stack's kind."""
+    def test_missing_kind_value_is_another_kind(self, random_patch):
+        """A patch which never stated a kind attr is not summed into one which did."""
         blank = random_patch.update_attrs(tag="")
-        bad = random_patch.update_attrs(tag="a").update_coords(distance_min=5)
-        good = random_patch.update_attrs(tag="b")
-        with pytest.warns(UserWarning, match="not equal"):
-            out = stack_patches([blank, bad, good])
-        assert np.allclose(out.data, 2 * random_patch.data)
-        assert out.attrs.tag == "b"
+        tagged = random_patch.update_attrs(tag="a")
+        with pytest.warns(UserWarning, match="not the same kind"):
+            out = stack_patches([blank, tagged])
+        assert np.allclose(out.data, random_patch.data)
+        assert out.attrs.tag == ""
 
     def test_stack_coords(self):
         """


### PR DESCRIPTION
## Description

Closes #983.

`#953` made a missing attribute value (`None`, `NaN`, `""`) conflict with nothing, and `#961` carried that into the concatenate planner. This splits that rule by **how many patches the operation combines**, because the two cases are asking different questions.

An operation with **two operands** — an operator, a ufunc, `Patch.where` — must produce one patch and has one answer available: a missing value is a wildcard, and the result carries the union of what the two patches knew. Sound, and unchanged here. It is the same rule the data units already follow, where a unitless operand takes the other's.

An operation which combines a **collection** — `concatenate`, `stack`, `chunk`, the gap reports — is not answering "do these two go together?" but "which of these go together?". That is a partition, and partitioning needs a transitive comparison. A wildcard is not transitive: `"a"` matches `""` matches `"b"`, yet `"a"` and `"b"` conflict, so the answer depends on which patch is looked at first. These operations now read a missing value as a *value*: equal to another missing value and nothing else.

Everything that existed to paper over the non-transitivity goes with it:

| Deleted | What it was for |
|---|---|
| `_KindRun` | order-dependent kind accumulation in `concatenate_patches`/`stack_patches` |
| run building in `_kind_codes` | canonical ordering, seed rows, "joins the one run it fits, else starts its own" |
| `PlanResolver._stamp`'s attr filling, with `_plan_attr_units` and `backend.attr_units_map` | refilling the assembled patch from its plan row so `get_contents` and the patch agreed |
| `_carried_columns`' "first *known*" carry | ditto, in the planner |
| `units_run`, `_with_kind`, `_with_data_units` | the same accumulation for data units and kind |
| the `PlanResolver` kind-rule pin (`kind_attrs` + `config_context`) | assembly no longer re-gates kind |

Partitioning is a `groupby` again, and a plan row agrees with its assembled patch by construction rather than by being stamped afterwards.

`dev` is unreleased since `#953` and `#961` landed, so nothing is deprecated; this restores what `master` does today.

### Decisions

- **All attrs, not just kind.** The `conflict` policy follows the same rule, so `foo="a"` beside a member which never recorded `foo` is a conflict, and `keep_first` now means the first member's value *stated or not*. This is what makes `_stamp` and the first-known carry deletable; keeping tolerance for non-kind attrs would have kept most of the machinery.
- **Data units are compared for equality** in `concatenate_patches`/`stack_patches` — `"m" == "meter"`, and no units equals only no units. Nothing is converted for the caller.
- **`check_kind` gained `strict=`** rather than splitting into two functions; the collection callers pass `strict=True` against the first patch, which is enough because equality is transitive.
- **Coordinates were left alone.** An earlier draft made the concatenated dimension's value kind and units strict too, so a patch with no values along it (`patch.mean("time")`) would partition away from its own sources. That is not what the non-transitivity argument covers — a value-less row carries no value to conflict with, so it binds nothing and there is no order dependence to fix — and it would have made `Spool.concatenate` disagree with `concatenate_patches`. Value-less rows still follow the one spelling the stated rows share, and stay apart when there are two.
- **Data units are reconciled, not policed.** They scale the data rather than labelling it, so `concatenate_planned` converts every member to the first units any member states and declares them. Whether differing units may be combined at all is still `conflict`'s to say.
- **The legacy `network`/`station` stay** in `patch_kind_attrs`: a name no patch in a spool states is still ignored, and an archive which predates `acquisition_key` states them throughout.

### What users see

Mixed keyed and un-keyed files from one acquisition no longer fold together automatically; `diverse_das` gains outputs where the un-keyed patches used to be absorbed. To fold them deliberately, state the value — `spool.map(lambda p: p.update_attrs(acquisition_key=...))` — or say that the attribute neither partitions nor has to agree:

```python
spool.chunk(time=None, group=("tag",), conflict="keep_first")
```

Note that `group=` **alone** is not enough: an attribute outside the group is still policed by `conflict`. The [Patch Compatibility](https://dascore.org/notes/patch_compatibility.html) note now explains the arity split and both recipes, and its cells execute during the doc build.

### Review

Six independent reviews (Codex plus five Claude reviewers, each blind to the others) ran against the diff; findings are in `.scratch/adversarial-review/`. The load-bearing one was found by **two reviewers independently**: with a unitless first member, `keep_first` took its silence for `data_units`, which suppressed the conversion in `concatenate_planned` and spliced metre- and kilometre-scaled samples into one unlabelled array. Fixed by reconciling units as described above, with a test asserting the rescaling rather than just the label.

The others: `build_concat_plan`'s docstring still stated the pre-change rule three times, in the one function that decides it; the consolidated stamping test gave both members the same attrs, so it passed without the name-vs-envelope logic it named (rewritten to differ the values, and mutation-checked — breaking `_coord_owner` now fails it); three single-caller helpers and some duplicated bookkeeping left over from the deletions were folded away.

Two pre-existing bugs surfaced and were filed rather than fixed here, since neither is caused by this change (both reproduce unchanged on `dev`):

- #986 — `_carried_columns` resolves an attribute once per *partition* while a segmented chunk makes many outputs from one, so under `keep_first` a row can describe a patch by a value it does not hold, and `select()` then returns it.
- #987 — the promote-to-coordinate rule from the design note: rather than `keep_first` fabricating provenance for half the array, a differing non-kind attr should become a coordinate along the concatenated dimension. Agreed as a follow-up.

### Checks

Full suite 9631 passed / 114 skipped / 2 xfailed; `pytest dascore --doctest-modules` 207 passed; `pre-commit run --all` clean; coverage 100% on every file touched (`chunk_plan.py`, `patch.py`, `attrs.py`, `planned.py`, `backend.py`); both executable notes re-run cell by cell. Net −154 lines.

## Changelog

- changed: A missing attribute value (`None`, `NaN`, or `""`) is now a value rather than a wildcard for the operations which combine a collection of patches — `Spool.chunk`, `Spool.concatenate`, `Spool.stack`, `Spool.get_gaps`, `Spool.get_coverage`, and the `conflict` policy — so a patch which never recorded an attribute is no longer combined with one which did. Operators and ufuncs still treat it as a wildcard.
- changed: `conflict="keep_first"` now keeps the first patch's value for an attribute whether or not that patch stated one, instead of the first stated value among the patches.
- changed: `concatenate` and `stack` require the patches' data units to be equal, so a patch with no units is no longer spliced onto one which has them.
- added: `dascore.utils.patch.check_kind` accepts `strict=True` to compare a missing value as a value rather than as a wildcard.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Missing attributes now conflict with recorded values during merging and chunking.
  * Missing values form separate groups in spool partitioning, coverage, and gap reporting.
  * Operators may treat missing kind values as wildcards, while concatenation and stacking require exact kind and data-unit matches.
  * Concatenation preserves and reports reconciled unit metadata more consistently.

* **Documentation**
  * Updated compatibility, chunking, configuration, and grouping guidance with new missing-value and unit-matching rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->