### PR TITLE
Let a repr's tree be a tree

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -730,16 +730,19 @@ class CoordManager(RichRepr, DascoreBaseModel):
             msg = f"Cannot use {kwargs} for query; some coords share a dimension."
             raise CoordError(msg)
 
-    def _repr_section(self) -> Section:
+    def _repr_section(self, depth: int = 0) -> Section:
         """
         The coordinates block: its title, and the table under it.
 
         The same rows the text renders on their own lines, so a panel
         draws them in columns without either medium re-deriving what a
-        coordinate says.
+        coordinate says. ``depth`` is how far into a containment tree
+        the block sits, which is nothing today -- it is stated so that
+        every ``_repr_section`` in the package is one protocol, and a
+        container which came to hold coordinates could nest them.
         """
         header, table = self._repr_parts()
-        return Section(header, (table,))
+        return Section(header, (table,), depth)
 
     def __rich__(self) -> Text:
         """Rich formatting for the coordinate manager."""

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -56,9 +56,9 @@ from dascore.models import (
 from dascore.utils.display import (
     NodeRepr,
     Repr,
+    Section,
+    child_sections,
     get_header_text,
-    indent_text,
-    limit_reprs,
     mapping_to_text,
     model_to_line,
     split_block,
@@ -237,7 +237,7 @@ class CoordinateReferenceSystem(InventoryModel):
             raise InvalidInventoryError(msg)
         return self
 
-    def __rich__(self) -> Text:
+    def _repr_line(self) -> Text:
         """
         One line naming the frame and its axes.
 
@@ -438,7 +438,7 @@ class _IntervalModel(InventoryModel):
             raise InvalidInventoryError(msg)
         return self
 
-    def __rich__(self) -> Text:
+    def _repr_line(self) -> Text:
         """One line stating the interval this item covers."""
         return _distance_line(self)
 
@@ -912,7 +912,7 @@ class DistanceMap(InventoryModel):
             )
             raise InvalidInventoryError(msg)
 
-    def __rich__(self) -> Text:
+    def _repr_line(self) -> Text:
         """
         One line naming the axes mapped and how many points do it.
 
@@ -1327,7 +1327,7 @@ class OpticalPath(TimeRangedModel):
         """
         return tuple(sorted(value, key=lambda x: x.interval))
 
-    def __rich__(self) -> Text:
+    def _repr_line(self) -> Text:
         """One line naming the path, its extent, and its track sizes."""
         return _distance_line(self)
 
@@ -1859,12 +1859,13 @@ class FiberArray(TimeRangedModel):
         default=(), description="Optical paths associated with this fiber array."
     )
 
-    def __rich__(self) -> Text:
-        """The array's own line, then the reprs of what it holds."""
-        base = model_to_line(self, skip=("acquisitions", "optical_paths"))
-        for child in limit_reprs((*self.acquisitions, *self.optical_paths)):
-            base += Text("\n") + indent_text(child)
-        return base
+    def _repr_line(self) -> Text:
+        """One line naming the array, without the things it holds."""
+        return model_to_line(self, skip=("acquisitions", "optical_paths"))
+
+    def _repr_children(self) -> tuple[InventoryModel, ...]:
+        """What an array holds, each of which prints itself."""
+        return (*self.acquisitions, *self.optical_paths)
 
     def check(self) -> Self:
         """
@@ -1919,12 +1920,13 @@ class Network(TimeRangedModel):
         default=(), description="Stations in this network."
     )
 
-    def __rich__(self) -> Text:
-        """The network's own line, then the reprs of what it holds."""
-        base = model_to_line(self, skip=("fiber_arrays", "stations"))
-        for child in limit_reprs((*self.fiber_arrays, *self.stations)):
-            base += Text("\n") + indent_text(child)
-        return base
+    def _repr_line(self) -> Text:
+        """One line naming the network, without the things it holds."""
+        return model_to_line(self, skip=("fiber_arrays", "stations"))
+
+    def _repr_children(self) -> tuple[InventoryModel, ...]:
+        """What a network holds, each of which prints itself."""
+        return (*self.fiber_arrays, *self.stations)
 
     def check(self) -> Self:
         """
@@ -2284,14 +2286,14 @@ class Inventory(NodeRepr, NamespaceOwner, InventoryModel):
         """
         The banner, the network tree, and what the manifest itself states.
 
-        The tree is the networks' own reprs indented into place, so an
-        inventory says nothing about a network the network does not.
+        The tree is a block per network, each holding a block per thing
+        the network holds, so an inventory says nothing about a network
+        the network does not. A terminal draws that as indentation and a
+        panel draws it as nesting, from the one set of blocks.
         """
         header = get_header_text("Inventory 📖")
-        networks = Text("➤ ") + Text("Networks", style=dascore_styles["dc_blue"])
-        networks += Text(f" ({len(self.networks)})")
-        for network in limit_reprs(self.networks):
-            networks += Text("\n") + indent_text(network)
+        title = Text("➤ ") + Text("Networks", style=dascore_styles["dc_blue"])
+        title += Text(f" ({len(self.networks)})")
         # schema_version, resources and the CRS are stated whether or not
         # they are the defaults: an inventory has a version and a frame,
         # and a blank line for either would read as having neither.
@@ -2305,7 +2307,7 @@ class Inventory(NodeRepr, NamespaceOwner, InventoryModel):
         return Repr(
             header=header,
             body=(
-                split_block(networks),
+                Section(title, child_sections(self.networks, 1)),
                 split_block(mapping_to_text(attrs, "Attributes")),
             ),
         )

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -2282,6 +2282,10 @@ class Inventory(NodeRepr, NamespaceOwner, InventoryModel):
         self.__pydantic_fields_set__.update({"resources", "networks"})
         return self
 
+    def _repr_children(self) -> tuple[Network, ...]:
+        """The networks, which are what an inventory's tree is made of."""
+        return self.networks
+
     def _repr_node(self) -> Repr:
         """
         The banner, the network tree, and what the manifest itself states.
@@ -2294,6 +2298,7 @@ class Inventory(NodeRepr, NamespaceOwner, InventoryModel):
         header = get_header_text("Inventory 📖")
         title = Text("➤ ") + Text("Networks", style=dascore_styles["dc_blue"])
         title += Text(f" ({len(self.networks)})")
+        networks = child_sections(self._repr_children(), 1)
         # schema_version, resources and the CRS are stated whether or not
         # they are the defaults: an inventory has a version and a frame,
         # and a blank line for either would read as having neither.
@@ -2307,7 +2312,7 @@ class Inventory(NodeRepr, NamespaceOwner, InventoryModel):
         return Repr(
             header=header,
             body=(
-                Section(title, child_sections(self.networks, 1)),
+                Section(title, networks),
                 split_block(mapping_to_text(attrs, "Attributes")),
             ),
         )

--- a/dascore/models/base.py
+++ b/dascore/models/base.py
@@ -35,7 +35,6 @@ from dascore.utils.display import (
     child_sections,
     model_to_line,
     render_text,
-    section_indent,
 )
 from dascore.utils.misc import _all_null, all_close
 from dascore.utils.time import to_datetime64
@@ -270,13 +269,10 @@ class InventoryModel(RichRepr, DascoreBaseModel):
         The block a repr draws this object in.
 
         ``depth`` is how far into a containment tree it sits, which a
-        terminal shows by indenting and a panel shows by nesting. The
-        indentation is stated in the title, for the same reason a section
-        body carries the newline which separated it from one: rendering
-        has then only to concatenate.
+        terminal shows by indenting and a panel shows by nesting.
         """
-        title = section_indent(depth) + self._repr_line()
-        return Section(title, child_sections(self._repr_children(), depth + 1), depth)
+        children = child_sections(self._repr_children(), depth + 1)
+        return Section(self._repr_line(), children, depth)
 
     def __rich__(self) -> Text:
         """The line naming this object, then whatever it holds."""

--- a/dascore/models/base.py
+++ b/dascore/models/base.py
@@ -29,7 +29,14 @@ from dascore.models.registry import (
     register_model,
 )
 from dascore.models.types import DateTime64, FrozenDictType
-from dascore.utils.display import RichRepr, model_to_line
+from dascore.utils.display import (
+    RichRepr,
+    Section,
+    child_sections,
+    model_to_line,
+    render_text,
+    section_indent,
+)
 from dascore.utils.misc import _all_null, all_close
 from dascore.utils.time import to_datetime64
 
@@ -239,9 +246,41 @@ class InventoryModel(RichRepr, DascoreBaseModel):
         out.update(kwargs)
         return self.__class__(**out)
 
-    def __rich__(self) -> Text:
-        """One line naming the class and what it states."""
+    def _repr_line(self) -> Text:
+        """
+        The one line which names this object and what it states.
+
+        What a container puts on the line it gives this object, and the
+        whole of the repr for one which holds nothing.
+        """
         return model_to_line(self)
+
+    def _repr_children(self) -> tuple[InventoryModel, ...]:
+        """
+        The objects this one holds, each of which prints itself.
+
+        Empty by default: a model whose children are worth a count in its
+        own line rather than a line each says nothing here, which is why
+        a station shows ``channels: 3`` and not three channels.
+        """
+        return ()
+
+    def _repr_section(self, depth: int = 0) -> Section:
+        """
+        The block a repr draws this object in.
+
+        ``depth`` is how far into a containment tree it sits, which a
+        terminal shows by indenting and a panel shows by nesting. The
+        indentation is stated in the title, for the same reason a section
+        body carries the newline which separated it from one: rendering
+        has then only to concatenate.
+        """
+        title = section_indent(depth) + self._repr_line()
+        return Section(title, child_sections(self._repr_children(), depth + 1), depth)
+
+    def __rich__(self) -> Text:
+        """The line naming this object, then whatever it holds."""
+        return render_text(self._repr_section())
 
 
 class TimeRangedModel(InventoryModel):

--- a/dascore/repr.css
+++ b/dascore/repr.css
@@ -120,13 +120,22 @@ panel reads the same in a notebook and on the docs site. */
   display: block;
   list-style: none;
   cursor: pointer;
-  padding: 0.1em 0;
+  /* Room for the triangle, which is pulled back into it below. A line
+  can run to more than one line -- a description usually does -- and
+  given to the triangle alone the rest would start a marker to the left
+  of the first, under the triangle rather than beside it. */
+  padding: 0.1em 0 0.1em 1.1em;
   color: inherit;
   font-size: 1em;
   border-radius: 3px;
   /* A title can carry spaces a producer put there, and HTML would
   collapse runs of them. */
   white-space: pre;
+  /* And it scrolls inside itself, the way every other block here does.
+  A network's line can run to a few hundred characters, and without
+  this one of them pushes the banner and every block below it sideways
+  along with it. */
+  overflow-x: auto;
 }
 
 .dc-repr summary::-webkit-details-marker { display: none; }
@@ -135,6 +144,7 @@ panel reads the same in a notebook and on the docs site. */
   content: "\25B8";
   display: inline-block;
   width: 1.1em;
+  margin-left: -1.1em;
   color: var(--dc-grey50);
 }
 
