### PR TITLE
Read the OTDR acquisition parameters an SOR file states

### DIFF
--- a/dascore/io/sr4731/utils.py
+++ b/dascore/io/sr4731/utils.py
@@ -18,8 +18,9 @@ files and makes these specific assumptions:
   declaring another count is refused rather than silently misread.
 - The averaging time is read as the standard's tenths of a second. Several
   vendors write that field on their own scale, so only a supplier known to
-  keep the standard has it promoted to the time coordinate's step; every
-  other file keeps the bare instant and reports the value as an attr.
+  keep the standard has it read as a duration, which is then both reported
+  and promoted to the time coordinate's step. Every other file keeps the
+  bare instant and states no averaging time.
 - ``DataPts`` is a single unsegmented trace with unsigned little-endian
   16-bit samples and the display scale documented in ``_parse_data_points``.
 - Trace samples follow pyotdr's SR-4731 display convention:
@@ -51,8 +52,8 @@ REQUIRED_BLOCKS = frozenset(
 SPEED_OF_LIGHT_KM_PER_USEC = 0.299792458
 
 # Suppliers whose averaging time is known to be the standard's tenths of
-# a second. Noyes writes hundredths and EXFO whole seconds, so a value
-# from an unlisted supplier is reported but never sized into a step.
+# a second. Noyes writes hundredths and EXFO whole seconds, so the field
+# an unlisted supplier states names no duration this reader can size.
 _STANDARD_AVERAGING_SUPPLIERS = frozenset({"FIBERCLOUD"})
 
 
@@ -193,12 +194,12 @@ def _parse_fixed_params(payload: bytes) -> dict[str, Any]:
     n_samples = _unpack_from("<I", payload, 24)[0]
     refractive_index = _unpack_from("<I", payload, 28)[0] * 1e-5
     n_averages = _unpack_from("<I", payload, 34)[0]
-    # Tenths of a second, which is the standard's scale and the one
-    # pyotdr and otdrs both read this field with. Vendors disagree in
-    # practice -- the same half minute is written 300 here, 3000 by
-    # Noyes and 30 by EXFO -- so the value is reported as read and only
-    # trusted as a duration for a supplier known to keep the standard.
-    averaging_time = _unpack_from("<H", payload, 38)[0] * 0.1
+    # Kept as the number the file states, since what it counts depends
+    # on who wrote it: the standard's tenths of a second, which pyotdr
+    # and otdrs both assume, but hundredths for Noyes and whole seconds
+    # for EXFO. Only `_averaging_seconds`, which knows the supplier,
+    # can turn it into a duration.
+    averaging_time_raw = _unpack_from("<H", payload, 38)[0]
     display_range_km = _unpack_from("<I", payload, 40)[0] * 2e-5
     if sample_spacing_usec <= 0 or refractive_index <= 0:
         msg = "SR-4731 SOR FxdParams block has invalid distance scaling fields."
@@ -212,7 +213,7 @@ def _parse_fixed_params(payload: bytes) -> dict[str, Any]:
         "wavelength_nm": wavelength_nm,
         "pulse_width": pulse_width,
         "n_averages": n_averages,
-        "averaging_time": averaging_time,
+        "averaging_time_raw": averaging_time_raw,
         "sample_spacing_usec": sample_spacing_usec,
         "n_samples": n_samples,
         "refractive_index": refractive_index,
@@ -295,6 +296,25 @@ def _parse_sor(resource, load_samples: bool = True) -> dict[str, Any]:
     }
 
 
