### PR TITLE
Stop a spool repr saying a track's category twice

### DIFF
--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -12,7 +12,7 @@ from functools import cache, singledispatch
 from graphlib import CycleError, TopologicalSorter
 from html import escape
 from importlib.resources import files
-from itertools import pairwise
+from itertools import groupby, pairwise
 from typing import TypeVar
 
 import numpy as np
@@ -1167,6 +1167,9 @@ def group_names(
     for _, row in frame.iterrows():
         stated_values = (str(row[x]) for x in telling if pd.notnull(row[x]))
         parts = [x for x in stated_values if x]
+        # A part repeating the one before it says the same thing twice:
+        # DSS data tagged "DSS" named its track "XM.MINE1.03.WSF · DSS · DSS".
+        parts = [value for value, _ in groupby(parts)]
         # Nothing tells a lone group apart, since there is nothing to
         # tell it apart from, and every group of a spool of one
         # acquisition is in that position. It is still a named thing,

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -2082,6 +2082,22 @@ class TestSpoolRepr:
         assert "➤ Tracks (7 along time)" in rendered
         assert "... 7 more" in rendered
 
+    def test_a_track_says_its_category_once(self):
+        """A tag repeating the category is not printed twice. See #1044."""
+        spool = dc.spool(
+            [
+                dc.get_example_patch("random_das", tag="DSS").update_attrs(
+                    data_category="DSS"
+                ),
+                dc.get_example_patch("random_das", tag="DAS_LF").update_attrs(
+                    data_category="DAS"
+                ),
+            ]
+        )
+        rendered = str(spool)
+        assert "DSS · DSS" not in rendered
+        assert "DAS · DAS_LF" in rendered
+
     def test_a_lone_group_shows_no_tracks(self):
         """One track is the whole spool, which the dimensions already state."""
         rendered = str(dc.get_example_spool("random_das"))

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -456,6 +456,21 @@ class TestGroupNames:
             "group 0"
         ]
 
+    def test_a_repeated_part_is_said_once(self):
+        """Two columns agreeing on a word name the group with it once."""
+        frame = pd.DataFrame({"kind": ["DSS", "DAS"], "tag": ["DSS", "DAS_LF"]})
+        assert group_names(frame) == ["DSS", "DAS · DAS_LF"]
+
+    def test_groups_collapsing_alike_take_their_ordinals(self):
+        """Saying a word once cannot make two groups into one."""
+        frame = pd.DataFrame({"a": ["x", "x", "z"], "b": ["x", "", "w"]})
+        assert group_names(frame, ordinals=[7, 9, 11]) == ["x (7)", "x (9)", "z · w"]
+
+    def test_only_a_neighboring_repeat_is_collapsed(self):
+        """A word said again after another word is said again."""
+        frame = pd.DataFrame({"a": ["x", "y"], "b": ["z", "w"], "c": ["x", "q"]})
+        assert group_names(frame) == ["x · z · x", "y · w · q"]
+
     def test_an_unstated_value_is_not_a_blank(self):
         """A group which recorded nothing is not named by an empty part."""
         frame = pd.DataFrame({"tag": ["a", ""], "kind": ["das", "dss"]})


### PR DESCRIPTION
## Description

Closes #1044.

The spool repr's track label joins the values which tell one track from another, and when two of those columns hold the same word it printed the word twice: `XM.MINE1.03.WSF · DSS · DSS` is `data_category="DSS"` followed by `tag="DSS"`.

`group_names` now collapses a part which repeats the one before it, so that track reads `XM.MINE1.03.WSF · DSS`. Only a neighbouring repeat is collapsed — `x · z · x` is still three things said about the group — and the collapse happens before the shared-description check, so two tracks which collapse to the same name still take their ordinals and stay two tracks.

Coverage plots name their lanes through the same function, so they collapse the same way.

## Changelog

- fixed: A spool repr's track label no longer says the same word twice when two of the columns naming it agree.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
