### PR TITLE
Draw coordinates in columns where there are columns

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -73,7 +73,13 @@ from dascore.models import (
     frozen_dict_validator,
 )
 from dascore.utils.array_api import array_namespace
-from dascore.utils.display import RichRepr
+from dascore.utils.display import (
+    RichRepr,
+    Row,
+    Section,
+    Table,
+    render_text,
+)
 from dascore.utils.docs import compose_docstring
 from dascore.utils.mapping import FrozenDict
 from dascore.utils.misc import (
@@ -158,6 +164,13 @@ def _get_indexers_and_new_coords_dict(
         _indirect_coord_updates(cm, dim_name, coord_name, reductions, new_coords)
     indexers = tuple(dim_reductions[x] for x in cm.dims)
     return new_coords, indexers
+
+
+# Fields a table lines up on the right, where a reader compares them
+# down the column. Not all of them read as numbers -- a shape is a
+# tuple and a time is an instant -- but all of them are read by their
+# last characters rather than their first.
+_COORD_NUMERIC = frozenset({"min", "max", "step", "shape"})
 
 
 class CoordManager(RichRepr, DascoreBaseModel):
@@ -717,8 +730,24 @@ class CoordManager(RichRepr, DascoreBaseModel):
             msg = f"Cannot use {kwargs} for query; some coords share a dimension."
             raise CoordError(msg)
 
+    def _repr_section(self) -> Section:
+        """
+        The coordinates block: its title, and the table under it.
+
+        The same rows the text renders on their own lines, so a panel
+        draws them in columns without either medium re-deriving what a
+        coordinate says.
+        """
+        header, table = self._repr_parts()
+        return Section(header, (table,))
+
     def __rich__(self) -> Text:
         """Rich formatting for the coordinate manager."""
+        header, table = self._repr_parts()
+        return header + render_text(table)
+
+    def _repr_parts(self) -> tuple[Text, Table]:
+        """The block's title, and the rows under it."""
         dc_blue = dascore_styles["dc_blue"]
         header_text = Text("➤ ") + Text("Coordinates", style=dc_blue) + Text(" (")
         lens = {x: self.coord_map[x].shape[0] for x in self.dims}
@@ -730,23 +759,25 @@ class CoordManager(RichRepr, DascoreBaseModel):
                 for x in self.dims
             ]
         )
-        out = [header_text, dim_texts, ")"]
-        # sort coords by dims, coords
         non_dim_coords = sorted(set(self.coord_map) - set(self.dims))
-        names = list(self.dims) + non_dim_coords
+        names = [x for x in list(self.dims) + non_dim_coords if not x.startswith("_")]
+        rows = []
         for name in names:
-            # skip private coords for display
-            if name.startswith("_"):
-                continue
             coord = self.coord_map[name]
-            coord_dims = self.dim_map[name]
             if name in self.dims:
-                base = Text.assemble("\n    *", Text(name, style="bold"), ": ")
+                stated = Text("*") + Text(name, style="bold")
             else:
