### PR TITLE
Let istft rebuild associated coordinates

### DIFF
--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -641,15 +641,18 @@ def _get_istft_coord(coords, frequency_axis, time_axis):
     Get the coordinate manager for the inverse of the short time fourier transform.
     """
     dims = coords.dims
-    # Create new time coordinate.
-    coord_map = dict(coords.coord_map)
+    freq_name, time_name = dims[frequency_axis], dims[time_axis]
+    # Drop the transformed dims and any coords associated with them; those
+    # coords are indexed by frequency or window and cannot survive the inverse.
+    stripped = coords.drop_coords(freq_name, time_name)[0]
+    # Use the tuple map so associated coords keep their dimensions.
+    coord_map = stripped.get_coord_tuple_map()
     coord_map.pop("_stft_window")
-    time = coord_map.pop("_stft_old_coord")
-    coord_map.pop(coords.dims[frequency_axis])
-    coord_map[dims[time_axis]] = time
+    time = coord_map.pop("_stft_old_coord")[1]
+    coord_map[time_name] = (time_name, time)
     # Get new dimensions
     new_dims = list(dims)
-    new_dims[frequency_axis] = dims[time_axis]
+    new_dims[frequency_axis] = time_name
     new_dims.pop(time_axis)
     return get_coord_manager(coords=coord_map, dims=tuple(new_dims)), time
 
@@ -688,6 +691,17 @@ def istft(patch) -> dc.Patch:
     >>> pa1 = patch.stft(time=10*second, overlap=4*second)
     >>> pa2 = pa1.istft()
     >>> assert pa2.equals(patch, close=True)
+
+    Notes
+    -----
+    - Non-dimensional coordinates associated with un-transformed dimensions
+      are restored. Those associated with the transformed dimension are
+      already dropped by [stft](`dascore.transform.fourier.stft`) so they
+      cannot be restored.
+
+    See Also
+    --------
+    [Patch.stft](`dascore.Patch.stft`), [Patch.idft](`dascore.Patch.idft`)
     """
     time_axis, frequency_axis = _get_inverse_axes(patch)
     detrended = patch.attrs.get("_stft_detrended")

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -695,9 +695,12 @@ def istft(patch) -> dc.Patch:
     Notes
     -----
     - Non-dimensional coordinates associated with un-transformed dimensions
-      are restored. Those associated with the transformed dimension are
+      are preserved. Those associated with the transformed dimension are
       already dropped by [stft](`dascore.transform.fourier.stft`) so they
       cannot be restored.
+    - Coordinates associated with the frequency or window dimensions the
+      stft created are dropped, since neither dimension survives the
+      inverse. [idft](`dascore.Patch.idft`) behaves the same way.
 
     See Also
     --------

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -614,3 +614,52 @@ class TestInverseSTFT:
         msg = "Inverse stft not possible"
         with pytest.raises(PatchError, match=msg):
             chirp_stft_detrend_patch.istft()
