### PR TITLE
Say what a spool spans and what it holds

### DIFF
--- a/dascore/config.py
+++ b/dascore/config.py
@@ -62,9 +62,9 @@ class DascoreConfig(BaseModel):
         ge=0,
         description=(
             "Patches a spool may hold before its repr stops summarizing "
-            "what it covers. Summarizing realizes the whole index "
-            "relation, which past this many rows is more work than a "
-            "glance is worth, so the repr states its count and path alone."
+            "what it covers and states its count and path alone. "
+            "Summarizing realizes the whole index relation, which past "
+            "this many rows is more work than a glance is worth."
         ),
     )
     patch_history: Literal["standard", "disabled"] = Field(

--- a/dascore/config.py
+++ b/dascore/config.py
@@ -62,9 +62,11 @@ class DascoreConfig(BaseModel):
         ge=0,
         description=(
             "Patches a spool may hold before its repr stops summarizing "
-            "what it covers and states its count and path alone. "
-            "Summarizing realizes the whole index relation, which past "
-            "this many rows is more work than a glance is worth."
+            "what it covers and prints its count, its path, and the "
+            "limit it exceeded instead. Summarizing realizes the whole "
+            "index relation, which past this many rows is more work "
+            "than a glance is worth; the limit holds whether or not "
+            "that relation happens to be realized already."
         ),
     )
     patch_history: Literal["standard", "disabled"] = Field(

--- a/dascore/config.py
+++ b/dascore/config.py
@@ -57,6 +57,16 @@ class DascoreConfig(BaseModel):
         ge=0,
         description="Maximum children a repr lists per level before eliding.",
     )