@@ -170,8 +180,9 @@ custom properties loses nothing a reader needed. */
 }
 
 /* A leaf has no disclosure triangle, so it is given the width of one:
-without it a leaf's text would start where its parent's triangle does
-rather than where its parent's text does, and read as the level above. */
+without it a leaf's text starts where its parent's text starts, a marker
+to the left of where the blocks beside it start, and reads as the level
+above. */
 .dc-repr .dc-line.dc-nest { padding-left: 1.65em; }
 
 .dc-repr .dc-d0 { --dc-rail: var(--dc-d0); }

--- a/dascore/repr.css
+++ b/dascore/repr.css
@@ -21,6 +21,10 @@ each given a value per theme below.
   --dc-cyan: #0e7490;
   --dc-dark_orange: #bc4c00;
   --dc-grey50: #6b7280;
+  --dc-d0: #32709d;
+  --dc-d1: #6d5acb;
+  --dc-d2: #a83ab9;
+  --dc-d3: #9a5c31;
   --dc-rule: color-mix(in oklab, currentcolor 22%, transparent);
   font-family: var(--jp-code-font-family, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: var(--jp-code-font-size, 0.8125rem);
@@ -42,6 +46,10 @@ each given a value per theme below.
     --dc-cyan: #7dcfff;
     --dc-dark_orange: #ffa657;
     --dc-grey50: #9ca3af;
+    --dc-d0: #73abd3;
+    --dc-d1: #a79ce0;
+    --dc-d2: #d08cdb;
+    --dc-d3: #d29870;
   }
 }
 
@@ -58,6 +66,10 @@ body.quarto-light .dc-repr {
   --dc-cyan: #0e7490;
   --dc-dark_orange: #bc4c00;
   --dc-grey50: #6b7280;
+  --dc-d0: #32709d;
+  --dc-d1: #6d5acb;
+  --dc-d2: #a83ab9;
+  --dc-d3: #9a5c31;
 }
 
 body[data-jp-theme-light="false"] .dc-repr,
@@ -71,6 +83,10 @@ body[data-vscode-theme-kind*="dark"] .dc-repr {
   --dc-cyan: #7dcfff;
   --dc-dark_orange: #ffa657;
   --dc-grey50: #9ca3af;
+  --dc-d0: #73abd3;
+  --dc-d1: #a79ce0;
+  --dc-d2: #d08cdb;
+  --dc-d3: #d29870;
 }
 
 .dc-repr .dc-bold { font-weight: 600; }
@@ -137,6 +153,35 @@ states its path indented -- and HTML would collapse them. */
   overflow-x: auto;
 }
 
+
+/* A block which sits inside another. The nesting is the markup here, so
+the indentation a terminal has to write into the text is set instead --
+one step per level, which compounds down the tree on its own.
+
+The rail is what a reader follows back to the thing a line belongs to,
+and its color says which level that is. It is decoration, not
+information: which network an array is under is legible from the nesting
+whether or not the colors resolve, so a printer or a host which drops
+custom properties loses nothing a reader needed. */
+.dc-repr .dc-nest {
+  margin-left: 0.55em;
+  padding-left: 0.55em;
+  border-left: 2px solid color-mix(in oklab, var(--dc-rail) 50%, transparent);
+}
+
+/* A leaf has no disclosure triangle, so it is given the width of one:
+without it a leaf's text would start where its parent's triangle does
+rather than where its parent's text does, and read as the level above. */
+.dc-repr .dc-line.dc-nest { padding-left: 1.65em; }
+
+.dc-repr .dc-d0 { --dc-rail: var(--dc-d0); }
+.dc-repr .dc-d1 { --dc-rail: var(--dc-d1); }
+.dc-repr .dc-d2 { --dc-rail: var(--dc-d2); }
+.dc-repr .dc-d3 { --dc-rail: var(--dc-d3); }
+
+/* The triangle takes the rail's color so the level reads from the line
+itself, not only from the margin beside it. */
+.dc-repr .dc-nest > summary::before { color: var(--dc-rail); }
 
 /* This scrolls itself. Without `overflow-x` a hundred-column coordinate
 line would push the whole page sideways rather than just this block. */

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -147,12 +147,12 @@ class Section:
 
     A section with no body is a statement rather than a container.
 
-    Sections nest, which is what an inventory is: a network holds fiber
-    arrays, which hold acquisitions and optical paths. ``depth`` says how
-    far down one sits, so a panel can draw the nesting a terminal draws
-    with indentation. A title states its own indentation for the
-    terminal's sake, the same way a body states the newline which
-    separated it, and a panel drops it because the nesting says it.
+    Sections nest, which is what an inventory is: its networks hold
+    fiber arrays and stations, and its fiber arrays hold acquisitions
+    and optical paths. ``depth`` says how far down one sits. The title
+    is the bare line either way; a terminal sets it in by its depth,
+    since indentation is the only nesting it has, and a panel puts it
+    in a block inside its parent's.
     """
 
     title: Text
@@ -202,7 +202,7 @@ def _render_table(node: Table) -> Text:
 
 @render_text.register
 def _render_section(node: Section) -> Text:
-    out = node.title.copy()
+    out = section_title(node.title, node.depth)
     for child in node.body:
         out += render_text(child)
     return out
@@ -245,10 +245,10 @@ def split_block(text: Text) -> Section:
 _SECTION_MARKER = "\u27a4 "
 _HTML_ROOT = "dc-repr"
 
-# How many colors the nesting ramp holds before it repeats. Four covers
-# every level an inventory has -- network, array, path, track -- and a
-# deeper tree reads by its rails rather than by a fifth hue nobody could
-# name.
+# How many colors the nesting ramp holds before it repeats. An inventory
+# nests three levels -- network, fiber array, then what an array holds --
+# and one spare covers a tree which grows a fourth; past that it reads by
+# its rails rather than by a hue nobody could name.
 _NEST_COLORS = 4
 
 # Style words a class exists for. A color outside this list still draws
@@ -450,17 +450,17 @@ def _section_lines(node: Section) -> int:
     # a reader open a large tree a level at a time: an inventory of
     # twenty networks counts twenty lines here rather than every
     # acquisition under all of them, so its own block still opens.
-    return 1 + (_body_lines(node) if _section_opens(node) else 0)
+    #
+    # Counted once and held: asking again after deciding would walk the
+    # same subtree a second time at every level, which is exponential in
+    # how deep the tree goes.
+    lines = _body_lines(node)
+    return 1 + (lines if lines <= get_config().display_html_open_lines else 0)
 
 
 def _body_lines(node: Section) -> int:
     """How many lines opening a section would show."""
     return sum(_visible_lines(x) for x in node.body)
-
-
-def _section_opens(node: Section) -> bool:
-    """Whether a section is worth showing a reader without being asked."""
-    return _body_lines(node) <= get_config().display_html_open_lines
 
 
 def _nest_classes(depth: int) -> tuple[str, ...]:
@@ -478,22 +478,19 @@ def _nest_classes(depth: int) -> tuple[str, ...]:
 
 @render_html.register
 def _html_section(node: Section) -> str:
+    # A title is the bare line: the indentation a terminal draws nesting
+    # with is added when a terminal draws it, and here the nesting is
+    # the markup.
     title = node.title
-    if node.depth:
-        # The indentation a nested title carries is for the terminal,
-        # which has no other way to show nesting. Here the nesting is
-        # the markup and `summary` keeps whitespace, so a title drawn as
-        # handed over would open on a blank line.
-        plain = title.plain
-        title = title[len(plain) - len(plain.lstrip()) :]
     if title.plain.startswith(_SECTION_MARKER):
         title = title[len(_SECTION_MARKER) :]
     title = text_to_html(title)
     nest = _nest_classes(node.depth)
-    if not any(_visible_lines(x) for x in node.body):
+    lines = _body_lines(node)
+    if not lines:
         # Nothing to fold, so nothing to offer folding.
         return f'<div class="{" ".join(("dc-line", *nest))}">{title}</div>'
-    state = " open" if _section_opens(node) else ""
+    state = " open" if lines <= get_config().display_html_open_lines else ""
     body = "".join(render_html(x) for x in node.body)
     css = f' class="{" ".join(nest)}"' if nest else ""
     return f"<details{css}{state}><summary>{title}</summary>{body}</details>"
@@ -695,17 +692,21 @@ def get_header_text(name: str, style: str = "bold") -> Text:
 _INDENT = "    "
 
 
-def section_indent(depth: int) -> Text:
+def section_title(line: Text, depth: int) -> Text:
     """
