### PR TITLE
Let a chunk tolerance say a distance, not only a sample count

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -2597,7 +2597,12 @@ class CoordSegmented(BaseCoord):
             tolerance = 0
         if hasattr(tolerance, "units"):  # pint quantity tolerances
             target = "s" if dtype_time_like(self.dtype) else self.units
-            tolerance = convert_units(tolerance.magnitude, target, tolerance.units)
+            # A tolerance is a DELTA, so it converts between two anchor
+            # points: 20 degC of deviation is 36 degF, never 68.
+            anchor = convert_units(0.0, target, tolerance.units)
+            tolerance = (
+                convert_units(tolerance.magnitude, target, tolerance.units) - anchor
+            )
         if dtype_time_like(self.dtype):
             tolerance = dc.to_timedelta64(tolerance)
             zero = dc.to_timedelta64(0)

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -2595,14 +2595,20 @@ class CoordSegmented(BaseCoord):
         """Coerce the tolerance to the dtype expected for value deviations."""
         if tolerance is None:
             tolerance = 0
-        if hasattr(tolerance, "units"):  # pint quantity tolerances
+        stated = None
+        if is_timedelta64(tolerance) and not dtype_time_like(self.dtype):
+            # A timedelta against a numeric coordinate is a length in
+            # seconds, which only the coordinate's units can place.
+            stated = (to_float(tolerance), "s")
+        elif hasattr(tolerance, "units"):  # pint quantity tolerances
+            stated = (tolerance.magnitude, tolerance.units)
+        if stated is not None:
+            magnitude, from_units = stated
             target = "s" if dtype_time_like(self.dtype) else self.units
             # A tolerance is a DELTA, so it converts between two anchor
             # points: 20 degC of deviation is 36 degF, never 68.
-            anchor = convert_units(0.0, target, tolerance.units)
-            tolerance = (
-                convert_units(tolerance.magnitude, target, tolerance.units) - anchor
-            )
+            anchor = convert_units(0.0, target, from_units)
+            tolerance = convert_units(magnitude, target, from_units) - anchor
         if dtype_time_like(self.dtype):
             tolerance = dc.to_timedelta64(tolerance)
             zero = dc.to_timedelta64(0)

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -1789,8 +1789,9 @@ class Spool(NodeRepr, NamespaceOwner):
         boundary is measured against the furthest point reached so far,
         not the previous row.
 
-        Patches whose step is unknown report no gaps, since the tolerance
-        has no sample to scale.
+        Patches whose step is unknown report no gaps against a sample
+        count, which has no sample to scale. An absolute tolerance needs
+        none, so it reports their gaps like any others.
 
         See Also
         --------
@@ -1869,9 +1870,10 @@ class Spool(NodeRepr, NamespaceOwner):
         Coverage is measured between patches, from the envelopes the
         index records; a hole *inside* a patch is not visible here. Nor
         is one in a group whose step is unknown, which reports no gaps
-        and so counts as fully covered. Both are what `chunk` would
-        make of the data, so a `coverage` of 1.0 says "nothing chunk
-        would refuse to merge", not "nothing missing".
+        against a sample count and so counts as fully covered — an
+        absolute tolerance measures those groups too. Both are what
+        `chunk` would make of the data, so a `coverage` of 1.0 says
+        "nothing chunk would refuse to merge", not "nothing missing".
 
         See Also
         --------

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -1758,8 +1758,8 @@ class Spool(NodeRepr, NamespaceOwner):
         tolerance
             The maximum number of samples patches can be spaced and still
             count as contiguous, or a quantity or timedelta stating that
-            limit as a distance (eg `1 * s`). Same meaning as chunk's
-            `tolerance`.
+            limit in the coordinate's own units (eg `1 * s`). Same
+            meaning as chunk's `tolerance`.
         group
             Attributes which separate patches into unrelated groups; a gap
             is never reported between two groups. Defaults to the config
@@ -1789,9 +1789,9 @@ class Spool(NodeRepr, NamespaceOwner):
         boundary is measured against the furthest point reached so far,
         not the previous row.
 
-        Patches whose step is unknown report no gaps against a sample
-        count, which has no sample to scale. An absolute tolerance needs
-        none, so it reports their gaps like any others.
+        A sample-count tolerance scales the step, so patches whose step
+        is unknown report no gaps. An absolute tolerance needs no step,
+        so it reports their gaps like any other patch's.
 
         See Also
         --------
@@ -1845,8 +1845,8 @@ class Spool(NodeRepr, NamespaceOwner):
         tolerance
             The maximum number of samples patches can be spaced and still
             count as contiguous, or a quantity or timedelta stating that
-            limit as a distance (eg `1 * s`). Same meaning as chunk's
-            `tolerance`.
+            limit in the coordinate's own units (eg `1 * s`). Same
+            meaning as chunk's `tolerance`.
         group
             Attributes which separate patches into unrelated groups.
             Defaults to the config option `patch_kind_attrs`; sampling
@@ -1869,11 +1869,12 @@ class Spool(NodeRepr, NamespaceOwner):
 
         Coverage is measured between patches, from the envelopes the
         index records; a hole *inside* a patch is not visible here. Nor
-        is one in a group whose step is unknown, which reports no gaps
-        against a sample count and so counts as fully covered — an
-        absolute tolerance measures those groups too. Both are what
-        `chunk` would make of the data, so a `coverage` of 1.0 says
-        "nothing chunk would refuse to merge", not "nothing missing".
+        is one in a group whose step is unknown: a sample-count tolerance
+        has nothing to scale there, so the group reports no gaps and
+        counts as fully covered. An absolute tolerance does measure it.
+        Both are what `chunk` would make of the data, so a `coverage` of
+        1.0 says "nothing chunk would refuse to merge", not "nothing
+        missing".
 
         See Also
         --------
@@ -1928,15 +1929,17 @@ class Spool(NodeRepr, NamespaceOwner):
         snap_coords
             If True (default), simplify the coordinates of joined patches to
             an evenly sampled range when doing so moves no coordinate value
-            by more than `tolerance` (samples, or the distance itself when
-            it states one). Merges whose gaps exceed that keep an exact
-            segmented coordinate instead.
+            by more than `tolerance` (samples, or the length itself when
+            the tolerance states one). Merges whose gaps exceed that keep
+            an exact segmented coordinate instead.
         tolerance
             The maximum number of samples a block of data can be spaced (gap)
             and still be considered contiguous. A quantity or timedelta
-            states the same limit as a distance instead of a sample count
-            (eg `tolerance=1 * s`), which also works for patches whose
-            sampling interval is unknown.
+            states that limit in the coordinate's own units instead (eg
+            `tolerance=1 * s`), which also works for patches whose
+            sampling interval is unknown. Either way a boundary of one
+            sample is contiguous, so a tolerance below one sample never
+            splits adjacent patches.
         conflict
             {conflict_desc}
         group

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -74,6 +74,7 @@ from dascore.exceptions import (
     ParameterError,
     UnresolvedPatchError,
 )
+from dascore.units import Quantity
 from dascore.utils.chunk_plan import (
     _SOURCE_COLUMNS,
     ChunkPlan,
@@ -1678,7 +1679,7 @@ class Spool(NodeRepr, NamespaceOwner):
         overlap: numeric_types | timeable_types | None = None,
         keep_partial: bool = False,
         snap_coords: bool = True,
-        tolerance: float = 1.5,
+        tolerance: float | Quantity | np.timedelta64 = 1.5,
         conflict: Literal["drop", "raise", "keep_first"] = "raise",
         group: str | Sequence[str] | None = None,
         missing_dim: Literal["raise", "drop"] = "raise",
@@ -1739,7 +1740,7 @@ class Spool(NodeRepr, NamespaceOwner):
         self,
         dim: str = "time",
         *,
-        tolerance: float = 1.5,
+        tolerance: float | Quantity | np.timedelta64 = 1.5,
         group: str | Sequence[str] | None = None,
         missing_dim: Literal["raise", "drop"] = "drop",
     ) -> pd.DataFrame:
@@ -1756,7 +1757,9 @@ class Spool(NodeRepr, NamespaceOwner):
             The dimension to look for gaps along.
         tolerance
             The maximum number of samples patches can be spaced and still
-            count as contiguous. Same meaning as chunk's `tolerance`.
+            count as contiguous, or a quantity or timedelta stating that
+            limit as a distance (eg `1 * s`). Same meaning as chunk's
+            `tolerance`.
         group
             Attributes which separate patches into unrelated groups; a gap
             is never reported between two groups. Defaults to the config
@@ -1821,7 +1824,7 @@ class Spool(NodeRepr, NamespaceOwner):
         self,
         dim: str = "time",
         *,
-        tolerance: float = 1.5,
+        tolerance: float | Quantity | np.timedelta64 = 1.5,
         group: str | Sequence[str] | None = None,
         missing_dim: Literal["raise", "drop"] = "drop",
     ) -> pd.DataFrame:
@@ -1840,7 +1843,9 @@ class Spool(NodeRepr, NamespaceOwner):
             The dimension to measure along.
         tolerance
             The maximum number of samples patches can be spaced and still
-            count as contiguous. Same meaning as chunk's `tolerance`.
+            count as contiguous, or a quantity or timedelta stating that
+            limit as a distance (eg `1 * s`). Same meaning as chunk's
+            `tolerance`.
         group
             Attributes which separate patches into unrelated groups.
             Defaults to the config option `patch_kind_attrs`; sampling
@@ -1901,7 +1906,7 @@ class Spool(NodeRepr, NamespaceOwner):
         overlap: numeric_types | timeable_types | None = None,
         keep_partial: bool = False,
         snap_coords: bool = True,
-        tolerance: float = 1.5,
+        tolerance: float | Quantity | np.timedelta64 = 1.5,
         conflict: Literal["drop", "raise", "keep_first"] = "raise",
         group: str | Sequence[str] | None = None,
         missing_dim: Literal["raise", "drop"] = "raise",
@@ -1921,11 +1926,15 @@ class Spool(NodeRepr, NamespaceOwner):
         snap_coords
             If True (default), simplify the coordinates of joined patches to
             an evenly sampled range when doing so moves no coordinate value
-            by more than `tolerance` samples. Merges whose gaps exceed that
-            keep an exact segmented coordinate instead.
+            by more than `tolerance` (samples, or the distance itself when
+            it states one). Merges whose gaps exceed that keep an exact
+            segmented coordinate instead.
         tolerance
             The maximum number of samples a block of data can be spaced (gap)
-            and still be considered contiguous.
+            and still be considered contiguous. A quantity or timedelta
+            states the same limit as a distance instead of a sample count
+            (eg `tolerance=1 * s`), which also works for patches whose
+            sampling interval is unknown.
         conflict
             {conflict_desc}
         group
