### PR TITLE
Keep the dtype of an all-null coordinate

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -3234,6 +3234,14 @@ def get_coord(
         elif monotonic:
             return CoordMonotonicArray(values=data, units=units)
         elif np.all(pd.isnull(data)):
+            # The values say nothing, but their type still does: an array of
+            # NaT came from datetimes and should stay datetimes, as the
+            # empty case above also keeps. Only a kind whose null the
+            # values can actually hold is recorded; an object array of
+            # Nones has no null but NaN, so claiming "object" would state
+            # a dtype which `values` then contradicts.
+            if dtype is None and data.dtype.kind in "fmM":
+                dtype = data.dtype
             return CoordPartial(
                 shape=data.shape,
                 units=units,

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1419,6 +1419,10 @@ class CoordPartial(BaseCoord):
     def values(self):
         """Return the internal data. Same as values attribute."""
         null_val = np.asarray(_get_nullish(self.dtype))
+        # NaN is a plain python float, so a narrower floating dtype has to
+        # be asked for by name or the values contradict the recorded dtype.
+        if self.dtype is not None and np.dtype(self.dtype).kind == "f":
+            null_val = null_val.astype(self.dtype)
         data = np.broadcast_to(null_val, self.shape)
         return data
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -1799,20 +1799,24 @@ def _joinable(coords, dim: str) -> list[np.ndarray]:
     """
     The coordinates' values, the value-less ones taking the others' kind.
 
-    A member with no values along the dimension holds placeholders whose
-    dtype says nothing (floating NaN); numpy cannot join those with, say,
-    datetimes, so they are recast as the stated members' own nulls. Where
-    the stated kind has no null to write — whole numbers, booleans, text —
-    the join is refused rather than inventing zeros or empty labels.
+    A member with no values along the dimension holds nothing but
+    placeholders. Its own dtype cannot be trusted to join with the others'
+    — floating NaN will not concatenate with datetimes, and neither will
+    NaT with floats — so a blank member is rewritten as the stated
+    members' own null. Where the stated kind has no null to write — whole
+    numbers, booleans, text — the join is refused rather than inventing
+    zeros or empty labels.
+
+    Blankness is a question about values, not about type: a coordinate
+    which states no values is blank whether it remembers being made of
+    times or has forgotten.
     """
     arrays = [x.values for x in coords]
-    blank = [x.dtype.kind == "f" and bool(np.all(pd.isnull(x))) for x in arrays]
+    blank = [bool(np.all(pd.isnull(x))) for x in arrays]
     if all(blank) or not any(blank):
         return arrays
     target = np.result_type(*[x.dtype for x, b in zip(arrays, blank) if not b])
-    if target.kind == "f":
-        return arrays
-    if target.kind not in "mM":
+    if target.kind not in "fmM":
         msg = (
             f"Cannot concatenate along {dim!r}: a patch states no values "
             f"there, and a {target} coordinate has no missing value to "

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -1785,7 +1785,9 @@ def _concatenate_group(
                 )
                 raise CoordMergeError(msg) from err
             rider_axis = cdims.index(dim)
-            joined = np.concatenate([x.values for x in members], axis=rider_axis)
+            # a rider joins the same way its dimension does: a member which
+            # states nothing takes the kind of the members which do
+            joined = np.concatenate(_joinable(members, dim), axis=rider_axis)
             riders[name] = (cdims, dc.core.coords.get_coord(data=joined, units=units))
         if riders:
             coords = coords.update(**riders)
@@ -1809,14 +1811,28 @@ def _joinable(coords, dim: str) -> list[np.ndarray]:
 
     Blankness is a question about values, not about type: a coordinate
     which states no values is blank whether it remembers being made of
-    times or has forgotten.
+    times or has forgotten. A member with no entries at all is blank too,
+    but nothing is written into it, so it never forces a refusal.
     """
     arrays = [x.values for x in coords]
     blank = [bool(np.all(pd.isnull(x))) for x in arrays]
-    if all(blank) or not any(blank):
+    if not any(blank):
         return arrays
-    target = np.result_type(*[x.dtype for x, b in zip(arrays, blank) if not b])
-    if target.kind not in "fmM":
+    # Only the members which state something choose the kind. When none
+    # do, the blanks choose among themselves, the empty ones last.
+    stated = [x.dtype for x, b in zip(arrays, blank) if not b]
+    if stated:
+        target = np.result_type(*stated)
+    else:
+        voters = [x.dtype for x in arrays if x.size] or [x.dtype for x in arrays]
+        try:
+            target = np.result_type(*voters)
+        except TypeError:
+            # NaT beside NaN and nothing stated either way: no kind is the
+            # right one, and no values are lost by falling back to floats.
+            target = np.dtype("float64")
+    written = any(b and x.size for x, b in zip(arrays, blank))
+    if written and target.kind not in "fmM":
         msg = (
             f"Cannot concatenate along {dim!r}: a patch states no values "
             f"there, and a {target} coordinate has no missing value to "

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1855,6 +1855,22 @@ class TestPartialCoord:
         assert coord.dtype == dtype
         assert coord.values.dtype == dtype
 
+    @pytest.mark.parametrize("dtype", ["float32", "float64"])
+    def test_all_null_floats_keep_their_width(self, dtype):
+        """
+        A recorded floating dtype is one the values actually have.
+
+        NaN is a plain python float, so a narrower dtype has to be asked
+        for by name; without that the coord reports float32 while its
+        values report float64, and anything promoting against them, such
+        as concatenation, takes the wrong one.
+        """
+        dtype = np.dtype(dtype)
+        coord = get_coord(data=np.full(3, np.nan, dtype=dtype))
+        assert isinstance(coord, CoordPartial)
+        assert coord.dtype == dtype
+        assert coord.values.dtype == dtype
+
     def test_all_null_object_array_claims_no_dtype(self):
         """
         A dtype is only worth recording when the values can honor it.

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -1839,6 +1839,40 @@ class TestPartialCoord:
         coord = CoordPartial(shape=(3,), dtype=dtype)
         assert coord.values.dtype == dtype
 
+    @pytest.mark.parametrize("dtype", ["datetime64[ns]", "timedelta64[us]"])
+    def test_all_null_array_keeps_its_dtype(self, dtype):
+        """
+        An array of nulls says nothing about when, but still says what.
+
+        The values are gone, the kind of thing they were is not, and a
+        partial coord has a dtype to record it. Dropping it turned missing
+        datetimes into untyped NaN. Float is left out of the parameters:
+        an unset dtype already reads as float64, so it cannot regress.
+        """
+        dtype = np.dtype(dtype)
+        coord = get_coord(data=np.full(3, "NaT", dtype=dtype))
+        assert isinstance(coord, CoordPartial)
+        assert coord.dtype == dtype
+        assert coord.values.dtype == dtype
+
+    def test_all_null_object_array_claims_no_dtype(self):
+        """
+        A dtype is only worth recording when the values can honor it.
+
+        The null of an object array is NaN, so its values are floats;
+        saying "object" would state a dtype which `values` contradicts.
+        """
+        coord = get_coord(data=np.array([None, None, None]))
+        assert isinstance(coord, CoordPartial)
+        assert coord.values.dtype == np.dtype("float64")
+        assert coord.dtype in (None, np.dtype("float64"))
+
+    def test_given_dtype_beats_the_array(self):
+        """A caller who names a dtype is not overruled by the values."""
+        data = np.full(3, "NaT", dtype="datetime64[ns]")
+        coord = get_coord(data=data, dtype="timedelta64[ns]")
+        assert coord.dtype == np.dtype("timedelta64[ns]")
+
     def test_set_units_positionally(self, basic_non_coord):
         """Units are set the same way as on any other coord."""
         out = basic_non_coord.set_units("m")

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -731,6 +731,48 @@ class TestConcatenate:
         assert len(out) == 1
         assert out[0].get_coord("time").max() == patch_2.get_coord("time").max()
 
+    def test_aggregated_patches_keep_their_dim_kind(self, random_spool):
+        """
+        Joining patches which state no values leaves the kind behind.
+
+        An aggregation with the default dim_reduce leaves a coordinate
+        holding no values but still knowing its dtype. Concatenating such
+        patches must not turn missing datetimes into untyped NaN.
+        """
+        means = [patch.mean("time") for patch in random_spool]
+        assert all(x.get_coord("time").dtype.kind == "M" for x in means)
+
+        out = concatenate_patches(means, time=None)[0]
+        coord = out.get_coord("time")
+        assert coord.dtype.kind == "M", "the axis is still made of times"
+        assert coord.values.dtype.kind == "M"
+
+    @pytest.mark.parametrize(("other", "expected"), [("datetime", "M"), ("float", "f")])
+    def test_blank_member_takes_the_stated_kind(self, random_patch, other, expected):
+        """A patch stating no times joins one that does, as its own null."""
+        size = len(random_patch.get_array("time"))
+        blank = random_patch.update_coords(
+            time=np.full(size, "NaT", dtype="datetime64[ns]")
+        )
+        values = (
+            random_patch.get_array("time")
+            if other == "datetime"
+            else np.arange(size, dtype=float)
+        )
+        stated = random_patch.update_coords(time=values)
+        out = concatenate_patches([blank, stated], time=None)[0]
+        assert out.get_coord("time").values.dtype.kind == expected
+
+    def test_blank_member_against_a_kind_with_no_null_raises(self, random_patch):
+        """Whole numbers have no missing value, so the join is refused."""
+        size = len(random_patch.get_array("time"))
+        blank = random_patch.update_coords(
+            time=np.full(size, "NaT", dtype="datetime64[ns]")
+        )
+        stated = random_patch.update_coords(time=np.arange(size))
+        with pytest.raises(CoordMergeError, match="states no values there"):
+            concatenate_patches([blank, stated], time=None)
+
     def test_different_dims_raises(self, random_patch):
         """Patches can't be concated when they have different dims."""
         p1 = random_patch

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -773,6 +773,72 @@ class TestConcatenate:
         with pytest.raises(CoordMergeError, match="states no values there"):
             concatenate_patches([blank, stated], time=None)
 
+    def test_every_member_blank_with_clashing_kinds(self, random_patch):
+        """
+        Members which all state nothing fall back to the floating null.
+
+        No kind is the right one when a blank datetime axis meets a blank
+        floating axis, and no values are lost by degrading to NaN; handing
+        numpy the two arrays as they stand only raises.
+        """
+        size = len(random_patch.get_array("time"))
+        nat = random_patch.update_coords(
+            time=np.full(size, "NaT", dtype="datetime64[ns]")
+        )
+        nan = random_patch.update_coords(time=np.full(size, np.nan))
+        out = concatenate_patches([nat, nan], time=None)[0]
+        values = out.get_coord("time").values
+        assert values.dtype.kind == "f"
+        assert len(values) == 2 * size
+        assert np.all(pd.isnull(values))
+
+    def test_empty_dim_joins_a_stated_one(self, random_patch):
+        """
+        A dimension with no entries states nothing and refuses nothing.
+
+        Every value of an empty array is null, but there are none to write
+        a null into, so the kinds which have no null must still join.
+        """
+        size = len(random_patch.get_array("distance"))
+        labeled = random_patch.update_coords(
+            distance=np.array([f"d{i}" for i in range(size)])
+        )
+        empty = labeled.select(distance=(0, 0), samples=True)
+        assert len(empty.get_array("distance")) == 0
+
+        out = concatenate_patches([empty, labeled], distance=None)[0]
+        assert out.get_coord("distance").dtype.kind == "U"
+        assert np.all(out.get_array("distance") == labeled.get_array("distance"))
+
+    @pytest.mark.parametrize(("other", "expected"), [("datetime", "M"), ("float", "f")])
+    def test_blank_rider_takes_the_stated_kind(self, random_patch, other, expected):
+        """A coordinate riding the dimension is joined as the dimension is."""
+        size = len(random_patch.get_array("time"))
+        blank = random_patch.update_coords(
+            rider=("time", np.full(size, "NaT", dtype="datetime64[ns]"))
+        )
+        values = (
+            random_patch.get_array("time")
+            if other == "datetime"
+            else np.arange(size, dtype=float)
+        )
+        stated = random_patch.update_coords(rider=("time", values))
+        out = concatenate_patches([blank, stated], time=None)[0]
+        joined = out.get_array("rider")
+        assert joined.dtype.kind == expected
+        assert np.all(pd.isnull(joined[:size]))
+        assert np.all(joined[size:] == values)
+
+    def test_blank_rider_against_a_kind_with_no_null_raises(self, random_patch):
+        """A rider is refused for the same reason its dimension would be."""
+        size = len(random_patch.get_array("time"))
+        blank = random_patch.update_coords(
+            rider=("time", np.full(size, "NaT", dtype="datetime64[ns]"))
+        )
+        stated = random_patch.update_coords(rider=("time", np.arange(size)))
+        with pytest.raises(CoordMergeError, match="states no values there"):
+            concatenate_patches([blank, stated], time=None)
+
     def test_different_dims_raises(self, random_patch):
         """Patches can't be concated when they have different dims."""
         p1 = random_patch


### PR DESCRIPTION
## Description

Two changes which have to travel together: a coordinate which states no values keeps the type of the thing that is missing, and the concatenation which joins such coordinates stops deciding what "value-less" means by looking at that type.

### Keeping the dtype

`get_coord` has two branches which build a `CoordPartial` out of array data. The empty-array branch keeps the array's type; the all-null branch passed on the bare `dtype` argument, `None` whenever the caller did not name one. An array of `NaT` therefore became a coordinate which had forgotten it was ever made of times, its values degrading from `NaT` to floating `NaN`.

Aggregating with the default `dim_reduce="empty"` already leaves a coordinate which states no values but knows its dtype, and the join of those `NaT`s was already correct; the type was lost only at the end, when the joined array went back through `get_coord`. So

```python
means = spool.map(lambda patch: patch.mean("time"))
day = dc.spool(means).concatenate(time=None)[0]
```

gave a patch whose time axis was `[nan nan nan]` of dtype `None`, and now gives `[NaT NaT NaT]` of `datetime64[ns]` — the same missing information, saying what kind of thing is missing.

A dtype is only recorded when the values can honor it. `_get_nullish` writes `NaN` for everything that is not time-like, so an object array of `None`s keeps no dtype rather than claiming `object` and being contradicted by its own `values`.

### Classifying by nullness, not by float-ness

`_joinable` decided which members were blank with `x.dtype.kind == "f" and all(isnull(x))`. That test was only ever accidentally right: it worked because a value-less coordinate degraded to float. Once such a coordinate keeps `datetime64`, the predicate stops recognizing exactly the members it exists to recognize, `all(blank)`/`not any(blank)` short-circuits, and the deliberately worded refusal below it becomes unreachable. Concretely, on `dev`:

```python
concatenate_patches([states_no_times, states_int64_times], time=None)
# CoordMergeError: Cannot concatenate along 'time': a patch states no values
# there, and a int64 coordinate has no missing value to stand in for them.
```

and without this half of the change, that same call raises `numpy DTypePromotionError` out of `dascore.utils.patch` instead — and a join against a float axis, which succeeded on `dev`, fails outright.

So blankness is now a question about values rather than about type, and the branch which returned the arrays untouched for a float target rewrites the blank members as the target's null like every other kind. `dev`'s behavior is restored for all three cases: refused for whole numbers, joined as float against a float axis, joined as times against a time axis. That error branch had no test; it has three now.

### What review caught

Recording a dtype makes four more places care about it, and the first commit handled none of them.

`np.all` is true of an empty array, so the new predicate counted every zero-length coordinate as a member which states no values. A member with no entries has no null written into it, so it no longer forces the refusal, and an empty string dimension joins a stated one as it did before.

When every member is blank their kinds still have to meet. NaT beside NaN has no common type and nothing is stated either way, so the join degrades to the floating null rather than handing numpy two arrays it cannot promote. Where some member does state values, incompatible stated kinds raise out of numpy exactly as they do on `dev`.

A coordinate riding the concatenated dimension is joined by `_concatenate_group` directly, not through `_joinable`, so a blank datetime rider beside a stated floating rider raised `DTypePromotionError`. Riders now go through `_joinable` too. That makes one behavior stricter than `dev`: a blank rider beside an integer, boolean or text rider is refused with the same message the dimension coordinate already gets, where `dev` quietly widened it to floating NaN. The dimension and its riders saying different things about the same missing values was the accident, not the rule.

Finally `CoordPartial.values` built its null from a plain python NaN, so a coordinate which recorded `float32` reported `float64` values and contradicted the dtype it had just kept. The null is now written in the recorded floating dtype.

Refs #1029. That issue also covers the *silence* — that concatenating patches which all state no values yields an entirely unlabeled axis without a word — which is a behavior question rather than a bug and is deliberately left open.

Not addressed here, and filed separately as #1047: the dtype this preserves is dropped again by `CoordPartial.__getitem__` and `change_length`, so a `select` on the result loses it. That is a pre-existing inconsistency in the class rather than something this introduces, but it does limit how far the improvement travels.

## Changelog

- fixed: A coordinate whose values are all null keeps its dtype, so aggregated patches no longer concatenate to an untyped NaN axis.
- fixed: Concatenating a patch which states no values along a dimension now decides what to do by whether values are stated rather than by their dtype, restoring the refusal for kinds which have no null.
- fixed: A dimension with no entries at all is no longer treated as one which states no values, so an empty coordinate still concatenates with a stated coordinate of any kind.
- fixed: Concatenating patches which all state no values along a dimension falls back to the floating null when their kinds have no common type, rather than raising out of numpy.
- fixed: A coordinate riding the concatenated dimension takes the stated members' kind, so a blank datetime rider no longer raises out of numpy.
- fixed: A coordinate which states no values writes its null in the floating dtype it records, so its values no longer contradict its dtype.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved floating-point, datetime, and timedelta types for coordinates containing only null values.
  * Improved handling of empty coordinates when combining or aggregating data.
  * Prevented unsupported combinations, such as empty and integer coordinates, from being merged incorrectly.
  * Maintained expected behavior for object-based coordinates and explicit type selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