-    What a nested block's title opens with in a terminal.
+    How a terminal draws the line which names a block.
 
     A block below the top starts on a line of its own, set in by how deep
     it sits; the top of a tree opens wherever its container left off, so
-    it states neither. Carried in the title rather than added by the
-    renderer for the same reason a section's body carries the newline
-    which separated it: rendering is then only concatenation.
+    it is drawn as it stands. Every line is set in, not just the first: a
+    field value may hold a newline -- a description usually does -- and a
+    continuation left at column zero reads as a block of its own.
     """
-    return Text("\n" + _INDENT * depth) if depth else Text("")
+    if not depth:
+        # A copy, not the node's own line: a renderer which appends to
+        # what it drew would otherwise rewrite the node it read.
+        return line.copy()
+    return Text("\n") + indent_text(line, _INDENT * depth)
 
 
 def child_sections(items, depth: int) -> tuple[Section, ...]:
@@ -718,7 +719,7 @@ def child_sections(items, depth: int) -> tuple[Section, ...]:
     shown, left_out = limit_items(items)
     out = [x._repr_section(depth) for x in shown]
     if left_out:
-        out.append(Section(section_indent(depth) + elision_text(left_out), depth=depth))
+        out.append(Section(elision_text(left_out), depth=depth))
     return tuple(out)
 
 
@@ -754,20 +755,6 @@ def limit_items(items, limit: int | None = None) -> tuple[list, int]:
     items = list(items)
     shown = items[:limit]
     return shown, len(items) - len(shown)
-
-
-def limit_reprs(items, limit: int | None = None) -> list[Text]:
-    """
-    Render at most ``limit`` items, with a line naming what was left out.
-
-    Only the items which are shown are rendered, so the cost of a repr is
-    what it prints rather than what the object holds.
-    """
-    shown, left_out = limit_items(items, limit)
-    texts = [x.__rich__() for x in shown]
-    if left_out:
-        texts.append(elision_text(left_out))
-    return texts
 
 
 def _length(value) -> int | None:

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -770,6 +770,9 @@ def limit_items(
     stopping at ten reads as though ten is all there were.
     """
     limit = get_config().display_max_items if limit is None else limit
+    # Config forbids a negative one, so only a caller can state it, and
+    # `items[:-1]` would quietly show all but the last rather than none.
+    assert limit >= 0, f"a display limit is a count, not {limit}"
     items = list(items)
     shown = items[:limit]
     return shown, len(items) - len(shown)

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -12,6 +12,7 @@ from graphlib import CycleError, TopologicalSorter
 from html import escape
 from importlib.resources import files
 from itertools import pairwise
+from typing import TypeVar
 
 import numpy as np
 import pandas as pd
@@ -27,6 +28,10 @@ from dascore.config import get_config
 from dascore.constants import dascore_styles
 from dascore.units import get_quantity, get_quantity_str
 from dascore.utils.time import to_float
+
+# What a container holds, whatever that is: `limit_items` takes any of
+# them and hands back the same kind.
+_Item = TypeVar("_Item")
 
 # How wide one value may print before it is elided. A repr is a glance at
 # an object, and a single long field should not push the rest off screen.
@@ -444,6 +449,16 @@ def _table_lines(node: Table) -> int:
     return len(node.rows) + 1 if node.rows else 0
 
 
+def _title_lines(node: Section) -> int:
+    """How many lines the line which names a block runs to.
+
+    Usually one. A field value may hold a newline -- a description
+    often does -- and both a `summary` and a `.dc-line` keep it, so a
+    block which counted its title as one line would fold a level late.
+    """
+    return node.title.plain.count("\n") + 1
+
+
 @_visible_lines.register
 def _section_lines(node: Section) -> int:
     # A folded section is one line, whatever it holds. That is what lets
@@ -455,7 +470,8 @@ def _section_lines(node: Section) -> int:
     # same subtree a second time at every level, which is exponential in
     # how deep the tree goes.
     lines = _body_lines(node)
-    return 1 + (lines if lines <= get_config().display_html_open_lines else 0)
+    shown = lines if lines <= get_config().display_html_open_lines else 0
+    return _title_lines(node) + shown
 
 
 def _body_lines(node: Section) -> int:
@@ -743,7 +759,9 @@ def elision_text(left_out: int) -> Text:
     return Text(f"... {left_out} more", style=dascore_styles["keys"])
 
 
-def limit_items(items, limit: int | None = None) -> tuple[list, int]:
+def limit_items(
+    items: Iterable[_Item], limit: int | None = None
+) -> tuple[list[_Item], int]:
     """
     Take at most ``limit`` items, and say how many were left behind.
 

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -146,10 +146,18 @@ class Section:
     A titled block: the line which names it, and what sits under it.
 
     A section with no body is a statement rather than a container.
+
+    Sections nest, which is what an inventory is: a network holds fiber
+    arrays, which hold acquisitions and optical paths. ``depth`` says how
+    far down one sits, so a panel can draw the nesting a terminal draws
+    with indentation. A title states its own indentation for the
+    terminal's sake, the same way a body states the newline which
+    separated it, and a panel drops it because the nesting says it.
     """
 
     title: Text
-    body: tuple[Raw | Table, ...] = ()
+    body: tuple[Raw | Table | Section, ...] = ()
+    depth: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -236,6 +244,12 @@ def split_block(text: Text) -> Section:
 # markers for one thing.
 _SECTION_MARKER = "\u27a4 "
 _HTML_ROOT = "dc-repr"
+
+# How many colors the nesting ramp holds before it repeats. Four covers
+# every level an inventory has -- network, array, path, track -- and a
+# deeper tree reads by its rails rather than by a fifth hue nobody could
+# name.
+_NEST_COLORS = 4
 
 # Style words a class exists for. A color outside this list still draws
 # in a terminal, where rich knows every color it can parse; here it
@@ -401,32 +415,88 @@ def _html_table(node: Table) -> str:
     )
 
 
+@singledispatch
+def _visible_lines(node) -> int:
+    """
+    How many lines a reader sees of a node as it is drawn.
+
+    Zero where a node draws nothing, which is what says a block has no
+    body to fold: a section whose only child is the newline which
+    separated it from its title is a statement, not a container.
+    """
+    msg = f"cannot count {type(node).__name__}"
+    raise NotImplementedError(msg)
+
+
+@_visible_lines.register
+def _raw_lines(node: Raw) -> int:
+    # Counted on what is drawn, not on what was handed over: the body
+    # loses the newline which separated it from its title and any it
+    # ends on, and a block counted before that folds one line early.
+    plain = _body_text(node.text).plain
+    return plain.count("\n") + 1 if plain else 0
+
+
+@_visible_lines.register
+def _table_lines(node: Table) -> int:
+    # Its heading row is a line a reader sees, so a table of two records
+    # draws three.
+    return len(node.rows) + 1 if node.rows else 0
+
+
+@_visible_lines.register
+def _section_lines(node: Section) -> int:
+    # A folded section is one line, whatever it holds. That is what lets
+    # a reader open a large tree a level at a time: an inventory of
+    # twenty networks counts twenty lines here rather than every
+    # acquisition under all of them, so its own block still opens.
+    return 1 + (_body_lines(node) if _section_opens(node) else 0)
+
+
+def _body_lines(node: Section) -> int:
+    """How many lines opening a section would show."""
+    return sum(_visible_lines(x) for x in node.body)
+
+
+def _section_opens(node: Section) -> bool:
+    """Whether a section is worth showing a reader without being asked."""
+    return _body_lines(node) <= get_config().display_html_open_lines
+
+
+def _nest_classes(depth: int) -> tuple[str, ...]:
+    """
+    What says how deep in a nesting something sits.
+
+    A top-level block sits in no nesting and is given nothing. The color
+    ramp wraps rather than deepening forever: past a few levels it is the
+    rails which tell them apart, not which color they are.
+    """
+    if not depth:
+        return ()
+    return ("dc-nest", f"dc-d{(depth - 1) % _NEST_COLORS}")
+
+
 @render_html.register
 def _html_section(node: Section) -> str:
     title = node.title
+    if node.depth:
+        # The indentation a nested title carries is for the terminal,
+        # which has no other way to show nesting. Here the nesting is
+        # the markup and `summary` keeps whitespace, so a title drawn as
+        # handed over would open on a blank line.
+        plain = title.plain
+        title = title[len(plain) - len(plain.lstrip()) :]
     if title.plain.startswith(_SECTION_MARKER):
         title = title[len(_SECTION_MARKER) :]
     title = text_to_html(title)
