### PR TITLE
Add Patch.squeeze_coords

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -371,6 +371,7 @@ class Patch(NamespaceOwner):
     pipe = dascore.proc.pipe
     set_dims = dascore.proc.set_dims
     squeeze = dascore.proc.coords.squeeze
+    squeeze_coords = dascore.proc.coords.squeeze_coords
     append_dims = dascore.proc.coords.append_dims
     split_gaps = dascore.proc.coords.split_gaps
     transpose = dascore.proc.coords.transpose

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -958,12 +958,14 @@ def _get_lone_value(coord: BaseCoord):
     if values.dtype.kind not in _STATEABLE_KINDS:
         return _NO_VALUE
     value = values[0]
-    if values.size > 1 and not bool(np.all(values == value)):
-        return _NO_VALUE
     # A nullish value is what a coord says when it doesn't know, which a
     # partial coord says for every sample. Not something to state as an
-    # attr, so such a coord keeps its shape and stays a coord.
+    # attr, so such a coord keeps its shape and stays a coord. Asked
+    # first: a partial coord's values are a broadcast view, and the
+    # comparison below would make a real array the size of the coord.
     if pd.isnull(value):
+        return _NO_VALUE
+    if values.size > 1 and not bool(np.all(values == value)):
         return _NO_VALUE
     # Times stay numpy scalars, matching how the other attrs store them;
     # everything else stores better as a python scalar.

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -23,6 +23,7 @@ from dascore.utils.array_api import array_namespace
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import get_parent_code_name, iterate
 from dascore.utils.patch import patch_function
