### PR TITLE
Unify the nullish getters

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -147,8 +147,7 @@ def _reduce_time_like(func, data):
     data = np.asarray(data)
     valid = data[~pd.isnull(data)]
     if not valid.size:
-        nfunc = np.datetime64 if is_datetime64(data) else np.timedelta64
-        return np.atleast_1d(nfunc("NaT", "ns"))
+        return np.atleast_1d(_get_nullish(data.dtype))
 
     # Some reducers cannot operate directly on time-like dtypes. If direct
     # reduction fails, or returns only nulls despite valid input, fall back to

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -200,11 +200,16 @@ def _all_null(maybe_ar):
 
 
 def _get_nullish(dtype=np.floating):
-    """Get nullish values for a given dtype."""
-    if np.issubdtype(dtype, np.datetime64):
-        return np.datetime64("NaT", "ns")
-    elif np.issubdtype(dtype, np.timedelta64):
-        return np.timedelta64("NaT", "ns")
+    """
+    Return the value which stands for a missing entry of this dtype.
+
+    Time-like dtypes get NaT at their own resolution rather than a fixed
+    one, so a datetime64[us] array is filled with microsecond NaT and
+    never has a nanosecond value cast into it. Everything else gets NaN,
+    which means an integer array widens to float to hold the result.
+    """
+    if np.issubdtype(dtype, np.datetime64) or np.issubdtype(dtype, np.timedelta64):
+        return np.array("NaT").astype(dtype)[()]
     return np.nan
 
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -53,6 +53,7 @@ from dascore.utils.docs import compose_docstring
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import (
     _apply_union_indexers,
+    _get_nullish,
     _merge_tuples,
     get_middle_value,
     iterate,
@@ -1818,7 +1819,7 @@ def _joinable(coords, dim: str) -> list[np.ndarray]:
             "stand in for them."
         )
         raise CoordMergeError(msg)
-    null = np.array("NaT").astype(target)
+    null = _get_nullish(target)
     return [
         np.full(x.shape, null, dtype=target) if b else x for x, b in zip(arrays, blank)
     ]

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1824,6 +1824,21 @@ class TestPartialCoord:
         """A partial coord coerces an int shape like every other coord."""
         assert CoordPartial(shape=5, dtype="float64").shape == (5,)
 