-    if not any(
-        x.rows if isinstance(x, Table) else _body_text(x.text).plain for x in node.body
-    ):
-        # Nothing to fold, so nothing to offer folding. A block whose
-        # body is only the newline which separated it has none.
-        return f'<div class="dc-line">{title}</div>'
-    # Counted on what is drawn, not on what was handed over: the body
-    # loses the newline which separated it and any it ends on, and a
-    # block counted before that folds one line early.
-    lines = sum(
-        # Its heading row is a line a reader sees, so a table of two
-        # records draws three.
-        len(x.rows) + 1
-        if isinstance(x, Table)
-        else _body_text(x.text).plain.count("\n") + 1
-        for x in node.body
-    )
-    state = " open" if lines <= get_config().display_html_open_lines else ""
+    nest = _nest_classes(node.depth)
+    if not any(_visible_lines(x) for x in node.body):
+        # Nothing to fold, so nothing to offer folding.
+        return f'<div class="{" ".join(("dc-line", *nest))}">{title}</div>'
+    state = " open" if _section_opens(node) else ""
     body = "".join(render_html(x) for x in node.body)
-    return f"<details{state}><summary>{title}</summary>{body}</details>"
+    css = f' class="{" ".join(nest)}"' if nest else ""
+    return f"<details{css}{state}><summary>{title}</summary>{body}</details>"
 
 
 @render_html.register
@@ -620,7 +690,39 @@ def get_header_text(name: str, style: str = "bold") -> Text:
     return header + Text("\n") + Text("-" * header.cell_len)
 
 
-def indent_text(text: Text, prefix: str = "    ") -> Text:
+# What one level of a containment tree is set in from the one above, in
+# a terminal. A panel nests instead, and drops it.
+_INDENT = "    "
+
+
+def section_indent(depth: int) -> Text:
+    """
+    What a nested block's title opens with in a terminal.
+
+    A block below the top starts on a line of its own, set in by how deep
+    it sits; the top of a tree opens wherever its container left off, so
+    it states neither. Carried in the title rather than added by the
+    renderer for the same reason a section's body carries the newline
+    which separated it: rendering is then only concatenation.
+    """
+    return Text("\n" + _INDENT * depth) if depth else Text("")
+
+
+def child_sections(items, depth: int) -> tuple[Section, ...]:
+    """
+    The blocks a container's children draw, and a line for any left out.
+
+    Only what is shown is rendered, so the cost of a repr is what it
+    prints rather than what the tree holds.
+    """
+    shown, left_out = limit_items(items)
+    out = [x._repr_section(depth) for x in shown]
+    if left_out:
+        out.append(Section(section_indent(depth) + elision_text(left_out), depth=depth))
+    return tuple(out)
+
+
+def indent_text(text: Text, prefix: str = _INDENT) -> Text:
     """
     Indent every line of a rich Text, keeping its styles.
 
@@ -640,19 +742,30 @@ def elision_text(left_out: int) -> Text:
     return Text(f"... {left_out} more", style=dascore_styles["keys"])
 
 
+def limit_items(items, limit: int | None = None) -> tuple[list, int]:
+    """
+    Take at most ``limit`` items, and say how many were left behind.
+
+    Where a repr stops early it says how much it is not showing, so the
+    count is as much a part of the answer as the items are; silently
+    stopping at ten reads as though ten is all there were.
+    """
+    limit = get_config().display_max_items if limit is None else limit
+    items = list(items)
+    shown = items[:limit]
+    return shown, len(items) - len(shown)
+
+
 def limit_reprs(items, limit: int | None = None) -> list[Text]:
     """
     Render at most ``limit`` items, with a line naming what was left out.
 
     Only the items which are shown are rendered, so the cost of a repr is
-    what it prints rather than what the object holds. A repr also says how
-    much it is not showing; silently stopping at ten reads as though ten
-    is all there were.
+    what it prints rather than what the object holds.
     """
-    limit = get_config().display_max_items if limit is None else limit
-    items = list(items)
-    texts = [x.__rich__() for x in items[:limit]]
-    if left_out := len(items) - len(texts):
+    shown, left_out = limit_items(items, limit)
+    texts = [x.__rich__() for x in shown]
+    if left_out:
         texts.append(elision_text(left_out))
     return texts
 

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import pickle
+import re
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -1956,6 +1957,97 @@ class TestDisplay:
         with config_context(display_max_items=2):
             out = str(network)
         assert "... 3 more" in out
+
+    def test_a_model_holding_nothing_is_one_line(self):
+        """
+        What a model holds is a count on its line unless it says
+        otherwise.
+
+        A station lists no channels for the same reason an acquisition
+        lists no measurements: the count is the useful fact, and three
+        hundred channels would bury the tree they sit in.
+        """
+        station = inv.Station(code="S1", channels=[{"code": f"H{x}"} for x in range(3)])
+        assert str(station).count("\n") == 0
+        assert "channels: 3" in str(station)
+
+    def test_the_tree_is_indented_by_level(self, tunnel):
+        """
+        Each level is set in one step from the one above it.
+
+        Every line is checked rather than one of them: an indent applied
+        at the wrong level puts a fiber array where a network goes and
+        still leaves the object names in the right order.
+        """
+        network = tunnel.networks[0]
+        array = network.fiber_arrays[0]
+        levels = {"Network(": 4, "FiberArray(": 8, "Acquisition(": 12}
+        levels["OpticalPath("] = 12
+        for line in str(tunnel).split("\n"):
+            for name, indent in levels.items():
+                if line.lstrip().startswith(name):
+                    assert len(line) - len(line.lstrip()) == indent, line
+        # And on its own a network opens where it was put, not indented.
+        assert not str(network).startswith(" ")
+        assert str(array).split("\n")[1].startswith("    Acquisition(")
+
+
+class TestPanel:
+    """Tests for the panel a notebook draws an inventory as."""
+
+    @pytest.fixture(scope="class")
+    def tunnel(self):
+        """A populated inventory with two optical paths."""
+        return dc.get_example_inventory("tunnel")
+
+    @pytest.fixture(scope="class")
+    def markup(self, tunnel):
+        """The panel with its stylesheet cut off the front."""
+        html = tunnel._repr_html_()
+        return html[html.index("</style>") + len("</style>") :]
+
+    def test_the_tree_nests(self, markup):
+        """
+        A network holds its arrays rather than standing beside them.
+
+        The blocks a reader folds are what says which thing is inside
+        which, so a flat list of them says nothing at all.
+        """
+        # Networks, then the network, then the array inside it.
+        assert markup.count("<details") == 4
+        network = markup.index('<summary><span class="dc-bold">Network</span>')
+        array = markup.index('<summary><span class="dc-bold">FiberArray</span>')
+        assert network < array < markup.index("</details>")
+
+    def test_a_long_line_is_no_longer_in_the_array_dump(self, markup):
+        """
+        An acquisition's line is a line, and can scroll as one.
+
+        Drawn inside one `pre` with the whole tree it could not: the
+        block scrolls, so the longest line in it decides how far every
+        other line is pushed.
+        """
+        assert "Acquisition" in markup
+        pres = re.findall(r"<pre[^>]*>(.*?)</pre>", markup, re.DOTALL)
+        assert not any("Acquisition" in x for x in pres)
+
+    def test_each_level_says_which_it_is(self, markup):
+        """A reader can tell an array's line from the network's above it."""
+        for depth in range(3):
+            assert f"dc-nest dc-d{depth}" in markup
+
+    def test_a_title_carries_no_indentation(self, markup):
+        """The nesting is the markup here, and `summary` keeps whitespace."""
+        for title in re.findall(r"<summary>(.*?)</summary>", markup, re.DOTALL):
+            assert title == title.lstrip()
+
+    def test_what_is_left_out_is_said(self):
+        """A tree which stops early says so where it stopped."""
+        network = inv.Network(code="XT", stations=[{"code": f"S{x}"} for x in range(5)])
+        inventory = inv.Inventory(networks=(network,))
+        with config_context(display_max_items=2):
+            html = inventory._repr_html_()
+        assert "... 3 more" in html
 
 
 class TestObjectTypeTag:

--- a/tests/test_core/test_inventory.py
+++ b/tests/test_core/test_inventory.py
@@ -1878,13 +1878,14 @@ class TestCoverageCompleteness:
         assert values_equal((1.0, np.nan), (1.0, np.nan))
 
 
+@pytest.fixture(scope="module")
+def tunnel():
+    """A populated inventory with two optical paths."""
+    return dc.get_example_inventory("tunnel")
+
+
 class TestDisplay:
     """Tests for the inventory's text representation."""
-
-    @pytest.fixture(scope="class")
-    def tunnel(self):
-        """A populated inventory with two optical paths."""
-        return dc.get_example_inventory("tunnel")
 
     def test_rich(self, tunnel):
         """An inventory has a rich representation."""
@@ -1975,30 +1976,51 @@ class TestDisplay:
         """
         Each level is set in one step from the one above it.
 
-        Every line is checked rather than one of them: an indent applied
-        at the wrong level puts a fiber array where a network goes and
-        still leaves the object names in the right order.
+        Stated as the whole tree rather than as a rule each line is
+        checked against: a level which stopped being drawn matches no
+        rule and passes one, and dropping a level is exactly what a
+        rewrite of the tree gets wrong.
         """