@@ -2000,7 +2009,9 @@ class Spool(NodeRepr, NamespaceOwner):
         merge_kwargs = {
             "conflict": conflict,
             "snap_coords": snap_coords,
-            "tolerance": tolerance,
+            # the plan's copy is normalized (eg a dimensionless quantity
+            # has become the plain multiple it means)
+            "tolerance": plan.params["tolerance"],
         }
         catalog = derived_catalog(
             source_rows=source_rows,

--- a/dascore/units.py
+++ b/dascore/units.py
@@ -367,6 +367,17 @@ def _validate_quantity_str(quant_str: str) -> None:
         raise UnitError(msg) from e
 
 
+def carries_units(value) -> bool:
+    """
+    Return True if a value states its own units.
+
+    A quantity says them outright; a timedelta is a time by construction.
+    Anything else is a bare number, which only means something against a
+    unit the caller supplies.
+    """
+    return isinstance(value, Quantity) or is_timedelta64(value)
+
+
 def get_inverted_quant(quant: Quantity | None, data_units):
     """Convert to inverted units."""
     if quant is None:

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -291,6 +291,14 @@ def _is_absolute_tolerance(tolerance) -> bool:
 def _check_tolerance_value(value, name, shown=None):
     """Reject a tolerance no gap could be measured against."""
     shown = value if shown is None else shown
+    # One tolerance, not one per patch: a one-element array passes every
+    # test below and then broadcasts through the gap comparison.
+    if np.asarray(value).ndim:
+        msg = (
+            f"The tolerance for {name!r} must be a single value, got an "
+            f"array of {np.asarray(value).size}."
+        )
+        raise ParameterError(msg)
     try:
         finite = not pd.isnull(value) and np.isfinite(value)
     except TypeError:

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -69,6 +69,21 @@ _DEFAULT_TOLERANCE = 1.5
 
 
 @dataclass(frozen=True)
+class _AbsoluteTolerance:
+    """
+    A continuity tolerance stated as a distance, not a sample count.
+
+    A quantity (or timedelta) tolerance resolves to one of these per
+    cell, since the cell fixes the units and dtype the distance is in.
+    Wrapped rather than passed bare so the gap test can tell an absolute
+    margin from a relative multiplier, which for a unitless coordinate
+    are both just numbers.
+    """
+
+    value: Any
+
+
+@dataclass(frozen=True)
 class ChunkPlan:
     """
     A materialization-free description of a chunk operation.
@@ -268,6 +283,80 @@ def _sampling_group(step: pd.Series, tolerance: float) -> pd.Series:
     return pd.Series(labels, index=step.index)
 
 
+def _is_absolute_tolerance(tolerance) -> bool:
+    """True when a tolerance states a distance rather than a sample count."""
+    return isinstance(tolerance, Quantity) or is_timedelta64(tolerance)
+
+
+def _check_tolerance_value(value, name, shown=None):
+    """Reject a tolerance no gap could be measured against."""
+    shown = value if shown is None else shown
+    try:
+        finite = not pd.isnull(value) and np.isfinite(value)
+    except TypeError:
+        msg = (
+            f"The tolerance for {name!r} must be a sample count, a quantity, "
+            f"or a timedelta, got {shown!r}. A unit-bearing string becomes a "
+            "quantity with dascore.get_quantity."
+        )
+        raise ParameterError(msg) from None
+    if not finite:
+        msg = f"The tolerance for {name!r} must be finite, got {shown}."
+        raise ParameterError(msg)
+    # a timedelta compares against a bare zero as its own zero
+    if value < 0:
+        msg = f"The tolerance for {name!r} must not be negative, got {shown}."
+        raise ParameterError(msg)
+
+
+def _normalize_tolerance(tolerance, name):
+    """
+    Validate a continuity tolerance and reduce it to one of two forms.
+
+    A number is a multiple of the sampling interval; a quantity or
+    timedelta is an absolute distance, which only a cell can resolve (it
+    fixes the units and dtype), so it passes through to be resolved
+    there. A dimensionless quantity *is* the multiple, so it becomes a
+    number.
+    """
+    if is_timedelta64(tolerance):
+        tolerance = to_timedelta64(tolerance)
+        _check_tolerance_value(tolerance, name)
+        return tolerance
+    if isinstance(tolerance, Quantity):
+        _validate_quantity("tolerance", tolerance, name)
+        if is_data_size(tolerance):
+            msg = (
+                f"Cannot use a tolerance of {tolerance} for {name!r}: a data "
+                "size does not measure a gap along a coordinate."
+            )
+            raise UnitError(msg)
+        if not tolerance.dimensionless:
+            _check_tolerance_value(tolerance.magnitude, name, shown=tolerance)
+            return tolerance
+        # a dimensionless quantity is the sample count it spells out
+        tolerance = float(tolerance.m_as("dimensionless"))
+    _check_tolerance_value(tolerance, name)
+    return tolerance
+
+
+def _cell_tolerance(tolerance, sub, name):
+    """Resolve an absolute tolerance into one cell's own units."""
+    if not _is_absolute_tolerance(tolerance):
+        return tolerance
+    start, _, _ = get_interval_columns(sub, name)
+    prefix = f"Cannot use a tolerance of {tolerance} for {name!r}"
+    if not isinstance(tolerance, Quantity):
+        # A timedelta is already the distance the cell measures in, but
+        # only a time-like coordinate measures in it.
+        if not (is_datetime64(start.dtype) or is_timedelta64(start.dtype)):
+            msg = f"{prefix}: the coordinate is not time-like."
+            raise UnitError(msg)
+        return _AbsoluteTolerance(tolerance)
+    value = _quantity_to_dim_value(tolerance, sub, name, start.dtype, prefix=prefix)
+    return _AbsoluteTolerance(value)
+
+
 def _gap_boundaries(start, stop, step, tolerance):
     """
     Locate the discontinuities in one cell (spec 2.4).
@@ -276,8 +365,11 @@ def _gap_boundaries(start, stop, step, tolerance):
     `reach` is the furthest stop seen *before* each row, so an
     overlapping or fully-nested row can never open a gap behind it, and
     `has_gap` marks each row whose start clears that reach by more than
-    `tolerance` steps. The first row has nothing behind it, and a row
-    whose step is unknown compares False, so neither reports a gap.
+    the continuity margin: `tolerance` steps for a plain number, or the
+    tolerance itself when it is an
+    [`_AbsoluteTolerance`](`dascore.utils.chunk_plan._AbsoluteTolerance`).
+    The first row has nothing behind it, and a row whose step is unknown
+    compares False against a relative margin, so neither reports a gap.
 
     Arrays rather than a frame, and an explicit first-row mask rather
     than `shift`, whose NaN fill would upcast integer envelopes to
@@ -302,7 +394,11 @@ def _gap_boundaries(start, stop, step, tolerance):
     has_gap = np.zeros(len(starts), dtype=bool)
     ahead = starts > reach
     if ahead.any():
-        has_gap[ahead] = (starts[ahead] - reach[ahead]) > steps[ahead] * tolerance
+        if isinstance(tolerance, _AbsoluteTolerance):
+            margin = tolerance.value
+        else:
+            margin = steps[ahead] * tolerance
+        has_gap[ahead] = (starts[ahead] - reach[ahead]) > margin
     has_gap[:1] = False
     return order, reach, has_gap
 
@@ -508,14 +604,23 @@ def _partition(
     cell = _cell_labels(df, name, group_attrs, sampling_tolerance)
     cont = pd.Series(0, index=df.index, dtype=np.int64)
     forced_merge = False
+    # An absolute tolerance has no sample count to compare against the
+    # default, so whether it forced a merge is only knowable by running
+    # the default too.
+    loose = _is_absolute_tolerance(tolerance) or tolerance > _DEFAULT_TOLERANCE
     for _, index in df.groupby(cell, sort=False).groups.items():
         sub = df.loc[index]
         s, e, st = get_interval_columns(sub, name)
-        labels = _continuity_group(s, e, st, tolerance).astype(np.int64)
+        tol = _cell_tolerance(tolerance, sub, name)
+        labels = _continuity_group(s, e, st, tol).astype(np.int64)
         cont.loc[index] = labels
-        if tolerance > _DEFAULT_TOLERANCE and not forced_merge:
+        if loose and not forced_merge:
+            # A partition which holds more than one of the default's is
+            # one the tolerance forced together. Counting partitions
+            # instead would miss a tolerance which merges one boundary
+            # while splitting another, which an absolute one can.
             default = _continuity_group(s, e, st, _DEFAULT_TOLERANCE)
-            forced_merge = default.nunique() > labels.nunique()
+            forced_merge = bool(default.groupby(labels).nunique().gt(1).any())
     return cell + "_" + cont.astype(str), forced_merge
 
 
@@ -720,15 +825,22 @@ def _packing_factor(sub: pd.DataFrame, name: str, step_float: float) -> float:
     return 1.0 if packing < 1 + 1e-9 else packing
 
 
-def _quantity_to_dim_value(quant, sub, name, start_dtype):
-    """Convert a (non-size) quantity into the chunked dimension's units."""
+def _quantity_to_dim_value(quant, sub, name, start_dtype, prefix=None):
+    """
+    Convert a (non-size) quantity into the chunked dimension's units.
+
+    `prefix` opens the error messages; it names what the quantity was
+    for, since the same conversion serves both a chunk length and a
+    continuity tolerance.
+    """
+    prefix = prefix if prefix is not None else f"Cannot chunk {name!r} by {quant}"
     if is_datetime64(start_dtype) or is_timedelta64(start_dtype):
         try:
             seconds = quant.to("s").magnitude
         except DimensionalityError:
             msg = (
-                f"Cannot chunk {name!r} by {quant}: the coordinate is "
-                "time-like, so the value must have units of time."
+                f"{prefix}: the coordinate is time-like, so the "
+                "value must have units of time."
             )
             raise UnitError(msg) from None
         return to_timedelta64(seconds)
@@ -737,8 +849,8 @@ def _quantity_to_dim_value(quant, sub, name, start_dtype):
         units = sub[units_col].iloc[0]
         if units is None or pd.isnull(units) or units == "":
             msg = (
-                f"Cannot chunk {name!r} by {quant}: the coordinate has no "
-                "units, so a unit-bearing length is ambiguous."
+                f"{prefix}: the coordinate has no units, so a "
+                "unit-bearing length is ambiguous."
             )
             raise UnitError(msg)
         try:
@@ -752,16 +864,13 @@ def _quantity_to_dim_value(quant, sub, name, start_dtype):
             end = convert_units(magnitude, to_units=units, from_units=from_units)
             return end - anchor
         except (DimensionalityError, UnitError):
-            msg = (
-                f"Cannot chunk {name!r} by {quant}: incompatible with the "
-                f"coordinate's units of {units}."
-            )
+            msg = f"{prefix}: incompatible with the coordinate's units of {units}."
             raise UnitError(msg) from None
     # A frame with no units column states no units at all; envelopes are
     # native magnitudes, so there is nothing to convert the quantity to.
     msg = (
-        f"Cannot chunk {name!r} by {quant}: the frame records no units "
-        "for the coordinate, so a unit-bearing length is ambiguous."
+        f"{prefix}: the frame records no units for the coordinate, "
+        "so a unit-bearing length is ambiguous."
     )
     raise UnitError(msg)
 
@@ -1092,7 +1201,7 @@ def _gap_carried_columns(df: pd.DataFrame, name: str, group_attrs) -> list[str]:
     return list(dict.fromkeys(cols))
 
 
-def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance: float):
+def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance):
     """
     Yield `(cell rows, gaps in that cell)` for every cell in `df`.
 
@@ -1122,7 +1231,8 @@ def _cell_gaps(df: pd.DataFrame, name: str, group_attrs, tolerance: float):
     for group_id, label in enumerate(order):
         sub = df.loc[groups[label]]
         start, stop, step = get_interval_columns(sub, name)
-        row_order, reach, has_gap = _gap_boundaries(start, stop, step, tolerance)
+        tol = _cell_tolerance(tolerance, sub, name)
+        row_order, reach, has_gap = _gap_boundaries(start, stop, step, tol)
         found = np.flatnonzero(has_gap)
         # the row opening each gap states the step, signed as the
         # coordinate is -- only the continuity margin needs a magnitude
@@ -1156,7 +1266,7 @@ def build_gap_frame(
     df: pd.DataFrame,
     name: str,
     *,
-    tolerance: float = _DEFAULT_TOLERANCE,
+    tolerance: float | Quantity | np.timedelta64 = _DEFAULT_TOLERANCE,
     group: str | Sequence[str] | None = None,
     missing_dim: Literal["raise", "drop"] = "drop",
 ) -> pd.DataFrame:
@@ -1171,6 +1281,7 @@ def build_gap_frame(
     """
     df, group_attrs, carried, names = _report_preamble(df, name, group, missing_dim)
     min_name, max_name, step_name = names
+    tolerance = _normalize_tolerance(tolerance, name)
     columns = [min_name, max_name, step_name, "gap_size", "group_id", *carried]
     # Contiguous cells are dropped rather than concatenated: their empty
     # frames carry object-dtype attr columns, which would widen the
@@ -1195,7 +1306,7 @@ def build_coverage_frame(
     df: pd.DataFrame,
     name: str,
     *,
-    tolerance: float = _DEFAULT_TOLERANCE,
+    tolerance: float | Quantity | np.timedelta64 = _DEFAULT_TOLERANCE,
     group: str | Sequence[str] | None = None,
     missing_dim: Literal["raise", "drop"] = "drop",
 ) -> pd.DataFrame:
