### PR TITLE
Add rich text representations for Inventory and AnnotationSet

### DIFF
--- a/dascore/config.py
+++ b/dascore/config.py
@@ -52,6 +52,11 @@ class DascoreConfig(BaseModel):
         default=10,
         description="Maximum history length to display before summarizing entries.",
     )
+    display_max_items: int = Field(
+        default=10,
+        ge=0,
+        description="Maximum children a repr lists per level before eliding.",
+    )
     patch_history: Literal["standard", "disabled"] = Field(
         default="standard",
         description="Controls whether DASCore appends processing history to patches.",

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -939,9 +939,13 @@ class AnnotationSet(NamespaceOwner):
     def _contents(self) -> dict:
         """What the set holds: its kinds, its groups, and its columns."""
         contents = {}
-        for name in ("geometry", "group"):
-            if name in self._df.columns:
-                contents[name] = counts_to_text(self._df[name].value_counts())
+        # Every row has a geometry, whether or not it spells one: a blank
+        # cell, and a frame with no such column, are regions. Counting only
+        # what the column states would hide them.
+        if len(self._df):
+            contents["geometry"] = counts_to_text(self._kinds().value_counts())
+        if "group" in self._df.columns:
+            contents["group"] = counts_to_text(self._df["group"].value_counts())
         if len(self._df.columns):
             contents["columns"] = ", ".join(str(x) for x in self._df.columns)
         if len(self._vertices):
@@ -949,6 +953,12 @@ class AnnotationSet(NamespaceOwner):
         return contents
 
     # --- internals
+
+    def _kinds(self) -> pd.Series:
+        """The geometry kind each row states, read as ``_geometry`` reads it."""
+        if "geometry" not in self._df.columns:
+            return pd.Series("region", index=self._df.index)
+        return self._df["geometry"].map(lambda x: _text(x) or "region")
 
     def _geometry(self, row) -> Region | Path | Polygon:
         """Build the geometry a row states."""

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -928,8 +928,10 @@ class AnnotationSet(NamespaceOwner):
             if not len(values):
                 base += Text("unstated", key_style)
                 continue
-            base += Text("min: ", key_style) + get_nice_text(values.min())
-            base += Text(" max: ", key_style) + get_nice_text(values.max())
+            base += Text("min: ", key_style)
+            base += get_nice_text(values.min())
+            base += Text(" max: ", key_style)
+            base += get_nice_text(values.max())
             kind = "point" if spelling.point else "range"
             base += Text(f" ({kind})", key_style)
         return base

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -41,8 +41,9 @@ from pydantic import (
     ValidationError,
     model_validator,
 )
+from rich.text import Text
 
-from dascore.constants import max_lens
+from dascore.constants import dascore_styles, max_lens
 from dascore.core.inventory import CreationInfo
 from dascore.exceptions import ParameterError
 from dascore.models import (
@@ -52,6 +53,14 @@ from dascore.models import (
     FrozenDictType,
     PositiveFiniteFloat,
     UnitQuantity,
+)
+from dascore.utils.display import (
+    counts_to_text,
+    get_header_text,
+    get_nice_text,
+    mapping_to_text,
+    model_to_line,
+    stated_fields,
 )
 from dascore.utils.documents import write_document
 from dascore.utils.intervals import normalize_value, value_kind
@@ -277,6 +286,15 @@ class _AnnotationModel(DascoreBaseModel):
         validate_default=True,
         arbitrary_types_allowed=True,
     )
+
+    def __rich__(self) -> Text:
+        """One line naming the class and what it states."""
+        return model_to_line(self)
+
+    def __str__(self) -> str:
+        return str(self.__rich__())
+
+    __repr__ = __str__
 
 
 # --- Curves ---------------------------------------------------------------
@@ -877,12 +895,56 @@ class AnnotationSet(NamespaceOwner):
             )
         )
 
-    def __repr__(self) -> str:
-        """Name the set by what it holds."""
-        dims = ", ".join(self.dims)
-        return f"AnnotationSet({len(self)} annotations, dims=({dims}))"
+    def __rich__(self) -> Text:
+        """The banner, then what the set spans, holds, and says of itself."""
+        count = len(self)
+        plural = "" if count == 1 else "s"
+        name = f"AnnotationSet \U0001f3f7 ({count} Annotation{plural})"
+        blocks = [get_header_text(name), self._dims_text()]
+        if contents := self._contents():
+            blocks.append(mapping_to_text(contents, "Contents", style="dc_red"))
+        attrs = stated_fields(self._attrs, skip=("dims",))
+        if attrs:
+            blocks.append(mapping_to_text(attrs, "Attributes"))
+        return Text("\n").join(blocks)
 
-    __str__ = __repr__
+    def __str__(self) -> str:
+        return str(self.__rich__())
+
+    __repr__ = __str__
+
+    def _dims_text(self) -> Text:
+        """The extent each dimension is annotated over, and how it is spelled."""
+        key_style = dascore_styles["keys"]
+        base = Text("➤ ") + Text("Dimensions", style=dascore_styles["dc_blue"])
+        base += Text(" (") + Text(", ".join(self.dims), style="bold") + Text(")")
+        for dim in self.dims:
+            spelling = self._spellings[dim]
+            spelled = (spelling.point, spelling.start, spelling.end)
+            names = [x for x in spelled if x and x in self._df.columns]
+            columns = [self._df[x] for x in names] or [pd.Series(dtype=float)]
+            values = pd.concat(columns, ignore_index=True).dropna()
+            base += Text.assemble("\n    *", Text(dim, style="bold"), ": ")
+            if not len(values):
+                base += Text("unstated", key_style)
+                continue
+            base += Text("min: ", key_style) + get_nice_text(values.min())
+            base += Text(" max: ", key_style) + get_nice_text(values.max())
+            kind = "point" if spelling.point else "range"
+            base += Text(f" ({kind})", key_style)
+        return base
+
+    def _contents(self) -> dict:
+        """What the set holds: its kinds, its groups, and its columns."""
+        contents = {}
+        for name in ("geometry", "group"):
+            if name in self._df.columns:
+                contents[name] = counts_to_text(self._df[name].value_counts())
+        if len(self._df.columns):
+            contents["columns"] = ", ".join(str(x) for x in self._df.columns)
+        if len(self._vertices):
+            contents["vertices"] = len(self._vertices)
+        return contents
 
     # --- internals
 

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -42,8 +42,9 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from rich.text import Text
 