+        drawn = [
+            (len(x) - len(x.lstrip()), x.strip().split("(")[0])
+            for x in str(tunnel).split("\n")
+            # A model's line, which closes on " )"; the block titles
+            # above them close on a count in brackets instead.
+            if x.endswith(" )")
+        ]
+        assert drawn == [
+            (4, "Network"),
+            (8, "FiberArray"),
+            (12, "Acquisition"),
+            (12, "OpticalPath"),
+            (12, "OpticalPath"),
+            (4, "coordinate_reference_system: CoordinateReferenceSystem"),
+        ]
+
+    def test_a_field_value_which_holds_a_newline(self):
+        """
+        Every line of a model's line is set in, not just the first.
+
+        A description is free text and is routinely written over more
+        than one line. Indented only on its first, the rest falls to
+        column zero and reads as a block of its own -- which is the
+        misreading the indentation exists to prevent.
+        """
+        array = inv.FiberArray(code="FA1", description="line one\nline two")
+        network = inv.Network(code="XT", fiber_arrays=(array,))
+        drawn = str(inv.Inventory(networks=(network,))).split("\n")
+        assert "        FiberArray( description: line one" in drawn
+        assert "        line two code: FA1 )" in drawn
+
+    def test_a_tree_opens_where_it_was_put(self, tunnel):
+        """A model printed on its own is not indented; what it holds is."""
         network = tunnel.networks[0]
-        array = network.fiber_arrays[0]
-        levels = {"Network(": 4, "FiberArray(": 8, "Acquisition(": 12}
-        levels["OpticalPath("] = 12
-        for line in str(tunnel).split("\n"):
-            for name, indent in levels.items():
-                if line.lstrip().startswith(name):
-                    assert len(line) - len(line.lstrip()) == indent, line
-        # And on its own a network opens where it was put, not indented.
         assert not str(network).startswith(" ")
-        assert str(array).split("\n")[1].startswith("    Acquisition(")
+        assert str(network).split("\n")[1].startswith("    FiberArray(")
 
 
 class TestPanel:
     """Tests for the panel a notebook draws an inventory as."""
-
-    @pytest.fixture(scope="class")
-    def tunnel(self):
-        """A populated inventory with two optical paths."""
-        return dc.get_example_inventory("tunnel")
 
     @pytest.fixture(scope="class")
     def markup(self, tunnel):
@@ -2024,22 +2046,20 @@ class TestPanel:
         An acquisition's line is a line, and can scroll as one.
 
         Drawn inside one `pre` with the whole tree it could not: the
-        block scrolls, so the longest line in it decides how far every
-        other line is pushed.
+        longest line in a block sets that block's scroll width, so
+        reading it drags every other line in the tree sideways.
         """
         assert "Acquisition" in markup
         pres = re.findall(r"<pre[^>]*>(.*?)</pre>", markup, re.DOTALL)
+        # The attributes block is still one, so an empty list here would
+        # mean the search stopped working rather than the tree moving.
+        assert len(pres) == 1
         assert not any("Acquisition" in x for x in pres)
 
     def test_each_level_says_which_it_is(self, markup):
         """A reader can tell an array's line from the network's above it."""
         for depth in range(3):
             assert f"dc-nest dc-d{depth}" in markup
-
-    def test_a_title_carries_no_indentation(self, markup):
-        """The nesting is the markup here, and `summary` keeps whitespace."""
-        for title in re.findall(r"<summary>(.*?)</summary>", markup, re.DOTALL):
-            assert title == title.lstrip()
 
     def test_what_is_left_out_is_said(self):
         """A tree which stops early says so where it stopped."""

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -33,6 +33,7 @@ from dascore.utils.display import (
     Row,
     Section,
     Table,
+    _body_lines,
     _storage_quantum,
     _visible_lines,
     array_to_text,
@@ -1390,8 +1391,8 @@ class TestVisibleLines:
 
     def test_an_open_section_counts_what_it_holds(self):
         """A parent counts everything below it while it is open."""
-        leaf = Section(Text("\n        leaf"), depth=2)
-        mid = Section(Text("\n    mid"), (leaf, leaf), depth=1)
+        leaf = Section(Text("leaf"), depth=2)
+        mid = Section(Text("mid"), (leaf, leaf), depth=1)
         with config_context(display_html_open_lines=12):
             assert _visible_lines(mid) == 3
             assert _visible_lines(Section(Text("top"), (mid,))) == 4
@@ -1404,8 +1405,8 @@ class TestVisibleLines:
         counted in full, a container of twenty full networks would fold
         the block which lists them, and the panel would open on nothing.
         """
-        leaf = Section(Text("\n        leaf"), depth=2)
-        mid = Section(Text("\n    mid"), (leaf,) * 6, depth=1)
+        leaf = Section(Text("leaf"), depth=2)
+        mid = Section(Text("mid"), (leaf,) * 6, depth=1)
         top = Section(Text("top"), (mid,) * 3)
         with config_context(display_html_open_lines=3):
             assert _visible_lines(mid) == 1
@@ -1417,6 +1418,24 @@ class TestVisibleLines:
             html = render_html(top)
             assert html.count(" open>") == 1
             assert html.startswith("<details open>")
