### PR TITLE
Draw a spectrogram when the other dimension has one sample

### DIFF
--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -145,7 +145,11 @@ def spectrogram(
             spec = _spectrogram_patch(patch_aggr, dim, **kwargs)
         elif aggr_domain == "frequency":
             _spec = _spectrogram_patch(patch, dim, **kwargs).squeeze()
-            spec = _spec.aggregate(other_dim, method="mean").squeeze()
+            # A length one other_dim is squeezed out above, and a dimension
+            # of one sample has nothing to average over anyway.
+            if other_dim in _spec.dims:
+                _spec = _spec.aggregate(other_dim, method="mean").squeeze()
+            spec = _spec
         else:
             raise ValueError(
                 f"The aggr_domain '{aggr_domain}' should be 'time' or 'frequency'."

--- a/tests/test_viz/test_spectrogram.py
+++ b/tests/test_viz/test_spectrogram.py
@@ -78,6 +78,14 @@ class TestPlotSpectrogram:
         axis = patch.viz.spectrogram(dim="time")
         assert isinstance(axis, plt.Axes)
 
+    @pytest.mark.parametrize("aggr_domain", ["time", "frequency"])
+    def test_length_one_other_dim(self, random_patch, aggr_domain):
+        """A single channel still has a spectrogram; there is just no mean."""
+        patch = random_patch.select(distance=(0, 1), samples=True)
+        assert patch.ndim == 2, "the length one dimension should be kept"
+        axis = patch.viz.spectrogram(dim="time", aggr_domain=aggr_domain)
+        assert isinstance(axis, plt.Axes)
+
     def test_show(self, random_patch, shown):
         """Ensure show path is callable."""
         axis = random_patch.viz.spectrogram(dim="time", show=True)


### PR DESCRIPTION
## Description

`Patch.viz.spectrogram` raised when the patch was 2D but the dimension it was *not* transforming had length one — a single channel selected out of a larger patch, for example.

The `aggr_domain="frequency"` branch squeezes the spectrogram patch and then averages over `other_dim`:

```python
_spec = _spectrogram_patch(patch, dim, **kwargs).squeeze()
spec = _spec.aggregate(other_dim, method="mean").squeeze()
```

The squeeze drops `other_dim` when it holds a single sample, so the aggregate then asked for a dimension that was no longer there:

```
ParameterError: You must specify at least one dimension name in args or kwargs.
You passed the following kwargs: {} args: ('distance',) to a patch with
dimensions ('ft_time', 'time')
```

A dimension of one sample has nothing to average over, so the aggregation is skipped when the squeeze has already removed it. The `aggr_domain="time"` branch already worked on such a patch, and the `aggr_domain` docstring says as much ("No need to specify if the other dimension's coordinate size is 1"), so this brings the code to what was already documented.

Tested for both `aggr_domain` values, on a patch whose length-one dimension is kept rather than squeezed away by the caller.

Closes #1028.

## Changelog

- fixed: `Patch.viz.spectrogram` no longer raises when the dimension it is not transforming holds a single sample.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spectrogram generation for data with a single channel or length-one dimension.
  * Prevented errors when aggregating frequency-domain data after dimensions are reduced.
  * Preserved the expected two-dimensional spectrogram shape across time and frequency aggregation modes.

* **Tests**
  * Added coverage for single-channel spectrogram generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->