### PR TITLE
Trim a chunk only on the dimension it was chunked on

### DIFF
--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -523,10 +523,10 @@ class PlanResolver(PatchResolver):
         return nested
 
     def _assembler(self):
-
         return PatchAssembler(
             load_patch=self._load_member,
             merge_kwargs=self.merge_kwargs,
+            plan_dim=self.dim,
         )
 
     def _load_member(self, kwargs: Mapping) -> dc.Patch:

--- a/dascore/utils/patch_assembly.py
+++ b/dascore/utils/patch_assembly.py
@@ -102,13 +102,45 @@ def _match_merge_units(patch, merge_dim, target_units):
     return patch, target_units
 
 
-def _coord_only_kwargs(patch, kwargs) -> dict:
-    """Keep only the kwargs naming a dim or coordinate of patch."""
-    return {
-        k: v
-        for k, v in kwargs.items()
-        if k in patch.dims or k in patch.coords.coord_map
-    }
+def _drop_associated_ranges(row, kwargs, plan_dim) -> dict:
+    """
+    Drop the ranges of coordinates which merely ride a dimension.
+
+    `_convert_min_max_in_kwargs` turns every `<name>_min`/`<name>_max`
+    pair the row carries into a `<name>: [min, max]` range, and those
+    ranges travel on as read hints. Only the planned dimension's range
+    is a trim; an associated (non-dimensional) coordinate's is its whole
+    extent, and asking a reader to select on it drops the channels a
+    string coordinate labels with neither endpoint, or a numeric one
+    leaves NaN.
+    """
+    # a row which doesn't name its dimensions keeps only the plan's range,
+    # costing the reader a hint rather than risking a wrong trim
+    raw = row.get("dims")
+    dims = {x for x in raw.split(",") if x} if isinstance(raw, str) else set()
+    ranged = {x.rsplit("_", 1)[0] for x in row if x.endswith(("_min", "_max"))}
+    drop = ranged - dims - {plan_dim}
+    return {k: v for k, v in kwargs.items() if k not in drop}
+
+
+def _plan_trim_kwargs(patch, kwargs, plan_dim) -> dict:
+    """
+    Keep only the trim the plan actually narrows.
+
+    A member row is its source row with the *planned* dimension's
+    envelope replaced by the member's trim range; every other range
+    column still describes the whole source. Selecting on those would
+    re-select a coordinate to its own extent, which is a no-op for a
+    sorted numeric range but not for a string coordinate (a range of
+    labels), one holding NaN (missing values fall outside every range),
+    or one which cannot be range-selected at all.
+    """
+    # an unmodified member states no range, and a patch without the
+    # planned coordinate has nothing of that name to trim
+    coord_map = patch.coords.coord_map
+    if plan_dim is None or plan_dim not in kwargs or plan_dim not in coord_map:
+        return {}
+    return {plan_dim: kwargs[plan_dim]}
 
 
 def _as_plan_units(patch, kwargs, row) -> dict:
@@ -154,13 +186,15 @@ class PatchAssembler:
     Assemble output patches from joined member rows.
 
     ``load_patch`` resolves one member row to its source patch (residual
-    selections included); ``merge_kwargs`` carries the merge behavior.
-    The plan resolver hands this the joined member frame for one output
-    at a time.
+    selections included); ``merge_kwargs`` carries the merge behavior;
+    ``plan_dim`` names the one dimension whose range the plan narrowed,
+    and so the only one a member needs trimming on. The plan resolver
+    hands this the joined member frame for one output at a time.
     """
 
     load_patch: Callable[[Mapping], dc.Patch]
     merge_kwargs: Mapping
+    plan_dim: str | None = None
 
     def _patch_from_instruction_df(self, joined):
         """Get the patches joined columns of instruction df."""
@@ -197,14 +231,15 @@ class PatchAssembler:
         """Load a single patch and trim it to its instruction range."""
         # convert kwargs to format understood by parser/patch.select
         kwargs = _convert_min_max_in_kwargs(patch_kwargs, joined)
+        kwargs = _drop_associated_ranges(patch_kwargs, kwargs, self.plan_dim)
         patch = self.load_patch(kwargs)
         # If the limits of the source patch were not modified, we can just
         # skip selection. This is important for missing coordinates
         # (NaN values) to not get trimmed out.
         source_kwargs = kwargs if kwargs.get("_modified") else {}
-        # attr-style entries filter rows above; only coordinate entries
-        # are valid patch selections.
-        if select_kwargs := _coord_only_kwargs(patch, source_kwargs):
+        # attr-style entries filter rows above, and the plan only ever
+        # narrows its own dimension; everything else loads untouched.
+        if select_kwargs := _plan_trim_kwargs(patch, source_kwargs, self.plan_dim):
             patch = patch.select(**_as_plan_units(patch, select_kwargs, patch_kwargs))
         return patch
 

--- a/dascore/utils/patch_assembly.py
+++ b/dascore/utils/patch_assembly.py
@@ -106,18 +106,16 @@ def _drop_associated_ranges(row, kwargs, plan_dim) -> dict:
     """
     Drop the ranges of coordinates which merely ride a dimension.
 