+
+
+class TestInverseSTFTAssociatedCoords:
+    """Tests that istft round-trips patches with associated coordinates."""
+
+    @pytest.fixture(scope="class")
+    def patch_with_coords(self):
+        """A patch with associated coords on each dimension."""
+        patch = dc.get_example_patch("random_das", shape=(10, 200))
+        dist_len = len(patch.get_coord("distance"))
+        time_len = len(patch.get_coord("time"))
+        return patch.update_coords(
+            depth=("distance", np.arange(dist_len, dtype=float) * 2.0),
+            tlabel=("time", np.arange(time_len, dtype=float)),
+            note=(None, np.array(["a", "b"])),
+        )
+
+    def test_coord_on_untransformed_dim(self, patch_with_coords):
+        """A coord on an untransformed dim survives the round trip. See #1039."""
+        patch = patch_with_coords.drop_coords("tlabel", "note")
+        out = patch.stft(time=0.1).istft()
+        assert out.dims == patch.dims
+        assert out.coords == patch.coords
+        assert np.allclose(out.data, patch.data)
+
+    def test_coord_on_transformed_dim(self, patch_with_coords):
+        """A coord on the transformed dim is dropped by stft, not restored."""
+        patch = patch_with_coords.drop_coords("depth", "note")
+        stft_patch = patch.stft(time=0.1)
+        assert "tlabel" not in stft_patch.coords.coord_map
+        out = stft_patch.istft()
+        assert "tlabel" not in out.coords.coord_map
+        assert out.dims == patch.dims
+        assert np.allclose(out.data, patch.data)
+
+    def test_multiple_associated_coords(self, patch_with_coords):
+        """Several associated coords round trip, minus the transformed one."""
+        patch = patch_with_coords
+        out = patch.stft(time=0.1).istft()
+        expected = patch.drop_coords("tlabel")
+        assert out.coords == expected.coords
+        assert np.allclose(out.data, patch.data)
+
+    def test_coord_on_untransformed_time(self, patch_with_coords):
+        """Transforming distance leaves the time-associated coord intact."""
+        patch = patch_with_coords
+        out = patch.stft(distance=4).istft()
+        assert out.coords == patch.drop_coords("depth").coords
+        assert np.allclose(out.data, patch.data)

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -621,7 +621,7 @@ class TestInverseSTFTAssociatedCoords:
 
     @pytest.fixture(scope="class")
     def patch_with_coords(self):
-        """A patch with associated coords on each dimension."""
+        """A patch with coords on each dimension and one on no dimension."""
         patch = dc.get_example_patch("random_das", shape=(10, 200))
         dist_len = len(patch.get_coord("distance"))
         time_len = len(patch.get_coord("time"))
@@ -654,6 +654,7 @@ class TestInverseSTFTAssociatedCoords:
         patch = patch_with_coords
         out = patch.stft(time=0.1).istft()
         expected = patch.drop_coords("tlabel")
+        assert out.dims == patch.dims
         assert out.coords == expected.coords
         assert np.allclose(out.data, patch.data)
 
@@ -661,5 +662,19 @@ class TestInverseSTFTAssociatedCoords:
         """Transforming distance leaves the time-associated coord intact."""
         patch = patch_with_coords
         out = patch.stft(distance=4).istft()
+        assert out.dims == patch.dims
         assert out.coords == patch.drop_coords("depth").coords
         assert np.allclose(out.data, patch.data)
+
+    def test_coords_on_stft_dims_dropped(self, patch_with_coords):
+        """Coords on the frequency or window dims cannot survive the inverse."""
+        stft_patch = patch_with_coords.drop_coords("tlabel", "note").stft(time=0.1)
+        freq_len = len(stft_patch.get_coord("ft_time"))
+        win_len = len(stft_patch.get_coord("time"))
+        marked = stft_patch.update_coords(
+            snr=("ft_time", np.arange(freq_len, dtype=float)),
+            wlabel=("time", np.arange(win_len, dtype=float)),
+        )
+        out = marked.istft()
+        assert {"snr", "wlabel"}.isdisjoint(out.coords.coord_map)
+        assert out.coords == stft_patch.istft().coords


### PR DESCRIPTION
## Description

`Patch.istft` raised on any patch carrying an associated (non-dimensional) coordinate. `_get_istft_coord` rebuilt the coordinate manager from `coords.coord_map`, which yields bare coordinates, so `get_coord_manager` rejected every coordinate whose name isn't a dimension name.

The fix uses `get_coord_tuple_map()` — the same pattern `idft` already uses in `_get_idft_coords_and_sizes` — so associated coordinates keep their dimensions. It also drops the frequency and window dimensions with `drop_coords` first, since coordinates associated with those are indexed by frequency or by window and cannot survive the inverse.

Round-trip behavior now matches `dft`/`idft`: coordinates associated with un-transformed dimensions come back unchanged, and coordinates associated with the transformed dimension are gone because `stft` already drops them (documented in its Notes). The `istft` docstring gained a Notes section saying so.

Closes #1039

## Changelog

- fixed: `Patch.istft` no longer raises on patches that carry associated (non-dimensional) coordinates.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