+    display_max_patches: int = Field(
+        default=1_000,
+        ge=0,
+        description=(
+            "Patches a spool may hold before its repr stops summarizing "
+            "what it covers. Summarizing realizes the whole index "
+            "relation, which past this many rows is more work than a "
+            "glance is worth, so the repr states its count and path alone."
+        ),
+    )
     patch_history: Literal["standard", "disabled"] = Field(
         default="standard",
         description="Controls whether DASCore appends processing history to patches.",

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -14,7 +14,11 @@ from typing import TYPE_CHECKING, ClassVar, Literal, NamedTuple, Self, TypeVar, 
 
 import numpy as np
 import pandas as pd
-from pandas.errors import OutOfBoundsDatetime, OutOfBoundsTimedelta
+from pandas.errors import (
+    OutOfBoundsDatetime,
+    OutOfBoundsTimedelta,
+    PerformanceWarning,
+)
 from rich.text import Text
 
 import dascore as dc
@@ -77,6 +81,7 @@ from dascore.utils.chunk_plan import (
     ChunkPlan,
     _ensure_patch_id,
     _resolve_group_attrs,
+    _structural,
     build_chunk_plan,
     build_concat_plan,
     build_coverage_frame,
@@ -2348,13 +2353,16 @@ class Spool(NamespaceOwner):
             # A repr which raises makes an object undebuggable at the
             # one moment someone needs to look at it, so nothing a
             # summary does is allowed to stop the header from printing.
-            # Nor is it allowed to warn: building a directory index
-            # makes pandas warn, once per insert, that the frame is
-            # fragmented -- a hundred lines of advice about a frame the
-            # caller never asked for, from typing a name. Every category
-            # goes, since a repr only reads; anything worth warning
-            # about is warned again by the call which does the work.
-            with suppress(Exception), suppress_warnings():
+            # Nor is it allowed to warn about how pandas built the
+            # frame: a directory index warns once per insert that it is
+            # fragmented, a hundred lines of advice about a frame the
+            # caller never asked for, from typing a name.
+            #
+            # Only that category. A realized frame is cached, so the
+            # first reader is the only one who ever warns -- suppress
+            # anything else here and a repr does not delay it, it eats
+            # it, and the `get_contents` after it goes quiet too.
+            with suppress(Exception), suppress_warnings(PerformanceWarning):
                 blocks.extend(self._summary_blocks())
         else:
             blocks.append(
@@ -2380,16 +2388,19 @@ class Spool(NamespaceOwner):
         """
         Which rows have this dimension as an axis and state both its ends.
 
-        Three things are asked. The relation carries an envelope for
-        every coordinate, dimensional or not, and a patch may ride a
-        coordinate of this name along a different axis -- so `dims` is
-        what says whose axis it is, row by row rather than over the
-        frame. `dims` alone is not enough: a patch may name an axis
+        Two things are asked, and the first is asked with the same
+        function `get_coverage` asks it with: the relation carries an
+        envelope for every coordinate, dimensional or not, and a patch
+        may ride a coordinate of this name along a different axis, so
+        `dims` is what says whose axis it is, row by row. A track and
+        the lane of the same patches have to agree on that, which they
+        cannot do from two spellings of one rule.
+
+        Being an axis is not enough on its own: a patch may name one
         whose envelope it never filled in, and an unstated end bounds
         nothing.
         """
-        spelled = df["dims"].astype(str).fillna("")
-        axis = spelled.str.split(",").map(lambda x: dim in [y.strip() for y in x])
+        axis = pd.Series(_structural(df, dim), index=df.index)
         return axis & df[f"{dim}_min"].notna() & df[f"{dim}_max"].notna()
 
     def _comparable(self, df, dim: str) -> bool:
@@ -2417,7 +2428,7 @@ class Spool(NamespaceOwner):
                 kinds.add("instant")
             elif isinstance(value, pd.Timedelta | np.timedelta64):
                 kinds.add("offset")
-            elif isinstance(value, numbers.Number | np.number):
+            elif isinstance(value, numbers.Number):
                 kinds.add("number")
             else:
                 kinds.add("label")
@@ -2497,7 +2508,7 @@ class Spool(NamespaceOwner):
         # different claim about a different quantity.
         if isinstance(low, _TIMES):
             return self._duration_text(low, high)
-        if isinstance(low, numbers.Number | np.number):
+        if isinstance(low, numbers.Number):
             # A width is only in a unit where every patch agrees on one;
             # stating the first of several would label a track in a unit
             # it was not measured in.

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -2333,7 +2333,7 @@ class Spool(NamespaceOwner):
             # does is allowed to stop the header from printing.
             with suppress(Exception):
                 blocks.extend(self._summary_blocks())
-        elif count:
+        else:
             limit = dc.get_config().display_max_patches
             blocks.append(
                 Text(
@@ -2422,23 +2422,25 @@ class Spool(NamespaceOwner):
         # already state; naming it would only repeat them.
         if len(frame) < 2:
             return None
-        names = group_names(frame, ignore=("_n", "_low", "_high"))
-        width = max(len(x) for x in names)
         base = Text("➤ ") + Text("Tracks", style=dascore_styles["dc_red"])
         base += Text(f" ({len(frame)} along ") + Text(dim, style="bold") + Text(")")
         limit = dc.get_config().display_max_items
-        counted = [f"{x:,d} patch{'' if x == 1 else 'es'}" for x in frame["_n"]]
-        held = max(len(x) for x in counted)
+        shown = frame.head(limit)
+        names = group_names(frame, ignore=("_n", "_low", "_high"))[:limit]
+        counted = [f"{x:,d} patch{'' if x == 1 else 'es'}" for x in shown["_n"]]
+        # The columns are measured over the lines which are drawn: a name
+        # elided below should not pad the names above it.
+        width = max((len(x) for x in names), default=0)
+        held = max((len(x) for x in counted), default=0)
         # iterrows, not itertuples: the aggregate columns are named
         # privately so no attr of that name can collide with them, and
         # itertuples renames a private column to its position.
-        rows = zip(names[:limit], counted, frame.iterrows(), strict=False)
-        for name, count, (_, row) in rows:
+        for name, count, (_, row) in zip(names, counted, shown.iterrows(), strict=True):
             base += Text.assemble("\n    ", Text(f"{name:<{width}}", "bold"), "  ")
             base += Text(f"{count:>{held}}", dascore_styles["keys"])
             base += Text("  ") + get_nice_text(row["_low"])
             base += Text(f" <{human_duration(row['_high'] - row['_low'])}>")
-        if (left_out := len(frame) - limit) > 0:
+        if (left_out := len(frame) - len(shown)) > 0:
             base += Text(f"\n    ... {left_out} more", dascore_styles["keys"])
         base += Text("\n    (coverage: spool.viz.coverage())", dascore_styles["keys"])
         return base

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal, NamedTuple, Self, TypeVar, 
 
 import numpy as np
 import pandas as pd
+from pandas.errors import OutOfBoundsDatetime, OutOfBoundsTimedelta
 from rich.text import Text
 
 import dascore as dc
@@ -137,9 +138,10 @@ class _InventoryQuery(NamedTuple):
     kwargs: dict
 
 
-# What a dimension measured in time is stated as. Both are a duration
-# apart, which is a fact its two ends do not carry; every other
-# dimension states its own magnitude.
+# The types a dimension measured in time is stated in, instants and
+# offsets alike. Two such ends are a duration apart, which is a fact
+# neither end carries; every other dimension states its own magnitude
+# in its own units.
 _TIMES = (pd.Timestamp, np.datetime64, pd.Timedelta, np.timedelta64)
 
 
@@ -2346,9 +2348,12 @@ class Spool(NamespaceOwner):
             # A repr which raises makes an object undebuggable at the
             # one moment someone needs to look at it, so nothing a
             # summary does is allowed to stop the header from printing.
-            # Nor is it allowed to warn: building the relation can say a
-            # great deal about how it was built, and none of that was
-            # asked for by typing a name.
+            # Nor is it allowed to warn: building a directory index
+            # makes pandas warn, once per insert, that the frame is
+            # fragmented -- a hundred lines of advice about a frame the
+            # caller never asked for, from typing a name. Every category
+            # goes, since a repr only reads; anything worth warning
+            # about is warned again by the call which does the work.
             with suppress(Exception), suppress_warnings():
                 blocks.extend(self._summary_blocks())
         else:
@@ -2375,26 +2380,43 @@ class Spool(NamespaceOwner):
         """
         Which rows have this dimension as an axis and state both its ends.
 
-        Three things are asked, and each is needed. The relation carries
-        an envelope for every coordinate, dimensional or not, and a
-        patch may ride a coordinate of this name along a different axis
-        -- so `dims` is what says whose axis it is, row by row rather
-        than over the frame. And the relation carries time whatever the
-        patches state, so a column of NaT is a dimension nothing has.
+        Three things are asked. The relation carries an envelope for
+        every coordinate, dimensional or not, and a patch may ride a
+        coordinate of this name along a different axis -- so `dims` is
+        what says whose axis it is, row by row rather than over the
+        frame. `dims` alone is not enough: a patch may name an axis
+        whose envelope it never filled in, and an unstated end bounds
+        nothing.
         """
-        axis = df["dims"].fillna("").str.split(",").map(lambda x: dim in x)
+        spelled = df["dims"].astype(str).fillna("")
+        axis = spelled.str.split(",").map(lambda x: dim in [y.strip() for y in x])
         return axis & df[f"{dim}_min"].notna() & df[f"{dim}_max"].notna()
+
+    def _comparable(self, df, dim: str) -> bool:
+        """Whether this dimension's ends can be measured against each other."""
+        measured = df[self._measured(df, dim)]
+        # Two kinds do not subtract, and neither do two units: a metre
+        # taken from a foot is a number standing for nothing.
+        return (
+            len(self._value_kinds(measured[f"{dim}_min"])) == 1
+            and len(self._dim_units(measured, dim)) <= 1
+        )
 
     @staticmethod
     def _value_kinds(values) -> set[str]:
-        """How many kinds of thing an envelope column holds."""
+        """Which kinds of thing an envelope column holds."""
         # One dimension name can be a time on one patch and a number on
         # another. Their envelopes share a column and do not compare, so
         # asking for the extent of the two together raises.
         kinds = set()
         for value in values.dropna():
-            if isinstance(value, _TIMES):
-                kinds.add("time")
+            # An instant and an offset are both times and still do not
+            # compare: a date is not a length, and asking for the
+            # smaller of the two raises.
+            if isinstance(value, pd.Timestamp | np.datetime64):
+                kinds.add("instant")
+            elif isinstance(value, pd.Timedelta | np.timedelta64):
+                kinds.add("offset")
             elif isinstance(value, numbers.Number | np.number):
                 kinds.add("number")
             else:
@@ -2416,7 +2438,7 @@ class Spool(NamespaceOwner):
                 base += Text("mixed value kinds", key_style)
                 continue
             low, high = measured[f"{dim}_min"].min(), measured[f"{dim}_max"].max()
-            units = self._dim_units(df, dim)
+            units = self._dim_units(measured, dim)
             base += get_nice_text(low) + Text(" to ", key_style) + get_nice_text(high)
             if len(units) > 1:
                 # Envelopes are stored in the units each patch was read
@@ -2457,7 +2479,14 @@ class Spool(NamespaceOwner):
         zero, which reads as a label on a gap and as an empty pair of
         brackets here.
         """
-        if not (said := human_duration(high - low)):
+        try:
+            span = high - low
+        except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
+            # Two instants can lie further apart than a Timedelta holds.
+            # How long that is matters less than the extents it would
+            # otherwise take down with it.
+            return None
+        if not (said := human_duration(span)):
             return None
         return Text(f"<{said}>", dascore_styles["keys"])
 
@@ -2552,12 +2581,8 @@ class Spool(NamespaceOwner):
             return []
         blocks = [self._dims_text(df, dims)]
         # Tracks are measured along one dimension, which has to be one
-        # whose ends can be compared; a mixed-kind dimension has none.
-        measurable = [
-            x
-            for x in dims
-            if len(self._value_kinds(df[self._measured(df, x)][f"{x}_min"])) == 1
-        ]
+        # whose ends can be compared.
+        measurable = [x for x in dims if self._comparable(df, x)]
         if measurable and (tracks := self._tracks_text(df, measurable[0])) is not None:
             blocks.append(tracks)
         return blocks

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import warnings
 from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
+from contextlib import suppress
 from dataclasses import replace
 from functools import singledispatch
 from pathlib import Path
@@ -22,6 +23,7 @@ from dascore.constants import (
     ExecutorType,
     PatchType,
     attr_conflict_description,
+    dascore_styles,
     enrich_attrs_description,
     enrich_conflict_description,
     enrich_coords_description,
@@ -80,7 +82,12 @@ from dascore.utils.chunk_plan import (
     samples_adjusted_envelopes,
     subdivision_pieces,
 )
-from dascore.utils.display import get_dascore_text, get_nice_text
+from dascore.utils.display import (
+    get_header_text,
+    get_nice_text,
+    group_names,
+    human_duration,
+)
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import (
     _spool_map,
@@ -94,6 +101,7 @@ from dascore.utils.patch import (
 from dascore.utils.paths import coerce_to_upath, requires_local_directory
 from dascore.utils.pd import (
     drop_selector_names,
+    get_dim_names_from_columns,
     present_columns,
     requested_selector_names,
     resolve_selector_namespaces,
@@ -2305,31 +2313,147 @@ class Spool(NamespaceOwner):
         return {"rows": _strip_identity(rows)}
 
     def __rich__(self):
-        """Rich rep. of spool."""
-        base = get_dascore_text() + Text(" ")
-        base += Text(self.__class__.__name__, style=self._rich_style)
-        base += Text(" 🧵 ")
-        patch_len = len(self)
-        base += Text(f"({patch_len:d}")
-        base += Text(" Patches)") if patch_len != 1 else Text(" Patch)")
-        path = self.spool_path
-        if path is not None:
-            base += Text(f"\n    Path: {path}")
-        # Only render a time span when realization is cheap: live
-        # contents, single files, and derived catalogs are in memory; a
-        # huge directory index is not realized for a repr.
-        cheap = self.indexer is None
-        if cheap:
-            df = self._df
-            if df is not None and len(df) and "time_min" in df.columns:
-                t1, t2 = df["time_min"].min(), df["time_min"].max()
-                if pd.notna(t1) and pd.notna(t2):
-                    duration = get_nice_text(t2 - t1)
-                    base += Text(
-                        f"\n    Time Span: <{duration}> "
-                        f"{get_nice_text(t1)} to {get_nice_text(t2)}"
-                    )
+        """
+        What the spool is, what it spans, and the tracks it holds.
+
+        Summarizing realizes the index relation, which a spool of many
+        patches should not do for a glance; `display_max_patches` says
+        how many is too many, and past it the repr states its count and
+        path alone.
+        """
+        count = len(self)
+        plural = "" if count == 1 else "es"
+        name = f"{self.__class__.__name__} 🧵 ({count:,d} Patch{plural})"
+        blocks = [get_header_text(name, style=self._rich_style)]
+        if (path := self.spool_path) is not None:
+            blocks.append(Text(f"    Path: {path}"))
+        if self._summarizable():
+            # A repr which raises makes an object undebuggable at the one
+            # moment someone needs to look at it, so nothing a summary
+            # does is allowed to stop the header from printing.
+            with suppress(Exception):
+                blocks.extend(self._summary_blocks())
+        elif count:
+            limit = dc.get_config().display_max_patches
+            blocks.append(
+                Text(
+                    f"    Not summarized: {count:,d} patches exceeds "
+                    f"display_max_patches={limit:,d}.",
+                    style=dascore_styles["keys"],
+                )
+            )
+        return Text("\n").join(blocks)
+
+    def _summarizable(self) -> bool:
+        """Whether summarizing what this spool holds is worth a repr."""
+        # A frame already built for this revision costs nothing to read
+        # again, however many rows it holds. Otherwise the count is the
+        # price of the question: it pushes to SQL and never projects, so
+        # asking it of a million-file index is free.
+        if self._catalog.is_realized:
+            return True
+        return len(self) <= dc.get_config().display_max_patches
+
+    def _stated_dims(self, df) -> list[str]:
+        """The dimensions this spool's patches actually have."""
+        # Two filters, and both are needed. The relation carries the
+        # envelope columns of every coordinate, dimensional or not, so
+        # `dims` is what says which of them is an axis; and it carries
+        # time_min/time_max whatever the patches state, so a column of
+        # NaT is a dimension nothing here has.
+        named = set()
+        for spelling in df["dims"].dropna().unique():
+            named.update(x for x in str(spelling).split(",") if x)
+        stated = [
+            x
+            for x in get_dim_names_from_columns(df)
+            if x in named and df[f"{x}_min"].notna().any()
+        ]
+        # Time leads where it is one of them: it is the dimension a
+        # reader looks for, and the one the tracks are measured along.
+        return sorted(stated, key=lambda x: (x != "time", x))
+
+    def _dims_text(self, df, dims: list[str]) -> Text:
+        """The extent this spool covers along each of its dimensions."""
+        key_style = dascore_styles["keys"]
+        base = Text("➤ ") + Text("Dimensions", style=dascore_styles["dc_blue"])
+        base += Text(" (") + Text(", ".join(dims), style="bold") + Text(")")
+        width = max(len(x) for x in dims)
+        for dim in dims:
+            low, high = df[f"{dim}_min"].min(), df[f"{dim}_max"].max()
+            base += Text.assemble("\n    ", Text(f"{dim + ':':<{width + 1}} ", "bold"))
+            base += get_nice_text(low) + Text(" to ", key_style) + get_nice_text(high)
+            span = high - low
+            if isinstance(span, pd.Timedelta | np.timedelta64):
+                base += Text(f"  <{human_duration(span)}>", key_style)
+            elif (units := self._dim_units(df, dim)) is not None:
+                base += Text(" ") + Text(units, dascore_styles["units"])
         return base
+
+    @staticmethod
+    def _dim_units(df, dim: str) -> str | None:
+        """
+        What a dimension is measured in, where its patches agree.
+
+        The units column is private in the relation and renamed only on
+        the way out through `present_columns`, so both spellings are
+        asked for: a repr reads the frame before that rename.
+        """
+        for name in (f"{dim}_units", f"_{dim}_units"):
+            if (stated := df.get(name)) is None:
+                continue
+            values = {str(x) for x in stated.dropna().unique() if str(x)}
+            if len(values) == 1:
+                return values.pop()
+        return None
+
+    def _tracks_text(self, df, dim: str) -> Text | None:
+        """The groups this spool holds, named as its coverage plot names them."""
+        keys = [x for x in dc.get_config().patch_kind_attrs if x in df.columns]
+        if not keys:
+            return None
+        low, high = f"{dim}_min", f"{dim}_max"
+        frame = (
+            df.groupby(keys, dropna=False)
+            .agg(_n=(low, "size"), _low=(low, "min"), _high=(high, "max"))
+            .reset_index()
+        )
+        # One track is the whole spool, which the dimensions above
+        # already state; naming it would only repeat them.
+        if len(frame) < 2:
+            return None
+        names = group_names(frame, ignore=("_n", "_low", "_high"))
+        width = max(len(x) for x in names)
+        base = Text("➤ ") + Text("Tracks", style=dascore_styles["dc_red"])
+        base += Text(f" ({len(frame)} along ") + Text(dim, style="bold") + Text(")")
+        limit = dc.get_config().display_max_items
+        counted = [f"{x:,d} patch{'' if x == 1 else 'es'}" for x in frame["_n"]]
+        held = max(len(x) for x in counted)
+        # iterrows, not itertuples: the aggregate columns are named
+        # privately so no attr of that name can collide with them, and
+        # itertuples renames a private column to its position.
+        rows = zip(names[:limit], counted, frame.iterrows(), strict=False)
+        for name, count, (_, row) in rows:
+            base += Text.assemble("\n    ", Text(f"{name:<{width}}", "bold"), "  ")
+            base += Text(f"{count:>{held}}", dascore_styles["keys"])
+            base += Text("  ") + get_nice_text(row["_low"])
+            base += Text(f" <{human_duration(row['_high'] - row['_low'])}>")
+        if (left_out := len(frame) - limit) > 0:
+            base += Text(f"\n    ... {left_out} more", dascore_styles["keys"])
+        base += Text("\n    (coverage: spool.viz.coverage())", dascore_styles["keys"])
+        return base
+
+    def _summary_blocks(self) -> list[Text]:
+        """The blocks stating what this spool spans and what it holds."""
+        df = self._df
+        if df is None or not len(df) or "dims" not in df.columns:
+            return []
+        if not (dims := self._stated_dims(df)):
+            return []
+        blocks = [self._dims_text(df, dims)]
+        if (tracks := self._tracks_text(df, dims[0])) is not None:
+            blocks.append(tracks)
+        return blocks
 
     def __str__(self):
         return str(self.__rich__())

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numbers
 import os
 import warnings
 from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
@@ -74,6 +75,7 @@ from dascore.utils.chunk_plan import (
     _SOURCE_COLUMNS,
     ChunkPlan,
     _ensure_patch_id,
+    _resolve_group_attrs,
     build_chunk_plan,
     build_concat_plan,
     build_coverage_frame,
@@ -83,6 +85,7 @@ from dascore.utils.chunk_plan import (
     subdivision_pieces,
 )
 from dascore.utils.display import (
+    elision_text,
     get_header_text,
     get_nice_text,
     group_names,
@@ -92,6 +95,7 @@ from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import (
     _spool_map,
     deep_equality_check,
+    suppress_warnings,
 )
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import (
@@ -130,6 +134,12 @@ class _InventoryQuery(NamedTuple):
     # The `_coords` spec and kwargs with the channel names taken out.
     coords: namespace_select_type
     kwargs: dict
+
+
+# What a dimension measured in time is stated as. Both are a duration
+# apart, which is a fact its two ends do not carry; every other
+# dimension states its own magnitude.
+_TIMES = (pd.Timestamp, np.datetime64, pd.Timedelta, np.timedelta64)
 
 
 class Spool(NamespaceOwner):
@@ -2327,14 +2337,20 @@ class Spool(NamespaceOwner):
         blocks = [get_header_text(name, style=self._rich_style)]
         if (path := self.spool_path) is not None:
             blocks.append(Text(f"    Path: {path}"))
-        if self._summarizable(count):
-            # A repr which raises makes an object undebuggable at the one
-            # moment someone needs to look at it, so nothing a summary
-            # does is allowed to stop the header from printing.
-            with suppress(Exception):
+        # The limit is what it says whatever the spool has been asked
+        # before: a repr which summarized only once a frame happened to
+        # be built would print two different things for one object.
+        limit = dc.get_config().display_max_patches
+        if count <= limit:
+            # A repr which raises makes an object undebuggable at the
+            # one moment someone needs to look at it, so nothing a
+            # summary does is allowed to stop the header from printing.
+            # Nor is it allowed to warn: building the relation can say a
+            # great deal about how it was built, and none of that was
+            # asked for by typing a name.
+            with suppress(Exception), suppress_warnings():
                 blocks.extend(self._summary_blocks())
         else:
-            limit = dc.get_config().display_max_patches
             blocks.append(
                 Text(
                     f"    Not summarized: {count:,d} patches exceeds "
@@ -2343,22 +2359,6 @@ class Spool(NamespaceOwner):
                 )
             )
         return Text("\n").join(blocks)
-
-    def _summarizable(self, count: int) -> bool:
-        """
-        Whether summarizing what this spool holds is worth a repr.
-
-        Takes the count the header already asked for: on a view a query
-        cannot resolve in SQL, counting projects the relation, and doing
-        that twice for one repr is once too many.
-        """
-        # A frame already built for this revision costs nothing to read
-        # again, however many rows it holds. Otherwise the count is the
-        # price of the question: it pushes to SQL and never projects, so
-        # asking it of a million-file index is free.
-        if self._catalog.is_realized:
-            return True
-        return count <= dc.get_config().display_max_patches
 
     def _stated_dims(self, df) -> list[str]:
         """The dimensions this spool's patches actually have."""
@@ -2400,11 +2400,12 @@ class Spool(NamespaceOwner):
                 # in, so a min and a max from two of them are not two
                 # ends of one extent. Say so rather than imply otherwise.
                 base += Text(f"  (mixed units: {', '.join(units)})", key_style)
-            elif isinstance(high - low, pd.Timedelta | np.timedelta64):
+            elif isinstance(low, _TIMES):
                 # A time is stated as an instant, so how long the two of
                 # them are apart is a fact the line does not yet carry.
                 # Any other dimension states its own magnitude already.
-                base += Text(f"  <{human_duration(high - low)}>", key_style)
+                if (span := self._duration_text(low, high)) is not None:
+                    base += Text("  ") + span
             elif units:
                 base += Text(" ") + Text(units[0], dascore_styles["units"])
         return base
@@ -2425,16 +2426,33 @@ class Spool(NamespaceOwner):
         return tuple(sorted({str(x) for x in stated.dropna().unique() if str(x)}))
 
     @staticmethod
-    def _span_text(low, high, units: tuple[str, ...]) -> Text:
+    def _duration_text(low, high) -> Text | None:
+        """
+        How long an extent lasted. Only asked of one measured in time.
+
+        None where it lasted no time: `human_duration` says nothing of a
+        zero, which reads as a label on a gap and as an empty pair of
+        brackets here.
+        """
+        if not (said := human_duration(high - low)):
+            return None
+        return Text(f"<{said}>", dascore_styles["keys"])
+
+    def _span_text(self, low, high, units: tuple[str, ...]) -> Text | None:
         """How wide an extent is, measured in what the dimension is."""
-        span = high - low
-        # Only a time span is a duration. Any other dimension is as wide
-        # as its own units say, and calling that many seconds would be a
+        # A time span is a duration. Any other dimension is as wide as
+        # its own units say, and calling that many seconds would be a
         # different claim about a different quantity.
-        if isinstance(span, pd.Timedelta | np.timedelta64):
-            return Text(f"<{human_duration(span)}>", dascore_styles["keys"])
-        stated = f" {units[0]}" if units else ""
-        return Text(f"<{float(span):g}{stated}>", dascore_styles["keys"])
+        if isinstance(low, _TIMES):
+            return self._duration_text(low, high)
+        if isinstance(low, numbers.Number | np.number):
+            # A width is only in a unit where every patch agrees on one;
+            # stating the first of several would label a track in a unit
+            # it was not measured in.
+            stated = f" {units[0]}" if len(units) == 1 else ""
+            return Text(f"<{float(high - low):g}{stated}>", dascore_styles["keys"])
+        # A dimension of labels has two ends and no width between them.
+        return None
 
     def _tracks_text(self, df, dim: str) -> Text | None:
         """
@@ -2443,17 +2461,15 @@ class Spool(NamespaceOwner):
         A track is one kind of patch, which is the partition
         [`chunk`](`dascore.Spool.chunk`) starts from. Coverage may cut a
         kind finer still -- two sampling rates are two lanes of one tag
-        -- so a lane there is a track here or a part of one, and the
-        names agree wherever the partitions do.
+        -- so a lane there is a track here or a part of one, and the two
+        are named by one rule rather than given one name.
         """
-        # dict.fromkeys, not a set: the order is the one the names are
-        # read in, and a config may name an attribute twice, which a
-        # groupby refuses to insert twice.
-        keys = list(
-            dict.fromkeys(
-                x for x in dc.get_config().patch_kind_attrs if x in df.columns
-            )
-        )
+        # The same resolution chunk does, rather than a second reading
+        # of the config which could drift from it. It dedupes, which is
+        # what lets the config name an attribute twice: the groupby
+        # tolerates that, but reset_index will not put one column back
+        # under two labels.
+        keys = list(_resolve_group_attrs(None, set(df.columns)))
         if not keys:
             return None
         low, high = f"{dim}_min", f"{dim}_max"
@@ -2490,9 +2506,10 @@ class Spool(NamespaceOwner):
             base += Text.assemble("\n    ", Text(f"{name:<{width}}", "bold"), "  ")
             base += Text(f"{count:>{held}}", dascore_styles["keys"])
             base += Text("  ") + get_nice_text(row["_low"])
-            base += Text(" ") + self._span_text(row["_low"], row["_high"], units)
+            if (span := self._span_text(row["_low"], row["_high"], units)) is not None:
+                base += Text(" ") + span
         if (left_out := len(frame) - len(shown)) > 0:
-            base += Text(f"\n    ... {left_out} more", dascore_styles["keys"])
+            base += Text("\n    ") + elision_text(left_out)
         base += Text("\n    (coverage: spool.viz.coverage())", dascore_styles["keys"])
         return base
 

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -85,6 +85,7 @@ from dascore.utils.chunk_plan import (
     subdivision_pieces,
 )
 from dascore.utils.display import (
+    ACQUISITION_ATTR,
     elision_text,
     get_header_text,
     get_nice_text,
@@ -2362,18 +2363,8 @@ class Spool(NamespaceOwner):
 
     def _stated_dims(self, df) -> list[str]:
         """The dimensions this spool's patches actually have."""
-        # Two filters, and both are needed. The relation carries the
-        # envelope columns of every coordinate, dimensional or not, so
-        # `dims` is what says which of them is an axis; and it carries
-        # time_min/time_max whatever the patches state, so a column of
-        # NaT is a dimension nothing here has.
-        named = set()
-        for spelling in df["dims"].dropna().unique():
-            named.update(x for x in str(spelling).split(",") if x)
         stated = [
-            x
-            for x in get_dim_names_from_columns(df)
-            if x in named and self._measured(df, x).any()
+            x for x in get_dim_names_from_columns(df) if self._measured(df, x).any()
         ]
         # Time leads where it is one of them: it is the dimension a
         # reader looks for, and the one the tracks are measured along.
@@ -2381,8 +2372,34 @@ class Spool(NamespaceOwner):
 
     @staticmethod
     def _measured(df, dim: str):
-        """Which rows state both ends of their extent along a dimension."""
-        return df[f"{dim}_min"].notna() & df[f"{dim}_max"].notna()
+        """
+        Which rows have this dimension as an axis and state both its ends.
+
+        Three things are asked, and each is needed. The relation carries
+        an envelope for every coordinate, dimensional or not, and a
+        patch may ride a coordinate of this name along a different axis
+        -- so `dims` is what says whose axis it is, row by row rather
+        than over the frame. And the relation carries time whatever the
+        patches state, so a column of NaT is a dimension nothing has.
+        """
+        axis = df["dims"].fillna("").str.split(",").map(lambda x: dim in x)
+        return axis & df[f"{dim}_min"].notna() & df[f"{dim}_max"].notna()
+
+    @staticmethod
+    def _value_kinds(values) -> set[str]:
+        """How many kinds of thing an envelope column holds."""
+        # One dimension name can be a time on one patch and a number on
+        # another. Their envelopes share a column and do not compare, so
+        # asking for the extent of the two together raises.
+        kinds = set()
+        for value in values.dropna():
+            if isinstance(value, _TIMES):
+                kinds.add("time")
+            elif isinstance(value, numbers.Number | np.number):
+                kinds.add("number")
+            else:
+                kinds.add("label")
+        return kinds
 
     def _dims_text(self, df, dims: list[str]) -> Text:
         """The extent this spool covers along each of its dimensions."""
@@ -2391,9 +2408,15 @@ class Spool(NamespaceOwner):
         base += Text(" (") + Text(", ".join(dims), style="bold") + Text(")")
         width = max(len(x) for x in dims)
         for dim in dims:
-            low, high = df[f"{dim}_min"].min(), df[f"{dim}_max"].max()
-            units = self._dim_units(df, dim)
+            measured = df[self._measured(df, dim)]
             base += Text.assemble("\n    ", Text(f"{dim + ':':<{width + 1}} ", "bold"))
+            if len(self._value_kinds(measured[f"{dim}_min"])) > 1:
+                # Two kinds do not compare, so there are no two ends to
+                # state. Saying so beats the whole summary disappearing.
+                base += Text("mixed value kinds", key_style)
+                continue
+            low, high = measured[f"{dim}_min"].min(), measured[f"{dim}_max"].max()
+            units = self._dim_units(df, dim)
             base += get_nice_text(low) + Text(" to ", key_style) + get_nice_text(high)
             if len(units) > 1:
                 # Envelopes are stored in the units each patch was read
@@ -2493,7 +2516,14 @@ class Spool(NamespaceOwner):
         base += Text(f" ({len(frame)} along ") + Text(dim, style="bold") + Text(")")
         limit = dc.get_config().display_max_items
         shown = frame.head(limit)
-        names = group_names(frame, ignore=("_n", "_low", "_high"))[:limit]
+        names = group_names(
+            frame,
+            ignore=("_n", "_low", "_high"),
+            # The same fallback the plot names a lane by, or a group
+            # nothing tells apart is a track called "group 0" and a lane
+            # called by its acquisition -- one rule, two names.
+            fallback=ACQUISITION_ATTR,
+        )[:limit]
         counted = [f"{x:,d} patch{'' if x == 1 else 'es'}" for x in shown["_n"]]
         # The columns are measured over the lines which are drawn: a name
         # elided below should not pad the names above it.
@@ -2521,7 +2551,14 @@ class Spool(NamespaceOwner):
         if not (dims := self._stated_dims(df)):
             return []
         blocks = [self._dims_text(df, dims)]
-        if (tracks := self._tracks_text(df, dims[0])) is not None:
+        # Tracks are measured along one dimension, which has to be one
+        # whose ends can be compared; a mixed-kind dimension has none.
+        measurable = [
+            x
+            for x in dims
+            if len(self._value_kinds(df[self._measured(df, x)][f"{x}_min"])) == 1
+        ]
+        if measurable and (tracks := self._tracks_text(df, measurable[0])) is not None:
             blocks.append(tracks)
         return blocks
 

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -2327,7 +2327,7 @@ class Spool(NamespaceOwner):
         blocks = [get_header_text(name, style=self._rich_style)]
         if (path := self.spool_path) is not None:
             blocks.append(Text(f"    Path: {path}"))
-        if self._summarizable():
+        if self._summarizable(count):
             # A repr which raises makes an object undebuggable at the one
             # moment someone needs to look at it, so nothing a summary
             # does is allowed to stop the header from printing.
@@ -2344,15 +2344,21 @@ class Spool(NamespaceOwner):
             )
         return Text("\n").join(blocks)
 
-    def _summarizable(self) -> bool:
-        """Whether summarizing what this spool holds is worth a repr."""
+    def _summarizable(self, count: int) -> bool:
+        """
+        Whether summarizing what this spool holds is worth a repr.
+
+        Takes the count the header already asked for: on a view a query
+        cannot resolve in SQL, counting projects the relation, and doing
+        that twice for one repr is once too many.
+        """
         # A frame already built for this revision costs nothing to read
         # again, however many rows it holds. Otherwise the count is the
         # price of the question: it pushes to SQL and never projects, so
         # asking it of a million-file index is free.
         if self._catalog.is_realized:
             return True
-        return len(self) <= dc.get_config().display_max_patches
+        return count <= dc.get_config().display_max_patches
 
     def _stated_dims(self, df) -> list[str]:
         """The dimensions this spool's patches actually have."""
@@ -2367,11 +2373,16 @@ class Spool(NamespaceOwner):
         stated = [
             x
             for x in get_dim_names_from_columns(df)
-            if x in named and df[f"{x}_min"].notna().any()
+            if x in named and self._measured(df, x).any()
         ]
         # Time leads where it is one of them: it is the dimension a
         # reader looks for, and the one the tracks are measured along.
         return sorted(stated, key=lambda x: (x != "time", x))
+
+    @staticmethod
+    def _measured(df, dim: str):
+        """Which rows state both ends of their extent along a dimension."""
+        return df[f"{dim}_min"].notna() & df[f"{dim}_max"].notna()
 
     def _dims_text(self, df, dims: list[str]) -> Text:
         """The extent this spool covers along each of its dimensions."""
@@ -2381,38 +2392,77 @@ class Spool(NamespaceOwner):
         width = max(len(x) for x in dims)
         for dim in dims:
             low, high = df[f"{dim}_min"].min(), df[f"{dim}_max"].max()
+            units = self._dim_units(df, dim)
             base += Text.assemble("\n    ", Text(f"{dim + ':':<{width + 1}} ", "bold"))
             base += get_nice_text(low) + Text(" to ", key_style) + get_nice_text(high)
-            span = high - low
-            if isinstance(span, pd.Timedelta | np.timedelta64):
-                base += Text(f"  <{human_duration(span)}>", key_style)
-            elif (units := self._dim_units(df, dim)) is not None:
-                base += Text(" ") + Text(units, dascore_styles["units"])
+            if len(units) > 1:
+                # Envelopes are stored in the units each patch was read
+                # in, so a min and a max from two of them are not two
+                # ends of one extent. Say so rather than imply otherwise.
+                base += Text(f"  (mixed units: {', '.join(units)})", key_style)
+            elif isinstance(high - low, pd.Timedelta | np.timedelta64):
+                # A time is stated as an instant, so how long the two of
+                # them are apart is a fact the line does not yet carry.
+                # Any other dimension states its own magnitude already.
+                base += Text(f"  <{human_duration(high - low)}>", key_style)
+            elif units:
+                base += Text(" ") + Text(units[0], dascore_styles["units"])
         return base
 
     @staticmethod
-    def _dim_units(df, dim: str) -> str | None:
+    def _dim_units(df, dim: str) -> tuple[str, ...]:
         """
-        What a dimension is measured in, where its patches agree.
+        What a dimension is measured in, as its patches state it.
 
         The units column is private in the relation and renamed only on
         the way out through `present_columns`, so both spellings are
         asked for: a repr reads the frame before that rename.
         """
-        for name in (f"{dim}_units", f"_{dim}_units"):
-            if (stated := df.get(name)) is None:
-                continue
-            values = {str(x) for x in stated.dropna().unique() if str(x)}
-            if len(values) == 1:
-                return values.pop()
-        return None
+        stated = df.get(f"{dim}_units", df.get(f"_{dim}_units"))
+        # Only a dimension the relation describes is ever asked about,
+        # and it describes each of them with a units column, empty or not.
+        assert stated is not None, f"the relation states no units for {dim}"
+        return tuple(sorted({str(x) for x in stated.dropna().unique() if str(x)}))
+
+    @staticmethod
+    def _span_text(low, high, units: tuple[str, ...]) -> Text:
+        """How wide an extent is, measured in what the dimension is."""
+        span = high - low
+        # Only a time span is a duration. Any other dimension is as wide
+        # as its own units say, and calling that many seconds would be a
+        # different claim about a different quantity.
+        if isinstance(span, pd.Timedelta | np.timedelta64):
+            return Text(f"<{human_duration(span)}>", dascore_styles["keys"])
+        stated = f" {units[0]}" if units else ""
+        return Text(f"<{float(span):g}{stated}>", dascore_styles["keys"])
 
     def _tracks_text(self, df, dim: str) -> Text | None:
-        """The groups this spool holds, named as its coverage plot names them."""
-        keys = [x for x in dc.get_config().patch_kind_attrs if x in df.columns]
+        """
+        The kinds of patch this spool holds, named as its lanes are named.
+
+        A track is one kind of patch, which is the partition
+        [`chunk`](`dascore.Spool.chunk`) starts from. Coverage may cut a
+        kind finer still -- two sampling rates are two lanes of one tag
+        -- so a lane there is a track here or a part of one, and the
+        names agree wherever the partitions do.
+        """
+        # dict.fromkeys, not a set: the order is the one the names are
+        # read in, and a config may name an attribute twice, which a
+        # groupby refuses to insert twice.
+        keys = list(
+            dict.fromkeys(
+                x for x in dc.get_config().patch_kind_attrs if x in df.columns
+            )
+        )
         if not keys:
             return None
         low, high = f"{dim}_min", f"{dim}_max"
+        # A patch which does not have this dimension is not a track along
+        # it; get_coverage drops it too rather than report an empty one.
+        df = df[self._measured(df, dim)]
+        # The dimension came from _stated_dims, which is the set of them
+        # some row measures, so something is always left to group.
+        assert len(df), f"no patch measures {dim}"
         frame = (
             df.groupby(keys, dropna=False)
             .agg(_n=(low, "size"), _low=(low, "min"), _high=(high, "max"))
@@ -2422,6 +2472,7 @@ class Spool(NamespaceOwner):
         # already state; naming it would only repeat them.
         if len(frame) < 2:
             return None
+        units = self._dim_units(df, dim)
         base = Text("➤ ") + Text("Tracks", style=dascore_styles["dc_red"])
         base += Text(f" ({len(frame)} along ") + Text(dim, style="bold") + Text(")")
         limit = dc.get_config().display_max_items
@@ -2439,7 +2490,7 @@ class Spool(NamespaceOwner):
             base += Text.assemble("\n    ", Text(f"{name:<{width}}", "bold"), "  ")
             base += Text(f"{count:>{held}}", dascore_styles["keys"])
             base += Text("  ") + get_nice_text(row["_low"])
-            base += Text(f" <{human_duration(row['_high'] - row['_low'])}>")
+            base += Text(" ") + self._span_text(row["_low"], row["_high"], units)
         if (left_out := len(frame) - len(shown)) > 0:
             base += Text(f"\n    ... {left_out} more", dascore_styles["keys"])
         base += Text("\n    (coverage: spool.viz.coverage())", dascore_styles["keys"])

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -915,6 +915,18 @@ class PatchCatalog:
 
     # --- realization ------------------------------------------------------
 
+    @property
+    def is_realized(self) -> bool:
+        """
+        Whether the flat relation is already built for this revision.
+
+        What a caller asks before deciding a summary is too expensive:
+        a frame already paid for costs nothing to read again, however
+        many rows it holds.
+        """
+        with self._revision.lock:
+            return self._df_cache.get(self._revision.value) is not None
+
     def to_df(self) -> pd.DataFrame:
         """
         The spool-facing flat patch-row relation under the selection.

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -915,18 +915,6 @@ class PatchCatalog:
 
     # --- realization ------------------------------------------------------
 
-    @property
-    def is_realized(self) -> bool:
-        """
-        Whether the flat relation is already built for this revision.
-
-        What a caller asks before deciding a summary is too expensive:
-        a frame already paid for costs nothing to read again, however
-        many rows it holds.
-        """
-        with self._revision.lock:
-            return self._df_cache.get(self._revision.value) is not None
-
     def to_df(self) -> pd.DataFrame:
         """
         The spool-facing flat patch-row relation under the selection.

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from collections import Counter
-from collections.abc import Mapping, Sized
+from collections.abc import Iterable, Mapping, Sized
 from contextlib import suppress
 from functools import singledispatch
 
@@ -231,7 +231,7 @@ def _length(value) -> int | None:
     return None
 
 
-def human_duration(value) -> str:
+def human_duration(value: np.timedelta64 | pd.Timedelta | float) -> str:
     """Say how long something lasted, in the largest unit which fits."""
     # to_float reads a duration in seconds, whichever time type states
     # it, and passes a plain number through as itself.
@@ -255,7 +255,19 @@ def percent(value: float) -> str:
     return "<100%"
 
 
-def group_names(frame, ignore=(), ordinals=None, fallback=None) -> list[str]:
+# What names a group which shares every attribute it states with the
+# others, or states none: the key the acquisition is filed under. It is
+# the first of the config's `patch_kind_attrs`, and the one of them
+# which names a place rather than describing it.
+ACQUISITION_ATTR = "acquisition_key"
+
+
+def group_names(
+    frame: pd.DataFrame,
+    ignore: Iterable[str] = (),
+    ordinals: Iterable | None = None,
+    fallback: str | None = None,
+) -> list[str]:
     """
     Name each row of a group frame by what tells it apart from the others.
 

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import textwrap
+from collections import Counter
 from collections.abc import Mapping, Sized
 from contextlib import suppress
 from functools import singledispatch
@@ -18,6 +19,7 @@ import dascore as dc
 from dascore.config import get_config
 from dascore.constants import dascore_styles
 from dascore.units import get_quantity_str
+from dascore.utils.time import to_float
 
 # How wide one value may print before it is elided. A repr is a glance at
 # an object, and a single long field should not push the rest off screen.
@@ -32,6 +34,21 @@ _IDENTITY_FIELDS = frozenset({"object_type", "resource_id"})
 # a Series or a frame is a table, and has a string form of its own which
 # already knows how much of itself to show.
 _SEQUENCE_TYPES = (tuple, list, set, frozenset)
+
+_SECONDS_IN_DAY = 86_400.0
+
+# Steps a duration is worth reading in, largest first. A year is the
+# Gregorian mean, the same one numpy converts a timedelta64 with, since
+# a multi-year outage reads as "40.7 y" rather than "14852 d".
+_UNITS = (
+    ("y", 365.2425 * _SECONDS_IN_DAY),
+    ("d", _SECONDS_IN_DAY),
+    ("h", 3_600.0),
+    ("m", 60.0),
+    ("s", 1.0),
+    ("ms", 1e-3),
+    ("µs", 1e-6),
+)
 
 # The scalar types a model field is left unset as.
 _NULLABLE_TYPES = (
@@ -202,6 +219,89 @@ def _length(value) -> int | None:
     with suppress(TypeError):
         return len(value)
     return None
+
+
+def human_duration(value) -> str:
+    """Say how long something lasted, in the largest unit which fits."""
+    # to_float reads a duration in seconds, whichever time type states
+    # it, and passes a plain number through as itself.
+    seconds = to_float(value)
+    if not np.isfinite(seconds) or seconds == 0:
+        return ""
+    size = abs(seconds)
+    for name, scale in _UNITS:
+        if size >= scale:
+            return f"{size / scale:.1f} {name}".replace(".0 ", " ")
+    return f"{size:.3g} s"
+
+
+def percent(value: float) -> str:
+    """Say a fraction as a percentage, without rounding a hole away."""
+    for places in range(4):
+        text = f"{value:.{places}%}"
+        # 100% is a claim about the whole span, so only a whole span earns it.
+        if value >= 1.0 or float(text.rstrip("%")) < 100.0:
+            return text
+    return "<100%"
+
+
+def group_names(frame, ignore=(), ordinals=None, fallback=None) -> list[str]:
+    """
+    Name each row of a group frame by what tells it apart from the others.
+
+    The one naming rule a spool has, so the lanes a coverage plot draws
+    and the tracks a spool's repr prints answer to the same names.
+
+    Parameters
+    ----------
+    frame
+        One row per group.
+    ignore
+        Columns which describe the groups rather than tell them apart,
+        such as the extent each is measured over.
+    ordinals
+        What to call a group its own values cannot name. The row's
+        position by default; a report passes its ``group_id``.
+    fallback
+        A column to name a group by when nothing tells it apart, asked
+        before the ordinal is.
+    """
+    ignore = set(ignore)
+    ordinals = range(len(frame)) if ordinals is None else list(ordinals)
+    stated = [
+        x for x in frame.columns if x not in ignore and not str(x).startswith("_")
+    ]
+    telling = [x for x in stated if frame[x].astype(str).nunique() > 1]
+    described = []
+    for _, row in frame.iterrows():
+        stated_values = (str(row[x]) for x in telling if pd.notnull(row[x]))
+        parts = [x for x in stated_values if x]
+        # Nothing tells a lone group apart, since there is nothing to
+        # tell it apart from, and every group of a spool of one
+        # acquisition is in that position. It is still a named thing,
+        # and the fallback says what its ordinal cannot.
+        if not parts and fallback is not None:
+            named = row.get(fallback)
+            if pd.notnull(named) and str(named):
+                parts = [str(named)]
+        # A group which states neither is left blank here and named by
+        # its ordinal below; the blank is a value it states, but drawing
+        # it as an empty label would read as a rendering gap.
+        described.append(" · ".join(parts))
+    # Two groups can state the same attributes and still be two groups --
+    # sampling rate and coordinate structure part them without being
+    # shown -- so where a description is shared its ordinal tells them
+    # apart. A lane which named two groups would silently draw one.
+    shared = Counter(described)
+    names = []
+    for description, ordinal in zip(described, ordinals, strict=True):
+        if not description:
+            names.append(f"group {ordinal}")
+        elif shared[description] > 1:
+            names.append(f"{description} ({ordinal})")
+        else:
+            names.append(description)
+    return names
 
 
 def counts_to_text(counts, limit: int | None = None) -> Text:

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -190,6 +190,16 @@ def indent_text(text: Text, prefix: str = "    ") -> Text:
     return Text("\n").join(Text(prefix) + line for line in text.split("\n"))
 
 
+def elision_text(left_out: int) -> Text:
+    """
+    Say how many of something a repr did not show.
+
+    One wording for every repr which stops early, so a spool's tracks
+    and an inventory's networks say it the same way in one terminal.
+    """
+    return Text(f"... {left_out} more", style=dascore_styles["keys"])
+
+
 def limit_reprs(items, limit: int | None = None) -> list[Text]:
     """
     Render at most ``limit`` items, with a line naming what was left out.
@@ -203,7 +213,7 @@ def limit_reprs(items, limit: int | None = None) -> list[Text]:
     items = list(items)
     texts = [x.__rich__() for x in items[:limit]]
     if left_out := len(items) - len(texts):
-        texts.append(Text(f"... {left_out} more", style=dascore_styles["keys"]))
+        texts.append(elision_text(left_out))
     return texts
 
 
@@ -249,8 +259,10 @@ def group_names(frame, ignore=(), ordinals=None, fallback=None) -> list[str]:
     """
     Name each row of a group frame by what tells it apart from the others.
 
-    The one naming rule a spool has, so the lanes a coverage plot draws
-    and the tracks a spool's repr prints answer to the same names.
+    The one naming rule a spool has, kept apart from the drawing of it
+    so a coverage plot's lanes and a spool repr's tracks are named the
+    same way. The same way, not always the same name: each caller says
+    what to fall back on, and they partition their rows differently.
 
     Parameters
     ----------
@@ -258,7 +270,9 @@ def group_names(frame, ignore=(), ordinals=None, fallback=None) -> list[str]:
         One row per group.
     ignore
         Columns which describe the groups rather than tell them apart,
-        such as the extent each is measured over.
+        such as the extent each is measured over. A column whose name
+        begins with an underscore is skipped whether it is named here
+        or not.
     ordinals
         What to call a group its own values cannot name. The row's
         position by default; a report passes its ``group_id``.
@@ -316,7 +330,7 @@ def counts_to_text(counts, limit: int | None = None) -> Text:
     shown = ", ".join(f"{name}: {count}" for name, count in items[:limit])
     if len(items) <= limit:
         return Text(shown)
-    left_out = Text(f"... {len(items) - limit} more", dascore_styles["keys"])
+    left_out = elision_text(len(items) - limit)
     # A zero limit shows nothing, and nothing needs no comma after it.
     return Text(f"{shown}, ") + left_out if shown else left_out
 

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -273,8 +273,10 @@ def group_names(
 
     The one naming rule a spool has, kept apart from the drawing of it
     so a coverage plot's lanes and a spool repr's tracks are named the
-    same way. The same way, not always the same name: each caller says
-    what to fall back on, and they partition their rows differently.
+    same way. The same way, not always the same name: both callers fall
+    back on the same attribute, but they partition their rows
+    differently and number an unnameable group differently -- the plot
+    by its ``group_id``, a repr by row position.
 
     Parameters
     ----------

--- a/dascore/viz/spool.py
+++ b/dascore/viz/spool.py
@@ -14,6 +14,7 @@ from dascore.exceptions import ParameterError
 from dascore.utils.chunk_plan import _REPORT_COLUMNS
 from dascore.utils.display import (
     _SECONDS_IN_DAY,
+    ACQUISITION_ATTR,
     group_names,
     human_duration,
     percent,
@@ -46,12 +47,6 @@ _GAP_TICKS = (1.0, 60.0, 600.0, 3_600.0, 6 * 3_600.0, _SECONDS_IN_DAY)
 # is drawn over, so naming the lane with them would repeat the axis.
 _ENVELOPE_SUFFIXES = ("min", "max", "step", "units")
 
-# What names a group which shares every attribute it states with the
-# others, or states none: the key the acquisition is filed under. It is
-# the first of the config's `patch_kind_attrs`, and the one of them
-# which names a place rather than describing it.
-_ACQUISITION_ATTR = "acquisition_key"
-
 
 def _lane_names(report: pd.DataFrame, dim: str) -> list[str]:
     """Name each group by what tells it apart, and how complete it is."""
@@ -63,7 +58,7 @@ def _lane_names(report: pd.DataFrame, dim: str) -> list[str]:
         report,
         ignore=set(_REPORT_COLUMNS) | envelope,
         ordinals=report["group_id"],
-        fallback=_ACQUISITION_ATTR,
+        fallback=ACQUISITION_ATTR,
     )
     return [
         f"{name}  {percent(coverage)}"

--- a/dascore/viz/spool.py
+++ b/dascore/viz/spool.py
@@ -12,12 +12,15 @@ from matplotlib.colors import LogNorm
 
 from dascore.exceptions import ParameterError
 from dascore.utils.chunk_plan import _REPORT_COLUMNS
+from dascore.utils.display import (
+    _SECONDS_IN_DAY,
+    group_names,
+    human_duration,
+    percent,
+)
 from dascore.utils.plotting import _format_time_axis, _get_cmap
-from dascore.utils.time import to_float
 
 from ._lanes import plot_lanes
-
-_SECONDS_IN_DAY = 86_400.0
 
 # Data and its absence are a closed pair, so their colors are pinned
 # rather than drawn from the palette other values share.
@@ -49,33 +52,6 @@ _ENVELOPE_SUFFIXES = ("min", "max", "step", "units")
 # which names a place rather than describing it.
 _ACQUISITION_ATTR = "acquisition_key"
 
-# Steps a duration is worth reading in, largest first. A year is the
-# Gregorian mean, the same one numpy converts a timedelta64 with, since
-# a multi-year outage reads as "40.7 y" rather than "14852 d".
-_UNITS = (
-    ("y", 365.2425 * _SECONDS_IN_DAY),
-    ("d", _SECONDS_IN_DAY),
-    ("h", 3_600.0),
-    ("m", 60.0),
-    ("s", 1.0),
-    ("ms", 1e-3),
-    ("µs", 1e-6),
-)
-
-
-def _human_duration(value) -> str:
-    """Say how long something lasted, in the largest unit which fits."""
-    # to_float reads a duration in seconds, whichever time type states
-    # it, and passes a plain number through as itself.
-    seconds = to_float(value)
-    if not np.isfinite(seconds) or seconds == 0:
-        return ""
-    size = abs(seconds)
-    for name, scale in _UNITS:
-        if size >= scale:
-            return f"{size / scale:.1f} {name}".replace(".0 ", " ")
-    return f"{size:.3g} s"
-
 
 def _lane_names(report: pd.DataFrame, dim: str) -> list[str]:
     """Name each group by what tells it apart, and how complete it is."""
@@ -83,42 +59,16 @@ def _lane_names(report: pd.DataFrame, dim: str) -> list[str]:
     # attribute may legitimately be called `site_min`, and it names its
     # group as any other attribute does.
     envelope = {f"{dim}_{x}" for x in _ENVELOPE_SUFFIXES}
-    stated = [
-        x
-        for x in report.columns
-        if x not in _REPORT_COLUMNS and x not in envelope and not x.startswith("_")
+    names = group_names(
+        report,
+        ignore=set(_REPORT_COLUMNS) | envelope,
+        ordinals=report["group_id"],
+        fallback=_ACQUISITION_ATTR,
+    )
+    return [
+        f"{name}  {percent(coverage)}"
+        for name, coverage in zip(names, report["coverage"], strict=True)
     ]
-    telling = [x for x in stated if report[x].astype(str).nunique() > 1]
-    described = []
-    for _, row in report.iterrows():
-        stated_values = (str(row[x]) for x in telling if pd.notnull(row[x]))
-        parts = [x for x in stated_values if x]
-        # Nothing tells a lone group apart, since there is nothing to
-        # tell it apart from, and every group of a spool of one
-        # acquisition is in that position. It is still a named
-        # acquisition, and its key says what its ordinal cannot.
-        if not parts:
-            key = row.get(_ACQUISITION_ATTR)
-            if pd.notnull(key) and str(key):
-                parts = [str(key)]
-        # A group which states neither is left blank here and named by
-        # its ordinal below; the blank is a value it states, but drawing
-        # it as an empty label would read as a rendering gap.
-        described.append(" · ".join(parts))
-    # Two groups can state the same attributes and still be two groups —
-    # sampling rate and coordinate structure part them without being
-    # shown — so where a description is shared its ordinal tells them
-    # apart. A lane which named two groups would silently draw one.
-    shared = {x for x in described if described.count(x) > 1}
-    names = []
-    for description, (_, row) in zip(described, report.iterrows(), strict=True):
-        name = description
-        if not name:
-            name = f"group {row['group_id']}"
-        elif description in shared:
-            name = f"{description} ({row['group_id']})"
-        names.append(f"{name}  {_percent(row['coverage'])}")
-    return names
 
 
 def _new_ax(ax, height: float):
@@ -127,16 +77,6 @@ def _new_ax(ax, height: float):
         return ax
     _, ax = plt.subplots(1, figsize=(10.0, min(height, 14.0)), layout="constrained")
     return ax
-
-
-def _percent(value: float) -> str:
-    """Say a fraction as a percentage, without rounding a hole away."""
-    for places in range(4):
-        text = f"{value:.{places}%}"
-        # 100% is a claim about the whole span, so only a whole span earns it.
-        if value >= 1.0 or float(text.rstrip("%")) < 100.0:
-            return text
-    return "<100%"
 
 
 def _runs(report: pd.DataFrame, gaps: pd.DataFrame, dim: str) -> pd.DataFrame:
@@ -161,7 +101,7 @@ def _runs(report: pd.DataFrame, gaps: pd.DataFrame, dim: str) -> pd.DataFrame:
 def _gap_label(size, units: str, dated: bool) -> str:
     """Say how wide a gap is, in what its own dimension is measured in."""
     if dated:
-        return _human_duration(size)
+        return human_duration(size)
     value = float(size)
     if not np.isfinite(value) or value == 0:
         return ""
@@ -544,7 +484,7 @@ def calendar(
         bar.ax.yaxis.set_major_locator(ticker.MaxNLocator(integer=True))
     if method == "gap":
         bar.set_ticks(list(_GAP_TICKS))
-        bar.set_ticklabels([_human_duration(x) for x in _GAP_TICKS])
+        bar.set_ticklabels([human_duration(x) for x in _GAP_TICKS])
         bar.minorticks_off()
     if show:
         plt.show()

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -54,11 +54,14 @@ with config_context(patch_kind_attrs=("acquisition_key",)):
     ...  # tag and data_category no longer separate patches
 ```
 
-How objects print is configurable as well: `display_float_precision` sets the decimals shown for floats, `display_array_threshold` how much of an array is printed before it is elided, and `display_max_items` how many children a repr lists per level before saying how many it left out.
+How objects print is configurable as well: `display_float_precision` sets the decimals shown for floats, `display_array_threshold` how much of an array is printed before it is elided, `display_max_items` how many children a repr lists per level before saying how many it left out, and `display_max_patches` how large a spool may be before its repr stops summarizing what it covers and states its count and path alone.
 
 ```python
 with config_context(display_max_items=3):
     print(inventory)  # at most three networks, arrays or paths per level
+
+with config_context(display_max_patches=100):
+    print(spool)  # a bigger spool states its count and path, and no more
 ```
 
 For remote IO settings such as `allow_remote_cache`,

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -54,14 +54,14 @@ with config_context(patch_kind_attrs=("acquisition_key",)):
     ...  # tag and data_category no longer separate patches
 ```
 
-How objects print is configurable as well: `display_float_precision` sets the decimals shown for floats, `display_array_threshold` how much of an array is printed before it is elided, `display_max_items` how many children a repr lists per level before saying how many it left out, and `display_max_patches` how large a spool may be before its repr stops summarizing what it covers and states its count and path alone.
+How objects print is configurable as well: `display_float_precision` sets the decimals shown for floats, `display_array_threshold` how much of an array is printed before it is elided, `display_max_items` how many children a repr lists per level before saying how many it left out, and `display_max_patches` how large a spool may be before its repr stops summarizing what it covers and names the limit it exceeded instead.
 
 ```python
 with config_context(display_max_items=3):
     print(inventory)  # at most three networks, arrays or paths per level
 
 with config_context(display_max_patches=100):
-    print(spool)  # a bigger spool states its count and path, and no more
+    print(spool)  # a bigger spool names the limit rather than its extents
 ```
 
 For remote IO settings such as `allow_remote_cache`,

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -59,7 +59,7 @@ directory_path = fetch('terra15_das_1_trimmed.hdf5').parent
 spool3 = dc.spool(directory_path).update()
 ```
 
-An indexed directory summarizes itself when printed, the same as any other spool.
+An indexed directory summarizes itself when printed, the same as any other spool; see [what a spool says of itself](#what-a-spool-says-of-itself).
 
 If you want the index file to exist somewhere else, for example if you can't write to the data directory, you can specify an index path.
 
@@ -213,7 +213,7 @@ A boolean mask is applied by position, so it must come from the contents of the 
 
 # What a spool says of itself
 
-Printing a spool states how many patches it holds, the extent it covers along each dimension its patches have, and one *track* per kind of patch. A track is named by the values which tell its kind apart from the others, by the same rule the [coverage plot](visualization.qmd#spool) names its lanes.
+Printing a spool states how many patches it holds, the extent it covers along each dimension its patches have, and one *track* per kind of patch. A track is named by the values which tell its kind apart from the others, by the same rule the [coverage plot](visualization.qmd#spool) names its lanes. Tracks are measured along one dimension — time where the patches have it — and patches which do not have that dimension are left out of them. A spool of a single kind prints no tracks at all, since the extents above already state what its one track would.
 
 ```{python}
 import dascore as dc
@@ -361,7 +361,7 @@ gappy.get_coverage()
 
 `gap_total` is the sum of that group's `get_gaps` rows, `span` is the extent it covers end to end, and `coverage` is the fraction of that span the patches cover. It is measured between patches, from the index's envelopes, so a hole *inside* a patch does not show up. Patches divide into groups the way `chunk` divides them — on the kind attributes, but also on sampling rate and coordinate structure — so a single tag can span several rows. `group_id` names the group in both frames, which is how a gap is traced back to the row that counts it.
 
-Both frames are drawn by [`Spool.viz.coverage`](`dascore.viz.spool.coverage`), and a long archive by [`Spool.viz.calendar`](`dascore.viz.spool.calendar`); see the [visualization tutorial](visualization.qmd#spool). The lanes that plot draws are named as the spool's own repr names its tracks, with the coverage each group measured appended.
+Both frames are drawn by [`Spool.viz.coverage`](`dascore.viz.spool.coverage`), and a long archive by [`Spool.viz.calendar`](`dascore.viz.spool.calendar`); see the [visualization tutorial](visualization.qmd#spool). Those lanes and the [tracks a spool prints](#what-a-spool-says-of-itself) are named by one rule, with the coverage each group measured appended here; because the groups above are the finer partition, a lane is a track or a part of one.
 
 # concatenate
 Similar to `chunk`, [`Spool.concatenate`](`dascore.Spool.concatenate`) is used to combine patches together. However, `concatenate` ignores gaps and overlaps along the concatenation axis — it joins each group's patches in the order of that dimension (spool order when the dimension has no step to tell its orientation) — and can even be used to create new patch dimensions. It partitions patches as `chunk` does (by kind, dimensions, the other dimensions' identities, and the concatenated dimension's units), so patches which cannot be concatenated together simply land in separate outputs, and it polices the remaining attributes with the same `conflict` argument (coordinates are not policed: they are joined along the concatenated dimension, or must agree). Like `chunk`, it produces a lazy, plan-backed result.

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -213,7 +213,7 @@ A boolean mask is applied by position, so it must come from the contents of the 
 
 # What a spool says of itself
 
-Printing a spool states how many patches it holds, the extent it covers along each dimension its patches have, and one *track* per group of patches. A track is named by the values which tell its group apart from the others, which is the same name the [coverage plot](visualization.qmd#spool) puts on the matching lane, so the text and the picture can be read against each other.
+Printing a spool states how many patches it holds, the extent it covers along each dimension its patches have, and one *track* per kind of patch. A track is named by the values which tell its kind apart from the others, by the same rule the [coverage plot](visualization.qmd#spool) names its lanes.
 
 ```{python}
 import dascore as dc

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -59,6 +59,8 @@ directory_path = fetch('terra15_das_1_trimmed.hdf5').parent
 spool3 = dc.spool(directory_path).update()
 ```
 
+An indexed directory summarizes itself when printed, the same as any other spool.
+
 If you want the index file to exist somewhere else, for example if you can't write to the data directory, you can specify an index path.
 
 ```{python}
@@ -209,6 +211,18 @@ assert len(new) == (df["tag"] == "some_tag").sum()
 
 A boolean mask is applied by position, so it must come from the contents of the spool it selects; build it from that spool's `get_contents` rather than from a differently ordered or already filtered view.
 
+# What a spool says of itself
+
+Printing a spool states how many patches it holds, the extent it covers along each dimension its patches have, and one *track* per group of patches. A track is named by the values which tell its group apart from the others, which is the same name the [coverage plot](visualization.qmd#spool) puts on the matching lane, so the text and the picture can be read against each other.
+
+```{python}
+import dascore as dc
+
+dc.get_example_spool("diverse_das")
+```
+
+Summarizing realizes the whole index relation, which is more work than a glance is worth on a very large archive. The `display_max_patches` [configuration option](configuration.qmd) says where that line is; past it a spool states its count and its path alone. Nothing here measures coverage — that runs a chunk plan, and is what `get_coverage` below is for.
+
 # get_contents
 
 The [`get_contents`](`dascore.core.spool.Spool.get_contents`) method returns a dataframe listing the spool contents. It realizes the whole relation, so it can be expensive over a large remote archive.
@@ -347,7 +361,7 @@ gappy.get_coverage()
 
 `gap_total` is the sum of that group's `get_gaps` rows, `span` is the extent it covers end to end, and `coverage` is the fraction of that span the patches cover. It is measured between patches, from the index's envelopes, so a hole *inside* a patch does not show up. Patches divide into groups the way `chunk` divides them — on the kind attributes, but also on sampling rate and coordinate structure — so a single tag can span several rows. `group_id` names the group in both frames, which is how a gap is traced back to the row that counts it.
 
-Both frames are drawn by [`Spool.viz.coverage`](`dascore.viz.spool.coverage`), and a long archive by [`Spool.viz.calendar`](`dascore.viz.spool.calendar`); see the [visualization tutorial](visualization.qmd#spool).
+Both frames are drawn by [`Spool.viz.coverage`](`dascore.viz.spool.coverage`), and a long archive by [`Spool.viz.calendar`](`dascore.viz.spool.calendar`); see the [visualization tutorial](visualization.qmd#spool). The lanes that plot draws are named as the spool's own repr names its tracks, with the coverage each group measured appended.
 
 # concatenate
 Similar to `chunk`, [`Spool.concatenate`](`dascore.Spool.concatenate`) is used to combine patches together. However, `concatenate` ignores gaps and overlaps along the concatenation axis — it joins each group's patches in the order of that dimension (spool order when the dimension has no step to tell its orientation) — and can even be used to create new patch dimensions. It partitions patches as `chunk` does (by kind, dimensions, the other dimensions' identities, and the concatenated dimension's units), so patches which cannot be concatenated together simply land in separate outputs, and it polices the remaining attributes with the same `conflict` argument (coordinates are not policed: they are joined along the concatenated dimension, or must agree). Like `chunk`, it produces a lazy, plan-backed result.

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -221,7 +221,7 @@ import dascore as dc
 dc.get_example_spool("diverse_das")
 ```
 
-Summarizing realizes the whole index relation, which is more work than a glance is worth on a very large archive. The `display_max_patches` [configuration option](configuration.qmd) says where that line is; past it a spool states its count and its path alone. Nothing here measures coverage — that runs a chunk plan, and is what `get_coverage` below is for.
+Summarizing realizes the whole index relation, which is more work than a glance is worth on a very large archive. The `display_max_patches` [configuration option](configuration.qmd) says where that line is, and it holds however the spool got here: past it a spool prints its count, its path, and a line naming the limit it exceeded — never the extents — whether or not the relation was already realized. Nothing here measures coverage — that runs a chunk plan, and is what `get_coverage` below is for.
 
 # get_contents
 

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -141,6 +141,8 @@ spool.viz.coverage(show=True);
 
 Both acquisitions lose the four days in the middle of January, which is the site's own outage; the strain acquisition started later and was pulled out earlier, which is why its lane is shorter rather than gappy at the ends.
 
+A lane is named by the values which tell its group apart from the others, with that group's coverage appended. The [spool's own repr](spool.qmd#what-a-spool-says-of-itself) names its tracks by the same rule, so a lane here and a track there refer to the same patches.
+
 Time is measured by default; any other dimension the spool states can be named instead, as `spool.viz.coverage("distance")`. The whole of it is drawn, because part of a spool is a smaller spool: select the window first and the lanes, and the percentages on them, are of that window rather than of a window drawn over percentages of everything.
 
 ```{python}

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -141,7 +141,7 @@ spool.viz.coverage(show=True);
 
 Both acquisitions lose the four days in the middle of January, which is the site's own outage; the strain acquisition started later and was pulled out earlier, which is why its lane is shorter rather than gappy at the ends.
 
-A lane is named by the values which tell its group apart from the others, with that group's coverage appended. The [spool's own repr](spool.qmd#what-a-spool-says-of-itself) names its tracks by the same rule, so a lane here and a track there refer to the same patches.
+A lane is named by the values which tell its group apart from the others, with that group's coverage appended. The [spool's own repr](spool.qmd#what-a-spool-says-of-itself) names its tracks by the same rule, so the two can be read against each other. A track is one kind of patch, which is where the grouping here starts; a lane can be finer, because sampling rate and coordinate structure part two lanes of one kind.
 
 Time is measured by default; any other dimension the spool states can be named instead, as `spool.viz.coverage("distance")`. The whole of it is drawn, because part of a spool is a smaller spool: select the window first and the lanes, and the percentages on them, are of that window rather than of a window drawn over percentages of everything.
 

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -12,6 +12,7 @@ from unittest import mock
 import numpy as np
 import pandas as pd
 import pytest
+from pandas.errors import PerformanceWarning
 
 import dascore as dc
 import dascore.utils.patch_assembly as assembly_mod
@@ -2065,13 +2066,42 @@ class TestSpoolRepr:
         assert "➤ Dimensions" not in rendered
         assert "display_max_patches=1" in rendered
 
-    def test_a_repr_does_not_warn(self, indexed_directory):
+    def test_a_repr_does_not_advise_on_pandas(self):
         """Typing a name asked for a glance, not for advice on pandas."""
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            rendered = str(indexed_directory)
+        spool = dc.get_example_spool("diverse_das")
+        frame = spool.get_contents()
+        real = Spool._df
+
+        def _fragmented(self):
+            # What assembling a directory index does, once per insert.
+            warnings.warn("DataFrame is highly fragmented", PerformanceWarning)
+            return frame
+
+        with mock.patch.object(Spool, "_df", property(_fragmented)):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                rendered = str(spool)
+        assert Spool._df is real  # the patch is undone
         assert "➤ Dimensions" in rendered
-        assert not caught
+        assert not [x for x in caught if issubclass(x.category, PerformanceWarning)]
+
+    def test_a_repr_does_not_eat_a_warning(self):
+        """A realized frame warns once, and a repr must not be who hears it."""
+        spool = dc.get_example_spool("diverse_das")
+        message = "something worth saying"
+
+        def _warn(self):
+            warnings.warn(message, UserWarning, stacklevel=2)
+            return pd.DataFrame()
+
+        # Only pandas' own advice is suppressed. Anything else a repr
+        # provokes is the first and only time it will be said, because
+        # the frame it came from is cached.
+        with mock.patch.object(Spool, "_df", property(_warn)):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                str(spool)
+        assert any(message in str(x.message) for x in caught)
 
     def test_repr_never_raises(self, monkeypatch):
         """A summary which fails still leaves an object you can look at."""
@@ -2252,8 +2282,8 @@ class TestSpoolRepr:
         patches = [
             dc.Patch(
                 data=data,
-                coords={"epoch": epoch, "distance": np.arange(4.0)},
-                dims=("epoch", "distance"),
+                coords={"aepoch": epoch, "distance": np.arange(4.0)},
+                dims=("aepoch", "distance"),
                 attrs={"tag": tag},
             )
             for tag, epoch in (
@@ -2262,8 +2292,9 @@ class TestSpoolRepr:
             )
         ]
         rendered = str(dc.spool(patches))
-        assert "epoch:    mixed value kinds" in rendered
-        # And tracks fall through to a dimension whose ends do compare.
+        assert "aepoch:   mixed value kinds" in rendered
+        # Named to sort first, so it is the dimension tracks would be
+        # measured along and the filter is the only thing moving them.
         assert "➤ Tracks (2 along distance)" in rendered
 
     def test_ends_too_far_apart_to_subtract_still_state_themselves(self):

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -1992,6 +1992,13 @@ class TestSpoolRepr:
         assert "... 4 more" in rendered
         assert rendered.count(" patches  ") + rendered.count(" patch  ") == 3
 
+    def test_no_tracks_may_be_listed_at_all(self):
+        """A zero limit lists nothing, and still says what it did not list."""
+        with config_context(display_max_items=0):
+            rendered = str(dc.get_example_spool("diverse_das"))
+        assert "➤ Tracks (7 along time)" in rendered
+        assert "... 7 more" in rendered
+
     def test_a_lone_group_shows_no_tracks(self):
         """One track is the whole spool, which the dimensions already state."""
         rendered = str(dc.get_example_spool("random_das"))

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import functools
 import shutil
+import warnings
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from unittest import mock
 
@@ -29,12 +30,12 @@ from dascore.exceptions import (
 )
 from dascore.io.index.planned import PlanResolver
 from dascore.io.segy import SegyV1_0
-from dascore.utils.chunk_plan import _REPORT_COLUMNS
-from dascore.utils.display import get_nice_text, group_names
+from dascore.utils.display import get_nice_text
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch_assembly import _estimate_merge_samples, _get_varying_dim
 from dascore.utils.time import to_datetime64, to_timedelta64
+from dascore.viz.spool import _lane_names
 
 
 def _gigo(garbage):
@@ -1976,17 +1977,23 @@ class TestSpoolRepr:
         """A track and the lane of the same patches carry the same name."""
         spool = dc.get_example_spool("diverse_das")
         rendered = str(spool)
-        report = spool.get_coverage("time")
-        envelope = {f"time_{x}" for x in ("min", "max", "step", "units")}
-        names = group_names(
-            report,
-            ignore=set(_REPORT_COLUMNS) | envelope,
-            ordinals=report["group_id"],
-        )
+        # The plot's own function, not a rebuild of its arguments: a
+        # rebuild agrees with itself no matter how the two drift.
+        lanes = _lane_names(spool.get_coverage("time"), "time")
+        # A lane appends the coverage it measured; a track does not.
+        names = [x.rsplit("  ", 1)[0] for x in lanes]
         # This spool's kinds and its coverage groups partition alike, so
         # here the two sets of names are the same set.
         assert len(names) == len(set(names)) == 7
-        assert all(x in rendered for x in names)
+        # Whole track lines, not substrings: "random" occurs inside
+        # "DAS2.R2D1..RAW · random", so a substring check cannot tell
+        # the two apart, and survives every name being decorated.
+        drawn = [
+            x.strip().split("  ")[0]
+            for x in rendered.splitlines()
+            if x.startswith("    ") and "patch" in x
+        ]
+        assert sorted(drawn) == sorted(names)
 
     def test_coverage_may_cut_a_track_finer(self):
         """A kind of patch is one track, whatever coverage makes of it."""
@@ -1995,15 +2002,24 @@ class TestSpoolRepr:
         spool = dc.spool([first, second])
         # Two sampling rates are two coverage groups of one kind, and a
         # kind is what a track is; the repr does not claim otherwise.
+        rendered = str(spool)
         assert len(spool.get_coverage("time")) == 2
-        assert "➤ Tracks" not in str(spool)
+        # A presence assertion, so the summary failing outright -- which
+        # the repr suppresses -- cannot satisfy the absence below.
+        assert "➤ Dimensions" in rendered
+        assert "➤ Tracks" not in rendered
 
     def test_tracks_are_bounded(self):
         """A repr says how many tracks it did not list."""
         with config_context(display_max_items=3):
             rendered = str(dc.get_example_spool("diverse_das"))
         assert "... 4 more" in rendered
-        assert rendered.count(" patches  ") + rendered.count(" patch  ") == 3
+        drawn = [x for x in rendered.splitlines() if "patch" in x and "➤" not in x]
+        assert len(drawn) == 3
+        # Measured over the lines drawn, not the frame: the widest name
+        # here is "overlaps", so no line is padded out to the elided
+        # "DAS2.R2D1..RAW · random".
+        assert drawn[0] == "    big_gaps  3 patches  2020-01-03 <26 s>"
 
     def test_no_tracks_may_be_listed_at_all(self):
         """A zero limit lists nothing, and still says what it did not list."""
@@ -2015,6 +2031,7 @@ class TestSpoolRepr:
     def test_a_lone_group_shows_no_tracks(self):
         """One track is the whole spool, which the dimensions already state."""
         rendered = str(dc.get_example_spool("random_das"))
+        assert "➤ Dimensions" in rendered
         assert "➤ Tracks" not in rendered
         assert "group 0" not in rendered
 
@@ -2030,13 +2047,31 @@ class TestSpoolRepr:
         assert "display_max_patches=1" in rendered
         assert "➤ Dimensions" not in rendered
 
-    def test_a_realized_frame_is_always_summarized(self):
-        """A frame already paid for is read again however large the spool."""
+    def test_the_limit_holds_whatever_the_spool_was_asked_before(self):
+        """Realizing a frame does not buy a summary the limit refuses."""
         spool = dc.get_example_spool("diverse_das")
         spool.get_contents()  # realize the relation
         with config_context(display_max_patches=1):
             rendered = str(spool)
+        # One object, one repr: a summary which appeared only once
+        # something happened to build the frame would print two.
+        assert "➤ Dimensions" not in rendered
+        assert "display_max_patches=1" in rendered
+
+    def test_a_directory_spool_degrades(self, indexed_directory):
+        """The case the limit exists for: an index too large to realize."""
+        with config_context(display_max_patches=1):
+            rendered = str(indexed_directory)
+        assert "➤ Dimensions" not in rendered
+        assert "display_max_patches=1" in rendered
+
+    def test_a_repr_does_not_warn(self, indexed_directory):
+        """Typing a name asked for a glance, not for advice on pandas."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            rendered = str(indexed_directory)
         assert "➤ Dimensions" in rendered
+        assert not caught
 
     def test_repr_never_raises(self, monkeypatch):
         """A summary which fails still leaves an object you can look at."""
@@ -2052,7 +2087,11 @@ class TestSpoolRepr:
     @pytest.mark.parametrize("spool", [Spool(), dc.spool([]), dc.spool(dc.Patch())])
     def test_empty_spools_render(self, spool):
         """A spool with nothing to summarize still says what it is."""
-        assert "Spool" in str(spool)
+        rendered = str(spool)
+        assert "Spool 🧵" in rendered
+        # Nothing to summarize is a header and no blocks, not a header
+        # standing in for blocks which failed.
+        assert "➤ " not in rendered
 
     def test_a_patch_without_the_dimension_is_not_a_track(self):
         """A patch off the axis is dropped, as get_coverage drops it."""
@@ -2070,6 +2109,10 @@ class TestSpoolRepr:
             ]
         )
         rendered = str(spool)
+        # Presence first: removing the filter raises inside the summary
+        # rather than printing NaT, and the repr swallows that.
+        assert "➤ Dimensions" in rendered
+        assert "time:" in rendered
         assert "NaT" not in rendered
         # One kind is left along time, and one track is no track block.
         assert len(spool.get_coverage("time")) == 1
@@ -2092,6 +2135,72 @@ class TestSpoolRepr:
         assert "➤ Tracks (2 along distance)" in rendered
         assert "<5>" in rendered
         assert " s>" not in rendered
+
+    def test_a_track_states_the_unit_its_dimension_agrees_on(self):
+        """Where every patch measures in metres, a width is in metres."""
+        data = np.random.default_rng().random((6, 4))
+        patches = [
+            dc.Patch(
+                data=data,
+                coords={"distance": np.arange(6.0), "frequency": np.arange(4.0)},
+                dims=("distance", "frequency"),
+                attrs={"tag": tag},
+            ).convert_units(distance="m")
+            for tag in ("a", "b")
+        ]
+        assert "<5 m>" in str(dc.spool(patches))
+
+    def test_a_dimension_of_labels_has_ends_and_no_width(self):
+        """A string dimension cannot be subtracted, and must not be."""
+        data = np.random.default_rng().random((3, 4))
+        patches = [
+            dc.Patch(
+                data=data,
+                coords={
+                    "channel_id": np.array(["a", "b", "c"]),
+                    "distance": np.arange(4.0),
+                },
+                dims=("channel_id", "distance"),
+                attrs={"tag": tag},
+            )
+            for tag in ("one", "two")
+        ]
+        # channel_id sorts first, so it is the dimension tracks measure
+        # along -- the path where a width would have to be subtracted.
+        rendered = str(dc.spool(patches))
+        assert "channel_id: a to c" in rendered
+        # The whole summary used to vanish here, suppressed TypeError and all.
+        assert "➤ Dimensions" in rendered
+        assert "distance:" in rendered
+        # Two ends, and no width claimed between them, on both lines.
+        assert "➤ Tracks (2 along channel_id)" in rendered
+        assert "<" not in rendered.split("➤ Tracks")[1]
+
+    def test_an_extent_of_no_duration_states_none(self):
+        """One sample spans an instant, which is not a span of nothing."""
+        patch = dc.get_example_patch().select(time=(0, 1), samples=True)
+        rendered = str(dc.spool([patch]))
+        assert "time:" in rendered
+        # human_duration says nothing of a zero, which read as "<>".
+        assert "<>" not in rendered
+
+    def test_a_track_is_not_labelled_in_a_unit_it_was_not_measured_in(self):
+        """Where patches disagree on a unit, no track claims either one."""
+        data = np.random.default_rng().random((6, 4))
+        patches = [
+            dc.Patch(
+                data=data,
+                coords={"distance": np.arange(6.0), "frequency": np.arange(4.0)},
+                dims=("distance", "frequency"),
+                attrs={"tag": tag},
+            ).convert_units(distance=units)
+            for tag, units in (("metric", "m"), ("imperial", "ft"))
+        ]
+        rendered = str(dc.spool(patches))
+        assert "➤ Tracks (2 along distance)" in rendered
+        # Both tracks read <5 ft> when the first unit stood for every one.
+        assert "ft>" not in rendered
+        assert " m>" not in rendered
 
     def test_a_kind_attr_named_twice_is_one_key(self):
         """A config may repeat an attribute; a groupby may not."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -2202,6 +2202,68 @@ class TestSpoolRepr:
         assert "ft>" not in rendered
         assert " m>" not in rendered
 
+    def test_a_nameless_track_is_named_as_its_lane_is(self):
+        """A group nothing tells apart falls back where the plot does."""
+        spool = dc.spool(
+            [
+                dc.get_example_patch().update_attrs(
+                    acquisition_key="XM.A..HSF", station="A"
+                ),
+                dc.get_example_patch().update_attrs(acquisition_key="XM.A..HSF"),
+            ]
+        )
+        rendered = str(spool)
+        lanes = _lane_names(spool.get_coverage("time"), "time")
+        # The plot named this group by its acquisition; a track calling
+        # it "group 0" would be one rule reaching two names.
+        assert "XM.A..HSF" in rendered
+        assert "group 0" not in rendered
+        assert all(x.rsplit("  ", 1)[0] in rendered for x in lanes)
+
+    def test_a_dimension_of_two_kinds_states_no_one_extent(self):
+        """One name backed by times and by numbers has no two ends."""
+        data = np.random.default_rng().random((3, 4))
+        patches = [
+            dc.Patch(
+                data=data,
+                coords={"epoch": epoch, "distance": np.arange(4.0)},
+                dims=("epoch", "distance"),
+                attrs={"tag": tag},
+            )
+            for tag, epoch in (
+                ("dated", dc.to_datetime64(np.arange(3.0))),
+                ("numeric", np.arange(3.0)),
+            )
+        ]
+        rendered = str(dc.spool(patches))
+        # Comparing the two raised, and the whole summary went with it.
+        assert "epoch:" in rendered
+        assert "mixed value kinds" in rendered
+        assert "distance: 0.000 to 3.000" in rendered
+        # Tracks are measured along a dimension whose ends compare.
+        assert "➤ Tracks (2 along distance)" in rendered
+
+    def test_a_coordinate_riding_another_axis_is_not_this_one(self):
+        """A name may be a dimension on one patch and a rider on another."""
+        data = np.random.default_rng().random((4, 5))
+        as_dim = dc.Patch(
+            data=data,
+            coords={"quality": np.arange(4.0), "time": np.arange(5.0)},
+            dims=("quality", "time"),
+            attrs={"tag": "dim"},
+        )
+        as_rider = dc.Patch(
+            data=data,
+            coords={"channel": np.arange(4.0), "time": np.arange(5.0)},
+            dims=("channel", "time"),
+            attrs={"tag": "rider"},
+        ).update_coords(quality=("channel", np.linspace(100.0, 200.0, 4)))
+        rendered = str(dc.spool([as_dim, as_rider]))
+        # The rider's 100-200 is not part of the quality axis, whose
+        # only patch spans 0 to 3.
+        assert "quality: 0.000 to 3.000" in rendered
+        assert "200" not in rendered
+
     def test_a_kind_attr_named_twice_is_one_key(self):
         """A config may repeat an attribute; a groupby may not."""
         with config_context(patch_kind_attrs=("tag", "tag")):

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -6,6 +6,7 @@ import copy
 import functools
 import shutil
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -13,6 +14,7 @@ import pytest
 
 import dascore as dc
 import dascore.utils.patch_assembly as assembly_mod
+from dascore.config import config_context
 from dascore.core.coords import get_coord
 from dascore.core.spool import BaseSpool, Spool
 from dascore.examples import ricker_moveout
@@ -27,6 +29,8 @@ from dascore.exceptions import (
 )
 from dascore.io.index.planned import PlanResolver
 from dascore.io.segy import SegyV1_0
+from dascore.utils.chunk_plan import _REPORT_COLUMNS
+from dascore.utils.display import get_nice_text, group_names
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch_assembly import _estimate_merge_samples, _get_varying_dim
@@ -1052,31 +1056,17 @@ class TestSpoolCoverageEdges:
             out.append(nxt)
         return out
 
-    def test_equality_and_repr(self):
-        """Spool equality strips synthetic identity; repr shows a time span."""
+    def test_equality(self):
+        """Spool equality strips synthetic identity."""
         patch = dc.get_example_patch()
         left, right = dc.spool([patch]), dc.spool([patch])
         left.get_contents()  # realize so equality compares built frames
         right.get_contents()
         assert left == right
-        assert "Time Span" in left.__rich__().__str__()
 
     def test_equality_of_empty_spools(self):
         """Empty spools (None frames) compare equal via the None-strip path."""
         assert Spool() == Spool()
-
-    def test_repr_without_time_coordinate(self):
-        """A spool whose patches have no time coord omits the time-span line."""
-        data = np.random.default_rng().random((6, 4))
-        coords = {"distance": np.arange(6), "frequency": np.arange(4.0)}
-        patch = dc.Patch(data=data, coords=coords, dims=("distance", "frequency"))
-        rendered = dc.spool([patch]).__rich__().__str__()
-        assert "Spool" in rendered
-        assert "Time Span" not in rendered  # no time coordinate to summarize
-
-    def test_repr_with_time_coordinate(self):
-        """A normal spool renders its time span."""
-        assert "Time Span" in dc.spool([dc.get_example_patch()]).__rich__().__str__()
 
     def test_large_merge_dedups(self, many_contiguous):
         """Merging >10 sources into one patch exercises the de-dup branch."""
@@ -1915,3 +1905,139 @@ class TestEmptyConcatenate:
         out = dc.spool([]).concatenate(**kwargs)
         assert len(out) == 0
         assert list(out) == []
+
+
+class TestSpoolRepr:
+    """What a spool says of itself when it is printed."""
+
+    @pytest.fixture(scope="class")
+    def off_the_time_axis(self):
+        """A spool of patches which state no time."""
+        data = np.random.default_rng().random((6, 4))
+        coords = {"distance": np.arange(6), "frequency": np.arange(4.0)}
+        patch = dc.Patch(data=data, coords=coords, dims=("distance", "frequency"))
+        return dc.spool([patch])
+
+    @pytest.fixture(scope="class")
+    def indexed_directory(self, tmp_path_factory):
+        """A directory spool of a few files, indexed."""
+        path = tmp_path_factory.mktemp("repr_directory")
+        spool = dc.get_example_spool("random_das")
+        for index, patch in enumerate(spool):
+            patch.io.write(path / f"patch_{index}.h5", "dasdae")
+        return dc.spool(path).update()
+
+    def test_span_reaches_the_last_patch_end(self):
+        """The span ends where the data does, not where the last patch starts."""
+        spool = dc.get_example_spool("random_das")
+        df = spool.get_contents()
+        # The bug this pins: reading both ends off time_min made every
+        # single-patch spool span zero time.
+        assert df["time_min"].max() != df["time_max"].max()
+        assert str(get_nice_text(df["time_max"].max())) in str(spool)
+
+    def test_a_single_patch_spans_its_own_length(self):
+        """One patch is a span of its duration, not a span of nothing."""
+        rendered = str(dc.spool(dc.get_example_patch()))
+        assert "<8 s>" in rendered
+
+    def test_duration_is_readable(self):
+        """A span of decades reads in years, not in seconds of float."""
+        rendered = str(dc.get_example_spool("diverse_das"))
+        assert "<40.7 y>" in rendered
+        assert "e+09" not in rendered
+
+    def test_directory_spool_is_summarized(self, indexed_directory):
+        """An indexed directory states what it covers; it used to state nothing."""
+        rendered = str(indexed_directory)
+        assert "➤ Dimensions" in rendered
+        assert "time:" in rendered
+
+    def test_a_spool_off_the_time_axis(self, off_the_time_axis):
+        """A spool states the dimensions it has, and only those."""
+        rendered = str(off_the_time_axis)
+        assert "distance:" in rendered
+        assert "frequency:" in rendered
+        # The relation carries time columns whatever the patches state.
+        assert "time:" not in rendered
+
+    def test_a_non_dimensional_coord_is_not_a_dimension(self):
+        """A coord with an envelope is not thereby an axis of the patch."""
+        patch = dc.get_example_patch()
+        size = patch.coords.coord_size("time")
+        # The relation gives every coord an envelope, dimensional or not,
+        # so `dims` is what says which of them the repr may name.
+        patch = patch.update_coords(temperature=("time", np.linspace(10.0, 20.0, size)))
+        rendered = str(dc.spool([patch]))
+        assert "➤ Dimensions (time, distance)" in rendered
+        assert "temperature" not in rendered
+
+    def test_tracks_are_named_as_the_plot_names_lanes(self):
+        """The tracks a repr prints are the lanes a coverage plot draws."""
+        spool = dc.get_example_spool("diverse_das")
+        rendered = str(spool)
+        report = spool.get_coverage("time")
+        envelope = {f"time_{x}" for x in ("min", "max", "step", "units")}
+        names = group_names(
+            report,
+            ignore=set(_REPORT_COLUMNS) | envelope,
+            ordinals=report["group_id"],
+        )
+        assert all(x in rendered for x in names)
+
+    def test_tracks_are_bounded(self):
+        """A repr says how many tracks it did not list."""
+        with config_context(display_max_items=3):
+            rendered = str(dc.get_example_spool("diverse_das"))
+        assert "... 4 more" in rendered
+        assert rendered.count(" patches  ") + rendered.count(" patch  ") == 3
+
+    def test_a_lone_group_shows_no_tracks(self):
+        """One track is the whole spool, which the dimensions already state."""
+        rendered = str(dc.get_example_spool("random_das"))
+        assert "➤ Tracks" not in rendered
+        assert "group 0" not in rendered
+
+    def test_a_big_spool_degrades(self):
+        """Past the limit a repr states its count and never reads the frame."""
+        spool = dc.get_example_spool("diverse_das")
+        with config_context(display_max_patches=1):
+            with mock.patch.object(
+                Spool, "_df", new_callable=mock.PropertyMock
+            ) as realize:
+                rendered = str(spool)
+        realize.assert_not_called()
+        assert "display_max_patches=1" in rendered
+        assert "➤ Dimensions" not in rendered
+
+    def test_a_realized_frame_is_always_summarized(self):
+        """A frame already paid for is read again however large the spool."""
+        spool = dc.get_example_spool("diverse_das")
+        spool.get_contents()  # realize the relation
+        with config_context(display_max_patches=1):
+            rendered = str(spool)
+        assert "➤ Dimensions" in rendered
+
+    def test_repr_never_raises(self, monkeypatch):
+        """A summary which fails still leaves an object you can look at."""
+
+        def _boom(self, df, dims):
+            raise ValueError("nope")
+
+        monkeypatch.setattr(Spool, "_dims_text", _boom)
+        rendered = str(dc.get_example_spool("diverse_das"))
+        assert "Spool" in rendered
+        assert "➤ Dimensions" not in rendered
+
+    @pytest.mark.parametrize("spool", [Spool(), dc.spool([]), dc.spool(dc.Patch())])
+    def test_empty_spools_render(self, spool):
+        """A spool with nothing to summarize still says what it is."""
+        assert "Spool" in str(spool)
+
+    def test_a_dimension_with_no_agreed_units_states_none(self):
+        """Two patches measuring a dimension differently name no unit."""
+        first = dc.get_example_patch().convert_units(distance="m")
+        second = dc.get_example_patch().convert_units(distance="ft")
+        rendered = str(dc.spool([first, second]))
+        assert "distance:" in rendered
+        assert "ft" not in rendered

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -1973,7 +1973,7 @@ class TestSpoolRepr:
         assert "temperature" not in rendered
 
     def test_tracks_are_named_as_the_plot_names_lanes(self):
-        """The tracks a repr prints are the lanes a coverage plot draws."""
+        """A track and the lane of the same patches carry the same name."""
         spool = dc.get_example_spool("diverse_das")
         rendered = str(spool)
         report = spool.get_coverage("time")
@@ -1983,7 +1983,20 @@ class TestSpoolRepr:
             ignore=set(_REPORT_COLUMNS) | envelope,
             ordinals=report["group_id"],
         )
+        # This spool's kinds and its coverage groups partition alike, so
+        # here the two sets of names are the same set.
+        assert len(names) == len(set(names)) == 7
         assert all(x in rendered for x in names)
+
+    def test_coverage_may_cut_a_track_finer(self):
+        """A kind of patch is one track, whatever coverage makes of it."""
+        first = dc.get_example_patch(time_step=0.004)
+        second = dc.get_example_patch(time_step=0.008)
+        spool = dc.spool([first, second])
+        # Two sampling rates are two coverage groups of one kind, and a
+        # kind is what a track is; the repr does not claim otherwise.
+        assert len(spool.get_coverage("time")) == 2
+        assert "➤ Tracks" not in str(spool)
 
     def test_tracks_are_bounded(self):
         """A repr says how many tracks it did not list."""
@@ -2041,10 +2054,61 @@ class TestSpoolRepr:
         """A spool with nothing to summarize still says what it is."""
         assert "Spool" in str(spool)
 
-    def test_a_dimension_with_no_agreed_units_states_none(self):
-        """Two patches measuring a dimension differently name no unit."""
+    def test_a_patch_without_the_dimension_is_not_a_track(self):
+        """A patch off the axis is dropped, as get_coverage drops it."""
+        data = np.random.default_rng().random((6, 4))
+        coords = {"distance": np.arange(6.0), "frequency": np.arange(4.0)}
+        spool = dc.spool(
+            [
+                dc.get_example_patch().update_attrs(tag="timed"),
+                dc.Patch(
+                    data=data,
+                    coords=coords,
+                    dims=("distance", "frequency"),
+                    attrs={"tag": "untimed"},
+                ),
+            ]
+        )
+        rendered = str(spool)
+        assert "NaT" not in rendered
+        # One kind is left along time, and one track is no track block.
+        assert len(spool.get_coverage("time")) == 1
+        assert "➤ Tracks" not in rendered
+
+    def test_a_track_off_the_time_axis_is_not_measured_in_seconds(self):
+        """A distance span is as wide as distance is, not that many seconds."""
+        data = np.random.default_rng().random((6, 4))
+        coords = {"distance": np.arange(6.0), "frequency": np.arange(4.0)}
+        patches = [
+            dc.Patch(
+                data=data,
+                coords=coords,
+                dims=("distance", "frequency"),
+                attrs={"tag": tag},
+            )
+            for tag in ("a", "b")
+        ]
+        rendered = str(dc.spool(patches))
+        assert "➤ Tracks (2 along distance)" in rendered
+        assert "<5>" in rendered
+        assert " s>" not in rendered
+
+    def test_a_kind_attr_named_twice_is_one_key(self):
+        """A config may repeat an attribute; a groupby may not."""
+        with config_context(patch_kind_attrs=("tag", "tag")):
+            rendered = str(dc.get_example_spool("diverse_das"))
+        assert "➤ Tracks" in rendered
+
+    def test_mixed_units_are_not_one_extent(self):
+        """Two ends read in different units are not two ends of one span."""
         first = dc.get_example_patch().convert_units(distance="m")
         second = dc.get_example_patch().convert_units(distance="ft")
         rendered = str(dc.spool([first, second]))
-        assert "distance:" in rendered
-        assert "ft" not in rendered
+        assert "mixed units: ft, m" in rendered
+
+    def test_the_count_is_asked_for_once(self):
+        """Counting a view can project the relation; a repr does it once."""
+        spool = dc.get_example_spool("diverse_das")
+        with mock.patch.object(Spool, "__len__", return_value=18) as counted:
+            str(spool)
+        assert counted.call_count == 1

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -2184,8 +2184,8 @@ class TestSpoolRepr:
         # human_duration says nothing of a zero, which read as "<>".
         assert "<>" not in rendered
 
-    def test_a_track_is_not_labelled_in_a_unit_it_was_not_measured_in(self):
-        """Where patches disagree on a unit, no track claims either one."""
+    def test_tracks_are_not_measured_across_two_units(self):
+        """A metre taken from a foot is a number standing for nothing."""
         data = np.random.default_rng().random((6, 4))
         patches = [
             dc.Patch(
@@ -2197,7 +2197,10 @@ class TestSpoolRepr:
             for tag, units in (("metric", "m"), ("imperial", "ft"))
         ]
         rendered = str(dc.spool(patches))
-        assert "➤ Tracks (2 along distance)" in rendered
+        # distance is the dimension tracks would be measured along, and
+        # its patches disagree; frequency is the one whose ends compare.
+        assert "distance:  0.000 to 5.000  (mixed units: ft, m)" in rendered
+        assert "➤ Tracks (2 along frequency)" in rendered
         # Both tracks read <5 ft> when the first unit stood for every one.
         assert "ft>" not in rendered
         assert " m>" not in rendered
@@ -2242,6 +2245,66 @@ class TestSpoolRepr:
         assert "distance: 0.000 to 3.000" in rendered
         # Tracks are measured along a dimension whose ends compare.
         assert "➤ Tracks (2 along distance)" in rendered
+
+    def test_an_instant_and_an_offset_are_two_kinds(self):
+        """A date and a length are both times and do not compare."""
+        data = np.random.default_rng().random((3, 4))
+        patches = [
+            dc.Patch(
+                data=data,
+                coords={"epoch": epoch, "distance": np.arange(4.0)},
+                dims=("epoch", "distance"),
+                attrs={"tag": tag},
+            )
+            for tag, epoch in (
+                ("instant", dc.to_datetime64(np.arange(3.0))),
+                ("offset", dc.to_timedelta64(np.arange(3.0))),
+            )
+        ]
+        rendered = str(dc.spool(patches))
+        assert "epoch:    mixed value kinds" in rendered
+        # And tracks fall through to a dimension whose ends do compare.
+        assert "➤ Tracks (2 along distance)" in rendered
+
+    def test_ends_too_far_apart_to_subtract_still_state_themselves(self):
+        """A duration pandas cannot hold is not a reason to say nothing."""
+        spool = dc.spool(
+            [
+                dc.get_example_patch(
+                    time_min=dc.to_datetime64("1700-01-01")
+                ).update_attrs(tag="old"),
+                dc.get_example_patch(
+                    time_min=dc.to_datetime64("2200-01-01")
+                ).update_attrs(tag="new"),
+            ]
+        )
+        rendered = str(spool)
+        # 500 years overflows a Timedelta; the extents survive it.
+        assert "1700-01-01 to 2200-01-01" in rendered
+        assert "distance: 0.000 to 299.000 m" in rendered
+
+    def test_a_dimension_states_the_units_of_its_own_rows(self):
+        """A coordinate riding another axis does not name this one's unit."""
+        data = np.random.default_rng().random((4, 5))
+        as_dim = dc.Patch(
+            data=data,
+            coords={"quality": np.arange(4.0), "time": np.arange(5.0)},
+            dims=("quality", "time"),
+            attrs={"tag": "dim"},
+        )
+        as_rider = dc.Patch(
+            data=data,
+            coords={"channel": np.arange(4.0), "time": np.arange(5.0)},
+            dims=("channel", "time"),
+            attrs={"tag": "rider"},
+        ).update_coords(quality=("channel", np.arange(4.0)))
+        as_rider = as_rider.convert_units(quality="ft")
+        rendered = str(dc.spool([as_dim, as_rider]))
+        # The rider's feet are not the axis's units, and are not a
+        # conflict with them either.
+        assert "quality: 0.000 to 3.000" in rendered
+        assert "mixed units" not in rendered
+        assert "ft" not in rendered
 
     def test_a_coordinate_riding_another_axis_is_not_this_one(self):
         """A name may be a dimension on one patch and a rider on another."""

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 from pydantic import BaseModel, ConfigDict
 from rich.text import Text
 
@@ -17,10 +18,13 @@ from dascore.utils.display import (
     counts_to_text,
     get_header_text,
     get_nice_text,
+    group_names,
+    human_duration,
     indent_text,
     limit_reprs,
     mapping_to_text,
     model_to_line,
+    percent,
     stated_fields,
     value_to_text,
 )
@@ -306,3 +310,104 @@ class TestValueToText:
     def test_nat_is_text(self):
         """An unset time renders like every other value, not as a str."""
         assert str(value_to_text("a", np.datetime64("NaT"))) == "NaT"
+
+
+class TestPercent:
+    """How a fraction says itself."""
+
+    @pytest.mark.parametrize(
+        "value, text",
+        [
+            (1.0, "100%"),
+            (0.9993334, "99.9%"),
+            (0.92276, "92%"),
+            (1.246e-08, "0%"),
+            (0.0, "0%"),
+        ],
+    )
+    def test_percent(self, value, text):
+        """A percentage reads at the precision it needs."""
+        assert percent(value) == text
+
+    def test_a_hole_is_never_rounded_away(self):
+        """Only a whole span reads as 100%."""
+        assert percent(0.999999999) == "<100%"
+        assert percent(1.0) == "100%"
+
+
+class TestHumanDuration:
+    """How long something lasted, in the unit which fits."""
+
+    @pytest.mark.parametrize(
+        "seconds, text",
+        [
+            (0.0, ""),
+            (0.008, "8 ms"),
+            (1.004, "1 s"),
+            (90.0, "1.5 m"),
+            (7200.0, "2 h"),
+            (86_400.0 * 3, "3 d"),
+            # A multi-year outage is not worth reading in days.
+            (86_400.0 * 400, "1.1 y"),
+            (86_400.0 * 14_852, "40.7 y"),
+        ],
+    )
+    def test_human_duration(self, seconds, text):
+        """A duration is stated in the largest unit which fits it."""
+        assert human_duration(pd.Timedelta(seconds=seconds)) == text
+
+    def test_duration_of_a_plain_number(self):
+        """A dimension which is not time still measures in seconds."""
+        assert human_duration(12.0) == "12 s"
+
+    def test_duration_smaller_than_any_unit(self):
+        """A span under a microsecond still says how long it is."""
+        assert human_duration(1e-9) == "1e-09 s"
+
+    def test_an_unmeasurable_duration_says_nothing(self):
+        """A duration nothing states is not a duration of zero."""
+        assert human_duration(np.nan) == ""
+
+
+class TestGroupNames:
+    """How a group is named by what tells it apart."""
+
+    def test_only_what_differs_names_a_group(self):
+        """A value every group shares tells none of them apart."""
+        frame = pd.DataFrame({"tag": ["a", "b"], "kind": ["das", "das"]})
+        assert group_names(frame) == ["a", "b"]
+
+    def test_several_values_join(self):
+        """A group stating two telling values is named by both."""
+        frame = pd.DataFrame({"tag": ["a", "b"], "kind": ["das", "dss"]})
+        assert group_names(frame) == ["a · das", "b · dss"]
+
+    def test_a_nameless_group_takes_its_position(self):
+        """A group nothing tells apart falls back to its ordinal."""
+        frame = pd.DataFrame({"tag": ["same", "same"]})
+        assert group_names(frame) == ["group 0", "group 1"]
+
+    def test_ordinals_may_be_given(self):
+        """A caller with its own group ids names by those instead."""
+        frame = pd.DataFrame({"tag": ["same", "same"]})
+        assert group_names(frame, ordinals=[7, 9]) == ["group 7", "group 9"]
+
+    def test_a_shared_description_is_told_apart(self):
+        """Two groups describing themselves alike are still two groups."""
+        frame = pd.DataFrame({"tag": ["a", "a", "b"], "n": [1, 2, 3]})
+        assert group_names(frame, ignore=("n",)) == ["a (0)", "a (1)", "b"]
+
+    def test_ignored_columns_never_name(self):
+        """A column describing the group does not tell it apart."""
+        frame = pd.DataFrame({"tag": ["a", "b"], "span": [1.0, 2.0]})
+        assert group_names(frame, ignore=("span",)) == ["a", "b"]
+
+    def test_a_private_column_never_names(self):
+        """A column the index keeps to itself is not a value a group states."""
+        frame = pd.DataFrame({"tag": ["a", "b"], "_key": ["x", "y"]})
+        assert group_names(frame) == ["a", "b"]
+
+    def test_an_unstated_value_is_not_a_blank(self):
+        """A group which recorded nothing is not named by an empty part."""
+        frame = pd.DataFrame({"tag": ["a", ""], "kind": ["das", "dss"]})
+        assert group_names(frame) == ["a · das", "dss"]

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -413,6 +413,13 @@ class TestGroupNames:
         assert group_names(frame, fallback="acquisition_key") == ["XM.A..HSF"]
         assert group_names(frame) == ["group 0"]
 
+    def test_the_fallback_yields_to_what_does_tell_them_apart(self):
+        """A fallback names a group nothing else can, and only that."""
+        frame = pd.DataFrame(
+            {"tag": ["alpha", "beta"], "acquisition_key": ["XM.A..HSF"] * 2}
+        )
+        assert group_names(frame, fallback="acquisition_key") == ["alpha", "beta"]
+
     def test_a_shared_fallback_still_takes_the_ordinal(self):
         """Two groups the fallback names alike are still two groups."""
         frame = pd.DataFrame({"tag": ["das"] * 2, "acquisition_key": ["XM.A..HSF"] * 2})

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -357,7 +357,7 @@ class TestHumanDuration:
         assert human_duration(pd.Timedelta(seconds=seconds)) == text
 
     def test_duration_of_a_plain_number(self):
-        """A dimension which is not time still measures in seconds."""
+        """A plain number is read as a count of seconds, as the gap ticks are."""
         assert human_duration(12.0) == "12 s"
 
     def test_duration_smaller_than_any_unit(self):

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -407,6 +407,29 @@ class TestGroupNames:
         frame = pd.DataFrame({"tag": ["a", "b"], "_key": ["x", "y"]})
         assert group_names(frame) == ["a", "b"]
 
+    def test_a_fallback_names_what_nothing_tells_apart(self):
+        """A lone group has nothing to be told apart from, but has a name."""
+        frame = pd.DataFrame({"tag": ["das"], "acquisition_key": ["XM.A..HSF"]})
+        assert group_names(frame, fallback="acquisition_key") == ["XM.A..HSF"]
+        assert group_names(frame) == ["group 0"]
+
+    def test_a_shared_fallback_still_takes_the_ordinal(self):
+        """Two groups the fallback names alike are still two groups."""
+        frame = pd.DataFrame({"tag": ["das"] * 2, "acquisition_key": ["XM.A..HSF"] * 2})
+        assert group_names(frame, fallback="acquisition_key") == [
+            "XM.A..HSF (0)",
+            "XM.A..HSF (1)",
+        ]
+
+    @pytest.mark.parametrize(
+        "frame", [{"tag": ["das"], "acquisition_key": [""]}, {"tag": ["das"]}]
+    )
+    def test_a_fallback_which_says_nothing_is_not_a_name(self, frame):
+        """A blank fallback, or none at all, leaves the ordinal to name it."""
+        assert group_names(pd.DataFrame(frame), fallback="acquisition_key") == [
+            "group 0"
+        ]
+
     def test_an_unstated_value_is_not_a_blank(self):
         """A group which recorded nothing is not named by an empty part."""
         frame = pd.DataFrame({"tag": ["a", ""], "kind": ["das", "dss"]})

--- a/tests/test_viz/test_spool_viz.py
+++ b/tests/test_viz/test_spool_viz.py
@@ -16,8 +16,6 @@ from dascore.viz import VizSpoolNameSpace
 from dascore.viz import spool as spool_viz
 from dascore.viz.spool import (
     COVERAGE_COLORS,
-    _human_duration,
-    _percent,
     _union,
     calendar,
     coverage,
@@ -276,47 +274,6 @@ class TestNaming:
     """How a lane says which group it is and how complete."""
 
     @pytest.mark.parametrize(
-        "value, text",
-        [
-            (1.0, "100%"),
-            (0.9993334, "99.9%"),
-            (0.92276, "92%"),
-            (1.246e-08, "0%"),
-            (0.0, "0%"),
-        ],
-    )
-    def test_percent(self, value, text):
-        """A percentage reads at the precision it needs."""
-        assert _percent(value) == text
-
-    def test_a_hole_is_never_rounded_away(self):
-        """Only a whole span reads as 100%."""
-        assert _percent(0.999999999) == "<100%"
-        assert _percent(1.0) == "100%"
-
-    @pytest.mark.parametrize(
-        "seconds, text",
-        [
-            (0.0, ""),
-            (0.008, "8 ms"),
-            (1.004, "1 s"),
-            (90.0, "1.5 m"),
-            (7200.0, "2 h"),
-            (86_400.0 * 3, "3 d"),
-            # A multi-year outage is not worth reading in days.
-            (86_400.0 * 400, "1.1 y"),
-            (86_400.0 * 14_852, "40.7 y"),
-        ],
-    )
-    def test_human_duration(self, seconds, text):
-        """A gap is stated in the largest unit which fits it."""
-        assert _human_duration(pd.Timedelta(seconds=seconds)) == text
-
-    def test_duration_of_a_plain_number(self):
-        """A dimension which is not time still labels its gaps."""
-        assert _human_duration(12.0) == "12 s"
-
-    @pytest.mark.parametrize(
         "size, units, text",
         [
             (13.0, "m", "13 m"),
@@ -329,10 +286,6 @@ class TestNaming:
     def test_gap_label_off_the_time_axis(self, size, units, text):
         """A gap along another dimension is measured in that dimension."""
         assert spool_viz._gap_label(size, units, dated=False) == text
-
-    def test_duration_smaller_than_any_unit(self):
-        """A gap under a microsecond still says how long it is."""
-        assert _human_duration(1e-9) == "1e-09 s"
 
     def test_an_attr_spelled_like_an_envelope(self):
         """Only the measured dimension owns the envelope column names."""


### PR DESCRIPTION
## Description

A spool's repr is the first thing anyone sees when they type its name in a notebook, and it said almost nothing — part of it wrong.

Before, an in-memory spool printed:

```
DASCore Spool 🧵 (18 Patches)
    Time Span: <1.2832128e+09s> 1989-05-04 to 2030-01-01
```

and a directory-backed spool of 82 files printed only its count and its path.

Three defects and two gaps:

1. Both ends of the span were read off `time_min`, so `time_max` was never used. The span always understated by the last patch's duration, and every single-patch spool reported `<0.0s>`.
2. The duration was raw float seconds. Forty years read as `1.2832128e+09s`.
3. `cheap = self.indexer is None` skipped the whole span for any directory-backed spool — the archives people actually keep.
4. Only `time` was summarized; a distance- or frequency-domain spool said nothing.
5. Nothing said what was *in* the spool.

Now:

```
DASCore Spool 🧵 (82 Patches)
-----------------------------
    Path: /data/fiber
➤ Dimensions (time, distance)
    time:     2026-07-09T12:51:37 to 2026-08-06T23:12:00.247917312  <28.4 d>
    distance: 0.000 to 4181.324 m
➤ Tracks (4 along time)
    OTDR                          2 patches  2026-07-09T12:51:37 <20.9 d>
    XM.MINE1.03.WSF · DSS · DSS  48 patches  2026-08-04T22:43:44.598228224 <2 d>
    XM.MINE1.04.FSF · DAS · DAS     1 patch  2026-08-06T10:13:25.000455872 <15 s>
    XM.MINE1.04.MSF · DAS_LF     31 patches  2026-08-06T10:00:52.486669056 <31.1 m>
    (coverage: spool.viz.coverage())
```

### What a track is, and what it is not

A track is one *kind* of patch — the partition `chunk` starts from. Coverage may cut a kind finer, since sampling rate and coordinate structure part two lanes of one tag, so a lane is a track or a part of one and the names agree wherever the partitions do.

They agree because they are now the same code. `_lane_names` had the rule; a repr cannot ask the viz module for it, because `dascore/viz/spool.py` imports matplotlib at module scope and `import dascore` deliberately defers that (233 ms). So the rule moves to `dascore/utils/display.py` as `group_names`, along with the two formatters it reads with, and `_lane_names` becomes what is left over — the same names with each group's coverage appended. Plot output is unchanged; its tests pin the exact strings.

### Why the repr does not measure coverage

`get_coverage` runs a chunk plan. Measured on this branch: a ~9.6 ms floor even for one patch, plus ~1.9 ms per group, with the group count unbounded and not visible to the caller — 2000 patches in 500 groups takes 1.1 s — and it can raise `ParameterError`. A repr fires on every stray cell echo, so it does none of that: the tracks come from a groupby on `patch_kind_attrs`, which gives the same four tracks on the archive above in 3.3 ms instead of 90 ms.

### Bounding the cost

Summarizing realizes the index relation, ~0.55 ms/row cold. `display_max_patches` (default 1000) is where that stops being worth a glance; past it the repr states its count and its path, and the count pushes to SQL rather than reading a row. A frame already built for this revision is free to read again, which `PatchCatalog.is_realized` says.

### Reviewed

Six reviewers read this before it was opened — a Codex CLI pass and five Claude agents on separate lenses. What they found and what changed is in the commits; the ones worth naming here:

- `display_max_patches` did not bound anything once a frame happened to exist, because `is_realized` short-circuited it. Two reviewers found that independently. Setting the limit to zero still printed a full summary, and one spool printed two different things depending on whether anything had realized it first. The short-circuit is gone, and with it the `is_realized` it was the only caller of.
- Printing a directory spool emitted a hundred warnings — ninety-nine of them pandas on frame fragmentation. `get_contents` emits the same hundred, so this is not new, but a repr should not be where you meet them. The summary is built quietly.
- A string dimension wiped out the whole summary: `str - str` raised inside the suppression and the spool printed only its header. Now `channel_id: a to c`, with no width claimed.
- Two distance tracks measured in different units were both labelled with the alphabetically first one, so a metric track read `<5 ft>`.
- A one-sample extent read `<>`, and a timedelta dimension got no width at all.
- The tests these should have failed, they did not: every test asserting only that something was *absent* was satisfied by the summary failing outright. Mutation testing found five such holes; all five mutants now fail the suite.

### Not in this PR

`RichDisplay` — giving every rich object rich's own mime bundle so a notebook cell echoes it in color — was written and then taken back out. It renders through `rich.get_console()`, which hard-wraps at the console width before the page sees it (a patch's 128-column coordinate line comes back broken across two, `units: m )` stranded on the second), and the HTML bakes rich's terminal palette in as literal hex with no background behind it, while the docs ship `dark: darkly`. Both want a width and a palette the page chooses, which is a design question of its own. The work is kept on `spool-rich-notebook`.

## Changelog

- fixed: a spool's repr read both ends of its time span from `time_min`, so it understated the span and reported a single-patch spool as covering no time at all.
- changed: a spool's repr states the extent it covers along every dimension its patches have, not only time, and says a duration in the largest unit which fits it rather than in seconds of float.
- added: a spool's repr lists one track per kind of patch, named by the same rule the coverage plot names its lanes.
- added: directory-backed spools summarize themselves, which they previously never did.
- added: `display_max_patches` bounds how large a spool may be before its repr stops summarizing what it covers.
- added: `dascore.utils.display` gained `group_names`, `human_duration`, `percent` and `elision_text`, which name and measure a group of patches without drawing it.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spool summaries now show patch counts, paths, dimensions, time spans, durations, and visualization tracks.
  * Large spools can limit detailed output with the new `display_max_patches` setting.
  * Display formatting now includes readable durations, percentages, group names, and concise overflow indicators.
  * Visualization lane and gap labels use consistent shared formatting.

* **Documentation**
  * Added guidance for spool summaries, display limits, coverage groups, and visualization lane naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->