-from dascore.constants import DataCategory, DataType
+from dascore.constants import DataCategory, DataType, dascore_styles
 from dascore.exceptions import InvalidInventoryError, ParameterError
 from dascore.models import (
     DateTime64,
@@ -52,6 +53,14 @@ from dascore.models import (
     InventoryModel,
     TimeRangedModel,
     UnitQuantity,
+)
+from dascore.utils.display import (
+    get_header_text,
+    indent_text,
+    limit_reprs,
+    mapping_to_text,
+    model_to_line,
+    stated_fields,
 )
 from dascore.utils.documents import (
     dump_document,
@@ -230,6 +239,20 @@ class CoordinateReferenceSystem(InventoryModel):
             )
             raise InvalidInventoryError(msg)
         return self
+
+    def __rich__(self) -> Text:
+        """
+        One line naming the frame and its axes.
+
+        Stated in full rather than through the usual default-skipping
+        summary: the default CRS is a real answer, and an empty line for
+        it would say the inventory has no frame.
+        """
+        base = Text(self.__class__.__name__, style="bold") + Text("(")
+        base += Text(f" {self.authority}:{self.code}")
+        base += Text("  axes: ", dascore_styles["keys"])
+        base += Text(", ".join(self.coordinate_labels))
+        return base + Text(" )")
 
     def axis_index(self, label: str) -> int:
         """
@@ -628,6 +651,16 @@ class Geometry(InventoryModel):
         return out
 
 
+def _distance_line(model, skip=()) -> Text:
+    """One line for a model covering an interval of optical distance."""
+    span = f"[{model.start_distance:g}, {model.end_distance:g}) m"
+    return model_to_line(
+        model,
+        skip=(*skip, "start_distance", "end_distance"),
+        extra={"distance": span},
+    )
+
+
 class _IntervalModel(InventoryModel):
     """
     Base for items covering the half-open interval [start, end) of optical
@@ -661,6 +694,10 @@ class _IntervalModel(InventoryModel):
             )
             raise InvalidInventoryError(msg)
         return self
+
+    def __rich__(self) -> Text:
+        """One line stating the interval this item covers."""
+        return _distance_line(self)
 
     @property
     def optical_length(self) -> float:
@@ -826,6 +863,20 @@ class DistanceMap(InventoryModel):
                 "interrogator samples at a fixed spacing."
             )
             raise InvalidInventoryError(msg)
+
+    def __rich__(self) -> Text:
+        """
+        One line naming the axes mapped and how many points do it.
+
+        The control points themselves are a table rather than a fact, and
+        a measured map holds enough of them to bury the line it sits on.
+        """
+        axes = " and ".join(self.axes)
+        points = f"{len(self.distance)} control points"
+        base = Text(self.__class__.__name__, style="bold") + Text("(")
+        base += Text(f" {axes} -> distance", dascore_styles["keys"])
+        base += Text(f", {points}")
+        return base + Text(" )")
 
     @property
     def axes(self) -> tuple[str, ...]:
@@ -1195,6 +1246,10 @@ class OpticalPath(TimeRangedModel):
         default=(),
         description="OTDR and other optical measurements of this whole path.",
     )
+
+    def __rich__(self) -> Text:
+        """One line naming the path, its extent, and its track sizes."""
+        return _distance_line(self)
 
     @property
     def optical_length(self) -> float:
@@ -1708,6 +1763,13 @@ class FiberArray(TimeRangedModel):
         default=(), description="Optical paths associated with this fiber array."
     )
 
+    def __rich__(self) -> Text:
+        """The array's own line, then the reprs of what it holds."""
+        base = model_to_line(self, skip=("acquisitions", "optical_paths"))
+        for child in limit_reprs((*self.acquisitions, *self.optical_paths)):
+            base += Text("\n") + indent_text(child)
+        return base
+
     def check(self) -> Self:
         """
         Check epoch rules for this fiber array.
@@ -1760,6 +1822,13 @@ class Network(TimeRangedModel):
     stations: tuple[Station, ...] = Field(
         default=(), description="Stations in this network."
     )
+
+    def __rich__(self) -> Text:
+        """The network's own line, then the reprs of what it holds."""
+        base = model_to_line(self, skip=("fiber_arrays", "stations"))
+        for child in limit_reprs((*self.fiber_arrays, *self.stations)):
+            base += Text("\n") + indent_text(child)
+        return base
 
     def check(self) -> Self:
         """
@@ -2107,6 +2176,35 @@ class Inventory(NamespaceOwner, InventoryModel):
         object.__setattr__(self, "networks", networks)
         self.__pydantic_fields_set__.update({"resources", "networks"})
         return self
+
+    def __rich__(self) -> Text:
+        """
+        The banner, the network tree, and what the manifest itself states.
+
+        The tree is the networks' own reprs indented into place, so an
+        inventory says nothing about a network the network does not.
+        """
+        header = get_header_text("Inventory 📖")
+        networks = Text("➤ ") + Text("Networks", style=dascore_styles["dc_blue"])
+        networks += Text(f" ({len(self.networks)})")
+        for network in limit_reprs(self.networks):
+            networks += Text("\n") + indent_text(network)
+        # schema_version, resources and the CRS are stated whether or not
+        # they are the defaults: an inventory has a version and a frame,
+        # and a blank line for either would read as having neither.
+        shown = ("networks", "schema_version", "resources")
+        attrs = {
+            "schema_version": self.schema_version,
+            "resources": len(self.resources),
+            **stated_fields(self, skip=shown),
+            "coordinate_reference_system": self.coordinate_reference_system,
+        }
+        return Text("\n").join([header, networks, mapping_to_text(attrs, "Attributes")])
+
+    def __str__(self) -> str:
+        return str(self.__rich__())
+
+    __repr__ = __str__
 
     def get_resource(self, resource_id: str):
         """Return the shareable resource registered under a resource_id."""

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -248,11 +248,13 @@ class CoordinateReferenceSystem(InventoryModel):
         summary: the default CRS is a real answer, and an empty line for
         it would say the inventory has no frame.
         """
-        base = Text(self.__class__.__name__, style="bold") + Text("(")
-        base += Text(f" {self.authority}:{self.code}")
+        base = Text("")
+        base += Text(self.__class__.__name__, style="bold")
+        base += Text(f"( {self.authority}:{self.code}")
         base += Text("  axes: ", dascore_styles["keys"])
         base += Text(", ".join(self.coordinate_labels))
-        return base + Text(" )")
+        base += Text(" )")
+        return base
 
     def axis_index(self, label: str) -> int:
         """
@@ -873,10 +875,13 @@ class DistanceMap(InventoryModel):
         """
         axes = " and ".join(self.axes)
         points = f"{len(self.distance)} control points"
-        base = Text(self.__class__.__name__, style="bold") + Text("(")
+        base = Text("")
+        base += Text(self.__class__.__name__, style="bold")
+        base += Text("(")
         base += Text(f" {axes} -> distance", dascore_styles["keys"])
         base += Text(f", {points}")