-                base = Text(f"\n    {name} {coord_dims}: ")
-            text = Text.assemble(base, coord.__rich__())
-            out.append(text)
-        return Text.assemble(*out)
+                stated = Text(f"{name} {self.dim_map[name]}")
+            rows.append(
+                Row(
+                    name=stated,
+                    kind=Text(type(coord).__name__, style=coord._rich_style),
+                    fields=coord._repr_fields(),
+                )
+            )
+        return Text.assemble(header_text, dim_texts, ")"), Table(
+            tuple(rows), numeric=_COORD_NUMERIC
+        )
 
     def get_axis(self: Self, dim: str) -> int:
         """

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -611,35 +611,53 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         """Total number of elements."""
         return self.shape[0]
 
+    def _repr_fields(self) -> tuple[tuple[str, Text, bool], ...]:
+        """
+        The facts this coordinate states, in the order it states them.
+
+        One source for the line a terminal prints and the row a panel
+        draws, so the two cannot come to hold different facts. A field
+        the coordinate has nothing to say for is left out rather than
+        stated blank.
+
+        This is the hook a subclass states extra facts through. A
+        manager builds its rows from these rather than from each
+        coordinate's rendered line, so facts added by overriding
+        ``__rich__`` alone would show on the coordinate and nowhere it
+        is held.
+        """
+        fields: list[tuple[str, Text, bool]] = []
+        if not pd.isnull(self.min()):
+            fields.append(("min", get_nice_text(self.min()), True))
+        if not pd.isnull(self.max()):
+            fields.append(("max", get_nice_text(self.max()), True))
+        # Only a time. Two instants say nothing about how far apart they
+        # are; a distance from 0 to 299 m already says 299 m.
+        if dtype_time_like(self.dtype) and not pd.isnull(self.min()):
+            if (span := duration_text(self.min(), self.max())) is not None:
+                # The brackets say what it is, so a line does not
+                # need the label a column heading gives it.
+                fields.append(("span", span, False))
+        if not pd.isnull(self.step):
+            step = get_nice_text(self.step)
+            if (rate := rate_text(self.step)) is not None:
+                step = step + rate
+            fields.append(("step", step, True))
+        fields.append(("shape", get_nice_text(self.shape), True))
+        fields.append(("dtype", get_nice_text(self.dtype), True))
+        if self.units is not None:
+            unit_str = get_quantity_str(self.units)
+            fields.append(("units", get_nice_text(unit_str, style="units"), True))
+        return tuple(fields)
+
     def __rich__(self):
         key_style = dascore_styles["keys"]
         base = Text("")
         base += Text(self.__class__.__name__, style=self._rich_style)
         base += Text("(")
-        if not pd.isnull(self.min()):
-            base += Text(" min: ", key_style)
-            base += get_nice_text(self.min())
-        if not pd.isnull(self.max()):
-            base += Text(" max: ", key_style)
-            base += get_nice_text(self.max())
-        # Only a time. Two instants say nothing about how far apart they
-        # are; a distance from 0 to 299 m already says 299 m.
-        if dtype_time_like(self.dtype) and not pd.isnull(self.min()):
-            if (span := duration_text(self.min(), self.max())) is not None:
-                base += Text(" ") + span
-        if not pd.isnull(self.step):
-            base += Text(" step: ", key_style)
-            base += get_nice_text(self.step)
-            if (rate := rate_text(self.step)) is not None:
-                base += rate
-        base += Text(" shape: ", key_style)
-        base += get_nice_text(self.shape)
-        base += Text(" dtype: ", key_style)
-        base += get_nice_text(self.dtype)
-        if self.units is not None:
-            base += Text(" units: ", key_style)
-            unit_str = get_quantity_str(self.units)
-            base += get_nice_text(unit_str, style="units")
+        for label, value, labelled in self._repr_fields():
+            base += Text(f" {label}: ", key_style) if labelled else Text(" ")
+            base += value
         base += Text(" )")
         return base
 

--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -216,7 +216,7 @@ class Patch(NodeRepr, NamespaceOwner):
         return Repr(
             header=get_header_text("Patch ⚡"),
             body=(
-                split_block(self.coords.__rich__()),
+                self.coords._repr_section(),
                 split_block(
                     array_to_text(self.data, units=attrs.get("data_units")),
                 ),

--- a/dascore/repr.css
+++ b/dascore/repr.css
@@ -153,6 +153,44 @@ line would push the whole page sideways rather than just this block. */
   max-width: 100%;
 }
 
+/* A section of records, drawn in columns rather than on a line each.
+Every rule here is a reset as much as a style: a table inherits a good
+deal from a docs theme, and a repr should look the same in a notebook. */
+.dc-repr .dc-table {
+  border-collapse: collapse;
+  border: none;
+  margin: 0 0 0.3em 1.1em;
+  width: auto;
+  font-size: 1em;
+  background: none;
+}
+
+.dc-repr .dc-table th,
+.dc-repr .dc-table td {
+  border: none;
+  padding: 0 0.9em 0 0;
+  text-align: left;
+  vertical-align: baseline;
+  white-space: nowrap;
+  font-weight: 400;
+  background: none;
+}
+
+/* The label a column is read by, said once here rather than on every
+row as a terminal has to say it. */
+.dc-repr .dc-table thead th {
+  color: var(--dc-grey50);
+  font-size: 0.9em;
+  padding-bottom: 0.15em;
+  border-bottom: 1px solid var(--dc-rule);
+}
+
+.dc-repr .dc-table tbody th { font-weight: 600; }
+
+/* Numbers line up on the right, where a reader compares them down the
+column; `tabular-nums` on the panel keeps the digits the same width. */
+.dc-repr .dc-table td.dc-num { text-align: right; padding-right: 1.1em; }
+
 /* Print renders a closed `details` closed, so open them all: paper has
 no disclosure triangle to click. */
 @media print {

--- a/dascore/repr.css
+++ b/dascore/repr.css
@@ -156,18 +156,43 @@ line would push the whole page sideways rather than just this block. */
 /* A section of records, drawn in columns rather than on a line each.
 Every rule here is a reset as much as a style: a table inherits a good
 deal from a docs theme, and a repr should look the same in a notebook. */
+/* The table scrolls inside its own wrapper: `overflow` does nothing on
+a `display: table`, so a wide coordinates block would otherwise scroll
+the whole panel rather than itself. */
+.dc-repr .dc-scroll {
+  margin: 0 0 0.3em 1.1em;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
 .dc-repr .dc-table {
   border-collapse: collapse;
   border: none;
-  margin: 0 0 0.3em 1.1em;
+  margin: 0;
   width: auto;
+  table-layout: auto;
   font-size: 1em;
+  line-height: inherit;
+  color: inherit;
+  background: none;
+}
+
+/* A notebook stripes and highlights the rows of a table it renders --
+`.jp-RenderedHTMLCommon tbody tr:nth-child(even)` and `tr:hover` -- and
+transparent cells let both paint through. A repr is not a data grid. */
+.dc-repr .dc-table tr,
+.dc-repr .dc-table tbody tr:nth-child(even),
+.dc-repr .dc-table tbody tr:nth-child(odd),
+.dc-repr .dc-table tbody tr:hover {
   background: none;
 }
 
 .dc-repr .dc-table th,
 .dc-repr .dc-table td {
   border: none;
+  line-height: inherit;
+  color: inherit;
+  letter-spacing: normal;
   padding: 0 0.9em 0 0;
   text-align: left;
   vertical-align: baseline;

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import textwrap
 from collections import Counter
-from collections.abc import Callable, Iterable, Mapping, Sized
+from collections.abc import Callable, Iterable, Mapping, Sequence, Sized
 from contextlib import suppress
 from dataclasses import dataclass, field
 from functools import cache, singledispatch
+from graphlib import CycleError, TopologicalSorter
 from html import escape
 from importlib.resources import files
 from itertools import pairwise
@@ -329,25 +330,55 @@ def _html_raw(node: Raw) -> str:
     return f'<pre class="dc-body">{text_to_html(text)}</pre>'
 
 
+def _merge_columns(rows: Sequence[Row]) -> list[str]:
+    """
+    One column order which every row's own order agrees with.
+
+    Rows state different fields -- only a time coordinate has a span,
+    and a coordinate which selected nothing states neither a min nor a
+    max -- so the columns are the union. Sorted rather than merged by
+    hand: what each row states is an ordering constraint on part of the
+    whole, and reading them in as edges is what keeps a field which
+    appears late in one row and early in another from landing where no
+    row puts it.
+
+    Two rows can disagree outright, which is a cycle and has no answer;
+    the order they were first stated in is the one taken then.
+    """
+    graph: dict[str, set[str]] = {}
+    for row in rows:
+        previous = None
+        for label, _, _ in row.fields:
+            graph.setdefault(label, set())
+            if previous is not None:
+                graph[label].add(previous)
+            previous = label
+    first = {label: index for index, label in enumerate(graph)}
+    sorter = TopologicalSorter(graph)
+    try:
+        sorter.prepare()
+    except CycleError:
+        return list(graph)
+    # Taken one at a time, earliest-stated first, so fields which
+    # constrain nothing in each other -- two records sharing none --
+    # stay in the order they were stated rather than interleaving.
+    ready: list[str] = []
+    out: list[str] = []
+    while sorter.is_active():
+        ready.extend(sorter.get_ready())
+        ready.sort(key=first.__getitem__)
+        label = ready.pop(0)
+        out.append(label)
+        sorter.done(label)
+    return out
+
+
 @render_html.register
 def _html_table(node: Table) -> str:
     # Every label any row states, in the order they are first stated, so
     # a row which says nothing for one leaves that cell empty rather
     # than shifting the ones after it.
-    labels: list[str] = []
-    for row in node.rows:
-        # Merged rather than collected first-seen, so each row's own
-        # order survives: a span is a time's alone and belongs between
-        # its max and its step, not after every field a distance
-        # states. A new field goes after the last column placed, or
-        # after the last one this row shares, whichever is later.
-        at = len(labels)
-        for label, _, _ in row.fields:
-            if label in labels:
-                at = labels.index(label) + 1
-                continue
-            labels.insert(at, label)
-            at += 1
+    labels = _merge_columns(node.rows)
     # What each record is, which a terminal states in front of its
     # fields. A column of its own here rather than nothing at all.
     head = "<th>kind</th>" + "".join(

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -101,6 +101,45 @@ class Raw:
 
 
 @dataclass(frozen=True, slots=True)
+class Row:
+    """
+    One record, as the cells a table draws it in.
+
+    The name is what the row is called; the fields are what it states,
+    each one already rendered. A field a record has nothing to say for
+    is absent rather than blank, so two rows need not state the same
+    ones.
+
+    Every field has a label, which is the column it belongs in, and
+    says whether it wants that label printed as well. A value which
+    already says what it is -- a span, in brackets -- does not, since a
+    line has no heading to say it and a column does.
+    """
+
+    name: Text
+    kind: Text
+    fields: tuple[tuple[str, Text, bool], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class Table:
+    """
+    Records of one sort, drawn together.
+
+    They need not state the same fields -- only a time coordinate has a
+    span -- so a column exists for every field any row states and a row
+    with nothing for one leaves it empty.
+
+    A terminal draws each record on its own line, which is what keeps
+    `str()` unchanged; a panel draws them in columns, where each label
+    is a heading said once.
+    """
+
+    rows: tuple[Row, ...] = ()
+    numeric: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True, slots=True)
 class Section:
     """
     A titled block: the line which names it, and what sits under it.
