### PR TITLE
Stop rastering the image once per legend fitting pass

### DIFF
--- a/dascore/viz/_labels.py
+++ b/dascore/viz/_labels.py
@@ -16,7 +16,7 @@ measurement itself.
 from __future__ import annotations
 
 from contextlib import contextmanager
-from itertools import pairwise
+from itertools import count, pairwise
 from typing import NamedTuple
 
 import matplotlib.patheffects as pe
@@ -262,18 +262,32 @@ def label_runs(values, name: str) -> LabelRuns:
 
 
 def _artist_ids(ax, prefix: str):
-    """Number artists so no two on the figure share a gid.
+    """Hand out gids no artist on the figure already carries.
 
     Matplotlib writes a gid out as an SVG id, which has to name one
     element of the whole document. Numbering within the call is not
     enough: a figure may carry a labelled plot on every axes, and one
-    axes may be drawn on twice. Counted rather than made up, so the same
-    figure carries the same ids however often it is built.
+    axes may be drawn on twice.
+
+    Each candidate is checked against what the figure holds rather than
+    counted from it, so removing an artist and drawing again cannot land
+    on a number still in use. The count starts from nothing every time,
+    which keeps a figure built twice carrying the same ids -- a running
+    counter would make a rendered document differ from itself.
     """
     figure = ax.get_figure()
     panel = figure.axes.index(ax) if ax in figure.axes else 0
-    already = sum(1 for x in ax.lines if str(x.get_gid()).startswith(prefix))
-    return lambda index: f"{prefix}-{panel}-{already + index}"
+    taken = {str(y.get_gid()) for x in figure.axes for y in x.get_children()}
+    counter = count()
+
+    def name() -> str:
+        while True:
+            candidate = f"{prefix}-{panel}-{next(counter)}"
+            if candidate not in taken:
+                taken.add(candidate)
+                return candidate
+
+    return name
 
 
 def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
@@ -291,7 +305,6 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
     starts_at, ends_at = edges
     identify = _artist_ids(ax, BAR_GID)
     bounds = np.concatenate([[0], starts, [len(codes)]]).astype(int)
-    drawn = 0
     for low, high in pairwise(bounds):
         code = codes[low]
         if code < 0:
@@ -312,9 +325,8 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
                 # The half of its width outside the axes goes with that.
                 clip_on=True,
                 zorder=5,
-                gid=identify(drawn),
+                gid=identify(),
             )
-            drawn += 1
 
 
 @contextmanager
@@ -348,7 +360,7 @@ def _draw_changes(ax, axis: str, edges, starts) -> None:
     starts_at, _ = edges
     identify = _artist_ids(ax, SEAM_GID)
     line = ax.axvline if axis == "x" else ax.axhline
-    for drawn, index in enumerate(starts):
+    for index in starts:
         line(
             starts_at[index],
             path_effects=[
@@ -358,7 +370,7 @@ def _draw_changes(ax, axis: str, edges, starts) -> None:
                     alpha=_SEAM_HALO_ALPHA,
                 )
             ],
-            gid=identify(drawn),
+            gid=identify(),
             **_SEAM_KWARGS,
         )
 

--- a/dascore/viz/_labels.py
+++ b/dascore/viz/_labels.py
@@ -51,7 +51,8 @@ _SEAM_HALO_WIDTH = 2.0
 _SEAM_HALO_ALPHA = 0.5
 
 # What each artist is, for a caller reading a figure back. Each carries
-# the prefix and its own number, so no two share an id.
+# the prefix, the axes it sits on and its own number, so no two on one
+# figure share an id.
 BAR_GID = "dascore-label-bar"
 SEAM_GID = "dascore-label-change"
 
@@ -260,6 +261,21 @@ def label_runs(values, name: str) -> LabelRuns:
     return LabelRuns(starts, codes, labels, membership)
 
 
+def _artist_ids(ax, prefix: str):
+    """Number artists so no two on the figure share a gid.
+
+    Matplotlib writes a gid out as an SVG id, which has to name one
+    element of the whole document. Numbering within the call is not
+    enough: a figure may carry a labelled plot on every axes, and one
+    axes may be drawn on twice. Counted rather than made up, so the same
+    figure carries the same ids however often it is built.
+    """
+    figure = ax.get_figure()
+    panel = figure.axes.index(ax) if ax in figure.axes else 0
+    already = sum(1 for x in ax.lines if str(x.get_gid()).startswith(prefix))
+    return lambda index: f"{prefix}-{panel}-{already + index}"
+
+
 def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
     """Draw a bar along both spines over the stretch each label covers.
 