+
+    def test_a_title_which_runs_on_counts_every_line(self):
+        """
+        A folded block still draws all of its title.
+
+        A value may hold a newline, and both a `summary` and a
+        `.dc-line` keep it, so seven two-line blocks draw fourteen
+        lines. Counted as seven, the block holding them opens under a
+        limit it is really twice the size of.
+        """
+        leaf = Section(Text("first\nsecond"), depth=1)
+        assert _visible_lines(leaf) == 2
+        top = Section(Text("top"), (leaf,) * 7)
+        assert _body_lines(top) == 14
+        with config_context(display_html_open_lines=12):
+            assert " open>" not in render_html(top)
+        with config_context(display_html_open_lines=14):
+            assert " open>" in render_html(top)
 
     def test_a_node_is_counted_once(self, monkeypatch):
         """

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -26,6 +26,7 @@ from dascore.core.annotations import (
 from dascore.core.inventory import Acquisition, Cable, Network
 from dascore.utils import display
 from dascore.utils.display import (
+    _NEST_COLORS,
     _STYLE_WORDS,
     Raw,
     Repr,
@@ -33,8 +34,10 @@ from dascore.utils.display import (
     Section,
     Table,
     _storage_quantum,
+    _visible_lines,
     array_to_text,
     attrs_to_text,
+    child_sections,
     counts_to_text,
     duration_text,
     get_header_text,
@@ -44,6 +47,7 @@ from dascore.utils.display import (
     human_duration,
     human_size,
     indent_text,
+    limit_items,
     limit_reprs,
     mapping_to_text,
     model_to_line,
@@ -51,6 +55,7 @@ from dascore.utils.display import (
     rate_text,
     render_html,
     render_text,
+    section_indent,
     split_block,
     stated_fields,
     style_classes,
@@ -1286,6 +1291,225 @@ class TestRenderHtml:
             render_html(42)
 
 
+class TestLimitItems:
+    """Tests for taking only as much of a container as a repr shows."""
+
+    def test_everything_fits(self):
+        """Nothing is left behind while everything fits."""
+        assert limit_items([1, 2, 3], limit=3) == ([1, 2, 3], 0)
+
+    def test_the_tail_is_counted(self):
+        """What is not shown is counted rather than dropped silently."""
+        assert limit_items(range(10), limit=4) == ([0, 1, 2, 3], 6)
+
+    def test_nothing_is_shown(self):
+        """A limit of none still says how much there was."""
+        assert limit_items([1, 2], limit=0) == ([], 2)
+
+    def test_the_limit_comes_from_config(self):
+        """The default cap is a runtime setting, not a constant here."""
+        with config_context(display_max_items=1):
+            assert limit_items("abc") == (["a"], 2)
+
+
+class TestSectionIndent:
+    """Tests for the indentation a nested title carries."""
+
+    def test_the_top_states_none(self):
+        """A tree's root opens where its container left off."""
+        assert section_indent(0).plain == ""
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    def test_a_level_starts_a_line(self, depth):
+        """
+        Every level below the top begins on its own line, set in.
+
+        The newline is the title's, not the renderer's, for the same
+        reason a section body carries the one which separated it:
+        rendering is then only concatenation.
+        """
+        assert section_indent(depth).plain == "\n" + "    " * depth
+
+
+class _Leaf:
+    """A model-like object which holds nothing."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def _repr_section(self, depth=0):
+        return Section(section_indent(depth) + Text(self.name), depth=depth)
+
+
+class TestChildSections:
+    """Tests for the blocks a container's children draw."""
+
+    def test_one_block_per_child(self):
+        """Each child draws itself, at the depth it was given."""
+        out = child_sections([_Leaf("a"), _Leaf("b")], 2)
+        assert [x.title.plain for x in out] == ["\n        a", "\n        b"]
+        assert {x.depth for x in out} == {2}
+
+    def test_the_tail_is_named(self):
+        """A container which stops early says how much it stopped short of."""
+        with config_context(display_max_items=2):
+            out = child_sections([_Leaf(str(x)) for x in range(5)], 1)
+        assert len(out) == 3
+        assert out[-1].title.plain == "\n    ... 3 more"
+        # The line sits with the children it stands for, not beside them.
+        assert out[-1].depth == 1
+
+    def test_a_hidden_child_is_not_drawn(self):
+        """Cost is what a repr prints, not what the tree holds."""
+        drawn = []
+
+        class Counted(_Leaf):
+            def _repr_section(self, depth=0):
+                drawn.append(self.name)
+                return super()._repr_section(depth)
+
+        with config_context(display_max_items=2):
+            child_sections([Counted(str(x)) for x in range(50)], 1)
+        assert drawn == ["0", "1"]
+
+    def test_no_children(self):
+        """A container which holds nothing states nothing."""
+        assert child_sections((), 1) == ()
+
+
+class TestVisibleLines:
+    """Tests for how many lines a node is counted as showing."""
+
+    def test_a_raw_counts_what_is_drawn(self):
+        """The newline which separated a body from its title is not a line."""
+        assert _visible_lines(Raw(Text("\na\nb\n"))) == 2
+
+    def test_an_empty_raw_draws_nothing(self):
+        """A body which is only the separator is no body at all."""
+        assert _visible_lines(Raw(Text("\n"))) == 0
+
+    def test_a_table_counts_its_heading(self):
+        """Its heading row is a line a reader sees."""
+        row = Row(Text("x"), Text("k"), (("a", Text("1"), True),))
+        assert _visible_lines(Table((row, row))) == 3
+
+    def test_an_empty_table_draws_nothing(self):
+        """A table of no records has no heading to draw either."""
+        assert _visible_lines(Table()) == 0
+
+    def test_an_open_section_counts_what_it_holds(self):
+        """A parent counts everything below it while it is open."""
+        leaf = Section(Text("\n        leaf"), depth=2)
+        mid = Section(Text("\n    mid"), (leaf, leaf), depth=1)
+        with config_context(display_html_open_lines=12):
+            assert _visible_lines(mid) == 3
+            assert _visible_lines(Section(Text("top"), (mid,))) == 4
+
+    def test_a_folded_section_is_one_line(self):
+        """
+        What is folded is one line, whatever it holds.
+
+        Which is what lets a reader open a large tree a level at a time:
+        counted in full, a container of twenty full networks would fold
+        the block which lists them, and the panel would open on nothing.
+        """
+        leaf = Section(Text("\n        leaf"), depth=2)
+        mid = Section(Text("\n    mid"), (leaf,) * 6, depth=1)
+        top = Section(Text("top"), (mid,) * 3)
+        with config_context(display_html_open_lines=3):
+            assert _visible_lines(mid) == 1
+            assert _visible_lines(top) == 4
+            # And so the outer block still opens, on three folded lines.
+            assert "<details open>" in render_html(top)
+            assert render_html(top).count("<details open>") == 1
+
+    def test_something_which_is_not_a_node(self):
+        """A counter says what it cannot count rather than guessing."""
+        with pytest.raises(NotImplementedError, match="cannot count int"):
+            _visible_lines(42)
+
+
+class TestNestedSections:
+    """Tests for a block drawn inside another block."""
+
+    @pytest.fixture
+    def tree(self):
+        """A title, a child, and a grandchild under it."""
+        leaf = Section(Text("\n        leaf"), depth=2)
+        mid = Section(Text("\n    mid"), (leaf,), depth=1)
+        return Section(Text("\u27a4 top"), (mid,))
+
+    def test_text_is_concatenation(self, tree):
+        """
+        A terminal draws the nesting by the indentation in the titles.
+
+        Which is what keeps `str()` unchanged: the nodes state exactly
+        the characters the old hand-built text stated.
+        """
+        assert render_text(tree).plain == "\u27a4 top\n    mid\n        leaf"
+
+    def test_the_panel_nests(self, tree):
+        """
+        A child block is drawn inside its parent, not after it.
+
+        Checked by where the parent closes: a child which came after
+        would sit past the `</details>` which ends it, and the tree
+        would read as three blocks side by side rather than one.
+        """
+        html = render_html(tree)
+        assert html.count("<details") == 2
+        opened = html.index("<summary>top</summary>") + len("<summary>top</summary>")
+        closed = html.index("</details>")
+        assert opened < html.index("<summary>mid</summary>") < closed
+        assert opened < html.index(">leaf<") < closed
+
+    def test_a_nested_title_drops_its_indentation(self, tree):
+        """
+        The indentation is the terminal's way of showing nesting.
+
+        A panel nests the markup instead, and `summary` keeps
+        whitespace, so a title drawn as handed over would open on a
+        blank line.
+        """
+        html = render_html(tree)
+        for title in re.findall(r"<summary>(.*?)</summary>", html, re.DOTALL):
+            assert title == title.lstrip()
+        assert '<div class="dc-line dc-nest dc-d1">leaf</div>' in html
+
+    def test_a_level_is_said_in_the_markup(self, tree):
+        """
+        Which level a line belongs to is a class, not a color here.
+
+        A host which drops the stylesheet still nests, so this says only
+        that the depth reaches the markup at all.
+        """
+        html = render_html(tree)
+        assert 'class="dc-nest dc-d0"' in html
+        assert "dc-d1" in html
+
+    def test_the_top_is_in_no_nesting(self):
+        """A block at the top of a repr sits inside nothing."""
+        html = render_html(Section(Text("top"), (Raw(Text("\nbody")),)))
+        assert "dc-nest" not in html
+
+    def test_the_ramp_wraps(self):
+        """
+        Past a few levels it is the rails which tell them apart.
+
+        Checked at the wrap rather than at the first level, since a ramp
+        which ran off the end would draw an undefined color there.
+        """
+        node = Section(Text("x"), depth=_NEST_COLORS + 1)
+        assert f"dc-d{(_NEST_COLORS + 1 - 1) % _NEST_COLORS}" in render_html(node)
+
+    def test_a_deep_tree_folds(self, tree):
+        """A parent folds on everything under it, not on its own children."""
+        with config_context(display_html_open_lines=2):
+            assert "<details open>" in render_html(tree)
+        with config_context(display_html_open_lines=1):
+            assert "<details open>" not in render_html(tree)
+
+
 class TestBodyText:
     """Tests for the whitespace which frames a section body."""
 
@@ -1560,16 +1784,7 @@ class TestStylesheet:
             dc.get_example_spool("diverse_das"),
             dc.get_example_inventory("tunnel"),
         ):
-            texts = [obj._repr_node().header]
-            for section in obj._repr_node().body:
-                texts.append(section.title)
-                for part in section.body:
-                    if isinstance(part, Table):
-                        for row in part.rows:
-                            texts.extend([row.name, row.kind])
-                            texts.extend(v for _, v, _ in row.fields)
-                    else:
-                        texts.append(part.text)
+            texts = [obj._repr_node().header, *_node_texts(obj._repr_node().body)]
             for text in texts:
                 for offset in range(len(text.plain)):
                     style = text.get_style_at_offset(console, offset)
@@ -1578,6 +1793,39 @@ class TestStylesheet:
         assert seen
         for style in seen:
             assert style_classes(style), style
+
+    def test_a_rule_exists_for_every_nesting_level(self):
+        """A level the renderer can reach and the CSS cannot draws no rail."""
+        css = get_stylesheet()
+        for depth in range(_NEST_COLORS):
+            assert f".dc-d{depth} {{" in css, depth
+
+    def test_a_nested_leaf_is_given_a_marker_of_room(self):
+        """
+        A leaf has no disclosure triangle, and is given the width of one.
+
+        Without it a leaf's text starts where its parent's triangle
+        does rather than where its parent's text does, and the tree
+        reads as though the leaf sits a level higher than it does.
+        """
+        assert ".dc-line.dc-nest" in get_stylesheet()
+
+    def test_every_theme_states_the_whole_ramp(self):
+        """
+        A token defined in one theme and not another draws nothing there.
+
+        The rails are decoration, so what is lost is not information --
+        but a rail which is there on a light page and gone on a dark one
+        is the kind of difference nobody chose.
+        """
+        css = get_stylesheet()
+        # A block which defines any of the palette defines all of it:
+        # those are the theme blocks, whatever host they are written for.
+        blocks = re.findall(r"\{([^{}]*--dc-blue:[^{}]*)\}", css)
+        assert len(blocks) >= 3  # the default, the reader's OS, the host
+        for block in blocks:
+            for depth in range(_NEST_COLORS):
+                assert f"--dc-d{depth}:" in block, (depth, block[:40])
 
     def test_a_class_exists_for_every_style_word(self):
         """
@@ -1661,6 +1909,28 @@ def _decompose(line: str) -> list[str]:
     return out
 
 
+def _node_texts(nodes) -> list[Text]:
+    """
+    Every Text a tree of repr nodes states, top down.
+
+    Recursive because sections nest: an inventory's networks hold fiber
+    arrays which hold acquisitions, and a walk which stopped at the top
+    would check the one level nothing much is drawn on.
+    """
+    out: list[Text] = []
+    for node in nodes:
+        if isinstance(node, Table):
+            for row in node.rows:
+                out.extend([row.name, row.kind])
+                out.extend(v for _, v, _ in row.fields)
+        elif isinstance(node, Section):
+            out.append(node.title)
+            out.extend(_node_texts(node.body))
+        else:
+            out.append(node.text)
+    return out
+
+
 def _drawn_values(html: str) -> list[str]:
     """
     What a reader sees in a panel, in the order it is drawn.
@@ -1674,7 +1944,7 @@ def _drawn_values(html: str) -> list[str]:
         r'<div class="dc-banner">(?P<banner>.*?)</div>'
         r"|<summary>(?P<summary>.*?)</summary>"
         r'|<pre class="dc-body">(?P<pre>.*?)</pre>'
