### PR TITLE
Always return an evenly sampled distance coord from Febus readers

### DIFF
--- a/dascore/io/febus/__init__.py
+++ b/dascore/io/febus/__init__.py
@@ -13,6 +13,23 @@ A1 files report ``interrogator.name`` from the Source's ``Hostname`` (eg
 ``interrogator.manufacturer`` and ``interrogator.model`` are asserted by the
 format, not read from the header. The G1 BSL and MTX HDF5 files carry no
 interrogator metadata, so they report none.
+
+Distance sampling
+-----------------
+The interrogator fixes the spatial sampling, so a read returns an evenly
+sampled ``distance`` coordinate. A1 files state the spacing in the header and
+the coordinate is built from it. The G1 BSL/MTX HDF5 and T1 files instead
+store a distance per sample, and those arrays can carry sub-step jitter: the
+G1 files seen so far hold an even grid restated in float32, whose
+quantization exceeds the tolerance ``get_coord`` uses to recognize an even
+coordinate and leaves a monotonic coord with no step. Those are put back on
+the grid they restate.
+
+The correction is well under a millimeter on the files seen so far, but it is
+not bounded in principle: a file whose distance axis were genuinely
+discontinuous, such as one covering several acquisition zones, would be
+smeared onto a single grid. ``scan(..., snap=False)`` reports the stored
+values exactly, for ``distance`` as for ``time``.
 """
 
 from __future__ import annotations

--- a/dascore/io/febus/g1utils.py
+++ b/dascore/io/febus/g1utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import numpy as np
 
 import dascore as dc
-from dascore.io.utils import get_exact_coord
+from dascore.io.utils import get_exact_coord, get_gridded_coord
 from dascore.utils.misc import maybe_get_items, unbyte
 
 _G1_H5_BASE_DATASETS = frozenset(
@@ -207,7 +207,15 @@ def _get_g1_h5_base_coords(resource, dims, extra_coords=None, snap=True):
     # the jitter into a linear drift. Built exactly, and ignoring `snap`,
     # because that jitter is the signal.
     sample_span = get_exact_coord(dc.to_timedelta64(ends - starts))
-    distance = _coord(resource["distances"][...], units="m")
+    # The interrogator fixes the spatial sampling, so the stored distances
+    # only restate a grid, quantized to float32. That quantization can exceed
+    # the tolerance get_coord uses to recognize an even coordinate, leaving a
+    # monotonic coord with no step, so put it back on the grid it restates.
+    distances = resource["distances"][...]
+    if snap:
+        distance = get_gridded_coord(distances, units="m")
+    else:
+        distance = get_exact_coord(distances, units="m")
     temperature = _coord(resource["temperatures"][...], units="°C")
     coords = {
         "time": time,

--- a/dascore/io/febus/t1utils.py
+++ b/dascore/io/febus/t1utils.py
@@ -8,7 +8,7 @@ import dascore as dc
 from dascore import get_coord_manager
 from dascore.constants import timeable_types
 from dascore.io.core import make_scan_payload
-from dascore.io.utils import drop_blank_attrs, get_exact_coord
+from dascore.io.utils import drop_blank_attrs, get_exact_coord, get_gridded_coord
 from dascore.utils.hdf5 import H5Reader
 from dascore.utils.misc import maybe_get_items
 
@@ -27,10 +27,15 @@ def _is_t1_file(fi: H5Reader) -> bool:
 
 
 def _get_distance_coord(fi, snap=True):
-    """Get the distances from the T1 file"""
+    """
+    Get the distances from the T1 file.
+
+    The interrogator fixes the spatial sampling, so the snapped path puts the
+    stored values back on the grid they restate.
+    """
     dist = fi["Data/Distance"][()]
     if snap:
-        return dc.get_coord(values=dist, units="m")
+        return get_gridded_coord(dist, units="m")
     return get_exact_coord(dist, units="m")
 
 
@@ -44,6 +49,7 @@ def _get_time_coord(fi, snap=True):
 
 
 def _get_coords(fi, snap=True) -> dc.CoordManager:
+    """Return the T1 coord manager."""
     time_coord = _get_time_coord(fi, snap=snap)
     distance_coord = _get_distance_coord(fi, snap=snap)
     dims = ("time", "distance")

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -152,6 +152,37 @@ def build_patches(
     return [dc.Patch(data=data[...], coords=coords, attrs=patch_attrs)]
 
 
+def get_gridded_coord(values, units=None) -> BaseCoord:
+    """
+    Return a stored coordinate array forced onto an even grid.
+
+    For axes the instrument samples on a fixed grid, where the stored values
+    only restate that grid and any departure from it is representation noise.
+    Such an array can jitter past the tolerance `get_coord` uses to recognize
+    an even coordinate and leave a monotonic coord with no step.
+
+    Parameters
+    ----------
+    values
+        The stored coordinate values.
+    units
+        Units to attach to the returned coordinate.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dascore.io.utils import get_gridded_coord
+    >>> # an even grid restated in float32, as some formats store it
+    >>> values = np.linspace(4000.0, 4009.9, 100, dtype=np.float32)
+    >>> coord = get_gridded_coord(values.astype(np.float64), units="m")
+    >>> float(round(coord.step, 4))
+    0.1
+    """
+    coord = get_coord(data=np.atleast_1d(np.asarray(values)), units=units)
+    # A lone sample states no spacing, and snap would invent a step of 1.
+    return coord.snap() if len(coord) > 1 else coord
+
+
 def get_exact_coord(values, units=None) -> BaseCoord:
     """Return an exact coordinate, including for non-monotonic values."""
     # atleast_1d matches get_coord(values=...): a squeezed single-sample

--- a/tests/test_io/test_febus/test_febusbsl.py
+++ b/tests/test_io/test_febus/test_febusbsl.py
@@ -10,11 +10,20 @@ import pytest
 from numpy.testing import assert_allclose
 
 import dascore as dc
+from dascore.core.coords import CoordMonotonicArray, CoordRange
 from dascore.io.febus import FebusBSLH5V1
 from dascore.io.febus.g1utils import _get_g1_h5_base_coords
 from dascore.utils.downloader import fetch
 
 BSL_NAME = "febusg1_C2_2026-06-03T17.18.13+0200.bsl.h5"
+
+# A distance array with the signature real G1 files have: an even grid
+# restated in float32, so consecutive steps differ in the last bit. The
+# offset matters; nearer the origin the quantization is fine enough that
+# get_coord still recognizes the grid and the tests below go vacuous.
+_QUANTIZED_DISTANCE = np.linspace(
+    4000.0, 4000.0 + 99 * 0.1, 100, dtype=np.float32
+).astype(np.float64)
 
 
 class TestFebusBSL:
@@ -64,8 +73,9 @@ class TestFebusBSL:
         assert bsl_patch.coords.dim_map["temperature"] == ("time",)
 
     def test_distance_range(self, bsl_patch):
-        """Distance should span 50-149 m."""
+        """Distance should span 50-149 m on an even grid."""
         dist = bsl_patch.get_coord("distance")
+        assert isinstance(dist, CoordRange)
         assert_allclose(dist.min(), 50.0)
         assert_allclose(dist.max(), 149.0)
         assert_allclose(dist.step, 1.0)
@@ -185,3 +195,76 @@ class TestFebusBSL:
         assert out.get_coord("time").max() == time.values[20]
         assert_allclose(out.get_coord("distance").min(), 55.0)
         assert_allclose(out.get_coord("distance").max(), 60.0)
+
+
+class TestG1DistanceGrid:
+    """A read grids the stored distances; snap=False still reports them raw."""
+
+    @staticmethod
+    def _coords(distances, temperatures=None, snap=True):
+        """Build the shared G1 coords around a given distance array."""
+        starts = np.array([0.0, 1.0, 2.05, 3.0])
+        if temperatures is None:
+            temperatures = np.zeros(len(starts), dtype=np.float64)
+        return _get_g1_h5_base_coords(
+            {
+                "start_times": starts,
+                "end_times": starts + 0.5,
+                "distances": distances,
+                "temperatures": temperatures,
+            },
+            dims=("time", "distance"),
+            snap=snap,
+        )
+
+    def test_quantized_distance_is_uneven_on_its_own(self):
+        """The fixture array must actually defeat get_coord's tolerance.
+
+        Without this the snapping tests would pass even if the reader stopped
+        snapping, or if that tolerance were ever loosened.
+        """
+        coord = dc.get_coord(data=_QUANTIZED_DISTANCE, units="m")
+        assert isinstance(coord, CoordMonotonicArray)
+        assert coord.step is None
+
+    def test_quantized_distance_is_snapped(self):
+        """A float32-quantized distance array still reads as an even grid."""
+        coord = self._coords(_QUANTIZED_DISTANCE).coord_map["distance"]
+        assert isinstance(coord, CoordRange)
+        assert_allclose(coord.step, 0.1, rtol=1e-3)
+        # Snapping moves interior values only; the ends are the stored ones.
+        assert coord.min() == _QUANTIZED_DISTANCE[0]
+        assert coord.max() == _QUANTIZED_DISTANCE[-1]
+        assert len(coord) == len(_QUANTIZED_DISTANCE)
+
+    def test_even_distance_is_unchanged(self):
+        """Snapping a distance array that is already even is a no-op."""
+        distances = np.arange(100, dtype=np.float64)
+        coord = self._coords(distances).coord_map["distance"]
+        assert isinstance(coord, CoordRange)
+        assert coord.step == 1.0
+        assert np.array_equal(coord.values, distances)
+
+    def test_distance_exact_when_snap_false(self):
+        """snap=False still reports the stored distances exactly."""
+        coords = self._coords(_QUANTIZED_DISTANCE, snap=False)
+        distance = coords.coord_map["distance"]
+        assert np.array_equal(distance.values, _QUANTIZED_DISTANCE)
+        # The jittery start times are the file's own, so they stay exact too.
+        expected = dc.to_datetime64(np.array([0.0, 1.0, 2.05, 3.0]))
+        assert np.array_equal(coords.coord_map["time"].values, expected)
+
+    def test_single_channel_states_no_step(self):
+        """One channel states no spacing, so none should be invented."""
+        coord = self._coords(np.array([42.0])).coord_map["distance"]
+        assert len(coord) == 1
+        assert coord.step is None
+        assert coord.min() == 42.0
+
+    def test_temperature_exact_when_snap_false(self):
+        """Distance snapping must not leak into the shared coord helper."""
+        temperatures = np.array([10.0, 11.0, 13.5, 14.0])
+        coords = self._coords(
+            _QUANTIZED_DISTANCE, temperatures=temperatures, snap=False
+        )
+        assert np.array_equal(coords.coord_map["temperature"].values, temperatures)

--- a/tests/test_io/test_febus/test_febust1.py
+++ b/tests/test_io/test_febus/test_febust1.py
@@ -10,7 +10,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 import dascore as dc
-from dascore.core.coords import CoordMonotonicArray
+from dascore.core.coords import CoordMonotonicArray, CoordRange
 from dascore.io.febus import FebusT1V1
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import unbyte
@@ -48,8 +48,9 @@ class TestFebusT1:
         assert_allclose(step_minutes, 5.35, rtol=1e-3)
 
     def test_distance_range(self, t1_patch):
-        """Distance should span roughly 0-90 m."""
+        """Distance should span roughly 0-90 m on an even grid."""
         dist = t1_patch.get_coord("distance")
+        assert isinstance(dist, CoordRange)
         assert dist.min() >= 0
         assert_allclose(dist.max(), 89.9, rtol=1e-3)
         assert_allclose(dist.step, 0.0816, rtol=1e-3)
@@ -116,3 +117,62 @@ class TestFebusT1Interrogator:
         attrs = dict(dc.scan(path)[0].attrs)
         assert "interrogator.name" not in attrs
         assert attrs["interrogator.model"] == "T1"
+
+
+class TestFebusT1DistanceGrid:
+    """A read grids the stored distances; snap=False still reports them raw."""
+
+    parser = FebusT1V1()
+
+    @pytest.fixture(scope="class")
+    def t1_path(self):
+        """Path to a 12-reading T1 test file."""
+        return fetch("febus_dts.h5")
+
+    @pytest.fixture(scope="class")
+    def quantized_distance(self):
+        """An even grid restated in float32.
+
+        The registered T1 files are float64-precise, but nothing in the format
+        stops a T1 file carrying the same quantization the G1 files do, and
+        the reader should handle it the same way.
+
+        The offset matters; nearer the origin the quantization is fine enough
+        that get_coord still recognizes the grid on its own.
+        """
+        return np.linspace(2000.0, 2000.0 + 1102 * 0.1, 1103, dtype=np.float32).astype(
+            np.float64
+        )
+
+    def test_fixture_is_uneven_on_its_own(self, quantized_distance):
+        """The array must actually defeat get_coord, or the next test is moot."""
+        coord = dc.get_coord(values=quantized_distance, units="m")
+        assert isinstance(coord, CoordMonotonicArray)
+        assert coord.step is None
+
+    def test_quantized_distance_is_snapped(self, t1_path, tmp_path, quantized_distance):
+        """A float32-quantized distance array still reads as an even grid."""
+        path = tmp_path / "quantized_distance.h5"
+        shutil.copy2(t1_path, path)
+        with h5py.File(path, "r+") as fi:
+            del fi["Data/Distance"]
+            fi.create_dataset("Data/Distance", data=quantized_distance)
+        dist = self.parser.read(path)[0].get_coord("distance")
+        assert isinstance(dist, CoordRange)
+        assert_allclose(dist.step, 0.1, rtol=1e-3)
+        assert dist.min() == quantized_distance[0]
+        assert dist.max() == quantized_distance[-1]
+        assert len(dist) == len(quantized_distance)
+
+    def test_distance_exact_when_snap_false(
+        self, t1_path, tmp_path, quantized_distance
+    ):
+        """snap=False still reports the stored distances exactly."""
+        path = tmp_path / "quantized_distance_exact.h5"
+        shutil.copy2(t1_path, path)
+        with h5py.File(path, "r+") as fi:
+            del fi["Data/Distance"]
+            fi.create_dataset("Data/Distance", data=quantized_distance)
+        payload = dc.scan_payloads(path, snap=False)[0]
+        dist = payload["coords"].coord_map["distance"]
+        assert np.array_equal(dist.values, quantized_distance)


### PR DESCRIPTION
## Description

The G1 BSL/MTX HDF5 and T1 Febus readers built `distance` from the per-sample array the file
stores. Real G1 BSL files hold an even grid restated in float32, so for a nominal 0.1 m spacing
the steps span 0.099853515625 … 0.100097656250 — a relative spread of 2.44e-3. `get_coord`
decides evenness with `np.allclose(diffs, median, rtol=0.001)` (`all_diffs_close_enough`), so
the coordinate degraded to a `CoordMonotonicArray` with `step=None`.

Downstream that means `distance_step` is `NaN` in spool contents, and `Patch.viz.waterfall`
takes the `pcolormesh` branch — a 2.2M-quad `QuadMesh` rather than an `imshow`, ~3x the draw
time, re-rendered on every pan and zoom.

The spatial sampling of a Febus interrogator is fixed by the instrument; the stored array
restates it rather than measuring it. So snap the array back onto a grid, and do it whatever
`snap` says — the same choice `terra15`, `prodml`, and `ap_sensing` already make by not
consulting `snap` in their distance builders, and the same choice the A1 Febus reader already
makes by building distance from `Spacing`/`Origin`. `snap` still governs `time` and
`sample_span`, where the jitter is real signal.

This also *reduces* scan/read divergence rather than adding it: no Febus `read()` accepts
`snap` today, so `read()` and `scan(snap=False)` already disagreed about distance; now they
agree bit-for-bit.

`snap()` is a no-op on an already-even coordinate, so every existing Febus fixture is
unaffected — none of them reproduce the problem (the BSL and MTX files have an exactly 1.0 m
step, both DTS files are regular to 7e-13). The new tests therefore build the quantized case
synthetically, with a guard test asserting the fixture array really does defeat `get_coord`
so the snapping tests cannot pass vacuously.

Verified on a 48-file `febus_bsl_h5` DSS set: `distance` is now a `CoordRange` with
`step=0.09999999486`, `min=850.0`, `max=2749.89990234375` over 19000 samples, `distance_step`
scans as 0.1 rather than `NaN`, and `waterfall` takes the `imshow` path.

The `snap` contract in `FiberIO.scan` and `docs/contributing/new_format.qmd` gains one clause
so instrument-fixed coordinates are inside the documented carve-out rather than an unstated
exception.

## Changelog

- fixed: Febus G1 HDF5 and T1 readers now always return an evenly sampled `distance` coordinate, so float32-quantized distance arrays no longer degrade into a monotonic coordinate with no step.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distance-coordinate handling for FEBUS G1 and T1 data.
  * Distance values are now consistently recognized as evenly spaced where appropriate, including data affected by float32 precision.
  * Preserved exact stored distance values when scanning with snapping disabled.
  * Maintained accurate handling for single-channel data and associated temperature values.

* **Documentation**
  * Documented distance sampling behavior across supported FEBUS formats, including precision-related considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->