### PR TITLE
Add idxmax and idxmin

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -465,6 +465,8 @@ class Patch(NodeRepr, NamespaceOwner):
     all = dascore.proc.agg.all
     first = dascore.proc.agg.first
     last = dascore.proc.agg.last
+    idxmax = dascore.proc.agg.idxmax
+    idxmin = dascore.proc.agg.idxmin
 
     # --- Universal functions
     add = PatchUFunc(np.add)

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -7,9 +7,17 @@ from collections.abc import Callable, Sequence
 import numpy as np
 
 from dascore.constants import _AGG_FUNCS, DIM_REDUCE_DOCS, PatchType
+from dascore.core.coords import CoordPartial
 from dascore.exceptions import ParameterError
-from dascore.utils.array import _apply_aggregator
+from dascore.utils.array import _apply_aggregator, is_numpy
+from dascore.utils.array_api import (
+    asarray_like,
+    backend_name,
+    to_numpy,
+    warn_numpy_fallback,
+)
 from dascore.utils.docs import compose_docstring
+from dascore.utils.misc import _get_nullish
 from dascore.utils.patch import patch_function
 from dascore.utils.time import dtype_time_like
 
@@ -312,77 +320,134 @@ IDX_DOC_STR = f"""
 patch
     The input Patch.
 dim
-    The dimension along which to find the extreme value.
+    The name of the dimension along which to find the extreme value.
+    Unlike the other aggregations this takes exactly one dimension;
+    None or a sequence raises a ParameterError.
 {DIM_REDUCE_DOCS}
 """
 
 IDX_NOTES = """
 Notes
 -----
-- NaN values are ignored. A slice which is entirely NaN has no extreme
-  value to point at, so it yields NaT for a time-like coordinate and NaN
-  otherwise; an integer coordinate is upcast to float so it can hold the
-  NaN.
-
 - The returned data are coordinate values, not the data values found
-  there, so the patch's data units become the coordinate's units. Use
+  there, so they take the coordinate's dtype and units. Use
   [`Patch.max`](`dascore.proc.aggregate.max`) or
   [`Patch.min`](`dascore.proc.aggregate.min`) for the values themselves.
+
+- Missing samples (NaN in float data, NaT in time-like data) are skipped.
+  A slice which is missing everywhere has no coordinate to point at, so
+  it yields NaT for a time-like coordinate and NaN otherwise. An integer
+  coordinate is widened to float64 to hold that NaN, which loses
+  exactness above 2**53; a coordinate which can hold neither, such as a
+  string one, raises instead.
 
 - Ties go to the first occurrence along the dimension, as in NumPy.
 """
 
 
-def _nan_fill(dtype):
-    """Return the null value and output dtype used for all-NaN slices."""
-    if dtype_time_like(dtype):
-        return np.array("NaT", dtype=dtype), dtype
-    if np.issubdtype(dtype, np.floating):
-        return np.array(np.nan, dtype=dtype), dtype
-    # Integer and everything else cannot hold NaN, so widen to float.
-    return np.float64(np.nan), np.dtype(np.float64)
+def _missing_mask(data):
+    """Return a mask of missing samples, or None if the dtype has none."""
+    if dtype_time_like(data.dtype):
+        return np.isnat(data)
+    if np.issubdtype(data.dtype, np.inexact):
+        return np.isnan(data)
+    # Integers and booleans have no value which means "missing".
+    return None
 
 
-def _index_to_coord(coord_values, arg_func, extreme_func):
+def _comparable(data):
+    """Return data in a form NumPy can order, and its extreme fills."""
+    if dtype_time_like(data.dtype):
+        # NaT does not compare, but its int64 view is simply the smallest
+        # int64, so the view orders correctly once NaT is filled.
+        info = np.iinfo(np.int64)
+        return data.view(np.int64), info.min, info.max
+    return data, -np.inf, np.inf
+
+
+def _extreme_index(data, axis, want_max):
     """
-    Build a reduction mapping data to the coord value at its extreme.
+    Return the index of the extreme along axis, and the all-missing slices.
 
-    `arg_func` is the nan-aware argmin/argmax and `extreme_func` its
-    nan-aware counterpart, used only to locate all-NaN slices.
+    The index for an all-missing slice is arbitrary; the mask says which
+    ones those are so the caller can null them out.
     """
+    missing = _missing_mask(data)
+    if missing is None or not missing.any():
+        arg = np.argmax if want_max else np.argmin
+        return arg(_comparable(data)[0], axis=axis), None
+    values, least, most = _comparable(data)
+    filled = np.where(missing, least if want_max else most, values)
+    extreme = filled.max(axis=axis) if want_max else filled.min(axis=axis)
+    # Match the extreme in the unfilled data rather than taking the arg of
+    # the filled data: a genuine -inf equals the fill for a max, and an arg
+    # reduction breaking that tie first-wins would point at the missing
+    # sample instead of the real one. A missing sample cannot match here,
+    # since NaN equals nothing and NaT views as the smallest int64, which
+    # is only ever the extreme when the whole slice is missing.
+    hit = values == np.expand_dims(extreme, axis)
+    return hit.argmax(axis=axis), missing.all(axis=axis)
+
+
+def _fill_empty(values, empty):
+    """Put a null where a slice had nothing to point at."""
+    dtype = values.dtype
+    if dtype_time_like(dtype) or np.issubdtype(dtype, np.inexact):
+        return np.where(empty, _get_nullish(dtype), values)
+    if np.issubdtype(dtype, np.integer) and not np.issubdtype(dtype, np.bool_):
+        # Integers cannot hold a null, so widen as Patch.pad does.
+        return np.where(empty, np.nan, values.astype(np.float64))
+    msg = (
+        f"A slice with no valid sample has no {dtype} coordinate to point "
+        "at. Drop or fill the empty slices before calling idxmax/idxmin."
+    )
+    raise ParameterError(msg)
+
+
+def _index_to_coord(coord, want_max, name):
+    """Build a reduction mapping data to the coord value at its extreme."""
+    coord_values = coord.values
 
     def _func(data, axis):
-        data = np.asarray(data)
-        # nanargmin/nanargmax raise on an all-NaN slice, so find those first
-        # and hand the reduction a slice it can answer.
-        if np.issubdtype(data.dtype, np.inexact):
-            empty = np.all(np.isnan(data), axis=axis)
-            safe = np.where(np.isnan(data), extreme_func, data)
-        else:
-            empty, safe = None, data
-        out = np.asarray(coord_values)[arg_func(safe, axis=axis)]
-        if empty is not None and empty.any():
-            fill, dtype = _nan_fill(out.dtype)
-            out = np.where(empty, fill, out.astype(dtype))
-        return out
+        original = data
+        if not is_numpy(data):
+            # The index gymnastics below are numpy only, so say so rather
+            # than quietly pulling a lazy or device array into memory.
+            warn_numpy_fallback(name, backend_name(data))
+            data = to_numpy(data)
+        index, empty = _extreme_index(data, axis, want_max)
+        out = coord_values[index]
+        if empty is not None:
+            out = _fill_empty(out, empty)
+        return out if data is original else asarray_like(out, original)
 
     return _func
 
 
-def _idx_aggregate(patch, dim, arg_func, extreme_func, dim_reduce):
+def _idx_aggregate(patch, dim, want_max, name, dim_reduce):
     """Shared implementation of idxmax and idxmin."""
     if not isinstance(dim, str):