+from dascore.utils.time import dtype_time_like
 from dascore.workflow.processor import (
     PatchProcessor,
     register_implementation,
@@ -901,6 +902,11 @@ def squeeze(self: PatchType, dim=None) -> PatchType:
     >>>
     >>> # Squeeze the length-1 time dimension
     >>> squeezed = single_time.squeeze(dim="time")
+
+    Notes
+    -----
+    Non-dimensional coordinates which hold a single value are removed by
+    [`Patch.squeeze_coords`](`dascore.Patch.squeeze_coords`).
     """
     coords = self.coords.squeeze(dim)
     # Nothing to squeeze; the coord manager returned self, so reuse this patch.
@@ -913,6 +919,140 @@ def squeeze(self: PatchType, dim=None) -> PatchType:
     xp = array_namespace(self.data)
     data = xp.squeeze(self.data, axis=axes)
     return self.new(data=data, coords=coords)
+
+
+# Says a coord has no lone value, told apart from a coord whose lone
+# value is itself falsey.
+_NO_VALUE = object()
+
+# The attrs the patch machinery owns, which a coord cannot be stored
+# under: `dims` is dropped on the way into the attrs, `coords` is refused
+# there, and the rest are stamped over by the decorator once this returns.
+_RESERVED_ATTRS = frozenset({"coords", "dims", "history", "patch_id", "processing_id"})
+
+
+def _get_lone_value(coord: BaseCoord):
+    """Return the only value a coord holds, or _NO_VALUE if it has no such."""
+    if not coord.size:
+        return _NO_VALUE
+    values = np.asarray(coord.values).reshape(-1)
+    value = values[0]
+    if values.size > 1 and not bool(np.all(values == value)):
+        return _NO_VALUE
+    # A nullish value is what a coord says when it doesn't know, which a
+    # partial coord says for every sample. Not something to state as an
+    # attr, so such a coord keeps its shape and stays a coord.
+    if pd.isnull(value):
+        return _NO_VALUE
+    # Times stay numpy scalars, as the rest of the attrs spell them;
+    # everything else is nicer to store as the python value.
+    if not dtype_time_like(values.dtype) and hasattr(value, "item"):
+        value = value.item()
+    return value
+
+
+@patch_function()
+def squeeze_coords(self: PatchType, *coords: str | Iterable[str]) -> PatchType:
+    """
+    Convert coordinates which hold a single value to attributes.
+
+    A coordinate whose values are all the same says one thing about the
+    patch rather than one thing about each sample. Each such coordinate is
+    dropped and its value stored in the patch attrs under the coordinate's
+    name.
+
+    Parameters
+    ----------
+    *coords
+        The names of the coordinates to squeeze, or sequences of them. If
+        none are given, every non-dimensional coordinate which holds a
+        single value is squeezed.
+
+    Raises
+    ------
+    CoordError
+        If a named coordinate is not in the patch, is a dimension, is
+        named for an attr the patch machinery owns, or does not hold
+        exactly one non-null value.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import dascore as dc
+    >>>
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # Add a coordinate which has the same value for each distance.
+    >>> quality = np.ones(patch.coord_shapes["distance"])
+    >>> patch = patch.update_coords(quality=("distance", quality))
+    >>>
+    >>> # The coordinate becomes an attribute.
+    >>> out = patch.squeeze_coords()
+    >>> assert "quality" not in out.coords.coord_map
+    >>> assert out.attrs.get("quality") == 1
+
+    Notes
+    -----
+    - Dimensions are never squeezed, even when they have length one; use
+      [`Patch.squeeze`](`dascore.Patch.squeeze`) for those.
+    - Coordinate units are not kept, only the value.
+    - A coordinate whose only value is null (NaN or NaT) says nothing to
+      store, and is left alone.
+    - An attribute of the same name is overwritten, and the value it is
+      given must be one the attrs can hold.
+    """
+    cm = self.coords
+    # Whether the caller named the coords, rather than whether naming
+    # them came to anything: an empty sequence asks for nothing, and
+    # gets it.
+    named = bool(coords)
+    if named:
+        names = tuple(x for coord in coords for x in iterate(coord))
+    else:
+        names = tuple(x for x in cm.coord_map if x not in cm.dims)
+    values = {}
+    for name in names:
+        # A named coord must qualify, so the caller hears about one which
+        # doesn't; the sweep just passes over it.
+        if named:
+            _validate_squeezable(cm, name)
+        elif name in _RESERVED_ATTRS:
+            continue
+        value = _get_lone_value(cm.coord_map[name])
+        if value is _NO_VALUE:
+            if not named:
+                continue
+            msg = (
+                f"Cannot squeeze coordinate {name} because it does not "
+                f"hold exactly one non-null value."
+            )
+            raise CoordError(msg)
+        values[name] = value
+    # Nothing qualified, so nothing happened.
+    if not values:
+        return self
+    new_coords, _ = cm.drop_coords(*values)
+    attrs = self.attrs.model_dump(exclude_unset=True) | values
+    return self.new(coords=new_coords, attrs=attrs)
+
+
+def _validate_squeezable(cm, name: str) -> None:
+    """Ensure a named coord is one which could become an attr."""
+    if name not in cm.coord_map:
+        msg = f"Coordinate {name} not found in Patch. Cannot squeeze it."
+        raise CoordError(msg)
+    if name in cm.dims:
+        msg = (
+            f"Cannot squeeze coordinate {name} because it is a dimension. "
+            f"Use Patch.squeeze to remove length one dimensions."
+        )
+        raise CoordError(msg)
+    if name in _RESERVED_ATTRS:
+        msg = (
+            f"Cannot squeeze coordinate {name} because the patch attrs "
+            f"reserve that name. Rename the coordinate first."
+        )
+        raise CoordError(msg)
 
 
 @patch_function()

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -24,6 +24,7 @@ from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import get_parent_code_name, iterate
 from dascore.utils.patch import patch_function
 from dascore.utils.time import dtype_time_like
+from dascore.utils.transformatter import FourierTransformatter
 from dascore.workflow.processor import (
     PatchProcessor,
     register_implementation,
@@ -905,8 +906,9 @@ def squeeze(self: PatchType, dim=None) -> PatchType:
 
     Notes
     -----
-    Non-dimensional coordinates which hold a single value are removed by
-    [`Patch.squeeze_coords`](`dascore.Patch.squeeze_coords`).
+    [`Patch.squeeze_coords`](`dascore.Patch.squeeze_coords`) does the
+    analogous thing for non-dimensional coordinates whose values are all
+    the same: it drops them and stores the value in the attrs.
     """
     coords = self.coords.squeeze(dim)
     # Nothing to squeeze; the coord manager returned self, so reuse this patch.
@@ -921,21 +923,40 @@ def squeeze(self: PatchType, dim=None) -> PatchType:
     return self.new(data=data, coords=coords)
 
 
-# Says a coord has no lone value, told apart from a coord whose lone
-# value is itself falsey.
+# Sentinel for a coord with no lone value, since a lone value can itself
+# be falsey.
 _NO_VALUE = object()
 
-# The attrs the patch machinery owns, which a coord cannot be stored
-# under: `dims` is dropped on the way into the attrs, `coords` is refused
-# there, and the rest are stamped over by the decorator once this returns.
-_RESERVED_ATTRS = frozenset({"coords", "dims", "history", "patch_id", "processing_id"})
+
+# Names the attrs already use, so a coord value cannot be stored under
+# them. Asked of the class rather than listed: a declared field validates
+# or coerces whatever it is given (`data_type=3.0` becomes `"3.0"`), a
+# method shadows the value on the way back out, `dims` is dropped on the
+# way in and `coords` refused there, and the decorator stamps `history`
+# and both ids over once this returns.
+def _reserved_attr(name: str) -> bool:
+    """Whether the patch attrs already use a name for something else."""
+    attrs = dc.PatchAttrs
+    if name in {"coords", "dims"} or name in attrs.model_fields:
+        return True
+    return hasattr(attrs, name)
+
+
+# What an attr can hold and the rest of DASCore can write down: numbers,
+# booleans, text, times. An object coord holds python objects, which need
+# not even compare elementwise (an entry which is itself a sequence
+# broadcasts instead), and a complex value is read back as a time by the
+# spool index.
+_STATEABLE_KINDS = frozenset("biufSUMm")
 
 
 def _get_lone_value(coord: BaseCoord):
-    """Return the only value a coord holds, or _NO_VALUE if it has no such."""
+    """Return the single distinct value a coord holds, or _NO_VALUE if it has none."""
     if not coord.size:
         return _NO_VALUE
     values = np.asarray(coord.values).reshape(-1)
+    if values.dtype.kind not in _STATEABLE_KINDS:
+        return _NO_VALUE
     value = values[0]
     if values.size > 1 and not bool(np.all(values == value)):
         return _NO_VALUE
@@ -944,8 +965,8 @@ def _get_lone_value(coord: BaseCoord):
     # attr, so such a coord keeps its shape and stays a coord.
     if pd.isnull(value):
         return _NO_VALUE
-    # Times stay numpy scalars, as the rest of the attrs spell them;
-    # everything else is nicer to store as the python value.
+    # Times stay numpy scalars, matching how the other attrs store them;
+    # everything else stores better as a python scalar.
     if not dtype_time_like(values.dtype) and hasattr(value, "item"):
         value = value.item()
     return value
@@ -972,8 +993,9 @@ def squeeze_coords(self: PatchType, *coords: str | Iterable[str]) -> PatchType:
     ------
     CoordError
         If a named coordinate is not in the patch, is a dimension, is
-        named for an attr the patch machinery owns, or does not hold
-        exactly one non-null value.
+        private, is named for something the patch attrs already use, is
+        needed to invert a transform, or does not hold the same non-null
+        value the attrs can state for every sample.
 
     Examples
     --------
@@ -996,63 +1018,89 @@ def squeeze_coords(self: PatchType, *coords: str | Iterable[str]) -> PatchType:
     - Dimensions are never squeezed, even when they have length one; use
       [`Patch.squeeze`](`dascore.Patch.squeeze`) for those.
     - Coordinate units are not kept, only the value.
-    - A coordinate whose only value is null (NaN or NaT) says nothing to
-      store, and is left alone.
-    - An attribute of the same name is overwritten, and the value it is
-      given must be one the attrs can hold.
+    - A coordinate whose only value is null (NaN or NaT), or whose values
+      are of a type the attrs cannot state (an object or a complex
+      number), is left alone.
+    - So are the coordinates which are not the patch's to state: a
+      private one (whose name begins with an underscore), one needed to
+      invert a transform ([`Patch.idft`](`dascore.Patch.idft`) reads
+      `time` off a patch whose dimension is `ft_time`), and one named
+      for something the attrs already use, such as `tag` or `history`.
+      All of these are passed over by the sweep, and raise when named.
+    - An attribute of the same name is overwritten.
+    - Which coordinates the sweep takes depends on the values a patch
+      holds, so patches in a spool can come out with different
+      coordinates. Name the coordinates to squeeze the same ones
+      everywhere.
     """
     cm = self.coords
-    # Whether the caller named the coords, rather than whether naming
-    # them came to anything: an empty sequence asks for nothing, and
-    # gets it.
-    named = bool(coords)
-    if named:
-        names = tuple(x for coord in coords for x in iterate(coord))
-    else:
-        names = tuple(x for x in cm.coord_map if x not in cm.dims)
+    # True when the caller named coords at all: an explicitly empty
+    # sequence squeezes nothing rather than sweeping every coord.
+    given = tuple(x for x in coords if x is not None)
+    named = bool(given)
+    names = (
+        tuple(x for coord in given for x in iterate(coord))
+        if named
+        else tuple(cm.coord_map)
+    )
     values = {}
     for name in names:
-        # A named coord must qualify, so the caller hears about one which
-        # doesn't; the sweep just passes over it.
-        if named:
-            _validate_squeezable(cm, name)
-        elif name in _RESERVED_ATTRS:
+        value, refusal = _get_squeezed_value(cm, name)
+        # A named coord must qualify, so one which doesn't raises; the
+        # sweep skips it silently.
+        if refusal:
+            if named:
+                raise CoordError(refusal)
             continue
-        value = _get_lone_value(cm.coord_map[name])
-        if value is _NO_VALUE:
-            if not named:
-                continue
-            msg = (
-                f"Cannot squeeze coordinate {name} because it does not "
-                f"hold exactly one non-null value."
-            )
-            raise CoordError(msg)
         values[name] = value
     # Nothing qualified, so nothing happened.
     if not values:
         return self
     new_coords, _ = cm.drop_coords(*values)
-    attrs = self.attrs.model_dump(exclude_unset=True) | values
-    return self.new(coords=new_coords, attrs=attrs)
+    return self.new(coords=new_coords, attrs=self.attrs.update(**values))
 
 
-def _validate_squeezable(cm, name: str) -> None:
-    """Ensure a named coord is one which could become an attr."""
+def _get_squeezed_value(cm, name: str) -> tuple[Any, str]:
+    """Return the value a coord becomes, and why it cannot become one."""
     if name not in cm.coord_map:
-        msg = f"Coordinate {name} not found in Patch. Cannot squeeze it."
-        raise CoordError(msg)
+        # Said as `Patch.get_coord` says it, listing what is there.
+        coords = sorted(cm.coord_map)
+        msg = f"Coordinate '{name}' not found in Patch coordinates: {coords}"
+        return _NO_VALUE, msg
     if name in cm.dims:
         msg = (
             f"Cannot squeeze coordinate {name} because it is a dimension. "
             f"Use Patch.squeeze to remove length one dimensions."
         )
-        raise CoordError(msg)
-    if name in _RESERVED_ATTRS:
+        return _NO_VALUE, msg
+    if _reserved_attr(name):
         msg = (
             f"Cannot squeeze coordinate {name} because the patch attrs "
-            f"reserve that name. Rename the coordinate first."
+            f"already use that name. Rename the coordinate first."
         )
-        raise CoordError(msg)
+        return _NO_VALUE, msg
+    # A private coord belongs to whichever operation put it there --
+    # `stft` reads its window back in `istft` -- so it is not the
+    # patch's to state as an attr.
+    if name.startswith("_"):
+        return _NO_VALUE, f"Cannot squeeze coordinate {name} because it is private."
+    # A transform leaves the coordinate it consumed behind under its own
+    # name so the transform can be undone: `idft` reads `time` off a
+    # patch whose dimension is `ft_time`.
+    if name in FourierTransformatter().rename_dims(cm.dims, forward=False):
+        msg = (
+            f"Cannot squeeze coordinate {name} because the transform "
+            f"which made this patch needs it to be inverted."
+        )
+        return _NO_VALUE, msg
+    value = _get_lone_value(cm.coord_map[name])
+    if value is _NO_VALUE:
+        msg = (
+            f"Cannot squeeze coordinate {name} because its values are "
+            f"not all the same non-null value."
+        )
+        return _NO_VALUE, msg
+    return value, ""
 
 
 @patch_function()

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -42,6 +42,26 @@ squeezed = flat_patch.squeeze()
 print(f"Post-squeeze shape: {squeezed.shape}")
 ```
 
+## Squeeze coords
+
+[`squeeze_coords`](`dascore.Patch.squeeze_coords`) does the same for non-dimensional coordinates: a coordinate whose values are all the same is dropped and its value stored in the patch attrs under the coordinate's name. Units are not kept.
+
+```{python}
+import numpy as np
+
+import dascore as dc
+
+patch = dc.get_example_patch()
+
+# Add a coordinate which has the same value for every distance.
+quality = np.ones(patch.coord_shapes["distance"])
+patch = patch.update_coords(quality=("distance", quality))
+
+squeezed = patch.squeeze_coords()
+print(f"quality coord: {'quality' in squeezed.coords.coord_map}")
+print(f"quality attr: {squeezed.attrs.get('quality')}")
+```
+
 ## Dropna
 
 The [`dropna` patch function](`dascore.Patch.dropna`) patch function drops "nullish" values from a given label.

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -44,7 +44,7 @@ print(f"Post-squeeze shape: {squeezed.shape}")
 
 ## Squeeze coords
 
-[`squeeze_coords`](`dascore.Patch.squeeze_coords`) does the same for non-dimensional coordinates: a coordinate whose values are all the same is dropped and its value stored in the patch attrs under the coordinate's name. Units are not kept.
+[`squeeze_coords`](`dascore.Patch.squeeze_coords`) does something similar for non-dimensional coordinates: a coordinate whose values are all the same, however long it is, is dropped and its value stored in the patch attrs under the coordinate's name. Units are not kept.
 
 ```{python}
 import numpy as np

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -915,6 +915,18 @@ class TestSqueezeCoords:
         out = patch.squeeze_coords()
         assert out.attrs.tag == "mytag"
 
+    def test_attrs_class_kept(self, patch_with_flat_coords):
+        """A format's own attrs class survives the squeeze."""
+
+        class _SubAttrs(dc.PatchAttrs):
+            """Attrs as a format might extend them."""
+
+            extra_field: str = "x"
+
+        attrs = _SubAttrs(**patch_with_flat_coords.attrs.model_dump(exclude_unset=True))
+        patch = patch_with_flat_coords.new(attrs=attrs)
+        assert isinstance(patch.squeeze_coords().attrs, _SubAttrs)
+
     def test_dim_coord_intact(self, patch_with_flat_coords):
         """The dim a squeezed coord hung off is left as it was."""
         out = patch_with_flat_coords.squeeze_coords()

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -9,7 +9,7 @@ import pytest
 import dascore as dc
 import dascore.proc.coords
 from dascore.compat import is_array
-from dascore.core.coords import BaseCoord
+from dascore.core.coords import BaseCoord, CoordPartial
 from dascore.exceptions import (
     CoordError,
     ParameterError,
@@ -878,6 +878,142 @@ class TestSqueeze:
         """CoordManager squeeze with no length-1 dims returns self."""
         coords = random_patch.coords
         assert coords.squeeze() is coords
+
+
+class TestSqueezeCoords:
+    """Tests for turning single valued coords into attrs."""
+
+    @pytest.fixture(scope="class")
+    def patch_with_flat_coords(self, random_patch):
+        """A patch with a few coords which hold only one value."""
+        dist_len = random_patch.coord_shapes["distance"][0]
+        time_start = random_patch.get_coord("time").min()
+        return random_patch.update_coords(
+            quality=("distance", np.ones(dist_len)),
+            start=("distance", np.full(dist_len, time_start)),
+            varying=("distance", np.arange(dist_len)),
+            lone=(None, np.array([12])),
+            label=("distance", np.array(["good"] * dist_len)),
+        )
+
+    def test_coords_become_attrs(self, patch_with_flat_coords):
+        """Single valued coords should be dropped and stored in attrs."""
+        out = patch_with_flat_coords.squeeze_coords()
+        assert {"quality", "lone"}.isdisjoint(out.coords.coord_map)
+        assert out.attrs.get("quality") == 1
+        assert out.attrs.get("lone") == 12
+
+    def test_data_unchanged(self, patch_with_flat_coords):
+        """Only coords are squeezed; the data are not touched."""
+        out = patch_with_flat_coords.squeeze_coords()
+        assert out.shape == patch_with_flat_coords.shape
+        assert np.array_equal(out.data, patch_with_flat_coords.data)
+
+    def test_multi_valued_coord_kept(self, patch_with_flat_coords):
+        """A coord with more than one value stays a coord."""
+        out = patch_with_flat_coords.squeeze_coords()
+        assert "varying" in out.coords.coord_map
+
+    def test_string_coord(self, patch_with_flat_coords):
+        """A string coord becomes a plain string attr."""
+        out = patch_with_flat_coords.squeeze_coords()
+        assert out.attrs.get("label") == "good"
+
+    def test_time_stays_datetime(self, patch_with_flat_coords):
+        """A time-like coord keeps its numpy type in the attrs."""
+        out = patch_with_flat_coords.squeeze_coords()
+        assert isinstance(out.attrs.get("start"), np.datetime64)
+
+    def test_specified_coords(self, patch_with_flat_coords):
+        """Naming coords squeezes only those, and sequences work."""
+        out = patch_with_flat_coords.squeeze_coords(["quality"])
+        assert "quality" not in out.coords.coord_map
+        assert "lone" in out.coords.coord_map
+
+    def test_units_dropped(self, random_patch):
+        """Only the value of the coord is kept, not its units."""
+        dist_len = random_patch.coord_shapes["distance"][0]
+        patch = random_patch.update_coords(
+            depth=("distance", np.full(dist_len, 10.0))
+        ).set_units(depth="m")
+        out = patch.squeeze_coords()
+        assert out.attrs.get("depth") == 10.0
+
+    def test_dim_raises(self, patch_with_flat_coords):
+        """Dimensions are never squeezed, even when named."""
+        msg = "because it is a dimension"
+        with pytest.raises(CoordError, match=msg):
+            patch_with_flat_coords.squeeze_coords("distance")
+
+    def test_missing_coord_raises(self, patch_with_flat_coords):
+        """A coord which isn't in the patch raises."""
+        msg = "not found in Patch"
+        with pytest.raises(CoordError, match=msg):
+            patch_with_flat_coords.squeeze_coords("not_a_coord")
+
+    def test_multi_valued_named_raises(self, patch_with_flat_coords):
+        """Naming a coord with several values raises."""
+        msg = "does not hold exactly one non-null value"
+        with pytest.raises(CoordError, match=msg):
+            patch_with_flat_coords.squeeze_coords("varying")
+
+    def test_null_coord_not_squeezed(self, random_patch):
+        """A coord with no known values doesn't become an attr."""
+        dist_len = random_patch.coord_shapes["distance"][0]
+        patch = random_patch.update_coords(
+            nully=("distance", np.full(dist_len, np.nan))
+        )
+        assert "nully" in patch.squeeze_coords().coords.coord_map
+
+    def test_single_null_value_not_squeezed(self, random_patch):
+        """One null value is still nothing to say in an attr."""
+        patch = random_patch.update_coords(
+            lone_nan=(None, np.array([np.nan])),
+            lone_nat=(None, np.array(["NaT"], dtype="datetime64[ns]")),
+        )
+        assert patch.squeeze_coords() is patch
+
+    def test_partial_coord_not_squeezed(self, random_patch):
+        """A coord which only knows its shape holds no value."""
+        dist_len = random_patch.coord_shapes["distance"][0]
+        coord = CoordPartial(shape=(dist_len,), dtype=np.float64)
+        patch = random_patch.update_coords(partial=("distance", coord))
+        assert "partial" in patch.squeeze_coords().coords.coord_map
+
+    def test_empty_coord_not_squeezed(self, random_patch):
+        """A coord with no values at all holds nothing to store."""
+        patch = random_patch.update_coords(empty=(None, np.array([])))
+        assert patch.squeeze_coords() is patch
+
+    def test_empty_selection_does_nothing(self, patch_with_flat_coords):
+        """Asking for no coords squeezes no coords."""
+        assert patch_with_flat_coords.squeeze_coords([]) is patch_with_flat_coords
+
+    def test_multi_dim_coord(self, random_patch):
+        """A coord spanning several dims is squeezed like any other."""
+        patch = random_patch.update_coords(
+            grid=(random_patch.dims, np.ones(random_patch.shape))
+        )
+        out = patch.squeeze_coords()
+        assert out.attrs.get("grid") == 1
+        assert out.shape == random_patch.shape
+
+    def test_reserved_name_not_squeezed(self, random_patch):
+        """A coord named for an attr the patch owns is left alone."""
+        patch = random_patch.update_coords(history=(None, np.array(["abc"])))
+        assert patch.squeeze_coords() is patch
+        msg = "reserve that name"
+        with pytest.raises(CoordError, match=msg):
+            patch.squeeze_coords("history")
+
+    def test_length_one_dim_untouched(self, random_patch):
+        """A length one dimension is left for Patch.squeeze."""
+        patch = random_patch.select(distance=0, samples=True)
+        assert patch.squeeze_coords() is patch
+
+    def test_noop_returns_self(self, random_patch):
+        """A patch with nothing to squeeze is handed back."""
+        assert random_patch.squeeze_coords() is random_patch
 
 
 class TestGetCoord:

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -909,14 +909,27 @@ class TestSqueezeCoords:
         assert out.shape == patch_with_flat_coords.shape
         assert np.array_equal(out.data, patch_with_flat_coords.data)
 
+    def test_other_attrs_kept(self, patch_with_flat_coords):
+        """Squeezing adds to the attrs rather than replacing them."""
+        patch = patch_with_flat_coords.update_attrs(tag="mytag")
+        out = patch.squeeze_coords()
+        assert out.attrs.tag == "mytag"
+
+    def test_dim_coord_intact(self, patch_with_flat_coords):
+        """The dim a squeezed coord hung off is left as it was."""
+        out = patch_with_flat_coords.squeeze_coords()
+        assert out.get_coord("distance") == patch_with_flat_coords.get_coord("distance")
+
     def test_multi_valued_coord_kept(self, patch_with_flat_coords):
         """A coord with more than one value stays a coord."""
         out = patch_with_flat_coords.squeeze_coords()
         assert "varying" in out.coords.coord_map
 
-    def test_string_coord(self, patch_with_flat_coords):
-        """A string coord becomes a plain string attr."""
+    def test_values_are_python_scalars(self, patch_with_flat_coords):
+        """Values which aren't times are stored as python scalars."""
         out = patch_with_flat_coords.squeeze_coords()
+        assert type(out.attrs.get("label")) is str
+        assert type(out.attrs.get("quality")) is float
         assert out.attrs.get("label") == "good"
 
     def test_time_stays_datetime(self, patch_with_flat_coords):
@@ -953,7 +966,7 @@ class TestSqueezeCoords:
 
     def test_multi_valued_named_raises(self, patch_with_flat_coords):
         """Naming a coord with several values raises."""
-        msg = "does not hold exactly one non-null value"
+        msg = "values are not all the same non-null value"
         with pytest.raises(CoordError, match=msg):
             patch_with_flat_coords.squeeze_coords("varying")
 
@@ -975,10 +988,11 @@ class TestSqueezeCoords:
 
     def test_partial_coord_not_squeezed(self, random_patch):
         """A coord which only knows its shape holds no value."""
-        dist_len = random_patch.coord_shapes["distance"][0]
-        coord = CoordPartial(shape=(dist_len,), dtype=np.float64)
-        patch = random_patch.update_coords(partial=("distance", coord))
-        assert "partial" in patch.squeeze_coords().coords.coord_map
+        # Length one, so it gets past the all-the-same test and is
+        # refused for the nullish value a partial coord stands for.
+        coord = CoordPartial(shape=(1,), dtype=np.float64)
+        patch = random_patch.update_coords(partial=(None, coord))
+        assert patch.squeeze_coords() is patch
 
     def test_empty_coord_not_squeezed(self, random_patch):
         """A coord with no values at all holds nothing to store."""
@@ -998,18 +1012,58 @@ class TestSqueezeCoords:
         assert out.attrs.get("grid") == 1
         assert out.shape == random_patch.shape
 
-    def test_reserved_name_not_squeezed(self, random_patch):
-        """A coord named for an attr the patch owns is left alone."""
-        patch = random_patch.update_coords(history=(None, np.array(["abc"])))
+    def test_private_coord_not_squeezed(self, random_patch):
+        """A private coord belongs to the operation which made it."""
+        patch = random_patch.stft(time=0.1, taper_window="boxcar")
+        assert "_stft_window" in patch.coords.coord_map
         assert patch.squeeze_coords() is patch
-        msg = "reserve that name"
+        msg = "because it is private"
         with pytest.raises(CoordError, match=msg):
-            patch.squeeze_coords("history")
+            patch.squeeze_coords("_stft_window")
+
+    def test_object_coord_not_squeezed(self, random_patch):
+        """An object coord holds no value the attrs can state."""
+        dist_len = random_patch.coord_shapes["distance"][0]
+        values = np.empty(dist_len, dtype=object)
+        values[:] = [(1, 2)] * dist_len
+        patch = random_patch.update_coords(pairs=("distance", values))
+        assert patch.squeeze_coords() is patch
+
+    @pytest.mark.parametrize("name", ["history", "tag", "data_units", "update"])
+    def test_reserved_name_not_squeezed(self, random_patch, name):
+        """A coord named for something the attrs use is left alone."""
+        patch = random_patch.update_coords(**{name: (None, np.array(["abc"]))})
+        assert patch.squeeze_coords() is patch
+        msg = "already use that name"
+        with pytest.raises(CoordError, match=msg):
+            patch.squeeze_coords(name)
+
+    def test_transform_source_coord_not_squeezed(self, random_patch):
+        """The coord a transform needs to invert itself is left alone."""
+        patch = random_patch.select(time=(0, 1), samples=True).dft("time")
+        assert patch.squeeze_coords() is patch
+        msg = "needs it to be inverted"
+        with pytest.raises(CoordError, match=msg):
+            patch.squeeze_coords("time")
+
+    def test_complex_coord_not_squeezed(self, random_patch):
+        """A complex value is not one the attrs can state."""
+        patch = random_patch.update_coords(phase=(None, np.array([1 + 1j])))
+        assert patch.squeeze_coords() is patch
+
+    def test_none_sweeps(self, patch_with_flat_coords):
+        """A None argument means no argument, as Patch.squeeze spells it."""
+        out = patch_with_flat_coords.squeeze_coords(None)
+        assert out.equals(patch_with_flat_coords.squeeze_coords())
 
     def test_length_one_dim_untouched(self, random_patch):
         """A length one dimension is left for Patch.squeeze."""
-        patch = random_patch.select(distance=0, samples=True)
-        assert patch.squeeze_coords() is patch
+        patch = random_patch.select(distance=0, samples=True).update_coords(
+            quality=("distance", np.ones(1))
+        )
+        out = patch.squeeze_coords()
+        assert "distance" in out.dims
+        assert out.attrs.get("quality") == 1
 
     def test_noop_returns_self(self, random_patch):
         """A patch with nothing to squeeze is handed back."""

--- a/tests/test_workflow/_calls.py
+++ b/tests/test_workflow/_calls.py
@@ -99,6 +99,10 @@ def get_patch(name: str):
         # Dimensions which carry no coordinate, which is the shape
         # `make_broadcastable_to` is for.
         return patch.mean()
+    if name == "flat_coord":
+        # A non-dimensional coord which says one thing about the patch.
+        ones = np.ones(patch.coord_shapes["distance"])
+        return patch.update_coords(quality=("distance", ones))
     if name == "shifted":
         # Each channel carries the time it should be aligned by.
         small = patch.select(distance=(0, 50))
@@ -180,6 +184,7 @@ CALLS: tuple[tuple[str, str, tuple, dict], ...] = (
     ("envelope", "default", ("time",), {}),
     ("dropna", "null", ("time",), {"how": "all"}),
     ("squeeze", "default", (), {"dim": None}),
+    ("squeeze_coords", "flat_coord", ("quality",), {}),
     ("idft", "dft", (), {"dim": "ft_time"}),
     ("sobel_filter", "default", ("time",), {"mode": "reflect"}),
     # -- aggregations


### PR DESCRIPTION
## Description

Adds `Patch.squeeze_coords`, which converts non-dimensional coordinates holding a single value into patch attributes.

A coordinate whose values are all the same says one thing about the patch rather than one thing about each sample. `squeeze_coords` drops each such coordinate and stores its value in the attrs under the coordinate's name:

```python
patch = patch.update_coords(quality=("distance", np.ones(n)))

patch.squeeze_coords()           # every non-dim coord which qualifies
patch.squeeze_coords("quality")  # or only the ones named
```

It complements `Patch.squeeze`, which removes length one *dimensions*: `squeeze_coords` never touches a dimension, so `patch.squeeze_coords().squeeze()` keeps what a bare `squeeze()` would throw away (dropping a dimension drops the coordinates which depend on it).

Details:

- Naming a coordinate which is a dimension, is not in the patch, or does not hold exactly one non-null value raises `CoordError`. The unnamed sweep passes over those instead, and an empty selection (`squeeze_coords([])`) does nothing.
- Coordinate units are not kept, only the value. Times stay `np.datetime64`; every other value is stored as a python scalar.
- A null value (NaN or NaT) is not a value to state, so an all-null or partial coordinate is left alone.
- The five attr names the patch machinery owns (`coords`, `dims`, `history`, `patch_id`, `processing_id`) cannot hold a coordinate's value — `dims` is dropped by `PatchAttrs.from_dict`, `coords` is refused there, and the last three are stamped over by the `patch_function` decorator after the body returns. A coordinate named for one of them is skipped by the sweep and refused when named.
- A patch with nothing to squeeze is handed back unchanged.

`tests/test_workflow/_calls.py` gains a catalogued call, which `TestEveryPatchFunction` requires of every patch function.

## Changelog

- added: `Patch.squeeze_coords` converts non-dimensional coordinates which hold a single value into patch attributes.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `squeeze_coords` to convert single-value, non-dimensional coordinates into patch attributes.
  * Supports selecting specific coordinates or automatically processing eligible coordinates.
  * Preserves coordinate values across string, datetime, numeric, and unit-based data.

* **Documentation**
  * Added a tutorial example demonstrating coordinate squeezing.

* **Bug Fixes**
  * Added validation for invalid, empty, multi-valued, dimensional, and reserved-name coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->