-    `_convert_min_max_in_kwargs` turns every `<name>_min`/`<name>_max`
-    pair the row carries into a `<name>: [min, max]` range, and those
-    ranges travel on as read hints. Only the planned dimension's range
-    is a trim; an associated (non-dimensional) coordinate's is its whole
-    extent, and asking a reader to select on it drops the channels a
-    string coordinate labels with neither endpoint, or a numeric one
-    leaves NaN.
+    `_convert_min_max_in_kwargs` collapses the row's `<name>_min`/
+    `<name>_max` pairs into `<name>: [min, max]` ranges, which travel on
+    as read hints. Only the planned dimension's range is a trim; an
+    associated (non-dimensional) coordinate's is its whole extent, and
+    asking a reader to select on it drops the channels a string
+    coordinate labels with neither endpoint, or a numeric one leaves NaN.
     """
-    # a row which doesn't name its dimensions keeps only the plan's range,
-    # costing the reader a hint rather than risking a wrong trim
-    raw = row.get("dims")
-    dims = {x for x in raw.split(",") if x} if isinstance(raw, str) else set()
+    raw_dims = row["dims"]
+    assert isinstance(raw_dims, str), "a member row always names its dimensions"
+    dims = {x for x in raw_dims.split(",") if x}
     ranged = {x.rsplit("_", 1)[0] for x in row if x.endswith(("_min", "_max"))}
     drop = ranged - dims - {plan_dim}
     return {k: v for k, v in kwargs.items() if k not in drop}
@@ -135,11 +133,10 @@ def _plan_trim_kwargs(patch, kwargs, plan_dim) -> dict:
     labels), one holding NaN (missing values fall outside every range),
     or one which cannot be range-selected at all.
     """
-    # an unmodified member states no range, and a patch without the
-    # planned coordinate has nothing of that name to trim
-    coord_map = patch.coords.coord_map
-    if plan_dim is None or plan_dim not in kwargs or plan_dim not in coord_map:
+    if plan_dim not in kwargs:  # an unmodified member states no range
         return {}
+    coord_map = patch.coords.coord_map
+    assert plan_dim in coord_map, "the plan's dimension is on every member"
     return {plan_dim: kwargs[plan_dim]}
 
 
@@ -194,7 +191,7 @@ class PatchAssembler:
 
     load_patch: Callable[[Mapping], dc.Patch]
     merge_kwargs: Mapping
-    plan_dim: str | None = None
+    plan_dim: str
 
     def _patch_from_instruction_df(self, joined):
         """Get the patches joined columns of instruction df."""

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -16,6 +16,7 @@ import pandas as pd
 import pytest
 
 import dascore as dc
+import dascore.examples as ex
 import dascore.utils.patch_assembly as assembly_module
 from dascore.exceptions import ChunkError, CoordMergeError, ParameterError, UnitError
 from dascore.units import get_quantity
@@ -1541,3 +1542,81 @@ class TestChunkEdgeBetweenPatches:
         coords = [patch.get_coord("time") for patch in out]
         assert all(len(coord) == len(coords[0]) for coord in coords)
         assert all(a.max() < b.min() for a, b in pairwise(coords))