-        msg = "idxmax/idxmin reduce a single dimension; dim must be its name."
+        msg = f"{name} reduces a single dimension; dim must be its name."
         raise ParameterError(msg)
     coord = patch.get_coord(dim)
-    func = _index_to_coord(coord.values, arg_func, extreme_func)
+    if isinstance(coord, CoordPartial):
+        # A partial coord, such as the one the default dim_reduce leaves
+        # behind, would index as NaN and quietly null the whole result.
+        msg = (
+            f"The '{dim}' coordinate holds no values for {name} to return. "
+            "This happens when the dimension has already been reduced."
+        )
+        raise ParameterError(msg)
+    func = _index_to_coord(coord, want_max, name)
     out = _apply_aggregator(patch, dim, func, dim_reduce)
-    # The data are now coordinate values, so they carry the coord's units
-    # and none of the original data's meaning.
-    return out.update_attrs(data_units=coord.units, data_type="")
+    # datetime64 and timedelta64 carry their unit in the dtype, and the
+    # coord's unit describes the step rather than the magnitude, so
+    # labelling nanoseconds "s" would silently scale any unit maths.
+    units = None if dtype_time_like(coord.dtype) else coord.units
+    return out.update_attrs(data_units=units)
 
 
-@patch_function()
+@patch_function(data_type="")
 @compose_docstring(params=IDX_DOC_STR, notes=IDX_NOTES)
 def idxmax(
     patch: PatchType,
@@ -407,18 +472,18 @@ def idxmax(
     >>> # The time of each channel's largest sample.
     >>> peak_time = patch.idxmax("time")
     >>>
-    >>> # Drop the reduced dimension entirely, as xarray's idxmax does.
-    >>> peak_time = patch.idxmax("time", dim_reduce="squeeze")
+    >>> # Drop the reduced dimension, as xarray's idxmax does.
+    >>> squeezed = patch.idxmax("time", dim_reduce="squeeze")
 
     See Also
     --------
     - [`Patch.idxmin`](`dascore.proc.aggregate.idxmin`)
     - [`Patch.max`](`dascore.proc.aggregate.max`)
     """
-    return _idx_aggregate(patch, dim, np.argmax, -np.inf, dim_reduce)
+    return _idx_aggregate(patch, dim, True, "idxmax", dim_reduce)
 
 
-@patch_function()
+@patch_function(data_type="")
 @compose_docstring(params=IDX_DOC_STR, notes=IDX_NOTES)
 def idxmin(
     patch: PatchType,
@@ -448,4 +513,4 @@ def idxmin(
     - [`Patch.idxmax`](`dascore.proc.aggregate.idxmax`)
     - [`Patch.min`](`dascore.proc.aggregate.min`)
     """
-    return _idx_aggregate(patch, dim, np.argmin, np.inf, dim_reduce)
+    return _idx_aggregate(patch, dim, False, "idxmin", dim_reduce)

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -320,71 +320,55 @@ IDX_DOC_STR = f"""
 patch
     The input Patch.
 dim
-    The name of the dimension along which to find the extreme value.
-    Unlike the other aggregations this takes exactly one dimension;
-    None or a sequence raises a ParameterError.
+    The name of the single dimension to reduce. None or a sequence,
+    which the other aggregations accept, raises here.
 {DIM_REDUCE_DOCS}
 """
 
 IDX_NOTES = """
 Notes
 -----
-- The returned data are coordinate values, not the data values found
-  there, so they take the coordinate's dtype and units. Use
+- The data become coordinate values rather than the values found there,
+  so they take the coordinate's dtype. Use
   [`Patch.max`](`dascore.proc.aggregate.max`) or
   [`Patch.min`](`dascore.proc.aggregate.min`) for the values themselves.
 
-- Missing samples (NaN in float data, NaT in time-like data) are skipped.
-  A slice which is missing everywhere has no coordinate to point at, so
-  it yields NaT for a time-like coordinate and NaN otherwise. An integer
-  coordinate is widened to float64 to hold that NaN, which loses
-  exactness above 2**53; a coordinate which can hold neither, such as a
-  string one, raises instead.
+- NaN and NaT samples are skipped. A slice with none left has no
+  coordinate to point at, so it yields a null; an integer coordinate is
+  widened to float64 to hold one, which loses exactness above 2**53, and
+  a coordinate which can hold no null, such as a string one, raises.
 
-- Ties go to the first occurrence along the dimension, as in NumPy.
+- Ties go to the first occurrence, as in NumPy.
 """
-
-
-def _missing_mask(data):
-    """Return a mask of missing samples, or None if the dtype has none."""
-    if dtype_time_like(data.dtype):
-        return np.isnat(data)
-    if np.issubdtype(data.dtype, np.inexact):
-        return np.isnan(data)
-    # Integers and booleans have no value which means "missing".
-    return None
-
-
-def _comparable(data):
-    """Return data in a form NumPy can order, and its extreme fills."""
-    if dtype_time_like(data.dtype):
-        # NaT does not compare, but its int64 view is simply the smallest
-        # int64, so the view orders correctly once NaT is filled.
-        info = np.iinfo(np.int64)
-        return data.view(np.int64), info.min, info.max
-    return data, -np.inf, np.inf
 
 
 def _extreme_index(data, axis, want_max):
     """
     Return the index of the extreme along axis, and the all-missing slices.
 
-    The index for an all-missing slice is arbitrary; the mask says which
-    ones those are so the caller can null them out.
+    The index of an all-missing slice is arbitrary; the mask says which
+    those are so the caller can null them out.
     """
-    missing = _missing_mask(data)
+    if dtype_time_like(data.dtype):
+        # NaT does not compare, but its int64 view is the smallest int64,
+        # so the view orders correctly once the missing are filled away.
+        info = np.iinfo(np.int64)
+        missing, values = np.isnat(data), data.view(np.int64)
+        fill = info.min if want_max else info.max
+    else:
+        values, fill = data, (-np.inf if want_max else np.inf)
+        # Integers and booleans have no value which means "missing".
+        inexact = np.issubdtype(data.dtype, np.inexact)
+        missing = np.isnan(data) if inexact else None
     if missing is None or not missing.any():
-        arg = np.argmax if want_max else np.argmin
-        return arg(_comparable(data)[0], axis=axis), None
-    values, least, most = _comparable(data)
-    filled = np.where(missing, least if want_max else most, values)
+        return (np.argmax if want_max else np.argmin)(values, axis=axis), None
+    filled = np.where(missing, fill, values)
     extreme = filled.max(axis=axis) if want_max else filled.min(axis=axis)
-    # Match the extreme in the unfilled data rather than taking the arg of
-    # the filled data: a genuine -inf equals the fill for a max, and an arg
-    # reduction breaking that tie first-wins would point at the missing
-    # sample instead of the real one. A missing sample cannot match here,
-    # since NaN equals nothing and NaT views as the smallest int64, which
-    # is only ever the extreme when the whole slice is missing.
+    # Match the extreme against the unfilled data rather than taking the
+    # arg of the filled data: a real -inf equals the fill for a max, and a
+    # first-wins tie would then answer with the missing sample. Nothing
+    # missing can match here, since NaN equals nothing and NaT is only the
+    # extreme when the whole slice is missing.
     hit = values == np.expand_dims(extreme, axis)
     return hit.argmax(axis=axis), missing.all(axis=axis)
 
@@ -392,57 +376,48 @@ def _extreme_index(data, axis, want_max):
 def _fill_empty(values, empty):
     """Put a null where a slice had nothing to point at."""
     dtype = values.dtype
-    if dtype_time_like(dtype) or np.issubdtype(dtype, np.inexact):
-        return np.where(empty, _get_nullish(dtype), values)
-    if np.issubdtype(dtype, np.integer) and not np.issubdtype(dtype, np.bool_):
-        # Integers cannot hold a null, so widen as Patch.pad does.
-        return np.where(empty, np.nan, values.astype(np.float64))
-    msg = (
-        f"A slice with no valid sample has no {dtype} coordinate to point "
-        "at. Drop or fill the empty slices before calling idxmax/idxmin."
-    )
-    raise ParameterError(msg)
+    if not (dtype_time_like(dtype) or np.issubdtype(dtype, np.number)):
+        msg = (
+            f"A slice with no valid sample has no {dtype} coordinate to "
+            "point at. Drop or fill the empty slices first."
+        )
+        raise ParameterError(msg)
+    # An integer coordinate cannot hold NaN, so where widens it to float.
+    return np.where(empty, _get_nullish(dtype), values)
 
 
-def _index_to_coord(coord, want_max, name):
-    """Build a reduction mapping data to the coord value at its extreme."""
-    coord_values = coord.values
-
-    def _func(data, axis):
-        original = data
-        if not is_numpy(data):
-            # The index gymnastics below are numpy only, so say so rather
-            # than quietly pulling a lazy or device array into memory.
-            warn_numpy_fallback(name, backend_name(data))
-            data = to_numpy(data)
-        index, empty = _extreme_index(data, axis, want_max)
-        out = coord_values[index]
-        if empty is not None:
-            out = _fill_empty(out, empty)
-        return out if data is original else asarray_like(out, original)
-
-    return _func
-
-
-def _idx_aggregate(patch, dim, want_max, name, dim_reduce):
+def _idx_aggregate(patch, dim, want_max, dim_reduce):
     """Shared implementation of idxmax and idxmin."""
+    name = "idxmax" if want_max else "idxmin"
     if not isinstance(dim, str):
         msg = f"{name} reduces a single dimension; dim must be its name."
         raise ParameterError(msg)
     coord = patch.get_coord(dim)
     if isinstance(coord, CoordPartial):
-        # A partial coord, such as the one the default dim_reduce leaves
-        # behind, would index as NaN and quietly null the whole result.
+        # The coord the default dim_reduce leaves behind holds no values,
+        # so indexing it would quietly null the whole result.
         msg = (
-            f"The '{dim}' coordinate holds no values for {name} to return. "
-            "This happens when the dimension has already been reduced."
+            f"The '{dim}' coordinate holds no values for {name} to return; "
+            "the dimension has already been reduced."
         )
         raise ParameterError(msg)
-    func = _index_to_coord(coord, want_max, name)
-    out = _apply_aggregator(patch, dim, func, dim_reduce)
-    # datetime64 and timedelta64 carry their unit in the dtype, and the
-    # coord's unit describes the step rather than the magnitude, so
-    # labelling nanoseconds "s" would silently scale any unit maths.
+    coord_values = coord.values
+
+    def _func(data, axis):
+        original = data
+        if not is_numpy(data):
+            # The indexing below is numpy only, so say so rather than
+            # quietly pulling a lazy or device array into memory.
+            warn_numpy_fallback(name, backend_name(data))
+            data = to_numpy(data)
+        index, empty = _extreme_index(data, axis, want_max)
+        out = coord_values[index]
+        out = out if empty is None else _fill_empty(out, empty)
+        return out if data is original else asarray_like(out, original)
+
+    out = _apply_aggregator(patch, dim, _func, dim_reduce)
+    # A time coord's units describe its step, not its magnitude, so
+    # labelling nanoseconds "s" would scale any unit maths by a billion.
     units = None if dtype_time_like(coord.dtype) else coord.units
     return out.update_attrs(data_units=units)
 
@@ -480,7 +455,7 @@ def idxmax(
     - [`Patch.idxmin`](`dascore.proc.aggregate.idxmin`)
     - [`Patch.max`](`dascore.proc.aggregate.max`)
     """
-    return _idx_aggregate(patch, dim, True, "idxmax", dim_reduce)
+    return _idx_aggregate(patch, dim, True, dim_reduce)
 
 
 @patch_function(data_type="")
@@ -503,14 +478,11 @@ def idxmin(
     --------
     >>> import dascore as dc
     >>>
-    >>> patch = dc.get_example_patch()
-    >>>
-    >>> # The time of each channel's smallest sample.
-    >>> trough_time = patch.idxmin("time")
+    >>> trough_time = dc.get_example_patch().idxmin("time")
 
     See Also
     --------
     - [`Patch.idxmax`](`dascore.proc.aggregate.idxmax`)
     - [`Patch.min`](`dascore.proc.aggregate.min`)
     """
-    return _idx_aggregate(patch, dim, False, "idxmin", dim_reduce)
+    return _idx_aggregate(patch, dim, False, dim_reduce)

--- a/dascore/proc/aggregate.py
+++ b/dascore/proc/aggregate.py
@@ -7,9 +7,11 @@ from collections.abc import Callable, Sequence
 import numpy as np
 
 from dascore.constants import _AGG_FUNCS, DIM_REDUCE_DOCS, PatchType
+from dascore.exceptions import ParameterError
 from dascore.utils.array import _apply_aggregator
 from dascore.utils.docs import compose_docstring
 from dascore.utils.patch import patch_function
+from dascore.utils.time import dtype_time_like
 
 AGG_DOC_STR = f"""
 patch
@@ -304,3 +306,146 @@ def all(
     {notes}
     """
     return aggregate.func(patch, dim=dim, method=np.all, dim_reduce=dim_reduce)
+
+
+IDX_DOC_STR = f"""
+patch
+    The input Patch.
+dim
+    The dimension along which to find the extreme value.
+{DIM_REDUCE_DOCS}
+"""
+
+IDX_NOTES = """
+Notes
+-----
+- NaN values are ignored. A slice which is entirely NaN has no extreme
+  value to point at, so it yields NaT for a time-like coordinate and NaN
+  otherwise; an integer coordinate is upcast to float so it can hold the
+  NaN.
+
+- The returned data are coordinate values, not the data values found
+  there, so the patch's data units become the coordinate's units. Use
+  [`Patch.max`](`dascore.proc.aggregate.max`) or
+  [`Patch.min`](`dascore.proc.aggregate.min`) for the values themselves.
+
+- Ties go to the first occurrence along the dimension, as in NumPy.
+"""
+
+
+def _nan_fill(dtype):
+    """Return the null value and output dtype used for all-NaN slices."""
+    if dtype_time_like(dtype):
+        return np.array("NaT", dtype=dtype), dtype
+    if np.issubdtype(dtype, np.floating):
+        return np.array(np.nan, dtype=dtype), dtype
+    # Integer and everything else cannot hold NaN, so widen to float.
+    return np.float64(np.nan), np.dtype(np.float64)
+
+
+def _index_to_coord(coord_values, arg_func, extreme_func):
+    """
+    Build a reduction mapping data to the coord value at its extreme.
+
+    `arg_func` is the nan-aware argmin/argmax and `extreme_func` its
+    nan-aware counterpart, used only to locate all-NaN slices.
+    """
+
+    def _func(data, axis):
+        data = np.asarray(data)
+        # nanargmin/nanargmax raise on an all-NaN slice, so find those first
+        # and hand the reduction a slice it can answer.
+        if np.issubdtype(data.dtype, np.inexact):
+            empty = np.all(np.isnan(data), axis=axis)
+            safe = np.where(np.isnan(data), extreme_func, data)
+        else:
+            empty, safe = None, data
+        out = np.asarray(coord_values)[arg_func(safe, axis=axis)]
+        if empty is not None and empty.any():
+            fill, dtype = _nan_fill(out.dtype)
+            out = np.where(empty, fill, out.astype(dtype))
+        return out
+
+    return _func
+
+
+def _idx_aggregate(patch, dim, arg_func, extreme_func, dim_reduce):
+    """Shared implementation of idxmax and idxmin."""
+    if not isinstance(dim, str):
+        msg = "idxmax/idxmin reduce a single dimension; dim must be its name."
+        raise ParameterError(msg)
+    coord = patch.get_coord(dim)
+    func = _index_to_coord(coord.values, arg_func, extreme_func)
+    out = _apply_aggregator(patch, dim, func, dim_reduce)
+    # The data are now coordinate values, so they carry the coord's units
+    # and none of the original data's meaning.
+    return out.update_attrs(data_units=coord.units, data_type="")
+
+
+@patch_function()
+@compose_docstring(params=IDX_DOC_STR, notes=IDX_NOTES)
+def idxmax(
+    patch: PatchType,
+    dim: str,
+    dim_reduce: str | Callable = "empty",
+) -> PatchType:
+    """
+    Return the coordinate value where the data are largest along a dimension.
+
+    Parameters
+    ----------
+    {params}
+
+    {notes}
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>>
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # The time of each channel's largest sample.
+    >>> peak_time = patch.idxmax("time")
+    >>>
+    >>> # Drop the reduced dimension entirely, as xarray's idxmax does.
+    >>> peak_time = patch.idxmax("time", dim_reduce="squeeze")
+
+    See Also
+    --------
+    - [`Patch.idxmin`](`dascore.proc.aggregate.idxmin`)
+    - [`Patch.max`](`dascore.proc.aggregate.max`)
+    """
+    return _idx_aggregate(patch, dim, np.argmax, -np.inf, dim_reduce)
+
+
+@patch_function()
+@compose_docstring(params=IDX_DOC_STR, notes=IDX_NOTES)
+def idxmin(
+    patch: PatchType,
+    dim: str,
+    dim_reduce: str | Callable = "empty",
+) -> PatchType:
+    """
+    Return the coordinate value where the data are smallest along a dimension.
+
+    Parameters
+    ----------
+    {params}
+
+    {notes}
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>>
+    >>> patch = dc.get_example_patch()
+    >>>
+    >>> # The time of each channel's smallest sample.
+    >>> trough_time = patch.idxmin("time")
+
+    See Also
+    --------
+    - [`Patch.idxmax`](`dascore.proc.aggregate.idxmax`)
+    - [`Patch.min`](`dascore.proc.aggregate.min`)
+    """
+    return _idx_aggregate(patch, dim, np.argmin, np.inf, dim_reduce)

--- a/scripts/differential_check.py
+++ b/scripts/differential_check.py
@@ -114,6 +114,8 @@ MATRIX_CALLS = {
     "dropna_all": lambda patch: patch.dropna("distance", how="all"),
     "dropna_any": lambda patch: patch.dropna("time", how="any"),
     "fillna_0": lambda patch: patch.fillna(0),
+    "idxmax": lambda patch: patch.idxmax("time"),
+    "idxmin": lambda patch: patch.idxmin("time"),
     "fillna_noinf": lambda patch: patch.fillna(2, include_inf=False),
     "flip_both": lambda patch: patch.flip(*patch.dims),
     "flip_one": lambda patch: patch.flip("time"),

--- a/tests/test_proc/test_aggregate.py
+++ b/tests/test_proc/test_aggregate.py
@@ -263,3 +263,112 @@ class TestApplyOperators:
         agg = random_patch.first("time")
         out1 = random_patch + agg
         assert isinstance(out1, dc.Patch)
+
+
+class TestIdxMaxMin:
+    """Tests for idxmax and idxmin."""
+
+    @pytest.fixture(scope="class")
+    def nan_patch(self, random_patch):
+        """A patch whose first channel is NaN for every time."""
+        data = np.asarray(random_patch.data).astype(float).copy()
+        axis = random_patch.get_axis("distance")
+        index = broadcast_for_index(data.ndim, axis, 0)
+        data[index] = np.nan
+        return random_patch.new(data=data)
+
+    @pytest.mark.parametrize("dim", ["time", "distance"])
+    def test_matches_numpy(self, random_patch, dim):
+        """The returned values are the coord values numpy's argmax picks."""
+        axis = random_patch.get_axis(dim)
+        values = random_patch.get_coord(dim).values
+        for name, arg in (("idxmax", np.argmax), ("idxmin", np.argmin)):
+            out = getattr(random_patch, name)(dim, dim_reduce="squeeze")
+            expected = values[arg(random_patch.data, axis=axis)]
+            assert np.array_equal(np.asarray(out.data), expected)
+
+    def test_squeeze_drops_dimension(self, random_patch):
+        """dim_reduce='squeeze' removes the reduced dimension."""
+        out = random_patch.idxmax("time", dim_reduce="squeeze")
+        assert "time" not in out.dims
+        assert out.dims == ("distance",)
+
+    def test_empty_keeps_dimension(self, random_patch):
+        """The default keeps the reduced dimension with length one."""
+        out = random_patch.idxmax("time")
+        assert out.dims == random_patch.dims
+        assert out.shape[random_patch.get_axis("time")] == 1
+
+    def test_data_takes_coord_dtype_and_units(self, random_patch):
+        """Output data are coordinate values, so they carry its dtype/units."""
+        coord = random_patch.get_coord("time")
+        out = random_patch.idxmax("time")
+        assert out.data.dtype == coord.dtype
+        assert out.attrs.data_units == coord.units
+
+    def test_partial_nan_ignored(self, random_patch):
+        """NaN samples are skipped rather than winning the comparison."""
+        data = np.asarray(random_patch.data).astype(float).copy()
+        data[0, :3] = np.nan
+        patch = random_patch.new(data=data)
+        out = patch.idxmax("time", dim_reduce="squeeze")
+        values = random_patch.get_coord("time").values
+        assert np.asarray(out.data)[0] == values[np.nanargmax(data[0])]
+
+    def test_all_nan_slice_is_null(self, nan_patch):
+        """A slice with no valid sample yields NaT for a time coordinate."""
+        out = nan_patch.idxmax("time", dim_reduce="squeeze")
+        values = np.asarray(out.data)
+        assert np.isnat(values[0])
+        assert not np.isnat(values[1:]).any()
+
+    def test_all_nan_slice_upcasts_int_coord(self, random_patch):
+        """An integer coordinate widens to float so it can hold the null."""
+        coord = random_patch.get_coord("distance")
+        assert np.issubdtype(coord.dtype, np.integer)
+        # Blank one whole time sample so reducing distance has nothing to pick.
+        data = np.asarray(random_patch.data).astype(float).copy()
+        axis = random_patch.get_axis("time")
+        data[broadcast_for_index(data.ndim, axis, 0)] = np.nan
+        out = random_patch.new(data=data).idxmin("distance", dim_reduce="squeeze")
+        values = np.asarray(out.data)
+        assert np.issubdtype(values.dtype, np.floating)
+        assert np.isnan(values[0])
+        assert not np.isnan(values[1:]).any()
+
+    def test_ties_take_first(self):
+        """Equal values resolve to the first along the dimension, as numpy does."""
+        data = np.ones((2, 4))
+        patch = dc.Patch(
+            data=data,
+            coords={"distance": np.arange(2), "time": np.arange(4)},
+            dims=("distance", "time"),
+        )
+        out = patch.idxmax("time", dim_reduce="squeeze")
+        assert np.array_equal(np.asarray(out.data), np.zeros(2))
+
+    @pytest.mark.parametrize("dim", [None, ["time"], ("time", "distance")])
+    def test_non_string_dim_raises(self, random_patch, dim):
+        """These reduce exactly one dimension, named by a string."""
+        with pytest.raises(ParameterError, match="single dimension"):
+            random_patch.idxmax(dim)
+
+    def test_bad_dim_raises(self, random_patch):
+        """A dimension the patch does not have is an error."""
+        with pytest.raises(Exception):
+            random_patch.idxmax("not_a_dim")
+
+    def test_recovers_a_known_slope(self):
+        """A linear moveout is recovered exactly by idxmax."""
+        n_dist, n_time, shift = 8, 50, 2
+        data = np.zeros((n_dist, n_time))
+        for i in range(n_dist):
+            data[i, 5 + i * shift] = 1.0
+        patch = dc.Patch(
+            data=data,
+            coords={"distance": np.arange(n_dist), "time": np.arange(n_time)},
+            dims=("distance", "time"),
+        )
+        out = patch.idxmax("time", dim_reduce="squeeze")
+        expected = 5 + np.arange(n_dist) * shift
+        assert np.array_equal(np.asarray(out.data), expected)

--- a/tests/test_proc/test_aggregate.py
+++ b/tests/test_proc/test_aggregate.py
@@ -11,9 +11,10 @@ import pytest
 import dascore
 import dascore as dc
 from dascore.core.coords import _is_translation_equivariant, _reduce_time_like
-from dascore.exceptions import ParameterError
+from dascore.exceptions import CoordError, ParameterError
 from dascore.proc.aggregate import _AGG_FUNCS
 from dascore.utils.misc import broadcast_for_index
+from dascore.warnings import NumpyFallbackWarning
 
 
 class TestReduceTimeLike:
@@ -265,27 +266,57 @@ class TestApplyOperators:
         assert isinstance(out1, dc.Patch)
 
 
+@pytest.fixture(scope="module")
+def offset_patch():
+    """A patch whose coordinate values are never equal to their indices."""
+    rng = np.random.default_rng(42)
+    return dc.Patch(
+        data=rng.random((5, 7)),
+        coords={"distance": np.arange(5) * 10 + 100, "time": np.arange(7) * 3 + 50},
+        dims=("distance", "time"),
+    )
+
+
+def _one_row(data, time_values):
+    """Build a one channel patch from a single row of data."""
+    array = np.asarray(data).reshape(1, -1)
+    return dc.Patch(
+        data=array,
+        coords={"distance": np.arange(1), "time": np.asarray(time_values)},
+        dims=("distance", "time"),
+    )
+
+
 class TestIdxMaxMin:
     """Tests for idxmax and idxmin."""
 
     @pytest.fixture(scope="class")
-    def nan_patch(self, random_patch):
-        """A patch whose first channel is NaN for every time."""
+    def dead_channel_patch(self, random_patch):
+        """A patch whose first channel is NaN at every time."""
         data = np.asarray(random_patch.data).astype(float).copy()
-        axis = random_patch.get_axis("distance")
-        index = broadcast_for_index(data.ndim, axis, 0)
+        index = broadcast_for_index(data.ndim, random_patch.get_axis("distance"), 0)
         data[index] = np.nan
         return random_patch.new(data=data)
 
     @pytest.mark.parametrize("dim", ["time", "distance"])
-    def test_matches_numpy(self, random_patch, dim):
-        """The returned values are the coord values numpy's argmax picks."""
+    @pytest.mark.parametrize("name,arg", [("idxmax", np.argmax), ("idxmin", np.argmin)])
+    def test_matches_numpy(self, random_patch, dim, name, arg):
+        """The values are the coord values numpy's arg reduction picks."""
         axis = random_patch.get_axis(dim)
         values = random_patch.get_coord(dim).values
-        for name, arg in (("idxmax", np.argmax), ("idxmin", np.argmin)):
-            out = getattr(random_patch, name)(dim, dim_reduce="squeeze")
-            expected = values[arg(random_patch.data, axis=axis)]
-            assert np.array_equal(np.asarray(out.data), expected)
+        out = getattr(random_patch, name)(dim, dim_reduce="squeeze")
+        expected = values[arg(random_patch.data, axis=axis)]
+        assert np.array_equal(np.asarray(out.data), expected)
+
+    @pytest.mark.parametrize("name", ["idxmax", "idxmin"])
+    def test_returns_coord_values_not_indices(self, offset_patch, name):
+        """The output holds coordinate values, which are not the indices."""
+        out = getattr(offset_patch, name)("time", dim_reduce="squeeze")
+        values = np.asarray(out.data)
+        time = offset_patch.get_coord("time").values
+        assert set(values.tolist()).issubset(set(time.tolist()))
+        # Every coord value is >= 50, so an index would be out of range.
+        assert values.min() >= time.min()
 
     def test_squeeze_drops_dimension(self, random_patch):
         """dim_reduce='squeeze' removes the reduced dimension."""
@@ -299,33 +330,70 @@ class TestIdxMaxMin:
         assert out.dims == random_patch.dims
         assert out.shape[random_patch.get_axis("time")] == 1
 
-    def test_data_takes_coord_dtype_and_units(self, random_patch):
-        """Output data are coordinate values, so they carry its dtype/units."""
+    def test_data_takes_coord_dtype(self, random_patch):
+        """Output data are coordinate values, so they carry its dtype."""
         coord = random_patch.get_coord("time")
         out = random_patch.idxmax("time")
         assert out.data.dtype == coord.dtype
-        assert out.attrs.data_units == coord.units
+        # The values are no longer whatever the patch measured.
+        assert not out.attrs.data_type
 
-    def test_partial_nan_ignored(self, random_patch):
+    @pytest.mark.parametrize(
+        "name,agg", [("idxmax", np.nanargmax), ("idxmin", np.nanargmin)]
+    )
+    def test_partial_nan_ignored(self, random_patch, name, agg):
         """NaN samples are skipped rather than winning the comparison."""
         data = np.asarray(random_patch.data).astype(float).copy()
         data[0, :3] = np.nan
         patch = random_patch.new(data=data)
-        out = patch.idxmax("time", dim_reduce="squeeze")
+        out = getattr(patch, name)("time", dim_reduce="squeeze")
         values = random_patch.get_coord("time").values
-        assert np.asarray(out.data)[0] == values[np.nanargmax(data[0])]
+        assert np.asarray(out.data)[0] == values[agg(data[0])]
 
-    def test_all_nan_slice_is_null(self, nan_patch):
+    @pytest.mark.parametrize(
+        "name,data,expected",
+        [
+            # A real -inf must beat a NaN for a max, and +inf for a min,
+            # even though each is what the missing sample is filled with.
+            ("idxmax", [np.nan, -np.inf], 20),
+            ("idxmin", [np.nan, np.inf], 20),
+            ("idxmax", [-np.inf, np.nan], 10),
+            ("idxmin", [np.inf, np.nan], 10),
+        ],
+    )
+    def test_nan_does_not_beat_infinity(self, name, data, expected):
+        """A missing sample never outranks a genuine infinity."""
+        patch = _one_row(data, [10, 20])
+        out = getattr(patch, name)("time", dim_reduce="squeeze")
+        assert np.asarray(out.data)[0] == expected
+
+    @pytest.mark.parametrize("name", ["idxmax", "idxmin"])
+    def test_nat_in_time_like_data_is_skipped(self, name):
+        """NaT is missing data too, not the largest or smallest value."""
+        start = dc.to_datetime64("2020-01-01")
+        nat = np.datetime64("NaT", "ns")
+        data = np.array([[start + dc.to_timedelta64(5), nat]])
+        out = getattr(_one_row(data, [10, 20]), name)("time", dim_reduce="squeeze")
+        assert np.asarray(out.data)[0] == 10
+
+    def test_chained_calls_skip_the_null(self, dead_channel_patch):
+        """The NaT this leaves behind is skipped by a second call."""
+        peaks = dead_channel_patch.idxmax("time")
+        assert np.isnat(np.asarray(peaks.data)).any()
+        out = peaks.idxmin("distance", dim_reduce="squeeze")
+        dead = dead_channel_patch.get_coord("distance").values[0]
+        assert np.asarray(out.data).ravel()[0] != dead
+
+    def test_all_nan_slice_is_null(self, dead_channel_patch):
         """A slice with no valid sample yields NaT for a time coordinate."""
-        out = nan_patch.idxmax("time", dim_reduce="squeeze")
+        out = dead_channel_patch.idxmax("time", dim_reduce="squeeze")
         values = np.asarray(out.data)
         assert np.isnat(values[0])
         assert not np.isnat(values[1:]).any()
 
     def test_all_nan_slice_upcasts_int_coord(self, random_patch):
         """An integer coordinate widens to float so it can hold the null."""
-        coord = random_patch.get_coord("distance")
-        assert np.issubdtype(coord.dtype, np.integer)
+        assert np.issubdtype(random_patch.get_coord("distance").dtype, np.integer)
         # Blank one whole time sample so reducing distance has nothing to pick.
         data = np.asarray(random_patch.data).astype(float).copy()
         axis = random_patch.get_axis("time")
@@ -336,16 +404,29 @@ class TestIdxMaxMin:
         assert np.isnan(values[0])
         assert not np.isnan(values[1:]).any()
 
+    @pytest.mark.parametrize("coord", [np.array(["a", "b"]), np.array([True, False])])
+    def test_null_needs_a_coord_which_can_hold_it(self, coord):
+        """A coordinate with no null value says so rather than crashing."""
+        patch = _one_row([np.nan, np.nan], coord)
+        with pytest.raises(ParameterError, match="no valid sample"):
+            patch.idxmax("time")
+
     def test_ties_take_first(self):
-        """Equal values resolve to the first along the dimension, as numpy does."""
-        data = np.ones((2, 4))
-        patch = dc.Patch(
-            data=data,
-            coords={"distance": np.arange(2), "time": np.arange(4)},
-            dims=("distance", "time"),
+        """Equal extremes resolve to the first along the dimension."""
+        # The max appears at index 1 and 3; the min at index 0 and 2.
+        patch = _one_row([0.0, 1.0, 0.0, 1.0], [10, 20, 30, 40])
+        assert np.asarray(patch.idxmax("time").data).ravel()[0] == 20
+        assert np.asarray(patch.idxmin("time").data).ravel()[0] == 10
+
+    @pytest.mark.parametrize("name,arg", [("idxmax", np.argmax), ("idxmin", np.argmin)])
+    def test_integer_data(self, name, arg):
+        """Integer data have no missing value, so no masking is needed."""
+        data = np.array([[3, 9, 1, 9]])
+        out = getattr(_one_row(data, [10, 20, 30, 40]), name)(
+            "time", dim_reduce="squeeze"
         )
-        out = patch.idxmax("time", dim_reduce="squeeze")
-        assert np.array_equal(np.asarray(out.data), np.zeros(2))
+        expected = np.array([10, 20, 30, 40])[arg(data[0])]
+        assert np.asarray(out.data)[0] == expected
 
     @pytest.mark.parametrize("dim", [None, ["time"], ("time", "distance")])
     def test_non_string_dim_raises(self, random_patch, dim):
@@ -355,20 +436,36 @@ class TestIdxMaxMin:
 
     def test_bad_dim_raises(self, random_patch):
         """A dimension the patch does not have is an error."""
-        with pytest.raises(Exception):
+        with pytest.raises(CoordError, match="not found"):
             random_patch.idxmax("not_a_dim")
 
-    def test_recovers_a_known_slope(self):
-        """A linear moveout is recovered exactly by idxmax."""
-        n_dist, n_time, shift = 8, 50, 2
-        data = np.zeros((n_dist, n_time))
-        for i in range(n_dist):
-            data[i, 5 + i * shift] = 1.0
-        patch = dc.Patch(
-            data=data,
-            coords={"distance": np.arange(n_dist), "time": np.arange(n_time)},
-            dims=("distance", "time"),
-        )
-        out = patch.idxmax("time", dim_reduce="squeeze")
-        expected = 5 + np.arange(n_dist) * shift
-        assert np.array_equal(np.asarray(out.data), expected)
+    def test_time_like_coord_leaves_units_unset(self, random_patch):
+        """A nanosecond magnitude must not be labelled with the coord's unit."""
+        out = random_patch.idxmax("time")
+        assert np.issubdtype(out.data.dtype, np.datetime64)
+        assert out.attrs.data_units is None
+
+    def test_numeric_coord_keeps_units(self, random_patch):
+        """A numeric coordinate's values do carry its units."""
+        coord = random_patch.get_coord("distance")
+        out = random_patch.idxmax("distance")
+        assert out.attrs.data_units == coord.units
+
+    @pytest.mark.parametrize("name", ["idxmax", "idxmin"])
+    def test_reduced_dimension_raises(self, random_patch, name):
+        """The partial coord left behind has no values to point at."""
+        once = getattr(random_patch, name)("time")
+        with pytest.raises(ParameterError, match="holds no values"):
+            getattr(once, name)("time")
+
+    def test_non_numpy_backend_warns(self, random_patch):
+        """A lazy or device array is pulled to numpy, and says so."""
+        dask_array = pytest.importorskip("dask.array")
+        data = np.asarray(random_patch.data)
+        patch = random_patch.new(data=dask_array.from_array(data, chunks=(100, 500)))
+        with pytest.warns(NumpyFallbackWarning, match="idxmax"):
+            out = patch.idxmax("time", dim_reduce="squeeze")
+        values = random_patch.get_coord("time").values
+        assert np.array_equal(np.asarray(out.data), values[data.argmax(axis=1)])
+        # The fallback converts back, so the caller keeps its backend.
+        assert not isinstance(out.data, np.ndarray)

--- a/tests/test_proc/test_aggregate.py
+++ b/tests/test_proc/test_aggregate.py
@@ -266,22 +266,10 @@ class TestApplyOperators:
         assert isinstance(out1, dc.Patch)
 
 
-@pytest.fixture(scope="module")
-def offset_patch():
-    """A patch whose coordinate values are never equal to their indices."""
-    rng = np.random.default_rng(42)
-    return dc.Patch(
-        data=rng.random((5, 7)),
-        coords={"distance": np.arange(5) * 10 + 100, "time": np.arange(7) * 3 + 50},
-        dims=("distance", "time"),
-    )
-
-
-def _one_row(data, time_values):
+def _row(data, time_values):
     """Build a one channel patch from a single row of data."""
-    array = np.asarray(data).reshape(1, -1)
     return dc.Patch(
-        data=array,
+        data=np.asarray(data).reshape(1, -1),
         coords={"distance": np.arange(1), "time": np.asarray(time_values)},
         dims=("distance", "time"),
     )
@@ -302,41 +290,34 @@ class TestIdxMaxMin:
     @pytest.mark.parametrize("name,arg", [("idxmax", np.argmax), ("idxmin", np.argmin)])
     def test_matches_numpy(self, random_patch, dim, name, arg):
         """The values are the coord values numpy's arg reduction picks."""
-        axis = random_patch.get_axis(dim)
         values = random_patch.get_coord(dim).values
         out = getattr(random_patch, name)(dim, dim_reduce="squeeze")
-        expected = values[arg(random_patch.data, axis=axis)]
+        expected = values[arg(random_patch.data, axis=random_patch.get_axis(dim))]
         assert np.array_equal(np.asarray(out.data), expected)
 
-    @pytest.mark.parametrize("name", ["idxmax", "idxmin"])
-    def test_returns_coord_values_not_indices(self, offset_patch, name):
+    def test_returns_coord_values_not_indices(self):
         """The output holds coordinate values, which are not the indices."""
-        out = getattr(offset_patch, name)("time", dim_reduce="squeeze")
-        values = np.asarray(out.data)
-        time = offset_patch.get_coord("time").values
-        assert set(values.tolist()).issubset(set(time.tolist()))
-        # Every coord value is >= 50, so an index would be out of range.
-        assert values.min() >= time.min()
+        # Every coord value is far past the last index, so the two differ.
+        out = _row([3.0, 9.0, 1.0], [50, 60, 70]).idxmax("time")
+        assert np.asarray(out.data).ravel()[0] == 60
 
-    def test_squeeze_drops_dimension(self, random_patch):
-        """dim_reduce='squeeze' removes the reduced dimension."""
-        out = random_patch.idxmax("time", dim_reduce="squeeze")
-        assert "time" not in out.dims
-        assert out.dims == ("distance",)
+    def test_dim_reduce_shapes(self, random_patch):
+        """The default keeps the reduced dimension; squeeze drops it."""
+        kept = random_patch.idxmax("time")
+        assert kept.dims == random_patch.dims
+        assert kept.shape[random_patch.get_axis("time")] == 1
+        assert random_patch.idxmax("time", dim_reduce="squeeze").dims == ("distance",)
 
-    def test_empty_keeps_dimension(self, random_patch):
-        """The default keeps the reduced dimension with length one."""
-        out = random_patch.idxmax("time")
-        assert out.dims == random_patch.dims
-        assert out.shape[random_patch.get_axis("time")] == 1
-
-    def test_data_takes_coord_dtype(self, random_patch):
-        """Output data are coordinate values, so they carry its dtype."""
-        coord = random_patch.get_coord("time")
-        out = random_patch.idxmax("time")
-        assert out.data.dtype == coord.dtype
+    def test_output_dtype_and_units(self, random_patch):
+        """A time coord's unit describes its step, so it must not be copied."""
+        time = random_patch.idxmax("time")
+        assert time.data.dtype == random_patch.get_coord("time").dtype
+        # Labelling a nanosecond magnitude "s" would scale unit maths by 1e9.
+        assert time.attrs.data_units is None
         # The values are no longer whatever the patch measured.
-        assert not out.attrs.data_type
+        assert not time.attrs.data_type
+        distance = random_patch.idxmax("distance")
+        assert distance.attrs.data_units == random_patch.get_coord("distance").units
 
     @pytest.mark.parametrize(
         "name,agg", [("idxmax", np.nanargmax), ("idxmin", np.nanargmin)]
@@ -345,8 +326,7 @@ class TestIdxMaxMin:
         """NaN samples are skipped rather than winning the comparison."""
         data = np.asarray(random_patch.data).astype(float).copy()
         data[0, :3] = np.nan
-        patch = random_patch.new(data=data)
-        out = getattr(patch, name)("time", dim_reduce="squeeze")
+        out = getattr(random_patch.new(data=data), name)("time", dim_reduce="squeeze")
         values = random_patch.get_coord("time").values
         assert np.asarray(out.data)[0] == values[agg(data[0])]
 
@@ -363,21 +343,19 @@ class TestIdxMaxMin:
     )
     def test_nan_does_not_beat_infinity(self, name, data, expected):
         """A missing sample never outranks a genuine infinity."""
-        patch = _one_row(data, [10, 20])
-        out = getattr(patch, name)("time", dim_reduce="squeeze")
-        assert np.asarray(out.data)[0] == expected
+        out = getattr(_row(data, [10, 20]), name)("time")
+        assert np.asarray(out.data).ravel()[0] == expected
 
     @pytest.mark.parametrize("name", ["idxmax", "idxmin"])
     def test_nat_in_time_like_data_is_skipped(self, name):
         """NaT is missing data too, not the largest or smallest value."""
         start = dc.to_datetime64("2020-01-01")
-        nat = np.datetime64("NaT", "ns")
-        data = np.array([[start + dc.to_timedelta64(5), nat]])
-        out = getattr(_one_row(data, [10, 20]), name)("time", dim_reduce="squeeze")
-        assert np.asarray(out.data)[0] == 10
+        data = np.array([[start + dc.to_timedelta64(5), np.datetime64("NaT", "ns")]])
+        out = getattr(_row(data, [10, 20]), name)("time")
+        assert np.asarray(out.data).ravel()[0] == 10
 
     def test_chained_calls_skip_the_null(self, dead_channel_patch):
-        """The NaT this leaves behind is skipped by a second call."""
+        """The NaT one call leaves behind is skipped by the next."""
         peaks = dead_channel_patch.idxmax("time")
         assert np.isnat(np.asarray(peaks.data)).any()
         out = peaks.idxmin("distance", dim_reduce="squeeze")
@@ -386,8 +364,9 @@ class TestIdxMaxMin:
 
     def test_all_nan_slice_is_null(self, dead_channel_patch):
         """A slice with no valid sample yields NaT for a time coordinate."""
-        out = dead_channel_patch.idxmax("time", dim_reduce="squeeze")
-        values = np.asarray(out.data)
+        values = np.asarray(
+            dead_channel_patch.idxmax("time", dim_reduce="squeeze").data
+        )
         assert np.isnat(values[0])
         assert not np.isnat(values[1:]).any()
 
@@ -396,8 +375,7 @@ class TestIdxMaxMin:
         assert np.issubdtype(random_patch.get_coord("distance").dtype, np.integer)
         # Blank one whole time sample so reducing distance has nothing to pick.
         data = np.asarray(random_patch.data).astype(float).copy()
-        axis = random_patch.get_axis("time")
-        data[broadcast_for_index(data.ndim, axis, 0)] = np.nan
+        data[broadcast_for_index(data.ndim, random_patch.get_axis("time"), 0)] = np.nan
         out = random_patch.new(data=data).idxmin("distance", dim_reduce="squeeze")
         values = np.asarray(out.data)
         assert np.issubdtype(values.dtype, np.floating)
@@ -407,26 +385,21 @@ class TestIdxMaxMin:
     @pytest.mark.parametrize("coord", [np.array(["a", "b"]), np.array([True, False])])
     def test_null_needs_a_coord_which_can_hold_it(self, coord):
         """A coordinate with no null value says so rather than crashing."""
-        patch = _one_row([np.nan, np.nan], coord)
         with pytest.raises(ParameterError, match="no valid sample"):
-            patch.idxmax("time")
+            _row([np.nan, np.nan], coord).idxmax("time")
 
     def test_ties_take_first(self):
         """Equal extremes resolve to the first along the dimension."""
         # The max appears at index 1 and 3; the min at index 0 and 2.
-        patch = _one_row([0.0, 1.0, 0.0, 1.0], [10, 20, 30, 40])
+        patch = _row([0.0, 1.0, 0.0, 1.0], [10, 20, 30, 40])
         assert np.asarray(patch.idxmax("time").data).ravel()[0] == 20
         assert np.asarray(patch.idxmin("time").data).ravel()[0] == 10
 
-    @pytest.mark.parametrize("name,arg", [("idxmax", np.argmax), ("idxmin", np.argmin)])
-    def test_integer_data(self, name, arg):
+    def test_integer_data(self):
         """Integer data have no missing value, so no masking is needed."""
-        data = np.array([[3, 9, 1, 9]])
-        out = getattr(_one_row(data, [10, 20, 30, 40]), name)(
-            "time", dim_reduce="squeeze"
-        )
-        expected = np.array([10, 20, 30, 40])[arg(data[0])]
-        assert np.asarray(out.data)[0] == expected
+        patch = _row([3, 9, 1, 9], [10, 20, 30, 40])
+        assert np.asarray(patch.idxmax("time").data).ravel()[0] == 20
+        assert np.asarray(patch.idxmin("time").data).ravel()[0] == 30
 
     @pytest.mark.parametrize("dim", [None, ["time"], ("time", "distance")])
     def test_non_string_dim_raises(self, random_patch, dim):
@@ -439,24 +412,10 @@ class TestIdxMaxMin:
         with pytest.raises(CoordError, match="not found"):
             random_patch.idxmax("not_a_dim")
 
-    def test_time_like_coord_leaves_units_unset(self, random_patch):
-        """A nanosecond magnitude must not be labelled with the coord's unit."""
-        out = random_patch.idxmax("time")
-        assert np.issubdtype(out.data.dtype, np.datetime64)
-        assert out.attrs.data_units is None
-
-    def test_numeric_coord_keeps_units(self, random_patch):
-        """A numeric coordinate's values do carry its units."""
-        coord = random_patch.get_coord("distance")
-        out = random_patch.idxmax("distance")
-        assert out.attrs.data_units == coord.units
-
-    @pytest.mark.parametrize("name", ["idxmax", "idxmin"])
-    def test_reduced_dimension_raises(self, random_patch, name):
+    def test_reduced_dimension_raises(self, random_patch):
         """The partial coord left behind has no values to point at."""
-        once = getattr(random_patch, name)("time")
         with pytest.raises(ParameterError, match="holds no values"):
-            getattr(once, name)("time")
+            random_patch.idxmax("time").idxmax("time")
 
     def test_non_numpy_backend_warns(self, random_patch):
         """A lazy or device array is pulled to numpy, and says so."""

--- a/tests/test_workflow/_calls.py
+++ b/tests/test_workflow/_calls.py
@@ -187,6 +187,8 @@ CALLS: tuple[tuple[str, str, tuple, dict], ...] = (
     ("all", "default", (), {"dim": "time"}),
     ("any", "default", (), {"dim": "time"}),
     ("first", "default", (), {"dim": "time"}),
+    ("idxmax", "default", ("time",), {}),
+    ("idxmin", "default", ("time",), {}),
     ("last", "default", (), {"dim": "time"}),
     ("max", "default", (), {"dim": "time"}),
     ("mean", "default", (), {"dim": "time"}),


### PR DESCRIPTION
## Description

The aggregations answer *what* the extreme value is; none of them answer *where* it is. Finding a moveout, an arrival time, or the lag of a correlation peak therefore means leaving patch-land:

```python
lag = dc.to_float(cc.get_array("lag_time"))
picks = lag[cc.data.argmax(axis=cc.get_axis("lag_time"))]
```

That hand-written step is also where the time-like dtypes bite. The coordinate comes back as `datetime64` or `timedelta64`, so every use needs a `dc.to_float` before it is good for anything, and the axis has to be looked up separately from the dimension name.

`idxmax` and `idxmin` return the coordinate value at the extreme, taking the dtype and units of the coordinate they came from:

```python
picks = patch.idxmax("lag_time", dim_reduce="squeeze")
```

The names follow pandas and xarray, where `idx*` gives the label and `arg*` the position. The `arg*` half already exists here as `patch.aggregate(dim, method=np.argmax)`, which returns indices; this adds the half that returns labels.

### Notes for review

- **`dim_reduce` default.** These follow the house convention (`"empty"`, a length-1 partial coord) rather than xarray's, which drops the dimension. `dim_reduce="squeeze"` gives the xarray shape. Happy to flip the default if the xarray-matching behavior is preferred for these two specifically.
- **Missing samples.** NaN in float data and NaT in time-like data are skipped. A slice which is missing everywhere has no coordinate to point at, so it yields `NaT` for a time-like coordinate and `NaN` otherwise, matching what `mean` already does. An integer coordinate is widened to float64 to hold that null, which is the one place the output dtype is not the coordinate's; a coordinate that can hold neither, such as a string one, raises instead.
- **Time-like output leaves `data_units` unset.** A time coordinate's unit describes its step, not its magnitude, so labelling a nanosecond value `s` would scale unit arithmetic by a billion. The `datetime64`/`timedelta64` dtype carries the unit instead. Numeric coordinates do pass their units through.
- **Known gaps, both pre-existing and neither introduced here**, but newly reachable now that a patch's data can be `datetime64`: DASDAE does not round trip datetime data (`_read_patch` reads the array raw, so it returns as `int64`), and `viz.waterfall` cannot draw the two dimensional default output. Happy to open issues for both.
- `dim` is a single dimension name, not the `None`/sequence the other aggregations accept — reducing several dimensions in turn is meaningless when the output is coordinate values from the first.

## Changelog

- added: `Patch.idxmax` and `Patch.idxmin` return the coordinate value where the data reach their extreme along a dimension.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `idxmax` and `idxmin` aggregation shortcuts to `Patch`.
  - Aggregations now return coordinate values for maximum and minimum locations.
  - Improved handling of time-based coordinates, missing values, ties, integer data, and chained reductions.
  - Added validation for unsupported or invalid dimensions.

- **Bug Fixes**
  - Improved behavior for all-missing data and non-NumPy processing backends, including appropriate fallback warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->