-        return base + Text(" )")
+        base += Text(" )")
+        return base
 
     @property
     def axes(self) -> tuple[str, ...]:

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -26,7 +26,7 @@ from dascore.utils.array import (
     patch_array_ufunc,
 )
 from dascore.utils.array_api import to_numpy
-from dascore.utils.display import array_to_text, attrs_to_text, get_dascore_text
+from dascore.utils.display import array_to_text, attrs_to_text, get_header_text
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import check_patch_attrs, check_patch_coords, get_patch_names
 from dascore.utils.time import to_float
@@ -205,16 +205,12 @@ class Patch(NamespaceOwner):
         return out
 
     def __rich__(self):
-        dascore_text = get_dascore_text()
-        name = "Patch ⚡"
-        patch_text = Text(name, style="bold")
-        header = Text.assemble(dascore_text, " ", patch_text)
-        line = Text("-" * len(header))
+        header = get_header_text("Patch ⚡")
         coords = self.coords.__rich__()
         attrs = self.attrs
         data = array_to_text(self.data, units=attrs.get("data_units"))
         attrs = attrs_to_text(self.attrs)
-        out = Text("\n").join([header, line, coords, data, attrs])
+        out = Text("\n").join([header, coords, data, attrs])
         return out
 
     def __str__(self):

--- a/dascore/models/base.py
+++ b/dascore/models/base.py
@@ -17,6 +17,7 @@ from pydantic import (
     model_serializer,
     model_validator,
 )
+from rich.text import Text
 
 from dascore.compat import is_array_like
 from dascore.exceptions import InvalidInventoryError
@@ -28,6 +29,7 @@ from dascore.models.registry import (
     register_model,
 )
 from dascore.models.types import DateTime64, FrozenDictType
+from dascore.utils.display import model_to_line
 from dascore.utils.misc import _all_null, all_close
 from dascore.utils.time import to_datetime64
 
@@ -236,6 +238,15 @@ class InventoryModel(DascoreBaseModel):
         out = self.model_dump()
         out.update(kwargs)
         return self.__class__(**out)
+
+    def __rich__(self) -> Text:
+        """One line naming the class and what it states."""
+        return model_to_line(self)
+
+    def __str__(self) -> str:
+        return str(self.__rich__())
+
+    __repr__ = __str__
 
 
 class TimeRangedModel(InventoryModel):

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -336,7 +336,11 @@ def model_to_line(model, skip=(), style=None, extra=None) -> Text:
         model computes rather than stores.
     """
     key_style = dascore_styles["keys"]
-    base = Text(model.__class__.__name__, style=style or "bold")
+    # Started empty and appended to: a Text built as Text(x, style=...) makes
+    # that style the base of everything appended after it, so the class name's
+    # style would bleed onto every value.
+    base = Text("")
+    base += Text(model.__class__.__name__, style=style or "bold")
     base += Text("(")
     fields = {**stated_fields(model, skip=skip), **dict(extra or {})}
     for name, value in fields.items():

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -156,6 +156,7 @@ def get_header_text(name: str, style: str = "bold") -> Text:
     style
         A rich style, or a key of dascore.constants.dascore_styles.
     """
+    style = dascore_styles.get(style, style)
     header = Text.assemble(get_dascore_text(), " ", Text(name, style=style))
     # cell_len, not len: an emoji is one character and two columns wide,
     # and the underline is drawn in columns.
@@ -215,9 +216,9 @@ def counts_to_text(counts, limit: int | None = None) -> Text:
     shown = ", ".join(f"{name}: {count}" for name, count in items[:limit])
     if len(items) <= limit:
         return Text(shown)
-    return Text(shown) + Text(
-        f", ... {len(items) - limit} more", dascore_styles["keys"]
-    )
+    left_out = Text(f"... {len(items) - limit} more", dascore_styles["keys"])
+    # A zero limit shows nothing, and nothing needs no comma after it.
+    return Text(f"{shown}, ") + left_out if shown else left_out
 
 
 def _stated(value) -> bool:
@@ -340,7 +341,8 @@ def model_to_line(model, skip=(), style=None, extra=None) -> Text:
     # that style the base of everything appended after it, so the class name's
     # style would bleed onto every value.
     base = Text("")
-    base += Text(model.__class__.__name__, style=style or "bold")
+    style = dascore_styles.get(style, style or "bold")
+    base += Text(model.__class__.__name__, style=style)
     base += Text("(")
     fields = {**stated_fields(model, skip=skip), **dict(extra or {})}
     for name, value in fields.items():

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import textwrap
+from collections.abc import Mapping, Sized
+from contextlib import suppress
 from functools import singledispatch
 
 import numpy as np
 import pandas as pd
+from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
 from rich.style import Style
 from rich.text import Text
 
@@ -14,6 +18,31 @@ import dascore as dc
 from dascore.config import get_config
 from dascore.constants import dascore_styles
 from dascore.units import get_quantity_str
+
+# How wide one value may print before it is elided. A repr is a glance at
+# an object, and a single long field should not push the rest off screen.
+_MAX_VALUE_CELLS = 80
+
+# Fields which name a record rather than describe it. Hidden for the same
+# reason a patch's lineage ids are: they would put a line of hex in every
+# repr of every object without telling a reader anything.
+_IDENTITY_FIELDS = frozenset({"object_type", "resource_id"})
+
+# What is unrolled into its items rather than printed as itself. An array,
+# a Series or a frame is a table, and has a string form of its own which
+# already knows how much of itself to show.
+_SEQUENCE_TYPES = (tuple, list, set, frozenset)
+
+# The scalar types a model field is left unset as.
+_NULLABLE_TYPES = (
+    float,
+    np.floating,
+    np.datetime64,
+    np.timedelta64,
+    pd.Timestamp,
+    pd.Timedelta,
+    type(pd.NaT),
+)
 
 
 @singledispatch
@@ -98,7 +127,7 @@ def _nice_datetime(value, style=None):
         return out
 
     if pd.isnull(value):
-        return str(value)
+        return get_nice_text(Text(str(value)), style)
 
     stylized_text = stylize_str(str(value))
     simplified_text = simplify_str(stylized_text)
@@ -114,6 +143,235 @@ def get_dascore_text():
     c = Text("C", style=c_style)
     ore = Text("ore", style=ore_style)
     return Text.assemble(das, c, ore)