+
+
+class TestChunkWithAssociatedCoords:
+    """Chunking must not trim on coordinates riding another dimension."""
+
+    @pytest.fixture(scope="class")
+    def base_patch(self):
+        """A patch whose distance coordinate carries the associated ones."""
+        return dc.get_example_patch()
+
+    @pytest.fixture(scope="class")
+    def string_patch(self, base_patch):
+        """A patch with a three-valued string coordinate on distance."""
+        dist = base_patch.get_array("distance")
+        third = len(dist) // 3
+        label = np.full(len(dist), "middle", dtype="<U6")
+        label[:third], label[-third:] = "start", "end"
+        return base_patch.update_coords(label=("distance", label))
+
+    @pytest.fixture(scope="class")
+    def nan_patch(self, base_patch):
+        """A patch with a numeric coordinate missing on some channels."""
+        dist = base_patch.get_array("distance")
+        values = np.where(dist > dist.mean(), dist * 2.0, np.nan)
+        return base_patch.update_coords(hole_depth=("distance", values))
+
+    @pytest.fixture(scope="class")
+    def numeric_patch(self, base_patch):
+        """A patch with a plain numeric coordinate on distance."""
+        dist = base_patch.get_array("distance")
+        return base_patch.update_coords(depth=("distance", dist * 2.0))
+
+    def test_string_coord_keeps_all_channels(self, string_patch):
+        """A string coordinate is not a range the trim may select on."""
+        out = list(dc.spool(string_patch).chunk(time=2))
+        assert len(out) > 1
+        expected = set(np.unique(string_patch.get_array("label")))
+        for patch in out:
+            assert patch.shape[0] == string_patch.shape[0]
+            assert set(np.unique(patch.get_array("label"))) == expected
+
+    def test_nan_coord_keeps_all_channels(self, nan_patch):
+        """Channels the coordinate says nothing about must survive."""
+        expected = np.isnan(nan_patch.get_array("hole_depth")).sum()
+        assert expected  # the fixture must actually hold missing values
+        out = list(dc.spool(nan_patch).chunk(time=2))
+        assert len(out) > 1
+        for patch in out:
+            assert patch.shape[0] == nan_patch.shape[0]
+            assert np.isnan(patch.get_array("hole_depth")).sum() == expected
+
+    def test_numeric_coord_keeps_all_channels(self, numeric_patch):
+        """The well-behaved case must keep working."""
+        out = list(dc.spool(numeric_patch).chunk(time=2))
+        assert len(out) > 1
+        for patch in out:
+            assert patch.shape[0] == numeric_patch.shape[0]
+
+    def test_chunk_along_shared_dim(self, nan_patch, string_patch):
+        """Chunking the dimension the coordinate rides must not raise."""
+        for patch in (nan_patch, string_patch):
+            out = list(dc.spool(patch).chunk(distance=100))
+            assert len(out) > 1
+            total = sum(x.shape[0] for x in out)
+            assert total == patch.shape[0]
+            assert all(x.shape[1] == patch.shape[1] for x in out)
+
+    @pytest.mark.parametrize("kwargs", [{"time": 2}, {"distance": 100}])
+    def test_matches_file_backed_spool(self, string_patch, tmp_path_factory, kwargs):
+        """An in-memory spool must chunk like a spool of the same file."""
+        path = tmp_path_factory.mktemp("associated_coord_chunk")
+        ex.spool_to_directory(dc.spool(string_patch), path=path)
+        memory = list(dc.spool(string_patch).chunk(**kwargs))
+        file_backed = list(dc.spool(path).update().chunk(**kwargs))
+        assert len(memory) == len(file_backed) > 1
+        for patch, other in zip(memory, file_backed):
+            assert patch.shape == other.shape
+            assert np.all(patch.get_array("label") == other.get_array("label"))

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -743,7 +743,7 @@ class TestChunkMerge:
 
 def _bare_assembler():
     """An assembler with no frames, for direct streaming-merge tests."""
-    return PatchAssembler(load_patch=None, merge_kwargs={})
+    return PatchAssembler(load_patch=None, merge_kwargs={}, plan_dim="time")
 
 
 class TestStreamingMerge:
@@ -1617,6 +1617,12 @@ class TestChunkWithAssociatedCoords:
         memory = list(dc.spool(string_patch).chunk(**kwargs))
         file_backed = list(dc.spool(path).update().chunk(**kwargs))
         assert len(memory) == len(file_backed) > 1
