### PR TITLE
Let a scalar adopt a dimensionless unit instead of being scaled into it

### DIFF
--- a/dascore/utils/array.py
+++ b/dascore/utils/array.py
@@ -307,6 +307,38 @@ def _is_offset_unit(quantity) -> bool:
     return np.isclose(two - one, one - zero) and not np.isclose(zero, 0)
 
 
+# Bounded rather than unbounded: a ufunc can be made at runtime
+# (np.frompyfunc) and the cache holds a reference to whatever it is given.
+@functools.lru_cache(maxsize=64)
+def _needs_equal_units(operator) -> bool:
+    """
+    Return True when an operator wants both of its operands in one unit.
+
+    Metres are the yardstick: the registry refuses a bare number beside
+    them, so what comes back is the operator's own requirement rather than
+    the unit's. An operator which wants dimensionless operands refuses
+    metres beside metres too, which is how the two are told apart. The
+    registry decides by dimensionality, so the operand order does not
+    change the answer.
+    """
+    meter, dimensionless = get_quantity("meter"), get_quantity("dimensionless")
+    assert meter is not None and dimensionless is not None
+
+    def _refuses(other):
+        # DimensionalityError is a TypeError, so these clauses may not be
+        # reordered. The second catches every other way the registry can
+        # decline (an unimplemented ufunc, a dtype, a gufunc's shapes).
+        try:
+            operator(2.0 * meter, other)
+        except DimensionalityError:
+            return True
+        except (TypeError, ValueError):
+            return False
+        return False
+
+    return _refuses(1.5 * dimensionless) and not _refuses(1.5 * meter)
+
+
 def _is_logarithmic_unit(quantity) -> bool:
     """
     Return True for a logarithmic unit (dB), whose base conversion is not linear.
@@ -439,12 +471,16 @@ def _apply_binary_ufunc(
         The side without units conflicts with nothing: it is taken as
         dimensionless first (right for products and quotients) and, if the
         operator rejects that, as sharing the other side's units (right for
-        sums, differences, and comparisons). The units of one unit of output
-        are settled on scalars — the probe's result over the bare result —
-        so the data stay bare, a scale in the units ("100 cm") rides along
-        unchanged, and nothing large is ever wrapped by the unit registry.
-        A ufunc the registry does not implement falls through to numpy with
-        the units left as they were.
+        sums, differences, and comparisons). A unit whose base is itself
+        dimensionless (µϵ) is one the registry coerces the bare side into
+        rather than rejecting, so there the operator is asked outright and
+        the bare side adopts the units wherever it wants one unit on both
+        sides. The units of one unit of output are settled on scalars —
+        the probe's result over the bare result — so the data stay bare, a
+        scale in the units ("100 cm") rides along unchanged, and nothing
+        large is ever wrapped by the unit registry. A ufunc the registry
+        does not implement falls through to numpy with the units left as
+        they were.
         """
         known = data_units if data_units is not None else other_units
         if _is_offset_unit(known):
