### PR TITLE
One definition of how an object prints

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -303,20 +303,20 @@ conflict
 """.strip()
 
 
-# Rich styles for various object displays.
+# Rich styles for various object displays. Every value has to be one rich can
+# parse: it resolves an unparsable style to a blank one rather than raising,
+# so a misspelling here does not fail, it silently stops colouring.
 dascore_styles = dict(
     dc_blue="blue",
     dc_red="red",
     dc_yellow="yellow",
     default_coord="bold",
     coord_range="bold green",
-    coord_monotonic="bold grey",
+    coord_monotonic="bold grey50",
     coord_segmented="bold cyan",
-    coord_array="bold orange",
-    coord_degenerate="bold red",
+    coord_array="bold dark_orange",
     coord_non="bold red",
-    units="bright blue",
-    dtypes="bright black",
+    units="bright_blue",
     keys="grey50",
     # these are for formatting date times
     ymd="blue",

--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -305,7 +305,7 @@ conflict
 
 # Rich styles for various object displays. Every value has to be one rich can
 # parse: it resolves an unparsable style to a blank one rather than raising,
-# so a misspelling here does not fail, it silently stops colouring.
+# so a misspelling here does not fail, it silently stops coloring.
 dascore_styles = dict(
     dc_blue="blue",
     dc_red="red",

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -60,6 +60,7 @@ from dascore.models import (
     UnitQuantity,
 )
 from dascore.utils.display import (
+    NodeRepr,
     Repr,
     RichRepr,
     counts_to_text,
@@ -67,7 +68,6 @@ from dascore.utils.display import (
     get_nice_text,
     mapping_to_text,
     model_to_line,
-    render_text,
     split_block,
     stated_fields,
 )
@@ -750,7 +750,7 @@ class _Spelling(NamedTuple):
     high: str | None
 
 
-class AnnotationSet(RichRepr, NamespaceOwner):
+class AnnotationSet(NodeRepr, NamespaceOwner):
     """
     An immutable, dataframe-backed set of annotations over patch dimensions.
 
@@ -921,22 +921,16 @@ class AnnotationSet(RichRepr, NamespaceOwner):
         count = len(self)
         plural = "" if count == 1 else "s"
         name = f"AnnotationSet \U0001f3f7 ({count} Annotation{plural})"
-        blocks = [(self._dims_text(), "coords")]
+        blocks = [self._dims_text()]
         if contents := self._contents():
-            blocks.append(
-                (mapping_to_text(contents, "Contents", style="dc_red"), "contents")
-            )
+            blocks.append(mapping_to_text(contents, "Contents", style="dc_red"))
         attrs = stated_fields(self._attrs, skip=("dims",))
         if attrs:
-            blocks.append((mapping_to_text(attrs, "Attributes"), "attrs"))
+            blocks.append(mapping_to_text(attrs, "Attributes"))
         return Repr(
             header=get_header_text(name),
-            body=tuple(split_block(x, kind=k) for x, k in blocks),
-            kind="annotation_set",
+            body=tuple(split_block(x) for x in blocks),
         )
-
-    def __rich__(self) -> Text:
-        return render_text(self._repr_node())
 
     def _dims_text(self) -> Text:
         """The extent each dimension is annotated over, and how it is spelled."""

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -60,11 +60,15 @@ from dascore.models import (
     UnitQuantity,
 )
 from dascore.utils.display import (
+    Repr,
+    RichRepr,
     counts_to_text,
     get_header_text,
     get_nice_text,
     mapping_to_text,
     model_to_line,
+    render_text,
+    split_block,
     stated_fields,
 )
 from dascore.utils.documents import write_document
@@ -289,7 +293,7 @@ def _tag(name: str):
     return Field(default=name, repr=False)
 
 
