### PR TITLE
Say a time range's shared head once

### DIFF
--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -69,6 +69,7 @@ from dascore.utils.display import (
     get_nice_text,
     mapping_to_text,
     model_to_line,
+    range_end_text,
     split_block,
     stated_fields,
 )
@@ -952,7 +953,7 @@ class AnnotationSet(NodeRepr, NamespaceOwner):
             base += Text("min: ", key_style)
             base += get_nice_text(low)
             base += Text(" max: ", key_style)
-            base += get_nice_text(high)
+            base += range_end_text(low, high)
             if (span := duration_text(low, high)) is not None:
                 base += Text(" ") + span
             kind = "point" if spelling.point else "range"

--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -66,10 +66,9 @@ from dascore.utils.display import (
     counts_to_text,
     duration_text,
     get_header_text,
-    get_nice_text,
     mapping_to_text,
     model_to_line,
-    range_end_text,
+    range_texts,
     split_block,
     stated_fields,
 )
@@ -950,10 +949,14 @@ class AnnotationSet(NodeRepr, NamespaceOwner):
                 base += Text("unstated", key_style)
                 continue
             low, high = values.min(), values.max()
+            near, far = range_texts(low, high)
+            # Appended one at a time: a Text built as Text(x, style=...)
+            # makes that style the base of anything added to it, so the
+            # label's grey would bleed onto the value after it.
             base += Text("min: ", key_style)
-            base += get_nice_text(low)
+            base += near
             base += Text(" max: ", key_style)
-            base += range_end_text(low, high)
+            base += far
             if (span := duration_text(low, high)) is not None:
                 base += Text(" ") + span
             kind = "point" if spelling.point else "range"

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -58,6 +58,7 @@ from dascore.utils.display import (
     RichRepr,
     duration_text,
     get_nice_text,
+    range_end_text,
     rate_text,
 )
 from dascore.utils.docs import compose_docstring, get_docstring
@@ -629,7 +630,7 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         if not pd.isnull(self.min()):
             fields.append(("min", get_nice_text(self.min()), True))
         if not pd.isnull(self.max()):
-            fields.append(("max", get_nice_text(self.max()), True))
+            fields.append(("max", range_end_text(self.min(), self.max()), True))
         # Only a time. Two instants say nothing about how far apart they
         # are; a distance from 0 to 299 m already says 299 m.
         if dtype_time_like(self.dtype) and not pd.isnull(self.min()):

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -58,7 +58,7 @@ from dascore.utils.display import (
     RichRepr,
     duration_text,
     get_nice_text,
-    range_end_text,
+    range_texts,
     rate_text,
 )
 from dascore.utils.docs import compose_docstring, get_docstring
