### PR TITLE
Spell every bound the same way, and let a component say where it is

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -136,6 +136,7 @@ max_lens = {
 # Tested against the models in tests/test_core/test_attrs.py.
 INVENTORY_ATTRS = (
     "closed_fiber_loop",
+    "distance_step",
     "firmware_version",
     "gauge_length",
     "interrogator.instrument_type",
@@ -148,7 +149,6 @@ INVENTORY_ATTRS = (
     "pulse_width",
     "sample_rate",
     "software_version",
-    "spatial_interval",
 )
 
 # Methods FileFormatter needs to support
@@ -266,7 +266,7 @@ attrs
     is authoritative for, a tuple of names to copy exactly those, or
     False to copy none. The blanket form excludes `data_type`,
     `data_category`, and `data_units`, which describe the data as it
-    now stands, and `sample_rate` and `spatial_interval`, which the
+    now stands, and `sample_rate` and `distance_step`, which the
     patch's own coordinates already state; naming one restores the
     as-acquired value.
 """.strip()

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -136,7 +136,6 @@ max_lens = {
 # Tested against the models in tests/test_core/test_attrs.py.
 INVENTORY_ATTRS = (
     "closed_fiber_loop",
-    "distance_step",
     "firmware_version",
     "gauge_length",
     "interrogator.instrument_type",
@@ -149,6 +148,7 @@ INVENTORY_ATTRS = (
     "pulse_width",
     "sample_rate",
     "software_version",
+    "spatial_interval",
 )
 
 # Methods FileFormatter needs to support
@@ -266,7 +266,7 @@ attrs
     is authoritative for, a tuple of names to copy exactly those, or
     False to copy none. The blanket form excludes `data_type`,
     `data_category`, and `data_units`, which describe the data as it
-    now stands, and `sample_rate` and `distance_step`, which the
+    now stands, and `sample_rate` and `spatial_interval`, which the
     patch's own coordinates already state; naming one restores the
     as-acquired value.
 """.strip()

--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -728,12 +728,8 @@ def _get_label_coord(path, group, distances):
 
 def _get_track_coord(path, track, field, distances):
     """Return the coordinate values of one field of a typed track."""
-    if track == "optical_components":
-        items = path.optical_components
-        intervals = list(path.component_intervals())
-    else:
-        items = getattr(path, track)
-        intervals = [x.interval for x in items]
+    items = getattr(path, track)
+    intervals = [x.interval for x in items]
     if not items:
         return None
     values = [getattr(x, field, None) for x in items]

--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -278,7 +278,7 @@ def normalize_enrich_kwargs(kwargs) -> dict:
 # decimating changes both. Nothing should be redundant between coords and
 # attrs, so a blanket request leaves these alone; naming one restores the
 # as-acquired value.
-COORD_REDUNDANT_ATTRS = ("sample_rate", "distance_step")
+COORD_REDUNDANT_ATTRS = ("sample_rate", "spatial_interval")
 
 # Attrs describing the data as it now stands rather than the system which
 # recorded it. Processing functions maintain them, so blanket enrichment

--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -278,7 +278,7 @@ def normalize_enrich_kwargs(kwargs) -> dict:
 # decimating changes both. Nothing should be redundant between coords and
 # attrs, so a blanket request leaves these alone; naming one restores the
 # as-acquired value.
-COORD_REDUNDANT_ATTRS = ("sample_rate", "spatial_interval")
+COORD_REDUNDANT_ATTRS = ("sample_rate", "distance_step")
 
 # Attrs describing the data as it now stands rather than the system which
 # recorded it. Processing functions maintain them, so blanket enrichment
@@ -822,22 +822,22 @@ def _epoch_bounds(inventory, acquisition_key: Sequence[str]) -> np.ndarray:
     for network in inventory.networks:
         if network.code != net_code:
             continue
-        times += [network.start_time, network.end_time]
+        times += [network.time_min, network.time_max]
         for array in network.fiber_arrays:
             if array.code != array_code:
                 continue
-            times += [array.start_time, array.end_time]
+            times += [array.time_min, array.time_max]
             times += [
                 x
                 for acq in array.acquisitions
                 if acq.code == acq_code and acq.location_code == location
-                for x in (acq.start_time, acq.end_time)
+                for x in (acq.time_min, acq.time_max)
             ]
             times += [
                 x
                 for path in array.optical_paths
                 if path.location_code == location
-                for x in (path.start_time, path.end_time)
+                for x in (path.time_min, path.time_max)
             ]
     stamps = [x for x in times if not np.isnat(x)]
     return np.unique(np.array(stamps, dtype="datetime64[ns]"))

--- a/dascore/core/annotation_loader.py
+++ b/dascore/core/annotation_loader.py
@@ -46,8 +46,8 @@ import pandas as pd
 from pydantic import ValidationError
 
 from dascore.core.annotations import (
-    _END,
-    _START,
+    _MAX,
+    _MIN,
     _VERTEX_COLUMNS,
     ANNOTATION_STEM,
     ATTRS_STEM,
@@ -202,7 +202,7 @@ def _read_basis(series: pd.Series, path: Path) -> pd.Series:
 
 def _dimension_spellings(dims: Sequence[str]) -> frozenset[str]:
     """Every column name a declared dimension may be spelled with."""
-    return frozenset(x for dim in dims for x in (dim, f"{dim}{_START}", f"{dim}{_END}"))
+    return frozenset(x for dim in dims for x in (dim, f"{dim}{_MIN}", f"{dim}{_MAX}"))
 
 
 def _is_text(series: pd.Series) -> bool:
@@ -393,7 +393,7 @@ def _read_pragma(path: Path) -> tuple[tuple[str, ...] | None, int]:
 
         # dims: distance, time
         # picked by hand
-        group,time_start,time_end
+        group,time_min,time_max
 
     Nothing above the header is skipped unless one of those lines is the
     declaration. A column name may begin with the comment mark -- `# note`
@@ -839,7 +839,7 @@ def _refuse_undeclared_dims(
     for name, frame in frames.items():
         undeclared = set(dims) - set(loaded[name].dims)
         for dim in sorted(undeclared):
-            spelled = [dim, f"{dim}{_START}", f"{dim}{_END}"]
+            spelled = [dim, f"{dim}{_MIN}", f"{dim}{_MAX}"]
             held = sorted(x for x in spelled if x in frame.columns)
             if not held:
                 continue
@@ -858,14 +858,14 @@ def _refuse_mixed_spellings(frames: Mapping[str, pd.DataFrame], dims) -> None:
     Refuse a dimension two sets spell differently.
 
     A set holds one spelling of a dimension, so a merged table cannot hold
-    both a bare ``time`` and a ``time_start``/``time_end`` pair; the
+    both a bare ``time`` and a ``time_min``/``time_max`` pair; the
     constructor refuses that too, but without naming the sets. Neither
     spelling stands in for the other: a half-open range of no width holds
     nothing, so a point is not a range and cannot be rewritten as one.
     """
     for dim in dims:
         points = [name for name, x in frames.items() if dim in x.columns]
-        ranges = [name for name, x in frames.items() if f"{dim}{_START}" in x.columns]
+        ranges = [name for name, x in frames.items() if f"{dim}{_MIN}" in x.columns]
         if points and ranges:
             msg = (
                 f"The dimension {dim!r} is spelled as a point in "
@@ -913,7 +913,7 @@ def _refuse_mixed_kinds(frames: Mapping[str, pd.DataFrame], dims, what: str) -> 
     kinds: dict[str, dict[str, str]] = {}
     for name, frame in frames.items():
         for dim in dims:
-            for column in (dim, f"{dim}{_START}", f"{dim}{_END}"):
+            for column in (dim, f"{dim}{_MIN}", f"{dim}{_MAX}"):
                 if column not in frame.columns:
                     continue
                 kind = _kind(frame[column])

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -136,6 +136,12 @@ DIMS_KEY = "dascore:dims"
 # spells one: a patch's attrs, the spool index, and the inventory.
 _MIN, _MAX = "_min", "_max"
 
+# What it used to be spelled with. A set written before the rename is
+# this format's own former spelling, not a stranger's columns, so it is
+# told what to write instead -- otherwise its bounds read as extras and
+# the annotation silently covers everything rather than what it states.
+_RETIRED_RANGE = ("_start", "_end")
+
 # The resolution DASCore holds a time and a duration at.
 _NS_TIME = np.dtype("datetime64[ns]")
 _NS_SPAN = np.dtype("timedelta64[ns]")
@@ -1108,6 +1114,16 @@ def _check_columns(frame: pd.DataFrame, attrs: AnnotationSetAttrs) -> None:
     known = set(RESERVED_COLUMNS) | set(attrs.dims)
     known |= {f"{dim}{end}" for dim in attrs.dims for end in (_MIN, _MAX)}
     extras = [str(x) for x in frame.columns if x not in known]
+    low, high = _RETIRED_RANGE
+    retired = {x[: -len(low)] for x in extras if x.endswith(low)}
+    retired &= {x[: -len(high)] for x in extras if x.endswith(high)}
+    if named := ", ".join(sorted(retired & set(attrs.dims))):
+        msg = (
+            f"The column(s) {named} state a range as {low}/{high}, which this "
+            f"format now spells {_MIN}/{_MAX}, as every other range in DASCore "
+            "is spelled. Rename the columns."
+        )
+        raise ParameterError(msg)
     stems = {x[: -len(_MIN)] for x in extras if x.endswith(_MIN)}
     stems &= {x[: -len(_MAX)] for x in extras if x.endswith(_MAX)}
     if stems:
@@ -1450,9 +1466,14 @@ def _fill_vertex_bounds(frame, vertices, spellings) -> pd.DataFrame:
         if spelling.point is not None:
             _fill_point_bounds(out, ids, bounds, dim, spelling.point)
             continue
-        for column, side in ((spelling.low, "min"), (spelling.high, "max")):
+        for column, side, suffix in (
+            (spelling.low, "min", _MIN),
+            (spelling.high, "max", _MAX),
+        ):
             if column is None:
-                out[f"{dim}_{side}"] = pd.Series(ids.map(bounds[side]), index=out.index)
+                out[f"{dim}{suffix}"] = pd.Series(
+                    ids.map(bounds[side]), index=out.index
+                )
                 continue
             derived = ids.map(bounds[side])
             stated = out[column]

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -7,7 +7,7 @@ itself belong to the inventory instead, in optical distance; see
 [dascore.core.inventory](`dascore.core.inventory`).
 
 A set is dataframe-backed, one row per annotation. Columns name the
-dimensions a row constrains: ``<dim>_start``/``<dim>_end`` state a
+dimensions a row constrains: ``<dim>_min``/``<dim>_max`` state a
 half-open range, a bare ``<dim>`` states a point, and a dimension no
 column names is unconstrained. Those columns hold coordinates -- numbers,
 times or durations -- since that is what a bound is compared as. Paths
@@ -68,7 +68,11 @@ from dascore.utils.display import (
     stated_fields,
 )
 from dascore.utils.documents import write_document
-from dascore.utils.intervals import normalize_value, value_kind
+from dascore.utils.intervals import (
+    interval_value_type,
+    normalize_value,
+    value_kind,
+)
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import iterate, to_str, validate_acquisition_key
 from dascore.utils.namespace import NamespaceOwner
@@ -128,8 +132,9 @@ OBJECT_SUFFIXES = (".json", ".yaml", ".yml")
 # namespaced, so a file may carry both without either reading the other's.
 DIMS_KEY = "dascore:dims"
 
-# What a range column is spelled with.
-_START, _END = "_start", "_end"
+# What a range column is spelled with, as every other range in DASCore
+# spells one: a patch's attrs, the spool index, and the inventory.
+_MIN, _MAX = "_min", "_max"
 
 # The resolution DASCore holds a time and a duration at.
 _NS_TIME = np.dtype("datetime64[ns]")
@@ -144,15 +149,10 @@ _TEXT_KINDS = "OTUS"
 DISTANCE_DIM, TIME_DIM = "distance", "time"
 
 
-def _annotation_value(value):
-    """Normalize an annotation value so its Python type survives validation."""
-    return normalize_value(value, error=ParameterError)
-
-
 # An annotation states membership by carrying no value, so a value, when
-# there is one, is text or a number; its Python type must survive
-# validation, so 1 must not become 1.0.
-AnnotationValue = Annotated[str | int | float, BeforeValidator(_annotation_value)]
+# there is one, is text or a number; the same value an inventory label
+# carries, refused in this subsystem's own vocabulary.
+AnnotationValue = interval_value_type(ParameterError)
 
 
 # Spelled as PatchAttrs spells them, so a set and the data it describes
@@ -319,7 +319,7 @@ class AnnotationBasis(_AnnotationModel):
     time, a distance is a distance -- so it is anchored without a separate
     origin and its vertices drop straight into the vertices frame. A curve
     parameterized in a dimension's raw numbers would put an apex at 1.6e18
-    nanoseconds and a velocity in metres per nanosecond, which nobody can
+    nanoseconds and a velocity in meters per nanosecond, which nobody can
     read, write or check.
     """
 
@@ -392,7 +392,7 @@ class Moveout(AnnotationBasis):
     The arrival time of a wavefront along the fiber, as a function of distance.
 
     Physics rather than geometry, so it is pinned to ``distance`` against
-    ``time``. A source sitting ``standoff`` metres off the cable, abreast of
+    ``time``. A source sitting ``standoff`` meters off the cable, abreast of
     fiber distance ``apex_distance``, arrives everywhere at
 
     ``time = apex_time + (hypot(standoff, distance - apex_distance)
@@ -406,34 +406,34 @@ class Moveout(AnnotationBasis):
 
     object_type: Literal["Moveout"] = _tag("Moveout")
     apex_distance: FiniteFloat = Field(
-        description="Fiber distance the wavefront arrives earliest at, in metres."
+        description="Fiber distance the wavefront arrives earliest at, in meters."
     )
     apex_time: DateTime64 = Field(description="Time of that earliest arrival.")
     velocity: PositiveFiniteFloat = Field(
-        description="Speed the wavefront moves along the fiber, in metres/second."
+        description="Speed the wavefront moves along the fiber, in meters/second."
     )
     standoff: FiniteFloat = Field(
         default=0.0,
         ge=0,
         description=(
-            "Perpendicular distance from the fiber to the source, in metres. "
+            "Perpendicular distance from the fiber to the source, in meters. "
             "Zero is a source on the cable, whose moveout is straight."
         ),
     )
-    distance_start: FiniteFloat = Field(
-        description="Fiber distance the curve is drawn from, in metres."
+    distance_min: FiniteFloat = Field(
+        description="Fiber distance the curve is drawn from, in meters."
     )
-    distance_end: FiniteFloat = Field(
-        description="Fiber distance the curve is drawn to, in metres."
+    distance_max: FiniteFloat = Field(
+        description="Fiber distance the curve is drawn to, in meters."
     )
 
     @model_validator(mode="after")
     def _check_span(self) -> Self:
         """A curve with no span draws no vertices."""
-        if not self.distance_end > self.distance_start:
+        if not self.distance_max > self.distance_min:
             msg = (
-                f"Moveout distance_end {self.distance_end} must exceed "
-                f"distance_start {self.distance_start}."
+                f"Moveout distance_max {self.distance_max} must exceed "
+                f"distance_min {self.distance_min}."
             )
             raise ValueError(msg)
         return self
@@ -446,8 +446,8 @@ class Moveout(AnnotationBasis):
     def vertices(self, count: int = 64) -> dict[str, np.ndarray]:
         """Return ``count`` arrivals evenly spaced along the fiber."""
         fraction = self._fractions(count)
-        distance = self.distance_start + fraction * (
-            self.distance_end - self.distance_start
+        distance = self.distance_min + fraction * (
+            self.distance_max - self.distance_min
         )
         along = np.hypot(self.standoff, distance - self.apex_distance)
         seconds = (along - self.standoff) / self.velocity
@@ -688,7 +688,7 @@ class AnnotationSetAttrs(_AnnotationModel):
             msg = f"Annotation dimensions must be unique; got {list(self.dims)}."
             raise ValueError(msg)
         for dim in self.dims:
-            for end in (_START, _END):
+            for end in (_MIN, _MAX):
                 stem = dim[: -len(end)] if dim.endswith(end) else None
                 if stem and stem in self.dims:
                     msg = (
@@ -741,8 +741,8 @@ class _Spelling(NamedTuple):
 
     dim: str
     point: str | None  # the bare column, where the dimension is a point
-    start: str | None  # the range columns, where it is a span
-    end: str | None
+    low: str | None  # the range columns, where it is a span
+    high: str | None
 
 
 class AnnotationSet(NamespaceOwner):
@@ -780,7 +780,7 @@ class AnnotationSet(NamespaceOwner):
     >>> import pandas as pd
     >>> import dascore as dc
     >>> frame = pd.DataFrame(
-    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ...     {"group": ["event"], "distance_min": [10.0], "distance_max": [80.0]}
     ... )
     >>> picks = dc.AnnotationSet(frame, dims=("time", "distance"))
     >>> len(picks), picks[0].group
@@ -936,7 +936,7 @@ class AnnotationSet(NamespaceOwner):
         base += Text(" (") + Text(", ".join(self.dims), style="bold") + Text(")")
         for dim in self.dims:
             spelling = self._spellings[dim]
-            spelled = (spelling.point, spelling.start, spelling.end)
+            spelled = (spelling.point, spelling.low, spelling.high)
             names = [x for x in spelled if x and x in self._df.columns]
             columns = [self._df[x] for x in names] or [pd.Series(dtype=float)]
             values = pd.concat(columns, ignore_index=True).dropna()
@@ -1080,17 +1080,17 @@ def _read_spellings(frame: pd.DataFrame, dims) -> dict[str, _Spelling]:
     out = {}
     for dim in dims:
         point = dim if dim in columns else None
-        start = f"{dim}{_START}" if f"{dim}{_START}" in columns else None
-        end = f"{dim}{_END}" if f"{dim}{_END}" in columns else None
+        start = f"{dim}{_MIN}" if f"{dim}{_MIN}" in columns else None
+        end = f"{dim}{_MAX}" if f"{dim}{_MAX}" in columns else None
         if point is not None and (start is not None or end is not None):
             msg = (
                 f"The dimension {dim!r} is spelled both as a point ({dim}) and "
-                f"as a range ({dim}{_START}/{dim}{_END}); it is one or the other."
+                f"as a range ({dim}{_MIN}/{dim}{_MAX}); it is one or the other."
             )
             raise ParameterError(msg)
         if (start is None) != (end is None):
             stated = start or end
-            missing = f"{dim}{_END}" if start is not None else f"{dim}{_START}"
+            missing = f"{dim}{_MAX}" if start is not None else f"{dim}{_MIN}"
             msg = f"{stated} states half a range; {missing} is not a column."
             raise ParameterError(msg)
         out[dim] = _Spelling(dim, point, start, end)
@@ -1101,15 +1101,15 @@ def _check_columns(frame: pd.DataFrame, attrs: AnnotationSetAttrs) -> None:
     """
     Refuse a column which nearly names something, and check stated dtypes.
 
-    An undeclared ``<name>_start``/``<name>_end`` pair is a dimension the
+    An undeclared ``<name>_min``/``<name>_max`` pair is a dimension the
     set forgot to declare rather than two unrelated extras, and reading it
     as extras would quietly drop the constraint it states.
     """
     known = set(RESERVED_COLUMNS) | set(attrs.dims)
-    known |= {f"{dim}{end}" for dim in attrs.dims for end in (_START, _END)}
+    known |= {f"{dim}{end}" for dim in attrs.dims for end in (_MIN, _MAX)}
     extras = [str(x) for x in frame.columns if x not in known]
-    stems = {x[: -len(_START)] for x in extras if x.endswith(_START)}
-    stems &= {x[: -len(_END)] for x in extras if x.endswith(_END)}
+    stems = {x[: -len(_MIN)] for x in extras if x.endswith(_MIN)}
+    stems &= {x[: -len(_MAX)] for x in extras if x.endswith(_MAX)}
     if stems:
         named = ", ".join(sorted(stems))
         msg = (
@@ -1179,16 +1179,16 @@ def _check_ranges(frame: pd.DataFrame, spellings) -> None:
     raising later, on whichever operation happened to touch that row.
     """
     for dim, spelling in spellings.items():
-        if spelling.start is None or spelling.end is None:
+        if spelling.low is None or spelling.high is None:
             continue
-        start, end = frame[spelling.start], frame[spelling.end]
+        start, end = frame[spelling.low], frame[spelling.high]
         stated = start.notna() & end.notna()
         half = start.notna() ^ end.notna()
         if half.any():
             first = frame.index[half][0]
             msg = (
                 f"Row {first} states half a {dim} range; a range states both "
-                f"{spelling.start} and {spelling.end}, and neither states an "
+                f"{spelling.low} and {spelling.high}, and neither states an "
                 "unconstrained dimension."
             )
             raise ParameterError(msg)
@@ -1271,7 +1271,7 @@ def _check_values(frame: pd.DataFrame) -> None:
     for name, index in frame.groupby(groups.values, sort=True).groups.items():
         values = [x if _stated(x) else None for x in frame.loc[index, "value"]]
         try:
-            kinds = {value_kind(_annotation_value(x)) for x in values}
+            kinds = {value_kind(normalize_value(x, ParameterError)) for x in values}
         except ParameterError as error:
             msg = f"The annotation group {str(name)!r}: {error}"
             raise ParameterError(msg) from error
@@ -1450,11 +1450,9 @@ def _fill_vertex_bounds(frame, vertices, spellings) -> pd.DataFrame:
         if spelling.point is not None:
             _fill_point_bounds(out, ids, bounds, dim, spelling.point)
             continue
-        for column, side in ((spelling.start, "min"), (spelling.end, "max")):
+        for column, side in ((spelling.low, "min"), (spelling.high, "max")):
             if column is None:
-                out[f"{dim}{_START if side == 'min' else _END}"] = pd.Series(
-                    ids.map(bounds[side]), index=out.index
-                )
+                out[f"{dim}_{side}"] = pd.Series(ids.map(bounds[side]), index=out.index)
                 continue
             derived = ids.map(bounds[side])
             stated = out[column]
@@ -1484,7 +1482,7 @@ def _fill_point_bounds(out, ids, bounds, dim: str, column: str) -> None:
         msg = (
             f"The path or polygon id(s) {named} span {dim}, which this set "
             f"spells as a point ({column}); a spanning geometry needs "
-            f"{dim}{_START}/{dim}{_END}."
+            f"{dim}{_MIN}/{dim}{_MAX}."
         )
         raise ParameterError(msg)
     derived = ids.map(bounds["min"])
@@ -1509,8 +1507,8 @@ def _read_bounds(row, spellings) -> dict[str, tuple[Any, Any]]:
             if _stated(value):
                 out[dim] = (_scalar(value), _scalar(value))
             continue
-        start = row.get(spelling.start) if spelling.start else None
-        end = row.get(spelling.end) if spelling.end else None
+        start = row.get(spelling.low) if spelling.low else None
+        end = row.get(spelling.high) if spelling.high else None
         if _stated(start) and _stated(end):
             out[dim] = (_scalar(start), _scalar(end))
     return out
@@ -1527,7 +1525,7 @@ def _read_extra(row, dims, spellings) -> dict[str, Any]:
     """Return the columns a row states which the set does not model."""
     known = set(RESERVED_COLUMNS)
     for spelling in spellings.values():
-        known |= {x for x in (spelling.point, spelling.start, spelling.end) if x}
+        known |= {x for x in (spelling.point, spelling.low, spelling.high) if x}
     known |= set(dims)
     return {
         str(k): _freeze(v) for k, v in row.items() if str(k) not in known and _stated(v)
@@ -1699,7 +1697,7 @@ def _is_number(value) -> bool:
 
 def _type_dimensions(frame: pd.DataFrame, spellings) -> pd.DataFrame:
     """Read every column which spells a dimension as the coordinates it states."""
-    named = {x for one in spellings.values() for x in (one.point, one.start, one.end)}
+    named = {x for one in spellings.values() for x in (one.point, one.low, one.high)}
     changed = {}
     for name in frame.columns:
         if name not in named:
@@ -1783,7 +1781,7 @@ def _normalize_times(frame: pd.DataFrame, dims: Sequence[str] = ()) -> pd.DataFr
     the geometry a row builds reads that spelling back, so a frame which
     kept the text would disagree with the region built from it.
     """
-    spelled = {x for dim in dims for x in (dim, f"{dim}{_START}", f"{dim}{_END}")}
+    spelled = {x for dim in dims for x in (dim, f"{dim}{_MIN}", f"{dim}{_MAX}")}
     changed = {}
     for name in frame.columns:
         series = frame[name]
@@ -2109,7 +2107,7 @@ def annotation_set_to_dataframe(annotations: AnnotationSet) -> pd.DataFrame:
     >>> import pandas as pd
     >>> import dascore as dc
     >>> frame = pd.DataFrame(
-    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ...     {"group": ["event"], "distance_min": [10.0], "distance_max": [80.0]}
     ... )
     >>> annotations = dc.AnnotationSet(frame, dims=("time", "distance"))
     >>> list(annotations.io.to_dataframe()["group"])
@@ -2134,7 +2132,7 @@ def annotation_set_to_vertices(annotations: AnnotationSet) -> pd.DataFrame:
     >>> import pandas as pd
     >>> import dascore as dc
     >>> frame = pd.DataFrame(
-    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ...     {"group": ["event"], "distance_min": [10.0], "distance_max": [80.0]}
     ... )
     >>> annotations = dc.AnnotationSet(frame, dims=("time", "distance"))
     >>> annotations.io.to_vertices().empty  # a region states no vertices
@@ -2175,7 +2173,7 @@ def annotation_set_to_csv(
     >>> import pandas as pd
     >>> import dascore as dc
     >>> frame = pd.DataFrame(
-    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ...     {"group": ["event"], "distance_min": [10.0], "distance_max": [80.0]}
     ... )
     >>> annotations = dc.AnnotationSet(frame, dims=("time", "distance"))
     >>> "group" in annotations.io.to_csv()
@@ -2223,7 +2221,7 @@ def annotation_set_to_parquet(
     >>> import pandas as pd
     >>> import dascore as dc
     >>> frame = pd.DataFrame(
-    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ...     {"group": ["event"], "distance_min": [10.0], "distance_max": [80.0]}
     ... )
     >>> annotations = dc.AnnotationSet(frame, dims=("time", "distance"))
     >>> path = annotations.io.to_parquet("picks.parquet")  # doctest: +SKIP
@@ -2248,7 +2246,7 @@ def _refuse_unwritable_durations(annotations: AnnotationSet) -> None:
     this.
     """
     spelled = {
-        x for dim in annotations.dims for x in (dim, f"{dim}{_START}", f"{dim}{_END}")
+        x for dim in annotations.dims for x in (dim, f"{dim}{_MIN}", f"{dim}{_MAX}")
     }
     named = sorted(
         str(name)
@@ -2330,7 +2328,7 @@ def save_annotation_set(
     >>> import pandas as pd
     >>> import dascore as dc
     >>> frame = pd.DataFrame(
-    ...     {"group": ["event"], "distance_start": [10.0], "distance_end": [80.0]}
+    ...     {"group": ["event"], "distance_min": [10.0], "distance_max": [80.0]}
     ... )
     >>> annotations = dc.AnnotationSet(frame, dims=("time", "distance"))
     >>> directory = annotations.io.save("picks")  # doctest: +SKIP

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -388,9 +388,72 @@ _Resource: TypeAlias = Annotated[
 ]
 
 
-class _OpticalComponentBase(InventoryModel):
+def _distance_line(model, skip=()) -> Text:
+    """One line for a model covering an interval of optical distance."""
+    span = f"[{model.distance_min:g}, {model.distance_max:g}) m"
+    return model_to_line(
+        model,
+        skip=(*skip, "distance_min", "distance_max"),
+        extra={"distance": span},
+    )
+
+
+class _IntervalModel(InventoryModel):
+    """
+    Base for items covering the half-open interval [start, end) of optical
+    distance, matching the start/end idiom of time epochs and how interval
+    bounds read off OTDR and interrogator displays.
+
+    Equal start and end make the item a point marker (e.g. a clamp or a
+    labeled spot): it documents a location but covers no distance, so it
+    never participates in coverage, enrichment, or overlap checks.
+    """
+
+    distance_min: float = Field(
+        allow_inf_nan=False,
+        description="Start optical distance of this interval in meters.",
+    )
+    distance_max: float = Field(
+        allow_inf_nan=False,
+        description=(
+            "End optical distance of this interval in meters; equal to "
+            "distance_min for a point marker."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _check_interval_order(self) -> Self:
+        """The end may not precede the start."""
+        if self.distance_max < self.distance_min:
+            msg = (
+                f"distance_max {self.distance_max} must not precede "
+                f"distance_min {self.distance_min}."
+            )
+            raise InvalidInventoryError(msg)
+        return self
+
+    def __rich__(self) -> Text:
+        """One line stating the interval this item covers."""
+        return _distance_line(self)
+
+    @property
+    def optical_length(self) -> float:
+        """The interval length in meters."""
+        return self.distance_max - self.distance_min
+
+    @property
+    def interval(self) -> tuple[float, float]:
+        """The (start, end) optical distance covered by this item."""
+        return (self.distance_min, self.distance_max)
+
+
+class _OpticalComponentBase(_IntervalModel):
     """
     Base class for physical optical components in an optical path.
+
+    A component states the stretch of optical distance it occupies, the
+    way every other track of a path does, rather than a length which only
+    means something after the lengths before it are added up.
 
     Every component carries a unified one-way transmission ``loss_db`` and
     return ``reflectance_db`` (the two quantities an OTDR trace shows per
@@ -400,12 +463,10 @@ class _OpticalComponentBase(InventoryModel):
     """
 
     _identity_field: ClassVar[str] = "name"
-    optical_length: FiniteFloat = Field(
-        default=0.0,
-        ge=0.0,
-        allow_inf_nan=False,
-        description="Optical component length along the optical path in meters.",
-    )
+    # `optical_length` is computed from the bounds rather than stored, but
+    # it is still a fact about the component a channel inside it takes, so
+    # it is named here to keep it selectable and projectable.
+    _derived_value_fields: ClassVar[tuple[str, ...]] = ("optical_length",)
     name: str = Field(default="", description="Human-readable component name.")
     loss_db: FiniteFloat | tuple[FiniteFloat, ...] | None = Field(
         default=None,
@@ -491,7 +552,26 @@ class FiberSegment(_OpticalComponentBase):
         return self.loss_db / km
 
 
-class Connector(_OpticalComponentBase):
+class _PointComponent(_OpticalComponentBase):
+    """
+    A component which sits at a point on the fiber unless it says otherwise.
+
+    A connector, splice or terminator occupies no measurable length, so it
+    states one distance and the end follows. A fiber segment states both:
+    one silently collapsing to a point would lose the fiber it stands for.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _end_where_it_begins(cls, data):
+        """A stated start with no end is a marker at that distance."""
+        if isinstance(data, Mapping) and "distance_max" not in data:
+            if (start := data.get("distance_min")) is not None:
+                data = {**data, "distance_max": start}
+        return data
+
+
+class Connector(_PointComponent):
     """Optical connector in an optical path."""
 
     object_type: Literal["Connector"] = _object_type_tag("Connector")
@@ -501,7 +581,7 @@ class Connector(_OpticalComponentBase):
     connector_type: str = Field(default="", description="Connector type.")
 
 
-class Splice(_OpticalComponentBase):
+class Splice(_PointComponent):
     """Optical splice in an optical path."""
 
     object_type: Literal["Splice"] = _object_type_tag("Splice")
@@ -511,7 +591,7 @@ class Splice(_OpticalComponentBase):
     splice_type: str = Field(default="", description="Splice type, such as fusion.")
 
 
-class Terminator(_OpticalComponentBase):
+class Terminator(_PointComponent):
     """Optical path terminator."""
 
     object_type: Literal["Terminator"] = _object_type_tag("Terminator")
@@ -645,65 +725,6 @@ class Geometry(InventoryModel):
             )
             out[name] = column
         return out
-
-
-def _distance_line(model, skip=()) -> Text:
-    """One line for a model covering an interval of optical distance."""
-    span = f"[{model.distance_min:g}, {model.distance_max:g}) m"
-    return model_to_line(
-        model,
-        skip=(*skip, "distance_min", "distance_max"),
-        extra={"distance": span},
-    )
-
-
-class _IntervalModel(InventoryModel):
-    """
-    Base for items covering the half-open interval [start, end) of optical
-    distance, matching the start/end idiom of time epochs and how interval
-    bounds read off OTDR and interrogator displays.
-
-    Equal start and end make the item a point marker (e.g. a clamp or a
-    labeled spot): it documents a location but covers no distance, so it
-    never participates in coverage, enrichment, or overlap checks.
-    """
-
-    distance_min: float = Field(
-        allow_inf_nan=False,
-        description="Start optical distance of this interval in meters.",
-    )
-    distance_max: float = Field(
-        allow_inf_nan=False,
-        description=(
-            "End optical distance of this interval in meters; equal to "
-            "distance_min for a point marker."
-        ),
-    )
-
-    @model_validator(mode="after")
-    def _check_interval_order(self) -> Self:
-        """The end may not precede the start."""
-        if self.distance_max < self.distance_min:
-            msg = (
-                f"distance_max {self.distance_max} must not precede "
-                f"distance_min {self.distance_min}."
-            )
-            raise InvalidInventoryError(msg)
-        return self
-
-    def __rich__(self) -> Text:
-        """One line stating the interval this item covers."""
-        return _distance_line(self)
-
-    @property
-    def optical_length(self) -> float:
-        """The interval length in meters."""
-        return self.distance_max - self.distance_min
-
-    @property
-    def interval(self) -> tuple[float, float]:
-        """The (start, end) optical distance covered by this item."""
-        return (self.distance_min, self.distance_max)
 
 
 class CouplingCondition(_IntervalModel):
@@ -1214,23 +1235,14 @@ class OpticalPath(TimeRangedModel):
     """
     Continuous optical path described by independent tracks.
 
-    Optical components tile ``[distance_min, distance_min + optical
-    length)``. Geometry and coupling are function tracks (partial coverage,
-    no overlap); labels overlap as their group's value kind allows. No
-    more than one path per ``(FiberArray, location_code)`` is valid at a
-    time.
+    Optical components tile the path: each begins where the last ended,
+    so they state its extent between them. Geometry and coupling are
+    function tracks (partial coverage, no overlap); labels overlap as
+    their group's value kind allows. No more than one path per
+    ``(FiberArray, location_code)`` is valid at a time.
     """
 
     name: str = Field(default="", description="Human-readable optical path name.")
-    distance_min: float = Field(
-        default=0.0,
-        allow_inf_nan=False,
-        description=(
-            "Origin of this path's optical-distance axis in meters; 0 for "
-            "whole paths. Set by select and split_at so pieces keep absolute "
-            "optical distances."
-        ),
-    )
     location_code: LocationCodeStr = Field(
         default="",
         description=(
@@ -1239,7 +1251,11 @@ class OpticalPath(TimeRangedModel):
         ),
     )
     optical_components: tuple[OpticalComponent, ...] = Field(
-        default=(), description="Ordered optical components on this path."
+        default=(),
+        description=(
+            "Optical components on this path, held in distance order "
+            "whatever order they were stated in."
+        ),
     )
     geometry: tuple[Geometry, ...] = Field(
         default=(), description="Piecewise geometry segments on this path."
@@ -1255,28 +1271,43 @@ class OpticalPath(TimeRangedModel):
         description="OTDR and other optical measurements of this whole path.",
     )
 
+    @model_validator(mode="after")
+    def _order_components(self) -> Self:
+        """
+        Hold the components in the order they lie along the fiber.
+
+        Their distances say where they are, so the order rows were written
+        in decides nothing -- and a point marker sorts before the segment
+        it touches, which is where the fiber puts it.
+        """
+        stated = self.optical_components
+        ordered = tuple(sorted(stated, key=lambda x: x.interval))
+        if ordered != stated:
+            # __dict__, not model_copy: an after-validator returning a copy
+            # re-enters validation, and this one would then never settle.
+            self.__dict__["optical_components"] = ordered
+        return self
+
     def __rich__(self) -> Text:
         """One line naming the path, its extent, and its track sizes."""
         return _distance_line(self)
 
     @property
     def optical_length(self) -> float:
-        """Total optical length, computed from the optical components."""
-        return float(sum(x.optical_length for x in self.optical_components))
+        """The optical distance this path spans."""
+        return self.distance_max - self.distance_min
+
+    @property
+    def distance_min(self) -> float:
+        """The start of this path's optical-distance axis."""
+        components = self.optical_components
+        return components[0].distance_min if components else 0.0
 
     @property
     def distance_max(self) -> float:
         """The end of this path's optical-distance axis."""
-        return self.distance_min + self.optical_length
-
-    def component_intervals(self) -> tuple[tuple[float, float], ...]:
-        """Return each component's (start, end) on the absolute axis."""
-        out, position = [], self.distance_min
-        for comp in self.optical_components:
-            nxt = position + comp.optical_length
-            out.append((position, nxt))
-            position = nxt
-        return tuple(out)
+        components = self.optical_components
+        return components[-1].distance_max if components else 0.0
 
     def coordinates_at(self, distances, crs) -> np.ndarray:
         """
@@ -1338,11 +1369,11 @@ class OpticalPath(TimeRangedModel):
         """
         Check track rules for this path.
 
-        Checks that geometry and coupling stay within path bounds and do not
-        overlap (partial coverage is legal), and that labels stay within
-        bounds. Component tiling is inherent to the cumulative layout.
+        Checks that the components tile the path, that geometry and coupling
+        stay within its bounds and do not overlap (partial coverage is
+        legal), and that labels stay within bounds.
         """
-        errors = []
+        errors = self._check_component_tiling(tolerance)
         start, end = self.distance_min, self.distance_max
         geo_spans = [seg.interval for seg in self.geometry]
         coup_spans = [c.interval for c in self.coupling]
@@ -1370,6 +1401,30 @@ class OpticalPath(TimeRangedModel):
             msg = "Optical path validation failed:\n" + "\n".join(errors)
             raise InvalidInventoryError(msg)
         return self
+
+    def _check_component_tiling(self, tolerance: float) -> list[str]:
+        """
+        Check that the components tile the path, each beginning where the
+        last ended.
+
+        Light passes through every component in turn, so a gap is fiber the
+        path does not account for and an overlap is fiber counted twice.
+        The components are already in distance order, so it is enough to
+        compare each with the one before it.
+        """
+        errors = []
+        for first, second in itertools.pairwise(self.optical_components):
+            gap = second.distance_min - first.distance_max
+            if abs(gap) <= tolerance:
+                continue
+            what = "leaves a gap of" if gap > 0 else "overlaps by"
+            errors.append(
+                f"Components {first.name!r} {first.interval} and "
+                f"{second.name!r} {second.interval} {what} {abs(gap)}; "
+                "components tile the path, each beginning where the last "
+                "ended."
+            )
+        return errors
 
     def _check_geometry_columns(self) -> list[str]:
         """
@@ -1466,8 +1521,8 @@ class OpticalPath(TimeRangedModel):
         """
         Return a new path clipped to a distance interval.
 
-        Absolute optical distances are preserved: the piece's
-        ``distance_min`` becomes the clip start, never zero.
+        Absolute optical distances are preserved: every track keeps the
+        distances it had, clipped to the piece rather than rebased on it.
         """
         lo = self.distance_min if distance[0] is None else float(distance[0])
         hi = self.distance_max if distance[1] is None else float(distance[1])
@@ -1476,15 +1531,8 @@ class OpticalPath(TimeRangedModel):
         if hi <= lo:
             msg = f"Empty distance selection ({distance})."
             raise ParameterError(msg)
-        components = []
-        for comp, (c_lo, c_hi) in zip(
-            self.optical_components, self.component_intervals(), strict=True
-        ):
-            new_lo, new_hi = max(c_lo, lo), min(c_hi, hi)
-            at_outer = c_lo == hi == self.distance_max
-            if new_hi > new_lo or (c_lo == c_hi and (lo <= c_lo < hi or at_outer)):
-                length = max(new_hi - new_lo, 0.0)
-                components.append(comp.model_copy(update={"optical_length": length}))
+        outer = self.distance_max
+        components = clip_intervals(self.optical_components, lo, hi, outer)
         geometry = []
         for seg in self.geometry:
             s_lo, s_hi = seg.interval
@@ -1502,12 +1550,10 @@ class OpticalPath(TimeRangedModel):
             # would leave `columns` a plain mutable dict nothing had
             # checked against the new distance array.
             geometry.append(seg.new(distance=tuple(new_dist), columns=new_columns))
-        outer = self.distance_max
         coupling = clip_intervals(self.coupling, lo, hi, outer)
         labels = clip_intervals(self.labels, lo, hi, outer)
         return self.model_copy(
             update={
-                "distance_min": lo,
                 "optical_components": tuple(components),
                 "geometry": tuple(geometry),
                 "coupling": tuple(coupling),
@@ -1558,20 +1604,20 @@ class OpticalPath(TimeRangedModel):
             }
             return item.model_copy(update=update)
 
-        coupling = sorted(
-            (flip_item(c) for c in self.coupling),
-            key=lambda c: c.distance_min,
-        )
-        labels = sorted(
-            (flip_item(a) for a in self.labels),
-            key=lambda a: a.distance_min,
-        )
+        def flipped(items):
+            return tuple(
+                sorted((flip_item(x) for x in items), key=lambda x: x.interval)
+            )
+
+        # The components are flipped like any other interval track now that
+        # they carry their own distances; reversing the tuple would leave
+        # every one of them where it was.
         return self.model_copy(
             update={
-                "optical_components": tuple(reversed(self.optical_components)),
+                "optical_components": flipped(self.optical_components),
                 "geometry": tuple(geometry),
-                "coupling": tuple(coupling),
-                "labels": tuple(labels),
+                "coupling": flipped(self.coupling),
+                "labels": flipped(self.labels),
             }
         )
 
@@ -1616,12 +1662,12 @@ class OpticalPath(TimeRangedModel):
 
         coupling = tuple(shift_item(c) for c in other.coupling)
         labels = tuple(shift_item(a) for a in other.labels)
+        # The right path's components carry its own distances, so they are
+        # shifted onto the combined axis like every other track of it.
+        components = tuple(shift_item(c) for c in other.optical_components)
         return self.model_copy(
             update={
-                "optical_components": (
-                    *self.optical_components,
-                    *other.optical_components,
-                ),
+                "optical_components": (*self.optical_components, *components),
                 "geometry": (*self.geometry, *geometry),
                 "coupling": (*self.coupling, *coupling),
                 "labels": (*self.labels, *labels),
@@ -1964,16 +2010,23 @@ def _value_field_names(model) -> tuple[str, ...]:
     """
     Return the fields of a model which state a fact about one thing.
 
+    A model may also name values it computes rather than stores, in
+    `_derived_value_fields`. They are taken on the model's word: a stored
+    field is checked against its annotation for holding one value, and a
+    property has no annotation to check. `_value_shape` still refuses a
+    multi-valued one where it is asked for.
+
     Cached on the class: the answer is a property of the model, and an
     inventory asked for its names walks every item of every track.
     """
     structural = frozenset(TimeRangedModel.model_fields) | _IDENTITY_FIELDS
     structural |= _EXTENT_FIELDS
-    return tuple(
+    stored = tuple(
         name
         for name, info in model.model_fields.items()
         if name not in structural and _is_value_field(info)
     )
+    return (*stored, *getattr(model, "_derived_value_fields", ()))
 
 
 TRACK_IDENTITY_FIELDS = _track_identity_fields()

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -400,23 +400,26 @@ def _distance_line(model, skip=()) -> Text:
 
 class _IntervalModel(InventoryModel):
     """
-    Base for items covering the half-open interval [start, end) of optical
-    distance, matching the start/end idiom of time epochs and how interval
-    bounds read off OTDR and interrogator displays.
+    Base for items covering the half-open interval [distance_min,
+    distance_max) of optical distance, spelled the way DASCore spells
+    every other range and the way interval bounds read off OTDR and
+    interrogator displays.
 
-    Equal start and end make the item a point marker (e.g. a clamp or a
-    labeled spot): it documents a location but covers no distance, so it
-    never participates in coverage, enrichment, or overlap checks.
+    Equal bounds make the item a point marker (e.g. a clamp or a labeled
+    spot): it documents a location but covers no distance, so it takes no
+    channel and never overlaps anything. A component is the exception --
+    it is a point in a track which must tile, so where it sits still has
+    to be where its neighbours meet.
     """
 
     distance_min: float = Field(
         allow_inf_nan=False,
-        description="Start optical distance of this interval in meters.",
+        description="Lower optical distance of this interval in meters.",
     )
     distance_max: float = Field(
         allow_inf_nan=False,
         description=(
-            "End optical distance of this interval in meters; equal to "
+            "Upper optical distance of this interval in meters; equal to "
             "distance_min for a point marker."
         ),
     )
@@ -452,8 +455,8 @@ class _OpticalComponentBase(_IntervalModel):
     Base class for physical optical components in an optical path.
 
     A component states the stretch of optical distance it occupies, the
-    way every other track of a path does, rather than a length which only
-    means something after the lengths before it are added up.
+    way every other track of a path does; ``optical_length`` is what that
+    pair implies.
 
     Every component carries a unified one-way transmission ``loss_db`` and
     return ``reflectance_db`` (the two quantities an OTDR trace shows per
@@ -564,11 +567,33 @@ class _PointComponent(_OpticalComponentBase):
     @model_validator(mode="before")
     @classmethod
     def _end_where_it_begins(cls, data):
-        """A stated start with no end is a marker at that distance."""
-        if isinstance(data, Mapping) and "distance_max" not in data:
-            if (start := data.get("distance_min")) is not None:
-                data = {**data, "distance_max": start}
-        return data
+        """A start with no end stated is a marker at that distance.
+
+        Blank counts as unstated, not as an error: a CSV cell arrives
+        dropped and a YAML one arrives as None, and the two spell the same
+        thing.
+        """
+        if not isinstance(data, Mapping):
+            return data
+        if data.get("distance_max") is not None:
+            return data
+        if (start := data.get("distance_min")) is None:
+            return data
+        return {**data, "distance_max": start}
+
+    def new(self, **kwargs) -> Self:
+        """
+        Return a copy with some fields updated.
+
+        Moving a point marker moves both its ends. `new` merges the fields
+        already set, so the end would otherwise stay where it was and the
+        marker would silently acquire a length -- or refuse to move past
+        its own end.
+        """
+        moved = "distance_min" in kwargs and "distance_max" not in kwargs
+        if moved and self.distance_min == self.distance_max:
+            kwargs["distance_max"] = kwargs["distance_min"]
+        return super().new(**kwargs)
 
 
 class Connector(_PointComponent):
@@ -818,7 +843,7 @@ class DistanceMap(InventoryModel):
     piecewise-linearly interpolated; channels outside the covered range are
     undefined (NaN). A single-point map states an origin and takes its
     slope from the axis it is read on: the acquisition's nominal
-    ``distance_step`` on the channel axis, and one meter of path per
+    ``spatial_interval`` on the channel axis, and one meter of path per
     interrogator meter on the instrument_distance axis.
     """
 
@@ -943,7 +968,7 @@ class DistanceMap(InventoryModel):
             if slope is None:
                 msg = (
                     "A single-point DistanceMap requires a slope "
-                    "(the acquisition's distance_step)."
+                    "(the acquisition's spatial_interval)."
                 )
                 raise InvalidInventoryError(msg)
             return dist[0] + (vals - source[0]) * slope
@@ -960,7 +985,7 @@ class Acquisition(TimeRangedModel):
     overlapping time ranges. The ``location_code`` names the optical path
     lineage this acquisition interrogates. The ``distance_map`` is the one
     channel-resolution mechanism: a single control point states an origin
-    (and, on the channel axis, takes ``distance_step`` as its slope),
+    (and, on the channel axis, takes ``spatial_interval`` as its slope),
     and more points describe a measured, bending relationship.
     On export to FDSN DAS metadata, ``extra_fields`` maps to native_headers.
     """
@@ -1016,7 +1041,7 @@ class Acquisition(TimeRangedModel):
     sample_rate: FiniteFloat | None = Field(
         default=None, description="FDSN-style acquisition sample rate in Hz."
     )
-    distance_step: FiniteFloat | None = Field(
+    spatial_interval: FiniteFloat | None = Field(
         default=None,
         description=(
             "Nominal spatial sampling interval between channels in meters. "
@@ -1043,7 +1068,7 @@ class Acquisition(TimeRangedModel):
 
         Both spellings are refused: `start_distance` is what the field was
         called when it existed, and `distance_min` is what it would be
-        called now, so neither reads as an origin the acquisition honours.
+        called now, so neither reads as an origin the acquisition honors.
         """
         if not isinstance(data, Mapping):
             return data
@@ -1055,7 +1080,7 @@ class Acquisition(TimeRangedModel):
                 "is the one channel-resolution mechanism. Write "
                 f"{name}: {data[name]} as distance_map: "
                 f"{{channel: [0], distance: [{data[name]}]}}, which "
-                "states the same origin and takes distance_step as its slope."
+                "states the same origin and takes spatial_interval as its slope."
             )
             raise InvalidInventoryError(msg)
         return data
@@ -1082,7 +1107,7 @@ class Acquisition(TimeRangedModel):
         # The slope carries the units of the axis being read: meters of path
         # per channel on the channel axis, and per interrogator meter --
         # nominally one -- on the instrument_distance axis.
-        slope = self.distance_step if axis == "channel" else 1.0
+        slope = self.spatial_interval if axis == "channel" else 1.0
         return dist_map.map_to_distance(values, axis=axis, slope=slope)
 
 
@@ -1243,6 +1268,21 @@ class OpticalPath(TimeRangedModel):
     """
 
     name: str = Field(default="", description="Human-readable optical path name.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_start_distance(cls, data):
+        """Explain the removed origin rather than 'extra inputs'."""
+        if isinstance(data, Mapping) and "start_distance" in data:
+            msg = (
+                "OpticalPath no longer takes start_distance; its components "
+                "carry absolute distances, so the path spans whatever they "
+                "do. Give the first component a distance_min of "
+                f"{data['start_distance']} instead."
+            )
+            raise InvalidInventoryError(msg)
+        return data
+
     location_code: LocationCodeStr = Field(
         default="",
         description=(
@@ -1271,8 +1311,9 @@ class OpticalPath(TimeRangedModel):
         description="OTDR and other optical measurements of this whole path.",
     )
 
-    @model_validator(mode="after")
-    def _order_components(self) -> Self:
+    @field_validator("optical_components")
+    @classmethod
+    def _order_components(cls, value):
         """
         Hold the components in the order they lie along the fiber.
 
@@ -1280,13 +1321,7 @@ class OpticalPath(TimeRangedModel):
         in decides nothing -- and a point marker sorts before the segment
         it touches, which is where the fiber puts it.
         """
-        stated = self.optical_components
-        ordered = tuple(sorted(stated, key=lambda x: x.interval))
-        if ordered != stated:
-            # __dict__, not model_copy: an after-validator returning a copy
-            # re-enters validation, and this one would then never settle.
-            self.__dict__["optical_components"] = ordered
-        return self
+        return tuple(sorted(value, key=lambda x: x.interval))
 
     def __rich__(self) -> Text:
         """One line naming the path, its extent, and its track sizes."""
@@ -1300,14 +1335,17 @@ class OpticalPath(TimeRangedModel):
     @property
     def distance_min(self) -> float:
         """The start of this path's optical-distance axis."""
+        # The outermost bound rather than the first component's: model_copy
+        # skips the ordering validator, and a path is asked its extent
+        # before anything has checked that its components tile.
         components = self.optical_components
-        return components[0].distance_min if components else 0.0
+        return min((x.distance_min for x in components), default=0.0)
 
     @property
     def distance_max(self) -> float:
         """The end of this path's optical-distance axis."""
         components = self.optical_components
-        return components[-1].distance_max if components else 0.0
+        return max((x.distance_max for x in components), default=0.0)
 
     def coordinates_at(self, distances, crs) -> np.ndarray:
         """

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -573,22 +573,25 @@ class _PointComponent(_OpticalComponentBase):
         dropped and a YAML one arrives as None, and the two spell the same
         thing.
         """
-        if not isinstance(data, Mapping):
-            return data
-        if data.get("distance_max") is not None:
-            return data
-        if (start := data.get("distance_min")) is None:
-            return data
-        return {**data, "distance_max": start}
+        stated = isinstance(data, Mapping) and data.get("distance_max") is None
+        if stated and (start := data.get("distance_min")) is not None:
+            return {**data, "distance_max": start}
+        return data
 
     def new(self, **kwargs) -> Self:
         """
         Return a copy with some fields updated.
 
-        Moving a point marker moves both its ends. `new` merges the fields
-        already set, so the end would otherwise stay where it was and the
-        marker would silently acquire a length -- or refuse to move past
-        its own end.
+        Moving a marker moves the end which was filled in for it: `new`
+        merges the fields already set, so an end nobody stated would
+        otherwise stay where it was and the marker would silently acquire
+        a length -- or refuse to move past itself.
+
+        Setting ``distance_max`` is not the mirror of this and does not
+        move the start. The end of a marker is filled in, so carrying it
+        keeps the author's one number true; the start is theirs, and a
+        stated end is them giving the item a length. An end before the
+        start is then refused here as it is on every other interval.
         """
         moved = "distance_min" in kwargs and "distance_max" not in kwargs
         if moved and self.distance_min == self.distance_max:
@@ -1070,10 +1073,8 @@ class Acquisition(TimeRangedModel):
         called when it existed, and `distance_min` is what it would be
         called now, so neither reads as an origin the acquisition honors.
         """
-        if not isinstance(data, Mapping):
-            return data
         for name in ("distance_min", "start_distance"):
-            if name not in data:
+            if not isinstance(data, Mapping) or name not in data:
                 continue
             msg = (
                 f"Acquisition no longer takes {name}; the distance_map "

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -37,7 +37,6 @@ from uuid import uuid4
 import numpy as np
 from pydantic import (
     AfterValidator,
-    BeforeValidator,
     Field,
     field_validator,
     model_validator,
@@ -70,8 +69,8 @@ from dascore.utils.documents import (
 from dascore.utils.intervals import (
     clip_intervals,
     interval_masks,
+    interval_value_type,
     intervals_overlap,
-    normalize_value,
     value_kind,
 )
 from dascore.utils.mapping import FrozenDict
@@ -129,14 +128,9 @@ ResourceIdStr = Annotated[
 ]
 
 
-def _label_value(value):
-    """Normalize a label value so its Python type survives validation."""
-    return normalize_value(value, error=InvalidInventoryError)
-
-
 # A label states membership by carrying no value, so a value, when there is
 # one, is text or a number; its kind decides the group's shape.
-LabelValue = Annotated[str | int | float, BeforeValidator(_label_value)]
+LabelValue = interval_value_type(InvalidInventoryError)
 
 
 def _object_type_tag(name: str):
@@ -566,14 +560,14 @@ class Geometry(InventoryModel):
     >>> trench = Geometry(
     ...     name="trench",
     ...     distance=(0.0, 100.0),
-    ...     coordinates={"x": (0.0, 86.6), "y": (0.0, 0.0), "z": (-0.5, -0.5)},
+    ...     columns={"x": (0.0, 86.6), "y": (0.0, 0.0), "z": (-0.5, -0.5)},
     ... )
     >>>
     >>> # A curve which is not a position at all.
     >>> chainage = Geometry(
     ...     name="chainage",
     ...     distance=(0.0, 100.0),
-    ...     coordinates={"chainage": (1200.0, 1290.0)},
+    ...     columns={"chainage": (1200.0, 1290.0)},
     ...     units={"chainage": "m"},
     ... )
     """
@@ -586,7 +580,7 @@ class Geometry(InventoryModel):
             "increasing values whose span is the segment's coverage."
         ),
     )
-    coordinates: FrozenDictType[str, tuple[float, ...]] = Field(
+    columns: FrozenDictType[str, tuple[float, ...]] = Field(
         description=(
             "Columns measured along this segment, keyed by name; each holds "
             "one value per distance."
@@ -601,12 +595,12 @@ class Geometry(InventoryModel):
     def _validate_geometry(self) -> Self:
         """Enforce paired, strictly increasing control points."""
         _check_control_points(self.distance, "Geometry distance", minimum=2)
-        if not self.coordinates:
+        if not self.columns:
             msg = "Geometry states no columns, so it describes nothing."
             raise InvalidInventoryError(msg)
         wrong = sorted(
             name
-            for name, values in self.coordinates.items()
+            for name, values in self.columns.items()
             if len(values) != len(self.distance)
         )
         if wrong:
@@ -615,13 +609,13 @@ class Geometry(InventoryModel):
                 f"distance; distance states {len(self.distance)}."
             )
             raise InvalidInventoryError(msg)
-        for name, values in self.coordinates.items():
+        for name, values in self.columns.items():
             if not np.all(np.isfinite(np.asarray(values, dtype=float))):
                 msg = f"Geometry column {name!r} must hold finite values."
                 raise InvalidInventoryError(msg)
         # Units name a column or nothing; the alternative is a unit sitting
         # on a column the segment never states, which no reader would find.
-        if orphaned := sorted(set(self.units) - set(self.coordinates)):
+        if orphaned := sorted(set(self.units) - set(self.columns)):
             msg = f"Geometry states units for {orphaned}, which it has no column for."
             raise InvalidInventoryError(msg)
         return self
@@ -644,7 +638,7 @@ class Geometry(InventoryModel):
         inside = (dist >= start) & (dist < end)
         knots = np.asarray(self.distance, dtype=float)
         out = {}
-        for name, values in self.coordinates.items():
+        for name, values in self.columns.items():
             column = np.full(len(dist), np.nan)
             column[inside] = np.interp(
                 dist[inside], knots, np.asarray(values, dtype=float)
@@ -655,10 +649,10 @@ class Geometry(InventoryModel):
 
 def _distance_line(model, skip=()) -> Text:
     """One line for a model covering an interval of optical distance."""
-    span = f"[{model.start_distance:g}, {model.end_distance:g}) m"
+    span = f"[{model.distance_min:g}, {model.distance_max:g}) m"
     return model_to_line(
         model,
-        skip=(*skip, "start_distance", "end_distance"),
+        skip=(*skip, "distance_min", "distance_max"),
         extra={"distance": span},
     )
 
@@ -674,25 +668,25 @@ class _IntervalModel(InventoryModel):
     never participates in coverage, enrichment, or overlap checks.
     """
 
-    start_distance: float = Field(
+    distance_min: float = Field(
         allow_inf_nan=False,
         description="Start optical distance of this interval in meters.",
     )
-    end_distance: float = Field(
+    distance_max: float = Field(
         allow_inf_nan=False,
         description=(
             "End optical distance of this interval in meters; equal to "
-            "start_distance for a point marker."
+            "distance_min for a point marker."
         ),
     )
 
     @model_validator(mode="after")
     def _check_interval_order(self) -> Self:
         """The end may not precede the start."""
-        if self.end_distance < self.start_distance:
+        if self.distance_max < self.distance_min:
             msg = (
-                f"end_distance {self.end_distance} must not precede "
-                f"start_distance {self.start_distance}."
+                f"distance_max {self.distance_max} must not precede "
+                f"distance_min {self.distance_min}."
             )
             raise InvalidInventoryError(msg)
         return self
@@ -704,19 +698,19 @@ class _IntervalModel(InventoryModel):
     @property
     def optical_length(self) -> float:
         """The interval length in meters."""
-        return self.end_distance - self.start_distance
+        return self.distance_max - self.distance_min
 
     @property
     def interval(self) -> tuple[float, float]:
         """The (start, end) optical distance covered by this item."""
-        return (self.start_distance, self.end_distance)
+        return (self.distance_min, self.distance_max)
 
 
 class CouplingCondition(_IntervalModel):
     """
     Acoustic coupling condition for an interval of an optical path.
 
-    Covers ``[start_distance, end_distance)``. Coverage may be partial
+    Covers ``[distance_min, distance_max)``. Coverage may be partial
     and conditions may not overlap.
     """
 
@@ -803,7 +797,7 @@ class DistanceMap(InventoryModel):
     piecewise-linearly interpolated; channels outside the covered range are
     undefined (NaN). A single-point map states an origin and takes its
     slope from the axis it is read on: the acquisition's nominal
-    ``spatial_interval`` on the channel axis, and one meter of path per
+    ``distance_step`` on the channel axis, and one meter of path per
     interrogator meter on the instrument_distance axis.
     """
 
@@ -928,7 +922,7 @@ class DistanceMap(InventoryModel):
             if slope is None:
                 msg = (
                     "A single-point DistanceMap requires a slope "
-                    "(the acquisition's spatial_interval)."
+                    "(the acquisition's distance_step)."
                 )
                 raise InvalidInventoryError(msg)
             return dist[0] + (vals - source[0]) * slope
@@ -945,7 +939,7 @@ class Acquisition(TimeRangedModel):
     overlapping time ranges. The ``location_code`` names the optical path
     lineage this acquisition interrogates. The ``distance_map`` is the one
     channel-resolution mechanism: a single control point states an origin
-    (and, on the channel axis, takes ``spatial_interval`` as its slope),
+    (and, on the channel axis, takes ``distance_step`` as its slope),
     and more points describe a measured, bending relationship.
     On export to FDSN DAS metadata, ``extra_fields`` maps to native_headers.
     """
@@ -1001,7 +995,7 @@ class Acquisition(TimeRangedModel):
     sample_rate: FiniteFloat | None = Field(
         default=None, description="FDSN-style acquisition sample rate in Hz."
     )
-    spatial_interval: FiniteFloat | None = Field(
+    distance_step: FiniteFloat | None = Field(
         default=None,
         description=(
             "Nominal spatial sampling interval between channels in meters. "
@@ -1024,14 +1018,23 @@ class Acquisition(TimeRangedModel):
     @model_validator(mode="before")
     @classmethod
     def _reject_start_distance(cls, data):
-        """Explain the removed affine form rather than 'extra inputs'."""
-        if isinstance(data, Mapping) and "start_distance" in data:
+        """Explain the removed affine form rather than 'extra inputs'.
+
+        Both spellings are refused: `start_distance` is what the field was
+        called when it existed, and `distance_min` is what it would be
+        called now, so neither reads as an origin the acquisition honours.
+        """
+        if not isinstance(data, Mapping):
+            return data
+        for name in ("distance_min", "start_distance"):
+            if name not in data:
+                continue
             msg = (
-                "Acquisition no longer takes start_distance; the distance_map "
+                f"Acquisition no longer takes {name}; the distance_map "
                 "is the one channel-resolution mechanism. Write "
-                f"start_distance: {data['start_distance']} as distance_map: "
-                f"{{channel: [0], distance: [{data['start_distance']}]}}, which "
-                "states the same origin and takes spatial_interval as its slope."
+                f"{name}: {data[name]} as distance_map: "
+                f"{{channel: [0], distance: [{data[name]}]}}, which "
+                "states the same origin and takes distance_step as its slope."
             )
             raise InvalidInventoryError(msg)
         return data
@@ -1058,7 +1061,7 @@ class Acquisition(TimeRangedModel):
         # The slope carries the units of the axis being read: meters of path
         # per channel on the channel axis, and per interrogator meter --
         # nominally one -- on the instrument_distance axis.
-        slope = self.spatial_interval if axis == "channel" else 1.0
+        slope = self.distance_step if axis == "channel" else 1.0
         return dist_map.map_to_distance(values, axis=axis, slope=slope)
 
 
@@ -1077,8 +1080,8 @@ def _overlapping_epochs(items, key) -> list[tuple]:
 
 def _epoch_span(item) -> str:
     """Name an epoch's range the way an error can show it."""
-    start = "the beginning" if np.isnat(item.start_time) else str(item.start_time)
-    end = "ongoing" if np.isnat(item.end_time) else str(item.end_time)
+    start = "the beginning" if np.isnat(item.time_min) else str(item.time_min)
+    end = "ongoing" if np.isnat(item.time_max) else str(item.time_max)
     return f"{start} to {end}"
 
 
@@ -1093,13 +1096,13 @@ def _containment_errors(parent, children, what: str, name) -> list[str]:
     not happen -- and since resolution walks down from the container, that
     is metadata no query can reach.
     """
-    start, end = parent.start_time, parent.end_time
+    start, end = parent.time_min, parent.time_max
     errors = []
     for child in children:
-        before = not np.isnat(start) and not np.isnat(child.start_time)
-        before = before and child.start_time < start
-        after = not np.isnat(end) and not np.isnat(child.end_time)
-        after = after and child.end_time > end
+        before = not np.isnat(start) and not np.isnat(child.time_min)
+        before = before and child.time_min < start
+        after = not np.isnat(end) and not np.isnat(child.time_max)
+        after = after and child.time_max > end
         if before or after or not child.overlaps(parent):
             errors.append(
                 f"{what} {name(child)} is valid {_epoch_span(child)}, outside "
@@ -1117,7 +1120,7 @@ def axis_columns(segment, crs) -> dict[str, int]:
     other column is a quantity along the fiber rather than a position.
     """
     out = {}
-    for name in segment.coordinates:
+    for name in segment.columns:
         with suppress(InvalidInventoryError):
             out[name] = crs.axis_index(name)
     return out
@@ -1132,7 +1135,7 @@ def _placed(segment, name: str, distances) -> np.ndarray:
     point rather than left NaN.
     """
     column = segment.interpolate(distances)[name]
-    column[np.isnan(column)] = segment.coordinates[name][-1]
+    column[np.isnan(column)] = segment.columns[name][-1]
     return column
 
 
@@ -1211,7 +1214,7 @@ class OpticalPath(TimeRangedModel):
     """
     Continuous optical path described by independent tracks.
 
-    Optical components tile ``[start_distance, start_distance + optical
+    Optical components tile ``[distance_min, distance_min + optical
     length)``. Geometry and coupling are function tracks (partial coverage,
     no overlap); labels overlap as their group's value kind allows. No
     more than one path per ``(FiberArray, location_code)`` is valid at a
@@ -1219,7 +1222,7 @@ class OpticalPath(TimeRangedModel):
     """
 
     name: str = Field(default="", description="Human-readable optical path name.")
-    start_distance: float = Field(
+    distance_min: float = Field(
         default=0.0,
         allow_inf_nan=False,
         description=(
@@ -1262,13 +1265,13 @@ class OpticalPath(TimeRangedModel):
         return float(sum(x.optical_length for x in self.optical_components))
 
     @property
-    def end_distance(self) -> float:
+    def distance_max(self) -> float:
         """The end of this path's optical-distance axis."""
-        return self.start_distance + self.optical_length
+        return self.distance_min + self.optical_length
 
     def component_intervals(self) -> tuple[tuple[float, float], ...]:
         """Return each component's (start, end) on the absolute axis."""
-        out, position = [], self.start_distance
+        out, position = [], self.distance_min
         for comp in self.optical_components:
             nxt = position + comp.optical_length
             out.append((position, nxt))
@@ -1313,7 +1316,7 @@ class OpticalPath(TimeRangedModel):
         `OpticalPath.coordinates_at`, and values never bridge two segments:
         distance between them is uncovered, whatever either side holds.
         """
-        stating = [x for x in self.geometry if name in x.coordinates]
+        stating = [x for x in self.geometry if name in x.columns]
         if not stating:
             return None
         dist = np.atleast_1d(np.asarray(distances, dtype=float))
@@ -1328,7 +1331,7 @@ class OpticalPath(TimeRangedModel):
         """Return every column name this path's geometry segments state."""
         seen: dict[str, None] = {}
         for segment in self.geometry:
-            seen.update(dict.fromkeys(segment.coordinates))
+            seen.update(dict.fromkeys(segment.columns))
         return tuple(seen)
 
     def check(self, tolerance: float = 1e-9) -> Self:
@@ -1340,7 +1343,7 @@ class OpticalPath(TimeRangedModel):
         bounds. Component tiling is inherent to the cumulative layout.
         """
         errors = []
-        start, end = self.start_distance, self.end_distance
+        start, end = self.distance_min, self.distance_max
         geo_spans = [seg.interval for seg in self.geometry]
         coup_spans = [c.interval for c in self.coupling]
         label_spans = [a.interval for a in self.labels]
@@ -1382,7 +1385,7 @@ class OpticalPath(TimeRangedModel):
         spans: dict[str, list[tuple[float, float]]] = {}
         units: dict[str, set[str]] = {}
         for segment in self.geometry:
-            for name in segment.coordinates:
+            for name in segment.columns:
                 spans.setdefault(name, []).append(segment.interval)
                 if name in segment.units:
                     units.setdefault(name, set()).add(segment.units[name])
@@ -1464,12 +1467,12 @@ class OpticalPath(TimeRangedModel):
         Return a new path clipped to a distance interval.
 
         Absolute optical distances are preserved: the piece's
-        ``start_distance`` becomes the clip start, never zero.
+        ``distance_min`` becomes the clip start, never zero.
         """
-        lo = self.start_distance if distance[0] is None else float(distance[0])
-        hi = self.end_distance if distance[1] is None else float(distance[1])
-        lo = max(lo, self.start_distance)
-        hi = min(hi, self.end_distance)
+        lo = self.distance_min if distance[0] is None else float(distance[0])
+        hi = self.distance_max if distance[1] is None else float(distance[1])
+        lo = max(lo, self.distance_min)
+        hi = min(hi, self.distance_max)
         if hi <= lo:
             msg = f"Empty distance selection ({distance})."
             raise ParameterError(msg)
@@ -1478,7 +1481,7 @@ class OpticalPath(TimeRangedModel):
             self.optical_components, self.component_intervals(), strict=True
         ):
             new_lo, new_hi = max(c_lo, lo), min(c_hi, hi)
-            at_outer = c_lo == hi == self.end_distance
+            at_outer = c_lo == hi == self.distance_max
             if new_hi > new_lo or (c_lo == c_hi and (lo <= c_lo < hi or at_outer)):
                 length = max(new_hi - new_lo, 0.0)
                 components.append(comp.model_copy(update={"optical_length": length}))
@@ -1491,20 +1494,20 @@ class OpticalPath(TimeRangedModel):
             dist = np.asarray(seg.distance, dtype=float)
             inside = (dist > new_lo) & (dist < new_hi)
             new_dist = np.concatenate([[new_lo], dist[inside], [new_hi]])
-            new_coords = {
+            new_columns = {
                 name: tuple(np.interp(new_dist, dist, np.asarray(values, dtype=float)))
-                for name, values in seg.coordinates.items()
+                for name, values in seg.columns.items()
             }
             # new(), not model_copy(): a copy skips the validators, and
-            # would leave `coordinates` a plain mutable dict whose columns
-            # nothing had checked against the new distance array.
-            geometry.append(seg.new(distance=tuple(new_dist), coordinates=new_coords))
-        outer = self.end_distance
+            # would leave `columns` a plain mutable dict nothing had
+            # checked against the new distance array.
+            geometry.append(seg.new(distance=tuple(new_dist), columns=new_columns))
+        outer = self.distance_max
         coupling = clip_intervals(self.coupling, lo, hi, outer)
         labels = clip_intervals(self.labels, lo, hi, outer)
         return self.model_copy(
             update={
-                "start_distance": lo,
+                "distance_min": lo,
                 "optical_components": tuple(components),
                 "geometry": tuple(geometry),
                 "coupling": tuple(coupling),
@@ -1529,7 +1532,7 @@ class OpticalPath(TimeRangedModel):
         the left, exact interval endpoints swap membership under reversal
         (measure-zero; ``reverse().reverse()`` is exact).
         """
-        start, end = self.start_distance, self.end_distance
+        start, end = self.distance_min, self.distance_max
 
         def flip(d):
             return start + end - d
@@ -1540,9 +1543,9 @@ class OpticalPath(TimeRangedModel):
             geometry.append(
                 seg.new(
                     distance=tuple(flip(dist)[::-1]),
-                    coordinates={
+                    columns={
                         name: tuple(values[::-1])
-                        for name, values in seg.coordinates.items()
+                        for name, values in seg.columns.items()
                     },
                 )
             )
@@ -1550,18 +1553,18 @@ class OpticalPath(TimeRangedModel):
 
         def flip_item(item):
             update = {
-                "start_distance": flip(item.end_distance),
-                "end_distance": flip(item.start_distance),
+                "distance_min": flip(item.distance_max),
+                "distance_max": flip(item.distance_min),
             }
             return item.model_copy(update=update)
 
         coupling = sorted(
             (flip_item(c) for c in self.coupling),
-            key=lambda c: c.start_distance,
+            key=lambda c: c.distance_min,
         )
         labels = sorted(
             (flip_item(a) for a in self.labels),
-            key=lambda a: a.start_distance,
+            key=lambda a: a.distance_min,
         )
         return self.model_copy(
             update={
@@ -1577,7 +1580,7 @@ class OpticalPath(TimeRangedModel):
         Concatenate paths, rewriting the second onto the combined axis.
 
         Both paths must share a lineage and an epoch: the result carries the
-        left path's ``location_code``, ``start_time``, and ``end_time``, so
+        left path's ``location_code``, ``time_min``, and ``time_max``, so
         combining across either would misattribute the right path's metadata.
         """
         if not isinstance(other, OpticalPath):
@@ -1586,8 +1589,8 @@ class OpticalPath(TimeRangedModel):
             name
             for name, same in (
                 ("location_code", self.location_code == other.location_code),
-                ("start_time", _times_equal(self.start_time, other.start_time)),
-                ("end_time", _times_equal(self.end_time, other.end_time)),
+                ("time_min", _times_equal(self.time_min, other.time_min)),
+                ("time_max", _times_equal(self.time_max, other.time_max)),
             )
             if not same
         ]
@@ -1598,7 +1601,7 @@ class OpticalPath(TimeRangedModel):
                 "left path's identity for both."
             )
             raise InvalidInventoryError(msg)
-        offset = self.end_distance - other.start_distance
+        offset = self.distance_max - other.distance_min
         geometry = tuple(
             seg.model_copy(update={"distance": tuple(d + offset for d in seg.distance)})
             for seg in other.geometry
@@ -1606,8 +1609,8 @@ class OpticalPath(TimeRangedModel):
 
         def shift_item(item):
             update = {
-                "start_distance": item.start_distance + offset,
-                "end_distance": item.end_distance + offset,
+                "distance_min": item.distance_min + offset,
+                "distance_max": item.distance_max + offset,
             }
             return item.model_copy(update=update)
 
@@ -2279,7 +2282,7 @@ class Inventory(NamespaceOwner, InventoryModel):
             for segment in path.geometry:
                 axes = axis_columns(segment, crs)
                 columns.update(
-                    dict.fromkeys(x for x in segment.coordinates if x not in axes)
+                    dict.fromkeys(x for x in segment.columns if x not in axes)
                 )
             for track in TRACK_IDENTITY_FIELDS:
                 for item in getattr(path, track):

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -453,10 +453,10 @@ class _Table(NamedTuple):
     # The column assigning points to objects, for a collection of them.
     # None where the attribute is a single object, or a row is an object.
     group: str | None = None
-    # The column rows are read in the order of. Where a table names one,
-    # row position decides nothing and re-sorting a spreadsheet is
-    # harmless; where it does not, the rows keep the order they were
-    # written in, which the model reads as a set rather than a sequence.
+    # The axis a point table's parallel arrays are built along, which its
+    # rows are sorted by so re-sorting a spreadsheet cannot change what it
+    # means. An object table names none: each of its rows states where it
+    # sits, so the model reads them as a set.
     order: str | None = None
     # The field every column but the order gathers into, keyed by header.
     # None where each column names a field of the object directly.
@@ -475,8 +475,6 @@ _TABLES: Mapping[str, _Table] = {
     "distance_map": _Table(points=True, order="distance"),
 }
 
-# The one column of a point table which is not a field of the object it
-# builds; components order by it and drop it.
 # The one suffix a table takes, and the table stems folded once so the
 # near-miss check can match a shouted name without folding them per file.
 _CSV_SUFFIX = ".csv"
@@ -493,12 +491,8 @@ _RETIRED_TABLES = {"annotations": "labels"}
 # The columns of geometry.csv which are not columns of the segment: the one
 # naming it and the one placing each row along it. Read off the registry so
 # the headers and the fields they fill cannot drift apart.
-_GEOMETRY_STRUCTURAL = frozenset(
-    x for x in (_TABLES["geometry"].group, _TABLES["geometry"].order) if x is not None
-)
-# Both are set above; a geometry table which named neither could not gather
-# its points into segments at all.
-assert len(_GEOMETRY_STRUCTURAL) == 2, _GEOMETRY_STRUCTURAL
+_GEOMETRY_STRUCTURAL = frozenset({"name", "distance"})
+assert _GEOMETRY_STRUCTURAL == {_TABLES["geometry"].group, _TABLES["geometry"].order}
 
 # Columns this format used to read, by the table which read them. A file
 # written before a rename is this format's own former spelling, so it is
@@ -508,18 +502,32 @@ _RETIRED_COLUMNS = {
     "optical_components": {
         "sequence": (
             "components state distance_min and distance_max, which say "
-            "where each one is without being counted through"
+            "where each one is without being counted through. Drop the "
+            "column."
+        ),
+        "optical_length": (
+            "a component's length is the span between its distance_min "
+            "and distance_max, which place it as well. State those."
+        ),
+    },
+    "geometry": {
+        "segment": (
+            "the column naming a segment is now name, which is the field "
+            "it fills. Rename the column."
         )
-    }
+    },
 }
 
 
 def _object_rows(frame: pd.DataFrame, table: _Table, path: Path) -> list[dict]:
-    """Read a table whose every row is one object."""
-    require_columns(frame, [table.order], path)
-    require_stated(frame, [table.order], path)
-    ordered = ordered_rows(frame, table.order, path)
-    return [row_cells(row) for _, row in ordered.iterrows()]
+    """
+    Read a table whose every row is one object.
+
+    Row order carries nothing: each row states where it sits, so the model
+    reads them as a set. Only a point table orders its rows, and it does
+    so by the axis its arrays are built along.
+    """
+    return [row_cells(row) for _, row in frame.iterrows()]
 
 
 def _point_rows(
@@ -862,14 +870,21 @@ def _load_table(path: Path, table: _Table, stem: str, crs):
 
 
 def _refuse_retired_columns(frame: pd.DataFrame, stem: str, path: Path) -> None:
-    """Explain a column this format used to read, rather than shrugging."""
+    """
+    Explain a column this format used to read, rather than shrugging.
+
+    A file written before a rename is this format's own former spelling,
+    not a crew's own file which owes it nothing, so it is told what to
+    write instead. Without this a dropped column reports as a field the
+    model has never heard of, and a renamed one as the column now missing.
+    """
     retired = _RETIRED_COLUMNS.get(stem, {})
     for column in frame.columns:
-        if (why := retired.get(str(column))) is None:
+        if (advice := retired.get(str(column))) is None:
             continue
         msg = (
             f"{_quote(path)} states {column}, which this format no longer "
-            f"reads: {why}. Drop the column."
+            f"reads: {advice}"
         )
         raise InvalidInventoryError(msg)
 

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -458,10 +458,6 @@ class _Table(NamedTuple):
     # harmless; where it does not, the rows keep the order they were
     # written in, which the model reads as a set rather than a sequence.
     order: str | None = None
-    # True where that column is the table's own scaffolding rather than a
-    # field, so nothing else records where a row sits and it must place
-    # each row unambiguously.
-    places: bool = False
     # The field every column but the order gathers into, keyed by header.
     # None where each column names a field of the object directly.
     columns: str | None = None
@@ -472,7 +468,7 @@ class _Table(NamedTuple):
 # property of the attribute, and stating it is shorter than deducing it.
 # TestTableRegistry pins every key to a field of the model declaring it.
 _TABLES: Mapping[str, _Table] = {
-    "optical_components": _Table(order="sequence", places=True),
+    "optical_components": _Table(),
     "coupling": _Table(),
     "labels": _Table(),
     "geometry": _Table(points=True, group="name", order="distance", columns="columns"),
@@ -504,25 +500,18 @@ _GEOMETRY_STRUCTURAL = frozenset(
 # its points into segments at all.
 assert len(_GEOMETRY_STRUCTURAL) == 2, _GEOMETRY_STRUCTURAL
 
-_SEQUENCE = "sequence"
-
-
-def _check_places(keys: pd.Series, column: str, path: Path) -> None:
-    """
-    Refuse an ordering which does not place every row.
-
-    Components tile the path, each starting where the previous ends, so
-    two rows sharing a place would be ordered by where they happen to sit
-    in the file -- which is the one thing this column exists to stop
-    deciding anything.
-    """
-    repeated = sorted({str(x) for x in keys[keys.duplicated()]})
-    if repeated:
-        msg = (
-            f"{_quote(path)} states {column} {', '.join(repeated)} more than "
-            "once, so it does not say which row comes first."
+# Columns this format used to read, by the table which read them. A file
+# written before a rename is this format's own former spelling, so it is
+# told what to write instead rather than having the column reported as a
+# field the model has never heard of.
+_RETIRED_COLUMNS = {
+    "optical_components": {
+        "sequence": (
+            "components state distance_min and distance_max, which say "
+            "where each one is without being counted through"
         )
-        raise InvalidInventoryError(msg)
+    }
+}
 
 
 def _object_rows(frame: pd.DataFrame, table: _Table, path: Path) -> list[dict]:
@@ -530,20 +519,7 @@ def _object_rows(frame: pd.DataFrame, table: _Table, path: Path) -> list[dict]:
     require_columns(frame, [table.order], path)
     require_stated(frame, [table.order], path)
     ordered = ordered_rows(frame, table.order, path)
-    if table.places and table.order is not None:
-        _check_places(ordered[table.order], table.order, path)
-    out = []
-    for _, row in ordered.iterrows():
-        cells = row_cells(row)
-        # The order column is the table's own scaffolding where the object
-        # has no such field, so it is dropped -- but only where the table
-        # says it has one. Dropped everywhere, a stray sequence column in
-        # coupling.csv would vanish instead of being refused as the
-        # unknown field the model calls it.
-        if table.places:
-            cells.pop(table.order, None)
-        out.append(cells)
-    return out
+    return [row_cells(row) for _, row in ordered.iterrows()]
 
 
 def _point_rows(
@@ -885,6 +861,19 @@ def _load_table(path: Path, table: _Table, stem: str, crs):
         raise InvalidInventoryError(str(error)) from error
 
 
+def _refuse_retired_columns(frame: pd.DataFrame, stem: str, path: Path) -> None:
+    """Explain a column this format used to read, rather than shrugging."""
+    retired = _RETIRED_COLUMNS.get(stem, {})
+    for column in frame.columns:
+        if (why := retired.get(str(column))) is None:
+            continue
+        msg = (
+            f"{_quote(path)} states {column}, which this format no longer "
+            f"reads: {why}. Drop the column."
+        )
+        raise InvalidInventoryError(msg)
+
+
 def _read_track_table(path: Path, table: _Table, stem: str, crs):
     """Read one track table, in the table utilities' own error vocabulary."""
     frame = read_table(path, what="no track")
@@ -899,6 +888,7 @@ def _read_track_table(path: Path, table: _Table, stem: str, crs):
     # are both none of its business. A table of nothing else keeps its
     # rows, and is refused by the columns it then fails to state.
     frame = drop_private_columns(frame)
+    _refuse_retired_columns(frame, stem, path)
     units: Mapping[str, str] = {}
     if stem == "geometry":
         frame, units = _geometry_columns(frame, crs, path)

--- a/dascore/core/inventory_loader.py
+++ b/dascore/core/inventory_loader.py
@@ -426,17 +426,17 @@ def _load_entry(entry: Path, data_source: Path, container: _Container, crs) -> _
     _refuse_supplied(data, container.supplied, data_source, "an object file")
     name, epoch = _split_epoch(entry, container.epochs)
     address = _apply_identity(data, container, name, data_source)
-    if epoch is not None and "start_time" not in data:
-        data["start_time"] = epoch
+    if epoch is not None and "time_min" not in data:
+        data["time_min"] = epoch
     # After the epoch, not before: an entity's first path epoch starts
     # where the entity does, so its own start has to be known by then.
     if entry.is_dir():
         _merge_tables(data, entry, model, crs, data_source)
-        _merge_paths(data, entry, model, crs, data_source, data.get("start_time"))
+        _merge_paths(data, entry, model, crs, data_source, data.get("time_min"))
     built = _build(model, data, data_source)
-    if epoch is not None and built.start_time != epoch:
+    if epoch is not None and built.time_min != epoch:
         msg = (
-            f"{_quote(data_source)} states start_time {built.start_time} but "
+            f"{_quote(data_source)} states time_min {built.time_min} but "
             f"its name says {epoch}. A restated address must agree with the "
             "name."
         )
@@ -475,9 +475,7 @@ _TABLES: Mapping[str, _Table] = {
     "optical_components": _Table(order="sequence", places=True),
     "coupling": _Table(),
     "labels": _Table(),
-    "geometry": _Table(
-        points=True, group="segment", order="distance", columns="coordinates"
-    ),
+    "geometry": _Table(points=True, group="name", order="distance", columns="columns"),
     "distance_map": _Table(points=True, order="distance"),
 }
 
@@ -495,6 +493,16 @@ _TABLES_BY_FOLD = {x.casefold(): x for x in _TABLES}
 # The document doors already refuse the same fact, so this is what keeps
 # one stored inventory from breaking two different ways.
 _RETIRED_TABLES = {"annotations": "labels"}
+
+# The columns of geometry.csv which are not columns of the segment: the one
+# naming it and the one placing each row along it. Read off the registry so
+# the headers and the fields they fill cannot drift apart.
+_GEOMETRY_STRUCTURAL = frozenset(
+    x for x in (_TABLES["geometry"].group, _TABLES["geometry"].order) if x is not None
+)
+# Both are set above; a geometry table which named neither could not gather
+# its points into segments at all.
+assert len(_GEOMETRY_STRUCTURAL) == 2, _GEOMETRY_STRUCTURAL
 
 _SEQUENCE = "sequence"
 
@@ -557,14 +565,13 @@ def _point_rows(
     # dropna=False: a blank grouping cell would otherwise take its row out
     # of the table without a word. require_stated has already refused one,
     # and this keeps that the reason nothing is missing.
-    groups = (
-        frame.groupby(table.group, sort=True, dropna=False)
-        if table.group
-        else [(None, frame)]
-    )
+    group = table.group
+    groups = frame.groupby(group, sort=True, dropna=False) if group else [(None, frame)]
     out = []
     for name, rows in groups:
-        point: dict[str, Any] = {} if name is None else {"name": str(name)}
+        # A name only comes back where the table names a grouping column,
+        # which is the field each group's name fills.
+        point: dict[str, Any] = {} if group is None else {group: str(name)}
         gathered: dict[str, tuple] = {}
         for column in rows.columns:
             if column == table.group:
@@ -664,18 +671,18 @@ def _load_path(directory: Path, crs, begins):
             "with the name."
         )
         raise InvalidInventoryError(msg)
-    if epoch is not None and "start_time" not in data:
-        data["start_time"] = epoch
+    if epoch is not None and "time_min" not in data:
+        data["time_min"] = epoch
     # The bare `path` directory is the first epoch, and it starts where the
     # fiber array holding it does -- left unset it would claim the
     # unbounded past, which is before the array it belongs to exists.
-    if epoch is None and "start_time" not in data and not pd.isnull(begins):
-        data["start_time"] = begins
+    if epoch is None and "time_min" not in data and not pd.isnull(begins):
+        data["time_min"] = begins
     _merge_tables(data, directory, OpticalPath, crs, attrs)
     built = _build(OpticalPath, data, attrs)
-    if epoch is not None and built.start_time != epoch:
+    if epoch is not None and built.time_min != epoch:
         msg = (
-            f"{_quote(attrs)} states start_time {built.start_time} but its "
+            f"{_quote(attrs)} states time_min {built.time_min} but its "
             f"directory says {epoch}. A restated address must agree with "
             "the name."
         )
@@ -701,27 +708,25 @@ def _close_lineages(paths: list, sources: dict) -> list:
         # An unset start is the unbounded past, so the bare `path` directory
         # sorts before every epoch which names an instant, rather than after
         # them as a null ordinarily would.
-        ordered = sorted(
-            lineage, key=lambda x: (not pd.isnull(x.start_time), x.start_time)
-        )
+        ordered = sorted(lineage, key=lambda x: (not pd.isnull(x.time_min), x.time_min))
         for first, second in itertools.pairwise(ordered):
             # _times_equal, not ==: NaT equals nothing, itself included,
             # so two undated epochs of one lineage would never collide.
-            if _times_equal(first.start_time, second.start_time):
+            if _times_equal(first.time_min, second.time_min):
                 msg = (
                     f"{_quote(sources[id(first)])} and "
                     f"{_quote(sources[id(second)])} start at the same instant, "
                     "so they are two spellings of one epoch."
                 )
                 raise InvalidInventoryError(msg)
-            if pd.isnull(first.end_time):
-                out.append(first.new(end_time=second.start_time))
+            if pd.isnull(first.time_max):
+                out.append(first.new(time_max=second.time_min))
                 continue
-            if first.end_time > second.start_time:
+            if first.time_max > second.time_min:
                 msg = (
-                    f"{_quote(sources[id(first)])} ends at {first.end_time}, "
+                    f"{_quote(sources[id(first)])} ends at {first.time_max}, "
                     f"after the epoch which follows it begins at "
-                    f"{second.start_time}."
+                    f"{second.time_min}."
                 )
                 raise InvalidInventoryError(msg)
             out.append(first)
@@ -936,7 +941,7 @@ def _geometry_columns(frame: pd.DataFrame, crs, path: Path):
     labels = tuple(crs.coordinate_labels)
     renamed, units = {}, {}
     for header in frame.columns:
-        if header in {"segment", "distance"}:
+        if header in _GEOMETRY_STRUCTURAL:
             continue
         name, unit = header, ""
         if (match := _UNIT_SUFFIX.match(header)) is not None:
@@ -953,7 +958,7 @@ def _geometry_columns(frame: pd.DataFrame, crs, path: Path):
     # Counted against the structural columns as well: `distance (m)` renames
     # to a column the table already has, and two of them would reach pandas
     # rather than this message.
-    written = [*renamed.values(), "segment", "distance"]
+    written = [*renamed.values(), *_GEOMETRY_STRUCTURAL]
     if repeated := sorted({x for x in written if written.count(x) > 1}):
         msg = (
             f"{_quote(path)} names the column(s) {repeated} more than once; "
@@ -1173,12 +1178,12 @@ def _escapes(child, parent) -> str:
     end -- which is how a child with no epoch of its own escapes a parent
     which has one.
     """
-    if not pd.isnull(parent.start_time) and (
-        pd.isnull(child.start_time) or child.start_time < parent.start_time
+    if not pd.isnull(parent.time_min) and (
+        pd.isnull(child.time_min) or child.time_min < parent.time_min
     ):
         return "starts before"
-    if not pd.isnull(parent.end_time) and (
-        pd.isnull(child.end_time) or child.end_time > parent.end_time
+    if not pd.isnull(parent.time_max) and (
+        pd.isnull(child.time_max) or child.time_max > parent.time_max
     ):
         return "runs past"
     return ""
@@ -1205,10 +1210,10 @@ def _place(children: list[_Entry], parents: list[_Entry], kind: str):
         matches = [
             index
             for index, parent in enumerate(parents)
-            if parent.model.is_effective_at(child.model.start_time)
+            if parent.model.is_effective_at(child.model.time_min)
         ]
         if len(matches) != 1:
-            start = child.model.start_time
+            start = child.model.time_min
             when = "at any time" if pd.isnull(start) else f"at {start}"
             named = ".".join(child.address)
             msg = (
@@ -1218,10 +1223,10 @@ def _place(children: list[_Entry], parents: list[_Entry], kind: str):
             raise InvalidInventoryError(msg)
         parent = parents[matches[0]]
         if escape := _escapes(child.model, parent.model):
-            span = f"{parent.model.start_time} to {parent.model.end_time}"
+            span = f"{parent.model.time_min} to {parent.model.time_max}"
             msg = (
-                f"{_quote(child.source)} is valid from {child.model.start_time} "
-                f"to {child.model.end_time}, so it {escape} the {kind} epoch "
+                f"{_quote(child.source)} is valid from {child.model.time_min} "
+                f"to {child.model.time_max}, so it {escape} the {kind} epoch "
                 f"holding it, which runs {span}. State it once per epoch it "
                 "spans."
             )

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -842,7 +842,7 @@ def inventory_patch_pair():
         data_type="velocity",
         data_category="DAS",
         gauge_length=10.0,
-        spatial_interval=1.0,
+        distance_step=1.0,
         sample_rate=1.0 / dc.to_float(patch.get_coord("time").step),
         pulse_width=1e-8,
         interrogator=Interrogator(
@@ -863,7 +863,7 @@ def inventory_patch_pair():
                 distance=(100.0, 400.0),
                 # The canonical axis names, so the segment states the CRS's
                 # axes whatever this inventory's CRS happens to call them.
-                coordinates={
+                columns={
                     "x": (-117.0, -117.0),
                     "y": (40.0, 40.1),
                     "z": (1500.0, 1500.0),
@@ -872,20 +872,20 @@ def inventory_patch_pair():
         ),
         coupling=(
             CouplingCondition(
-                start_distance=100.0,
-                end_distance=250.0,
+                distance_min=100.0,
+                distance_max=250.0,
                 coupling_type="trench",
                 medium="soil",
             ),
         ),
         labels=(
             OpticalPathLabel(
-                start_distance=100.0, end_distance=200.0, group="zone", value="north"
+                distance_min=100.0, distance_max=200.0, group="zone", value="north"
             ),
             OpticalPathLabel(
-                start_distance=200.0, end_distance=400.0, group="zone", value="south"
+                distance_min=200.0, distance_max=400.0, group="zone", value="south"
             ),
-            OpticalPathLabel(start_distance=150.0, end_distance=300.0, group="noisy"),
+            OpticalPathLabel(distance_min=150.0, distance_max=300.0, group="noisy"),
         ),
     )
     inventory = Inventory(
@@ -1132,7 +1132,7 @@ def _tunnel_geometry(at, runs):
         first, last = at[name]
         rows.append((name, first, *start))
         rows.append((name, last, *end))
-    frame = pd.DataFrame(rows, columns=["segment", "distance", "x", "y", "z"])
+    frame = pd.DataFrame(rows, columns=["name", "distance", "x", "y", "z"])
     return frame.to_csv(index=False)
 
 
@@ -1156,8 +1156,8 @@ def _tunnel_coupling(at, trench_parts):
     frame = pd.DataFrame(
         rows,
         columns=[
-            "start_distance",
-            "end_distance",
+            "distance_min",
+            "distance_max",
             "coupling_type",
             "medium",
             "attachment",
@@ -1176,7 +1176,7 @@ def _tunnel_labels(at, trench_parts):
         rows.append((*span, "section", "borehole"))
         rows.append((*span, "borehole", number))
     frame = pd.DataFrame(
-        rows, columns=["start_distance", "end_distance", "group", "value"]
+        rows, columns=["distance_min", "distance_max", "group", "value"]
     )
     return frame.to_csv(index=False)
 
@@ -1262,7 +1262,7 @@ def tunnel_inventory_files(repaired: bool = True) -> dict[str, str]:
             "data_units: 1/s\n"
             "interrogator: das-interrogator\n"
             "gauge_length: 10.0\n"
-            "spatial_interval: 1.0\n"
+            "distance_step: 1.0\n"
             "sample_rate: 250.0\n"
             "distance_map:\n"
             "  instrument_distance: [0.0, 2000.0]\n"

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -856,7 +856,9 @@ def inventory_patch_pair():
     path = OpticalPath(
         name="main",
         location_code="",
-        optical_components=(FiberSegment(name="cable", optical_length=500.0),),
+        optical_components=(
+            FiberSegment(name="cable", distance_min=0.0, distance_max=500.0),
+        ),
         geometry=(
             Geometry(
                 name="trench",
@@ -1022,33 +1024,33 @@ for _label, _name in [
     )
 
 _TUNNEL_COMPONENTS = """\
-sequence,object_type,optical_length,name,container
-1,FiberSegment,1500.0,telemetry lead-in,telemetry-cable
-2,Splice,0.0,splice at box A,splice-box-a
-3,FiberSegment,2.5,drop into the trench,trench-cable
-4,FiberSegment,25.0,trench B to the coil,trench-cable
-5,FiberSegment,10.0,cable coil at C,trench-cable
-6,FiberSegment,25.0,trench from the coil to D,trench-cable
-7,FiberSegment,2.5,rise out of the trench,trench-cable
-8,Splice,0.0,splice at box E,splice-box-e
-9,FiberSegment,15.0,link E to borehole 3,connecting-cable
-10,FiberSegment,20.0,borehole 3 down,borehole-cable
-11,Splice,0.0,borehole 3 turnaround,turnaround-3
-12,FiberSegment,20.0,borehole 3 up,borehole-cable
-13,FiberSegment,15.0,link borehole 3 to coupler G,connecting-cable
-14,Connector,0.0,coupler G,
-15,FiberSegment,15.0,link coupler G to borehole 2,connecting-cable
-16,FiberSegment,20.0,borehole 2 down,borehole-cable
-17,Splice,0.0,borehole 2 turnaround,turnaround-2
-18,FiberSegment,20.0,borehole 2 up,borehole-cable
-19,FiberSegment,15.0,link borehole 2 to coupler H,connecting-cable
-20,Connector,0.0,coupler H,
-21,FiberSegment,15.0,link coupler H to borehole 1,connecting-cable
-22,FiberSegment,20.0,borehole 1 down,borehole-cable
-23,Splice,0.0,borehole 1 turnaround,turnaround-1
-24,FiberSegment,20.0,borehole 1 up,borehole-cable
-25,FiberSegment,15.0,link borehole 1 back to box A,connecting-cable
-26,Terminator,0.0,path end,
+object_type,distance_min,distance_max,name,container
+FiberSegment,0,1500,telemetry lead-in,telemetry-cable
+Splice,1500,,splice at box A,splice-box-a
+FiberSegment,1500,1502.5,drop into the trench,trench-cable
+FiberSegment,1502.5,1527.5,trench B to the coil,trench-cable
+FiberSegment,1527.5,1537.5,cable coil at C,trench-cable
+FiberSegment,1537.5,1562.5,trench from the coil to D,trench-cable
+FiberSegment,1562.5,1565,rise out of the trench,trench-cable
+Splice,1565,,splice at box E,splice-box-e
+FiberSegment,1565,1580,link E to borehole 3,connecting-cable
+FiberSegment,1580,1600,borehole 3 down,borehole-cable
+Splice,1600,,borehole 3 turnaround,turnaround-3
+FiberSegment,1600,1620,borehole 3 up,borehole-cable
+FiberSegment,1620,1635,link borehole 3 to coupler G,connecting-cable
+Connector,1635,,coupler G,
+FiberSegment,1635,1650,link coupler G to borehole 2,connecting-cable
+FiberSegment,1650,1670,borehole 2 down,borehole-cable
+Splice,1670,,borehole 2 turnaround,turnaround-2
+FiberSegment,1670,1690,borehole 2 up,borehole-cable
+FiberSegment,1690,1705,link borehole 2 to coupler H,connecting-cable
+Connector,1705,,coupler H,
+FiberSegment,1705,1720,link coupler H to borehole 1,connecting-cable
+FiberSegment,1720,1740,borehole 1 down,borehole-cable
+Splice,1740,,borehole 1 turnaround,turnaround-1
+FiberSegment,1740,1760,borehole 1 up,borehole-cable
+FiberSegment,1760,1775,link borehole 1 back to box A,connecting-cable
+Terminator,1775,,path end,
 """
 
 # The surveyed waypoints, lettered as the recipe's drawing letters them.
@@ -1081,11 +1083,17 @@ _TUNNEL_REPAIRED_TRENCH = (
 )
 
 
+def _tunnel_components(components_csv):
+    """Read the components table, with each point component's end filled in."""
+    frame = pd.read_csv(io.StringIO(components_csv))
+    frame["distance_max"] = frame["distance_max"].fillna(frame["distance_min"])
+    return frame
+
+
 def _tunnel_spans(components_csv):
     """Map each component's name to the optical interval it covers."""
-    frame = pd.read_csv(io.StringIO(components_csv))
-    end = frame["optical_length"].cumsum()
-    return dict(zip(frame["name"], zip(end - frame["optical_length"], end)))
+    frame = _tunnel_components(components_csv)
+    return dict(zip(frame["name"], zip(frame["distance_min"], frame["distance_max"])))
 
 
 def _tunnel_bottom(number):
@@ -1181,46 +1189,55 @@ def _tunnel_labels(at, trench_parts):
     return frame.to_csv(index=False)
 
 
+# What the contractor put in where the trench cable was cut, as the
+# length of each piece: fifteen meters of the original run, the two
+# splices holding a two-meter patch cord, and the rest of the run.
+_TUNNEL_REPAIR = (
+    ("FiberSegment", 15.0, "trench B to the break", "trench-cable"),
+    ("Splice", 0.0, "repair splice near side", "repair-box"),
+    ("FiberSegment", 2.0, "repair patch cord", "repair-cord"),
+    ("Splice", 0.0, "repair splice far side", "repair-box"),
+    ("FiberSegment", 10.0, "trench from the break to the coil", "trench-cable"),
+)
+
+
 def _tunnel_repaired_components():
-    """One row becomes five where the contractor cut the trench cable."""
-    rows = pd.read_csv(io.StringIO(_TUNNEL_COMPONENTS)).to_dict("records")
+    """
+    One row becomes five where the contractor cut the trench cable.
+
+    The repair leaves two meters more fiber than it replaced, so every
+    component past it sits two meters further along the path. That shift
+    is the price of an absolute distance, and it is applied here once
+    rather than retyped into every row below the break.
+    """
+    rows = _tunnel_components(_TUNNEL_COMPONENTS).to_dict("records")
     index = next(
         i for i, row in enumerate(rows) if row["name"] == "trench B to the coil"
     )
-    rows[index : index + 1] = [
-        dict(
-            object_type="FiberSegment",
-            optical_length=15.0,
-            name="trench B to the break",
-            container="trench-cable",
-        ),
-        dict(
-            object_type="Splice",
-            optical_length=0.0,
-            name="repair splice near side",
-            container="repair-box",
-        ),
-        dict(
-            object_type="FiberSegment",
-            optical_length=2.0,
-            name="repair patch cord",
-            container="repair-cord",
-        ),
-        dict(
-            object_type="Splice",
-            optical_length=0.0,
-            name="repair splice far side",
-            container="repair-box",
-        ),
-        dict(
-            object_type="FiberSegment",
-            optical_length=10.0,
-            name="trench from the break to the coil",
-            container="trench-cable",
-        ),
-    ]
+    cut = rows[index]
+    position = cut["distance_min"]
+    replacement = []
+    for object_type, length, name, container in _TUNNEL_REPAIR:
+        replacement.append(
+            dict(
+                object_type=object_type,
+                distance_min=position,
+                distance_max=position + length,
+                name=name,
+                container=container,
+            )
+        )
+        position += length
+    shift = position - cut["distance_max"]
+    for row in rows[index + 1 :]:
+        row["distance_min"] += shift
+        row["distance_max"] += shift
+    rows[index : index + 1] = replacement
     frame = pd.DataFrame(rows)
-    frame["sequence"] = range(1, len(frame) + 1)
+    # A point component states one distance; writing its end back would
+    # make the repaired table say more than the original one does.
+    point = frame["distance_min"] == frame["distance_max"]
+    frame.loc[point, "distance_max"] = None
     return frame.to_csv(index=False)
 
 

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -842,7 +842,7 @@ def inventory_patch_pair():
         data_type="velocity",
         data_category="DAS",
         gauge_length=10.0,
-        distance_step=1.0,
+        spatial_interval=1.0,
         sample_rate=1.0 / dc.to_float(patch.get_coord("time").step),
         pulse_width=1e-8,
         interrogator=Interrogator(
@@ -1279,7 +1279,7 @@ def tunnel_inventory_files(repaired: bool = True) -> dict[str, str]:
             "data_units: 1/s\n"
             "interrogator: das-interrogator\n"
             "gauge_length: 10.0\n"
-            "distance_step: 1.0\n"
+            "spatial_interval: 1.0\n"
             "sample_rate: 250.0\n"
             "distance_map:\n"
             "  instrument_distance: [0.0, 2000.0]\n"

--- a/dascore/models/base.py
+++ b/dascore/models/base.py
@@ -252,15 +252,15 @@ class InventoryModel(DascoreBaseModel):
 class TimeRangedModel(InventoryModel):
     """Base class for inventory objects with time-validity epochs.
 
-    Validity intervals are half-open, ``[start_time, end_time)``; an unset
+    Validity intervals are half-open, ``[time_min, time_max)``; an unset
     (NaT) end time means the epoch is ongoing. All times are UTC.
     """
 
-    start_time: DateTime64 = Field(
+    time_min: DateTime64 = Field(
         default=np.datetime64("NaT", "ns"),
         description="Start time for which this metadata item is valid (UTC).",
     )
-    end_time: DateTime64 = Field(
+    time_max: DateTime64 = Field(
         default=np.datetime64("NaT", "ns"),
         description=(
             "End time for which this metadata item is valid (UTC); NaT while ongoing."
@@ -270,9 +270,9 @@ class TimeRangedModel(InventoryModel):
     @model_validator(mode="after")
     def _check_time_order(self):
         """A set end time must follow the start time."""
-        start, end = self.start_time, self.end_time
+        start, end = self.time_min, self.time_max
         if not pd.isnull(start) and not pd.isnull(end) and end <= start:
-            msg = f"end_time {end} must be after start_time {start}."
+            msg = f"time_max {end} must be after time_min {start}."
             raise InvalidInventoryError(msg)
         return self
 
@@ -281,8 +281,8 @@ class TimeRangedModel(InventoryModel):
         time = to_datetime64(time)
         if pd.isnull(time):
             return True
-        start = self.start_time
-        end = self.end_time
+        start = self.time_min
+        end = self.time_max
         after_start = pd.isnull(start) or start <= time
         before_end = pd.isnull(end) or time < end
         return bool(after_start and before_end)
@@ -294,10 +294,10 @@ class TimeRangedModel(InventoryModel):
         Unset (NaT) starts are unbounded past; unset ends are ongoing.
         """
         s1, e1, s2, e2 = (
-            self.start_time,
-            self.end_time,
-            other.start_time,
-            other.end_time,
+            self.time_min,
+            self.time_max,
+            other.time_min,
+            other.time_max,
         )
         first_starts_before = pd.isnull(e2) or pd.isnull(s1) or s1 < e2
         second_starts_before = pd.isnull(e1) or pd.isnull(s2) or s2 < e1

--- a/dascore/utils/intervals.py
+++ b/dascore/utils/intervals.py
@@ -10,8 +10,11 @@ distance tracks, and the annotation sets which describe patch data.
 from __future__ import annotations
 
 import itertools
+from functools import partial
+from typing import Annotated
 
 import numpy as np
+from pydantic import BeforeValidator
 
 from dascore.exceptions import ParameterError
 
@@ -30,7 +33,7 @@ def interval_masks(values, intervals) -> list[np.ndarray]:
     values
         The values, along the interval axis, to test for coverage.
     intervals
-        A sequence of (start, end) pairs.
+        A sequence of (min, max) pairs.
 
     Examples
     --------
@@ -66,7 +69,7 @@ def intervals_overlap(intervals) -> tuple | None:
     Parameters
     ----------
     intervals
-        A sequence of (start, end) pairs.
+        A sequence of (min, max) pairs.
 
     Examples
     --------
@@ -88,8 +91,8 @@ def clip_intervals(
     lo: float,
     hi: float,
     outer: float | None = None,
-    start_field: str = "start_distance",
-    end_field: str = "end_distance",
+    min_field: str = "distance_min",
+    max_field: str = "distance_max",
 ) -> list:
     """
     Clip interval items to [lo, hi), dropping those left with no coverage.
@@ -100,8 +103,8 @@ def clip_intervals(
     Parameters
     ----------
     items
-        Models whose start and end are held by ``start_field`` and
-        ``end_field``, and which support pydantic's ``model_copy``.
+        Models whose bounds are held by ``min_field`` and ``max_field``,
+        and which support pydantic's ``model_copy``.
     lo
         The inclusive start of the clip.
     hi
@@ -109,25 +112,25 @@ def clip_intervals(
     outer
         The outermost value the clipped axis holds, if any. A point marker
         sitting exactly there survives, since nothing beyond it can claim it.
-    start_field
-        Name of the field holding each item's interval start.
-    end_field
-        Name of the field holding each item's interval end.
+    min_field
+        Name of the field holding each item's lower bound.
+    max_field
+        Name of the field holding each item's upper bound.
 
     Examples
     --------
     >>> from pydantic import BaseModel
     >>> from dascore.utils.intervals import clip_intervals
     >>> class Span(BaseModel):
-    ...     start_distance: float
-    ...     end_distance: float
-    >>> clipped = clip_intervals([Span(start_distance=0, end_distance=10)], 2, 6)
-    >>> clipped[0].start_distance, clipped[0].end_distance
+    ...     distance_min: float
+    ...     distance_max: float
+    >>> clipped = clip_intervals([Span(distance_min=0, distance_max=10)], 2, 6)
+    >>> clipped[0].distance_min, clipped[0].distance_max
     (2, 6)
     """
     out = []
     for item in items:
-        start, end = getattr(item, start_field), getattr(item, end_field)
+        start, end = getattr(item, min_field), getattr(item, max_field)
         if start == end:
             if lo <= start < hi or (outer is not None and start == hi == outer):
                 out.append(item)
@@ -135,7 +138,7 @@ def clip_intervals(
         new_lo, new_hi = max(start, lo), min(end, hi)
         if new_hi <= new_lo:
             continue
-        out.append(item.model_copy(update={start_field: new_lo, end_field: new_hi}))
+        out.append(item.model_copy(update={min_field: new_lo, max_field: new_hi}))
     return out
 
 
@@ -197,3 +200,31 @@ def normalize_value(value, error: type[Exception] = ParameterError):
         msg = f"A value must be finite; got {value}."
         raise error(msg)
     return value
+
+
+def interval_value_type(error: type[Exception] = ParameterError):
+    """
+    Return the annotated type of the one value an interval may carry.
+
+    An item states membership by carrying no value, so a value, when there
+    is one, is text or a number, and its Python type must survive
+    validation: a 1 must not be written back as 1.0.
+
+    Parameters
+    ----------
+    error
+        The exception raised for a value the interval cannot carry, so
+        each caller refuses in the vocabulary of its own subsystem.
+
+    Examples
+    --------
+    >>> from pydantic import BaseModel
+    >>> from dascore.utils.intervals import interval_value_type
+    >>> class Item(BaseModel):
+    ...     value: interval_value_type() | None = None
+    >>> Item(value=1).value
+    1
+    """
+    return Annotated[
+        str | int | float, BeforeValidator(partial(normalize_value, error=error))
+    ]

--- a/dascore/utils/intervals.py
+++ b/dascore/utils/intervals.py
@@ -214,7 +214,10 @@ def interval_value_type(error: type[Exception] = ParameterError):
     ----------
     error
         The exception raised for a value the interval cannot carry, so
-        each caller refuses in the vocabulary of its own subsystem.
+        each caller refuses in the vocabulary of its own subsystem. It
+        surfaces as itself only where `normalize_value` is called
+        directly; pydantic wraps whatever a validator raises in a
+        `ValidationError`, keeping the message but not the type.
 
     Examples
     --------

--- a/dascore/viz/inventory.py
+++ b/dascore/viz/inventory.py
@@ -211,14 +211,12 @@ def _track_frame(path, acquisitions) -> pd.DataFrame:
                 "label": acquisition.code,
             }
         )
-    for component, (low, high) in zip(
-        path.optical_components, path.component_intervals(), strict=True
-    ):
+    for component in path.optical_components:
         rows.append(
             {
                 "lane": "components",
-                "start": low,
-                "end": high,
+                "start": component.distance_min,
+                "end": component.distance_max,
                 "value": type(component).__name__,
                 "label": component.name or type(component).__name__,
             }

--- a/dascore/viz/inventory.py
+++ b/dascore/viz/inventory.py
@@ -48,7 +48,7 @@ def _effective_epoch(*models):
     """The epoch a model is really valid over, clipped by its containers."""
     start, end = pd.NaT, pd.NaT
     for model in models:
-        low, high = model.start_time, model.end_time
+        low, high = model.time_min, model.time_max
         if not pd.isnull(low):
             start = low if pd.isnull(start) else max(start, low)
         if not pd.isnull(high):
@@ -97,9 +97,9 @@ def _sample_distances(path, low: float, high: float, count: int) -> np.ndarray:
 
 def _epoch_label(path) -> str:
     """Name a path epoch by when it starts, for a chart title."""
-    if pd.isnull(path.start_time):
+    if pd.isnull(path.time_min):
         return "from the beginning"
-    return f"from {str(path.start_time)[:10]}"
+    return f"from {str(path.time_min)[:10]}"
 
 
 def _select_path(inventory, optical_path=None, acquisition_key=None, time=None):
@@ -227,8 +227,8 @@ def _track_frame(path, acquisitions) -> pd.DataFrame:
         rows.append(
             {
                 "lane": "coupling",
-                "start": coupling.start_distance,
-                "end": coupling.end_distance,
+                "start": coupling.distance_min,
+                "end": coupling.distance_max,
                 "value": coupling.coupling_type,
                 "label": coupling.coupling_type,
             }
@@ -237,8 +237,8 @@ def _track_frame(path, acquisitions) -> pd.DataFrame:
         rows.append(
             {
                 "lane": item.group,
-                "start": item.start_distance,
-                "end": item.end_distance,
+                "start": item.distance_min,
+                "end": item.distance_max,
                 "value": item.value,
                 # The renderer's own rule for what a value reads as.
                 "label": _default_label(item.value),
@@ -310,13 +310,13 @@ def _select_tracks(frame, tracks, path):
 
 
 def _distance_window(asked, span):
-    """Resolve a (low, high) distance selection against a path's span."""
+    """Resolve a (min, max) distance selection against a path's span."""
     if asked is None:
         return span
     try:
         low, high = asked
     except (TypeError, ValueError):
-        msg = f"distance={asked!r} must be a (low, high) pair."
+        msg = f"distance={asked!r} must be a (min, max) pair."
         raise ParameterError(msg) from None
     low = span[0] if low is None or low is ... else float(low)
     high = span[1] if high is None or high is ... else float(high)
@@ -372,7 +372,7 @@ def path(
         The instant to resolve at, which is how one epoch of a repaired
         path is chosen.
     distance
-        The optical distances to draw between, as (low, high). Either
+        The optical distances to draw between, as (min, max). Either
         end may be None, or ..., to run to the path's own bound. A long
         lead-in otherwise crushes the instrumented part into a corner.
     tracks
@@ -426,7 +426,7 @@ def path(
             "state none, so there is no distance axis to draw."
         )
         raise ParameterError(msg)
-    limits = _distance_window(distance, (chosen.start_distance, chosen.end_distance))
+    limits = _distance_window(distance, (chosen.distance_min, chosen.distance_max))
     frame = _track_frame(chosen, _path_acquisitions(array, chosen, time))
     # The palette is the path's, not this figure's, so drawing some of the
     # tracks colors them as drawing all of them does.
@@ -512,13 +512,13 @@ def path(
 
 
 def _time_window(asked):
-    """Resolve a (start, end) time selection to matplotlib dates."""
+    """Resolve a (min, max) time selection to matplotlib dates."""
     if asked is None:
         return None, None
     try:
         low, high = asked
     except (TypeError, ValueError):
-        msg = f"time={asked!r} must be a (start, end) pair."
+        msg = f"time={asked!r} must be a (min, max) pair."
         raise ParameterError(msg) from None
 
     def one(value):
@@ -701,7 +701,7 @@ def map_path(
     pieces = []
     for address, _, one in chosen:
         distances = _sample_distances(
-            one, one.start_distance, one.end_distance, n_samples
+            one, one.distance_min, one.distance_max, n_samples
         )
         coords = one.coordinates_at(distances, crs)
         points = np.column_stack([coords[:, x_axis], coords[:, y_axis]])
@@ -940,7 +940,7 @@ def timeline(
     color
         "interrogator", "data_type", or "kind".
     time
-        The times to draw between, as (start, end). Either end may be
+        The times to draw between, as (min, max). Either end may be
         None, or ..., to run to what the epochs themselves state.
     ax
         An Axes to draw on.

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -178,7 +178,7 @@ name and who may change it later.
 2. **Observing-system facts** — what the instrument was doing. Use the names
    in `dascore.constants.INVENTORY_ATTRS`, which are the
    fields of the DASDAE inventory's acquisition (`gauge_length`,
-   `spatial_interval`, `pulse_width`, …) and of its interrogator, dotted
+   `distance_step`, `pulse_width`, …) and of its interrogator, dotted
    (`interrogator.serial_number`). Using a vendor spelling for one of these
    splits one fact into two attrs that nothing downstream can reconcile.
    These attrs carry fixed units — seconds, hertz, meters — so convert at the

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -178,7 +178,7 @@ name and who may change it later.
 2. **Observing-system facts** — what the instrument was doing. Use the names
    in `dascore.constants.INVENTORY_ATTRS`, which are the
    fields of the DASDAE inventory's acquisition (`gauge_length`,
-   `distance_step`, `pulse_width`, …) and of its interrogator, dotted
+   `spatial_interval`, `pulse_width`, …) and of its interrogator, dotted
    (`interrogator.serial_number`). Using a vendor spelling for one of these
    splits one fact into two attrs that nothing downstream can reconcile.
    These attrs carry fixed units — seconds, hertz, meters — so convert at the

--- a/docs/recipes/tunnel_inventory.qmd
+++ b/docs/recipes/tunnel_inventory.qmd
@@ -303,7 +303,7 @@ print(repaired_geometry.head(6).to_string(index=False))
 
 repaired = dc.inventory(root)
 for epoch in repaired.networks[0].fiber_arrays[0].optical_paths:
-    began = "the beginning" if np.isnat(epoch.start_time) else str(epoch.start_time)[:10]
+    began = "the beginning" if np.isnat(epoch.time_min) else str(epoch.time_min)[:10]
     print(f"from {began}: {epoch.optical_length:.1f} m")
 ```
 

--- a/docs/recipes/tunnel_inventory.qmd
+++ b/docs/recipes/tunnel_inventory.qmd
@@ -113,7 +113,7 @@ table(f"{PATH}/optical_components.csv").head(9)
 
 Every column is a field of the class the `object_type` column names, so the table is barely a format of its own — it is the objects, written the way rows of the same shape are worth writing. Row order decides nothing: the distances say where each component is, and the path holds them in that order whatever order they were written in. The blank `container` on the terminator is a field left unset; the ones which are filled are `resource_id`s pointing back at the files above.
 
-The other three tables are written against the same distances, and they are in the table rather than implied by it, so a row can be read on its own:
+The other three tables are written against these same distances, which the components state outright rather than imply, so a component row can be read on its own. Reading them out is then a matter of pairing the two columns:
 
 ```{python}
 def spans(csv_text):
@@ -272,7 +272,7 @@ In September a contractor puts a bucket through the trench cable, fifteen meters
 
 This is what epochs are for. The old description is not edited. A second directory is added, named for the day of the repair, and the first path runs until the second begins.
 
-The components table is where the repair happens: one row becomes five, and the table is renumbered.
+The components table is where the repair happens: one row becomes five, and everything past them moves along the fiber.
 
 ```{python}
 EPOCH = "fiber_arrays/XT.TUN1/path.00@2024-09-01"
@@ -297,8 +297,6 @@ The repair leaves two meters more fiber than it replaced, so every component pas
 #| code-summary: "path.00@2024-09-01 — the same tracks, against the new distances"
 repaired_at = spans(repaired_csv)
 
-# The three other tracks are regenerated from the shifted distances
-# rather than edited row by row.
 repaired_geometry = table(f"{EPOCH}/geometry.csv")
 print(repaired_geometry.head(6).to_string(index=False))
 

--- a/docs/recipes/tunnel_inventory.qmd
+++ b/docs/recipes/tunnel_inventory.qmd
@@ -99,7 +99,7 @@ show("fiber_arrays/XT.TUN1/attrs.yaml")
 
 # The path, as a table
 
-An optical path is the ordered list of things the light passes through. Each component states its own optical length and they tile the path end to end, which is what gives the path its length. No row states a start distance, because the `sequence` column already did.
+An optical path is the list of things the light passes through. Each component states the stretch of optical distance it occupies — `distance_min` to `distance_max` — and they tile the path end to end, which is what gives the path its extent. A splice or a connector occupies no measurable length, so it states one distance and leaves the other blank.
 
 This is @tbl-path with the parts named, and it goes in `path.00` — the directory naming the optical path at location code `00`.
 
@@ -111,16 +111,17 @@ components_csv = files[f"{PATH}/optical_components.csv"]
 table(f"{PATH}/optical_components.csv").head(9)
 ```
 
-Every column but `sequence` is a field of the class the `object_type` column names, so the table is barely a format of its own — it is the objects, written the way rows of the same shape are worth writing. `sequence` belongs to the table, and is dropped once it has put the rows in order. The blank `container` on the terminator is a field left unset; the ones which are filled are `resource_id`s pointing back at the files above.
+Every column is a field of the class the `object_type` column names, so the table is barely a format of its own — it is the objects, written the way rows of the same shape are worth writing. Row order decides nothing: the distances say where each component is, and the path holds them in that order whatever order they were written in. The blank `container` on the terminator is a field left unset; the ones which are filled are `resource_id`s pointing back at the files above.
 
-The other three tables are written against distances along this path, and those distances are the running totals of this one column. Adding them up by hand is how a table stops agreeing with its neighbours, so add them up once:
+The other three tables are written against the same distances, and they are in the table rather than implied by it, so a row can be read on its own:
 
 ```{python}
 def spans(csv_text):
     """Map each component's name to the optical interval it covers."""
     frame = pd.read_csv(io.StringIO(csv_text))
-    end = frame["optical_length"].cumsum()
-    return dict(zip(frame["name"], zip(end - frame["optical_length"], end)))
+    # A point component states one distance; the other end is the same one.
+    ends = frame["distance_max"].fillna(frame["distance_min"])
+    return dict(zip(frame["name"], zip(frame["distance_min"], ends)))
 
 
 at = spans(components_csv)
@@ -289,14 +290,14 @@ index = int(repaired_components.index[repaired_components["name"] == "trench B t
 repaired_components.iloc[index - 1 : index + 5]
 ```
 
-Everything else follows from that table, which is the argument for having written it this way: the three other tracks are regenerated from the new running totals rather than edited row by row.
+The repair leaves two meters more fiber than it replaced, so every component past it moves two meters further along the path. That shift is the price of writing a distance down rather than counting to it, and it is why the tables are generated from one description of the repair rather than edited row by row.
 
 ```{python}
 #| code-fold: true
 #| code-summary: "path.00@2024-09-01 — the same tracks, against the new distances"
 repaired_at = spans(repaired_csv)
 
-# The three other tracks are regenerated from the new running totals
+# The three other tracks are regenerated from the shifted distances
 # rather than edited row by row.
 repaired_geometry = table(f"{EPOCH}/geometry.csv")
 print(repaired_geometry.head(6).to_string(index=False))

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -36,7 +36,7 @@ flowchart LR
   OpticalPath -->|labels| OpticalPathLabel
 ```
 
-The components are the physical pieces the light passes through, and they are what gives the path its extent: each one states the stretch of optical distance it occupies, and they tile — each begins where the last ended — so the path runs from the first to the last. They are read in distance order whatever order the rows are written in, so a component states where it is rather than being counted through to it. The other three describe intervals of that length — the geometry holds the measured curves along the fiber, of which the columns the coordinate reference system names are position; the coupling says how the fiber is attached to the ground there; and the labels name anything else worth recording per interval. Each of those covers what it covers, and none of them has to cover the whole path.
+The components are the physical pieces the light passes through, and they are what gives the path its extent: each one states the stretch of optical distance it occupies, and they tile — each begins where the last ended — so the path runs from the first to the last. They are read in distance order whatever order the rows are written in, so a component states where it is rather than being counted through to it. The other three describe intervals of that extent — the geometry holds the measured curves along the fiber, of which the columns the coordinate reference system names are position; the coupling says how the fiber is attached to the ground there; and the labels name anything else worth recording per interval. Each of those covers what it covers, and none of them has to cover the whole path.
 
 Objects reused in several places — interrogators, cables, enclosures, measurements — are written once under the inventory's `resources` and referred to elsewhere by their `resource_id`. Such a field accepts either the object itself or that string, which is what the dashed edges below mean.
 
@@ -75,7 +75,7 @@ files = {
         "data_category: DAS\n"
         "data_type: velocity\n"
         "gauge_length: 10.0\n"
-        "distance_step: 1.0\n"
+        "spatial_interval: 1.0\n"
         "interrogator: fi-1\n"
         # Where the interrogator's own axis lands on the optical path.
         "distance_map:\n"

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -36,7 +36,7 @@ flowchart LR
   OpticalPath -->|labels| OpticalPathLabel
 ```
 
-The components are the ordered physical pieces the light passes through, and they are what gives the path its length: each one tiles the interval after the last, so the path ends where the final component does. The other three describe intervals of that length — the geometry holds the measured curves along the fiber, of which the columns the coordinate reference system names are position; the coupling says how the fiber is attached to the ground there; and the labels name anything else worth recording per interval. Each of those covers what it covers, and none of them has to cover the whole path.
+The components are the physical pieces the light passes through, and they are what gives the path its extent: each one states the stretch of optical distance it occupies, and they tile — each begins where the last ended — so the path runs from the first to the last. They are read in distance order whatever order the rows are written in, so a component states where it is rather than being counted through to it. The other three describe intervals of that length — the geometry holds the measured curves along the fiber, of which the columns the coordinate reference system names are position; the coupling says how the fiber is attached to the ground there; and the labels name anything else worth recording per interval. Each of those covers what it covers, and none of them has to cover the whole path.
 
 Objects reused in several places — interrogators, cables, enclosures, measurements — are written once under the inventory's `resources` and referred to elsewhere by their `resource_id`. Such a field accepts either the object itself or that string, which is what the dashed edges below mean.
 
@@ -91,10 +91,10 @@ files = {
     ),
     # The tracks along the path, as tables.
     "fiber_arrays/DAS.R2D1/path/optical_components.csv": (
-        "sequence,object_type,optical_length,name\n"
-        "1,FiberSegment,100.0,lead-in\n"
-        "2,Splice,0.0,wellhead splice\n"
-        "3,FiberSegment,400.0,trench cable\n"
+        "object_type,distance_min,distance_max,name\n"
+        "FiberSegment,0,100,lead-in\n"
+        "Splice,100,,wellhead splice\n"
+        "FiberSegment,100,500,trench cable\n"
     ),
     "fiber_arrays/DAS.R2D1/path/coupling.csv": (
         "distance_min,distance_max,coupling_type,medium\n"
@@ -128,6 +128,8 @@ for name, text in files.items():
 
 inventory = dc.inventory(inventory_path)
 ```
+
+A point component — a splice, a connector, a terminator — occupies no measurable length, so it states one distance and leaves `distance_max` blank; the wellhead splice above is one. A fiber segment states both, since one silently collapsing to a point would lose the fiber it stands for.
 
 A few rules make that directory readable without a schema in front of you:
 

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -75,7 +75,7 @@ files = {
         "data_category: DAS\n"
         "data_type: velocity\n"
         "gauge_length: 10.0\n"
-        "spatial_interval: 1.0\n"
+        "distance_step: 1.0\n"
         "interrogator: fi-1\n"
         # Where the interrogator's own axis lands on the optical path.
         "distance_map:\n"
@@ -97,14 +97,14 @@ files = {
         "3,FiberSegment,400.0,trench cable\n"
     ),
     "fiber_arrays/DAS.R2D1/path/coupling.csv": (
-        "start_distance,end_distance,coupling_type,medium\n"
+        "distance_min,distance_max,coupling_type,medium\n"
         "100,400,trench,soil\n"
     ),
     # A geometry column is any number measured along the fiber. This one
     # is the trench's own chainage, and the middle segment is a coil: the
     # chainage stands still while ten meters of fiber goes by.
     "fiber_arrays/DAS.R2D1/path/geometry.csv": (
-        "segment,distance,chainage (m)\n"
+        "name,distance,chainage (m)\n"
         "to the coil,100,1200\n"
         "to the coil,240,1340\n"
         "slack coil,240,1340\n"
@@ -113,7 +113,7 @@ files = {
         "past the coil,400,1490\n"
     ),
     "fiber_arrays/DAS.R2D1/path/labels.csv": (
-        "start_distance,end_distance,group,value\n"
+        "distance_min,distance_max,group,value\n"
         "100,250,zone,north\n"
         "250,400,zone,south\n"
         "150,300,noisy,\n"
@@ -139,7 +139,7 @@ A few rules make that directory readable without a schema in front of you:
 
 Two tracks can hold something that varies along the fiber, and which one to use is decided by how a value behaves between the points which state it. **A quantity which interpolates goes in `geometry.csv`**, one column per quantity, read as a curve through its control points; a column may name its units in its header, `chainage (m)`. **A value which holds over a stretch and then stops goes in `labels.csv`**, a set of intervals rather than a curve — a zone name has no meaning between two of them, and neither does a borehole number. Labels are usually words, then, but a number which identifies rather than measures is a label too. A column of text in a geometry table is refused, and says so.
 
-Position is not a separate kind of thing: a column whose name the coordinate reference system declares — or its canonical `x`, `y`, `z` alias — *is* that axis, takes its units from the CRS, and must be stated with all its siblings, since half a position is not a position. A segment which names none of them, like the chainage above, states no position at all and is perfectly valid. The `segment` names themselves are for humans; what a channel gets is the columns.
+Position is not a separate kind of thing: a column whose name the coordinate reference system declares — or its canonical `x`, `y`, `z` alias — *is* that axis, takes its units from the CRS, and must be stated with all its siblings, since half a position is not a position. A segment which names none of them, like the chainage above, states no position at all and is perfectly valid. The segment `name`s themselves are for humans; what a channel gets is the columns.
 
 # The shape of a track
 

--- a/tests/test_core/test_annotation_loader.py
+++ b/tests/test_core/test_annotation_loader.py
@@ -70,8 +70,8 @@ def curve() -> Moveout:
         apex_time=np.datetime64("2020-01-01T00:00:05"),
         velocity=1500.0,
         standoff=30.0,
-        distance_start=0.0,
-        distance_end=200.0,
+        distance_min=0.0,
+        distance_max=200.0,
     )
 
 
@@ -83,13 +83,13 @@ def regions() -> dc.AnnotationSet:
             "id": ["r1", "r2"],
             "group": ["noise", "noise"],
             "tags": [("road", "car"), None],
-            "distance_start": [120.0, 10.0],
-            "distance_end": [340.0, 60.0],
-            "time_start": [
+            "distance_min": [120.0, 10.0],
+            "distance_max": [340.0, 60.0],
+            "time_min": [
                 np.datetime64("2020-01-01T00:00:10"),
                 np.datetime64("2020-01-01T00:00:20"),
             ],
-            "time_end": [
+            "time_max": [
                 np.datetime64("2020-01-01T00:00:12"),
                 np.datetime64("2020-01-01T00:00:22"),
             ],
@@ -126,8 +126,8 @@ def with_vertices(curve) -> dc.AnnotationSet:
             "group": ["picks", "picks", "noise"],
             "geometry": ["path", "path", "region"],
             "basis": [None, curve, None],
-            "distance_start": [np.nan, np.nan, 5.0],
-            "distance_end": [np.nan, np.nan, 15.0],
+            "distance_min": [np.nan, np.nan, 5.0],
+            "distance_max": [np.nan, np.nan, 15.0],
         }
     )
     return dc.AnnotationSet(frame, dims=DIMS, vertices=vertices)
@@ -141,11 +141,11 @@ def picks() -> dc.AnnotationSet:
             "id": ["m1", "m2"],
             "group": ["arrival", "arrival"],
             "value": ["p", "s"],
-            "time_start": [
+            "time_min": [
                 np.datetime64("2020-01-01T00:00:01"),
                 np.datetime64("2020-01-01T00:00:03"),
             ],
-            "time_end": [
+            "time_max": [
                 np.datetime64("2020-01-01T00:00:02"),
                 np.datetime64("2020-01-01T00:00:04"),
             ],
@@ -189,7 +189,7 @@ class TestRoundTrip:
 
     def test_a_set_of_no_annotations(self, tmp_path):
         """A set with columns and no rows is still that set."""
-        frame = pd.DataFrame({"id": [], "distance_start": [], "distance_end": []})
+        frame = pd.DataFrame({"id": [], "distance_min": [], "distance_max": []})
         out = dc.AnnotationSet(frame, dims=DIMS)
         assert dc.annotations(out.io.save(tmp_path / "picks")) == out
 
@@ -200,7 +200,7 @@ class TestRoundTrip:
             {"id": ["p"] * 2, "seq": [0, 1], "time": TIMES[:2], "distance": [1.0, 5.0]}
         )
         out = dc.AnnotationSet(frame, dims=DIMS, vertices=vertices)
-        held = out.io.to_dataframe()["time_start"]
+        held = out.io.to_dataframe()["time_min"]
         assert held.dtype == np.dtype("datetime64[ns]")
         assert dc.annotations(out.io.save(tmp_path / "picks")) == out
 
@@ -264,8 +264,8 @@ class TestRoundTrip:
         frame = pd.DataFrame(
             {
                 "group": ["a", "b"],
-                "distance_start": [1.0, np.nan],
-                "distance_end": [2.0, np.nan],
+                "distance_min": [1.0, np.nan],
+                "distance_max": [2.0, np.nan],
             }
         )
         annotations = dc.AnnotationSet(frame, dims=("distance",))
@@ -282,8 +282,8 @@ class TestDeclaredDtypes:
         """A set declaring a categorical and a nullable integer column."""
         frame = pd.DataFrame(
             {
-                "distance_start": [0.0, 1.0],
-                "distance_end": [1.0, 2.0],
+                "distance_min": [0.0, 1.0],
+                "distance_max": [1.0, 2.0],
                 "kind": pd.Series(["a", "b"], dtype="category"),
                 "count": pd.Series([1, None], dtype="Int64"),
             }
@@ -315,7 +315,7 @@ class TestDeclaredDtypes:
     def test_a_declared_text_dtype_keeps_blank_cells_unset(self, tmp_path):
         """Text is not cast on reload, so a blank stays a blank, not the word 'nan'."""
         frame = pd.DataFrame(
-            {"distance_start": [0.0, 1.0], "distance_end": [1.0, 2.0], "n": ["a", None]}
+            {"distance_min": [0.0, 1.0], "distance_max": [1.0, 2.0], "n": ["a", None]}
         )
         built = dc.AnnotationSet(
             frame, dims=("distance",), columns={"n": {"dtype": "str"}}
@@ -330,8 +330,8 @@ class TestDeclaredDtypes:
         """
         frame = pd.DataFrame(
             {
-                "distance_start": [0.0, 1.0, 2.0],
-                "distance_end": [1.0, 2.0, 3.0],
+                "distance_min": [0.0, 1.0, 2.0],
+                "distance_max": [1.0, 2.0, 3.0],
                 "label": ["001", "true", "2020-01-01"],
             }
         )
@@ -356,7 +356,7 @@ class TestDeclaredDtypes:
 
     def test_an_unreadable_declared_dtype(self, tmp_path):
         """A dtype naming nothing is refused on reload as it is on building."""
-        frame = pd.DataFrame({"distance_start": [0.0], "distance_end": [1.0], "n": [1]})
+        frame = pd.DataFrame({"distance_min": [0.0], "distance_max": [1.0], "n": [1]})
         directory = dc.AnnotationSet(frame, dims=("distance",)).io.save(
             tmp_path / "set"
         )
@@ -369,7 +369,7 @@ class TestDeclaredDtypes:
 
     def test_a_declaration_which_is_not_one(self, tmp_path):
         """A column spec which is no mapping is refused as a bad attrs file."""
-        frame = pd.DataFrame({"distance_start": [0.0], "distance_end": [1.0], "n": [1]})
+        frame = pd.DataFrame({"distance_min": [0.0], "distance_max": [1.0], "n": [1]})
         directory = dc.AnnotationSet(frame, dims=("distance",)).io.save(
             tmp_path / "set"
         )
@@ -382,9 +382,7 @@ class TestDeclaredDtypes:
 
     def test_a_declaration_the_cells_cannot_hold(self, tmp_path):
         """A declaration edited to something the column is not says so."""
-        frame = pd.DataFrame(
-            {"distance_start": [0.0], "distance_end": [1.0], "n": ["x"]}
-        )
+        frame = pd.DataFrame({"distance_min": [0.0], "distance_max": [1.0], "n": ["x"]})
         directory = dc.AnnotationSet(frame, dims=("distance",)).io.save(
             tmp_path / "set"
         )
@@ -520,7 +518,7 @@ class TestDurationDimensions:
         """A set whose dimension is an offset from something."""
         spans = np.array([1, 3], dtype="timedelta64[s]")
         frame = pd.DataFrame(
-            {"id": ["a"], "offset_start": spans[:1], "offset_end": spans[1:]}
+            {"id": ["a"], "offset_min": spans[:1], "offset_max": spans[1:]}
         )
         return dc.AnnotationSet(frame, dims=("offset",))
 
@@ -881,7 +879,7 @@ class TestTheTables:
     def test_a_dimension_no_row_states(self, tmp_path):
         """A column every row leaves empty constrains nothing."""
         path = tmp_path / "picks.csv"
-        path.write_text("group,time_start,time_end\nquiet,,\n")
+        path.write_text("group,time_min,time_max\nquiet,,\n")
         loaded = dc.annotations(path, dims=("time",))
         assert "time" not in loaded[0].region.bounds
 
@@ -890,8 +888,8 @@ class TestTheTables:
         frame = pd.DataFrame(
             {
                 "group": ["a"],
-                "time_start": [np.datetime64("2020-01-01T12:30")],
-                "time_end": [np.datetime64("2020-01-01T12:35")],
+                "time_min": [np.datetime64("2020-01-01T12:30")],
+                "time_max": [np.datetime64("2020-01-01T12:35")],
             }
         )
         annotations = dc.AnnotationSet(frame, dims=("time",))
@@ -905,8 +903,8 @@ class TestTheTables:
         frame = pd.DataFrame(
             {
                 "group": ["a", "b"],
-                "time_start": ["2020-01-01", blank],
-                "time_end": ["2020-01-02", blank],
+                "time_min": ["2020-01-01", blank],
+                "time_max": ["2020-01-02", blank],
             }
         )
         out = dc.AnnotationSet(frame, dims=("time",))
@@ -915,9 +913,9 @@ class TestTheTables:
 
     def test_a_text_dimension_column_agrees_with_its_region(self):
         """The frame and the geometry built from it say the same thing."""
-        frame = pd.DataFrame({"time_start": ["2020-01-01"], "time_end": ["2020-01-02"]})
+        frame = pd.DataFrame({"time_min": ["2020-01-01"], "time_max": ["2020-01-02"]})
         out = dc.AnnotationSet(frame, dims=("time",))
-        held = out.io.to_dataframe()["time_start"][0]
+        held = out.io.to_dataframe()["time_min"][0]
         assert isinstance(held, pd.Timestamp | np.datetime64)
         assert out[0].region.bounds["time"][0] == np.datetime64("2020-01-01")
 
@@ -1011,14 +1009,14 @@ class TestCollections:
     def test_a_dimension_one_set_leaves_blank(self, tmp_path):
         """A set stating no time beside one which does still holds times."""
         root = tmp_path / "sets"
-        blank = pd.DataFrame({"id": ["a"], "time_start": [None], "time_end": [None]})
+        blank = pd.DataFrame({"id": ["a"], "time_min": [None], "time_max": [None]})
         dc.AnnotationSet(blank, dims=DIMS).io.save(root / "one")
         stated = pd.DataFrame(
-            {"id": ["b"], "time_start": TIMES[:1], "time_end": TIMES[1:2]}
+            {"id": ["b"], "time_min": TIMES[:1], "time_max": TIMES[1:2]}
         )
         dc.AnnotationSet(stated, dims=DIMS).io.save(root / "two")
         merged = dc.annotations(root)
-        held = merged.io.to_dataframe()["time_start"]
+        held = merged.io.to_dataframe()["time_min"]
         assert held.dtype == np.dtype("datetime64[ns]")
         assert dc.annotations(merged.io.save(tmp_path / "flat")) == merged
 
@@ -1116,7 +1114,7 @@ class TestCollections:
             directory = root / name
             directory.mkdir(parents=True)
             (directory / "annotations.csv").write_text(
-                f"id,group,time_start,time_end\n{name},noise,1.0,2.0\n"
+                f"id,group,time_min,time_max\n{name},noise,1.0,2.0\n"
             )
         assert len(dc.annotations(root, dims=("time",))) == 2
         with pytest.raises(InvalidAnnotationError, match="states no dimensions"):
@@ -1127,7 +1125,7 @@ class TestCollections:
         root = tmp_path / "sets"
         directory = root / "hand"
         directory.mkdir(parents=True)
-        (directory / "annotations.csv").write_text("group,time_start,time_end\nq,1,2\n")
+        (directory / "annotations.csv").write_text("group,time_min,time_max\nq,1,2\n")
         (root / "attrs.json").write_text('{"dims": ["time"]}')
         assert dc.annotations(root).dims == ("time",)
         with pytest.raises(
@@ -1182,11 +1180,11 @@ class TestCollections:
             {
                 "id": ["m1", "m2"],
                 "acquisition_key": ["NET.OTHER.00.das", None],
-                "time_start": [
+                "time_min": [
                     np.datetime64("2020-01-01T00:00:31"),
                     np.datetime64("2020-01-01T00:00:33"),
                 ],
-                "time_end": [
+                "time_max": [
                     np.datetime64("2020-01-01T00:00:32"),
                     np.datetime64("2020-01-01T00:00:34"),
                 ],
@@ -1240,7 +1238,7 @@ class TestCollections:
         picks.io.save(root / "phasenet")
         blank = root / "quiet"
         blank.mkdir(parents=True)
-        (blank / "annotations.csv").write_text("group,time_start,time_end\nq,,\n")
+        (blank / "annotations.csv").write_text("group,time_min,time_max\nq,,\n")
         (blank / "attrs.json").write_text('{"dims": ["time"]}')
         assert len(dc.annotations(root)) == len(picks) + 1
 
@@ -1411,14 +1409,14 @@ class TestDeclaringDimensionsInTheTable:
     def test_a_bare_table_declares_them(self, tmp_path):
         """The dimensions travel with the file rather than with the call."""
         path = tmp_path / "picks.csv"
-        path.write_text("# dims: distance, time\ngroup,time_start,time_end\nq,1,2\n")
+        path.write_text("# dims: distance, time\ngroup,time_min,time_max\nq,1,2\n")
         loaded = dc.annotations(path)
         assert loaded.dims == ("distance", "time")
         # The header is the one below the pragma, not the pragma itself.
         assert set(loaded.io.to_dataframe().columns) == {
             "group",
-            "time_start",
-            "time_end",
+            "time_min",
+            "time_max",
         }
         assert loaded[0].group == "q"
         assert loaded[0].region.bounds["time"] == (1.0, 2.0)
@@ -1692,8 +1690,7 @@ class TestPrivateColumns:
         """A note on how something was deployed stays in the file."""
         path = tmp_path / "picks.csv"
         path.write_text(
-            "id,group,distance_start,distance_end,_crew\n"
-            "r1,noise,10.0,60.0,north crew\n"
+            "id,group,distance_min,distance_max,_crew\nr1,noise,10.0,60.0,north crew\n"
         )
         loaded = dc.annotations(path, dims=DIMS)
         assert "_crew" not in loaded.io.to_dataframe().columns
@@ -1765,11 +1762,11 @@ class TestParquet:
                 "group": ["noise", "quiet"],
                 "value": ["car", 3],
                 "tags": [("road", "car"), None],
-                "time_start": [
+                "time_min": [
                     np.datetime64("2020-01-01T00:00:10"),
                     np.datetime64("2020-01-01T00:00:20"),
                 ],
-                "time_end": [
+                "time_max": [
                     np.datetime64("2020-01-01T00:00:12"),
                     np.datetime64("2020-01-01T00:00:22"),
                 ],

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -397,6 +397,17 @@ class TestColumns:
         out = AnnotationSet(pd.DataFrame({"score": [np.nan]}), dims=DIMS)
         assert "score" not in out[0].extra
 
+    def test_a_retired_range_spelling_says_what_to_write(self):
+        """A set written before the rename is told its columns' new names.
+
+        Left alone, `<dim>_start`/`<dim>_end` read as two unrelated extras
+        and the annotation covers everything instead of what it states --
+        a wrong answer rather than a refusal.
+        """
+        frame = pd.DataFrame({"group": ["quiet"], "time_start": [0], "time_end": [1]})
+        with pytest.raises(ParameterError, match="now spells _min/_max"):
+            AnnotationSet(frame, dims=DIMS)
+
     def test_undeclared_range_pair_refused(self):
         """A range naming no declared dimension is a forgotten dimension."""
         frame = pd.DataFrame({"depth_min": [1], "depth_max": [2]})

--- a/tests/test_core/test_annotations.py
+++ b/tests/test_core/test_annotations.py
@@ -41,8 +41,8 @@ def region_set():
         {
             "group": ["event", "event", "noisy"],
             "value": ["car", "truck", None],
-            "distance_start": [10.0, 30.0, 0.0],
-            "distance_end": [80.0, 90.0, 100.0],
+            "distance_min": [10.0, 30.0, 0.0],
+            "distance_max": [80.0, 90.0, 100.0],
         }
     )
     return AnnotationSet(frame, dims=DIMS)
@@ -57,8 +57,8 @@ def path_set():
             "group": ["pick", "pick"],
             "value": ["car", "truck"],
             "geometry": ["path", "region"],
-            "distance_start": [np.nan, 10.0],
-            "distance_end": [np.nan, 80.0],
+            "distance_min": [np.nan, 10.0],
+            "distance_max": [np.nan, 80.0],
         }
     )
     vertices = pd.DataFrame(
@@ -156,8 +156,8 @@ class TestConstruction:
             {
                 "id": ["a", "b", "c"],
                 "geometry": ["path", "", None],
-                "distance_start": [np.nan, 10.0, 20.0],
-                "distance_end": [np.nan, 80.0, 90.0],
+                "distance_min": [np.nan, 10.0, 20.0],
+                "distance_max": [np.nan, 80.0, 90.0],
             }
         )
         vertices = pd.DataFrame(
@@ -232,7 +232,7 @@ class TestDimensionSpelling:
     def test_timedelta_endpoints_keep_their_type(self):
         """A bound on a lag dimension is a duration, not the integer behind it."""
         lags = np.array([1, 5], dtype="timedelta64[s]")
-        frame = pd.DataFrame({"time_start": lags[:1], "time_end": lags[1:]})
+        frame = pd.DataFrame({"time_min": lags[:1], "time_max": lags[1:]})
         start, end = AnnotationSet(frame, dims=DIMS)[0].region.bounds["time"]
         assert isinstance(start, np.timedelta64)
         assert isinstance(end, np.timedelta64)
@@ -243,36 +243,36 @@ class TestDimensionSpelling:
 
     def test_unstated_cell_is_unconstrained(self):
         """A blank cell constrains nothing, even where the column exists."""
-        frame = pd.DataFrame({"distance_start": [np.nan], "distance_end": [np.nan]})
+        frame = pd.DataFrame({"distance_min": [np.nan], "distance_max": [np.nan]})
         assert AnnotationSet(frame, dims=DIMS)[0].region.bounds == {}
 
     def test_both_spellings_refused(self):
         """One dimension is spelled one way."""
-        frame = pd.DataFrame({"time": [1], "time_start": [1], "time_end": [2]})
+        frame = pd.DataFrame({"time": [1], "time_min": [1], "time_max": [2]})
         with pytest.raises(ParameterError, match="both as a point"):
             AnnotationSet(frame, dims=DIMS)
 
     def test_half_a_range_refused(self):
         """A start with no end does not bound anything."""
         with pytest.raises(ParameterError, match="half a range"):
-            AnnotationSet(pd.DataFrame({"time_start": [1]}), dims=DIMS)
+            AnnotationSet(pd.DataFrame({"time_min": [1]}), dims=DIMS)
 
     def test_reversed_range_refused(self):
         """An impossible range is structural, so the set does not load."""
-        frame = pd.DataFrame({"distance_start": [9.0], "distance_end": [1.0]})
+        frame = pd.DataFrame({"distance_min": [9.0], "distance_max": [1.0]})
         with pytest.raises(ParameterError, match="ends before it starts"):
             AnnotationSet(frame, dims=DIMS)
 
     def test_reversed_range_names_its_row(self):
         """The refused row is named, so a long set says which one."""
-        frame = pd.DataFrame({"distance_start": [0.0, 9.0], "distance_end": [1.0, 1.0]})
+        frame = pd.DataFrame({"distance_min": [0.0, 9.0], "distance_max": [1.0, 1.0]})
         with pytest.raises(ParameterError, match="Row 1"):
             AnnotationSet(frame, dims=DIMS)
 
-    @pytest.mark.parametrize("side", ["distance_start", "distance_end"])
+    @pytest.mark.parametrize("side", ["distance_min", "distance_max"])
     def test_half_a_range_cell_refused(self, side):
         """A row states both ends or neither; one end bounds nothing."""
-        frame = pd.DataFrame({"distance_start": [np.nan], "distance_end": [np.nan]})
+        frame = pd.DataFrame({"distance_min": [np.nan], "distance_max": [np.nan]})
         frame[side] = [1.0]
         with pytest.raises(ParameterError, match="half a distance range"):
             AnnotationSet(frame, dims=DIMS)
@@ -280,23 +280,23 @@ class TestDimensionSpelling:
     def test_incomparable_range_refused(self):
         """A range whose ends cannot be compared says so, not TypeError."""
         when = np.datetime64("2020-01-01", "ns")
-        frame = pd.DataFrame({"distance_start": [1.0], "distance_end": [when]})
+        frame = pd.DataFrame({"distance_min": [1.0], "distance_max": [when]})
         with pytest.raises(ParameterError, match="cannot be compared"):
             AnnotationSet(frame, dims=DIMS)
 
-    @pytest.mark.parametrize("spelling", ["distance", "distance_start"])
+    @pytest.mark.parametrize("spelling", ["distance", "distance_min"])
     def test_text_in_a_dimension_refused(self, spelling):
         """A dimension is a coordinate, so a word is no place on it."""
         frame = pd.DataFrame({spelling: ["alpha"]})
         if spelling != "distance":
-            frame["distance_end"] = ["omega"]
+            frame["distance_max"] = ["omega"]
         with pytest.raises(ParameterError, match="neither numbers, times"):
             AnnotationSet(frame, dims=DIMS)
 
     def test_numeric_text_in_a_dimension_is_read_as_numbers(self):
         """Read as a stored table reads it, so the two cannot disagree."""
         frame = pd.DataFrame(
-            {"distance_start": ["1.5", None], "distance_end": ["2", None]}
+            {"distance_min": ["1.5", None], "distance_max": ["2", None]}
         )
         out = AnnotationSet(frame, dims=DIMS)
         assert out[0].region.bounds["distance"] == (1.5, 2.0)
@@ -349,9 +349,9 @@ class TestDimensionSpelling:
     def test_a_duration_dimension_is_a_coordinate(self):
         """A dimension may be an offset from something, which is a duration."""
         spans = np.array([1, 3], dtype="timedelta64[s]")
-        frame = pd.DataFrame({"offset_start": spans[:1], "offset_end": spans[1:]})
+        frame = pd.DataFrame({"offset_min": spans[:1], "offset_max": spans[1:]})
         out = AnnotationSet(frame, dims=("offset",))
-        assert out.io.to_dataframe()["offset_start"].dtype == "timedelta64[ns]"
+        assert out.io.to_dataframe()["offset_min"].dtype == "timedelta64[ns]"
 
     def test_a_dimension_mixing_numbers_and_times(self):
         """A number already read as one is not re-read as an epoch."""
@@ -378,7 +378,7 @@ class TestDimensionSpelling:
 
     def test_datetime_endpoints_keep_their_type(self):
         """A time bound is a time, not the integer behind it."""
-        frame = pd.DataFrame({"time_start": TIMES[:1], "time_end": TIMES[2:]})
+        frame = pd.DataFrame({"time_min": TIMES[:1], "time_max": TIMES[2:]})
         start, end = AnnotationSet(frame, dims=DIMS)[0].region.bounds["time"]
         assert isinstance(start, np.datetime64)
         assert isinstance(end, np.datetime64)
@@ -399,14 +399,14 @@ class TestColumns:
 
     def test_undeclared_range_pair_refused(self):
         """A range naming no declared dimension is a forgotten dimension."""
-        frame = pd.DataFrame({"depth_start": [1], "depth_end": [2]})
+        frame = pd.DataFrame({"depth_min": [1], "depth_max": [2]})
         with pytest.raises(ParameterError, match="name no declared dimension"):
             AnnotationSet(frame, dims=DIMS)
 
     def test_lone_range_column_is_an_extra(self):
         """One half of a range names no dimension, so it is just a column."""
-        out = AnnotationSet(pd.DataFrame({"depth_start": [1]}), dims=DIMS)
-        assert out[0].extra["depth_start"] == 1
+        out = AnnotationSet(pd.DataFrame({"depth_min": [1]}), dims=DIMS)
+        assert out[0].extra["depth_min"] == 1
 
     def test_the_set_column_is_a_label(self):
         """A row read with others says which set it came from."""
@@ -429,7 +429,7 @@ class TestColumns:
     def test_a_private_column_states_no_dimension(self):
         """Underscoring a range column makes it nothing, not a bound."""
         frame = pd.DataFrame(
-            {"group": ["a"], "_distance_start": [1.0], "_distance_end": [2.0]}
+            {"group": ["a"], "_distance_min": [1.0], "_distance_max": [2.0]}
         )
         out = AnnotationSet(frame, dims=DIMS)
         assert out[0].region.bounds == {}
@@ -521,8 +521,8 @@ class TestColumns:
         """A categorical extra is carried like any other, blank cells and all."""
         frame = pd.DataFrame(
             {
-                "distance_start": [0.0, 1.0],
-                "distance_end": [1.0, 2.0],
+                "distance_min": [0.0, 1.0],
+                "distance_max": [1.0, 2.0],
                 "note": pd.Series(["a", ""], dtype="category"),
             }
         )
@@ -532,7 +532,7 @@ class TestColumns:
 
     def test_a_column_named_by_something_other_than_a_string(self):
         """A table names a column by a string, so a set does too."""
-        frame = pd.DataFrame({"distance_start": [0.0], "distance_end": [1.0], 1: ["x"]})
+        frame = pd.DataFrame({"distance_min": [0.0], "distance_max": [1.0], 1: ["x"]})
         with pytest.raises(ParameterError, match="other than a string"):
             AnnotationSet(frame, dims=DIMS)
 
@@ -610,8 +610,8 @@ class TestValues:
             {
                 "group": ["g", "g"],
                 "value": ["a", "b"],
-                "distance_start": [0.0, 5.0],
-                "distance_end": [10.0, 15.0],
+                "distance_min": [0.0, 5.0],
+                "distance_max": [10.0, 15.0],
             }
         )
         assert len(AnnotationSet(frame, dims=DIMS)) == 2
@@ -738,7 +738,7 @@ class TestIdentity:
         bounds beside it.
         """
         frame = pd.DataFrame(
-            {"id": [1], "value": [1], "distance_start": [0.0], "distance_end": [1.0]}
+            {"id": [1], "value": [1], "distance_min": [0.0], "distance_max": [1.0]}
         )
         out = AnnotationSet(frame, dims=DIMS)[0]
         assert out.id == "1"
@@ -882,7 +882,7 @@ class TestVertices:
     def test_derived_bounds_reach_the_frame(self, path_set):
         """The derived box is a real column, so table operations see it."""
         row = path_set.io.to_dataframe().iloc[0]
-        assert (row["distance_start"], row["distance_end"]) == (1.0, 9.0)
+        assert (row["distance_min"], row["distance_max"]) == (1.0, 9.0)
 
     def test_stated_bounds_must_agree(self):
         """The vertices are the shape; a box which disagrees is refused."""
@@ -890,8 +890,8 @@ class TestVertices:
             {
                 "id": ["x"],
                 "geometry": ["path"],
-                "distance_start": [99.0],
-                "distance_end": [100.0],
+                "distance_min": [99.0],
+                "distance_max": [100.0],
             }
         )
         vertices = pd.DataFrame(
@@ -1163,9 +1163,9 @@ class TestAttrs:
             AnnotationSetAttrs(dims=("time", "time"))
 
     def test_dim_may_not_alias_another_dims_range(self):
-        """`distance_start` would be both a point and the start of `distance`."""
+        """`distance_min` would be both a point and the start of `distance`."""
         with pytest.raises(ValidationError, match="spelled like the range column"):
-            AnnotationSetAttrs(dims=("distance", "distance_start"))
+            AnnotationSetAttrs(dims=("distance", "distance_min"))
 
     def test_dim_may_not_shadow_a_reserved_column(self):
         """A dimension named `group` would collide with the group column."""
@@ -1281,8 +1281,8 @@ class TestBasis:
             apex_distance=50.0,
             apex_time=TIMES[0],
             velocity=3000.0,
-            distance_start=0.0,
-            distance_end=100.0,
+            distance_min=0.0,
+            distance_max=100.0,
         )
         drawn = out.vertices(11)
         assert drawn["time"].min() == TIMES[0]
@@ -1294,8 +1294,8 @@ class TestBasis:
             apex_distance=50.0,
             apex_time=TIMES[0],
             velocity=3000.0,
-            distance_start=0.0,
-            distance_end=100.0,
+            distance_min=0.0,
+            distance_max=100.0,
         )
         seconds = (out.vertices(3)["time"] - TIMES[0]) / np.timedelta64(1, "s")
         assert np.allclose(seconds, [50 / 3000, 0.0, 50 / 3000])
@@ -1306,8 +1306,8 @@ class TestBasis:
             "apex_distance": 50.0,
             "apex_time": TIMES[0],
             "velocity": 3000.0,
-            "distance_start": 0.0,
-            "distance_end": 100.0,
+            "distance_min": 0.0,
+            "distance_max": 100.0,
         }
         straight = Moveout(**shared).vertices(3)["time"]
         curved = Moveout(**shared, standoff=40.0).vertices(3)["time"]
@@ -1320,8 +1320,8 @@ class TestBasis:
             apex_distance=0.0,
             apex_time=TIMES[0],
             velocity=1000.0,
-            distance_start=0.0,
-            distance_end=10.0,
+            distance_min=0.0,
+            distance_max=10.0,
         )
         assert out.vertices(2)["time"].dtype == np.dtype("datetime64[ns]")
 
@@ -1331,8 +1331,8 @@ class TestBasis:
             apex_distance=0.0,
             apex_time=TIMES[0],
             velocity=1000.0,
-            distance_start=0.0,
-            distance_end=1.0,
+            distance_min=0.0,
+            distance_max=1.0,
         )
         assert out.dims == ("distance", "time")
 
@@ -1343,8 +1343,8 @@ class TestBasis:
                 apex_distance=0.0,
                 apex_time=TIMES[0],
                 velocity=0.0,
-                distance_start=0.0,
-                distance_end=1.0,
+                distance_min=0.0,
+                distance_max=1.0,
             )
 
     def test_moveout_standoff_not_negative(self):
@@ -1355,8 +1355,8 @@ class TestBasis:
                 apex_time=TIMES[0],
                 velocity=1.0,
                 standoff=-1.0,
-                distance_start=0.0,
-                distance_end=1.0,
+                distance_min=0.0,
+                distance_max=1.0,
             )
 
     def test_moveout_span_must_be_positive(self):
@@ -1366,8 +1366,8 @@ class TestBasis:
                 apex_distance=0.0,
                 apex_time=TIMES[0],
                 velocity=1.0,
-                distance_start=1.0,
-                distance_end=1.0,
+                distance_min=1.0,
+                distance_max=1.0,
             )
 
     @pytest.mark.parametrize("count", [0, 1])
@@ -1404,8 +1404,8 @@ class TestBasis:
             apex_time=TIMES[0],
             velocity=3000.0,
             standoff=40.0,
-            distance_start=0.0,
-            distance_end=100.0,
+            distance_min=0.0,
+            distance_max=100.0,
         )
         drawn = basis.vertices(5)
         vertices = pd.DataFrame({"id": ["m"] * 5, "seq": range(5), **drawn})
@@ -1496,8 +1496,8 @@ class TestBasisColumn:
             apex_distance=0.0,
             apex_time=TIMES[0],
             velocity=2.0,
-            distance_start=0.0,
-            distance_end=1.0,
+            distance_min=0.0,
+            distance_max=1.0,
         )
         frame = pd.DataFrame({"id": ["x"], "geometry": ["path"], "basis": [basis]})
         out = AnnotationSet(frame, dims=DIMS, vertices=self._vertices())
@@ -1554,8 +1554,8 @@ class TestSerialization:
                 apex_distance=0.0,
                 apex_time=TIMES[0],
                 velocity=1.0,
-                distance_start=0.0,
-                distance_end=1.0,
+                distance_min=0.0,
+                distance_max=1.0,
             ),
         ],
     )
@@ -1569,8 +1569,8 @@ class TestSerialization:
             apex_distance=0.0,
             apex_time=TIMES[0],
             velocity=2.0,
-            distance_start=0.0,
-            distance_end=1.0,
+            distance_min=0.0,
+            distance_max=1.0,
         )
         path = Path(
             region=Region(bounds={"distance": (0.0, 1.0)}),

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -572,6 +572,19 @@ class TestComponentPlacement:
         marker = inv.Connector(distance_min=5.0)
         assert marker.new(distance_min=moved).interval == (moved, moved)
 
+    def test_stating_an_end_gives_a_marker_a_length(self):
+        """Setting the end is not the mirror of moving the marker.
+
+        A marker's end is filled in, so moving the start carries it. The
+        start is the author's, so stating an end is them giving the item a
+        length rather than moving it -- and an end before the start is
+        refused here as on every other interval.
+        """
+        marker = inv.Connector(distance_min=5.0)
+        assert marker.new(distance_max=8.0).interval == (5.0, 8.0)
+        with pytest.raises(ValidationError, match="must not precede"):
+            marker.new(distance_max=3.0)
+
     def test_a_sized_point_component_keeps_its_length(self):
         """Only a marker's end follows; a stated length is the author's."""
         splice = inv.Splice(distance_min=5.0, distance_max=5.5)

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -29,39 +29,39 @@ def build_inventory() -> inv.Inventory:
     acquisition = inv.Acquisition(
         code="RAW",
         location_code="00",
-        start_time="2026-06-01",
+        time_min="2026-06-01",
         data_category="DAS",
         data_type="strain_rate",
         sample_rate=500.0,
         gauge_length=10.0,
-        spatial_interval=1.0,
+        distance_step=1.0,
         distance_map=inv.DistanceMap(channel=(0.0,), distance=(0.0,)),
     )
     geometry = inv.Geometry(
         name="survey",
         distance=(0.0, 100.0, 200.0),
-        coordinates={"x": (0.0, 1.0, 2.0), "y": (0.0, 0.0, 0.0), "z": (0.0, 0.0, 1.0)},
+        columns={"x": (0.0, 1.0, 2.0), "y": (0.0, 0.0, 0.0), "z": (0.0, 0.0, 1.0)},
     )
     path = inv.OpticalPath(
         name="main",
         location_code="00",
-        start_time="2026-06-01",
+        time_min="2026-06-01",
         optical_components=(inv.FiberSegment(name="fiber", optical_length=250.0),),
         geometry=(geometry,),
         coupling=(
             inv.CouplingCondition(
-                start_distance=0.0, end_distance=200.0, coupling_type="trench"
+                distance_min=0.0, distance_max=200.0, coupling_type="trench"
             ),
         ),
         labels=(
             inv.OpticalPathLabel(
-                start_distance=0.0, end_distance=100.0, group="zone", value="east"
+                distance_min=0.0, distance_max=100.0, group="zone", value="east"
             ),
         ),
     )
     array = inv.FiberArray(
         code="L001",
-        start_time="2026-06-01",
+        time_min="2026-06-01",
         acquisitions=(acquisition,),
         optical_paths=(path,),
     )
@@ -81,7 +81,7 @@ def build_full_inventory() -> inv.Inventory:
     path = inv.OpticalPath(
         name="main",
         location_code="00",
-        start_time="2026-06-01",
+        time_min="2026-06-01",
         optical_components=(
             inv.FiberSegment(
                 name="lead",
@@ -100,7 +100,7 @@ def build_full_inventory() -> inv.Inventory:
             inv.Geometry(
                 name="trench",
                 distance=(100.0, 400.0),
-                coordinates={
+                columns={
                     "x": (-117.0, -117.0),
                     "y": (40.0, 40.1),
                     "z": (1500.0, 1500.0),
@@ -109,8 +109,8 @@ def build_full_inventory() -> inv.Inventory:
         ),
         coupling=(
             inv.CouplingCondition(
-                start_distance=100.0,
-                end_distance=250.0,
+                distance_min=100.0,
+                distance_max=250.0,
                 coupling_type="trench",
                 medium="soil",
                 depth=1.0,
@@ -118,16 +118,14 @@ def build_full_inventory() -> inv.Inventory:
         ),
         labels=(
             inv.OpticalPathLabel(
-                start_distance=100.0, end_distance=200.0, group="zone", value="north"
+                distance_min=100.0, distance_max=200.0, group="zone", value="north"
+            ),
+            inv.OpticalPathLabel(distance_min=150.0, distance_max=300.0, group="noisy"),
+            inv.OpticalPathLabel(
+                distance_min=100.0, distance_max=200.0, group="count", value=0
             ),
             inv.OpticalPathLabel(
-                start_distance=150.0, end_distance=300.0, group="noisy"
-            ),
-            inv.OpticalPathLabel(
-                start_distance=100.0, end_distance=200.0, group="count", value=0
-            ),
-            inv.OpticalPathLabel(
-                start_distance=200.0, end_distance=300.0, group="offset", value=0.0
+                distance_min=200.0, distance_max=300.0, group="offset", value=0.0
             ),
         ),
         measurements=(measurement,),
@@ -135,13 +133,13 @@ def build_full_inventory() -> inv.Inventory:
     acquisition = inv.Acquisition(
         code="RAW",
         location_code="00",
-        start_time="2026-06-01",
+        time_min="2026-06-01",
         data_category="DAS",
         data_type="strain_rate",
         data_units="strain/s",
         sample_rate=500.0,
         gauge_length=10.0,
-        spatial_interval=1.0,
+        distance_step=1.0,
         interrogator=interrogator,
         interrogator_port="1",
         extra_fields={"native_key": "", "count": 0},
@@ -164,14 +162,14 @@ def build_full_inventory() -> inv.Inventory:
     array = inv.FiberArray(
         code="R2D1",
         name="array one",
-        start_time="2026-06-01",
+        time_min="2026-06-01",
         acquisitions=(acquisition,),
         optical_paths=(path,),
     )
     network = inv.Network(
         code="DAS",
         name="network one",
-        start_time="2026-06-01",
+        time_min="2026-06-01",
         fiber_arrays=(array,),
         stations=(station,),
     )
@@ -205,7 +203,7 @@ class TestGeometryColumns:
         chainage = inv.Geometry(
             name="chainage",
             distance=(0.0, 100.0),
-            coordinates={"chainage": (1200.0, 1300.0)},
+            columns={"chainage": (1200.0, 1300.0)},
             units={"chainage": "m"},
         )
         assert self._inventory(chainage).check() is not None
@@ -215,7 +213,7 @@ class TestGeometryColumns:
     def test_a_segment_with_no_axes_is_legal(self):
         """A path may be described without ever being placed in space."""
         depth = inv.Geometry(
-            distance=(0.0, 40.0), coordinates={"borehole_depth": (0.0, 40.0)}
+            distance=(0.0, 40.0), columns={"borehole_depth": (0.0, 40.0)}
         )
         inventory = self._inventory(depth)
         assert inventory.check() is inventory
@@ -226,7 +224,7 @@ class TestGeometryColumns:
     def test_axes_are_all_or_none(self):
         """Half a position is not a position."""
         partial = inv.Geometry(
-            name="partial", distance=(0.0, 10.0), coordinates={"x": (0.0, 1.0)}
+            name="partial", distance=(0.0, 10.0), columns={"x": (0.0, 1.0)}
         )
         with pytest.raises(InvalidInventoryError, match="every axis or none"):
             self._inventory(partial).check()
@@ -239,7 +237,7 @@ class TestGeometryColumns:
         doubled = inv.Geometry(
             name="doubled",
             distance=(0.0, 10.0),
-            coordinates={
+            columns={
                 "x": (0.0, 1.0),
                 "easting": (0.0, 1.0),
                 "northing": (0.0, 1.0),
@@ -250,18 +248,18 @@ class TestGeometryColumns:
 
     def test_overlap_is_refused_per_column(self):
         """Two segments may overlap unless they state the same column."""
-        first = inv.Geometry(distance=(0.0, 60.0), coordinates={"depth": (0.0, 6.0)})
-        second = inv.Geometry(distance=(50.0, 80.0), coordinates={"depth": (5.0, 8.0)})
+        first = inv.Geometry(distance=(0.0, 60.0), columns={"depth": (0.0, 6.0)})
+        second = inv.Geometry(distance=(50.0, 80.0), columns={"depth": (5.0, 8.0)})
         with pytest.raises(InvalidInventoryError, match="for column 'depth'"):
             self._inventory(first, second).check()
 
     def test_different_columns_may_overlap(self):
         """Each column is its own function track, so they are independent."""
         depth = inv.Geometry(
-            name="hole 1", distance=(0.0, 60.0), coordinates={"depth": (0.0, 6.0)}
+            name="hole 1", distance=(0.0, 60.0), columns={"depth": (0.0, 6.0)}
         )
         azimuth = inv.Geometry(
-            name="hole 1", distance=(50.0, 80.0), coordinates={"azimuth": (5.0, 8.0)}
+            name="hole 1", distance=(50.0, 80.0), columns={"azimuth": (5.0, 8.0)}
         )
         inventory = self._inventory(depth, azimuth)
         assert inventory.check() is inventory
@@ -271,27 +269,27 @@ class TestGeometryColumns:
         depth = inv.Geometry(
             name="depth survey",
             distance=(0.0, 60.0),
-            coordinates={"depth": (0.0, 6.0)},
+            columns={"depth": (0.0, 6.0)},
         )
         azimuth = inv.Geometry(
             name="azimuth survey",
             distance=(50.0, 80.0),
-            coordinates={"azimuth": (5.0, 8.0)},
+            columns={"azimuth": (5.0, 8.0)},
         )
         with pytest.raises(InvalidInventoryError, match="share its name"):
             self._inventory(depth, azimuth).check()
 
     def test_a_reserved_column_name(self):
         """A column becomes a coordinate, so it cannot shadow one."""
-        clash = inv.Geometry(distance=(0.0, 10.0), coordinates={"time": (0.0, 1.0)})
+        clash = inv.Geometry(distance=(0.0, 10.0), columns={"time": (0.0, 1.0)})
         with pytest.raises(InvalidInventoryError, match="reserved name"):
             self._inventory(clash).check()
 
     def test_a_column_which_is_also_a_label_group(self):
         """One name is one coordinate, whichever track would define it."""
-        column = inv.Geometry(distance=(0.0, 10.0), coordinates={"zone": (0.0, 1.0)})
+        column = inv.Geometry(distance=(0.0, 10.0), columns={"zone": (0.0, 1.0)})
         label = inv.OpticalPathLabel(
-            start_distance=0.0, end_distance=10.0, group="zone", value=1.0
+            distance_min=0.0, distance_max=10.0, group="zone", value=1.0
         )
         with pytest.raises(InvalidInventoryError, match="one name is one coordinate"):
             self._inventory(column, labels=(label,)).check()
@@ -301,7 +299,7 @@ class TestGeometryColumns:
         segment = inv.Geometry(
             name="axed",
             distance=(0.0, 10.0),
-            coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
+            columns={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
             units={"x": "furlong"},
         )
         with pytest.raises(InvalidInventoryError, match="states the units of its own"):
@@ -312,7 +310,7 @@ class TestGeometryColumns:
         with pytest.raises(ValidationError, match="has no column"):
             inv.Geometry(
                 distance=(0.0, 10.0),
-                coordinates={"depth": (0.0, 1.0)},
+                columns={"depth": (0.0, 1.0)},
                 units={"dpeth": "m"},
             )
 
@@ -320,12 +318,12 @@ class TestGeometryColumns:
         """Two segments cannot measure one column in two units."""
         meters = inv.Geometry(
             distance=(0.0, 10.0),
-            coordinates={"depth": (0.0, 1.0)},
+            columns={"depth": (0.0, 1.0)},
             units={"depth": "m"},
         )
         feet = inv.Geometry(
             distance=(20.0, 30.0),
-            coordinates={"depth": (0.0, 1.0)},
+            columns={"depth": (0.0, 1.0)},
             units={"depth": "ft"},
         )
         with pytest.raises(InvalidInventoryError, match="has one unit"):
@@ -339,7 +337,7 @@ class TestGeometryColumns:
         )
         segment = inv.Geometry(
             distance=(0.0, 40.0),
-            coordinates={"depth": (0.0, 40.0)},
+            columns={"depth": (0.0, 40.0)},
             units={"depth": "m"},
         )
         inventory = self._inventory(segment, crs=crs)
@@ -348,8 +346,8 @@ class TestGeometryColumns:
 
     def test_a_column_never_bridges_two_segments(self):
         """Distance between two segments is uncovered, whatever they hold."""
-        first = inv.Geometry(distance=(0.0, 10.0), coordinates={"depth": (0.0, 1.0)})
-        second = inv.Geometry(distance=(20.0, 30.0), coordinates={"depth": (2.0, 3.0)})
+        first = inv.Geometry(distance=(0.0, 10.0), columns={"depth": (0.0, 1.0)})
+        second = inv.Geometry(distance=(20.0, 30.0), columns={"depth": (2.0, 3.0)})
         path = self._inventory(first, second).networks[0].fiber_arrays[0]
         values = path.optical_paths[0].column_at("depth", [5.0, 15.0, 25.0])
         assert not np.isnan(values[0]) and not np.isnan(values[2])
@@ -357,7 +355,7 @@ class TestGeometryColumns:
 
     def test_a_column_no_segment_states(self):
         """None, so the caller's on_missing policy rules rather than a nan."""
-        segment = inv.Geometry(distance=(0.0, 10.0), coordinates={"depth": (0.0, 1.0)})
+        segment = inv.Geometry(distance=(0.0, 10.0), columns={"depth": (0.0, 1.0)})
         path = self._inventory(segment).networks[0].fiber_arrays[0].optical_paths[0]
         assert path.column_at("azimuth", [5.0]) is None
 
@@ -384,12 +382,12 @@ class TestGeometryColumnReviewFindings:
         canonical = inv.Geometry(
             name="a",
             distance=(0.0, 10.0),
-            coordinates={"x": (0.0, 10.0), "y": (0.0, 10.0), "z": (0.0, 10.0)},
+            columns={"x": (0.0, 10.0), "y": (0.0, 10.0), "z": (0.0, 10.0)},
         )
         labelled = inv.Geometry(
             name="b",
             distance=(5.0, 15.0),
-            coordinates={
+            columns={
                 "longitude": (100.0, 110.0),
                 "latitude": (100.0, 110.0),
                 "elevation": (100.0, 110.0),
@@ -403,7 +401,7 @@ class TestGeometryColumnReviewFindings:
         doubled = inv.Geometry(
             name="doubled",
             distance=(0.0, 10.0),
-            coordinates={
+            columns={
                 "x": (0.0, 10.0),
                 "longitude": (100.0, 110.0),
                 "y": (0.0, 1.0),
@@ -419,12 +417,12 @@ class TestGeometryColumnReviewFindings:
         placed = inv.Geometry(
             name="placed",
             distance=(0.0, 10.0),
-            coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
+            columns={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
         )
         measured = inv.Geometry(
             name="measured",
             distance=(10.0, 20.0),
-            coordinates={"borehole_depth": (0.0, 10.0)},
+            columns={"borehole_depth": (0.0, 10.0)},
         )
         crs = inv.CoordinateReferenceSystem()
         out = self._path(placed, measured).coordinates_at([10.0], crs)
@@ -433,7 +431,7 @@ class TestGeometryColumnReviewFindings:
     def test_a_dotted_column_name(self):
         """A dotted name is how a field of a typed track is asked for."""
         dotted = inv.Geometry(
-            distance=(0.0, 10.0), coordinates={"coupling.depth": (0.0, 1.0)}
+            distance=(0.0, 10.0), columns={"coupling.depth": (0.0, 1.0)}
         )
         with pytest.raises(InvalidInventoryError, match="dotted name"):
             self._inventory(dotted).check()
@@ -443,13 +441,13 @@ class TestGeometryColumnReviewFindings:
         segment = inv.Geometry(
             name="run",
             distance=(0.0, 10.0),
-            coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
+            columns={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
         )
         out = self._path(segment).select(distance=(2.0, 8.0))
-        coordinates = out.geometry[0].coordinates
-        assert isinstance(coordinates, Mapping)
+        columns = out.geometry[0].columns
+        assert isinstance(columns, Mapping)
         with pytest.raises(TypeError):
-            coordinates["x"] = (0.0,)
+            columns["x"] = (0.0,)
 
     def test_a_canonical_name_the_crs_has_no_axis_for(self):
         """`z` is a column of its own where the CRS declares two axes."""
@@ -457,7 +455,7 @@ class TestGeometryColumnReviewFindings:
             coordinate_labels=("easting", "northing"), units=("meter", "meter")
         )
         segment = inv.Geometry(
-            distance=(0.0, 10.0), coordinates={"z": (0.0, 1.0)}, units={"z": "m"}
+            distance=(0.0, 10.0), columns={"z": (0.0, 1.0)}, units={"z": "m"}
         )
         inventory = self._inventory(segment, crs=crs)
         assert inventory.check() is inventory
@@ -470,25 +468,25 @@ class TestGeometry:
     def test_requires_two_points(self):
         """Requires two points."""
         with pytest.raises(ValidationError, match="at least 2 control points"):
-            inv.Geometry(distance=(1.0,), coordinates={"x": (0.0,), "y": (0.0,)})
+            inv.Geometry(distance=(1.0,), columns={"x": (0.0,), "y": (0.0,)})
 
     def test_strictly_increasing(self):
         """Strictly increasing."""
         with pytest.raises(ValidationError, match="strictly increasing"):
             inv.Geometry(
-                distance=(1.0, 1.0), coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0)}
+                distance=(1.0, 1.0), columns={"x": (0.0, 1.0), "y": (0.0, 1.0)}
             )
 
     def test_paired_lengths(self):
         """Paired lengths."""
         with pytest.raises(ValidationError, match="one value per distance"):
-            inv.Geometry(distance=(0.0, 1.0), coordinates={"x": (0.0,), "y": (0.0,)})
+            inv.Geometry(distance=(0.0, 1.0), columns={"x": (0.0,), "y": (0.0,)})
 
     def test_coil_repeated_coordinates(self):
         """A coil interpolates to a constant coordinate."""
         coil = inv.Geometry(
             distance=(1200.0, 1300.0),
-            coordinates={"x": (500.0, 500.0), "y": (120.0, 120.0)},
+            columns={"x": (500.0, 500.0), "y": (120.0, 120.0)},
         )
         out = coil.interpolate([1200.0, 1250.0, 1299.0])
         assert np.allclose(out["x"], [500.0] * 3)
@@ -497,7 +495,7 @@ class TestGeometry:
     def test_uncovered_is_nan(self):
         """Uncovered is nan."""
         geo = inv.Geometry(
-            distance=(10.0, 20.0), coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0)}
+            distance=(10.0, 20.0), columns={"x": (0.0, 1.0), "y": (0.0, 1.0)}
         )
         out = geo.interpolate([5.0, 25.0])
         assert all(np.all(np.isnan(x)) for x in out.values())
@@ -517,10 +515,10 @@ class TestPathTracks:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             coupling=(
                 inv.CouplingCondition(
-                    start_distance=0.0, end_distance=60.0, coupling_type="trench"
+                    distance_min=0.0, distance_max=60.0, coupling_type="trench"
                 ),
                 inv.CouplingCondition(
-                    start_distance=50.0, end_distance=70.0, coupling_type="conduit"
+                    distance_min=50.0, distance_max=70.0, coupling_type="conduit"
                 ),
             ),
         )
@@ -529,7 +527,7 @@ class TestPathTracks:
 
     def test_geometry_overlap_raises(self):
         """Geometry overlap raises."""
-        seg = dict(coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0)})
+        seg = dict(columns={"x": (0.0, 1.0), "y": (0.0, 1.0)})
         path = inv.OpticalPath(
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             geometry=(
@@ -546,13 +544,13 @@ class TestPathTracks:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
                 inv.OpticalPathLabel(
-                    start_distance=0.0, end_distance=60.0, group="noisy"
+                    distance_min=0.0, distance_max=60.0, group="noisy"
                 ),
                 inv.OpticalPathLabel(
-                    start_distance=50.0, end_distance=70.0, group="noisy"
+                    distance_min=50.0, distance_max=70.0, group="noisy"
                 ),
                 inv.OpticalPathLabel(
-                    start_distance=40.0, end_distance=80.0, group="repaired"
+                    distance_min=40.0, distance_max=80.0, group="repaired"
                 ),
             ),
         )
@@ -564,14 +562,14 @@ class TestPathTracks:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
                 inv.OpticalPathLabel(
-                    start_distance=0.0,
-                    end_distance=60.0,
+                    distance_min=0.0,
+                    distance_max=60.0,
                     group="rock_type",
                     value="granite",
                 ),
                 inv.OpticalPathLabel(
-                    start_distance=50.0,
-                    end_distance=70.0,
+                    distance_min=50.0,
+                    distance_max=70.0,
                     group="rock_type",
                     value="shale",
                 ),
@@ -586,10 +584,10 @@ class TestPathTracks:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
                 inv.OpticalPathLabel(
-                    start_distance=0.0, end_distance=10.0, group="zone", value="east"
+                    distance_min=0.0, distance_max=10.0, group="zone", value="east"
                 ),
                 inv.OpticalPathLabel(
-                    start_distance=20.0, end_distance=30.0, group="zone"
+                    distance_min=20.0, distance_max=30.0, group="zone"
                 ),
             ),
         )
@@ -604,8 +602,8 @@ class TestPathTracks:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
                 inv.OpticalPathLabel(
-                    start_distance=0.0,
-                    end_distance=10.0,
+                    distance_min=0.0,
+                    distance_max=10.0,
                     group="acquisition_key",
                     value="bad",
                 ),
@@ -620,14 +618,14 @@ class TestPathTracks:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
                 inv.OpticalPathLabel(
-                    start_distance=0.0,
-                    end_distance=40.0,
+                    distance_min=0.0,
+                    distance_max=40.0,
                     group="frost_depth",
                     value=1.2,
                 ),
                 inv.OpticalPathLabel(
-                    start_distance=40.0,
-                    end_distance=90.0,
+                    distance_min=40.0,
+                    distance_max=90.0,
                     group="frost_depth",
                     value=0.8,
                 ),
@@ -641,7 +639,7 @@ class TestPathTracks:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             coupling=(
                 inv.CouplingCondition(
-                    start_distance=90.0, end_distance=150.0, coupling_type="trench"
+                    distance_min=90.0, distance_max=150.0, coupling_type="trench"
                 ),
             ),
         )
@@ -740,15 +738,15 @@ class TestAcquisition:
     """Acquisition resolution mechanisms and code rules."""
 
     def test_single_point_channel_map_is_affine(self):
-        """One point states an origin; spatial_interval is the slope."""
+        """One point states an origin; distance_step is the slope."""
         dmap = inv.DistanceMap(channel=(0.0,), distance=(10.0,))
-        acq = inv.Acquisition(code="RAW", spatial_interval=2.0, distance_map=dmap)
+        acq = inv.Acquisition(code="RAW", distance_step=2.0, distance_map=dmap)
         assert np.allclose(acq.channel_to_distance([0, 5]), [10.0, 20.0])
 
     def test_single_point_instrument_map_is_an_offset(self):
         """Interrogator meters map onto path meters one for one."""
         dmap = inv.DistanceMap(instrument_distance=(-120.5,), distance=(0.0,))
-        acq = inv.Acquisition(code="RAW", spatial_interval=2.0, distance_map=dmap)
+        acq = inv.Acquisition(code="RAW", distance_step=2.0, distance_map=dmap)
         assert np.allclose(acq.channel_to_distance([-120.5, -20.5]), [0.0, 100.0])
 
     def test_map_mapping_used_when_present(self):
@@ -791,15 +789,15 @@ class TestEpochContainment:
 
     def test_a_path_starting_before_its_array(self):
         """The array did not exist then, so nothing can resolve to the path."""
-        array = self._array({"start_time": "2024-01-01"}, {"start_time": "2020-01-01"})
+        array = self._array({"time_min": "2024-01-01"}, {"time_min": "2020-01-01"})
         with pytest.raises(InvalidInventoryError, match="outside its container"):
             array.check()
 
     def test_a_path_ending_after_its_array(self):
         """The far bound is checked the same way as the near one."""
         array = self._array(
-            {"start_time": "2024-01-01", "end_time": "2025-01-01"},
-            {"start_time": "2024-06-01", "end_time": "2030-01-01"},
+            {"time_min": "2024-01-01", "time_max": "2025-01-01"},
+            {"time_min": "2024-06-01", "time_max": "2030-01-01"},
         )
         with pytest.raises(InvalidInventoryError, match="outside its container"):
             array.check()
@@ -807,22 +805,22 @@ class TestEpochContainment:
     def test_a_path_entirely_after_its_array(self):
         """Neither bound is out of order, and the whole epoch is elsewhere."""
         array = self._array(
-            {"start_time": "2024-01-01", "end_time": "2025-01-01"},
-            {"start_time": "2026-01-01"},
+            {"time_min": "2024-01-01", "time_max": "2025-01-01"},
+            {"time_min": "2026-01-01"},
         )
         with pytest.raises(InvalidInventoryError, match="outside its container"):
             array.check()
 
     def test_an_unset_bound_defers_to_the_container(self):
         """A path stating no start begins when its fiber array does."""
-        array = self._array({"start_time": "2024-01-01"}, {})
+        array = self._array({"time_min": "2024-01-01"}, {})
         assert array.check() is array
 
     def test_a_contained_epoch_is_legal(self):
         """The ordinary case: a path living inside its array's lifetime."""
         array = self._array(
-            {"start_time": "2024-01-01", "end_time": "2026-01-01"},
-            {"start_time": "2024-06-01", "end_time": "2025-01-01"},
+            {"time_min": "2024-01-01", "time_max": "2026-01-01"},
+            {"time_min": "2024-06-01", "time_max": "2025-01-01"},
         )
         assert array.check() is array
 
@@ -830,16 +828,16 @@ class TestEpochContainment:
         """Acquisitions are contained by the same rule as paths."""
         array = inv.FiberArray(
             code="L001",
-            start_time="2024-01-01",
-            acquisitions=(inv.Acquisition(code="RAW", start_time="2020-01-01"),),
+            time_min="2024-01-01",
+            acquisitions=(inv.Acquisition(code="RAW", time_min="2020-01-01"),),
         )
         with pytest.raises(InvalidInventoryError, match="outside its container"):
             array.check()
 
     def test_a_fiber_array_outside_its_network(self):
         """And the rule holds one level up, for what a network contains."""
-        array = inv.FiberArray(code="L001", start_time="2020-01-01")
-        network = inv.Network(code="XX", start_time="2024-01-01", fiber_arrays=(array,))
+        array = inv.FiberArray(code="L001", time_min="2020-01-01")
+        network = inv.Network(code="XX", time_min="2024-01-01", fiber_arrays=(array,))
         with pytest.raises(InvalidInventoryError, match="outside its container"):
             network.check()
 
@@ -847,15 +845,15 @@ class TestEpochContainment:
         """Stations contain channels the same way."""
         station = inv.Station(
             code="STA1",
-            start_time="2024-01-01",
-            channels=(inv.Channel(code="BHZ", start_time="2020-01-01"),),
+            time_min="2024-01-01",
+            channels=(inv.Channel(code="BHZ", time_min="2020-01-01"),),
         )
         with pytest.raises(InvalidInventoryError, match="outside its container"):
             station.check()
 
     def test_the_error_names_both_epochs(self):
         """A reader has to see which range reaches outside which."""
-        array = self._array({"start_time": "2024-01-01"}, {"start_time": "2020-01-01"})
+        array = self._array({"time_min": "2024-01-01"}, {"time_min": "2020-01-01"})
         with pytest.raises(InvalidInventoryError) as info:
             array.check()
         message = str(info.value)
@@ -871,8 +869,8 @@ class TestEpochs:
         array = inv.FiberArray(
             code="L001",
             optical_paths=(
-                inv.OpticalPath(name="a", start_time="2020-01-01"),
-                inv.OpticalPath(name="b", start_time="2021-01-01"),
+                inv.OpticalPath(name="a", time_min="2020-01-01"),
+                inv.OpticalPath(name="b", time_min="2021-01-01"),
             ),
         )
         with pytest.raises(InvalidInventoryError, match="overlap in time"):
@@ -883,8 +881,8 @@ class TestEpochs:
         array = inv.FiberArray(
             code="L001",
             optical_paths=(
-                inv.OpticalPath(name="a", location_code="00", start_time="2020-01-01"),
-                inv.OpticalPath(name="b", location_code="01", start_time="2020-01-01"),
+                inv.OpticalPath(name="a", location_code="00", time_min="2020-01-01"),
+                inv.OpticalPath(name="b", location_code="01", time_min="2020-01-01"),
             ),
         )
         assert array.check() is array
@@ -894,10 +892,8 @@ class TestEpochs:
         array = inv.FiberArray(
             code="L001",
             optical_paths=(
-                inv.OpticalPath(
-                    name="a", start_time="2020-01-01", end_time="2021-01-01"
-                ),
-                inv.OpticalPath(name="b", start_time="2021-01-01"),
+                inv.OpticalPath(name="a", time_min="2020-01-01", time_max="2021-01-01"),
+                inv.OpticalPath(name="b", time_min="2021-01-01"),
             ),
         )
         assert array.check() is array
@@ -907,8 +903,8 @@ class TestEpochs:
         array = inv.FiberArray(
             code="L001",
             acquisitions=(
-                inv.Acquisition(code="RAW", start_time="2020-01-01"),
-                inv.Acquisition(code="RAW", start_time="2020-06-01"),
+                inv.Acquisition(code="RAW", time_min="2020-01-01"),
+                inv.Acquisition(code="RAW", time_min="2020-06-01"),
             ),
         )
         with pytest.raises(InvalidInventoryError, match="overlap in time"):
@@ -920,9 +916,9 @@ class TestEpochs:
             code="L001",
             acquisitions=(
                 inv.Acquisition(
-                    code="RAW", start_time="2020-01-01", end_time="2020-06-01"
+                    code="RAW", time_min="2020-01-01", time_max="2020-06-01"
                 ),
-                inv.Acquisition(code="RAW", start_time="2020-07-15"),
+                inv.Acquisition(code="RAW", time_min="2020-07-15"),
             ),
         )
         assert array.check() is array
@@ -931,8 +927,8 @@ class TestEpochs:
         """Station fiber code collision raises."""
         network = inv.Network(
             code="DAS",
-            fiber_arrays=(inv.FiberArray(code="L001", start_time="2020-01-01"),),
-            stations=(inv.Station(code="L001", start_time="2020-06-01"),),
+            fiber_arrays=(inv.FiberArray(code="L001", time_min="2020-01-01"),),
+            stations=(inv.Station(code="L001", time_min="2020-06-01"),),
         )
         with pytest.raises(InvalidInventoryError, match="share code"):
             network.check()
@@ -956,11 +952,11 @@ class TestResolution:
             acquisitions=(
                 inv.Acquisition(
                     code="RAW",
-                    start_time="2020-01-01",
-                    end_time="2021-01-01",
+                    time_min="2020-01-01",
+                    time_max="2021-01-01",
                     gauge_length=10.0,
                 ),
-                inv.Acquisition(code="RAW", start_time="2021-01-01", gauge_length=20.0),
+                inv.Acquisition(code="RAW", time_min="2021-01-01", gauge_length=20.0),
             ),
         )
         inventory = inv.Inventory(
@@ -1004,7 +1000,7 @@ class TestPathOperations:
     def test_component_intervals(self, path):
         """Components tile the absolute axis cumulatively."""
         two = inv.OpticalPath(
-            start_distance=100.0,
+            distance_min=100.0,
             optical_components=(
                 inv.FiberSegment(optical_length=50.0),
                 inv.Splice(optical_length=0.5),
@@ -1015,7 +1011,7 @@ class TestPathOperations:
     def test_select_preserves_absolute_distances(self, path):
         """Select preserves absolute distances."""
         piece = path.select(distance=(50.0, 150.0))
-        assert piece.start_distance == 50.0
+        assert piece.distance_min == 50.0
         assert np.isclose(piece.optical_length, 100.0)
         assert piece.geometry[0].distance[0] == 50.0
         piece.check()
@@ -1023,7 +1019,7 @@ class TestPathOperations:
     def test_split_and_rejoin(self, path):
         """Split and rejoin."""
         left, right = path.split_at(100.0)
-        assert left.end_distance == right.start_distance == 100.0
+        assert left.distance_max == right.distance_min == 100.0
         joined = left + right
         assert np.isclose(joined.optical_length, path.optical_length)
         joined.check()
@@ -1110,14 +1106,14 @@ class TestReviewRegressions:
 
     def test_far_future_open_epochs_overlap(self):
         """Ongoing epochs overlap finite epochs beyond any sentinel date."""
-        a = inv.OpticalPath(name="a", start_time="2259-01-01")
-        b = inv.OpticalPath(name="b", start_time="2261-01-01", end_time="2262-01-01")
+        a = inv.OpticalPath(name="a", time_min="2259-01-01")
+        b = inv.OpticalPath(name="b", time_min="2261-01-01", time_max="2262-01-01")
         assert a.overlaps(b) and b.overlaps(a)
 
     def test_reversed_epoch_raises(self):
         """End before start fails at construction."""
         with pytest.raises(ValidationError, match="must be after"):
-            inv.Acquisition(code="RAW", start_time="2022-01-01", end_time="2021-01-01")
+            inv.Acquisition(code="RAW", time_min="2022-01-01", time_max="2021-01-01")
 
     def test_replace_type_mismatch_raises(self):
         """Replace type mismatch raises."""
@@ -1155,7 +1151,7 @@ class TestReviewRegressions:
     def test_columnless_geometry_raises(self):
         """A segment which measures nothing describes nothing."""
         with pytest.raises(ValidationError, match="states no columns"):
-            inv.Geometry(distance=(0.0, 1.0), coordinates={})
+            inv.Geometry(distance=(0.0, 1.0), columns={})
 
     def test_station_extra_fields_forbidden(self):
         """Coordinates are canonical (x, y, z); label fields are not stored."""
@@ -1396,8 +1392,8 @@ class TestInternalReviewRegressions:
         net = inv.Network(
             code="DAS",
             fiber_arrays=(
-                inv.FiberArray(code="L001", start_time="2020-01-01"),
-                inv.FiberArray(code="L001", start_time="2021-01-01"),
+                inv.FiberArray(code="L001", time_min="2020-01-01"),
+                inv.FiberArray(code="L001", time_min="2021-01-01"),
             ),
         )
         with pytest.raises(InvalidInventoryError, match="Duplicate fiber array"):
@@ -1409,11 +1405,11 @@ class TestInternalReviewRegressions:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             geometry=(
                 inv.Geometry(
-                    distance=(0.0, 10.0), coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0)}
+                    distance=(0.0, 10.0), columns={"x": (0.0, 1.0), "y": (0.0, 1.0)}
                 ),
                 inv.Geometry(
                     distance=(20.0, 30.0),
-                    coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
+                    columns={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
                 ),
             ),
         )
@@ -1473,11 +1469,11 @@ class TestCodexReviewRegressions:
         """Nonfinite interval values raise."""
         with pytest.raises(ValidationError):
             inv.CouplingCondition(
-                start_distance=np.nan, end_distance=10.0, coupling_type="trench"
+                distance_min=np.nan, distance_max=10.0, coupling_type="trench"
             )
         with pytest.raises(ValidationError, match="finite"):
             inv.Geometry(
-                distance=(0.0, np.inf), coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0)}
+                distance=(0.0, np.inf), columns={"x": (0.0, 1.0), "y": (0.0, 1.0)}
             )
         with pytest.raises(ValidationError, match="finite"):
             inv.DistanceMap(channel=(0.0, np.inf), distance=(0.0, 1.0))
@@ -1499,7 +1495,7 @@ class TestCoverageCompleteness:
     def test_interval_optical_length(self):
         """Interval items report their length from start/end distances."""
         cond = inv.CouplingCondition(
-            start_distance=10.0, end_distance=60.0, coupling_type="trench"
+            distance_min=10.0, distance_max=60.0, coupling_type="trench"
         )
         assert cond.optical_length == 50.0
 
@@ -1553,7 +1549,7 @@ class TestCoverageCompleteness:
 
     def test_select_drops_out_of_range_geometry(self):
         """Selection drops segments entirely outside the clip."""
-        seg = dict(coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0)})
+        seg = dict(columns={"x": (0.0, 1.0), "y": (0.0, 1.0)})
         path = inv.OpticalPath(
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             geometry=(
@@ -1580,8 +1576,8 @@ class TestCoverageCompleteness:
             code="L001",
             acquisitions=(inv.Acquisition(code="RAW"),),
             optical_paths=(
-                inv.OpticalPath(name="a", start_time="2020-01-01"),
-                inv.OpticalPath(name="b", start_time="2021-01-01"),
+                inv.OpticalPath(name="a", time_min="2020-01-01"),
+                inv.OpticalPath(name="b", time_min="2021-01-01"),
             ),
         )
         inventory = inv.Inventory(
@@ -1593,7 +1589,7 @@ class TestCoverageCompleteness:
     def test_replace_network_and_station_and_path(self):
         """Replace works at network, station, and path levels."""
         station = inv.Station(code="S1")
-        path = inv.OpticalPath(name="p", start_time="2020-01-01")
+        path = inv.OpticalPath(name="p", time_min="2020-01-01")
         array = inv.FiberArray(code="L001", optical_paths=(path,))
         net = inv.Network(code="DAS", fiber_arrays=(array,), stations=(station,))
         inventory = inv.Inventory(networks=(net,))
@@ -1690,13 +1686,13 @@ class TestDisplay:
     def test_path_states_its_extent(self, tunnel):
         """An optical path shows the distances it covers."""
         path = tunnel.networks[0].fiber_arrays[0].optical_paths[0]
-        assert f"[{path.start_distance:g}, {path.end_distance:g}) m" in str(path)
+        assert f"[{path.distance_min:g}, {path.distance_max:g}) m" in str(path)
 
     def test_interval_states_its_extent(self, tunnel):
         """So does anything else which covers an interval of distance."""
         label = tunnel.networks[0].fiber_arrays[0].optical_paths[0].labels[0]
         assert "distance: [" in str(label)
-        assert "start_distance" not in str(label)  # stated by the interval
+        assert "distance_min" not in str(label)  # stated by the interval
 
     def test_distance_map_counts_points(self, tunnel):
         """A measured map names its axes rather than listing its points."""
@@ -1901,18 +1897,18 @@ class TestStationXmlAlignment:
         array = inv.FiberArray(code="L001", acquisitions=(acquisition,))
         first = inv.Network(
             code="XX",
-            start_time="2020-01-01",
-            end_time="2021-01-01",
+            time_min="2020-01-01",
+            time_max="2021-01-01",
             fiber_arrays=(array,),
         )
-        second = first.new(start_time="2021-01-01", end_time="")
+        second = first.new(time_min="2021-01-01", time_max="")
         inventory = inv.Inventory(networks=(first, second)).check()
         context = inventory.resolve("XX.L001..RAW", time="2022-06-01")
-        assert context.network.start_time == np.datetime64("2021-01-01")
+        assert context.network.time_min == np.datetime64("2021-01-01")
 
     def test_network_epochs(self):
         """Networks carry validity epochs like every other container."""
-        net = inv.Network(code="XX", start_time="2020-01-01", end_time="2022-01-01")
+        net = inv.Network(code="XX", time_min="2020-01-01", time_max="2022-01-01")
         assert net.is_effective_at("2021-06-01")
         assert not net.is_effective_at("2022-01-01")
 
@@ -1936,7 +1932,7 @@ class TestPointMarkers:
     def test_aerial_coupling_type(self):
         """Aerial coupling type."""
         cond = inv.CouplingCondition(
-            start_distance=0.0, end_distance=100.0, coupling_type="aerial"
+            distance_min=0.0, distance_max=100.0, coupling_type="aerial"
         )
         assert cond.coupling_type == "aerial"
 
@@ -1946,11 +1942,11 @@ class TestPointMarkers:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             coupling=(
                 inv.CouplingCondition(
-                    start_distance=0.0, end_distance=80.0, coupling_type="trench"
+                    distance_min=0.0, distance_max=80.0, coupling_type="trench"
                 ),
                 inv.CouplingCondition(
-                    start_distance=40.0,
-                    end_distance=40.0,
+                    distance_min=40.0,
+                    distance_max=40.0,
                     coupling_type="other",
                     description="clamp point",
                 ),
@@ -1961,7 +1957,7 @@ class TestPointMarkers:
     def test_point_label(self):
         """Point label."""
         label = inv.OpticalPathLabel(
-            start_distance=350.0, end_distance=350.0, group="wellhead"
+            distance_min=350.0, distance_max=350.0, group="wellhead"
         )
         assert label.interval == (350.0, 350.0)
 
@@ -1971,12 +1967,12 @@ class TestPointMarkers:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
                 inv.OpticalPathLabel(
-                    start_distance=50.0, end_distance=50.0, group="clamp"
+                    distance_min=50.0, distance_max=50.0, group="clamp"
                 ),
             ),
             coupling=(
                 inv.CouplingCondition(
-                    start_distance=25.0, end_distance=25.0, coupling_type="other"
+                    distance_min=25.0, distance_max=25.0, coupling_type="other"
                 ),
             ),
         )
@@ -1990,7 +1986,7 @@ class TestPointMarkers:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
                 inv.OpticalPathLabel(
-                    start_distance=95.0, end_distance=95.0, group="clamp"
+                    distance_min=95.0, distance_max=95.0, group="clamp"
                 ),
             ),
         )
@@ -2002,7 +1998,7 @@ class TestPointMarkers:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
                 inv.OpticalPathLabel(
-                    start_distance=100.0, end_distance=100.0, group="end_cap"
+                    distance_min=100.0, distance_max=100.0, group="end_cap"
                 ),
             ),
         )
@@ -2013,7 +2009,7 @@ class TestPointMarkers:
         """An end before the start is rejected."""
         with pytest.raises(ValidationError, match="must not precede"):
             inv.CouplingCondition(
-                start_distance=10.0, end_distance=5.0, coupling_type="trench"
+                distance_min=10.0, distance_max=5.0, coupling_type="trench"
             )
 
 
@@ -2145,15 +2141,20 @@ class TestCrsShape:
 class TestPrReviewFindings:
     """Regressions for findings raised while reviewing the model PR."""
 
-    def test_non_finite_spatial_interval_rejected(self):
+    def test_non_finite_distance_step_rejected(self):
         """A nan interval would silently poison every resolved distance."""
         with pytest.raises(ValidationError):
-            inv.Acquisition(code="RAW", spatial_interval=np.nan)
+            inv.Acquisition(code="RAW", distance_step=np.nan)
 
-    def test_start_distance_explains_its_removal(self):
-        """An inventory written against the affine form says what to do."""
-        with pytest.raises(ValidationError, match="no longer takes start_distance"):
-            inv.Acquisition(code="RAW", start_distance=100.0)
+    @pytest.mark.parametrize("name", ["distance_min", "start_distance"])
+    def test_removed_origin_explains_itself(self, name):
+        """An inventory written against the affine form says what to do.
+
+        Both spellings are refused: the field's old name, and the name it
+        would carry now.
+        """
+        with pytest.raises(ValidationError, match=f"no longer takes {name}"):
+            inv.Acquisition(code="RAW", **{name: 100.0})
 
     def test_duplicate_channel_identity_raises(self):
         """Channel (location_code, code) names a stream; it must be unique."""
@@ -2175,8 +2176,8 @@ class TestPrReviewFindings:
         station = inv.Station(
             code="VA01",
             channels=(
-                inv.Channel(code="BHZ", start_time="2020-01-01", end_time="2021-01-01"),
-                inv.Channel(code="BHZ", start_time="2021-01-01"),
+                inv.Channel(code="BHZ", time_min="2020-01-01", time_max="2021-01-01"),
+                inv.Channel(code="BHZ", time_min="2021-01-01"),
             ),
         )
         assert station.check() is station
@@ -2194,17 +2195,17 @@ class TestPrReviewFindings:
     def test_add_rejects_different_epoch(self):
         """Concatenating across epochs would advertise the wrong validity."""
         left = inv.OpticalPath(
-            start_time="2020-01-01",
+            time_min="2020-01-01",
             optical_components=(inv.FiberSegment(optical_length=10.0),),
         )
-        right = left.new(start_time="2021-01-01")
+        right = left.new(time_min="2021-01-01")
         with pytest.raises(InvalidInventoryError, match="one lineage and"):
             _ = left + right
 
     def test_add_allows_matching_ongoing_epochs(self):
         """Two unset end times are the same epoch, not two unknowns."""
         path = inv.OpticalPath(
-            start_time="2020-01-01",
+            time_min="2020-01-01",
             optical_components=(inv.FiberSegment(optical_length=10.0),),
         )
         assert (path + path).optical_length == 20.0
@@ -2256,11 +2257,11 @@ class TestPrReviewFindings:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             geometry=(
                 inv.Geometry(
-                    distance=(0.0, 10.0), coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0)}
+                    distance=(0.0, 10.0), columns={"x": (0.0, 1.0), "y": (0.0, 1.0)}
                 ),
                 inv.Geometry(
                     distance=(20.0, 30.0),
-                    coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
+                    columns={"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)},
                 ),
             ),
         )
@@ -2276,7 +2277,7 @@ class TestPrReviewFindings:
                 inv.Geometry(
                     name="flat",
                     distance=(0.0, 10.0),
-                    coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0)},
+                    columns={"x": (0.0, 1.0), "y": (0.0, 1.0)},
                 ),
             ),
         )
@@ -2328,7 +2329,7 @@ class TestConstraintsMatchDescriptions:
         """A nan control point would read as uncovered distance."""
         with pytest.raises(ValidationError, match="must hold finite"):
             inv.Geometry(
-                distance=(0.0, 1.0), coordinates={"x": (np.nan, 1.0), "y": (0.0, 1.0)}
+                distance=(0.0, 1.0), columns={"x": (np.nan, 1.0), "y": (0.0, 1.0)}
             )
 
     def test_point_coordinates_must_be_finite(self):
@@ -2351,7 +2352,7 @@ class TestConstraintsMatchDescriptions:
     def test_label_value_keeps_numpy_type(self):
         """A numpy int is an identifier, not a measurement."""
         counted = inv.OpticalPathLabel(
-            start_distance=0.0, end_distance=1.0, group="shots", value=np.int64(5)
+            distance_min=0.0, distance_max=1.0, group="shots", value=np.int64(5)
         )
         assert isinstance(counted.value, int) and not isinstance(counted.value, bool)
 
@@ -2360,7 +2361,7 @@ class TestConstraintsMatchDescriptions:
         """Membership is stated by having no value, so a boolean states nothing."""
         with pytest.raises(ValidationError, match="true and false are not"):
             inv.OpticalPathLabel(
-                start_distance=0.0, end_distance=1.0, group="noisy", value=value
+                distance_min=0.0, distance_max=1.0, group="noisy", value=value
             )
 
     def test_physical_quantities_must_be_finite(self):
@@ -2374,7 +2375,7 @@ class TestConstraintsMatchDescriptions:
         """A non-finite value cannot survive a JSON round trip."""
         with pytest.raises(ValidationError, match="must be finite"):
             inv.OpticalPathLabel(
-                start_distance=0.0, end_distance=1.0, group="g", value=np.inf
+                distance_min=0.0, distance_max=1.0, group="g", value=np.inf
             )
 
 
@@ -2392,14 +2393,14 @@ def _sample_inventories() -> dict[str, inv.Inventory]:
     segment = inv.FiberSegment(name="run", optical_length=100.0, container=cable)
     labels = (
         inv.OpticalPathLabel(
-            start_distance=0.0, end_distance=50.0, group="zone", value="east"
+            distance_min=0.0, distance_max=50.0, group="zone", value="east"
         ),
-        inv.OpticalPathLabel(start_distance=0.0, end_distance=50.0, group="noisy"),
+        inv.OpticalPathLabel(distance_min=0.0, distance_max=50.0, group="noisy"),
         inv.OpticalPathLabel(
-            start_distance=0.0, end_distance=50.0, group="shots", value=0
+            distance_min=0.0, distance_max=50.0, group="shots", value=0
         ),
         inv.OpticalPathLabel(
-            start_distance=50.0, end_distance=100.0, group="offset", value=0.0
+            distance_min=50.0, distance_max=100.0, group="offset", value=0.0
         ),
     )
 
@@ -2560,10 +2561,10 @@ class TestSerializationIsLossless:
             optical_components=(inv.FiberSegment(optical_length=100.0),),
             labels=(
                 inv.OpticalPathLabel(
-                    start_distance=0.0, end_distance=10.0, group="hole", value=1
+                    distance_min=0.0, distance_max=10.0, group="hole", value=1
                 ),
                 inv.OpticalPathLabel(
-                    start_distance=20.0, end_distance=30.0, group="hole", value=2
+                    distance_min=20.0, distance_max=30.0, group="hole", value=2
                 ),
             ),
         )
@@ -2650,7 +2651,7 @@ class TestSerializationIsLossless:
         """
         with pytest.raises(ValidationError, match="may not be the empty string"):
             inv.OpticalPathLabel(
-                start_distance=0.0, end_distance=50.0, group="rock", value=""
+                distance_min=0.0, distance_max=50.0, group="rock", value=""
             )
 
 
@@ -2774,7 +2775,7 @@ class TestGetNames:
         the distance map and interrogator hold whole records rather than
         values; none of them is something a patch could carry as an attr.
         """
-        excluded = {"code", "location_code", "start_time", "end_time"}
+        excluded = {"code", "location_code", "time_min", "time_max"}
         excluded |= {"distance_map", "interrogator", "extra_fields", "description"}
         assert not set(names.attrs) & excluded
 
@@ -2816,8 +2817,8 @@ class TestGetNames:
         geometry's control points are the segment itself; neither is a
         number a channel inside it carries.
         """
-        excluded = {"coupling.start_distance", "coupling.end_distance"}
-        excluded |= {"geometry.distance", "geometry.coordinates"}
+        excluded = {"coupling.distance_min", "coupling.distance_max"}
+        excluded |= {"geometry.distance", "geometry.columns"}
         assert not set(names.coords) & excluded
 
     def test_coords_omit_absent_tracks(self):

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -34,7 +34,7 @@ def build_inventory() -> inv.Inventory:
         data_type="strain_rate",
         sample_rate=500.0,
         gauge_length=10.0,
-        distance_step=1.0,
+        spatial_interval=1.0,
         distance_map=inv.DistanceMap(channel=(0.0,), distance=(0.0,)),
     )
     geometry = inv.Geometry(
@@ -147,7 +147,7 @@ def build_full_inventory() -> inv.Inventory:
         data_units="strain/s",
         sample_rate=500.0,
         gauge_length=10.0,
-        distance_step=1.0,
+        spatial_interval=1.0,
         interrogator=interrogator,
         interrogator_port="1",
         extra_fields={"native_key": "", "count": 0},
@@ -562,6 +562,32 @@ class TestComponentPlacement:
         with pytest.raises(ValidationError, match="distance_max"):
             inv.FiberSegment(distance_min=0.0)
 
+    @pytest.mark.parametrize("moved", [3.0, 9.0])
+    def test_moving_a_point_marker_moves_both_ends(self, moved):
+        """`new` merges the fields already set, so the end must follow.
+
+        Left alone, moving one back silently gives the marker a length,
+        and moving one forward past its own end refuses outright.
+        """
+        marker = inv.Connector(distance_min=5.0)
+        assert marker.new(distance_min=moved).interval == (moved, moved)
+
+    def test_a_sized_point_component_keeps_its_length(self):
+        """Only a marker's end follows; a stated length is the author's."""
+        splice = inv.Splice(distance_min=5.0, distance_max=5.5)
+        assert splice.new(distance_min=5.2).interval == (5.2, 5.5)
+
+    @pytest.mark.parametrize("blank", [None, {}])
+    def test_a_blank_end_is_an_unstated_one(self, blank):
+        """A CSV cell arrives dropped and a YAML one as None; both are blank."""
+        kwargs = {"distance_max": blank} if blank is None else blank
+        assert inv.Splice(distance_min=1.0, **kwargs).interval == (1.0, 1.0)
+
+    def test_a_segment_end_may_not_be_blank(self):
+        """Blank is unstated only where the item is a point by nature."""
+        with pytest.raises(ValidationError, match="distance_max"):
+            inv.FiberSegment(distance_min=0.0, distance_max=None)
+
     def test_components_are_held_in_distance_order(self):
         """Row order decides nothing; a point sorts before what it touches."""
         path = self._path(
@@ -572,6 +598,27 @@ class TestComponentPlacement:
         assert [x.name for x in path.optical_components] == ["a", "s", "b"]
         assert path.check() is path
 
+    def test_the_removed_origin_explains_itself(self):
+        """A path written against the old layout says what to write now."""
+        with pytest.raises(ValidationError, match="no longer takes start_distance"):
+            inv.OpticalPath(start_distance=100.0)
+
+    def test_extent_survives_a_copy_which_skips_validation(self):
+        """`model_copy` skips the ordering validator; the span must hold.
+
+        The extent is asked for before anything has checked that the
+        components tile, so reading the first and last would report a
+        path spanning (100, 100) for one covering [0, 200).
+        """
+        path = self._path(
+            inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            inv.FiberSegment(distance_min=100.0, distance_max=200.0),
+        )
+        jumbled = path.model_copy(
+            update={"optical_components": tuple(reversed(path.optical_components))}
+        )
+        assert (jumbled.distance_min, jumbled.distance_max) == (0.0, 200.0)
+
     def test_a_path_with_no_components_spans_nothing(self):
         """An empty path has no extent to take from anything."""
         path = inv.OpticalPath()
@@ -579,27 +626,16 @@ class TestComponentPlacement:
         assert path.optical_length == 0.0
 
     def test_optical_length_stays_selectable(self):
-        """A computed length is still a fact about the component."""
-        names = inv.Inventory(
-            networks=(
-                inv.Network(
-                    code="XX",
-                    fiber_arrays=(
-                        inv.FiberArray(
-                            code="L001",
-                            optical_paths=(
-                                self._path(
-                                    inv.FiberSegment(
-                                        distance_min=0.0, distance_max=500.0
-                                    )
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            )
-        ).get_names()
-        assert "optical_components.optical_length" in names.coords
+        """A computed length is still a fact about the component.
+
+        `optical_length` is a property rather than a field now, so it is
+        only in the vocabulary because the model names it as one it
+        derives. The bounds it comes from are deliberately not: they place
+        the component rather than say anything about the fiber in it.
+        """
+        coords = build_inventory().get_names().coords
+        assert "optical_components.optical_length" in coords
+        assert "optical_components.distance_min" not in coords
 
 
 class TestPathTracks:
@@ -855,15 +891,15 @@ class TestAcquisition:
     """Acquisition resolution mechanisms and code rules."""
 
     def test_single_point_channel_map_is_affine(self):
-        """One point states an origin; distance_step is the slope."""
+        """One point states an origin; spatial_interval is the slope."""
         dmap = inv.DistanceMap(channel=(0.0,), distance=(10.0,))
-        acq = inv.Acquisition(code="RAW", distance_step=2.0, distance_map=dmap)
+        acq = inv.Acquisition(code="RAW", spatial_interval=2.0, distance_map=dmap)
         assert np.allclose(acq.channel_to_distance([0, 5]), [10.0, 20.0])
 
     def test_single_point_instrument_map_is_an_offset(self):
         """Interrogator meters map onto path meters one for one."""
         dmap = inv.DistanceMap(instrument_distance=(-120.5,), distance=(0.0,))
-        acq = inv.Acquisition(code="RAW", distance_step=2.0, distance_map=dmap)
+        acq = inv.Acquisition(code="RAW", spatial_interval=2.0, distance_map=dmap)
         assert np.allclose(acq.channel_to_distance([-120.5, -20.5]), [0.0, 100.0])
 
     def test_map_mapping_used_when_present(self):
@@ -1132,22 +1168,56 @@ class TestPathOperations:
         assert (two.distance_min, two.distance_max) == (100.0, 150.5)
         assert "distance_min" not in inv.OpticalPath.model_fields
 
+    @pytest.fixture()
+    def tiled(self):
+        """A path of three components, asymmetric so reversal shows.
+
+        The fixture path holds one component spanning its whole extent,
+        which maps onto itself under reversal and so cannot tell a working
+        `reverse` from one which only re-orders the tuple.
+        """
+        return inv.OpticalPath(
+            optical_components=(
+                inv.FiberSegment(name="a", distance_min=0.0, distance_max=100.0),
+                inv.Splice(name="s", distance_min=100.0),
+                inv.FiberSegment(name="b", distance_min=100.0, distance_max=250.0),
+            )
+        )
+
     @pytest.mark.parametrize(
-        "operation",
+        ("operation", "expected"),
         [
-            lambda p: p.select(distance=(50.0, 150.0)),
-            lambda p: p.split_at(100.0)[1],
-            lambda p: p.reverse(),
-            lambda p: p + p,
+            (
+                lambda p: p.select(distance=(50.0, 150.0)),
+                [("a", (50.0, 100.0)), ("s", (100.0, 100.0)), ("b", (100.0, 150.0))],
+            ),
+            (
+                lambda p: p.split_at(100.0)[1],
+                [("s", (100.0, 100.0)), ("b", (100.0, 250.0))],
+            ),
+            (
+                lambda p: p.reverse(),
+                [("b", (0.0, 150.0)), ("s", (150.0, 150.0)), ("a", (150.0, 250.0))],
+            ),
+            (
+                lambda p: p + p,
+                [
+                    ("a", (0.0, 100.0)),
+                    ("s", (100.0, 100.0)),
+                    ("b", (100.0, 250.0)),
+                    ("a", (250.0, 350.0)),
+                    ("s", (350.0, 350.0)),
+                    ("b", (350.0, 500.0)),
+                ],
+            ),
         ],
         ids=["select", "split_at", "reverse", "add"],
     )
-    def test_components_keep_absolute_distances(self, path, operation):
-        """However a path is cut about, its components still tile it."""
-        out = operation(path)
-        components = out.optical_components
-        assert components[0].distance_min == out.distance_min
-        assert components[-1].distance_max == out.distance_max
+    def test_components_keep_absolute_distances(self, tiled, operation, expected):
+        """However a path is cut about, its components land where they are."""
+        out = operation(tiled)
+        assert [(x.name, x.interval) for x in out.optical_components] == expected
+        # And the result is still a path: the pieces tile what they span.
         assert out.check() is out
 
     def test_select_preserves_absolute_distances(self, path):
@@ -2311,10 +2381,10 @@ class TestCrsShape:
 class TestPrReviewFindings:
     """Regressions for findings raised while reviewing the model PR."""
 
-    def test_non_finite_distance_step_rejected(self):
+    def test_non_finite_spatial_interval_rejected(self):
         """A nan interval would silently poison every resolved distance."""
         with pytest.raises(ValidationError):
-            inv.Acquisition(code="RAW", distance_step=np.nan)
+            inv.Acquisition(code="RAW", spatial_interval=np.nan)
 
     @pytest.mark.parametrize("name", ["distance_min", "start_distance"])
     def test_removed_origin_explains_itself(self, name):

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -46,7 +46,9 @@ def build_inventory() -> inv.Inventory:
         name="main",
         location_code="00",
         time_min="2026-06-01",
-        optical_components=(inv.FiberSegment(name="fiber", optical_length=250.0),),
+        optical_components=(
+            inv.FiberSegment(name="fiber", distance_min=0.0, distance_max=250.0),
+        ),
         geometry=(geometry,),
         coupling=(
             inv.CouplingCondition(
@@ -85,16 +87,22 @@ def build_full_inventory() -> inv.Inventory:
         optical_components=(
             inv.FiberSegment(
                 name="lead",
-                optical_length=100.0,
+                distance_min=0.0,
+                distance_max=100.0,
                 container=cable,
                 fiber_number=1,
                 loss_db=0.2,
                 loss_measurement=measurement,
             ),
-            inv.Connector(name="patch", container=enclosure),
-            inv.Splice(name="splice", container=enclosure),
-            inv.FiberSegment(name="run", optical_length=400.0, container=cable),
-            inv.Terminator(name="end", container=enclosure),
+            inv.Connector(name="patch", distance_min=100.0, container=enclosure),
+            inv.Splice(name="splice", distance_min=100.0, container=enclosure),
+            inv.FiberSegment(
+                name="run",
+                distance_min=100.0,
+                distance_max=500.0,
+                container=cable,
+            ),
+            inv.Terminator(name="end", distance_min=500.0, container=enclosure),
         ),
         geometry=(
             inv.Geometry(
@@ -188,7 +196,9 @@ class TestGeometryColumns:
     def _inventory(*geometry, crs=None, labels=()):
         """Wrap geometry segments in the smallest inventory holding them."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=1000.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=1000.0),
+            ),
             geometry=geometry,
             labels=labels,
         )
@@ -366,7 +376,9 @@ class TestGeometryColumnReviewFindings:
     @staticmethod
     def _path(*geometry):
         return inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             geometry=geometry,
         )
 
@@ -501,6 +513,95 @@ class TestGeometry:
         assert all(np.all(np.isnan(x)) for x in out.values())
 
 
+class TestComponentPlacement:
+    """Components state where they are, and tile the path between them."""
+
+    @staticmethod
+    def _path(*components):
+        """A path holding the given components."""
+        return inv.OpticalPath(optical_components=components)
+
+    def test_a_gap_is_refused(self):
+        """Fiber the path does not account for is fiber nobody can select."""
+        path = self._path(
+            inv.FiberSegment(name="a", distance_min=0.0, distance_max=100.0),
+            inv.FiberSegment(name="b", distance_min=120.0, distance_max=500.0),
+        )
+        with pytest.raises(InvalidInventoryError, match="leaves a gap of 20"):
+            path.check()
+
+    def test_an_overlap_is_refused(self):
+        """Two components over one stretch would count that fiber twice."""
+        path = self._path(
+            inv.FiberSegment(name="a", distance_min=0.0, distance_max=100.0),
+            inv.FiberSegment(name="b", distance_min=80.0, distance_max=500.0),
+        )
+        with pytest.raises(InvalidInventoryError, match="overlaps by 20"):
+            path.check()
+
+    def test_a_gap_within_tolerance_passes(self):
+        """Distances written to a few decimals must not read as a gap."""
+        path = self._path(
+            inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            inv.FiberSegment(distance_min=100.0 + 1e-12, distance_max=500.0),
+        )
+        assert path.check() is path
+
+    def test_a_point_component_states_one_distance(self):
+        """A splice occupies no length, so its end follows from its start."""
+        splice = inv.Splice(distance_min=100.0)
+        assert splice.interval == (100.0, 100.0)
+        assert splice.optical_length == 0.0
+
+    def test_a_point_component_may_still_state_both(self):
+        """A splice with a measurable length is not overruled."""
+        assert inv.Splice(distance_min=100.0, distance_max=100.5).optical_length == 0.5
+
+    def test_a_segment_must_state_both(self):
+        """A segment collapsing to a point would lose the fiber it stands for."""
+        with pytest.raises(ValidationError, match="distance_max"):
+            inv.FiberSegment(distance_min=0.0)
+
+    def test_components_are_held_in_distance_order(self):
+        """Row order decides nothing; a point sorts before what it touches."""
+        path = self._path(
+            inv.FiberSegment(name="b", distance_min=100.0, distance_max=500.0),
+            inv.Splice(name="s", distance_min=100.0),
+            inv.FiberSegment(name="a", distance_min=0.0, distance_max=100.0),
+        )
+        assert [x.name for x in path.optical_components] == ["a", "s", "b"]
+        assert path.check() is path
+
+    def test_a_path_with_no_components_spans_nothing(self):
+        """An empty path has no extent to take from anything."""
+        path = inv.OpticalPath()
+        assert (path.distance_min, path.distance_max) == (0.0, 0.0)
+        assert path.optical_length == 0.0
+
+    def test_optical_length_stays_selectable(self):
+        """A computed length is still a fact about the component."""
+        names = inv.Inventory(
+            networks=(
+                inv.Network(
+                    code="XX",
+                    fiber_arrays=(
+                        inv.FiberArray(
+                            code="L001",
+                            optical_paths=(
+                                self._path(
+                                    inv.FiberSegment(
+                                        distance_min=0.0, distance_max=500.0
+                                    )
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        ).get_names()
+        assert "optical_components.optical_length" in names.coords
+
+
 class TestPathTracks:
     """Track-kind rules: tiling, function tracks, set track."""
 
@@ -512,7 +613,9 @@ class TestPathTracks:
     def test_coupling_overlap_raises(self):
         """Coupling overlap raises."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             coupling=(
                 inv.CouplingCondition(
                     distance_min=0.0, distance_max=60.0, coupling_type="trench"
@@ -529,7 +632,9 @@ class TestPathTracks:
         """Geometry overlap raises."""
         seg = dict(columns={"x": (0.0, 1.0), "y": (0.0, 1.0)})
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             geometry=(
                 inv.Geometry(distance=(0.0, 60.0), **seg),
                 inv.Geometry(distance=(50.0, 80.0), **seg),
@@ -541,7 +646,9 @@ class TestPathTracks:
     def test_boolean_labels_overlap_freely(self):
         """Membership labels overlap, within and across groups."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             labels=(
                 inv.OpticalPathLabel(
                     distance_min=0.0, distance_max=60.0, group="noisy"
@@ -559,7 +666,9 @@ class TestPathTracks:
     def test_valued_label_groups_may_not_overlap(self):
         """A single-valued group cannot claim two values at one distance."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             labels=(
                 inv.OpticalPathLabel(
                     distance_min=0.0,
@@ -581,7 +690,9 @@ class TestPathTracks:
     def test_label_group_holds_one_kind_of_value(self):
         """Mixing value kinds in one group is a modeling error."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             labels=(
                 inv.OpticalPathLabel(
                     distance_min=0.0, distance_max=10.0, group="zone", value="east"
@@ -599,7 +710,9 @@ class TestPathTracks:
         patch's identity rather than a thing a label may say.
         """
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             labels=(
                 inv.OpticalPathLabel(
                     distance_min=0.0,
@@ -615,7 +728,9 @@ class TestPathTracks:
     def test_numeric_label_group(self):
         """Numeric groups are single valued but otherwise ordinary."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             labels=(
                 inv.OpticalPathLabel(
                     distance_min=0.0,
@@ -636,7 +751,9 @@ class TestPathTracks:
     def test_out_of_bounds_raises(self):
         """Out of bounds raises."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             coupling=(
                 inv.CouplingCondition(
                     distance_min=90.0, distance_max=150.0, coupling_type="trench"
@@ -782,7 +899,9 @@ class TestEpochContainment:
         """A fiber array holding one optical path, each with its own epoch."""
         path = inv.OpticalPath(
             name="main",
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             **path_kwargs,
         )
         return inv.FiberArray(code="L001", optical_paths=(path,), **array_kwargs)
@@ -997,16 +1116,39 @@ class TestPathOperations:
         """Return the example path."""
         return build_inventory().networks[0].fiber_arrays[0].optical_paths[0]
 
-    def test_component_intervals(self, path):
-        """Components tile the absolute axis cumulatively."""
+    def test_components_place_themselves(self, path):
+        """Each component carries the absolute stretch it occupies."""
         two = inv.OpticalPath(
-            distance_min=100.0,
             optical_components=(
-                inv.FiberSegment(optical_length=50.0),
-                inv.Splice(optical_length=0.5),
+                inv.FiberSegment(distance_min=100.0, distance_max=150.0),
+                inv.Splice(distance_min=150.0, distance_max=150.5),
             ),
         )
-        assert two.component_intervals() == ((100.0, 150.0), (150.0, 150.5))
+        assert [x.interval for x in two.optical_components] == [
+            (100.0, 150.0),
+            (150.0, 150.5),
+        ]
+        # And the path takes its own extent from them, stating none itself.
+        assert (two.distance_min, two.distance_max) == (100.0, 150.5)
+        assert "distance_min" not in inv.OpticalPath.model_fields
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda p: p.select(distance=(50.0, 150.0)),
+            lambda p: p.split_at(100.0)[1],
+            lambda p: p.reverse(),
+            lambda p: p + p,
+        ],
+        ids=["select", "split_at", "reverse", "add"],
+    )
+    def test_components_keep_absolute_distances(self, path, operation):
+        """However a path is cut about, its components still tile it."""
+        out = operation(path)
+        components = out.optical_components
+        assert components[0].distance_min == out.distance_min
+        assert components[-1].distance_max == out.distance_max
+        assert out.check() is out
 
     def test_select_preserves_absolute_distances(self, path):
         """Select preserves absolute distances."""
@@ -1126,8 +1268,8 @@ class TestReviewRegressions:
         """A terminator at the path end survives full selection and splits."""
         path = inv.OpticalPath(
             optical_components=(
-                inv.FiberSegment(optical_length=100.0),
-                inv.Terminator(optical_length=0.0),
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+                inv.Terminator(distance_min=100.0),
             ),
         )
         full = path.select(distance=(None, None))
@@ -1211,7 +1353,7 @@ class TestResourcePool:
     def test_inline_resource_normalizes_to_pool(self):
         """An inline cable moves to the pool; the field keeps its id."""
         cable = inv.Cable(resource_id="cable-01", name="c")
-        seg = inv.FiberSegment(optical_length=100.0, container=cable)
+        seg = inv.FiberSegment(distance_min=0.0, distance_max=100.0, container=cable)
         inventory = self._inventory_with(seg)
         stored = (
             inventory.networks[0].fiber_arrays[0].optical_paths[0].optical_components[0]
@@ -1224,8 +1366,8 @@ class TestResourcePool:
         coupler = inv.Enclosure(resource_id="coupler-01")
         path = inv.OpticalPath(
             optical_components=(
-                inv.Connector(container=coupler),
-                inv.Connector(container=coupler),
+                inv.Connector(distance_min=0.0, container=coupler),
+                inv.Connector(distance_min=0.0, container=coupler),
             ),
         )
         array = inv.FiberArray(code="L001", optical_paths=(path,))
@@ -1240,8 +1382,8 @@ class TestResourcePool:
         b = inv.Cable(resource_id="cable-01", fiber_count=4)
         path = inv.OpticalPath(
             optical_components=(
-                inv.FiberSegment(optical_length=1.0, container=a),
-                inv.FiberSegment(optical_length=1.0, container=b),
+                inv.FiberSegment(distance_min=0.0, distance_max=1.0, container=a),
+                inv.FiberSegment(distance_min=1.0, distance_max=2.0, container=b),
             ),
         )
         array = inv.FiberArray(code="L001", optical_paths=(path,))
@@ -1250,7 +1392,9 @@ class TestResourcePool:
 
     def test_dangling_reference_raises(self):
         """Dangling reference raises."""
-        seg = inv.FiberSegment(optical_length=1.0, container="no-such-cable")
+        seg = inv.FiberSegment(
+            distance_min=0.0, distance_max=1.0, container="no-such-cable"
+        )
         with pytest.raises(ValidationError, match="Dangling"):
             self._inventory_with(seg)
 
@@ -1258,7 +1402,7 @@ class TestResourcePool:
         """A cable inside a pipe: both land in the pool, linked by id."""
         pipe = inv.Enclosure(resource_id="pipe-01", enclosure_type="pipe")
         cable = inv.Cable(resource_id="cable-01", container=pipe)
-        seg = inv.FiberSegment(optical_length=1.0, container=cable)
+        seg = inv.FiberSegment(distance_min=0.0, distance_max=1.0, container=cable)
         inventory = self._inventory_with(seg)
         assert inventory.get_resource("cable-01").container == "pipe-01"
         assert inventory.get_resource("pipe-01") == pipe
@@ -1266,7 +1410,7 @@ class TestResourcePool:
     def test_interrogator_normalizes(self):
         """Interrogator normalizes."""
         unit = inv.Interrogator(resource_id="int-01", model="DAS-1000")
-        seg = inv.FiberSegment(optical_length=1.0)
+        seg = inv.FiberSegment(distance_min=0.0, distance_max=1.0)
         inventory = self._inventory_with(seg, interrogator=unit)
         acq = inventory.networks[0].fiber_arrays[0].acquisitions[0]
         assert acq.interrogator == "int-01"
@@ -1275,7 +1419,7 @@ class TestResourcePool:
     def test_resource_correction_is_single_site(self):
         """Replacing a pooled resource touches only the pool."""
         cable = inv.Cable(resource_id="cable-01", fiber_count=1)
-        seg = inv.FiberSegment(optical_length=1.0, container=cable)
+        seg = inv.FiberSegment(distance_min=0.0, distance_max=1.0, container=cable)
         inventory = self._inventory_with(seg)
         fixed = cable.new(fiber_count=4)
         updated = inventory.replace(cable, fixed)
@@ -1288,7 +1432,7 @@ class TestResourcePool:
     def test_resource_correction_must_keep_id(self):
         """Resource correction must keep id."""
         cable = inv.Cable(resource_id="cable-01")
-        seg = inv.FiberSegment(optical_length=1.0, container=cable)
+        seg = inv.FiberSegment(distance_min=0.0, distance_max=1.0, container=cable)
         inventory = self._inventory_with(seg)
         renamed = cable.new(resource_id="cable-02")
         with pytest.raises(InvalidInventoryError, match="same resource_id"):
@@ -1297,7 +1441,7 @@ class TestResourcePool:
     def test_yaml_roundtrip_stays_flat(self, tmp_path):
         """Serialized form holds ids, not inline copies, and round-trips."""
         cable = inv.Cable(resource_id="cable-01", name="c")
-        seg = inv.FiberSegment(optical_length=100.0, container=cable)
+        seg = inv.FiberSegment(distance_min=0.0, distance_max=100.0, container=cable)
         inventory = self._inventory_with(seg)
         text = inventory.io.to_yaml()
         assert text.count("cable-01") >= 2
@@ -1316,7 +1460,7 @@ class TestInternalReviewRegressions:
     def test_new_preserves_union_discriminators(self):
         """new() works on models holding discriminated unions."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=10.0),)
+            optical_components=(inv.FiberSegment(distance_min=0.0, distance_max=10.0),)
         )
         renamed = path.new(name="renamed")
         assert renamed.name == "renamed"
@@ -1402,7 +1546,9 @@ class TestInternalReviewRegressions:
     def test_partial_axes_fail_the_inventory_check(self):
         """A segment stating some axes and not others fails the check."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             geometry=(
                 inv.Geometry(
                     distance=(0.0, 10.0), columns={"x": (0.0, 1.0), "y": (0.0, 1.0)}
@@ -1484,12 +1630,12 @@ class TestCoverageCompleteness:
 
     def test_attenuation_none_without_loss(self):
         """No loss value means no derivable attenuation rate."""
-        seg = inv.FiberSegment(optical_length=100.0)
+        seg = inv.FiberSegment(distance_min=0.0, distance_max=100.0)
         assert seg.attenuation_db_per_km is None
 
     def test_attenuation_scalar(self):
         """A scalar loss over a known length gives a per-km rate."""
-        seg = inv.FiberSegment(optical_length=2000.0, loss_db=0.8)
+        seg = inv.FiberSegment(distance_min=0.0, distance_max=2000.0, loss_db=0.8)
         assert seg.attenuation_db_per_km == pytest.approx(0.4)
 
     def test_interval_optical_length(self):
@@ -1504,7 +1650,8 @@ class TestCoverageCompleteness:
         m1 = inv.OpticalMeasurement(resource_id="m1", method="otdr", wavelength=1550.0)
         m2 = inv.OpticalMeasurement(resource_id="m2", method="otdr", wavelength=1310.0)
         segment = inv.FiberSegment(
-            optical_length=10.0,
+            distance_min=0.0,
+            distance_max=10.0,
             loss_db=(0.4, 0.5),
             loss_measurement=("m1", "m2"),
         )
@@ -1542,7 +1689,7 @@ class TestCoverageCompleteness:
     def test_coordinates_at_without_geometry(self):
         """Coordinates at without geometry."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=10.0),)
+            optical_components=(inv.FiberSegment(distance_min=0.0, distance_max=10.0),)
         )
         crs = inv.CoordinateReferenceSystem()
         assert np.all(np.isnan(path.coordinates_at([5.0], crs)))
@@ -1551,7 +1698,9 @@ class TestCoverageCompleteness:
         """Selection drops segments entirely outside the clip."""
         seg = dict(columns={"x": (0.0, 1.0), "y": (0.0, 1.0)})
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             geometry=(
                 inv.Geometry(distance=(0.0, 20.0), **seg),
                 inv.Geometry(distance=(80.0, 100.0), **seg),
@@ -1563,7 +1712,7 @@ class TestCoverageCompleteness:
     def test_add_rejects_non_path(self):
         """Add rejects non path."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=10.0),)
+            optical_components=(inv.FiberSegment(distance_min=0.0, distance_max=10.0),)
         )
         with pytest.raises(TypeError):
             _ = path + 5
@@ -1781,7 +1930,9 @@ class TestImmutability:
     def _stocked_inventory(resource_id="fixed"):
         """An inventory whose frozen mappings both carry contents."""
         cable = inv.Cable(resource_id="cable-01", name="c")
-        segment = inv.FiberSegment(optical_length=100.0, container=cable)
+        segment = inv.FiberSegment(
+            distance_min=0.0, distance_max=100.0, container=cable
+        )
         array = inv.FiberArray(
             code="L001",
             optical_paths=(inv.OpticalPath(optical_components=(segment,)),),
@@ -1875,7 +2026,9 @@ class TestImmutability:
     def test_json_mode_still_reaches_pooled_resources(self):
         """The pool's own serializer does not shadow what it holds."""
         run = inv.OpticalMeasurement(resource_id="otdr-1", time="2020-01-01")
-        segment = inv.FiberSegment(optical_length=10.0, loss_measurement=run)
+        segment = inv.FiberSegment(
+            distance_min=0.0, distance_max=10.0, loss_measurement=run
+        )
         array = inv.FiberArray(
             code="L001",
             optical_paths=(inv.OpticalPath(optical_components=(segment,)),),
@@ -1939,7 +2092,9 @@ class TestPointMarkers:
     def test_point_clamp_inside_span_is_legal(self):
         """A point marker inside a covered span does not count as overlap."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             coupling=(
                 inv.CouplingCondition(
                     distance_min=0.0, distance_max=80.0, coupling_type="trench"
@@ -1964,7 +2119,9 @@ class TestPointMarkers:
     def test_point_markers_survive_select(self):
         """A clamp inside the clip is not coverage, but it is not nothing."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             labels=(
                 inv.OpticalPathLabel(
                     distance_min=50.0, distance_max=50.0, group="clamp"
@@ -1983,7 +2140,9 @@ class TestPointMarkers:
     def test_point_markers_outside_the_clip_are_dropped(self):
         """A marker beyond the requested window does not belong to the piece."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             labels=(
                 inv.OpticalPathLabel(
                     distance_min=95.0, distance_max=95.0, group="clamp"
@@ -1995,7 +2154,9 @@ class TestPointMarkers:
     def test_point_marker_at_the_outer_endpoint_is_kept(self):
         """The outermost endpoint of the path is included, as everywhere."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             labels=(
                 inv.OpticalPathLabel(
                     distance_min=100.0, distance_max=100.0, group="end_cap"
@@ -2018,7 +2179,7 @@ class TestOpticalLoss:
 
     def test_scalar_loss_no_provenance(self):
         """Plain numbers with no measurement records are legal."""
-        splice = inv.Splice(loss_db=0.08, reflectance_db=-55.0)
+        splice = inv.Splice(distance_min=0.0, loss_db=0.08, reflectance_db=-55.0)
         assert splice.loss_db == 0.08
 
     def test_shared_measurement_pooled_once(self):
@@ -2033,9 +2194,13 @@ class TestOpticalLoss:
         path = inv.OpticalPath(
             optical_components=(
                 inv.FiberSegment(
-                    optical_length=1000.0, loss_db=0.3, loss_measurement=run
+                    distance_min=0.0,
+                    distance_max=1000.0,
+                    loss_db=0.3,
+                    loss_measurement=run,
                 ),
                 inv.Splice(
+                    distance_min=1000.0,
                     loss_db=0.05,
                     loss_measurement=run,
                     reflectance_db=-60.0,
@@ -2063,7 +2228,8 @@ class TestOpticalLoss:
             resource_id="ds-1310", method="datasheet", wavelength=1310.0
         )
         seg = inv.FiberSegment(
-            optical_length=2000.0,
+            distance_min=0.0,
+            distance_max=2000.0,
             loss_db=(0.6, 0.7),
             loss_measurement=(sheet_1550, sheet_1310),
         )
@@ -2072,13 +2238,14 @@ class TestOpticalLoss:
     def test_tuple_loss_requires_tuple_measurements(self):
         """Tuple loss requires tuple measurements."""
         with pytest.raises(ValidationError, match="equal-length"):
-            inv.FiberSegment(optical_length=10.0, loss_db=(0.1, 0.2))
+            inv.FiberSegment(distance_min=0.0, distance_max=10.0, loss_db=(0.1, 0.2))
 
     def test_length_mismatch_raises(self):
         """Length mismatch raises."""
         with pytest.raises(ValidationError, match="has 2 values"):
             inv.FiberSegment(
-                optical_length=10.0,
+                distance_min=0.0,
+                distance_max=10.0,
                 loss_db=(0.1, 0.2),
                 loss_measurement=("m1", "m2", "m3"),
             )
@@ -2086,7 +2253,10 @@ class TestOpticalLoss:
     def test_dangling_measurement_ref_raises(self):
         """Dangling measurement ref raises."""
         seg = inv.FiberSegment(
-            optical_length=10.0, loss_db=0.1, loss_measurement="no-such-run"
+            distance_min=0.0,
+            distance_max=10.0,
+            loss_db=0.1,
+            loss_measurement="no-such-run",
         )
         path = inv.OpticalPath(optical_components=(seg,))
         array = inv.FiberArray(code="L001", optical_paths=(path,))
@@ -2186,7 +2356,7 @@ class TestPrReviewFindings:
         """Concatenating unrelated paths would misattribute the result."""
         left = inv.OpticalPath(
             location_code="00",
-            optical_components=(inv.FiberSegment(optical_length=10.0),),
+            optical_components=(inv.FiberSegment(distance_min=0.0, distance_max=10.0),),
         )
         right = left.new(location_code="01")
         with pytest.raises(InvalidInventoryError, match="one lineage and"):
@@ -2196,7 +2366,7 @@ class TestPrReviewFindings:
         """Concatenating across epochs would advertise the wrong validity."""
         left = inv.OpticalPath(
             time_min="2020-01-01",
-            optical_components=(inv.FiberSegment(optical_length=10.0),),
+            optical_components=(inv.FiberSegment(distance_min=0.0, distance_max=10.0),),
         )
         right = left.new(time_min="2021-01-01")
         with pytest.raises(InvalidInventoryError, match="one lineage and"):
@@ -2206,17 +2376,17 @@ class TestPrReviewFindings:
         """Two unset end times are the same epoch, not two unknowns."""
         path = inv.OpticalPath(
             time_min="2020-01-01",
-            optical_components=(inv.FiberSegment(optical_length=10.0),),
+            optical_components=(inv.FiberSegment(distance_min=0.0, distance_max=10.0),),
         )
         assert (path + path).optical_length == 20.0
 
     def test_replace_rejects_ambiguous_match(self):
         """Equal items are indistinguishable, so replacing one is undefined."""
-        connector = inv.Connector(connector_type="E2000")
+        connector = inv.Connector(distance_min=0.0, connector_type="E2000")
         path = inv.OpticalPath(
             optical_components=(
                 connector,
-                inv.FiberSegment(optical_length=10.0),
+                inv.FiberSegment(distance_min=0.0, distance_max=10.0),
                 connector,
             ),
         )
@@ -2254,7 +2424,9 @@ class TestPrReviewFindings:
     def test_coordinates_at_rejects_mixed_dimensions(self):
         """An unchecked, mixed-dimension path fails loudly, not by broadcast."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             geometry=(
                 inv.Geometry(
                     distance=(0.0, 10.0), columns={"x": (0.0, 1.0), "y": (0.0, 1.0)}
@@ -2272,7 +2444,9 @@ class TestPrReviewFindings:
     def test_coordinate_width_must_match_crs(self):
         """Coordinates are read through the CRS, so they must fit its axes."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             geometry=(
                 inv.Geometry(
                     name="flat",
@@ -2369,7 +2543,7 @@ class TestConstraintsMatchDescriptions:
         with pytest.raises(ValidationError):
             inv.Acquisition(code="RAW", sample_rate=np.nan)
         with pytest.raises(ValidationError):
-            inv.FiberSegment(optical_length=10.0, loss_db=(0.4, np.inf))
+            inv.FiberSegment(distance_min=0.0, distance_max=10.0, loss_db=(0.4, np.inf))
 
     def test_label_value_must_be_finite(self):
         """A non-finite value cannot survive a JSON round trip."""
@@ -2390,7 +2564,9 @@ def _sample_inventories() -> dict[str, inv.Inventory]:
         units=("m", "m"),
     )
     cable = inv.Cable(resource_id="cable-1", name="trunk")
-    segment = inv.FiberSegment(name="run", optical_length=100.0, container=cable)
+    segment = inv.FiberSegment(
+        name="run", distance_min=0.0, distance_max=100.0, container=cable
+    )
     labels = (
         inv.OpticalPathLabel(
             distance_min=0.0, distance_max=50.0, group="zone", value="east"
@@ -2558,7 +2734,9 @@ class TestSerializationIsLossless:
     def test_a_label_value_of_one_survives(self):
         """`1 == True`; when the default was True, pruning defaults dropped it."""
         path = inv.OpticalPath(
-            optical_components=(inv.FiberSegment(optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(distance_min=0.0, distance_max=100.0),
+            ),
             labels=(
                 inv.OpticalPathLabel(
                     distance_min=0.0, distance_max=10.0, group="hole", value=1
@@ -2682,20 +2860,24 @@ class TestFiberSegmentFields:
     def test_fiber_number_and_color(self):
         """Fiber identity within a cable uses telecom naming."""
         segment = inv.FiberSegment(
-            optical_length=10.0, fiber_number=3, fiber_color="blue"
+            distance_min=0.0, distance_max=10.0, fiber_number=3, fiber_color="blue"
         )
         assert segment.fiber_number == 3
         assert segment.fiber_color == "blue"
 
     def test_refractive_index(self):
         """The group index converts time of flight into distance."""
-        segment = inv.FiberSegment(optical_length=10.0, refractive_index=1.4682)
+        segment = inv.FiberSegment(
+            distance_min=0.0, distance_max=10.0, refractive_index=1.4682
+        )
         assert segment.refractive_index == 1.4682
 
     def test_refractive_index_must_be_finite(self):
         """A non-finite index would poison every distance it scales."""
         with pytest.raises(ValidationError):
-            inv.FiberSegment(optical_length=10.0, refractive_index=np.nan)
+            inv.FiberSegment(
+                distance_min=0.0, distance_max=10.0, refractive_index=np.nan
+            )
 
 
 class TestDepthLabel:

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -1340,7 +1340,7 @@ class TestTrackTables:
         """A map has no grouping column: every point belongs to the one map."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\ndistance_step: 1.0\n"
+                "object_type: Acquisition\nspatial_interval: 1.0\n"
             ),
             "acquisitions/DAS.L001.02.DEC/distance_map.csv": (
                 "channel,distance\n512,500.0\n1710,1698.0\n"
@@ -1770,7 +1770,7 @@ class TestUnreadableTables:
         """A column every row leaves empty states nothing, and is not empty."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\ndistance_step: 1.0\n"
+                "object_type: Acquisition\nspatial_interval: 1.0\n"
             ),
             "acquisitions/DAS.L001.02.DEC/distance_map.csv": (
                 "channel,instrument_distance,distance\n512,,500.0\n1710,,1698.0\n"
@@ -1864,7 +1864,51 @@ class TestUnreadableTables:
                 "1,FiberSegment,0,100,a\n"
             ),
         }
-        with pytest.raises(InvalidInventoryError, match="no longer reads"):
+        with pytest.raises(InvalidInventoryError, match="Drop the column"):
+            make_inventory(files)
+
+    def test_a_components_table_which_does_not_tile_is_refused(self, make_inventory):
+        """The loader checks what it builds, or a bad table loads fine.
+
+        The tiling rule lives on `OpticalPath.check`; this holds the read
+        path to calling it, which is what makes the rule reach a file.
+        """
+        files = {
+            **MINIMAL,
+            **TRACKS,
+            "fiber_arrays/DAS.L001/path/optical_components.csv": (
+                "object_type,distance_min,distance_max,name\n"
+                "FiberSegment,0,100,a\n"
+                "FiberSegment,120,500,b\n"
+            ),
+        }
+        with pytest.raises(InvalidInventoryError, match="leaves a gap of 20"):
+            make_inventory(files)
+
+    def test_a_retired_length_column_says_what_to_write(self, make_inventory):
+        """The other column the components table lost is explained too."""
+        files = {
+            **MINIMAL,
+            **TRACKS,
+            "fiber_arrays/DAS.L001/path/optical_components.csv": (
+                "object_type,optical_length,name\nFiberSegment,100,a\n"
+            ),
+        }
+        with pytest.raises(InvalidInventoryError, match="State those"):
+            make_inventory(files)
+
+    def test_a_retired_segment_column_says_what_to_write(self, make_inventory):
+        """A renamed column is told its new name, not that one is missing."""
+        files = {
+            **MINIMAL,
+            **TRACKS,
+            "fiber_arrays/DAS.L001/path/geometry.csv": (
+                "segment,distance,longitude,latitude,elevation\n"
+                "S100,100.0,-117.0,40.0,687.0\n"
+                "S100,102.0,-117.1,40.1,685.0\n"
+            ),
+        }
+        with pytest.raises(InvalidInventoryError, match="now name"):
             make_inventory(files)
 
     def test_a_cell_which_does_not_pertain_to_its_row(self, make_inventory):
@@ -1910,11 +1954,18 @@ class TestTableRegistry:
             assert stem  # every key names something
 
     def test_a_retired_column_names_no_field_of_the_model(self):
-        """A column explained as retired must not still be readable."""
+        """A column explained as retired must not still be readable.
+
+        A name which is still a field would be refused by the explanation
+        rather than read, which is a worse failure than the bare unknown
+        field the explanation exists to replace.
+        """
         for stem, retired in loader._RETIRED_COLUMNS.items():
-            model = inv.OpticalPath.model_fields[stem].annotation
-            for column in retired:
-                assert column not in str(model)
+            track = inv.OpticalPath.model_fields[stem].annotation
+            members = inv._annotation_members(inv.get_args(track)[0])
+            assert members  # a track holds models, or this checks nothing
+            for model in members:
+                assert not (set(retired) & set(model.model_fields))
 
 
 class TestSilentlyLostRows:
@@ -1966,7 +2017,7 @@ class TestSilentlyLostRows:
         """Columns become parallel arrays, so a gap would pair the unpaired."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\ndistance_step: 1.0\n"
+                "object_type: Acquisition\nspatial_interval: 1.0\n"
             ),
             # Channel 5 states no distance and 100 states no channel; read
             # column by column they would pair up as though they had.
@@ -2229,7 +2280,7 @@ class TestPRReviewFindings:
         """The frame is sorted and split by then, so positions lie."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\ndistance_step: 1.0\n"
+                "object_type: Acquisition\nspatial_interval: 1.0\n"
             ),
             # Sorted by distance these rows reverse, so a position within
             # the sorted frame is not the line the author would open.
@@ -2249,7 +2300,7 @@ class TestPRReviewFindings:
         """A header and no rows describes no map, rather than raising bare."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\ndistance_step: 1.0\n"
+                "object_type: Acquisition\nspatial_interval: 1.0\n"
             ),
             "acquisitions/DAS.L001.02.DEC/distance_map.csv": "channel,distance\n",
         }

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -27,7 +27,7 @@ PATH_DIRECTORY = {
     "fiber_arrays/DAS.L001/path/attrs.yaml": "object_type: OpticalPath\n",
     # A path with length, so a track laid along it is inside the path.
     "fiber_arrays/DAS.L001/path/optical_components.csv": (
-        "sequence,object_type,optical_length,name\n1,FiberSegment,1000.0,fiber 1\n"
+        "object_type,distance_min,distance_max,name\nFiberSegment,0,1000,fiber 1\n"
     ),
 }
 
@@ -1065,9 +1065,9 @@ TRACKS = {
     "fiber_arrays/DAS.L001/attrs.yaml": "object_type: FiberArray\nname: array\n",
     "fiber_arrays/DAS.L001/path/attrs.yaml": "object_type: OpticalPath\nname: main\n",
     "fiber_arrays/DAS.L001/path/optical_components.csv": (
-        "sequence,object_type,optical_length,name,fiber_number,fiber_color\n"
-        "2,Splice,0.1,splice 1,,\n"
-        "1,FiberSegment,1000.0,fiber 1,1,blue\n"
+        "object_type,distance_min,distance_max,name,fiber_number,fiber_color\n"
+        "Splice,1000,1000.1,splice 1,,\n"
+        "FiberSegment,0,1000,fiber 1,1,blue\n"
     ),
     "fiber_arrays/DAS.L001/path/coupling.csv": (
         "distance_min,distance_max,coupling_type,description\n"
@@ -1109,9 +1109,9 @@ class TestTrackTables:
         assert [x.name for x in path.geometry] == ["S100"]
 
     def test_rows_are_read_in_the_order_they_state(self, make_inventory):
-        """Sequence decides the order, never row position."""
+        """Distance decides the order of components, never row position."""
         path = one_path(make_inventory({**MINIMAL, **TRACKS}))
-        # The file lists the splice first; sequence puts it second.
+        # The file lists the splice first; its distance puts it second.
         assert [x.object_type for x in path.optical_components] == [
             "FiberSegment",
             "Splice",
@@ -1472,15 +1472,15 @@ class TestTrackTables:
             make_inventory(files)
 
     def test_a_table_missing_the_column_it_is_read_by(self, make_inventory):
-        """Components are placed by sequence, so a table without one raises."""
+        """Geometry points are placed by distance, so a table needs one."""
         files = {
             **MINIMAL,
             **TRACKS,
-            "fiber_arrays/DAS.L001/path/optical_components.csv": (
-                "object_type,optical_length,name\nFiberSegment,1000.0,fiber 1\n"
+            "fiber_arrays/DAS.L001/path/geometry.csv": (
+                "name,longitude,latitude,elevation\nS100,-117.0,40.0,687.0\n"
             ),
         }
-        with pytest.raises(InvalidInventoryError, match="no sequence column"):
+        with pytest.raises(InvalidInventoryError, match="no distance column"):
             make_inventory(files)
 
     def test_a_column_stated_twice(self, make_inventory):
@@ -1757,12 +1757,13 @@ class TestUnreadableTables:
         files = {
             **MINIMAL,
             **TRACKS,
-            "fiber_arrays/DAS.L001/path/optical_components.csv": (
-                "sequence,object_type,optical_length,name\n"
-                "first,FiberSegment,1000.0,fiber 1\n"
+            "fiber_arrays/DAS.L001/path/geometry.csv": (
+                "name,distance,longitude,latitude,elevation\n"
+                "S100,near,-117.0,40.0,687.0\n"
+                "S100,far,-117.1,40.1,685.0\n"
             ),
         }
-        with pytest.raises(InvalidInventoryError, match="non-numeric sequence"):
+        with pytest.raises(InvalidInventoryError, match="non-numeric distance"):
             make_inventory(files)
 
     def test_a_column_no_row_states(self, make_inventory):
@@ -1853,18 +1854,17 @@ class TestUnreadableTables:
         with pytest.raises(InvalidInventoryError, match="its header names 3 columns"):
             make_inventory(files)
 
-    def test_a_sequence_which_places_two_rows_alike(self, make_inventory):
-        """Components tile the path, so no two may claim one place."""
+    def test_a_retired_sequence_column_says_what_to_write(self, make_inventory):
+        """A table written when order decided placement is told what changed."""
         files = {
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/optical_components.csv": (
-                "sequence,object_type,optical_length,name\n"
-                "1,FiberSegment,100.0,a\n"
-                "1,Splice,0.1,b\n"
+                "sequence,object_type,distance_min,distance_max,name\n"
+                "1,FiberSegment,0,100,a\n"
             ),
         }
-        with pytest.raises(InvalidInventoryError, match="does not say which row"):
+        with pytest.raises(InvalidInventoryError, match="no longer reads"):
             make_inventory(files)
 
     def test_a_cell_which_does_not_pertain_to_its_row(self, make_inventory):
@@ -1873,8 +1873,8 @@ class TestUnreadableTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/optical_components.csv": (
-                "sequence,object_type,optical_length,name,fiber_color\n"
-                "1,Splice,0.1,b,blue\n"
+                "object_type,distance_min,distance_max,name,fiber_color\n"
+                "Splice,0,0.1,b,blue\n"
             ),
         }
         # A splice has no fiber colour; only a segment does.
@@ -1909,12 +1909,12 @@ class TestTableRegistry:
                 assert column is None or column not in loader._TABLES
             assert stem  # every key names something
 
-    def test_only_a_placing_table_drops_its_order_column(self):
-        """A column dropped where it is not scaffolding would vanish unseen."""
-        placing = {k for k, v in loader._TABLES.items() if v.places}
-        assert placing == {"optical_components"}
-        # And that column is the one the model has no field for.
-        assert "sequence" not in inv.OpticalPath.model_fields
+    def test_a_retired_column_names_no_field_of_the_model(self):
+        """A column explained as retired must not still be readable."""
+        for stem, retired in loader._RETIRED_COLUMNS.items():
+            model = inv.OpticalPath.model_fields[stem].annotation
+            for column in retired:
+                assert column not in str(model)
 
 
 class TestSilentlyLostRows:
@@ -1953,10 +1953,10 @@ class TestSilentlyLostRows:
         files = {
             **MINIMAL,
             **TRACKS,
-            "fiber_arrays/DAS.L001/path/optical_components.csv": (
-                "sequence,object_type,optical_length,name\n"
-                "1,FiberSegment,100.0,a\n"
-                ",Splice,0.1,b\n"
+            "fiber_arrays/DAS.L001/path/geometry.csv": (
+                "name,distance,longitude,latitude,elevation\n"
+                "S100,100.0,-117.0,40.0,687.0\n"
+                "S100,,-117.1,40.1,685.0\n"
             ),
         }
         with pytest.raises(InvalidInventoryError, match="state no place"):
@@ -1978,7 +1978,7 @@ class TestSilentlyLostRows:
             make_inventory(files)
 
     def test_a_stray_ordering_column_is_refused(self, make_inventory):
-        """A sequence column is scaffolding only where the table says so."""
+        """No table reads a sequence column, so the model calls it unknown."""
         files = {
             **MINIMAL,
             **TRACKS,
@@ -1986,7 +1986,6 @@ class TestSilentlyLostRows:
                 "sequence,distance_min,distance_max,coupling_type\n1,0,340,conduit\n"
             ),
         }
-        # Coupling is not placed by sequence, so the model calls it unknown.
         with pytest.raises(InvalidInventoryError, match="Could not read OpticalPath"):
             make_inventory(files)
 
@@ -2089,8 +2088,8 @@ class TestGapsMutationTestingFound:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/optical_components.csv": (
-                "sequence,object_type,optical_length,name,fiber_color\n"
-                "1,Splice,0.1,b,blue\n"
+                "object_type,distance_min,distance_max,name,fiber_color\n"
+                "Splice,0,0.1,b,blue\n"
             ),
         }
         with pytest.raises(InvalidInventoryError, match="fiber_color"):
@@ -2296,7 +2295,7 @@ class TestPRReviewFindings:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/optical_components.csv": (
-                "sequence,object_type,optical_length,name\n1,FiberSegment,3000.0,a\n"
+                "object_type,distance_min,distance_max,name\nFiberSegment,0,3000,a\n"
             ),
             "fiber_arrays/DAS.L001/path/geometry.csv": (
                 f"name,distance,longitude,latitude,elevation\n{rows}\n"

--- a/tests/test_core/test_inventory_loader.py
+++ b/tests/test_core/test_inventory_loader.py
@@ -288,7 +288,7 @@ class TestEpochNames:
             {"acquisitions/DAS.L001..RAW@2024-06-01.yaml": "object_type: Acquisition\n"}
         )
         acquisition = out.networks[0].fiber_arrays[0].acquisitions[0]
-        assert acquisition.start_time == np.datetime64("2024-06-01T00:00:00", "ns")
+        assert acquisition.time_min == np.datetime64("2024-06-01T00:00:00", "ns")
 
     def test_basic_time_and_fractional_seconds(self, make_inventory):
         """The time portion is ISO basic, since ':' is not a legal filename."""
@@ -301,26 +301,26 @@ class TestEpochNames:
         )
         acquisition = out.networks[0].fiber_arrays[0].acquisitions[0]
         expected = np.datetime64("2024-05-12T10:30:00.12", "ns")
-        assert acquisition.start_time == expected
+        assert acquisition.time_min == expected
 
     def test_suffix_agrees_with_stated_start(self, make_inventory):
         """A restated start time is checked rather than overridden."""
         out = make_inventory(
             {
                 "acquisitions/DAS.L001..RAW@2024-06-01.yaml": (
-                    "object_type: Acquisition\nstart_time: '2024-06-01'\n"
+                    "object_type: Acquisition\ntime_min: '2024-06-01'\n"
                 )
             }
         )
         acquisition = out.networks[0].fiber_arrays[0].acquisitions[0]
-        assert acquisition.start_time == np.datetime64("2024-06-01", "ns")
+        assert acquisition.time_min == np.datetime64("2024-06-01", "ns")
 
     def test_epochs_of_one_acquisition(self, make_inventory):
         """Two epochs of one acquisition are two entries under one array."""
         out = make_inventory(
             {
                 "acquisitions/DAS.L001..RAW.yaml": (
-                    "object_type: Acquisition\nend_time: '2024-06-01'\n"
+                    "object_type: Acquisition\ntime_max: '2024-06-01'\n"
                     "gauge_length: 10.0\n"
                 ),
                 "acquisitions/DAS.L001..RAW@2024-06-01.yaml": (
@@ -338,7 +338,7 @@ class TestEpochNames:
         out = make_inventory(
             {
                 "fiber_arrays/DAS.L001.yaml": (
-                    "object_type: FiberArray\nname: first\nend_time: '2024-06-01'\n"
+                    "object_type: FiberArray\nname: first\ntime_max: '2024-06-01'\n"
                 ),
                 "fiber_arrays/DAS.L001@2024-06-01.yaml": (
                     "object_type: FiberArray\nname: second\n"
@@ -398,7 +398,7 @@ class TestNearMisses:
         """The epoch suffix is a restated address, so it must agree."""
         files = {
             "acquisitions/DAS.L001..RAW@2024-06-01.yaml": (
-                "object_type: Acquisition\nstart_time: '2024-06-02'\n"
+                "object_type: Acquisition\ntime_min: '2024-06-02'\n"
             )
         }
         with pytest.raises(InvalidInventoryError, match="must agree with the name"):
@@ -502,7 +502,7 @@ class TestOverlookedInput:
         """Starting inside an epoch is not enough to belong to it."""
         files = {
             "fiber_arrays/DAS.L001.yaml": (
-                "object_type: FiberArray\nend_time: '2024-06-01'\n"
+                "object_type: FiberArray\ntime_max: '2024-06-01'\n"
             ),
             "fiber_arrays/DAS.L001@2024-06-01.yaml": "object_type: FiberArray\n",
             # Starts inside the first epoch and never ends, so resolution
@@ -517,11 +517,11 @@ class TestOverlookedInput:
         out = make_inventory(
             {
                 "fiber_arrays/DAS.L001.yaml": (
-                    "object_type: FiberArray\nend_time: '2024-06-01'\n"
+                    "object_type: FiberArray\ntime_max: '2024-06-01'\n"
                 ),
                 "fiber_arrays/DAS.L001@2024-06-01.yaml": "object_type: FiberArray\n",
                 "acquisitions/DAS.L001..RAW@2024-05-01.yaml": (
-                    "object_type: Acquisition\nend_time: '2024-06-01'\n"
+                    "object_type: Acquisition\ntime_max: '2024-06-01'\n"
                 ),
             }
         )
@@ -558,7 +558,7 @@ class TestOverlookedInput:
             "networks/DAS@2024-01-01.yaml": "object_type: Network\n",
             # No start of its own, so it claims the unbounded past, which is
             # outside a network beginning in 2024.
-            "stations/DAS.STA1.yaml": "object_type: Station\nend_time: '2020-01-01'\n",
+            "stations/DAS.STA1.yaml": "object_type: Station\ntime_max: '2020-01-01'\n",
         }
         with pytest.raises(InvalidInventoryError, match="starts before"):
             make_inventory(files)
@@ -567,11 +567,11 @@ class TestOverlookedInput:
         """The far end refuses a real end time, not only an unset one."""
         files = {
             "fiber_arrays/DAS.L001.yaml": (
-                "object_type: FiberArray\nend_time: '2024-06-01'\n"
+                "object_type: FiberArray\ntime_max: '2024-06-01'\n"
             ),
             "fiber_arrays/DAS.L001@2024-06-01.yaml": "object_type: FiberArray\n",
             "acquisitions/DAS.L001..RAW@2024-05-01.yaml": (
-                "object_type: Acquisition\nend_time: '2024-07-01'\n"
+                "object_type: Acquisition\ntime_max: '2024-07-01'\n"
             ),
         }
         with pytest.raises(InvalidInventoryError, match="runs past"):
@@ -631,17 +631,17 @@ class TestOverlookedInput:
         out = make_inventory(
             {
                 "fiber_arrays/DAS.L001.yaml": (
-                    "object_type: FiberArray\nstart_time: 2024-01-01\n"
-                    "end_time: 2024-07-01\n"
+                    "object_type: FiberArray\ntime_min: 2024-01-01\n"
+                    "time_max: 2024-07-01\n"
                 ),
                 "acquisitions/DAS.L001..RAW@2024-02-01.yaml": (
-                    "object_type: Acquisition\nend_time: 2024-03-01\n"
+                    "object_type: Acquisition\ntime_max: 2024-03-01\n"
                 ),
             }
         )
         array = out.networks[0].fiber_arrays[0]
-        assert array.end_time == np.datetime64("2024-07-01", "ns")
-        assert array.acquisitions[0].end_time == np.datetime64("2024-03-01", "ns")
+        assert array.time_max == np.datetime64("2024-07-01", "ns")
+        assert array.acquisitions[0].time_max == np.datetime64("2024-03-01", "ns")
 
     def test_type_which_is_not_a_name(self, make_inventory):
         """A type which is not a name at all names no model either."""
@@ -721,7 +721,7 @@ class TestOneIdentityOneSpelling:
         """Two epochs of one entity may not overlap, not merely coincide."""
         files = {
             "acquisitions/DAS.L001..RAW@2024-01-01.yaml": (
-                "object_type: Acquisition\nend_time: '2024-08-01'\n"
+                "object_type: Acquisition\ntime_max: '2024-08-01'\n"
             ),
             "acquisitions/DAS.L001..RAW@2024-06-01.yaml": "object_type: Acquisition\n",
         }
@@ -875,7 +875,7 @@ class TestEpochTimestamps:
             }
         )
         acquisition = out.networks[0].fiber_arrays[0].acquisitions[0]
-        assert acquisition.start_time == np.datetime64("2262-04-11T23:47:16", "ns")
+        assert acquisition.time_min == np.datetime64("2262-04-11T23:47:16", "ns")
 
     def test_two_epoch_markers(self, make_inventory):
         """A name carries at most one epoch."""
@@ -910,7 +910,7 @@ class TestEpochPlacement:
         """A child falling in no epoch of its container is misfiled."""
         files = {
             "fiber_arrays/DAS.L001.yaml": (
-                "object_type: FiberArray\nend_time: '2024-06-01'\n"
+                "object_type: FiberArray\ntime_max: '2024-06-01'\n"
             ),
             "acquisitions/DAS.L001..RAW@2024-07-01.yaml": "object_type: Acquisition\n",
         }
@@ -921,7 +921,7 @@ class TestEpochPlacement:
         """An unset start beside several container epochs is ambiguous."""
         files = {
             "fiber_arrays/DAS.L001.yaml": (
-                "object_type: FiberArray\nend_time: '2024-06-01'\n"
+                "object_type: FiberArray\ntime_max: '2024-06-01'\n"
             ),
             "fiber_arrays/DAS.L001@2024-06-01.yaml": "object_type: FiberArray\n",
             "acquisitions/DAS.L001..RAW.yaml": "object_type: Acquisition\n",
@@ -933,7 +933,7 @@ class TestEpochPlacement:
         """Networks epoch like everything else which is time-ranged."""
         out = make_inventory(
             {
-                "networks/DAS.yaml": "object_type: Network\nend_time: '2024-06-01'\n",
+                "networks/DAS.yaml": "object_type: Network\ntime_max: '2024-06-01'\n",
                 "networks/DAS@2024-06-01.yaml": "object_type: Network\nname: later\n",
                 "stations/DAS.STA1@2024-07-01.yaml": "object_type: Station\n",
             }
@@ -1070,18 +1070,18 @@ TRACKS = {
         "1,FiberSegment,1000.0,fiber 1,1,blue\n"
     ),
     "fiber_arrays/DAS.L001/path/coupling.csv": (
-        "start_distance,end_distance,coupling_type,description\n"
+        "distance_min,distance_max,coupling_type,description\n"
         "0,340,conduit,\n"
         "340,355,trench,backfilled\n"
     ),
     "fiber_arrays/DAS.L001/path/labels.csv": (
-        "start_distance,end_distance,group,value\n"
+        "distance_min,distance_max,group,value\n"
         "0,340,rock_type,granite\n"
         "0,120,noisy,\n"
         "120,340,frost_depth,1.2\n"
     ),
     "fiber_arrays/DAS.L001/path/geometry.csv": (
-        "segment,distance,longitude,latitude,elevation\n"
+        "name,distance,longitude,latitude,elevation\n"
         "S100,100.0,-117.0,40.0,687.0\n"
         "S100,102.0,-117.1,40.1,685.0\n"
     ),
@@ -1134,7 +1134,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/labels.csv": (
-                f"start_distance,end_distance,group,value\n0,340,g,{text}\n"
+                f"distance_min,distance_max,group,value\n0,340,g,{text}\n"
             ),
         }
         value = one_path(make_inventory(files)).labels[0].value
@@ -1146,7 +1146,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/labels.csv": (
-                "start_distance,end_distance,group,value\n"
+                "distance_min,distance_max,group,value\n"
                 "0,120,zone,north\n"
                 "120,340,zone,\n"
             ),
@@ -1160,7 +1160,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/labels.csv": (
-                "start_distance,end_distance,group,value\n"
+                "distance_min,distance_max,group,value\n"
                 "0,120,hole,3\n"
                 "120,340,hole,deep\n"
             ),
@@ -1185,13 +1185,13 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,longitude,latitude,elevation,borehole_depth\n"
+                "name,distance,longitude,latitude,elevation,borehole_depth\n"
                 "S100,100.0,-117.0,40.0,687.0,0.0\n"
                 "S100,102.0,-117.1,40.1,685.0,2.0\n"
             ),
         }
         geometry = one_path(make_inventory(files)).geometry[0]
-        assert geometry.coordinates["borehole_depth"] == (0.0, 2.0)
+        assert geometry.columns["borehole_depth"] == (0.0, 2.0)
         assert geometry.units == {}
 
     def test_a_column_states_its_units_in_its_header(self, make_inventory):
@@ -1200,11 +1200,11 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,depth (m)\nS100,100.0,0.0\nS100,102.0,2.0\n"
+                "name,distance,depth (m)\nS100,100.0,0.0\nS100,102.0,2.0\n"
             ),
         }
         geometry = one_path(make_inventory(files)).geometry[0]
-        assert geometry.coordinates["depth"] == (0.0, 2.0)
+        assert geometry.columns["depth"] == (0.0, 2.0)
         assert geometry.units["depth"] == "m"
 
     def test_units_on_an_axis_header(self, make_inventory):
@@ -1213,7 +1213,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,longitude,latitude,elevation (ft)\n"
+                "name,distance,longitude,latitude,elevation (ft)\n"
                 "S100,100.0,-117.0,40.0,687.0\n"
                 "S100,102.0,-117.1,40.1,685.0\n"
             ),
@@ -1227,7 +1227,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,zone\nS100,100.0,north\nS100,102.0,south\n"
+                "name,distance,zone\nS100,100.0,north\nS100,102.0,south\n"
             ),
         }
         with pytest.raises(InvalidInventoryError, match=r"labels\.csv"):
@@ -1239,7 +1239,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,distance (m)\nS100,100.0,100.0\nS100,102.0,102.0\n"
+                "name,distance,distance (m)\nS100,100.0,100.0\nS100,102.0,102.0\n"
             ),
         }
         with pytest.raises(InvalidInventoryError, match="more than once"):
@@ -1257,11 +1257,11 @@ class TestTrackTables:
                 "  units: [meter, meter]\n"
             ),
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,z (m)\nS100,100.0,0.0\nS100,102.0,2.0\n"
+                "name,distance,z (m)\nS100,100.0,0.0\nS100,102.0,2.0\n"
             ),
         }
         geometry = one_path(make_inventory(files)).geometry[0]
-        assert geometry.coordinates["z"] == (0.0, 2.0)
+        assert geometry.columns["z"] == (0.0, 2.0)
         assert geometry.units["z"] == "m"
 
     def test_one_column_stated_twice(self, make_inventory):
@@ -1270,7 +1270,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,depth,depth (m)\nS100,100.0,0.0,0.0\n"
+                "name,distance,depth,depth (m)\nS100,100.0,0.0,0.0\n"
                 "S100,102.0,2.0,2.0\n"
             ),
         }
@@ -1283,8 +1283,8 @@ class TestTrackTables:
         geometry = path.geometry[0]
         assert geometry.distance == (100.0, 102.0)
         # A column is keyed by the header which states it.
-        assert geometry.coordinates["longitude"] == (-117.0, -117.1)
-        assert geometry.coordinates["elevation"] == (687.0, 685.0)
+        assert geometry.columns["longitude"] == (-117.0, -117.1)
+        assert geometry.columns["elevation"] == (687.0, 685.0)
 
     def test_a_declared_frame_renames_the_axes(self, make_inventory):
         """The envelope decides which headers a geometry table may state."""
@@ -1300,14 +1300,14 @@ class TestTrackTables:
                 "  units: [meter, meter, meter]\n"
             ),
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,x,y,elevation\n"
+                "name,distance,x,y,elevation\n"
                 "S100,100.0,2562048.25,1137365.53,687.0\n"
                 "S100,102.0,2562048.17,1137365.63,685.0\n"
             ),
         }
         geometry = one_path(make_inventory(files)).geometry[0]
-        assert geometry.coordinates["x"] == (2562048.25, 2562048.17)
-        assert geometry.coordinates["elevation"] == (687.0, 685.0)
+        assert geometry.columns["x"] == (2562048.25, 2562048.17)
+        assert geometry.columns["elevation"] == (687.0, 685.0)
 
     def test_a_partial_set_of_axes(self, make_inventory):
         """A segment states every axis the frame declares, or none of them."""
@@ -1315,7 +1315,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,longitude,latitude\nS100,100.0,1.0,2.0\n"
+                "name,distance,longitude,latitude\nS100,100.0,1.0,2.0\n"
                 "S100,102.0,1.1,2.1\n"
             ),
         }
@@ -1328,7 +1328,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,longitude,latitude,elevation\n"
+                "name,distance,longitude,latitude,elevation\n"
                 "S100,100.0,-117.0,40.0,687.0\n"
                 "S100,102.0,-117.1,,685.0\n"
             ),
@@ -1340,7 +1340,7 @@ class TestTrackTables:
         """A map has no grouping column: every point belongs to the one map."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\nspatial_interval: 1.0\n"
+                "object_type: Acquisition\ndistance_step: 1.0\n"
             ),
             "acquisitions/DAS.L001.02.DEC/distance_map.csv": (
                 "channel,distance\n512,500.0\n1710,1698.0\n"
@@ -1364,8 +1364,7 @@ class TestTrackTables:
             "fiber_arrays/DAS.L001/path/crew_notes.csv": "who,when\nderrick,tuesday\n",
             "fiber_arrays/DAS.L001/path/components.csv": "a,b\n1,2\n",
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,longitude,latitude,elevation\n"
-                "S,0,0,0,0\nS,100,1,1,0\n"
+                "name,distance,longitude,latitude,elevation\nS,0,0,0,0\nS,100,1,1,0\n"
             ),
         }
         inventory = make_inventory(files)
@@ -1377,7 +1376,7 @@ class TestTrackTables:
         """A near-miss did claim to be a track, so it is not quietly dropped."""
         files = {
             **PATH_DIRECTORY,
-            f"fiber_arrays/DAS.L001/path/{name}.csv": "segment,distance\nS,0\n",
+            f"fiber_arrays/DAS.L001/path/{name}.csv": "name,distance\nS,0\n",
         }
         with pytest.raises(InvalidInventoryError, match="Did you mean"):
             make_inventory(files)
@@ -1400,7 +1399,7 @@ class TestTrackTables:
         """The right file one directory too high still says it is a track."""
         files = {
             **PATH_DIRECTORY,
-            "fiber_arrays/DAS.L001/geometry.csv": "segment,distance\nS,0\n",
+            "fiber_arrays/DAS.L001/geometry.csv": "name,distance\nS,0\n",
         }
         with pytest.raises(InvalidInventoryError, match="names the track geometry"):
             make_inventory(files)
@@ -1410,7 +1409,7 @@ class TestTrackTables:
         """Case decides nothing here, as it decides nothing for a suffix."""
         files = {
             **PATH_DIRECTORY,
-            f"fiber_arrays/DAS.L001/path/{name}.CSV": "segment,distance\nS,0\n",
+            f"fiber_arrays/DAS.L001/path/{name}.CSV": "name,distance\nS,0\n",
         }
         with pytest.raises(InvalidInventoryError, match="Did you mean geometry"):
             make_inventory(files)
@@ -1426,7 +1425,7 @@ class TestTrackTables:
         files = {
             **PATH_DIRECTORY,
             "fiber_arrays/DAS.L001/path/annotations.csv": (
-                "start_distance,end_distance,group,value\n0,10,zone,north\n"
+                "distance_min,distance_max,group,value\n0,10,zone,north\n"
             ),
         }
         with pytest.raises(InvalidInventoryError, match="now reads as labels"):
@@ -1464,8 +1463,8 @@ class TestTrackTables:
             "fiber_arrays/DAS.L001/path/attrs.yaml": (
                 "object_type: OpticalPath\nname: main\n"
                 "coupling:\n"
-                "  - start_distance: 0.0\n"
-                "    end_distance: 10.0\n"
+                "  - distance_min: 0.0\n"
+                "    distance_max: 10.0\n"
                 "    coupling_type: trench\n"
             ),
         }
@@ -1490,7 +1489,7 @@ class TestTrackTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/coupling.csv": (
-                "start_distance,end_distance,coupling_type,coupling_type\n"
+                "distance_min,distance_max,coupling_type,coupling_type\n"
                 "0,340,conduit,trench\n"
             ),
         }
@@ -1528,13 +1527,13 @@ class TestPrivateColumns:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,longitude,latitude,elevation,_surveyed_by\n"
+                "name,distance,longitude,latitude,elevation,_surveyed_by\n"
                 "S100,100.0,-117.0,40.0,687.0,north crew\n"
                 "S100,102.0,-117.1,40.1,685.0,north crew\n"
             ),
         }
         segment = one_path(make_inventory(files)).geometry[0]
-        assert set(segment.coordinates) == {"longitude", "latitude", "elevation"}
+        assert set(segment.columns) == {"longitude", "latitude", "elevation"}
 
     def test_a_table_of_only_private_columns(self, make_inventory):
         """A table which states nothing of its own states no track."""
@@ -1543,7 +1542,7 @@ class TestPrivateColumns:
             **TRACKS,
             "fiber_arrays/DAS.L001/path/coupling.csv": "_crew\nnorth crew\n",
         }
-        with pytest.raises(InvalidInventoryError, match="start_distance"):
+        with pytest.raises(InvalidInventoryError, match="distance_min"):
             make_inventory(files)
 
     def test_a_private_column_states_nothing(self, make_inventory):
@@ -1552,10 +1551,10 @@ class TestPrivateColumns:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/coupling.csv": (
-                "_start_distance,end_distance,coupling_type\n0,340,conduit\n"
+                "_distance_min,distance_max,coupling_type\n0,340,conduit\n"
             ),
         }
-        with pytest.raises(InvalidInventoryError, match="start_distance"):
+        with pytest.raises(InvalidInventoryError, match="distance_min"):
             make_inventory(files)
 
 
@@ -1566,7 +1565,7 @@ class TestPathEpochs:
         """The bare directory is the blank location, starting where the array does."""
         path = one_path(make_inventory({**MINIMAL, **TRACKS}))
         assert path.location_code == ""
-        assert pd.isnull(path.start_time)
+        assert pd.isnull(path.time_min)
 
     def test_a_location_joins_the_stem_with_a_dot(self, make_inventory):
         """Each location code is its own lineage."""
@@ -1604,9 +1603,9 @@ class TestPathEpochs:
         }
         boundary = np.datetime64("2024-05-12T10:30:00", "ns")
         # The first epoch was left open and the directory closed it.
-        assert paths["first"].end_time == boundary
-        assert paths["second"].start_time == boundary
-        assert pd.isnull(paths["second"].end_time)
+        assert paths["first"].time_max == boundary
+        assert paths["second"].time_min == boundary
+        assert pd.isnull(paths["second"].time_max)
 
     def test_an_epoch_may_end_early(self, make_inventory):
         """A dark interval: an epoch states an end before its successor."""
@@ -1614,7 +1613,7 @@ class TestPathEpochs:
             **MINIMAL,
             "fiber_arrays/DAS.L001/attrs.yaml": "object_type: FiberArray\n",
             "fiber_arrays/DAS.L001/path/attrs.yaml": (
-                "object_type: OpticalPath\nname: first\nend_time: 2024-01-01\n"
+                "object_type: OpticalPath\nname: first\ntime_max: 2024-01-01\n"
             ),
             "fiber_arrays/DAS.L001/path@2024-05-12T103000/attrs.yaml": (
                 "object_type: OpticalPath\nname: second\n"
@@ -1624,7 +1623,7 @@ class TestPathEpochs:
             x.name: x
             for x in make_inventory(files).networks[0].fiber_arrays[0].optical_paths
         }
-        assert paths["first"].end_time == np.datetime64("2024-01-01", "ns")
+        assert paths["first"].time_max == np.datetime64("2024-01-01", "ns")
 
     def test_an_epoch_may_not_end_late(self, make_inventory):
         """An epoch cannot claim time its successor already holds."""
@@ -1632,7 +1631,7 @@ class TestPathEpochs:
             **MINIMAL,
             "fiber_arrays/DAS.L001/attrs.yaml": "object_type: FiberArray\n",
             "fiber_arrays/DAS.L001/path/attrs.yaml": (
-                "object_type: OpticalPath\nname: first\nend_time: 2025-01-01\n"
+                "object_type: OpticalPath\nname: first\ntime_max: 2025-01-01\n"
             ),
             "fiber_arrays/DAS.L001/path@2024-05-12T103000/attrs.yaml": (
                 "object_type: OpticalPath\nname: second\n"
@@ -1742,7 +1741,7 @@ class TestUnreadableTables:
         root = write_inventory(tmp_path / "wide", {**MINIMAL, **TRACKS})
         cell = "x" * (csv.field_size_limit() + 1)
         (root / "fiber_arrays/DAS.L001/path/coupling.csv").write_text(
-            f"start_distance,end_distance,coupling_type,description\n0,340,conduit,{cell}\n"
+            f"distance_min,distance_max,coupling_type,description\n0,340,conduit,{cell}\n"
         )
         with pytest.raises(InvalidInventoryError, match="Could not read"):
             dc.inventory(root)
@@ -1770,7 +1769,7 @@ class TestUnreadableTables:
         """A column every row leaves empty states nothing, and is not empty."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\nspatial_interval: 1.0\n"
+                "object_type: Acquisition\ndistance_step: 1.0\n"
             ),
             "acquisitions/DAS.L001.02.DEC/distance_map.csv": (
                 "channel,instrument_distance,distance\n512,,500.0\n1710,,1698.0\n"
@@ -1786,7 +1785,7 @@ class TestUnreadableTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/labels.csv": (
-                "start_distance,end_distance,group,value\n0,120,noisy,\n"
+                "distance_min,distance_max,group,value\n0,120,noisy,\n"
             ),
         }
         label = one_path(make_inventory(files)).labels[0]
@@ -1798,7 +1797,7 @@ class TestUnreadableTables:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/labels.csv": (
-                "start_distance,end_distance,group,value\n"
+                "distance_min,distance_max,group,value\n"
                 "0,120,noisy,  \n"
                 "120,340,noisy,\n"
             ),
@@ -1812,7 +1811,7 @@ class TestUnreadableTables:
             **MINIMAL,
             "fiber_arrays/DAS.L001/attrs.yaml": "object_type: FiberArray\n",
             "fiber_arrays/DAS.L001/path@2024-06-01/attrs.yaml": (
-                "object_type: OpticalPath\nstart_time: 2024-06-02\n"
+                "object_type: OpticalPath\ntime_min: 2024-06-02\n"
             ),
         }
         with pytest.raises(InvalidInventoryError, match="must agree with the name"):
@@ -1841,14 +1840,14 @@ class TestUnreadableTables:
 
         Pandas refuses neither: a surplus cell silently pushes the first
         column into the index, so `0,340,conduit,extra` would load as
-        start_distance=340, end_distance=conduit, coupling_type=extra --
+        distance_min=340, distance_max=conduit, coupling_type=extra --
         every value one field left of what it says.
         """
         files = {
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/coupling.csv": (
-                f"start_distance,end_distance,coupling_type\n{row}\n"
+                f"distance_min,distance_max,coupling_type\n{row}\n"
             ),
         }
         with pytest.raises(InvalidInventoryError, match="its header names 3 columns"):
@@ -1927,7 +1926,7 @@ class TestSilentlyLostRows:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,longitude,latitude,elevation\n"
+                "name,distance,longitude,latitude,elevation\n"
                 "S100,100.0,-117.0,40.0,687.0\n"
                 ",102.0,-117.1,40.1,685.0\n"
             ),
@@ -1941,7 +1940,7 @@ class TestSilentlyLostRows:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,longitude,latitude,elevation\n"
+                "name,distance,longitude,latitude,elevation\n"
                 ",100.0,-117.0,40.0,687.0\n"
                 ",102.0,-117.1,40.1,685.0\n"
             ),
@@ -1967,7 +1966,7 @@ class TestSilentlyLostRows:
         """Columns become parallel arrays, so a gap would pair the unpaired."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\nspatial_interval: 1.0\n"
+                "object_type: Acquisition\ndistance_step: 1.0\n"
             ),
             # Channel 5 states no distance and 100 states no channel; read
             # column by column they would pair up as though they had.
@@ -1984,7 +1983,7 @@ class TestSilentlyLostRows:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/coupling.csv": (
-                "sequence,start_distance,end_distance,coupling_type\n1,0,340,conduit\n"
+                "sequence,distance_min,distance_max,coupling_type\n1,0,340,conduit\n"
             ),
         }
         # Coupling is not placed by sequence, so the model calls it unknown.
@@ -2006,13 +2005,13 @@ class TestPathEpochsBelongToTheirArray:
             ),
         }
         array = make_inventory(files).networks[0].fiber_arrays[0]
-        assert array.start_time == np.datetime64("2024-01-01", "ns")
-        assert array.optical_paths[0].start_time == array.start_time
+        assert array.time_min == np.datetime64("2024-01-01", "ns")
+        assert array.optical_paths[0].time_min == array.time_min
 
     def test_an_undated_array_leaves_its_path_undated(self, make_inventory):
         """There is nothing to inherit, so the path keeps its own unset start."""
         path = one_path(make_inventory({**MINIMAL, **TRACKS}))
-        assert pd.isnull(path.start_time)
+        assert pd.isnull(path.time_min)
 
     @pytest.mark.skipif(
         not KEEPS_TRAILING_DOT, reason="this filesystem holds one of the two"
@@ -2042,7 +2041,7 @@ class TestPathEpochsBelongToTheirArray:
                 **MINIMAL,
                 "fiber_arrays/DAS.L001/attrs.yaml": "object_type: FiberArray\n",
                 "fiber_arrays/DAS.L001/path/attrs.yaml": (
-                    "object_type: OpticalPath\nend_time: 2025-01-01\n"
+                    "object_type: OpticalPath\ntime_max: 2025-01-01\n"
                 ),
                 "fiber_arrays/DAS.L001/path@2024-05-12T103000/attrs.yaml": (
                     "object_type: OpticalPath\n"
@@ -2070,7 +2069,7 @@ class TestGapsMutationTestingFound:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                "segment,distance,longitude,latitude,elevation\n"
+                "name,distance,longitude,latitude,elevation\n"
                 "S100,100.0,-117.0,40.0,687.0\n"
                 "S120,200.0,-117.2,40.2,690.0\n"
                 "S100,102.0,-117.1,40.1,685.0\n"
@@ -2082,7 +2081,7 @@ class TestGapsMutationTestingFound:
         # Interleaved in the file; gathered by name and ordered by distance.
         assert geometry["S100"].distance == (100.0, 102.0)
         assert geometry["S120"].distance == (200.0, 202.0)
-        assert geometry["S100"].coordinates["latitude"] == (40.0, 40.1)
+        assert geometry["S100"].columns["latitude"] == (40.0, 40.1)
 
     def test_a_wrong_cell_names_the_field_it_could_not_take(self, make_inventory):
         """Matching only 'Could not read' would pass for any path failure."""
@@ -2105,7 +2104,7 @@ class TestGapsMutationTestingFound:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/labels.csv": (
-                f"start_distance,end_distance,group,value\n"
+                f"distance_min,distance_max,group,value\n"
                 f"0,120,thickness,{first}\n120,340,thickness,{second}\n"
             ),
         }
@@ -2121,7 +2120,7 @@ class TestGapsMutationTestingFound:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/labels.csv": (
-                f"start_distance,end_distance,group,value\n0,120,noisy,{text}\n"
+                f"distance_min,distance_max,group,value\n0,120,noisy,{text}\n"
             ),
         }
         with pytest.raises(InvalidInventoryError, match=r"row 2.*not values"):
@@ -2133,7 +2132,7 @@ class TestGapsMutationTestingFound:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/labels.csv": (
-                "start_distance,end_distance,group,value\n0,120,thickness,1.0\n"
+                "distance_min,distance_max,group,value\n0,120,thickness,1.0\n"
             ),
         }
         value = one_path(make_inventory(files)).labels[0].value
@@ -2145,7 +2144,7 @@ class TestGapsMutationTestingFound:
             **MINIMAL,
             "fiber_arrays/DAS.L001/attrs.yaml": "object_type: FiberArray\n",
             "fiber_arrays/DAS.L001/path/attrs.yaml": (
-                "object_type: OpticalPath\nname: first\nend_time: 2024-05-12T10:30:00\n"
+                "object_type: OpticalPath\nname: first\ntime_max: 2024-05-12T10:30:00\n"
             ),
             "fiber_arrays/DAS.L001/path@2024-05-12T103000/attrs.yaml": (
                 "object_type: OpticalPath\nname: second\n"
@@ -2155,7 +2154,7 @@ class TestGapsMutationTestingFound:
             x.name: x
             for x in make_inventory(files).networks[0].fiber_arrays[0].optical_paths
         }
-        assert paths["first"].end_time == paths["second"].start_time
+        assert paths["first"].time_max == paths["second"].time_min
 
     def test_lineages_of_two_locations_stay_apart(self, make_inventory):
         """Each location is its own lineage, so neither closes the other."""
@@ -2174,8 +2173,8 @@ class TestGapsMutationTestingFound:
             for x in make_inventory(files).networks[0].fiber_arrays[0].optical_paths
         }
         # Pooled into one lineage, `a` would have been closed by `b`.
-        assert pd.isnull(paths["a"].end_time)
-        assert pd.isnull(paths["b"].end_time)
+        assert pd.isnull(paths["a"].time_max)
+        assert pd.isnull(paths["b"].time_max)
 
     def test_a_shouted_table_suffix_and_a_hidden_sidecar(self, tmp_path):
         """A table is found however its suffix is cased, and a dotfile is not."""
@@ -2193,7 +2192,7 @@ class TestGapsMutationTestingFound:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/coupling.csv": (
-                "start_distance,end_distance,coupling_type\n0,340,conduit\n\n"
+                "distance_min,distance_max,coupling_type\n0,340,conduit\n\n"
             ),
         }
         assert len(one_path(make_inventory(files)).coupling) == 1
@@ -2204,7 +2203,7 @@ class TestGapsMutationTestingFound:
             **MINIMAL,
             **TRACKS,
             "fiber_arrays/DAS.L001/path/coupling.csv": (
-                "start_distance,end_distance,coupling_type,description\n"
+                "distance_min,distance_max,coupling_type,description\n"
                 "0,340,conduit,NA\n"
             ),
         }
@@ -2219,7 +2218,7 @@ class TestGapsMutationTestingFound:
         first = inv.OpticalPath(name="first")
         second = inv.OpticalPath(name="second")
         sources = {id(first): tmp_path / "a.yaml", id(second): tmp_path / "b.yaml"}
-        assert pd.isnull(first.start_time) and pd.isnull(second.start_time)
+        assert pd.isnull(first.time_min) and pd.isnull(second.time_min)
         with pytest.raises(InvalidInventoryError, match="two spellings of one epoch"):
             loader._close_lineages([first, second], sources)
 
@@ -2231,7 +2230,7 @@ class TestPRReviewFindings:
         """The frame is sorted and split by then, so positions lie."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\nspatial_interval: 1.0\n"
+                "object_type: Acquisition\ndistance_step: 1.0\n"
             ),
             # Sorted by distance these rows reverse, so a position within
             # the sorted frame is not the line the author would open.
@@ -2251,7 +2250,7 @@ class TestPRReviewFindings:
         """A header and no rows describes no map, rather than raising bare."""
         files = {
             "acquisitions/DAS.L001.02.DEC/attrs.yaml": (
-                "object_type: Acquisition\nspatial_interval: 1.0\n"
+                "object_type: Acquisition\ndistance_step: 1.0\n"
             ),
             "acquisitions/DAS.L001.02.DEC/distance_map.csv": "channel,distance\n",
         }
@@ -2300,7 +2299,7 @@ class TestPRReviewFindings:
                 "sequence,object_type,optical_length,name\n1,FiberSegment,3000.0,a\n"
             ),
             "fiber_arrays/DAS.L001/path/geometry.csv": (
-                f"segment,distance,longitude,latitude,elevation\n{rows}\n"
+                f"name,distance,longitude,latitude,elevation\n{rows}\n"
             ),
         }
         assert len(one_path(make_inventory(files)).geometry[0].distance) == 2000

--- a/tests/test_core/test_spool_inventory.py
+++ b/tests/test_core/test_spool_inventory.py
@@ -1754,7 +1754,8 @@ class TestSharedNames:
                 optical_components=(
                     FiberSegment(
                         name="c",
-                        optical_length=100.0,
+                        distance_min=0.0,
+                        distance_max=100.0,
                         loss_db=loss,
                         loss_measurement=measurement,
                     ),
@@ -3122,7 +3123,9 @@ def _float_grid_pair(distance, span):
     path = OpticalPath(
         name="main",
         location_code="",
-        optical_components=(FiberSegment(name="c", optical_length=span + 10),),
+        optical_components=(
+            FiberSegment(name="c", distance_min=0.0, distance_max=span + 10),
+        ),
         labels=(
             OpticalPathLabel(
                 distance_min=span * 0.23,

--- a/tests/test_core/test_spool_inventory.py
+++ b/tests/test_core/test_spool_inventory.py
@@ -695,8 +695,8 @@ class TestOnUnresolved:
             array,
             array.new(
                 acquisitions=(
-                    acquisition.new(end_time=middle),
-                    acquisition.new(start_time=middle, gauge_length=20.0),
+                    acquisition.new(time_max=middle),
+                    acquisition.new(time_min=middle, gauge_length=20.0),
                 )
             ),
         )
@@ -1068,8 +1068,8 @@ class TestInventorySelect:
             old,
             old.new(
                 acquisitions=(
-                    acq.new(end_time=middle, gauge_length=10.0),
-                    acq.new(start_time=middle, gauge_length=20.0),
+                    acq.new(time_max=middle, gauge_length=10.0),
+                    acq.new(time_min=middle, gauge_length=20.0),
                 )
             ),
         )
@@ -1442,9 +1442,9 @@ class TestInventorySelectCoverage:
         array = network.fiber_arrays[0]
         elsewhere = network.new(
             code="ZZ",
-            fiber_arrays=(array.new(code="L999", start_time="2001-01-01"),),
+            fiber_arrays=(array.new(code="L999", time_min="2001-01-01"),),
         )
-        sibling = array.new(code="L998", start_time="2001-01-02")
+        sibling = array.new(code="L998", time_min="2001-01-02")
         crowded = inventory.new(
             networks=(
                 elsewhere,
@@ -1541,8 +1541,8 @@ class TestNothingToResolveWith:
             array,
             array.new(
                 acquisitions=(
-                    acquisition.new(end_time=split, gauge_length=10.0),
-                    acquisition.new(start_time=split, gauge_length=20.0),
+                    acquisition.new(time_max=split, gauge_length=10.0),
+                    acquisition.new(time_min=split, gauge_length=20.0),
                 )
             ),
         )
@@ -1719,8 +1719,8 @@ class TestSharedNames:
                 labels=(
                     *path.labels,
                     OpticalPathLabel(
-                        start_distance=0.0,
-                        end_distance=100.0,
+                        distance_min=0.0,
+                        distance_max=100.0,
                         group="gauge_length",
                         value="odd",
                     ),
@@ -1786,7 +1786,7 @@ def _split_epochs(inventory, when, *, acquisitions=False, second=None):
     array = inventory.networks[0].fiber_arrays[0]
     old = array.acquisitions[0] if acquisitions else array.optical_paths[0]
     changed = {} if second is None else second
-    halves = (old.new(end_time=when), old.new(start_time=when, **changed))
+    halves = (old.new(time_max=when), old.new(time_min=when, **changed))
     field = "acquisitions" if acquisitions else "optical_paths"
     return inventory.replace(array, array.new(**{field: halves})).check()
 
@@ -2081,7 +2081,7 @@ class TestConformSubdivision:
             when,
             second={
                 "labels": (
-                    moved.new(value="moved", start_distance=100.0, end_distance=400.0),
+                    moved.new(value="moved", distance_min=100.0, distance_max=400.0),
                 )
             },
         )
@@ -2099,9 +2099,9 @@ class TestConformSubdivision:
         old = array.optical_paths[0]
         edges = [coord.min() + coord.step * x for x in (500, 1000)]
         paths = (
-            old.new(end_time=edges[0]),
-            old.new(start_time=edges[0], end_time=edges[1], name="middle"),
-            old.new(start_time=edges[1], name="last"),
+            old.new(time_max=edges[0]),
+            old.new(time_min=edges[0], time_max=edges[1], name="middle"),
+            old.new(time_min=edges[1], name="last"),
         )
         split = inventory.replace(array, array.new(optical_paths=paths)).check()
         out = dc.spool(patch).attach_inventory(split).conform_to_inventory()
@@ -2122,9 +2122,9 @@ class TestConformSubdivision:
         old = array.optical_paths[0]
         edges = [coord.min() + coord.step * 500 + x for x in (-coord.step / 3, 0)]
         paths = (
-            old.new(end_time=edges[0]),
-            old.new(start_time=edges[0], end_time=edges[1], name="blink"),
-            old.new(start_time=edges[1], name="after"),
+            old.new(time_max=edges[0]),
+            old.new(time_min=edges[0], time_max=edges[1], name="blink"),
+            old.new(time_min=edges[1], name="after"),
         )
         split = inventory.replace(array, array.new(optical_paths=paths)).check()
         out = dc.spool(patch).attach_inventory(split).conform_to_inventory()
@@ -2158,8 +2158,8 @@ class TestConformSubdivision:
             network,
             network.new(
                 fiber_arrays=(
-                    array.new(end_time=when),
-                    array.new(start_time=when, description="renamed"),
+                    array.new(time_max=when),
+                    array.new(time_min=when, description="renamed"),
                 )
             ),
         ).check()
@@ -2189,8 +2189,8 @@ class TestConformSubdivision:
             network,
             network.new(
                 fiber_arrays=(
-                    array.new(end_time=when),
-                    array.new(start_time=when, description="renamed"),
+                    array.new(time_max=when),
+                    array.new(time_min=when, description="renamed"),
                 )
             ),
         ).check()
@@ -2302,7 +2302,7 @@ class TestConformPartialCoverage:
         lapsed = inventory.replace(
             array,
             array.new(
-                acquisitions=(array.acquisitions[0].new(end_time=off_grid_boundary),)
+                acquisitions=(array.acquisitions[0].new(time_max=off_grid_boundary),)
             ),
         ).check()
         spool = dc.spool(patch).attach_inventory(lapsed)
@@ -2327,7 +2327,7 @@ class TestConformPartialCoverage:
         lapsed = inventory.replace(
             array,
             array.new(
-                optical_paths=(array.optical_paths[0].new(end_time=off_grid_boundary),)
+                optical_paths=(array.optical_paths[0].new(time_max=off_grid_boundary),)
             ),
         ).check()
         out = dc.spool(patch).attach_inventory(lapsed).conform_to_inventory()
@@ -2397,10 +2397,10 @@ def two_zones(inventory):
             labels=(
                 *path.labels,
                 OpticalPathLabel(
-                    start_distance=110.0, end_distance=150.0, group="hole", value="a"
+                    distance_min=110.0, distance_max=150.0, group="hole", value="a"
                 ),
                 OpticalPathLabel(
-                    start_distance=300.0, end_distance=340.0, group="hole", value="a"
+                    distance_min=300.0, distance_max=340.0, group="hole", value="a"
                 ),
             )
         ),
@@ -2926,8 +2926,8 @@ class TestChannelSelectEdges:
                 labels=(
                     *path.labels,
                     OpticalPathLabel(
-                        start_distance=100.0,
-                        end_distance=200.0,
+                        distance_min=100.0,
+                        distance_max=200.0,
                         group="frost_depth",
                         value=1.5,
                     ),
@@ -3014,10 +3014,10 @@ def uneven_spool(patch, inventory):
     acquisition, path = array.acquisitions[0], array.optical_paths[0]
     holes = (
         OpticalPathLabel(
-            start_distance=110.0, end_distance=150.0, group="hole", value="a"
+            distance_min=110.0, distance_max=150.0, group="hole", value="a"
         ),
         OpticalPathLabel(
-            start_distance=300.0, end_distance=340.0, group="hole", value="a"
+            distance_min=300.0, distance_max=340.0, group="hole", value="a"
         ),
     )
     both = inventory.replace(
@@ -3125,8 +3125,8 @@ def _float_grid_pair(distance, span):
         optical_components=(FiberSegment(name="c", optical_length=span + 10),),
         labels=(
             OpticalPathLabel(
-                start_distance=span * 0.23,
-                end_distance=span * 0.61,
+                distance_min=span * 0.23,
+                distance_max=span * 0.61,
                 group="zone",
                 value="mid",
             ),
@@ -3192,8 +3192,8 @@ class TestChannelSelectContracts:
             path.new(
                 coupling=(
                     CouplingCondition(
-                        start_distance=100.0,
-                        end_distance=250.0,
+                        distance_min=100.0,
+                        distance_max=250.0,
                         coupling_type="trench",
                         medium="soil",
                         depth=2.0,
@@ -3286,8 +3286,8 @@ class TestChannelSelectContracts:
             path.new(
                 labels=(
                     OpticalPathLabel(
-                        start_distance=100.0,
-                        end_distance=200.0,
+                        distance_min=100.0,
+                        distance_max=200.0,
                         group="output_id",
                         value="a",
                     ),
@@ -3312,8 +3312,8 @@ class TestChannelSelectContracts:
             path.new(
                 labels=(
                     OpticalPathLabel(
-                        start_distance=100.0,
-                        end_distance=400.0,
+                        distance_min=100.0,
+                        distance_max=400.0,
                         group="acquisition_key",
                         value="bad",
                     ),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -133,9 +133,9 @@ class TestTunnelInventory:
     def test_epochs_are_open_at_the_ends(self, inventory):
         """The first path runs from the beginning, the second is ongoing."""
         first, second = inventory.networks[0].fiber_arrays[0].optical_paths
-        assert pd.isnull(first.start_time)
-        assert first.end_time == second.start_time
-        assert pd.isnull(second.end_time)
+        assert pd.isnull(first.time_min)
+        assert first.time_max == second.time_min
+        assert pd.isnull(second.time_max)
 
     def test_geometry_gap_is_a_real_gap(self, inventory, original):
         """Fiber nobody surveyed gets no position rather than a guess."""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -156,8 +156,8 @@ class TestTunnelInventory:
 
     def test_holds_point_markers(self, original):
         """Splices and connectors have no length, so they are points."""
-        intervals = original.component_intervals()
-        assert sum(1 for start, end in intervals if start == end) > 1
+        points = [x for x in original.optical_components if x.optical_length == 0]
+        assert len(points) > 1
 
     def test_coupling_covers_only_part_of_the_path(self, original):
         """Partial coverage is legal and is what a coverage plot must show."""

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -140,7 +140,7 @@ class TestAttrs:
         decimated = patch.decimate(time=2)
         out = decimated.enrich(inventory, coords=False)
         assert "sample_rate" not in dict(out.attrs)
-        assert "distance_step" not in dict(out.attrs)
+        assert "spatial_interval" not in dict(out.attrs)
 
     def test_named_coord_redundant_restores(self, patch, inventory):
         """Naming one restores the as-acquired value, as for data state."""
@@ -831,7 +831,7 @@ class TestEnrichContracts:
         """Interrogator meters map onto path meters one for one."""
         acq = inventory.networks[0].fiber_arrays[0].acquisitions[0]
         one_point = acq.new(
-            distance_step=2.0,
+            spatial_interval=2.0,
             distance_map=DistanceMap(instrument_distance=(0.0,), distance=(100.0,)),
         )
         inv = inventory.replace(acq, one_point)
@@ -927,7 +927,7 @@ class TestEnrichContracts:
         """A channel axis with no spacing does not veto the other axis."""
         no_slope = _replace_acquisition(
             inventory,
-            distance_step=None,
+            spatial_interval=None,
             distance_map=DistanceMap(
                 channel=(0.0,), instrument_distance=(0.0,), distance=(100.0,)
             ),
@@ -941,7 +941,7 @@ class TestEnrichContracts:
         """When no axis can be read, the reasons are reported together."""
         no_slope = _replace_acquisition(
             inventory,
-            distance_step=None,
+            spatial_interval=None,
             distance_map=DistanceMap(channel=(0.0,), distance=(100.0,)),
         )
         channels = np.arange(len(patch.get_coord("distance")))

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -117,8 +117,8 @@ class TestResolution:
         old = inventory.networks[0].fiber_arrays[0]
         acq = old.acquisitions[0]
         middle = patch.get_coord("time").values[len(patch.get_coord("time")) // 2]
-        first = acq.new(end_time=middle, gauge_length=10.0)
-        second = acq.new(start_time=middle, gauge_length=20.0)
+        first = acq.new(time_max=middle, gauge_length=10.0)
+        second = acq.new(time_min=middle, gauge_length=20.0)
         split = inventory.replace(old, old.new(acquisitions=(first, second)))
         with pytest.raises(PatchError, match="spans a change of acquisition"):
             patch.enrich(split, coords=False)
@@ -140,7 +140,7 @@ class TestAttrs:
         decimated = patch.decimate(time=2)
         out = decimated.enrich(inventory, coords=False)
         assert "sample_rate" not in dict(out.attrs)
-        assert "spatial_interval" not in dict(out.attrs)
+        assert "distance_step" not in dict(out.attrs)
 
     def test_named_coord_redundant_restores(self, patch, inventory):
         """Naming one restores the as-acquired value, as for data state."""
@@ -331,7 +331,7 @@ class TestGeometryColumns:
         segment = Geometry(
             name="hole",
             distance=(100.0, 200.0),
-            coordinates={"borehole_depth": (0.0, 100.0)},
+            columns={"borehole_depth": (0.0, 100.0)},
             units={"borehole_depth": "m"},
             **kwargs,
         )
@@ -381,7 +381,7 @@ class TestGeometryColumns:
         segment = Geometry(
             name="hole",
             distance=(100.0, 200.0),
-            coordinates={"borehole_depth": (0.0, 100.0)},
+            columns={"borehole_depth": (0.0, 100.0)},
         )
         inv = _replace_path(inventory, geometry=(segment,))
         with pytest.raises(PatchError, match="defines no 'x'"):
@@ -396,12 +396,12 @@ class TestGeometryColumns:
         first = Geometry(
             name="hole 1",
             distance=(100.0, 150.0),
-            coordinates={"borehole_depth": (0.0, 50.0)},
+            columns={"borehole_depth": (0.0, 50.0)},
         )
         second = Geometry(
             name="hole 2",
             distance=(300.0, 350.0),
-            coordinates={"borehole_depth": (0.0, 50.0)},
+            columns={"borehole_depth": (0.0, 50.0)},
         )
         path = inventory.networks[0].fiber_arrays[0].optical_paths[0]
         inv = _replace_path(inventory, geometry=(*path.geometry, first, second))
@@ -443,7 +443,7 @@ class TestCoords:
         """A numeric group carries NaN where uncovered."""
         labels = (
             OpticalPathLabel(
-                start_distance=100.0, end_distance=200.0, group="frost", value=1.5
+                distance_min=100.0, distance_max=200.0, group="frost", value=1.5
             ),
         )
         inv = _replace_path(inventory, labels=labels)
@@ -521,7 +521,7 @@ class TestCoords:
         """A label marking a spot documents it without covering it."""
         labels = (
             OpticalPathLabel(
-                start_distance=150.0, end_distance=150.0, group="zone", value="clamp"
+                distance_min=150.0, distance_max=150.0, group="zone", value="clamp"
             ),
         )
         inv = _replace_path(inventory, labels=labels)
@@ -590,8 +590,8 @@ class TestEdgeCases:
         path = array.optical_paths[0]
         time = patch.get_coord("time")
         middle = time.values[len(time) // 2]
-        first = path.new(end_time=middle)
-        second = path.new(start_time=middle, name="repaired")
+        first = path.new(time_max=middle)
+        second = path.new(time_min=middle, name="repaired")
         split = inventory.replace(array, array.new(optical_paths=(first, second)))
         with pytest.raises(PatchError, match="spans a change of optical path"):
             patch.enrich(split, coords=False)
@@ -623,7 +623,7 @@ class TestEdgeCases:
         flat = Geometry(
             name="flat",
             distance=(100.0, 400.0),
-            coordinates={"x": (0.0, 1.0), "y": (0.0, 1.0)},
+            columns={"x": (0.0, 1.0), "y": (0.0, 1.0)},
         )
         crs = CoordinateReferenceSystem(
             coordinate_labels=("easting", "northing"), units=("meter", "meter")
@@ -729,10 +729,10 @@ class TestProjectionDetails:
         inv = _replace_path(
             inventory,
             coupling=(
-                coupling.new(end_distance=200.0),
+                coupling.new(distance_max=200.0),
                 coupling.new(
-                    start_distance=200.0,
-                    end_distance=300.0,
+                    distance_min=200.0,
+                    distance_max=300.0,
                     medium="clay_and_gravel_backfill",
                 ),
             ),
@@ -758,7 +758,7 @@ class TestEnrichContracts:
     def test_endpoint_belongs_to_its_own_run(self, patch, inventory):
         """A track's coverage end is local: a later interval cannot move it."""
         path = inventory.networks[0].fiber_arrays[0].optical_paths[0]
-        far = path.coupling[0].new(start_distance=300.0, end_distance=400.0)
+        far = path.coupling[0].new(distance_min=300.0, distance_max=400.0)
         with_far = _replace_path(inventory, coupling=(path.coupling[0], far))
         near = patch.enrich(inventory, attrs=False, coords=("coupling.medium",))
         both = with_far.networks and patch.enrich(
@@ -771,10 +771,10 @@ class TestEnrichContracts:
     def test_geometry_endpoint_is_local(self, patch, inventory):
         """The same rule holds for the geometry track."""
         columns = {"x": (0.0, 1.0), "y": (0.0, 1.0), "z": (0.0, 1.0)}
-        first = Geometry(distance=(100.0, 200.0), coordinates=columns)
+        first = Geometry(distance=(100.0, 200.0), columns=columns)
         second = Geometry(
             distance=(300.0, 400.0),
-            coordinates={"x": (3.0, 4.0), "y": (3.0, 4.0), "z": (3.0, 4.0)},
+            columns={"x": (3.0, 4.0), "y": (3.0, 4.0), "z": (3.0, 4.0)},
         )
         inv = _replace_path(inventory, geometry=(first, second))
         out = patch.enrich(inv, attrs=False, coords=("x",))
@@ -831,7 +831,7 @@ class TestEnrichContracts:
         """Interrogator meters map onto path meters one for one."""
         acq = inventory.networks[0].fiber_arrays[0].acquisitions[0]
         one_point = acq.new(
-            spatial_interval=2.0,
+            distance_step=2.0,
             distance_map=DistanceMap(instrument_distance=(0.0,), distance=(100.0,)),
         )
         inv = inventory.replace(acq, one_point)
@@ -842,15 +842,15 @@ class TestEnrichContracts:
     def test_reserved_label_group_raises(self, inventory):
         """A group named after a coordinate would shadow it at enrichment."""
         path = inventory.networks[0].fiber_arrays[0].optical_paths[0]
-        label = OpticalPathLabel(start_distance=100.0, end_distance=200.0, group="time")
+        label = OpticalPathLabel(distance_min=100.0, distance_max=200.0, group="time")
         with pytest.raises(InvalidInventoryError, match="reserved name"):
             path.new(labels=(label,)).check()
 
     def test_membership_group_is_a_union(self, patch, inventory):
         """Membership groups overlap; a channel belongs if any interval has it."""
         labels = (
-            OpticalPathLabel(start_distance=100.0, end_distance=250.0, group="wet"),
-            OpticalPathLabel(start_distance=200.0, end_distance=400.0, group="wet"),
+            OpticalPathLabel(distance_min=100.0, distance_max=250.0, group="wet"),
+            OpticalPathLabel(distance_min=200.0, distance_max=400.0, group="wet"),
         )
         inv = _replace_path(inventory, labels=labels)
         out = patch.enrich(inv, attrs=False, coords=("wet",))
@@ -927,7 +927,7 @@ class TestEnrichContracts:
         """A channel axis with no spacing does not veto the other axis."""
         no_slope = _replace_acquisition(
             inventory,
-            spatial_interval=None,
+            distance_step=None,
             distance_map=DistanceMap(
                 channel=(0.0,), instrument_distance=(0.0,), distance=(100.0,)
             ),
@@ -941,7 +941,7 @@ class TestEnrichContracts:
         """When no axis can be read, the reasons are reported together."""
         no_slope = _replace_acquisition(
             inventory,
-            spatial_interval=None,
+            distance_step=None,
             distance_map=DistanceMap(channel=(0.0,), distance=(100.0,)),
         )
         channels = np.arange(len(patch.get_coord("distance")))
@@ -1009,7 +1009,7 @@ class TestEmptyIsUnambiguous:
         """A group saying nothing would read as an uncovered channel."""
         with pytest.raises(ValidationError, match="may not be the empty string"):
             OpticalPathLabel(
-                start_distance=0.0, end_distance=10.0, group="zone", value=""
+                distance_min=0.0, distance_max=10.0, group="zone", value=""
             )
 
     def test_empty_key_is_not_resolvable(self, inventory):

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -191,12 +191,12 @@ class TestStatedFields:
 
     def test_unset_times_dropped(self):
         """An unset (NaT) epoch is not a fact about the object."""
-        assert "start_time" not in stated_fields(Network(code="XT"))
+        assert "time_min" not in stated_fields(Network(code="XT"))
 
     def test_set_times_kept(self):
         """A stated epoch is."""
-        network = Network(code="XT", start_time="2020-01-01")
-        assert "start_time" in stated_fields(network)
+        network = Network(code="XT", time_min="2020-01-01")
+        assert "time_min" in stated_fields(network)
 
     def test_uncomparable_default_is_stated(self):
         """A default which cannot be compared is shown rather than hidden."""

--- a/tests/test_utils/test_intervals.py
+++ b/tests/test_utils/test_intervals.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
+from dascore.core import annotations, inventory
+from dascore.core.annotations import AnnotationSet
 from dascore.exceptions import ParameterError
 from dascore.utils.intervals import (
     clip_intervals,
@@ -171,3 +174,32 @@ class TestNormalizeValue:
 
         with pytest.raises(_MyError, match="must be finite"):
             normalize_value(np.nan, error=_MyError)
+
+
+class TestIntervalValueType:
+    """One value type, refused in each subsystem's own vocabulary."""
+
+    @pytest.mark.parametrize("annotated", ["LabelValue", "AnnotationValue"])
+    def test_the_refusal_reaches_the_caller(self, annotated):
+        """Both subsystems refuse a boolean, and say why.
+
+        The type each raises is not observable here: pydantic wraps
+        whatever a validator raises, keeping the message. The message is
+        therefore what the caller actually gets, so it is what is pinned.
+        """
+        module = inventory if annotated == "LabelValue" else annotations
+        adapter = TypeAdapter(getattr(module, annotated))
+        with pytest.raises(ValidationError, match="true and false are not values"):
+            adapter.validate_python(True)
+
+    def test_a_direct_call_raises_the_stated_error(self):
+        """Where the value is checked outside pydantic, the type survives.
+
+        `AnnotationSet` checks its own frame, so this is the path on which
+        the factory's `error` argument is the difference it claims to be.
+        """
+        frame = pd.DataFrame(
+            {"group": ["g"], "value": [True], "time_min": [0], "time_max": [1]}
+        )
+        with pytest.raises(ParameterError, match="true and false are not values"):
+            AnnotationSet(frame, dims=("time",))

--- a/tests/test_utils/test_intervals.py
+++ b/tests/test_utils/test_intervals.py
@@ -19,8 +19,8 @@ from dascore.utils.intervals import (
 class _Span(BaseModel):
     """A minimal interval item with the default field names."""
 
-    start_distance: float
-    end_distance: float
+    distance_min: float
+    distance_max: float
     label: str = ""
 
 
@@ -88,28 +88,28 @@ class TestClipIntervals:
 
     def test_clipped_to_bounds(self):
         """An interval straddling the clip is trimmed to it."""
-        (out,) = clip_intervals([_Span(start_distance=0, end_distance=10)], 2, 6)
-        assert (out.start_distance, out.end_distance) == (2, 6)
+        (out,) = clip_intervals([_Span(distance_min=0, distance_max=10)], 2, 6)
+        assert (out.distance_min, out.distance_max) == (2, 6)
 
     def test_outside_dropped(self):
         """An interval left with no coverage is dropped."""
-        assert clip_intervals([_Span(start_distance=8, end_distance=10)], 2, 6) == []
+        assert clip_intervals([_Span(distance_min=8, distance_max=10)], 2, 6) == []
 
     def test_other_fields_kept(self):
         """Only the bounds change; the item itself is left alone."""
-        span = _Span(start_distance=0, end_distance=10, label="rail")
+        span = _Span(distance_min=0, distance_max=10, label="rail")
         (out,) = clip_intervals([span], 2, 6)
         assert out.label == "rail"
-        assert (span.start_distance, span.end_distance) == (0, 10)
+        assert (span.distance_min, span.distance_max) == (0, 10)
 
     def test_point_inside_survives(self):
         """A point marker inside the clip is kept as it was."""
-        point = _Span(start_distance=3, end_distance=3)
+        point = _Span(distance_min=3, distance_max=3)
         assert clip_intervals([point], 2, 6) == [point]
 
     def test_point_on_outer_end_survives(self):
         """A point on the outermost included endpoint is not lost."""
-        point = _Span(start_distance=6, end_distance=6)
+        point = _Span(distance_min=6, distance_max=6)
         assert clip_intervals([point], 2, 6) == []
         assert clip_intervals([point], 2, 6, outer=6) == [point]
 
@@ -117,7 +117,7 @@ class TestClipIntervals:
         """Any pair of start/end fields works, not just the inventory's."""
         window = _Window(time_start=0, time_end=10)
         (out,) = clip_intervals(
-            [window], 2, 6, start_field="time_start", end_field="time_end"
+            [window], 2, 6, min_field="time_start", max_field="time_end"
         )
         assert (out.time_start, out.time_end) == (2, 6)
 

--- a/tests/test_utils/test_tables.py
+++ b/tests/test_utils/test_tables.py
@@ -138,8 +138,8 @@ class TestDropPrivateColumns:
 
     def test_an_underscore_inside_a_name_stays(self):
         """The prefix states the intent; a name merely holding one does not."""
-        frame = pd.DataFrame({"start_distance": [0.0], "mid_": [1.0]})
-        assert list(drop_private_columns(frame).columns) == ["start_distance", "mid_"]
+        frame = pd.DataFrame({"distance_min": [0.0], "mid_": [1.0]})
+        assert list(drop_private_columns(frame).columns) == ["distance_min", "mid_"]
 
 
 class TestRowCells:

--- a/tests/test_viz/test_inventory_viz.py
+++ b/tests/test_viz/test_inventory_viz.py
@@ -54,10 +54,10 @@ def _main_path(epoch: int) -> inv.OpticalPath:
         name="main",
         location_code="00",
         optical_components=(
-            inv.FiberSegment(name="lead", optical_length=100.0),
-            inv.Connector(name="patch"),
-            inv.FiberSegment(name="run", optical_length=run),
-            inv.Terminator(name="end"),
+            inv.FiberSegment(name="lead", distance_min=0.0, distance_max=100.0),
+            inv.Connector(name="patch", distance_min=100.0),
+            inv.FiberSegment(name="run", distance_min=100.0, distance_max=100.0 + run),
+            inv.Terminator(name="end", distance_min=100.0 + run),
         ),
         geometry=(
             # Two surveyed runs with an unsurveyed gap from 300 to 350.
@@ -119,7 +119,9 @@ def build_site_inventory() -> inv.Inventory:
     spur = inv.OpticalPath(
         name="spur",
         location_code="01",
-        optical_components=(inv.FiberSegment(name="spur", optical_length=50.0),),
+        optical_components=(
+            inv.FiberSegment(name="spur", distance_min=0.0, distance_max=50.0),
+        ),
     )
     common = dict(data_category="DAS", sample_rate=100.0, gauge_length=10.0)
     acquisitions = (
@@ -189,7 +191,9 @@ def build_labeled_inventory(values: int, crs, lines: int = 1) -> inv.Inventory:
                                 name="holes",
                                 location_code="00",
                                 optical_components=(
-                                    inv.FiberSegment(name="run", optical_length=300.0),
+                                    inv.FiberSegment(
+                                        name="run", distance_min=0.0, distance_max=300.0
+                                    ),
                                 ),
                                 labels=labels,
                             ),
@@ -312,7 +316,9 @@ class TestSelectPath:
             one = inv.OpticalPath(
                 name="main",
                 location_code="00",
-                optical_components=(inv.FiberSegment(name="f", optical_length=100.0),),
+                optical_components=(
+                    inv.FiberSegment(name="f", distance_min=0.0, distance_max=100.0),
+                ),
             )
             array = inv.FiberArray(code="L1", optical_paths=(one,), **times)
             return inv.Network(code=code, fiber_arrays=(array,), **times)
@@ -339,7 +345,9 @@ class TestSelectPath:
             location_code="00",
             time_min="2020-01-01",
             time_max="2021-01-01",
-            optical_components=(inv.FiberSegment(name="f", optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(name="f", distance_min=0.0, distance_max=100.0),
+            ),
         )
         array = inv.FiberArray(code="L1", optical_paths=(one,))
         inventory = inv.Inventory(
@@ -584,7 +592,9 @@ class TestPath:
     def test_zero_length_path(self):
         """A path whose components state no length has no axis."""
         stub = inv.OpticalPath(
-            name="stub", location_code="09", optical_components=(inv.Connector(),)
+            name="stub",
+            location_code="09",
+            optical_components=(inv.Connector(distance_min=0.0),),
         )
         array = inv.FiberArray(code="A", optical_paths=(stub,))
         inventory = inv.Inventory(
@@ -662,7 +672,9 @@ class TestPath:
         one = inv.OpticalPath(
             name="main",
             location_code="00",
-            optical_components=(inv.FiberSegment(name="f", optical_length=300.0),),
+            optical_components=(
+                inv.FiberSegment(name="f", distance_min=0.0, distance_max=300.0),
+            ),
             geometry=(
                 inv.Geometry(
                     name="run",
@@ -725,7 +737,9 @@ class TestMap:
         one = inv.OpticalPath(
             name="long",
             location_code="00",
-            optical_components=(inv.FiberSegment(name="f", optical_length=100_000.0),),
+            optical_components=(
+                inv.FiberSegment(name="f", distance_min=0.0, distance_max=100_000.0),
+            ),
             geometry=(
                 inv.Geometry(
                     name="west",
@@ -808,7 +822,9 @@ class TestMap:
         one = inv.OpticalPath(
             name="hole",
             location_code="00",
-            optical_components=(inv.FiberSegment(name="f", optical_length=40.0),),
+            optical_components=(
+                inv.FiberSegment(name="f", distance_min=0.0, distance_max=40.0),
+            ),
             geometry=(
                 inv.Geometry(
                     name="down",
@@ -847,7 +863,9 @@ class TestMap:
             return inv.OpticalPath(
                 name=f"p{location}",
                 location_code=location,
-                optical_components=(inv.FiberSegment(name="f", optical_length=200.0),),
+                optical_components=(
+                    inv.FiberSegment(name="f", distance_min=0.0, distance_max=200.0),
+                ),
                 geometry=(
                     inv.Geometry(
                         name="run",
@@ -945,7 +963,9 @@ class TestMap:
             return inv.OpticalPath(
                 name=f"p{location}",
                 location_code=location,
-                optical_components=(inv.FiberSegment(name="f", optical_length=200.0),),
+                optical_components=(
+                    inv.FiberSegment(name="f", distance_min=0.0, distance_max=200.0),
+                ),
                 geometry=(
                     inv.Geometry(
                         name="run",
@@ -1006,7 +1026,9 @@ class TestMap:
             return inv.OpticalPath(
                 name=f"p{location}",
                 location_code=location,
-                optical_components=(inv.FiberSegment(name="f", optical_length=200.0),),
+                optical_components=(
+                    inv.FiberSegment(name="f", distance_min=0.0, distance_max=200.0),
+                ),
                 geometry=(
                     inv.Geometry(
                         name="run",
@@ -1069,7 +1091,9 @@ class TestMap:
             return inv.OpticalPath(
                 name=f"p{location}",
                 location_code=location,
-                optical_components=(inv.FiberSegment(name="f", optical_length=200.0),),
+                optical_components=(
+                    inv.FiberSegment(name="f", distance_min=0.0, distance_max=200.0),
+                ),
                 geometry=(
                     inv.Geometry(
                         name="run",
@@ -1114,7 +1138,9 @@ class TestMap:
             location_code="00",
             time_min="2020-01-01",
             time_max="2021-01-01",
-            optical_components=(inv.FiberSegment(name="f", optical_length=100.0),),
+            optical_components=(
+                inv.FiberSegment(name="f", distance_min=0.0, distance_max=100.0),
+            ),
             geometry=(
                 inv.Geometry(
                     name="run",

--- a/tests/test_viz/test_inventory_viz.py
+++ b/tests/test_viz/test_inventory_viz.py
@@ -49,7 +49,7 @@ def _legend_labels(ax):
 def _main_path(epoch: int) -> inv.OpticalPath:
     """One epoch of the surveyed path; the second is the repaired fiber."""
     run = 400.0 if epoch == 1 else 402.0
-    times = {"end_time": "2026-07-01"} if epoch == 1 else {"start_time": "2026-07-01"}
+    times = {"time_max": "2026-07-01"} if epoch == 1 else {"time_min": "2026-07-01"}
     return inv.OpticalPath(
         name="main",
         location_code="00",
@@ -64,54 +64,50 @@ def _main_path(epoch: int) -> inv.OpticalPath:
             inv.Geometry(
                 name="west",
                 distance=(100.0, 300.0),
-                coordinates={"x": (0.0, 200.0), "y": (0.0, 0.0), "z": (0.0, -1.0)},
+                columns={"x": (0.0, 200.0), "y": (0.0, 0.0), "z": (0.0, -1.0)},
             ),
             inv.Geometry(
                 name="east",
                 distance=(350.0, 500.0),
-                coordinates={"x": (250.0, 400.0), "y": (0.0, 5.0), "z": (-1.0, 0.0)},
+                columns={"x": (250.0, 400.0), "y": (0.0, 5.0), "z": (-1.0, 0.0)},
             ),
             # Columns of those same stretches, so they share the runs' names.
             inv.Geometry(
                 name="west",
                 distance=(100.0, 300.0),
-                coordinates={"chainage": (0.0, 200.0), "depth": (0.5, 1.5)},
+                columns={"chainage": (0.0, 200.0), "depth": (0.5, 1.5)},
                 units={"chainage": "m"},
             ),
             inv.Geometry(
                 name="east",
                 distance=(350.0, 500.0),
-                coordinates={"chainage": (250.0, 400.0)},
+                columns={"chainage": (250.0, 400.0)},
                 units={"chainage": "m"},
             ),
         ),
         coupling=(
             inv.CouplingCondition(
-                start_distance=100.0, end_distance=300.0, coupling_type="trench"
+                distance_min=100.0, distance_max=300.0, coupling_type="trench"
             ),
             inv.CouplingCondition(
-                start_distance=350.0, end_distance=500.0, coupling_type="conduit"
+                distance_min=350.0, distance_max=500.0, coupling_type="conduit"
             ),
         ),
         labels=(
             inv.OpticalPathLabel(
-                start_distance=100.0, end_distance=200.0, group="zone", value="north"
+                distance_min=100.0, distance_max=200.0, group="zone", value="north"
             ),
             inv.OpticalPathLabel(
-                start_distance=200.0, end_distance=400.0, group="zone", value="south"
+                distance_min=200.0, distance_max=400.0, group="zone", value="south"
             ),
             # A label group states membership by stating no value.
+            inv.OpticalPathLabel(distance_min=150.0, distance_max=300.0, group="noisy"),
+            inv.OpticalPathLabel(distance_min=300.0, distance_max=400.0, group="noisy"),
             inv.OpticalPathLabel(
-                start_distance=150.0, end_distance=300.0, group="noisy"
+                distance_min=100.0, distance_max=200.0, group="count", value=0
             ),
             inv.OpticalPathLabel(
-                start_distance=300.0, end_distance=400.0, group="noisy"
-            ),
-            inv.OpticalPathLabel(
-                start_distance=100.0, end_distance=200.0, group="count", value=0
-            ),
-            inv.OpticalPathLabel(
-                start_distance=200.0, end_distance=300.0, group="count", value=2.5
+                distance_min=200.0, distance_max=300.0, group="count", value=2.5
             ),
         ),
         **times,
@@ -130,10 +126,10 @@ def build_site_inventory() -> inv.Inventory:
         inv.Acquisition(
             code="RAW",
             location_code="00",
-            start_time="2026-06-01",
-            end_time="2026-06-15",
+            time_min="2026-06-01",
+            time_max="2026-06-15",
             data_type="strain_rate",
-            spatial_interval=1.0,
+            distance_step=1.0,
             interrogator=inv.Interrogator(manufacturer="Fake", model="FI-1"),
             distance_map=inv.DistanceMap(channel=(0.0, 300.0), distance=(100.0, 400.0)),
             **common,
@@ -141,8 +137,8 @@ def build_site_inventory() -> inv.Inventory:
         inv.Acquisition(
             code="RAW",
             location_code="00",
-            start_time="2026-07-01",
-            spatial_interval=1.0,
+            time_min="2026-07-01",
+            distance_step=1.0,
             interrogator=inv.Interrogator(serial_number="sn-9"),
             # One point states an origin but no extent, so it draws as a tick.
             distance_map=inv.DistanceMap(channel=(0.0,), distance=(100.0,)),
@@ -173,8 +169,8 @@ def build_labeled_inventory(values: int, crs, lines: int = 1) -> inv.Inventory:
     """One path of one label group, stating this many distinct values."""
     labels = tuple(
         inv.OpticalPathLabel(
-            start_distance=float(x * 10),
-            end_distance=float(x * 10 + 8),
+            distance_min=float(x * 10),
+            distance_max=float(x * 10 + 8),
             group="hole",
             value="\n".join([f"H{x % values:02d}"] * lines),
         )
@@ -323,8 +319,8 @@ class TestSelectPath:
 
         inventory = inv.Inventory(
             networks=(
-                build("AA", start_time="2020-01-01", end_time="2021-01-01"),
-                build("BB", start_time="2021-01-01"),
+                build("AA", time_min="2020-01-01", time_max="2021-01-01"),
+                build("BB", time_min="2021-01-01"),
             )
         ).check()
         # Neither path states a bound, so only their containers can tell
@@ -341,8 +337,8 @@ class TestSelectPath:
         one = inv.OpticalPath(
             name="main",
             location_code="00",
-            start_time="2020-01-01",
-            end_time="2021-01-01",
+            time_min="2020-01-01",
+            time_max="2021-01-01",
             optical_components=(inv.FiberSegment(name="f", optical_length=100.0),),
         )
         array = inv.FiberArray(code="L1", optical_paths=(one,))
@@ -570,7 +566,7 @@ class TestPath:
     @pytest.mark.parametrize(
         "asked, match",
         [
-            (5, "must be a .low, high. pair"),
+            (5, "must be a .min, max. pair"),
             ((10, 5), "must be increasing"),
             ((900, 1000), "clips everything away"),
         ],
@@ -655,8 +651,8 @@ class TestPath:
         """A colorbar must not steal width from the lanes alone."""
         readings = tuple(
             inv.OpticalPathLabel(
-                start_distance=100.0 + 10 * index,
-                end_distance=110.0 + 10 * index,
+                distance_min=100.0 + 10 * index,
+                distance_max=110.0 + 10 * index,
                 group="reading",
                 value=float(index),
             )
@@ -671,7 +667,7 @@ class TestPath:
                 inv.Geometry(
                     name="run",
                     distance=(100.0, 300.0),
-                    coordinates={"chainage": (0.0, 200.0)},
+                    columns={"chainage": (0.0, 200.0)},
                     units={"chainage": "m"},
                 ),
             ),
@@ -734,12 +730,12 @@ class TestMap:
                 inv.Geometry(
                     name="west",
                     distance=(0.0, 50_000.0),
-                    coordinates={"x": (0.0, 500.0), "y": (0.0, 0.0), "z": (0.0, 0.0)},
+                    columns={"x": (0.0, 500.0), "y": (0.0, 0.0), "z": (0.0, 0.0)},
                 ),
                 inv.Geometry(
                     name="east",
                     distance=(50_010.0, 100_000.0),
-                    coordinates={
+                    columns={
                         "x": (600.0, 1000.0),
                         "y": (0.0, 0.0),
                         "z": (0.0, 0.0),
@@ -818,7 +814,7 @@ class TestMap:
                     name="down",
                     distance=(0.0, 40.0),
                     # Straight down: nothing to see in plan view at all.
-                    coordinates={"x": (5.0, 5.0), "y": (2.0, 2.0), "z": (0.0, -40.0)},
+                    columns={"x": (5.0, 5.0), "y": (2.0, 2.0), "z": (0.0, -40.0)},
                 ),
             ),
         )
@@ -856,7 +852,7 @@ class TestMap:
                     inv.Geometry(
                         name="run",
                         distance=(0.0, 200.0),
-                        coordinates={
+                        columns={
                             "x": (0.0, 100.0),
                             "y": (float(location), float(location)),
                             "z": (0.0, 0.0),
@@ -866,8 +862,8 @@ class TestMap:
                 labels=(
                     (
                         inv.OpticalPathLabel(
-                            start_distance=0.0,
-                            end_distance=200.0,
+                            distance_min=0.0,
+                            distance_max=200.0,
                             group=group,
                             value=value,
                         ),
@@ -954,7 +950,7 @@ class TestMap:
                     inv.Geometry(
                         name="run",
                         distance=(0.0, 200.0),
-                        coordinates={
+                        columns={
                             "x": (0.0, 100.0),
                             "y": (float(location), float(location)),
                             "z": (0.0, 0.0),
@@ -963,8 +959,8 @@ class TestMap:
                 ),
                 labels=tuple(
                     inv.OpticalPathLabel(
-                        start_distance=100.0 * index,
-                        end_distance=100.0 * (index + 1),
+                        distance_min=100.0 * index,
+                        distance_max=100.0 * (index + 1),
                         group="zone",
                         value=value,
                     )
@@ -1015,7 +1011,7 @@ class TestMap:
                     inv.Geometry(
                         name="run",
                         distance=(0.0, 200.0),
-                        coordinates={
+                        columns={
                             "x": (0.0, 100.0),
                             "y": (float(location), float(location)),
                             "z": (0.0, 0.0),
@@ -1024,14 +1020,14 @@ class TestMap:
                 ),
                 labels=(
                     inv.OpticalPathLabel(
-                        start_distance=0.0,
-                        end_distance=100.0,
+                        distance_min=0.0,
+                        distance_max=100.0,
                         group="reading",
                         value=value,
                     ),
                     inv.OpticalPathLabel(
-                        start_distance=100.0,
-                        end_distance=200.0,
+                        distance_min=100.0,
+                        distance_max=200.0,
                         group="reading",
                         value=value + 1.0,
                     ),
@@ -1078,7 +1074,7 @@ class TestMap:
                     inv.Geometry(
                         name="run",
                         distance=(0.0, 200.0),
-                        coordinates={
+                        columns={
                             "x": (0.0, 100.0),
                             "y": (float(location), float(location)),
                             "z": (0.0, 0.0),
@@ -1092,7 +1088,7 @@ class TestMap:
             "01",
             (
                 inv.OpticalPathLabel(
-                    start_distance=0.0, end_distance=200.0, group="zone", value="north"
+                    distance_min=0.0, distance_max=200.0, group="zone", value="north"
                 ),
             ),
         )
@@ -1116,14 +1112,14 @@ class TestMap:
         one = inv.OpticalPath(
             name="main",
             location_code="00",
-            start_time="2020-01-01",
-            end_time="2021-01-01",
+            time_min="2020-01-01",
+            time_max="2021-01-01",
             optical_components=(inv.FiberSegment(name="f", optical_length=100.0),),
             geometry=(
                 inv.Geometry(
                     name="run",
                     distance=(0.0, 100.0),
-                    coordinates={"x": (0.0, 1.0), "y": (0.0, 0.0), "z": (0.0, 0.0)},
+                    columns={"x": (0.0, 1.0), "y": (0.0, 0.0), "z": (0.0, 0.0)},
                 ),
             ),
         )
@@ -1247,7 +1243,7 @@ class TestTimeline:
         "bad, match",
         [
             (("2026-07-01", "2026-06-01"), "must be increasing"),
-            ("nope", "must be a .start, end. pair"),
+            ("nope", "must be a .min, max. pair"),
             (("not a time", None), "not a time"),
         ],
     )
@@ -1276,8 +1272,8 @@ class TestTimeline:
         acquisition = inv.Acquisition(
             code="RAW",
             location_code="00",
-            start_time="2026-06-01",
-            end_time="2026-06-15",
+            time_min="2026-06-01",
+            time_max="2026-06-15",
             data_category="DAS",
             sample_rate=1.0,
             gauge_length=1.0,
@@ -1297,8 +1293,8 @@ class TestTimeline:
         acquisition = inv.Acquisition(
             code="RAW",
             location_code="00",
-            start_time="2026-06-01",
-            end_time="2026-06-15",
+            time_min="2026-06-01",
+            time_max="2026-06-15",
             data_category="DAS",
             sample_rate=1.0,
             gauge_length=1.0,

--- a/tests/test_viz/test_inventory_viz.py
+++ b/tests/test_viz/test_inventory_viz.py
@@ -18,6 +18,7 @@ from dascore.viz.inventory import (
     COMPONENT_COLORS,
     _distance_window,
     _legend_names,
+    _track_frame,
     map_path,
     path,
     timeline,
@@ -131,7 +132,7 @@ def build_site_inventory() -> inv.Inventory:
             time_min="2026-06-01",
             time_max="2026-06-15",
             data_type="strain_rate",
-            distance_step=1.0,
+            spatial_interval=1.0,
             interrogator=inv.Interrogator(manufacturer="Fake", model="FI-1"),
             distance_map=inv.DistanceMap(channel=(0.0, 300.0), distance=(100.0, 400.0)),
             **common,
@@ -140,7 +141,7 @@ def build_site_inventory() -> inv.Inventory:
             code="RAW",
             location_code="00",
             time_min="2026-07-01",
-            distance_step=1.0,
+            spatial_interval=1.0,
             interrogator=inv.Interrogator(serial_number="sn-9"),
             # One point states an origin but no extent, so it draws as a tick.
             distance_map=inv.DistanceMap(channel=(0.0,), distance=(100.0,)),
@@ -369,6 +370,23 @@ class TestSelectPath:
 
 class TestPath:
     """The tracks along one path."""
+
+    def test_the_component_lane_is_where_the_components_are(self):
+        """The lane frame reads each component's own bounds.
+
+        Every fixture path here begins at zero, where a running total and
+        an absolute distance agree; a path which does not is what tells
+        the two apart.
+        """
+        one = inv.OpticalPath(
+            optical_components=(
+                inv.FiberSegment(name="lead", distance_min=100.0, distance_max=200.0),
+                inv.FiberSegment(name="run", distance_min=200.0, distance_max=350.0),
+            )
+        )
+        frame = _track_frame(one, ())
+        lane = frame[frame["lane"] == "components"]
+        assert list(zip(lane["start"], lane["end"])) == [(100.0, 200.0), (200.0, 350.0)]
 
     def test_all_tracks(self, site):
         """Every track becomes a lane, channels first."""


### PR DESCRIPTION
## Description

Two problems in the inventory, found together. Follows the naming discussion in #1000.

**Filling out an inventory was unpleasant.** An optical component stated `optical_length` and nothing else, so its position on the fiber was the running total of every length before it. That guaranteed the components tiled the path, but it meant the author could not write down what they measured. The tunnel recipe admitted as much in prose — *"those distances are the running totals of this one column. Adding them up by hand is how a table stops agreeing with its neighbours, so add them up once"* — followed by a `cumsum` the reader had to run to know where anything was. An OTDR trace reads out start and end distances; the inventory now takes them.

**A bound had four spellings.** DASCore spells a range `<name>_min`/`<name>_max` everywhere else — patch attrs, the spool index, `spool.select`. The inventory said `start_distance`/`end_distance` and `start_time`/`end_time`, and annotations said `<dim>_start`/`<dim>_end`.

Nothing here is on `master`: the inventory and annotation subsystems are unreleased work on `dev`, so none of it is breaking against the last release.

Three commits: the rename, the behaviour change, and the review fixes.

### 1. `Spell every bound the way DASCore spells one`

A pure rename, no behaviour change.

| From | To |
|---|---|
| `_IntervalModel.start_distance`/`end_distance` | `distance_min`/`distance_max` |
| `TimeRangedModel.start_time`/`end_time` | `time_min`/`time_max` |
| annotation range columns `<dim>_start`/`<dim>_end` | `<dim>_min`/`<dim>_max` |
| `Moveout.distance_start`/`distance_end` | `distance_min`/`distance_max` |
| `clip_intervals(start_field=, end_field=)` | `min_field=`/`max_field=` |

`Line.start`/`Line.end` are left alone — they are the two ends of a directed line, not bounds along an axis, so min and max would be a lie. `Acquisition` now refuses `distance_min` as well as `start_distance`, since the rename would otherwise reopen the door that validator closed.

Three more names in the same subsystems that fought their neighbours:

- **`Geometry.coordinates` → `Geometry.columns`**, which is what the docstring, `geometry_columns()`, `axis_columns()` and the viz panels already called them. It also stops the field colliding with the patch coordinates the inventory produces, which is a third meaning of the same word.
- **`geometry.csv`'s grouping header `segment` → `name`**, the field it actually fills. It is now read off the table registry, so the two cannot drift apart again.
- **`LabelValue` and `AnnotationValue`** were byte-identical annotated types differing only in which exception they raised. Both now come from `interval_value_type` in `dascore/utils/intervals.py`, beside the `normalize_value` they already shared, and each keeps its own error.

Plus two prose fixes: `_distance_window` demanded a `(low, high)` pair while `_time_window` twelve lines away demanded `(start, end)`; both now say `(min, max)`. And `metres` in five annotation field descriptions becomes `meters`, which is what the eleven inventory ones say and what renders beside them.

### 2. `Let a component say where it is, not how long it is`

`_OpticalComponentBase` inherits `_IntervalModel`, so a component states `distance_min` and `distance_max` like every other track of a path. `optical_length` survives as the read-only property that pair implies.

```
optical_components.csv

object_type,distance_min,distance_max,name
FiberSegment,0,100,lead-in
Splice,100,,wellhead splice
FiberSegment,100,500,trench cable
```

`Connector`, `Splice` and `Terminator` share a new `_PointComponent` base which fills `distance_max` from `distance_min`, so a splice states one number. `FiberSegment` still requires both — one silently collapsing to a point would lose the fiber it stands for.

**`OpticalPath.start_distance` goes with it.** That field existed only to be the origin the cumulative sum started from. Nothing outside the class ever set one, and neither `dascore/proc/inventory.py` nor `dascore/core/_spool_inventory.py` read it, since channel-to-distance goes entirely through `DistanceMap`, which already carries absolute distances. `distance_min`/`distance_max` are now properties reading the first and last component, and `component_intervals()` is gone — callers use `x.interval` like every other track, which collapses the special case in `_get_track_coord` and in the viz lane frame.

**Tiling stops being an accident of the layout and becomes a stated rule.** `check()` gained `_check_component_tiling`, reporting a gap or an overlap against the same tolerance the bounds check uses, so a table whose numbers do not line up says so rather than quietly describing different fiber than its author meant. Components are held in distance order by a validator, so row order decides nothing and a point marker sorts between the two segments meeting at its distance.

Consequently `optical_components.csv` no longer has a `sequence` column — the distances place the rows. A file which still states one is told what to write instead, rather than having `sequence` reported as a field the model has never heard of.

One thing worth flagging: making `optical_length` a property would have dropped it from the selectable vocabulary, since `_value_field_names` reads `model_fields`. A model may now name what it computes in `_derived_value_fields`, so `spool.select(**{"optical_components.optical_length": (400, 600)})` keeps working.

### One rename tried and dropped

`Acquisition.spatial_interval` is the same fact a patch's coordinate calls `distance_step`, and renaming it looked like the last piece of the same cleanup. It is not viable: `distance_step` is in `RESERVED_ATTR_COLUMNS`, so the spool index refuses it as an attr — `patch.enrich(inv, attrs=("distance_step",))` warns *"Skipping reserved attr name 'distance_step'; it collides with a structural index column"* and the value becomes unqueryable. The two numbers also diverge after decimation: the nominal as-acquired spacing is not the patch's actual step, and one name would collapse them. `sample_rate` escapes only because the index spells its twin `time_step`. Left alone.

### The cost, stated plainly

Inserting a component now shifts every downstream row, where a running total absorbed it. The tunnel recipe's repair epoch is exactly that case, and it now says so instead of selling the old design.

## Changelog

- changed: Inventory and annotation interval bounds are spelled `distance_min`/`distance_max` and `time_min`/`time_max`, matching how DASCore names a range everywhere else.
- changed: Optical components state the absolute distances they occupy rather than a length, so `optical_components.csv` has `distance_min` and `distance_max` columns and no `sequence` column.
- changed: `Geometry.coordinates` is now `Geometry.columns`, and `geometry.csv` groups its points by `name` rather than `segment`.
- added: `OpticalPath.check` refuses optical components which leave a gap or overlap, which the cumulative layout used to make impossible to express.
- removed: `OpticalPath.start_distance` and `OpticalPath.component_intervals`; a path takes its extent from its components, which carry their own distances.

## Review

Six adversarial reviewers (Codex plus five Claude agents, blind to each other) ran over the first two commits; the third addresses what they found. Two independently caught the `distance_step` collision above. Reports are in `.scratch/adversarial-review/` (untracked).

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed time fields to `time_min`/`time_max`.
  * Renamed interval fields to `distance_min`/`distance_max` and annotation bounds to `_min`/`_max`.
  * Renamed geometry’s `coordinates` field to `columns`.
  * Removed legacy distance and range field names.

* **Improvements**
  * Optical components now use explicit absolute intervals, preserving point components and validating gaps or overlaps.
  * Inventory loading and visualization now follow distance-based component ordering.
  * Added clearer validation for legacy fields and invalid annotation values.

* **Documentation**
  * Updated inventory tutorials, recipes, and examples for the new field names and interval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->