@@ -488,6 +524,10 @@ def _apply_binary_ufunc(
         assert dimensionless is not None
         patch_q = data_units if data_units is not None else dimensionless
         other_q = other_units if other_units is not None else dimensionless
+        # µϵ is dimensionless, so the registry would coerce the bare side
+        # into it (1.5 becomes 1.5e6 µϵ) instead of asking it to adopt.
+        if known.dimensionless and _needs_equal_units(operator):
+            patch_q = other_q = known
 
         def _probe(value, probe_other):
             pair = (value * patch_q, probe_other * other_q)

--- a/tests/test_utils/test_array_utils.py
+++ b/tests/test_utils/test_array_utils.py
@@ -27,6 +27,7 @@ from dascore.utils.array import (
     PatchUFunc,
     _BoundPatchUFunc,
     _is_offset_unit,
+    _needs_equal_units,
     apply_array_func,
     apply_ufunc,
     convert_bytes_to_strings,
@@ -494,6 +495,135 @@ class TestApplyUfunc:
         assert isinstance(out, dc.Patch)
         assert out.shape[1] == 1
         assert out2.equals(out)
+
+
+class TestDimensionlessUnits:
+    """Tests for units whose base units are dimensionless (µϵ, mrad, %)."""
+
+    units = ("µϵ", "mrad", "percent", "ϵ", "mm")
+    # The operators which need both sides in the same units.
+    equal_unit_ops = (
+        np.add,
+        np.subtract,
+        np.maximum,
+        np.minimum,
+        np.hypot,
+        np.copysign,
+        np.nextafter,
+    )
+    # The operators which want their operands dimensionless outright.
+    dimensionless_ops = (np.logaddexp, np.logaddexp2, np.power)
+    # A level survives these, but not being added to; see _is_logarithmic_unit.
+    level_ops = (np.maximum, np.minimum, np.hypot, np.copysign, np.nextafter)
+
+    @pytest.mark.parametrize("unit", units)
+    @pytest.mark.parametrize("operator", equal_unit_ops)
+    @pytest.mark.parametrize("flipped", (False, True))
+    def test_bare_operand_adopts_units(self, random_patch, unit, operator, flipped):
+        """
+        A bare number takes the patch's units rather than being scaled into them.
+
+        The registry coerces a bare number into a unit whose base is
+        dimensionless instead of refusing it, which would make the units of
+        one unit of output the unit's magnitude (1 µϵ became 428572 µϵ).
+        """
+        patch = random_patch.set_units(unit)
+        data = random_patch.data
+        out = operator(1.5, patch) if flipped else operator(patch, 1.5)
+        expected = operator(1.5, data) if flipped else operator(data, 1.5)
+        assert np.allclose(out.data, expected)
+        assert get_quantity(out.attrs.data_units) == get_quantity(unit)
+
+    @pytest.mark.parametrize("unit", units)
+    def test_comparison_drops_units(self, random_patch, unit):
+        """A comparison against a bare number is boolean and has no units."""
+        patch = random_patch.set_units(unit)
+        out = patch > 0.5
+        assert out.attrs.data_units is None
+        assert np.array_equal(out.data, random_patch.data > 0.5)
+
+    @pytest.mark.parametrize("unit", units)
+    def test_products_keep_the_bare_side_dimensionless(self, random_patch, unit):
+        """A bare number in a product or a power is dimensionless, as it was."""
+        patch = random_patch.set_units(unit)
+        quantity = get_quantity(unit)
+        assert get_quantity((patch * 2).attrs.data_units) == quantity
+        assert get_quantity((patch / 2).attrs.data_units) == quantity
+        assert get_quantity((2 / patch).attrs.data_units) == 1 / quantity
+        assert get_quantity((patch**2).attrs.data_units) == quantity**2
+
+    def test_units_do_not_accumulate(self, random_patch):
+        """The label stays put, so a later conversion is still right."""
+        patch = random_patch.set_units("µϵ")
+        data = random_patch.data
+        out = (patch + 1) + 1
+        assert get_quantity(out.attrs.data_units) == get_quantity("µϵ")
+        assert np.allclose(out.data, data + 2)
+        assert np.allclose((patch + 1).convert_units("ϵ").data, (data + 1) * 1e-6)
+
+    def test_operators_are_told_apart(self):
+        """
+        Only an operator which wants one unit on both sides gets the bare side.
+
+        An operator which wants dimensionless operands (logaddexp, an
+        exponent) already has them, so it is left as the registry finds it.
+        """
+        for operator in (*self.equal_unit_ops, np.arctan2):
+            assert _needs_equal_units(operator)
+        for operator in (*self.dimensionless_ops, np.multiply, np.divide):
+            assert not _needs_equal_units(operator)
+
+    def test_operator_the_registry_lacks(self, random_patch):
+        """A ufunc the registry does not implement keeps the patch's units."""
+        patch = random_patch.set_units("µϵ")
+        out = np.fmax(patch, 1.5)
+        assert get_quantity(out.attrs.data_units) == get_quantity("µϵ")
+        assert np.allclose(out.data, np.fmax(random_patch.data, 1.5))
+        # a gufunc cannot be probed on scalars either
+        square = dc.get_example_patch(shape=(10, 10)).set_units("µϵ")
+        out = np.matmul(square, np.eye(10))
+        assert get_quantity(out.attrs.data_units) == get_quantity("µϵ")
+
+    @pytest.mark.parametrize("unit", units)
+    def test_arctan2_is_an_angle(self, random_patch, unit):
+        """An operator with units of its own still gets an unscaled operand."""
+        patch = random_patch.set_units(unit)
+        out = np.arctan2(patch, 1.5)
+        assert get_quantity(out.attrs.data_units) == get_quantity("rad")
+        assert np.allclose(out.data, np.arctan2(random_patch.data, 1.5))
+
+    def test_scaled_dimensionless_units_keep_their_scale(self, random_patch):
+        """A magnitude in the units rides along, as it does for "100 cm"."""
+        patch = random_patch.set_units("2 percent")
+        out = patch + 1
+        assert np.allclose(out.data, random_patch.data + 1)
+        assert get_quantity(out.attrs.data_units) == get_quantity("2 percent")
+        out = random_patch.set_units("100 cm") + 1
+        assert get_quantity(out.attrs.data_units) == get_quantity("100 cm")
+
+    def test_units_only_on_the_other_side(self, random_patch):
+        """A patch without units adopts a dimensionless operand's units."""
+        for other in (3 * get_quantity("µϵ"), "3 µϵ"):
+            out = random_patch + other
+            assert np.allclose(out.data, random_patch.data + 3)
+            assert get_quantity(out.attrs.data_units) == get_quantity("µϵ")
+
+    @pytest.mark.parametrize("operator", (*level_ops, np.arctan2))
+    @pytest.mark.parametrize("flipped", (False, True))
+    def test_logarithmic_units_adopt_too(self, random_patch, operator, flipped):
+        """
+        A level in dB is dimensionless, so it is one of these units.
+
+        Only for the operators a level survives: adding a bare number to
+        one is refused before the units are ever probed.
+        """
+        level = random_patch.set_units("dB")
+        data = random_patch.data
+        out = operator(1.5, level) if flipped else operator(level, 1.5)
+        expected = operator(1.5, data) if flipped else operator(data, 1.5)
+        assert np.allclose(out.data, expected)
+        units = get_quantity("rad" if operator is np.arctan2 else "dB")
+        assert get_quantity(out.attrs.data_units) == units
 
 
 class TestPatchUFunc:


### PR DESCRIPTION
## Description

Closes #1037.

Adding a bare scalar to a patch whose data units were a *prefixed dimensionless* unit (`µϵ`, `mrad`, `percent`, `ppm`) left the data right but wrote a scaled unit label on the result: `dc.get_example_patch().set_units("µϵ") + 1` came out as `428572.0 µϵ` instead of `1 µϵ`, and the wrong label then rode through every later operation, so a `convert_units` or a division by another patch was silently off by ~1e6.

`_apply_op_one_unitful` decides how to read the operand without units by probing the registry: dimensionless first (right for products and quotients), and, if the registry raises `DimensionalityError`, the other side's units (right for sums, differences, and comparisons). Microstrain *is* dimensionless, so the registry never refused — it coerced `1.5` into `1.5e6 µϵ` — and the adopt branch never ran. The units of one unit of output, taken as the probe's result over the bare result, then came out as the unit's magnitude.

`docs/notes/patch_compatibility.qmd` already documents the behaviour this PR produces — "takes the other operand's units where the operation needs equal units" — so the code was violating its own published contract for these units. No doc change is needed.

### The fix

Ask the operator, rather than the unit, what it wants of its operands. `_needs_equal_units` puts the same probe to metres, where the registry does refuse a bare number, and a second one to metres beside metres: an operator which wants **one unit on both sides** refuses the first and accepts the second, and there the bare side adopts the known units. An operator which wants its operands **dimensionless outright** — `logaddexp`, an exponent in `2 ** patch` — refuses both, and is left exactly as it was, since a dimensionless unit already satisfies what it asked for.

I kept this as a probe rather than the hand-written `frozenset` that `_OFFSET_UNIT_OPERATORS` uses three lines above, even though the probe's output today is a fixed 14-ufunc set. The two answer different kinds of question: `_OFFSET_UNIT_OPERATORS` is dascore's own policy on what stays meaningful on a temperature, so writing it out states a decision, while this one restates pint's classification of its ufuncs — a fact about a dependency, which a literal set would silently get wrong the day pint reclassifies one. The probe re-derives it. The two costs a set would avoid are addressed directly: the `reversed` argument is gone (I checked all 41 distinct numpy 2-in/1-out ufuncs; the answer never depends on operand order), and the cache is `lru_cache(maxsize=64)` rather than unbounded, so a runtime-built `np.frompyfunc` cannot accumulate in it.

### Blast radius

I checked every binary ufunc against every unit class before and after. The data are identical everywhere; only labels move, and only for units whose base is dimensionless. Nothing at all changes for a unit with a dimension (`mm`, `km`, `kHz`, `µm`, `m/s`, `100 cm`), for an offset unit (`degC`), or for a patch with no units.

For the dimensionless units, `add`, `subtract`, `maximum`, `minimum`, `hypot`, `copysign`, `nextafter` and `arctan2` now agree with what `mm` does. Three cases worth calling out beyond the `µϵ`/`mrad`/`%` of the issue:

- `ϵ`, `rad` and `count` used to lose their label entirely on a reversed operand, so that `1.5 - patch` had no units; they keep it now.
- A level in `dB` is dimensionless in pint, so it is one of these units too: `maximum`, `minimum`, `hypot`, `copysign`, `nextafter` and `arctan2` against a bare number now label `1 dB` (or `1 rad`) instead of `0.79`, `None`, `0.87`. Adding a bare number to a level is still refused earlier, by the logarithmic guard.
- A unit carrying its own magnitude keeps it: `set_units("2 percent") + 1` gives `2.0 %`, exactly as `set_units("100 cm") + 1` gives `100.0 cm`.

### Not fixed here

An operator which needs its operands genuinely dimensionless still runs on the bare data, so `2 ** patch` and `np.logaddexp(patch, 1.5)` on a `µϵ` patch are off by the unit's magnitude and carry a meaningless label — the same shape of bug as #1037, through a different operator. This PR leaves that behavior bit-identical to `dev` rather than papering over it; it is filed as #1059.

## Changelog

- fixed: Adding or subtracting a bare number no longer scales the units of a patch whose data units are a prefixed dimensionless unit such as `µϵ`, `mrad`, or `percent`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of operations involving unit-aware values.
  * Dimensionless and logarithmic units now propagate correctly during supported operations.
  * Comparisons, products, scaled units, and unsupported operations now receive more consistent unit handling.
  * Behavior is consistent across supported computation backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->