@@ -273,6 +289,7 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
     else:
         transform = blended_transform_factory(ax.transData, ax.transAxes)
     starts_at, ends_at = edges
+    identify = _artist_ids(ax, BAR_GID)
     bounds = np.concatenate([[0], starts, [len(codes)]]).astype(int)
     drawn = 0
     for low, high in pairwise(bounds):
@@ -295,9 +312,7 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
                 # The half of its width outside the axes goes with that.
                 clip_on=True,
                 zorder=5,
-                # Numbered: matplotlib writes a gid out as an SVG id, and
-                # an id is meant to name one element.
-                gid=f"{BAR_GID}-{drawn}",
+                gid=identify(drawn),
             )
             drawn += 1
 
@@ -331,6 +346,7 @@ def _right_edge(figure) -> float:
 def _draw_changes(ax, axis: str, edges, starts) -> None:
     """Join the two bars with a hairline wherever the label changes."""
     starts_at, _ = edges
+    identify = _artist_ids(ax, SEAM_GID)
     line = ax.axvline if axis == "x" else ax.axhline
     for drawn, index in enumerate(starts):
         line(
@@ -342,7 +358,7 @@ def _draw_changes(ax, axis: str, edges, starts) -> None:
                     alpha=_SEAM_HALO_ALPHA,
                 )
             ],
-            gid=f"{SEAM_GID}-{drawn}",
+            gid=identify(drawn),
             **_SEAM_KWARGS,
         )
 

--- a/dascore/viz/_labels.py
+++ b/dascore/viz/_labels.py
@@ -15,6 +15,7 @@ measurement itself.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from itertools import pairwise
 from typing import NamedTuple
 
@@ -49,7 +50,8 @@ _SEAM_KWARGS = {"color": "0.1", "linewidth": 0.7, "alpha": 0.55, "zorder": 4}
 _SEAM_HALO_WIDTH = 2.0
 _SEAM_HALO_ALPHA = 0.5
 
-# What each artist is, for a caller reading a figure back.
+# What each artist is, for a caller reading a figure back. Each carries
+# the prefix and its own number, so no two share an id.
 BAR_GID = "dascore-label-bar"
 SEAM_GID = "dascore-label-change"
 
@@ -272,6 +274,7 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
         transform = blended_transform_factory(ax.transData, ax.transAxes)
     starts_at, ends_at = edges
     bounds = np.concatenate([[0], starts, [len(codes)]]).astype(int)
+    drawn = 0
     for low, high in pairwise(bounds):
         code = codes[low]
         if code < 0:
@@ -292,8 +295,31 @@ def _draw_bars(ax, axis: str, edges, starts, codes, labels, colors) -> None:
                 # The half of its width outside the axes goes with that.
                 clip_on=True,
                 zorder=5,
-                gid=BAR_GID,
+                # Numbered: matplotlib writes a gid out as an SVG id, and
+                # an id is meant to name one element.
+                gid=f"{BAR_GID}-{drawn}",
             )
+            drawn += 1
+
+
+@contextmanager
+def _measuring(ax):
+    """Hide what is costly to draw while the legend is being measured.
+
+    Seating the legend means laying the figure out several times over,
+    and each pass would otherwise raster the image again -- four fifths
+    of the time a labelled waterfall takes on a large patch. Nothing the
+    measurements read is drawn from it: the tick labels, the axes' own
+    box and the legend are all laid out the same either way.
+    """
+    hidden = [x for x in (*ax.images, *ax.collections) if x.get_visible()]
+    for artist in hidden:
+        artist.set_visible(False)
+    try:
+        yield
+    finally:
+        for artist in hidden:
+            artist.set_visible(True)
 
 
 def _right_edge(figure) -> float:
@@ -306,7 +332,7 @@ def _draw_changes(ax, axis: str, edges, starts) -> None:
     """Join the two bars with a hairline wherever the label changes."""
     starts_at, _ = edges
     line = ax.axvline if axis == "x" else ax.axhline