@@ -109,7 +148,7 @@ class Section:
     """
 
     title: Text
-    body: tuple[Raw, ...] = ()
+    body: tuple[Raw | Table, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -132,6 +171,24 @@ def _render_raw(node: Raw) -> Text:
     # A copy, not the node's own Text: a caller which appends to what it
     # rendered would otherwise rewrite the node it just read.
     return node.text.copy()
+
+
+@render_text.register
+def _render_row(node: Row) -> Text:
+    key_style = dascore_styles["keys"]
+    out = Text("\n    ") + node.name + Text(": ") + node.kind + Text("(")
+    for label, value, labelled in node.fields:
+        out += Text(f" {label}: ", key_style) if labelled else Text(" ")
+        out += value
+    return out + Text(" )")
+
+
+@render_text.register
+def _render_table(node: Table) -> Text:
+    # Joined on nothing: a row states the newline which puts it on its
+    # own line, the same way a section body carries the one which
+    # separated it from its title.
+    return Text("").join(render_text(x) for x in node.rows)
 
 
 @render_text.register
@@ -273,19 +330,66 @@ def _html_raw(node: Raw) -> str:
 
 
 @render_html.register
+def _html_table(node: Table) -> str:
+    # Every label any row states, in the order they are first stated, so
+    # a row which says nothing for one leaves that cell empty rather
+    # than shifting the ones after it.
+    labels: list[str] = []
+    for row in node.rows:
+        # Merged rather than collected first-seen, so each row's own
+        # order survives: a span is a time's alone and belongs between
+        # its max and its step, not after every field a distance
+        # states. A new field goes after the last column placed, or
+        # after the last one this row shares, whichever is later.
+        at = len(labels)
+        for label, _, _ in row.fields:
+            if label in labels:
+                at = labels.index(label) + 1
+                continue
+            labels.insert(at, label)
+            at += 1
+    # What each record is, which a terminal states in front of its
+    # fields. A column of its own here rather than nothing at all.
+    head = "<th>kind</th>" + "".join(
+        f"<th>{escape(x, quote=False)}</th>" for x in labels
+    )
+    body = []
+    for row in node.rows:
+        stated = {label: value for label, value, _ in row.fields}
+        name = text_to_html(row.name)
+        cells = [f"<td>{text_to_html(row.kind)}</td>"]
+        for label in labels:
+            css = ' class="dc-num"' if label in node.numeric else ""
+            value = stated.get(label)
+            cells.append(f"<td{css}>{text_to_html(value) if value else ''}</td>")
+        body.append(f'<tr><th scope="row">{name}</th>{"".join(cells)}</tr>')
+    return (
+        f'<table class="dc-table"><thead><tr><th></th>{head}</tr></thead>'
+        f"<tbody>{''.join(body)}</tbody></table>"
+    )
+
+
+@render_html.register
 def _html_section(node: Section) -> str:
     title = node.title
     if title.plain.startswith(_SECTION_MARKER):
         title = title[len(_SECTION_MARKER) :]
     title = text_to_html(title)
-    if not any(_body_text(x.text).plain for x in node.body):
+    if not any(
+        x.rows if isinstance(x, Table) else _body_text(x.text).plain for x in node.body
+    ):
         # Nothing to fold, so nothing to offer folding. A block whose
         # body is only the newline which separated it has none.
         return f'<div class="dc-line">{title}</div>'
     # Counted on what is drawn, not on what was handed over: the body
     # loses the newline which separated it and any it ends on, and a
     # block counted before that folds one line early.
-    lines = sum(_body_text(x.text).plain.count("\n") + 1 for x in node.body)
+    lines = sum(
+        len(x.rows)
+        if isinstance(x, Table)
+        else _body_text(x.text).plain.count("\n") + 1
+        for x in node.body
+    )
     state = " open" if lines <= get_config().display_html_open_lines else ""
     body = "".join(render_html(x) for x in node.body)
     return f"<details{state}><summary>{title}</summary>{body}</details>"

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -395,8 +395,9 @@ def _html_table(node: Table) -> str:
             cells.append(f"<td{css}>{text_to_html(value) if value else ''}</td>")
         body.append(f'<tr><th scope="row">{name}</th>{"".join(cells)}</tr>')
     return (
-        f'<table class="dc-table"><thead><tr><th></th>{head}</tr></thead>'
-        f"<tbody>{''.join(body)}</tbody></table>"
+        f'<div class="dc-scroll"><table class="dc-table">'
+        f"<thead><tr><th></th>{head}</tr></thead>"
+        f"<tbody>{''.join(body)}</tbody></table></div>"
     )
 
 
@@ -416,7 +417,9 @@ def _html_section(node: Section) -> str:
     # loses the newline which separated it and any it ends on, and a
     # block counted before that folds one line early.
     lines = sum(
-        len(x.rows)
+        # Its heading row is a line a reader sees, so a table of two
+        # records draws three.
+        len(x.rows) + 1
         if isinstance(x, Table)
         else _body_text(x.text).plain.count("\n") + 1
         for x in node.body

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -29,7 +29,9 @@ from dascore.utils.display import (
     _STYLE_WORDS,
     Raw,
     Repr,
+    Row,
     Section,
+    Table,
     _storage_quantum,
     array_to_text,
     attrs_to_text,
@@ -1312,6 +1314,59 @@ class TestBodyText:
         assert ">a\n\nb<" in html
 
 
+class TestTableColumns:
+    """Tests for which column a value is drawn in."""
+
+    @staticmethod
+    def _columns(rows):
+        """The headings a table of these rows draws."""
+        made = tuple(
+            Row(Text(name), Text("K"), tuple((x, Text(x), True) for x in fields))
+            for name, fields in rows
+        )
+        return re.findall(r"<th>(\w+)</th>", render_html(Table(made)))
+
+    def test_rows_which_state_the_same_fields(self):
+        """The order one row states them in is the order they are in."""
+        assert self._columns([("a", "xy"), ("b", "xy")]) == ["kind", "x", "y"]
+
+    def test_a_field_only_one_row_states(self):
+        """
+        It belongs where the row stating it puts it.
+
+        Only a time coordinate has a span, and it states it between its
+        max and its step rather than after everything a distance says.
+        """
+        assert self._columns([("a", "xz"), ("b", "xyz")]) == ["kind", "x", "y", "z"]
+
+    def test_rows_which_share_no_fields(self):
+        """
+        A record sharing nothing with the ones before it adds its fields
+        after theirs, not in front of them.
+        """
+        assert self._columns([("a", "ab"), ("b", "cd")]) == ["kind", "a", "b", "c", "d"]
+
+    def test_a_value_is_drawn_in_its_own_column(self):
+        """
+        Every row states a cell for every column, so a row which says
+        nothing for one leaves it empty rather than shifting the rest.
+        """
+        rows = (
+            Row(Text("first"), Text("K"), (("x", Text("1"), True),)),
+            Row(
+                Text("second"),
+                Text("K"),
+                (("x", Text("2"), True), ("y", Text("3"), True)),
+            ),
+        )
+        html = render_html(Table(rows))
+        heads = re.findall(r"<th>(\w+)</th>", html)
+        for row in re.findall(r"<tr><th scope=\"row\">.*?</tr>", html, re.DOTALL):
+            assert len(re.findall(r"<td[^>]*>", row)) == len(heads)
+        body = re.search(r"<tbody>(.*)</tbody>", html, re.DOTALL).group(1)
+        assert "<td>1</td><td></td>" in body
+
+
 class TestStylesheet:
     """Tests for the CSS every repr carries."""
 
@@ -1362,7 +1417,13 @@ class TestStylesheet:
             texts = [obj._repr_node().header]
             for section in obj._repr_node().body:
                 texts.append(section.title)
-                texts.extend(x.text for x in section.body)
+                for part in section.body:
+                    if isinstance(part, Table):
+                        for row in part.rows:
+                            texts.extend([row.name, row.kind])
+                            texts.extend(v for _, v, _ in row.fields)
+                    else:
+                        texts.append(part.text)
             for text in texts:
                 for offset in range(len(text.plain)):
                     style = text.get_style_at_offset(console, offset)
@@ -1421,29 +1482,83 @@ class TestStylesheet:
         assert get_stylesheet() is get_stylesheet()
 
 
-def _drawn_lines(html: str) -> list[str]:
+def _decompose(line: str) -> list[str]:
     """