+
+
+def get_header_text(name: str, style: str = "bold") -> Text:
+    """
+    Get the banner which opens the repr of a top-level dascore object.
+
+    Parameters
+    ----------
+    name
+        What the object is called, including any icon (e.g. "Patch ⚡").
+    style
+        A rich style, or a key of dascore.constants.dascore_styles.
+    """
+    header = Text.assemble(get_dascore_text(), " ", Text(name, style=style))
+    # cell_len, not len: an emoji is one character and two columns wide,
+    # and the underline is drawn in columns.
+    return header + Text("\n") + Text("-" * header.cell_len)
+
+
+def indent_text(text: Text, prefix: str = "    ") -> Text:
+    """
+    Indent every line of a rich Text, keeping its styles.
+
+    This is what lets a container drop a child's ``__rich__`` into place
+    rather than describing the child itself.
+    """
+    return Text("\n").join(Text(prefix) + line for line in text.split("\n"))
+
+
+def limit_reprs(items, limit: int | None = None) -> list[Text]:
+    """
+    Render at most ``limit`` items, with a line naming what was left out.
+
+    Only the items which are shown are rendered, so the cost of a repr is
+    what it prints rather than what the object holds. A repr also says how
+    much it is not showing; silently stopping at ten reads as though ten
+    is all there were.
+    """
+    limit = get_config().display_max_items if limit is None else limit
+    items = list(items)
+    texts = [x.__rich__() for x in items[:limit]]
+    if left_out := len(items) - len(texts):
+        texts.append(Text(f"... {left_out} more", style=dascore_styles["keys"]))
+    return texts
+
+
+def _length(value) -> int | None:
+    """
+    Return how many items a value holds, or None where it holds no items.
+
+    A pint Quantity claims to be Sized and then refuses ``len`` when it
+    wraps a scalar, so asking is the only way to know.
+    """
+    if not isinstance(value, Sized) or isinstance(value, str):
+        return None
+    with suppress(TypeError):
+        return len(value)
+    return None
+
+
+def counts_to_text(counts, limit: int | None = None) -> Text:
+    """
+    Render a mapping of name to count as ``a: 2, b: 1``.
+
+    Names past ``limit`` (config's ``display_max_items``) are summarized
+    rather than dropped silently.
+    """
+    limit = get_config().display_max_items if limit is None else limit
+    items = list(dict(counts).items())
+    shown = ", ".join(f"{name}: {count}" for name, count in items[:limit])
+    if len(items) <= limit:
+        return Text(shown)
+    return Text(shown) + Text(
+        f", ... {len(items) - limit} more", dascore_styles["keys"]
+    )
+
+
+def _stated(value) -> bool:
+    """Whether a value says anything: unset, blank and empty all do not."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value)
+    if isinstance(value, BaseModel):
+        # A model which states nothing says nothing, however present it is.
+        return bool(stated_fields(value))
+    if (length := _length(value)) is not None:
+        return length > 0
+    # Only the scalar types a field is left unset as are asked; pandas
+    # answers for anything, and an object it cannot judge is not null.
+    if isinstance(value, _NULLABLE_TYPES):
+        return not bool(pd.isnull(value))
+    return True
+
+
+def _is_default(info, value) -> bool:
+    """
+    Whether a field still holds the default it was given.
+
+    Errs toward saying no: a default which cannot be compared (an array)
+    or which is built fresh each time is treated as stated, so a doubtful
+    field is shown rather than quietly dropped.
+    """
+    if info.default_factory is not None or info.default is PydanticUndefined:
+        return False
+    with suppress(Exception):
+        return bool(info.default == value)
+    return False
+
+
+def stated_fields(model, skip=()) -> dict:
+    """
+    Return the fields of a pydantic model which state something.
+
+    Unset, blank, empty and still-default fields are dropped, as are the
+    identity fields and anything named in ``skip``. What is left is what
+    the object actually says about itself.
+    """
+    skip = _IDENTITY_FIELDS | set(skip)
+    out = {}
+    for name, info in type(model).model_fields.items():
+        if name in skip or name.startswith("_"):
+            continue
+        value = getattr(model, name, None)
+        if not _stated(value) or _is_default(info, value):
+            continue
+        out[name] = value
+    return out
+
+
+def value_to_text(name: str, value, style=None, truncate: bool = True) -> Text:
+    """
+    Get the text one value prints as, given the name it is stated under.
+
+    A value which knows how to display itself is asked to; a collection of
+    such values is counted rather than unrolled.
+
+    Parameters
+    ----------
+    name
+        The name the value is stated under; units are read off it.
+    value
+        What to render.
+    style
+        A rich style for the rendered value.
+    truncate
+        Whether to elide a long value. True where many values share a
+        line, False where the value has a line to itself.
+    """
+    if isinstance(value, Text):  # already rendered by the caller
+        return value.copy()
+    if isinstance(value, Mapping):
+        if any(isinstance(x, BaseModel) for x in value.values()):
+            text = Text(f"{len(value)}")
+        else:
+            text = Text(", ".join(f"{k}={v}" for k, v in value.items()))
+    elif isinstance(value, _SEQUENCE_TYPES):
+        values = list(value)
+        if any(isinstance(x, BaseModel) for x in values):
+            text = Text(f"{len(values)}")
+        else:
+            text = Text(", ".join(str(x) for x in values))
+    elif name.endswith("units"):
+        text = get_nice_text(get_quantity_str(value), style="units")
+    elif hasattr(value, "__rich__"):
+        text = value.__rich__()
+    else:
+        text = get_nice_text(value, style=style)
+    if truncate:
+        text.truncate(_MAX_VALUE_CELLS, overflow="ellipsis")
+    return text
+
+
+def model_to_line(model, skip=(), style=None, extra=None) -> Text:
+    """
+    Get a one-line summary of a pydantic model.
+
+    Shaped like a coordinate's repr: the class name, then each field the
+    model states. Containers of other models show how many they hold.
+
+    Parameters
+    ----------
+    model
+        The pydantic model to summarize.
+    skip
+        Field names to leave out, e.g. children the caller lists itself.
+    style
+        A rich style for the class name.
+    extra
+        Derived values to state after the fields, such as an interval a
+        model computes rather than stores.
+    """
+    key_style = dascore_styles["keys"]
+    base = Text(model.__class__.__name__, style=style or "bold")
+    base += Text("(")
+    fields = {**stated_fields(model, skip=skip), **dict(extra or {})}
+    for name, value in fields.items():
+        base += Text(f" {name}: ", key_style)
+        base += value_to_text(name, value)
+    base += Text(" )")
+    return base
+
+
+def mapping_to_text(mapping, header: str, style: str = "dc_yellow") -> Text:
+    """
+    Get the "➤ Header" block a mapping of names to values prints as.
+
+    Parameters
+    ----------
+    mapping
+        The names and values to list, one per line.
+    header
+        What to call the block.
+    style
+        A rich style, or a key of dascore.constants.dascore_styles.
+    """
+    txt = Text("➤ ") + Text(header, style=dascore_styles.get(style, style))
+    for name, value in dict(mapping).items():
+        # skip private entries for display
+        if str(name).startswith("_"):
+            continue
+        txt += Text("\n    ")
+        txt += Text(f"{name}: ", dascore_styles["keys"])
+        # A block gives each value its own line, so it is not elided; a
+        # one-line summary packs many values and has to bound each.
+        txt += value_to_text(
+            name, value, style=dascore_styles.get(name, None), truncate=False
+        )
+    return txt
 
 
 def array_to_text(data, units=None) -> Text:
@@ -139,19 +397,4 @@ def attrs_to_text(attrs) -> Text:
     # The lineage ids are not metadata a reader is looking at a patch to
     # read; they would put a line of hex on every patch anyone prints.
     attrs.pop("patch_id", None), attrs.pop("processing_id", None)
-    txt = Text("➤ ") + Text("Attributes", style=dascore_styles["dc_yellow"])
-    txt += Text("\n")
-    for name, attr in dict(attrs).items():
-        # skip private coords for display
-        if name.startswith("_"):
-            continue
-        # determine styles here based on keys
-        style = dascore_styles.get(name, None)
-        if name.endswith("units"):
-            attr = get_quantity_str(attr)
-        # assemble text
-        txt += Text("    ")
-        txt += Text(f"{name}: ", dascore_styles["keys"])
-        txt += get_nice_text(attr, style=style)
-        txt += Text("\n")
-    return txt
+    return mapping_to_text(attrs, "Attributes") + Text("\n")

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -54,6 +54,13 @@ with config_context(patch_kind_attrs=("acquisition_key",)):
     ...  # tag and data_category no longer separate patches
 ```
 
+How objects print is configurable as well: `display_float_precision` sets the decimals shown for floats, `display_array_threshold` how much of an array is printed before it is elided, and `display_max_items` how many children a repr lists per level before saying how many it left out.
+
+```python
+with config_context(display_max_items=3):
+    print(inventory)  # at most three networks, arrays or paths per level
+```
+
 For remote IO settings such as `allow_remote_cache`,
 `allow_remote_cache_for_metadata`, `warn_on_remote_cache`,
 `remote_hdf5_block_size`, `remote_hdf5_max_blocks`, and `warn_on_gc_pause`,

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -200,7 +200,15 @@ Listing a name is not promising a value for it. This example's geometry states c
 
 # Seeing an inventory
 
-An inventory draws itself through its `viz` namespace, and each of the three plots looks along one coordinate.
+Printing an inventory summarizes what it holds. Each line is the repr of one object in the tree, so the same line you see nested here is what you get printing that network, fiber array or optical path on its own:
+
+```{python}
+print(inventory)
+```
+
+Only what an object states is shown, so a field left at its default does not take up a line. `Networks` lists at most `display_max_items` children per level (see the [configuration](configuration.qmd) page) and says how many it left out.
+
+An inventory also draws itself through its `viz` namespace, and each of the three plots looks along one coordinate.
 
 [`Inventory.viz.path`](`dascore.viz.inventory.path`) looks along **optical distance**, which is the coordinate the data is in. Every track the path describes becomes a lane, so the channels an acquisition places, the components, the coupling, and each label group line up against the same axis:
 

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from pydantic import ValidationError
+from rich.text import Text
 
 import dascore as dc
 from dascore.core.annotations import (
@@ -131,8 +132,45 @@ class TestConstruction:
 
     def test_repr_names_contents(self, region_set):
         """The repr says how many annotations and over which dimensions."""
-        assert "3 annotations" in repr(region_set)
-        assert "time" in repr(region_set)
+        out = repr(region_set)
+        assert "3 Annotations" in out
+        assert "time" in out and "distance" in out
+        assert "event: 2" in out  # the groups it holds, and how many of each
+
+    def test_repr_states_dimension_extent(self, region_set):
+        """A dimension the set states is shown by what it spans."""
+        out = repr(region_set)
+        assert "min: 0.000 max: 100.000" in out
+        # A dimension no column spells has no extent to state.
+        assert "unstated" in out
+
+    def test_repr_of_empty_set(self):
+        """An empty set still has a repr, and claims no contents."""
+        out = repr(AnnotationSet(None, dims=DIMS))
+        assert "0 Annotations" in out
+        assert "Contents" not in out
+
+    def test_repr_counts_vertices(self, path_set):
+        """A set holding a path names its geometry kinds and its vertices."""
+        out = repr(path_set)
+        assert "path: 1" in out and "region: 1" in out
+        assert "vertices: 3" in out
+
+    def test_repr_shows_attributes(self):
+        """What the set says of itself is shown, and defaults are not."""
+        out = repr(AnnotationSet(None, dims=DIMS, acquisition_key="XT.TUN1.00.DAS"))
+        assert "acquisition_key: XT.TUN1.00.DAS" in out
+        assert "history" not in out  # unset, so it states nothing
+
+    def test_rich(self, region_set):
+        """Annotation sets have a rich representation."""
+        assert isinstance(region_set.__rich__(), Text)
+
+    def test_annotation_repr(self, region_set):
+        """One annotation names its class and what it states."""
+        out = repr(region_set[0])
+        assert out.startswith("Annotation(")
+        assert "group: event" in out
 
     def test_equality(self, region_set):
         """Two sets built the same way are equal."""

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -150,6 +150,28 @@ class TestConstruction:
         assert "0 Annotations" in out
         assert "Contents" not in out
 
+    def test_repr_counts_default_geometry(self):
+        """A row which spells no geometry is a region, and is counted as one."""
+        frame = pd.DataFrame(
+            {
+                "id": ["a", "b", "c"],
+                "geometry": ["path", "", None],
+                "distance_start": [np.nan, 10.0, 20.0],
+                "distance_end": [np.nan, 80.0, 90.0],
+            }
+        )
+        vertices = pd.DataFrame(
+            {"id": ["a"] * 3, "seq": [0, 1, 2], "distance": [1.0, 5.0, 9.0]}
+        )
+        annotations = AnnotationSet(frame, dims=DIMS, vertices=vertices)
+        kinds = [type(x.geometry).__name__ for x in annotations]
+        assert kinds == ["Path", "Region", "Region"]
+        assert "geometry: region: 2, path: 1" in repr(annotations)
+
+    def test_repr_counts_geometry_without_the_column(self, region_set):
+        """A frame which never spells geometry holds regions all the same."""
+        assert "geometry: region: 3" in repr(region_set)
+
     def test_repr_counts_vertices(self, path_set):
         """A set holding a path names its geometry kinds and its vertices."""
         out = repr(path_set)

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -166,6 +166,13 @@ class TestConstruction:
         """Annotation sets have a rich representation."""
         assert isinstance(region_set.__rich__(), Text)
 
+    def test_dimension_values_not_styled_as_keys(self, region_set):
+        """A dimension's extent is a value, not the label in front of it."""
+        text = region_set.__rich__()
+        assert text.style == ""
+        start = text.plain.index("100.000")
+        assert not [x for x in text.spans if x.start <= start < x.end]
+
     def test_annotation_repr(self, region_set):
         """One annotation names its class and what it states."""
         out = repr(region_set[0])

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -11,8 +11,10 @@ import numpy as np
 import pytest
 import yaml
 from pydantic import ValidationError