+def _averaging_seconds(parsed: dict[str, Any]) -> float | None:
+    """
+    Return the averaging time in seconds, or None when it cannot be read.
+
+    The field is the standard's tenths of a second, but vendors write
+    it on their own scale -- the same half minute is 300 here, 3000 for
+    Noyes and 30 for EXFO -- and `get_format` accepts any version-200
+    file, not only the subset this module documents. A number scaled by
+    the wrong vendor's rule is wrong by a factor of ten, so a supplier
+    this reader does not know states no averaging time at all rather
+    than one which reads as physical and is not.
+    """
+    raw = parsed["fixed"]["averaging_time_raw"]
+    manufacturer = next(iter(parsed["supplier"]), "").strip().upper()
+    if raw <= 0 or manufacturer not in _STANDARD_AVERAGING_SUPPLIERS:
+        return None
+    return raw * 0.1
+
+
 def _get_time_coord(parsed: dict[str, Any]) -> BaseCoord:
     """
     Create the singleton time coordinate from the fixed-params timestamp.
@@ -305,16 +325,13 @@ def _get_time_coord(parsed: dict[str, Any]) -> BaseCoord:
     measurements rather than one unbroken recording, which is what a
     stepless instant reads as.
 
-    Only a supplier known to write the standard's scale earns that,
-    since the step sizes the continuity tolerance and a vendor scale is
-    wrong by a factor of ten. A file which states no averaging time, or
-    states one this reader cannot size, keeps the bare instant.
+    A file whose averaging time this reader cannot read (see
+    [`_averaging_seconds`](`dascore.io.sr4731.utils._averaging_seconds`))
+    keeps the bare instant, which is no worse than saying nothing.
     """
-    fixed = parsed["fixed"]
-    start = np.datetime64(fixed["timestamp"], "s").astype("datetime64[ns]")
-    averaging_time = fixed.get("averaging_time") or 0.0
-    manufacturer = next(iter(parsed["supplier"]), "").strip().upper()
-    if averaging_time <= 0 or manufacturer not in _STANDARD_AVERAGING_SUPPLIERS:
+    start = np.datetime64(parsed["fixed"]["timestamp"], "s").astype("datetime64[ns]")
+    averaging_time = _averaging_seconds(parsed)
+    if averaging_time is None:
         return get_coord(data=np.asarray([start]))
     step = np.timedelta64(round(averaging_time * 1e9), "ns")
     return get_coord(start=start, stop=start + step, step=step)
@@ -351,7 +368,7 @@ def _get_attr_dict(parsed: dict[str, Any]) -> dict:
         "acquisition_range_m": parsed["fixed"]["acquisition_range_m"],
         "sample_spacing_usec": parsed["fixed"]["sample_spacing_usec"],
         "refractive_index": parsed["fixed"]["refractive_index"],
-        "averaging_time": parsed["fixed"]["averaging_time"],
+        "averaging_time": _averaging_seconds(parsed),
         "n_averages": parsed["fixed"]["n_averages"],
         "trace_count": data_points["trace_count"],
         "sample_scale": data_points["scale"],

--- a/dascore/io/sr4731/utils.py
+++ b/dascore/io/sr4731/utils.py
@@ -10,9 +10,16 @@ files and makes these specific assumptions:
 - The map block version is ``200``.
 - ``SupParams`` stores manufacturer, model, and serial number in the first
   three null-separated fields.
-- ``FxdParams`` exposes the timestamp, distance unit, wavelength, sample
-  spacing, index of refraction, and display range fields documented in
-  ``_parse_fixed_params``.
+- ``FxdParams`` exposes the timestamp, distance unit, wavelength, pulse
+  width, sample spacing, index of refraction, averaging, and display range
+  fields documented in ``_parse_fixed_params``.
+- ``FxdParams`` carries exactly one pulse-width entry. The fields after it
+  sit at fixed offsets which a second entry would shift, so a file
+  declaring another count is refused rather than silently misread.
+- The averaging time is read as the standard's tenths of a second. Several
+  vendors write that field on their own scale, so only a supplier known to
+  keep the standard has it promoted to the time coordinate's step; every
+  other file keeps the bare instant and reports the value as an attr.
 - ``DataPts`` is a single unsegmented trace with unsigned little-endian
   16-bit samples and the display scale documented in ``_parse_data_points``.
 - Trace samples follow pyotdr's SR-4731 display convention:
@@ -43,6 +50,11 @@ REQUIRED_BLOCKS = frozenset(
 )
 SPEED_OF_LIGHT_KM_PER_USEC = 0.299792458
 
+# Suppliers whose averaging time is known to be the standard's tenths of
+# a second. Noyes writes hundredths and EXFO whole seconds, so a value
+# from an unlisted supplier is reported but never sized into a step.
+_STANDARD_AVERAGING_SUPPLIERS = frozenset({"FIBERCLOUD"})
+
 
 @dataclass(frozen=True)
 class Block:
@@ -58,9 +70,12 @@ class SR4731PatchAttrs(PatchAttrs):
     """Patch attributes for supported SR-4731 SOR files."""
 
     wavelength_nm: OptionalFiniteFloat = None
+    pulse_width: OptionalFiniteFloat = None
     acquisition_range_m: OptionalFiniteFloat = None
     sample_spacing_usec: OptionalFiniteFloat = None
     refractive_index: OptionalFiniteFloat = None
+    averaging_time: OptionalFiniteFloat = None
+    n_averages: int = 0
     trace_count: int = 0
     sample_scale: int = 0
 
@@ -150,16 +165,40 @@ def _parse_fixed_params(payload: bytes) -> dict[str, Any]:
     # OFL100/FIBERCLOUD FxdParams fields used here:
     #   0: uint32 unix timestamp, 4: 2-byte distance unit,
     #   6: uint16 wavelength in tenths of nm,
+    #   16: uint16 pulse-width entry count,
+    #   18: uint16 pulse width in ns,
     #   20: uint32 sample spacing in 1e-8 microseconds,
     #   24: uint32 sample count,
     #   28: uint32 group index of refraction in 1e-5,
+    #   34: uint32 number of averages,
+    #   38: uint16 averaging time in tenths of a second,
     #   40: uint32 display range in 2e-5 km.
+    # Every offset past 18 assumes the single pulse-width entry the
+    # subset declares; a second entry would shift all of them, so the
+    # count is checked rather than trusted.
     timestamp = _unpack_from("<I", payload, 0)[0]
     unit = payload[4:6].decode("ascii", "replace")
     wavelength_nm = _unpack_from("<H", payload, 6)[0] / 10
+    pulse_width_entries = _unpack_from("<H", payload, 16)[0]
+    if pulse_width_entries != 1:
+        msg = (
+            "SR-4731 SOR FxdParams block declares "
+            f"{pulse_width_entries} pulse-width entries; this reader "
+            "supports the single-entry subset, whose later fields sit at "
+            "offsets another entry would shift."
+        )
+        raise InvalidFiberFileError(msg)
+    pulse_width = _unpack_from("<H", payload, 18)[0] * 1e-9
     sample_spacing_usec = _unpack_from("<I", payload, 20)[0] * 1e-8
     n_samples = _unpack_from("<I", payload, 24)[0]
     refractive_index = _unpack_from("<I", payload, 28)[0] * 1e-5
+    n_averages = _unpack_from("<I", payload, 34)[0]
+    # Tenths of a second, which is the standard's scale and the one
+    # pyotdr and otdrs both read this field with. Vendors disagree in
+    # practice -- the same half minute is written 300 here, 3000 by
+    # Noyes and 30 by EXFO -- so the value is reported as read and only
+    # trusted as a duration for a supplier known to keep the standard.
+    averaging_time = _unpack_from("<H", payload, 38)[0] * 0.1
     display_range_km = _unpack_from("<I", payload, 40)[0] * 2e-5
     if sample_spacing_usec <= 0 or refractive_index <= 0:
         msg = "SR-4731 SOR FxdParams block has invalid distance scaling fields."
@@ -171,6 +210,9 @@ def _parse_fixed_params(payload: bytes) -> dict[str, Any]:
         "timestamp": timestamp,
         "distance_unit": unit,
         "wavelength_nm": wavelength_nm,
