### PR TITLE
Say what a repr's numbers mean

### DIFF
--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -64,6 +64,7 @@ from dascore.utils.display import (
     Repr,
     RichRepr,
     counts_to_text,
+    duration_text,
     get_header_text,
     get_nice_text,
     mapping_to_text,
@@ -947,10 +948,13 @@ class AnnotationSet(NodeRepr, NamespaceOwner):
             if not len(values):
                 base += Text("unstated", key_style)
                 continue
+            low, high = values.min(), values.max()
             base += Text("min: ", key_style)
-            base += get_nice_text(values.min())
+            base += get_nice_text(low)
             base += Text(" max: ", key_style)
-            base += get_nice_text(values.max())
+            base += get_nice_text(high)
+            if (span := duration_text(low, high)) is not None:
+                base += Text(" ") + span
             kind = "point" if spelling.point else "range"
             base += Text(f" ({kind})", key_style)
         return base

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -54,7 +54,12 @@ from dascore.utils.array import (
     _is_text_coercible_array,
     hash_array,
 )
-from dascore.utils.display import RichRepr, get_nice_text
+from dascore.utils.display import (
+    RichRepr,
+    duration_text,
+    get_nice_text,
+    rate_text,
+)
 from dascore.utils.docs import compose_docstring, get_docstring
 from dascore.utils.misc import (
     _get_nullish,
@@ -617,9 +622,16 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         if not pd.isnull(self.max()):
             base += Text(" max: ", key_style)
             base += get_nice_text(self.max())
+        # Only a time. Two instants say nothing about how far apart they
+        # are; a distance from 0 to 299 m already says 299 m.
+        if dtype_time_like(self.dtype) and not pd.isnull(self.min()):
+            if (span := duration_text(self.min(), self.max())) is not None:
+                base += Text(" ") + span
         if not pd.isnull(self.step):
             base += Text(" step: ", key_style)
             base += get_nice_text(self.step)
+            if (rate := rate_text(self.step)) is not None:
+                base += rate
         base += Text(" shape: ", key_style)
         base += get_nice_text(self.shape)
         base += Text(" dtype: ", key_style)

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -89,6 +89,7 @@ from dascore.utils.chunk_plan import (
     subdivision_pieces,
 )
 from dascore.utils.display import (
+    _TIME_TYPES,
     ACQUISITION_ATTR,
     NodeRepr,
     Repr,
@@ -148,7 +149,7 @@ class _InventoryQuery(NamedTuple):
 # offsets alike. Two such ends are a duration apart, which is a fact
 # neither end carries; every other dimension states its own magnitude
 # in its own units.
-_TIMES = (pd.Timestamp, np.datetime64, pd.Timedelta, np.timedelta64)
+_TIMES = _TIME_TYPES
 
 
 class Spool(NodeRepr, NamespaceOwner):

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -15,8 +15,6 @@ from typing import TYPE_CHECKING, ClassVar, Literal, NamedTuple, Self, TypeVar, 
 import numpy as np
 import pandas as pd
 from pandas.errors import (
-    OutOfBoundsDatetime,
-    OutOfBoundsTimedelta,
     PerformanceWarning,
 )
 from rich.text import Text
@@ -94,11 +92,11 @@ from dascore.utils.display import (
     ACQUISITION_ATTR,
     NodeRepr,
     Repr,
+    duration_text,
     elision_text,
     get_header_text,
     get_nice_text,
     group_names,
-    human_duration,
     split_block,
 )
 from dascore.utils.docs import compose_docstring
@@ -2480,7 +2478,7 @@ class Spool(NodeRepr, NamespaceOwner):
                 # A time is stated as an instant, so how long the two of
                 # them are apart is a fact the line does not yet carry.
                 # Any other dimension states its own magnitude already.
-                if (span := self._duration_text(low, high)) is not None:
+                if (span := duration_text(low, high)) is not None:
                     base += Text("  ") + span
             elif units:
                 base += Text(" ") + Text(units[0], dascore_styles["units"])
@@ -2501,33 +2499,13 @@ class Spool(NodeRepr, NamespaceOwner):
         assert stated is not None, f"the relation states no units for {dim}"
         return tuple(sorted({str(x) for x in stated.dropna().unique() if str(x)}))
 
-    @staticmethod
-    def _duration_text(low, high) -> Text | None:
-        """
-        How long an extent lasted. Only asked of one measured in time.
-
-        None where it lasted no time: `human_duration` says nothing of a
-        zero, which reads as a label on a gap and as an empty pair of
-        brackets here.
-        """
-        try:
-            span = high - low
-        except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
-            # Two instants can lie further apart than a Timedelta holds.
-            # How long that is matters less than the extents it would
-            # otherwise take down with it.
-            return None
-        if not (said := human_duration(span)):
-            return None
-        return Text(f"<{said}>", dascore_styles["keys"])
-
     def _span_text(self, low, high, units: tuple[str, ...]) -> Text | None:
         """How wide an extent is, measured in what the dimension is."""
         # A time span is a duration. Any other dimension is as wide as
         # its own units say, and calling that many seconds would be a
         # different claim about a different quantity.
         if isinstance(low, _TIMES):
-            return self._duration_text(low, high)
+            return duration_text(low, high)
         if isinstance(low, numbers.Number):
             # A width is only in a unit where every patch agrees on one;
             # stating the first of several would label a track in a unit

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -447,7 +447,11 @@ def _storage_quantum(step) -> float:
     if dtype is None:
         return _NANOSECOND
     unit, count = np.datetime_data(dtype)
-    return to_float(np.timedelta64(count, unit))  # ty: ignore[no-matching-overload]
+    # Divided, not read with `to_float`: that counts whole nanoseconds,
+    # so the quantum of a picosecond step came back as zero and no rate
+    # could ever land inside it.
+    quantum = np.timedelta64(count, unit)  # ty: ignore[no-matching-overload]
+    return float(quantum / np.timedelta64(1, "s"))
 
 
 def rate_text(step) -> Text | None:
@@ -465,7 +469,12 @@ def rate_text(step) -> Text | None:
     # Divided rather than read with `to_float`, which counts whole
     # nanoseconds: a step of 1500 ps truncates to 1 ns there, and the
     # repr would state 1 GHz of sampling which happens at 666.7 MHz.
-    seconds = abs(step / np.timedelta64(1, "s"))
+    try:
+        seconds = abs(step / np.timedelta64(1, "s"))
+    except TypeError:
+        # A month is not a fixed number of seconds, so it is not a fixed
+        # number of samples per second either.
+        return None
     if not np.isfinite(seconds) or seconds == 0:
         return None
     # A descending axis samples at the rate an ascending one does; the
@@ -496,7 +505,9 @@ def rate_text(step) -> Text | None:
     # Positional, and only as many figures as the value has: `g` would
     # print 250 Hz as 2.5e+02 at the two figures it needs, and 1953.125
     # as 1.95312 at pint's default six.
-    magnitude = np.format_float_positional(quantity.magnitude, trim="-")
+    magnitude = np.format_float_positional(
+        quantity.magnitude, precision=figures, fractional=False, trim="-"
+    )
     said = f"{magnitude} {quantity.units:~P}"
     return Text(" · ", dascore_styles["keys"]) + Text(said, dascore_styles["units"])
 
@@ -793,8 +804,9 @@ def array_to_text(data, units=None) -> Text:
     # How much room it takes up. A repr states the dtype and the shape,
     # which is the size in pieces; whether it fits in memory is the
     # question those two are usually being multiplied to answer.
-    if (byte_count := getattr(data, "nbytes", None)) is not None:
-        header += Text(", ") + Text(human_size(byte_count), dascore_styles["keys"])
+    byte_count = getattr(data, "nbytes", None)
+    if byte_count is not None and (size := human_size(byte_count)):
+        header += Text(", ") + Text(size, dascore_styles["keys"])
     header += Text(")")
     config = get_config()
     np_str = np.array2string(

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -20,7 +20,7 @@ from rich.text import Text
 import dascore as dc
 from dascore.config import get_config
 from dascore.constants import dascore_styles
-from dascore.units import get_quantity_str
+from dascore.units import get_quantity, get_quantity_str
 from dascore.utils.time import to_float
 
 # How wide one value may print before it is elided. A repr is a glance at
@@ -39,21 +39,23 @@ _SEQUENCE_TYPES = (tuple, list, set, frozenset)
 
 _SECONDS_IN_DAY = 86_400.0
 
-# The resolution a datetime64 step is stored at, and so the closest two
-# rates can be and still describe the same sampling.
+# What a step is stored to when it does not say, as a pandas Timedelta
+# does not. Two steps closer together than one of these are the same
+# sampling as far as anything can tell.
 _NANOSECOND = 1e-9
 
 # What counts as a time, and so what has a duration between two of it.
 _TIME_TYPES = (pd.Timestamp, np.datetime64, pd.Timedelta, np.timedelta64)
 
-# How many figures a rate may need and still read as one. 96 kHz stored
-# as a whole number of nanoseconds is 95996.9 Hz exactly; six figures of
-# it is the step again, not the rate anyone would recognise.
+# The most figures a rate is quoted to when it cannot state its step
+# exactly. A rate which can gets as many as that takes, up to the point
+# where it has stopped being a rate and become the step in other units.
 _RATE_FIGURES = 4
+_RATE_EXACT_FIGURES = 9
 
-# What a rate is read in, largest first -- the same rule a duration and a
-# byte count are read by. Nobody says 96000 Hz.
-_RATE_UNITS = (("MHz", 1e6), ("kHz", 1e3), ("Hz", 1.0))
+# What a byte count is read in, smallest first.
+_SIZE_UNITS = ("B", "KiB", "MiB", "GiB", "TiB")
+
 
 # Steps a duration is worth reading in, largest first. A year is the
 # Gregorian mean, the same one numpy converts a timedelta64 with, since
@@ -409,16 +411,43 @@ def duration_text(low, high) -> Text | None:
         # long that is matters less than the extents it would otherwise
         # take down with it.
         return None
-    # Or the subtraction wraps instead of raising: two datetime64[s] a
-    # few centuries apart are more nanoseconds than an int64 holds, and
-    # numpy says so by coming back negative rather than by complaining.
-    # `human_duration` takes the size of what it is given, so an
-    # overflowed span would be reported as a plausible short one.
-    if high >= low and to_float(span) < 0:
+    # Divided by a second rather than read with `to_float`, which counts
+    # nanoseconds: a span of centuries is more of those than an int64
+    # holds, and the wrap is silent. Ten thousand years read that way
+    # came back as sixty one.
+    try:
+        seconds = span / np.timedelta64(1, "s")
+    except TypeError:
+        # A span held in years or months is not a fixed number of
+        # seconds, so numpy refuses to say how many. Neither will this.
         return None
-    if not (said := human_duration(span)):
+    if not (said := human_duration(seconds)):
         return None
     return Text(f"<{said}>", dascore_styles["keys"])
+
+
+def _fewest_figures(value: float, accept) -> int | None:
+    """The fewest significant figures of a value which `accept` allows."""
+    for figures in range(1, _RATE_EXACT_FIGURES + 1):
+        if accept(float(f"{value:.{figures}g}")):
+            return figures
+    return None
+
+
+def _storage_quantum(step) -> float:
+    """
+    How finely the step is stored, in seconds.
+
+    What counts as the same sampling: a step held to nanoseconds and a
+    rate which inverts to within half of one cannot be told apart, while
+    the same slack on a step held to picoseconds would hide a real
+    difference.
+    """
+    dtype = getattr(step, "dtype", None)
+    if dtype is None:
+        return _NANOSECOND
+    unit, count = np.datetime_data(dtype)
+    return to_float(np.timedelta64(count, unit))  # ty: ignore[no-matching-overload]
 
 
 def rate_text(step) -> Text | None:
@@ -433,21 +462,43 @@ def rate_text(step) -> Text | None:
     """
     if not isinstance(step, np.timedelta64 | pd.Timedelta):
         return None
-    seconds = to_float(step)
-    if not np.isfinite(seconds) or seconds <= 0:
+    # Divided rather than read with `to_float`, which counts whole
+    # nanoseconds: a step of 1500 ps truncates to 1 ns there, and the
+    # repr would state 1 GHz of sampling which happens at 666.7 MHz.
+    seconds = abs(step / np.timedelta64(1, "s"))
+    if not np.isfinite(seconds) or seconds == 0:
         return None
-    # Say it only if what is said gives the step back. A rate reads as a
-    # round number -- 250 Hz, 1 kHz -- and one which needs six figures to
-    # be true is not a fact a reader wanted, it is the step again.
-    hertz = float(f"{1.0 / seconds:.{_RATE_FIGURES}g}")
-    if abs(1.0 / hertz - seconds) > _NANOSECOND / 2:
-        return None
-    name, scale = next(((x, y) for x, y in _RATE_UNITS if hertz >= y), _RATE_UNITS[-1])
-    scaled = hertz / scale
-    said = f"{scaled:g}" if scaled != int(scaled) else f"{int(scaled)}"
-    return Text(" · ", dascore_styles["keys"]) + Text(
-        f"{said} {name}", dascore_styles["units"]
-    )
+    # A descending axis samples at the rate an ascending one does; the
+    # direction is the sign of the step, not of the frequency.
+    quantum = _storage_quantum(step)
+    # Say it only if what is said gives the step back, in as few figures
+    # as that takes. An exact rate is preferred over a shorter one which
+    # merely lands inside the step's own resolution: an 8 ms step held
+    # to milliseconds is exactly 125 Hz, and 120 Hz also inverts to
+    # within half a millisecond of it, so taking the shortest first
+    # states 120 Hz for sampling which happens at 125.
+    exact = 1.0 / seconds
+    figures = _fewest_figures(exact, lambda x: x == exact)
+    if figures is None:
+        # Not a rate any short number states exactly, so it is quoted to
+        # the figures a rate is quoted to and has to land inside the
+        # step's own resolution. Taking the fewest figures here instead
+        # would say 300 Hz of a 3 ms step, which samples at 333.3.
+        figures = _RATE_FIGURES
+        if abs(1 / float(f"{exact:.{figures}g}") - seconds) > quantum / 2:
+            return None
+    hertz = float(f"{exact:.{figures}g}")
+    # pint picks the prefix, so this reaches GHz and past it without a
+    # table of its own to keep in step with.
+    quantity = get_quantity(f"{hertz} Hz")
+    assert quantity is not None  # a literal frequency always parses
+    quantity = quantity.to_compact()
+    # Positional, and only as many figures as the value has: `g` would
+    # print 250 Hz as 2.5e+02 at the two figures it needs, and 1953.125
+    # as 1.95312 at pint's default six.
+    magnitude = np.format_float_positional(quantity.magnitude, trim="-")
+    said = f"{magnitude} {quantity.units:~P}"
+    return Text(" · ", dascore_styles["keys"]) + Text(said, dascore_styles["units"])
 
 
 def percent(value: float) -> str:
@@ -716,11 +767,22 @@ def mapping_to_text(mapping, header: str, style: str = "dc_yellow") -> Text:
 def human_size(byte_count: int) -> str:
     """How much room something takes up, in the largest unit which fits."""
     size = float(byte_count)
-    for name in ("B", "KiB", "MiB", "GiB", "TiB"):
-        if size < 1024 or name == "TiB":
+    if not np.isfinite(size):
+        # A dask array of unknown chunks reports nan bytes, and
+        # "nan TiB" is a worse answer than not saying.
+        return ""
+    # The largest name takes whatever is left however big, so it is the
+    # one the loop never has to decide about -- and the line after a
+    # loop which always returns is a line no test can reach.
+    *smaller, largest = _SIZE_UNITS
+    for name in smaller:
+        # Rounded before it is compared: a count a hair under a boundary
+        # prints as 1024 of the smaller unit otherwise, which is the one
+        # answer "the largest unit which fits" rules out.
+        if round(size, 1) < 1024:
             return f"{size:.1f} {name}".replace(".0 ", " ")
         size /= 1024
-    return f"{size:.1f} TiB"
+    return f"{size:.1f} {largest}".replace(".0 ", " ")
 
 
 def array_to_text(data, units=None) -> Text:

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -43,6 +43,18 @@ _SECONDS_IN_DAY = 86_400.0
 # rates can be and still describe the same sampling.
 _NANOSECOND = 1e-9
 
+# What counts as a time, and so what has a duration between two of it.
+_TIME_TYPES = (pd.Timestamp, np.datetime64, pd.Timedelta, np.timedelta64)
+
+# How many figures a rate may need and still read as one. 96 kHz stored
+# as a whole number of nanoseconds is 95996.9 Hz exactly; six figures of
+# it is the step again, not the rate anyone would recognise.
+_RATE_FIGURES = 4
+
+# What a rate is read in, largest first -- the same rule a duration and a
+# byte count are read by. Nobody says 96000 Hz.
+_RATE_UNITS = (("MHz", 1e6), ("kHz", 1e3), ("Hz", 1.0))
+
 # Steps a duration is worth reading in, largest first. A year is the
 # Gregorian mean, the same one numpy converts a timedelta64 with, since
 # a multi-year outage reads as "40.7 y" rather than "14852 d".
@@ -383,7 +395,13 @@ def duration_text(low, high) -> Text | None:
     instant, so how far apart two of them are is a fact the line does
     not otherwise carry; every other kind of dimension states its own
     magnitude already, and saying it twice is not saying more.
+
+    Only of two times. A duration is read in seconds, so a distance of
+    299 handed to this would come back as "5 m" -- five minutes, of a
+    span measured in metres.
     """
+    if not isinstance(low, _TIME_TYPES) or not isinstance(high, _TIME_TYPES):
+        return None
     try:
         span = high - low
     except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
@@ -419,13 +437,16 @@ def rate_text(step) -> Text | None:
     if not np.isfinite(seconds) or seconds <= 0:
         return None
     # Say it only if what is said gives the step back. A rate reads as a
-    # round number -- 250 Hz, 1 kHz -- and one which needs ten digits to
+    # round number -- 250 Hz, 1 kHz -- and one which needs six figures to
     # be true is not a fact a reader wanted, it is the step again.
-    said = f"{1.0 / seconds:.6g}"
-    if abs(1.0 / float(said) - seconds) > _NANOSECOND / 2:
+    hertz = float(f"{1.0 / seconds:.{_RATE_FIGURES}g}")
+    if abs(1.0 / hertz - seconds) > _NANOSECOND / 2:
         return None
+    name, scale = next(((x, y) for x, y in _RATE_UNITS if hertz >= y), _RATE_UNITS[-1])
+    scaled = hertz / scale
+    said = f"{scaled:g}" if scaled != int(scaled) else f"{int(scaled)}"
     return Text(" · ", dascore_styles["keys"]) + Text(
-        f"{said} Hz", dascore_styles["units"]
+        f"{said} {name}", dascore_styles["units"]
     )
 
 

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -11,6 +11,7 @@ from functools import singledispatch
 
 import numpy as np
 import pandas as pd
+from pandas.errors import OutOfBoundsDatetime, OutOfBoundsTimedelta
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 from rich.style import Style
@@ -37,6 +38,10 @@ _IDENTITY_FIELDS = frozenset({"object_type", "resource_id"})
 _SEQUENCE_TYPES = (tuple, list, set, frozenset)
 
 _SECONDS_IN_DAY = 86_400.0
+
+# The resolution a datetime64 step is stored at, and so the closest two
+# rates can be and still describe the same sampling.
+_NANOSECOND = 1e-9
 
 # Steps a duration is worth reading in, largest first. A year is the
 # Gregorian mean, the same one numpy converts a timedelta64 with, since
@@ -366,6 +371,64 @@ def human_duration(value: np.timedelta64 | pd.Timedelta | float) -> str:
     return f"{size:.3g} s"
 
 
+def duration_text(low, high) -> Text | None:
+    """
+    How long an extent lasted, as a repr states it.
+
+    None where it lasted no time: `human_duration` says nothing of a
+    zero, which reads as a label on a gap and as an empty pair of
+    brackets here.
+
+    Asked wherever a repr states two instants. A time is stated as an
+    instant, so how far apart two of them are is a fact the line does
+    not otherwise carry; every other kind of dimension states its own
+    magnitude already, and saying it twice is not saying more.
+    """
+    try:
+        span = high - low
+    except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
+        # Two instants can lie further apart than a Timedelta holds. How
+        # long that is matters less than the extents it would otherwise
+        # take down with it.
+        return None
+    # Or the subtraction wraps instead of raising: two datetime64[s] a
+    # few centuries apart are more nanoseconds than an int64 holds, and
+    # numpy says so by coming back negative rather than by complaining.
+    # `human_duration` takes the size of what it is given, so an
+    # overflowed span would be reported as a plausible short one.
+    if high >= low and to_float(span) < 0:
+        return None
+    if not (said := human_duration(span)):
+        return None
+    return Text(f"<{said}>", dascore_styles["keys"])
+
+
+def rate_text(step) -> Text | None:
+    """
+    A sampling step said the way acquisition is quoted, or nothing.
+
+    Only a step measured in time gets one: a rate is the reciprocal of a
+    duration, and one over a distance is not how anyone states channel
+    spacing. Only an exact one, too -- a step of 0.0039999998 s is
+    250.0000125 Hz, and rounding that to 250 Hz claims a precision the
+    step does not have.
+    """
+    if not isinstance(step, np.timedelta64 | pd.Timedelta):
+        return None
+    seconds = to_float(step)
+    if not np.isfinite(seconds) or seconds <= 0:
+        return None
+    # Say it only if what is said gives the step back. A rate reads as a
+    # round number -- 250 Hz, 1 kHz -- and one which needs ten digits to
+    # be true is not a fact a reader wanted, it is the step again.
+    said = f"{1.0 / seconds:.6g}"
+    if abs(1.0 / float(said) - seconds) > _NANOSECOND / 2:
+        return None
+    return Text(" · ", dascore_styles["keys"]) + Text(
+        f"{said} Hz", dascore_styles["units"]
+    )
+
+
 def percent(value: float) -> str:
     """Say a fraction as a percentage, without rounding a hole away."""
     for places in range(4):
@@ -629,11 +692,27 @@ def mapping_to_text(mapping, header: str, style: str = "dc_yellow") -> Text:
     return txt
 
 
+def human_size(byte_count: int) -> str:
+    """How much room something takes up, in the largest unit which fits."""
+    size = float(byte_count)
+    for name in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if size < 1024 or name == "TiB":
+            return f"{size:.1f} {name}".replace(".0 ", " ")
+        size /= 1024
+    return f"{size:.1f} TiB"
+
+
 def array_to_text(data, units=None) -> Text:
     """Convert a coordinate to string."""
     header = Text("➤ ") + Text("Data", style=dascore_styles["dc_red"])
     unitstr = Text("") if units is None else Text(f", units: {units}")
-    header += Text(f" ({data.dtype}") + unitstr + Text(")")
+    header += Text(f" ({data.dtype}") + unitstr
+    # How much room it takes up. A repr states the dtype and the shape,
+    # which is the size in pieces; whether it fits in memory is the
+    # question those two are usually being multiplied to answer.
+    if (byte_count := getattr(data, "nbytes", None)) is not None:
+        header += Text(", ") + Text(human_size(byte_count), dascore_styles["keys"])
+    header += Text(")")
     config = get_config()
     np_str = np.array2string(
         data,

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -738,13 +738,26 @@ class TestRateText:
         [
             (np.timedelta64(4_000_000, "ns"), "250 Hz"),
             (np.timedelta64(1, "s"), "1 Hz"),
-            (np.timedelta64(1, "ms"), "1000 Hz"),
-            (np.timedelta64(976_562, "ns"), "1024 Hz"),
+            (np.timedelta64(1, "ms"), "1 kHz"),
+            (np.timedelta64(976_562, "ns"), "1.024 kHz"),
+            (np.timedelta64(10_417, "ns"), "96 kHz"),
+            (np.timedelta64(1_000, "ns"), "1 MHz"),
         ],
     )
     def test_a_time_step_states_its_rate(self, step, expected):
         """A step in time is quoted in Hz, which is what a rate is."""
         assert expected in str(rate_text(step))
+
+    def test_a_rate_is_read_in_the_unit_it_is_spoken_in(self):
+        """
+        Nobody says 96000 Hz.
+
+        A whole number of nanoseconds is rarely a whole number of hertz,
+        so the rate is rounded to the figures a rate is quoted to and
+        then checked against the step it came from.
+        """
+        assert "96 kHz" in str(rate_text(np.timedelta64(10_417, "ns")))
+        assert "95996" not in str(rate_text(np.timedelta64(10_417, "ns")))
 
     def test_a_rate_which_would_not_give_the_step_back(self):
         """
@@ -757,7 +770,8 @@ class TestRateText:
         assert rate_text(np.timedelta64(39_999_998, "ns") / 10) is None
 
     @pytest.mark.parametrize(
-        "step", [1.0, 300, "not a step", None, np.timedelta64(0, "ns")]
+        "step",
+        [1.0, 300, "not a step", None, np.timedelta64(0, "ns"), np.timedelta64("NaT")],
     )
     def test_only_a_step_measured_in_time(self, step):
         """
@@ -803,6 +817,20 @@ class TestDurationText:
         instant = np.datetime64("2020-01-01T00:00:00")
         assert duration_text(instant, instant) is None
 
+    @pytest.mark.parametrize(
+        ("low", "high"),
+        [(0.0, 299.0), (0, 299), ("a", "b"), (None, None), (1, np.datetime64("now"))],
+        ids=["floats", "ints", "strings", "none", "mixed"],
+    )
+    def test_only_two_times_have_a_duration(self, low, high):
+        """
+        A duration is read in seconds.
+
+        A distance of 299 handed to this would come back as "5 m" --
+        five minutes, of a span measured in metres.
+        """
+        assert duration_text(low, high) is None
+
     def test_further_apart_than_a_timedelta_holds(self):
         """
         Two instants can lie further apart than a Timedelta holds.
@@ -840,6 +868,17 @@ class TestValuesAReaderCanRead:
     def test_the_data_states_how_much_room_it_takes(self):
         """Whether it fits in memory is what dtype times shape is for."""
         assert "4.6 MiB" in str(dc.get_example_patch())
+
+    def test_an_annotation_set_over_distance_states_no_span(self):
+        """
+        A distance annotation is not measured in time.
+
+        299 metres read as a duration is "5 m", which is five minutes.
+        """
+        frame = pd.DataFrame({"distance_min": [0.0], "distance_max": [299.0]})
+        rendered = str(AnnotationSet(frame, dims=("distance",)))
+        assert "299" in rendered
+        assert "<" not in rendered
 
     def test_an_annotation_set_states_its_span(self):
         """The same fact a spool and a patch coordinate state."""

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -742,32 +742,106 @@ class TestRateText:
             (np.timedelta64(976_562, "ns"), "1.024 kHz"),
             (np.timedelta64(10_417, "ns"), "96 kHz"),
             (np.timedelta64(1_000, "ns"), "1 MHz"),
+            (np.timedelta64(1, "ns"), "1 GHz"),
+            (np.timedelta64(6_400_000, "ns"), "156.25 Hz"),
+            (np.timedelta64(512_000, "ns"), "1.953125 kHz"),
+            (np.timedelta64(2_000_000, "ns"), "500 Hz"),
+            # Slow acquisition: a rate under a hertz still reads as one.
+            (np.timedelta64(10, "s"), "100 mHz"),
         ],
     )
     def test_a_time_step_states_its_rate(self, step, expected):
         """A step in time is quoted in Hz, which is what a rate is."""
         assert expected in str(rate_text(step))
 
-    def test_a_rate_is_read_in_the_unit_it_is_spoken_in(self):
+    @pytest.mark.parametrize(
+        "step",
+        [
+            np.timedelta64(4_000_000, "ns"),
+            np.timedelta64(6_400_000, "ns"),
+            np.timedelta64(512_000, "ns"),
+            np.timedelta64(10_417, "ns"),
+            np.timedelta64(1, "ns"),
+            np.timedelta64(8, "ms"),
+            np.timedelta64(3, "ms"),
+            np.timedelta64(7, "s"),
+            pd.Timedelta(seconds=0.004),
+        ],
+    )
+    def test_the_rate_said_describes_the_step(self, step):
         """
-        Nobody says 96000 Hz.
+        Whatever is printed has to describe the step beside it.
 
-        A whole number of nanoseconds is rarely a whole number of hertz,
-        so the rate is rounded to the figures a rate is quoted to and
-        then checked against the step it came from.
+        Held over the printed characters rather than the number they
+        came from, since a rate rounded for the check and then formatted
+        to fewer figures, or into exponent notation, states something
+        the step does not. A rate is quoted to four figures, so four
+        figures is how closely it has to agree -- not to a fixed
+        nanosecond, which only matches the code for steps stored in
+        them.
         """
-        assert "96 kHz" in str(rate_text(np.timedelta64(10_417, "ns")))
-        assert "95996" not in str(rate_text(np.timedelta64(10_417, "ns")))
+        magnitude, unit = str(rate_text(step)).strip().removeprefix("· ").split(" ")
+        prefixes = {"mHz": 1e-3, "Hz": 1.0, "kHz": 1e3, "MHz": 1e6, "GHz": 1e9}
+        said = float(magnitude) * prefixes[unit]
+        true_rate = 1.0 / (step / np.timedelta64(1, "s"))
+        assert abs(said - true_rate) <= abs(true_rate) * 5e-4
+
+    @pytest.mark.parametrize(
+        ("step", "expected"),
+        [
+            (np.timedelta64(8, "ms"), "125 Hz"),
+            (np.timedelta64(4, "ms"), "250 Hz"),
+            (np.timedelta64(3, "ms"), "333.3 Hz"),
+            (np.timedelta64(13, "ms"), "76.92 Hz"),
+        ],
+    )
+    def test_a_step_stored_coarser_than_a_nanosecond(self, step, expected):
+        """
+        A step held to milliseconds is exact, not rounded.
+
+        An 8 ms step is exactly 125 Hz, and 120 Hz also inverts to
+        within half a millisecond of it. Taking the shortest rate which
+        lands inside the step's resolution states 120 Hz of sampling
+        which happens at 125, so an exact rate is preferred.
+        """
+        assert expected in str(rate_text(step))
+
+    def test_a_descending_axis_samples_at_the_same_rate(self):
+        """
+        Direction is the sign of the step, not of the frequency.
+
+        A time axis which counts down samples exactly as often as the
+        one which counts up.
+        """
+        down = rate_text(np.timedelta64(-4, "ms"))
+        up = rate_text(np.timedelta64(4, "ms"))
+        assert str(down) == str(up)
+        assert "250 Hz" in str(down)
+
+    def test_a_step_finer_than_a_nanosecond(self):
+        """
+        A step is read at the resolution it is stored at.
+
+        1500 ps counted in whole nanoseconds is 1 ns, which would state
+        1 GHz of sampling that happens at 666.7 MHz. The true rate is
+        not a round one, so the honest answer is to say no rate.
+        """
+        assert rate_text(np.timedelta64(1500, "ps")) is None
+        assert "1 GHz" in str(rate_text(np.timedelta64(1000, "ps")))
+
+    def test_a_rate_never_reads_in_exponent_notation(self):
+        """250 Hz needs two figures, and `g` prints those as 2.5e+02."""
+        assert "e+" not in str(rate_text(np.timedelta64(4_000_000, "ns")))
 
     def test_a_rate_which_would_not_give_the_step_back(self):
         """
         A step which is not a round rate says no rate at all.
 
-        0.0039999998 s is 250.0000125 Hz. Saying "250 Hz" would state a
-        precision the step does not have, and saying all ten digits is
-        the step again in different units.
+        3999999 ns is 250.0000625 Hz. Saying "250 Hz" would claim a
+        precision the step does not have, and saying every figure of it
+        is the step again in different units.
         """
-        assert rate_text(np.timedelta64(39_999_998, "ns") / 10) is None
+        assert rate_text(np.timedelta64(3_999_999, "ns")) is None
 
     @pytest.mark.parametrize(
         "step",
@@ -791,7 +865,15 @@ class TestHumanSize:
         [
             (0, "0 B"),
             (512, "512 B"),
+            # A byte count is read in binary, so a thousand of them is
+            # still a thousand bytes and not a kibibyte.
+            (1000, "1000 B"),
+            (1023, "1023 B"),
             (1024, "1 KiB"),
+            # A hair under a boundary belongs in the unit above it:
+            # "1024 KiB" is the one answer "largest which fits" rules out.
+            (1024**2 - 1, "1 MiB"),
+            (1024**3 - 1, "1 GiB"),
             (4_800_000, "4.6 MiB"),
             (2**30, "1 GiB"),
             (2**40, "1 TiB"),
@@ -801,6 +883,14 @@ class TestHumanSize:
     def test_size_in_the_largest_unit_which_fits(self, count, expected):
         """A byte count is read in whatever unit keeps it short."""
         assert human_size(count) == expected
+
+    def test_a_size_which_is_not_a_number(self):
+        """
+        A dask array of unknown chunks reports nan bytes.
+
+        "nan TiB" is a worse answer than not saying.
+        """
+        assert human_size(float("nan")) == ""
 
 
 class TestDurationText:
@@ -812,6 +902,17 @@ class TestDurationText:
         high = np.datetime64("2020-01-01T00:00:24")
         assert "24 s" in str(duration_text(low, high))
 
+    @pytest.mark.parametrize("unit", ["Y", "M"])
+    def test_a_span_of_years_or_months(self, unit):
+        """
+        Neither is a fixed number of seconds.
+
+        numpy refuses to divide one into seconds rather than guessing a
+        calendar, and so does this rather than raising out of a repr.
+        """
+        low, high = np.datetime64("2000", unit), np.datetime64("2010", unit)
+        assert duration_text(low, high) is None
+
     def test_no_time_at_all_says_nothing(self):
         """A zero would read as a label on a gap."""
         instant = np.datetime64("2020-01-01T00:00:00")
@@ -819,8 +920,18 @@ class TestDurationText:
 
     @pytest.mark.parametrize(
         ("low", "high"),
-        [(0.0, 299.0), (0, 299), ("a", "b"), (None, None), (1, np.datetime64("now"))],
-        ids=["floats", "ints", "strings", "none", "mixed"],
+        [
+            (0.0, 299.0),
+            (0, 299),
+            ("a", "b"),
+            (None, None),
+            (1, np.datetime64("2020-01-01")),
+            # The other way round: `low` is a time and `high` is not, so
+            # only the second half of the guard can refuse it. Without
+            # that half numpy raises out of the middle of a repr.
+            (np.datetime64("2020-01-01"), 1),
+        ],
+        ids=["floats", "ints", "strings", "none", "mixed_low", "mixed_high"],
     )
     def test_only_two_times_have_a_duration(self, low, high):
         """
@@ -838,9 +949,25 @@ class TestDurationText:
         How long that is matters less than the extents it would
         otherwise take down with it.
         """
-        low = np.datetime64("1677-09-21T00:12:44")
-        high = np.datetime64("2262-04-11T23:47:16")
-        assert duration_text(low, high) is None
+        assert duration_text(pd.Timestamp.min, pd.Timestamp.max) is None
+
+    @pytest.mark.parametrize(
+        ("low", "high", "expected"),
+        [
+            ("1677-09-21T00:12:44", "2262-04-11T23:47:16", "584.6 y"),
+            ("0001-01-01", "9999-12-31", "9999 y"),
+        ],
+        ids=["centuries", "millennia"],
+    )
+    def test_a_span_too_long_to_count_in_nanoseconds(self, low, high, expected):
+        """
+        A long span is still said, and said correctly.
+
+        Read as nanoseconds these overflow an int64 silently: the first
+        of them came back as 1.7 seconds, and the second as 61.6 years.
+        """
+        said = duration_text(np.datetime64(low), np.datetime64(high))
+        assert expected in str(said)
 
 
 class TestValuesAReaderCanRead:

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -26,6 +26,7 @@ from dascore.utils.display import (
     Raw,
     Repr,
     Section,
+    _storage_quantum,
     array_to_text,
     attrs_to_text,
     counts_to_text,
@@ -823,11 +824,38 @@ class TestRateText:
         A step is read at the resolution it is stored at.
 
         1500 ps counted in whole nanoseconds is 1 ns, which would state
-        1 GHz of sampling that happens at 666.7 MHz. The true rate is
-        not a round one, so the honest answer is to say no rate.
+        1 GHz of sampling that happens at 666.7 MHz.
         """
-        assert rate_text(np.timedelta64(1500, "ps")) is None
+        assert "666.7 MHz" in str(rate_text(np.timedelta64(1500, "ps")))
         assert "1 GHz" in str(rate_text(np.timedelta64(1000, "ps")))
+
+    def test_a_quantum_finer_than_a_nanosecond_is_not_zero(self):
+        """
+        The resolution a step is held at is read the same way it is.
+
+        Counted in whole nanoseconds a picosecond quantum is zero, and
+        no rate at all can land inside a tolerance of nothing.
+        """
+        assert _storage_quantum(np.timedelta64(1, "ps")) == pytest.approx(1e-12)
+
+    @pytest.mark.parametrize("unit", ["M", "Y"])
+    def test_a_step_held_in_months_or_years(self, unit):
+        """
+        Neither is a fixed number of seconds.
+
+        So neither is a fixed number of samples per second, and asking
+        numpy raises out of the middle of a repr.
+        """
+        assert rate_text(np.timedelta64(1, unit)) is None
+
+    def test_a_rate_carries_no_float_noise(self):
+        """
+        What is printed is rounded to the figures it was chosen at.
+
+        A day step is 11.57 µHz; the shortest exact form of the float
+        behind it is 11.569999999999999.
+        """
+        assert "11.57 µHz" in str(rate_text(np.timedelta64(1, "D")))
 
     def test_a_rate_never_reads_in_exponent_notation(self):
         """250 Hz needs two figures, and `g` prints those as 2.5e+02."""
@@ -883,6 +911,19 @@ class TestHumanSize:
     def test_size_in_the_largest_unit_which_fits(self, count, expected):
         """A byte count is read in whatever unit keeps it short."""
         assert human_size(count) == expected
+
+    def test_an_unknown_size_draws_no_comma(self):
+        """The comma introduces a size, so it goes when there is none."""
+
+        class UnknownChunks(np.ndarray):
+            """An array which cannot say how much room it takes up."""
+
+            nbytes = float("nan")
+
+        data = np.zeros((2, 2)).view(UnknownChunks)
+        rendered = str(array_to_text(data))
+        assert "float64)" in rendered
+        assert ", )" not in rendered
 
     def test_a_size_which_is_not_a_number(self):
         """

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -29,15 +29,18 @@ from dascore.utils.display import (
     array_to_text,
     attrs_to_text,
     counts_to_text,
+    duration_text,
     get_header_text,
     get_nice_text,
     group_names,
     human_duration,
+    human_size,
     indent_text,
     limit_reprs,
     mapping_to_text,
     model_to_line,
     percent,
+    rate_text,
     render_text,
     split_block,
     stated_fields,
@@ -725,3 +728,125 @@ class TestSpoolReprNode:
         rendered = str(spool)
         assert "Spool" in rendered
         assert "Dimensions" not in rendered
+
+
+class TestRateText:
+    """Tests for stating a sampling step as the rate it is quoted in."""
+
+    @pytest.mark.parametrize(
+        ("step", "expected"),
+        [
+            (np.timedelta64(4_000_000, "ns"), "250 Hz"),
+            (np.timedelta64(1, "s"), "1 Hz"),
+            (np.timedelta64(1, "ms"), "1000 Hz"),
+            (np.timedelta64(976_562, "ns"), "1024 Hz"),
+        ],
+    )
+    def test_a_time_step_states_its_rate(self, step, expected):
+        """A step in time is quoted in Hz, which is what a rate is."""
+        assert expected in str(rate_text(step))
+
+    def test_a_rate_which_would_not_give_the_step_back(self):
+        """
+        A step which is not a round rate says no rate at all.
+
+        0.0039999998 s is 250.0000125 Hz. Saying "250 Hz" would state a
+        precision the step does not have, and saying all ten digits is
+        the step again in different units.
+        """
+        assert rate_text(np.timedelta64(39_999_998, "ns") / 10) is None
+
+    @pytest.mark.parametrize(
+        "step", [1.0, 300, "not a step", None, np.timedelta64(0, "ns")]
+    )
+    def test_only_a_step_measured_in_time(self, step):
+        """
+        A rate is the reciprocal of a duration.
+
+        One over a distance is not how anyone states channel spacing,
+        and one over zero is not a rate at all.
+        """
+        assert rate_text(step) is None
+
+
+class TestHumanSize:
+    """Tests for saying how much room something takes up."""
+
+    @pytest.mark.parametrize(
+        ("count", "expected"),
+        [
+            (0, "0 B"),
+            (512, "512 B"),
+            (1024, "1 KiB"),
+            (4_800_000, "4.6 MiB"),
+            (2**30, "1 GiB"),
+            (2**40, "1 TiB"),
+            (2**51, "2048 TiB"),
+        ],
+    )
+    def test_size_in_the_largest_unit_which_fits(self, count, expected):
+        """A byte count is read in whatever unit keeps it short."""
+        assert human_size(count) == expected
+
+
+class TestDurationText:
+    """Tests for how long an extent lasted."""
+
+    def test_two_instants_state_their_distance(self):
+        """The fact two times do not carry on their own."""
+        low = np.datetime64("2020-01-01T00:00:00")
+        high = np.datetime64("2020-01-01T00:00:24")
+        assert "24 s" in str(duration_text(low, high))
+
+    def test_no_time_at_all_says_nothing(self):
+        """A zero would read as a label on a gap."""
+        instant = np.datetime64("2020-01-01T00:00:00")
+        assert duration_text(instant, instant) is None
+
+    def test_further_apart_than_a_timedelta_holds(self):
+        """
+        Two instants can lie further apart than a Timedelta holds.
+
+        How long that is matters less than the extents it would
+        otherwise take down with it.
+        """
+        low = np.datetime64("1677-09-21T00:12:44")
+        high = np.datetime64("2262-04-11T23:47:16")
+        assert duration_text(low, high) is None
+
+
+class TestValuesAReaderCanRead:
+    """Tests for the facts a repr states about the things it shows."""
+
+    def test_a_time_coord_states_its_span(self):
+        """Two instants say nothing about how far apart they are."""
+        coord = dc.get_example_patch().coords.coord_map["time"]
+        assert "<8 s>" in str(coord)
+
+    def test_a_time_coord_states_its_rate(self):
+        """DAS acquisition is quoted in Hz, not in seconds per sample."""
+        coord = dc.get_example_patch().coords.coord_map["time"]
+        assert "250 Hz" in str(coord)
+
+    def test_a_distance_coord_states_neither(self):
+        """
+        A distance from 0 to 299 m already says how wide it is, and a
+        rate over it is not a quantity anyone quotes.
+        """
+        rendered = str(dc.get_example_patch().coords.coord_map["distance"])
+        assert "Hz" not in rendered
+        assert "<" not in rendered
+
+    def test_the_data_states_how_much_room_it_takes(self):
+        """Whether it fits in memory is what dtype times shape is for."""
+        assert "4.6 MiB" in str(dc.get_example_patch())
+
+    def test_an_annotation_set_states_its_span(self):
+        """The same fact a spool and a patch coordinate state."""
+        frame = pd.DataFrame(
+            {
+                "time_min": pd.to_datetime(["2020-01-01T00:00:00"]),
+                "time_max": pd.to_datetime(["2020-01-01T00:00:09"]),
+            }
+        )
+        assert "<9 s>" in str(AnnotationSet(frame, dims=("time",)))


### PR DESCRIPTION
## Description

PR 2 of the repr series (after #1011). Unlike that one, **this changes printed output** — four facts a reader wants that a repr did not state, each following a rule the code already had rather than a new one.

**A time coordinate says how long it spans.** The spool has said this for its own time dimension all along, with a comment giving the reason: two instants carry no sense of the distance between them, while `0.000 to 299.000 m` states its own width. That rule was applied in one of the three places which state a time extent; now in all three, from the same helper.

**A step measured in time says the rate it is quoted in** — `0.004s · 250 Hz`. Keyed on the step's dtype rather than the dimension's name, so a coordinate called `gps_time` and a frequency axis after an FFT are not guessed at.

**The data says how much room it takes up.** A repr states the dtype and the shape, which is the size in pieces; whether it fits in memory is the question those two get multiplied to answer.

**An annotation set says its span**, in the same spelling as the other two.

`min:`/`max:` keep their names. One spelling shared with the spool's `A to B` was considered and rejected: they are not one fact. A spool dimension is an extent and always ordered; a coordinate states the bounds of values which need not be — `CoordArray` is not monotonic, and calling its first bound `from` would claim an order it does not have. Keeping them also made this diff additive, which is why it churns no existing assertions.

### On the arithmetic

A rate is only stated if what is printed describes the step beside it. An exact rate wins over a shorter approximate one — an 8 ms step stored to milliseconds is exactly 125 Hz, and 120 Hz also inverts to within half a millisecond of it. A rate which cannot be exact is quoted to four figures and must land inside the step's *own* storage resolution, so a picosecond step is judged at picoseconds. A step which is not a round rate at all says no rate.

Unit scaling is pint's `to_compact()`, which is how it reaches both GHz and mHz. Byte sizes and durations keep small tables because no library selects from binary prefixes or calendar units — pint's `to_compact` gives `1.024 kB` and `1.28 Gs`, pandas' private `_sizeof_fmt` labels binary quantities with decimal names, and pint's `to_preferred` crashes on Python ≥3.12 (pint#2121).

### Review

Six blind reviews (Codex plus five lenses), and the worst finding was in my own first fix: an exact **125 Hz printed as 120 Hz**. Also found and fixed: a 1500 ps step printing `1 GHz` for 666.7 MHz sampling; a descending axis losing its rate entirely; a 299 metre annotation printing `<5 m>` (five *minutes*); a ~10,000 year span printing `<61.6 y>`; year/month spans raising out of a repr; and `human_size` printing `1024 KiB` a byte under a mebibyte.

The tests missed all of that, so the guards were mutation tested. Six were dropped in turn and all six now fail: the storage-derived tolerance, the exact-rate preference, the second half of the type check, the binary threshold, the year/month refusal and the nan guard.

### Verification

Full suite 10044 passed / 114 skipped / 2 xfailed · doctests 211 passed · `pre-commit run --all` clean.

## Changelog

- added: A time coordinate states how long it spans, and a step measured in time states its sampling rate.
- added: A patch's data block states how much memory it occupies.
- added: An annotation set states the span of its time dimensions.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer duration displays for time-based coordinates, annotations, and data spans.
  - Added sampling-rate formatting for time-based coordinate steps.
  - Added human-readable byte-size formatting to array displays.
  - Standardized duration and rate formatting across data views.
- **Bug Fixes**
  - Improved handling of zero-duration, unsupported, and out-of-range time spans.
  - Enhanced formatting for data sizes, including large values and unavailable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->