@@ -627,10 +627,13 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         is held.
         """
         fields: list[tuple[str, Text, bool]] = []
+        # Drawn as one range: the two ends state the same blocks, and
+        # the second states only what the first did not already.
+        near, far = range_texts(self.min(), self.max())
         if not pd.isnull(self.min()):
-            fields.append(("min", get_nice_text(self.min()), True))
+            fields.append(("min", near, True))
         if not pd.isnull(self.max()):
-            fields.append(("max", range_end_text(self.min(), self.max()), True))
+            fields.append(("max", far, True))
         # Only a time. Two instants say nothing about how far apart they
         # are; a distance from 0 to 299 m already says 299 m.
         if dtype_time_like(self.dtype) and not pd.isnull(self.min()):

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -98,6 +98,7 @@ from dascore.utils.display import (
     get_header_text,
     get_nice_text,
     group_names,
+    range_end_text,
     split_block,
 )
 from dascore.utils.docs import compose_docstring
@@ -2469,7 +2470,8 @@ class Spool(NodeRepr, NamespaceOwner):
                 continue
             low, high = measured[f"{dim}_min"].min(), measured[f"{dim}_max"].max()
             units = self._dim_units(measured, dim)
-            base += get_nice_text(low) + Text(" to ", key_style) + get_nice_text(high)
+            base += get_nice_text(low) + Text(" to ", key_style)
+            base += range_end_text(low, high)
             if len(units) > 1:
                 # Envelopes are stored in the units each patch was read
                 # in, so a min and a max from two of them are not two

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -98,7 +98,7 @@ from dascore.utils.display import (
     get_header_text,
     get_nice_text,
     group_names,
-    range_end_text,
+    range_texts,
     split_block,
 )
 from dascore.utils.docs import compose_docstring
@@ -2470,8 +2470,8 @@ class Spool(NodeRepr, NamespaceOwner):
                 continue
             low, high = measured[f"{dim}_min"].min(), measured[f"{dim}_max"].max()
             units = self._dim_units(measured, dim)
-            base += get_nice_text(low) + Text(" to ", key_style)
-            base += range_end_text(low, high)
+            near, far = range_texts(low, high)
+            base += near + Text(" to ", key_style) + far
             if len(units) > 1:
                 # Envelopes are stored in the units each patch was read
                 # in, so a min and a max from two of them are not two

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -58,6 +58,20 @@ _NANOSECOND = 1e-9
 # What counts as a time, and so what has a duration between two of it.
 _TIME_TYPES = (pd.Timestamp, np.datetime64, pd.Timedelta, np.timedelta64)
 
+# What an instant is, and so what is stated in calendar fields a range
+# can share. An offset is not one: 1.5s and 1.25s have a leading "1" in
+# common and it is not a field either of them states.
+_INSTANT_TYPES = (pd.Timestamp, np.datetime64)
+
+# What stands in a range's far end for the fields its near end already
+# stated. Read as "and the rest of it is what you just read".
+_REPEAT_MARK = "…"
+
+# What divides one field of a rendered time from the next, kept so a
+# head can be measured in whole fields. The date is not split here: it
+# is one field, elided whole or not at all.
+_TIME_FIELDS = re.compile(r"([:.])")
+
 # The most figures a rate is quoted to when it cannot state its step
 # exactly. A rate which can gets as many as that takes, up to the point
 # where it has stopped being a rate and become the step in other units.
@@ -873,6 +887,95 @@ def duration_text(low, high) -> Text | None:
     if not (said := human_duration(seconds)):
         return None
     return Text(f"<{said}>", dascore_styles["keys"])
+
+
+def _split_instant(rendered: str) -> tuple[str, str]:
+    """
+    A rendered instant, as the date it states and the time it states.
+
+    One of the two is empty where the value did not need it: a repr
+    drops a date of the epoch and a time of midnight, so the two ends
+    of one range can arrive in different shapes.
+    """
+    date, divider, time = rendered.partition("T")
+    if divider:
+        return date, time
+    # No divider, so it is one or the other. A date has dashes in it, a
+    # time has colons, and neither has the other's.
+    return (date, "") if "-" in date else ("", date)
+
+
+def _shared_head(low: str, high: str) -> int:
+    """
+    How many leading characters of `high` repeat what `low` already says.
+
+    Measured in whole fields, so a mark never stands for the first digit
+    of one. The date is a single field: two instants on different days
+    share nothing, since eliding the year of 2023-06-01 and 2023-07-01
+    would leave the month to be noticed on its own.
+    """
+    low_date, low_time = _split_instant(low)
+    high_date, high_time = _split_instant(high)
+    # A date one end states and the other does not is not a date they
+    # share, whatever the characters under it say.
+    if bool(low_date) != bool(high_date) or low_date != high_date:
+        return 0
+    shared = len(high_date)
+    # The divider sits between the date and the fields below it, and is
+    # part of neither.
+    at = shared + 1 if high_date and high_time else shared
+    low_fields = _TIME_FIELDS.split(low_time)
+    high_fields = _TIME_FIELDS.split(high_time)
+    # Field, separator, field, at even indices and odd: a separator
+    # counts toward the head like anything else, but the head only ends
+    # at a field, so what is left starts with the separator before it.
+    for index, (stated, repeated) in enumerate(zip(low_fields, high_fields)):
+        if stated != repeated:
+            break
+        at += len(repeated)
+        if index % 2 == 0:
+            shared = at
+    return shared
+
+
+def range_end_text(low, high) -> Text:
+    """
+    The far end of a range, with what it repeats of the near end elided.
+
+    The two ends of a time range stand next to each other, so the
+    leading fields of the second are a fact the reader has just read.
+    They are replaced by one mark, which says the rest is as stated: a
+    range inside one day states that day once.
+
+    Compared on what the near end is drawn as, not on what it holds.
+    A repr trims each instant on its own -- a start at midnight comes
+    out as a bare date -- and a mark may not stand for a field which is
+    then nowhere to be read.
+
+    Only of two instants, and only where they share a field. An offset
+    of 1.25s repeats nothing of one of 1.5s -- the digit they lead with
+    is not a field either of them states -- and anything else comes
+    back as it would have been drawn anyway.
+    """
+    high_text = get_nice_text(high)
+    if not isinstance(low, _INSTANT_TYPES) or not isinstance(high, _INSTANT_TYPES):
+        return high_text
+    if pd.isnull(low) or pd.isnull(high):
+        return high_text
+    if not (shared := _shared_head(get_nice_text(low).plain, high_text.plain)):
+        return high_text
+    rest = high_text[shared:]
+    # The divider only tells a date from a time, and the date is what
+    # was just elided. A colon or a point stays: it says which field
+    # the number after it is, so 41.5 cannot be read as an hour.
+    if rest.plain.startswith("T"):
+        rest = rest[1:]
+    # Started empty and appended to: a Text built as Text(x, style=...)
+    # makes that style the base of everything appended after it, so the
+    # mark's grey would bleed onto the fields which survived it.
+    said = Text("")
+    said += Text(_REPEAT_MARK, dascore_styles["keys"])
+    return said + rest
 
 
 def _fewest_figures(value: float, accept) -> int | None:

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -72,6 +72,13 @@ _REPEAT_MARK = "…"
 # is one field, elided whole or not at all.
 _TIME_FIELDS = re.compile(r"([:.])")
 
+# What an instant has to say to be taken apart by position: a four digit
+# year, a divider numpy writes as T and pandas as a space, and nothing
+# after the fraction. One which says more -- a timezone offset, or a
+# year of five digits -- is drawn as it states itself rather than sliced
+# into fields which would then be wrong.
+_INSTANT_LAYOUT = re.compile(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?")
+
 # The most figures a rate is quoted to when it cannot state its step
 # exactly. A rate which can gets as many as that takes, up to the point
 # where it has stopped being a rate and become the step in other units.
@@ -663,27 +670,33 @@ def _nice_timedelta(value, style=None):
     return get_nice_text(Text(f"{sec:.9}s"), style)
 
 
-def _instant_string(value) -> str:
+def _instant_string(value) -> str | None:
     """
     An instant as the ISO string its blocks are read out of.
 
     A value of coarser precision states less than that -- a date has no
     time on it at all -- so it is read back at the precision everything
     else here assumes.
