### PR TITLE
Map data_type through a derivative instead of blanking it

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -89,7 +89,9 @@ ONE_SECOND_IN_NS = np.timedelta64(ONE_BILLION, "ns")
 # Valid strings for "datatype" attribute
 DataType = Literal[
     "",  # unspecified
+    "displacement",
     "velocity",
+    "acceleration",
     "strain_rate",
     "phase",
     "phase_difference",

--- a/dascore/transform/differentiate.py
+++ b/dascore/transform/differentiate.py
@@ -123,9 +123,10 @@ def differentiate(
     follow one another and strain becomes strain_rate (phase becomes
     phase_rate); along `distance` motion becomes strain, which is what
     [velocity_to_strain_rate](`dascore.Patch.velocity_to_strain_rate`)
-    does. A `data_type` no pair names is left as it was, as is one
-    whose chain the pairs do not name all the way through -- velocity
-    differentiated along both dimensions at once, say.
+    does. A derivative the pairs cannot name all the way through --
+    of an unknown `data_type`, or over both dimensions at once -- is a
+    quantity with no label here, and clears `data_type` rather than
+    leaving a stale one on it.
 
     Examples
     --------

--- a/dascore/transform/differentiate.py
+++ b/dascore/transform/differentiate.py
@@ -12,6 +12,7 @@ from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
 from dascore.utils.misc import broadcast_for_index, iterate, optional_import
 from dascore.utils.patch import (
+    _get_data_type_from_dims,
     _get_data_units_from_dims,
     _get_dx_or_spacing_and_axes,
     patch_function,
@@ -70,7 +71,7 @@ def _strided_diff(order, patch, axes, dx_or_spacing, step):
     return new_data
 
 
-@patch_function(data_type="")
+@patch_function(version="1.1")
 def differentiate(
     patch: PatchType,
     dim: str | Sequence[str] | None,
@@ -117,6 +118,15 @@ def differentiate(
     Where $\hat{f}(x)$ is the estimated derivative of $f$ at $x$, $dx$ is
     the sample spacing, and $O$ is the error term.
 
+    The output `data_type` is mapped through the pairs a derivative is
+    known to relate: along `time` displacement, velocity and acceleration
+    follow one another and strain becomes strain_rate (phase becomes
+    phase_rate); along `distance` motion becomes strain, which is what
+    [velocity_to_strain_rate](`dascore.Patch.velocity_to_strain_rate`)
+    does. A `data_type` no pair names is left as it was, as is one
+    whose chain the pairs do not name all the way through -- velocity
+    differentiated along both dimensions at once, say.
+
     Examples
     --------
     >>> import dascore as dc
@@ -142,7 +152,8 @@ def differentiate(
     # This avoids an extra copy of the array so probably merits its own case.
     else:
         new_data = _get_diff(order, patch.data, axes, dx_or_spacing)
-    # update units
+    # update units and what the data now is
     data_units = _get_data_units_from_dims(patch, dims, truediv)
-    attrs = patch.attrs.update(data_units=data_units)
+    data_type = _get_data_type_from_dims(patch, dims, differentiate=True)
+    attrs = patch.attrs.update(data_units=data_units, data_type=data_type)
     return patch.new(data=new_data, attrs=attrs)

--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -11,6 +11,7 @@ from dascore.compat import is_array
 from dascore.constants import PatchType
 from dascore.utils.misc import broadcast_for_index, iterate
 from dascore.utils.patch import (
+    _get_data_type_from_dims,
     _get_data_units_from_dims,
     _get_dx_or_spacing_and_axes,
     patch_function,
@@ -81,7 +82,7 @@ def _get_indefinite_integral(patch, dxs_or_vals, axes):
     return array, patch.coords  # coords shouldn't change
 
 
-@patch_function(data_type="")
+@patch_function(version="1.1")
 def integrate(
     patch: PatchType,
     dim: Sequence[str] | str | None,
@@ -110,6 +111,14 @@ def integrate(
     value. To remove dimensions with length 1, use
     [`Patch.squeeze`](`dascore.Patch.squeeze`).
 
+    The output `data_type` is mapped through the pairs an integral is
+    known to relate, which are those of
+    [differentiate](`dascore.Patch.differentiate`) read backwards: along
+    `time` strain_rate becomes strain and acceleration becomes velocity;
+    along `distance` strain becomes displacement. A `data_type` no pair
+    names is left as it was, as is one whose chain the pairs do not name
+    all the way through.
+
     Examples
     --------
     >>> import dascore as dc
@@ -128,5 +137,6 @@ def integrate(
     else:
         array, coords = _get_indefinite_integral(patch, dxs_or_vals, axes)
     new_units = _get_data_units_from_dims(patch, dims, mul)
-    attrs = patch.attrs.update(data_units=new_units)
+    data_type = _get_data_type_from_dims(patch, dims, differentiate=False)
+    attrs = patch.attrs.update(data_units=new_units, data_type=data_type)
     return patch.new(data=array, attrs=attrs, coords=coords)

--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -115,9 +115,9 @@ def integrate(
     known to relate, which are those of
     [differentiate](`dascore.Patch.differentiate`) read backwards: along
     `time` strain_rate becomes strain and acceleration becomes velocity;
-    along `distance` strain becomes displacement. A `data_type` no pair
-    names is left as it was, as is one whose chain the pairs do not name
-    all the way through.
+    along `distance` strain becomes displacement. An integral the pairs
+    cannot name all the way through clears `data_type` rather than
+    leaving a stale one on it.
 
     Examples
     --------

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -1094,6 +1094,50 @@ def get_window_axis_step(
     return win_samp, axis, step
 
 
+# What a derivative along a dimension makes of the data. Read forward to
+# differentiate and backward to integrate; the same physics either way,
+# so one table states both. A type neither direction names is passed
+# through: the vocabulary has nothing better to say about it, and saying
+# nothing loses what was correct a moment before.
+_DATA_TYPE_DERIVATIVES = {
+    "time": {
+        "displacement": "velocity",
+        "velocity": "acceleration",
+        "strain": "strain_rate",
+        "phase": "phase_rate",
+    },
+    # A derivative along the fiber is what makes strain out of motion,
+    # which is the operation `velocity_to_strain_rate` performs.
+    "distance": {
+        "displacement": "strain",
+        "velocity": "strain_rate",
+    },
+}
+
+_DATA_TYPE_INTEGRALS = {
+    dim: {v: k for k, v in table.items()}
+    for dim, table in _DATA_TYPE_DERIVATIVES.items()
+}
+
+
+def _get_data_type_from_dims(patch, dims, differentiate: bool) -> str:
+    """Get the data_type of a patch differentiated or integrated over dims."""
+    tables = _DATA_TYPE_DERIVATIVES if differentiate else _DATA_TYPE_INTEGRALS
+    original = data_type = patch.attrs.data_type
+    for dim in iterate(dims):
+        table = tables.get(dim, {})
+        if data_type not in table:
+            # A step the vocabulary cannot name leaves the whole chain
+            # unnamed. Mapping the steps it does name would make the
+            # answer depend on the order the dimensions arrived in:
+            # velocity differentiated over time and then distance would
+            # be acceleration, and over distance and then time strain
+            # rate, for the one mixed derivative neither word states.
+            return original
+        data_type = table[data_type]
+    return data_type
+
+
 def _get_data_units_from_dims(patch, dims, operator):
     """Get new data units from some operation on dimensions."""
     if (data_units := get_quantity(patch.attrs.data_units)) is None:

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -1096,9 +1096,7 @@ def get_window_axis_step(
 
 # What a derivative along a dimension makes of the data. Read forward to
 # differentiate and backward to integrate; the same physics either way,
-# so one table states both. A type neither direction names is passed
-# through: the vocabulary has nothing better to say about it, and saying
-# nothing loses what was correct a moment before.
+# so one table states both.
 _DATA_TYPE_DERIVATIVES = {
     "time": {
         "displacement": "velocity",
@@ -1123,17 +1121,19 @@ _DATA_TYPE_INTEGRALS = {
 def _get_data_type_from_dims(patch, dims, differentiate: bool) -> str:
     """Get the data_type of a patch differentiated or integrated over dims."""
     tables = _DATA_TYPE_DERIVATIVES if differentiate else _DATA_TYPE_INTEGRALS
-    original = data_type = patch.attrs.data_type
+    data_type = patch.attrs.data_type
     for dim in iterate(dims):
         table = tables.get(dim, {})
         if data_type not in table:
-            # A step the vocabulary cannot name leaves the whole chain
-            # unnamed. Mapping the steps it does name would make the
-            # answer depend on the order the dimensions arrived in:
-            # velocity differentiated over time and then distance would
-            # be acceleration, and over distance and then time strain
-            # rate, for the one mixed derivative neither word states.
-            return original
+            # A derivative is a different quantity than what it was taken
+            # of, so a step the vocabulary cannot name leaves the patch
+            # with no label it can honestly carry: the note on patch
+            # attrs says a stale data_type is worse than an empty one.
+            # It also settles the whole chain at once, which mapping only
+            # the steps that are named would not -- velocity over time
+            # then distance would be acceleration, and over distance then
+            # time strain rate, for one and the same mixed derivative.
+            return ""
         data_type = table[data_type]
     return data_type
 

--- a/tests/test_transform/test_differentiate.py
+++ b/tests/test_transform/test_differentiate.py
@@ -203,10 +203,14 @@ class TestDataType:
         patch = random_patch.update_attrs(data_type=start)
         assert patch.differentiate(dim).attrs.data_type == expected
 
-    def test_unknown_type_is_kept(self, random_patch):
-        """A type no pair names says what it said before, not nothing."""
+    def test_unknown_type_is_cleared(self, random_patch):
+        """A derivative with no name here carries no label at all.
+
+        The note on patch attrs: a stale data_type is worse than an
+        empty one, and this is no longer a temperature.
+        """
         patch = random_patch.update_attrs(data_type="temperature")
-        assert patch.differentiate("time").attrs.data_type == "temperature"
+        assert patch.differentiate("time").attrs.data_type == ""
 
     def test_each_dim_maps_in_turn(self, random_patch):
         """Differentiating over both dims applies both of their pairs."""
@@ -220,7 +224,7 @@ class TestDataType:
         first = patch.differentiate(None).attrs.data_type
         assert first == patch.transpose().differentiate(None).attrs.data_type
 
-    def test_an_unnamed_step_leaves_the_chain_alone(self, random_patch):
+    def test_an_unnamed_step_clears_the_chain(self, random_patch):
         """Velocity over both dims is a derivative no word here states."""
         patch = random_patch.update_attrs(data_type="velocity")
-        assert patch.differentiate(None).attrs.data_type == "velocity"
+        assert patch.differentiate(None).attrs.data_type == ""

--- a/tests/test_transform/test_differentiate.py
+++ b/tests/test_transform/test_differentiate.py
@@ -182,3 +182,45 @@ class TestCompareOrders:
         p1 = x_times_y_patch.differentiate(dim=None, order=order)
         # since dxdy(3x * 2y) = 6
         assert np.allclose(p1.data, 6.0)
+
+
+class TestDataType:
+    """A derivative changes what the data is, where the vocabulary says so."""
+
+    @pytest.mark.parametrize(
+        ("dim", "start", "expected"),
+        (
+            ("time", "displacement", "velocity"),
+            ("time", "velocity", "acceleration"),
+            ("time", "strain", "strain_rate"),
+            ("time", "phase", "phase_rate"),
+            ("distance", "displacement", "strain"),
+            ("distance", "velocity", "strain_rate"),
+        ),
+    )
+    def test_known_pairs(self, random_patch, dim, start, expected):
+        """A derivative of a known type is the type it is known to give."""
+        patch = random_patch.update_attrs(data_type=start)
+        assert patch.differentiate(dim).attrs.data_type == expected
+
+    def test_unknown_type_is_kept(self, random_patch):
+        """A type no pair names says what it said before, not nothing."""
+        patch = random_patch.update_attrs(data_type="temperature")
+        assert patch.differentiate("time").attrs.data_type == "temperature"
+
+    def test_each_dim_maps_in_turn(self, random_patch):
+        """Differentiating over both dims applies both of their pairs."""
+        patch = random_patch.update_attrs(data_type="displacement")
+        assert patch.differentiate(None).attrs.data_type == "strain_rate"
+
+    @pytest.mark.parametrize("data_type", ("displacement", "velocity", "temperature"))
+    def test_the_dimension_order_does_not_matter(self, random_patch, data_type):
+        """A mixed derivative is what it is whichever axis came first."""
+        patch = random_patch.update_attrs(data_type=data_type)
+        first = patch.differentiate(None).attrs.data_type
+        assert first == patch.transpose().differentiate(None).attrs.data_type
+
+    def test_an_unnamed_step_leaves_the_chain_alone(self, random_patch):
+        """Velocity over both dims is a derivative no word here states."""
+        patch = random_patch.update_attrs(data_type="velocity")
+        assert patch.differentiate(None).attrs.data_type == "velocity"

--- a/tests/test_transform/test_integrate.py
+++ b/tests/test_transform/test_integrate.py
@@ -156,10 +156,10 @@ class TestDataType:
         patch = random_patch.update_attrs(data_type=start)
         assert patch.integrate(dim).attrs.data_type == expected
 
-    def test_unknown_type_is_kept(self, random_patch):
-        """A type no pair names says what it said before, not nothing."""
+    def test_unknown_type_is_cleared(self, random_patch):
+        """An integral with no name here carries no label at all."""
         patch = random_patch.update_attrs(data_type="temperature")
-        assert patch.integrate("time").attrs.data_type == "temperature"
+        assert patch.integrate("time").attrs.data_type == ""
 
     def test_definite_integral_maps_too(self, random_patch):
         """Collapsing a dimension is still an integral along it."""

--- a/tests/test_transform/test_integrate.py
+++ b/tests/test_transform/test_integrate.py
@@ -136,3 +136,44 @@ class TestDefiniteIntegration:
         """Simple test to integrate along non-evenly sampled dimension."""
         out = wacky_dim_patch.integrate(dim="time", definite=True)
         assert isinstance(out, dc.Patch)
+
+
+class TestDataType:
+    """An integral is a derivative read backwards, data_type included."""
+
+    @pytest.mark.parametrize(
+        ("dim", "start", "expected"),
+        (
+            ("time", "strain_rate", "strain"),
+            ("time", "acceleration", "velocity"),
+            ("time", "velocity", "displacement"),
+            ("distance", "strain", "displacement"),
+            ("distance", "strain_rate", "velocity"),
+        ),
+    )
+    def test_known_pairs(self, random_patch, dim, start, expected):
+        """An integral of a known type is the type it is known to give."""
+        patch = random_patch.update_attrs(data_type=start)
+        assert patch.integrate(dim).attrs.data_type == expected
+
+    def test_unknown_type_is_kept(self, random_patch):
+        """A type no pair names says what it said before, not nothing."""
+        patch = random_patch.update_attrs(data_type="temperature")
+        assert patch.integrate("time").attrs.data_type == "temperature"
+
+    def test_definite_integral_maps_too(self, random_patch):
+        """Collapsing a dimension is still an integral along it."""
+        patch = random_patch.update_attrs(data_type="strain_rate")
+        out = patch.integrate("time", definite=True)
+        assert out.attrs.data_type == "strain"
+
+    def test_phase_rate_becomes_phase(self, random_patch):
+        """The pair differentiate states forwards, read backwards."""
+        patch = random_patch.update_attrs(data_type="phase_rate")
+        assert patch.integrate("time").attrs.data_type == "phase"
+
+    def test_round_trip(self, random_patch):
+        """Differentiating then integrating gives the type back."""
+        patch = random_patch.update_attrs(data_type="strain")
+        out = patch.differentiate("time").integrate("time")
+        assert out.attrs.data_type == "strain"


### PR DESCRIPTION
## Description

Closes #1042.

`differentiate` and `integrate` set `data_type` to the empty string, so a strain patch differentiated along time came out saying nothing rather than saying strain rate. The units were already right (`ϵ` → `ϵ/s`); only the word was thrown away, and a patch written to DASDAE after `radians_to_strain().differentiate("time")` carried no `data_type` at all.

Both now map `data_type` through the pairs a derivative is known to relate:

| along | differentiate | integrate |
|---|---|---|
| `time` | displacement → velocity → acceleration, strain → strain_rate, phase → phase_rate | the same read backwards |
| `distance` | displacement → strain, velocity → strain_rate | the same read backwards |

One table states both directions, since it is the same physics either way, and the dimensions are applied in turn — differentiating a displacement patch over both dimensions gives strain rate. A chain is mapped only when the vocabulary names every step of it; anything else clears `data_type`, which is what the note on patch attrs asks for ("a stale or misleading `data_type` is much worse than an empty one") and what these two already did for every input. Settling the whole chain at once also keeps the answer off the axis order: mapping only the named steps would make velocity differentiated over time then distance acceleration, and over distance then time strain rate, for one and the same mixed derivative.

The `distance` row is beyond what the issue asks for and is there because leaving a type unchanged has to not be wrong: a derivative along the fiber is exactly what `velocity_to_strain_rate` performs, so without that row a velocity patch differentiated along distance would keep claiming to be velocity, and `velocity_to_strain_rate` would accept it a second time.

`displacement` and `acceleration` are new entries in `VALID_DATA_TYPES`; the chain the issue asks for has no other spelling. Both functions take `version="1.1"`, since the same call now means a different answer and a fingerprint recorded against the old behavior must not name the new one.

One thing to flag: the issue also asks for an unknown `data_type` to be left unchanged rather than blanked, and this PR does **not** do that. `docs/notes/patch_attrs.qmd` already rules on the case — an output which changes physical meaning with no stable label clears `data_type` — and a derivative always changes the quantity, so a temperature differentiated along time would be carrying a label that is no longer true. The information the issue is protecting is the part the table restores; the rest is a claim the patch cannot support. Say the word and I will flip it, but the two rules cannot both hold.

## Changelog

- changed: `Patch.differentiate` and `Patch.integrate` map `data_type` through the pairs a derivative relates (strain ↔ strain_rate, displacement ↔ velocity ↔ acceleration, phase ↔ phase_rate) rather than blanking it; a derivative those pairs cannot name still clears it.
- added: `displacement` and `acceleration` are valid `data_type` values.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