-    The lines a reader sees in a panel, in the order they are drawn.
+    A stated line as the values in it, without the framing.
+
+    Labels, class names and punctuation are how a printed line says
+    which value is which; a table says that with a column heading, so
+    both sides are read this way and compared on what they state.
+    """
+    said = line.strip().removeprefix("\u27a4 ")
+    if not said or set(said) == {"-"}:
+        return []
+    record = re.match(r"(\S+): (\w+)\((.*) \)$", said)
+    if record is None:
+        return [said]
+    name, kind, fields = record.groups()
+    out = [name, kind]
+    for value in re.split(r"\s\w+: ", " " + fields):
+        value = value.strip()
+        if not value:
+            continue
+        # A span states itself in brackets rather than by a label, so a
+        # label does not split it off; a column heading says which
+        # column it is in and the panel gives it a cell of its own.
+        span = re.search(r"\s(<[^>]*>)$", value)
+        if span:
+            out.extend([value[: span.start()].strip(), span.group(1)])
+        else:
+            out.append(value)
+    return out
+
+
+def _drawn_values(html: str) -> list[str]:
+    """
+    What a reader sees in a panel, in the order it is drawn.
 
     Taken block by block rather than by stripping every tag, since the
-    tags inside one are spans which color part of a line and stripping
-    them into newlines would make a line out of each.
+    tags inside one are spans coloring part of a line and stripping them
+    into newlines would make a line out of each.
     """
-    blocks = re.findall(
-        r'<div class="dc-banner">(.*?)</div>'
-        r"|<summary>(.*?)</summary>"
-        r'|<pre class="dc-body">(.*?)</pre>'
-        r'|<div class="dc-line">(.*?)</div>',
+    out: list[str] = []
+    for block in re.finditer(
+        r'<div class="dc-banner">(?P<banner>.*?)</div>'
+        r"|<summary>(?P<summary>.*?)</summary>"
+        r'|<pre class="dc-body">(?P<pre>.*?)</pre>'
+        r'|<div class="dc-line">(?P<line>.*?)</div>'
+        r'|<table class="dc-table">(?P<table>.*?)</table>',
         html,
         re.DOTALL,
-    )
-    out = []
-    for block in blocks:
-        content = next(x for x in block if (x is not None and x != "") or x == "")
-        content = "".join(x for x in block if x)
-        for line in unescape(re.sub(r"<[^>]+>", "", content)).split("\n"):
-            if line.strip():
-                out.append(line.strip())
+    ):
+        [(kind, content)] = [
+            (k, v) for k, v in block.groupdict().items() if v is not None
+        ]
+        if kind == "table":
+            # Already one value per cell, which is what a table is for.
+            for row in re.findall(r"<tr>(.*?)</tr>", content, re.DOTALL):
+                cells = [
+                    _bare(x)
+                    for x in re.findall(r"<t[dh][^>]*>(.*?)</t[dh]>", row, re.DOTALL)
+                ]
+                if cells and cells[0]:
+                    out.extend(x for x in cells if x)
+            continue
+        for line in _bare(content).split("\n"):
+            out.extend(_decompose(line))
+    return out
+
+
+def _bare(html: str) -> str:
+    """The text of an HTML fragment, with its tags and entities read back."""
+    return unescape(re.sub(r"<[^>]+>", "", html)).strip()
+
+
+def _said_values(text: str) -> list[str]:
+    """What a printed repr states, read the same way the panel is."""
+    out: list[str] = []
+    for line in text.split("\n"):
+        out.extend(_decompose(line))
     return out
 
 
@@ -1545,14 +1660,9 @@ class TestHtmlRepr:
         it draws as a disclosure triangle instead.
         """
         for name, obj in html_objects.items():
