### PR TITLE
Let apply_ufunc be called as a patch method

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -390,10 +390,42 @@ class Patch(NodeRepr, NamespaceOwner):
     drop_private_coords = dascore.proc.drop_private_coords
     coords_from_df = dascore.proc.coords_from_df
     make_broadcastable_to = dascore.proc.make_broadcastable_to
-    apply_ufunc = apply_ufunc
     get_patch_names = get_patch_names
     get_axis = dascore.proc.get_axis
     full = dascore.proc.full
+
+    def apply_ufunc(self, ufunc, *args, **kwargs) -> Patch:
+        """
+        Apply a ufunc with the patch as its first operand.
+
+        Parameters
+        ----------
+        ufunc
+            The ufunc to apply.
+        *args
+            The remaining operands, which can contain patches.
+        **kwargs
+            Keyword arguments which configure the operation, such as `dim`
+            for a reduction or accumulation.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import dascore as dc
+        >>> patch = dc.get_example_patch()
+        >>>
+        >>> # Take the absolute value of the patch.
+        >>> abs_patch = patch.apply_ufunc(np.abs)
+        >>>
+        >>> # Multiply the patch by 10.
+        >>> scaled_patch = patch.apply_ufunc(np.multiply, 10)
+
+        See Also
+        --------
+        [`apply_ufunc`](`dascore.utils.array.apply_ufunc`)
+        """
+        # The module-level function, not this method.
+        return apply_ufunc(ufunc, self, *args, **kwargs)
 
     def get_patch_name(self, *args, **kwargs) -> str:
         """

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -999,6 +999,10 @@ sin_patch = np.sin(patch)
 
 # Add patches together using numpy ufuncs
 sum_patch = np.add(patch, patch)
+
+# Or name the ufunc, with the patch as its first operand
+same_abs_patch = patch.apply_ufunc(np.abs)
+scaled_patch = patch.apply_ufunc(np.multiply, 10)
 ```
 
 Some of the Patch methods are ufuncs which means they support accumulation and reduction along specified dimensions.

--- a/tests/test_core/test_patch.py
+++ b/tests/test_core/test_patch.py
@@ -30,6 +30,7 @@ from dascore.io.core import (
     _select_patch_from_spool,
 )
 from dascore.proc.basic import apply_operator
+from dascore.utils.array import apply_ufunc
 from dascore.utils.misc import suppress_warnings
 
 
@@ -1301,6 +1302,52 @@ class TestNumpyFuncs:
         # Test ufunc accumulate
         out = func.accumulate("time")
         assert isinstance(out, dc.Patch)
+
+
+class TestApplyUfunc:
+    """Tests for the apply_ufunc patch method."""
+
+    def test_unary_ufunc(self, random_patch):
+        """The patch should be the ufunc's only operand."""
+        out = random_patch.apply_ufunc(np.abs)
+        assert isinstance(out, dc.Patch)
+        assert np.allclose(out.data, np.abs(random_patch.data))
+
+    def test_binary_ufunc_patch(self, random_patch):
+        """A second patch operand should follow the patch."""
+        out = random_patch.apply_ufunc(np.add, random_patch)
+        assert np.allclose(out.data, random_patch.data * 2)
+
+    def test_binary_ufunc_scalar(self, random_patch):
+        """A scalar operand should also follow the patch."""
+        out = random_patch.apply_ufunc(np.multiply, 10)
+        assert np.allclose(out.data, random_patch.data * 10)
+
+    def test_binary_ufunc_not_reversed(self, random_patch):
+        """The patch is the first operand, not the second."""
+        out = random_patch.apply_ufunc(np.subtract, 1)
+        assert np.allclose(out.data, random_patch.data - 1)
+
+    def test_keywords(self, random_patch):
+        """`dim` is consumed on the reduce path, other keywords reach the ufunc."""
+        axis = random_patch.get_axis("time")
+        reduced = random_patch.apply_ufunc(np.add.reduce, dim="time")
+        assert reduced.shape[axis] == 1
+        assert np.allclose(
+            reduced.data, random_patch.data.sum(axis=axis, keepdims=True)
+        )
+        cast = random_patch.apply_ufunc(np.multiply, 2, dtype="float32")
+        assert cast.data.dtype == np.float32
+
+    def test_function_form(self, random_patch):
+        """The function form should still work and agree with the method."""
+        out = apply_ufunc(np.abs, random_patch)
+        assert out.equals(random_patch.apply_ufunc(np.abs))
+
+    def test_unbound_form(self, random_patch):
+        """The method should also work unbound, called off the class."""
+        out = dc.Patch.apply_ufunc(random_patch, np.abs)
+        assert out.equals(random_patch.apply_ufunc(np.abs))
 
 
 class TestStringCoordinatePatch:


### PR DESCRIPTION
## Description

`Patch.apply_ufunc` was `dascore.utils.array.apply_ufunc` attached to the class unchanged, so calling it as a method put the patch in the `ufunc` slot and `patch.apply_ufunc(np.abs)` raised `AttributeError: Patch has no attribute '__name__'`. It could not be used as a method at all.

This wraps it in a real method which passes the patch as the first operand, following the `Patch.get_patch_name` idiom already in the class. Keeping the name rather than deleting it: `Patch.apply_ufunc` is public and present in v0.1.21, so removing it would break code written against the last release, and the unbound form `Patch.apply_ufunc(patch, np.abs)` now reads like every other patch method. The function form `apply_ufunc(np.abs, patch)` and the protocol form `np.abs(patch)` are unchanged.

```python
patch.apply_ufunc(np.abs)                 # unary
patch.apply_ufunc(np.multiply, 10)        # patch is the first operand
patch.apply_ufunc(np.add.reduce, dim="time")
```

The one thing that changes for existing code is the class-level call: in v0.1.21 the class attribute was the plain function, so `Patch.apply_ufunc(np.abs, patch)` worked and now raises. That form was never documented and `dascore.utils.array.apply_ufunc` still accepts it, but it is a break against the last release, so it is called out in the changelog.

Closes #1040

## Changelog

- fixed: `Patch.apply_ufunc` can now be called as a method, with the patch used as the ufunc's first operand.
- changed **breaking**: `Patch.apply_ufunc` now takes the patch as its first argument rather than the ufunc. Code which called the class attribute as `Patch.apply_ufunc(ufunc, patch)` should use `dascore.utils.array.apply_ufunc`, which still has that signature.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for applying NumPy universal functions directly to patches.
  * Supports unary and binary operations, operand ordering, reductions, and additional options.
  * Added examples showing absolute-value and scalar multiplication operations.

* **Bug Fixes**
  * Patch-based ufunc operations now behave consistently with the equivalent function-based usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->