### PR TITLE
Anchor the gridded coord on the values a file states

### DIFF
--- a/dascore/io/febus/__init__.py
+++ b/dascore/io/febus/__init__.py
@@ -23,7 +23,9 @@ store a distance per sample, and those arrays can carry sub-step jitter: the
 G1 files seen so far hold an even grid restated in float32, whose
 quantization exceeds the tolerance ``get_coord`` uses to recognize an even
 coordinate and leaves a monotonic coord with no step. Those are put back on
-the grid they restate.
+the grid they restate, which depends only on the first and last stored values
+and the sample count, so files spanning the same fiber agree sample for
+sample and still merge.
 
 The correction is well under a millimeter on the files seen so far, but it is
 not bounded in principle: a file whose distance axis were genuinely

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -194,8 +194,14 @@ def get_gridded_coord(values, units=None) -> BaseCoord:
     coord = get_coord(data=values, units=units)
     if len(coord) < 2 or not isinstance(coord, CoordRange | CoordMonotonicArray):
         return coord
-    # Anchored on the stored values rather than by snapping `coord`, because
-    # get_coord may already have inferred a range off the median step, which
+    # An array whose steps are all the same value states its grid outright,
+    # and get_coord already built that grid. Rebuilding gains nothing and
+    # would compute the span in the stored dtype, which overflows for a
+    # narrow integer coordinate spanning most of its range.
+    if len(np.unique(np.diff(values))) == 1:
+        return coord
+    # Otherwise anchor on the stored values rather than snapping `coord`,
+    # because get_coord may have inferred a range off the median step, which
     # leaves the last sample a few ulp from the stored one. Two files whose
     # jitter landed on opposite sides of that tolerance would then disagree
     # about a grid they both state identically, and would no longer merge.

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -11,7 +11,13 @@ import numpy as np
 import dascore as dc
 from dascore.constants import INVENTORY_ATTRS
 from dascore.core.coordmanager import CoordManager
-from dascore.core.coords import BaseCoord, CoordSegmented, get_coord
+from dascore.core.coords import (
+    BaseCoord,
+    CoordMonotonicArray,
+    CoordRange,
+    CoordSegmented,
+    get_coord,
+)
 from dascore.exceptions import CoordError, UnitError
 from dascore.models import ArrayLike
 from dascore.units import convert_units, get_quantity_str
@@ -161,6 +167,12 @@ def get_gridded_coord(values, units=None) -> BaseCoord:
     Such an array can jitter past the tolerance `get_coord` uses to recognize
     an even coordinate and leave a monotonic coord with no step.
 
+    The grid is a function of the first and last stored values and the sample
+    count, and of nothing else, so two files stating the same span agree on
+    every sample and still merge. Values that are not strictly monotonic are
+    not a grid and are returned unchanged, as is a lone sample, which states
+    no spacing.
+
     Parameters
     ----------
     values
@@ -178,9 +190,16 @@ def get_gridded_coord(values, units=None) -> BaseCoord:
     >>> float(round(coord.step, 4))
     0.1
     """
-    coord = get_coord(data=np.atleast_1d(np.asarray(values)), units=units)
-    # A lone sample states no spacing, and snap would invent a step of 1.
-    return coord.snap() if len(coord) > 1 else coord
+    values = np.atleast_1d(np.asarray(values))
+    coord = get_coord(data=values, units=units)
+    if len(coord) < 2 or not isinstance(coord, CoordRange | CoordMonotonicArray):
+        return coord
+    # Anchored on the stored values rather than by snapping `coord`, because
+    # get_coord may already have inferred a range off the median step, which
+    # leaves the last sample a few ulp from the stored one. Two files whose
+    # jitter landed on opposite sides of that tolerance would then disagree
+    # about a grid they both state identically, and would no longer merge.
+    return CoordMonotonicArray(values=values, units=units).snap()
 
 
 def get_exact_coord(values, units=None) -> BaseCoord:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -339,6 +339,18 @@ class TestGetGriddedCoord:
 
         np.testing.assert_array_equal(first.values, second.values)
 
+    def test_narrow_integer_range_does_not_overflow(self):
+        """An integer grid spanning most of its dtype keeps its own range.
+
+        Recomputing the span in the stored dtype would wrap it negative.
+        """
+        values = np.array([-30000, 0, 30000], dtype=np.int16)
+
+        coord = get_gridded_coord(values, units="m")
+
+        assert isinstance(coord, CoordRange)
+        np.testing.assert_array_equal(coord.values, values)
+
     def test_single_sample_states_no_step(self):
         """One sample states no spacing, so none should be invented."""
         coord = get_gridded_coord(np.array([42.0]), units="m")

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -20,7 +20,12 @@ from upath import UPath
 import dascore as dc
 from dascore.config import config_context
 from dascore.core.coordmanager import get_coord_manager
-from dascore.core.coords import CoordSegmented, get_coord
+from dascore.core.coords import (
+    CoordMonotonicArray,
+    CoordRange,
+    CoordSegmented,
+    get_coord,
+)
 from dascore.exceptions import (
     DependencyError,
     InvalidFiberIOError,
@@ -50,7 +55,12 @@ from dascore.io.core import (
     make_scan_payload,
 )
 from dascore.io.dasdae.core import DASDAEV1
-from dascore.io.utils import build_patches, convert_attr_units, get_exact_coord
+from dascore.io.utils import (
+    build_patches,
+    convert_attr_units,
+    get_exact_coord,
+    get_gridded_coord,
+)
 from dascore.utils.downloader import fetch
 from dascore.utils.io import BinaryReader, BinaryWriter, IOResourceManager
 from dascore.utils.misc import suppress_warnings
@@ -292,6 +302,57 @@ class _DependencyErrorFormatter(FiberIO):
         if path.suffix == ".dep" and path.name == "dependency_error.dep":
             return self.name, self.version
         return False
+
+
+class TestGetGriddedCoord:
+    """Tests for forcing a stored array onto the grid it restates."""
+
+    def test_quantized_array_becomes_a_range(self):
+        """Quantization past get_coord's tolerance still yields a grid."""
+        values = np.linspace(4000.0, 4009.9, 100, dtype=np.float32).astype(np.float64)
+        assert isinstance(get_coord(data=values), CoordMonotonicArray)
+
+        coord = get_gridded_coord(values, units="m")
+
+        assert isinstance(coord, CoordRange)
+        assert coord.min() == values[0]
+        assert coord.max() == values[-1]
+        assert len(coord) == len(values)
+
+    def test_grid_depends_only_on_span_and_count(self):
+        """Two arrays stating the same span must agree on every sample.
+
+        One lands inside get_coord's evenness tolerance and one outside, so
+        anchoring on what get_coord infers rather than on the stored values
+        would make them disagree and stop them merging.
+        """
+        n = 2_000
+        even = np.linspace(850.0, 1049.9, n)
+        jittered = even.copy()
+        jittered[1:-1] += np.random.default_rng(1).normal(0, 5e-4, n - 2)
+        jittered[0], jittered[-1] = even[0], even[-1]
+        assert isinstance(get_coord(data=even), CoordRange)
+        assert isinstance(get_coord(data=jittered), CoordMonotonicArray)
+
+        first = get_gridded_coord(even, units="m")
+        second = get_gridded_coord(jittered, units="m")
+
+        np.testing.assert_array_equal(first.values, second.values)
+
+    def test_single_sample_states_no_step(self):
+        """One sample states no spacing, so none should be invented."""
+        coord = get_gridded_coord(np.array([42.0]), units="m")
+
+        assert coord.step is None
+        assert coord.min() == 42.0
+
+    def test_non_monotonic_values_preserved(self):
+        """Values that are not a grid are returned untouched."""
+        values = np.array([0.0, 5.0, 2.0, 9.0])
+
+        coord = get_gridded_coord(values, units="m")
+
+        np.testing.assert_array_equal(coord.values, values)
 
 
 class TestGetExactCoord:


### PR DESCRIPTION
## Description

Follow-up to #1001. That PR made `get_gridded_coord` snap whatever `get_coord` returned, which
is not stable across files stating the same grid.

`CoordMonotonicArray.snap` anchors on the first and last values, but `get_coord` does not always
return a monotonic array to snap: when the stored jitter happens to fall inside its evenness
tolerance (`np.allclose(diffs, median, rtol=0.001)`) it infers a `CoordRange` off the *median
step*, and `snap` is then effectively a no-op on a range whose last sample is already a few ulp
away from the stored one. Which branch a file takes depends on nothing but where its jitter
landed relative to that tolerance.

So two files stating an identical span disagreed about the grid. Reproduced on real
`febus_bsl_h5` data — two files, both spanning exactly 850.0 to 2749.9 in 19000 samples, one
inside the tolerance and one outside:

```
grids differ by:  1.7e-09 m
spool.chunk(time=None, conflict="drop") -> 2 patches   # did not merge
```

Deriving the grid from the stored endpoints and the sample count fixes it, and makes the
contract something you can state: the grid is a function of what the file says its first
sample, last sample, and sample count are, and of nothing else. Same two files now merge.

The two guards from #1001 are unchanged and now explicit rather than incidental: a single
sample is returned untouched (no spacing is stated, and `snap` would invent a step of 1), and
values that are not strictly monotonic are not a grid and are returned untouched too.

Effect on the merge behavior that motivated all of this, measured end to end with
`spool.chunk(time=None, conflict="drop")` over two real DSS files:

| stored arrays | before #1001 | after #1001 | this PR |
| --- | --- | --- | --- |
| identical | merges | merges | merges |
| 10 µm interior drift | no merge | merges | merges |
| same endpoints, opposite sides of the tolerance | no merge | no merge | merges |
| endpoint drifts by one float32 ulp | no merge | no merge | no merge |

The last row is deliberate: files that disagree about where the fiber starts or ends disagree
about something the format states, and quietly averaging that away would be worse than
declining to merge.

For reference, xarray requires exact index equality and models no step at all, so the same
10 µm interior drift takes `concat` from 1000 to 1998 distance points at its current default
`join="outer"`, half of them NaN, or down to 2 shared points under `join="inner"`. Gridding at
read time is what lets these files align without the caller reaching for
`reindex(method="nearest", tolerance=...)`.

## Changelog

- fixed: `dascore.io.utils.get_gridded_coord` now derives the grid from the stored endpoints and sample count, so files stating the same span agree sample for sample and still merge.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordinate grid handling for distance-sampling data.
  * Ensured files covering the same fiber use consistent evenly spaced coordinates.
  * Preserved single-sample and non-monotonic coordinates correctly.
  * Reduced inconsistencies caused by jittered or quantized sample spacing.

* **Tests**
  * Added coverage for snapped grids, integer ranges, singleton coordinates, and non-monotonic values.

* **Documentation**
  * Clarified how G1 file coordinates are normalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->