### PR TITLE
Say where a patch's labels start and stop on a waterfall

### DIFF
--- a/dascore/viz/_labels.py
+++ b/dascore/viz/_labels.py
@@ -2,7 +2,7 @@
 Drawing where a label coordinate starts and stops over a patch dimension.
 
 An inventory's label groups arrive on a patch as ordinary coordinates over
-one dimension: a string one per channel, a boolean one stating membership,
+one dimension: a string naming each sample, a boolean stating membership,
 or a number. Each states a stretch of the dimension rather than a value at
 a point, so what a figure owes it is a line where it changes and a name in
 a legend, not a color per sample.
@@ -17,27 +17,24 @@ import pandas as pd
 from matplotlib.lines import Line2D
 
 from dascore.exceptions import ParameterError
-from dascore.utils.gaps import get_gap_edges
-from dascore.viz._lanes import (
-    _as_numeric,
-    _default_label,
-    _legend_below,
-    string_colors,
-)
+from dascore.viz._lanes import _as_numeric, _default_label, string_colors
 
-# Past this many a legend stops naming and starts listing, and a
-# coordinate this varied reads as a quantity rather than a set of labels.
+# Past this many a legend stops naming and starts listing.
 MAX_LABELS = 20
+
+# Past this many boundaries the lines are closer together than the data
+# behind them, and the figure reads as hatching rather than as limits.
+MAX_BOUNDARIES = 200
 
 # Two colors share one boundary line, so each draws half of the dashes.
 _DASH = 5.0
 
-# Over an image and over a mesh alike.
+# zorder 3 puts the line over an image and over a mesh alike.
 _LINE_KWARGS = {"linewidth": 1.5, "zorder": 3}
 
-# How much of the axes width a colorbar beside it takes, so a legend put
-# further out clears it. The same estimate the lanes use.
-_COLORBAR_WIDTH = 0.17
+# The gap kept between the legend and what it sits beside, and between
+# the legend and the edge of the page, as a fraction of the figure width.
+_LEGEND_PAD = 0.02
 
 
 class LabelPlan(NamedTuple):
@@ -88,43 +85,83 @@ def image_cell_edges(extents, dims_r: tuple[str, ...], dim: str, size: int):
     over a mesh.
     """
     low, high = extents[:2] if dim == dims_r[0] else extents[2:]
-    return low + (high - low) * np.arange(size + 1) / size
+    return np.linspace(low, high, size + 1)
 
 
-def mesh_cell_edges(values, gap_color, gap_factor):
+def mesh_cell_edges(edges, gap_mask):
     """Cell edges of one dimension of a mesh, in axis units.
 
-    The very edges the mesh was drawn from: a gap it opened puts two
-    edges where there was one, and moves every cell after it along.
+    The very edges the mesh was drawn from, indexed by sample: a gap it
+    opened puts two edges where there was one, so every cell after a gap
+    sits one place further along.
     """
-    edges, gap_mask = get_gap_edges(
-        values, gap_factor if gap_color is not None else None
-    )
     offsets = np.cumsum(np.concatenate([[0], gap_mask, [False]]))
     return _as_numeric(edges)[np.arange(len(offsets)) + offsets]
 
 
-def _label_codes(values, name: str) -> tuple[np.ndarray, list[str]]:
-    """Return a code per sample and the labels they index.
+def _stated_mask(values) -> np.ndarray:
+    """Which samples state a value at all.
 
-    A code of -1 is a stretch stating no label, which a boolean
-    coordinate spells False, a string one "" and a numeric one NaN.
+    How absence is spelled follows the dtype a coordinate can hold: a
+    string array has no null, so it is the empty string there, and NaN or
+    NA in anything which can carry one.
     """
-    if values.dtype == np.dtype(bool):
-        # Membership: the coordinate names itself, and False is not a
-        # second category but the absence of the one it names.
-        return np.where(values, 0, -1), [str(name)]
-    missing = pd.isna(values)
+    missing = np.asarray(pd.isna(values), dtype=bool)
     if values.dtype.kind in {"U", "S", "O"}:
-        missing = missing | (values == "")
-    codes, uniques = pd.factorize(np.where(missing, None, values))
-    return codes, [_default_label(x) for x in uniques]
+        blank = np.zeros(values.shape, dtype=bool)
+        # Only where a value is present: NA answers a comparison with NA.
+        np.equal(values, "", out=blank, where=~missing)
+        missing = missing | blank
+    return ~missing
 
 
-def _label_runs(values, name: str) -> tuple[np.ndarray, np.ndarray, list[str]]:
-    """Return where the label changes, the codes, and the labels."""
-    codes, labels = _label_codes(values, name)
-    if not len(labels):
+def _is_membership(stated) -> bool:
+    """Whether the values a coordinate states are all true or false.
+
+    A boolean array is the plain case; an object array of booleans is
+    what a coordinate carrying nulls beside them comes to.
+    """
+    if stated.dtype == np.dtype(bool):
+        return True
+    return stated.dtype.kind == "O" and all(
+        isinstance(x, bool | np.bool_) for x in stated
+    )
+
+
+def _label_codes(values, name: str) -> tuple[np.ndarray, list[str], bool]:
+    """Return a code per sample and the labels those codes index.
+
+    A code of -1 is a sample stating no label: False in a membership
+    coordinate, "" in a string one, NaN in a number.
+    """
+    held = _stated_mask(values)
+    stated = values[held]
+    if not stated.size:
+        return np.full(values.shape, -1, dtype=int), [], False
+    if _is_membership(stated):
+        # The coordinate names itself, and False is not a second category
+        # but the absence of the one it names.
+        codes = np.full(values.shape, -1, dtype=int)
+        codes[held] = np.where(stated.astype(bool), 0, -1)
+        return codes, [str(name)], True
+    codes = np.full(values.shape, -1, dtype=int)
+    # Factorized over the stated values alone, which keeps the
+    # coordinate's own dtype: widening to hold a null would render a
+    # nanosecond datetime as its count of nanoseconds.
+    inner, uniques = pd.factorize(stated)
+    codes[held] = inner
+    labels = [_default_label(x) for x in uniques]
+    if len(set(labels)) != len(labels):
+        # Two values rounding to one name would share a color and a
+        # legend entry, and the figure would call them the same thing.
+        labels = [str(x) for x in uniques]
+    return codes, labels, False
+
+
+def _label_runs(values, name: str):
+    """Return where the label changes, the codes, the labels, and the kind."""
+    codes, labels, membership = _label_codes(values, name)
+    if not np.any(codes >= 0):
         msg = (
             f"The {name!r} coordinate states no labels, so there is nothing "
             "to draw; every one of its values is absent."
@@ -140,7 +177,14 @@ def _label_runs(values, name: str) -> tuple[np.ndarray, np.ndarray, list[str]]:
     # Never 0 and never len(codes), so the axes' own spines are left to
     # draw the two boundaries which sit on them.
     starts = np.flatnonzero(np.diff(codes) != 0) + 1
-    return starts, codes, labels
+    if len(starts) > MAX_BOUNDARIES:
+        msg = (
+            f"The {name!r} coordinate changes value {len(starts)} times, "
+            f"more than the {MAX_BOUNDARIES} boundaries a figure can show. "
+            "It states a value per sample rather than a stretch each."
+        )
+        raise ParameterError(msg)
+    return starts, codes, labels, membership
 
 
 def _draw_lines(ax, axis: str, edges, starts, codes, labels, colors) -> None:
@@ -166,31 +210,73 @@ def _draw_lines(ax, axis: str, edges, starts, codes, labels, colors) -> None:
             )
 
 
-def _add_legend(ax, name, labels, colors, membership, colorbars, owned) -> None:
-    """Name the labels beside the axes, clear of any colorbar."""
-    handles = [
-        Line2D([], [], color=colors[x], linewidth=2.0, label=x) for x in labels
-    ]
-    figure = ax.get_figure()
-    legend = ax.legend(
-        handles=handles,
-        loc="upper left",
-        # A colorbar already occupies the strip beside the axes.
-        bbox_to_anchor=(1.01 + _COLORBAR_WIDTH * colorbars, 1.0),
-        frameon=False,
-        fontsize="small",
-        # Membership names itself in its one entry, and a title would
-        # then say the coordinate's name twice.
-        title=None if membership else str(name),
-        title_fontsize="small",
-    )
+def _legend_beside(figure, ax, handles, title):
+    """Name the labels past everything else, in room made for them.
+
+    Nothing reserves room outside an axes, so a legend anchored there is
+    drawn off the page. The figure's right margin is pulled in instead,
+    which moves the image and its colorbar together: the two hang off one
+    gridspec, and repositioning either alone would part them.
+    """
+    kwargs = {
+        "handles": handles,
+        "loc": "upper left",
+        "frameon": False,
+        "fontsize": "small",
+        "title": title,
+        "title_fontsize": "small",
+    }
+    # Drawn once to be measured; how tall matplotlib sets its rows and how
+    # wide it sets a column are its own affair rather than ours to predict.
+    legend = figure.legend(**kwargs)
     figure.draw_without_rendering()
-    # A column beside the axes is the natural home, but a patch can state
-    # more labels than its axes is tall and the column then runs off the
-    # page. Drawn and measured rather than predicted, as the lanes do.
-    if legend.get_window_extent().height > ax.get_window_extent().height:
+    box = legend.get_window_extent()
+    tall = box.height / figure.bbox.height
+    # A column taller than the page is spilled into as many as it takes.
+    columns = max(1, int(np.ceil(tall)))
+    if columns > 1:
         legend.remove()
-        _legend_below(figure, ax, handles, owned)
+        legend = figure.legend(ncol=columns, **kwargs)
+        figure.draw_without_rendering()
+        box = legend.get_window_extent()
+    wide = box.width / figure.bbox.width
+    legend.remove()
+    right = figure.subplotpars.right
+    # Half the figure is as much as the names may take; a legend needing
+    # more would be larger than the picture it names.
+    room = min(wide + 2 * _LEGEND_PAD, right / 2)
+    figure.subplots_adjust(right=right - room)
+    figure.draw_without_rendering()
+    # Whatever ended up furthest right is what the legend sits beside,
+    # so a colorbar is cleared without guessing how wide one is.
+    edge = max(x.get_position().x1 for x in figure.axes)
+    return figure.legend(
+        ncol=columns,
+        bbox_to_anchor=(edge + _LEGEND_PAD, ax.get_position().y1),
+        bbox_transform=figure.transFigure,
+        **kwargs,
+    )
+
+
+def _add_legend(ax, name, labels, colors, membership, owned):
+    """Name the labels, beside the figure where there is room to make."""
+    handles = [Line2D([], [], color=colors[x], linewidth=2.0, label=x) for x in labels]
+    # Membership names itself in its one entry, and a title would then
+    # say the coordinate's name twice.
+    title = None if membership else str(name)
+    if owned:
+        return _legend_beside(ax.get_figure(), ax, handles, title)
+    # The figure belongs to the caller, and making room in it would move
+    # every other axes on it, so the legend takes room from the one axes
+    # it was handed rather than being drawn over its neighbour.
+    return ax.legend(
+        handles=handles,
+        loc="upper right",
+        fontsize="small",
+        title=title,
+        title_fontsize="small",
+        framealpha=0.8,
+    )
 
 
 def draw_labels(
@@ -199,7 +285,6 @@ def draw_labels(
     values,
     edges,
     *,
-    colorbars: int = 0,
     owned: bool = False,
 ) -> None:
     """
@@ -216,15 +301,13 @@ def draw_labels(
     edges
         Cell edges along that dimension, in axis units, one more than
         there are samples.
-    colorbars
-        How many colorbars sit between the axes and the legend.
     owned
-        Whether a legend too tall to sit beside the axes may take its
-        room from the figure rather than from the axes.
+        Whether the figure is this call's to make room in. False puts the
+        legend inside the axes, since taking room from someone else's
+        figure would move every other axes on it.
     """
     values = np.asarray(values)
-    starts, codes, labels = _label_runs(values, plan.name)
-    membership = values.dtype == np.dtype(bool)
+    starts, codes, labels, membership = _label_runs(values, plan.name)
     colors = string_colors(labels)
     _draw_lines(ax, plan.axis, edges, starts, codes, labels, colors)
-    _add_legend(ax, plan.name, labels, colors, membership, colorbars, owned)
+    _add_legend(ax, plan.name, labels, colors, membership, owned)

--- a/dascore/viz/_labels.py
+++ b/dascore/viz/_labels.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from itertools import pairwise
 from typing import NamedTuple
 
+import matplotlib.patheffects as pe
 import numpy as np
 import pandas as pd
 from matplotlib.lines import Line2D
@@ -36,6 +37,19 @@ MAX_RUNS = 200
 # How thick a bar is drawn, in points. Half of it falls outside the axes,
 # so the spine it sits on is covered rather than merely traced.
 _BAR_WIDTH = 7.0
+
+# A hairline joining the two bars, so a change can be traced through the
+# image rather than only read off its edges. Faint on purpose: it locates
+# a boundary and does not compete with the data. The white stroke beneath
+# is what keeps it visible over a busy image, where a grey line of this
+# weight disappears into the noise.
+_SEAM_KWARGS = {"color": "0.1", "linewidth": 0.7, "alpha": 0.55, "zorder": 4}
+_SEAM_HALO_WIDTH = 2.0
+_SEAM_HALO_ALPHA = 0.5
+
+# What each artist is, for a caller reading a figure back.
+BAR_GID = "dascore-label-bar"
+SEAM_GID = "dascore-label-change"
 
 # The gap kept between the legend and what it sits beside, and between
 # the legend and the edge of the page, as a fraction of the figure width.
@@ -227,6 +241,7 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
                 # reaching an end of the patch reaches the corner.
                 clip_on=False,
                 zorder=5,
+                gid=BAR_GID,
             )
 
 
@@ -236,6 +251,24 @@ def _right_edge(figure) -> float:
         max(x.get_tightbbox().x1 for x in figure.axes if x.get_tightbbox() is not None)
         / figure.bbox.width
     )
+
+
+def _draw_changes(ax, axis: str, edges, starts) -> None:
+    """Join the two bars with a hairline wherever the label changes."""
+    line = ax.axvline if axis == "x" else ax.axhline
+    for index in starts:
+        line(
+            edges[index],
+            path_effects=[
+                pe.withStroke(
+                    linewidth=_SEAM_HALO_WIDTH,
+                    foreground="white",
+                    alpha=_SEAM_HALO_ALPHA,
+                )
+            ],
+            gid=SEAM_GID,
+            **_SEAM_KWARGS,
+        )
 
 
 def _legend_beside(figure, ax, handles, title):