-            said = [
-                x.strip().removeprefix("\u27a4 ")
-                for x in str(obj).split("\n")
-                if x.strip() and set(x.strip()) != {"-"}
-            ]
             # As a sequence, so a section drawn twice or drawn out of
             # order is a difference rather than a match.
-            assert _drawn_lines(obj._repr_html_()) == said, name
+            assert _drawn_values(obj._repr_html_()) == _said_values(str(obj)), name
 
     def test_the_stylesheet_stays_small(self):
         """

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -1467,6 +1467,31 @@ class TestTableColumns:
         """
         assert self._columns([("a", "ab"), ("b", "cd")]) == ["kind", "a", "b", "c", "d"]
 
+    def test_a_table_scrolls_inside_its_own_wrapper(self):
+        """
+        `overflow` does nothing on a `display: table`, so without a
+        wrapper a wide coordinates block scrolls the whole panel.
+
+        Asserted on the markup rather than on the panel, since the
+        stylesheet names the class too and a search of the whole panel
+        finds it whether or not anything is wrapped in it.
+        """
+        markup = dc.get_example_patch()._repr_html_().split("</style>", 1)[1]
+        assert '<div class="dc-scroll"><table' in markup
+
+    def test_the_heading_counts_as_a_line(self):
+        """
+        A table of two records draws three lines.
+
+        The limit is what a reader would count, and they count the
+        headings.
+        """
+        section = dc.get_example_patch().coords._repr_section()
+        with config_context(display_html_open_lines=2):
+            assert "<details open>" not in render_html(section)
+        with config_context(display_html_open_lines=3):
+            assert "<details open>" in render_html(section)
+
     def test_a_value_is_drawn_in_its_own_column(self):
         """
         Every row states a cell for every column, so a row which says

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -1314,6 +1314,97 @@ class TestBodyText:
         assert ">a\n\nb<" in html
 
 
+class TestCoordinatesAreStated:
+    """
+    Tests for what the coordinates block says, rather than for the two
+    renderings of it agreeing.
+
+    Parity is a relative claim: it holds just as well when both reprs
+    say nothing. Deleting every coordinate from the block left it
+    passing, so these say what has to be there.
+    """
+
+    @pytest.fixture(scope="class")
+    def patch(self):
+        """A patch with a dimension coordinate and one riding on it."""
+        return dc.get_example_patch().update_coords(quality=("distance", np.ones(300)))
+
+    def test_the_text_states_every_coordinate(self, patch):
+        """A block which names none of them is not a coordinates block."""
+        rendered = str(patch.coords)
+        for name in ("distance", "time", "quality"):
+            assert name in rendered, name
+
+    def test_the_panel_states_every_coordinate(self, patch):
+        """The same, drawn."""
+        html = patch._repr_html_()
+        for name in ("distance", "time", "quality"):
+            assert name in html, name
+
+    def test_a_dimension_is_marked(self, patch):
+        """
+        The `*` is how a reader tells a dimension from a coordinate
+        which merely rides on one.
+        """
+        assert "*distance" in str(patch.coords)
+        assert "*<span" in patch._repr_html_()
+
+    def test_a_coordinate_which_is_not_a_dimension_states_its_dims(self, patch):
+        """Which axis it lies along is the thing it has to say."""
+        assert "quality ('distance',)" in str(patch.coords)
+
+    def test_a_private_coordinate_is_not_shown(self):
+        """
+        A name starting with an underscore is the manager's business.
+
+        Left in, every patch would print the coordinates it keeps for
+        bookkeeping beside the ones a reader asked for.
+        """
+        patch = dc.get_example_patch()
+        coords = patch.coords.update(_hidden=("distance", np.ones(300)))
+        assert "_hidden" not in str(coords)
+        assert "_hidden" not in render_html(coords._repr_section())
+
+    @pytest.mark.parametrize(
+        ("label", "value"),
+        [
+            ("min", "0"),
+            ("max", "299"),
+            ("step", "1"),
+            ("shape", "(300,)"),
+            ("dtype", "int64"),
+            ("units", "m"),
+        ],
+    )
+    def test_the_facts_a_coordinate_states(self, patch, label, value):
+        """
+        Both the label and the value, in both renderings.
+
+        Stripped from both sides by the parity check -- it compares what
+        is said, not what it is called -- so renaming a label passed.
+        """
+        assert f"{label}: " in str(patch.coords)
+        assert f"<th>{label}</th>" in patch._repr_html_()
+        assert value in str(patch.coords)
+
+    def test_the_kind_of_each_coordinate(self, patch):
+        """A terminal states it in front of the fields; a panel columns it."""
+        assert "CoordRange(" in str(patch.coords)
+        assert "CoordRange" in patch._repr_html_()
+
+    def test_a_name_which_looks_like_markup(self):
+        """
+        A coordinate name is a value someone else chose, and it is the
+        one cell of the new markup a file can fill.
+        """
+        patch = dc.get_example_patch().update_coords(
+            **{"<script>": ("distance", np.ones(300))}
+        )
+        html = patch._repr_html_()
+        assert "<script>" not in html.replace("<script>alert", "X")
+        assert "&lt;script&gt;" in html
+
+
 class TestTableColumns:
     """Tests for which column a value is drawn in."""
 
@@ -1338,6 +1429,32 @@ class TestTableColumns:
         max and its step rather than after everything a distance says.
         """
         assert self._columns([("a", "xz"), ("b", "xyz")]) == ["kind", "x", "y", "z"]