+from rich.text import Text
 
 import dascore as dc
+from dascore.config import config_context
 from dascore.constants import INVENTORY_ATTRS
 from dascore.core import Inventory
 from dascore.core import inventory as inv
@@ -1645,6 +1647,71 @@ class TestCoverageCompleteness:
         assert values_equal(np.array([1.0, np.nan]), np.array([1.0, np.nan]))
         assert not values_equal({"a": 1}, {"b": 1})
         assert values_equal((1.0, np.nan), (1.0, np.nan))
+
+
+class TestDisplay:
+    """Tests for the inventory's text representation."""
+
+    @pytest.fixture(scope="class")
+    def tunnel(self):
+        """A populated inventory with two optical paths."""
+        return dc.get_example_inventory("tunnel")
+
+    def test_rich(self, tunnel):
+        """An inventory has a rich representation."""
+        assert isinstance(tunnel.__rich__(), Text)
+
+    def test_empty_inventory(self):
+        """An empty inventory still prints, and says it holds nothing."""
+        out = str(dc.Inventory())
+        assert "Networks (0)" in out
+        assert "schema_version: 1" in out
+
+    def test_names_the_tree(self, tunnel):
+        """The tree is composed of the reprs of what the inventory holds."""
+        out = str(tunnel)
+        network = tunnel.networks[0]
+        array = network.fiber_arrays[0]
+        assert str(network.__rich__()).splitlines()[0] in out
+        assert str(array.__rich__()).splitlines()[0] in out
+        for path in array.optical_paths:
+            assert str(path.__rich__()) in out
+
+    def test_shorter_than_a_field_dump(self, tunnel):
+        """A repr is a glance; the whole manifest is not."""
+        dumped = len(str(tunnel.model_dump()))
+        assert len(str(tunnel)) < dumped / 10
+
+    def test_coordinate_reference_system_stated(self, tunnel):
+        """The frame is shown even where it is the default one."""
+        assert "coordinate_reference_system" in str(tunnel)
+        assert "EPSG:4979" in str(dc.Inventory())
+
+    def test_path_states_its_extent(self, tunnel):
+        """An optical path shows the distances it covers."""
+        path = tunnel.networks[0].fiber_arrays[0].optical_paths[0]
+        assert f"[{path.start_distance:g}, {path.end_distance:g}) m" in str(path)
+
+    def test_interval_states_its_extent(self, tunnel):
+        """So does anything else which covers an interval of distance."""
+        label = tunnel.networks[0].fiber_arrays[0].optical_paths[0].labels[0]
+        assert "distance: [" in str(label)
+        assert "start_distance" not in str(label)  # stated by the interval
+
+    def test_distance_map_counts_points(self, tunnel):
+        """A measured map names its axes rather than listing its points."""
+        acquisition = tunnel.networks[0].fiber_arrays[0].acquisitions[0]
+        out = str(acquisition.distance_map)
+        assert "-> distance" in out
+        assert "control points" in out
+
+    def test_children_elided(self):
+        """A container says how many children it is not showing."""
+        stations = [{"code": f"S{x}"} for x in range(5)]
+        network = inv.Network(code="XT", stations=stations)
+        with config_context(display_max_items=2):
+            out = str(network)
+        assert "... 3 more" in out
 
 
 class TestObjectTypeTag:

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -1705,6 +1705,22 @@ class TestDisplay:
         assert "-> distance" in out
         assert "control points" in out
 
