### PR TITLE
Keep a hairline coverage box the color it states

### DIFF
--- a/dascore/viz/_lanes.py
+++ b/dascore/viz/_lanes.py
@@ -126,6 +126,12 @@ class _SeparatedBoxes(PatchCollection):
         """The separator where a box has room for it, its own color where not."""
         flat = np.column_stack([self._bounds.ravel(), np.zeros(self._bounds.size)])
         drawn = self.get_transform().transform(flat)[:, 0]
+        axes = self.axes
+        if axes is not None:
+            # What a box has room for is what it shows. A run reaching
+            # off the axis is as wide as the part of it drawn, and the
+            # rest is room it does not have here.
+            drawn = np.clip(drawn, axes.bbox.x0, axes.bbox.x1)
         widths = np.abs(np.diff(drawn.reshape(self._bounds.shape), axis=1)).ravel()
         # The renderer says what a point comes to; not every backend
         # reads it as the figure's dpi over seventy-two.
@@ -773,11 +779,20 @@ def plot_lanes(
                 )
             )
         if boxes:
+            # Widest first, so a box which can be covered is drawn over
+            # the ones which would cover it. A separator reaches past
+            # the box it borders, and the narrower the neighbour the
+            # more of it a separator drawn later takes.
+            widest = sorted(
+                range(len(boxes)),
+                key=lambda x: box_bounds[x][1] - box_bounds[x][0],
+                reverse=True,
+            )
             ax.add_collection(
                 _SeparatedBoxes(
-                    boxes,
-                    facecolors=box_colors,
-                    bounds=box_bounds,
+                    [boxes[x] for x in widest],
+                    facecolors=[box_colors[x] for x in widest],
+                    bounds=[box_bounds[x] for x in widest],
                     zorder=2,
                 )
             )

--- a/dascore/viz/_lanes.py
+++ b/dascore/viz/_lanes.py
@@ -107,29 +107,37 @@ class _SeparatedBoxes(PatchCollection):
             linewidth=SEPARATOR_WIDTH,
             **kwargs,
         )
-        self._faces = to_rgba_array(facecolors)
         self._bounds = np.asarray(bounds, dtype=float)
 
     def draw(self, renderer):
-        # How much room a box has is settled by the axis it is drawn
-        # on, so it is answered again at every draw rather than once.
-        colors = self._edge_colors()
+        # How much room a box has is settled by the axis it is drawn on
+        # and by what the renderer makes of a point, so it is answered
+        # again at every draw rather than once.
+        stale = self.stale
+        colors = self._edge_colors(renderer)
         self.set_edgecolor(colors)  # ty: ignore[invalid-argument-type]
+        # Choosing a color is how this collection draws itself rather
+        # than a change made to it, and a blit which drew it on its own
+        # would otherwise be left with a figure asking to be drawn again.
+        self.stale = stale
         super().draw(renderer)
 
-    def _edge_colors(self) -> np.ndarray:
+    def _edge_colors(self, renderer) -> np.ndarray:
         """The separator where a box has room for it, its own color where not."""
-        figure = self.get_figure()
-        # A collection with no figure is not being drawn to a canvas,
-        # and points are what it is measured in until it is.
-        dpi = _MEASURED_DPI if figure is None else figure.dpi
         flat = np.column_stack([self._bounds.ravel(), np.zeros(self._bounds.size)])
         drawn = self.get_transform().transform(flat)[:, 0]
         widths = np.abs(np.diff(drawn.reshape(self._bounds.shape), axis=1)).ravel()
-        stroke = SEPARATOR_WIDTH * dpi / _MEASURED_DPI
-        edges = np.tile(to_rgba_array(SEPARATOR_COLOR), (len(self._faces), 1))
+        # The renderer says what a point comes to; not every backend
+        # reads it as the figure's dpi over seventy-two.
+        stroke = renderer.points_to_pixels(SEPARATOR_WIDTH)
+        edges = np.tile(to_rgba_array(SEPARATOR_COLOR), (len(widths), 1))
         cramped = widths < _SEPARATOR_ROOM * stroke
-        edges[cramped] = self._faces[cramped]
+        # Read now rather than kept, so a box recolored after it was
+        # built is edged in the color it states now. One color may stand
+        # for every box, as matplotlib lets it, so the colors cycle.
+        faces = self.get_facecolor()
+        if len(faces):
+            edges[cramped] = faces[np.nonzero(cramped)[0] % len(faces)]
         return edges
 
 