+        "pulse_width": pulse_width,
+        "n_averages": n_averages,
+        "averaging_time": averaging_time,
         "sample_spacing_usec": sample_spacing_usec,
         "n_samples": n_samples,
         "refractive_index": refractive_index,
@@ -254,10 +296,28 @@ def _parse_sor(resource, load_samples: bool = True) -> dict[str, Any]:
 
 
 def _get_time_coord(parsed: dict[str, Any]) -> BaseCoord:
-    """Create a singleton time coordinate from the fixed-params timestamp."""
-    timestamp = parsed["fixed"]["timestamp"]
-    time = np.asarray([timestamp], dtype="datetime64[s]").astype("datetime64[ns]")
-    return get_coord(data=time)
+    """
+    Create the singleton time coordinate from the fixed-params timestamp.
+
+    A trace is one sample, and the averaging time is the span of fiber
+    time it was built from, which is what a step states: the extent the
+    sample stands for. Saying it keeps two traces taken weeks apart two
+    measurements rather than one unbroken recording, which is what a
+    stepless instant reads as.
+
+    Only a supplier known to write the standard's scale earns that,
+    since the step sizes the continuity tolerance and a vendor scale is
+    wrong by a factor of ten. A file which states no averaging time, or
+    states one this reader cannot size, keeps the bare instant.
+    """
+    fixed = parsed["fixed"]
+    start = np.datetime64(fixed["timestamp"], "s").astype("datetime64[ns]")
+    averaging_time = fixed.get("averaging_time") or 0.0
+    manufacturer = next(iter(parsed["supplier"]), "").strip().upper()
+    if averaging_time <= 0 or manufacturer not in _STANDARD_AVERAGING_SUPPLIERS:
+        return get_coord(data=np.asarray([start]))
+    step = np.timedelta64(round(averaging_time * 1e9), "ns")
+    return get_coord(start=start, stop=start + step, step=step)
 
 
 def _get_distance_coord(parsed: dict[str, Any]) -> BaseCoord:
@@ -287,9 +347,12 @@ def _get_attr_dict(parsed: dict[str, Any]) -> dict:
         "data_type": "otdr",
         "data_units": "dB",
         "wavelength_nm": parsed["fixed"]["wavelength_nm"],
+        "pulse_width": parsed["fixed"]["pulse_width"],
         "acquisition_range_m": parsed["fixed"]["acquisition_range_m"],
         "sample_spacing_usec": parsed["fixed"]["sample_spacing_usec"],
         "refractive_index": parsed["fixed"]["refractive_index"],