+    def test_child_styles_do_not_bleed(self, tunnel):
+        """A container does not paint its children with its own style."""
+        network = tunnel.networks[0]
+        text = network.__rich__()
+        assert text.style == ""
+        # The indent a child is placed under carries no style of its own.
+        indent = text.plain.index("FiberArray") - 4
+        assert not [x for x in text.spans if x.start <= indent < x.end]
+
+    def test_crs_styles_only_its_name(self, tunnel):
+        """The frame's own line marks its class, not its axes."""
+        text = tunnel.coordinate_reference_system.__rich__()
+        assert text.style == ""
+        start = text.plain.index("local:tunnel")
+        assert not [x for x in text.spans if x.start <= start < x.end]
+
     def test_children_elided(self):
         """A container says how many children it is not showing."""
         stations = [{"code": f"S{x}"} for x in range(5)]

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -4,10 +4,25 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+from pydantic import BaseModel, ConfigDict
+from rich.text import Text
 
 import dascore as dc
 from dascore.config import config_context
-from dascore.utils.display import array_to_text, get_nice_text
+from dascore.core.annotations import AnnotationColumn, AnnotationSetAttrs
+from dascore.core.inventory import Acquisition, Cable, Network
+from dascore.utils.display import (
+    array_to_text,
+    counts_to_text,
+    get_header_text,
+    get_nice_text,
+    indent_text,
+    limit_reprs,
+    mapping_to_text,
+    model_to_line,
+    stated_fields,
+    value_to_text,
+)
 from dascore.utils.patch import _format_values
 
 
@@ -65,3 +80,199 @@ class TestArrayFormatting:
         ):
             out = _format_values(data)
         assert "..." in out
