### PR TITLE
Drop a chunk member the output edge leaves outside it

### DIFF
--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -858,19 +858,29 @@ def _member_envelopes(sorted_df: pd.DataFrame, seg_starts: np.ndarray, name: str
     Overlap-corrected source envelopes over the whole sorted relation.
 
     Within each partition (rows ordered by start, patch id) an
-    overlapping source's start moves to just past the previous source's
-    stop, so the earlier source owns the overlap (D3: complete overlaps
-    keep the first member, deterministically). Returns the corrected
-    starts, the row modification flags, and the kept-row mask (sources
-    left degenerate by the correction contribute nothing).
+    overlapping source's start moves to just past the furthest stop of
+    the sources before it, so the earliest source owns the overlap (D3:
+    complete overlaps keep the first member, deterministically). Returns
+    the corrected starts, the row modification flags, and the kept-row
+    mask (sources left degenerate by the correction contribute nothing).
     """
     start, stop, step = (x.to_numpy() for x in get_interval_columns(sorted_df, name))
     is_first = np.zeros(len(sorted_df), dtype=bool)
     is_first[seg_starts] = True
-    prev_stop = np.roll(stop, 1)
-    rolled_step = np.roll(step, 1)
-    isna = pd.isnull(rolled_step)
-    prev_step = np.where(~isna, rolled_step, np.zeros_like(rolled_step))
+    # The owner of the furthest stop so far in the partition: the last
+    # row whose stop set the running maximum. Comparing with the
+    # previous row alone would let a source nested in an earlier one
+    # re-emerge after a shorter neighbor and hand out samples the
+    # earlier source already owns.
+    codes = np.cumsum(is_first) - 1
+    running_max = pd.Series(stop).groupby(codes).cummax().to_numpy()
+    rows = np.arange(len(stop))
+    owner = np.maximum.accumulate(np.where(stop == running_max, rows, 0))
+    prev_owner = np.roll(owner, 1)
+    prev_stop = stop[prev_owner]
+    owner_step = step[prev_owner]
+    isna = pd.isnull(owner_step)
+    prev_step = np.where(~isna, owner_step, np.zeros_like(owner_step))
     # Add the step so consecutive sources do not share one sample; the
     # roll artifact at each partition's first row is masked out.
     overlaps = (start <= prev_stop) & ~is_first

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -1446,16 +1446,17 @@ def build_chunk_plan(
         rel_src = np.arange(total) - offsets + np.repeat(first_src, m_counts)
         lo = np.maximum(s1[rel_src], starts_p[rel_out])
         hi = np.minimum(s2[rel_src], stops_p[rel_out])
-        # Sources within a partition are continuous (partitioning splits
-        # on gaps) and start-corrected, so searchsorted never offers a
-        # source which does not overlap the output. Assert it rather
-        # than skipping: silently dropping a source would lose data, and
-        # the state cannot be reached from the public API.
+        # No sample lies between one source's stop and the next source's
+        # start, but an output edge can (any length that is not a whole
+        # number of samples). That edge selects an end source whose
+        # samples all fall outside the output, so its trim inverts;
+        # dropping it loses nothing (#1008).
         overlap_ok = lo <= hi
-        assert overlap_ok.all(), (
-            f"source {rel_src[int(np.argmax(~overlap_ok))]} does not "
-            f"overlap output {rel_out[int(np.argmax(~overlap_ok))]}"
-        )
+        if not overlap_ok.all():
+            rel_src, rel_out = rel_src[overlap_ok], rel_out[overlap_ok]
+            lo, hi = lo[overlap_ok], hi[overlap_ok]
+            m_counts = np.bincount(rel_out, minlength=n_out)
+            total = int(m_counts.sum())
         # Plan invariant: every published output has at least one member.
         # An advertised row that cannot assemble is never surfaced as a
         # runtime error; it is not surfaced at all.

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import random
 import warnings
+from itertools import pairwise
 
 import numpy as np
 import pandas as pd
@@ -1465,3 +1466,60 @@ class TestSizeChunk:
         """A chunk length is one value, not an array of them."""
         with pytest.raises(ParameterError, match="single quantity"):
             random_spool.chunk(time=np.array([1.0, 2.0]) * dc.units.MB)
+
+
+class TestChunkEdgeBetweenPatches:
+    """
+    Chunk lengths that are not a whole number of samples (#1008, #893).
+
+    An output edge then lands between the last sample of one patch and
+    the first of the next; chunking must give the same result as chunking
+    the patches once merged.
+    """
+
+    @pytest.fixture(scope="class")
+    def contiguous_spool(self):
+        """Three exactly contiguous patches of five one-second samples."""
+        step = np.timedelta64(1, "s")
+        t0 = np.datetime64("2026-01-01T00:00:00", "ns")
+        patches = []
+        for _ in range(3):
+            time = t0 + np.arange(5) * step
+            coords = {"time": time, "distance": np.arange(3.0)}
+            data = np.random.default_rng(len(patches)).random((5, 3))
+            patches.append(
+                dc.Patch(data=data, coords=coords, dims=("time", "distance"))
+            )
+            t0 = time[-1] + step
+        return dc.spool(patches)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            dict(time=4.5),
+            dict(time=5.5),
+            dict(time=5.5, keep_partial=True),
+            dict(time=6, overlap=1.5),
+            dict(time=2.3, overlap=0.4),
+        ],
+    )
+    def test_matches_chunking_merged_patch(self, contiguous_spool, kwargs):
+        """Patch boundaries must not change what a chunk contains."""
+        merged = contiguous_spool.chunk(time=None)
+        assert len(merged) == 1
+        out, expected = contiguous_spool.chunk(**kwargs), merged.chunk(**kwargs)
+        assert len(out) == len(expected)
+        assert all(a.equals(b) for a, b in zip(out, expected))
+
+    def test_boundary_in_sub_tolerance_gap(self):
+        """A boundary inside a gap the tolerance merges over chunks cleanly."""
+        p1 = dc.get_example_patch(time_min="2020-01-01")
+        time = p1.get_coord("time")
+        p2 = dc.get_example_patch(time_min=time.max() + 1.4 * time.step)
+        span = (time.max() - time.min()) + 0.7 * time.step
+        length = span / np.timedelta64(1, "s") / 2
+        out = dc.spool([p1, p2]).chunk(time=length)
+        assert len(out) == 4
+        coords = [patch.get_coord("time") for patch in out]
+        assert all(len(coord) == len(coords[0]) for coord in coords)
+        assert all(a.max() < b.min() for a, b in pairwise(coords))

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -1511,6 +1511,24 @@ class TestChunkEdgeBetweenPatches:
         assert len(out) == len(expected)
         assert all(a.equals(b) for a, b in zip(out, expected))
 
+    @pytest.mark.parametrize("length", [25, 35, 50])
+    def test_nested_patches_chunk_as_the_outer_one(self, length):
+        """Patches inside a longer one must not add or remove samples."""
+
+        def _patch(first, samples):
+            step = np.timedelta64(1, "s")
+            t0 = np.datetime64("2026-01-01", "ns") + first * step
+            data = np.arange(samples * 2, dtype=float).reshape(samples, 2)
+            coords = {"time": t0 + np.arange(samples) * step, "distance": [0.0, 1.0]}
+            return dc.Patch(data=data, coords=coords, dims=("time", "distance"))
+
+        outer = _patch(0, 101)
+        nested = dc.spool([outer, _patch(10, 11), _patch(30, 11)])
+        out = nested.chunk(time=length, keep_partial=True)
+        expected = dc.spool([outer]).chunk(time=length, keep_partial=True)
+        assert len(out) == len(expected)
+        assert all(a.equals(b) for a, b in zip(out, expected))
+
     def test_boundary_in_sub_tolerance_gap(self):
         """A boundary inside a gap the tolerance merges over chunks cleanly."""
         p1 = dc.get_example_patch(time_min="2020-01-01")

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -319,6 +319,24 @@ class TestEdgeInWindow:
         assert not ((starts > 9.0) & (starts < 10.4)).any()
         assert set(plan.outputs["output_id"]) == set(plan.members["output_id"])
 
+    def test_nested_sources_belong_to_the_first(self):
+        """
+        A source nested in an earlier one contributes nothing, even after
+        a shorter nested neighbor: the start correction is against the
+        furthest stop so far, not the previous row's.
+        """
+        df = pd.DataFrame(
+            {
+                "time_min": [0.0, 10.0, 30.0],
+                "time_max": [100.0, 20.0, 40.0],
+                "time_step": [1.0, 1.0, 1.0],
+            }
+        )
+        plan = build_chunk_plan(df, time=35, keep_partial=True)
+        self._check_members(plan)
+        assert plan.members["_patch_id"].unique().tolist() == [0]
+        assert plan.members["time_max"].tolist() == [34.0, 69.0, 100.0]
+
     def test_mixed_dtypes_resolve_per_output(self, contiguous_three):
         """Dropping an end source still resolves each output's dtype."""
         df = contiguous_three.assign(

--- a/tests/test_utils/test_chunk.py
+++ b/tests/test_utils/test_chunk.py
@@ -242,6 +242,93 @@ class TestChunkPlanDF:
         assert np.all(pd.isnull(chunk_df["time_step"]))
 
 
+class TestEdgeInWindow:
+    """
+    An output edge inside the window between two sources (#1008, #893).
+
+    No sample lies between one source's stop and the next source's start,
+    but a chunk length that is not a whole number of samples puts output
+    edges there. The end source those edges select holds no sample of the
+    output and must be dropped, not asserted on.
+    """
+
+    @pytest.fixture()
+    def contiguous_three(self):
+        """Three exactly contiguous sources of five unit samples each."""
+        return pd.DataFrame(
+            {
+                "time_min": [0.0, 5.0, 10.0],
+                "time_max": [4.0, 9.0, 14.0],
+                "time_step": [1.0, 1.0, 1.0],
+            }
+        )
+
+    @pytest.fixture()
+    def sub_tolerance_gap(self):
+        """Two sources with a 1.4 sample gap, which the default tolerance merges."""
+        return pd.DataFrame(
+            {"time_min": [0.0, 10.4], "time_max": [9.0, 19.4], "time_step": [1.0, 1.0]}
+        )
+
+    @staticmethod
+    def _check_members(plan):
+        """Every member trim is upright and inside its output."""
+        joined = plan.members.merge(plan.outputs, on="output_id", suffixes=("", "_out"))
+        assert (joined["time_min"] <= joined["time_max"]).all()
+        assert (joined["time_min"] >= joined["time_min_out"]).all()
+        assert (joined["time_max"] <= joined["time_max_out"]).all()
+
+    def test_start_in_window_drops_leading_source(self, contiguous_three):
+        """A start at 4.5 must not pull in the source ending at 4."""
+        plan = build_chunk_plan(contiguous_three, time=4.5)
+        self._check_members(plan)
+        second = plan.members[plan.members["output_id"] == 1]
+        assert second["_patch_id"].tolist() == [1]
+        assert second[["time_min", "time_max"]].to_numpy().tolist() == [[5.0, 8.0]]
+
+    def test_stop_in_window_drops_trailing_source(self, contiguous_three):
+        """A stop at 4.5 must not pull in the source starting at 5."""
+        plan = build_chunk_plan(contiguous_three, time=5.5)
+        self._check_members(plan)
+        first = plan.members[plan.members["output_id"] == 0]
+        assert first["_patch_id"].tolist() == [0]
+        assert not first["_modified"].any()
+
+    def test_output_spanning_window_keeps_both_sides(self, contiguous_three):
+        """An output crossing the window draws from both its sources."""
+        plan = build_chunk_plan(contiguous_three, time=4.5)
+        third = plan.members[plan.members["output_id"] == 2]
+        assert third["_patch_id"].tolist() == [1, 2]
+        assert third[["time_min", "time_max"]].to_numpy().tolist() == [
+            [9.0, 9.0],
+            [10.0, 12.5],
+        ]
+
+    def test_sub_tolerance_gap(self, sub_tolerance_gap):
+        """A boundary inside a merged gap drops the source before it."""
+        plan = build_chunk_plan(sub_tolerance_gap, time=5)
+        self._check_members(plan)
+        third = plan.members[plan.members["output_id"] == 2]
+        assert third["_patch_id"].tolist() == [1]
+        assert third["time_min"].tolist() == [10.4]
+
+    def test_output_inside_gap_is_not_published(self, sub_tolerance_gap):
+        """An output with no sample in any source has no row."""
+        plan = build_chunk_plan(sub_tolerance_gap, time=1)
+        starts = plan.outputs["time_min"].to_numpy()
+        assert not ((starts > 9.0) & (starts < 10.4)).any()
+        assert set(plan.outputs["output_id"]) == set(plan.members["output_id"])
+
+    def test_mixed_dtypes_resolve_per_output(self, contiguous_three):
+        """Dropping an end source still resolves each output's dtype."""
+        df = contiguous_three.assign(
+            _dtype=["float32", "float64", "float32"], dims="time"
+        )
+        plan = build_chunk_plan(df, time=4.5)
+        self._check_members(plan)
+        assert plan.outputs["_dtype"].tolist() == ["float32", "float64", "float64"]
+
+
 class TestChunkPlanToMerge:
     """Merge-mode planning on raw dataframes."""
 


### PR DESCRIPTION
## Description

`Spool.chunk` raised `AssertionError: source N does not overlap output M` whenever a chunk boundary landed between the last sample of one patch and the first sample of the next. The window between two sources holds no sample, but any chunk length or overlap that is not a whole number of samples puts output edges inside it, and the planner's two searchsorteds then select an end source with no sample in the output: a start in the window picks the source ending before it, a stop in the window picks the source starting after it. Its trim inverts and the assert fires. Exactly contiguous patches (#1008) and a sub-tolerance gap (#893) are the same failure; the #893 sketch only covered the leading end.

The planner now drops a member whose trim inverts and recounts the output's members. For that to be safe every interior source must overlap its output, which needs the kept stops sorted; `_member_envelopes` only corrected a source's start against the previous row's stop, so a source nested in an earlier one could re-emerge after a shorter nested neighbor (`[0,100]`, `[10,20]`, `[30,40]`) and hand out samples the first source already owned. It now corrects against the furthest stop so far in the partition, which drops every nested source. Every sample such a member holds lies outside the output, so nothing is lost, and an output left with no member is unpublished as before. The behavior already existed for a single patch, where a non-whole length drops the samples between one output's stop and the next output's start; chunking a contiguous multi-patch spool now gives the same result as chunking the merged patch, which the end-to-end test asserts for several lengths, overlaps and `keep_partial`.

Closes #1008, closes #893.

## Changelog

- fixed: `Spool.chunk` no longer raises an `AssertionError` when a chunk boundary lands between two patches, which any chunk length that is not a whole number of samples caused.
- fixed: `Spool.chunk` no longer duplicates the samples of a patch nested inside an earlier, longer one when a shorter nested patch sits between them.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