-class _AnnotationModel(DascoreBaseModel):
+class _AnnotationModel(RichRepr, DascoreBaseModel):
     """Base for the immutable models an annotation set hands out."""
 
     model_config = ConfigDict(
@@ -303,11 +307,6 @@ class _AnnotationModel(DascoreBaseModel):
     def __rich__(self) -> Text:
         """One line naming the class and what it states."""
         return model_to_line(self)
-
-    def __str__(self) -> str:
-        return str(self.__rich__())
-
-    __repr__ = __str__
 
 
 # --- Curves ---------------------------------------------------------------
@@ -751,7 +750,7 @@ class _Spelling(NamedTuple):
     high: str | None
 
 
-class AnnotationSet(NamespaceOwner):
+class AnnotationSet(RichRepr, NamespaceOwner):
     """
     An immutable, dataframe-backed set of annotations over patch dimensions.
 
@@ -917,23 +916,27 @@ class AnnotationSet(NamespaceOwner):
             )
         )
 
-    def __rich__(self) -> Text:
+    def _repr_node(self) -> Repr:
         """The banner, then what the set spans, holds, and says of itself."""
         count = len(self)
         plural = "" if count == 1 else "s"
         name = f"AnnotationSet \U0001f3f7 ({count} Annotation{plural})"
-        blocks = [get_header_text(name), self._dims_text()]
+        blocks = [(self._dims_text(), "coords")]
         if contents := self._contents():
-            blocks.append(mapping_to_text(contents, "Contents", style="dc_red"))
+            blocks.append(
+                (mapping_to_text(contents, "Contents", style="dc_red"), "contents")
+            )
         attrs = stated_fields(self._attrs, skip=("dims",))
         if attrs:
-            blocks.append(mapping_to_text(attrs, "Attributes"))
-        return Text("\n").join(blocks)
+            blocks.append((mapping_to_text(attrs, "Attributes"), "attrs"))
+        return Repr(
+            header=get_header_text(name),
+            body=tuple(split_block(x, kind=k) for x, k in blocks),
+            kind="annotation_set",
+        )
 
-    def __str__(self) -> str:
-        return str(self.__rich__())
-
-    __repr__ = __str__
+    def __rich__(self) -> Text:
+        return render_text(self._repr_node())
 
     def _dims_text(self) -> Text:
         """The extent each dimension is annotated over, and how it is spelled."""

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -73,6 +73,7 @@ from dascore.models import (
     frozen_dict_validator,
 )
 from dascore.utils.array_api import array_namespace
+from dascore.utils.display import RichRepr
 from dascore.utils.docs import compose_docstring
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import (
@@ -159,7 +160,7 @@ def _get_indexers_and_new_coords_dict(
     return new_coords, indexers
 
 
-class CoordManager(DascoreBaseModel):
+class CoordManager(RichRepr, DascoreBaseModel):
     """
     Class for managing coordinates.
 
@@ -763,11 +764,6 @@ class CoordManager(DascoreBaseModel):
         except (ValueError, IndexError):
             msg = f"Patch has no dimension: {dim}. Its dimensions are: {self.dims}"
             raise CoordError(msg)
-
-    def __str__(self):
-        return str(self.__rich__())
-
-    __repr__ = __str__
 
     def equals(self, other) -> bool:
         """Return True if other coordinates are approx equal."""

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -54,7 +54,7 @@ from dascore.utils.array import (
     _is_text_coercible_array,
     hash_array,
 )
-from dascore.utils.display import get_nice_text
+from dascore.utils.display import RichRepr, get_nice_text
 from dascore.utils.docs import compose_docstring, get_docstring
 from dascore.utils.misc import (
     _get_nullish,
@@ -350,7 +350,7 @@ def get_compatible_values(val, dtype):
     return val
 
 
-class BaseCoord(DascoreBaseModel, abc.ABC):
+class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
     """
     Coordinate interface.
 
@@ -630,11 +630,6 @@ class BaseCoord(DascoreBaseModel, abc.ABC):
             base += get_nice_text(unit_str, style="units")
         base += Text(" )")
         return base
-
-    def __str__(self):
-        return str(self.__rich__())
-
-    __repr__ = __str__
 
     def __array__(self, dtype=None, copy=False):
         """Numpy method for getting array data with `np.array(coord)`."""

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -54,13 +54,13 @@ from dascore.models import (
     UnitQuantity,
 )
 from dascore.utils.display import (
+    NodeRepr,
     Repr,
     get_header_text,
     indent_text,
     limit_reprs,
     mapping_to_text,
     model_to_line,
-    render_text,
     split_block,
     stated_fields,
 )
@@ -2097,7 +2097,7 @@ def _yaml_label(text: str) -> str:
     return f"{text!r}" if short else "the given YAML text"
 
 
-class Inventory(NamespaceOwner, InventoryModel):
+class Inventory(NodeRepr, NamespaceOwner, InventoryModel):
     """
     Top-level DASDAE inventory manifest.
 
@@ -2305,14 +2305,10 @@ class Inventory(NamespaceOwner, InventoryModel):
         return Repr(
             header=header,
             body=(
-                split_block(networks, kind="tree"),
-                split_block(mapping_to_text(attrs, "Attributes"), kind="attrs"),
+                split_block(networks),
+                split_block(mapping_to_text(attrs, "Attributes")),
             ),
-            kind="inventory",
         )
-
-    def __rich__(self) -> Text:
-        return render_text(self._repr_node())
 
     def get_resource(self, resource_id: str):
         """Return the shareable resource registered under a resource_id."""

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -54,11 +54,14 @@ from dascore.models import (
     UnitQuantity,
 )
 from dascore.utils.display import (
+    Repr,
     get_header_text,
     indent_text,
     limit_reprs,
     mapping_to_text,
     model_to_line,
+    render_text,
+    split_block,
     stated_fields,
 )
 from dascore.utils.documents import (
@@ -2277,7 +2280,7 @@ class Inventory(NamespaceOwner, InventoryModel):
         self.__pydantic_fields_set__.update({"resources", "networks"})
         return self
 
-    def __rich__(self) -> Text:
+    def _repr_node(self) -> Repr:
         """
         The banner, the network tree, and what the manifest itself states.
 
@@ -2299,12 +2302,17 @@ class Inventory(NamespaceOwner, InventoryModel):
             **stated_fields(self, skip=shown),
             "coordinate_reference_system": self.coordinate_reference_system,
         }
-        return Text("\n").join([header, networks, mapping_to_text(attrs, "Attributes")])
+        return Repr(
+            header=header,
+            body=(
+                split_block(networks, kind="tree"),
+                split_block(mapping_to_text(attrs, "Attributes"), kind="attrs"),
+            ),
+            kind="inventory",
+        )
 
-    def __str__(self) -> str:
-        return str(self.__rich__())
-
-    __repr__ = __str__
+    def __rich__(self) -> Text:
+        return render_text(self._repr_node())
 
     def get_resource(self, resource_id: str):
         """Return the shareable resource registered under a resource_id."""

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -26,12 +26,11 @@ from dascore.utils.array import (
 )
 from dascore.utils.array_api import to_numpy
 from dascore.utils.display import (
+    NodeRepr,
     Repr,
-    RichRepr,
     array_to_text,
     attrs_to_text,
     get_header_text,
-    render_text,
     split_block,
 )
 from dascore.utils.namespace import NamespaceOwner
@@ -40,7 +39,7 @@ from dascore.utils.time import to_float
 from dascore.workflow.identity import with_patch_id
 
 
-class Patch(RichRepr, NamespaceOwner):
+class Patch(NodeRepr, NamespaceOwner):
     """
     A Class for managing data and metadata.
 
@@ -217,18 +216,13 @@ class Patch(RichRepr, NamespaceOwner):
         return Repr(
             header=get_header_text("Patch ⚡"),
             body=(
-                split_block(self.coords.__rich__(), kind="coords"),
+                split_block(self.coords.__rich__()),
                 split_block(
                     array_to_text(self.data, units=attrs.get("data_units")),
-                    kind="data",
                 ),
-                split_block(attrs_to_text(attrs), kind="attrs"),
+                split_block(attrs_to_text(attrs)),
             ),
-            kind="patch",
         )
-
-    def __rich__(self):
-        return render_text(self._repr_node())
 
     def flat_dump(self, exclude=None) -> dict:
         """Return a flat summary dict for dataframe-oriented helpers."""

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -8,7 +8,6 @@ from typing import Any, Final
 from uuid import uuid4
 
 import numpy as np
-from rich.text import Text
 
 import dascore as dc
 import dascore.proc.coords
@@ -26,14 +25,22 @@ from dascore.utils.array import (
     patch_array_ufunc,
 )
 from dascore.utils.array_api import to_numpy
-from dascore.utils.display import array_to_text, attrs_to_text, get_header_text
+from dascore.utils.display import (
+    Repr,
+    RichRepr,
+    array_to_text,
+    attrs_to_text,
+    get_header_text,
+    render_text,
+    split_block,
+)
 from dascore.utils.namespace import NamespaceOwner
 from dascore.utils.patch import check_patch_attrs, check_patch_coords, get_patch_names
 from dascore.utils.time import to_float
 from dascore.workflow.identity import with_patch_id
 
 
-class Patch(NamespaceOwner):
+class Patch(RichRepr, NamespaceOwner):
     """
     A Class for managing data and metadata.
 
@@ -204,20 +211,24 @@ class Patch(NamespaceOwner):
         out = out if not copy else np.copy(out)
         return out
 
-    def __rich__(self):
-        header = get_header_text("Patch ⚡")
-        coords = self.coords.__rich__()
+    def _repr_node(self) -> Repr:
+        """The banner, the coordinates, the data and the attributes."""
         attrs = self.attrs
-        data = array_to_text(self.data, units=attrs.get("data_units"))
-        attrs = attrs_to_text(self.attrs)
-        out = Text("\n").join([header, coords, data, attrs])
-        return out
+        return Repr(
+            header=get_header_text("Patch ⚡"),
+            body=(
+                split_block(self.coords.__rich__(), kind="coords"),
+                split_block(
+                    array_to_text(self.data, units=attrs.get("data_units")),
+                    kind="data",
+                ),
+                split_block(attrs_to_text(attrs), kind="attrs"),
+            ),
+            kind="patch",
+        )
 
-    def __str__(self):
-        out = self.__rich__()
-        return str(out)
-
-    __repr__ = __str__
+    def __rich__(self):
+        return render_text(self._repr_node())
 
     def flat_dump(self, exclude=None) -> dict:
         """Return a flat summary dict for dataframe-oriented helpers."""

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -92,11 +92,15 @@ from dascore.utils.chunk_plan import (
 )
 from dascore.utils.display import (
     ACQUISITION_ATTR,
+    Repr,
+    RichRepr,
     elision_text,
     get_header_text,
     get_nice_text,
     group_names,
     human_duration,
+    render_text,
+    split_block,
 )
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import (
@@ -150,7 +154,7 @@ class _InventoryQuery(NamedTuple):
 _TIMES = (pd.Timestamp, np.datetime64, pd.Timedelta, np.timedelta64)
 
 
-class Spool(NamespaceOwner):
+class Spool(RichRepr, NamespaceOwner):
     """
     A container of patches: a view over a `PatchCatalog`.
 
@@ -2342,7 +2346,7 @@ class Spool(NamespaceOwner):
             rows = samples_adjusted_envelopes(rows, catalog.residuals, drop_empty=False)
         return {"rows": _strip_identity(rows)}
 
-    def __rich__(self):
+    def _repr_node(self) -> Repr:
         """
         What the spool is, what it spans, and the tracks it holds.
 
@@ -2384,7 +2388,12 @@ class Spool(NamespaceOwner):
                     style=dascore_styles["keys"],
                 )
             )
-        return Text("\n").join(blocks)
+        header, *rest = blocks
+        sections = tuple(split_block(x) for x in rest)
+        return Repr(header=header, body=sections, kind="spool")
+
+    def __rich__(self):
+        return render_text(self._repr_node())
 
     def _stated_dims(self, df) -> list[str]:
         """The dimensions this spool's patches actually have."""
@@ -2609,11 +2618,6 @@ class Spool(NamespaceOwner):
         if measurable and (tracks := self._tracks_text(df, measurable[0])) is not None:
             blocks.append(tracks)
         return blocks
-
-    def __str__(self):
-        return str(self.__rich__())
-
-    __repr__ = __str__
 
 
 # There is one spool class; the old ABC name stays as an alias so

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -92,14 +92,13 @@ from dascore.utils.chunk_plan import (
 )
 from dascore.utils.display import (
     ACQUISITION_ATTR,
+    NodeRepr,
     Repr,
-    RichRepr,
     elision_text,
     get_header_text,
     get_nice_text,
     group_names,
     human_duration,
-    render_text,
     split_block,
 )
 from dascore.utils.docs import compose_docstring
@@ -154,7 +153,7 @@ class _InventoryQuery(NamedTuple):
 _TIMES = (pd.Timestamp, np.datetime64, pd.Timedelta, np.timedelta64)
 
 
-class Spool(RichRepr, NamespaceOwner):
+class Spool(NodeRepr, NamespaceOwner):
     """
     A container of patches: a view over a `PatchCatalog`.
 
@@ -2367,8 +2366,11 @@ class Spool(RichRepr, NamespaceOwner):
         limit = dc.get_config().display_max_patches
         if count <= limit:
             # A repr which raises makes an object undebuggable at the
-            # one moment someone needs to look at it, so nothing a
+            # one moment someone needs to look at it, so nothing the
             # summary does is allowed to stop the header from printing.
+            # Only the summary: counting the spool and asking for its
+            # path happen above, and a catalog which cannot answer
+            # either of those still raises.
             # Nor is it allowed to warn about how pandas built the
             # frame: a directory index warns once per insert that it is
             # fragmented, a hundred lines of advice about a frame the
@@ -2390,10 +2392,7 @@ class Spool(RichRepr, NamespaceOwner):
             )
         header, *rest = blocks
         sections = tuple(split_block(x) for x in rest)
-        return Repr(header=header, body=sections, kind="spool")
-
-    def __rich__(self):
-        return render_text(self._repr_node())
+        return Repr(header=header, body=sections)
 
     def _stated_dims(self, df) -> list[str]:
         """The dimensions this spool's patches actually have."""

--- a/dascore/models/base.py
+++ b/dascore/models/base.py
@@ -29,7 +29,7 @@ from dascore.models.registry import (
     register_model,
 )
 from dascore.models.types import DateTime64, FrozenDictType
-from dascore.utils.display import model_to_line
+from dascore.utils.display import RichRepr, model_to_line
 from dascore.utils.misc import _all_null, all_close
 from dascore.utils.time import to_datetime64
 
@@ -199,7 +199,7 @@ class DascoreBaseModel(BaseModel):
     __hash__ = sensible_model_hash
 
 
-class InventoryModel(DascoreBaseModel):
+class InventoryModel(RichRepr, DascoreBaseModel):
     """
     Base class for immutable DASDAE inventory objects.
 
@@ -242,11 +242,6 @@ class InventoryModel(DascoreBaseModel):
     def __rich__(self) -> Text:
         """One line naming the class and what it states."""
         return model_to_line(self)
-
-    def __str__(self) -> str:
-        return str(self.__rich__())
-
-    __repr__ = __str__
 
 
 class TimeRangedModel(InventoryModel):

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import textwrap
 from collections import Counter
-from collections.abc import Iterable, Mapping, Sized
+from collections.abc import Callable, Iterable, Mapping, Sized
 from contextlib import suppress
+from dataclasses import dataclass, field
 from functools import singledispatch
 
 import numpy as np
@@ -60,6 +61,107 @@ _NULLABLE_TYPES = (
     pd.Timedelta,
     type(pd.NaT),
 )
+
+
+@dataclass(frozen=True, slots=True)
+class Raw:
+    """
+    Text whose producer has already laid it out.
+
+    A renderer emits it as it stands. This is what lets a class which
+    states no nodes of its own still render correctly inside one which
+    does, and it stays the home of anything whose spacing is load
+    bearing, such as an array printed in columns.
+    """
+
+    text: Text
+
+
+@dataclass(frozen=True, slots=True)
+class Section:
+    """
+    A titled block: the line which names it, and what sits under it.
+
+    The title is the line a reader is shown when the body is not; a
+    section with no body is a statement rather than a container.
+    """
+
+    title: Text
+    body: tuple[Raw, ...] = ()
+    kind: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Repr:
+    """A whole repr: the banner which names the object, then its sections."""
+
+    header: Text
+    body: tuple[Section, ...] = field(default_factory=tuple)
+    kind: str = ""
+
+
+@singledispatch
+def render_text(node) -> Text:
+    """Render a repr node as rich text."""
+    msg = f"cannot render {type(node).__name__} as text"
+    raise NotImplementedError(msg)
+
+
+@render_text.register
+def _render_raw(node: Raw) -> Text:
+    return node.text
+
+
+@render_text.register
+def _render_section(node: Section) -> Text:
+    out = node.title
+    for child in node.body:
+        out += Text("\n") + render_text(child)
+    return out
+
+
+@render_text.register
+def _render_repr(node: Repr) -> Text:
+    blocks = [node.header, *(render_text(x) for x in node.body)]
+    return Text("\n").join(blocks)
+
+
+def split_block(text: Text, kind: str = "") -> Section:
+    """
+    Turn a block of rendered text into a section, losslessly.
+
+    The first line names the block and the rest is its body, which is
+    how every block a dascore repr is built from already reads. Slicing
+    rather than splitting is deliberate: ``Text.split`` drops a trailing
+    blank line, and the attributes block ends on one.
+    """
+    index = text.plain.find("\n")
+    if index == -1:
+        return Section(text, kind=kind)
+    return Section(text[:index], (Raw(text[index + 1 :]),), kind=kind)
+
+
+class RichRepr:
+    """
+    Print an object the way its ``__rich__`` renders it.
+
+    One definition for every class which has a rich rendering, so a plain
+    terminal and a rich one say the same thing and neither drifts from the
+    other. A host states ``__rich__``; this states the rest.
+
+    List this before any base which defines its own ``__str__``, as a
+    pydantic model does. The one the MRO reaches first is the only one
+    called, and a host which lists this last prints a field dump.
+    """
+
+    # No ``__rich__`` stub here on purpose: every host states one, so a
+    # guard for its absence is a branch no test can reach.
+    __rich__: Callable[[], Text]
+
+    def __str__(self) -> str:
+        return str(self.__rich__())
+
+    __repr__ = __str__
 
 
 @singledispatch

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -116,7 +116,7 @@ def _render_raw(node: Raw) -> Text:
 def _render_section(node: Section) -> Text:
     out = node.title
     for child in node.body:
-        out += Text("\n") + render_text(child)
+        out += render_text(child)
     return out
 
 
@@ -128,17 +128,26 @@ def _render_repr(node: Repr) -> Text:
 
 def split_block(text: Text, kind: str = "") -> Section:
     """
-    Turn a block of rendered text into a section, losslessly.
+    Turn a block of rendered text into a section.
 
     The first line names the block and the rest is its body, which is
     how every block a dascore repr is built from already reads. Slicing
     rather than splitting is deliberate: ``Text.split`` drops a trailing
     blank line, and the attributes block ends on one.
+
+    The body keeps the newline which separates it from the title rather
+    than a renderer supplying one of its own, so a span which straddles
+    the break still covers every character it covered before.
+
+    Rendering the section gives back what came in. Not the same spans --
+    slicing states a base style as a span as well, and a span across the
+    break comes back as two touching ones -- but the same characters,
+    each drawn the same way.
     """
     index = text.plain.find("\n")
     if index == -1:
         return Section(text, kind=kind)
-    return Section(text[:index], (Raw(text[index + 1 :]),), kind=kind)
+    return Section(text[:index], (Raw(text[index:]),), kind=kind)
 
 
 class RichRepr:

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -82,13 +82,11 @@ class Section:
     """
     A titled block: the line which names it, and what sits under it.
 
-    The title is the line a reader is shown when the body is not; a
-    section with no body is a statement rather than a container.
+    A section with no body is a statement rather than a container.
     """
 
     title: Text
     body: tuple[Raw, ...] = ()
-    kind: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,7 +95,6 @@ class Repr:
 
     header: Text
     body: tuple[Section, ...] = field(default_factory=tuple)
-    kind: str = ""
 
 
 @singledispatch
@@ -109,12 +106,14 @@ def render_text(node) -> Text:
 
 @render_text.register
 def _render_raw(node: Raw) -> Text:
-    return node.text
+    # A copy, not the node's own Text: a caller which appends to what it
+    # rendered would otherwise rewrite the node it just read.
+    return node.text.copy()
 
 
 @render_text.register
 def _render_section(node: Section) -> Text:
-    out = node.title
+    out = node.title.copy()
     for child in node.body:
         out += render_text(child)
     return out
@@ -126,7 +125,7 @@ def _render_repr(node: Repr) -> Text:
     return Text("\n").join(blocks)
 
 
-def split_block(text: Text, kind: str = "") -> Section:
+def split_block(text: Text) -> Section:
     """
     Turn a block of rendered text into a section.
 
@@ -135,19 +134,16 @@ def split_block(text: Text, kind: str = "") -> Section:
     rather than splitting is deliberate: ``Text.split`` drops a trailing
     blank line, and the attributes block ends on one.
 
-    The body keeps the newline which separates it from the title rather
-    than a renderer supplying one of its own, so a span which straddles
-    the break still covers every character it covered before.
-
-    Rendering the section gives back what came in. Not the same spans --
-    slicing states a base style as a span as well, and a span across the
-    break comes back as two touching ones -- but the same characters,
-    each drawn the same way.
+    The body keeps the newline which separated it, so a span straddling
+    the break still covers what it covered. Rendering the section gives
+    back the same characters drawn the same way, though not the same
+    spans: slicing restates a base style as a span, and a span across
+    the break comes back as two touching ones.
     """
     index = text.plain.find("\n")
     if index == -1:
-        return Section(text, kind=kind)
-    return Section(text[:index], (Raw(text[index:]),), kind=kind)
+        return Section(text)
+    return Section(text[:index], (Raw(text[index:]),))
 
 
 class RichRepr:
@@ -171,6 +167,20 @@ class RichRepr:
         return str(self.__rich__())
 
     __repr__ = __str__
+
+
+class NodeRepr(RichRepr):
+    """
+    Print an object from the repr nodes it states.
+
+    A host states ``_repr_node``; rendering it is the same call every
+    time, so it is made once here.
+    """
+
+    _repr_node: Callable[[], Repr]
+
+    def __rich__(self) -> Text:
+        return render_text(self._repr_node())
 
 
 @singledispatch

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -15,7 +15,11 @@ from rich.text import Text
 import dascore as dc
 from dascore.config import config_context
 from dascore.constants import dascore_styles
-from dascore.core.annotations import AnnotationColumn, AnnotationSetAttrs
+from dascore.core.annotations import (
+    AnnotationColumn,
+    AnnotationSet,
+    AnnotationSetAttrs,
+)
 from dascore.core.inventory import Acquisition, Cable, Network
 from dascore.utils.display import (
     Raw,
@@ -485,6 +489,26 @@ class TestDascoreStyles:
         assert any(f'"{name}"' in x or f"'{name}'" in x for x in sources)
 
 
+def resolved_styles(text: Text) -> list:
+    """
+    The style each character of a Text actually renders with.
+
+    Spans are compared this way rather than as a list because how they
+    are grouped is not what a reader sees: a span which straddles a line
+    break comes back as two touching ones, and a base style comes back
+    as a span saying the same thing. Every character still draws the
+    same, which is the invariant worth holding.
+    """
+    console = Console()
+    base = console.get_style(text.style, default="")
+    out = [base] * len(text.plain)
+    for span in text.spans:
+        style = console.get_style(span.style, default="")
+        for index in range(span.start, min(span.end, len(out))):
+            out[index] = out[index] + style
+    return out
+
+
 @pytest.fixture(scope="module")
 def repr_blocks():
     """Every kind of block a dascore repr is built from."""
@@ -516,10 +540,55 @@ class TestSplitBlock:
         for name, text in repr_blocks.items():
             assert render_text(split_block(text)) == text, name
 
-    def test_round_trip_keeps_spans(self, repr_blocks):
+    def test_round_trip_keeps_styling(self, repr_blocks):
         """Colour survives the trip, not only the characters."""
         for name, text in repr_blocks.items():
-            assert render_text(split_block(text)).spans == text.spans, name
+            trip = render_text(split_block(text))
+            assert resolved_styles(trip) == resolved_styles(text), name
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            Text(""),
+            Text("\n"),
+            Text("\nbody"),
+            Text("head\n"),
+            Text("head\n\n"),
+            Text("solo"),
+            Text("a\n\nb"),
+            Text("head\nbody", style="bold green"),
+        ],
+        ids=[
+            "empty",
+            "newline",
+            "leading",
+            "trailing",
+            "two_trailing",
+            "no_newline",
+            "blank_middle",
+            "base_style",
+        ],
+    )
+    def test_round_trips_whatever_the_shape(self, text):
+        """Blocks a producer has not written yet still have to survive."""
+        trip = render_text(split_block(text))
+        assert trip.plain == text.plain
+        assert resolved_styles(trip) == resolved_styles(text)
+
+    def test_a_span_across_the_break_still_draws_the_same(self):
+        """
+        A span which straddles the split comes back as two.
+
+        The body carries the newline that split it, so the two spans
+        touch and the break itself keeps its style. What a reader sees
+        is unchanged; only the grouping differs.
+        """
+        text = Text("head\nbody")
+        text.stylize("bold", 2, 7)
+        trip = render_text(split_block(text))
+        assert trip.plain == text.plain
+        assert resolved_styles(trip) == resolved_styles(text)
+        assert len(trip.spans) == 2
 
     def test_a_trailing_blank_line_survives(self):
         """
@@ -553,9 +622,14 @@ class TestRenderText:
         text = Text("   already    spaced")
         assert render_text(Raw(text)) == text
 
-    def test_section_joins_body_with_newlines(self):
-        """A body sits on the lines under the title."""
-        node = Section(Text("title"), (Raw(Text("a")), Raw(Text("b"))))
+    def test_a_body_carries_its_own_separators(self):
+        """
+        A section concatenates its body rather than spacing it out.
+
+        ``Raw`` means text its producer has already laid out, and that
+        includes the newline which put it on the next line.
+        """
+        node = Section(Text("title"), (Raw(Text("\na")), Raw(Text("\nb"))))
         assert render_text(node).plain == "title\na\nb"
 
     def test_repr_joins_header_and_sections(self):
@@ -581,6 +655,9 @@ class TestRichRepr:
         """One of each class which prints through the mixin."""
         patch = dc.get_example_patch()
         inventory = dc.get_example_inventory("tunnel")
+        frame = pd.DataFrame(
+            {"time_min": [0.0, 1.0], "time_max": [0.5, 1.5], "group": ["a", "b"]}
+        )
         return {
             "patch": patch,
             "coord_manager": patch.coords,
@@ -588,6 +665,10 @@ class TestRichRepr:
             "spool": dc.get_example_spool(),
             "inventory": inventory,
             "network": inventory.networks[0],
+            "optical_path": inventory.networks[0].fiber_arrays[0].optical_paths[0],
+            "annotation_set": AnnotationSet(frame, dims=("time",)),
+            "annotation_column": AnnotationColumn(description="a pick", units="s"),
+            "empty_annotation_set": AnnotationSet(frame.iloc[:0], dims=("time",)),
         }
 
     def test_str_is_the_rich_rendering(self, rich_objects):

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
 from pydantic import BaseModel, ConfigDict
+from rich.console import Console
+from rich.style import Style
 from rich.text import Text
 
 import dascore as dc
@@ -441,3 +445,35 @@ class TestGroupNames:
         """A group which recorded nothing is not named by an empty part."""
         frame = pd.DataFrame({"tag": ["a", ""], "kind": ["das", "dss"]})
         assert group_names(frame) == ["a · das", "dss"]
+
+
+class TestDascoreStyles:
+    """Tests for the style table every repr draws from."""
+
+    @pytest.mark.parametrize("name", sorted(dascore_styles))
+    def test_every_style_parses(self, name):
+        """
+        Rich must be able to read every style dascore states.
+
+        It resolves a style it cannot parse to a blank one rather than
+        raising, so a misspelling here does not fail a test, it silently
+        stops colouring whatever states it.
+        """
+        assert Style.parse(dascore_styles[name])
+
+    @pytest.mark.parametrize("name", sorted(dascore_styles))
+    def test_every_style_colours_something(self, name):
+        """A style which resolves to nothing is not styling anything."""
+        assert Console().get_style(dascore_styles[name]) != Style()
+
+    @pytest.mark.parametrize("name", sorted(dascore_styles))
+    def test_every_style_is_used(self, name):
+        """
+        A style nothing asks for is a style no one maintains.
+
+        Two of them had gone unreferenced long enough to stop parsing
+        without anyone noticing.
+        """
+        used = Path(dc.__file__).parent.rglob("*.py")
+        sources = [x.read_text() for x in used if x.name != "constants.py"]
+        assert any(f'"{name}"' in x or f"'{name}'" in x for x in sources)

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import numpy as np
@@ -467,46 +468,41 @@ class TestDascoreStyles:
 
         It resolves a style it cannot parse to a blank one rather than
         raising, so a misspelling here does not fail a test, it silently
-        stops colouring whatever states it.
+        stops coloring whatever states it.
         """
         assert Style.parse(dascore_styles[name])
-
-    @pytest.mark.parametrize("name", sorted(dascore_styles))
-    def test_every_style_colours_something(self, name):
-        """A style which resolves to nothing is not styling anything."""
-        assert Console().get_style(dascore_styles[name]) != Style()
 
     @pytest.mark.parametrize("name", sorted(dascore_styles))
     def test_every_style_is_used(self, name):
         """
         A style nothing asks for is a style no one maintains.
 
-        Two of them had gone unreferenced long enough to stop parsing
-        without anyone noticing.
+        Both of the styles removed with this test had gone unasked-for
+        long enough that one of them had stopped parsing unnoticed.
+
+        The name has to be matched where a style is *looked up*, not
+        wherever it appears: `dtypes` is also an unrelated dict key in
+        `workflow/serialize.py`, so a plain search for the word says it
+        is used when nothing styles anything with it.
         """
-        used = Path(dc.__file__).parent.rglob("*.py")
-        sources = [x.read_text() for x in used if x.name != "constants.py"]
-        assert any(f'"{name}"' in x or f"'{name}'" in x for x in sources)
+        sources = [
+            x.read_text(encoding="utf-8")
+            for x in Path(dc.__file__).parent.rglob("*.py")
+            if x.name != "constants.py"
+        ]
+        lookups = [
+            rf"dascore_styles\[[\"']{name}[\"']\]",
+            rf"style\s*=\s*[\"']{name}[\"']",
+            rf"_rich_style\s*=\s*[\"']{name}[\"']",
+            rf"[\"']{name}[\"']\s*\)",
+        ]
+        assert any(re.search(p, x) for p in lookups for x in sources)
 
 
 def resolved_styles(text: Text) -> list:
-    """
-    The style each character of a Text actually renders with.
-
-    Spans are compared this way rather than as a list because how they
-    are grouped is not what a reader sees: a span which straddles a line
-    break comes back as two touching ones, and a base style comes back
-    as a span saying the same thing. Every character still draws the
-    same, which is the invariant worth holding.
-    """
+    """The style each character of a Text actually renders with."""
     console = Console()
-    base = console.get_style(text.style, default="")
-    out = [base] * len(text.plain)
-    for span in text.spans:
-        style = console.get_style(span.style, default="")
-        for index in range(span.start, min(span.end, len(out))):
-            out[index] = out[index] + style
-    return out
+    return [text.get_style_at_offset(console, x) for x in range(len(text.plain))]
 
 
 @pytest.fixture(scope="module")
@@ -532,18 +528,20 @@ class TestSplitBlock:
 
     def test_round_trips(self, repr_blocks):
         """
-        Splitting then rendering must give back exactly what went in.
+        Splitting then rendering gives back what went in.
 
-        This is what makes the node tree provably free of drift: the
-        text repr is not re-derived from the nodes, it is reassembled.
+        A node holds the `Text` its producer made rather than a recipe
+        for rebuilding it, which is what keeps the two reprs from
+        drifting: `render_text` reassembles, it does not re-derive.
+
+        Compared by what each character draws rather than with `==`,
+        which reads `Text.style` and `Text.spans` -- slicing moves a
+        base style into a span, so a block-level style would fail an
+        equality check while drawing exactly the same.
         """
         for name, text in repr_blocks.items():
-            assert render_text(split_block(text)) == text, name
-
-    def test_round_trip_keeps_styling(self, repr_blocks):
-        """Colour survives the trip, not only the characters."""
-        for name, text in repr_blocks.items():
             trip = render_text(split_block(text))
+            assert trip.plain == text.plain, name
             assert resolved_styles(trip) == resolved_styles(text), name
 
     @pytest.mark.parametrize(
@@ -590,16 +588,6 @@ class TestSplitBlock:
         assert resolved_styles(trip) == resolved_styles(text)
         assert len(trip.spans) == 2
 
-    def test_a_trailing_blank_line_survives(self):
-        """
-        The attributes block ends on a newline and must keep it.
-
-        ``Text.split`` drops a trailing blank, which is why the block is
-        sliced instead. A repr which lost it would print one line short.
-        """
-        text = Text("head\nbody\n")
-        assert render_text(split_block(text)).plain == "head\nbody\n"
-
     def test_first_line_is_the_title(self, repr_blocks):
         """The line a reader is shown when the body is not."""
         section = split_block(repr_blocks["coords"])
@@ -608,10 +596,6 @@ class TestSplitBlock:
     def test_a_single_line_has_no_body(self, repr_blocks):
         """A block with nothing under it is a statement, not a container."""
         assert split_block(repr_blocks["one_line"]).body == ()
-
-    def test_kind_is_carried(self, repr_blocks):
-        """The kind is what a renderer styles the section by."""
-        assert split_block(repr_blocks["data"], kind="data").kind == "data"
 
 
 class TestRenderText:
@@ -687,10 +671,57 @@ class TestRichRepr:
         for name, obj in rich_objects.items():
             assert repr(obj) == str(obj), name
 
-    def test_a_pydantic_host_does_not_print_a_field_dump(self, rich_objects):
-        """The failure mode the mixin ordering exists to prevent."""
-        for name in ("coord", "coord_manager", "network"):
-            obj = rich_objects[name]
-            fields = getattr(type(obj), "model_fields", {})
-            dumped = [f"{x}=" for x in fields]
-            assert not all(x in str(obj) for x in dumped), name
+
+class TestSpoolReprNode:
+    """
+    Tests for the sections a spool states.
+
+    The spool is the one repr whose summary is allowed to fail without
+    the repr failing, which means an assertion on what it says passes
+    just as well when it says nothing. These pin the branches instead.
+    """
+
+    @pytest.fixture(scope="class")
+    def directory_spool(self, tmp_path_factory):
+        """A spool which knows the directory it was read from."""
+        path = tmp_path_factory.mktemp("spool_repr")
+        for index, patch in enumerate(dc.get_example_spool()):
+            patch.io.write(path / f"patch_{index}.h5", "dasdae")
+        return dc.spool(path).update()
+
+    def test_a_path_is_its_own_section(self, directory_spool):
+        """A spool read from disk says where it was read from."""
+        titles = [str(x.title) for x in directory_spool._repr_node().body]
+        assert any("Path:" in x for x in titles)
+
+    def test_a_path_section_has_no_body(self, directory_spool):
+        """One line is a statement, and a renderer must not fold it."""
+        section = next(
+            x for x in directory_spool._repr_node().body if "Path:" in str(x.title)
+        )
+        assert section.body == ()
+
+    def test_too_many_patches_states_the_limit(self):
+        """Past the limit a spool says what it is instead of summarising."""
+        spool = dc.get_example_spool()
+        with config_context(display_max_patches=1):
+            rendered = str(spool)
+        assert "Not summarized" in rendered
+        assert "display_max_patches=1" in rendered
+        assert "Dimensions" not in rendered
+
+    def test_a_summary_which_raises_still_prints_the_header(self, monkeypatch):
+        """
+        A repr which raises makes an object undebuggable exactly when
+        someone needs to look at it, so the summary is allowed to fail
+        and the banner is not.
+        """
+        spool = dc.get_example_spool()
+
+        def boom(self):
+            raise ValueError("no summary for you")
+
+        monkeypatch.setattr(type(spool), "_summary_blocks", boom)
+        rendered = str(spool)
+        assert "Spool" in rendered
+        assert "Dimensions" not in rendered

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -18,7 +18,11 @@ from dascore.constants import dascore_styles
 from dascore.core.annotations import AnnotationColumn, AnnotationSetAttrs
 from dascore.core.inventory import Acquisition, Cable, Network
 from dascore.utils.display import (
+    Raw,
+    Repr,
+    Section,
     array_to_text,
+    attrs_to_text,
     counts_to_text,
     get_header_text,
     get_nice_text,
@@ -29,6 +33,8 @@ from dascore.utils.display import (
     mapping_to_text,
     model_to_line,
     percent,
+    render_text,
+    split_block,
     stated_fields,
     value_to_text,
 )
@@ -477,3 +483,133 @@ class TestDascoreStyles:
         used = Path(dc.__file__).parent.rglob("*.py")
         sources = [x.read_text() for x in used if x.name != "constants.py"]
         assert any(f'"{name}"' in x or f"'{name}'" in x for x in sources)
+
+
+@pytest.fixture(scope="module")
+def repr_blocks():
+    """Every kind of block a dascore repr is built from."""
+    patch = dc.get_example_patch()
+    inventory = dc.get_example_inventory("tunnel")
+    return {
+        "coords": patch.coords.__rich__(),
+        "coord": patch.coords.coord_map["time"].__rich__(),
+        "data": array_to_text(patch.data),
+        "attrs": attrs_to_text(patch.attrs),
+        "inventory": inventory.__rich__(),
+        "model": inventory.networks[0].__rich__(),
+        "header": get_header_text("Patch ⚡"),
+        "one_line": Text("no newline in this one", style="bold"),
+        "empty": Text(""),
+    }
+
+
+class TestSplitBlock:
+    """Tests for turning a rendered block into a section."""
+
+    def test_round_trips(self, repr_blocks):
+        """
+        Splitting then rendering must give back exactly what went in.
+
+        This is what makes the node tree provably free of drift: the
+        text repr is not re-derived from the nodes, it is reassembled.
+        """
+        for name, text in repr_blocks.items():
+            assert render_text(split_block(text)) == text, name
+
+    def test_round_trip_keeps_spans(self, repr_blocks):
+        """Colour survives the trip, not only the characters."""
+        for name, text in repr_blocks.items():
+            assert render_text(split_block(text)).spans == text.spans, name
+
+    def test_a_trailing_blank_line_survives(self):
+        """
+        The attributes block ends on a newline and must keep it.
+
+        ``Text.split`` drops a trailing blank, which is why the block is
+        sliced instead. A repr which lost it would print one line short.
+        """
+        text = Text("head\nbody\n")
+        assert render_text(split_block(text)).plain == "head\nbody\n"
+
+    def test_first_line_is_the_title(self, repr_blocks):
+        """The line a reader is shown when the body is not."""
+        section = split_block(repr_blocks["coords"])
+        assert section.title.plain == "➤ Coordinates (distance: 300, time: 2000)"
+
+    def test_a_single_line_has_no_body(self, repr_blocks):
+        """A block with nothing under it is a statement, not a container."""
+        assert split_block(repr_blocks["one_line"]).body == ()
+
+    def test_kind_is_carried(self, repr_blocks):
+        """The kind is what a renderer styles the section by."""
+        assert split_block(repr_blocks["data"], kind="data").kind == "data"
+
+
+class TestRenderText:
+    """Tests for rendering repr nodes as text."""
+
+    def test_raw_is_emitted_as_it_stands(self):
+        """A producer which laid its own text out is not re-laid-out."""
+        text = Text("   already    spaced")
+        assert render_text(Raw(text)) == text
+
+    def test_section_joins_body_with_newlines(self):
+        """A body sits on the lines under the title."""
+        node = Section(Text("title"), (Raw(Text("a")), Raw(Text("b"))))
+        assert render_text(node).plain == "title\na\nb"
+
+    def test_repr_joins_header_and_sections(self):
+        """The banner, then each section under it."""
+        node = Repr(Text("banner"), (Section(Text("one")), Section(Text("two"))))
+        assert render_text(node).plain == "banner\none\ntwo"
+
+    def test_a_repr_may_state_no_sections(self):
+        """An object with nothing to show is still an object."""
+        assert render_text(Repr(Text("banner"))).plain == "banner"
+
+    def test_something_which_is_not_a_node(self):
+        """A renderer says what it cannot draw rather than drawing it wrong."""
+        with pytest.raises(NotImplementedError, match="cannot render int"):
+            render_text(42)
+
+
+class TestRichRepr:
+    """Tests for the mixin every rich-rendered class prints through."""
+
+    @pytest.fixture(scope="class")
+    def rich_objects(self):
+        """One of each class which prints through the mixin."""
+        patch = dc.get_example_patch()
+        inventory = dc.get_example_inventory("tunnel")
+        return {
+            "patch": patch,
+            "coord_manager": patch.coords,
+            "coord": patch.coords.coord_map["time"],
+            "spool": dc.get_example_spool(),
+            "inventory": inventory,
+            "network": inventory.networks[0],
+        }
+
+    def test_str_is_the_rich_rendering(self, rich_objects):
+        """
+        What a plain terminal prints is what a rich one renders.
+
+        This is the assertion which catches a pydantic host listing the
+        mixin after ``BaseModel``: the field dump it would print instead
+        is still a non-empty string, so a weaker test passes.
+        """
+        for name, obj in rich_objects.items():
+            assert str(obj) == str(obj.__rich__()), name
+
+    def test_repr_is_str(self, rich_objects):
+        """Neither form drifts from the other."""
+        for name, obj in rich_objects.items():
+            assert repr(obj) == str(obj), name
+
+    def test_a_pydantic_host_does_not_print_a_field_dump(self, rich_objects):
+        """The failure mode the mixin ordering exists to prevent."""
+        for name in ("coord", "coord_manager", "network"):
+            obj = rich_objects[name]
+            fields = getattr(type(obj), "model_fields", {})
+            dumped = [f"{x}=" for x in fields]
+            assert not all(x in str(obj) for x in dumped), name


### PR DESCRIPTION
## Description

Groundwork for a collapsible HTML repr in notebooks (`_repr_html_`), split out so it can be reviewed on its own. **This PR changes no output**: `str(obj)` is byte-identical to `dev` for every affected class.

Three things:

**Four `dascore_styles` values were not styles rich can parse.** Rich resolves an unparseable style to a blank one rather than raising, so `units`, array coords and monotonic coords have been printing with no color at all and nothing said so. `bold grey`, `bold orange` and `bright blue` become the spellings rich accepts. `dtypes` and `coord_degenerate` are deleted rather than repaired — nothing has referenced either since #342/#375.

**Eight classes each carried their own copy of `__str__`/`__repr__`**, and `Inventory` carried a ninth it already inherited. They become a `RichRepr` mixin. It has to precede `BaseModel` in the bases of the four pydantic hosts; listed after it, pydantic's own `__str__` wins and the object prints a field dump — which is still a non-empty string, so every test we had passed. `test_str_is_the_rich_rendering` is the one that fails.

**A repr gains a shape it did not have:** `Raw`/`Section`/`Repr` nodes and a `render_text` that renders them, adopted by `Patch`, `Spool`, `AnnotationSet` and `Inventory` via `NodeRepr`. `split_block` and `render_text` reassemble rather than re-derive — a node holds the `Text` its producer made — so the text repr cannot drift from what a later HTML renderer emits. Nothing consumes the structure yet.

Classes that state no nodes of their own — coords, coord managers, inventory models — render inside their parents as `Raw` and are untouched. That is what `Raw` is for, and where an array printed in columns will stay.

### Verification

A 16-object corpus dumped from `dev` (via `git archive`) and from this branch: **16/16 byte-identical**. A reviewer independently repeated it over 25 objects — including chunked and empty spools, nested inventory models and eight coords — and also checked pickle, deepcopy, JSON round-trip, `model_fields` and the model registry. Only `__mro__` changes.

Full suite 9910 passed / 114 skipped / 2 xfailed · doctests 210 passed · `pre-commit run --all` clean · `dascore/utils/display.py` at 100% coverage.

### Review

Six blind reviews (Codex plus five lenses). Codex's first pass found that `split_block` dropped the newline and `render_text` synthesized a fresh one, so a span straddling the break came back as two with the break unstyled — fixed by carrying the source separator; its second pass was clean. The others found a renderer handing back the node's own mutable `Text`, two unread `kind` fields, four pasted `__rich__` bodies, and four tests that could not fail — including one blind to `dtypes`, the exact key it existed to catch, because the bare word also appears in `workflow/serialize.py`. All addressed in `Answer the reviewers`.

## Changelog

- fixed: Units, array coordinates and monotonic coordinates print in color again; four entries in `dascore_styles` were not styles rich could parse.
- removed **breaking**: The unused `dtypes` and `coord_degenerate` keys no longer appear in `dascore.constants.dascore_styles`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.