### PR TITLE
Make the html repr's helpers private

### DIFF
--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -30,7 +30,7 @@ from dascore.constants import dascore_styles
 from dascore.units import get_quantity, get_quantity_str
 from dascore.utils.time import to_float
 
-# What a container holds, whatever that is: `limit_items` takes any of
+# What a container holds, whatever that is: `_limit_items` takes any of
 # them and hands back the same kind.
 _Item = TypeVar("_Item")
 
@@ -208,7 +208,7 @@ def _render_table(node: Table) -> Text:
 
 @render_text.register
 def _render_section(node: Section) -> Text:
-    out = section_title(node.title, node.depth)
+    out = _section_title(node.title, node.depth)
     for child in node.body:
         out += render_text(child)
     return out
@@ -276,7 +276,7 @@ _STYLE_WORDS = frozenset(
 )
 
 
-def style_classes(style: Style) -> tuple[str, ...]:
+def _style_classes(style: Style) -> tuple[str, ...]:
     """Return the CSS classes a resolved rich style is drawn with."""
     words = [
         x for x, on in (("bold", style.bold), ("underline", style.underline)) if on
@@ -286,7 +286,7 @@ def style_classes(style: Style) -> tuple[str, ...]:
     return tuple(f"dc-{x}" for x in words if x in _STYLE_WORDS)
 
 
-def text_to_html(text: Text) -> str:
+def _text_to_html(text: Text) -> str:
     """Render a rich Text as an inline HTML fragment."""
     plain = text.plain
     bounds = sorted({0, len(plain)}.union(*((x.start, x.end) for x in text.spans)))
@@ -308,7 +308,7 @@ def text_to_html(text: Text) -> str:
     out = []
     for index, (start, end) in enumerate(pairwise(bounds)):
         chunk = escape(plain[start:end], quote=False)
-        classes = style_classes(styles[index])
+        classes = _style_classes(styles[index])
         out.append(
             f'<span class="{" ".join(classes)}">{chunk}</span>' if classes else chunk
         )
@@ -335,7 +335,7 @@ def _strip_css_comments(css: str) -> str:
 
 
 @cache
-def get_stylesheet() -> str:
+def _get_stylesheet() -> str:
     """
     Return the CSS every HTML repr carries, without its comments.
 
@@ -349,7 +349,7 @@ def get_stylesheet() -> str:
 
 
 @singledispatch
-def render_html(node) -> str:
+def _render_html(node) -> str:
     """Render a repr node as an HTML fragment."""
     msg = f"cannot render {type(node).__name__} as html"
     raise NotImplementedError(msg)
@@ -368,13 +368,13 @@ def _body_text(text: Text) -> Text:
     return text[start : len(plain.rstrip("\n"))]
 
 
-@render_html.register
+@_render_html.register
 def _html_raw(node: Raw) -> str:
     # A `pre`, because what a producer laid out is laid out in columns:
     # an array printed by numpy, a track list padded to line up. HTML
     # would collapse the runs of spaces which do that work.
     text = _body_text(node.text)
-    return f'<pre class="dc-body">{text_to_html(text)}</pre>'
+    return f'<pre class="dc-body">{_text_to_html(text)}</pre>'
 
 
 def _merge_columns(rows: Sequence[Row]) -> list[str]:
@@ -420,7 +420,7 @@ def _merge_columns(rows: Sequence[Row]) -> list[str]:
     return out
 
 
-@render_html.register
+@_render_html.register
 def _html_table(node: Table) -> str:
     # Every label any row states, in the order they are first stated, so
     # a row which says nothing for one leaves that cell empty rather
@@ -434,12 +434,12 @@ def _html_table(node: Table) -> str:
     body = []
     for row in node.rows:
         stated = {label: value for label, value, _ in row.fields}
-        name = text_to_html(row.name)
-        cells = [f"<td>{text_to_html(row.kind)}</td>"]
+        name = _text_to_html(row.name)
+        cells = [f"<td>{_text_to_html(row.kind)}</td>"]
         for label in labels:
             css = ' class="dc-num"' if label in node.numeric else ""
             value = stated.get(label)
-            cells.append(f"<td{css}>{text_to_html(value) if value else ''}</td>")
+            cells.append(f"<td{css}>{_text_to_html(value) if value else ''}</td>")
         body.append(f'<tr><th scope="row">{name}</th>{"".join(cells)}</tr>')
     return (
         f'<div class="dc-scroll"><table class="dc-table">'
@@ -520,7 +520,7 @@ def _nest_classes(depth: int) -> tuple[str, ...]:
     return ("dc-nest", f"dc-d{(depth - 1) % _NEST_COLORS}")
 
 
-@render_html.register
+@_render_html.register
 def _html_section(node: Section) -> str:
     # A title is the bare line: the indentation a terminal draws nesting
     # with is added when a terminal draws it, and here the nesting is
@@ -528,27 +528,27 @@ def _html_section(node: Section) -> str:
     title = node.title
     if title.plain.startswith(_SECTION_MARKER):
         title = title[len(_SECTION_MARKER) :]
-    title = text_to_html(title)
+    title = _text_to_html(title)
     nest = _nest_classes(node.depth)
     lines = _body_lines(node)
     if not lines:
         # Nothing to fold, so nothing to offer folding.
         return f'<div class="{" ".join(("dc-line", *nest))}">{title}</div>'
     state = " open" if lines <= get_config().display_html_open_lines else ""
-    body = "".join(render_html(x) for x in node.body)
+    body = "".join(_render_html(x) for x in node.body)
     css = f' class="{" ".join(nest)}"' if nest else ""
     return f"<details{css}{state}><summary>{title}</summary>{body}</details>"
 
 
-@render_html.register
+@_render_html.register
 def _html_repr(node: Repr) -> str:
     # The banner underlines itself with dashes in a terminal, drawn in
     # columns; here that is a border, and an emoji is not two columns
     # wide in every font a browser might choose.
-    banner = text_to_html(node.header.split("\n")[0])
-    body = "".join(render_html(x) for x in node.body)
+    banner = _text_to_html(node.header.split("\n")[0])
+    body = "".join(_render_html(x) for x in node.body)
     return (
-        f'<div class="{_HTML_ROOT}"><style>{get_stylesheet()}</style>'
+        f'<div class="{_HTML_ROOT}"><style>{_get_stylesheet()}</style>'
         f'<div class="dc-banner">{banner}</div>{body}</div>'
     )
 
@@ -606,7 +606,7 @@ class NodeRepr(RichRepr):
         if not get_config().display_html:
             return None
         try:
-            return render_html(self._repr_node())
+            return _render_html(self._repr_node())
         except Exception:
             if get_config().debug:
                 raise
@@ -736,7 +736,7 @@ def get_header_text(name: str, style: str = "bold") -> Text:
 _INDENT = "    "
 
 
-def section_title(line: Text, depth: int) -> Text:
+def _section_title(line: Text, depth: int) -> Text:
     """
     How a terminal draws the line which names a block.
 
@@ -750,7 +750,7 @@ def section_title(line: Text, depth: int) -> Text:
         # A copy, not the node's own line: a renderer which appends to
         # what it drew would otherwise rewrite the node it read.
         return line.copy()
-    return Text("\n") + indent_text(line, _INDENT * depth)
+    return Text("\n") + _indent_text(line, _INDENT * depth)
 
 
 def child_sections(items, depth: int) -> tuple[Section, ...]:
@@ -760,14 +760,14 @@ def child_sections(items, depth: int) -> tuple[Section, ...]:
     Only what is shown is rendered, so the cost of a repr is what it
     prints rather than what the tree holds.
     """
-    shown, left_out = limit_items(items)
+    shown, left_out = _limit_items(items)
     out = [x._repr_section(depth) for x in shown]
     if left_out:
         out.append(Section(elision_text(left_out), depth=depth))
     return tuple(out)
 
 
-def indent_text(text: Text, prefix: str = _INDENT) -> Text:
+def _indent_text(text: Text, prefix: str = _INDENT) -> Text:
     """
     Indent every line of a rich Text, keeping its styles.
 
@@ -787,7 +787,7 @@ def elision_text(left_out: int) -> Text:
     return Text(f"... {left_out} more", style=dascore_styles["keys"])
 
 
-def limit_items(
+def _limit_items(
     items: Iterable[_Item], limit: int | None = None
 ) -> tuple[list[_Item], int]:
     """
@@ -1118,7 +1118,7 @@ def stated_fields(model, skip=()) -> dict:
     return out
 
 
-def value_to_text(name: str, value, style=None, truncate: bool = True) -> Text:
+def _value_to_text(name: str, value, style=None, truncate: bool = True) -> Text:
     """
     Get the text one value prints as, given the name it is stated under.
 
@@ -1191,7 +1191,7 @@ def model_to_line(model, skip=(), style=None, extra=None) -> Text:
     fields = {**stated_fields(model, skip=skip), **dict(extra or {})}
     for name, value in fields.items():
         base += Text(f" {name}: ", key_style)
-        base += value_to_text(name, value)
+        base += _value_to_text(name, value)
     base += Text(" )")
     return base
 
@@ -1218,7 +1218,7 @@ def mapping_to_text(mapping, header: str, style: str = "dc_yellow") -> Text:
         txt += Text(f"{name}: ", dascore_styles["keys"])
         # A block gives each value its own line, so it is not elided; a
         # one-line summary packs many values and has to bound each.
-        txt += value_to_text(
+        txt += _value_to_text(
             name, value, style=dascore_styles.get(name, None), truncate=False
         )
     return txt

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -35,8 +35,16 @@ from dascore.utils.display import (
     Section,
     Table,
     _body_lines,
+    _get_stylesheet,
+    _indent_text,
+    _limit_items,
+    _render_html,
+    _section_title,
     _storage_quantum,
     _strip_css_comments,
+    _style_classes,
+    _text_to_html,
+    _value_to_text,
     _visible_lines,
     array_to_text,
     attrs_to_text,
@@ -45,24 +53,16 @@ from dascore.utils.display import (
     duration_text,
     get_header_text,
     get_nice_text,
-    get_stylesheet,
     group_names,
     human_duration,
     human_size,
-    indent_text,
-    limit_items,
     mapping_to_text,
     model_to_line,
     percent,
     rate_text,
-    render_html,
     render_text,
-    section_title,
     split_block,
     stated_fields,
-    style_classes,
-    text_to_html,
-    value_to_text,
 )
 from dascore.utils.patch import _format_values
 
@@ -155,13 +155,13 @@ class TestIndentText:
 
     def test_every_line_indented(self):
         """Each line gains the prefix, including the first."""
-        out = str(indent_text(Text("a\nb"), "  "))
+        out = str(_indent_text(Text("a\nb"), "  "))
         assert out == "  a\n  b"
 
     def test_styles_kept(self):
         """Indenting does not flatten the styles it wraps."""
         text = Text("red", style="red")
-        assert indent_text(text).spans
+        assert _indent_text(text).spans
 
 
 class TestCountsToText:
@@ -289,27 +289,27 @@ class TestValueToText:
 
     def test_long_value_elided(self):
         """A value sharing a line with others is bounded."""
-        out = str(value_to_text("a", "x" * 500))
+        out = str(_value_to_text("a", "x" * 500))
         assert len(out) < 500
         assert out.endswith("…")
 
     def test_pre_rendered_text_kept(self):
         """Text the caller built is used as-is, not re-read as a sequence."""
-        assert str(value_to_text("a", Text("a: 2, b: 1"))) == "a: 2, b: 1"
+        assert str(_value_to_text("a", Text("a: 2, b: 1"))) == "a: 2, b: 1"
 
     def test_array_keeps_its_own_repr(self):
         """An array states how much of itself to show; it is not unrolled."""
-        out = str(value_to_text("a", np.arange(10_000)))
+        out = str(_value_to_text("a", np.arange(10_000)))
         assert "..." in out and len(out) < 100
 
     def test_frame_keeps_its_own_repr(self):
         """Nor is a frame read as a sequence of its column names."""
-        out = str(value_to_text("a", pd.DataFrame({"a": [1, 2]}), truncate=False))
+        out = str(_value_to_text("a", pd.DataFrame({"a": [1, 2]}), truncate=False))
         assert "1" in out and "2" in out
 
     def test_nat_is_text(self):
         """An unset time renders like every other value, not as a str."""
-        assert str(value_to_text("a", np.datetime64("NaT"))) == "NaT"
+        assert str(_value_to_text("a", np.datetime64("NaT"))) == "NaT"
 
 
 class TestPercent:
@@ -1056,7 +1056,7 @@ class TestStyleClasses:
     )
     def test_the_words_of_a_style(self, style, expected):
         """Each word a class exists for becomes one."""
-        assert style_classes(Style.parse(style)) == expected
+        assert _style_classes(Style.parse(style)) == expected
 
     def test_a_background_is_not_a_foreground(self):
         """
@@ -1065,11 +1065,11 @@ class TestStyleClasses:
         Rich resolves that; reading the words would take the background
         for the color of the text.
         """
-        assert style_classes(Style.parse("red on blue")) == ("dc-red",)
+        assert _style_classes(Style.parse("red on blue")) == ("dc-red",)
 
     def test_a_style_which_turns_something_off(self):
         """Rich resolves "not bold" to not bold."""
-        assert style_classes(Style.parse("not bold")) == ()
+        assert _style_classes(Style.parse("not bold")) == ()
 
     @pytest.mark.parametrize("color", ["#ff0000", "purple4", "rgb(1,2,3)"])
     def test_a_color_no_class_exists_for(self, color):
@@ -1079,7 +1079,7 @@ class TestStyleClasses:
         Nothing an object states reaches a CSS attribute this way, so
         the stylesheet stays the only thing which says what a color is.
         """
-        assert style_classes(Style.parse(color)) == ()
+        assert _style_classes(Style.parse(color)) == ()
 
 
 class TestTextToHtml:
@@ -1096,15 +1096,15 @@ class TestTextToHtml:
         A trusted notebook does not sanitize what a repr emits, so what
         the repr emits has to be safe on its own.
         """
-        assert text_to_html(Text(plain)) == expected
+        assert _text_to_html(Text(plain)) == expected
 
     def test_quotes_are_left_alone(self):
         """Nothing is written into an attribute, so nothing needs it."""
-        assert text_to_html(Text('say "hi"')) == 'say "hi"'
+        assert _text_to_html(Text('say "hi"')) == 'say "hi"'
 
     def test_unstyled_text_emits_no_span(self):
         """A span which says nothing is bytes in every repr forever."""
-        assert "<span" not in text_to_html(Text("plain"))
+        assert "<span" not in _text_to_html(Text("plain"))
 
     def test_a_later_span_wins_a_color(self):
         """
@@ -1117,8 +1117,8 @@ class TestTextToHtml:
         text = Text("250 Hz")
         text.stylize("grey50", 0, 6)
         text.stylize("bright_blue", 0, 6)
-        assert 'class="dc-bright_blue"' in text_to_html(text)
-        assert "dc-grey50" not in text_to_html(text)
+        assert 'class="dc-bright_blue"' in _text_to_html(text)
+        assert "dc-grey50" not in _text_to_html(text)
 
     def test_a_repr_with_many_spans_is_not_slow(self):
         """
@@ -1134,7 +1134,7 @@ class TestTextToHtml:
             part.stylize("bright_blue", 8, 14)
             text += part
         start = time.perf_counter()
-        text_to_html(text)
+        _text_to_html(text)
         assert time.perf_counter() - start < 1.0
 
     def test_a_style_reaches_only_the_runs_it_covers(self):
@@ -1148,7 +1148,7 @@ class TestTextToHtml:
         text = Text("abcdef")
         text.stylize("bold", 0, 2)
         text.stylize("blue", 4, 6)
-        html = text_to_html(text)
+        html = _text_to_html(text)
         assert '<span class="dc-bold">ab</span>' in html
         assert "cd" in html.replace('<span class="dc-bold">ab</span>', "")
         assert '<span class="dc-blue">ef</span>' in html
@@ -1164,12 +1164,12 @@ class TestTextToHtml:
         text = Text("abcdef")
         text.stylize("bold", 0, 4)
         text.stylize("blue", 2, 6)
-        html = text_to_html(text)
+        html = _text_to_html(text)
         assert 'class="dc-bold dc-blue"' in html
 
     def test_an_empty_text(self):
         """An object may state a block with nothing in it."""
-        assert text_to_html(Text("")) == ""
+        assert _text_to_html(Text("")) == ""
 
 
 class TestRenderHtml:
@@ -1177,20 +1177,20 @@ class TestRenderHtml:
 
     def test_a_section_folds(self, repr_blocks):
         """A block with a body is what a reader opens and closes."""
-        html = render_html(split_block(repr_blocks["coords"]))
+        html = _render_html(split_block(repr_blocks["coords"]))
         assert html.startswith("<details")
         assert "<summary>" in html
 
     def test_a_section_with_no_body_does_not(self, repr_blocks):
         """One line is a statement; offering to fold it says otherwise."""
-        html = render_html(split_block(repr_blocks["one_line"]))
+        html = _render_html(split_block(repr_blocks["one_line"]))
         assert "<details" not in html
         assert 'class="dc-line"' in html
 
     def test_a_long_section_starts_closed(self, repr_blocks):
         """An array is not read at a glance, so it does not open at one."""
         with config_context(display_html_open_lines=0):
-            assert "<details>" in render_html(split_block(repr_blocks["coords"]))
+            assert "<details>" in _render_html(split_block(repr_blocks["coords"]))
 
     def test_a_short_section_starts_open(self, repr_blocks):
         """
@@ -1200,7 +1200,7 @@ class TestRenderHtml:
         is few enough, so it is asked for rather than assumed.
         """
         with config_context(display_html_open_lines=2):
-            assert "<details open>" in render_html(split_block(repr_blocks["coords"]))
+            assert "<details open>" in _render_html(split_block(repr_blocks["coords"]))
 
     @pytest.mark.parametrize("block", ["coords", "attrs"])
     def test_the_limit_counts_body_lines(self, repr_blocks, block):
@@ -1214,9 +1214,9 @@ class TestRenderHtml:
         """
         section = split_block(repr_blocks[block])
         with config_context(display_html_open_lines=1):
-            assert "<details>" in render_html(section)
+            assert "<details>" in _render_html(section)
         with config_context(display_html_open_lines=2):
-            assert "<details open>" in render_html(section)
+            assert "<details open>" in _render_html(section)
 
     def test_the_count_is_the_lines_a_reader_sees(self, repr_blocks):
         """The limit means what a reader would count, not what a Text holds."""
@@ -1224,13 +1224,13 @@ class TestRenderHtml:
             section = split_block(block)
             if not section.body:
                 continue
-            html = render_html(section)
+            html = _render_html(section)
             body = re.search(r"<pre[^>]*>(.*?)</pre>", html, re.DOTALL).group(1)
             drawn = re.sub(r"<[^>]+>", "", body).count("\n") + 1
             with config_context(display_html_open_lines=drawn):
-                assert "<details open>" in render_html(section), name
+                assert "<details open>" in _render_html(section), name
             with config_context(display_html_open_lines=drawn - 1):
-                assert "<details open>" not in render_html(section), name
+                assert "<details open>" not in _render_html(section), name
 
     def test_the_banner_drops_its_underline(self):
         """
@@ -1240,7 +1240,7 @@ class TestRenderHtml:
         every font a browser might choose.
         """
         node = Repr(get_header_text("Patch ⚡"))
-        assert "---" not in render_html(node)
+        assert "---" not in _render_html(node)
 
     def test_the_fragment_is_scoped(self):
         """
@@ -1249,12 +1249,12 @@ class TestRenderHtml:
         A repr is emitted into a notebook output, where a `style`
         applies to the whole document around it.
         """
-        assert render_html(Repr(Text("x"))).startswith('<div class="dc-repr">')
+        assert _render_html(Repr(Text("x"))).startswith('<div class="dc-repr">')
 
     def test_something_which_is_not_a_node(self):
         """A renderer says what it cannot draw rather than drawing it wrong."""
         with pytest.raises(NotImplementedError, match="cannot render int"):
-            render_html(42)
+            _render_html(42)
 
 
 class TestLimitItems:
@@ -1262,20 +1262,20 @@ class TestLimitItems:
 
     def test_everything_fits(self):
         """Nothing is left behind while everything fits."""
-        assert limit_items([1, 2, 3], limit=3) == ([1, 2, 3], 0)
+        assert _limit_items([1, 2, 3], limit=3) == ([1, 2, 3], 0)
 
     def test_the_tail_is_counted(self):
         """What is not shown is counted rather than dropped silently."""
-        assert limit_items(range(10), limit=4) == ([0, 1, 2, 3], 6)
+        assert _limit_items(range(10), limit=4) == ([0, 1, 2, 3], 6)
 
     def test_nothing_is_shown(self):
         """A limit of none still says how much there was."""
-        assert limit_items([1, 2], limit=0) == ([], 2)
+        assert _limit_items([1, 2], limit=0) == ([], 2)
 
     def test_the_limit_comes_from_config(self):
         """The default cap is a runtime setting, not a constant here."""
         with config_context(display_max_items=1):
-            assert limit_items("abc") == (["a"], 2)
+            assert _limit_items("abc") == (["a"], 2)
 
 
 class TestSectionTitle:
@@ -1283,18 +1283,18 @@ class TestSectionTitle:
 
     def test_the_top_is_drawn_as_it_stands(self):
         """A tree's root opens where its container left off."""
-        assert section_title(Text("a"), 0).plain == "a"
+        assert _section_title(Text("a"), 0).plain == "a"
 
     def test_the_top_is_not_the_line_it_was_given(self):
         """A renderer appends to what it drew, and must not rewrite it."""
         line = Text("a")
-        section_title(line, 0).append("b")
+        _section_title(line, 0).append("b")
         assert line.plain == "a"
 
     @pytest.mark.parametrize("depth", [1, 2, 3])
     def test_a_level_starts_a_line(self, depth):
         """Every level below the top begins on its own line, set in."""
-        assert section_title(Text("a"), depth).plain == "\n" + "    " * depth + "a"
+        assert _section_title(Text("a"), depth).plain == "\n" + "    " * depth + "a"
 
     @pytest.mark.parametrize("depth", [1, 2])
     def test_every_line_is_set_in(self, depth):
@@ -1305,7 +1305,7 @@ class TestSectionTitle:
         which is the misreading the indentation exists to prevent.
         """
         indent = "    " * depth
-        out = section_title(Text("a\nb"), depth).plain
+        out = _section_title(Text("a\nb"), depth).plain
         assert out == f"\n{indent}a\n{indent}b"
 
     def test_the_styles_survive(self):
@@ -1318,7 +1318,7 @@ class TestSectionTitle:
         """
         line = Text("ab")
         line.stylize("bold", 0, 1)
-        drawn = section_title(line, 1)
+        drawn = _section_title(line, 1)
         styles = dict(zip(drawn.plain, resolved_styles(drawn), strict=True))
         assert styles["a"].bold
         assert not styles["b"].bold
@@ -1417,7 +1417,7 @@ class TestVisibleLines:
             # Counted on " open>", since a nested block carries classes
             # between the tag and the attribute and "<details open>"
             # could only ever match the one at the top.
-            html = render_html(top)
+            html = _render_html(top)
             assert html.count(" open>") == 1
             assert html.startswith("<details open>")
 
@@ -1435,9 +1435,9 @@ class TestVisibleLines:
         top = Section(Text("top"), (leaf,) * 7)
         assert _body_lines(top) == 14
         with config_context(display_html_open_lines=12):
-            assert " open>" not in render_html(top)
+            assert " open>" not in _render_html(top)
         with config_context(display_html_open_lines=14):
-            assert " open>" in render_html(top)
+            assert " open>" in _render_html(top)
 
     def test_a_node_is_counted_once(self, monkeypatch):
         """
@@ -1497,7 +1497,7 @@ class TestNestedSections:
         would sit past the `</details>` which ends it, and the tree
         would read as three blocks side by side rather than one.
         """
-        html = render_html(tree)
+        html = _render_html(tree)
         assert html.count("<details") == 2
         opened = html.index("<summary>top</summary>") + len("<summary>top</summary>")
         closed = html.index("</details>")
@@ -1512,7 +1512,7 @@ class TestNestedSections:
         whitespace, so a title drawn as handed over would open on a
         blank line.
         """
-        html = render_html(tree)
+        html = _render_html(tree)
         for title in re.findall(r"<summary>(.*?)</summary>", html, re.DOTALL):
             assert title == title.lstrip()
         assert '<div class="dc-line dc-nest dc-d1">leaf</div>' in html
@@ -1524,13 +1524,13 @@ class TestNestedSections:
         A host which drops the stylesheet still nests, so this says only
         that the depth reaches the markup at all.
         """
-        html = render_html(tree)
+        html = _render_html(tree)
         assert 'class="dc-nest dc-d0"' in html
         assert "dc-d1" in html
 
     def test_the_top_is_in_no_nesting(self):
         """A block at the top of a repr sits inside nothing."""
-        html = render_html(Section(Text("top"), (Raw(Text("\nbody")),)))
+        html = _render_html(Section(Text("top"), (Raw(Text("\nbody")),)))
         assert "dc-nest" not in html
 
     def test_the_ramp_wraps(self):
@@ -1541,7 +1541,7 @@ class TestNestedSections:
         which ran off the end would draw an undefined color there.
         """
         node = Section(Text("x"), depth=_NEST_COLORS + 1)
-        assert f"dc-d{(_NEST_COLORS + 1 - 1) % _NEST_COLORS}" in render_html(node)
+        assert f"dc-d{(_NEST_COLORS + 1 - 1) % _NEST_COLORS}" in _render_html(node)
 
     @pytest.mark.parametrize(("limit", "open_blocks"), [(2, 2), (1, 1), (0, 0)])
     def test_a_deep_tree_folds_from_the_outside_in(self, tree, limit, open_blocks):
@@ -1553,7 +1553,7 @@ class TestNestedSections:
         under it close, and a reader opens as far down as they asked.
         """
         with config_context(display_html_open_lines=limit):
-            assert render_html(tree).count(" open>") == open_blocks
+            assert _render_html(tree).count(" open>") == open_blocks
 
 
 class TestBodyText:
@@ -1565,7 +1565,7 @@ class TestBodyText:
 
         Offering to fold nothing draws a triangle over an empty box.
         """
-        html = render_html(split_block(Text("title\n")))
+        html = _render_html(split_block(Text("title\n")))
         assert "<details" not in html
         assert 'class="dc-line"' in html
 
@@ -1580,7 +1580,7 @@ class TestBodyText:
 
     def test_a_body_keeps_the_lines_between(self):
         """Only the framing goes; a blank line inside the body stays."""
-        html = render_html(split_block(Text("title\na\n\nb\n")))
+        html = _render_html(split_block(Text("title\na\n\nb\n")))
         assert ">a\n\nb<" in html
 
 
@@ -1633,7 +1633,7 @@ class TestCoordinatesAreStated:
         patch = dc.get_example_patch()
         coords = patch.coords.update(_hidden=("distance", np.ones(300)))
         assert "_hidden" not in str(coords)
-        assert "_hidden" not in render_html(coords._repr_section())
+        assert "_hidden" not in _render_html(coords._repr_section())
 
     @pytest.mark.parametrize(
         ("label", "value"),
@@ -1689,7 +1689,7 @@ class TestTableColumns:
             Row(Text(name), Text("K"), tuple((x, Text(x), True) for x in fields))
             for name, fields in rows
         )
-        return re.findall(r"<th>(\w+)</th>", render_html(Table(made)))
+        return re.findall(r"<th>(\w+)</th>", _render_html(Table(made)))
 
     def test_rows_which_state_the_same_fields(self):
         """The order one row states them in is the order they are in."""
@@ -1758,9 +1758,9 @@ class TestTableColumns:
         """
         section = dc.get_example_patch().coords._repr_section()
         with config_context(display_html_open_lines=2):
-            assert "<details open>" not in render_html(section)
+            assert "<details open>" not in _render_html(section)
         with config_context(display_html_open_lines=3):
-            assert "<details open>" in render_html(section)
+            assert "<details open>" in _render_html(section)
 
     def test_a_value_is_drawn_in_its_own_column(self):
         """
@@ -1775,7 +1775,7 @@ class TestTableColumns:
                 (("x", Text("2"), True), ("y", Text("3"), True)),
             ),
         )
-        html = render_html(Table(rows))
+        html = _render_html(Table(rows))
         heads = re.findall(r"<th>(\w+)</th>", html)
         for row in re.findall(r"<tr><th scope=\"row\">.*?</tr>", html, re.DOTALL):
             assert len(re.findall(r"<td[^>]*>", row)) == len(heads)
@@ -1792,7 +1792,7 @@ def _css_body() -> str:
     ships is already stripped; ``test_the_sheet_ships_without_its_prose``
     is what holds that true.
     """
-    return get_stylesheet()
+    return _get_stylesheet()
 
 
 def _css_rule(selector: str) -> str:
@@ -1864,7 +1864,7 @@ class TestStylesheet:
                         seen.add(style)
         assert seen
         for style in seen:
-            assert style_classes(style), style
+            assert _style_classes(style), style
 
     def test_a_rule_exists_for_every_nesting_level(self):
         """A level the renderer can reach and the CSS cannot draws no rail."""
@@ -1905,10 +1905,10 @@ class TestStylesheet:
         source = files("dascore").joinpath("repr.css").read_text(encoding="utf-8")
         # A control: what is stripped is something the file really holds.
         assert "/*" in source
-        assert "/*" not in get_stylesheet()
+        assert "/*" not in _get_stylesheet()
         # And nothing else went with them.
-        assert ".dc-repr .dc-banner" in get_stylesheet()
-        assert len(get_stylesheet()) < len(source) / 1.5
+        assert ".dc-repr .dc-banner" in _get_stylesheet()
+        assert len(_get_stylesheet()) < len(source) / 1.5
 
     def test_a_value_which_reads_like_a_comment_is_kept(self):
         """
@@ -1972,7 +1972,7 @@ class TestStylesheet:
         A word which draws in a terminal and not in a browser is a
         difference between the two reprs that nobody chose.
         """
-        css = get_stylesheet()
+        css = _get_stylesheet()
         for word in _STYLE_WORDS:
             assert f".dc-{word}" in css, word
 
@@ -1991,7 +1991,7 @@ class TestStylesheet:
         A producer's indent is content: the spool states its path
         indented, and HTML collapses runs of spaces by default.
         """
-        css = get_stylesheet()
+        css = _get_stylesheet()
         for selector in (".dc-repr .dc-line", ".dc-repr summary"):
             block = css[css.index(selector) : css.index("}", css.index(selector))]
             assert "white-space: pre" in block, selector
@@ -2003,7 +2003,7 @@ class TestStylesheet:
         One named in the dark rule and not the light one keeps dark ink
         on a light page whenever the reader's system is dark.
         """
-        css = get_stylesheet()
+        css = _get_stylesheet()
         dark = css[css.index('data-jp-theme-light="false"') :]
         dark = dark[: dark.index("}")]
         light = css[css.index('data-jp-theme-light="true"') :]
@@ -2013,7 +2013,7 @@ class TestStylesheet:
 
     def test_it_is_read_once(self):
         """Every repr carries it, so every repr should not read it."""
-        assert get_stylesheet() is get_stylesheet()
+        assert _get_stylesheet() is _get_stylesheet()
 
 
 def _decompose(line: str) -> list[str]:
@@ -2206,13 +2206,13 @@ class TestHtmlRepr:
         which cannot be drawn should fail in CI and stay quiet for a
         reader. So this is a path only a reader takes.
         """
-        monkeypatch.setattr(display, "render_html", _boom)
+        monkeypatch.setattr(display, "_render_html", _boom)
         with config_context(debug=False):
             assert dc.get_example_patch()._repr_html_() is None
 
     def test_debug_mode_wants_the_traceback(self, monkeypatch):
         """Swallowing it in CI is how a broken repr ships unnoticed."""
-        monkeypatch.setattr(display, "render_html", _boom)
+        monkeypatch.setattr(display, "_render_html", _boom)
         with config_context(debug=True), pytest.raises(ValueError, match="no panel"):
             dc.get_example_patch()._repr_html_()
 
@@ -2242,7 +2242,7 @@ class TestHtmlRepr:
         deliberately whenever a block is added. It counts the sheet as
         it goes out, so a comment is free and a rule is not.
         """
-        assert len(get_stylesheet().encode()) < 6_000
+        assert len(_get_stylesheet().encode()) < 6_000
 
     def test_a_panel_is_mostly_the_object(self, html_objects):
         """
@@ -2251,6 +2251,6 @@ class TestHtmlRepr:
         Held apart from the sheet, so a section drawn twice is over the
         ceiling rather than lost inside the headroom.
         """
-        overhead = len(get_stylesheet().encode())
+        overhead = len(_get_stylesheet().encode())
         for name, obj in html_objects.items():
             assert len(obj._repr_html_().encode()) - overhead < 4_000, name


### PR DESCRIPTION
## Description

The eight helpers behind the html repr — `get_stylesheet`, `render_html`, `text_to_html`, `section_title`, `style_classes`, `value_to_text`, `indent_text`, and `limit_items` — are display internals that read as public API. Each one gets its own generated page in the API docs and its own entry in the sidebar, and nothing outside `dascore/utils/display.py` calls any of them.

They are renamed to private names as one change because `render_html` is a `singledispatch` function whose `.register` sites and monkeypatch tests have to move with it.

Evidence for each name, since a low reference count on its own does not make a name private:

| Name | Introduced | In `v0.1.21` | Re-exported | Referenced outside `display.py` |
|---|---|---|---|---|
| `get_stylesheet` | #1014 | no | no | tests only |
| `render_html` | #1014 | no | no | tests only |
| `text_to_html` | #1014 | no | no | tests only |
| `style_classes` | #1014 | no | no | tests only |
| `section_title` | #1019 | no | no | tests only |
| `limit_items` | #1019 | no | no | tests only |
| `value_to_text` | #989 | no | no | tests only |
| `indent_text` | #989 | no | no | tests only |

None of them exist in the latest release, so no released import path changes and no deprecation shim is needed. This is the first bounded cleanup from the API surface plan; the doc build measurement it is judged against is a separate PR.

Merge order: if that measurement PR lands first, its frozen URL baseline lists eight pages this PR removes. Rebase and re-run `python scripts/_api_urls.py freeze`.

## Changelog

- none