+        "averaging_time": parsed["fixed"]["averaging_time"],
+        "n_averages": parsed["fixed"]["n_averages"],
         "trace_count": data_points["trace_count"],
         "sample_scale": data_points["scale"],
         "interrogator.manufacturer": manufacturer,

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -150,6 +150,8 @@ VENDOR_ATTRS = frozenset(
         "amppower",
         "api",
         "average",
+        "averaging_time",
+        "n_averages",
         "channel",
         "channel_step",
         "distance_decimation_filter",

--- a/tests/test_io/test_sr4731/test_sr4731.py
+++ b/tests/test_io/test_sr4731/test_sr4731.py
@@ -14,6 +14,7 @@ from numpy.testing import assert_allclose
 import dascore as dc
 from dascore.io.sr4731 import SR4731V200
 from dascore.io.sr4731.utils import (
+    _get_attr_dict,
     _get_coords,
     _get_format,
     _get_time_coord,
@@ -131,7 +132,7 @@ def _expected_fixed_values(payload):
         "wavelength_nm": struct.unpack_from("<H", payload, 6)[0] / 10,
         "pulse_width": struct.unpack_from("<H", payload, 18)[0] * 1e-9,
         "n_averages": struct.unpack_from("<I", payload, 34)[0],
-        "averaging_time": struct.unpack_from("<H", payload, 38)[0] * 0.1,
+        "averaging_time_raw": struct.unpack_from("<H", payload, 38)[0],
         "sample_spacing_usec": sample_spacing_usec,
         "n_samples": n_samples,
         "refractive_index": refractive_index,
@@ -216,7 +217,7 @@ class TestSR4731:
         assert time.min() == expected_time
         assert time.max() == time.min()
         assert len(time) == 1
-        expected_step = np.timedelta64(round(fixed["averaging_time"] * 1e9), "ns")
+        expected_step = np.timedelta64(fixed["averaging_time_raw"] * 10**8, "ns")
         assert time.step == expected_step
 
     def test_distance_coord(self, sor_path, sor_patch):
@@ -277,19 +278,20 @@ class TestSR4731:
         assert time.step is None
         assert len(time) == 1
 
-    def test_unlisted_supplier_keeps_a_bare_instant(self):
-        """A vendor scale this reader cannot size is never made a step.
+    def test_unlisted_supplier_states_no_averaging_time(self):
+        """A vendor scale this reader cannot read is never made a duration.
 
         The same half minute is written 300 by the standard, 3000 by
-        Noyes and 30 by EXFO, and the step sizes the continuity
-        tolerance, so an unrecognised supplier keeps its instant rather
-        than a duration which may be wrong by a factor of ten.
+        Noyes and 30 by EXFO, so an unrecognised supplier keeps its bare
+        instant and reports no averaging time, rather than an axis and
+        an attr which may each be wrong by a factor of ten.
         """
         data = _make_sor_data(manufacturer=b"NOYES")
         parsed = _parse_sor(BytesIO(data), load_samples=False)
         assert _get_time_coord(parsed).step is None
-        # the value is still reported, just not sized into the axis
-        assert parsed["fixed"]["averaging_time"] == pytest.approx(5.0)
+        assert _get_attr_dict(parsed)["averaging_time"] is None
+        # the number the file states is read, it just names no duration
+        assert parsed["fixed"]["averaging_time_raw"] == 50
 
     def test_separated_traces_report_a_gap(self):
         """Two traces an hour apart are two measurements, not one run.
@@ -417,7 +419,7 @@ class TestSR4731Utils:
             "wavelength_nm": 1550.0,
             "pulse_width": pytest.approx(5e-8),
             "n_averages": 5,
-            "averaging_time": pytest.approx(5.0),
+            "averaging_time_raw": 50,
             "sample_spacing_usec": pytest.approx(0.00125003),
             "n_samples": 16384,
             "refractive_index": pytest.approx(1.46832),

--- a/tests/test_io/test_sr4731/test_sr4731.py
+++ b/tests/test_io/test_sr4731/test_sr4731.py
@@ -14,7 +14,9 @@ from numpy.testing import assert_allclose
 import dascore as dc
 from dascore.io.sr4731 import SR4731V200
 from dascore.io.sr4731.utils import (
+    _get_coords,
     _get_format,
+    _get_time_coord,
     _parse_blocks,
     _parse_data_points,
     _parse_fixed_params,
@@ -50,14 +52,25 @@ def _make_block(name, payload):
     return name.encode() + b"\0" + payload
 
 
-def _make_sor_data(fixed_n_samples=3, data_n_samples=3):
+def _make_sor_data(
+    fixed_n_samples=3,
+    data_n_samples=3,
+    averaging_raw=50,
+    timestamp=0,
+    manufacturer=b"FIBERCLOUD",
+):
     """Create a minimal supported SOR byte stream."""
     fixed = bytearray(44)
+    fixed[0:4] = np.uint32(timestamp).tobytes()
     fixed[4:6] = b"km"
     fixed[6:8] = np.uint16(15500).tobytes()
+    fixed[16:18] = np.uint16(1).tobytes()
+    fixed[18:20] = np.uint16(50).tobytes()
     fixed[20:24] = np.uint32(125003).tobytes()
     fixed[24:28] = np.uint32(fixed_n_samples).tobytes()
     fixed[28:32] = np.uint32(146832).tobytes()
+    fixed[34:38] = np.uint32(5).tobytes()
+    fixed[38:40] = np.uint16(averaging_raw).tobytes()
     fixed[40:44] = np.uint32(204805).tobytes()
 
     data_points = bytearray(12 + data_n_samples * 2)
@@ -69,7 +82,7 @@ def _make_sor_data(fixed_n_samples=3, data_n_samples=3):
 
     blocks = [
         _make_block("GenParams", b"gen\0"),
-        _make_block("SupParams", b"FIBERCLOUD\0" + b"OFL100\0" + b"0901001\0"),
+        _make_block("SupParams", manufacturer + b"\0OFL100\0" + b"0901001\0"),
         _make_block("FxdParams", bytes(fixed)),
         _make_block("DataPts", bytes(data_points)),
         _make_block("Cksum", b"\0\0"),
@@ -116,6 +129,9 @@ def _expected_fixed_values(payload):
     return {
         "timestamp": struct.unpack_from("<I", payload, 0)[0],
         "wavelength_nm": struct.unpack_from("<H", payload, 6)[0] / 10,
+        "pulse_width": struct.unpack_from("<H", payload, 18)[0] * 1e-9,
+        "n_averages": struct.unpack_from("<I", payload, 34)[0],
+        "averaging_time": struct.unpack_from("<H", payload, 38)[0] * 0.1,
         "sample_spacing_usec": sample_spacing_usec,
         "n_samples": n_samples,
         "refractive_index": refractive_index,
@@ -193,13 +209,15 @@ class TestSR4731:
         assert sor_patch.attrs.data_units == dc.get_quantity("dB")
 
     def test_time_coord(self, sor_path, sor_patch):
-        """The SOR acquisition timestamp is used as singleton time coordinate."""
+        """The timestamp is the sample and the averaging time its extent."""
         fixed = _expected_fixed_values(_get_block_payload(sor_path, "FxdParams"))
         time = sor_patch.get_coord("time")
         expected_time = np.datetime64(fixed["timestamp"], "s").astype("datetime64[ns]")
         assert time.min() == expected_time
         assert time.max() == time.min()
-        assert time.step is None
+        assert len(time) == 1
+        expected_step = np.timedelta64(round(fixed["averaging_time"] * 1e9), "ns")
+        assert time.step == expected_step
 
     def test_distance_coord(self, sor_path, sor_patch):
         """Distance coordinate is based on sample spacing and refractive index."""
@@ -229,6 +247,9 @@ class TestSR4731:
         distance = patch.get_coord("distance")
         assert patch.shape == (1, 16384)
         assert attrs.wavelength_nm == 1550.0
+        assert attrs.pulse_width == pytest.approx(5e-8)
+        assert attrs.n_averages == 5
+        assert attrs.averaging_time == pytest.approx(5.0)
         assert attrs.refractive_index == pytest.approx(1.46832)
         assert attrs.sample_spacing_usec == pytest.approx(0.00125003)
         assert attrs.acquisition_range_m == pytest.approx(4181.579556111035)
@@ -239,9 +260,59 @@ class TestSR4731:
         assert attrs.get("interrogator.serial_number") == "0901001"
         assert distance.step == pytest.approx(0.2552233615790427)
         assert patch.get_coord("time").min() == np.datetime64("2026-06-12T10:58:14")
+        assert patch.get_coord("time").step == np.timedelta64(5, "s")
         assert_allclose(patch.data[0, :5], [9.064, 10.146, 11.439, 11.98, 12.539])
         assert patch.data.min() == 0.0
         assert patch.data.max() == pytest.approx(20.304)
+
+    def test_no_averaging_time_keeps_a_bare_instant(self):
+        """A file stating no averaging time reads as it always did.
+
+        The step says how much fiber time the sample stands for, and a
+        file which does not say must not have one invented for it.
+        """
+        data = _make_sor_data(averaging_raw=0)
+        parsed = _parse_sor(BytesIO(data), load_samples=False)
+        time = _get_time_coord(parsed)
+        assert time.step is None
+        assert len(time) == 1
+
+    def test_unlisted_supplier_keeps_a_bare_instant(self):
+        """A vendor scale this reader cannot size is never made a step.
+
+        The same half minute is written 300 by the standard, 3000 by
+        Noyes and 30 by EXFO, and the step sizes the continuity
+        tolerance, so an unrecognised supplier keeps its instant rather
+        than a duration which may be wrong by a factor of ten.
+        """
+        data = _make_sor_data(manufacturer=b"NOYES")
+        parsed = _parse_sor(BytesIO(data), load_samples=False)
+        assert _get_time_coord(parsed).step is None
+        # the value is still reported, just not sized into the axis
+        assert parsed["fixed"]["averaging_time"] == pytest.approx(5.0)
+
+    def test_separated_traces_report_a_gap(self):
+        """Two traces an hour apart are two measurements, not one run.
+
+        This is what the averaging time buys: without a step the
+        continuity tolerance has no sample to scale, so the pair reads
+        as one unbroken recording and `get_coverage` calls the hour
+        between them covered.
+        """
+        first = _parse_sor(BytesIO(_make_sor_data(timestamp=1_000_000)))
+        later = _parse_sor(BytesIO(_make_sor_data(timestamp=1_003_600)))
+        patches = [
+            dc.Patch(
+                data=np.zeros((1, 3)),
+                coords=_get_coords(parsed),
+                dims=("time", "distance"),
+            )
+            for parsed in (first, later)
+        ]
+        spool = dc.spool(patches)
+        assert len(spool.get_gaps("time")) == 1
+        coverage = spool.get_coverage("time")["coverage"].iloc[0]
+        assert coverage < 0.01
 
     def test_select(self, sor_path, sor_patch):
         """Partial distance reads reduce coords and data consistently."""
@@ -331,15 +402,22 @@ class TestSR4731Utils:
         payload = bytearray(44)
         payload[4:6] = b"km"
         payload[6:8] = np.uint16(15500).tobytes()
+        payload[16:18] = np.uint16(1).tobytes()
+        payload[18:20] = np.uint16(50).tobytes()
         payload[20:24] = np.uint32(125003).tobytes()
         payload[24:28] = np.uint32(16384).tobytes()
         payload[28:32] = np.uint32(146832).tobytes()
+        payload[34:38] = np.uint32(5).tobytes()
+        payload[38:40] = np.uint16(50).tobytes()
         payload[40:44] = np.uint32(204805).tobytes()
         out = _parse_fixed_params(bytes(payload))
         assert out == {
             "timestamp": 0,
             "distance_unit": "km",
             "wavelength_nm": 1550.0,
+            "pulse_width": pytest.approx(5e-8),
+            "n_averages": 5,
+            "averaging_time": pytest.approx(5.0),
             "sample_spacing_usec": pytest.approx(0.00125003),
             "n_samples": 16384,
             "refractive_index": pytest.approx(1.46832),
@@ -352,7 +430,34 @@ class TestSR4731Utils:
         """Fixed params require sample spacing and refractive index."""
         payload = bytearray(44)
         payload[4:6] = b"km"
+        payload[16:18] = np.uint16(1).tobytes()
         with pytest.raises(dc.exceptions.InvalidFiberFileError):
+            _parse_fixed_params(bytes(payload))
+
+    def test_several_pulse_width_entries_raise(self):
+        """A second pulse-width entry shifts every field after it.
+
+        The reader trusts fixed offsets past the pulse width, so a file
+        which declares another entry must be refused rather than read
+        into a silently wrong distance axis.
+        """
+        payload = bytearray(44)
+        payload[4:6] = b"km"
+        payload[16:18] = np.uint16(2).tobytes()
+        payload[20:24] = np.uint32(125003).tobytes()
+        payload[28:32] = np.uint32(146832).tobytes()
+        with pytest.raises(dc.exceptions.InvalidFiberFileError, match="pulse-width"):
+            _parse_fixed_params(bytes(payload))
+
+    @pytest.mark.parametrize("entries", [0, 3])
+    def test_pulse_width_count_must_be_one(self, entries):
+        """Any count but one shifts the fields the reader takes on faith."""
+        payload = bytearray(44)
+        payload[4:6] = b"km"
+        payload[16:18] = np.uint16(entries).tobytes()
+        payload[20:24] = np.uint32(125003).tobytes()
+        payload[28:32] = np.uint32(146832).tobytes()
+        with pytest.raises(dc.exceptions.InvalidFiberFileError, match="pulse-width"):
             _parse_fixed_params(bytes(payload))
 
     def test_data_points_use_pyotdr_display_convention(self):


### PR DESCRIPTION
## Description

`FxdParams` states the pulse width, the number of averages and the averaging time, and the SR-4731 reader passed over all three.

The last of these matters beyond metadata. A trace is a single time sample, and without a step the continuity tolerance — which counts samples — has nothing to scale, so no two traces can ever be found separated. Two OTDR traces three weeks apart therefore read as one unbroken recording: `get_coverage` reported the group at `coverage == 1.0` and `Spool.viz.calendar` painted twenty days at 100% on days the archive holds no patch at all.

A trace is one sample built from its averaging time, which is exactly what a step states: the extent a sample stands for. Saying it makes the pair two measurements.

```python
# before: two instants, three weeks apart, neither stating a step
spool.get_coverage("time")["coverage"]    # 1.0  -- three weeks "fully covered"

# after
spool.get_coverage("time")["coverage"]    # 0.0  -- two 30 s measurements
len(spool.get_gaps("time"))               # 1    -- the three weeks between them
```

### Vocabulary

Pulse width is emitted as canonical `pulse_width` in seconds rather than a format-local spelling, so a value read from a header and the same value enriched from an inventory are one attr. `averaging_time` and `n_averages` have no inventory counterpart and are registered as vendor attrs.

### Vendor scales

The averaging time is read as the standard's tenths of a second, which is what pyOTDR and otdrs both use. Vendors disagree in practice: the same half minute is written `300` by the standard, `3000` by Noyes and `30` by EXFO. Since `get_format` accepts any version-200 file rather than only the FIBERCLOUD subset the module documents, a wrong scale here would both size the continuity tolerance wrongly and report a duration wrongly, each by a factor of ten.

So the field is kept as the count the file states, and only a supplier known to keep the standard has it read as seconds — reported as `averaging_time` and promoted to the coordinate's step. Every other file keeps the bare instant it has today and states no averaging time, which is no worse than the current behaviour and better than a number which reads as physical and is not. Widening that set is a matter of confirming one file per vendor.

### Pulse-width entry count

The fields after the pulse width sit at offsets a second pulse-width entry would shift. The reader took the single-entry layout on faith; it now checks the count and refuses anything else, in the same way it already refuses segmented `DataPts`. Such a file could only ever have been misread.

## Changelog

- added: The SR-4731 OTDR reader now reads the pulse width, number of averages and averaging time an SOR file's `FxdParams` block states, emitting the pulse width as the canonical `pulse_width` attr.
- fixed: An SR-4731 trace's time coordinate now carries its averaging time as a step, so traces recorded apart are no longer reported as one continuous recording by `get_gaps`, `get_coverage` and `Spool.viz.calendar`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SR4731 data now exposes pulse width, averaging time, and number of averages in metadata.
  - Averaging duration is interpreted in tenths of a second.
  - FIBERCLOUD files use averaging time to define time-coordinate steps.

- **Bug Fixes**
  - Invalid pulse-width configurations are rejected.
  - Separated traces now detect gaps more reliably.
  - Files without recognized averaging metadata retain a single timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