+
+    None where what it states cannot be taken apart by position at all.
+    A timezone offset and a five digit year both push every field along
+    by a character or two, and slicing them anyway draws an instant
+    which is not the one handed over.
     """
     stated = str(value)
     if len(stated) < 20:  # no room for a time, so it states none
         stated = str(dc.to_datetime64(stated))
-    # Enough characters to reach the decimal, which every block below is
-    # sliced against.
-    assert len(stated) >= 20
-    return stated
+    return stated if _INSTANT_LAYOUT.fullmatch(stated) else None
 
 
 @cache
 def _empty_instant() -> str:
     """The epoch, which is what a block saying nothing looks like."""
-    return _instant_string(dc.to_datetime64(0))
+    stated = _instant_string(dc.to_datetime64(0))
+    # The epoch is an instant of this library's own making, and states
+    # itself in the layout everything here is measured against.
+    assert stated is not None
+    return stated
 
 
 def _instant_blocks(*stated: str) -> tuple[bool, bool]:
@@ -735,9 +748,8 @@ def _instant_text(stated: str, date: bool, time: bool) -> Text:
 @get_nice_text.register(pd.Timestamp)
 def _nice_datetime(value, style=None):
     """Get a nice datetime value, in the blocks which say something."""
-    if pd.isnull(value):
+    if pd.isnull(value) or (stated := _instant_string(value)) is None:
         return get_nice_text(Text(str(value)), style)
-    stated = _instant_string(value)
     return get_nice_text(_instant_text(stated, *_instant_blocks(stated)), style)
 
 
@@ -991,7 +1003,10 @@ def range_texts(low, high) -> tuple[Text, Text]:
         return drawn
     if pd.isnull(low) or pd.isnull(high):
         return drawn
-    stated = (_instant_string(low), _instant_string(high))
+    near_stated, far_stated = _instant_string(low), _instant_string(high)
+    if near_stated is None or far_stated is None:
+        return drawn
+    stated = (near_stated, far_stated)
     blocks = _instant_blocks(*stated)
     near, far = (_instant_text(x, *blocks) for x in stated)
     if not (shared := _shared_head(near.plain, far.plain)):

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -663,57 +663,82 @@ def _nice_timedelta(value, style=None):
     return get_nice_text(Text(f"{sec:.9}s"), style)
 
 
+def _instant_string(value) -> str:
+    """
+    An instant as the ISO string its blocks are read out of.
+
+    A value of coarser precision states less than that -- a date has no
+    time on it at all -- so it is read back at the precision everything
+    else here assumes.
+    """
+    stated = str(value)
+    if len(stated) < 20:  # no room for a time, so it states none
+        stated = str(dc.to_datetime64(stated))
+    # Enough characters to reach the decimal, which every block below is
+    # sliced against.
+    assert len(stated) >= 20
+    return stated
+
+
+@cache
+def _empty_instant() -> str:
+    """The epoch, which is what a block saying nothing looks like."""
+    return _instant_string(dc.to_datetime64(0))
+
+
+def _instant_blocks(*stated: str) -> tuple[bool, bool]:
+    """
+    Which blocks instants are drawn in: the date, and the time.
+
+    A block is drawn where any of them needs it, so the two ends of one
+    range come out in one shape and can be read against each other. A
+    midnight start drawn beside a stop seconds later would otherwise be
+    a bare date beside a full instant, and the fields they have in
+    common could not be seen to be in common.
+
+    An instant of the epoch needs neither block, and is drawn as a time.
+    """
+    empty = _empty_instant()
+    date = any(x[:10] != empty[:10] for x in stated)
+    time = any(x[11:] != empty[11:] for x in stated)
+    return date, time or not date
+
+
+def _instant_text(stated: str, date: bool, time: bool) -> Text:
+    """
+    An instant drawn in the blocks asked for, each field styled.
+
+    The string is ISO 8601 but for its divider, which a pandas timestamp
+    states as a space; every field is taken by position, and the divider
+    is written rather than copied.
+    """
+    ymd = dascore_styles["ymd"]
+    hms = dascore_styles["hms"]
+    dec = dascore_styles["dec"]
+    out = Text("")
+    if date:
+        parts = (stated[:4], stated[5:7], stated[8:10])
+        out += Text("-").join([Text(x, ymd) for x in parts])
+    if time:
+        if date:
+            out += Text("T")
+        parts = (stated[11:13], stated[14:16], stated[17:19])
+        out += Text(":").join([Text(x, hms) for x in parts])
+        # Only what the fraction says. A step of a millisecond leaves
+        # six digits of nothing behind it at nanosecond precision.
+        if fraction := stated[20:].rstrip("0"):
+            out += Text(".") + Text(fraction, dec)
+    return out
+
+
 @get_nice_text.register(np.datetime64)
 @get_nice_text.register(pd.Timestamp)
 def _nice_datetime(value, style=None):
-    """Get a nice timedelta value."""
-
-    def simplify_str(dt_str):
-        """Simplify the string to only show needed parts."""
-        empty = str(dc.to_datetime64(0))
-        original_str = str(dt_str)
-        trimmed_str = original_str
-        # strip off YEAR-MONTH-DAY if they aren't used.
-        if empty.split("T")[0] == trimmed_str.split("T")[0]:
-            trimmed_str = trimmed_str.split("T")[-1]
-        # strip off HOUR-MIN-SEC if it isnt used
-        elif empty.split("T")[-1] == trimmed_str.split("T")[-1]:
-            trimmed_str = trimmed_str.split("T")[0]
-        if "." in trimmed_str:  # strip trailing 0s.
-            trimmed_str = trimmed_str.rstrip("0").rstrip(".")
-        ind = original_str.find(trimmed_str)
-        return dt_str[ind : ind + len(trimmed_str)]
-
-    def stylize_str(dt_str):
-        """
-        Apply color/style to strings. This assumes the string is formatted
-        in the standard ISO 8601 format.
-        """
-        # get relevant styles.
-        ymd = dascore_styles["ymd"]
-        hms = dascore_styles["hms"]
-        dec = dascore_styles["dec"]
-        if len(dt_str) < 20:  # this might be a timestamp string
-            dt_str = str(dc.to_datetime64(dt_str))
-        # parse out string components
-        assert len(dt_str) >= 20  # need chars at least up to decimal
-        year, month, day = dt_str[:4], dt_str[5:7], dt_str[8:10]
-        hour, minute, second = dt_str[11:13], dt_str[14:16], dt_str[17:19]
-        decimal_bit = dt_str[20:]
-        # assemble text with styling
-        out = Text("")
-        out += Text("-").join([Text(x, ymd) for x in [year, month, day]])
-        out += Text("T")
-        out += Text(":").join([Text(x, hms) for x in [hour, minute, second]])
-        out += Text(".") + Text(decimal_bit, dec)
-        return out
-
+    """Get a nice datetime value, in the blocks which say something."""
     if pd.isnull(value):
         return get_nice_text(Text(str(value)), style)
-
-    stylized_text = stylize_str(str(value))
-    simplified_text = simplify_str(stylized_text)
-    return get_nice_text(simplified_text, style)
+    stated = _instant_string(value)
+    return get_nice_text(_instant_text(stated, *_instant_blocks(stated)), style)
 
 
 def get_dascore_text():
@@ -938,36 +963,40 @@ def _shared_head(low: str, high: str) -> int:
     return shared
 
 
-def range_end_text(low, high) -> Text:
+def range_texts(low, high) -> tuple[Text, Text]:
     """
-    The far end of a range, with what it repeats of the near end elided.
+    The two ends of a range, drawn as one range rather than as two values.
 
-    The two ends of a time range stand next to each other, so the
-    leading fields of the second are a fact the reader has just read.
-    They are replaced by one mark, which says the rest is as stated: a
-    range inside one day states that day once.
+    Two things happen here which drawing each end on its own cannot do.
 