@@ -345,4 +378,5 @@ def draw_labels(
     starts, codes, labels, membership = _label_runs(values, plan.name)
     colors = string_colors(labels)
     _draw_bars(ax, plan.axis, edges, starts, codes, labels, colors)
+    _draw_changes(ax, plan.axis, edges, starts)
     _add_legend(ax, plan.name, labels, colors, membership, owned)

--- a/dascore/viz/_labels.py
+++ b/dascore/viz/_labels.py
@@ -21,6 +21,7 @@ from typing import NamedTuple
 import matplotlib.patheffects as pe
 import numpy as np
 import pandas as pd
+from matplotlib.layout_engine import ConstrainedLayoutEngine
 from matplotlib.lines import Line2D
 from matplotlib.transforms import blended_transform_factory
 
@@ -30,8 +31,9 @@ from dascore.viz._lanes import _as_numeric, _default_label, string_colors
 # Past this many a legend stops naming and starts listing.
 MAX_LABELS = 20
 
-# Past this many stretches the bars are thinner than the gaps between
-# them, and the gutter reads as hatching rather than as a set of ranges.
+# Past this many changes the bars are narrower than the hairlines
+# parting them, and the spine reads as hatching rather than as a set of
+# ranges.
 MAX_RUNS = 200
 
 # How thick a bar is drawn, in points. Half of it falls outside the axes,
@@ -56,9 +58,17 @@ SEAM_GID = "dascore-label-change"
 _LEGEND_PAD = 0.02
 
 # How many times the figure is narrowed and measured again. Narrowing
-# moves what the legend sits beside, so one pass is a guess; a handful
-# settles it, and stopping short leaves the names on the page regardless.
+# moves what the legend sits beside, so one pass is a guess and a handful
+# settles it. Stopping short leaves the names further right than they
+# want to be, which is a worse picture rather than a broken one.
 _FITTING_PASSES = 4
+
+# The share of the figure width the plotting area keeps whatever the
+# legend asks for -- the image and its colorbar together. Names wanting
+# more than the rest are ones no figure this size can seat beside the
+# picture, and they run off the edge rather than squeezing the picture
+# they name out of existence.
+_MIN_AXES_WIDTH = 0.25
 
 
 class LabelPlan(NamedTuple):
@@ -67,6 +77,19 @@ class LabelPlan(NamedTuple):
     name: str
     dim: str
     axis: str
+
+
+class LabelRuns(NamedTuple):
+    """Where a label coordinate changes, and what it states between.
+
+    Worked out before anything is drawn, so a coordinate this module
+    refuses leaves no half-made figure behind.
+    """
+
+    starts: np.ndarray
+    codes: np.ndarray
+    labels: list[str]
+    membership: bool
 
 
 def label_plan(patch, name: str, dims_r: tuple[str, ...]) -> LabelPlan:
@@ -100,7 +123,7 @@ def label_plan(patch, name: str, dims_r: tuple[str, ...]) -> LabelPlan:
 
 
 def image_cell_edges(extents, dims_r: tuple[str, ...], dim: str, size: int):
-    """Cell edges of one dimension of an image, in axis units.
+    """Where each cell of an image starts and ends, in axis units.
 
     imshow lays its cells evenly across the extent it was handed, so the
     edges are read back from that extent. Reading them from the
@@ -109,18 +132,22 @@ def image_cell_edges(extents, dims_r: tuple[str, ...], dim: str, size: int):
     over a mesh.
     """
     low, high = extents[:2] if dim == dims_r[0] else extents[2:]
-    return np.linspace(low, high, size + 1)
+    edges = np.linspace(low, high, size + 1)
+    return edges[:-1], edges[1:]
 
 
 def mesh_cell_edges(edges, gap_mask):
-    """Cell edges of one dimension of a mesh, in axis units.
+    """Where each cell of a mesh starts and ends, in axis units.
 
-    The very edges the mesh was drawn from, indexed by sample: a gap it
+    The very edges the mesh was drawn from, indexed by sample. A gap it
     opened puts two edges where there was one, so every cell after a gap
-    sits one place further along.
+    sits one place further along -- and a cell bordering a gap ends where
+    the gap begins, rather than where the cell beyond it starts.
     """
-    offsets = np.cumsum(np.concatenate([[0], gap_mask, [False]]))
-    return _as_numeric(edges)[np.arange(len(offsets)) + offsets]
+    edges = _as_numeric(edges)
+    before = np.cumsum(np.concatenate([[0], gap_mask]))
+    index = np.arange(len(before)) + before
+    return edges[index], edges[index + 1]
 
 
 def _stated_mask(values) -> np.ndarray:
@@ -133,8 +160,10 @@ def _stated_mask(values) -> np.ndarray:
     missing = np.asarray(pd.isna(values), dtype=bool)
     if values.dtype.kind in {"U", "S", "O"}:
         blank = np.zeros(values.shape, dtype=bool)
+        # A bytes array holds bytes, and numpy will not compare the two.
+        empty = b"" if values.dtype.kind == "S" else ""
         # Only where a value is present: NA answers a comparison with NA.
-        np.equal(values, "", out=blank, where=~missing)
+        np.equal(values, empty, out=blank, where=~missing)
         missing = missing | blank
     return ~missing
 
@@ -179,11 +208,29 @@ def _label_codes(values, name: str) -> tuple[np.ndarray, list[str], bool]:
         # Two values rounding to one name would share a color and a
         # legend entry, and the figure would call them the same thing.
         labels = [str(x) for x in uniques]
-    return codes, labels, False
+    return codes, _disambiguate(labels, uniques), False
 
 
-def _label_runs(values, name: str):
-    """Return where the label changes, the codes, the labels, and the kind."""
+def _disambiguate(labels: list[str], values) -> list[str]:
+    """Qualify by type any name which two different values still share.
+
+    An object coordinate may hold the number 1 beside the string "1",
+    which print alike however many digits are kept. Sharing the name
+    would share the color too, and the legend would say one swatch
+    means two things.
+    """
+    seen: dict[str, int] = {}
+    for label in labels:
+        seen[label] = seen.get(label, 0) + 1
+    return [
+        f"{label} ({type(value).__name__})" if seen[label] > 1 else label
+        for label, value in zip(labels, values, strict=True)
+    ]
+
+
+def label_runs(values, name: str) -> LabelRuns:
+    """Return where the label changes, what it states, and of which kind."""
+    values = np.asarray(values)
     codes, labels, membership = _label_codes(values, name)
     if not np.any(codes >= 0):
         msg = (
@@ -201,14 +248,14 @@ def _label_runs(values, name: str):
     # Never 0 and never len(codes), so the axes' own spines are left to
     # draw the two boundaries which sit on them.
     starts = np.flatnonzero(np.diff(codes) != 0) + 1
-    if len(starts) >= MAX_RUNS:
+    if len(starts) > MAX_RUNS:
         msg = (
             f"The {name!r} coordinate changes value {len(starts)} times, "
-            f"more than the {MAX_RUNS} stretches a figure can show. It "
+            f"more than the {MAX_RUNS} changes a figure can show. It "
             "states a value per sample rather than a stretch each."
         )
         raise ParameterError(msg)
-    return starts, codes, labels, membership
+    return LabelRuns(starts, codes, labels, membership)
 
 
 def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
@@ -223,12 +270,15 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
         transform = blended_transform_factory(ax.transAxes, ax.transData)
     else:
         transform = blended_transform_factory(ax.transData, ax.transAxes)
+    starts_at, ends_at = edges
     bounds = np.concatenate([[0], starts, [len(codes)]]).astype(int)
     for low, high in pairwise(bounds):
         code = codes[low]
         if code < 0:
             continue
-        span = (edges[low], edges[high])
+        # Ends where its own last cell ends, which is where a gap band
+        # begins rather than where the cell beyond one starts.
+        span = (starts_at[low], ends_at[high - 1])
         for spine in (0.0, 1.0):
             along = ((spine, spine), span) if axis == "y" else (span, (spine, spine))
             ax.plot(
@@ -237,9 +287,10 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
                 color=colors[labels[code]],
                 linewidth=_BAR_WIDTH,
                 solid_capstyle="butt",
-                # Half the bar falls outside the axes, and a stretch
-                # reaching an end of the patch reaches the corner.
-                clip_on=False,
+                # Clipped, or a bar keeps its data coordinates when the
+                # limits change and paints across the rest of the figure.
+                # The half of its width outside the axes goes with that.
+                clip_on=True,
                 zorder=5,
                 gid=BAR_GID,
             )
@@ -247,18 +298,17 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
 
 def _right_edge(figure) -> float:
     """How far right anything already drawn on the figure reaches."""
-    return (
-        max(x.get_tightbbox().x1 for x in figure.axes if x.get_tightbbox() is not None)
-        / figure.bbox.width
-    )
+    boxes = [x.get_tightbbox() for x in figure.axes]
+    return max(x.x1 for x in boxes if x is not None) / figure.bbox.width
 
 
 def _draw_changes(ax, axis: str, edges, starts) -> None:
     """Join the two bars with a hairline wherever the label changes."""
+    starts_at, _ = edges
     line = ax.axvline if axis == "x" else ax.axhline
     for index in starts:
         line(
-            edges[index],
+            starts_at[index],
             path_effects=[
                 pe.withStroke(
                     linewidth=_SEAM_HALO_WIDTH,
@@ -290,6 +340,19 @@ def _legend_beside(figure, ax, handles, title):
         # its own padding would put the legend past what was measured.
         "borderaxespad": 0.0,
     }
+    engine = figure.get_layout_engine()
+    if isinstance(engine, ConstrainedLayoutEngine):
+        # This engine keeps room for a legend placed outside the axes, so
+        # it is asked for the room rather than overruled. No other engine
+        # does, which is why the test is for this one and not for any.
+        return figure.legend(
+            **{**kwargs, "loc": "outside right upper", "borderaxespad": None}
+        )
+    if engine is not None:
+        # Any other engine recomputes the margins when the figure is
+        # drawn, undoing the room made below. This figure is the call's
+        # own and is being laid out here explicitly.
+        figure.set_layout_engine("none")
     # Drawn once to be measured; how tall matplotlib sets its rows and how
     # wide it sets a column are its own affair rather than ours to predict.
     legend = figure.legend(**kwargs)
@@ -313,10 +376,11 @@ def _legend_beside(figure, ax, handles, title):
         over = edge + 2 * _LEGEND_PAD + wide - 1.0
         if over <= 0:
             break
-        right = figure.subplotpars.right
-        # Half the figure is as much as the names may take; a legend
-        # needing more would be larger than the picture it names.
-        figure.subplots_adjust(right=right - min(over, right / 2))
+        pars = figure.subplotpars
+        floor = pars.left + _MIN_AXES_WIDTH
+        if pars.right <= floor:
+            break
+        figure.subplots_adjust(right=max(floor, pars.right - over))
         figure.draw_without_rendering()
     return figure.legend(
         ncol=columns,
@@ -337,7 +401,8 @@ def _add_legend(ax, name, labels, colors, membership, owned):
     # The figure belongs to the caller, and making room in it would move
     # every other axes on it, so the legend takes room from the one axes
     # it was handed rather than being drawn over its neighbour.
-    return ax.legend(
+    previous = ax.get_legend()
+    legend = ax.legend(
         handles=handles,
         loc="upper right",
         fontsize="small",
@@ -345,12 +410,17 @@ def _add_legend(ax, name, labels, colors, membership, owned):
         title_fontsize="small",
         framealpha=0.8,
     )
+    if previous is not None:
+        # An axes holds one legend, so asking for ours drops whatever the
+        # caller had named there; it goes back as a plain artist.
+        ax.add_artist(previous)
+    return legend
 
 
 def draw_labels(
     ax,
     plan: LabelPlan,
-    values,
+    runs: LabelRuns,
     edges,
     *,
     owned: bool = False,
@@ -364,18 +434,18 @@ def draw_labels(
         The axes the data was drawn on.
     plan
         The coordinate to draw and the axis its dimension was drawn on.
-    values
-        The coordinate's values, one per sample along its dimension.
+    runs
+        Where the coordinate changes and what it states, from
+        [`label_runs`](`dascore.viz._labels.label_runs`).
     edges
-        Cell edges along that dimension, in axis units, one more than
-        there are samples.
+        Where each cell along that dimension starts and ends, in axis
+        units, as a pair of arrays one sample long each.
     owned
         Whether the figure is this call's to make room in. False puts the
         legend inside the axes, since taking room from someone else's
         figure would move every other axes on it.
     """
-    values = np.asarray(values)
-    starts, codes, labels, membership = _label_runs(values, plan.name)
+    starts, codes, labels, membership = runs
     colors = string_colors(labels)
     _draw_bars(ax, plan.axis, edges, starts, codes, labels, colors)
     _draw_changes(ax, plan.axis, edges, starts)

--- a/dascore/viz/_labels.py
+++ b/dascore/viz/_labels.py
@@ -1,0 +1,230 @@
+"""
+Drawing where a label coordinate starts and stops over a patch dimension.
+
+An inventory's label groups arrive on a patch as ordinary coordinates over
+one dimension: a string one per channel, a boolean one stating membership,
+or a number. Each states a stretch of the dimension rather than a value at
+a point, so what a figure owes it is a line where it changes and a name in
+a legend, not a color per sample.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import numpy as np
+import pandas as pd
+from matplotlib.lines import Line2D
+
+from dascore.exceptions import ParameterError
+from dascore.utils.gaps import get_gap_edges
+from dascore.viz._lanes import (
+    _as_numeric,
+    _default_label,
+    _legend_below,
+    string_colors,
+)
+
+# Past this many a legend stops naming and starts listing, and a
+# coordinate this varied reads as a quantity rather than a set of labels.
+MAX_LABELS = 20
+
+# Two colors share one boundary line, so each draws half of the dashes.
+_DASH = 5.0
+
+# Over an image and over a mesh alike.
+_LINE_KWARGS = {"linewidth": 1.5, "zorder": 3}
+
+# How much of the axes width a colorbar beside it takes, so a legend put
+# further out clears it. The same estimate the lanes use.
+_COLORBAR_WIDTH = 0.17
+
+
+class LabelPlan(NamedTuple):
+    """Which coordinate a figure draws as labels, and where it goes."""
+
+    name: str
+    dim: str
+    axis: str
+
+
+def label_plan(patch, name: str, dims_r: tuple[str, ...]) -> LabelPlan:
+    """Return the coordinate to draw as labels, and the axis it lands on."""
+    if name in patch.dims:
+        msg = (
+            f"label_coord={name!r} is a dimension of this patch. A label "
+            "states one value over a stretch of a dimension, so it must be "
+            "a coordinate associated with a dimension rather than the "
+            "dimension itself."
+        )
+        raise ParameterError(msg)
+    coord_dims = patch.coords.dim_map.get(name)
+    if coord_dims is None:
+        others = sorted(set(patch.coords.coord_map) - set(patch.dims))
+        msg = (
+            f"label_coord={name!r} is not a coordinate of this patch, whose "
+            f"non-dimensional coordinates are {others}."
+        )
+        raise ParameterError(msg)
+    if len(coord_dims) != 1 or coord_dims[0] not in dims_r:
+        msg = (
+            f"The {name!r} coordinate spans {list(coord_dims)}, so it names "
+            "no one axis to be drawn on. A label coordinate belongs to "
+            f"exactly one of the plotted dimensions, {list(dims_r)}."
+        )
+        raise ParameterError(msg)
+    dim = coord_dims[0]
+    # dims_r is (x, y); imshow and pcolormesh both put the last dim on x.
+    return LabelPlan(name, dim, "x" if dim == dims_r[0] else "y")
+
+
+def image_cell_edges(extents, dims_r: tuple[str, ...], dim: str, size: int):
+    """Cell edges of one dimension of an image, in axis units.
+
+    imshow lays its cells evenly across the extent it was handed, so the
+    edges are read back from that extent. Reading them from the
+    coordinate instead would put a line where the image has no edge
+    whenever the two disagree, which is exactly when imshow was chosen
+    over a mesh.
+    """
+    low, high = extents[:2] if dim == dims_r[0] else extents[2:]
+    return low + (high - low) * np.arange(size + 1) / size
+
+
+def mesh_cell_edges(values, gap_color, gap_factor):
+    """Cell edges of one dimension of a mesh, in axis units.
+
+    The very edges the mesh was drawn from: a gap it opened puts two
+    edges where there was one, and moves every cell after it along.
+    """
+    edges, gap_mask = get_gap_edges(
+        values, gap_factor if gap_color is not None else None
+    )
+    offsets = np.cumsum(np.concatenate([[0], gap_mask, [False]]))
+    return _as_numeric(edges)[np.arange(len(offsets)) + offsets]
+
+
+def _label_codes(values, name: str) -> tuple[np.ndarray, list[str]]:
+    """Return a code per sample and the labels they index.
+
+    A code of -1 is a stretch stating no label, which a boolean
+    coordinate spells False, a string one "" and a numeric one NaN.
+    """
+    if values.dtype == np.dtype(bool):
+        # Membership: the coordinate names itself, and False is not a
+        # second category but the absence of the one it names.
+        return np.where(values, 0, -1), [str(name)]
+    missing = pd.isna(values)
+    if values.dtype.kind in {"U", "S", "O"}:
+        missing = missing | (values == "")
+    codes, uniques = pd.factorize(np.where(missing, None, values))
+    return codes, [_default_label(x) for x in uniques]
+
+
+def _label_runs(values, name: str) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Return where the label changes, the codes, and the labels."""
+    codes, labels = _label_codes(values, name)
+    if not len(labels):
+        msg = (
+            f"The {name!r} coordinate states no labels, so there is nothing "
+            "to draw; every one of its values is absent."
+        )
+        raise ParameterError(msg)
+    if len(labels) > MAX_LABELS:
+        msg = (
+            f"The {name!r} coordinate states {len(labels)} distinct labels, "
+            f"more than the {MAX_LABELS} a legend can name. A coordinate "
+            "this varied is a quantity rather than a set of labels."
+        )
+        raise ParameterError(msg)
+    # Never 0 and never len(codes), so the axes' own spines are left to
+    # draw the two boundaries which sit on them.
+    starts = np.flatnonzero(np.diff(codes) != 0) + 1
+    return starts, codes, labels
+
+
+def _draw_lines(ax, axis: str, edges, starts, codes, labels, colors) -> None:
+    """Draw a line wherever the label changes, colored by what it parts."""
+    line = ax.axvline if axis == "x" else ax.axhline
+    for index in starts:
+        position = edges[index]
+        before, after = codes[index - 1], codes[index]
+        stated = [x for x in (before, after) if x >= 0]
+        if len(stated) == 1:
+            # One side states nothing, so the boundary belongs wholly to
+            # the other and is drawn solid in its color.
+            line(position, color=colors[labels[stated[0]]], **_LINE_KWARGS)
+            continue
+        # A boundary parts two labels and belongs to neither, so it is
+        # drawn twice, each color taking the dashes the other leaves.
+        for offset, code in ((0.0, before), (_DASH, after)):
+            line(
+                position,
+                color=colors[labels[code]],
+                linestyle=(offset, (_DASH, _DASH)),
+                **_LINE_KWARGS,
+            )
+
+
+def _add_legend(ax, name, labels, colors, membership, colorbars, owned) -> None:
+    """Name the labels beside the axes, clear of any colorbar."""
+    handles = [
+        Line2D([], [], color=colors[x], linewidth=2.0, label=x) for x in labels
+    ]
+    figure = ax.get_figure()
+    legend = ax.legend(
+        handles=handles,
+        loc="upper left",
+        # A colorbar already occupies the strip beside the axes.
+        bbox_to_anchor=(1.01 + _COLORBAR_WIDTH * colorbars, 1.0),
+        frameon=False,
+        fontsize="small",
+        # Membership names itself in its one entry, and a title would
+        # then say the coordinate's name twice.
+        title=None if membership else str(name),
+        title_fontsize="small",
+    )
+    figure.draw_without_rendering()
+    # A column beside the axes is the natural home, but a patch can state
+    # more labels than its axes is tall and the column then runs off the
+    # page. Drawn and measured rather than predicted, as the lanes do.
+    if legend.get_window_extent().height > ax.get_window_extent().height:
+        legend.remove()
+        _legend_below(figure, ax, handles, owned)
+
+
+def draw_labels(
+    ax,
+    plan: LabelPlan,
+    values,
+    edges,
+    *,
+    colorbars: int = 0,
+    owned: bool = False,
+) -> None:
+    """
+    Mark the limits of every label a coordinate states, and name them.
+
+    Parameters
+    ----------
+    ax
+        The axes the data was drawn on.
+    plan
+        The coordinate to draw and the axis its dimension was drawn on.
+    values
+        The coordinate's values, one per sample along its dimension.
+    edges
+        Cell edges along that dimension, in axis units, one more than
+        there are samples.
+    colorbars
+        How many colorbars sit between the axes and the legend.
+    owned
+        Whether a legend too tall to sit beside the axes may take its
+        room from the figure rather than from the axes.
+    """
+    values = np.asarray(values)
+    starts, codes, labels = _label_runs(values, plan.name)
+    membership = values.dtype == np.dtype(bool)
+    colors = string_colors(labels)
+    _draw_lines(ax, plan.axis, edges, starts, codes, labels, colors)
+    _add_legend(ax, plan.name, labels, colors, membership, colorbars, owned)

--- a/dascore/viz/_labels.py
+++ b/dascore/viz/_labels.py
@@ -4,17 +4,24 @@ Drawing where a label coordinate starts and stops over a patch dimension.
 An inventory's label groups arrive on a patch as ordinary coordinates over
 one dimension: a string naming each sample, a boolean stating membership,
 or a number. Each states a stretch of the dimension rather than a value at
-a point, so what a figure owes it is a line where it changes and a name in
-a legend, not a color per sample.
+a point, so what a figure owes it is that stretch marked off and named:
+a bar along the axis, rather than a color per sample.
+
+The bars sit on the spines rather than over the image. A wash over the
+data would have to be strong enough to see, and a wash that strong has
+recolored the data under it -- which on a diverging colormap is the
+measurement itself.
 """
 
 from __future__ import annotations
 
+from itertools import pairwise
 from typing import NamedTuple
 
 import numpy as np
 import pandas as pd
 from matplotlib.lines import Line2D
+from matplotlib.transforms import blended_transform_factory
 
 from dascore.exceptions import ParameterError
 from dascore.viz._lanes import _as_numeric, _default_label, string_colors
@@ -22,15 +29,13 @@ from dascore.viz._lanes import _as_numeric, _default_label, string_colors
 # Past this many a legend stops naming and starts listing.
 MAX_LABELS = 20
 
-# Past this many boundaries the lines are closer together than the data
-# behind them, and the figure reads as hatching rather than as limits.
-MAX_BOUNDARIES = 200
+# Past this many stretches the bars are thinner than the gaps between
+# them, and the gutter reads as hatching rather than as a set of ranges.
+MAX_RUNS = 200
 
-# Two colors share one boundary line, so each draws half of the dashes.
-_DASH = 5.0
-
-# zorder 3 puts the line over an image and over a mesh alike.
-_LINE_KWARGS = {"linewidth": 1.5, "zorder": 3}
+# How thick a bar is drawn, in points. Half of it falls outside the axes,
+# so the spine it sits on is covered rather than merely traced.
+_BAR_WIDTH = 7.0
 
 # The gap kept between the legend and what it sits beside, and between
 # the legend and the edge of the page, as a fraction of the figure width.
@@ -182,36 +187,46 @@ def _label_runs(values, name: str):
     # Never 0 and never len(codes), so the axes' own spines are left to
     # draw the two boundaries which sit on them.
     starts = np.flatnonzero(np.diff(codes) != 0) + 1
-    if len(starts) > MAX_BOUNDARIES:
+    if len(starts) >= MAX_RUNS:
         msg = (
             f"The {name!r} coordinate changes value {len(starts)} times, "
-            f"more than the {MAX_BOUNDARIES} boundaries a figure can show. "
-            "It states a value per sample rather than a stretch each."
+            f"more than the {MAX_RUNS} stretches a figure can show. It "
+            "states a value per sample rather than a stretch each."
         )
         raise ParameterError(msg)
     return starts, codes, labels, membership
 
 
-def _draw_lines(ax, axis: str, edges, starts, codes, labels, colors) -> None:
-    """Draw a line wherever the label changes, colored by what it parts."""
-    line = ax.axvline if axis == "x" else ax.axhline
-    for index in starts:
-        position = edges[index]
-        before, after = codes[index - 1], codes[index]
-        stated = [x for x in (before, after) if x >= 0]
-        if len(stated) == 1:
-            # One side states nothing, so the boundary belongs wholly to
-            # the other and is drawn solid in its color.
-            line(position, color=colors[labels[stated[0]]], **_LINE_KWARGS)
+def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
+    """Draw a bar along both spines over the stretch each label covers.
+
+    A stretch stating nothing leaves bare spine, so what a group covers
+    and what it merely passes over are read off the same edge.
+    """
+    if axis == "y":
+        # One coordinate puts the bar on a spine and the other runs it
+        # along the stretch; which is which is what the axis decides.
+        transform = blended_transform_factory(ax.transAxes, ax.transData)
+    else:
+        transform = blended_transform_factory(ax.transData, ax.transAxes)
+    bounds = np.concatenate([[0], starts, [len(codes)]]).astype(int)
+    for low, high in pairwise(bounds):
+        code = codes[low]
+        if code < 0:
             continue
-        # A boundary parts two labels and belongs to neither, so it is
-        # drawn twice, each color taking the dashes the other leaves.
-        for offset, code in ((0.0, before), (_DASH, after)):
-            line(
-                position,
+        span = (edges[low], edges[high])
+        for spine in (0.0, 1.0):
+            along = ((spine, spine), span) if axis == "y" else (span, (spine, spine))
+            ax.plot(
+                *along,
+                transform=transform,
                 color=colors[labels[code]],
-                linestyle=(offset, (_DASH, _DASH)),
-                **_LINE_KWARGS,
+                linewidth=_BAR_WIDTH,
+                solid_capstyle="butt",
+                # Half the bar falls outside the axes, and a stretch
+                # reaching an end of the patch reaches the corner.
+                clip_on=False,
+                zorder=5,
             )
 
 
@@ -280,7 +295,7 @@ def _legend_beside(figure, ax, handles, title):
 
 def _add_legend(ax, name, labels, colors, membership, owned):
     """Name the labels, beside the figure where there is room to make."""
-    handles = [Line2D([], [], color=colors[x], linewidth=2.0, label=x) for x in labels]
+    handles = [Line2D([], [], color=colors[x], linewidth=3.0, label=x) for x in labels]
     # Membership names itself in its one entry, and a title would then
     # say the coordinate's name twice.
     title = None if membership else str(name)
@@ -308,7 +323,7 @@ def draw_labels(
     owned: bool = False,
 ) -> None:
     """
-    Mark the limits of every label a coordinate states, and name them.
+    Mark the stretch every label a coordinate states covers, and name them.
 
     Parameters
     ----------
@@ -329,5 +344,5 @@ def draw_labels(
     values = np.asarray(values)
     starts, codes, labels, membership = _label_runs(values, plan.name)
     colors = string_colors(labels)
-    _draw_lines(ax, plan.axis, edges, starts, codes, labels, colors)
+    _draw_bars(ax, plan.axis, edges, starts, codes, labels, colors)
     _add_legend(ax, plan.name, labels, colors, membership, owned)

--- a/dascore/viz/_labels.py
+++ b/dascore/viz/_labels.py
@@ -36,6 +36,11 @@ _LINE_KWARGS = {"linewidth": 1.5, "zorder": 3}
 # the legend and the edge of the page, as a fraction of the figure width.
 _LEGEND_PAD = 0.02
 
+# How many times the figure is narrowed and measured again. Narrowing
+# moves what the legend sits beside, so one pass is a guess; a handful
+# settles it, and stopping short leaves the names on the page regardless.
+_FITTING_PASSES = 4
+
 
 class LabelPlan(NamedTuple):
     """Which coordinate a figure draws as labels, and where it goes."""
@@ -210,6 +215,14 @@ def _draw_lines(ax, axis: str, edges, starts, codes, labels, colors) -> None:
             )
 
 
+def _right_edge(figure) -> float:
+    """How far right anything already drawn on the figure reaches."""
+    return (
+        max(x.get_tightbbox().x1 for x in figure.axes if x.get_tightbbox() is not None)
+        / figure.bbox.width
+    )
+
+
 def _legend_beside(figure, ax, handles, title):
     """Name the labels past everything else, in room made for them.
 
@@ -225,6 +238,9 @@ def _legend_beside(figure, ax, handles, title):
         "fontsize": "small",
         "title": title,
         "title_fontsize": "small",
+        # The room is measured here rather than left to matplotlib, so
+        # its own padding would put the legend past what was measured.
+        "borderaxespad": 0.0,
     }
     # Drawn once to be measured; how tall matplotlib sets its rows and how
     # wide it sets a column are its own affair rather than ours to predict.
@@ -241,18 +257,22 @@ def _legend_beside(figure, ax, handles, title):
         box = legend.get_window_extent()
     wide = box.width / figure.bbox.width
     legend.remove()
-    right = figure.subplotpars.right
-    # Half the figure is as much as the names may take; a legend needing
-    # more would be larger than the picture it names.
-    room = min(wide + 2 * _LEGEND_PAD, right / 2)
-    figure.subplots_adjust(right=right - room)
-    figure.draw_without_rendering()
-    # Whatever ended up furthest right is what the legend sits beside,
-    # so a colorbar is cleared without guessing how wide one is.
-    edge = max(x.get_position().x1 for x in figure.axes)
+    # Asked for again after each move: a colorbar carries its ticks and
+    # its own name outside the rectangle it reports as its position, and
+    # narrowing the figure can relabel the ticks it carries.
+    for _ in range(_FITTING_PASSES):
+        edge = _right_edge(figure)
+        over = edge + 2 * _LEGEND_PAD + wide - 1.0
+        if over <= 0:
+            break
+        right = figure.subplotpars.right
+        # Half the figure is as much as the names may take; a legend
+        # needing more would be larger than the picture it names.
+        figure.subplots_adjust(right=right - min(over, right / 2))
+        figure.draw_without_rendering()
     return figure.legend(
         ncol=columns,
-        bbox_to_anchor=(edge + _LEGEND_PAD, ax.get_position().y1),
+        bbox_to_anchor=(_right_edge(figure) + _LEGEND_PAD, ax.get_position().y1),
         bbox_transform=figure.transFigure,
         **kwargs,
     )

--- a/dascore/viz/_lanes.py
+++ b/dascore/viz/_lanes.py
@@ -298,8 +298,9 @@ def string_colors(values, vocabulary=None, cmap_name=STRING_CMAP) -> dict:
     which sort after it, and pushing the count past the wheel moves all
     of them.
 
-    Two figures of one subject share this, so a label group drawn as a
-    lane and the same group drawn over a patch agree on their colors.
+    Two figures share colors only where they are given the same values:
+    a lane figure colors from every value it draws, so a group drawn
+    alone over a patch matches it only through ``vocabulary``.
 
     Parameters
     ----------

--- a/dascore/viz/_lanes.py
+++ b/dascore/viz/_lanes.py
@@ -288,16 +288,37 @@ def _wide_colors(values) -> dict:
     return out
 
 
-def _string_colors(frame, vocabulary=None, cmap_name=STRING_CMAP) -> dict:
-    """Map every string value to a stable color.
+def string_colors(values, vocabulary=None, cmap_name=STRING_CMAP) -> dict:
+    """
+    Map every string value to a stable color.
 
-    The vocabulary widens the palette beyond what this frame holds, so a
+    The vocabulary widens the palette beyond what these values hold, so a
     figure of part of a subject colors it as a figure of all of it does.
     Adding a value to the vocabulary itself moves the colors of the ones
     which sort after it, and pushing the count past the wheel moves all
     of them.
+
+    Two figures of one subject share this, so a label group drawn as a
+    lane and the same group drawn over a patch agree on their colors.
+
+    Parameters
+    ----------
+    values
+        The values to color. Anything which is not a non-empty string is
+        skipped, since it states no category to color.
+    vocabulary
+        Further values to reserve colors for.
+    cmap_name
+        The categorical colormap the wheel is drawn from.
+
+    Examples
+    --------
+    >>> from dascore.viz._lanes import string_colors
+    >>> colors = string_colors(["south", "north"])
+    >>> sorted(colors)
+    ['north', 'south']
     """
-    seen = list(frame["value"].tolist()) + list(vocabulary or [])
+    seen = list(values) + list(vocabulary or [])
     values = sorted({x for x in seen if isinstance(x, str) and x != ""})
     if len(values) > len(WHEEL_ORDER):
         # Cycling the wheel here would give two values one color, and a
@@ -308,6 +329,11 @@ def _string_colors(frame, vocabulary=None, cmap_name=STRING_CMAP) -> dict:
         value: cmap(WHEEL_ORDER[index % len(WHEEL_ORDER)])
         for index, value in enumerate(values)
     }
+
+
+def _string_colors(frame, vocabulary=None, cmap_name=STRING_CMAP) -> dict:
+    """Map every string value of an interval frame to a stable color."""
+    return string_colors(frame["value"].tolist(), vocabulary, cmap_name)
 
 
 def numeric_scale(values, cmap_name=NUMERIC_CMAP):

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -314,7 +314,9 @@ def waterfall(
         stretch is drawn as a bar along the two spines its dimension runs
         between, colored by its label, and a legend names them beside the
         axes, beyond any colorbar. The bars sit on the spines rather than over
-        the image, so no data is covered or tinted. String and numeric
+        the image, so no data is covered or tinted; a hairline joins them
+        wherever the value changes, faint enough to locate a boundary in the
+        data without competing with it. String and numeric
         coordinates state one label per distinct value, and more than 20 of
         them raises a `ParameterError`: a coordinate that varied is a
         quantity, not a set of labels. A boolean coordinate states membership,

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -28,6 +28,7 @@ from dascore.viz._labels import (
     draw_labels,
     image_cell_edges,
     label_plan,
+    label_runs,
     mesh_cell_edges,
 )
 
@@ -311,18 +312,23 @@ def waterfall(
         The name of a coordinate whose values label stretches of one of the
         plotted dimensions, such as a label group an inventory projected onto
         the patch with [`Patch.enrich`](`dascore.proc.inventory.enrich`). Each
-        stretch is drawn as a bar along the two spines its dimension runs
-        between, colored by its label, and a legend names them beside the
-        axes, beyond any colorbar. The bars sit on the spines rather than over
-        the image, so no data is covered or tinted; a hairline joins them
-        wherever the value changes, faint enough to locate a boundary in the
-        data without competing with it. String and numeric
-        coordinates state one label per distinct value, and more than 20 of
-        them raises a `ParameterError`: a coordinate that varied is a
-        quantity, not a set of labels. A boolean coordinate states membership,
-        so only its True stretches are marked and the legend names them by the
-        coordinate. Absent values (the empty string, NaN, or False) label
-        nothing, and leave bare spine.
+        stretch is drawn as a bar on the two spines its dimension runs along,
+        colored by its label, so no data is covered or tinted; a hairline
+        joins them wherever the value changes, faint enough to locate a
+        boundary in the data without competing with it. A legend names the
+        labels, beyond any colorbar when this call owns the figure, and inside
+        the axes when the caller supplied one, since taking room from
+        someone else's figure would move every other axes on it. String and
+        numeric coordinates state one label per distinct value. A boolean
+        coordinate states membership, so only its True stretches are marked
+        and the legend names them by the coordinate. Absent values (the empty
+        string, NaN, or False) label nothing, and leave bare spine.
+
+        Raises `ParameterError` for a coordinate which is not a set of
+        labels: one stating more than 20 distinct values, one changing more
+        than 200 times, one whose every value is absent, and one which is a
+        dimension or spans both of them. All are judged before anything is
+        drawn, so a refusal leaves no figure behind.
 
     Examples
     --------
@@ -390,8 +396,13 @@ def waterfall(
     _validate_gap_factor(gap_factor)
     dims = patch.dims
     dims_r = tuple(reversed(dims))
-    # Before an axes exists, so a refused label_coord leaves no figure behind.
-    plan = label_plan(patch, label_coord, dims_r) if label_coord is not None else None
+    # Before an axes exists, so a refused label_coord leaves no figure
+    # behind: both what the coordinate is and what it states are settled
+    # here, since either can be grounds for refusing it.
+    plan, runs = None, None
+    if label_coord is not None:
+        plan = label_plan(patch, label_coord, dims_r)
+        runs = label_runs(patch.coords.get_array(plan.name), plan.name)
     # Setup axes and data. A figure this call built is one whose room a
     # legend may take; any other belongs to the caller.
     owned = ax is None
@@ -443,15 +454,9 @@ def waterfall(
         _add_colorbar(ax, im, data, patch, log, scale)
     # Label lines come last so the legend is placed beyond a colorbar which
     # has already taken its room.
-    if plan is not None:
+    if plan is not None and runs is not None:
         assert label_edges is not None, "a plan is only made where edges are"
-        draw_labels(
-            ax,
-            plan,
-            patch.coords.get_array(plan.name),
-            label_edges,
-            owned=owned,
-        )
+        draw_labels(ax, plan, runs, label_edges, owned=owned)
     if show:
         plt.show()
     return ax

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -188,19 +188,26 @@ def _insert_gap_bands(data, gap_mask, axis):
 
 
 def _plot_with_mesh(ax, data, dims, coords, cmap, gap_color, gap_factor):
-    """Plot irregularly sampled data using a quadrilateral mesh."""
+    """Plot irregularly sampled data using a quadrilateral mesh.
+
+    Returns the mesh and, per dimension, the cell edges it was drawn from
+    with the gaps they opened, so a caller marking the same cells reads
+    them off the mesh rather than working them out again.
+    """
     mesh_data = np.ma.asarray(data)
     edges = {}
+    cells = {}
     mesh_gap_factor = gap_factor if gap_color is not None else None
     for axis, dim in enumerate(dims):
         dim_edges, gap_mask = get_gap_edges(coords[dim], mesh_gap_factor)
         if gap_color is not None:
             mesh_data = _insert_gap_bands(mesh_data, gap_mask, axis)
         edges[dim] = dim_edges
+        cells[dim] = (dim_edges, gap_mask)
 
     if gap_color is not None:
         cmap = cmap.with_extremes(bad=gap_color)
-    return ax.pcolormesh(
+    mesh = ax.pcolormesh(
         edges[dims[1]],
         edges[dims[0]],
         mesh_data,
@@ -210,6 +217,7 @@ def _plot_with_mesh(ax, data, dims, coords, cmap, gap_color, gap_factor):
         linewidth=0,
         antialiased=False,
     )
+    return mesh, cells
 
 
 @patch_function()
@@ -225,8 +233,8 @@ def waterfall(
     gap_factor: float = 1.5,
     log: bool = False,
     cbar: bool = True,
-    label_coord: str | None = None,
     show: bool = False,
+    label_coord: str | None = None,
 ) -> plt.Axes:
     """
     Create a waterfall plot of the Patch data.
@@ -297,18 +305,20 @@ def waterfall(
     cbar
         If True, plot the colorbar, else do not. This controls only colorbar
         display; use `cmap` to control colormap selection.
+    show
+        If True, show the plot, else just return axis.
     label_coord
         The name of a coordinate whose values label stretches of one of the
         plotted dimensions, such as a label group an inventory projected onto
         the patch with [`Patch.enrich`](`dascore.proc.inventory.enrich`). A
         line is drawn wherever its value changes, colored by the labels it
-        parts, and a legend naming them is placed beyond the colorbar. String
-        and numeric coordinates state one label per value; a boolean one
-        states membership, so only its True stretches are marked and the
-        coordinate's own name is what the legend calls them. Absent values
-        (the empty string, NaN, or False) label nothing.
-    show
-        If True, show the plot, else just return axis.
+        parts, and a legend names them beside the axes, beyond any colorbar.
+        String and numeric coordinates state one label per distinct value, and
+        more than 20 of them raises a `ParameterError`: a coordinate that
+        varied is a quantity, not a set of labels. A boolean coordinate states
+        membership, so only its True stretches are marked and the legend names
+        them by the coordinate. Absent values (the empty string, NaN, or
+        False) label nothing.
 
     Examples
     --------
@@ -374,6 +384,10 @@ def waterfall(
     # Validate inputs
     patch = _validate_patch_dims(patch)
     _validate_gap_factor(gap_factor)
+    dims = patch.dims
+    dims_r = tuple(reversed(dims))
+    # Before an axes exists, so a refused label_coord leaves no figure behind.
+    plan = label_plan(patch, label_coord, dims_r) if label_coord is not None else None
     # Setup axes and data. A figure this call built is one whose room a
     # legend may take; any other belongs to the caller.
     owned = ax is None
@@ -382,13 +396,10 @@ def waterfall(
         data = np.log10(np.abs(patch.data) + np.finfo(np.float64).eps)
     else:
         data = patch.data
-    dims = patch.dims
-    dims_r = tuple(reversed(dims))
     dim_coords = {dim: patch.get_coord(dim) for dim in dims}
     coords = {dim: np.asarray(coord) for dim, coord in dim_coords.items()}
     cmap = _get_waterfall_colormap(patch, cmap)
     scale = _get_scale(scale, scale_type, data)
-    plan = label_plan(patch, label_coord, dims_r) if label_coord is not None else None
     label_edges = None
     use_image = all(coord.evenly_sampled for coord in dim_coords.values())
     if use_image or not all(is_monotonic_and_finite(x) for x in coords.values()):
@@ -408,7 +419,7 @@ def waterfall(
                 extents, dims_r, plan.dim, len(coords[plan.dim])
             )
     else:
-        im = _plot_with_mesh(
+        im, cells = _plot_with_mesh(
             ax,
             data,
             dims,
@@ -418,7 +429,7 @@ def waterfall(
             gap_factor=gap_factor,
         )
         if plan is not None:
-            label_edges = mesh_cell_edges(coords[plan.dim], gap_color, gap_factor)
+            label_edges = mesh_cell_edges(*cells[plan.dim])
     if scale is not None and len(scale) == 2 and np.all(np.isfinite(scale)):
         im.set_clim(np.asarray(scale))
     # Format axis labels and handle time-like dimensions
@@ -435,7 +446,6 @@ def waterfall(
             plan,
             patch.coords.get_array(plan.name),
             label_edges,
-            colorbars=int(bool(cbar)),
             owned=owned,
         )
     if show:

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -24,6 +24,12 @@ from dascore.utils.plotting import (
     _get_extents,
 )
 from dascore.utils.time import dtype_time_like, is_datetime64
+from dascore.viz._labels import (
+    draw_labels,
+    image_cell_edges,
+    label_plan,
+    mesh_cell_edges,
+)
 
 
 def _validate_scale_type(scale_type):
@@ -219,6 +225,7 @@ def waterfall(
     gap_factor: float = 1.5,
     log: bool = False,
     cbar: bool = True,
+    label_coord: str | None = None,
     show: bool = False,
 ) -> plt.Axes:
     """
@@ -290,6 +297,16 @@ def waterfall(
     cbar
         If True, plot the colorbar, else do not. This controls only colorbar
         display; use `cmap` to control colormap selection.
+    label_coord
+        The name of a coordinate whose values label stretches of one of the
+        plotted dimensions, such as a label group an inventory projected onto
+        the patch with [`Patch.enrich`](`dascore.proc.inventory.enrich`). A
+        line is drawn wherever its value changes, colored by the labels it
+        parts, and a legend naming them is placed beyond the colorbar. String
+        and numeric coordinates state one label per value; a boolean one
+        states membership, so only its True stretches are marked and the
+        coordinate's own name is what the legend calls them. Absent values
+        (the empty string, NaN, or False) label nothing.
     show
         If True, show the plot, else just return axis.
 
@@ -330,6 +347,12 @@ def waterfall(
     >>> _ = patch.viz.waterfall(scale=0.5, scale_type="absolute", ax=ax2)
     >>> _ = ax2.set_title("Absolute scaling (scale=0.5)")
     >>>
+    >>> # Mark where a label coordinate changes, such as the zones an
+    >>> # inventory places along the fiber.
+    >>> from dascore.examples import inventory_patch_pair
+    >>> zoned, inventory = inventory_patch_pair()
+    >>> _ = zoned.enrich(inventory).viz.waterfall(label_coord="zone")
+    >>>
     >>> # Undo Y axis inversion which occurs when time is on the Y
     >>> ax = patch.viz.waterfall()
     >>> ax.invert_yaxis()
@@ -351,7 +374,9 @@ def waterfall(
     # Validate inputs
     patch = _validate_patch_dims(patch)
     _validate_gap_factor(gap_factor)
-    # Setup axes and data
+    # Setup axes and data. A figure this call built is one whose room a
+    # legend may take; any other belongs to the caller.
+    owned = ax is None
     ax = _get_ax(ax)
     if log:
         data = np.log10(np.abs(patch.data) + np.finfo(np.float64).eps)
@@ -363,6 +388,8 @@ def waterfall(
     coords = {dim: np.asarray(coord) for dim, coord in dim_coords.items()}
     cmap = _get_waterfall_colormap(patch, cmap)
     scale = _get_scale(scale, scale_type, data)
+    plan = label_plan(patch, label_coord, dims_r) if label_coord is not None else None
+    label_edges = None
     use_image = all(coord.evenly_sampled for coord in dim_coords.values())
     if use_image or not all(is_monotonic_and_finite(x) for x in coords.values()):
         extents = _get_extents(dims_r, coords)
@@ -376,6 +403,10 @@ def waterfall(
                 interpolation=interpolation,
                 interpolation_stage=interpolation_stage,
             )
+        if plan is not None:
+            label_edges = image_cell_edges(
+                extents, dims_r, plan.dim, len(coords[plan.dim])
+            )
     else:
         im = _plot_with_mesh(
             ax,
@@ -386,6 +417,8 @@ def waterfall(
             gap_color=gap_color,
             gap_factor=gap_factor,
         )
+        if plan is not None:
+            label_edges = mesh_cell_edges(coords[plan.dim], gap_color, gap_factor)
     if scale is not None and len(scale) == 2 and np.all(np.isfinite(scale)):
         im.set_clim(np.asarray(scale))
     # Format axis labels and handle time-like dimensions
@@ -393,6 +426,18 @@ def waterfall(
     # Add colorbar if requested
     if cbar:
         _add_colorbar(ax, im, data, patch, log, scale)
+    # Label lines come last so the legend is placed beyond a colorbar which
+    # has already taken its room.
+    if plan is not None:
+        assert label_edges is not None, "a plan is only made where edges are"
+        draw_labels(
+            ax,
+            plan,
+            patch.coords.get_array(plan.name),
+            label_edges,
+            colorbars=int(bool(cbar)),
+            owned=owned,
+        )
     if show:
         plt.show()
     return ax

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -310,15 +310,17 @@ def waterfall(
     label_coord
         The name of a coordinate whose values label stretches of one of the
         plotted dimensions, such as a label group an inventory projected onto
-        the patch with [`Patch.enrich`](`dascore.proc.inventory.enrich`). A
-        line is drawn wherever its value changes, colored by the labels it
-        parts, and a legend names them beside the axes, beyond any colorbar.
-        String and numeric coordinates state one label per distinct value, and
-        more than 20 of them raises a `ParameterError`: a coordinate that
-        varied is a quantity, not a set of labels. A boolean coordinate states
-        membership, so only its True stretches are marked and the legend names
-        them by the coordinate. Absent values (the empty string, NaN, or
-        False) label nothing.
+        the patch with [`Patch.enrich`](`dascore.proc.inventory.enrich`). Each
+        stretch is drawn as a bar along the two spines its dimension runs
+        between, colored by its label, and a legend names them beside the
+        axes, beyond any colorbar. The bars sit on the spines rather than over
+        the image, so no data is covered or tinted. String and numeric
+        coordinates state one label per distinct value, and more than 20 of
+        them raises a `ParameterError`: a coordinate that varied is a
+        quantity, not a set of labels. A boolean coordinate states membership,
+        so only its True stretches are marked and the legend names them by the
+        coordinate. Absent values (the empty string, NaN, or False) label
+        nothing, and leave bare spine.
 
     Examples
     --------

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -45,6 +45,26 @@ plt.tight_layout()
 plt.show()
 ```
 
+### Marking where labels change
+
+An [inventory](inventory.qmd) states its label groups over stretches of the fiber, and [`Patch.enrich`](`dascore.proc.inventory.enrich`) projects each group onto the patch as its own coordinate. Naming one with `label_coord` draws a line wherever it changes and names its labels in a legend beyond the colorbar, so the plot reads in the vocabulary the inventory uses rather than in metres alone.
+
+```{python}
+from dascore.examples import inventory_patch_pair
+
+patch, inventory = inventory_patch_pair()
+
+patch.enrich(inventory).viz.waterfall(label_coord="zone", show=True);
+```
+
+The one line is the boundary between the two zones this path names, and it alternates their two colors because it belongs to neither: north ends where south begins. A boundary with a label on only one side — a stretch the group says nothing about — is drawn solid, in the color of the side which does state something.
+
+A boolean coordinate is a membership group: only the stretches it holds are marked, and the legend calls them by the coordinate's own name.
+
+```{python}
+patch.enrich(inventory).viz.waterfall(label_coord="noisy", show=True);
+```
+
 ## Wiggle
 The [`wiggle patch function`](`dascore.viz.wiggle`) creates a wiggle plot of the patch data. We'll use the same patch as above to model this function.
 

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -47,7 +47,7 @@ plt.show()
 
 ### Marking where labels change
 
-An [inventory](inventory.qmd) states its label groups over stretches of the fiber, and [`Patch.enrich`](`dascore.proc.inventory.enrich`) projects each group onto the patch as its own coordinate. Naming one with `label_coord` draws a line wherever it changes and names its labels in a legend beyond the colorbar, so the plot reads in the vocabulary the inventory uses rather than in metres alone.
+An [inventory](inventory.qmd) states its label groups over stretches of the fiber, and [`Patch.enrich`](`dascore.proc.inventory.enrich`) projects each group onto the patch as its own coordinate. Naming one with `label_coord` marks off each stretch and names it in a legend beyond the colorbar, so the plot reads in the vocabulary the inventory uses rather than in metres alone.
 
 ```{python}
 from dascore.examples import inventory_patch_pair
@@ -57,9 +57,11 @@ zoned, inventory = inventory_patch_pair()
 zoned.enrich(inventory).viz.waterfall(label_coord="zone", show=True);
 ```
 
-The one line is the boundary between the two zones this path names, and it alternates their two colors because it belongs to neither: north ends where south begins. A boundary with a label on only one side — a stretch the group says nothing about — is drawn solid, in the color of the side which does state something.
+Each zone is a bar along the left and right spines, covering the channels it applies to. The bars sit on the spines rather than over the image, because a wash over the data would have to be strong enough to see, and a wash that strong has recolored the data under it — which on a diverging colormap is the measurement itself.
 
-A boolean coordinate is a membership group: only the limits of the stretches it holds are drawn, and the legend calls them by the coordinate's own name. Both lines below are solid, since the group says nothing on the far side of either.
+Where a group says nothing the spine is left bare, so what a group covers and what it merely passes over are read off the same edge. A coordinate over `time` rather than `distance` puts its bars on the bottom and top spines instead; which dimension the coordinate belongs to is what decides, and nothing needs to be passed.
+
+A boolean coordinate is a membership group: only the stretches it holds are marked, and the legend calls them by the coordinate's own name.
 
 ```{python}
 zoned.enrich(inventory).viz.waterfall(label_coord="noisy", show=True);

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -59,6 +59,8 @@ zoned.enrich(inventory).viz.waterfall(label_coord="zone", show=True);
 
 Each zone is a bar along the left and right spines, covering the channels it applies to. The bars sit on the spines rather than over the image, because a wash over the data would have to be strong enough to see, and a wash that strong has recolored the data under it — which on a diverging colormap is the measurement itself.
 
+Joining the two bars wherever the value changes is a hairline, so a boundary can still be traced through the image rather than only read off its edges. It is drawn faint, over a white stroke which keeps it visible on a busy image without letting it compete with the data.
+
 Where a group says nothing the spine is left bare, so what a group covers and what it merely passes over are read off the same edge. A coordinate over `time` rather than `distance` puts its bars on the bottom and top spines instead; which dimension the coordinate belongs to is what decides, and nothing needs to be passed.
 
 A boolean coordinate is a membership group: only the stretches it holds are marked, and the legend calls them by the coordinate's own name.

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -52,17 +52,17 @@ An [inventory](inventory.qmd) states its label groups over stretches of the fibe
 ```{python}
 from dascore.examples import inventory_patch_pair
 
-patch, inventory = inventory_patch_pair()
+zoned, inventory = inventory_patch_pair()
 
-patch.enrich(inventory).viz.waterfall(label_coord="zone", show=True);
+zoned.enrich(inventory).viz.waterfall(label_coord="zone", show=True);
 ```
 
 The one line is the boundary between the two zones this path names, and it alternates their two colors because it belongs to neither: north ends where south begins. A boundary with a label on only one side — a stretch the group says nothing about — is drawn solid, in the color of the side which does state something.
 
-A boolean coordinate is a membership group: only the stretches it holds are marked, and the legend calls them by the coordinate's own name.
+A boolean coordinate is a membership group: only the limits of the stretches it holds are drawn, and the legend calls them by the coordinate's own name. Both lines below are solid, since the group says nothing on the far side of either.
 
 ```{python}
-patch.enrich(inventory).viz.waterfall(label_coord="noisy", show=True);
+zoned.enrich(inventory).viz.waterfall(label_coord="noisy", show=True);
 ```
 
 ## Wiggle

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -15,7 +15,7 @@ from dascore.examples import inventory_patch_pair
 from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, percent
 from dascore.utils.time import is_datetime64, to_timedelta64
-from dascore.viz._labels import MAX_LABELS
+from dascore.viz._labels import BAR_GID, MAX_LABELS, SEAM_GID
 from dascore.viz._lanes import string_colors
 
 
@@ -435,12 +435,22 @@ def _bars(ax, axis):
     """Return (low, high, spine, color) for every bar drawn."""
     out = []
     for line in ax.lines:
+        if line.get_gid() != BAR_GID:
+            continue
         across = line.get_xdata() if axis == "y" else line.get_ydata()
         along = line.get_ydata() if axis == "y" else line.get_xdata()
         out.append(
             (float(along[0]), float(along[1]), float(across[0]), line.get_color())
         )
     return out
+
+
+def _changes(ax, axis):
+    """Return where a hairline was drawn across the image."""
+    getter = "get_xdata" if axis == "x" else "get_ydata"
+    return sorted(
+        float(getattr(x, getter)()[0]) for x in ax.lines if x.get_gid() == SEAM_GID
+    )
 
 
 def _spans(ax, axis):
@@ -512,6 +522,8 @@ class TestLabelCoord:
         ax = zone_patch.viz.waterfall(label_coord="zone")
         bars = _bars(ax, "y")
         assert len(bars) == 4
+        # The hairline is a separate artist and is not counted as a bar.
+        assert len(ax.lines) == len(bars) + len(_changes(ax, "y"))
         # Two stretches, each drawn on the near and the far spine.
         assert sorted(x[2] for x in bars) == [0.0, 0.0, 1.0, 1.0]
         assert len(_spans(ax, "y")) == 2
@@ -529,6 +541,33 @@ class TestLabelCoord:
         colors = string_colors(["north", "south"])
         assert _span_color(ax, "y", edges[0], edges[1]) == colors["north"]
         assert _span_color(ax, "y", edges[1], edges[2]) == colors["south"]
+
+    def test_a_hairline_joins_the_bars_at_each_change(self, zone_patch):
+        """Where the label changes, a faint line crosses the image."""
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        size = zone_patch.coords.coord_size("distance")
+        split = size // self.split_fraction
+        # One change only: the two outer ends are the patch's own edges.
+        assert _changes(ax, "y") == [
+            pytest.approx(self._edge(zone_patch, "distance", split))
+        ]
+        hair = next(x for x in ax.lines if x.get_gid() == SEAM_GID)
+        # Faint enough to locate a boundary without competing with data.
+        assert hair.get_linewidth() < 1.0
+        assert hair.get_alpha() < 0.7
+
+    def test_a_hairline_marks_the_edge_of_an_absent_stretch(self, random_patch):
+        """A label meeting a stretch stating nothing is still a change."""
+        size = random_patch.coords.coord_size("distance")
+        values = np.full(size, "", dtype="<U5")
+        low, high = size // 3, 2 * size // 3
+        values[low:high] = "mid"
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert _changes(ax, "y") == [
+            pytest.approx(self._edge(patch, "distance", low)),
+            pytest.approx(self._edge(patch, "distance", high)),
+        ]
 
     def test_bar_ends_on_the_image_cell_edge(self, zone_patch):
         """The bar ends on the cell edge, not the coordinate midpoint."""

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -561,9 +561,20 @@ class TestLabelCoord:
         ax = zone_patch.viz.waterfall(label_coord="zone")
         figure = ax.get_figure()
         figure.canvas.draw()
-        box = _legend(ax).get_window_extent()
-        assert box.x1 <= figure.bbox.x1
-        assert box.x0 >= max(x.get_position().x1 for x in figure.axes) * figure.bbox.x1
+        assert _legend(ax).get_window_extent().x1 <= figure.bbox.x1
+
+    def test_legend_clears_the_colorbars_own_labels(self, zone_patch):
+        """The names sit past the bar's ticks, not the bar's rectangle.
+
+        A colorbar carries its ticks and its name outside the rectangle
+        it reports as its position, so measuring the rectangle alone
+        would lay the legend over them.
+        """
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        figure = ax.get_figure()
+        figure.canvas.draw()
+        drawn = max(x.get_tightbbox().x1 for x in figure.axes)
+        assert _legend(ax).get_window_extent().x0 >= drawn
 
     def test_colorbar_still_matches_the_image(self, zone_patch):
         """Making room for the legend moves the image and its bar together."""

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import pytest
 from matplotlib.collections import QuadMesh
 from matplotlib.image import AxesImage
@@ -13,6 +15,7 @@ from dascore.examples import inventory_patch_pair
 from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, percent
 from dascore.utils.time import is_datetime64, to_timedelta64
+from dascore.viz._labels import MAX_LABELS
 from dascore.viz._lanes import string_colors
 
 
@@ -416,43 +419,64 @@ class TestWaterfall:
         assert ax.images[0].cmap is not None
 
 
-def _line_positions(ax, axis):
-    """Return where each line the axes carries crosses the other axis."""
-    getter = "get_xdata" if axis == "x" else "get_ydata"
-    return [float(getattr(x, getter)()[0]) for x in ax.lines]
+def _legend(ax):
+    """Return the legend naming the labels, wherever it was placed."""
+    figure = ax.get_figure()
+    return figure.legends[0] if figure.legends else ax.get_legend()
 
 
 def _legend_labels(ax):
-    """Return the text of every entry in the axes' legend."""
-    legend = ax.get_legend()
+    """Return the text of every entry in that legend."""
+    legend = _legend(ax)
     return [] if legend is None else [x.get_text() for x in legend.get_texts()]
 
 
-def _dash_offsets(ax):
-    """Return the dash offset of each line, which parts a two-tone pair."""
-    return [x._dash_pattern[0] for x in ax.lines]
+def _lines(ax, axis):
+    """Return each line as (position, dash offset, color)."""
+    getter = "get_xdata" if axis == "x" else "get_ydata"
+    return [
+        (float(getattr(x, getter)()[0]), x._dash_pattern[0], x.get_color())
+        for x in ax.lines
+    ]
 
 
-def _anchor_x(ax):
-    """Return how far past the axes the legend was anchored."""
-    return ax.get_legend().get_bbox_to_anchor().x0
+def _positions(ax, axis):
+    """Return where each line crosses the other axis."""
+    return [x[0] for x in _lines(ax, axis)]
+
+
+def _color_of(ax, axis, position, offset):
+    """Return the color of the one line drawn there with that dash offset."""
+    matches = [
+        color
+        for where, dash, color in _lines(ax, axis)
+        if where == pytest.approx(position) and dash == pytest.approx(offset)
+    ]
+    assert len(matches) == 1, f"expected one line, got {len(matches)}"
+    return matches[0]
 
 
 class TestLabelCoord:
     """Tests for marking the limits of a label coordinate."""
 
+    # Deliberately not size // 2, the one index where the extent's cell
+    # edge and the midpoint between two coordinate values coincide.
+    split_fraction = 3
+
     @pytest.fixture(scope="class")
     def zone_patch(self, random_patch):
         """A patch whose distance is parted into two named zones."""
         size = random_patch.coords.coord_size("distance")
-        zones = np.where(np.arange(size) < size // 2, "north", "south")
+        split = size // self.split_fraction
+        zones = np.where(np.arange(size) < split, "north", "south")
         return random_patch.update_coords(zone=("distance", zones))
 
     @pytest.fixture(scope="class")
     def phase_patch(self, random_patch):
         """A patch whose time is parted into two named phases."""
         size = random_patch.coords.coord_size("time")
-        phases = np.where(np.arange(size) < size // 2, "early", "late")
+        split = size // self.split_fraction
+        phases = np.where(np.arange(size) < split, "early", "late")
         return random_patch.update_coords(phase=("time", phases))
 
     @pytest.fixture()
@@ -460,7 +484,7 @@ class TestLabelCoord:
         """A patch with a distance gap, parted into two named zones."""
         coord = random_patch.get_coord("distance")
         values = np.asarray(coord).copy()
-        split = len(values) // 2
+        split = len(values) // self.split_fraction
         values[split:] += coord.step * 10
         zones = np.where(np.arange(len(values)) < split, "near", "far")
         patch = random_patch.update_coords(distance=values, zone=("distance", zones))
@@ -472,65 +496,114 @@ class TestLabelCoord:
         patch, inventory = inventory_patch_pair()
         return patch.enrich(inventory)
 
-    def test_two_zones_draw_one_two_tone_boundary(self, zone_patch):
+    def _edge(self, patch, dim, index):
+        """Where the image put the edge between two samples of a dimension."""
+        coord = patch.get_coord(dim)
+        low, high = np.asarray(coord).min(), np.asarray(coord).max()
+        if is_datetime64(coord.dtype):
+            low, high = (mdates.date2num(dc.to_datetime64(x)) for x in (low, high))
+        return float(low) + (float(high) - float(low)) * index / len(coord)
+
+    def test_boundary_is_two_lines_in_both_colors(self, zone_patch):
         """A boundary parting two labels is drawn twice, in both colors."""
         ax = zone_patch.viz.waterfall(label_coord="zone")
-        positions = _line_positions(ax, "y")
-        assert len(positions) == 2
-        assert positions[0] == positions[1]
-        # Complementary dash offsets, so neither color covers the other.
-        assert _dash_offsets(ax) == [0.0, pytest.approx(7.5)]
-        colors = {x.get_color() for x in ax.lines}
-        assert len(colors) == 2
+        split = zone_patch.coords.coord_size("distance") // self.split_fraction
+        where = self._edge(zone_patch, "distance", split)
+        assert _positions(ax, "y") == [pytest.approx(where)] * 2
+        colors = string_colors(["north", "south"])
+        # The first half of the dashes belongs to the label before the
+        # boundary, the offset half to the label after it.
+        assert _color_of(ax, "y", where, 0.0) == colors["north"]
+        assert _color_of(ax, "y", where, 7.5) == colors["south"]
+
+    def test_boundary_lands_on_the_image_cell_edge(self, zone_patch):
+        """The line sits on the cell edge, not the coordinate midpoint."""
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        coord = np.asarray(zone_patch.get_coord("distance"))
+        split = len(coord) // self.split_fraction
+        midpoint = (coord[split - 1] + coord[split]) / 2
+        drawn = _positions(ax, "y")[0]
+        assert drawn == pytest.approx(self._edge(zone_patch, "distance", split))
+        # The two genuinely differ here, so the test can tell them apart.
+        assert drawn != pytest.approx(midpoint)
+
+    def test_boundary_on_time_lands_on_the_cell_edge(self, phase_patch):
+        """A coordinate over time is marked across the other axis."""
+        ax = phase_patch.viz.waterfall(label_coord="phase")
+        split = phase_patch.coords.coord_size("time") // self.split_fraction
+        expected = self._edge(phase_patch, "time", split)
+        assert _positions(ax, "x") == [pytest.approx(expected)] * 2
+        assert not _positions(ax, "y") or True
+
+    @pytest.mark.parametrize("gap_color", [None, "gray"])
+    def test_boundary_lands_on_the_mesh_cell_edge(self, zone_gap_patch, gap_color):
+        """The line sits where the mesh parted the two zones."""
+        patch, split = zone_gap_patch
+        ax = patch.viz.waterfall(label_coord="zone", gap_color=gap_color)
+        assert isinstance(ax.collections[0], QuadMesh)
+        values = np.asarray(patch.get_coord("distance"))
+        if gap_color is None:
+            # The cells bridge the gap, so they meet halfway across it.
+            expected = (values[split - 1] + values[split]) / 2
+        else:
+            # A band was opened, so the far zone starts at its own edge.
+            expected = values[split] - np.median(np.abs(np.diff(values))) / 2
+        assert _positions(ax, "y")[0] == pytest.approx(expected)
 
     def test_legend_names_the_labels(self, zone_patch):
         """The legend names each label and is titled by the coordinate."""
         ax = zone_patch.viz.waterfall(label_coord="zone")
         assert _legend_labels(ax) == ["north", "south"]
-        assert ax.get_legend().get_title().get_text() == "zone"
+        assert _legend(ax).get_title().get_text() == "zone"
 
-    def test_colors_match_the_lane_palette(self, zone_patch):
-        """A label is the color the lanes give it, so two figures agree."""
+    def test_legend_is_drawn_inside_the_figure(self, zone_patch):
+        """The names fit on the page, not past its right edge."""
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        figure = ax.get_figure()
+        figure.canvas.draw()
+        box = _legend(ax).get_window_extent()
+        assert box.x1 <= figure.bbox.x1
+        assert box.x0 >= max(x.get_position().x1 for x in figure.axes) * figure.bbox.x1
+
+    def test_colorbar_still_matches_the_image(self, zone_patch):
+        """Making room for the legend moves the image and its bar together."""
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        figure = ax.get_figure()
+        cax = next(x for x in figure.axes if x is not ax)
+        assert cax.get_position().y0 == pytest.approx(ax.get_position().y0)
+        assert cax.get_position().height == pytest.approx(ax.get_position().height)
+
+    def test_each_label_keeps_its_own_color(self, zone_patch):
+        """A label is drawn in the color the palette gives that label."""
         ax = zone_patch.viz.waterfall(label_coord="zone")
         expected = string_colors(["north", "south"])
-        drawn = {x.get_color() for x in ax.lines}
-        assert drawn == {expected["north"], expected["south"]}
+        handles = _legend(ax).legend_handles
+        drawn = dict(zip(_legend_labels(ax), [x.get_color() for x in handles]))
+        assert drawn == {"north": expected["north"], "south": expected["south"]}
 
-    def test_label_on_time_draws_vertical_lines(self, phase_patch):
-        """A coordinate over time is marked across the other axis."""
-        ax = phase_patch.viz.waterfall(label_coord="phase")
-        positions = _line_positions(ax, "x")
-        low, high = ax.get_xlim()
-        assert len(positions) == 2
-        assert all(low < x < high for x in positions)
-
-    def test_boundary_lands_on_the_image_cell_edge(self, zone_patch):
-        """The line sits where the image parted the two zones."""
-        ax = zone_patch.viz.waterfall(label_coord="zone")
-        coord = zone_patch.get_coord("distance")
-        size, split = len(coord), zone_patch.coords.coord_size("distance") // 2
-        low, high = float(coord.min()), float(coord.max())
-        expected = low + (high - low) * split / size
-        assert _line_positions(ax, "y")[0] == pytest.approx(expected)
-
-    def test_boundary_lands_on_the_mesh_cell_edge(self, zone_gap_patch):
-        """The line sits where the mesh parted the two zones."""
-        patch, split = zone_gap_patch
-        ax = patch.viz.waterfall(label_coord="zone", gap_color="gray")
-        values = np.asarray(patch.get_coord("distance"))
-        step = np.median(np.abs(np.diff(values)))
-        # The gap band ends where the far zone starts, not halfway across it.
-        assert _line_positions(ax, "y")[0] == pytest.approx(values[split] - step / 2)
-
-    def test_membership_names_itself(self, enriched_patch):
-        """A boolean coordinate marks only what it holds and names itself."""
+    def test_membership_marks_only_what_it_holds(self, enriched_patch):
+        """A boolean coordinate marks its True stretch and names itself."""
         ax = enriched_patch.viz.waterfall(label_coord="noisy")
         assert _legend_labels(ax) == ["noisy"]
         # A membership entry already carries the name, so no title repeats it.
-        assert ax.get_legend().get_title().get_text() == ""
-        # Both limits of the one True stretch, each parting a stated side
-        # from an unstated one, so each is drawn once.
-        assert len(_line_positions(ax, "y")) == 2
+        assert _legend(ax).get_title().get_text() == ""
+        held = np.flatnonzero(enriched_patch.coords.get_array("noisy"))
+        expected = [
+            self._edge(enriched_patch, "distance", held[0]),
+            self._edge(enriched_patch, "distance", held[-1] + 1),
+        ]
+        # Both limits of the True stretch, each parting a stated side from
+        # an unstated one, so each is drawn once and drawn solid.
+        assert _positions(ax, "y") == [pytest.approx(x) for x in expected]
+        assert all(x.get_linestyle() == "-" for x in ax.lines)
+
+    def test_all_true_membership_states_no_limits(self, random_patch):
+        """A group covering everything is named but bounded by the spines."""
+        size = random_patch.coords.coord_size("distance")
+        patch = random_patch.update_coords(tag=("distance", np.full(size, True)))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert _legend_labels(ax) == ["tag"]
+        assert not ax.lines
 
     def test_enriched_labels_are_drawn(self, enriched_patch):
         """A label group an inventory projected on a patch reaches the plot."""
@@ -547,6 +620,7 @@ class TestLabelCoord:
         assert _legend_labels(ax) == ["mid"]
         assert len(ax.lines) == 2
         assert all(x.get_linestyle() == "-" for x in ax.lines)
+        assert all(x.get_color() == string_colors(["mid"])["mid"] for x in ax.lines)
 
     def test_recurring_label_gets_one_entry(self, random_patch):
         """A label stated in two places is named once and marked twice."""
@@ -556,36 +630,75 @@ class TestLabelCoord:
         ax = patch.viz.waterfall(label_coord="tag")
         assert _legend_labels(ax) == ["even", "odd"]
         # Three interior boundaries, each parting two stated labels.
-        assert len(ax.lines) == 6
+        expected = [self._edge(patch, "distance", size // 4 * x) for x in (1, 2, 3)]
+        assert _positions(ax, "y") == [pytest.approx(x) for x in expected for _ in "ab"]
 
-    def test_numeric_labels_read_as_their_digits(self, random_patch):
-        """A numeric coordinate states one label per distinct value."""
+    def test_datetime_labels_read_as_times(self, random_patch):
+        """A nanosecond datetime label names a time, not a count of them."""
         size = random_patch.coords.coord_size("distance")
-        values = np.where(np.arange(size) < size // 2, 1.5, np.nan)
+        start = dc.to_datetime64("2020-01-01")
+        values = np.where(
+            np.arange(size) < size // 3, start, start + np.timedelta64(1, "s")
+        )
         patch = random_patch.update_coords(tag=("distance", values))
         ax = patch.viz.waterfall(label_coord="tag")
-        assert _legend_labels(ax) == ["1.5"]
+        assert all(x.startswith("2020-01-01") for x in _legend_labels(ax))
 
-    def test_legend_clears_the_colorbar(self, zone_patch):
-        """The legend sits beyond a colorbar, and beside the axes without."""
-        with_bar = zone_patch.viz.waterfall(label_coord="zone")
-        without = zone_patch.viz.waterfall(label_coord="zone", cbar=False)
-        assert _anchor_x(with_bar) > _anchor_x(without)
-
-    def test_tall_legend_falls_below(self, random_patch):
-        """A legend too tall for the axes takes its room under them."""
+    def test_close_numbers_keep_distinct_names(self, random_patch):
+        """Two values which round to one name are still named apart."""
         size = random_patch.coords.coord_size("distance")
-        values = np.asarray([f"group{x // 20}" for x in range(size)])
+        values = np.where(np.arange(size) < size // 3, 1.0, 1.0000001)
         patch = random_patch.update_coords(tag=("distance", values))
-        _, ax = plt.subplots(figsize=(4, 1.4))
-        ax = patch.viz.waterfall(label_coord="tag", ax=ax)
-        assert ax._dascore_legend_room > 0
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert len(set(_legend_labels(ax))) == 2
+
+    def test_nulls_beside_booleans_state_membership(self, random_patch):
+        """A boolean group carrying nulls is still a membership group."""
+        size = random_patch.coords.coord_size("distance")
+        values = np.array([True] * size, dtype=object)
+        values[: size // 3] = None
+        values[2 * size // 3 :] = False
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert _legend_labels(ax) == ["tag"]
+
+    def test_null_strings_do_not_raise(self, random_patch):
+        """A string group carrying nulls plots rather than failing on them."""
+        size = random_patch.coords.coord_size("distance")
+        values = np.array(["a"] * size, dtype=object)
+        values[size // 3 : 2 * size // 3] = pd.NA
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert _legend_labels(ax) == ["a"]
+
+    def test_caller_axes_keeps_its_legend_inside(self, zone_patch):
+        """A figure this call did not build keeps the room it had."""
+        figure, (left, right) = plt.subplots(1, 2)
+        before = right.get_position().bounds
+        ax = zone_patch.viz.waterfall(label_coord="zone", ax=left)
+        figure.canvas.draw()
+        # The neighbour did not move, and the names sit over the image.
+        assert right.get_position().bounds == before
+        assert not figure.legends
+        assert ax.get_legend().get_window_extent().x1 <= ax.get_window_extent().x1
+
+    def test_many_labels_spill_into_columns(self, random_patch):
+        """A legend too tall for the page is set in as many columns as fit."""
+        size = random_patch.coords.coord_size("distance")
+        values = np.asarray([f"group{x * MAX_LABELS // size}" for x in range(size)])
+        patch = random_patch.update_coords(tag=("distance", values))
+        with plt.rc_context({"figure.figsize": (6.0, 1.6)}):
+            ax = patch.viz.waterfall(label_coord="tag")
+        legend = _legend(ax)
+        assert len(_legend_labels(ax)) == MAX_LABELS
+        assert legend._ncols > 1
+        assert legend.get_window_extent().height <= ax.get_figure().bbox.height
 
     def test_no_label_coord_draws_nothing(self, zone_patch):
         """The default leaves the plot as it was."""
         ax = zone_patch.viz.waterfall()
         assert not ax.lines
-        assert ax.get_legend() is None
+        assert _legend(ax) is None
 
     @pytest.mark.parametrize(
         ("name", "match"),
@@ -596,8 +709,11 @@ class TestLabelCoord:
     )
     def test_bad_name_raises(self, zone_patch, name, match):
         """A name which states no label coordinate is refused."""
+        before = len(plt.get_fignums())
         with pytest.raises(ParameterError, match=match):
             zone_patch.viz.waterfall(label_coord=name)
+        # Refused before an axes exists, so no figure is left behind.
+        assert len(plt.get_fignums()) == before
 
     def test_multi_dim_coord_raises(self, random_patch):
         """A coordinate over both dimensions names no axis to be drawn on."""
@@ -607,12 +723,19 @@ class TestLabelCoord:
         with pytest.raises(ParameterError, match="names no one axis"):
             patch.viz.waterfall(label_coord="grid")
 
-    def test_no_labels_raises(self, random_patch):
+    @pytest.mark.parametrize(
+        "values",
+        [
+            np.full(300, "", dtype="<U4"),
+            np.full(300, np.nan),
+            np.full(300, False),
+        ],
+        ids=["blank", "nan", "false"],
+    )
+    def test_no_labels_raises(self, random_patch, values):
         """A coordinate stating nothing throughout has nothing to draw."""
         size = random_patch.coords.coord_size("distance")
-        patch = random_patch.update_coords(
-            tag=("distance", np.full(size, "", dtype="<U4"))
-        )
+        patch = random_patch.update_coords(tag=("distance", values[:size]))
         with pytest.raises(ParameterError, match="states no labels"):
             patch.viz.waterfall(label_coord="tag")
 
@@ -623,4 +746,11 @@ class TestLabelCoord:
             tag=("distance", np.arange(size).astype(float))
         )
         with pytest.raises(ParameterError, match="distinct labels"):
+            patch.viz.waterfall(label_coord="tag")
+
+    def test_too_many_boundaries_raises(self, random_patch):
+        """A coordinate changing every sample states no stretches."""
+        size = random_patch.coords.coord_size("distance")
+        patch = random_patch.update_coords(tag=("distance", np.arange(size) % 2 == 0))
+        with pytest.raises(ParameterError, match="changes value"):
             patch.viz.waterfall(label_coord="tag")

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -16,7 +16,7 @@ from dascore.examples import inventory_patch_pair
 from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, percent
 from dascore.utils.time import is_datetime64, to_timedelta64
-from dascore.viz._labels import BAR_GID, MAX_LABELS, SEAM_GID
+from dascore.viz._labels import BAR_GID, MAX_LABELS, MAX_RUNS, SEAM_GID
 from dascore.viz._lanes import string_colors
 
 
@@ -446,6 +446,12 @@ def _bars(ax, axis):
     return out
 
 
+def _on_canvas(line):
+    """Where a line actually lands, in display pixels."""
+    points = np.column_stack([line.get_xdata(), line.get_ydata()])
+    return line.get_transform().transform(points)
+
+
 def _changes(ax, axis):
     """Return where a hairline was drawn across the image."""
     getter = "get_xdata" if axis == "x" else "get_ydata"
@@ -483,6 +489,18 @@ class TestLabelCoord:
         size = random_patch.coords.coord_size("distance")
         split = size // self.split_fraction
         zones = np.where(np.arange(size) < split, "north", "south")
+        return random_patch.update_coords(zone=("distance", zones))
+
+    @pytest.fixture(scope="class")
+    def unsorted_zone_patch(self, random_patch):
+        """A patch whose first label is not the first alphabetically.
+
+        Codes run in order of appearance and colors are keyed by sorted
+        name, so a fixture where the two agree cannot tell them apart.
+        """
+        size = random_patch.coords.coord_size("distance")
+        split = size // self.split_fraction
+        zones = np.where(np.arange(size) < split, "south", "north")
         return random_patch.update_coords(zone=("distance", zones))
 
     @pytest.fixture(scope="class")
@@ -570,6 +588,37 @@ class TestLabelCoord:
             pytest.approx(self._edge(patch, "distance", high)),
         ]
 
+    def test_bars_land_on_the_spines_on_the_canvas(self, zone_patch):
+        """The bars reach the axes edges, not merely claim to.
+
+        The data handed to matplotlib is the same whichever way the
+        blended transform is built, so only where a bar lands can tell
+        the two apart.
+        """
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        ax.get_figure().canvas.draw()
+        box = ax.get_window_extent()
+        for line in [x for x in ax.lines if x.get_gid() == BAR_GID]:
+            points = _on_canvas(line)
+            across, along = points[:, 0], points[:, 1]
+            # Upright on the page, and on one of the two upright edges.
+            assert across[0] == pytest.approx(across[1])
+            assert min(abs(across[0] - box.x0), abs(across[0] - box.x1)) < 1.0
+            # Running along part of the axes, neither collapsed nor loose.
+            assert box.y0 - 1 <= min(along)
+            assert max(along) <= box.y1 + 1
+            assert max(along) - min(along) > 1.0
+
+    def test_a_label_keeps_its_color_whatever_its_order(self, unsorted_zone_patch):
+        """Colors follow the label, not the order it first appears in."""
+        ax = unsorted_zone_patch.viz.waterfall(label_coord="zone")
+        colors = string_colors(["north", "south"])
+        first, second = _spans(ax, "y")
+        # South is stated first here, and is still south's color.
+        assert _span_color(ax, "y", *first) == colors["south"]
+        assert _span_color(ax, "y", *second) == colors["north"]
+        assert _legend_labels(ax) == ["south", "north"]
+
     def test_bar_ends_on_the_image_cell_edge(self, zone_patch):
         """The bar ends on the cell edge, not the coordinate midpoint."""
         ax = zone_patch.viz.waterfall(label_coord="zone")
@@ -646,12 +695,20 @@ class TestLabelCoord:
         assert _legend(ax).get_window_extent().x0 >= drawn
 
     def test_colorbar_still_matches_the_image(self, zone_patch):
-        """Making room for the legend moves the image and its bar together."""
-        ax = zone_patch.viz.waterfall(label_coord="zone")
-        figure = ax.get_figure()
-        cax = next(x for x in figure.axes if x is not ax)
-        assert cax.get_position().y0 == pytest.approx(ax.get_position().y0)
-        assert cax.get_position().height == pytest.approx(ax.get_position().height)
+        """Making room for the legend moves the image and its bar together.
+
+        The two hang off one gridspec; repositioning either alone parts
+        them, which is why the room is taken from the figure margin.
+        """
+        plain = zone_patch.viz.waterfall()
+        named = zone_patch.viz.waterfall(label_coord="zone")
+        # Room really was taken, or the alignment below proves nothing.
+        assert named.get_position().width < plain.get_position().width
+        figure = named.get_figure()
+        cax = next(x for x in figure.axes if x is not named)
+        assert cax.get_position().x0 > named.get_position().x1
+        assert cax.get_position().y0 == pytest.approx(named.get_position().y0)
+        assert cax.get_position().height == pytest.approx(named.get_position().height)
 
     def test_each_label_keeps_its_own_color(self, zone_patch):
         """A label is drawn in the color the palette gives that label."""
@@ -885,6 +942,38 @@ class TestLabelCoord:
             box = _legend(ax).get_window_extent()
             assert box.x0 >= drawn
             assert box.x1 <= figure.bbox.x1
+
+    @pytest.mark.parametrize("over", [False, True])
+    def test_label_ceiling_is_inclusive(self, random_patch, over):
+        """Exactly MAX_LABELS is allowed; one more is refused."""
+        size = random_patch.coords.coord_size("distance")
+        count = MAX_LABELS + int(over)
+        values = np.asarray([f"g{x * count // size}" for x in range(size)])
+        assert len(set(values)) == count
+        patch = random_patch.update_coords(tag=("distance", values))
+        if over:
+            with pytest.raises(ParameterError, match="distinct labels"):
+                patch.viz.waterfall(label_coord="tag")
+        else:
+            assert len(_legend_labels(patch.viz.waterfall(label_coord="tag")))
+
+    @pytest.mark.parametrize("over", [False, True])
+    def test_change_ceiling_is_inclusive(self, random_patch, over):
+        """Exactly MAX_RUNS changes is allowed; one more is refused."""
+        size = random_patch.coords.coord_size("distance")
+        changes = MAX_RUNS + int(over)
+        # Alternating over the head gives one change per element there;
+        # the tail repeats the last of them and adds none.
+        head = np.arange(changes + 1) % 2 == 0
+        values = np.full(size, head[-1], dtype=bool)
+        values[: changes + 1] = head
+        assert int(np.count_nonzero(np.diff(values))) == changes
+        patch = random_patch.update_coords(tag=("distance", values))
+        if over:
+            with pytest.raises(ParameterError, match="changes value"):
+                patch.viz.waterfall(label_coord="tag")
+        else:
+            assert patch.viz.waterfall(label_coord="tag") is not None
 
     def test_bars_stay_inside_their_axes_after_a_zoom(self, zone_patch):
         """A bar keeps to its own axes when the limits change.

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -9,9 +9,11 @@ from matplotlib.collections import QuadMesh
 from matplotlib.image import AxesImage
 
 import dascore as dc
+from dascore.examples import inventory_patch_pair
 from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, percent
 from dascore.utils.time import is_datetime64, to_timedelta64
+from dascore.viz._lanes import string_colors
 
 
 def check_label_units(patch, ax):
@@ -412,3 +414,213 @@ class TestWaterfall:
         patch = random_patch.update_attrs(data_type="velocity")
         ax = patch.viz.waterfall()
         assert ax.images[0].cmap is not None
+
+
+def _line_positions(ax, axis):
+    """Return where each line the axes carries crosses the other axis."""
+    getter = "get_xdata" if axis == "x" else "get_ydata"
+    return [float(getattr(x, getter)()[0]) for x in ax.lines]
+
+
+def _legend_labels(ax):
+    """Return the text of every entry in the axes' legend."""
+    legend = ax.get_legend()
+    return [] if legend is None else [x.get_text() for x in legend.get_texts()]
+
+
+def _dash_offsets(ax):
+    """Return the dash offset of each line, which parts a two-tone pair."""
+    return [x._dash_pattern[0] for x in ax.lines]
+
+
+def _anchor_x(ax):
+    """Return how far past the axes the legend was anchored."""
+    return ax.get_legend().get_bbox_to_anchor().x0
+
+
+class TestLabelCoord:
+    """Tests for marking the limits of a label coordinate."""
+
+    @pytest.fixture(scope="class")
+    def zone_patch(self, random_patch):
+        """A patch whose distance is parted into two named zones."""
+        size = random_patch.coords.coord_size("distance")
+        zones = np.where(np.arange(size) < size // 2, "north", "south")
+        return random_patch.update_coords(zone=("distance", zones))
+
+    @pytest.fixture(scope="class")
+    def phase_patch(self, random_patch):
+        """A patch whose time is parted into two named phases."""
+        size = random_patch.coords.coord_size("time")
+        phases = np.where(np.arange(size) < size // 2, "early", "late")
+        return random_patch.update_coords(phase=("time", phases))
+
+    @pytest.fixture()
+    def zone_gap_patch(self, random_patch):
+        """A patch with a distance gap, parted into two named zones."""
+        coord = random_patch.get_coord("distance")
+        values = np.asarray(coord).copy()
+        split = len(values) // 2
+        values[split:] += coord.step * 10
+        zones = np.where(np.arange(len(values)) < split, "near", "far")
+        patch = random_patch.update_coords(distance=values, zone=("distance", zones))
+        return patch, split
+
+    @pytest.fixture(scope="class")
+    def enriched_patch(self):
+        """The inventory example patch, carrying the labels its path states."""
+        patch, inventory = inventory_patch_pair()
+        return patch.enrich(inventory)
+
+    def test_two_zones_draw_one_two_tone_boundary(self, zone_patch):
+        """A boundary parting two labels is drawn twice, in both colors."""
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        positions = _line_positions(ax, "y")
+        assert len(positions) == 2
+        assert positions[0] == positions[1]
+        # Complementary dash offsets, so neither color covers the other.
+        assert _dash_offsets(ax) == [0.0, pytest.approx(7.5)]
+        colors = {x.get_color() for x in ax.lines}
+        assert len(colors) == 2
+
+    def test_legend_names_the_labels(self, zone_patch):
+        """The legend names each label and is titled by the coordinate."""
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        assert _legend_labels(ax) == ["north", "south"]
+        assert ax.get_legend().get_title().get_text() == "zone"
+
+    def test_colors_match_the_lane_palette(self, zone_patch):
+        """A label is the color the lanes give it, so two figures agree."""
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        expected = string_colors(["north", "south"])
+        drawn = {x.get_color() for x in ax.lines}
+        assert drawn == {expected["north"], expected["south"]}
+
+    def test_label_on_time_draws_vertical_lines(self, phase_patch):
+        """A coordinate over time is marked across the other axis."""
+        ax = phase_patch.viz.waterfall(label_coord="phase")
+        positions = _line_positions(ax, "x")
+        low, high = ax.get_xlim()
+        assert len(positions) == 2
+        assert all(low < x < high for x in positions)
+
+    def test_boundary_lands_on_the_image_cell_edge(self, zone_patch):
+        """The line sits where the image parted the two zones."""
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        coord = zone_patch.get_coord("distance")
+        size, split = len(coord), zone_patch.coords.coord_size("distance") // 2
+        low, high = float(coord.min()), float(coord.max())
+        expected = low + (high - low) * split / size
+        assert _line_positions(ax, "y")[0] == pytest.approx(expected)
+
+    def test_boundary_lands_on_the_mesh_cell_edge(self, zone_gap_patch):
+        """The line sits where the mesh parted the two zones."""
+        patch, split = zone_gap_patch
+        ax = patch.viz.waterfall(label_coord="zone", gap_color="gray")
+        values = np.asarray(patch.get_coord("distance"))
+        step = np.median(np.abs(np.diff(values)))
+        # The gap band ends where the far zone starts, not halfway across it.
+        assert _line_positions(ax, "y")[0] == pytest.approx(values[split] - step / 2)
+
+    def test_membership_names_itself(self, enriched_patch):
+        """A boolean coordinate marks only what it holds and names itself."""
+        ax = enriched_patch.viz.waterfall(label_coord="noisy")
+        assert _legend_labels(ax) == ["noisy"]
+        # A membership entry already carries the name, so no title repeats it.
+        assert ax.get_legend().get_title().get_text() == ""
+        # Both limits of the one True stretch, each parting a stated side
+        # from an unstated one, so each is drawn once.
+        assert len(_line_positions(ax, "y")) == 2
+
+    def test_enriched_labels_are_drawn(self, enriched_patch):
+        """A label group an inventory projected on a patch reaches the plot."""
+        ax = enriched_patch.viz.waterfall(label_coord="zone")
+        assert _legend_labels(ax) == ["north", "south"]
+
+    def test_absent_values_get_a_solid_boundary(self, random_patch):
+        """Where a label meets nothing, the line is wholly the label's."""
+        size = random_patch.coords.coord_size("distance")
+        values = np.full(size, "", dtype="<U5")
+        values[size // 3 : 2 * size // 3] = "mid"
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert _legend_labels(ax) == ["mid"]
+        assert len(ax.lines) == 2
+        assert all(x.get_linestyle() == "-" for x in ax.lines)
+
+    def test_recurring_label_gets_one_entry(self, random_patch):
+        """A label stated in two places is named once and marked twice."""
+        size = random_patch.coords.coord_size("distance")
+        values = np.where((np.arange(size) // (size // 4)) % 2, "odd", "even")
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert _legend_labels(ax) == ["even", "odd"]
+        # Three interior boundaries, each parting two stated labels.
+        assert len(ax.lines) == 6
+
+    def test_numeric_labels_read_as_their_digits(self, random_patch):
+        """A numeric coordinate states one label per distinct value."""
+        size = random_patch.coords.coord_size("distance")
+        values = np.where(np.arange(size) < size // 2, 1.5, np.nan)
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert _legend_labels(ax) == ["1.5"]
+
+    def test_legend_clears_the_colorbar(self, zone_patch):
+        """The legend sits beyond a colorbar, and beside the axes without."""
+        with_bar = zone_patch.viz.waterfall(label_coord="zone")
+        without = zone_patch.viz.waterfall(label_coord="zone", cbar=False)
+        assert _anchor_x(with_bar) > _anchor_x(without)
+
+    def test_tall_legend_falls_below(self, random_patch):
+        """A legend too tall for the axes takes its room under them."""
+        size = random_patch.coords.coord_size("distance")
+        values = np.asarray([f"group{x // 20}" for x in range(size)])
+        patch = random_patch.update_coords(tag=("distance", values))
+        _, ax = plt.subplots(figsize=(4, 1.4))
+        ax = patch.viz.waterfall(label_coord="tag", ax=ax)
+        assert ax._dascore_legend_room > 0
+
+    def test_no_label_coord_draws_nothing(self, zone_patch):
+        """The default leaves the plot as it was."""
+        ax = zone_patch.viz.waterfall()
+        assert not ax.lines
+        assert ax.get_legend() is None
+
+    @pytest.mark.parametrize(
+        ("name", "match"),
+        [
+            ("bad_name", "not a coordinate"),
+            ("distance", "is a dimension"),
+        ],
+    )
+    def test_bad_name_raises(self, zone_patch, name, match):
+        """A name which states no label coordinate is refused."""
+        with pytest.raises(ParameterError, match=match):
+            zone_patch.viz.waterfall(label_coord=name)
+
+    def test_multi_dim_coord_raises(self, random_patch):
+        """A coordinate over both dimensions names no axis to be drawn on."""
+        patch = random_patch.update_coords(
+            grid=(("distance", "time"), np.zeros(random_patch.shape))
+        )
+        with pytest.raises(ParameterError, match="names no one axis"):
+            patch.viz.waterfall(label_coord="grid")
+
+    def test_no_labels_raises(self, random_patch):
+        """A coordinate stating nothing throughout has nothing to draw."""
+        size = random_patch.coords.coord_size("distance")
+        patch = random_patch.update_coords(
+            tag=("distance", np.full(size, "", dtype="<U4"))
+        )
+        with pytest.raises(ParameterError, match="states no labels"):
+            patch.viz.waterfall(label_coord="tag")
+
+    def test_too_many_labels_raises(self, random_patch):
+        """A coordinate too varied to name is a quantity, not a set of labels."""
+        size = random_patch.coords.coord_size("distance")
+        patch = random_patch.update_coords(
+            tag=("distance", np.arange(size).astype(float))
+        )
+        with pytest.raises(ParameterError, match="distinct labels"):
+            patch.viz.waterfall(label_coord="tag")

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 from matplotlib.collections import QuadMesh
 from matplotlib.image import AxesImage
+from matplotlib.legend import Legend
 
 import dascore as dc
 from dascore.examples import inventory_patch_pair
@@ -594,18 +595,29 @@ class TestLabelCoord:
 
     @pytest.mark.parametrize("gap_color", [None, "gray"])
     def test_bar_ends_on_the_mesh_cell_edge(self, zone_gap_patch, gap_color):
-        """The bar ends where the mesh parted the two zones."""
+        """A bar ends where its own last cell ends, not across a gap.
+
+        With a gap band opened the two zones no longer share an edge, and
+        a bar drawn to where the next one starts would state that the
+        near zone covers ground the mesh shows no data for.
+        """
         patch, split = zone_gap_patch
         ax = patch.viz.waterfall(label_coord="zone", gap_color=gap_color)
         assert isinstance(ax.collections[0], QuadMesh)
         values = np.asarray(patch.get_coord("distance"))
+        step = np.median(np.abs(np.diff(values)))
+        near_end, far_start = _spans(ax, "y")[0][1], _spans(ax, "y")[1][0]
         if gap_color is None:
             # The cells bridge the gap, so they meet halfway across it.
-            expected = (values[split - 1] + values[split]) / 2
+            middle = (values[split - 1] + values[split]) / 2
+            assert near_end == pytest.approx(middle)
+            assert far_start == pytest.approx(middle)
         else:
-            # A band was opened, so the far zone starts at its own edge.
-            expected = values[split] - np.median(np.abs(np.diff(values))) / 2
-        assert _spans(ax, "y")[0][1] == pytest.approx(expected)
+            # A band was opened, so each zone stops at its own edge and
+            # the band between them is claimed by neither.
+            assert near_end == pytest.approx(values[split - 1] + step / 2)
+            assert far_start == pytest.approx(values[split] - step / 2)
+            assert near_end < far_start
 
     def test_legend_names_the_labels(self, zone_patch):
         """The legend names each label and is titled by the coordinate."""
@@ -721,14 +733,6 @@ class TestLabelCoord:
         ax = patch.viz.waterfall(label_coord="tag")
         assert all(x.startswith("2020-01-01") for x in _legend_labels(ax))
 
-    def test_close_numbers_keep_distinct_names(self, random_patch):
-        """Two values which round to one name are still named apart."""
-        size = random_patch.coords.coord_size("distance")
-        values = np.where(np.arange(size) < size // 3, 1.0, 1.0000001)
-        patch = random_patch.update_coords(tag=("distance", values))
-        ax = patch.viz.waterfall(label_coord="tag")
-        assert len(set(_legend_labels(ax))) == 2
-
     def test_nulls_beside_booleans_state_membership(self, random_patch):
         """A boolean group carrying nulls is still a membership group."""
         size = random_patch.coords.coord_size("distance")
@@ -760,6 +764,16 @@ class TestLabelCoord:
         assert right.get_position().bounds == before
         assert not figure.legends
         assert ax.get_legend().get_window_extent().x1 <= ax.get_window_extent().x1
+
+    def test_a_callers_own_legend_survives(self, zone_patch):
+        """Naming the labels does not drop what the caller had named."""
+        _, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1], label="expected")
+        ax.legend(loc="lower left")
+        zone_patch.viz.waterfall(label_coord="zone", ax=ax)
+        drawn = [x for x in ax.artists if isinstance(x, Legend)] + [ax.get_legend()]
+        named = {y.get_text() for x in drawn if x for y in x.get_texts()}
+        assert {"expected", "north", "south"} <= named
 
     def test_many_labels_spill_into_columns(self, random_patch):
         """A legend too tall for the page is set in as many columns as fit."""
@@ -803,33 +817,104 @@ class TestLabelCoord:
             patch.viz.waterfall(label_coord="grid")
 
     @pytest.mark.parametrize(
-        "values",
+        ("values", "match"),
         [
-            np.full(300, "", dtype="<U4"),
-            np.full(300, np.nan),
-            np.full(300, False),
+            (np.full(300, "", dtype="<U4"), "states no labels"),
+            (np.full(300, np.nan), "states no labels"),
+            (np.full(300, False), "states no labels"),
+            (np.arange(300).astype(float), "distinct labels"),
+            (np.arange(300) % 2 == 0, "changes value"),
         ],
-        ids=["blank", "nan", "false"],
+        ids=["blank", "nan", "false", "many-labels", "many-runs"],
     )
-    def test_no_labels_raises(self, random_patch, values):
-        """A coordinate stating nothing throughout has nothing to draw."""
+    def test_refusal_leaves_no_figure(self, random_patch, values, match):
+        """What a coordinate states is judged before anything is drawn.
+
+        Refusing after the image and colorbar exist would leave an owned
+        figure open, and a caller's axes half drawn on.
+        """
         size = random_patch.coords.coord_size("distance")
         patch = random_patch.update_coords(tag=("distance", values[:size]))
-        with pytest.raises(ParameterError, match="states no labels"):
+        plt.close("all")
+        with pytest.raises(ParameterError, match=match):
             patch.viz.waterfall(label_coord="tag")
+        assert not plt.get_fignums()
 
-    def test_too_many_labels_raises(self, random_patch):
-        """A coordinate too varied to name is a quantity, not a set of labels."""
+    def test_values_printing_alike_are_told_apart(self, random_patch):
+        """Two values which print the same are named, and colored, apart."""
         size = random_patch.coords.coord_size("distance")
-        patch = random_patch.update_coords(
-            tag=("distance", np.arange(size).astype(float))
-        )
-        with pytest.raises(ParameterError, match="distinct labels"):
-            patch.viz.waterfall(label_coord="tag")
+        values = np.array([1] * (size // 2) + ["1"] * (size - size // 2), dtype=object)
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert _legend_labels(ax) == ["1 (int)", "1 (str)"]
+        assert len({x[3] for x in _bars(ax, "y")}) == 2
 
-    def test_too_many_runs_raises(self, random_patch):
-        """A coordinate changing every sample states no stretches."""
+    def test_close_numbers_are_not_qualified(self, random_patch):
+        """A name which is already unique is left as it is."""
         size = random_patch.coords.coord_size("distance")
-        patch = random_patch.update_coords(tag=("distance", np.arange(size) % 2 == 0))
-        with pytest.raises(ParameterError, match="changes value"):
-            patch.viz.waterfall(label_coord="tag")
+        values = np.where(np.arange(size) < size // 3, 1.0, 1.0000001)
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert _legend_labels(ax) == ["1.0", "1.0000001"]
+
+    def test_constrained_layout_reserves_the_room(self, zone_patch):
+        """A figure whose engine holds the margins is asked, not overruled.
+
+        Constrained layout ignores subplots_adjust, so taking the room
+        that way would leave the names hanging off the page.
+        """
+        with plt.rc_context({"figure.constrained_layout.use": True}):
+            ax = zone_patch.viz.waterfall(label_coord="zone")
+            figure = ax.get_figure()
+            figure.canvas.draw()
+            assert figure.get_layout_engine() is not None
+            assert _legend(ax).get_window_extent().x1 <= figure.bbox.x1
+
+    def test_tight_layout_still_reserves_the_room(self, zone_patch):
+        """An engine which is not constrained is stood down, not obeyed.
+
+        Only constrained layout keeps room for a legend outside the axes;
+        any other engine recomputes the margins at draw time and would
+        undo the room made for it.
+        """
+        with plt.rc_context({"figure.autolayout": True}):
+            ax = zone_patch.viz.waterfall(label_coord="zone")
+            figure = ax.get_figure()
+            figure.canvas.draw()
+            drawn = max(x.get_tightbbox().x1 for x in figure.axes)
+            box = _legend(ax).get_window_extent()
+            assert box.x0 >= drawn
+            assert box.x1 <= figure.bbox.x1
+
+    def test_bars_stay_inside_their_axes_after_a_zoom(self, zone_patch):
+        """A bar keeps to its own axes when the limits change.
+
+        Bars are placed in data coordinates along their dimension, so an
+        unclipped one paints across the whole figure once a zoom moves
+        the limits under it -- into a neighbour which was never given a
+        label_coord.
+        """
+        figure, (top, bottom) = plt.subplots(2, 1)
+        zone_patch.viz.waterfall(label_coord="zone", ax=top, cbar=False)
+        zone_patch.viz.waterfall(ax=bottom, cbar=False)
+        size = zone_patch.coords.coord_size("distance")
+        top.set_ylim(size // 3, size // 2)
+        figure.canvas.draw()
+        pixels = np.asarray(figure.canvas.buffer_rgba())[..., :3] / 255.0
+        below = int(pixels.shape[0] - top.get_window_extent().y0) + 3
+        north = np.array(string_colors(["north", "south"])["north"][:3])
+        strays = np.abs(pixels[below:] - north).sum(axis=2) < 0.05
+        assert not strays.any()
+
+    def test_names_too_wide_to_seat_do_not_crash(self, random_patch):
+        """Names wanting more room than there is leave the picture alone.
+
+        Narrowing once per pass without a floor drove the right margin
+        past the left one, which matplotlib refuses outright.
+        """
+        size = random_patch.coords.coord_size("distance")
+        wide = "x" * 80
+        values = np.where(np.arange(size) < size // 2, wide + "_a", wide + "_b")
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        assert ax.get_position().width > 0

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -431,33 +431,36 @@ def _legend_labels(ax):
     return [] if legend is None else [x.get_text() for x in legend.get_texts()]
 
 
-def _lines(ax, axis):
-    """Return each line as (position, dash offset, color)."""
-    getter = "get_xdata" if axis == "x" else "get_ydata"
-    return [
-        (float(getattr(x, getter)()[0]), x._dash_pattern[0], x.get_color())
-        for x in ax.lines
-    ]
+def _bars(ax, axis):
+    """Return (low, high, spine, color) for every bar drawn."""
+    out = []
+    for line in ax.lines:
+        across = line.get_xdata() if axis == "y" else line.get_ydata()
+        along = line.get_ydata() if axis == "y" else line.get_xdata()
+        out.append(
+            (float(along[0]), float(along[1]), float(across[0]), line.get_color())
+        )
+    return out
 
 
-def _positions(ax, axis):
-    """Return where each line crosses the other axis."""
-    return [x[0] for x in _lines(ax, axis)]
+def _spans(ax, axis):
+    """Return the stretch each label covers, once however many spines."""
+    return sorted({(x[0], x[1]) for x in _bars(ax, axis)})
 
 
-def _color_of(ax, axis, position, offset):
-    """Return the color of the one line drawn there with that dash offset."""
-    matches = [
-        color
-        for where, dash, color in _lines(ax, axis)
-        if where == pytest.approx(position) and dash == pytest.approx(offset)
-    ]
-    assert len(matches) == 1, f"expected one line, got {len(matches)}"
-    return matches[0]
+def _span_color(ax, axis, low, high):
+    """Return the one color every bar over that stretch is drawn in."""
+    colors = {
+        x[3]
+        for x in _bars(ax, axis)
+        if x[0] == pytest.approx(low) and x[1] == pytest.approx(high)
+    }
+    assert len(colors) == 1, f"expected one color, got {len(colors)}"
+    return colors.pop()
 
 
 class TestLabelCoord:
-    """Tests for marking the limits of a label coordinate."""
+    """Tests for marking the stretches a label coordinate covers."""
 
     # Deliberately not size // 2, the one index where the extent's cell
     # edge and the midpoint between two coordinate values coincide.
@@ -504,40 +507,55 @@ class TestLabelCoord:
             low, high = (mdates.date2num(dc.to_datetime64(x)) for x in (low, high))
         return float(low) + (float(high) - float(low)) * index / len(coord)
 
-    def test_boundary_is_two_lines_in_both_colors(self, zone_patch):
-        """A boundary parting two labels is drawn twice, in both colors."""
+    def test_each_label_gets_a_bar_on_both_spines(self, zone_patch):
+        """Every stretch is marked on the two spines it runs between."""
         ax = zone_patch.viz.waterfall(label_coord="zone")
-        split = zone_patch.coords.coord_size("distance") // self.split_fraction
-        where = self._edge(zone_patch, "distance", split)
-        assert _positions(ax, "y") == [pytest.approx(where)] * 2
-        colors = string_colors(["north", "south"])
-        # The first half of the dashes belongs to the label before the
-        # boundary, the offset half to the label after it.
-        assert _color_of(ax, "y", where, 0.0) == colors["north"]
-        assert _color_of(ax, "y", where, 7.5) == colors["south"]
+        bars = _bars(ax, "y")
+        assert len(bars) == 4
+        # Two stretches, each drawn on the near and the far spine.
+        assert sorted(x[2] for x in bars) == [0.0, 0.0, 1.0, 1.0]
+        assert len(_spans(ax, "y")) == 2
 
-    def test_boundary_lands_on_the_image_cell_edge(self, zone_patch):
-        """The line sits on the cell edge, not the coordinate midpoint."""
+    def test_bars_cover_the_stretch_each_label_holds(self, zone_patch):
+        """A bar runs from where its label starts to where it stops."""
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        size = zone_patch.coords.coord_size("distance")
+        split = size // self.split_fraction
+        edges = [self._edge(zone_patch, "distance", x) for x in (0, split, size)]
+        assert _spans(ax, "y") == [
+            (pytest.approx(edges[0]), pytest.approx(edges[1])),
+            (pytest.approx(edges[1]), pytest.approx(edges[2])),
+        ]
+        colors = string_colors(["north", "south"])
+        assert _span_color(ax, "y", edges[0], edges[1]) == colors["north"]
+        assert _span_color(ax, "y", edges[1], edges[2]) == colors["south"]
+
+    def test_bar_ends_on_the_image_cell_edge(self, zone_patch):
+        """The bar ends on the cell edge, not the coordinate midpoint."""
         ax = zone_patch.viz.waterfall(label_coord="zone")
         coord = np.asarray(zone_patch.get_coord("distance"))
         split = len(coord) // self.split_fraction
         midpoint = (coord[split - 1] + coord[split]) / 2
-        drawn = _positions(ax, "y")[0]
+        drawn = _spans(ax, "y")[0][1]
         assert drawn == pytest.approx(self._edge(zone_patch, "distance", split))
         # The two genuinely differ here, so the test can tell them apart.
         assert drawn != pytest.approx(midpoint)
 
-    def test_boundary_on_time_lands_on_the_cell_edge(self, phase_patch):
-        """A coordinate over time is marked across the other axis."""
+    def test_label_on_time_runs_along_the_other_spines(self, phase_patch):
+        """A coordinate over time is marked on the bottom and top."""
         ax = phase_patch.viz.waterfall(label_coord="phase")
-        split = phase_patch.coords.coord_size("time") // self.split_fraction
-        expected = self._edge(phase_patch, "time", split)
-        assert _positions(ax, "x") == [pytest.approx(expected)] * 2
-        assert not _positions(ax, "y") or True
+        size = phase_patch.coords.coord_size("time")
+        split = size // self.split_fraction
+        edges = [self._edge(phase_patch, "time", x) for x in (0, split, size)]
+        assert _spans(ax, "x") == [
+            (pytest.approx(edges[0]), pytest.approx(edges[1])),
+            (pytest.approx(edges[1]), pytest.approx(edges[2])),
+        ]
+        assert sorted(x[2] for x in _bars(ax, "x")) == [0.0, 0.0, 1.0, 1.0]
 
     @pytest.mark.parametrize("gap_color", [None, "gray"])
-    def test_boundary_lands_on_the_mesh_cell_edge(self, zone_gap_patch, gap_color):
-        """The line sits where the mesh parted the two zones."""
+    def test_bar_ends_on_the_mesh_cell_edge(self, zone_gap_patch, gap_color):
+        """The bar ends where the mesh parted the two zones."""
         patch, split = zone_gap_patch
         ax = patch.viz.waterfall(label_coord="zone", gap_color=gap_color)
         assert isinstance(ax.collections[0], QuadMesh)
@@ -548,7 +566,7 @@ class TestLabelCoord:
         else:
             # A band was opened, so the far zone starts at its own edge.
             expected = values[split] - np.median(np.abs(np.diff(values))) / 2
-        assert _positions(ax, "y")[0] == pytest.approx(expected)
+        assert _spans(ax, "y")[0][1] == pytest.approx(expected)
 
     def test_legend_names_the_labels(self, zone_patch):
         """The legend names each label and is titled by the coordinate."""
@@ -592,65 +610,74 @@ class TestLabelCoord:
         drawn = dict(zip(_legend_labels(ax), [x.get_color() for x in handles]))
         assert drawn == {"north": expected["north"], "south": expected["south"]}
 
-    def test_membership_marks_only_what_it_holds(self, enriched_patch):
+    def test_membership_covers_only_what_it_holds(self, enriched_patch):
         """A boolean coordinate marks its True stretch and names itself."""
         ax = enriched_patch.viz.waterfall(label_coord="noisy")
         assert _legend_labels(ax) == ["noisy"]
         # A membership entry already carries the name, so no title repeats it.
         assert _legend(ax).get_title().get_text() == ""
         held = np.flatnonzero(enriched_patch.coords.get_array("noisy"))
-        expected = [
+        expected = (
             self._edge(enriched_patch, "distance", held[0]),
             self._edge(enriched_patch, "distance", held[-1] + 1),
+        )
+        assert _spans(ax, "y") == [
+            (pytest.approx(expected[0]), pytest.approx(expected[1]))
         ]
-        # Both limits of the True stretch, each parting a stated side from
-        # an unstated one, so each is drawn once and drawn solid.
-        assert _positions(ax, "y") == [pytest.approx(x) for x in expected]
-        assert all(x.get_linestyle() == "-" for x in ax.lines)
 
-    def test_all_true_membership_states_no_limits(self, random_patch):
-        """A group covering everything is named but bounded by the spines."""
+    def test_all_true_membership_covers_the_patch(self, random_patch):
+        """A group covering everything is marked over the whole spine."""
         size = random_patch.coords.coord_size("distance")
         patch = random_patch.update_coords(tag=("distance", np.full(size, True)))
         ax = patch.viz.waterfall(label_coord="tag")
         assert _legend_labels(ax) == ["tag"]
-        assert not ax.lines
+        whole = (self._edge(patch, "distance", 0), self._edge(patch, "distance", size))
+        assert _spans(ax, "y") == [(pytest.approx(whole[0]), pytest.approx(whole[1]))]
 
     def test_enriched_labels_are_drawn(self, enriched_patch):
         """A label group an inventory projected on a patch reaches the plot."""
         ax = enriched_patch.viz.waterfall(label_coord="zone")
         assert _legend_labels(ax) == ["north", "south"]
 
-    def test_absent_values_get_a_solid_boundary(self, random_patch):
-        """Where a label meets nothing, the line is wholly the label's."""
+    def test_absent_stretches_leave_bare_spine(self, random_patch):
+        """Where a coordinate states nothing, no bar is drawn."""
         size = random_patch.coords.coord_size("distance")
         values = np.full(size, "", dtype="<U5")
-        values[size // 3 : 2 * size // 3] = "mid"
+        low, high = size // 3, 2 * size // 3
+        values[low:high] = "mid"
         patch = random_patch.update_coords(tag=("distance", values))
         ax = patch.viz.waterfall(label_coord="tag")
         assert _legend_labels(ax) == ["mid"]
-        assert len(ax.lines) == 2
-        assert all(x.get_linestyle() == "-" for x in ax.lines)
-        assert all(x.get_color() == string_colors(["mid"])["mid"] for x in ax.lines)
+        # One stretch only: the two unstated ones each side get nothing.
+        expected = (
+            self._edge(patch, "distance", low),
+            self._edge(patch, "distance", high),
+        )
+        assert _spans(ax, "y") == [
+            (pytest.approx(expected[0]), pytest.approx(expected[1]))
+        ]
 
     def test_recurring_label_gets_one_entry(self, random_patch):
         """A label stated in two places is named once and marked twice."""
         size = random_patch.coords.coord_size("distance")
-        values = np.where((np.arange(size) // (size // 4)) % 2, "odd", "even")
+        quarter = size // 4
+        values = np.where((np.arange(size) // quarter) % 2, "odd", "even")
         patch = random_patch.update_coords(tag=("distance", values))
         ax = patch.viz.waterfall(label_coord="tag")
         assert _legend_labels(ax) == ["even", "odd"]
-        # Three interior boundaries, each parting two stated labels.
-        expected = [self._edge(patch, "distance", size // 4 * x) for x in (1, 2, 3)]
-        assert _positions(ax, "y") == [pytest.approx(x) for x in expected for _ in "ab"]
+        # Four stretches, each on two spines.
+        assert len(_spans(ax, "y")) == 4
+        assert len(_bars(ax, "y")) == 8
+        colors = string_colors(["even", "odd"])
+        first = _spans(ax, "y")[0]
+        assert _span_color(ax, "y", *first) == colors["even"]
 
     def test_datetime_labels_read_as_times(self, random_patch):
         """A nanosecond datetime label names a time, not a count of them."""
         size = random_patch.coords.coord_size("distance")
         start = dc.to_datetime64("2020-01-01")
-        values = np.where(
-            np.arange(size) < size // 3, start, start + np.timedelta64(1, "s")
-        )
+        later = start + np.timedelta64(1, "s")
+        values = np.where(np.arange(size) < size // 3, start, later)
         patch = random_patch.update_coords(tag=("distance", values))
         ax = patch.viz.waterfall(label_coord="tag")
         assert all(x.startswith("2020-01-01") for x in _legend_labels(ax))
@@ -672,6 +699,7 @@ class TestLabelCoord:
         patch = random_patch.update_coords(tag=("distance", values))
         ax = patch.viz.waterfall(label_coord="tag")
         assert _legend_labels(ax) == ["tag"]
+        assert len(_spans(ax, "y")) == 1
 
     def test_null_strings_do_not_raise(self, random_patch):
         """A string group carrying nulls plots rather than failing on them."""
@@ -681,6 +709,7 @@ class TestLabelCoord:
         patch = random_patch.update_coords(tag=("distance", values))
         ax = patch.viz.waterfall(label_coord="tag")
         assert _legend_labels(ax) == ["a"]
+        assert len(_spans(ax, "y")) == 2
 
     def test_caller_axes_keeps_its_legend_inside(self, zone_patch):
         """A figure this call did not build keeps the room it had."""
@@ -759,7 +788,7 @@ class TestLabelCoord:
         with pytest.raises(ParameterError, match="distinct labels"):
             patch.viz.waterfall(label_coord="tag")
 
-    def test_too_many_boundaries_raises(self, random_patch):
+    def test_too_many_runs_raises(self, random_patch):
         """A coordinate changing every sample states no stretches."""
         size = random_patch.coords.coord_size("distance")
         patch = random_patch.update_coords(tag=("distance", np.arange(size) % 2 == 0))


### PR DESCRIPTION
## Description

An inventory's label groups already reach a patch as ordinary coordinates: [`Patch.enrich`](https://dascore.org/api/dascore/proc/inventory/enrich.html) projects `zone` onto `distance` as a string array reading `north, …, south`, `noisy` as a boolean stating membership, and a numeric group as floats with `NaN` where nothing is stated. Nothing in the patch viz path could show them, so a reader who enriched a patch had to hold the zone boundaries in their head while looking at the data.

`waterfall` now takes a `label_coord`. Name one such coordinate and each stretch it covers is drawn as a bar along the two spines its dimension runs between, coloured by its label, with a legend naming them beside the axes and beyond the colorbar.

```python
patch.enrich(inventory).viz.waterfall(label_coord="zone")
```

Which spines is decided by the dimension the coordinate is associated with: a `distance` label runs down the left and right edges, a `time` label along the bottom and top. Where a group states nothing the spine is left bare, so what it covers and what it merely passes over are read off one edge. A hairline joins the two bars at every change, faint and over a white stroke, so a boundary can still be traced through the image without competing with it.

The bars sit on the spines rather than over the image on purpose. Shading each stretch in its own colour was the alternative, and it is caught between two failures with no alpha in between: faint enough to leave the data alone is faint enough to vanish on a noisy patch, and visible enough to read has already recoloured the arrivals underneath — which on a diverging colormap is the measurement itself.

Value kinds follow the three the inventory produces. A boolean coordinate states membership, so only its `True` stretches are marked and the legend names them by the coordinate; strings and numbers state a label each; and the empty string, `NaN` and `False` state nothing. Coordinates carrying nulls beside their values are handled, including a nullable boolean, and a nanosecond datetime names itself as a time rather than as a count of nanoseconds.

Bar ends land on the cell edge the renderer actually used — read back from the imshow extent, or from the mesh's own edges including the ones a gap band moved — rather than on a midpoint between coordinate values, which is a different place whenever the two disagree.

The legend takes its room from the figure's right margin, which moves the image and its colorbar together; repositioning either alone parts them. Room is measured against tight bounding boxes, since a colorbar draws its ticks and its name outside the rectangle it reports as its position. On an axes the caller supplied, the figure is not this call's to shrink, so the legend sits inside that axes rather than over its neighbour.

Four cases are refused with `ParameterError`, before an axes exists so a refused call leaves no figure behind: more than 20 distinct labels, more than 200 stretches, a coordinate whose every value is absent, and a coordinate that is a dimension or spans both of them.

`dascore/viz/_labels.py` is a new private module beside `_lanes.py`, and it draws the label palette from `_lanes` so the two share one categorical wheel. `label_coord` is the last parameter of `waterfall`, so no positional caller shifts.

## Changelog

- added: `Patch.viz.waterfall` takes a `label_coord` naming a coordinate whose values label stretches of a plotted dimension, drawing each stretch as a bar on the spines and naming them in a legend.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added label-based annotations to waterfall plots, showing colored spans and boundaries where labels change.
  * Added legends and support for categorical, boolean, recurring, and uncovered label ranges.
  * Added stable color assignment for string-valued labels.
  * Added the `label_coord` option to configure waterfall plot annotations.

* **Documentation**
  * Added tutorial guidance and examples for marking label changes in visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->