### PR TITLE
Let map_fiber color by the patch's data, and label the bar properly

### DIFF
--- a/dascore/viz/map_fiber.py
+++ b/dascore/viz/map_fiber.py
@@ -38,6 +38,35 @@ def _set_scale(im, scale, scale_type, color_coords):
     im.set_clim(scale)
 
 
+def _get_colorbar_label(data_type, data_units):
+    """Label the colorbar, leaving out whichever part is unset."""
+    name = str(data_type) if data_type else ""
+    units = str(data_units) if data_units else ""
+    if name and units:
+        return f"{name} ({units})"
+    return name or units
+
+
+def _get_data_to_color(patch, x):
+    """The patch's own data, checked against the points being drawn."""
+    points = np.shape(x)
+    data = patch.data
+    # An aggregated dimension is left as length one rather than squeezed
+    # out, and such a patch does hold one value per channel, so measure the
+    # dimensions which actually spread rather than the raw shape.
+    spread = [size for size in data.shape if size != 1]
+    if len(spread) > 1 or data.size != np.prod(points, dtype=int):
+        msg = (
+            "map_fiber draws one point per plotted coordinate, so coloring "
+            "by data needs one value for each. The patch data has shape "
+            f"{data.shape} and the plotted coordinates have shape {points}; "
+            "reduce the patch to one value per channel first, for example "
+            "with patch.std('time')."
+        )
+        raise ParameterError(msg)
+    return data.reshape(points)
+
+
 @patch_function()
 def map_fiber(
     patch: PatchType,
@@ -62,8 +91,9 @@ def map_fiber(
     y
         y coordinate: can be an array or a str representing a patch coordinate.
     color
-        The color parameter to plot: can be an array or a str representing a patch
-        attribute.
+        The color parameter to plot: can be an array, the name of a patch
+        coordinate, or "data" to color by the patch's own data, which needs
+        one value for each point drawn. A coordinate of that name wins.
     ax
         A matplotlib object, if None create one.
     cmap
@@ -90,6 +120,10 @@ def map_fiber(
     >>> patch = dc.get_example_patch("random_patch_with_lat_lon")
     >>> patch = patch.set_units(latitude="m", longitude="m")
     >>> _ = patch.viz.map_fiber("latitude", "longitude", "distance")
+    >>>
+    >>> # Color by the data itself, reduced to one value per channel.
+    >>> reduced = patch.std("time").squeeze()
+    >>> _ = reduced.viz.map_fiber("latitude", "longitude", "data")
     """
     dims = []
     if isinstance(x, str):
@@ -105,12 +139,20 @@ def map_fiber(
         dims.append(y)
         y = patch.coords.get_array(y)
     if isinstance(color, str):
-        if color not in patch.coords:
-            msg = f"{color} not found in patch coordinates"
+        if color in patch.coords:
+            data_type = color
+            data_units = patch.coords.coord_map[color].units
+            color = patch.coords.get_array(color)
+        elif color == "data":
+            data_type = patch.attrs.data_type
+            data_units = patch.attrs.data_units
+            color = _get_data_to_color(patch, x)
+        else:
+            msg = (
+                f"{color} not found in patch coordinates. Use 'data' to "
+                "color by the patch's own data."
+            )
             raise ParameterError(msg)
-        data_type = color
-        data_units = patch.coords.coord_map[color].units
-        color = patch.coords.get_array(color)
     else:
         data_type = ""
         data_units = ""
@@ -131,9 +173,7 @@ def map_fiber(
     # add color bar with title
     if cmap is not None:
         cb = ax.get_figure().colorbar(im, ax=ax, fraction=0.05, pad=0.025)
-        dunits = f" ({data_units})" if (data_type and data_units) else f"{data_units}"
-        label = f"{data_type}{dunits}"
-        cb.set_label(label)
+        cb.set_label(_get_colorbar_label(data_type, data_units))
 
     if show:
         plt.show()

--- a/tests/test_viz/test_map_fiber.py
+++ b/tests/test_viz/test_map_fiber.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
 import dascore as dc
@@ -111,10 +112,74 @@ class TestPlotMap:
         ax = new.viz.map_fiber("latitude", "longitude")
         check_label_units(new, ax, ["latitude", "longitude"])
 
+    def test_unitless_coord_label_has_no_units(self, random_patch_with_lat_lon):
+        """An unset unit contributes nothing rather than the word None."""
+        ax = (
+            random_patch_with_lat_lon.std("time")
+            .squeeze()
+            .viz.map_fiber("latitude", "longitude", "latitude")
+        )
+        assert ax.get_figure().axes[-1].get_ylabel() == "latitude"
+
     def test_show(self, random_patch, shown):
         """Ensure show path is callable."""
         random_patch.viz.map_fiber(show=True)
         assert shown
+
+
+class TestMapFiberColorByData:
+    """Tests for coloring the fiber by the patch's own data."""
+
+    @pytest.fixture()
+    def reduced_patch(self, random_patch_with_lat_lon):
+        """A patch with one value per channel, which is what can be drawn."""
+        return random_patch_with_lat_lon.std("time").squeeze()
+
+    def test_data_colors_the_fiber(self, reduced_patch):
+        """The data is drawn without having to be pulled out by hand."""
+        ax = reduced_patch.viz.map_fiber("latitude", "longitude", "data")
+        collection = ax.collections[0]
+        assert np.array_equal(collection.get_array(), reduced_patch.data)
+
+    def test_data_label_comes_from_attrs(self, reduced_patch):
+        """The patch knows its data type and units, so the bar is labeled."""
+        patch = reduced_patch.update_attrs(data_type="velocity").set_units("m/s")
+        ax = patch.viz.map_fiber("latitude", "longitude", "data")
+        label = ax.get_figure().axes[-1].get_ylabel()
+        assert label.startswith("velocity")
+        assert "m / s" in label or "m/s" in label
+
+    def test_coord_named_data_still_wins(self, reduced_patch):
+        """A coordinate of that name keeps working as it did."""
+        values = np.arange(len(reduced_patch.get_array("distance")), dtype=float)
+        patch = reduced_patch.update_coords(data=("distance", values))
+        ax = patch.viz.map_fiber("latitude", "longitude", "data")
+        assert np.array_equal(ax.collections[0].get_array(), values)
+
+    def test_aggregated_patch_is_accepted(self, random_patch_with_lat_lon):
+        """An aggregation leaves a length one dim; that is still one per channel."""
+        patch = random_patch_with_lat_lon.std("time")
+        assert patch.ndim == 2, "the aggregated dimension should be kept"
+        ax = patch.viz.map_fiber("latitude", "longitude", "data")
+        expected = patch.data.reshape(-1)
+        assert np.array_equal(ax.collections[0].get_array(), expected)
+
+    def test_units_without_a_data_type_still_label(self, random_patch_with_lat_lon):
+        """An unnamed quantity is still worth putting on the bar."""
+        patch = random_patch_with_lat_lon.std("time").squeeze().set_units("m/s")
+        assert not patch.attrs.data_type, "this patch should have no data type"
+        ax = patch.viz.map_fiber("latitude", "longitude", "data")
+        assert ax.get_figure().axes[-1].get_ylabel().strip()
+
+    def test_unreduced_patch_raises(self, random_patch_with_lat_lon):
+        """Two dimensions of data cannot color one point per channel."""
+        with pytest.raises(ParameterError, match="one value for each"):
+            random_patch_with_lat_lon.viz.map_fiber("latitude", "longitude", "data")
+
+    def test_bad_color_names_data_as_an_option(self, reduced_patch):
+        """The error should say what the caller probably wanted."""
+        with pytest.raises(ParameterError, match="Use 'data'"):
+            reduced_patch.viz.map_fiber("latitude", "longitude", "not_a_coord")
 
 
 class TestMapFiberErrors:


### PR DESCRIPTION
## Description

Two fixes to `Patch.viz.map_fiber`, both in how the color is chosen and labeled.

**Coloring by the patch's data (#1031).** `map_fiber` could color the fiber by any coordinate given by name, or by an array passed directly, but not by the patch's own data — the thing the plot usually exists to show. `color="data"` was refused as a missing coordinate, and the array workaround (`color=patch.data`) lost the colorbar label, since the labeling branch only ran for a `str`.

`color="data"` now colors by `patch.data` and labels the bar from the patch's `data_type` and `data_units`. A coordinate literally named `data` still wins, so no call that works today changes meaning. An aggregation such as `patch.std("time")` leaves its dimension as length one rather than squeezing it out, and such a patch does hold one value per channel, so it is accepted and reshaped; what is refused is data that genuinely spreads over more than one dimension:

```
ParameterError: map_fiber draws one point per plotted coordinate, so coloring
by data needs one value for each. The patch data has shape (300, 2000) and the
plotted coordinates have shape (300,); reduce the patch to one value per
channel first, for example with patch.std('time').
```

**The colorbar label (#1032).** The label was built by pasting the name and units together, formatting the units into the string even when there were none, so any unitless coordinate got the word `None` glued on — `latitudeNone`. `_get_colorbar_label` now leaves out whichever part is unset. With both present the label is unchanged, which the existing `test_units` assertions cover.

The two are together because the first needs the second: coloring by data on a patch with no `data_units` would otherwise have labeled the bar `None`.

One nearby wart is deliberately left alone: units are stored as a `pint` `Quantity` of magnitude 1, so every unit-bearing label reads `latitude (1 ft)` rather than `latitude (ft)`. That is pre-existing and changes the label of every unit-bearing plot rather than only the unitless case, so it is filed separately as #1033.

Closes #1031. Closes #1032.

## Changelog

- added: `Patch.viz.map_fiber` accepts `color="data"` to color the fiber by the patch's own data.
- fixed: `Patch.viz.map_fiber` no longer labels the colorbar with the word `None` when the coordinate has no units.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