--- a/dascore/viz/_lanes.py
+++ b/dascore/viz/_lanes.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.collections import PatchCollection
-from matplotlib.colors import BoundaryNorm, ListedColormap
+from matplotlib.colors import BoundaryNorm, ListedColormap, to_rgba_array
 from matplotlib.font_manager import FontProperties
 from matplotlib.layout_engine import ConstrainedLayoutEngine
 from matplotlib.patches import Patch as PatchArtist
@@ -40,6 +40,14 @@ WHEEL_ORDER = (0, 2, 4, 6, 8, 10, 12, 16, 18, 1, 3, 5, 7, 9, 11, 13, 17, 19)
 LANE_CMAP = "tab10"
 NUMERIC_CMAP = "viridis"
 UNCOVERED_COLOR = "0.7"
+
+# One box is parted from the next by a stroke of this width, in points.
+SEPARATOR_COLOR = "white"
+SEPARATOR_WIDTH = 0.5
+# How many separators wide a box must be before it can afford to carry
+# one. Two leaves a box at least as much of itself as it gives away.
+_SEPARATOR_ROOM = 2.0
+
 
 # The wheel holds every color tab20 offers which is not a grey, so a
 # palette past it can only repeat itself. Values then walk the hue circle:
@@ -77,6 +85,52 @@ _MAX_SUB_ROWS = 8
 # Past this many distinct numbers a lane earns a colorbar rather than
 # relying on the value printed in each box.
 _MAX_DISCRETE = 6
+
+
+class _SeparatedBoxes(PatchCollection):
+    """
+    Boxes parted by a stroke which never outgrows the box it borders.
+
+    The separator is a fixed width while a box is however wide the axis
+    makes it, so a box narrower than the stroke is painted out by its
+    own edge: it reads as the background rather than as itself. A short
+    gap between two long runs is exactly that box, and drawing it white
+    says there is no gap. So a box without the room for a separator is
+    stroked in its own color instead, which reads as itself down to the
+    pixel, and takes the separator back up once a zoom gives it room.
+    """
+
+    def __init__(self, patches, *, facecolors, bounds, **kwargs):
+        super().__init__(
+            patches,
+            facecolors=facecolors,
+            linewidth=SEPARATOR_WIDTH,
+            **kwargs,
+        )
+        self._faces = to_rgba_array(facecolors)
+        self._bounds = np.asarray(bounds, dtype=float)
+
+    def draw(self, renderer):
+        # How much room a box has is settled by the axis it is drawn
+        # on, so it is answered again at every draw rather than once.
+        colors = self._edge_colors()
+        self.set_edgecolor(colors)  # ty: ignore[invalid-argument-type]
+        super().draw(renderer)
+
+    def _edge_colors(self) -> np.ndarray:
+        """The separator where a box has room for it, its own color where not."""
+        figure = self.get_figure()
+        # A collection with no figure is not being drawn to a canvas,
+        # and points are what it is measured in until it is.
+        dpi = _MEASURED_DPI if figure is None else figure.dpi
+        flat = np.column_stack([self._bounds.ravel(), np.zeros(self._bounds.size)])
+        drawn = self.get_transform().transform(flat)[:, 0]
+        widths = np.abs(np.diff(drawn.reshape(self._bounds.shape), axis=1)).ravel()
+        stroke = SEPARATOR_WIDTH * dpi / _MEASURED_DPI
+        edges = np.tile(to_rgba_array(SEPARATOR_COLOR), (len(self._faces), 1))
+        cramped = widths < _SEPARATOR_ROOM * stroke
+        edges[cramped] = self._faces[cramped]
+        return edges
 
 
 def _as_numeric(values):