+
+    def test_a_row_which_states_part_of_what_a_later_row_does(self):
+        """
+        A record stating a subset which is not a prefix.
+
+        Selecting nothing leaves a coordinate with only a shape and a
+        dtype, and merging by index put the units of the row after it
+        between them -- an order no row states.
+        """
+        assert self._columns([("a", "cd"), ("b", "abcde")]) == [
+            "kind",
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+        ]
+
+    def test_rows_which_state_fields_in_conflicting_orders(self):
+        """
+        Two records can disagree outright, which has no answer.
+
+        The order they were first stated in is taken, rather than
+        raising out of the middle of a repr.
+        """
+        assert self._columns([("a", "ab"), ("b", "ba")]) == ["kind", "a", "b"]
 
     def test_rows_which_share_no_fields(self):
         """
@@ -1493,7 +1610,9 @@ def _decompose(line: str) -> list[str]:
     said = line.strip().removeprefix("\u27a4 ")
     if not said or set(said) == {"-"}:
         return []
-    record = re.match(r"(\S+): (\w+)\((.*) \)$", said)
+    # The name may hold a space: a coordinate which is not a dimension
+    # states the dimensions it rides on, as `quality ('distance',)`.
+    record = re.match(r"(.+?): (\w+)\((.*) \)$", said)
     if record is None:
         return [said]
     name, kind, fields = record.groups()
@@ -1577,6 +1696,15 @@ class TestHtmlRepr:
             "patch": dc.get_example_patch(),
             "spool": dc.get_example_spool("diverse_das"),
             "inventory": dc.get_example_inventory("tunnel"),
+            # A coordinate which is not a dimension, whose name carries
+            # the dimensions it rides on.
+            "non_dim": dc.get_example_patch().update_coords(
+                quality=("distance", np.ones(300))
+            ),
+            # A coordinate which selected nothing states only a shape
+            # and a dtype, which is a subset of what the one beside it
+            # states and not a prefix of it.
+            "partial": dc.get_example_patch().select(distance=(1e9, 2e9)),
         }
 
     def test_each_states_a_panel(self, html_objects):
@@ -1669,9 +1797,11 @@ class TestHtmlRepr:
         Every repr carries it, so a notebook carries one copy per cell.
 
         Held on its own rather than on the panel, where growth in one
-        hides growth in the other.
+        hides growth in the other. The ceiling is roughly a quarter
+        above what it holds, so a section's worth of rules trips it
+        rather than a rule or two.
         """
