### PR TITLE
docs: improve See Also links for resampling methods

### DIFF
--- a/dascore/proc/detrend.py
+++ b/dascore/proc/detrend.py
@@ -33,6 +33,15 @@ def detrend(
     -------
     The Patch instance after applying the detrend function.
 
+    See Also
+    --------
+    [Patch.taper](`dascore.Patch.taper`)
+        Taper the ends of a signal, often used with detrending before transforms.
+    [Patch.pass_filter](`dascore.Patch.pass_filter`)
+        Apply a Butterworth highpass, lowpass, or bandpass filter.
+    [Patch.savgol_filter](`dascore.Patch.savgol_filter`)
+        Smooth data using a Savitzky-Golay filter while preserving local trends.
+
     Examples
     --------
     >>> import dascore # import dascore library

--- a/dascore/proc/detrend.py
+++ b/dascore/proc/detrend.py
@@ -33,15 +33,6 @@ def detrend(
     -------
     The Patch instance after applying the detrend function.
 
-    See Also
-    --------
-    [Patch.taper](`dascore.Patch.taper`)
-        Taper the ends of a signal, often used with detrending before transforms.
-    [Patch.pass_filter](`dascore.Patch.pass_filter`)
-        Apply a Butterworth highpass, lowpass, or bandpass filter.
-    [Patch.savgol_filter](`dascore.Patch.savgol_filter`)
-        Smooth data using a Savitzky-Golay filter while preserving local trends.
-
     Examples
     --------
     >>> import dascore # import dascore library

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -74,6 +74,12 @@ def decimate(
     - If the decimation dimension is small, this can fail due to lack of
       padding values.
 
+    See Also
+    --------
+    [resample](`dascore.proc.resample.resample`)
+        Change sampling to a specified interval or number of samples, rather
+        than by an integer decimation factor.
+
     Examples
     --------
     # Simple example using iir
@@ -122,7 +128,12 @@ def interpolate(patch: PatchType, kind: str | int = "linear", **kwargs) -> Patch
     This function just uses scipy's interp1d function under the hood.
     See scipy.interpolate.interp1d for information.
 
-    See also [snap](`dascore.core.Patch.snap_coords`).
+    See Also
+    --------
+    [Patch.snap_coords](`dascore.Patch.snap_coords`)
+        Snap coordinates to evenly sampled values without interpolating data.
+    [resample](`dascore.proc.resample.resample`)
+        Resample data to a target sampling interval or number of samples.
 
     Examples
     --------


### PR DESCRIPTION
## Summary

Adds focused `See Also` cross-links among the closely related resampling APIs in `dascore.proc.resample`.

Changes:

- `decimate` now links to `resample`, clarifying when to use a target sampling interval/count instead of an integer decimation factor.
- `interpolate` now has a proper `See Also` section linking to `Patch.snap_coords` and `resample`, with the distinction between coordinate snapping and data interpolation made explicit.
- The existing `resample` links to `decimate` and `interpolate` are retained, making the relationship reciprocal.

The earlier detrend links were removed; they were too loosely related.

Documentation-only change; no runtime behavior is modified.

## Changelog

none