-    for index in starts:
+    for drawn, index in enumerate(starts):
         line(
             starts_at[index],
             path_effects=[
@@ -316,9 +342,43 @@ def _draw_changes(ax, axis: str, edges, starts) -> None:
                     alpha=_SEAM_HALO_ALPHA,
                 )
             ],
-            gid=SEAM_GID,
+            gid=f"{SEAM_GID}-{drawn}",
             **_SEAM_KWARGS,
         )
+
+
+def _measure(figure, ax, kwargs) -> int:
+    """Make room for the legend, and say how many columns it wants.
+
+    Drawn rather than predicted: how tall matplotlib sets its rows and
+    how wide it sets a column are its own affair. The figure is narrowed
+    and asked again after each move, since a colorbar carries its ticks
+    and its own name outside the rectangle it reports as its position,
+    and narrowing can relabel the ticks it carries.
+    """
+    legend = figure.legend(**kwargs)
+    figure.draw_without_rendering()
+    box = legend.get_window_extent()
+    # A column taller than the page is spilled into as many as it takes.
+    columns = max(1, int(np.ceil(box.height / figure.bbox.height)))
+    if columns > 1:
+        legend.remove()
+        legend = figure.legend(ncol=columns, **kwargs)
+        figure.draw_without_rendering()
+        box = legend.get_window_extent()
+    wide = box.width / figure.bbox.width
+    legend.remove()
+    for _ in range(_FITTING_PASSES):
+        over = _right_edge(figure) + 2 * _LEGEND_PAD + wide - 1.0
+        if over <= 0:
+            break
+        pars = figure.subplotpars
+        floor = pars.left + _MIN_AXES_WIDTH
+        if pars.right <= floor:
+            break
+        figure.subplots_adjust(right=max(floor, pars.right - over))
+        figure.draw_without_rendering()
+    return columns
 
 
 def _legend_beside(figure, ax, handles, title):
@@ -353,35 +413,8 @@ def _legend_beside(figure, ax, handles, title):
         # drawn, undoing the room made below. This figure is the call's
         # own and is being laid out here explicitly.
         figure.set_layout_engine("none")
