### PR TITLE
Say what the user can do about it

### DIFF
--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -9,7 +9,7 @@ from scipy.ndimage import median_filter
 
 from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
-from dascore.utils.moving import move_median
+from dascore.utils.moving import has_engine, move_median
 from dascore.utils.patch import get_patch_window_size, patch_function
 
 
@@ -125,8 +125,10 @@ def hampel_filter(
 
     Warning
     -------
-    With `approximate=False`, runtime scales with the window's area, so
-    large multi-dimensional windows can be *very* slow.
+    Runtime scales with the window's area when `approximate=False`, and
+    with the sum of its sides when `approximate=True`, so large windows
+    can be *very* slow. Installing `bottleneck` makes the approximate
+    filter nearly insensitive to window size.
 
     Returns
     -------
@@ -145,10 +147,9 @@ def hampel_filter(
 
     **Performance:**
     - `approximate=True` provides 3-4x speedup over exact calculations
-    - `approximate=True` is also insensitive to window size, while the
-      exact filter's cost grows with the window's area.
-    - Installing the `bottleneck` package can further improve
-      approximate-mode performance. Without it scipy is used instead.
+    - Installing the `bottleneck` package further improves
+      approximate-mode performance, and makes it nearly insensitive to
+      window size. Without it scipy is used instead.
 
     See Also
     --------
@@ -188,9 +189,10 @@ def hampel_filter(
     # For now we just hardcode mode as it is probably the only one that
     # makes sense in a DAS data context.
     mode = "reflect"
-    # Only the exact filter's cost grows with the window; the separable
-    # approximation is nearly flat in window size.
-    warn_above = None if approximate else 100
+    # Only bottleneck's moving median is flat in window size; the exact
+    # filter and scipy's median_filter both grow with the window.
+    fast = approximate and has_engine("bottleneck")
+    warn_above = None if fast else 100
     size = get_patch_window_size(
         patch, kwargs, samples, require_odd=True, warn_above=warn_above, min_samples=3
     )

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -125,8 +125,8 @@ def hampel_filter(
 
     Warning
     -------
-    Selecting windows with many samples can be *very* slow. It is recommended
-    window size in each dimension be <10 samples.
+    With `approximate=False`, runtime scales with the window's area, so
+    large multi-dimensional windows can be *very* slow.
 
     Returns
     -------
@@ -145,8 +145,10 @@ def hampel_filter(
 
     **Performance:**
     - `approximate=True` provides 3-4x speedup over exact calculations
-    - Installing `bottleneck` package can further improve approximate-mode
-      performance.
+    - `approximate=True` is also insensitive to window size, while the
+      exact filter's cost grows with the window's area.
+    - Installing the `bottleneck` package can further improve
+      approximate-mode performance. Without it scipy is used instead.
 
     See Also
     --------
@@ -186,8 +188,11 @@ def hampel_filter(
     # For now we just hardcode mode as it is probably the only one that
     # makes sense in a DAS data context.
     mode = "reflect"
+    # Only the exact filter's cost grows with the window; the separable
+    # approximation is nearly flat in window size.
+    warn_above = None if approximate else 100
     size = get_patch_window_size(
-        patch, kwargs, samples, require_odd=True, warn_above=10, min_samples=3
+        patch, kwargs, samples, require_odd=True, warn_above=warn_above, min_samples=3
     )
     # Need to convert ints to float for calculations to avoid roundoff error.
     # There were issues using np.issubdtype not working so this uses kind.

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -30,7 +30,7 @@ def _apply_scipy_decimation(patch, factor, ftype, axis):
         data = scipy_decimate(patch.data, factor, ftype=ftype, axis=axis)
     except ValueError as e:
         msg = (
-            "Scipy decimation failed. This can happen for dimensions with"
+            "Scipy decimation failed. This can happen for dimensions with "
             "few elements. Consider setting filter_type to False. The raised "
             f"exception was {e}"
         )

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -387,6 +387,13 @@ def _normalize_chunk_units(df: pd.DataFrame, name: str) -> pd.DataFrame:
     return df
 
 
+def _partition_unit(df: pd.DataFrame, name: str, row: int) -> str:
+    """The unit a partition's envelope is stated in, or "" if it states none."""
+    col = df.get(f"_{name}_units")
+    unit = None if col is None else col.iloc[row]
+    return "" if pd.isnull(unit) else str(unit)
+
+
 def _validate_missing_dim(missing_dim) -> None:
     """Reject a missing_dim value that is neither policy."""
     if missing_dim not in ("raise", "drop"):
@@ -1535,15 +1542,23 @@ def build_chunk_plan(
         # request is in bytes, not comparable to a coordinate duration.
         if not merge_mode and not (isinstance(value, Quantity) and is_data_size(value)):
             assert value is not None  # a null value is merge_mode
-            longest = ((g_stops - g_starts) + np.abs(part_steps)).max()
-            # durations in seconds, which is what a time value would be
-            # given in; other dimensions in their own units
-            fmt = (lambda x: f"{to_float(x)} s") if is_timedelta64(longest) else str
+            spans = (g_stops - g_starts) + np.abs(part_steps)
+            best = int(np.argmax(spans))
+            longest, requested = spans[best], value
+            if is_timedelta64(longest):
+                # seconds, which is what a time value is given in
+                longest = f"{to_float(longest)} s"
+                requested = f"{to_float(requested)} s"
+            else:
+                # the envelope is in the longest partition's own unit, so
+                # name it; the request may be stated in another (#1058)
+                unit = _partition_unit(sorted_df, name, seg_starts[best])
+                longest = f"{longest} {unit}".strip()
             msg = (
                 f"Could not chunk. The longest contiguous segment along "
-                f"{name!r} is {fmt(longest)}, shorter than the requested "
-                f"chunk value of {fmt(value)}. Use a smaller chunk value, a "
-                f"larger tolerance to join segments separated by gaps, or "
+                f"{name!r} is {longest}, shorter than the requested chunk "
+                f"value of {requested}. Use a smaller chunk value, a larger "
+                f"tolerance to join segments separated by gaps, or "
                 f"keep_partial=True to keep the short segments."
             )
         raise ChunkError(msg)

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -1530,6 +1530,22 @@ def build_chunk_plan(
             warnings.warn(msg, UserWarning, stacklevel=_user_stacklevel())
     if not fed_counts.sum():
         msg = "Could not chunk. No segments with sufficient length found."
+        # Say how short the data actually is, and name the two knobs which
+        # make an over-long request work. Size chunks are excluded; their
+        # request is in bytes, not comparable to a coordinate duration.
+        if not merge_mode and not (isinstance(value, Quantity) and is_data_size(value)):
+            assert value is not None  # a null value is merge_mode
+            longest = ((g_stops - g_starts) + np.abs(part_steps)).max()
+            # durations in seconds, which is what a time value would be
+            # given in; other dimensions in their own units
+            fmt = (lambda x: f"{to_float(x)} s") if is_timedelta64(longest) else str
+            msg = (
+                f"Could not chunk. The longest contiguous segment along "
+                f"{name!r} is {fmt(longest)}, shorter than the requested "
+                f"chunk value of {fmt(value)}. Use a smaller chunk value, a "
+                f"larger tolerance to join segments separated by gaps, or "
+                f"keep_partial=True to keep the short segments."
+            )
         raise ChunkError(msg)
     # Assemble the outputs table: envelopes and step, then the carried
     # columns (each partition's single value repeated over its outputs),

--- a/dascore/utils/moving.py
+++ b/dascore/utils/moving.py
@@ -219,15 +219,19 @@ def _get_engine_function(engine: str, func_name: str) -> Callable:
 def _select_engine(preferred: str, operation: str) -> str:
     """Select best available engine with fallback."""
     available = _get_available_engines()
+    # "auto" asks for whatever is installed, so falling back is the answer
+    # to the question, not a problem to warn about (see #1046).
+    requested = preferred
     preferred = "bottleneck" if preferred == "auto" else preferred
 
     if preferred not in available:
         engine = available[0]
-        msg = (
-            f"Preferred engine {preferred} is not available; falling back to {engine}. "
-            "It may require an additional installation."
-        )
-        warnings.warn(msg, UserWarning, stacklevel=4)
+        if requested != "auto":
+            msg = (
+                f"Preferred engine {preferred} is not available; falling back "
+                f"to {engine}. It may require an additional installation."
+            )
+            warnings.warn(msg, UserWarning, stacklevel=4)
         preferred = engine
 
     # Check if operation is available in preferred engine
@@ -266,7 +270,8 @@ def moving_window(
     axis : int, default 0
         Axis along which to operate
     engine : {"auto", "scipy", "bottleneck"}, default "auto"
-        Engine to use
+        Engine to use. "auto" prefers bottleneck and quietly uses scipy when
+        bottleneck is not installed; naming an engine which is missing warns.
         Bottleneck non-median windows keep the bottleneck engine for even
         windows. These are shifted toward centered alignment but can differ
         from scipy's even-window convention.

--- a/dascore/utils/moving.py
+++ b/dascore/utils/moving.py
@@ -207,6 +207,11 @@ def _get_available_engines() -> tuple[str, ...]:
     return tuple(["scipy", *bottle_list])
 
 
+def has_engine(engine: str) -> bool:
+    """Return True if the named moving window engine is installed."""
+    return engine in _get_available_engines()
+
+
 def _get_engine_function(engine: str, func_name: str) -> Callable:
     """Get and cache engine function."""
     spec = OPERATION_REGISTRY[func_name][engine]

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+import math
 import sys
 import warnings
 from collections import namedtuple
@@ -62,7 +63,7 @@ from dascore.utils.misc import (
     yield_sub_sequences,
 )
 from dascore.utils.paths import is_memory_uri
-from dascore.utils.time import to_float
+from dascore.utils.time import is_timedelta64, to_float
 from dascore.workflow.builtin import Concatenate, Stack
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
 from dascore.workflow.identity import (
@@ -945,7 +946,8 @@ def get_patch_window_size(
         If True, require odd window sizes. When samples=False, even sizes
         are adjusted to be odd. When samples=True, even sizes raise ParameterError.
     warn_above
-        If specified, warn when any dimension window size exceeds this value.
+        If specified, warn when the total window size (the product of the
+        sample counts of each dimension) exceeds this value.
     min_samples
         Minimum number of samples required per dimension.
     enforce_lt_coord
@@ -976,9 +978,20 @@ def get_patch_window_size(
 
         # Check minimum samples requirement
         if samps < min_samples:
+            if samples:
+                hint = "Try increasing its value."
+            else:
+                # in seconds, which is what a time value would be given in
+                step = coord.step
+                step = f"{to_float(step)} s" if is_timedelta64(step) else step
+                hint = (
+                    f"The value is in the units of {name}, which is sampled "
+                    f"every {step}; increase it, or use samples=True to give "
+                    "the window in samples."
+                )
             msg = (
                 f"Window must have at least {min_samples} samples along each "
-                f"dimension. {name} has {samps} samples. Try increasing its value."
+                f"dimension. {name} has {samps} samples. {hint}"
             )
             raise ParameterError(msg)
 
@@ -995,15 +1008,18 @@ def get_patch_window_size(
                 )
                 raise ParameterError(msg)
 
-        # Issue warning for large window sizes
-        if warn_above is not None and samps > warn_above:
-            msg = (
-                f"Large window size ({samps} samples) in dimension '{name}' "
-                f"may result in slow performance. Consider reducing the window size."
-            )
-            warnings.warn(msg, UserWarning, stacklevel=3)
-
         size[axis] = samps
+
+    # Warn on the total window, not each dimension: the cost of a windowed
+    # operation tracks the number of samples the window covers, so a 2D
+    # window is as expensive as its area.
+    total = math.prod(size)
+    if warn_above is not None and total > warn_above:
+        msg = (
+            f"Large window size ({total} samples) may result in slow "
+            "performance. Consider reducing the window size."
+        )
+        warnings.warn(msg, UserWarning, stacklevel=3)
 
     return tuple(size)
 

--- a/docs/recipes/despiking.qmd
+++ b/docs/recipes/despiking.qmd
@@ -66,7 +66,7 @@ The resulting signal had some of the spikes removed with minimal distortion to t
 
 
 ::: {.callout-warning}
-The Hampel filter can be quite slow if large windows are used. We recommend using window sizes that correspond to <10 samples for most cases.
+With `approximate=False` the Hampel filter can be quite slow if large windows are used, since its cost grows with the window's area. The default (`approximate=True`) is nearly insensitive to window size.
 :::
 
 ### Multi-dimensional Filtering
@@ -87,7 +87,7 @@ ax.set_title("Filtered along Time and Distance");
 
 2. **Threshold selection**: Start with a conservative threshold (3.5-5.0) and adjust based on your data characteristics and noise level.
 
-3. **Window size**: Choose window sizes that are large enough to provide stable statistics but small enough to preserve local features. Start with ~5-9 samples per dimension.
+3. **Window size**: Choose window sizes that are large enough to provide stable statistics but small enough to preserve local features. Start with ~5-9 samples per dimension. Use `samples=True` to give the window in samples rather than coordinate units.
 
 4. **Performance optimization**: `approximate=True` (default) achieves a 3-4x speedup with minimal quality loss. It is usually good enough for simply removing data spikes, but exact median calculations can be achieved by setting this to False.
 

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -163,6 +163,14 @@ class TestChunk:
         msg = str(info.value)
         assert "tolerance" in msg and "keep_partial" in msg
 
+    def test_increment_too_big_names_units(self):
+        """The segment length carries the unit its coordinate states."""
+        p1 = dc.get_example_patch().set_units(distance="mm")
+        gap = p1.get_coord("time").max() + to_timedelta64(1000)
+        p2 = dc.get_example_patch(time_min=gap).set_units(distance="mm")
+        with pytest.raises(ChunkError, match=r"is 300\.0 mm,"):
+            dc.spool([p1, p2]).chunk(distance=2 * get_quantity("m"))
+
     def test_too_big_partial(self, diverse_spool):
         """When chunk is too large, all contiguous blocks should merge."""
         spool1 = diverse_spool.chunk(time=100000, keep_partial=True)

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -152,9 +152,16 @@ class TestChunk:
 
     def test_raise_increment_too_big(self, diverse_spool):
         """Ensure code raises an error if the increment is too large."""
-        msg = "No segments with sufficient length"
+        msg = "longest contiguous segment along 'time'"
         with pytest.raises(ChunkError, match=msg):
             diverse_spool.chunk(time=10000)
+
+    def test_increment_too_big_names_knobs(self, diverse_spool):
+        """The error should point at tolerance and keep_partial (#1046)."""
+        with pytest.raises(ChunkError) as info:
+            diverse_spool.chunk(time=10000)
+        msg = str(info.value)
+        assert "tolerance" in msg and "keep_partial" in msg
 
     def test_too_big_partial(self, diverse_spool):
         """When chunk is too large, all contiguous blocks should merge."""

--- a/tests/test_io/test_index/test_plan.py
+++ b/tests/test_io/test_index/test_plan.py
@@ -181,7 +181,7 @@ class TestSegmentPlan:
         df = _flat([p1, p2])
         plan = build_chunk_plan(df, time=5)
         assert len(plan.outputs) == 2  # one 5s chunk per 8s partition
-        with pytest.raises(ChunkError, match="sufficient length"):
+        with pytest.raises(ChunkError, match="longest contiguous segment"):
             build_chunk_plan(df, time=100)
 
     def test_middle_value_step(self):

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -11,6 +11,7 @@ import pytest
 
 import dascore as dc
 from dascore.exceptions import ParameterError
+from dascore.utils.misc import suppress_warnings
 
 
 def _get_interior_data(data, edge_size=5):
@@ -493,3 +494,16 @@ class TestHampelFilter:
         # Just in case, make sure the filter actually did something, otherwise
         # the check above is pointless.
         assert not np.all(original == out.data)
+
+    def test_no_warning_on_modest_window(self, patch_with_spikes):
+        """The approximate filter is flat in window size, so it shouldn't warn."""
+        with suppress_warnings(action="error"):
+            out = patch_with_spikes.hampel_filter(time=25, samples=True)
+        assert out.shape == patch_with_spikes.shape
+
+    def test_warns_on_large_exact_window(self, patch_with_spikes):
+        """Only the exact filter, whose cost grows with the window, warns."""
+        with pytest.warns(UserWarning, match="Large window size"):
+            patch_with_spikes.hampel_filter(
+                time=11, distance=11, samples=True, approximate=False
+            )

--- a/tests/test_proc/test_hampel.py
+++ b/tests/test_proc/test_hampel.py
@@ -11,6 +11,7 @@ import pytest
 
 import dascore as dc
 from dascore.exceptions import ParameterError
+from dascore.proc import hampel
 from dascore.utils.misc import suppress_warnings
 
 
@@ -496,10 +497,21 @@ class TestHampelFilter:
         assert not np.all(original == out.data)
 
     def test_no_warning_on_modest_window(self, patch_with_spikes):
-        """The approximate filter is flat in window size, so it shouldn't warn."""
+        """A modest window is fast on any engine, so it shouldn't warn."""
         with suppress_warnings(action="error"):
             out = patch_with_spikes.hampel_filter(time=25, samples=True)
         assert out.shape == patch_with_spikes.shape
+
+    def test_bottleneck_makes_large_windows_free(self, patch_with_spikes, monkeypatch):
+        """Only bottleneck's moving median is flat in window size."""
+        big = {"time": 51, "distance": 51, "samples": True}
+        monkeypatch.setattr(hampel, "has_engine", lambda engine: True)
+        with suppress_warnings(action="error"):
+            patch_with_spikes.hampel_filter(**big)
+        # Without it the approximate path falls back to scipy, which is not.
+        monkeypatch.setattr(hampel, "has_engine", lambda engine: False)
+        with pytest.warns(UserWarning, match="Large window size"):
+            patch_with_spikes.hampel_filter(**big)
 
     def test_warns_on_large_exact_window(self, patch_with_spikes):
         """Only the exact filter, whose cost grows with the window, warns."""

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -132,7 +132,7 @@ class TestDecimate:
     def test_decimate_small_dimension(self, random_patch):
         """Ensure decimation raises helpful error on small dimensions."""
         small_patch = random_patch.select(distance=(0, 10), samples=True)
-        match = "Scipy decimation failed."
+        match = "dimensions with few elements"
         with pytest.raises(FilterValueError, match=match):
             small_patch.decimate(distance=2)
 

--- a/tests/test_utils/test_moving.py
+++ b/tests/test_utils/test_moving.py
@@ -8,6 +8,8 @@ import numpy as np
 import pytest
 
 from dascore.exceptions import ParameterError
+from dascore.utils import moving
+from dascore.utils.misc import suppress_warnings
 from dascore.utils.moving import (
     OPERATION_REGISTRY,
     _get_available_engines,
@@ -197,6 +199,19 @@ class TestMovingWindow:
         # It should also return an array.
         assert isinstance(out, np.ndarray)
         assert out.shape == test_data["1d"].shape
+
+    def test_auto_engine_does_not_warn(self, test_data, monkeypatch):
+        """Auto asks for what is installed, so a fallback is not a warning."""
+        monkeypatch.setattr(moving, "_get_available_engines", lambda: ("scipy",))
+        with suppress_warnings(action="error"):
+            out = moving_window(test_data["1d"], 3, "median", engine="auto")
+        assert isinstance(out, np.ndarray)
+
+    def test_explicit_missing_engine_warns(self, test_data, monkeypatch):
+        """Naming an engine which is not installed still warns."""
+        monkeypatch.setattr(moving, "_get_available_engines", lambda: ("scipy",))
+        with pytest.warns(UserWarning, match="not available"):
+            moving_window(test_data["1d"], 3, "median", engine="bottleneck")
 
     def test_large_window_warning(self, test_data):
         """Test warning for window larger than data."""

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -1322,6 +1322,22 @@ class TestGetPatchWindowSize:
                 simple_patch, {"time": 15}, samples=True, warn_above=10
             )
 
+    def test_warn_above_uses_total_window(self, simple_patch):
+        """The threshold applies to the window's total size, not each dim."""
+        kwargs = {"time": 5, "distance": 5}
+        with pytest.warns(UserWarning, match="Large window size \\(25 samples\\)"):
+            get_patch_window_size(simple_patch, kwargs, samples=True, warn_above=10)
+
+    def test_min_samples_message_suggests_samples(self, simple_patch):
+        """A too-small window in coord units should mention samples (#1046)."""
+        with pytest.raises(ParameterError, match="samples=True"):
+            get_patch_window_size(simple_patch, {"time": 0.2}, min_samples=3)
+        # When the value is already in samples there is nothing to suggest.
+        with pytest.raises(ParameterError, match="Try increasing"):
+            get_patch_window_size(
+                simple_patch, {"time": 2}, samples=True, min_samples=3
+            )
+
     def test_no_warning_under_threshold(self, simple_patch):
         """Test no warning for window sizes under threshold."""
         with suppress_warnings(action="error"):


### PR DESCRIPTION
## Description

Closes #1046.

Five message papercuts met while working an archive on `dev`. None was wrong, but each cost a round trip because the message did not name the thing that would fix it.

1. **`decimate`** — `"...for dimensions withfew elements"` was missing a space.

2. **`chunk`** — `ChunkError: Could not chunk. No segments with sufficient length found.` said nothing about how short the data actually was, or that `tolerance=` is what makes an over-long request work. It now reads:

   > Could not chunk. The longest contiguous segment along 'time' is 24.0 s, shorter than the requested chunk value of 10000.0 s. Use a smaller chunk value, a larger tolerance to join segments separated by gaps, or keep_partial=True to keep the short segments.

   Durations are stated in seconds, which is what a time chunk value is given in; other dimensions are stated in their own units. Size-based chunks (`chunk(time="25 MB")`) keep the old message, since a byte count is not comparable to a coordinate span.

3. **`hampel_filter` / `wiener`** — a too-small window given in coordinate units said only "Try increasing its value", when the real fix is usually `samples=True`. The message now names the coordinate's sampling interval and both options. When the value was already in samples there is nothing to suggest, so the wording is unchanged.

4. **`hampel_filter` large-window warning** — it fired above 10 samples *per dimension*, which is far below where the filter is actually slow, and the per-dimension threshold is the wrong shape: cost tracks the whole window, not any one side. Measured on a (144, 17461) patch:

   | window | `approximate=True` (bottleneck) | `approximate=True` (scipy) | `approximate=False` |
   |---|---|---|---|
   | `time=25` | 0.20 s | 1.47 s | 1.7 s |
   | `time=201` | 0.26 s | 9.30 s | 9.4 s |
   | `time=11, distance=11` | 0.38 s | 1.33 s | 6.0 s |
   | `time=25, distance=25` | 0.46 s | 2.99 s | 29.5 s |

   Only bottleneck's moving median is flat in window size; scipy's `median_filter` — which backs both the exact path and the approximate path when bottleneck is missing — grows with it. So `warn_above` in `get_patch_window_size` now applies to the total window (the product across dimensions), and `hampel_filter` suppresses it only when the approximate path will actually reach bottleneck. Otherwise the threshold is 100 samples.

5. **`bottleneck` fallback warning** — `engine="auto"` warned every call that bottleneck was missing and scipy was being used. "auto" is a request for whatever is installed, so the fallback is the answer, not a problem; it is now silent. Naming an engine that is not installed (`engine="bottleneck"`) still warns.

The despiking recipe and the `hampel_filter` docstring carried the same "<10 samples" advice and were updated to match.

Both Codex review findings are addressed in 54ee8a9; see the review threads.

## Changelog

- fixed: `decimate`'s short-dimension error no longer runs two words together.
- changed: `chunk` says how long the longest contiguous segment is and names `tolerance` and `keep_partial` when the requested chunk value is too large.
- changed: a too-small processing window given in coordinate units now names the coordinate's sampling interval and suggests `samples=True`.
- changed: `hampel_filter`'s large-window warning measures the whole window rather than each dimension, and no longer fires when `bottleneck` makes the window size free.
- changed: moving window operations no longer warn when `engine="auto"` falls back to scipy because `bottleneck` is not installed.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