+    @pytest.mark.parametrize("unit", ["us", "ms", "s"])
+    @pytest.mark.parametrize("kind", ["datetime64", "timedelta64"])
+    def test_values_keep_the_declared_resolution(self, kind, unit):
+        """
+        The nulls a partial coord stands for are of its own dtype.
+
+        A fixed resolution here leaks out of the coordinate: the values
+        report one dtype while the coord reports another, and anything
+        which promotes against them, such as concatenation, takes the
+        wrong one.
+        """
+        dtype = np.dtype(f"{kind}[{unit}]")
+        coord = CoordPartial(shape=(3,), dtype=dtype)
+        assert coord.values.dtype == dtype
+
     def test_set_units_positionally(self, basic_non_coord):
         """Units are set the same way as on any other coord."""
         out = basic_non_coord.set_units("m")

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -21,7 +21,6 @@ from dascore.exceptions import MissingOptionalDependencyError, ParameterError
 from dascore.utils.misc import (
     _callable_name,
     _get_install_name,
-    _get_nullish,
     _iter_filesystem,
     _locked,
     _spool_map,
@@ -1257,42 +1256,3 @@ class TestIsStrictlyMonotonic:
         """Values which cannot be ordered are not monotonic."""
         values = np.array([{"a": 1}, {"b": 2}], dtype=object)
         assert not is_strictly_monotonic(values)
-
-
-class TestGetNullish:
-    """Tests for the value which stands in for a missing entry."""
-
-    @pytest.mark.parametrize("dtype", ["float64", "float32", "int64", "bool"])
-    def test_non_time_is_nan(self, dtype):
-        """Everything without a NaT of its own gets NaN."""
-        assert np.isnan(_get_nullish(np.dtype(dtype)))
-
-    def test_default_is_nan(self):
-        """The default covers the plain floating case."""
-        assert np.isnan(_get_nullish())
-
-    @pytest.mark.parametrize("unit", ["ns", "us", "ms", "s"])
-    @pytest.mark.parametrize("kind", ["datetime64", "timedelta64"])
-    def test_time_like_keeps_its_resolution(self, kind, unit):
-        """
-        NaT comes back at the dtype's own resolution.
-
-        A fixed resolution would mean a datetime64[s] array gets a
-        nanosecond NaT cast into it on every fill.
-        """
-        dtype = np.dtype(f"{kind}[{unit}]")
-        null = _get_nullish(dtype)
-        assert np.isnat(null)
-        assert np.array(null).dtype == dtype
-
-    @pytest.mark.parametrize("kind", [np.datetime64, np.timedelta64])
-    def test_abstract_time_type(self, kind):
-        """An unparameterized time type still yields NaT."""
-        assert np.isnat(_get_nullish(kind))
-
-    def test_fills_an_array_of_its_dtype(self):
-        """The value can stand in for a missing entry without casting."""
-        dtype = np.dtype("datetime64[us]")
-        array = np.full(3, _get_nullish(dtype), dtype=dtype)
-        assert array.dtype == dtype
-        assert np.isnat(array).all()

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -21,6 +21,7 @@ from dascore.exceptions import MissingOptionalDependencyError, ParameterError
 from dascore.utils.misc import (
     _callable_name,
     _get_install_name,
+    _get_nullish,
     _iter_filesystem,
     _locked,
     _spool_map,
@@ -1256,3 +1257,42 @@ class TestIsStrictlyMonotonic:
         """Values which cannot be ordered are not monotonic."""
         values = np.array([{"a": 1}, {"b": 2}], dtype=object)
         assert not is_strictly_monotonic(values)
+
+
+class TestGetNullish:
+    """Tests for the value which stands in for a missing entry."""
+
+    @pytest.mark.parametrize("dtype", ["float64", "float32", "int64", "bool"])
+    def test_non_time_is_nan(self, dtype):
+        """Everything without a NaT of its own gets NaN."""
+        assert np.isnan(_get_nullish(np.dtype(dtype)))
+
+    def test_default_is_nan(self):
+        """The default covers the plain floating case."""
+        assert np.isnan(_get_nullish())
+
+    @pytest.mark.parametrize("unit", ["ns", "us", "ms", "s"])
+    @pytest.mark.parametrize("kind", ["datetime64", "timedelta64"])
+    def test_time_like_keeps_its_resolution(self, kind, unit):
+        """
+        NaT comes back at the dtype's own resolution.
+
+        A fixed resolution would mean a datetime64[s] array gets a
+        nanosecond NaT cast into it on every fill.
+        """
+        dtype = np.dtype(f"{kind}[{unit}]")
+        null = _get_nullish(dtype)
+        assert np.isnat(null)
+        assert np.array(null).dtype == dtype
+
+    @pytest.mark.parametrize("kind", [np.datetime64, np.timedelta64])
+    def test_abstract_time_type(self, kind):
+        """An unparameterized time type still yields NaT."""
+        assert np.isnat(_get_nullish(kind))
+
+    def test_fills_an_array_of_its_dtype(self):
+        """The value can stand in for a missing entry without casting."""
+        dtype = np.dtype("datetime64[us]")
+        array = np.full(3, _get_nullish(dtype), dtype=dtype)
+        assert array.dtype == dtype
+        assert np.isnat(array).all()

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -999,6 +999,26 @@ class TestConcatenate:
         assert pa_concat.shape[-1] == len(sp)
         assert "time_min" in pa_concat.dims
 
+    @pytest.mark.parametrize("unit", ["us", "ms"])
+    def test_blank_coord_keeps_the_others_resolution(self, unit):
+        """
+        Joining across a patch which states no values holds resolution.
+
+        The blank patch contributes the null that stands in for its
+        missing values; if that null is of a fixed resolution it wins the
+        dtype promotion and quietly rewrites the coordinate.
+        """
+        time = np.arange(4).astype(f"datetime64[{unit}]")
+        patch = dc.Patch(
+            data=np.random.default_rng(0).random((4, 3)),
+            coords={"time": time, "distance": np.arange(3)},
+            dims=("time", "distance"),
+        )
+        blank = patch.max("time")
+        with suppress_warnings(UserWarning):
+            out = dc.spool([blank, patch]).concatenate(time=None)[0]
+        assert out.get_coord("time").dtype == time.dtype
+
 
 class TestStackPatches:
     """Tests for stacking (adding) spool content."""


### PR DESCRIPTION
## Description

Three places in the tree built the value that stands for a missing entry, and they did not agree.

`_get_nullish` in `dascore/utils/misc.py` always spelled NaT in nanoseconds:

```python
return np.datetime64("NaT", "ns")
```

while `_joinable` in `dascore/utils/patch.py` cast NaT to whatever it was about to fill:

```python
null = np.array("NaT").astype(target)
```

and `_reduce_time_like` in `dascore/core/coords.py` built its own from scratch, again at a fixed nanosecond resolution.

The concat helper is the one that is right. Deduplicating toward the shared helper as it stood would have been a regression: a `datetime64[us]` array would get a nanosecond NaT cast into it on every fill. So this makes the shared helper take the resolution of the dtype it is asked about, then points the two hand-built copies at it.

```python
def _get_nullish(dtype=np.floating):
    if np.issubdtype(dtype, np.datetime64) or np.issubdtype(dtype, np.timedelta64):
        return np.array("NaT").astype(dtype)[()]
    return np.nan
```

`[()]` keeps the return a scalar, as before, rather than a zero dimensional array.

### This fixes two live bugs, not just a latent trap

I first wrote this up as pure deduplication on the grounds that every time coordinate in the tree is nanosecond resolution. That was wrong: `get_coord` keeps the resolution it is given, so a `datetime64[us]` coordinate survives into a patch, and both callers of the fixed-resolution null misbehave for it on `dev`.

```python
time = np.arange(4).astype("datetime64[us]")
patch = dc.Patch(
    data=np.random.default_rng(0).random((4, 3)),
    coords={"time": time, "distance": np.arange(3)},
    dims=("time", "distance"),
)

coord = patch.max("time").get_coord("time")
coord.dtype         # datetime64[us]
coord.values.dtype  # datetime64[ns]  <- on dev
```

`CoordPartial.values` broadcasts the null, so a fixed resolution leaks straight out of the coordinate. That leak then wins the dtype promotion in `_joinable`, which rewrites the coordinate outright:

```python
blank = patch.max("time")
dc.spool([blank, patch]).concatenate(time=None)[0].get_coord("time").dtype
# datetime64[ns] on dev, datetime64[us] with this change
```

Concatenating across a patch which states no values silently changes the resolution of everyone else's time coordinate. That is the one worth having.

`is_datetime64` stays imported in `coords.py`; it has other callers there.

### Tests

At the two boundaries where the null escapes, rather than on the helper itself: `TestPartialCoord.test_values_keep_the_declared_resolution` and `TestConcatenate.test_blank_coord_keeps_the_others_resolution`, each parametrized over `us`/`ms`/`s` and both time-like kinds. Eight of those cases fail on `dev` and pass here.

An earlier revision tested `_get_nullish` directly. Those tests would have stayed green if either caller stopped using the helper, which is the thing this PR is for, so they are gone.

## Changelog

- fixed: a non-nanosecond `datetime64` or `timedelta64` coordinate keeps its resolution through aggregation and concatenation, where it was previously rewritten to nanoseconds.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of blank and null time values across coordinate and patch operations.
  - Preserved datetime and timedelta precision at microsecond, millisecond, and second resolutions.
  - Fixed patch concatenation so populated time coordinates retain their original resolution when combined with blank coordinates.
  - Improved compatibility for null values across different data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->