-    Compared on what the near end is drawn as, not on what it holds.
-    A repr trims each instant on its own -- a start at midnight comes
-    out as a bare date -- and a mark may not stand for a field which is
-    then nowhere to be read.
+    They are drawn in one shape: a block either end needs is drawn on
+    both, so a start at midnight comes out as ``2017-09-18T00:00:00``
+    beside its stop rather than as a bare date. What each states is then
+    in the same place, which is what lets the second be read against the
+    first.
 
-    Only of two instants, and only where they share a field. An offset
-    of 1.25s repeats nothing of one of 1.5s -- the digit they lead with
-    is not a field either of them states -- and anything else comes
-    back as it would have been drawn anyway.
+    And the far end states only what differs. The fields it repeats
+    stand next to it already, so they are replaced by one mark: a range
+    inside one day states that day once. A leading ``T`` goes with them,
+    since with the date gone it divides nothing, while a leading ``:``
+    or ``.`` stays -- it says which field the number after it is, so
+    41.5 cannot be read as an hour.
+
+    Only of two instants. An offset of 1.25s repeats nothing of one of
+    1.5s -- the digit they lead with is not a field either of them
+    states -- and any other pair is drawn as it would have been anyway.
     """
-    high_text = get_nice_text(high)
+    drawn = (get_nice_text(low), get_nice_text(high))
     if not isinstance(low, _INSTANT_TYPES) or not isinstance(high, _INSTANT_TYPES):
-        return high_text
+        return drawn
     if pd.isnull(low) or pd.isnull(high):
-        return high_text
-    if not (shared := _shared_head(get_nice_text(low).plain, high_text.plain)):
-        return high_text
-    rest = high_text[shared:]
-    # The divider only tells a date from a time, and the date is what
-    # was just elided. A colon or a point stays: it says which field
-    # the number after it is, so 41.5 cannot be read as an hour.
+        return drawn
+    stated = (_instant_string(low), _instant_string(high))
+    blocks = _instant_blocks(*stated)
+    near, far = (_instant_text(x, *blocks) for x in stated)
+    if not (shared := _shared_head(near.plain, far.plain)):
+        return near, far
+    rest = far[shared:]
     if rest.plain.startswith("T"):
         rest = rest[1:]
     # Started empty and appended to: a Text built as Text(x, style=...)
@@ -975,7 +1004,7 @@ def range_end_text(low, high) -> Text:
     # mark's grey would bleed onto the fields which survived it.
     said = Text("")
     said += Text(_REPEAT_MARK, dascore_styles["keys"])
-    return said + rest
+    return near, said + rest
 
 
 def _fewest_figures(value: float, accept) -> int | None:

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -384,6 +384,8 @@ The `data_type` attribute is an optional label for the kind of data in the patch
 
 A patch says what it holds. Where a display can render HTML — a notebook, or this page — it draws a panel whose sections fold; everywhere else, and with `display_html` off, it says the same words as text.
 
+A time range is stated from the first field which differs: the `…` on the far end stands for whatever it repeats of the near one, so a patch inside one day says that day once.
+
 ```{python}
 import dascore as dc
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -384,7 +384,7 @@ The `data_type` attribute is an optional label for the kind of data in the patch
 
 A patch says what it holds. Where a display can render HTML — a notebook, or this page — it draws a panel whose sections fold; everywhere else, and with `display_html` off, it says the same words as text.
 
-A time range is stated from the first field which differs: the `…` on the far end stands for whatever it repeats of the near one, so a patch inside one day says that day once.
+A time range is drawn as a range rather than as two values: both ends state the same fields, and the far one states only what differs, with `…` standing for whatever it repeats of the near one. A patch inside one day says that day once.
 
 ```{python}
 import dascore as dc

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -31,7 +31,7 @@ from dascore.exceptions import (
 )
 from dascore.io.index.planned import PlanResolver
 from dascore.io.segy import SegyV1_0
-from dascore.utils.display import get_nice_text
+from dascore.utils.display import range_end_text
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch_assembly import _estimate_merge_samples, _get_varying_dim
@@ -1984,7 +1984,11 @@ class TestSpoolRepr:
         # The bug this pins: reading both ends off time_min made every
         # single-patch spool span zero time.
         assert df["time_min"].max() != df["time_max"].max()
-        assert str(get_nice_text(df["time_max"].max())) in str(spool)
+        stated = range_end_text(df["time_min"].min(), df["time_max"].max())
+        assert str(stated) in str(spool)
+        # An end which repeats the start entirely draws as the mark and
+        # nothing else, which is the shape the bug would leave behind.
+        assert str(stated).lstrip("…")
 
     def test_a_single_patch_spans_its_own_length(self):
         """One patch is a span of its duration, not a span of nothing."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -1984,11 +1984,12 @@ class TestSpoolRepr:
         # The bug this pins: reading both ends off time_min made every
         # single-patch spool span zero time.
         assert df["time_min"].max() != df["time_max"].max()
+        # Written out rather than rendered here: an expectation built by
+        # the same helper the repr uses would follow it into a wrong
+        # answer, which is what a regression test is for catching.
+        assert "2020-01-03 to …00:00:23.996" in str(spool)
         stated = range_end_text(df["time_min"].min(), df["time_max"].max())
         assert str(stated) in str(spool)
-        # An end which repeats the start entirely draws as the mark and
-        # nothing else, which is the shape the bug would leave behind.
-        assert str(stated).lstrip("…")
 
     def test_a_single_patch_spans_its_own_length(self):
         """One patch is a span of its duration, not a span of nothing."""

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -31,7 +31,7 @@ from dascore.exceptions import (
 )
 from dascore.io.index.planned import PlanResolver
 from dascore.io.segy import SegyV1_0
-from dascore.utils.display import range_end_text
+from dascore.utils.display import range_texts
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch_assembly import _estimate_merge_samples, _get_varying_dim
@@ -1987,8 +1987,8 @@ class TestSpoolRepr:
         # Written out rather than rendered here: an expectation built by
         # the same helper the repr uses would follow it into a wrong
         # answer, which is what a regression test is for catching.
