### PR TITLE
Start Silixa H5 distance where the header says it starts

### DIFF
--- a/dascore/io/silixah5/utils.py
+++ b/dascore/io/silixah5/utils.py
@@ -83,13 +83,15 @@ def _get_time_coord(attr_dict, shape):
 
 
 def _get_distance_coord(attr_dict, data_shape):
-    """Get distance coordinate from AP sensing data."""
-    # Note: To be consistent with TDMS reader (see tdms.utils.get_distance_coord)
-    # We use this method for calculating distance, although start distance
-    # and stop distance are included.
+    """
+    Get the distance coordinate.
+
+    Channel i sits at ``start_distance + i * spatial_resolution *
+    fiber_length_multiplier``, the same convention as the Carina variant;
+    it lands on the file's Stop Distance to within the multiplier's rounding.
+    """
     multiplier = float(attr_dict["fiber_length_multiplier"])
-    total_length = float(attr_dict["measured_length"]) * multiplier
-    start = float(attr_dict["start_position"]) + total_length
+    start = float(attr_dict["start_distance"])
     step = float(attr_dict["spatial_resolution"]) * multiplier
     return get_coord(start=start, step=step, shape=(data_shape[1],), units="m")
 

--- a/tests/test_io/test_silixah5/test_silixa_distance.py
+++ b/tests/test_io/test_silixah5/test_silixa_distance.py
@@ -1,0 +1,52 @@
+"""The distance coordinate a Silixa V1 (Acoustic) file states."""
+
+import h5py
+import numpy as np
+import pytest
+
+from dascore.io.silixah5 import SilixaH5V1
+from dascore.utils.downloader import fetch
+
+
+@pytest.fixture(scope="module")
+def acoustic_path():
+    """Path to the Acoustic-dataset (V1) test file."""
+    return fetch("silixa_h5_1.hdf5")
+
+
+@pytest.fixture(scope="module")
+def header(acoustic_path):
+    """The distance-related header attrs, straight from the file."""
+    with h5py.File(acoustic_path, "r") as fi:
+        attrs = fi["Acoustic"].attrs
+        return {
+            "start": float(attrs["Start Distance (m)"]),
+            "stop": float(attrs["Stop Distance (m)"]),
+            "step": float(attrs["SpatialResolution[m]"])
+            * float(attrs["Fibre Length Multiplier"]),
+        }
+
+
+class TestSilixaV1Distance:
+    """Distance runs from the header's Start Distance to its Stop Distance."""
+
+    @pytest.fixture(scope="class")
+    def distance(self, acoustic_path):
+        """The distance coordinate of the read patch."""
+        return SilixaH5V1().read(acoustic_path)[0].get_coord("distance")
+
+    def test_first_channel_at_start_distance(self, distance, header):
+        """Start Distance is the first channel, not one cable length past it."""
+        assert np.isclose(distance.min(), header["start"])
+
+    def test_last_channel_at_stop_distance(self, distance, header):
+        """Start + (n - 1) * step lands on the header's Stop Distance.
+
+        The header rounds the fiber length multiplier to six digits, which
+        moves the far end by a few centimetres over eight kilometres.
+        """
+        assert np.isclose(distance.max(), header["stop"], atol=0.1)
+
+    def test_step(self, distance, header):
+        """The step is the spatial resolution scaled by the fiber multiplier."""
+        assert np.isclose(distance.step, header["step"])


### PR DESCRIPTION
## Description

The Silixa H5 V1 (Acoustic-dataset) reader built its distance origin as `StartPosition[m] + MeasureLength[m] * Fibre Length Multiplier`, so the coordinate started one full cable length down the fiber (8082.9 m instead of 0.77 m for `silixa_h5_1.hdf5`). The comment claimed parity with the TDMS reader, but TDMS uses that length as the *stop*.

The reader now anchors channel 0 on the header's `Start Distance (m)`, the convention the Carina (V2) variant already uses. With `SpatialResolution[m] * Fibre Length Multiplier` as the step, the last channel lands on the header's `Stop Distance (m)` to within the multiplier's six-digit rounding (4.5 cm over 7.8 km).

Closes #1025. Found while surveying distance origins across readers for #706.

## Changelog

- fixed: The Silixa H5 V1 reader now starts the distance coordinate at the header's `Start Distance (m)` instead of one cable length past `StartPosition[m]`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected distance coordinate calculations for Silixa V1 acoustic files.
  - Distance coordinates now begin at the file’s configured start distance and use the appropriate scaled channel spacing.

- **Tests**
  - Added coverage validating coordinate start, end, and spacing values against Silixa file metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->