### PR TITLE
Let progress=False mean no progress bar

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -173,13 +173,14 @@ STORAGE_PROVENANCE_ATTRS = (
 )
 
 # Level of progress bar
-PROGRESS_LEVELS = Literal["standard", "basic", None]
+PROGRESS_LEVELS = Literal["standard", "basic", None, False]
 
 progress_description = """
 progress
     Controls the progress bar. "standard" produces the standard progress
     bar. "basic" is a simplified version with lower refresh rates, best
-    for high-latency environments, and None disables the progress bar.
+    for high-latency environments, and None (or False) disables the
+    progress bar.
 """.strip()
 
 # Options for handling specific warnings. One spelling of "do nothing":

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -884,10 +884,10 @@ def _spool_map(
     **kwargs
         Keywords passed to func.
     """
-    # Checked before branching: with a client and an empty spool no
-    # patch is ever tracked, so a retired `progress=False` would be
-    # accepted or refused depending on how much data there was.
-    validate_progress_level(progress)
+    # Normalized before branching: with a client and an empty spool no
+    # patch is ever tracked, so an unsupported level would be accepted or
+    # refused depending on how much data there was.
+    progress = validate_progress_level(progress)
     # no client; simple for loop.
     if client is None:
         desc = f"Applying {_callable_name(func)} to spool"

--- a/dascore/utils/progress.py
+++ b/dascore/utils/progress.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Iterable, Sized
 from contextlib import suppress
-from typing import get_args
+from typing import Literal, get_args
 
 import rich.progress as prog
 
@@ -14,8 +14,16 @@ from dascore.config import get_config
 from dascore.constants import PROGRESS_LEVELS
 from dascore.exceptions import ParameterError
 
+#: The levels which actually produce a bar; the others turn it off.
+BAR_LEVELS = Literal["standard", "basic"]
 
-def get_progress_instance(progress: PROGRESS_LEVELS | Progress = "standard"):
+#: The levels safe to compare by equality. False is accepted, but only by
+#: identity: it is equal to 0, so leaving it here would accept any zero as
+#: a level and hand it on to be turned into a standard bar.
+_EQUATABLE_LEVELS = tuple(x for x in get_args(PROGRESS_LEVELS) if x is not False)
+
+
+def get_progress_instance(progress: BAR_LEVELS | Progress = "standard"):
     """
     Get the Rich progress bar instance based on complexity level.
     """
@@ -59,12 +67,17 @@ def get_track_length(sequence: Iterable, length: int | None, min_length: int) ->
 
 def validate_progress_level(progress):
     """
-    Ensure a progress argument is a supported level, or a caller's own bar.
+    Return a supported progress level, or the caller's own bar.
 
-    Anything else falls through to the standard bar, so a stale
-    `progress=False` would turn one on rather than off.
+    `False` is the obvious way to ask for no bar, so it is accepted and
+    returned as None. Callers must use the returned value: anything else
+    falls through to the standard bar, so a `False` passed on unchanged
+    would turn one on rather than off. `True` is not accepted, having no
+    one obvious meaning where there are two bars to choose between.
     """
-    if isinstance(progress, Progress) or progress in get_args(PROGRESS_LEVELS):
+    if progress is False:
+        return None
+    if isinstance(progress, Progress) or progress in _EQUATABLE_LEVELS:
         return progress
     msg = (
         f"progress must be one of {get_args(PROGRESS_LEVELS)} or a "
@@ -91,7 +104,7 @@ def track(
         A string describing the operation
     progress
         options are
-            None- disable progress bar,
+            None (or False) - disable progress bar,
             "basic" reduced refresh rate,
             "standard" - the normal progress bar
         can also accept a subclass of rich.progress.Progress.
@@ -100,7 +113,7 @@ def track(
     min_length
         The minimum length to emit a progress bar.
     """
-    validate_progress_level(progress)
+    progress = validate_progress_level(progress)
     total = get_track_length(sequence, length, min_length)
     # This is a dirty hack to allow debugging while running tests.
     # Otherwise, pdb doesn't work in any tracking scope.

--- a/tests/test_utils/test_progress.py
+++ b/tests/test_utils/test_progress.py
@@ -11,7 +11,12 @@ from rich.progress import Progress
 import dascore as dc
 from dascore.config import config_context
 from dascore.exceptions import ParameterError
-from dascore.utils.progress import get_progress_instance, get_track_length, track
+from dascore.utils.progress import (
+    get_progress_instance,
+    get_track_length,
+    track,
+    validate_progress_level,
+)
 
 
 class TestGetTrackLength:
@@ -70,18 +75,50 @@ class TestProgressBar:
         with config_context(debug=False):
             assert list(track([1, 2, 3], "off_tracker", None)) == [1, 2, 3]
 
-    @pytest.mark.parametrize("bad", [False, True, "quiet"])
+    def test_false_disables_the_bar(self):
+        """False is the other off switch, and iteration is unaffected."""
+        with config_context(debug=False):
+            assert list(track([1, 2, 3], "off_tracker", False)) == [1, 2, 3]
+
+    def test_false_disables_the_bar_in_map(self):
+        """The off switch has to survive the trip through Spool.map."""
+        spool = dc.get_example_spool()
+        with config_context(debug=False):
+            assert len(spool.map(lambda patch: patch.shape, progress=False)) == 3
+
+    def test_false_is_normalized_rather_than_passed_on(self):
+        """Passed on unchanged it would fall through to the standard bar."""
+        assert validate_progress_level(False) is None
+
+    @pytest.mark.parametrize("bad", [True, "quiet"])
     def test_a_value_outside_the_levels_raises(self, bad):
         """Anything else would fall through to the standard bar."""
         with pytest.raises(ParameterError, match="progress must be one of"):
             list(track([1, 2, 3], "bad_tracker", bad))
+
+    @pytest.mark.parametrize("zero", [0, 0.0, np.False_])
+    def test_something_merely_equal_to_false_is_not_a_level(self, zero):
+        """False is a level by identity only; zero equals it but is not one."""
+        with pytest.raises(ParameterError, match="progress must be one of"):
+            validate_progress_level(zero)
 
     def test_an_empty_spool_still_refuses_a_bad_level(self):
         """Acceptance must not depend on there being data to track."""
         client = ThreadPoolExecutor()
         try:
             with pytest.raises(ParameterError, match="progress must be one of"):
+                dc.spool([]).map(lambda patch: patch, client=client, progress="quiet")
+        finally:
+            client.shutdown()
+
+    def test_an_empty_spool_still_takes_the_off_switch(self):
+        """False is a level, so it must be accepted on the same path."""
+        client = ThreadPoolExecutor()
+        try:
+            assert (
                 dc.spool([]).map(lambda patch: patch, client=client, progress=False)
+                == []
+            )
         finally:
             client.shutdown()
 


### PR DESCRIPTION
## Description

`progress=False` was rejected everywhere a progress level is taken (`Spool.map`, `spool.update`, and so on); only `None`, `"basic"`, `"standard"`, or a `rich` `Progress` were accepted. `False` is the obvious way to ask for no progress bar in Python and is what most libraries take, so it cost a traceback to find that out.

It now means the same as `None`.

**This deliberately changes behavior that was tested.** The strictness was not an oversight — `validate_progress_level`'s docstring explained that an unvalidated `False` falls through to the standard bar and turns one *on* rather than off, and two tests locked that in. That property is preserved here, by normalizing rather than merely permitting: `validate_progress_level` returns `None` for `False`, and the two call sites (`track` and `_spool_map`) now use the returned value instead of discarding it. Passing `False` on unchanged would still turn a bar on, so the normalization has to be what callers see.

`True` is still refused, having no one obvious meaning where there are two bars to choose between.

**`False` is a level by identity only.** It is equal to `0`, so a naive membership test would accept `0`, `0.0` or `np.False_` as levels and pass them on to be turned into a standard bar — the same silent-bar failure, through a wider door, since `np.False_` reaches `Spool.map` from ordinary code like `progress=flags.any()`. `validate_progress_level` therefore matches `False` with `is`, and the equality-compared levels are built with `False` filtered out. Everything merely equal to `False` raises exactly as it does on `dev` today, and a test covers all three spellings.

`get_progress_instance` is annotated with a narrower `BAR_LEVELS`, since it handles only the two levels that actually produce a bar and is called after normalization.

The two tests that asserted `False` raises were rewritten: `test_a_value_outside_the_levels_raises` keeps `True` and `"quiet"`, and the empty-spool test now uses `"quiet"` as its bad level, with a companion asserting the empty-spool path *accepts* the off switch. New tests cover `False` through `track`, through `Spool.map`, and that `validate_progress_level` normalizes rather than passes it through.

`PROGRESS_LEVELS` gains `False` so the type hints and the error message stay honest, and the shared `progress_description` mentions it.

Closes #1030.

## Changelog

- added: `progress=False` now disables the progress bar, the same as `progress=None`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