-        assert "2020-01-03 to …00:00:23.996" in str(spool)
-        stated = range_end_text(df["time_min"].min(), df["time_max"].max())
+        assert "2020-01-03T00:00:00 to …:23.996" in str(spool)
+        stated = range_texts(df["time_min"].min(), df["time_max"].max())[1]
         assert str(stated) in str(spool)
 
     def test_a_single_patch_spans_its_own_length(self):
@@ -2364,7 +2364,7 @@ class TestSpoolRepr:
         )
         rendered = str(spool)
         # 500 years overflows a Timedelta; the extents survive it.
-        assert "1700-01-01 to 2200-01-01" in rendered
+        assert "1700-01-01T00:00:00 to 2200-01-01T00:00:07.996" in rendered
         assert "distance: 0.000 to 299.000 m" in rendered
 
     def test_a_dimension_states_the_units_of_its_own_rows(self):

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -54,7 +54,7 @@ from dascore.utils.display import (
     mapping_to_text,
     model_to_line,
     percent,
-    range_end_text,
+    range_texts,
     rate_text,
     render_html,
     render_text,
@@ -993,34 +993,83 @@ class TestDurationText:
         assert expected in str(said)
 
 
-class TestRangeEndText:
-    """Tests for the far end of a range, with what it repeats elided."""
+class TestRangeTexts:
+    """Tests for the two ends of a range, drawn as one range."""
 
     @pytest.mark.parametrize(
-        ("low", "high", "expected"),
+        ("low", "high", "near", "far"),
         [
-            # A start at midnight is drawn as a bare date, so the date
-            # is all the far end may leave out.
-            ("2017-09-18T00:00:00", "2017-09-18T00:00:07.996", "…00:00:07.996"),
-            ("2023-06-01T14:23:11", "2023-06-01T18:00:00", "…18:00:00"),
-            ("2023-06-01T14:23:11", "2023-06-01T14:00:41.5", "…:00:41.5"),
-            ("2023-06-01T14:23:11", "2023-06-01T14:23:41.5", "…:41.5"),
-            ("2023-06-01T14:23:11", "2023-06-01T14:23:11.5", "….5"),
-            # Both drawn as times of the epoch day, which is no less a
-            # head for being one neither of them prints.
-            ("1970-01-01T00:00:11", "1970-01-01T00:00:41.5", "…:41.5"),
+            # A start at midnight is drawn with its time, so the stop
+            # can be read against it down to the field which differs.
+            (
+                "2017-09-18T00:00:00",
+                "2017-09-18T00:00:07.996",
+                "2017-09-18T00:00:00",
+                "…:07.996",
+            ),
+            (
+                "2023-06-01T14:23:11",
+                "2023-06-01T18:00:00",
+                "2023-06-01T14:23:11",
+                "…18:00:00",
+            ),
+            (
+                "2023-06-01T14:23:11",
+                "2023-06-01T14:00:41.5",
+                "2023-06-01T14:23:11",
+                "…:00:41.5",
+            ),
+            (
+                "2023-06-01T14:23:11",
+                "2023-06-01T14:23:41.5",
+                "2023-06-01T14:23:11",
+                "…:41.5",
+            ),
+            (
+                "2023-06-01T14:23:11",
+                "2023-06-01T14:23:11.5",
+                "2023-06-01T14:23:11",
+                "….5",
+            ),
+            # Both are of the epoch day, which neither of them draws,
+            # and which is no less a head for that.
+            (
+                "1970-01-01T00:00:11",
+                "1970-01-01T00:00:41.5",
+                "00:00:11",
+                "…:41.5",
+            ),
+            # Neither end has a time to state, so neither states one and
+            # the date is all there is to repeat.
+            ("2017-09-18", "2017-09-18", "2017-09-18", "…"),
         ],
-        ids=["date", "hour", "hour_kept", "minute", "second", "epoch"],
+        ids=["date", "hour", "hour_kept", "minute", "second", "epoch", "days"],
     )
-    def test_a_shared_head_is_said_once(self, low, high, expected):
+    def test_a_shared_head_is_said_once(self, low, high, near, far):
         """What the near end already said is a mark on the far one."""
-        said = range_end_text(np.datetime64(low), np.datetime64(high))
-        assert str(said) == expected
+        drawn = range_texts(np.datetime64(low), np.datetime64(high))
+        assert [str(x) for x in drawn] == [near, far]
 
     def test_two_ends_of_one_instant(self):
         """A coordinate of one sample repeats its start entirely."""
         instant = np.datetime64("2017-09-18T00:00:03")
-        assert str(range_end_text(instant, instant)) == "…"
+        near, far = range_texts(instant, instant)
+        assert str(near) == "2017-09-18T00:00:03"
+        assert str(far) == "…"
+
+    def test_a_block_either_end_needs_is_drawn_on_both(self):
+        """
+        A date of the epoch is dropped from a value drawn on its own.
+
+        Dropped from one end of a range it leaves a bare time beside a
+        bare date, which reads as two unrelated values rather than as
+        the fifty years between them.
+        """
+        low, high = dc.to_datetime64(0), np.datetime64("2020-01-01T00:00:00")
+        assert str(get_nice_text(low)) == "00:00:00"
+        near, far = range_texts(low, high)
+        assert str(near) == "1970-01-01"
+        assert str(far) == "2020-01-01"
 
     @pytest.mark.parametrize(
         ("low", "high"),
@@ -1039,23 +1088,28 @@ class TestRangeEndText:
         day on its own, against a year and month they must take on
         trust.
         """
-        said = range_end_text(np.datetime64(low), np.datetime64(high))
-        assert str(said) == str(get_nice_text(np.datetime64(high)))
+        _, far = range_texts(np.datetime64(low), np.datetime64(high))
+        assert str(far) == str(get_nice_text(np.datetime64(high)))
 
-    def test_a_far_end_which_states_less_than_the_near_one(self):
+    def test_a_far_end_earlier_than_the_near_one(self):
         """
-        A far end drawn as a bare date states no field the near end did
-        not, so there is nothing left of it to draw but the mark.
+        Neither end is asked to be the larger.
+
+        A far end which states less is still drawn in the blocks the
+        pair states, so what it repeats can still be seen to repeat.
         """
         low = np.datetime64("2017-09-18T00:00:03")
         high = np.datetime64("2017-09-18T00:00:00")
-        assert str(range_end_text(low, high)) == "…"
+        assert [str(x) for x in range_texts(low, high)] == [
+            "2017-09-18T00:00:03",
+            "…:00",
+        ]
 
     def test_an_end_which_repeats_nothing(self):
         """A far end sharing no field is drawn as it always was."""
         low = np.datetime64("2023-06-01T14:23:11")
         high = np.datetime64("2024-11-30T09:00:00")
-        assert str(range_end_text(low, high)) == "2024-11-30T09:00:00"
+        assert str(range_texts(low, high)[1]) == "2024-11-30T09:00:00"
 
     @pytest.mark.parametrize(
         ("low", "high"),
@@ -1081,16 +1135,17 @@ class TestRangeEndText:
             "offsets",
         ],
     )
-    def test_only_two_instants_share_a_head(self, low, high):
+    def test_only_two_instants_are_drawn_as_a_range(self, low, high):
         """Anything else is drawn as it would have been anyway."""
-        assert str(range_end_text(low, high)) == str(get_nice_text(high))
+        drawn = [str(x) for x in range_texts(low, high)]
+        assert drawn == [str(get_nice_text(low)), str(get_nice_text(high))]
 
     @pytest.mark.parametrize("null", [np.datetime64("NaT"), pd.NaT])
     def test_a_null_end_repeats_nothing(self, null):
         """An end which is not a time cannot be a head for the other."""
         instant = np.datetime64("2020-01-01T00:00:00")
-        assert str(range_end_text(null, instant)) == str(get_nice_text(instant))
-        assert str(range_end_text(instant, null)) == str(get_nice_text(null))
+        assert str(range_texts(null, instant)[1]) == str(get_nice_text(instant))
+        assert str(range_texts(instant, null)[1]) == str(get_nice_text(null))
 
     def test_what_is_left_keeps_its_styles(self):
         """
@@ -1101,8 +1156,8 @@ class TestRangeEndText:
         """
         low = np.datetime64("2017-09-18T00:00:00")
         high = np.datetime64("2017-09-18T00:00:07.996")
-        said = range_end_text(low, high)
-        assert said.plain == "…00:00:07.996"
+        said = range_texts(low, high)[1]
+        assert said.plain == "…:07.996"
         # Read at an offset, not off the spans: a style can also arrive
         # as the base of the whole text, which is how it would bleed.
         console = Console()
@@ -1121,7 +1176,10 @@ class TestRangeEndText:
         """A frame states its extents as Timestamps, and a repr reads them."""
         low = pd.Timestamp("2020-01-03T00:00:00")
         high = pd.Timestamp("2020-01-03T00:00:23.996")
-        assert str(range_end_text(low, high)) == "…00:00:23.996"
+        assert [str(x) for x in range_texts(low, high)] == [
+            "2020-01-03T00:00:00",
+            "…:23.996",
+        ]
 
 
 class TestValuesAReaderCanRead:
@@ -1153,7 +1211,7 @@ class TestValuesAReaderCanRead:
     def test_a_time_coord_says_the_day_once(self):
         """The far end of a range starts where it stops repeating."""
         coord = dc.get_example_patch().coords.coord_map["time"]
-        assert "min: 2017-09-18 max: …00:00:07.996" in str(coord)
+        assert "min: 2017-09-18T00:00:00 max: …:07.996" in str(coord)
 
     def test_an_annotation_set_says_the_day_once(self):
         """The same elision a coordinate and a spool state."""
@@ -1164,7 +1222,7 @@ class TestValuesAReaderCanRead:
             }
         )
         rendered = str(AnnotationSet(frame, dims=("time",)))
-        assert "min: 2020-01-01 max: …00:00:09" in rendered
+        assert "min: 2020-01-01T00:00:00 max: …:09" in rendered
 
     def test_an_annotation_set_over_distance_states_no_span(self):
         """

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -1042,6 +1042,15 @@ class TestRangeEndText:
         said = range_end_text(np.datetime64(low), np.datetime64(high))
         assert str(said) == str(get_nice_text(np.datetime64(high)))
 
+    def test_a_far_end_which_states_less_than_the_near_one(self):
+        """
+        A far end drawn as a bare date states no field the near end did
+        not, so there is nothing left of it to draw but the mark.
+        """
+        low = np.datetime64("2017-09-18T00:00:03")
+        high = np.datetime64("2017-09-18T00:00:00")
+        assert str(range_end_text(low, high)) == "…"
+
     def test_an_end_which_repeats_nothing(self):
         """A far end sharing no field is drawn as it always was."""
         low = np.datetime64("2023-06-01T14:23:11")
@@ -1093,10 +1102,20 @@ class TestRangeEndText:
         low = np.datetime64("2017-09-18T00:00:00")
         high = np.datetime64("2017-09-18T00:00:07.996")
         said = range_end_text(low, high)
-        styles = {str(span.style) for span in said.spans}
-        assert dascore_styles["hms"] in styles
-        assert dascore_styles["dec"] in styles
-        assert said.spans[0].style == dascore_styles["keys"]
+        assert said.plain == "…00:00:07.996"
+        # Read at an offset, not off the spans: a style can also arrive
+        # as the base of the whole text, which is how it would bleed.
+        console = Console()
+
+        def style_at(offset):
+            return str(said.get_style_at_offset(console, offset))
+
+        assert style_at(0) == dascore_styles["keys"]
+        assert style_at(said.plain.index("07")) == dascore_styles["hms"]
+        assert style_at(said.plain.index("996")) == dascore_styles["dec"]
+        # The separators are what the elision left behind, and belong to
+        # neither the mark nor the fields around them.
+        assert style_at(said.plain.index(":")) == "none"
 
     def test_a_pandas_timestamp_is_an_instant(self):
         """A frame states its extents as Timestamps, and a repr reads them."""
@@ -1130,6 +1149,22 @@ class TestValuesAReaderCanRead:
     def test_the_data_states_how_much_room_it_takes(self):
         """Whether it fits in memory is what dtype times shape is for."""
         assert "4.6 MiB" in str(dc.get_example_patch())
+
+    def test_a_time_coord_says_the_day_once(self):
+        """The far end of a range starts where it stops repeating."""
+        coord = dc.get_example_patch().coords.coord_map["time"]
+        assert "min: 2017-09-18 max: …00:00:07.996" in str(coord)
+
+    def test_an_annotation_set_says_the_day_once(self):
+        """The same elision a coordinate and a spool state."""
+        frame = pd.DataFrame(
+            {
+                "time_min": pd.to_datetime(["2020-01-01T00:00:00"]),
+                "time_max": pd.to_datetime(["2020-01-01T00:00:09"]),
+            }
+        )
+        rendered = str(AnnotationSet(frame, dims=("time",)))
+        assert "min: 2020-01-01 max: …00:00:09" in rendered
 
     def test_an_annotation_set_over_distance_states_no_span(self):
         """

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -54,6 +54,7 @@ from dascore.utils.display import (
     mapping_to_text,
     model_to_line,
     percent,
+    range_end_text,
     rate_text,
     render_html,
     render_text,
@@ -990,6 +991,118 @@ class TestDurationText:
         """
         said = duration_text(np.datetime64(low), np.datetime64(high))
         assert expected in str(said)
+
+
+class TestRangeEndText:
+    """Tests for the far end of a range, with what it repeats elided."""
+
+    @pytest.mark.parametrize(
+        ("low", "high", "expected"),
+        [
+            # A start at midnight is drawn as a bare date, so the date
+            # is all the far end may leave out.
+            ("2017-09-18T00:00:00", "2017-09-18T00:00:07.996", "…00:00:07.996"),
+            ("2023-06-01T14:23:11", "2023-06-01T18:00:00", "…18:00:00"),
+            ("2023-06-01T14:23:11", "2023-06-01T14:00:41.5", "…:00:41.5"),
+            ("2023-06-01T14:23:11", "2023-06-01T14:23:41.5", "…:41.5"),
+            ("2023-06-01T14:23:11", "2023-06-01T14:23:11.5", "….5"),
+            # Both drawn as times of the epoch day, which is no less a
+            # head for being one neither of them prints.
+            ("1970-01-01T00:00:11", "1970-01-01T00:00:41.5", "…:41.5"),
+        ],
+        ids=["date", "hour", "hour_kept", "minute", "second", "epoch"],
+    )
+    def test_a_shared_head_is_said_once(self, low, high, expected):
+        """What the near end already said is a mark on the far one."""
+        said = range_end_text(np.datetime64(low), np.datetime64(high))
+        assert str(said) == expected
+
+    def test_two_ends_of_one_instant(self):
+        """A coordinate of one sample repeats its start entirely."""
+        instant = np.datetime64("2017-09-18T00:00:03")
+        assert str(range_end_text(instant, instant)) == "…"
+
+    @pytest.mark.parametrize(
+        ("low", "high"),
+        [
+            ("2023-06-01T23:59:59", "2023-06-02T00:00:30"),
+            ("2023-06-01T00:00:00", "2023-07-01T00:00:00"),
+            ("2023-06-01T00:00:00", "2024-06-01T00:00:00"),
+        ],
+        ids=["day", "month", "year"],
+    )
+    def test_a_date_is_elided_whole_or_not_at_all(self, low, high):
+        """
+        Eliding the year of two different days says less, not more.
+
+        A far end of "…-02T00:00:30" leaves the reader to notice the
+        day on its own, against a year and month they must take on
+        trust.
+        """
+        said = range_end_text(np.datetime64(low), np.datetime64(high))
+        assert str(said) == str(get_nice_text(np.datetime64(high)))
+
+    def test_an_end_which_repeats_nothing(self):
+        """A far end sharing no field is drawn as it always was."""
+        low = np.datetime64("2023-06-01T14:23:11")
+        high = np.datetime64("2024-11-30T09:00:00")
+        assert str(range_end_text(low, high)) == "2024-11-30T09:00:00"
+
+    @pytest.mark.parametrize(
+        ("low", "high"),
+        [
+            (0.0, 299.0),
+            (0, 299),
+            ("a", "b"),
+            (None, None),
+            (1, np.datetime64("2020-01-01")),
+            (np.datetime64("2020-01-01"), 1),
+            # Offsets, not instants. The "1" they lead with is not a
+            # field either of them states, and eliding it would leave
+            # 1.25s drawn as a fraction of nothing.
+            (np.timedelta64(1500, "ms"), np.timedelta64(1250, "ms")),
+        ],
+        ids=[
+            "floats",
+            "ints",
+            "strings",
+            "none",
+            "mixed_low",
+            "mixed_high",
+            "offsets",
+        ],
+    )
+    def test_only_two_instants_share_a_head(self, low, high):
+        """Anything else is drawn as it would have been anyway."""
+        assert str(range_end_text(low, high)) == str(get_nice_text(high))
+
+    @pytest.mark.parametrize("null", [np.datetime64("NaT"), pd.NaT])
+    def test_a_null_end_repeats_nothing(self, null):
+        """An end which is not a time cannot be a head for the other."""
+        instant = np.datetime64("2020-01-01T00:00:00")
+        assert str(range_end_text(null, instant)) == str(get_nice_text(instant))
+        assert str(range_end_text(instant, null)) == str(get_nice_text(null))
+
+    def test_what_is_left_keeps_its_styles(self):
+        """
+        The mark takes the place of fields, not of their colouring.
+
+        A repr colours a date, a time and a fraction differently, and
+        what survives the elision is coloured as it was before it.
+        """
+        low = np.datetime64("2017-09-18T00:00:00")
+        high = np.datetime64("2017-09-18T00:00:07.996")
+        said = range_end_text(low, high)
+        styles = {str(span.style) for span in said.spans}
+        assert dascore_styles["hms"] in styles
+        assert dascore_styles["dec"] in styles
+        assert said.spans[0].style == dascore_styles["keys"]
+
+    def test_a_pandas_timestamp_is_an_instant(self):
+        """A frame states its extents as Timestamps, and a repr reads them."""
+        low = pd.Timestamp("2020-01-03T00:00:00")
+        high = pd.Timestamp("2020-01-03T00:00:23.996")
+        assert str(range_end_text(low, high)) == "…00:00:23.996"
 
 
 class TestValuesAReaderCanRead:

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -84,6 +84,24 @@ class TestGetNiceText:
         txt3 = get_nice_text(dc.to_datetime64(1.111111111))
         assert str(txt3).endswith(".111111111")
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pd.Timestamp("2020-01-01T00:00:00+00:00"),
+            np.datetime64("10000-01-01T00:00:00"),
+        ],
+        ids=["offset", "expanded_year"],
+    )
+    def test_an_instant_which_cannot_be_taken_apart(self, value):
+        """
+        A value is drawn as it states itself where it says too much.
+
+        An offset and a five digit year both push every field along, and
+        slicing them by position drew an instant which was not the one
+        handed over: "2020-01-01T00:00:00.00:" for the first of these.
+        """
+        assert str(get_nice_text(value)) == str(value)
+
     def test_nat(self):
         """Tests for NaT."""
         dt = np.datetime64("NaT")