@@ -1210,6 +1321,7 @@ def build_coverage_frame(
     """
     df, group_attrs, carried, names = _report_preamble(df, name, group, missing_dim)
     min_name, max_name, step_name = names
+    tolerance = _normalize_tolerance(tolerance, name)
     columns = [
         min_name,
         max_name,
@@ -1273,7 +1385,7 @@ def build_chunk_plan(
     overlap=None,
     keep_partial: bool = False,
     snap_coords: bool = True,
-    tolerance: float = 1.5,
+    tolerance: float | Quantity | np.timedelta64 = 1.5,
     conflict: Literal["drop", "raise", "keep_first"] = "raise",
     group=None,
     missing_dim: Literal["raise", "drop"] = "raise",
@@ -1295,6 +1407,7 @@ def build_chunk_plan(
     # offending chunk call. See #804.
     validate_conflict(conflict)
     ((name, value),) = kwargs.items()
+    tolerance = _normalize_tolerance(tolerance, name)
     value = None if value is Ellipsis else value
     # Police quantities before merge_mode is decided: a NaN magnitude is
     # null, so a nan-valued size would silently merge the whole spool

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -21,6 +21,7 @@ import math
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Literal
 
@@ -39,10 +40,12 @@ from dascore.exceptions import (
 from dascore.units import (
     DimensionalityError,
     Quantity,
+    carries_units,
     convert_units,
     get_byte_count,
     get_quantity,
     is_data_size,
+    is_percent,
 )
 from dascore.utils.attrs import known_only, validate_conflict
 from dascore.utils.chunk import get_intervals
@@ -71,13 +74,12 @@ _DEFAULT_TOLERANCE = 1.5
 @dataclass(frozen=True)
 class _AbsoluteTolerance:
     """
-    A continuity tolerance stated as a distance, not a sample count.
+    A continuity tolerance stated in the coordinate's units, not in samples.
 
-    A quantity (or timedelta) tolerance resolves to one of these per
-    cell, since the cell fixes the units and dtype the distance is in.
-    Wrapped rather than passed bare so the gap test can tell an absolute
-    margin from a relative multiplier, which for a unitless coordinate
-    are both just numbers.
+    A quantity or timedelta tolerance resolves to one of these per cell,
+    since only the cell fixes the units and dtype to express it in. The
+    wrapper lets the gap test tell an absolute tolerance from a sample
+    count; on a unitless coordinate both are plain numbers.
     """
 
     value: Any
@@ -283,13 +285,14 @@ def _sampling_group(step: pd.Series, tolerance: float) -> pd.Series:
     return pd.Series(labels, index=step.index)
 
 
-def _is_absolute_tolerance(tolerance) -> bool:
-    """True when a tolerance states a distance rather than a sample count."""
-    return isinstance(tolerance, Quantity) or is_timedelta64(tolerance)
+def _check_tolerance_value(value, name, shown=None, *, allow_infinite=False):
+    """
+    Reject a tolerance no gap could be measured against.
 
-
-def _check_tolerance_value(value, name, shown=None):
-    """Reject a tolerance no gap could be measured against."""
+    An infinite sample count is a coherent request — no boundary is ever
+    a gap — but an infinite distance is not a distance, so only the
+    count is allowed to be one.
+    """
     shown = value if shown is None else shown
     # One tolerance, not one per patch: a one-element array passes every
     # test below and then broadcasts through the gap comparison.
@@ -300,7 +303,8 @@ def _check_tolerance_value(value, name, shown=None):
         )
         raise ParameterError(msg)
     try:
-        finite = not pd.isnull(value) and np.isfinite(value)
+        null = bool(pd.isnull(value))
+        negative = not null and value < 0
     except TypeError:
         msg = (
             f"The tolerance for {name!r} must be a sample count, a quantity, "
@@ -308,11 +312,10 @@ def _check_tolerance_value(value, name, shown=None):
             "quantity with dascore.get_quantity."
         )
         raise ParameterError(msg) from None
-    if not finite:
+    if null or (not allow_infinite and not np.isfinite(value)):
         msg = f"The tolerance for {name!r} must be finite, got {shown}."
         raise ParameterError(msg)
-    # a timedelta compares against a bare zero as its own zero
-    if value < 0:
+    if negative:
         msg = f"The tolerance for {name!r} must not be negative, got {shown}."
         raise ParameterError(msg)
 
@@ -322,21 +325,28 @@ def _normalize_tolerance(tolerance, name):
     Validate a continuity tolerance and reduce it to one of two forms.
 
     A number is a multiple of the sampling interval; a quantity or
-    timedelta is an absolute distance, which only a cell can resolve (it
-    fixes the units and dtype), so it passes through to be resolved
-    there. A dimensionless quantity *is* the multiple, so it becomes a
-    number.
+    timedelta states the limit in the coordinate's own units, which only
+    a cell can resolve (it fixes the units and dtype), so it passes
+    through to be resolved there. A dimensionless quantity *is* the
+    multiple, so it becomes a number.
     """
-    if is_timedelta64(tolerance):
+    if isinstance(tolerance, timedelta) or is_timedelta64(tolerance):
+        # to_timedelta64 takes the several spellings of a timedelta
         tolerance = to_timedelta64(tolerance)
         _check_tolerance_value(tolerance, name)
         return tolerance
     if isinstance(tolerance, Quantity):
-        _validate_quantity("tolerance", tolerance, name)
         if is_data_size(tolerance):
             msg = (
                 f"Cannot use a tolerance of {tolerance} for {name!r}: a data "
                 "size does not measure a gap along a coordinate."
+            )
+            raise UnitError(msg)
+        if is_percent(tolerance):
+            msg = (
+                f"Cannot use a tolerance of {tolerance} for {name!r}: a "
+                "percentage is neither a sample count nor a length. Pass the "
+                "count itself, or a length in the coordinate's units."
             )
             raise UnitError(msg)
         if not tolerance.dimensionless:
@@ -344,23 +354,27 @@ def _normalize_tolerance(tolerance, name):
             return tolerance
         # a dimensionless quantity is the sample count it spells out
         tolerance = float(tolerance.m_as("dimensionless"))
-    _check_tolerance_value(tolerance, name)
+    _check_tolerance_value(tolerance, name, allow_infinite=True)
     return tolerance
 
 
 def _cell_tolerance(tolerance, sub, name):
     """Resolve an absolute tolerance into one cell's own units."""
-    if not _is_absolute_tolerance(tolerance):
+    if not carries_units(tolerance):
         return tolerance
     start, _, _ = get_interval_columns(sub, name)
-    prefix = f"Cannot use a tolerance of {tolerance} for {name!r}"
-    if not isinstance(tolerance, Quantity):
-        # A timedelta is already the distance the cell measures in, but
-        # only a time-like coordinate measures in it.
-        if not (is_datetime64(start.dtype) or is_timedelta64(start.dtype)):
-            msg = f"{prefix}: the coordinate is not time-like."
-            raise UnitError(msg)
-        return _AbsoluteTolerance(tolerance)
+    if isinstance(tolerance, Quantity):
+        shown = tolerance
+    else:
+        # said in seconds, which is what a timedelta measures and how
+        # the message reads back
+        shown = f"{to_float(tolerance)} s"
+        if is_datetime64(start.dtype) or is_timedelta64(start.dtype):
+            return _AbsoluteTolerance(tolerance)
+        # A numeric coordinate can still be measured in time (a relative
+        # time axis, say), so the timedelta converts like any quantity.
+        tolerance = get_quantity(f"{to_float(tolerance)} s")
+    prefix = f"Cannot use a tolerance of {shown} for {name!r}"
     value = _quantity_to_dim_value(tolerance, sub, name, start.dtype, prefix=prefix)
     return _AbsoluteTolerance(value)
 
@@ -373,11 +387,11 @@ def _gap_boundaries(start, stop, step, tolerance):
     `reach` is the furthest stop seen *before* each row, so an
     overlapping or fully-nested row can never open a gap behind it, and
     `has_gap` marks each row whose start clears that reach by more than
-    the continuity margin: `tolerance` steps for a plain number, or the
-    tolerance itself when it is an
+    the margin: `tolerance` steps for a sample count, or the tolerance
+    itself (never under one step) for an
     [`_AbsoluteTolerance`](`dascore.utils.chunk_plan._AbsoluteTolerance`).
     The first row has nothing behind it, and a row whose step is unknown
-    compares False against a relative margin, so neither reports a gap.
+    compares False against a sample count, so neither reports a gap.
 
     Arrays rather than a frame, and an explicit first-row mask rather
     than `shift`, whose NaN fill would upcast integer envelopes to
@@ -403,7 +417,15 @@ def _gap_boundaries(start, stop, step, tolerance):
     ahead = starts > reach
     if ahead.any():
         if isinstance(tolerance, _AbsoluteTolerance):
-            margin = tolerance.value
+            # Adjacent patches sit exactly one step apart, so a margin
+            # narrower than the step would open a gap where no sample is
+            # missing. An unknown step has no floor to apply.
+            step_ahead = steps[ahead]
+            margin = np.where(
+                pd.isnull(step_ahead),
+                tolerance.value,
+                np.maximum(step_ahead, tolerance.value),
+            )
         else:
             margin = steps[ahead] * tolerance
         has_gap[ahead] = (starts[ahead] - reach[ahead]) > margin
@@ -596,6 +618,21 @@ def _cell_labels(df, name, group_attrs, sampling_tolerance) -> pd.Series:
     return base.astype(str) + "_" + samp.astype(str)
 
 
+def _may_exceed_default(tol, step: pd.Series) -> bool:
+    """True when an absolute margin can exceed the default anywhere in a cell.
+
+    The margin is `max(step, tol)` against the default's `1.5 * step`, so
+    the tolerance is looser exactly where it passes 1.5 steps — which is
+    at the cell's *smallest* step, since a cell may mix steps within the
+    sampling tolerance. A cell with no known step is never forced: the
+    default cannot close a boundary there at all.
+    """
+    steps = np.abs(to_float(step.to_numpy()))
+    if not np.isfinite(steps).any():
+        return False
+    return to_float(tol.value) > _DEFAULT_TOLERANCE * np.nanmin(steps)
+
+
 def _partition(
     df, name, group_attrs, tolerance, sampling_tolerance
 ) -> tuple[pd.Series, bool]:
@@ -612,23 +649,26 @@ def _partition(
     cell = _cell_labels(df, name, group_attrs, sampling_tolerance)
     cont = pd.Series(0, index=df.index, dtype=np.int64)
     forced_merge = False
-    # An absolute tolerance has no sample count to compare against the
-    # default, so whether it forced a merge is only knowable by running
-    # the default too.
-    loose = _is_absolute_tolerance(tolerance) or tolerance > _DEFAULT_TOLERANCE
+    absolute = carries_units(tolerance)
     for _, index in df.groupby(cell, sort=False).groups.items():
         sub = df.loc[index]
         s, e, st = get_interval_columns(sub, name)
         tol = _cell_tolerance(tolerance, sub, name)
         labels = _continuity_group(s, e, st, tol).astype(np.int64)
         cont.loc[index] = labels
-        if loose and not forced_merge:
-            # A partition which holds more than one of the default's is
-            # one the tolerance forced together. Counting partitions
-            # instead would miss a tolerance which merges one boundary
-            # while splitting another, which an absolute one can.
-            default = _continuity_group(s, e, st, _DEFAULT_TOLERANCE)
-            forced_merge = bool(default.groupby(labels).nunique().gt(1).any())
+        if forced_merge or not (absolute or tolerance > _DEFAULT_TOLERANCE):
+            continue
+        # An absolute tolerance can be looser than the default at one
+        # boundary and tighter at another, so it is checked against the
+        # default partition -- but only where it can be looser at all,
+        # since the second pass is not free.
+        if absolute and not _may_exceed_default(tol, st):
+            continue
+        # By containment, not by count: a partition holding more than one
+        # of the default's is one the tolerance forced together, even
+        # when the counts match.
+        default = _continuity_group(s, e, st, _DEFAULT_TOLERANCE)
+        forced_merge = bool(default.groupby(labels).nunique().gt(1).any())
     return cell + "_" + cont.astype(str), forced_merge
 
 
@@ -661,7 +701,7 @@ def _coerce_length_overlap(value, overlap, start_dtype):
 
 
 def _validate_quantity(label: str, quant, name: str) -> None:
-    """Reject quantity chunk lengths that cannot describe a length."""
+    """Reject a quantity chunk length or overlap that cannot describe one."""
     if not isinstance(quant, Quantity):
         return
     magnitude = np.asarray(quant.magnitude)
@@ -838,8 +878,8 @@ def _quantity_to_dim_value(quant, sub, name, start_dtype, prefix=None):
     Convert a (non-size) quantity into the chunked dimension's units.
 
     `prefix` opens the error messages; it names what the quantity was
-    for, since the same conversion serves both a chunk length and a
-    continuity tolerance.
+    for, since the same conversion serves a chunk length and a
+    continuity tolerance alike.
     """
     prefix = prefix if prefix is not None else f"Cannot chunk {name!r} by {quant}"
     if is_datetime64(start_dtype) or is_timedelta64(start_dtype):
@@ -851,7 +891,11 @@ def _quantity_to_dim_value(quant, sub, name, start_dtype, prefix=None):
                 "value must have units of time."
             )
             raise UnitError(msg) from None
-        return to_timedelta64(seconds)
+        try:
+            return to_timedelta64(seconds)
+        except OverflowError:
+            msg = f"{prefix}: it is too large to express as a time."
+            raise ParameterError(msg) from None
     units_col = f"_{name}_units"
     if units_col in sub.columns:
         units = sub[units_col].iloc[0]

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -32,7 +32,7 @@ from dascore.exceptions import (
     PatchCoordinateError,
     UnitError,
 )
-from dascore.units import Quantity, convert_units, get_quantity, is_percent
+from dascore.units import carries_units, convert_units, get_quantity, is_percent
 from dascore.utils.array_api import (
     asarray_like,
     backend_name,
@@ -63,7 +63,7 @@ from dascore.utils.misc import (
     yield_sub_sequences,
 )
 from dascore.utils.paths import is_memory_uri
-from dascore.utils.time import is_timedelta64, to_float
+from dascore.utils.time import to_float
 from dascore.workflow.builtin import Concatenate, Stack
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
 from dascore.workflow.identity import (
@@ -625,9 +625,9 @@ def _get_merged_coord(
             coords, dim=merge_dim, drop_conflicting=drop_conflicting
         )
     step = _middle_step(coords, merge_dim, merged.units)
-    if snap_coords and (isinstance(tolerance, Quantity) or is_timedelta64(tolerance)):
-        # An absolute tolerance needs no step: simplify reads it in the
-        # coordinate's own units itself.
+    if snap_coords and carries_units(tolerance):
+        # A tolerance which states its own units needs no step: simplify
+        # reads it in the coordinate's units itself.
         merged = merged.simplify(tolerance)
     elif snap_coords and step is not None:
         merged = merged.simplify(tolerance * np.abs(step))

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -32,7 +32,7 @@ from dascore.exceptions import (
     PatchCoordinateError,
     UnitError,
 )
-from dascore.units import convert_units, get_quantity, is_percent
+from dascore.units import Quantity, convert_units, get_quantity, is_percent
 from dascore.utils.array_api import (
     asarray_like,
     backend_name,
@@ -63,7 +63,7 @@ from dascore.utils.misc import (
     yield_sub_sequences,
 )
 from dascore.utils.paths import is_memory_uri
-from dascore.utils.time import to_float
+from dascore.utils.time import is_timedelta64, to_float
 from dascore.workflow.builtin import Concatenate, Stack
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
 from dascore.workflow.identity import (
@@ -609,8 +609,10 @@ def _get_merged_coord(
     concatenation of the member coords (exactly contiguous members fuse to
     a plain range; recorded seams otherwise), then — when `snap_coords` —
     simplified with bounded error: no value moves more than
-    `tolerance * step`. Merges whose gaps exceed that stay segmented
-    (honestly non-uniform) rather than being relabeled.
+    `tolerance * step`, or than the tolerance itself when it is a
+    quantity or timedelta, which states the bound outright. Merges whose
+    gaps exceed that stay segmented (honestly non-uniform) rather than
+    being relabeled.
     """
     from dascore.core.coords import concat_coords  # noqa: PLC0415
 
@@ -623,7 +625,11 @@ def _get_merged_coord(
             coords, dim=merge_dim, drop_conflicting=drop_conflicting
         )
     step = _middle_step(coords, merge_dim, merged.units)
-    if snap_coords and step is not None:
+    if snap_coords and (isinstance(tolerance, Quantity) or is_timedelta64(tolerance)):
+        # An absolute tolerance needs no step: simplify reads it in the
+        # coordinate's own units itself.
+        merged = merged.simplify(tolerance)
+    elif snap_coords and step is not None:
         merged = merged.simplify(tolerance * np.abs(step))
     # Passing the pre-built dim coord avoids materializing the members'
     # concatenated values only to discard them.

--- a/dascore/viz/spool.py
+++ b/dascore/viz/spool.py
@@ -158,8 +158,9 @@ def coverage(
         The dimension to measure along.
     tolerance
         How many samples patches may be spaced and still count as
-        contiguous, or a quantity or timedelta stating that limit as a
-        distance (eg `1 * s`). Same meaning as chunk's `tolerance`.
+        contiguous, or a quantity or timedelta stating that limit in the
+        coordinate's own units (eg `1 * s`). Same meaning as chunk's
+        `tolerance`.
     group
         Attributes which separate patches into unrelated groups; a gap
         is never reported between two groups. Defaults to the config
@@ -373,8 +374,9 @@ def calendar(
         - "count": how many patches overlap the day.
     tolerance
         How many samples patches may be spaced and still count as
-        contiguous, or a quantity or timedelta stating that limit as a
-        distance (eg `1 * s`). Same meaning as chunk's `tolerance`.
+        contiguous, or a quantity or timedelta stating that limit in the
+        coordinate's own units (eg `1 * s`). Same meaning as chunk's
+        `tolerance`.
     group
         Attributes which separate patches into unrelated groups. Defaults
         to the config option `patch_kind_attrs`. It decides which

--- a/dascore/viz/spool.py
+++ b/dascore/viz/spool.py
@@ -11,6 +11,7 @@ import pandas as pd
 from matplotlib.colors import LogNorm
 
 from dascore.exceptions import ParameterError
+from dascore.units import Quantity
 from dascore.utils.chunk_plan import _REPORT_COLUMNS
 from dascore.utils.display import (
     _SECONDS_IN_DAY,
@@ -132,7 +133,7 @@ def coverage(
     spool,
     dim: str = "time",
     *,
-    tolerance: float = 1.5,
+    tolerance: float | Quantity | np.timedelta64 = 1.5,
     group: str | Sequence[str] | None = None,
     color=None,
     ax: plt.Axes | None = None,
@@ -157,7 +158,8 @@ def coverage(
         The dimension to measure along.
     tolerance
         How many samples patches may be spaced and still count as
-        contiguous. Same meaning as chunk's `tolerance`.
+        contiguous, or a quantity or timedelta stating that limit as a
+        distance (eg `1 * s`). Same meaning as chunk's `tolerance`.
     group
         Attributes which separate patches into unrelated groups; a gap
         is never reported between two groups. Defaults to the config
@@ -345,7 +347,7 @@ def calendar(
     spool,
     *,
     method: str = "percent",
-    tolerance: float = 1.5,
+    tolerance: float | Quantity | np.timedelta64 = 1.5,
     group: str | Sequence[str] | None = None,
     ax: plt.Axes | None = None,
     show: bool = False,
@@ -371,7 +373,8 @@ def calendar(
         - "count": how many patches overlap the day.
     tolerance
         How many samples patches may be spaced and still count as
-        contiguous. Same meaning as chunk's `tolerance`.
+        contiguous, or a quantity or timedelta stating that limit as a
+        distance (eg `1 * s`). Same meaning as chunk's `tolerance`.
     group
         Attributes which separate patches into unrelated groups. Defaults
         to the config option `patch_kind_attrs`. It decides which

--- a/docs/notes/spool_chunking.qmd
+++ b/docs/notes/spool_chunking.qmd
@@ -34,7 +34,7 @@ Patches may only combine when they agree on all of:
 1. **Kind** — the config option `patch_kind_attrs` by default (conventional categorical identity: acquisition key, data category, and tag; see [Patch Compatibility](patch_compatibility.qmd)), overridden per call with `group=`. Differing values are never an error; the patches simply land in separate outputs. A missing value is a value: patches which never recorded an attribute partition together, and apart from those which did. Explicitly passed names must exist somewhere in the spool; config names are best-effort.
 2. **Structure** — the dimensions tuple, the coordinate identity of every non-chunked dimension, and the chunked dimension's units (a metre patch can never plan into one output with a seconds patch, or a unitful with a unitless one; compatible spellings such as metres and feet are normalized to one unit per dimensionality before partitioning, so they plan together, and assembly converts each member to the first member's units).
 3. **Sampling** — step magnitudes within the relative tolerance `config.sampling_group_tolerance` (default 5%) of the group's smallest member, with matching orientation (ascending never merges with descending; contiguous descending patches merge with each other).
-4. **Continuity** — patches within `tolerance` samples of each other, evaluated within each group so unrelated patches can never bridge a gap. `tolerance` may also be a quantity (`1 * s`, `2 * m`) or a timedelta, which states the same limit as a distance in the coordinate's own units rather than as a sample count. Since it needs no sampling interval, an absolute tolerance also measures gaps between patches whose step is unknown, which a sample count cannot scale and so never splits.
+4. **Continuity** — patches within `tolerance` samples of each other, evaluated within each group so unrelated patches can never bridge a gap. `tolerance` may also be a quantity (`1 * s`, `2 * m`) or a timedelta, which states the same limit in the coordinate's own units rather than as a sample count; it is never read as narrower than one sample, so adjacent patches stay contiguous under any tolerance. Since it needs no sampling interval, an absolute tolerance also measures gaps between patches whose step is unknown — patches a sample-count tolerance has nothing to scale, and so never splits.
 
 [`Spool.get_gaps`](`dascore.core.spool.Spool.get_gaps`) and [`Spool.get_coverage`](`dascore.core.spool.Spool.get_coverage`) read this same partition: a `get_coverage` row is one cell of criteria 1-3, and a `get_gaps` row is a boundary criterion 4 declines to close. So on a spool of unplanned patches the counts tie — merging yields one patch per coverage row plus one per gap reported. The reports read the rows a spool presents rather than a plan's members, so a spool that has already been chunked reports on the patches it now holds, and re-chunking it need not reproduce those counts.
 
@@ -133,7 +133,7 @@ A size measures the data array alone; coordinates, attrs, and copies made by lat
 
 ## Merged coordinates
 
-Assembly builds the chunked dimension's coordinate by exact concatenation of the member coordinates: contiguous members fuse to a plain evenly sampled range, and every real seam is recorded. When `snap_coords=True` (default) the result is then simplified with **bounded error** — no coordinate value moves more than `tolerance * step`, or more than the tolerance itself when it states a distance. A within-tolerance gap therefore comes back as an evenly sampled range whose worst label error is about half the gap (never more than the tolerance); this is the honest replacement for the old unconditional snap, whose error was unbounded. With `snap_coords=False`, or when accumulated gaps exceed the bound, the coordinate stays segmented — exactly non-uniform, with every gap queryable.
+Assembly builds the chunked dimension's coordinate by exact concatenation of the member coordinates: contiguous members fuse to a plain evenly sampled range, and every real seam is recorded. When `snap_coords=True` (default) the result is then simplified with **bounded error** — no coordinate value moves more than `tolerance * step`, or more than the tolerance itself when it states the limit in the coordinate's own units. A within-tolerance gap therefore comes back as an evenly sampled range whose worst label error is about half the gap (never more than the tolerance); this is the honest replacement for the old unconditional snap, whose error was unbounded. With `snap_coords=False`, or when accumulated gaps exceed the bound, the coordinate stays segmented — exactly non-uniform, with every gap queryable.
 
 ```{python}
 from dascore.core.coords import CoordRange, CoordSegmented
@@ -164,7 +164,7 @@ deviation = abs(snapped_coord.values - coord.values).max()
 assert deviation <= 5 * time.step
 
 # An absolute tolerance -- a quantity, or a timedelta -- bounds the
-# same movement, stated as a distance rather than a sample count.
+# same movement, stated in the coordinate's units rather than in samples.
 with pytest.warns(UserWarning, match="force merging"):
     absolute = dc.spool([p1, p_gap]).chunk(time=None, tolerance=5 * time.step)[0]
 assert absolute.get_coord("time") == snapped_coord

--- a/docs/notes/spool_chunking.qmd
+++ b/docs/notes/spool_chunking.qmd
@@ -34,7 +34,7 @@ Patches may only combine when they agree on all of:
 1. **Kind** — the config option `patch_kind_attrs` by default (conventional categorical identity: acquisition key, data category, and tag; see [Patch Compatibility](patch_compatibility.qmd)), overridden per call with `group=`. Differing values are never an error; the patches simply land in separate outputs. A missing value is a value: patches which never recorded an attribute partition together, and apart from those which did. Explicitly passed names must exist somewhere in the spool; config names are best-effort.
 2. **Structure** — the dimensions tuple, the coordinate identity of every non-chunked dimension, and the chunked dimension's units (a metre patch can never plan into one output with a seconds patch, or a unitful with a unitless one; compatible spellings such as metres and feet are normalized to one unit per dimensionality before partitioning, so they plan together, and assembly converts each member to the first member's units).
 3. **Sampling** — step magnitudes within the relative tolerance `config.sampling_group_tolerance` (default 5%) of the group's smallest member, with matching orientation (ascending never merges with descending; contiguous descending patches merge with each other).
-4. **Continuity** — patches within `tolerance` samples of each other, evaluated within each group so unrelated patches can never bridge a gap.
+4. **Continuity** — patches within `tolerance` samples of each other, evaluated within each group so unrelated patches can never bridge a gap. `tolerance` may also be a quantity (`1 * s`, `2 * m`) or a timedelta, which states the same limit as a distance in the coordinate's own units rather than as a sample count. Since it needs no sampling interval, an absolute tolerance also measures gaps between patches whose step is unknown, which a sample count cannot scale and so never splits.
 
 [`Spool.get_gaps`](`dascore.core.spool.Spool.get_gaps`) and [`Spool.get_coverage`](`dascore.core.spool.Spool.get_coverage`) read this same partition: a `get_coverage` row is one cell of criteria 1-3, and a `get_gaps` row is a boundary criterion 4 declines to close. So on a spool of unplanned patches the counts tie — merging yields one patch per coverage row plus one per gap reported. The reports read the rows a spool presents rather than a plan's members, so a spool that has already been chunked reports on the patches it now holds, and re-chunking it need not reproduce those counts.
 
@@ -162,6 +162,12 @@ snapped_coord = snapped.get_coord("time")
 assert isinstance(snapped_coord, CoordRange)
 deviation = abs(snapped_coord.values - coord.values).max()
 assert deviation <= 5 * time.step
+
+# An absolute tolerance -- a quantity, or a timedelta -- bounds the
+# same movement, stated as a distance rather than a sample count.
+with pytest.warns(UserWarning, match="force merging"):
+    absolute = dc.spool([p1, p_gap]).chunk(time=None, tolerance=5 * time.step)[0]
+assert absolute.get_coord("time") == snapped_coord
 ```
 
 Segmented coordinates are an in-memory representation only: a written patch must be contiguous, so saving raises unless `split=True` (or `patch.split_gaps()` is used first) to write each contiguous section as its own patch.

--- a/docs/notes/spool_chunking.qmd
+++ b/docs/notes/spool_chunking.qmd
@@ -133,7 +133,7 @@ A size measures the data array alone; coordinates, attrs, and copies made by lat
 
 ## Merged coordinates
 
-Assembly builds the chunked dimension's coordinate by exact concatenation of the member coordinates: contiguous members fuse to a plain evenly sampled range, and every real seam is recorded. When `snap_coords=True` (default) the result is then simplified with **bounded error** — no coordinate value moves more than `tolerance * step`. A within-tolerance gap therefore comes back as an evenly sampled range whose worst label error is about half the gap (never more than the tolerance); this is the honest replacement for the old unconditional snap, whose error was unbounded. With `snap_coords=False`, or when accumulated gaps exceed the bound, the coordinate stays segmented — exactly non-uniform, with every gap queryable.
+Assembly builds the chunked dimension's coordinate by exact concatenation of the member coordinates: contiguous members fuse to a plain evenly sampled range, and every real seam is recorded. When `snap_coords=True` (default) the result is then simplified with **bounded error** — no coordinate value moves more than `tolerance * step`, or more than the tolerance itself when it states a distance. A within-tolerance gap therefore comes back as an evenly sampled range whose worst label error is about half the gap (never more than the tolerance); this is the honest replacement for the old unconditional snap, whose error was unbounded. With `snap_coords=False`, or when accumulated gaps exceed the bound, the coordinate stays segmented — exactly non-uniform, with every gap queryable.
 
 ```{python}
 from dascore.core.coords import CoordRange, CoordSegmented

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -347,7 +347,7 @@ gappy = random_spool(time_gap=np.timedelta64(1, "s"), length=3)
 gappy.get_gaps()
 ```
 
-`time_min` is the last sample before the gap and `time_max` the first sample after it, so `gap_size` is one step wider than the extent actually missing; subtract the magnitude of the `time_step` column for the extent itself. Overlapping patches are never a gap, and neither is a hole the `tolerance` covers — a boundary is a gap once it exceeds `tolerance` samples, so at the default 1.5 a single missing sample already counts. A quantity or timedelta states the same limit as a distance instead — `get_gaps(tolerance=1 * s)` reports every hole wider than a second, whatever the sampling rate. It is the same `tolerance` `chunk` takes, so widening it here predicts exactly which merges will succeed.
+`time_min` is the last sample before the gap and `time_max` the first sample after it, so `gap_size` is one step wider than the extent actually missing; subtract the magnitude of the `time_step` column for the extent itself. Overlapping patches are never a gap, and neither is a hole the `tolerance` covers — a boundary is a gap once it exceeds `tolerance` samples, so at the default 1.5 a single missing sample already counts. A quantity or timedelta states the same limit in the coordinate's own units instead — `get_gaps(tolerance=1 * s)` reports every boundary wider than a second, whatever the sampling rate — and never reports one narrower than a single sample, so contiguous patches stay contiguous. It is the same `tolerance` `chunk` takes, so widening it here predicts exactly which merges will succeed.
 
 Pass another dimension to ask about it instead; `time` is only the default.
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -347,7 +347,7 @@ gappy = random_spool(time_gap=np.timedelta64(1, "s"), length=3)
 gappy.get_gaps()
 ```
 
-`time_min` is the last sample before the gap and `time_max` the first sample after it, so `gap_size` is one step wider than the extent actually missing; subtract the magnitude of the `time_step` column for the extent itself. Overlapping patches are never a gap, and neither is a hole the `tolerance` covers — a boundary is a gap once it exceeds `tolerance` samples, so at the default 1.5 a single missing sample already counts. It is the same `tolerance` `chunk` takes, so widening it here predicts exactly which merges will succeed.
+`time_min` is the last sample before the gap and `time_max` the first sample after it, so `gap_size` is one step wider than the extent actually missing; subtract the magnitude of the `time_step` column for the extent itself. Overlapping patches are never a gap, and neither is a hole the `tolerance` covers — a boundary is a gap once it exceeds `tolerance` samples, so at the default 1.5 a single missing sample already counts. A quantity or timedelta states the same limit as a distance instead — `get_gaps(tolerance=1 * s)` reports every hole wider than a second, whatever the sampling rate. It is the same `tolerance` `chunk` takes, so widening it here predicts exactly which merges will succeed.
 
 Pass another dimension to ask about it instead; `time` is only the default.
 

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import random
 import warnings
+from datetime import timedelta
 from itertools import pairwise
 
 import numpy as np
@@ -17,7 +18,7 @@ import pytest
 
 import dascore as dc
 import dascore.utils.patch_assembly as assembly_module
-from dascore.core.coords import CoordSegmented
+from dascore.core.coords import CoordRange, CoordSegmented
 from dascore.exceptions import ChunkError, CoordMergeError, ParameterError, UnitError
 from dascore.units import get_quantity
 from dascore.utils.misc import get_middle_value, suppress_warnings
@@ -1205,15 +1206,25 @@ class TestUnitChunkValue:
 
 
 class TestQuantityTolerance:
-    """Continuity tolerances stated as a distance rather than samples."""
+    """Continuity tolerances stated in the coordinate's own units."""
 
     @staticmethod
     def _gapped(patch, samples):
-        """Two patches separated by a hole `samples` steps wide."""
+        """Two patches whose boundary spans `samples` steps; `samples - 1` missing."""
         base = patch.update_attrs(history="")
         time = patch.get_coord("time")
         after = base.update_coords(
             time_min=time.max() + time.step * samples
+        ).update_attrs(history="")
+        return dc.spool((base, after))
+
+    @staticmethod
+    def _shifted(patch, dim, steps):
+        """Two patches whose boundary along `dim` spans `steps` steps."""
+        base = patch.update_attrs(history="")
+        coord = patch.get_coord(dim)
+        after = base.update_coords(
+            **{f"{dim}_min": coord.max() + coord.step * steps}
         ).update_attrs(history="")
         return dc.spool((base, after))
 
@@ -1226,15 +1237,6 @@ class TestQuantityTolerance:
         assert len(merged) == 1
         assert len(spool.chunk(time=None, tolerance=get_quantity(f"{step} s"))) == 2
 
-    def test_matches_equivalent_sample_count(self, random_patch):
-        """The same limit stated either way partitions identically."""
-        step = dc.to_float(random_patch.get_coord("time").step)
-        spool = self._gapped(random_patch, 5)
-        with suppress_warnings(UserWarning):
-            quantity = spool.chunk(time=None, tolerance=get_quantity(f"{6 * step} s"))
-            samples = spool.chunk(time=None, tolerance=6)
-        assert len(quantity) == len(samples) == 1
-
     def test_merged_coord_simplifies(self, random_patch):
         """A merge under an absolute tolerance still snaps to a range."""
         step = dc.to_float(random_patch.get_coord("time").step)
@@ -1244,28 +1246,88 @@ class TestQuantityTolerance:
         assert merged[0].get_coord("time").step is not None
 
     def test_distance_unit_converts(self, random_spool):
-        """A tolerance in feet is read in the coordinate's metres."""
+        """A tolerance in feet is read in the coordinate's metres, not as metres."""
         patch = random_spool[0]
-        step = patch.get_coord("distance").step
-        shifted = patch.update_coords(
-            distance_min=patch.get_coord("distance").max() + step * 4
-        )
-        spool = dc.spool([patch, shifted])
-        hole = float(step) * 4  # the distance from one patch's end to the next
+        step = float(patch.get_coord("distance").step)
+        spool = self._shifted(patch, "distance", 9)
+        hole = step * 9
+        # 20 ft is 6.1 m, under the 9 m hole; 40 ft is 12.2 m, over it.
+        # Read as metres instead, both would clear it and both legs would
+        # merge, so the pair pins the conversion in both directions.
+        assert step == 1.0 and hole == 9.0
         with suppress_warnings(UserWarning):
-            wide = 2 * hole
-            feet = spool.chunk(distance=None, tolerance=wide / 0.3048 * dc.units.ft)
-            metres = spool.chunk(distance=None, tolerance=wide * dc.units.m)
-        assert len(feet) == len(metres) == 1
-        assert len(spool.chunk(distance=None, tolerance=hole / 2 * dc.units.m)) == 2
+            wide = spool.chunk(distance=None, tolerance=40 * dc.units.ft)
+        assert len(wide) == 1
+        assert len(spool.chunk(distance=None, tolerance=20 * dc.units.ft)) == 2
+
+    def test_non_time_merge_assembles(self, random_spool):
+        """A distance merge under a converted tolerance assembles whole."""
+        spool = self._shifted(random_spool[0], "distance", 3)
+        with pytest.warns(UserWarning, match="gap in the patch"):
+            merged = spool.chunk(distance=None, tolerance=4 / 0.3048 * dc.units.ft)[0]
+        coord = merged.get_coord("distance")
+        assert coord.step is not None
+        assert len(coord) == sum(len(x.get_coord("distance")) for x in spool)
 
     def test_dimensionless_is_a_sample_count(self, random_patch):
-        """A dimensionless quantity means what the bare number means."""
-        spool = self._gapped(random_patch, 5)
+        """A dimensionless quantity is samples, not the coordinate's units."""
+        # A hole of 6 steps is 0.024 s: six samples merge it, and six
+        # seconds would too, so the gap has to be wide in seconds and
+        # narrow in samples to tell the two readings apart.
+        step = dc.to_float(random_patch.get_coord("time").step)
+        spool = self._gapped(random_patch, 3)
+        seconds_would_merge = 3 * step < 6
+        assert seconds_would_merge
+        assert (
+            len(spool.chunk(time=None, tolerance=get_quantity("2 dimensionless"))) == 2
+        )
         with suppress_warnings(UserWarning):
             quantity = spool.chunk(time=None, tolerance=get_quantity("6 dimensionless"))
             number = spool.chunk(time=None, tolerance=6)
         assert len(quantity) == len(number) == 1
+
+    def test_timedelta_is_absolute(self, random_patch):
+        """A timedelta says the same thing as a time quantity."""
+        step = random_patch.get_coord("time").step
+        spool = self._gapped(random_patch, 5)
+        with suppress_warnings(UserWarning):
+            delta = spool.chunk(time=None, tolerance=6 * step)
+            quantity = spool.chunk(
+                time=None, tolerance=get_quantity(f"{6 * dc.to_float(step)} s")
+            )
+        assert len(delta) == len(quantity) == 1
+        assert delta[0].equals(quantity[0])
+        assert len(spool.chunk(time=None, tolerance=step)) == 2
+
+    def test_datetime_timedelta_accepted(self, random_patch):
+        """The stdlib timedelta is a timedelta too."""
+        spool = self._gapped(random_patch, 5)
+        with suppress_warnings(UserWarning):
+            out = spool.chunk(time=None, tolerance=timedelta(seconds=1))
+        assert len(out) == 1
+
+    def test_timedelta_reads_a_numeric_time_coord(self, random_patch):
+        """A numeric coordinate measured in seconds takes a timedelta."""
+        coord = random_patch.get_coord("time")
+        numeric = dc.core.get_coord(
+            start=0.0, stop=float(len(coord)), step=1.0, units="s"
+        )
+        base = random_patch.rename_coords(time="shot").update_coords(shot=numeric)
+        spool = self._shifted(base, "shot", 3)
+        with suppress_warnings(UserWarning):
+            delta = spool.chunk(shot=None, tolerance=to_timedelta64(4))
+            quantity = spool.chunk(shot=None, tolerance=get_quantity("4 s"))
+        assert len(delta) == len(quantity) == 1
+        assert len(spool.chunk(shot=None, tolerance=to_timedelta64(1))) == 2
+
+    def test_sub_step_tolerance_keeps_contiguity(self, random_spool):
+        """A margin narrower than the step never splits adjacent patches."""
+        # The boundary between adjacent patches is one full step, so a
+        # tolerance under it must still read as "nothing missing".
+        tiny = get_quantity("1 ns")
+        assert len(random_spool.chunk(time=None, tolerance=tiny)) == 1
+        assert random_spool.get_gaps(tolerance=tiny).empty
+        assert (random_spool.get_coverage(tolerance=tiny)["coverage"] == 1).all()
 
     def test_unknown_step_gap_is_found(self, random_patch):
         """An absolute tolerance needs no sampling interval to measure a gap."""
@@ -1286,11 +1348,37 @@ class TestQuantityTolerance:
         # the sample count has no step to scale, so it merges blindly
         assert len(spool.chunk(time=None)) == 1
         assert len(spool.chunk(time=None, tolerance=get_quantity("0.5 s"))) == 2
+        # and the merging side of the same branch, which needs no step
+        with suppress_warnings(UserWarning):
+            merged = spool.chunk(time=None, tolerance=get_quantity("30 s"))
+        assert len(merged) == 1
+        assert len(merged[0].get_coord("time")) == sum(
+            len(x.get_coord("time")) for x in spool
+        )
+
+    def test_affine_units_convert_as_a_delta(self, random_patch):
+        """A tolerance is a difference, so an affine unit's offset cancels."""
+        coord = random_patch.get_coord("distance")
+        celsius = dc.core.get_coord(
+            start=0.0, stop=float(len(coord)), step=1.0, units="degC"
+        )
+        base = random_patch.rename_coords(distance="temp").update_coords(temp=celsius)
+        spool = self._shifted(base, "temp", 3)
+        # 4 K of extent is 4 degC of extent; read as a point it would be
+        # -269.15 degC, which simplify refuses as negative.
+        with suppress_warnings(UserWarning):
+            merged = spool.chunk(temp=None, tolerance=4 * dc.units.kelvin)[0]
+        assert merged.get_coord("temp").step is not None
 
     def test_wrong_dimensionality_raises(self, random_spool):
         """A tolerance must measure the dimension it is applied to."""
-        with pytest.raises(UnitError, match="time-like"):
+        with pytest.raises(UnitError, match="must have units of time"):
             random_spool.chunk(time=None, tolerance=10 * dc.units.m)
+
+    def test_timedelta_on_other_dim_raises(self, random_spool):
+        """A time tolerance cannot measure a coordinate of metres."""
+        with pytest.raises(UnitError, match="incompatible with the coordinate"):
+            random_spool.chunk(distance=None, tolerance=to_timedelta64(1))
 
     def test_unitless_coord_raises(self, random_spool):
         """A unit-bearing tolerance needs a coordinate with units."""
@@ -1303,102 +1391,42 @@ class TestQuantityTolerance:
         with pytest.raises(UnitError, match="data size"):
             random_spool.chunk(time=None, tolerance=get_quantity("25 MB"))
 
-    def test_negative_raises(self, random_spool):
-        """A negative distance is not a tolerance."""
-        with pytest.raises(ParameterError, match="not be negative"):
-            random_spool.chunk(time=None, tolerance=get_quantity("-1 s"))
+    def test_percent_raises(self, random_spool):
+        """A percentage is neither a count nor a length."""
+        with pytest.raises(UnitError, match="percentage"):
+            random_spool.chunk(time=None, tolerance=get_quantity("50%"))
 
-    def test_nan_raises(self, random_spool):
-        """A null tolerance would silently merge everything."""
-        with pytest.raises(ParameterError, match="finite"):
-            random_spool.chunk(time=None, tolerance=np.nan * dc.units.s)
+    def test_unrepresentable_time_raises(self, random_spool):
+        """A time too large for a timedelta64 says so, rather than overflowing."""
+        with pytest.raises(ParameterError, match="too large"):
+            random_spool.chunk(time=None, tolerance=get_quantity("1e11 s"))
 
-    def test_array_raises(self, random_spool):
-        """One tolerance, not one per patch."""
-        with pytest.raises(ParameterError, match="single quantity"):
-            random_spool.chunk(time=None, tolerance=np.array([1.0, 2.0]) * dc.units.s)
+    @pytest.mark.parametrize(
+        "tolerance,match",
+        [
+            (np.nan, "finite"),
+            (np.timedelta64("NaT"), "finite"),
+            (np.inf * dc.units.s, "finite"),
+            (-1, "not be negative"),
+            (get_quantity("-1 dimensionless"), "not be negative"),
+            (get_quantity("-1 s"), "not be negative"),
+            (-to_timedelta64(1), "not be negative"),
+            (np.array([2]), "single value"),
+            (np.array([1.0, 2.0]), "single value"),
+            (np.array([1.0, 2.0]) * dc.units.s, "single value"),
+            ("2 s", "get_quantity"),
+        ],
+    )
+    def test_unmeasurable_tolerance_raises(self, random_spool, tolerance, match):
+        """A tolerance no gap could be measured against is refused."""
+        with pytest.raises(ParameterError, match=match):
+            random_spool.chunk(time=None, tolerance=tolerance)
 
-    def test_timedelta_is_absolute(self, random_patch):
-        """A timedelta says the same thing as a time quantity."""
-        step = random_patch.get_coord("time").step
-        spool = self._gapped(random_patch, 5)
-        with suppress_warnings(UserWarning):
-            delta = spool.chunk(time=None, tolerance=6 * step)
-            quantity = spool.chunk(
-                time=None, tolerance=get_quantity(f"{6 * dc.to_float(step)} s")
-            )
-        assert len(delta) == len(quantity) == 1
-        assert delta[0].equals(quantity[0])
-        assert len(spool.chunk(time=None, tolerance=step)) == 2
-
-    def test_timedelta_on_other_dim_raises(self, random_spool):
-        """Only a time-like coordinate is measured in timedeltas."""
-        with pytest.raises(UnitError, match="not time-like"):
-            random_spool.chunk(distance=None, tolerance=to_timedelta64(1))
-
-    def test_null_timedelta_raises(self, random_spool):
-        """A null tolerance would silently merge everything."""
-        with pytest.raises(ParameterError, match="finite"):
-            random_spool.chunk(time=None, tolerance=np.timedelta64("NaT"))
-
-    def test_negative_timedelta_raises(self, random_spool):
-        """A negative distance is not a tolerance."""
-        with pytest.raises(ParameterError, match="not be negative"):
-            random_spool.chunk(time=None, tolerance=-to_timedelta64(1))
-
-    def test_snap_coords_false_keeps_seam(self, random_patch):
-        """The tolerance merges the patches; snap_coords says how to label them."""
-        step = random_patch.get_coord("time").step
-        spool = self._gapped(random_patch, 3)
+    def test_infinite_sample_count_merges_everything(self, random_patch):
+        """An infinite count is a coherent request: no boundary is a gap."""
+        spool = self._gapped(random_patch, 500)
         with pytest.warns(UserWarning, match="gap in the patch"):
-            exact = spool.chunk(time=None, tolerance=4 * step, snap_coords=False)[0]
-        coord = exact.get_coord("time")
-        assert isinstance(coord, CoordSegmented)
-        assert len(coord.get_discontinuities("gaps")) == 1
-
-    def test_snapped_values_stay_within_tolerance(self, random_patch):
-        """Simplifying under an absolute tolerance moves no value past it."""
-        step = random_patch.get_coord("time").step
-        spool = self._gapped(random_patch, 3)
-        with pytest.warns(UserWarning, match="gap in the patch"):
-            snapped = spool.chunk(time=None, tolerance=4 * step)[0]
-            exact = spool.chunk(time=None, tolerance=4 * step, snap_coords=False)[0]
-        deviation = abs(
-            snapped.get_coord("time").values - exact.get_coord("time").values
-        ).max()
-        assert deviation <= 4 * step
-
-    def test_non_time_merge_assembles(self, random_spool):
-        """A distance merge under a converted tolerance produces one patch."""
-        patch = random_spool[0].update_attrs(history="")
-        step = patch.get_coord("distance").step
-        shifted = patch.update_coords(
-            distance_min=patch.get_coord("distance").max() + step * 3
-        ).update_attrs(history="")
-        spool = dc.spool([patch, shifted])
-        tolerance = (float(step) * 4) / 0.3048 * dc.units.ft
-        with pytest.warns(UserWarning, match="gap in the patch"):
-            merged = spool.chunk(distance=None, tolerance=tolerance)[0]
-        coord = merged.get_coord("distance")
-        assert coord.step is not None
-        assert len(coord) == sum(len(x.get_coord("distance")) for x in spool)
-
-    def test_infinite_raises(self, random_spool):
-        """A tolerance which admits every gap is not a tolerance."""
-        for tolerance in (np.inf, np.inf * dc.units.s):
-            with pytest.raises(ParameterError, match="finite"):
-                random_spool.chunk(time=None, tolerance=tolerance)
-
-    def test_null_number_raises(self, random_spool):
-        """A null sample count would silently merge everything."""
-        with pytest.raises(ParameterError, match="finite"):
-            random_spool.chunk(time=None, tolerance=np.nan)
-
-    def test_negative_number_raises(self, random_spool):
-        """A negative sample count would split contiguous patches."""
-        for tolerance in (-1, get_quantity("-1 dimensionless")):
-            with pytest.raises(ParameterError, match="not be negative"):
-                random_spool.chunk(time=None, tolerance=tolerance)
+            assert len(spool.chunk(time=None, tolerance=np.inf)) == 1
 
     def test_exchanged_boundary_warns(self):
         """A forced merge warns even when the partition count is unchanged."""
@@ -1415,7 +1443,7 @@ class TestQuantityTolerance:
             return dc.Patch(data=data, coords=coords, dims=("distance", "time"))
 
         # Steps within the sampling group tolerance, so all three patches
-        # share a cell, and holes which the default and a 1.53 s
+        # share a cell; the holes are chosen so the default and a 1.53 s
         # tolerance split at *different* boundaries.
         first = _patch(t0, 1.0)
         second = _patch(first.get_coord("time").max() + to_timedelta64(1.55), 1.04)
@@ -1428,16 +1456,35 @@ class TestQuantityTolerance:
         # the same count, but not the same split
         assert default[0].get_coord("time").max() != absolute[0].get_coord("time").max()
 
-    def test_array_tolerance_raises(self, random_spool):
-        """One tolerance, not one per patch, even wrapped in an array."""
-        for tolerance in (np.array([2]), np.array([1.0, 2.0])):
-            with pytest.raises(ParameterError, match="single value"):
-                random_spool.chunk(time=None, tolerance=tolerance)
+    def test_merge_uses_the_normalized_tolerance(self, random_spool):
+        """The merge gets the tolerance the plan resolved, not the raw one.
 
-    def test_string_tolerance_says_what_to_do(self, random_spool):
-        """A unit-bearing string names the call which makes it a quantity."""
-        with pytest.raises(ParameterError, match="get_quantity"):
-            random_spool.chunk(time=None, tolerance="2 s")
+        Asserted on what the merge is handed rather than on a merged
+        coordinate: a dimensionless quantity reaching `simplify` is read
+        as *seconds*, which only shows up in a merged coordinate for
+        gap geometries where the snap bound is the binding constraint.
+        """
+        out = random_spool.chunk(time=None, tolerance=get_quantity("2"))
+        handed = out._catalog.resolver.merge_kwargs["tolerance"]
+        # a dimensionless quantity compares equal to the number it holds,
+        # so the type is what says which value was handed over
+        assert not isinstance(handed, dc.units.Quantity)
+        assert handed == 2.0
+
+    def test_snap_bound_holds_at_the_tolerance(self, random_patch):
+        """Simplifying under an absolute tolerance moves no value past it."""
+        step = random_patch.get_coord("time").step
+        spool = self._gapped(random_patch, 40)
+        with pytest.warns(UserWarning, match="gap in the patch"):
+            snapped = spool.chunk(time=None, tolerance=41 * step)[0]
+            exact = spool.chunk(time=None, tolerance=41 * step, snap_coords=False)[0]
+        snapped_coord, exact_coord = (x.get_coord("time") for x in (snapped, exact))
+        # the hole is wide enough that a looser bound would show: the
+        # exact coordinate keeps the seam, the snapped one does not
+        assert isinstance(exact_coord, CoordSegmented)
+        assert isinstance(snapped_coord, CoordRange)
+        deviation = abs(snapped_coord.values - exact_coord.values).max()
+        assert deviation <= 41 * step
 
     def test_plan_records_normalized_tolerance(self, random_spool):
         """The plan records the tolerance it actually used."""

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -20,7 +20,7 @@ import dascore.utils.patch_assembly as assembly_module
 from dascore.core.coords import CoordSegmented
 from dascore.exceptions import ChunkError, CoordMergeError, ParameterError, UnitError
 from dascore.units import get_quantity
-from dascore.utils.misc import get_middle_value
+from dascore.utils.misc import get_middle_value, suppress_warnings
 from dascore.utils.patch import _get_merged_coord
 from dascore.utils.patch_assembly import PatchAssembler, _match_merge_units
 from dascore.utils.time import to_timedelta64
@@ -1230,8 +1230,7 @@ class TestQuantityTolerance:
         """The same limit stated either way partitions identically."""
         step = dc.to_float(random_patch.get_coord("time").step)
         spool = self._gapped(random_patch, 5)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+        with suppress_warnings(UserWarning):
             quantity = spool.chunk(time=None, tolerance=get_quantity(f"{6 * step} s"))
             samples = spool.chunk(time=None, tolerance=6)
         assert len(quantity) == len(samples) == 1
@@ -1253,8 +1252,7 @@ class TestQuantityTolerance:
         )
         spool = dc.spool([patch, shifted])
         hole = float(step) * 4  # the distance from one patch's end to the next
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+        with suppress_warnings(UserWarning):
             wide = 2 * hole
             feet = spool.chunk(distance=None, tolerance=wide / 0.3048 * dc.units.ft)
             metres = spool.chunk(distance=None, tolerance=wide * dc.units.m)
@@ -1264,8 +1262,7 @@ class TestQuantityTolerance:
     def test_dimensionless_is_a_sample_count(self, random_patch):
         """A dimensionless quantity means what the bare number means."""
         spool = self._gapped(random_patch, 5)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+        with suppress_warnings(UserWarning):
             quantity = spool.chunk(time=None, tolerance=get_quantity("6 dimensionless"))
             number = spool.chunk(time=None, tolerance=6)
         assert len(quantity) == len(number) == 1
@@ -1325,8 +1322,7 @@ class TestQuantityTolerance:
         """A timedelta says the same thing as a time quantity."""
         step = random_patch.get_coord("time").step
         spool = self._gapped(random_patch, 5)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+        with suppress_warnings(UserWarning):
             delta = spool.chunk(time=None, tolerance=6 * step)
             quantity = spool.chunk(
                 time=None, tolerance=get_quantity(f"{6 * dc.to_float(step)} s")
@@ -1431,6 +1427,12 @@ class TestQuantityTolerance:
         assert len(default) == len(absolute) == 2
         # the same count, but not the same split
         assert default[0].get_coord("time").max() != absolute[0].get_coord("time").max()
+
+    def test_array_tolerance_raises(self, random_spool):
+        """One tolerance, not one per patch, even wrapped in an array."""
+        for tolerance in (np.array([2]), np.array([1.0, 2.0])):
+            with pytest.raises(ParameterError, match="single value"):
+                random_spool.chunk(time=None, tolerance=tolerance)
 
     def test_string_tolerance_says_what_to_do(self, random_spool):
         """A unit-bearing string names the call which makes it a quantity."""

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -17,6 +17,7 @@ import pytest
 
 import dascore as dc
 import dascore.utils.patch_assembly as assembly_module
+from dascore.core.coords import CoordSegmented
 from dascore.exceptions import ChunkError, CoordMergeError, ParameterError, UnitError
 from dascore.units import get_quantity
 from dascore.utils.misc import get_middle_value
@@ -1201,6 +1202,247 @@ class TestUnitChunkValue:
         patches = [x.set_units(distance=None) for x in random_spool]
         with pytest.raises(UnitError, match="no units"):
             dc.spool(patches).chunk(distance=100 * dc.units.ft)
+
+
+class TestQuantityTolerance:
+    """Continuity tolerances stated as a distance rather than samples."""
+
+    @staticmethod
+    def _gapped(patch, samples):
+        """Two patches separated by a hole `samples` steps wide."""
+        base = patch.update_attrs(history="")
+        time = patch.get_coord("time")
+        after = base.update_coords(
+            time_min=time.max() + time.step * samples
+        ).update_attrs(history="")
+        return dc.spool((base, after))
+
+    def test_merges_gap_it_spans(self, random_patch):
+        """A tolerance wider than the hole merges over it; a tighter one does not."""
+        step = dc.to_float(random_patch.get_coord("time").step)
+        spool = self._gapped(random_patch, 5)
+        with pytest.warns(UserWarning, match="gap in the patch"):
+            merged = spool.chunk(time=None, tolerance=get_quantity(f"{5 * step} s"))
+        assert len(merged) == 1
+        assert len(spool.chunk(time=None, tolerance=get_quantity(f"{step} s"))) == 2
+
+    def test_matches_equivalent_sample_count(self, random_patch):
+        """The same limit stated either way partitions identically."""
+        step = dc.to_float(random_patch.get_coord("time").step)
+        spool = self._gapped(random_patch, 5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            quantity = spool.chunk(time=None, tolerance=get_quantity(f"{6 * step} s"))
+            samples = spool.chunk(time=None, tolerance=6)
+        assert len(quantity) == len(samples) == 1
+
+    def test_merged_coord_simplifies(self, random_patch):
+        """A merge under an absolute tolerance still snaps to a range."""
+        step = dc.to_float(random_patch.get_coord("time").step)
+        spool = self._gapped(random_patch, 3)
+        with pytest.warns(UserWarning, match="gap in the patch"):
+            merged = spool.chunk(time=None, tolerance=get_quantity(f"{4 * step} s"))
+        assert merged[0].get_coord("time").step is not None
+
+    def test_distance_unit_converts(self, random_spool):
+        """A tolerance in feet is read in the coordinate's metres."""
+        patch = random_spool[0]
+        step = patch.get_coord("distance").step
+        shifted = patch.update_coords(
+            distance_min=patch.get_coord("distance").max() + step * 4
+        )
+        spool = dc.spool([patch, shifted])
+        hole = float(step) * 4  # the distance from one patch's end to the next
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            wide = 2 * hole
+            feet = spool.chunk(distance=None, tolerance=wide / 0.3048 * dc.units.ft)
+            metres = spool.chunk(distance=None, tolerance=wide * dc.units.m)
+        assert len(feet) == len(metres) == 1
+        assert len(spool.chunk(distance=None, tolerance=hole / 2 * dc.units.m)) == 2
+
+    def test_dimensionless_is_a_sample_count(self, random_patch):
+        """A dimensionless quantity means what the bare number means."""
+        spool = self._gapped(random_patch, 5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            quantity = spool.chunk(time=None, tolerance=get_quantity("6 dimensionless"))
+            number = spool.chunk(time=None, tolerance=6)
+        assert len(quantity) == len(number) == 1
+
+    def test_unknown_step_gap_is_found(self, random_patch):
+        """An absolute tolerance needs no sampling interval to measure a gap."""
+
+        def _jitter(patch, offset):
+            time = patch.get_coord("time").values + offset
+            rng = np.random.default_rng(13)
+            jittered = time + (rng.random(len(time)) * 1e6).astype("timedelta64[ns]")
+            return patch.update_coords(time=np.sort(jittered)).update_attrs(history="")
+
+        spool = dc.spool(
+            [
+                _jitter(random_patch, np.timedelta64(0, "s")),
+                _jitter(random_patch, np.timedelta64(20, "s")),
+            ]
+        )
+        assert pd.isnull(spool.get_contents()["time_step"]).all()
+        # the sample count has no step to scale, so it merges blindly
+        assert len(spool.chunk(time=None)) == 1
+        assert len(spool.chunk(time=None, tolerance=get_quantity("0.5 s"))) == 2
+
+    def test_wrong_dimensionality_raises(self, random_spool):
+        """A tolerance must measure the dimension it is applied to."""
+        with pytest.raises(UnitError, match="time-like"):
+            random_spool.chunk(time=None, tolerance=10 * dc.units.m)
+
+    def test_unitless_coord_raises(self, random_spool):
+        """A unit-bearing tolerance needs a coordinate with units."""
+        patches = [x.set_units(distance=None) for x in random_spool]
+        with pytest.raises(UnitError, match="no units"):
+            dc.spool(patches).chunk(distance=None, tolerance=10 * dc.units.ft)
+
+    def test_data_size_raises(self, random_spool):
+        """A data size does not describe a hole along a coordinate."""
+        with pytest.raises(UnitError, match="data size"):
+            random_spool.chunk(time=None, tolerance=get_quantity("25 MB"))
+
+    def test_negative_raises(self, random_spool):
+        """A negative distance is not a tolerance."""
+        with pytest.raises(ParameterError, match="not be negative"):
+            random_spool.chunk(time=None, tolerance=get_quantity("-1 s"))
+
+    def test_nan_raises(self, random_spool):
+        """A null tolerance would silently merge everything."""
+        with pytest.raises(ParameterError, match="finite"):
+            random_spool.chunk(time=None, tolerance=np.nan * dc.units.s)
+
+    def test_array_raises(self, random_spool):
+        """One tolerance, not one per patch."""
+        with pytest.raises(ParameterError, match="single quantity"):
+            random_spool.chunk(time=None, tolerance=np.array([1.0, 2.0]) * dc.units.s)
+
+    def test_timedelta_is_absolute(self, random_patch):
+        """A timedelta says the same thing as a time quantity."""
+        step = random_patch.get_coord("time").step
+        spool = self._gapped(random_patch, 5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            delta = spool.chunk(time=None, tolerance=6 * step)
+            quantity = spool.chunk(
+                time=None, tolerance=get_quantity(f"{6 * dc.to_float(step)} s")
+            )
+        assert len(delta) == len(quantity) == 1
+        assert delta[0].equals(quantity[0])
+        assert len(spool.chunk(time=None, tolerance=step)) == 2
+
+    def test_timedelta_on_other_dim_raises(self, random_spool):
+        """Only a time-like coordinate is measured in timedeltas."""
+        with pytest.raises(UnitError, match="not time-like"):
+            random_spool.chunk(distance=None, tolerance=to_timedelta64(1))
+
+    def test_null_timedelta_raises(self, random_spool):
+        """A null tolerance would silently merge everything."""
+        with pytest.raises(ParameterError, match="finite"):
+            random_spool.chunk(time=None, tolerance=np.timedelta64("NaT"))
+
+    def test_negative_timedelta_raises(self, random_spool):
+        """A negative distance is not a tolerance."""
+        with pytest.raises(ParameterError, match="not be negative"):
+            random_spool.chunk(time=None, tolerance=-to_timedelta64(1))
+
+    def test_snap_coords_false_keeps_seam(self, random_patch):
+        """The tolerance merges the patches; snap_coords says how to label them."""
+        step = random_patch.get_coord("time").step
+        spool = self._gapped(random_patch, 3)
+        with pytest.warns(UserWarning, match="gap in the patch"):
+            exact = spool.chunk(time=None, tolerance=4 * step, snap_coords=False)[0]
+        coord = exact.get_coord("time")
+        assert isinstance(coord, CoordSegmented)
+        assert len(coord.get_discontinuities("gaps")) == 1
+
+    def test_snapped_values_stay_within_tolerance(self, random_patch):
+        """Simplifying under an absolute tolerance moves no value past it."""
+        step = random_patch.get_coord("time").step
+        spool = self._gapped(random_patch, 3)
+        with pytest.warns(UserWarning, match="gap in the patch"):
+            snapped = spool.chunk(time=None, tolerance=4 * step)[0]
+            exact = spool.chunk(time=None, tolerance=4 * step, snap_coords=False)[0]
+        deviation = abs(
+            snapped.get_coord("time").values - exact.get_coord("time").values
+        ).max()
+        assert deviation <= 4 * step
+
+    def test_non_time_merge_assembles(self, random_spool):
+        """A distance merge under a converted tolerance produces one patch."""
+        patch = random_spool[0].update_attrs(history="")
+        step = patch.get_coord("distance").step
+        shifted = patch.update_coords(
+            distance_min=patch.get_coord("distance").max() + step * 3
+        ).update_attrs(history="")
+        spool = dc.spool([patch, shifted])
+        tolerance = (float(step) * 4) / 0.3048 * dc.units.ft
+        with pytest.warns(UserWarning, match="gap in the patch"):
+            merged = spool.chunk(distance=None, tolerance=tolerance)[0]
+        coord = merged.get_coord("distance")
+        assert coord.step is not None
+        assert len(coord) == sum(len(x.get_coord("distance")) for x in spool)
+
+    def test_infinite_raises(self, random_spool):
+        """A tolerance which admits every gap is not a tolerance."""
+        for tolerance in (np.inf, np.inf * dc.units.s):
+            with pytest.raises(ParameterError, match="finite"):
+                random_spool.chunk(time=None, tolerance=tolerance)
+
+    def test_null_number_raises(self, random_spool):
+        """A null sample count would silently merge everything."""
+        with pytest.raises(ParameterError, match="finite"):
+            random_spool.chunk(time=None, tolerance=np.nan)
+
+    def test_negative_number_raises(self, random_spool):
+        """A negative sample count would split contiguous patches."""
+        for tolerance in (-1, get_quantity("-1 dimensionless")):
+            with pytest.raises(ParameterError, match="not be negative"):
+                random_spool.chunk(time=None, tolerance=tolerance)
+
+    def test_exchanged_boundary_warns(self):
+        """A forced merge warns even when the partition count is unchanged."""
+        t0 = np.datetime64("2020-01-01T00:00:00", "ns")
+        rng = np.random.default_rng(42)
+
+        def _patch(start, step, samples=20):
+            step = to_timedelta64(step)
+            coord = dc.core.get_coord(
+                start=start, stop=start + step * samples, step=step
+            )
+            data = rng.random((5, samples))
+            coords = {"distance": np.arange(5) * 1.0, "time": coord}
+            return dc.Patch(data=data, coords=coords, dims=("distance", "time"))
+
+        # Steps within the sampling group tolerance, so all three patches
+        # share a cell, and holes which the default and a 1.53 s
+        # tolerance split at *different* boundaries.
+        first = _patch(t0, 1.0)
+        second = _patch(first.get_coord("time").max() + to_timedelta64(1.55), 1.04)
+        third = _patch(second.get_coord("time").max() + to_timedelta64(1.51), 1.0)
+        spool = dc.spool([first, second, third])
+        default = spool.chunk(time=None)
+        with pytest.warns(UserWarning, match="force merging"):
+            absolute = spool.chunk(time=None, tolerance=get_quantity("1.53 s"))
+        assert len(default) == len(absolute) == 2
+        # the same count, but not the same split
+        assert default[0].get_coord("time").max() != absolute[0].get_coord("time").max()
+
+    def test_string_tolerance_says_what_to_do(self, random_spool):
+        """A unit-bearing string names the call which makes it a quantity."""
+        with pytest.raises(ParameterError, match="get_quantity"):
+            random_spool.chunk(time=None, tolerance="2 s")
+
+    def test_plan_records_normalized_tolerance(self, random_spool):
+        """The plan records the tolerance it actually used."""
+        plan = random_spool.chunk_plan(time=None, tolerance=get_quantity("2 s"))
+        assert plan.params["tolerance"] == get_quantity("2 s")
+        plan = random_spool.chunk_plan(time=None, tolerance=get_quantity("2"))
+        assert plan.params["tolerance"] == 2.0
 
 
 class TestSizeChunk:

--- a/tests/test_core/test_patch_chunk.py
+++ b/tests/test_core/test_patch_chunk.py
@@ -1318,6 +1318,10 @@ class TestQuantityTolerance:
             delta = spool.chunk(shot=None, tolerance=to_timedelta64(4))
             quantity = spool.chunk(shot=None, tolerance=get_quantity("4 s"))
         assert len(delta) == len(quantity) == 1
+        # materialized, since the merge converts the tolerance a second
+        # time to bound the snap, and a raw timedelta cannot bound a
+        # numeric coordinate's deviations
+        assert delta[0].get_coord("shot") == quantity[0].get_coord("shot")
         assert len(spool.chunk(shot=None, tolerance=to_timedelta64(1))) == 2
 
     def test_sub_step_tolerance_keeps_contiguity(self, random_spool):

--- a/tests/test_core/test_spool_gaps.py
+++ b/tests/test_core/test_spool_gaps.py
@@ -171,7 +171,7 @@ class TestGetGaps:
 
 
 class TestQuantityTolerance:
-    """Reports whose tolerance is a distance rather than a sample count."""
+    """Reports whose tolerance is stated in the coordinate's own units."""
 
     def test_gaps_respect_absolute_tolerance(self, gappy_spool):
         """A tolerance wider than the holes leaves nothing to report."""
@@ -180,6 +180,13 @@ class TestQuantityTolerance:
         wide = gappy_spool.get_gaps(tolerance=dc.get_quantity("0.5 s"))
         assert len(wide) == len(gappy_spool) - 1
 
+    def test_timedelta_says_the_same(self, gappy_spool):
+        """A timedelta reports what the equivalent quantity reports."""
+        delta = gappy_spool.get_gaps(tolerance=2 * ONE_SECOND)
+        assert delta.empty
+        tight = gappy_spool.get_gaps(tolerance=ONE_SECOND / 2)
+        assert len(tight) == len(gappy_spool) - 1
+
     def test_coverage_respects_absolute_tolerance(self, gappy_spool):
         """Holes the tolerance closes are not missing coverage."""
         loose = gappy_spool.get_coverage(tolerance=dc.get_quantity("2 s"))
@@ -187,18 +194,26 @@ class TestQuantityTolerance:
         assert (gappy_spool.get_coverage()["coverage"] < 1).all()
 
     def test_distance_units_convert(self, distance_tiled_spool):
-        """A distance report reads the tolerance in its own units."""
+        """A distance report reads the tolerance in its own units, not as metres."""
         gaps = distance_tiled_spool.get_gaps("distance", tolerance=10 * dc.units.m)
         assert len(gaps) == 1
         hole = float(gaps["gap_size"].iloc[0])
+        # a foot is 0.3048 m, so a magnitude between the hole in feet and
+        # the hole in metres reports one way under each reading
+        between = (hole + float(gaps["distance_step"].iloc[0])) * 2
+        assert 0.3048 * between < hole < between
         feet = distance_tiled_spool.get_gaps(
-            "distance", tolerance=(hole * 2) / 0.3048 * dc.units.ft
+            "distance", tolerance=between * dc.units.ft
         )
-        assert feet.empty
+        assert len(feet) == 1
+        metres = distance_tiled_spool.get_gaps(
+            "distance", tolerance=between * dc.units.m
+        )
+        assert metres.empty
 
     def test_wrong_dimensionality_raises(self, gappy_spool):
         """A tolerance must measure the dimension it is applied to."""
-        with pytest.raises(UnitError, match="time-like"):
+        with pytest.raises(UnitError, match="must have units of time"):
             gappy_spool.get_gaps(tolerance=10 * dc.units.m)
 
 

--- a/tests/test_core/test_spool_gaps.py
+++ b/tests/test_core/test_spool_gaps.py
@@ -12,7 +12,7 @@ import pytest
 
 import dascore as dc
 from dascore.examples import random_spool
-from dascore.exceptions import ChunkError, ParameterError
+from dascore.exceptions import ChunkError, ParameterError, UnitError
 
 ONE_SECOND = np.timedelta64(1, "s")
 
@@ -168,6 +168,38 @@ class TestGetGaps:
         """An unknown dimension names the ones which exist."""
         with pytest.raises(ParameterError, match="Cannot report on"):
             gappy_spool.get_gaps("not_a_dim")
+
+
+class TestQuantityTolerance:
+    """Reports whose tolerance is a distance rather than a sample count."""
+
+    def test_gaps_respect_absolute_tolerance(self, gappy_spool):
+        """A tolerance wider than the holes leaves nothing to report."""
+        assert len(gappy_spool.get_gaps()) == len(gappy_spool) - 1
+        assert gappy_spool.get_gaps(tolerance=dc.get_quantity("2 s")).empty
+        wide = gappy_spool.get_gaps(tolerance=dc.get_quantity("0.5 s"))
+        assert len(wide) == len(gappy_spool) - 1
+
+    def test_coverage_respects_absolute_tolerance(self, gappy_spool):
+        """Holes the tolerance closes are not missing coverage."""
+        loose = gappy_spool.get_coverage(tolerance=dc.get_quantity("2 s"))
+        assert (loose["coverage"] == 1).all()
+        assert (gappy_spool.get_coverage()["coverage"] < 1).all()
+
+    def test_distance_units_convert(self, distance_tiled_spool):
+        """A distance report reads the tolerance in its own units."""
+        gaps = distance_tiled_spool.get_gaps("distance", tolerance=10 * dc.units.m)
+        assert len(gaps) == 1
+        hole = float(gaps["gap_size"].iloc[0])
+        feet = distance_tiled_spool.get_gaps(
+            "distance", tolerance=(hole * 2) / 0.3048 * dc.units.ft
+        )
+        assert feet.empty
+
+    def test_wrong_dimensionality_raises(self, gappy_spool):
+        """A tolerance must measure the dimension it is applied to."""
+        with pytest.raises(UnitError, match="time-like"):
+            gappy_spool.get_gaps(tolerance=10 * dc.units.m)
 
 
 class TestGetCoverage:

--- a/tests/test_viz/test_spool_viz.py
+++ b/tests/test_viz/test_spool_viz.py
@@ -164,6 +164,15 @@ class TestCoverage:
         loose = _kinds(diverse.viz.coverage(tolerance=1e6))["gap"]
         assert loose < tight
 
+    def test_absolute_tolerance(self, diverse):
+        """A tolerance in the coordinate's own units closes gaps too."""
+        tight = _kinds(diverse.viz.coverage(tolerance=dc.get_quantity("0.001 s")))[
+            "gap"
+        ]
+        plt.close("all")
+        loose = _kinds(diverse.viz.coverage(tolerance=dc.get_quantity("1000 s")))["gap"]
+        assert loose < tight
+
     def test_group_argument(self, diverse):
         """Grouping by nothing at all puts every patch in one lane."""
         ax = diverse.viz.coverage(group=[])


### PR DESCRIPTION
## Description

`chunk`'s `tolerance` could only be a number of samples. That works when every patch states a sampling interval and the reader thinks in samples, but the question people actually ask is "merge across holes shorter than a second" — and a spool whose patches record no step had no tolerance at all, since a sample count has nothing to scale.

`tolerance` now also accepts the limit in the coordinate's own units: a pint `Quantity` (`1 * s`, `2 * m`, `20 * ft`) or a `timedelta`. The gap test then compares the boundary against the tolerance itself rather than against `tolerance * step`, so it needs no sampling interval and converts compatible unit spellings. A dimensionless quantity is the sample count it already meant, so `1.5 * dimensionless` and `1.5` are the same call.

This runs everywhere the continuity rule does: `Spool.chunk`, `Spool.chunk_plan`, `Spool.get_gaps`, `Spool.get_coverage`, and `spool.viz.coverage`/`calendar`. `snap_coords` bounds coordinate movement by the same tolerance, and an absolute one passes to `simplify`, which already read a quantity.

Notes on the edges:

- **Never narrower than a sample.** Adjacent patches sit exactly one step apart, so the absolute margin is floored at one step: a tolerance below the sampling interval cannot report a hole where nothing is missing. Without that floor `get_coverage(tolerance=1 * ms)` painted a gapless 4 ms archive as 99.97% covered.
- A quantity resolves per cell, since a cell is what fixes the units and dtype the limit must be expressed in; cells already partition by the chunk dim's units, so one conversion serves each.
- A tolerance which cannot measure the dimension raises `UnitError` (metres against time, a unit-bearing tolerance against a unitless coordinate). A `timedelta` against a *numeric* coordinate is read as seconds, so a relative time axis in seconds takes one; against metres it raises like any incompatible quantity.
- A data size, a percentage, a null, a negative, an array, a bare string, and a time too large for a `timedelta64` all raise with a message naming the argument. This validation reaches the plain-number spelling too, which had none. `tolerance=inf` keeps working as "no boundary is ever a gap"; `nan` and negatives, which silently merged or split everything, do not.
- The "a loose tolerance forced a merge" warning (#662) is still issued. An absolute tolerance cannot be compared to the default up front, so the default partition is computed alongside it — but only for cells where the tolerance can exceed `1.5 * step` at all — and the warning fires when a partition holds more than one of the default's. That test replaces a comparison of partition counts, which an absolute tolerance can leave unchanged while merging one boundary and splitting another.
- Patches whose step is unknown now report gaps under an absolute tolerance. A sample count could never split them, so they merged blindly; that is unchanged when the tolerance is a number.
- `BaseCoord.simplify` now converts a quantity tolerance as a **delta** rather than as a point, so an affine unit's offset cancels (a `4 * kelvin` tolerance on a `degC` coordinate is 4 degC of movement, not −269.15). Before this PR a quantity never reached that path from `chunk`.

Known limitation, unchanged by this PR: a unitless non-time coordinate has no absolute spelling, since a unit-bearing tolerance needs units to convert into and a dimensionless one means samples. Use the sample count there.

## Changelog

- added: `Spool.chunk`, `Spool.chunk_plan`, `Spool.get_gaps`, `Spool.get_coverage`, and the spool coverage plots accept a `tolerance` stated in the coordinate's own units — a quantity such as `1 * s`, or a `timedelta` — instead of a number of samples.
- changed: a `tolerance` which is null, negative, array-valued, a percentage, or a data size now raises `ParameterError`/`UnitError` instead of silently merging or splitting everything.
- fixed: `BaseCoord.simplify` converts a quantity tolerance as a difference, so an affine unit (eg `degC`) no longer picks up the unit's offset.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for distance-based tolerances using quantities and timedeltas across chunking, gap, coverage, and visualization workflows.
  * Tolerances can use coordinate-native units, with automatic unit conversion.
  * Preserved adjacency by ensuring absolute tolerances are never narrower than one sample.
  * Improved handling of unknown sampling intervals and offset units.

* **Documentation**
  * Clarified tolerance behavior, units, and gap detection in guides and tutorials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->