-        assert len(get_stylesheet().encode()) < 6_000
+        assert len(get_stylesheet().encode()) < 8_000
 
     def test_a_panel_is_mostly_the_object(self, html_objects):
         """

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -1372,7 +1372,9 @@ class TestCoordinatesAreStated:
             ("max", "299"),
             ("step", "1"),
             ("shape", "(300,)"),
-            ("dtype", "int64"),
+            # Asked of the coordinate rather than stated: an integer is
+            # 32 bits where the suite runs in WebAssembly and 64 here.
+            ("dtype", None),
             ("units", "m"),
         ],
     )
@@ -1383,6 +1385,8 @@ class TestCoordinatesAreStated:
         Stripped from both sides by the parity check -- it compares what
         is said, not what it is called -- so renaming a label passed.
         """
+        if value is None:
+            value = str(patch.coords.coord_map["distance"].dtype)
         assert f"{label}: " in str(patch.coords)
         assert f"<th>{label}</th>" in patch._repr_html_()
         assert value in str(patch.coords)


### PR DESCRIPTION
## Description

PR 4 of the repr series (after #1011, #1012, #1014). The coordinates block becomes a real table in the HTML panel. **The printed text is unchanged** — 16/16 byte-identical to `dev` in the differential, and a reviewer independently confirmed it over ~140 objects covering every coordinate class, degenerate/empty/length-1/descending/no-units/no-step/NaT cases, and private and non-dimensional coordinates.

A coordinate line is the widest thing a patch prints — 143 characters, 43 of them the labels `min:`, `max:`, `step:` and the rest, repeated on every row. A terminal prints them that way and will keep printing them that way; a panel has headings and needs each label once.

So a coordinate states its facts as fields rather than as a line, and the two renderers lay the same fields out the way their medium reads. One source of facts, two layouts — no second formatter to drift.

Every field carries the column it belongs in and whether it wants that label printed as well. A span says what it is with its brackets, so a line does not need `span:` in front of it; a column still needs a heading, and the field says both.

Columns are ordered by reading each row's field order in as ordering constraints and sorting them, stably. A field only some rows state — a span, which only a time has — lands where those rows put it.

### Review

Six blind reviews. The worst finding was not a bug in the table but a hole under it:

**The parity test compares two renderings of one source, so it cannot see a bug in the source.** Deleting every coordinate from the block leaves both reprs saying nothing and the suite green. The same hole swallowed a dropped `dtype`, a dropped `units`, a private coordinate shown, and a dimension's `*` removed. Labels were stripped from both sides before comparing, so renaming `min` to `mim` changed the printed label *and* the column heading together and passed — on a branch whose whole contract is that the printed text does not change. What the block has to say is asserted now, absolutely. Nine previously-surviving mutants fail.

**The column order was wrong twice.** Records sharing no fields interleaved; records where an earlier one states a non-prefix subset — a coordinate which selected nothing states only a shape and a dtype — came out in an order *no record states*, reachable via `patch.select(distance=(1e9, 2e9))`. Hand-rolled index arithmetic twice was enough; it is a topological sort now.

**A notebook would have striped and hover-highlighted every table** — `.jp-RenderedHTMLCommon` paints through transparent cells. **The table had no scroll container**, so a wide coordinates block scrolled the whole panel. **`Row.kind` was optional** but a kindless row rendered as `tag: ( random )` and lost its value in HTML. **The parity helper could not parse a non-dimensional coordinate**, whose name carries the dimensions it rides on, so that whole kind was unverified.

### Verification

Full suite 10121 passed / 114 skipped / 2 xfailed · doctests 211 passed · `pre-commit run --all` clean · differential 16/16 identical to `dev`.

## Changelog

- changed: The coordinates section of the HTML repr draws as a table, with one heading per field instead of the label repeated on every row. The printed repr is unchanged.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured coordinate tables to rich text and HTML displays.
  - Coordinate details now show clearer labels, consistent column ordering, aligned numeric values, and formatted metadata.
  - Added improved table rendering with support for empty cells, headers, and scrollable layouts.
- **Bug Fixes**
  - Improved handling of hidden and non-dimensional coordinates in displayed metadata.
  - Improved HTML escaping and rendering for coordinate information.
- **Style**
  - Updated table styling for clearer headers, row labels, spacing, and numeric alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->