@@ -686,7 +740,8 @@ def plot_lanes(
             legend_entries.update(described[1])
         elif described and described[0] == "colorbar":
             colorbars.append(described[1])
-        boxes, box_colors, points, point_colors = [], [], [], []
+        boxes, box_colors, box_bounds = [], [], []
+        points, point_colors = [], []
         for (_, row), row_color, sub in zip(
             rows.iterrows(), colors, sub_rows, strict=True
         ):
@@ -699,6 +754,7 @@ def plot_lanes(
                 continue
             boxes.append(Rectangle((row["start"], low), width, height))
             box_colors.append(row_color)
+            box_bounds.append((row["start"], row["end"]))
             placements.append(
                 (
                     row["label"],
@@ -710,11 +766,10 @@ def plot_lanes(
             )
         if boxes:
             ax.add_collection(
-                PatchCollection(
+                _SeparatedBoxes(
                     boxes,
                     facecolors=box_colors,
-                    edgecolor="white",
-                    linewidth=0.5,
+                    bounds=box_bounds,
                     zorder=2,
                 )
             )

--- a/dascore/viz/spool.py
+++ b/dascore/viz/spool.py
@@ -43,6 +43,12 @@ _GAP_TICKS = (1.0, 60.0, 600.0, 3_600.0, 6 * 3_600.0, _SECONDS_IN_DAY)
 # is drawn over, so naming the lane with them would repeat the axis.
 _ENVELOPE_SUFFIXES = ("min", "max", "step", "units")
 
+# What names a group which shares every attribute it states with the
+# others, or states none: the key the acquisition is filed under. It is
+# the first of the config's `patch_kind_attrs`, and the one of them
+# which names a place rather than describing it.
+_ACQUISITION_ATTR = "acquisition_key"
+
 # Steps a duration is worth reading in, largest first. A year is the
 # Gregorian mean, the same one numpy converts a timedelta64 with, since
 # a multi-year outage reads as "40.7 y" rather than "14852 d".
@@ -111,11 +117,19 @@ def _lane_names(report: pd.DataFrame, dim: str) -> list[str]:
     telling = [x for x in stated if report[x].astype(str).nunique() > 1]
     described = []
     for _, row in report.iterrows():
-        # A group which recorded nothing is left blank here and named by
-        # its ordinal below; the blank is a value it states, but drawing
-        # it as an empty label would read as a rendering gap.
         stated_values = (str(row[x]) for x in telling if pd.notnull(row[x]))
         parts = [x for x in stated_values if x]
+        # Nothing tells a lone group apart, since there is nothing to
+        # tell it apart from, and every group of a spool of one
+        # acquisition is in that position. It is still a named
+        # acquisition, and its key says what its ordinal cannot.
+        if not parts:
+            key = row.get(_ACQUISITION_ATTR)
+            if pd.notnull(key) and str(key):
+                parts = [str(key)]
+        # A group which states neither is left blank here and named by
+        # its ordinal below; the blank is a value it states, but drawing
+        # it as an empty label would read as a rendering gap.
         described.append(" · ".join(parts))
     # Two groups can state the same attributes and still be two groups —
     # sampling rate and coordinate structure part them without being

--- a/tests/test_viz/test_lanes.py
+++ b/tests/test_viz/test_lanes.py
@@ -11,11 +11,13 @@ import pandas as pd
 import pytest
 from matplotlib.backends.backend_pdf import FigureCanvasPdf
 from matplotlib.collections import PatchCollection
+from matplotlib.colors import to_rgba_array
 from matplotlib.figure import Figure
 
 from dascore.exceptions import ParameterError
 from dascore.viz._lanes import (
     _LABEL_PAD,
+    SEPARATOR_COLOR,
     UNCOVERED_COLOR,
     WHEEL_ORDER,
     _pack_rows,
@@ -695,3 +697,41 @@ class TestColors:
         """legend=False draws none."""
         ax = plot_lanes(string_frame, lane="group", value="value", legend=False)
         assert ax.get_legend() is None
+
+
+class TestSeparator:
+    """The stroke which parts one box from the next."""
+
+    @staticmethod
+    def _edges(frame):
+        """The edge color of each box, as the renderer settles it."""
+        ax = plot_lanes(frame)
+        ax.get_figure().canvas.draw()
+        return _collections(ax)[0].get_edgecolor()
+
+    def test_a_box_with_room_carries_the_separator(self):
+        """Two boxes wide enough to be parted are parted by it."""
+        frame = pd.DataFrame({"start": [0.0, 10.0], "end": [5.0, 15.0]})
+        edges = self._edges(frame)
+        assert np.allclose(edges, to_rgba_array(SEPARATOR_COLOR))
+
+    def test_a_box_without_room_keeps_its_own_color(self):
+        """A box thinner than the separator would be painted out by it.
+
+        Drawing it as the separator says the interval is not there,
+        which for a short gap between two long runs is a lie.
+        """
+        frame = pd.DataFrame({"start": [0.0, 5.0], "end": [5.0, 5.0 + 1e-6]})
+        edges = self._edges(frame)
+        faces = _collections(plot_lanes(frame))[0].get_facecolor()
+        assert np.allclose(edges[0], to_rgba_array(SEPARATOR_COLOR))
+        assert np.allclose(edges[1], faces[1])
+
+    def test_zooming_in_gives_a_box_its_separator_back(self):
+        """The room a box has is the room the axis gives it, at each draw."""
+        frame = pd.DataFrame({"start": [0.0, 5.0], "end": [5.0, 5.0 + 1e-6]})
+        ax = plot_lanes(frame)
+        ax.set_xlim(5.0 - 1e-7, 5.0 + 2e-6)
+        ax.get_figure().canvas.draw()
+        edges = _collections(ax)[0].get_edgecolor()
+        assert np.allclose(edges[1], to_rgba_array(SEPARATOR_COLOR))

--- a/tests/test_viz/test_lanes.py
+++ b/tests/test_viz/test_lanes.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 from matplotlib.backends.backend_pdf import FigureCanvasPdf
 from matplotlib.collections import PatchCollection
-from matplotlib.colors import to_rgba_array
+from matplotlib.colors import to_rgba, to_rgba_array
 from matplotlib.figure import Figure
 
 from dascore.exceptions import ParameterError
@@ -138,7 +138,9 @@ class TestReadFrame:
         limits = pd.to_datetime(["2024-01-01", "2024-01-06"]).to_numpy()
         ax = plot_lanes(frame, x_limits=limits)
         widths = [w for _, w in _extents(_collections(ax)[0])]
-        assert widths == pytest.approx([1.0, 2.0])
+        # Sorted, since boxes are drawn widest first rather than in the
+        # order the frame states them.
+        assert sorted(widths) == pytest.approx([1.0, 2.0])
 
     def test_timezone_aware_bounds(self):
         """Zoned datetimes are drawn at their UTC instant."""
@@ -737,6 +739,51 @@ class TestSeparator:
         boxes.set_facecolor("red")
         ax.get_figure().canvas.draw()
         assert np.allclose(boxes.get_edgecolor()[1], to_rgba_array("red"))
+
+    @staticmethod
+    def _pixel(ax, x):
+        """The color drawn at one place on the lane, as rendered."""
+        figure = ax.get_figure()
+        figure.canvas.draw()
+        transform = ax.transData
+        buffer = np.asarray(figure.canvas.buffer_rgba())[..., :3].astype(float)
+        column = int(np.round(transform.transform([[x, 0.0]])[0][0]))
+        row = buffer.shape[0] - int(transform.transform([[0.0, 0.0]])[0][1])
+        return buffer[row - 4 : row + 4, column].mean(axis=0) / 255
+
+    @pytest.mark.parametrize("kind", ["first", "last"])
+    def test_a_cramped_box_is_drawn_over_its_neighbours(self, kind):
+        """A separator reaches past the box it borders, onto the next one.
+
+        So a box too narrow to carry one is covered by a neighbour's,
+        whichever of them the frame states first, unless it is drawn
+        last. Both orders occur: a lane of runs and gaps states every
+        run before every gap, which leaves a short run bordered by two
+        separators drawn after it.
+        """
+        wide = pd.DataFrame(
+            {
+                "start": [0.0, 150.0, 100.0, 150.0001],
+                "end": [100.0, 150.0001, 150.0, 300.0],
+                "v": ["a", "a", "b", "b"],
+            }
+        )
+        frame = wide if kind == "first" else wide.iloc[::-1]
+        ax = plot_lanes(frame, value="v", color={"a": "blue", "b": "orange"})
+        assert np.allclose(self._pixel(ax, 150.00005), to_rgba("blue")[:3], atol=0.4)
+
+    def test_a_clipped_box_is_measured_by_what_it_shows(self):
+        """A box reaching off the axis has only the room it is drawn in.
+
+        Measured whole it looks wide enough for a separator, which then
+        covers the sliver of it the window actually holds.
+        """
+        frame = pd.DataFrame(
+            {"start": [0.0, 99.001], "end": [99.001, 200.0], "v": ["a", "b"]}
+        )
+        ax = plot_lanes(frame, value="v", color={"a": "blue", "b": "orange"})
+        ax.set_xlim(99.0, 101.0)
+        assert np.allclose(self._pixel(ax, 99.0005), to_rgba("blue")[:3], atol=0.4)
 
     def test_zooming_in_gives_a_box_its_separator_back(self):
         """The room a box has is the room the axis gives it, at each draw."""

--- a/tests/test_viz/test_lanes.py
+++ b/tests/test_viz/test_lanes.py
@@ -727,6 +727,17 @@ class TestSeparator:
         assert np.allclose(edges[0], to_rgba_array(SEPARATOR_COLOR))
         assert np.allclose(edges[1], faces[1])
 
+    def test_recoloring_a_box_recolors_the_stroke(self):
+        """A box edged in its own color is edged in the one it states now."""
+        frame = pd.DataFrame({"start": [0.0, 5.0], "end": [5.0, 5.0 + 1e-6]})
+        ax = plot_lanes(frame)
+        boxes = _collections(ax)[0]
+        # One color for every box, which is what a caller reaching for
+        # the collection is most likely to set.
+        boxes.set_facecolor("red")
+        ax.get_figure().canvas.draw()
+        assert np.allclose(boxes.get_edgecolor()[1], to_rgba_array("red"))
+
     def test_zooming_in_gives_a_box_its_separator_back(self):
         """The room a box has is the room the axis gives it, at each draw."""
         frame = pd.DataFrame({"start": [0.0, 5.0], "end": [5.0, 5.0 + 1e-6]})

--- a/tests/test_viz/test_spool_viz.py
+++ b/tests/test_viz/test_spool_viz.py
@@ -385,6 +385,25 @@ class TestNaming:
         names = spool_viz._lane_names(spool.get_coverage("time"), "time")
         assert [x.split()[0] for x in names] == ["DAS1.R1..RAW", "DAS2.R2..RAW"]
 
+    def test_a_lone_group_is_named_by_its_key(self):
+        """Nothing tells one group apart, so its key says which it is."""
+        spool = dc.get_example_spool("random_das", acquisition_key="DAS1.R1..RAW")
+        names = spool_viz._lane_names(spool.get_coverage("time"), "time")
+        assert [x.split()[0] for x in names] == ["DAS1.R1..RAW"]
+
+    def test_a_group_without_a_key_falls_back_to_its_ordinal(self):
+        """A group states no key, so only its ordinal is left to name it."""
+        report = pd.DataFrame(
+            {
+                "group_id": [0],
+                "coverage": [1.0],
+                "acquisition_key": [""],
+                "time_min": [0.0],
+                "time_max": [1.0],
+            }
+        )
+        assert spool_viz._lane_names(report, "time") == ["group 0  100%"]
+
     def test_an_unrecorded_attr_is_not_a_value(self, diverse):
         """A group which states no acquisition key is not named by a blank."""
         names = spool_viz._lane_names(diverse.get_coverage("time"), "time")


### PR DESCRIPTION
## Description

Two fixes to what a coverage lane says about a spool, both found while plotting an archive whose acquisitions differ in length by four orders of magnitude.

**A hairline box was painted out by its own separator.** Every box in a lane plot carried a 0.5 point white stroke to part it from the next one. The stroke is a fixed width while a box is however wide the axis makes it, so a box narrower than the stroke was covered by its own edge and read as the background. A short gap between two long runs is exactly that box: on a spool of half-hourly DAS files, the sub-second gaps between them drew as white, which says there is no gap at all. Zooming in showed them; zoomed out, a 99.6% lane looked unbroken.

A box without the room for a separator is now stroked in its own color instead, so it reads as itself down to the pixel. How much room a box has is settled by the axis it is drawn on, so `_SeparatedBoxes` answers it at every draw rather than once, and a box takes the separator back as soon as a zoom gives it the width. Nothing changes for a box wide enough to afford one.

The same reasoning covers a short run as well as a short gap: a fifteen second acquisition drawn across two days went from zero visible pixels to a readable tick.

**A lone lane was named "group 0".** A lane is named by whatever attribute tells it apart from the others, and nothing tells one group apart, since there is nothing to tell it apart from. So `spool.select(tag="DAS_LF").viz.coverage()` drew a lane called `group 0` while the spool held the key the acquisition is filed under. The key now names the lane where the attributes cannot, and the ordinal is left for a group which states no key.

## Changelog

- fixed: A gap too short to fill a pixel is drawn in its own color rather than in the stroke which parts one box from the next, so `Spool.viz.coverage` shows it without zooming in.
- changed: A coverage lane which no attribute tells apart is named by its acquisition key, and falls back to its ordinal only when the group states no key.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