+        labels = set(np.unique(string_patch.get_array("label")))
         for patch, other in zip(memory, file_backed):
             assert patch.shape == other.shape
             assert np.all(patch.get_array("label") == other.get_array("label"))
+            # pin the file-backed result outright: matching a broken
+            # in-memory result would otherwise read as agreement
+            if "time" in kwargs:
+                assert other.shape[0] == string_patch.shape[0]
+                assert set(np.unique(other.get_array("label"))) == labels


### PR DESCRIPTION
## Description

Closes #1038.

A chunked spool assembles each output from *member rows*: the source row with the planned dimension's envelope replaced by the member's trim range. Every other `<name>_min`/`<name>_max` pair in that row still describes the whole source, but `PatchAssembler._load_trimmed_patch` fed all of them into `Patch.select` — and, because the converted kwargs travel on to `PlanResolver._load_member`, down to the reader as trim hints as well.

Re-selecting a coordinate to its own extent is a no-op for a sorted numeric range, and harmless for the dimensions. It is not harmless for an associated (non-dimensional) coordinate:

- a string coordinate becomes `select(label=[first, last])`, a membership test only the channels labelled with an endpoint pass;
- a numeric coordinate holding `NaN` loses the channels it says nothing about, since a missing value is outside every range;
- a coordinate that refuses range selection at all raises `CoordError` from `UnCoord`, which is why `chunk(distance=...)` crashed.

Every patch that has been through `Spool.enrich` carries such coordinates, so this hit ordinary use.

The fix gives `PatchAssembler` the plan's dimension — the only range a member row narrows — restricts the post-load trim to it, and drops the associated coordinates' ranges before the kwargs become reader trim hints. Dimensional ranges still travel as hints, so multi-patch file filtering is unchanged; patch binding goes by `source_patch_key`, never by the hints.

### Two corrections to the issue

**File-backed spools were broken too.** The issue reports them as correct; they are not. The converted `label: ['end', 'start']` kwarg reaches the DASDAE reader as a hint and `coords.select` performs the membership trim inside `_read_patch` (`dascore/io/dasdae/utils.py:339-353`), so a directory spool loses the same channels and raises the same `CoordError`. Both paths are fixed together, which the new equivalence test pins.

**The damage was wider than lost channels.** When the associated coordinate rides the *chunked* dimension, dev also produced wrong-length outputs, dropped whole output patches with `#583` "no patch remained" warnings, and left `get_contents()` describing patches the spool does not yield. A contents-vs-patch agreement check (each patch's real coord min/max against its `get_contents()` row) fails on dev in 4 of 11 spool constructions — in-memory and file-backed `chunk(distance=100)`, both `select`-then-chunk variants, and `chunk(time=2).chunk(distance=100)` — and passes on all 11 here. The fix restores an invariant rather than trading one bug for another.

### On coverage

The two remaining defensive guards — the planned dimension being on the loaded patch, and a member row naming its dimensions — are never reached by the suite, so they are written as `assert` statements on their own lines rather than folded into a covered `or` chain. This repo measures line coverage only, so folding them would have read as covered while saying nothing about them, which is what a `# pragma: no cover` would do. A third guard, `plan_dim is None`, is gone: the field is now required, since an assembler built without one trims nothing and hands every dimensional range on as a read hint. `dascore/utils/patch_assembly.py` and `dascore/io/index/planned.py` are both at 100%.

Three pre-existing problems on this seam are filed separately and untouched here: #1061 (associated coordinates disable the streaming merge), #1062 (concatenating a file-backed spool raises `KeyError`), #1063 (the unit-mismatch read-hint guard is inert in chunk mode).

## Changelog

- fixed: Chunking a spool no longer trims its patches on associated (non-dimensional) coordinates, which dropped channels, mis-sized or dropped whole output patches when the coordinate rode the chunked dimension, and could raise a `CoordError`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved planned patch loading so only the intended dimension is trimmed.
  * Preserved associated coordinates and unrelated dimensions during patch chunking.
  * Ensured consistent behavior for in-memory and file-backed patches.

* **Tests**
  * Added coverage for string, numeric, and missing-value coordinates.
  * Verified that all channels remain available after chunking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->