### PR TITLE
One spelling of each policy vocabulary

### DIFF
--- a/dascore/constants.py
+++ b/dascore/constants.py
@@ -186,6 +186,11 @@ progress
 # "ignore", which every policy argument in the library also spells.
 WARN_LEVELS = Literal["warn", "raise", "ignore"]
 
+# What `enrich` does about a name the inventory leaves undefined: the warn
+# levels, spelled by reference so the two sets cannot drift apart, plus the
+# fourth answer only this question has -- fill the missing marker.
+ON_MISSING = Literal[WARN_LEVELS, "null"]
+
 # The actions warnings.simplefilter and warnings.filterwarnings accept.
 # Spelled out because the standard library's alias for them is stub-only.
 # "all" is deliberately absent: Python only began accepting it in 3.14, and

--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -19,14 +19,14 @@ import threading
 import warnings
 from collections.abc import Sequence, Sized
 from itertools import pairwise
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, get_args
 
 import numpy as np
 import pandas as pd
 from pydantic import ValidationError
 
 import dascore as dc
-from dascore.constants import INVENTORY_ATTRS
+from dascore.constants import INVENTORY_ATTRS, ON_MISSING, WARN_LEVELS
 from dascore.core.coords import BaseCoord, get_coord
 from dascore.core.inventory import (
     DISTANCE_MAP_AXES,
@@ -56,10 +56,12 @@ from dascore.utils.time import to_datetime64
 # One vocabulary for both fiber verbs. What the quiet option leaves
 # behind still differs -- enrich leaves the patch as it was, conform
 # removes it -- but that is the verb's business rather than the value's.
-VALID_ON_UNRESOLVED = ("raise", "warn", "ignore")
+# Read off the annotation the verbs declare so a value cannot be accepted
+# by one and refused by the other.
+VALID_ON_UNRESOLVED = get_args(WARN_LEVELS)
 
 # What `Patch.enrich` does about a named attr the inventory leaves unset.
-VALID_ON_MISSING = ("raise", "warn", "ignore", "null")
+VALID_ON_MISSING = get_args(ON_MISSING)
 
 # Written once because both fiber verbs refuse for it, and two spellings
 # would let them start explaining the same refusal differently.

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -199,7 +199,7 @@ class Spool(NodeRepr, NamespaceOwner):
     # patch the inventory does not describe.
     _inventory = None
     _enrich_kwargs: dict | None = None
-    _on_unresolved: str = "warn"
+    _on_unresolved: WARN_LEVELS = "warn"
     # Whether this spool has already said its inventory covers only part of
     # it; the warning is worth making once, not once per patch.
     _warned_unresolved: bool = False
@@ -1049,7 +1049,7 @@ class Spool(NodeRepr, NamespaceOwner):
     def enrich(
         self,
         *,
-        on_unresolved: Literal["warn", "raise", "ignore"] = "warn",
+        on_unresolved: WARN_LEVELS = "warn",
         **kwargs,
     ) -> Self:
         """
@@ -1234,7 +1234,7 @@ class Spool(NodeRepr, NamespaceOwner):
     def conform_to_inventory(
         self,
         *,
-        on_unresolved: Literal["raise", "warn", "ignore"] = "raise",
+        on_unresolved: WARN_LEVELS = "raise",
     ) -> Self:
         """
         Return a spool the inventory describes exactly, patch for patch.

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -9,6 +9,7 @@ import numpy as np
 import dascore as dc
 from dascore.constants import (
     INVENTORY_ATTRS,
+    ON_MISSING,
     PatchType,
     enrich_attrs_description,
     enrich_conflict_description,
@@ -47,8 +48,6 @@ from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import iterate, validate_acquisition_key, warn_or_raise
 from dascore.utils.patch import patch_function
 from dascore.utils.time import to_datetime64
-
-OnMissing = Literal["raise", "warn", "ignore", "null"]
 
 
 def _get_acquisition_key(patch, acquisition_key) -> str:
@@ -415,7 +414,7 @@ def enrich(
     coords: bool | tuple[str, ...] = True,
     acquisition_key: str | None = None,
     time=None,
-    on_missing: OnMissing = "raise",
+    on_missing: ON_MISSING = "raise",
     conflict: Literal["drop", "raise", "keep_first"] = "keep_first",
 ) -> PatchType:
     """

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -517,7 +517,7 @@ def optional_import(
 
 def optional_import(
     package_name: str,
-    on_missing: Literal["raise", "warn", "ignore"] = "raise",
+    on_missing: WARN_LEVELS = "raise",
     required_for: str = "the requested functionality",
 ) -> ModuleType | None:
     """

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -104,16 +104,18 @@ def suppress_warnings(
         yield caught if record else None
 
 
-def validate_warn_level(behavior) -> WARN_LEVELS:
+def validate_warn_level(behavior, name: str = "behavior") -> WARN_LEVELS:
     """
     Ensure a warn-level argument is one of the supported values.
 
     Called where the argument arrives rather than where it is acted on:
     only an incompatible patch reaches `warn_or_raise`, so validating
     there would accept a retired spelling until the data made it matter.
+    `name` is the parameter the caller spells it as, so the refusal names
+    the argument the user actually passed.
     """
     if behavior not in get_args(WARN_LEVELS):
-        msg = f"behavior must be one of {get_args(WARN_LEVELS)}, got {behavior!r}."
+        msg = f"{name} must be one of {get_args(WARN_LEVELS)}, got {behavior!r}."
         raise ParameterError(msg)
     return behavior
 

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -1318,7 +1318,7 @@ def check_kind(
     >>> # but is a value of its own where patches are partitioned.
     >>> assert not check_kind(patch, keyed, check_behavior="ignore", strict=True)
     """
-    validate_warn_level(check_behavior)
+    validate_warn_level(check_behavior, "check_behavior")
     kind1, kind2 = get_patch_kind(patch1), get_patch_kind(patch2)
 
     def _equal(value1, value2) -> bool:
@@ -1360,7 +1360,7 @@ def check_data_units(patch1, patch2, check_behavior: WARN_LEVELS = "raise") -> b
         [`IncompatiblePatchError`](`dascore.exceptions.IncompatiblePatchError`),
         'warn' warns and returns False, 'ignore' returns False quietly.
     """
-    validate_warn_level(check_behavior)
+    validate_warn_level(check_behavior, "check_behavior")
     units1 = get_quantity(patch1.attrs.data_units)
     units2 = get_quantity(patch2.attrs.data_units)
     if units1 == units2:
@@ -1396,7 +1396,7 @@ def check_dims(
         when only broadcastability needs to be checked. If false require dims
         to be equal.
     """
-    validate_warn_level(check_behavior)
+    validate_warn_level(check_behavior, "check_behavior")
     dims1, dims2 = patch1.dims, patch2.dims
     if not intersection and patch1.dims == patch2.dims:
         return True
@@ -1446,7 +1446,7 @@ def check_coords(
         If True, the ignored dims must be equal shape to pass check.
         If dim_to_ignore is None this has no effect.
     """
-    validate_warn_level(check_behavior)
+    validate_warn_level(check_behavior, "check_behavior")
     cm1 = patch1.coords
     cm2 = patch2.coords
     cset1, cset2 = set(cm1.coord_map), set(cm2.coord_map)

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -616,7 +616,7 @@ class TestCheckKind:
 
     def test_retired_check_behavior_raises(self, random_patch):
         """The behavior argument is validated up front."""
-        with pytest.raises(ParameterError, match="behavior must be one of"):
+        with pytest.raises(ParameterError, match="check_behavior must be one of"):
             check_kind(random_patch, random_patch, check_behavior=None)
 
 
@@ -1042,12 +1042,12 @@ class TestStackPatches:
         patch1, patch2 = random_spool[0], random_spool[1]
         patch2 = patch2.select(time=(1, 30), samples=True)
         spool = dc.spool([patch1, patch2])
-        with pytest.raises(ParameterError, match="behavior must be one of"):
+        with pytest.raises(ParameterError, match="check_behavior must be one of"):
             stack_patches(spool, dim_vary="time", check_behavior=None)
 
     def test_retired_check_behavior_raises_on_compatible_patches(self, random_patch):
         """Acceptance must not wait for data which happens to disagree."""
-        with pytest.raises(ParameterError, match="behavior must be one of"):
+        with pytest.raises(ParameterError, match="check_behavior must be one of"):
             check_dims(random_patch, random_patch, check_behavior=None)
 
     def test_different_dimensions(self, random_spool):


### PR DESCRIPTION
## Description

The inventory workflow spelled its policy vocabularies more times than there are policies. The three-value set was written three ways — the `WARN_LEVELS` Literal in `constants.py`, a hand-written `VALID_ON_UNRESOLVED` tuple, and inline `Literal`s on `Spool.enrich` and `Spool.conform_to_inventory` which disagreed with each other on the order of the values. The four-value `on_missing` set was written twice, in two different files: an `OnMissing` Literal in `dascore/proc/inventory.py` and a `VALID_ON_MISSING` tuple in `dascore/core/_spool_inventory.py`, with nothing tying them together.

Now there are two aliases in `constants.py` and everything reads from them:

- `ON_MISSING = Literal[WARN_LEVELS, "null"]` says what it means — the warn levels plus the one answer only this question has — and cannot drift from `WARN_LEVELS`, because it is spelled in terms of it.
- `VALID_ON_UNRESOLVED` and `VALID_ON_MISSING` are `get_args` of the aliases the functions annotate, so a value cannot be accepted by the annotation and refused by the check.
- `Spool.enrich`, `Spool.conform_to_inventory`, `Spool._on_unresolved`, `Patch.enrich`, and `optional_import` annotate the aliases. `optional_import`'s overloads keep their narrower literals: those are what narrow its return type.

`on_unresolved` and `on_missing` keep their separate names. They answer different questions over different value sets — whether the inventory describes this patch at all, versus whether it defines a name that was explicitly asked for — and `Spool.enrich` takes both in one call. Their differing defaults are likewise deliberate: `enrich` leaves an unresolved patch unchanged, so `warn` costs nothing, while `conform_to_inventory` drops it, so it asks first.

One behavior change came along: `validate_warn_level` now takes the name of the parameter it is validating, so the four `check_behavior` callers stop refusing an argument nobody passed.

## Changelog

- changed: `check_kind`, `check_dims`, `check_coords`, and `check_data_units` now name `check_behavior` in the error raised for an unsupported value, rather than `behavior`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent options for handling missing data, including warning, error, ignore, and null behaviors.
  * Standardized warning-level settings across inventory, enrichment, import, and validation workflows.

* **Bug Fixes**
  * Validation errors now identify the relevant parameter, making configuration issues clearer.

* **Tests**
  * Updated validation tests to reflect the more specific error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->