### PR TITLE
Fix tau_p on (time, distance) patches

### DIFF
--- a/dascore/transform/taup.py
+++ b/dascore/transform/taup.py
@@ -86,7 +86,7 @@ def tau_p(
         func = _jit_taup_general
         dist_val = dist.values
 
-    slowness, tau_p_data = func(patch.data, dist_val, dt, 1.0 / velocities)
+    slowness, tau_p_data = func(patch_cop.data, dist_val, dt, 1.0 / velocities)
 
     attrs = patch.attrs.update(category="taup")
     coords = dict(slowness=slowness, time=time)

--- a/tests/test_transform/test_tau_p.py
+++ b/tests/test_transform/test_tau_p.py
@@ -180,3 +180,15 @@ class TestTauP:
         _jit_taup_uniform.func(data, dx, dt, p_vals)
         distance = np.arange(10) * dt
         _jit_taup_general.func(data, distance, dt, p_vals)
+
+    def test_time_distance_dim_order(self):
+        """Patches ordered (time, distance) transform like their transpose."""
+        pytest.importorskip("numba")
+        test_vels = np.linspace(1000, 3000, 21)
+        patch = linear_slope_patch(20, 100, 1500, 0.03)
+
+        expected = patch.tau_p(test_vels)
+        out = patch.transpose("time", "distance").tau_p(test_vels)
+
+        assert out.dims == expected.dims
+        assert np.array_equal(out.data, expected.data)


### PR DESCRIPTION
## Description

`tau_p` builds a transposed, unit-converted copy of the patch:

```python
patch_cop = patch.convert_units(distance="m", time="s").transpose("distance", "time")
```

but then hands the *original* array to the kernel:

```python
slowness, tau_p_data = func(patch.data, dist_val, dt, 1.0 / velocities)
```

`dist`, `time`, `dt` and the output coords all come from `patch_cop`, so the transpose was silently dropped for the data array only. A patch already ordered `(distance, time)` is unaffected — which is why the docstring example and the existing tests pass — but a `(time, distance)` patch has its axes swapped under the kernel, summing time samples as if they were channels and returning an array of shape `(2 * len(velocities), n_distance)`. Attaching that to the `(slowness, time)` coord manager raises:

```
CoordDataError: Data array has a shape of (200, 17) which doesnt match
the coordinate manager shape of (200, 30000).
```

Passing `patch_cop.data` fixes it. Added a regression test that transforms a patch and its transpose and asserts the two results are identical; it fails on `dev` with the error above.

## Changelog

- fixed: `Patch.tau_p` no longer raises `CoordDataError` on patches whose dimensions are ordered `(time, distance)`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