+
+
+class TestGetHeaderText:
+    """Tests for the banner which opens a top-level object's repr."""
+
+    def test_underline_matches_columns(self):
+        """The underline is as wide as the header prints, not as long."""
+        header, line = str(get_header_text("Patch ⚡")).split("\n")
+        assert len(line) == Text(header).cell_len
+        # An emoji is two columns wide, so the two differ in length.
+        assert len(line) > len(header)
+
+    def test_names_the_object(self):
+        """The name given is in the banner, beside the DASCore text."""
+        out = str(get_header_text("Inventory"))
+        assert out.startswith("DASCore Inventory")
+
+
+class TestIndentText:
+    """Tests for indenting a rich Text."""
+
+    def test_every_line_indented(self):
+        """Each line gains the prefix, including the first."""
+        out = str(indent_text(Text("a\nb"), "  "))
+        assert out == "  a\n  b"
+
+    def test_styles_kept(self):
+        """Indenting does not flatten the styles it wraps."""
+        text = Text("red", style="red")
+        assert indent_text(text).spans
+
+
+class TestLimitReprs:
+    """Tests for capping how many children a repr lists."""
+
+    def test_under_limit_unchanged(self):
+        """Nothing is added while everything fits."""
+        items = [Network(code="A"), Network(code="B")]
+        out = limit_reprs(items, limit=3)
+        assert [str(x) for x in out] == [str(x) for x in items]
+
+    def test_over_limit_says_what_is_missing(self):
+        """The tail is named rather than dropped silently."""
+        items = [Network(code=f"N{x}") for x in range(5)]
+        out = limit_reprs(items, limit=2)
+        assert len(out) == 3
+        assert "3 more" in str(out[-1])
+
+    def test_limit_from_config(self):
+        """The default cap comes from runtime config."""
+        with config_context(display_max_items=1):
+            out = limit_reprs([Network(code="A"), Network(code="B")])
+        assert len(out) == 2
+        assert "1 more" in str(out[-1])
+
+    def test_hidden_children_not_rendered(self):
+        """A child which is not shown is not built, however many there are."""
+        rendered = []
+
+        class Counted:
+            def __rich__(self):
+                rendered.append(1)
+                return Text("x")
+
+        limit_reprs([Counted() for _ in range(50)], limit=2)
+        assert len(rendered) == 2
+
+
+class TestCountsToText:
+    """Tests for rendering value counts."""
+
+    def test_pairs_rendered(self):
+        """Names and counts are paired on one line."""
+        assert str(counts_to_text({"a": 2, "b": 1})) == "a: 2, b: 1"
+
+    def test_tail_summarized(self):
+        """Names past the limit are counted rather than listed."""
+        out = str(counts_to_text({"a": 1, "b": 1, "c": 1}, limit=1))
+        assert out == "a: 1, ... 2 more"
+
+
+class TestStatedFields:
+    """Tests for reading what a model states about itself."""
+
+    def test_defaults_and_identity_dropped(self):
+        """A default, a blank and an identity field all state nothing."""
+        out = stated_fields(Cable(resource_id="c1", name="c"))
+        assert out == {"name": "c"}
+
+    def test_unset_times_dropped(self):
+        """An unset (NaT) epoch is not a fact about the object."""
+        assert "start_time" not in stated_fields(Network(code="XT"))
+
+    def test_set_times_kept(self):
+        """A stated epoch is."""
+        network = Network(code="XT", start_time="2020-01-01")
+        assert "start_time" in stated_fields(network)
+
+    def test_uncomparable_default_is_stated(self):
+        """A default which cannot be compared is shown rather than hidden."""
+
+        class Model(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+            data: np.ndarray = np.array([1, 2])
+
+        assert "data" in stated_fields(Model())
+
+    def test_mapping_of_models_counted(self):
+        """A pool of models says how many it holds, not what each one is."""
+        columns = {"pick": AnnotationColumn(description="a pick")}
+        attrs = AnnotationSetAttrs(dims=("time",), columns=columns)
+        assert "columns: 1" in str(model_to_line(attrs))
+
+
+class TestModelToLine:
+    """Tests for the one-line model summary."""
+
+    def test_names_class_and_fields(self):
+        """The line names the class, then what the model states."""
+        out = str(model_to_line(Network(code="XT")))
+        assert out == "Network( code: XT )"
+
+    def test_identity_field_hidden(self):
+        """The class tag is not something a reader asked about."""
+        assert "object_type" not in str(model_to_line(Cable(resource_id="c1")))
+
+    def test_children_counted(self):
+        """A container of models shows how many it holds, not each one."""
+        network = Network(code="XT", stations=[{"code": "S1"}, {"code": "S2"}])
+        assert "stations: 2" in str(model_to_line(network))
+
+    def test_units_formatted(self):
+        """A units field prints as a unit string."""
+        acq = Acquisition(code="DAS", data_units="m/s")
+        assert "data_units: m / s" in str(model_to_line(acq))
+
+    def test_extra_values_appended(self):
+        """Derived values a caller passes are stated after the fields."""
+        out = str(model_to_line(Network(code="XT"), extra={"span": "wide"}))
+        assert out.endswith("span: wide )")
+
+    def test_skip(self):
+        """Fields the caller lists itself can be left out."""
+        network = Network(code="XT", stations=[{"code": "S1"}])
+        assert "stations" not in str(model_to_line(network, skip=("stations",)))
+
+
+class TestMappingToText:
+    """Tests for the named block a mapping prints as."""
+
+    def test_header_and_entries(self):
+        """The block is a header and one line per entry."""
+        out = str(mapping_to_text({"a": 1}, "Things"))
+        assert out == "➤ Things\n    a: 1"
+
+    def test_private_skipped(self):
+        """Private names are not shown."""
+        assert "_b" not in str(mapping_to_text({"a": 1, "_b": 2}, "Things"))
+
+    def test_long_value_not_elided(self):
+        """A value with a line to itself is shown whole."""
+        long = "x" * 500
+        assert long in str(mapping_to_text({"a": long}, "Things"))
+
+    def test_sequence_joined(self):
+        """A sequence of plain values is listed rather than counted."""
+        out = str(mapping_to_text({"a": (1, 2, 3)}, "Things"))
+        assert out.endswith("a: 1, 2, 3")
+
+
+class TestValueToText:
+    """Tests for rendering one value."""
+
+    def test_long_value_elided(self):
+        """A value sharing a line with others is bounded."""
+        out = str(value_to_text("a", "x" * 500))
+        assert len(out) < 500
+        assert out.endswith("…")
+
+    def test_pre_rendered_text_kept(self):
+        """Text the caller built is used as-is, not re-read as a sequence."""
+        assert str(value_to_text("a", Text("a: 2, b: 1"))) == "a: 2, b: 1"
+
+    def test_array_keeps_its_own_repr(self):
+        """An array states how much of itself to show; it is not unrolled."""
+        out = str(value_to_text("a", np.arange(10_000)))
+        assert "..." in out and len(out) < 100
+
+    def test_frame_keeps_its_own_repr(self):
+        """Nor is a frame read as a sequence of its column names."""
+        out = str(value_to_text("a", pd.DataFrame({"a": [1, 2]}), truncate=False))
+        assert "1" in out and "2" in out
+
+    def test_nat_is_text(self):
+        """An unset time renders like every other value, not as a str."""
+        assert str(value_to_text("a", np.datetime64("NaT"))) == "NaT"

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -9,6 +9,7 @@ from rich.text import Text
 
 import dascore as dc
 from dascore.config import config_context
+from dascore.constants import dascore_styles
 from dascore.core.annotations import AnnotationColumn, AnnotationSetAttrs
 from dascore.core.inventory import Acquisition, Cable, Network
 from dascore.utils.display import (
@@ -194,8 +195,28 @@ class TestStatedFields:
         assert "columns: 1" in str(model_to_line(attrs))
 
 
+def styles_at(text, substring):
+    """Return the styles covering the first character of a substring."""
+    start = text.plain.index(substring)
+    return {x.style for x in text.spans if x.start <= start < x.end}
+
+
 class TestModelToLine:
     """Tests for the one-line model summary."""
+
+    def test_only_the_name_is_styled(self):
+        """
+        A style stays on what it marks.
+
+        Text(x, style=...) makes that style the base of everything appended
+        after it, so building a line that way paints every value with the
+        class name's style.
+        """
+        line = model_to_line(Network(code="XT"))
+        assert line.style == ""
+        assert styles_at(line, "Network") == {"bold"}
+        assert styles_at(line, " code: ") == {dascore_styles["keys"]}
+        assert styles_at(line, "XT") == set()  # the value is not a key
 
     def test_names_class_and_fields(self):
         """The line names the class, then what the model states."""

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -83,6 +83,12 @@ class TestArrayFormatting:
         assert "..." in out
 
 
+def styles_at(text, substring):
+    """Return the styles covering the first character of a substring."""
+    start = text.plain.index(substring)
+    return {x.style for x in text.spans if x.start <= start < x.end}
+
+
 class TestGetHeaderText:
     """Tests for the banner which opens a top-level object's repr."""
 
@@ -97,6 +103,11 @@ class TestGetHeaderText:
         """The name given is in the banner, beside the DASCore text."""
         out = str(get_header_text("Inventory"))
         assert out.startswith("DASCore Inventory")
+
+    def test_style_key_resolved(self):
+        """A dascore_styles key is resolved, as the other helpers resolve it."""
+        text = get_header_text("Thing", style="dc_blue")
+        assert styles_at(text, "Thing") == {dascore_styles["dc_blue"]}
 
 
 class TestIndentText:
@@ -161,6 +172,10 @@ class TestCountsToText:
         out = str(counts_to_text({"a": 1, "b": 1, "c": 1}, limit=1))
         assert out == "a: 1, ... 2 more"
 
+    def test_zero_limit_has_no_leading_comma(self):
+        """Nothing is shown, and nothing needs a comma after it."""
+        assert str(counts_to_text({"a": 1, "b": 2}, limit=0)) == "... 2 more"
+
 
 class TestStatedFields:
     """Tests for reading what a model states about itself."""
@@ -193,12 +208,6 @@ class TestStatedFields:
         columns = {"pick": AnnotationColumn(description="a pick")}
         attrs = AnnotationSetAttrs(dims=("time",), columns=columns)
         assert "columns: 1" in str(model_to_line(attrs))
-
-
-def styles_at(text, substring):
-    """Return the styles covering the first character of a substring."""
-    start = text.plain.index(substring)
-    return {x.style for x in text.spans if x.start <= start < x.end}
 
 
 class TestModelToLine:


### PR DESCRIPTION
## Description

`Inventory` had no repr, so printing one fell back to pydantic's recursive field dump — 3.2k characters for `get_example_inventory("random_das")` and 33k for the tunnel inventory. `AnnotationSet` had a single plain line. Both now print in the house style, beside `Patch` and `Spool`.

```
DASCore Inventory 📖
--------------------
➤ Networks (1)
    Network( code: XT )
        FiberArray( code: TUN1 name: tunnel fiber array )
            Acquisition( code: DAS location_code: 00 data_type: strain_rate ... )
            OpticalPath( end_time: 2024-09-01 location_code: 00 optical_components: 26 geometry: 10 coupling: 8 labels: 11 distance: [0, 1775) m )
            OpticalPath( start_time: 2024-09-01 location_code: 00 optical_components: 30 geometry: 11 coupling: 9 labels: 12 distance: [0, 1777) m )
➤ Attributes
    schema_version: 1
    resources: 12
    coordinate_reference_system: CoordinateReferenceSystem( local:tunnel  axes: x, y, z )
```

```
DASCore AnnotationSet 🏷 (2 Annotations)
---------------------------------------
➤ Dimensions (time, distance)
    *time: min: 2020-01-01 max: 2020-01-01T00:00:02 (range)
    *distance: min: 1.000 max: 80.000 (range)
➤ Contents
    geometry: path: 1, region: 1
    group: pick: 2
    columns: id, group, value, geometry, distance_start, distance_end, time_start, time_end
    vertices: 3
➤ Attributes
    creation_info: CreationInfo( author: derrick )
    acquisition_key: XT.TUN1.00.DAS
```

**The reprs compose.** Every inventory and annotation model renders itself as one line naming its class and what it states; a container renders its own line and then indents its children's own reprs. The line you see nested in the tree is exactly what you get printing that network, fiber array or optical path on its own — nothing describes a child twice.

**Only what an object states is shown.** Unset, blank, empty and still-default fields take no line, so a repr is what the object actually says rather than its full field list. `CoordinateReferenceSystem` is the exception and states itself in full: the default CRS is a real answer, and a blank line for it would read as no frame at all.

**Bounded by construction.** A container renders at most `display_max_items` children and says how many it left out; hidden children are never rendered, so the cost of a repr is what it prints rather than what the object holds.

The shared machinery lives in `dascore/utils/display.py` — `get_header_text`, `indent_text`, `limit_reprs`, `counts_to_text`, `stated_fields`, `value_to_text`, `model_to_line`, `mapping_to_text` — and `attrs_to_text` is refactored onto `mapping_to_text`, so patch, inventory and annotation attribute blocks are one renderer rather than three.

### Knock-on changes to `Patch`'s repr

Two, both from sharing the renderer:

- Collection-valued attributes are listed rather than printed as their Python container: `history: ("pass_filter(...)",)` becomes `history: pass_filter(...)`. This is what makes a multi-entry history readable, and it is now the same everywhere.
- The banner underline is one character longer. It is drawn with rich's `cell_len`, so it now matches the two columns the ⚡ actually occupies.

A value in a block gets a line to itself and is never elided; a value sharing a one-line summary is bounded at 80 columns.

### Review

Reviewed with the Codex CLI. Fixed from it: children are now rendered lazily rather than rendered-then-capped; arrays, Series and frames keep their own string form instead of being unrolled as sequences; `display_max_items` is `ge=0`; and `get_nice_text` returns `Text` for NaT rather than a bare `str`.

## Changelog

- added: `Inventory` and `AnnotationSet` now have rich text representations, as do the models they hold.
- changed: `Patch` attributes holding a collection are now listed (`history: a(), b()`) rather than printed as a Python container (`history: ('a()', 'b()')`).
- added: the `display_max_items` config option sets how many children a repr lists per level before saying how many it left out.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rich-formatted summaries for annotations, inventories, patches, and related objects.
  * Added configurable child-item limits, defaulting to 10.
  * Improved representations with clearer headers, fields, counts, dimensions, extents, and elision of excess content.
  * Added formatting for values, arrays, mappings, and model details.

* **Documentation**
  * Documented display precision, array truncation, and child-item limits.
  * Added summarized inventory output examples.

* **Tests**
  * Expanded coverage for rendering, formatting, truncation, and display limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->