-    # Drawn once to be measured; how tall matplotlib sets its rows and how
-    # wide it sets a column are its own affair rather than ours to predict.
-    legend = figure.legend(**kwargs)
-    figure.draw_without_rendering()
-    box = legend.get_window_extent()
-    tall = box.height / figure.bbox.height
-    # A column taller than the page is spilled into as many as it takes.
-    columns = max(1, int(np.ceil(tall)))
-    if columns > 1:
-        legend.remove()
-        legend = figure.legend(ncol=columns, **kwargs)
-        figure.draw_without_rendering()
-        box = legend.get_window_extent()
-    wide = box.width / figure.bbox.width
-    legend.remove()
-    # Asked for again after each move: a colorbar carries its ticks and
-    # its own name outside the rectangle it reports as its position, and
-    # narrowing the figure can relabel the ticks it carries.
-    for _ in range(_FITTING_PASSES):
-        edge = _right_edge(figure)
-        over = edge + 2 * _LEGEND_PAD + wide - 1.0
-        if over <= 0:
-            break
-        pars = figure.subplotpars
-        floor = pars.left + _MIN_AXES_WIDTH
-        if pars.right <= floor:
-            break
-        figure.subplots_adjust(right=max(floor, pars.right - over))
-        figure.draw_without_rendering()
+    with _measuring(ax):
+        columns = _measure(figure, ax, kwargs)
     return figure.legend(
         ncol=columns,
         bbox_to_anchor=(_right_edge(figure) + _LEGEND_PAD, ax.get_position().y1),

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -870,6 +870,27 @@ class TestLabelCoord:
         assert sum(str(x).startswith(BAR_GID) for x in gids) == 8
         assert sum(str(x).startswith(SEAM_GID) for x in gids) == 3
 
+    def test_ids_are_unique_across_the_whole_figure(self, zone_patch):
+        """An id names one element of the document, not one of a call.
+
+        A figure may carry a labelled plot on every axes, and one axes
+        may be drawn on twice; numbering within the call would repeat.
+        """
+        _, (left, right) = plt.subplots(1, 2)
+        for ax in (left, right, left):
+            zone_patch.viz.waterfall(label_coord="zone", ax=ax, cbar=False)
+        gids = [x.get_gid() for ax in (left, right) for x in ax.lines]
+        assert len(gids) == len(set(gids))
+
+    def test_ids_are_the_same_every_build(self, zone_patch):
+        """The same figure carries the same ids however often it is built."""
+        builds = []
+        for _ in range(2):
+            _, ax = plt.subplots()
+            zone_patch.viz.waterfall(label_coord="zone", ax=ax, cbar=False)
+            builds.append([x.get_gid() for x in ax.lines])
+        assert builds[0] == builds[1]
+
     def test_no_label_coord_draws_nothing(self, zone_patch):
         """The default leaves the plot as it was."""
         ax = zone_patch.viz.waterfall()

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -436,7 +436,7 @@ def _bars(ax, axis):
     """Return (low, high, spine, color) for every bar drawn."""
     out = []
     for line in ax.lines:
-        if line.get_gid() != BAR_GID:
+        if not str(line.get_gid()).startswith(BAR_GID):
             continue
         across = line.get_xdata() if axis == "y" else line.get_ydata()
         along = line.get_ydata() if axis == "y" else line.get_xdata()
@@ -456,7 +456,9 @@ def _changes(ax, axis):
     """Return where a hairline was drawn across the image."""
     getter = "get_xdata" if axis == "x" else "get_ydata"
     return sorted(
-        float(getattr(x, getter)()[0]) for x in ax.lines if x.get_gid() == SEAM_GID
+        float(getattr(x, getter)()[0])
+        for x in ax.lines
+        if str(x.get_gid()).startswith(SEAM_GID)
     )
 
 
@@ -570,7 +572,7 @@ class TestLabelCoord:
         assert _changes(ax, "y") == [
             pytest.approx(self._edge(zone_patch, "distance", split))
         ]
-        hair = next(x for x in ax.lines if x.get_gid() == SEAM_GID)
+        hair = next(x for x in ax.lines if str(x.get_gid()).startswith(SEAM_GID))
         # Faint enough to locate a boundary without competing with data.
         assert hair.get_linewidth() < 1.0
         assert hair.get_alpha() < 0.7
@@ -598,7 +600,7 @@ class TestLabelCoord:
         ax = zone_patch.viz.waterfall(label_coord="zone")
         ax.get_figure().canvas.draw()
         box = ax.get_window_extent()
-        for line in [x for x in ax.lines if x.get_gid() == BAR_GID]:
+        for line in [x for x in ax.lines if str(x.get_gid()).startswith(BAR_GID)]:
             points = _on_canvas(line)
             across, along = points[:, 0], points[:, 1]
             # Upright on the page, and on one of the two upright edges.
@@ -843,6 +845,30 @@ class TestLabelCoord:
         assert len(_legend_labels(ax)) == MAX_LABELS
         assert legend._ncols > 1
         assert legend.get_window_extent().height <= ax.get_figure().bbox.height
+
+    def test_the_image_is_put_back_after_measuring(self, zone_patch):
+        """Hiding the image to measure the legend does not leave it hidden.
+
+        Seating the legend lays the figure out several times, and the
+        image is hidden across those passes so it is not rastered each
+        time. It has to come back, whatever happened in between.
+        """
+        ax = zone_patch.viz.waterfall(label_coord="zone")
+        assert ax.images
+        assert all(x.get_visible() for x in ax.images)
+        assert all(x.get_visible() for x in ax.collections)
+
+    def test_every_artist_carries_its_own_id(self, random_patch):
+        """No two artists share a gid, which is written out as an SVG id."""
+        size = random_patch.coords.coord_size("distance")
+        quarter = size // 4
+        values = np.where((np.arange(size) // quarter) % 2, "odd", "even")
+        patch = random_patch.update_coords(tag=("distance", values))
+        ax = patch.viz.waterfall(label_coord="tag")
+        gids = [x.get_gid() for x in ax.lines]
+        assert len(gids) == len(set(gids))
+        assert sum(str(x).startswith(BAR_GID) for x in gids) == 8
+        assert sum(str(x).startswith(SEAM_GID) for x in gids) == 3
 
     def test_no_label_coord_draws_nothing(self, zone_patch):
         """The default leaves the plot as it was."""

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -10,6 +10,7 @@ import pytest
 from matplotlib.collections import QuadMesh
 from matplotlib.image import AxesImage
 from matplotlib.legend import Legend
+from matplotlib.lines import Line2D
 
 import dascore as dc
 from dascore.examples import inventory_patch_pair
@@ -880,6 +881,31 @@ class TestLabelCoord:
         for ax in (left, right, left):
             zone_patch.viz.waterfall(label_coord="zone", ax=ax, cbar=False)
         gids = [x.get_gid() for ax in (left, right) for x in ax.lines]
+        assert len(gids) == len(set(gids))
+
+    @pytest.mark.parametrize("occupied", [(0, 2), (1,), ()])
+    def test_ids_skip_numbers_already_in_use(self, zone_patch, occupied):
+        """A number already on the figure is passed over, not reused.
+
+        Counting artists would land on an occupied number wherever the
+        ones in use are not a run from zero -- which is what removing an
+        artist and drawing again leaves behind.
+        """
+        _, ax = plt.subplots()
+        for number in occupied:
+            ax.add_line(Line2D([0, 1], [0, 1], gid=f"{BAR_GID}-0-{number}"))
+        zone_patch.viz.waterfall(label_coord="zone", ax=ax, cbar=False)
+        gids = [x.get_gid() for x in ax.lines]
+        assert len(gids) == len(set(gids))
+
+    def test_ids_survive_an_artist_being_removed(self, zone_patch):
+        """Drawing again after a removal does not reuse the freed number."""
+        _, ax = plt.subplots()
+        zone_patch.viz.waterfall(label_coord="zone", ax=ax, cbar=False)
+        bars = [x for x in ax.lines if str(x.get_gid()).startswith(BAR_GID)]
+        bars[0].remove()
+        zone_patch.viz.waterfall(label_coord="zone", ax=ax, cbar=False)
+        gids = [x.get_gid() for x in ax.lines]
         assert len(gids) == len(set(gids))
 
     def test_ids_are_the_same_every_build(self, zone_patch):


### PR DESCRIPTION
## Description

Follow-up to #1006, taking the two findings from its review that were left out of scope there.

**The image was rastered once per legend fitting pass.** Seating the legend beside the axes lays the figure out up to six times — twice to measure what the legend comes to, and once more for each pass that narrows the figure to fit it. Every one of those drew the image again.

Nothing the measurements read is drawn from the image: the tick labels, the axes' own box, and the legend lay out the same whether it is there or not. It is now hidden across the fitting passes and put back afterwards.

Measured on a 300×60000 patch, best of three:

| | before | after |
|---|---|---|
| `viz.waterfall()` | 1.15 s | 1.15 s |
| `viz.waterfall(label_coord=…)` | 5.53 s | 1.30 s |

So the cost of naming the labels falls from 4.3 s to 0.15 s. The layout is unchanged, not merely similar — the legend lands on the same pixels (553.05 → 627.20) and the axes keeps the same right edge (0.74865) as on `dev`.

The fitting loop moved into its own function while it was being wrapped, since it was about as long as the function it lived in.

**Bars and hairlines are numbered.** Matplotlib writes an artist's `gid` out as an SVG `id`, and every bar of a figure carried the same one, so a saved SVG repeated an id up to `MAX_RUNS` times. Each artist now carries its own; the prefixes (`dascore-label-bar`, `dascore-label-change`) are unchanged, so anything filtering on them wants `startswith` rather than `==`.

Two tests come with it: the image is visible again after the legend is seated, and no two artists share a gid.

Not included, from the same review: descending coordinates mirror the bars, which is inherited from `_get_extents` and affects every waterfall rather than this option; and `dascore.viz._labels` is indexed into the generated API docs, which `scripts/_index_api.py` does for any private module — `_lanes` already contributes five entries on `dev`. Both are pre-existing and want their own change.

## Changelog

- fixed: `Patch.viz.waterfall(label_coord=...)` no longer redraws the image once per legend layout pass, which dominated its cost on large patches.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved legend layout measurement for waterfall visualizations.
  - Preserved the visibility of images and chart collections while legends are being arranged.
  - Ensured chart elements receive unique, stable identifiers for more reliable rendering and interaction.
  - Improved consistency when repeatedly generating the same visualization.

- **Tests**
  - Added coverage for element visibility during legend measurement.
  - Verified unique identifiers and expected counts for bars, seams, and line elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->