### PR TITLE
List the sixteen API sections, not every object

### DIFF
--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -6,14 +6,8 @@ on:
   pull_request:
     types: [labeled, synchronize]
 
-  # A manual run is how the sidebar experiment is measured: the same build,
-  # on the same runner class, with only the navigation changed.
+  # A manual run is how a full build is measured without waiting for a label.
   workflow_dispatch:
-    inputs:
-      compact_sidebar:
-        description: "Build the API sidebar with one entry per section"
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -31,8 +25,6 @@ env:
   # point at the released site, where a page added since the last release 404s
   # and the preview misleads the reviewer.
   DASCORE_DOC_SITE_URL: https://dascore.netlify.app
-  # Empty unless a manual run asked for the section level sidebar.
-  DASCORE_DOC_COMPACT_SIDEBAR: ${{ inputs.compact_sidebar && '1' || '' }}
 
 jobs:
   test_build_docs:

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ target/
 
 # docs
 docs/api/*
+# The generated pages are not tracked, but the sidebar they use is.
+!docs/api/_metadata.yml
 # Where a local `quarto render docs` puts the built site.
 docs/_site/
 _autosummary

--- a/docs/api/_metadata.yml
+++ b/docs/api/_metadata.yml
@@ -1,0 +1,4 @@
+# Every page under api/ uses the API sidebar. Only the 16 section pages
+# are listed in it, and quarto gives an unlisted page the first sidebar
+# it finds, which would be the one for the front matter.
+sidebar: API

--- a/docs/contributing/documentation.qmd
+++ b/docs/contributing/documentation.qmd
@@ -134,6 +134,14 @@ If you need to change the structure of the site, like adding a new section/subse
 Do not modify docs/_quarto.yml because it will be overwritten.
 :::
 
+## The API sidebar
+
+The API sidebar lists the sixteen top level sections, not every documented object. A reader reaches an object from the page of whatever owns it: each module page lists the modules, classes, and functions it holds, and each class page lists its methods.
+
+It was not always so. Naming all 1,388 objects put 165 KiB in the generated config and repeated it into every rendered page, and that turned out to cost more than everything else the build did: against a section level sidebar, quarto's page phase fell from 105 to 34 minutes, the API html from 635 to 42 MiB, and a typical API page from 489 to 31 KiB.
+
+Because only the section pages are listed, `docs/api/_metadata.yml` tells quarto which sidebar the rest of them use. Without it an unlisted page gets the first sidebar in the config, which is the one for the front matter.
+
 ## Measuring the build
 
 The documentation is by far the slowest thing CI builds, so each phase of it is timed and what it produced is measured. `scripts/_doc_report.py` collects that into one JSON report, which the doc workflows upload and summarize in the job summary. It runs the same way locally:

--- a/scripts/_doc_report.py
+++ b/scripts/_doc_report.py
@@ -111,7 +111,6 @@ def _get_context() -> dict:
         "dascore_path": str(Path(dc.__file__).absolute().parent),
         "platform": sys.platform,
         "runner": os.environ.get("RUNNER_NAME", ""),
-        "compact_sidebar": os.environ.get("DASCORE_DOC_COMPACT_SIDEBAR", ""),
         "run_id": os.environ.get("GITHUB_RUN_ID", ""),
         "workflow": os.environ.get("GITHUB_WORKFLOW", ""),
     }

--- a/scripts/_qmd_builder.py
+++ b/scripts/_qmd_builder.py
@@ -11,12 +11,6 @@ import dascore as dc
 
 API_PATH = Path(__file__).absolute().parent.parent / "docs" / "api"
 
-# separation for each level of toc tree
-LEVEL_SEP = "    "
-
-# What an environment variable which means yes can say.
-_TRUE = frozenset({"1", "true", "yes", "on"})
-
 
 def _build_content_string(path, api_path):
     """Build a content string."""
@@ -27,76 +21,20 @@ def _build_content_string(path, api_path):
     return out
 
 
-def _build_section_string(path, api_path):
-    """Build a string for entire sections."""
-    out = [
-        f"- section: {path.with_suffix('').name}",
-        f"  href: {path.relative_to(api_path)}",
-        "  contents:",
-    ]
-    return out
-
-
-def _get_level(path, base_path):
-    """Get the level of directory nested for path from base_path."""
-    level = len(str(path.relative_to(base_path)).split(os.sep)) - 1
-    return level
-
-
-def _use_compact_sidebar() -> bool:
-    """Return True if the build asked for a section level API sidebar."""
-    return os.environ.get("DASCORE_DOC_COMPACT_SIDEBAR", "").lower() in _TRUE
-
-
-def build_compact_toc_tree(api_path=API_PATH):
+def build_api_toc_tree(api_path=API_PATH):
     """
-    Build a toc tree with one entry per top level section.
+    Build the API toc tree: one entry per top level section.
 
-    The exhaustive tree names every documented object, which is most of the
-    generated config and, repeated into every page, most of the published
-    html. This is what the sidebar costs when it names sections instead;
-    it is measured before it is proposed, so it is off unless asked for.
+    Naming every documented object put 165 KiB in the generated config and
+    repeated it into all 1,388 rendered pages, which cost more than anything
+    else the build did: against a section level tree, quarto's page phase
+    fell from 105 to 34 minutes and the API html from 635 to 42 MiB. Readers
+    reach an object from its owner's page, which lists what it owns.
     """
     base_path = api_path.parent
     out = []
     for path in sorted((api_path / "dascore").glob("*.qmd")):
         out.extend(_build_content_string(path, base_path))
-    return out
-
-
-def build_amp_toc_tree(api_path=API_PATH):
-    """Build the toc tree for the API."""
-    if _use_compact_sidebar():
-        return build_compact_toc_tree(api_path)
-    # get all sub directories
-    base_path = api_path.parent
-    sub_dirs = sorted(x for x in api_path.rglob("*") if x.is_dir())
-    sub_dir_set = set(sub_dirs)
-    out = []
-    # iterate and make contents
-    for dir_path in sub_dirs:
-        # this is an un-cleaned up quarto dir from rendering
-        bad_endings = ["execute-results", "_files"]
-        bad_ending = any(dir_path.name.endswith(x) for x in bad_endings)
-        bad_p_ending = any(dir_path.parent.name.endswith(x) for x in bad_endings)
-        # the expected path of the qmd file related to this directory.
-        section_qmd = dir_path.with_suffix(".qmd")
-        if (bad_ending or bad_p_ending) and not section_qmd.exists():
-            continue
-        assert section_qmd.exists()
-        level = _get_level(section_qmd, api_path)
-        # see how deep we are in toc tree for determine spaces needed
-        section_list = _build_section_string(section_qmd, base_path)
-        for val in section_list:
-            out.append(LEVEL_SEP * (level) + val)
-        # now go through contents
-        contents = sorted(
-            x for x in dir_path.glob("*.qmd") if x.with_suffix("") not in sub_dir_set
-        )
-        for content in contents:
-            content_list = _build_content_string(content, base_path)
-            for val in content_list:
-                out.append(LEVEL_SEP * (level + 1) + val)
     return out
 
 
@@ -123,7 +61,7 @@ def create_quarto_qmd():
     """Create the _quarto.yml file."""
     temp = get_template("_quarto.yml")
     version_str = _get_dascore_title()
-    api_toc_tree = build_amp_toc_tree()
+    api_toc_tree = build_api_toc_tree()
     out = temp.render(
         dascore_version_str=version_str,
         api_toc_tree=api_toc_tree,

--- a/scripts/test_qmd_builder.py
+++ b/scripts/test_qmd_builder.py
@@ -48,18 +48,18 @@ class TestGetRepoBranch:
         assert _qmd_builder._get_repo_branch() == "dev"
 
 
-class TestCompactTocTree:
-    """Tests for the section level API sidebar."""
+class TestApiTocTree:
+    """Tests for the API sidebar."""
 
     def test_one_entry_per_section(self, tmp_path):
-        """A compact tree names sections, not the objects inside them."""
+        """The tree names sections, not the objects inside them."""
         api_path = tmp_path / "api"
         (api_path / "dascore" / "core").mkdir(parents=True)
         (api_path / "dascore" / "core.qmd").write_text("")
         (api_path / "dascore" / "io.qmd").write_text("")
         (api_path / "dascore" / "core" / "Patch.qmd").write_text("")
 
-        out = _qmd_builder.build_compact_toc_tree(api_path)
+        out = _qmd_builder.build_api_toc_tree(api_path)
 
         assert out == [
             "- text: core",
@@ -68,20 +68,8 @@ class TestCompactTocTree:
             "  href: api/dascore/io.qmd",
         ]
 
-    def test_off_by_default(self, monkeypatch):
-        """The exhaustive tree is what a build gets unless it asks."""
-        monkeypatch.delenv("DASCORE_DOC_COMPACT_SIDEBAR", raising=False)
+    def test_nothing_generated(self, tmp_path):
+        """A tree built before the API docs are is empty, not an error."""
+        (tmp_path / "api" / "dascore").mkdir(parents=True)
 
-        assert not _qmd_builder._use_compact_sidebar()
-
-    def test_environment_switch(self, monkeypatch, tmp_path):
-        """The benchmark switches trees without a code change."""
-        monkeypatch.setenv("DASCORE_DOC_COMPACT_SIDEBAR", "1")
-        api_path = tmp_path / "api"
-        (api_path / "dascore").mkdir(parents=True)
-        (api_path / "dascore" / "core.qmd").write_text("")
-
-        assert _qmd_builder.build_amp_toc_tree(api_path) == [
-            "- text: core",
-            "  href: api/dascore/core.qmd",
-        ]
+        assert _qmd_builder.build_api_toc_tree(tmp_path / "api") == []


### PR DESCRIPTION
## Description

The API sidebar named all 1,388 documented objects. That put 165 KiB in the generated `_quarto.yml` and repeated it into every page rendered from it, and it cost more than everything else the build did.

Two full CI builds differing only in this (32960776336 and 32960821408, on #1024):

| | every object | sixteen sections | |
|---|---:|---:|---:|
| quarto wall | 110.1 min | 34.1 min | −69% |
| page phase | 105.0 min | 33.8 min | −68% |
| notebook preparation | 7.96 min | 0.67 min | −92% |
| all timed phases | 118.3 min | 35.0 min | −70% |
| rendered site | 802.2 MiB | 208.5 MiB | −74% |
| API html, total | 635.0 MiB | 41.5 MiB | −93% |
| API page, p50 | 489.4 KiB | 31.0 KiB | −94% |
| generated `_quarto.yml` | 175,216 B | 7,268 B | −96% |

Per page, static pages fall from 3.76 s to 0.68 s. The cost was fixed overhead per page, not content, which is why even `build_notebooks.py` got 12x faster: each tutorial render parses the same config.

That meets both goals the API surface plan set — a cold build under 60 minutes, and at least a 75% cut in API html — without touching how pages are generated.

## What a reader loses, and does not

The sidebar no longer lists every object, so a reader reaches one from the page of whatever owns it. That already works: every module page lists the modules, classes, and functions it holds, and every class page lists its methods. Search is unchanged, since quarto indexes rendered pages rather than sidebar entries.

## Notes

- `docs/api/_metadata.yml` says which sidebar the unlisted pages use. Without it quarto gives an unlisted page the first sidebar in the config, which is the one for the front matter. Verified on a rendered `utils/time/to_datetime64.html`: all sixteen sections in its nav, 41 KB against 503 KB before. It needs a `.gitignore` negation, since `docs/api/*` is generated and untracked.
- The exhaustive builder and the `DASCORE_DOC_COMPACT_SIDEBAR` switch are both gone; the experiment they existed for is the table above.
- Stacked on #1022 for the measurement harness. Rebase to dev once that merges.

## Changelog

- changed: The API documentation sidebar lists the sixteen top level sections rather than every documented object, which cuts the documentation build from about two hours to about half an hour.