@@ -1104,6 +1122,17 @@ class TestRangeTexts:
             "2017-09-18T00:00:03",
             "…:00",
         ]
+
+    def test_ends_which_cannot_be_taken_apart(self):
+        """
+        A pair says nothing about a head it cannot measure.
+
+        Both ends are drawn as they state themselves, which is what a
+        value drawn on its own does with the same string.
+        """
+        low = pd.Timestamp("2020-01-01T00:00:00+00:00")
+        high = pd.Timestamp("2020-01-01T00:00:09+00:00")
+        assert [str(x) for x in range_texts(low, high)] == [str(low), str(high)]
 
     def test_an_end_which_repeats_nothing(self):
         """A far end sharing no field is drawn as it always was."""


### PR DESCRIPTION
## Description

Continues the repr series (#1011, #1012, #1014, #1018, #1019, #1020).

A repr which states a time range spelled both ends in full, from the year down, with the two standing next to each other:

```
*time: CoordRange( min: 2017-09-18 max: 2017-09-18T00:00:07.996 <8 s> step: 0.004s · 250 Hz ... )
time:  2020-01-03 to 2020-01-03T00:00:23.996  <24 s>
```

The leading fields of the second are a fact the reader has just read, and they cost width in a line which is already long — and a wide `max` column in the coordinate table #1018 introduced. A range is now drawn as a range rather than as two values:

```
*time: CoordRange( min: 2017-09-18T00:00:00 max: …:07.996 <8 s> step: 0.004s · 250 Hz ... )
time:  2020-01-03T00:00:00 to …:23.996  <24 s>
```

### One shape, then one mark

Two things happen which drawing each end on its own cannot do.

**Both ends state the same blocks.** A repr drops a date of the epoch and a time of midnight from a value drawn alone, which is right for one value and wrong for two: a start at midnight came out as a bare `2017-09-18` beside a full instant, and what the two had in common could not be seen to be in common. A block either end needs is now drawn on both. This is also what makes `min: 00:00:00 max: 2020-01-01` — the old rendering of a range from the epoch, where the near end kept a time and lost its date while the far end did the opposite — come out as `1970-01-01` to `2020-01-01`.

**The far end states only what differs**, with `…` standing for the fields it repeats. The date is one field, elided whole or not at all: eliding the year of `2023-06-01` and `2023-07-01` would leave the month to be noticed on its own. Below it the elision goes as deep as the fields match. A leading `T` goes with the date, since with the date gone it divides nothing; a leading `:` or `.` stays, because it says which field the number after it is, so `41.5` cannot be read as an hour.

| min | max is drawn as |
| --- | --- |
| `2017-09-18T00:00:00` | `…:07.996` |
| `2023-06-01T14:23:11` (hour differs) | `…18:00:00` |
| `2023-06-01T14:23:11` (hour shared) | `…:00:41.5` |
| `2023-06-01T14:23:11` (minute shared) | `…:41.5` |
| `2023-06-01T14:23:11` (second shared) | `….5` |
| `2023-06-01T23:59:59` (next day) | `2023-06-02T00:00:30` |
| `2017-09-18T00:00:03` (equal) | `…` |
| `2017-09-18` (neither end has a time) | `…` |

The zeros in the first row are what the mark is worth having: they are the only place the reader is told the far end is in the first minute of the day, and eliding them would make `…` mean "zero" on one line and "as above" on the next.

Only two instants. An offset is not one: `1.5s` and `1.25s` lead with a `1` which is not a field either of them states, and a numeric range never had a repeated head to begin with.

### The code

`range_texts(low, high)` sits beside `duration_text`, takes the same pair, and is called from the three places which state one: a coordinate's `min`/`max` fields, a spool's `X to Y` dimension line, and an annotation set's `min`/`max`. The HTML coordinate table draws whatever `_repr_fields` hands it, so its `max` column shortens with the text and keeps the mark grey against the fields which survived it.

`_nice_datetime` is split into the three steps a pair needs to share — read the instant at full precision, decide which blocks say something, draw those blocks — so one value and two are drawn by the same code rather than by two copies of it. What a single value renders as does not change.

Not applied to `model_to_line`, which draws an inventory's `time_min`/`time_max` as two independent fields. Giving those the mark means teaching a generic field renderer a naming convention, and routing a `_max` field around `value_to_text` would change how non-time ones are drawn. Left for its own change.

## Verification

- Full suite, doctests, and `pre-commit run --all` (twice) clean; coverage 100% on `display.py`, `coords.py` and `spool.py`, with the one uncovered line in `annotations.py` a pre-existing case-insensitive-filesystem branch this PR does not touch.
- Read the result in both media: the terminal reprs above, and the panel's coordinate table, where the mark is its own grey span and the fields after it keep their own colours.
- Codex CLI review. No correctness findings; four test-quality findings, all acted on — the spool regression test built its expectation with the helper under test and now pins the literal line, the style test now reads `get_style_at_offset` rather than a set of spans, and the coordinate and annotation reprs grew tests of their own.
- A CodeRabbit finding on the fixed-position slicing, acted on: an instant which does not state itself in the layout the fields are cut out of -- a timezone offset, or a five digit year -- is now drawn verbatim rather than sliced into fields which would be wrong. Both cases reproduce byte for byte on `dev`, so this is pre-existing behaviour rather than something the PR broke; it is guarded here because this is what gave the slicing a single entry point.
- One bug the existing tests caught during the rework: appending a value to `Text("min: ", key_style)` makes the label's grey the base style of the value after it. `test_dimension_values_not_styled_as_keys` failed on exactly that.

## Changelog

- changed: A repr draws the two ends of a time range in one shape, and states the far end only from the first field which differs, with `…` standing for what it repeats of the near end.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
