### PR TITLE
Let the spool plots draw what they are given, not select it

### DIFF
--- a/dascore/viz/inventory.py
+++ b/dascore/viz/inventory.py
@@ -393,7 +393,9 @@ def path(
         An Axes to draw the lanes on; one is created, a lane tall per
         track, when None. Pass one to say how large the plot is. Column
         panels need their own figure, so passing this and naming columns
-        is refused.
+        is refused; size that figure with
+        `path(...).get_figure().set_size_inches(width, height)`, which
+        lays it out again at the size asked for.
     show
         Whether to call plt.show.
 

--- a/dascore/viz/inventory.py
+++ b/dascore/viz/inventory.py
@@ -345,7 +345,6 @@ def path(
     color: str | Mapping | None = None,
     max_labels: int = 200,
     ax: plt.Axes | None = None,
-    figsize: tuple[float, float] | None = None,
     show: bool = False,
 ) -> plt.Axes:
     """
@@ -391,10 +390,10 @@ def path(
         count, a label too wide for its box is turned on its side, and
         dropped only if it does not fit that way either.
     ax
-        An Axes to draw the lanes on. Column panels need their own
-        figure, so passing this and naming columns is refused.
-    figsize
-        Size of the figure built when ax is None.
+        An Axes to draw the lanes on; one is created, a lane tall per
+        track, when None. Pass one to say how large the plot is. Column
+        panels need their own figure, so passing this and naming columns
+        is refused.
     show
         Whether to call plt.show.
 
@@ -440,7 +439,7 @@ def path(
         # into are estimated from the labels; guessing low gives back less
         # room than intended, which is the harmless direction.
         named = _legend_names(frame, color)
-        width = (figsize or (10.0, 0.0))[0]
+        width = 10.0
         lane_height = 1.2 + 0.42 * len(lanes)
         # A legend which would stand nearly as tall as the lanes it names
         # reads better under them, and short of that it belongs at their
@@ -461,7 +460,7 @@ def path(
         figure, all_axes = plt.subplots(
             1 + len(columns),
             1,
-            figsize=figsize or (10.0, height),
+            figsize=(width, height),
             sharex=True,
             height_ratios=[max(2.0, 0.5 * len(lanes))] + [1] * len(columns),
             squeeze=False,

--- a/dascore/viz/spool.py
+++ b/dascore/viz/spool.py
@@ -13,7 +13,7 @@ from matplotlib.colors import LogNorm
 from dascore.exceptions import ParameterError
 from dascore.utils.chunk_plan import _REPORT_COLUMNS
 from dascore.utils.plotting import _format_time_axis, _get_cmap
-from dascore.utils.time import to_datetime64, to_float
+from dascore.utils.time import to_float
 
 from ._lanes import plot_lanes
 
@@ -71,32 +71,6 @@ def _human_duration(value) -> str:
     return f"{size:.3g} s"
 
 
-def _pair(name, window) -> tuple | None:
-    """Read a window as its two ends, or None where all of it is asked for."""
-    if window is None or window is ...:
-        return None
-    try:
-        low, high = window
-    except (TypeError, ValueError):
-        msg = f"{name}={window!r} must be a (start, end) pair, or ... for all of it."
-        raise ParameterError(msg) from None
-    return (low, high)
-
-
-def _read_selection(kwargs) -> tuple[str, tuple | None]:
-    """Take the dimension to measure, and any window, from the kwargs."""
-    if not kwargs:
-        return "time", None
-    if len(kwargs) > 1:
-        msg = (
-            f"A spool is drawn along one dimension; {sorted(kwargs)} names "
-            f"{len(kwargs)}. Call once for each."
-        )
-        raise ParameterError(msg)
-    ((dim, window),) = kwargs.items()
-    return dim, _pair(dim, window)
-
-
 def _lane_names(report: pd.DataFrame, dim: str) -> list[str]:
     """Name each group by what tells it apart, and how complete it is."""
     # Named for the measured dimension rather than by suffix: an
@@ -133,13 +107,11 @@ def _lane_names(report: pd.DataFrame, dim: str) -> list[str]:
     return names
 
 
-def _new_ax(ax, figsize, height: float):
+def _new_ax(ax, height: float):
     """Build the figure a plot of this height needs, unless given one."""
     if ax is not None:
         return ax
-    _, ax = plt.subplots(
-        1, figsize=figsize or (10.0, min(height, 14.0)), layout="constrained"
-    )
+    _, ax = plt.subplots(1, figsize=(10.0, min(height, 14.0)), layout="constrained")
     return ax
 
 
@@ -207,47 +179,15 @@ def _tile(report: pd.DataFrame, gaps: pd.DataFrame, dim: str) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=["lane", "start", "end", "kind", "label"])
 
 
-def _bounds(window, low, high, dated: bool = True) -> tuple:
-    """
-    Resolve a window's two ends, taking either of them from the data.
-
-    Returns the pair in the units the data states, so a caller can
-    compare it against the frame it came from.
-    """
-    asked = (None, None) if window is None else window
-    edges = tuple(
-        fallback
-        if value is None or value is ...
-        else (to_datetime64(value) if dated else float(value))
-        for value, fallback in zip(asked, (low, high), strict=True)
-    )
-    if edges[1] < edges[0]:
-        msg = f"The window {window!r} must be increasing."
-        raise ParameterError(msg)
-    return edges
-
-
-def _x_limits(window, frame: pd.DataFrame, dated: bool):
-    """Resolve the window a lane plot draws between, or None for all of it."""
-    if window is None:
-        return None
-    low, high = _bounds(window, frame["start"].min(), frame["end"].max(), dated)
-    if high <= low:
-        msg = f"The window {window!r} must be increasing."
-        raise ParameterError(msg)
-    return (low, high)
-
-
 def coverage(
     spool,
+    dim: str = "time",
     *,
     tolerance: float = 1.5,
     group: str | Sequence[str] | None = None,
     color=None,
     ax: plt.Axes | None = None,
-    figsize: tuple[float, float] | None = None,
     show: bool = False,
-    **kwargs,
 ) -> plt.Axes:
     """
     Plot what a spool covers along a dimension, and where it does not.
@@ -264,6 +204,8 @@ def coverage(
     ----------
     spool
         The spool to measure.
+    dim
+        The dimension to measure along.
     tolerance
         How many samples patches may be spaced and still count as
         contiguous. Same meaning as chunk's `tolerance`.
@@ -274,18 +216,23 @@ def coverage(
     color
         A mapping of "data" and "gap" to colors, overriding the default.
     ax
-        A matplotlib Axes; one is created when None.
-    figsize
-        Size of the figure built when ax is None.
+        A matplotlib Axes; one is created, a lane tall per group, when
+        None. Pass one to say how large the plot is.
     show
         Whether to call plt.show.
-    **kwargs
-        The dimension to measure along, optionally with the window to
-        draw: `time=("2020-01-01", None)`. `time=...` states the
-        dimension and asks for all of it. Defaults to the whole of time.
 
     Notes
     -----
+    The whole of what the spool holds is drawn. A part of it is a
+    smaller spool: select it first, as
+    `spool.select(time=(start, end)).viz.coverage()`, and the lanes and
+    their percentages are of that window rather than of a window drawn
+    over percentages of everything. To keep the whole picture and look
+    at part of it instead -- where a lane running off the edge says the
+    data does not stop there -- set the limits on the axes this returns.
+    Labels are laid out for the extent drawn, so a zoom made that way
+    shows fewer of them than it has room for.
+
     Coverage is measured between patches, from the envelopes the index
     records, so a hole *inside* a patch is not visible here. A lane
     reading 100% says "nothing chunk would refuse to merge", not
@@ -298,16 +245,16 @@ def coverage(
     >>>
     >>> spool = dc.get_example_spool("diverse_das")
     >>> _ = coverage(spool)
-    >>> _ = coverage(spool, time=("2020-01-03", "2020-01-04"))
+    >>> _ = coverage(spool, "distance")
+    >>> _ = coverage(spool.select(time=("2020-01-03", "2020-01-04")))
     """
-    dim, window = _read_selection(kwargs)
     # get_coverage refuses a dimension the spool does not state, and
     # names the ones it does, so its message is better than any here.
     report = spool.get_coverage(dim, tolerance=tolerance, group=group)
     gaps = spool.get_gaps(dim, tolerance=tolerance, group=group)
     frame = _tile(report, gaps, dim)
     lanes = list(dict.fromkeys(frame["lane"]))
-    ax = _new_ax(ax, figsize, 1.2 + 0.45 * len(lanes))
+    ax = _new_ax(ax, 1.2 + 0.45 * len(lanes))
     dated = pd.api.types.is_datetime64_any_dtype(frame["start"])
     plot_lanes(
         frame,
@@ -317,7 +264,6 @@ def coverage(
         label="label",
         lanes=lanes,
         color=color or COVERAGE_COLORS,
-        x_limits=_x_limits(window, frame, dated),
         x_label="" if dated else dim,
     )
     if dated:
@@ -392,13 +338,13 @@ def _day_counts(contents: pd.DataFrame, days: np.ndarray, dim: str) -> np.ndarra
     )
 
 
-def _calendar_days(window, runs: pd.DataFrame, ends: np.ndarray) -> pd.DatetimeIndex:
+def _calendar_days(runs: pd.DataFrame, ends: np.ndarray) -> pd.DatetimeIndex:
     """Return every day the calendar shows, first and last included."""
     # A run covers up to its extended end without reaching it, so a run
     # stopping at midnight ends on the day before, and one reaching half
     # an hour past it earns the day it reaches into.
-    reach = ends.max() - np.timedelta64(1, "ns")
-    first, last = _bounds(window, runs["start"].min(), reach)
+    first = runs["start"].min()
+    last = ends.max() - np.timedelta64(1, "ns")
     # The last day is a day the spool has data in, so the calendar shows
     # it. An exclusive end would leave a one-day spool with no cells.
     return pd.date_range(
@@ -452,9 +398,7 @@ def calendar(
     method: str = "percent",
     tolerance: float = 1.5,
     group: str | Sequence[str] | None = None,
-    time: tuple | None = None,
     ax: plt.Axes | None = None,
-    figsize: tuple[float, float] | None = None,
     show: bool = False,
 ) -> plt.Axes:
     """
@@ -484,13 +428,9 @@ def calendar(
         to the config option `patch_kind_attrs`. It decides which
         boundaries are gaps; a day is the union of every group's data,
         so regrouping moves a day's total only where it moves a gap.
-    time
-        The days to draw, as a (start, end) pair. Either end may be None
-        to run to what the spool itself states.
     ax
-        A matplotlib Axes; one is created when None.
-    figsize
-        Size of the figure built when ax is None.
+        A matplotlib Axes; one is created, a row tall per month, when
+        None. Pass one to say how large the plot is.
     show
         Whether to call plt.show.
 
@@ -504,7 +444,10 @@ def calendar(
 
     `group` is not a way to pick one of them: select the patches first,
     as `spool.select(tag="temperature").viz.calendar()`, and the
-    calendar is of those alone.
+    calendar is of those alone. Days are chosen the same way — the
+    calendar runs from the first day the spool holds to the last, so
+    `spool.select(time=(start, end)).viz.calendar()` draws that season
+    and measures it.
 
     A run covers one sample past the last one it states, taken from the
     step its group reports. Patches within `sampling_group_tolerance` of
@@ -541,7 +484,7 @@ def calendar(
         msg = "This spool holds no time to draw a calendar of."
         raise ParameterError(msg)
     ends = _extended(runs, report, dim)
-    days = _calendar_days(_pair("time", time), runs, ends)
+    days = _calendar_days(runs, ends)
     stamps = days.to_numpy()
     if method == "count":
         values = _day_counts(spool.get_contents(), stamps, dim)
@@ -553,7 +496,7 @@ def calendar(
             else _SECONDS_IN_DAY - covered
         )
     matrix, labels = _calendar_cells(days, values)
-    ax = _new_ax(ax, figsize, 1.5 + 0.5 * len(labels))
+    ax = _new_ax(ax, 1.5 + 0.5 * len(labels))
     ax.set_facecolor(_UNSTATED_COLOR)
     cmap = _get_cmap(_CALENDAR_CMAPS[method]).copy()
     cmap.set_bad(_UNSTATED_COLOR)

--- a/dascore/viz/spool.py
+++ b/dascore/viz/spool.py
@@ -447,7 +447,11 @@ def calendar(
     calendar is of those alone. Days are chosen the same way — the
     calendar runs from the first day the spool holds to the last, so
     `spool.select(time=(start, end)).viz.calendar()` draws that season
-    and measures it.
+    and measures it. It draws the days that selection kept: an outage
+    at either end of the window falls outside the calendar rather than
+    filling it, and a window with no data in it at all is a spool of
+    nothing, which has no calendar. Draw the wider spool to see an
+    outage measured.
 
     A run covers one sample past the last one it states, taken from the
     step its group reports. Patches within `sampling_group_tolerance` of
@@ -481,7 +485,12 @@ def calendar(
         raise ParameterError(msg)
     runs = _runs(report, gaps, dim)
     if not len(runs):
-        msg = "This spool holds no time to draw a calendar of."
+        msg = (
+            "This spool holds no time to draw a calendar of. A window "
+            "which keeps no patches leaves a spool of nothing, which is "
+            "not the same as a spool of days covered by nothing: widen "
+            "the selection, or draw the spool it was made from."
+        )
         raise ParameterError(msg)
     ends = _extended(runs, report, dim)
     days = _calendar_days(runs, ends)

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -141,10 +141,19 @@ spool.viz.coverage(show=True);
 
 Both acquisitions lose the four days in the middle of January, which is the site's own outage; the strain acquisition started later and was pulled out earlier, which is why its lane is shorter rather than gappy at the ends.
 
-Any dimension the spool states can be measured, and a `(start, end)` pair windows it:
+Time is measured by default; any other dimension the spool states can be named instead, as `spool.viz.coverage("distance")`. The whole of it is drawn, because part of a spool is a smaller spool: select the window first and the lanes, and the percentages on them, are of that window rather than of a window drawn over percentages of everything.
 
 ```{python}
-spool.viz.coverage(time=("2024-01-15", "2024-01-25"), show=True);
+spool.select(time=("2024-01-15", "2024-01-25")).viz.coverage(show=True);
+```
+
+The lanes end where the selection does, which is what a spool of those ten days holds. Keeping the whole picture and looking at part of it is a different question, and one for the axes rather than the spool: a lane which runs off the edge there says the data does not stop at it.
+
+```{python}
+import numpy as np
+
+ax = spool.viz.coverage()
+ax.set_xlim(np.datetime64("2024-01-15"), np.datetime64("2024-01-25"));
 ```
 
 ## Calendar

--- a/tests/test_viz/test_inventory_viz.py
+++ b/tests/test_viz/test_inventory_viz.py
@@ -381,14 +381,14 @@ class TestPath:
         # Components take their fixed colors, so the legend names the types.
         assert "FiberSegment" in _legend_labels(ax)
 
-    def test_a_narrow_figure_keeps_its_legend_on_the_page(self, site):
-        """A figure too small to seat a legend must not be made nonsense of.
+    def test_a_legend_too_big_for_the_page_stays_on_it(self, site):
+        """A legend the figure cannot seat must not be made nonsense of.
 
         The lanes keep some of the figure whatever the legend needs, and
         neither they nor it leave the canvas.
         """
-        crowded = build_labeled_inventory(24, site.coordinate_reference_system)
-        ax = path(crowded, "DAS.L2.00", figsize=(3.0, 2.0))
+        crowded = build_labeled_inventory(24, site.coordinate_reference_system, lines=8)
+        ax = path(crowded, "DAS.L2.00")
         figure = ax.get_figure()
         figure.draw_without_rendering()
         lanes = ax.get_window_extent()
@@ -581,19 +581,17 @@ class TestPath:
         with pytest.raises(ParameterError, match="has no length"):
             path(inventory)
 
-    def test_color_override_and_figsize(self, site, shown):
-        """color= reaches the renderer, figsize the figure, show plt.show."""
+    def test_color_override_and_show(self, site, shown):
+        """color= reaches the renderer, and show calls plt.show."""
         ax = path(
             site,
             "DAS.L1.00",
             time="2026-06-10",
             tracks="coupling",
             color="black",
-            figsize=(4, 3),
             show=True,
         )
         assert shown
-        assert tuple(ax.get_figure().get_size_inches()) == (4.0, 3.0)
         assert np.allclose(_boxes(ax)[0].get_facecolors()[0][:3], [0, 0, 0])
 
     def test_components_keep_their_own_colors(self, site):

--- a/tests/test_viz/test_inventory_viz.py
+++ b/tests/test_viz/test_inventory_viz.py
@@ -394,6 +394,9 @@ class TestPath:
         lanes = ax.get_window_extent()
         assert lanes.height > 0 and lanes.y0 >= 0
         assert lanes.y1 <= figure.bbox.height
+        box = figure.legends[0].get_window_extent(figure.canvas.get_renderer())
+        assert box.y0 >= 0 and box.y1 <= figure.bbox.height
+        assert box.x0 >= 0 and box.x1 <= figure.bbox.width
 
     def test_a_value_on_two_lines_is_kept_room_for_both(self, site):
         """A legend entry of two lines stands as tall as two of one.
@@ -535,6 +538,19 @@ class TestPath:
         _, ax = plt.subplots()
         with pytest.raises(ParameterError, match="builds the figure"):
             path(site, "DAS.L1.00", time="2026-06-10", columns="chainage", ax=ax)
+
+    def test_a_figure_of_panels_is_sized_after_it_is_built(self, site):
+        """Panels take no ax, so their figure is the one asked to resize."""
+        figure = path(
+            site, "DAS.L1.00", time="2026-06-10", columns="chainage"
+        ).get_figure()
+        figure.set_size_inches(5, 4)
+        figure.draw_without_rendering()
+        assert tuple(figure.get_size_inches()) == (5.0, 4.0)
+        # Laid out again at the size asked for: the panels still fit.
+        for axes in figure.axes:
+            box = axes.get_window_extent()
+            assert box.height > 0 and box.y0 >= 0 and box.y1 <= figure.bbox.height
 
     def test_ax_without_columns(self, site):
         """Lanes alone draw onto an axes a caller provides."""

--- a/tests/test_viz/test_spool_viz.py
+++ b/tests/test_viz/test_spool_viz.py
@@ -171,40 +171,35 @@ class TestCoverage:
         ax = diverse.viz.coverage(group=[])
         assert len(_lanes(ax)) < len(diverse.get_coverage("time"))
 
-    def test_window(self, diverse):
-        """A window states the limits, and accepts times as text."""
-        ax = diverse.viz.coverage(time=("2020-01-03", "2020-01-03T00:00:30"))
+    def test_a_window_is_a_selection(self, diverse):
+        """A part of a spool is a smaller spool, and it draws as one."""
+        window = ("2020-01-03", "2020-01-03T00:00:30")
+        ax = diverse.select(time=window).viz.coverage()
+        assert len(_lanes(ax)) == len(diverse.select(time=window).get_coverage("time"))
+        # Only what the selection holds is drawn, so the axis is of it.
         low, high = ax.get_xlim()
-        assert high - low == pytest.approx(30.0 / 86_400, rel=1e-3)
+        assert high - low < 2 * 30.0 / 86_400
 
-    def test_half_open_window(self, diverse):
-        """Either end may be left to the data."""
-        ax = diverse.viz.coverage(time=("2020-01-03", None))
-        assert ax.get_xlim()[1] > ax.get_xlim()[0]
-        plt.close("all")
-        ax = diverse.viz.coverage(time=(None, "2020-01-03"))
-        assert ax.get_xlim()[1] > ax.get_xlim()[0]
-
-    def test_dimension_without_a_window(self, diverse):
-        """An Ellipsis names the dimension and asks for all of it."""
-        ax = diverse.viz.coverage(time=...)
+    def test_default_dimension(self, diverse):
+        """Time is what a spool is measured along unless another is named."""
+        ax = diverse.viz.coverage()
         assert len(_lanes(ax)) == len(diverse.get_coverage("time"))
 
     def test_another_dimension(self, diverse):
         """A spool can be measured along any dimension it states."""
-        ax = diverse.viz.coverage(distance=...)
+        ax = diverse.viz.coverage("distance")
         assert ax.get_xlabel() == "distance"
         assert len(_lanes(ax)) == len(diverse.get_coverage("distance"))
 
     def test_a_dimension_nothing_states(self, whole):
         """The spool's own refusal stands; it names the dimensions there are."""
         with pytest.raises(Exception, match="Cannot report on 'depth'") as info:
-            whole.viz.coverage(depth=...)
+            whole.viz.coverage("depth")
         assert "time" in str(info.value)
 
     def test_every_group_gets_a_lane(self, diverse):
         """Groups which state the same attributes are still separate lanes."""
-        ax = diverse.viz.coverage(distance=...)
+        ax = diverse.viz.coverage("distance")
         report = diverse.get_coverage("distance")
         lanes = _lanes(ax)
         # Along distance these groups share every shown attribute, and are
@@ -212,24 +207,15 @@ class TestCoverage:
         assert len(lanes) == len(report) > 6
         assert len(set(lanes)) == len(lanes)
 
-    @pytest.mark.parametrize(
-        "bad, match",
-        [
-            (dict(time=5), "must be a .start, end. pair"),
-            (dict(time=("2020-01-04", "2020-01-03")), "must be increasing"),
-            # A lane needs a width, so its two ends may not be one point.
-            (dict(time=("2020-01-03", "2020-01-03")), "must be increasing"),
-            (dict(time=..., distance=...), "names 2"),
-        ],
-    )
-    def test_bad_selection(self, diverse, bad, match):
-        """A selection which is not one is explained."""
-        with pytest.raises(ParameterError, match=match):
-            diverse.viz.coverage(**bad)
+    def test_a_window_is_not_a_plotting_argument(self, diverse):
+        """The plot draws a dimension; the spool is what states a window."""
+        with pytest.raises(TypeError, match="time"):
+            diverse.viz.coverage(time=("2020-01-03", "2020-01-04"))
 
     def test_gap_labels(self, diverse):
         """A gap says how long it is, in a unit worth reading."""
-        ax = diverse.viz.coverage(time=("2020-01-03", "2020-01-03T00:00:30"))
+        window = ("2020-01-03", "2020-01-03T00:00:30")
+        ax = diverse.select(time=window).viz.coverage()
         assert any(x.get_text().endswith(" s") for x in ax.texts)
 
     def test_color_override(self, diverse):
@@ -246,10 +232,13 @@ class TestCoverage:
         assert whole.viz.coverage(ax=ax, show=True) is ax
         assert called
 
-    def test_figsize(self, whole):
-        """Figsize sizes the figure built when no ax is given."""
-        ax = whole.viz.coverage(figsize=(5, 2))
-        assert tuple(ax.get_figure().get_size_inches()) == (5.0, 2.0)
+    def test_a_given_ax_sizes_the_plot(self, whole):
+        """The figure a caller built is the figure drawn on, at its size."""
+        _, ax = plt.subplots(figsize=(5, 2))
+        assert tuple(whole.viz.coverage(ax=ax).get_figure().get_size_inches()) == (
+            5.0,
+            2.0,
+        )
 
     def test_module_function(self, whole):
         """The plot is callable without the namespace, as tests need."""
@@ -259,7 +248,7 @@ class TestCoverage:
         """Only time is measured in seconds; distance says metres."""
         first = dc.get_example_patch("random_das", distance_min=0, shape=(10, 5))
         second = dc.get_example_patch("random_das", distance_min=22, shape=(10, 5))
-        ax = dc.spool([first, second]).viz.coverage(distance=...)
+        ax = dc.spool([first, second]).viz.coverage("distance")
         assert [x.get_text() for x in ax.texts if x.get_text()] == ["13 m"]
 
     def test_a_one_sample_run_is_drawn(self):
@@ -483,21 +472,17 @@ class TestCalendar:
         cells = _cells(deployment.viz.calendar())
         assert np.ma.getmaskarray(cells)[1, 29:].all()
 
-    def test_window(self, deployment):
-        """A window states the days to draw."""
-        ax = deployment.viz.calendar(time=("2024-01-05", "2024-01-09"))
+    def test_a_window_is_a_selection(self, deployment):
+        """The days drawn are the days the spool holds, so a select picks them."""
+        ax = deployment.select(time=("2024-01-05", "2024-01-09")).viz.calendar()
         assert np.count_nonzero(~np.ma.getmaskarray(_cells(ax))) == 5
 
-    def test_half_open_window(self, deployment):
-        """Either end may be left to the spool."""
-        ax = deployment.viz.calendar(time=(None, "2024-01-31"))
-        assert np.count_nonzero(~np.ma.getmaskarray(_cells(ax))) == 31
-
-    def test_a_window_of_one_day(self, deployment):
-        """Both ends may name the same day; a calendar cell is a day wide."""
-        ax = deployment.viz.calendar(time=("2024-01-18", "2024-01-18"))
+    def test_a_selection_of_one_day(self, deployment):
+        """A day is a day the spool holds, and a calendar cell is a day wide."""
+        day = deployment.select(time=("2024-01-05", "2024-01-05T23:59:59"))
+        ax = day.viz.calendar()
         assert np.count_nonzero(~np.ma.getmaskarray(_cells(ax))) == 1
-        assert _cell(ax, "2024-01-18") == 0.0
+        assert _cell(ax, "2024-01-05") > 0.0
 
     def test_tolerance_changes_what_counts(self, deployment):
         """A tolerance which closes the gaps fills the days they emptied."""
@@ -512,14 +497,17 @@ class TestCalendar:
         "bad, match",
         [
             (dict(method="nope"), "not a calendar measure"),
-            (dict(time=5), "must be a .start, end. pair"),
-            (dict(time=("2024-02-01", "2024-01-01")), "must be increasing"),
         ],
     )
     def test_bad_arguments(self, deployment, bad, match):
         """An argument which states nothing drawable is explained."""
         with pytest.raises(ParameterError, match=match):
             deployment.viz.calendar(**bad)
+
+    def test_a_window_is_not_a_plotting_argument(self, deployment):
+        """The calendar draws what the spool holds; a spool states the days."""
+        with pytest.raises(TypeError, match="time"):
+            deployment.viz.calendar(time=("2024-01-05", "2024-01-09"))
 
     def test_an_empty_spool(self):
         """A spool with no time in it has no calendar."""
@@ -546,10 +534,13 @@ class TestCalendar:
         assert whole.viz.calendar(ax=ax, show=True) is ax
         assert called
 
-    def test_figsize(self, whole):
-        """Figsize sizes the figure built when no ax is given."""
-        ax = whole.viz.calendar(figsize=(4, 3))
-        assert tuple(ax.get_figure().get_size_inches()) == (4.0, 3.0)
+    def test_a_given_ax_sizes_the_plot(self, whole):
+        """The figure a caller built is the figure drawn on, at its size."""
+        _, ax = plt.subplots(figsize=(4, 3))
+        assert tuple(whole.viz.calendar(ax=ax).get_figure().get_size_inches()) == (
+            4.0,
+            3.0,
+        )
 
     def test_module_function(self, whole):
         """The plot is callable without the namespace, as tests need."""

--- a/tests/test_viz/test_spool_viz.py
+++ b/tests/test_viz/test_spool_viz.py
@@ -509,6 +509,12 @@ class TestCalendar:
         with pytest.raises(TypeError, match="time"):
             deployment.viz.calendar(time=("2024-01-05", "2024-01-09"))
 
+    def test_a_window_of_pure_outage_says_what_it_is(self, deployment):
+        """A window keeping no patches is a spool of nothing, not of nothing seen."""
+        empty = deployment.select(time=("2024-01-18", "2024-01-20"))
+        with pytest.raises(ParameterError, match="widen the selection"):
+            empty.viz.calendar()
+
     def test_an_empty_spool(self):
         """A spool with no time in it has no calendar."""
         with pytest.raises(ParameterError, match="no time to draw"):


### PR DESCRIPTION
## Description

A window given to a spool plot was a selection made at the visualization layer, and it only half made it: `spool.viz.coverage(time=("2026-08-06T10:00", "2026-08-06T10:35"))` moved the axes but not the numbers, so a lane could read 100% of a spool while showing thirty-five minutes of it. Nothing marked a run which continued past the edge either, so the zoom said less than it appeared to.

A part of a spool is a smaller spool, and `spool.select` already says so. The window goes, from `coverage` and from `calendar`:

- `coverage` names its dimension plainly — `spool.viz.coverage("distance")` — rather than stating it through a keyword which doubled as the window. A window is `spool.select(time=(start, end)).viz.coverage()`, where the lanes and the percentages on them are of the window.
- `calendar` draws the days the spool holds; `spool.select(time=...)` picks them.

Keeping the whole picture and looking at part of it is a different question, and one for matplotlib: `coverage` returns the axes, and `ax.set_xlim(start, end)` zooms them with the lanes drawn full length, so a lane running off the edge says the data does not stop there. The docstring and the visualization tutorial both show it.

One thing the calendar loses with the window: a stretch of pure outage cannot be asked for, because a selection which keeps no patches is a spool of nothing rather than a spool of days covered by nothing. It says so now instead of reporting an empty spool, and the notes say to draw the wider spool to see an outage measured — grey days at the edge of a calendar are days it says nothing about, which is the weaker claim.

`figsize` goes the same way, from `coverage`, `calendar` and `Inventory.viz.path`: a caller who wants a particular size builds the axes and passes them, and the default figure is still sized from the number of lanes it has to hold.

## Changelog

- changed **breaking**: `Spool.viz.coverage` takes the dimension to measure as `dim` (`spool.viz.coverage("distance")`) and no longer accepts a window; select the window first, as `spool.select(time=(start, end)).viz.coverage()`.
- removed **breaking**: `Spool.viz.calendar` no longer takes `time`; select the days first.
- removed **breaking**: `figsize` is gone from `Spool.viz.coverage`, `Spool.viz.calendar` and `Inventory.viz.path`; pass an `ax` of the size you want, or size the figure `Inventory.viz.path` builds for its column panels with `set_size_inches`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