-        r'|<div class="dc-line">(?P<line>.*?)</div>'
+        r'|<div class="dc-line[^"]*">(?P<line>.*?)</div>'
         r'|<table class="dc-table">(?P<table>.*?)</table>',
         html,
         re.DOTALL,
@@ -1830,7 +2100,7 @@ class TestHtmlRepr:
         above what it holds, so a section's worth of rules trips it
         rather than a rule or two.
         """
-        assert len(get_stylesheet().encode()) < 8_000
+        assert len(get_stylesheet().encode()) < 10_000
 
     def test_a_panel_is_mostly_the_object(self, html_objects):
         """

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -48,14 +48,13 @@ from dascore.utils.display import (
     human_size,
     indent_text,
     limit_items,
-    limit_reprs,
     mapping_to_text,
     model_to_line,
     percent,
     rate_text,
     render_html,
     render_text,
-    section_indent,
+    section_title,
     split_block,
     stated_fields,
     style_classes,
@@ -160,42 +159,6 @@ class TestIndentText:
         """Indenting does not flatten the styles it wraps."""
         text = Text("red", style="red")
         assert indent_text(text).spans
-
-
-class TestLimitReprs:
-    """Tests for capping how many children a repr lists."""
-
-    def test_under_limit_unchanged(self):
-        """Nothing is added while everything fits."""
-        items = [Network(code="A"), Network(code="B")]
-        out = limit_reprs(items, limit=3)
-        assert [str(x) for x in out] == [str(x) for x in items]
-
-    def test_over_limit_says_what_is_missing(self):
-        """The tail is named rather than dropped silently."""
-        items = [Network(code=f"N{x}") for x in range(5)]
-        out = limit_reprs(items, limit=2)
-        assert len(out) == 3
-        assert "3 more" in str(out[-1])
-
-    def test_limit_from_config(self):
-        """The default cap comes from runtime config."""
-        with config_context(display_max_items=1):
-            out = limit_reprs([Network(code="A"), Network(code="B")])
-        assert len(out) == 2
-        assert "1 more" in str(out[-1])
-
-    def test_hidden_children_not_rendered(self):
-        """A child which is not shown is not built, however many there are."""
-        rendered = []
-
-        class Counted:
-            def __rich__(self):
-                rendered.append(1)
-                return Text("x")
-
-        limit_reprs([Counted() for _ in range(50)], limit=2)
-        assert len(rendered) == 2
 
 
 class TestCountsToText:
@@ -1312,23 +1275,51 @@ class TestLimitItems:
             assert limit_items("abc") == (["a"], 2)
 
 
-class TestSectionIndent:
-    """Tests for the indentation a nested title carries."""
+class TestSectionTitle:
+    """Tests for how a terminal sets a nested block's line in."""
 
-    def test_the_top_states_none(self):
+    def test_the_top_is_drawn_as_it_stands(self):
         """A tree's root opens where its container left off."""
-        assert section_indent(0).plain == ""
+        assert section_title(Text("a"), 0).plain == "a"
+
+    def test_the_top_is_not_the_line_it_was_given(self):
+        """A renderer appends to what it drew, and must not rewrite it."""
+        line = Text("a")
+        section_title(line, 0).append("b")
+        assert line.plain == "a"
 
     @pytest.mark.parametrize("depth", [1, 2, 3])
     def test_a_level_starts_a_line(self, depth):
-        """
-        Every level below the top begins on its own line, set in.
+        """Every level below the top begins on its own line, set in."""
+        assert section_title(Text("a"), depth).plain == "\n" + "    " * depth + "a"
 
-        The newline is the title's, not the renderer's, for the same
-        reason a section body carries the one which separated it:
-        rendering is then only concatenation.
+    @pytest.mark.parametrize("depth", [1, 2])
+    def test_every_line_is_set_in(self, depth):
         """
-        assert section_indent(depth).plain == "\n" + "    " * depth
+        A field value may hold a newline -- a description usually does.
+
+        A continuation left at column zero reads as a block of its own,
+        which is the misreading the indentation exists to prevent.
+        """
+        indent = "    " * depth
+        out = section_title(Text("a\nb"), depth).plain
+        assert out == f"\n{indent}a\n{indent}b"
+
+    def test_the_styles_survive(self):
+        """
+        Setting a line in does not repaint it, or paint the indent.
+
+        Read per character, since indenting splits a Text and rejoins
+        it, and a span which came back one character wide of where it
+        started would color the wrong word.
+        """
+        line = Text("ab")
+        line.stylize("bold", 0, 1)
+        drawn = section_title(line, 1)
+        styles = dict(zip(drawn.plain, resolved_styles(drawn), strict=True))
+        assert styles["a"].bold
+        assert not styles["b"].bold
+        assert not styles[" "].bold
 
 
 class _Leaf:
@@ -1338,7 +1329,7 @@ class _Leaf:
         self.name = name
 
     def _repr_section(self, depth=0):
-        return Section(section_indent(depth) + Text(self.name), depth=depth)
+        return Section(Text(self.name), depth=depth)
 
 
 class TestChildSections:
@@ -1347,7 +1338,7 @@ class TestChildSections:
     def test_one_block_per_child(self):
         """Each child draws itself, at the depth it was given."""
         out = child_sections([_Leaf("a"), _Leaf("b")], 2)
-        assert [x.title.plain for x in out] == ["\n        a", "\n        b"]
+        assert [x.title.plain for x in out] == ["a", "b"]
         assert {x.depth for x in out} == {2}
 
     def test_the_tail_is_named(self):
@@ -1355,7 +1346,7 @@ class TestChildSections:
         with config_context(display_max_items=2):
             out = child_sections([_Leaf(str(x)) for x in range(5)], 1)
         assert len(out) == 3
-        assert out[-1].title.plain == "\n    ... 3 more"
+        assert out[-1].title.plain == "... 3 more"
         # The line sits with the children it stands for, not beside them.
         assert out[-1].depth == 1
 
@@ -1409,7 +1400,7 @@ class TestVisibleLines:
         """
         What is folded is one line, whatever it holds.
 
-        Which is what lets a reader open a large tree a level at a time:
+        That is what lets a reader open a large tree a level at a time:
         counted in full, a container of twenty full networks would fold
         the block which lists them, and the panel would open on nothing.
         """
@@ -1420,8 +1411,37 @@ class TestVisibleLines:
             assert _visible_lines(mid) == 1
             assert _visible_lines(top) == 4
             # And so the outer block still opens, on three folded lines.
-            assert "<details open>" in render_html(top)
-            assert render_html(top).count("<details open>") == 1
+            # Counted on " open>", since a nested block carries classes
+            # between the tag and the attribute and "<details open>"
+            # could only ever match the one at the top.
+            html = render_html(top)
+            assert html.count(" open>") == 1
+            assert html.startswith("<details open>")
+
+    def test_a_node_is_counted_once(self, monkeypatch):
+        """
+        Every node is visited once, however deep the tree goes.
+
+        Asking a section how long it is and then asking again after
+        deciding to open it walks the same subtree twice at every level,
+        which doubles per level rather than adding one. Counted rather
+        than timed: the growth is the defect, and a clock only shows it
+        on a tree far larger than one anybody has.
+        """
+        seen = []
+        real = display._visible_lines
+
+        def counted(node):
+            seen.append(node)
+            return real(node)
+
+        monkeypatch.setattr(display, "_visible_lines", counted)
+        node = Section(Text("leaf"), depth=12)
+        for depth in range(11, -1, -1):
+            node = Section(Text(f"n{depth}"), (node,), depth=depth)
+        with config_context(display_html_open_lines=100):
+            counted(node)
+        assert len(seen) == 13
 
     def test_something_which_is_not_a_node(self):
         """A counter says what it cannot count rather than guessing."""
@@ -1435,15 +1455,15 @@ class TestNestedSections:
     @pytest.fixture
     def tree(self):
         """A title, a child, and a grandchild under it."""
-        leaf = Section(Text("\n        leaf"), depth=2)
-        mid = Section(Text("\n    mid"), (leaf,), depth=1)
+        leaf = Section(Text("leaf"), depth=2)
+        mid = Section(Text("mid"), (leaf,), depth=1)
         return Section(Text("\u27a4 top"), (mid,))
 
     def test_text_is_concatenation(self, tree):
         """
         A terminal draws the nesting by the indentation in the titles.
 
-        Which is what keeps `str()` unchanged: the nodes state exactly
+        That is what keeps `str()` unchanged: the nodes state exactly
         the characters the old hand-built text stated.
         """
         assert render_text(tree).plain == "\u27a4 top\n    mid\n        leaf"
@@ -1502,12 +1522,17 @@ class TestNestedSections:
         node = Section(Text("x"), depth=_NEST_COLORS + 1)
         assert f"dc-d{(_NEST_COLORS + 1 - 1) % _NEST_COLORS}" in render_html(node)
 
-    def test_a_deep_tree_folds(self, tree):
-        """A parent folds on everything under it, not on its own children."""
-        with config_context(display_html_open_lines=2):
-            assert "<details open>" in render_html(tree)
-        with config_context(display_html_open_lines=1):
-            assert "<details open>" not in render_html(tree)
+    @pytest.mark.parametrize(("limit", "open_blocks"), [(2, 2), (1, 1), (0, 0)])
+    def test_a_deep_tree_folds_from_the_outside_in(self, tree, limit, open_blocks):
+        """
+        Each level decides for itself, and an outer one counts a folded
+        child as the one line it draws.
+
+        So the block which holds the tree stays open while the levels
+        under it close, and a reader opens as far down as they asked.
+        """
+        with config_context(display_html_open_lines=limit):
+            assert render_html(tree).count(" open>") == open_blocks
 
 
 class TestBodyText:
@@ -1737,6 +1762,30 @@ class TestTableColumns:
         assert "<td>1</td><td></td>" in body
 
 
+def _css_body() -> str:
+    """The stylesheet with its comments taken out.
+
+    A rule and a comment about a rule read the same to a substring
+    search, and a test which cannot tell them apart passes on a rule
+    which was commented out.
+    """
+    return re.sub(r"/\*.*?\*/", "", get_stylesheet(), flags=re.DOTALL)
+
+
+def _css_rule(selector: str) -> str:
+    """
+    What one selector declares, or "" where it declares nothing.
+
+    Matched on the whole selector list a block states, so a rule found
+    here is one a browser would apply rather than a substring of the
+    name of another.
+    """
+    for block, body in re.findall(r"([^{}]+)\{([^{}]*)\}", _css_body()):
+        if any(x.strip() == selector for x in block.split(",")):
+            return body
+    return ""
+
+
 class TestStylesheet:
     """Tests for the CSS every repr carries."""
 
@@ -1747,7 +1796,7 @@ class TestStylesheet:
         The stylesheet travels inside a notebook output cell, where it
         applies to the whole document around it.
         """
-        body = re.sub(r"/\*.*?\*/", "", get_stylesheet(), flags=re.DOTALL)
+        body = _css_body()
         selectors = [
             part.strip()
             for block in re.findall(r"([^{}]+)\{", body)
@@ -1764,7 +1813,7 @@ class TestStylesheet:
         Neither can be written under a class, so a stylesheet which
         travels inside someone else's document must not state one.
         """
-        body = re.sub(r"/\*.*?\*/", "", get_stylesheet(), flags=re.DOTALL)
+        body = _css_body()
         for rule in ("@font-face", "@import", "@page"):
             assert rule not in body, rule
 
@@ -1796,19 +1845,41 @@ class TestStylesheet:
 
     def test_a_rule_exists_for_every_nesting_level(self):
         """A level the renderer can reach and the CSS cannot draws no rail."""
-        css = get_stylesheet()
         for depth in range(_NEST_COLORS):
-            assert f".dc-d{depth} {{" in css, depth
+            rule = _css_rule(f".dc-repr .dc-d{depth}")
+            assert f"--dc-rail: var(--dc-d{depth})" in rule, depth
 
     def test_a_nested_leaf_is_given_a_marker_of_room(self):
         """
         A leaf has no disclosure triangle, and is given the width of one.
 
-        Without it a leaf's text starts where its parent's triangle
-        does rather than where its parent's text does, and the tree
-        reads as though the leaf sits a level higher than it does.
+        Without it a leaf's text starts where its parent's text starts,
+        a marker to the left of the blocks beside it, and the tree reads
+        as though the leaf sat a level higher than it does.
         """
-        assert ".dc-line.dc-nest" in get_stylesheet()
+        assert "padding-left" in _css_rule(".dc-repr .dc-line.dc-nest")
+
+    def test_a_line_which_runs_on_stays_in_its_column(self):
+        """
+        A title can hold a newline, and both its lines start together.
+
+        The triangle is pulled back into a gutter the whole title is
+        set in by, rather than taking room from its first line only:
+        given the latter a continuation starts under the triangle, a
+        marker to the left of the line it continues.
+        """
+        assert "-1.1em" in _css_rule(".dc-repr summary::before")
+        assert "0.1em 0 0.1em 1.1em" in _css_rule(".dc-repr summary")
+
+    def test_a_wide_line_scrolls_inside_its_own_block(self):
+        """
+        A container's line sits in a `summary` now, not in the array dump.
+
+        Without an overflow of its own a long one pushes the whole
+        panel sideways, so the banner and every block below it scroll
+        along with it.
+        """
+        assert "overflow-x: auto" in _css_rule(".dc-repr summary")
 
     def test_every_theme_states_the_whole_ramp(self):
         """
@@ -1818,7 +1889,7 @@ class TestStylesheet:
         but a rail which is there on a light page and gone on a dark one
         is the kind of difference nobody chose.
         """
-        css = get_stylesheet()
+        css = _css_body()
         # A block which defines any of the palette defines all of it:
         # those are the theme blocks, whatever host they are written for.
         blocks = re.findall(r"\{([^{}]*--dc-blue:[^{}]*)\}", css)
@@ -2096,11 +2167,12 @@ class TestHtmlRepr:
         Every repr carries it, so a notebook carries one copy per cell.
 
         Held on its own rather than on the panel, where growth in one
-        hides growth in the other. The ceiling is roughly a quarter
-        above what it holds, so a section's worth of rules trips it
-        rather than a rule or two.
+        hides growth in the other. The ceiling sits about a section's
+        worth of rules above what the sheet holds, so a block of them
+        trips it rather than a rule or two -- which means it has to be
+        raised deliberately whenever a block is added.
         """
-        assert len(get_stylesheet().encode()) < 10_000
+        assert len(get_stylesheet().encode()) < 9_000
 
     def test_a_panel_is_mostly_the_object(self, html_objects):
         """


### PR DESCRIPTION
## Description

Fifth of the repr series, after #1011, #1012, #1014 and #1018. It makes the inventory's network tree an actual tree in the panel, and leaves the printed text byte-identical.

Today an inventory renders its children by rendering each one in full and indenting the whole block into place. A terminal has no other way to show nesting, so that is right there — but it hands the panel one flat `<pre>` holding a network, its fiber arrays and every acquisition under them. That block scrolls as a unit, so the 290-character `Acquisition(...)` line in the tunnel example decides how far every other line in it is pushed, and there is nothing to fold.

A model now states two things instead of one whole rendering: `_repr_line()`, the line which names it, and `_repr_children()`, what it holds. From those, `InventoryModel._repr_section(depth)` builds a `Section` per model holding a `Section` per child. `render_text` concatenates them and gets exactly the characters it got before; `render_html` nests `<details>`, so a network folds shut and each level carries a rail saying which level it is.

Six `__rich__` overrides in `inventory.py` became `_repr_line`, and `Network`/`FiberArray` lost their hand-written child loops entirely — `InventoryModel.__rich__` is now one definition for every model in the file.

Three details worth calling out:

**Folding counts what a reader would see, not everything below.** A folded child is one line, whatever it holds. Counted in full, an inventory of twenty populated networks would fold the block which lists them and open on nothing; counted this way it opens on twenty folded network lines, and a reader drills down a level per click.

**A title is the bare line, and the terminal is what sets it in.** Every line of it, not only the first: a field value may hold a newline — a description usually does — and a continuation left at column zero reads as a block of its own. The panel does not have to strip anything back off, so it cannot strip too much.

**Folding counts a node once.** Asking a section how long it is and asking again after deciding whether to open it walks the same subtree twice at every level, which doubles per level rather than adding one. A test counts the visits rather than timing them, since the growth is the defect and a clock only shows it on a tree larger than anyone has.

**The rails are decoration, not information.** Which array a line sits under is legible from the nesting whether or not the colors resolve, so a printer or a host which drops custom properties loses nothing a reader needed. Each of the four levels gets a hue, wrapping past that; the ramp is defined in every theme block, which a test checks.

### One assumption worth objecting to

The hook a model overrides to change how it prints is now `_repr_line` / `_repr_children`; `__rich__` is derived from them. A subclass which overrides `__rich__` alone still prints its own way standalone, but a container draws it from `_repr_line` — where before, a container composed children through their `__rich__`. Nothing in dascore does this and it is not a documented extension point, so I took the derived-`__rich__` contract over reflecting on which method a subclass replaced. Say so if you would rather it kept working both ways.

### Verification

`str()` is unchanged, checked directly against `origin/dev` over 210 objects — characters *and* rendered colors, since indenting a `Text` splits and rejoins it and a span which came back a character wide of where it started would paint the wrong word. The set covers every inventory model built bare, both example inventories walked to their leaves, empty containers, trees deeper than the display limit, field values holding newlines and padding, and `display_max_items` of 0, 1, 2, 3, 24, 25 and 26. Zero differences.

The panel is unchanged for everything that is not an inventory: the markup of fourteen patch and spool panels, across four `display_html_open_lines` settings, is byte-identical to dev.

Building the text is also about 1.5× faster on a large inventory (105 ms → 71 ms for a 10×10×10 tree). The old code re-split and re-joined each subtree's `Text` once per level it sat under; each line is now indented once.

Reviewed by Codex and five internal lenses; six findings were real and are fixed here, three of them found independently by more than one reviewer. The multi-line-description regression above was one of them, and it is now pinned by a test.

## Changelog

- changed: An inventory's HTML repr draws its networks as a nested tree which can be folded level by level, rather than as one block of text.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nested rendering for coordinate and inventory information.
  * Improved terminal and HTML displays with indentation, expandable sections, depth-based styling, and colored nesting guides.
  * Enhanced handling of multiline titles and omitted items in displays.

* **Bug Fixes**
  * Improved rendering of nested content and accurate section expansion based on visible lines.
  * Added clearer alignment and scrolling behavior for detailed displays.

* **Tests**
  * Expanded coverage for nested layouts, HTML output, styling, multiline content, and item elision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->