### PR TITLE
Draw a repr where a display can draw one

### DIFF
--- a/dascore/config.py
+++ b/dascore/config.py
@@ -69,6 +69,24 @@ class DascoreConfig(BaseModel):
             "that relation happens to be realized already."
         ),
     )
+    display_html: bool = Field(
+        default=True,
+        description=(
+            "Whether a display which renders HTML -- a notebook, the docs "
+            "site -- is offered the collapsible repr. False sends every "
+            "display back to the text repr, which says the same words."
+        ),
+    )
+    display_html_open_lines: int = Field(
+        default=12,
+        ge=0,
+        description=(
+            "Body lines a section of an HTML repr may hold and still open "
+            "on its own. A short section is worth a glance; a long one -- "
+            "an array, a deep tree -- is folded until it is asked for. "
+            "0 folds every section."
+        ),
+    )
     patch_history: Literal["standard", "disabled"] = Field(
         default="standard",
         description="Controls whether DASCore appends processing history to patches.",

--- a/dascore/repr.css
+++ b/dascore/repr.css
@@ -21,7 +21,7 @@ each given a value per theme below.
   --dc-cyan: #0e7490;
   --dc-dark_orange: #bc4c00;
   --dc-grey50: #6b7280;
-  --dc-rule: color-mix(in oklab, currentColor 22%, transparent);
+  --dc-rule: color-mix(in oklab, currentcolor 22%, transparent);
   font-family: var(--jp-code-font-family, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: var(--jp-code-font-size, 0.8125rem);
   line-height: 1.5;

--- a/dascore/repr.css
+++ b/dascore/repr.css
@@ -5,10 +5,11 @@ notebook output cell, where a <style> applies to the whole document, so
 one bare `pre` or `details` rule here would restyle every code block on
 the page around it.
 
-Color is inherited, never stated. A repr lands on grounds it cannot see
--- a light notebook, a dark one, a themed docs page -- and no color
-clears WCAG AA against both white and near-black, so the ink is the
-host's and the hues only ever draw rules and marks beside it.
+The body ink is inherited, never stated. A repr lands on grounds it
+cannot see -- a light notebook, a dark one, a themed docs page -- and no
+color clears WCAG AA against both white and near-black, so what a repr
+does not need to color it leaves to the host. The hues it does state are
+each given a value per theme below.
 */
 
 .dc-repr {
@@ -47,6 +48,7 @@ host's and the hues only ever draw rules and marks beside it.
 /* A host which states its theme outranks the reader's operating system:
 a light page on a dark laptop is a light page. */
 body[data-jp-theme-light="true"] .dc-repr,
+body[data-vscode-theme-kind*="light"] .dc-repr,
 body.quarto-light .dc-repr {
   --dc-blue: #0969da;
   --dc-bright_blue: #0a7ea4;
@@ -89,7 +91,7 @@ body[data-vscode-theme-kind*="dark"] .dc-repr {
 }
 
 /* Bootstrap gives a bare `details` a bottom margin and a bare `pre` a
-grey card with a border; JupyterLab gives neither. Reset both so the
+gray card with a border; JupyterLab gives neither. Reset both so the
 panel reads the same in a notebook and on the docs site. */
 .dc-repr details {
   margin: 0;
@@ -106,6 +108,9 @@ panel reads the same in a notebook and on the docs site. */
   color: inherit;
   font-size: 1em;
   border-radius: 3px;
+  /* A title can carry spaces a producer put there, and HTML would
+  collapse runs of them. */
+  white-space: pre;
 }
 
 .dc-repr summary::-webkit-details-marker { display: none; }
@@ -124,10 +129,17 @@ panel reads the same in a notebook and on the docs site. */
   outline-offset: 1px;
 }
 
-.dc-repr .dc-line { padding: 0.1em 0 0.1em 1.1em; }
+/* Both can carry leading spaces a producer put there -- the spool
+states its path indented -- and HTML would collapse them. */
+.dc-repr .dc-line {
+  padding: 0.1em 0 0.1em 1.1em;
+  white-space: pre;
+  overflow-x: auto;
+}
 
-/* The scroll container is the body's own: removing the host's would let
-a hundred-column line push the page sideways instead of itself. */
+
+/* This scrolls itself. Without `overflow-x` a hundred-column coordinate
+line would push the whole page sideways rather than just this block. */
 .dc-repr .dc-body {
   margin: 0 0 0.3em 1.1em;
   padding: 0;
@@ -144,6 +156,10 @@ a hundred-column line push the page sideways instead of itself. */
 /* Print renders a closed `details` closed, so open them all: paper has
 no disclosure triangle to click. */
 @media print {
+  /* Paper has no triangle to click, so nothing stays folded. The
+  first rule is what older engines honor and the second is what
+  Chromium honors; neither alone covers both. */
   .dc-repr details > *:not(summary) { display: block; }
+  .dc-repr details::details-content { content-visibility: visible; }
   .dc-repr summary::before { content: ""; }
 }

--- a/dascore/repr.css
+++ b/dascore/repr.css
@@ -1,0 +1,149 @@
+/* Styles for the HTML repr of dascore objects.
+
+Every selector is scoped under .dc-repr. A repr is emitted into a
+notebook output cell, where a <style> applies to the whole document, so
+one bare `pre` or `details` rule here would restyle every code block on
+the page around it.
+
+Color is inherited, never stated. A repr lands on grounds it cannot see
+-- a light notebook, a dark one, a themed docs page -- and no color
+clears WCAG AA against both white and near-black, so the ink is the
+host's and the hues only ever draw rules and marks beside it.
+*/
+
+.dc-repr {
+  --dc-blue: #0969da;
+  --dc-bright_blue: #0a7ea4;
+  --dc-red: #b03050;
+  --dc-yellow: #9a5b00;
+  --dc-green: #0f7a6c;
+  --dc-cyan: #0e7490;
+  --dc-dark_orange: #bc4c00;
+  --dc-grey50: #6b7280;
+  --dc-rule: color-mix(in oklab, currentColor 22%, transparent);
+  font-family: var(--jp-code-font-family, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: var(--jp-code-font-size, 0.8125rem);
+  line-height: 1.5;
+  color: inherit;
+  background: transparent;
+  max-width: 100%;
+  overflow-x: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-color-scheme: dark) {
+  .dc-repr {
+    --dc-blue: #7fb2ff;
+    --dc-bright_blue: #7dcfff;
+    --dc-red: #ff8fa8;
+    --dc-yellow: #f0a94e;
+    --dc-green: #4fd0bd;
+    --dc-cyan: #7dcfff;
+    --dc-dark_orange: #ffa657;
+    --dc-grey50: #9ca3af;
+  }
+}
+
+/* A host which states its theme outranks the reader's operating system:
+a light page on a dark laptop is a light page. */
+body[data-jp-theme-light="true"] .dc-repr,
+body.quarto-light .dc-repr {
+  --dc-blue: #0969da;
+  --dc-bright_blue: #0a7ea4;
+  --dc-red: #b03050;
+  --dc-yellow: #9a5b00;
+  --dc-green: #0f7a6c;
+  --dc-cyan: #0e7490;
+  --dc-dark_orange: #bc4c00;
+  --dc-grey50: #6b7280;
+}
+
+body[data-jp-theme-light="false"] .dc-repr,
+body.quarto-dark .dc-repr,
+body[data-vscode-theme-kind*="dark"] .dc-repr {
+  --dc-blue: #7fb2ff;
+  --dc-bright_blue: #7dcfff;
+  --dc-red: #ff8fa8;
+  --dc-yellow: #f0a94e;
+  --dc-green: #4fd0bd;
+  --dc-cyan: #7dcfff;
+  --dc-dark_orange: #ffa657;
+  --dc-grey50: #9ca3af;
+}
+
+.dc-repr .dc-bold { font-weight: 600; }
+.dc-repr .dc-underline { text-decoration: underline; }
+.dc-repr .dc-blue { color: var(--dc-blue); }
+.dc-repr .dc-bright_blue { color: var(--dc-bright_blue); }
+.dc-repr .dc-red { color: var(--dc-red); }
+.dc-repr .dc-yellow { color: var(--dc-yellow); }
+.dc-repr .dc-green { color: var(--dc-green); }
+.dc-repr .dc-cyan { color: var(--dc-cyan); }
+.dc-repr .dc-dark_orange { color: var(--dc-dark_orange); }
+.dc-repr .dc-grey50 { color: var(--dc-grey50); }
+
+.dc-repr .dc-banner {
+  padding-bottom: 0.25em;
+  margin-bottom: 0.35em;
+  border-bottom: 1px solid var(--dc-rule);
+}
+
+/* Bootstrap gives a bare `details` a bottom margin and a bare `pre` a
+grey card with a border; JupyterLab gives neither. Reset both so the
+panel reads the same in a notebook and on the docs site. */
+.dc-repr details {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+}
+
+.dc-repr summary {
+  display: block;
+  list-style: none;
+  cursor: pointer;
+  padding: 0.1em 0;
+  color: inherit;
+  font-size: 1em;
+  border-radius: 3px;
+}
+
+.dc-repr summary::-webkit-details-marker { display: none; }
+
+.dc-repr summary::before {
+  content: "\25B8";
+  display: inline-block;
+  width: 1.1em;
+  color: var(--dc-grey50);
+}
+
+.dc-repr details[open] > summary::before { content: "\25BE"; }
+
+.dc-repr summary:focus-visible {
+  outline: 2px solid var(--dc-blue);
+  outline-offset: 1px;
+}
+
+.dc-repr .dc-line { padding: 0.1em 0 0.1em 1.1em; }
+
+/* The scroll container is the body's own: removing the host's would let
+a hundred-column line push the page sideways instead of itself. */
+.dc-repr .dc-body {
+  margin: 0 0 0.3em 1.1em;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: 1em;
+  line-height: inherit;
+  white-space: pre;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+/* Print renders a closed `details` closed, so open them all: paper has
+no disclosure triangle to click. */
+@media print {
+  .dc-repr details > *:not(summary) { display: block; }
+  .dc-repr summary::before { content: ""; }
+}

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -17,6 +17,7 @@ import pandas as pd
 from pandas.errors import OutOfBoundsDatetime, OutOfBoundsTimedelta
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
+from rich.console import Console
 from rich.style import Style
 from rich.text import Text
 
@@ -170,14 +171,17 @@ def split_block(text: Text) -> Section:
 
 # --- Rendering a repr as HTML -------------------------------------------
 
-# The one class every fragment is wrapped in. Every rule in repr.css is
-# scoped under it, so a stylesheet which lands in a notebook output --
-# where it applies to the whole document -- cannot restyle anything else.
+# The one class every fragment is wrapped in, and what every rule in
+# repr.css is scoped under. See that file for why.
+# What a block title opens with in a terminal, where there is no
+# disclosure triangle to draw one. A panel draws one, and both is two
+# markers for one thing.
+_SECTION_MARKER = "\u27a4 "
 _HTML_ROOT = "dc-repr"
 
-# Style words a class exists for. Anything else is dropped, which is what
-# rich does with a word it cannot parse, so an unmappable style is
-# uncolored in a browser and in a terminal alike.
+# Style words a class exists for. A color outside this list still draws
+# in a terminal, where rich knows every color it can parse; here it
+# draws as the host's own ink, which is the safe way to be wrong.
 _STYLE_WORDS = frozenset(
     {
         "bold",
@@ -193,44 +197,40 @@ _STYLE_WORDS = frozenset(
     }
 )
 
-# Words which change what follows rather than describing it: "not bold"
-# is not bold, and "red on blue" paints a background. Read word by word
-# the first would invert and the second would be mistaken, so a style
-# using either is left unstyled.
-_STYLE_QUALIFIERS = frozenset({"not", "on"})
 
-
-def style_classes(style: str | Style | None) -> tuple[str, ...]:
-    """Return the CSS classes a rich style is drawn with."""
-    if style is None:
-        return ()
-    if isinstance(style, Style):
-        words = [
-            x for x, on in (("bold", style.bold), ("underline", style.underline)) if on
-        ]
-        if style.color is not None:
-            words.append(style.color.name)
-    else:
-        words = str(style).split()
-        if _STYLE_QUALIFIERS.intersection(words):
-            return ()
+def style_classes(style: Style) -> tuple[str, ...]:
+    """Return the CSS classes a resolved rich style is drawn with."""
+    words = [
+        x for x, on in (("bold", style.bold), ("underline", style.underline)) if on
+    ]
+    if style.color is not None:
+        words.append(style.color.name)
     return tuple(f"dc-{x}" for x in words if x in _STYLE_WORDS)
 
 
 def text_to_html(text: Text) -> str:
     """Render a rich Text as an inline HTML fragment."""
     plain = text.plain
-    cuts = {0, len(plain)}
+    bounds = sorted({0, len(plain)}.union(*((x.start, x.end) for x in text.spans)))
+    console = Console()
+    # One style per run, built by adding each span to the runs it covers
+    # rather than by asking every span about every run. A repr with a
+    # few thousand spans -- a patch of many coordinates, a spool of many
+    # tracks -- took over a second the other way round.
+    at = {position: index for index, position in enumerate(bounds)}
+    styles = [console.get_style(text.style, default="")] * max(len(bounds) - 1, 0)
     for span in text.spans:
-        cuts.update((span.start, span.end))
-    base = style_classes(text.style)
+        style = console.get_style(span.style, default="")
+        for index in range(at[span.start], at[span.end]):
+            # Added, not gathered: two spans can both state a color, and
+            # which one wins is rich's arithmetic. Stacking both classes
+            # and letting the stylesheet's source order pick made a
+            # units string grey in a panel and blue in a terminal.
+            styles[index] = styles[index] + style
     out = []
-    for start, end in pairwise(sorted(cuts)):
-        classes = list(base)
-        for span in text.spans:
-            if span.start <= start and end <= span.end:
-                classes.extend(x for x in style_classes(span.style) if x not in classes)
+    for index, (start, end) in enumerate(pairwise(bounds)):
         chunk = escape(plain[start:end], quote=False)
+        classes = style_classes(styles[index])
         out.append(
             f'<span class="{" ".join(classes)}">{chunk}</span>' if classes else chunk
         )
@@ -250,25 +250,42 @@ def render_html(node) -> str:
     raise NotImplementedError(msg)
 
 
+def _body_text(text: Text) -> Text:
+    """
+    What sits under a title, without the whitespace which framed it.
+
+    The leading newline separated the body from its title and belongs to
+    neither, and a trailing one drew a blank line inside the block --
+    `attrs_to_text` ends on one so a printed patch ends on one.
+    """
+    plain = text.plain
+    start = 1 if plain.startswith("\n") else 0
+    return text[start : len(plain.rstrip("\n"))]
+
+
 @render_html.register
 def _html_raw(node: Raw) -> str:
     # A `pre`, because what a producer laid out is laid out in columns:
     # an array printed by numpy, a track list padded to line up. HTML
     # would collapse the runs of spaces which do that work.
-    text = node.text
-    # The newline which separated this from its title belongs to neither.
-    if text.plain.startswith("\n"):
-        text = text[1:]
+    text = _body_text(node.text)
     return f'<pre class="dc-body">{text_to_html(text)}</pre>'
 
 
 @render_html.register
 def _html_section(node: Section) -> str:
-    title = text_to_html(node.title)
-    if not node.body:
-        # Nothing to fold, so nothing to offer folding.
+    title = node.title
+    if title.plain.startswith(_SECTION_MARKER):
+        title = title[len(_SECTION_MARKER) :]
+    title = text_to_html(title)
+    if not any(_body_text(x.text).plain for x in node.body):
+        # Nothing to fold, so nothing to offer folding. A block whose
+        # body is only the newline which separated it has none.
         return f'<div class="dc-line">{title}</div>'
-    lines = sum(x.text.plain.count("\n") for x in node.body)
+    # Counted on what is drawn, not on what was handed over: the body
+    # loses the newline which separated it and any it ends on, and a
+    # block counted before that folds one line early.
+    lines = sum(_body_text(x.text).plain.count("\n") + 1 for x in node.body)
     state = " open" if lines <= get_config().display_html_open_lines else ""
     body = "".join(render_html(x) for x in node.body)
     return f"<details{state}><summary>{title}</summary>{body}</details>"
@@ -315,8 +332,9 @@ class NodeRepr(RichRepr):
     Print an object from the repr nodes it states.
 
     A host states ``_repr_node``; rendering it is the same call every
-    time, so it is made once here -- as text for a terminal, and as
-    HTML for a display which draws it.
+    time, so it is written once here -- as text for a terminal, and as
+    HTML for a display which draws one. A notebook asks for both, so a
+    host whose nodes are expensive to build should cache them.
     """
 
     _repr_node: Callable[[], Repr]

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -7,7 +7,10 @@ from collections import Counter
 from collections.abc import Callable, Iterable, Mapping, Sized
 from contextlib import suppress
 from dataclasses import dataclass, field
-from functools import singledispatch
+from functools import cache, singledispatch
+from html import escape
+from importlib.resources import files
+from itertools import pairwise
 
 import numpy as np
 import pandas as pd
@@ -165,6 +168,125 @@ def split_block(text: Text) -> Section:
     return Section(text[:index], (Raw(text[index:]),))
 
 
+# --- Rendering a repr as HTML -------------------------------------------
+
+# The one class every fragment is wrapped in. Every rule in repr.css is
+# scoped under it, so a stylesheet which lands in a notebook output --
+# where it applies to the whole document -- cannot restyle anything else.
+_HTML_ROOT = "dc-repr"
+
+# Style words a class exists for. Anything else is dropped, which is what
+# rich does with a word it cannot parse, so an unmappable style is
+# uncolored in a browser and in a terminal alike.
+_STYLE_WORDS = frozenset(
+    {
+        "bold",
+        "underline",
+        "blue",
+        "bright_blue",
+        "red",
+        "yellow",
+        "green",
+        "cyan",
+        "dark_orange",
+        "grey50",
+    }
+)
+
+# Words which change what follows rather than describing it: "not bold"
+# is not bold, and "red on blue" paints a background. Read word by word
+# the first would invert and the second would be mistaken, so a style
+# using either is left unstyled.
+_STYLE_QUALIFIERS = frozenset({"not", "on"})
+
+
+def style_classes(style: str | Style | None) -> tuple[str, ...]:
+    """Return the CSS classes a rich style is drawn with."""
+    if style is None:
+        return ()
+    if isinstance(style, Style):
+        words = [
+            x for x, on in (("bold", style.bold), ("underline", style.underline)) if on
+        ]
+        if style.color is not None:
+            words.append(style.color.name)
+    else:
+        words = str(style).split()
+        if _STYLE_QUALIFIERS.intersection(words):
+            return ()
+    return tuple(f"dc-{x}" for x in words if x in _STYLE_WORDS)
+
+
+def text_to_html(text: Text) -> str:
+    """Render a rich Text as an inline HTML fragment."""
+    plain = text.plain
+    cuts = {0, len(plain)}
+    for span in text.spans:
+        cuts.update((span.start, span.end))
+    base = style_classes(text.style)
+    out = []
+    for start, end in pairwise(sorted(cuts)):
+        classes = list(base)
+        for span in text.spans:
+            if span.start <= start and end <= span.end:
+                classes.extend(x for x in style_classes(span.style) if x not in classes)
+        chunk = escape(plain[start:end], quote=False)
+        out.append(
+            f'<span class="{" ".join(classes)}">{chunk}</span>' if classes else chunk
+        )
+    return "".join(out)
+
+
+@cache
+def get_stylesheet() -> str:
+    """Return the CSS every HTML repr carries."""
+    return files("dascore").joinpath("repr.css").read_text(encoding="utf-8")
+
+
+@singledispatch
+def render_html(node) -> str:
+    """Render a repr node as an HTML fragment."""
+    msg = f"cannot render {type(node).__name__} as html"
+    raise NotImplementedError(msg)
+
+
+@render_html.register
+def _html_raw(node: Raw) -> str:
+    # A `pre`, because what a producer laid out is laid out in columns:
+    # an array printed by numpy, a track list padded to line up. HTML
+    # would collapse the runs of spaces which do that work.
+    text = node.text
+    # The newline which separated this from its title belongs to neither.
+    if text.plain.startswith("\n"):
+        text = text[1:]
+    return f'<pre class="dc-body">{text_to_html(text)}</pre>'
+
+
+@render_html.register
+def _html_section(node: Section) -> str:
+    title = text_to_html(node.title)
+    if not node.body:
+        # Nothing to fold, so nothing to offer folding.
+        return f'<div class="dc-line">{title}</div>'
+    lines = sum(x.text.plain.count("\n") for x in node.body)
+    state = " open" if lines <= get_config().display_html_open_lines else ""
+    body = "".join(render_html(x) for x in node.body)
+    return f"<details{state}><summary>{title}</summary>{body}</details>"
+
+
+@render_html.register
+def _html_repr(node: Repr) -> str:
+    # The banner underlines itself with dashes in a terminal, drawn in
+    # columns; here that is a border, and an emoji is not two columns
+    # wide in every font a browser might choose.
+    banner = text_to_html(node.header.split("\n")[0])
+    body = "".join(render_html(x) for x in node.body)
+    return (
+        f'<div class="{_HTML_ROOT}"><style>{get_stylesheet()}</style>'
+        f'<div class="dc-banner">{banner}</div>{body}</div>'
+    )
+
+
 class RichRepr:
     """
     Print an object the way its ``__rich__`` renders it.
@@ -193,13 +315,35 @@ class NodeRepr(RichRepr):
     Print an object from the repr nodes it states.
 
     A host states ``_repr_node``; rendering it is the same call every
-    time, so it is made once here.
+    time, so it is made once here -- as text for a terminal, and as
+    HTML for a display which draws it.
     """
 
     _repr_node: Callable[[], Repr]
 
     def __rich__(self) -> Text:
         return render_text(self._repr_node())
+
+    def _repr_html_(self) -> str | None:
+        """
+        The panel a notebook draws, or None to fall back to the text.
+
+        None is how the display protocol says "not this time", and it is
+        what a repr should say when it cannot draw itself: a traceback
+        out of a formatter is printed into the cell on every echo of the
+        object, which makes it undebuggable at the one moment someone is
+        looking at it. Debug mode wants the traceback instead, which is
+        what the test suite runs with, so a panel which cannot be drawn
+        fails there and stays quiet for a reader.
+        """
+        if not get_config().display_html:
+            return None
+        try:
+            return render_html(self._repr_node())
+        except Exception:
+            if get_config().debug:
+                raise
+            return None
 
 
 @singledispatch

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -64,6 +64,21 @@ with config_context(display_max_patches=100):
     print(spool)  # a bigger spool names the limit rather than its extents
 ```
 
+Where a display can render HTML -- a notebook, or this documentation --
+an object draws a panel whose sections fold, rather than the text above.
+`display_html` turns that off and sends every display back to the text,
+which says the same words. `display_html_open_lines` (12 by default) is
+how many lines a section may hold and still open on its own; a longer
+one, such as a patch's data, starts folded, and `0` folds every section.
+
+```python
+with config_context(display_html=False):
+    patch  # the text repr, even in a notebook
+
+with config_context(display_html_open_lines=0):
+    patch  # every section folded until it is asked for
+```
+
 For remote IO settings such as `allow_remote_cache`,
 `allow_remote_cache_for_metadata`, `warn_on_remote_cache`,
 `remote_hdf5_block_size`, `remote_hdf5_max_blocks`, and `warn_on_gc_pause`,

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from html import unescape
 from pathlib import Path
 
 import numpy as np
@@ -22,7 +23,9 @@ from dascore.core.annotations import (
     AnnotationSetAttrs,
 )
 from dascore.core.inventory import Acquisition, Cable, Network
+from dascore.utils import display
 from dascore.utils.display import (
+    _STYLE_WORDS,
     Raw,
     Repr,
     Section,
@@ -33,6 +36,7 @@ from dascore.utils.display import (
     duration_text,
     get_header_text,
     get_nice_text,
+    get_stylesheet,
     group_names,
     human_duration,
     human_size,
@@ -42,9 +46,12 @@ from dascore.utils.display import (
     model_to_line,
     percent,
     rate_text,
+    render_html,
     render_text,
     split_block,
     stated_fields,
+    style_classes,
+    text_to_html,
     value_to_text,
 )
 from dascore.utils.patch import _format_values
@@ -1057,3 +1064,288 @@ class TestValuesAReaderCanRead:
             }
         )
         assert "<9 s>" in str(AnnotationSet(frame, dims=("time",)))
+
+
+class TestStyleClasses:
+    """Tests for the classes a rich style is drawn with."""
+
+    @pytest.mark.parametrize(
+        ("style", "expected"),
+        [
+            ("blue", ("dc-blue",)),
+            ("bold green", ("dc-bold", "dc-green")),
+            ("bright_blue", ("dc-bright_blue",)),
+            ("bold dark_orange", ("dc-bold", "dc-dark_orange")),
+            ("underline", ("dc-underline",)),
+            ("", ()),
+        ],
+    )
+    def test_a_style_string(self, style, expected):
+        """Each word a class exists for becomes one."""
+        assert style_classes(style) == expected
+
+    def test_a_style_object_says_what_its_string_says(self):
+        """
+        The banner states real Style objects where the rest state words.
+
+        Both have to draw the same, or the object's name would be styled
+        one way and everything else another.
+        """
+        assert style_classes(Style(color="blue", bold=True)) == style_classes(
+            "bold blue"
+        )
+
+    @pytest.mark.parametrize("style", ["not bold", "red on blue", "on green"])
+    def test_a_style_which_changes_what_follows(self, style):
+        """
+        Read word by word, "not bold" is bold and "red on blue" is red.
+
+        Neither is what the style says, so it is drawn unstyled rather
+        than drawn wrong.
+        """
+        assert style_classes(style) == ()
+
+    @pytest.mark.parametrize("style", ["chartreuse", "#ff0000", None])
+    def test_a_style_no_class_exists_for(self, style):
+        """
+        Dropped, which is what rich does with a word it cannot parse.
+
+        Nothing an object states reaches a CSS attribute this way, so
+        the stylesheet stays the only thing which says what a color is.
+        """
+        assert style_classes(style) == ()
+
+    def test_a_truecolor_style(self):
+        """A hex color names no class, so it draws as the host's ink."""
+        assert style_classes(Style(color="#ff0000")) == ()
+
+
+class TestTextToHtml:
+    """Tests for rendering a rich Text as an HTML fragment."""
+
+    @pytest.mark.parametrize(
+        ("plain", "expected"),
+        [("a & b", "a &amp; b"), ("<script>", "&lt;script&gt;"), ("x > y", "x &gt; y")],
+    )
+    def test_content_is_escaped(self, plain, expected):
+        """
+        A tag, a unit or a path is a value someone else chose.
+
+        A trusted notebook does not sanitize what a repr emits, so what
+        the repr emits has to be safe on its own.
+        """
+        assert text_to_html(Text(plain)) == expected
+
+    def test_quotes_are_left_alone(self):
+        """Nothing is written into an attribute, so nothing needs it."""
+        assert text_to_html(Text('say "hi"')) == 'say "hi"'
+
+    def test_unstyled_text_emits_no_span(self):
+        """A span which says nothing is bytes in every repr forever."""
+        assert "<span" not in text_to_html(Text("plain"))
+
+    def test_overlapping_spans_compose(self):
+        """
+        A styled value inside a styled field keeps both.
+
+        `get_nice_text` stylizes a Text which already carries spans, so
+        this is how a date inside a coordinate line is drawn.
+        """
+        text = Text("abcdef")
+        text.stylize("bold", 0, 4)
+        text.stylize("blue", 2, 6)
+        html = text_to_html(text)
+        assert 'class="dc-bold dc-blue"' in html
+
+    def test_an_empty_text(self):
+        """An object may state a block with nothing in it."""
+        assert text_to_html(Text("")) == ""
+
+
+class TestRenderHtml:
+    """Tests for rendering repr nodes as HTML."""
+
+    def test_a_section_folds(self, repr_blocks):
+        """A block with a body is what a reader opens and closes."""
+        html = render_html(split_block(repr_blocks["coords"]))
+        assert html.startswith("<details")
+        assert "<summary>" in html
+
+    def test_a_section_with_no_body_does_not(self, repr_blocks):
+        """One line is a statement; offering to fold it says otherwise."""
+        html = render_html(split_block(repr_blocks["one_line"]))
+        assert "<details" not in html
+        assert 'class="dc-line"' in html
+
+    def test_a_long_section_starts_closed(self, repr_blocks):
+        """An array is not read at a glance, so it does not open at one."""
+        with config_context(display_html_open_lines=0):
+            assert "<details>" in render_html(split_block(repr_blocks["coords"]))
+
+    def test_the_banner_drops_its_underline(self):
+        """
+        A terminal underlines the banner with dashes, drawn in columns.
+
+        Here that is a border, and an emoji is not two columns wide in
+        every font a browser might choose.
+        """
+        node = Repr(get_header_text("Patch ⚡"))
+        assert "---" not in render_html(node)
+
+    def test_the_fragment_is_scoped(self):
+        """
+        Everything the stylesheet says is said about this class.
+
+        A repr is emitted into a notebook output, where a `style`
+        applies to the whole document.
+        """
+        assert render_html(Repr(Text("x"))).startswith('<div class="dc-repr">')
+
+    def test_something_which_is_not_a_node(self):
+        """A renderer says what it cannot draw rather than drawing it wrong."""
+        with pytest.raises(NotImplementedError, match="cannot render int"):
+            render_html(42)
+
+
+class TestStylesheet:
+    """Tests for the CSS every repr carries."""
+
+    def test_every_selector_is_scoped(self):
+        """
+        A bare `pre` rule here restyles every code block on the page.
+
+        The stylesheet travels inside a notebook output cell, where it
+        applies to the whole document around it.
+        """
+        body = re.sub(r"/\*.*?\*/", "", get_stylesheet(), flags=re.DOTALL)
+        selectors = [
+            part.strip()
+            for block in re.findall(r"([^{}]+)\{", body)
+            for part in block.split(",")
+        ]
+        stated = [x for x in selectors if x and not x.startswith("@")]
+        assert stated
+        assert all(".dc-repr" in x for x in stated)
+
+    def test_a_class_exists_for_every_style_word(self):
+        """
+        A word which draws in a terminal and not in a browser is a
+        difference between the two reprs that nobody chose.
+        """
+        css = get_stylesheet()
+        for word in _STYLE_WORDS:
+            assert f".dc-{word}" in css, word
+
+    def test_it_is_read_once(self):
+        """Every repr carries it, so every repr should not read it."""
+        assert get_stylesheet() is get_stylesheet()
+
+
+def _boom(node):
+    """Stand in for a renderer which cannot draw what it is given."""
+    raise ValueError("no panel for you")
+
+
+class TestHtmlRepr:
+    """Tests for the panel a notebook draws."""
+
+    @pytest.fixture(scope="class")
+    def html_objects(self):
+        """One of each class which states a panel."""
+        return {
+            "patch": dc.get_example_patch(),
+            "spool": dc.get_example_spool("diverse_das"),
+            "inventory": dc.get_example_inventory("tunnel"),
+        }
+
+    def test_each_states_a_panel(self, html_objects):
+        """The hook a display looks for, on the objects people echo."""
+        for name, obj in html_objects.items():
+            assert obj._repr_html_().startswith('<div class="dc-repr">'), name
+
+    def test_the_panel_is_deterministic(self, html_objects):
+        """
+        No uuid, no counter, no timestamp.
+
+        A notebook is a file in version control, and a repr which drew
+        itself differently every time would rewrite it on every run.
+        """
+        for name, obj in html_objects.items():
+            assert obj._repr_html_() == obj._repr_html_(), name
+            assert "id=" not in obj._repr_html_(), name
+
+    def test_the_panel_carries_no_inline_styles(self, html_objects):
+        """
+        Every color goes through a class, so the stylesheet is the only
+        thing which says what one is and both themes stay reachable.
+        """
+        for name, obj in html_objects.items():
+            assert 'style="' not in obj._repr_html_(), name
+
+    def test_a_value_which_looks_like_markup(self):
+        """A tag is a value someone else chose."""
+        patch = dc.get_example_patch().update_attrs(
+            tag="<script>alert(1)</script>", station="a & b"
+        )
+        html = patch._repr_html_()
+        assert "<script>alert" not in html
+        assert "&lt;script&gt;" in html
+        assert "a &amp; b" in html
+
+    def test_no_panel_when_it_is_turned_off(self, html_objects):
+        """
+        None is how the protocol says "not this time".
+
+        The display falls back to the text repr, which says the same
+        words.
+        """
+        with config_context(display_html=False):
+            for name, obj in html_objects.items():
+                assert obj._repr_html_() is None, name
+
+    def test_a_panel_which_cannot_be_drawn(self, monkeypatch):
+        """
+        A traceback out of a formatter is printed into the cell on every
+        echo of the object, which makes it undebuggable exactly when
+        someone is looking at it.
+
+        Only the drawing is broken here, not the object: breaking
+        `_repr_node` breaks the text repr too, and an object which
+        cannot be printed cannot be reported on either.
+
+        Debug is asked for explicitly because the suite runs with it on
+        (`tests/conftest.py`), which is the right way round -- a panel
+        which cannot be drawn should fail here and stay quiet for a
+        reader -- but it means this is the path CI never takes.
+        """
+        monkeypatch.setattr(display, "render_html", _boom)
+        with config_context(debug=False):
+            assert dc.get_example_patch()._repr_html_() is None
+
+    def test_debug_mode_wants_the_traceback(self, monkeypatch):
+        """Swallowing it in CI is how a broken repr ships unnoticed."""
+        monkeypatch.setattr(display, "render_html", _boom)
+        with config_context(debug=True), pytest.raises(ValueError, match="no panel"):
+            dc.get_example_patch()._repr_html_()
+
+    def test_the_panel_says_what_the_text_says(self, html_objects):
+        """
+        The two reprs are one repr shown two ways.
+
+        Tags stripped and entities read back, the panel holds every line
+        the text holds -- leading space aside, which the panel states
+        with a margin rather than with characters.
+        """
+        for name, obj in html_objects.items():
+            stripped = unescape(re.sub(r"<[^>]+>", "", obj._repr_html_()))
+            for line in str(obj).split("\n"):
+                if line.strip() and not set(line.strip()) <= {"-"}:
+                    assert line.strip() in stripped, (name, line)
+
+    def test_the_panel_stays_small(self, html_objects):
+        """
+        Every repr carries the stylesheet, so a notebook carries one
+        copy of it per output cell.
+        """
+        for name, obj in html_objects.items():
+            assert len(obj._repr_html_().encode()) < 12_000, name

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import time
 from html import unescape
 from pathlib import Path
 
@@ -1067,7 +1068,7 @@ class TestValuesAReaderCanRead:
 
 
 class TestStyleClasses:
-    """Tests for the classes a rich style is drawn with."""
+    """Tests for the classes a resolved rich style is drawn with."""
 
     @pytest.mark.parametrize(
         ("style", "expected"),
@@ -1080,44 +1081,32 @@ class TestStyleClasses:
             ("", ()),
         ],
     )
-    def test_a_style_string(self, style, expected):
+    def test_the_words_of_a_style(self, style, expected):
         """Each word a class exists for becomes one."""
-        assert style_classes(style) == expected
+        assert style_classes(Style.parse(style)) == expected
 
-    def test_a_style_object_says_what_its_string_says(self):
+    def test_a_background_is_not_a_foreground(self):
         """
-        The banner states real Style objects where the rest state words.
+        "red on blue" paints blue behind red text.
 
-        Both have to draw the same, or the object's name would be styled
-        one way and everything else another.
+        Rich resolves that; reading the words would take the background
+        for the color of the text.
         """
-        assert style_classes(Style(color="blue", bold=True)) == style_classes(
-            "bold blue"
-        )
+        assert style_classes(Style.parse("red on blue")) == ("dc-red",)
 
-    @pytest.mark.parametrize("style", ["not bold", "red on blue", "on green"])
-    def test_a_style_which_changes_what_follows(self, style):
-        """
-        Read word by word, "not bold" is bold and "red on blue" is red.
+    def test_a_style_which_turns_something_off(self):
+        """Rich resolves "not bold" to not bold."""
+        assert style_classes(Style.parse("not bold")) == ()
 
-        Neither is what the style says, so it is drawn unstyled rather
-        than drawn wrong.
+    @pytest.mark.parametrize("color", ["#ff0000", "purple4", "rgb(1,2,3)"])
+    def test_a_color_no_class_exists_for(self, color):
         """
-        assert style_classes(style) == ()
-
-    @pytest.mark.parametrize("style", ["chartreuse", "#ff0000", None])
-    def test_a_style_no_class_exists_for(self, style):
-        """
-        Dropped, which is what rich does with a word it cannot parse.
+        Drawn as the host's own ink rather than drawn wrong.
 
         Nothing an object states reaches a CSS attribute this way, so
         the stylesheet stays the only thing which says what a color is.
         """
-        assert style_classes(style) == ()
-
-    def test_a_truecolor_style(self):
-        """A hex color names no class, so it draws as the host's ink."""
-        assert style_classes(Style(color="#ff0000")) == ()
+        assert style_classes(Style.parse(color)) == ()
 
 
 class TestTextToHtml:
@@ -1143,6 +1132,54 @@ class TestTextToHtml:
     def test_unstyled_text_emits_no_span(self):
         """A span which says nothing is bytes in every repr forever."""
         assert "<span" not in text_to_html(Text("plain"))
+
+    def test_a_later_span_wins_a_color(self):
+        """
+        Two spans can both state a color, and rich says which wins.
+
+        Stacking both classes and letting the stylesheet's source order
+        pick made the sampling rate grey in a panel and blue in a
+        terminal.
+        """
+        text = Text("250 Hz")
+        text.stylize("grey50", 0, 6)
+        text.stylize("bright_blue", 0, 6)
+        assert 'class="dc-bright_blue"' in text_to_html(text)
+        assert "dc-grey50" not in text_to_html(text)
+
+    def test_a_repr_with_many_spans_is_not_slow(self):
+        """
+        A style is added to the runs it covers, not asked about each.
+
+        The other way round a few thousand spans -- a patch of many
+        coordinates -- took over a second to draw.
+        """
+        text = Text("")
+        for index in range(2000):
+            part = Text(f"field{index}: value{index} ")
+            part.stylize("grey50", 0, 7)
+            part.stylize("bright_blue", 8, 14)
+            text += part
+        start = time.perf_counter()
+        text_to_html(text)
+        assert time.perf_counter() - start < 1.0
+
+    def test_a_style_reaches_only_the_runs_it_covers(self):
+        """
+        A span states a style for its own characters and no others.
+
+        Applied to every run instead, the banner smears: DAS, C and ore
+        each take all three colors, and every value bleeds across its
+        line.
+        """
+        text = Text("abcdef")
+        text.stylize("bold", 0, 2)
+        text.stylize("blue", 4, 6)
+        html = text_to_html(text)
+        assert '<span class="dc-bold">ab</span>' in html
+        assert "cd" in html.replace('<span class="dc-bold">ab</span>', "")
+        assert '<span class="dc-blue">ef</span>' in html
+        assert "dc-blue" not in html.split("cd")[0]
 
     def test_overlapping_spans_compose(self):
         """
@@ -1182,6 +1219,46 @@ class TestRenderHtml:
         with config_context(display_html_open_lines=0):
             assert "<details>" in render_html(split_block(repr_blocks["coords"]))
 
+    def test_a_short_section_starts_open(self, repr_blocks):
+        """
+        What a reader would have opened anyway is opened for them.
+
+        The coordinates block is two lines; the limit is what says two
+        is few enough, so it is asked for rather than assumed.
+        """
+        with config_context(display_html_open_lines=2):
+            assert "<details open>" in render_html(split_block(repr_blocks["coords"]))
+
+    @pytest.mark.parametrize("block", ["coords", "attrs"])
+    def test_the_limit_counts_body_lines(self, repr_blocks, block):
+        """
+        One line either side of the limit decides differently.
+
+        A section is folded by how much it holds, so the count has to be
+        of what is drawn rather than of what was handed over. Both
+        blocks draw two lines; `attrs` is the one which also ends on a
+        newline, and counting that as a third folded it a line early.
+        """
+        section = split_block(repr_blocks[block])
+        with config_context(display_html_open_lines=1):
+            assert "<details>" in render_html(section)
+        with config_context(display_html_open_lines=2):
+            assert "<details open>" in render_html(section)
+
+    def test_the_count_is_the_lines_a_reader_sees(self, repr_blocks):
+        """The limit means what a reader would count, not what a Text holds."""
+        for name, block in repr_blocks.items():
+            section = split_block(block)
+            if not section.body:
+                continue
+            html = render_html(section)
+            body = re.search(r"<pre[^>]*>(.*?)</pre>", html, re.DOTALL).group(1)
+            drawn = re.sub(r"<[^>]+>", "", body).count("\n") + 1
+            with config_context(display_html_open_lines=drawn):
+                assert "<details open>" in render_html(section), name
+            with config_context(display_html_open_lines=drawn - 1):
+                assert "<details open>" not in render_html(section), name
+
     def test_the_banner_drops_its_underline(self):
         """
         A terminal underlines the banner with dashes, drawn in columns.
@@ -1197,7 +1274,7 @@ class TestRenderHtml:
         Everything the stylesheet says is said about this class.
 
         A repr is emitted into a notebook output, where a `style`
-        applies to the whole document.
+        applies to the whole document around it.
         """
         assert render_html(Repr(Text("x"))).startswith('<div class="dc-repr">')
 
@@ -1205,6 +1282,34 @@ class TestRenderHtml:
         """A renderer says what it cannot draw rather than drawing it wrong."""
         with pytest.raises(NotImplementedError, match="cannot render int"):
             render_html(42)
+
+
+class TestBodyText:
+    """Tests for the whitespace which frames a section body."""
+
+    def test_a_body_which_is_only_the_separator(self):
+        """
+        A block whose body is the newline which split it has no body.
+
+        Offering to fold nothing draws a triangle over an empty box.
+        """
+        html = render_html(split_block(Text("title\n")))
+        assert "<details" not in html
+        assert 'class="dc-line"' in html
+
+    def test_a_trailing_newline_draws_no_blank_line(self):
+        """
+        `attrs_to_text` ends on a newline so a printed patch does.
+
+        In a panel that is a blank line inside the block instead.
+        """
+        html = dc.get_example_patch()._repr_html_()
+        assert "\n</pre>" not in html
+
+    def test_a_body_keeps_the_lines_between(self):
+        """Only the framing goes; a blank line inside the body stays."""
+        html = render_html(split_block(Text("title\na\n\nb\n")))
+        assert ">a\n\nb<" in html
 
 
 class TestStylesheet:
@@ -1227,6 +1332,46 @@ class TestStylesheet:
         assert stated
         assert all(".dc-repr" in x for x in stated)
 
+    def test_it_states_no_rule_which_reaches_outside(self):
+        """
+        `@font-face` and `@import` are scoped to nothing at all.
+
+        Neither can be written under a class, so a stylesheet which
+        travels inside someone else's document must not state one.
+        """
+        body = re.sub(r"/\*.*?\*/", "", get_stylesheet(), flags=re.DOTALL)
+        for rule in ("@font-face", "@import", "@page"):
+            assert rule not in body, rule
+
+    def test_a_class_exists_for_every_style_a_repr_states(self):
+        """
+        A word which draws in a terminal and not in a browser is a
+        difference between the two reprs that nobody chose.
+
+        Walked from what the objects actually state, which is the
+        direction that bites: a word dropped from the list stops
+        coloring most of a panel and no test of the list notices.
+        """
+        console = Console()
+        seen = set()
+        for obj in (
+            dc.get_example_patch(),
+            dc.get_example_spool("diverse_das"),
+            dc.get_example_inventory("tunnel"),
+        ):
+            texts = [obj._repr_node().header]
+            for section in obj._repr_node().body:
+                texts.append(section.title)
+                texts.extend(x.text for x in section.body)
+            for text in texts:
+                for offset in range(len(text.plain)):
+                    style = text.get_style_at_offset(console, offset)
+                    if style.color or style.bold or style.underline:
+                        seen.add(style)
+        assert seen
+        for style in seen:
+            assert style_classes(style), style
+
     def test_a_class_exists_for_every_style_word(self):
         """
         A word which draws in a terminal and not in a browser is a
@@ -1236,9 +1381,70 @@ class TestStylesheet:
         for word in _STYLE_WORDS:
             assert f".dc-{word}" in css, word
 
+    def test_a_title_draws_one_marker(self):
+        """
+        A terminal opens a title with an arrow because it has no
+        triangle to draw; a panel draws the triangle, and both is two
+        markers for one thing.
+        """
+        html = dc.get_example_patch()._repr_html_()
+        assert "\u27a4" not in html
+        assert "Coordinates" in html
+
+    def test_a_line_and_a_summary_keep_their_spaces(self):
+        """
+        A producer's indent is content: the spool states its path
+        indented, and HTML collapses runs of spaces by default.
+        """
+        css = get_stylesheet()
+        for selector in (".dc-repr .dc-line", ".dc-repr summary"):
+            block = css[css.index(selector) : css.index("}", css.index(selector))]
+            assert "white-space: pre" in block, selector
+
+    def test_a_host_which_states_a_light_theme(self):
+        """
+        Every host which can say it is dark can say it is light.
+
+        One named in the dark rule and not the light one keeps dark ink
+        on a light page whenever the reader's system is dark.
+        """
+        css = get_stylesheet()
+        dark = css[css.index('data-jp-theme-light="false"') :]
+        dark = dark[: dark.index("}")]
+        light = css[css.index('data-jp-theme-light="true"') :]
+        light = light[: light.index("}")]
+        for host in ("vscode-theme-kind", "quarto-"):
+            assert host in dark and host in light, host
+
     def test_it_is_read_once(self):
         """Every repr carries it, so every repr should not read it."""
         assert get_stylesheet() is get_stylesheet()
+
+
+def _drawn_lines(html: str) -> list[str]:
+    """
+    The lines a reader sees in a panel, in the order they are drawn.
+
+    Taken block by block rather than by stripping every tag, since the
+    tags inside one are spans which color part of a line and stripping
+    them into newlines would make a line out of each.
+    """
+    blocks = re.findall(
+        r'<div class="dc-banner">(.*?)</div>'
+        r"|<summary>(.*?)</summary>"
+        r'|<pre class="dc-body">(.*?)</pre>'
+        r'|<div class="dc-line">(.*?)</div>',
+        html,
+        re.DOTALL,
+    )
+    out = []
+    for block in blocks:
+        content = next(x for x in block if (x is not None and x != "") or x == "")
+        content = "".join(x for x in block if x)
+        for line in unescape(re.sub(r"<[^>]+>", "", content)).split("\n"):
+            if line.strip():
+                out.append(line.strip())
+    return out
 
 
 def _boom(node):
@@ -1313,10 +1519,10 @@ class TestHtmlRepr:
         `_repr_node` breaks the text repr too, and an object which
         cannot be printed cannot be reported on either.
 
-        Debug is asked for explicitly because the suite runs with it on
-        (`tests/conftest.py`), which is the right way round -- a panel
-        which cannot be drawn should fail here and stay quiet for a
-        reader -- but it means this is the path CI never takes.
+        Debug is turned off here because the suite runs with it on
+        (`tests/conftest.py`), which is the right way round: a panel
+        which cannot be drawn should fail in CI and stay quiet for a
+        reader. So this is a path only a reader takes.
         """
         monkeypatch.setattr(display, "render_html", _boom)
         with config_context(debug=False):
@@ -1333,19 +1539,37 @@ class TestHtmlRepr:
         The two reprs are one repr shown two ways.
 
         Tags stripped and entities read back, the panel holds every line
-        the text holds -- leading space aside, which the panel states
-        with a margin rather than with characters.
+        the text holds. Two things it legitimately does not: the leading
+        space, which it states with a margin rather than with
+        characters, and the arrow a terminal opens a title with, which
+        it draws as a disclosure triangle instead.
         """
         for name, obj in html_objects.items():
-            stripped = unescape(re.sub(r"<[^>]+>", "", obj._repr_html_()))
-            for line in str(obj).split("\n"):
-                if line.strip() and not set(line.strip()) <= {"-"}:
-                    assert line.strip() in stripped, (name, line)
+            said = [
+                x.strip().removeprefix("\u27a4 ")
+                for x in str(obj).split("\n")
+                if x.strip() and set(x.strip()) != {"-"}
+            ]
+            # As a sequence, so a section drawn twice or drawn out of
+            # order is a difference rather than a match.
+            assert _drawn_lines(obj._repr_html_()) == said, name
 
-    def test_the_panel_stays_small(self, html_objects):
+    def test_the_stylesheet_stays_small(self):
         """
-        Every repr carries the stylesheet, so a notebook carries one
-        copy of it per output cell.
+        Every repr carries it, so a notebook carries one copy per cell.
+
+        Held on its own rather than on the panel, where growth in one
+        hides growth in the other.
         """
+        assert len(get_stylesheet().encode()) < 6_000
+
+    def test_a_panel_is_mostly_the_object(self, html_objects):
+        """
+        What a panel adds to the stylesheet is what it says.
+
+        Held apart from the sheet, so a section drawn twice is over the
+        ceiling rather than lost inside the headroom.
+        """
+        overhead = len(get_stylesheet().encode())
         for name, obj in html_objects.items():
-            assert len(obj._repr_html_().encode()) < 12_000, name
+            assert len(obj._repr_html_().encode()) - overhead < 4_000, name


### PR DESCRIPTION
## Description

PR 3 of the repr series (after #1011 and #1012). A notebook renders HTML and has been shown monospace text; `_repr_html_` is the hook it looks for, and this states one from the nodes a repr already builds. A patch opens as its coordinates and folds its data away.

The nodes are the same ones `render_text` renders. Neither renderer re-derives anything — a leaf holds the `Text` its producer made — so the panel cannot say something the printed repr does not, and a test holds the two to the same line sequence.

Section bodies stay `<pre>`. What a producer laid out is laid out in columns, and an array printed by numpy or a track list padded to line up would have its spacing collapsed by anything else. **Tables for the sections which are records rather than columns, and a nested tree for the inventory, come in the next PR.**

`dascore/repr.css` travels inside the output cell, where a stylesheet applies to the whole document around it, so every selector is scoped under `.dc-repr` and a test says so. Body ink is inherited rather than stated: a repr lands on grounds it cannot see, and no color clears WCAG AA against both white and near-black, so what a repr does not need to color it leaves to the host. Both themes are reached by what the host says it is before what the reader's system says, since a light page on a dark laptop is a light page.

`display_html` turns the panel off; `display_html_open_lines` says how much a section may hold and still open on its own. A panel which cannot be drawn returns `None`, which is how the protocol says "not this time" — a traceback out of a formatter is printed into the cell on every echo of the object. Not in debug mode, which the test suite runs with, so a panel which cannot be drawn fails there and stays quiet for a reader.

### Review

Six blind reviews. **Three of them independently found the same defect**: two spans can both state a color, and stacking both classes left the stylesheet's source order to pick — it picked grey where rich picks blue, so the panel and the terminal drew the sampling rate differently. Rich resolves the run now.

Also found and fixed:

- **Rendering was quadratic.** A few thousand spans took **1.2 s**; each style is added only to the runs it covers now, which is **10 ms**.
- **A two-line Attributes block folded closed at a limit of two** — the section counted lines on the text it was handed and drew it without the newlines framing it. The test written to catch that was parametrized on the one fixture block which does not end on a newline.
- **A title carried both markers** (`▾ ➤ Coordinates`). A terminal opens one with an arrow because it has no triangle to draw.
- A separator-only body drew an empty fold; a block ending on a newline drew a blank line inside itself; a one-line block and a title lost the spaces a producer put in them; a VS Code light theme kept dark ink; the print rule needed what Chromium honors as well as what older engines do.
- Two claims in my own prose the code contradicts.

The tests missed all of it, so they were rewritten and every mutant the reviewers used now fails: sections drawn twice, sections reversed, containment removed, the count taken on raw text, and any style word dropped from the list.

### Verification

Full suite 10102 passed / 114 skipped / 2 xfailed · doctests 211 passed · `pre-commit run --all` clean · `dascore/utils/display.py` at 100% coverage · `repr.css` confirmed present in a real `python -m build` wheel.

## Changelog

- added: Patch, Spool, AnnotationSet and Inventory render a collapsible HTML repr in notebooks and on the docs site.
- added: `display_html` turns the HTML repr off, and `display_html_open_lines` sets how large a section may be and still start open.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added rich HTML representations for supported displays, including styled text, collapsible sections, theme-aware formatting, and print-friendly layouts.
  - Added configuration options to enable or disable HTML representations and control when sections are expanded or collapsed.
  - HTML output safely escapes content, preserves formatting, supports scrolling, and falls back gracefully when unavailable.

- **Documentation**
  - Documented HTML display behavior and configuration options, including how to expand or collapse sections by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->