### PR TITLE
Make the ninth display helper private too

### DIFF
--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -1498,7 +1498,7 @@ def mapping_to_text(mapping, header: str, style: str = "dc_yellow") -> Text:
     return txt
 
 
-def human_size(byte_count: int) -> str:
+def _human_size(byte_count: int) -> str:
     """How much room something takes up, in the largest unit which fits."""
     size = float(byte_count)
     if not np.isfinite(size):
@@ -1528,7 +1528,7 @@ def array_to_text(data, units=None) -> Text:
     # which is the size in pieces; whether it fits in memory is the
     # question those two are usually being multiplied to answer.
     byte_count = getattr(data, "nbytes", None)
-    if byte_count is not None and (size := human_size(byte_count)):
+    if byte_count is not None and (size := _human_size(byte_count)):
         header += Text(", ") + Text(size, dascore_styles["keys"])
     header += Text(")")
     config = get_config()

--- a/scripts/_baselines/api_urls.tsv
+++ b/scripts/_baselines/api_urls.tsv
@@ -4847,7 +4847,6 @@ dascore.utils.display.get_quantity	/api/dascore/units/get_quantity.qmd
 dascore.utils.display.get_quantity_str	/api/dascore/units/get_quantity_str.qmd
 dascore.utils.display.group_names	/api/dascore/utils/display/group_names.qmd
 dascore.utils.display.human_duration	/api/dascore/utils/display/human_duration.qmd
-dascore.utils.display.human_size	/api/dascore/utils/display/human_size.qmd
 dascore.utils.display.mapping_to_text	/api/dascore/utils/display/mapping_to_text.qmd
 dascore.utils.display.model_to_line	/api/dascore/utils/display/model_to_line.qmd
 dascore.utils.display.percent	/api/dascore/utils/display/percent.qmd
@@ -7666,8 +7665,6 @@ docs/api/dascore/utils/display/group_names	/api/dascore/utils/display/group_name
 docs/api/dascore/utils/display/group_names.qmd	/api/dascore/utils/display/group_names.qmd
 docs/api/dascore/utils/display/human_duration	/api/dascore/utils/display/human_duration.qmd
 docs/api/dascore/utils/display/human_duration.qmd	/api/dascore/utils/display/human_duration.qmd
-docs/api/dascore/utils/display/human_size	/api/dascore/utils/display/human_size.qmd
-docs/api/dascore/utils/display/human_size.qmd	/api/dascore/utils/display/human_size.qmd
 docs/api/dascore/utils/display/mapping_to_text	/api/dascore/utils/display/mapping_to_text.qmd
 docs/api/dascore/utils/display/mapping_to_text.qmd	/api/dascore/utils/display/mapping_to_text.qmd
 docs/api/dascore/utils/display/model_to_line	/api/dascore/utils/display/model_to_line.qmd

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -39,6 +39,7 @@ from dascore.utils.display import (
     Table,
     _body_lines,
     _get_stylesheet,
+    _human_size,
     _indent_text,
     _limit_items,
     _render_html,
@@ -59,7 +60,6 @@ from dascore.utils.display import (
     get_nice_text,
     group_names,
     human_duration,
-    human_size,
     mapping_to_text,
     model_to_line,
     percent,
@@ -972,7 +972,7 @@ class TestHumanSize:
     )
     def test_size_in_the_largest_unit_which_fits(self, count, expected):
         """A byte count is read in whatever unit keeps it short."""
-        assert human_size(count) == expected
+        assert _human_size(count) == expected
 
     def test_an_unknown_size_draws_no_comma(self):
         """The comma introduces a size, so it goes when there is none."""
@@ -993,7 +993,7 @@ class TestHumanSize:
 
         "nan TiB" is a worse answer than not saying.
         """
-        assert human_size(float("nan")) == ""
+        assert _human_size(float("nan")) == ""
 
 
 class TestDurationText:


### PR DESCRIPTION
## Description

`dascore.utils.display.human_size` has exactly the profile of the eight helpers #1023 made private, and was missed only because that batch was drawn before #1012 merged.

| | evidence |
|---|---|
| introduced | #1012 (`fe164e8c`) |
| in `v0.1.21` | no |
| re-exported | no |
| referenced outside `display.py` | its own tests only |

So no released import path changes and no deprecation shim is needed, same as the eight.

Found by the adversarial review of the API surface plan, which asked for it to be added or for a reason not to. There is no reason not to.

The frozen URL manifest records the one page this takes with it: `_api_urls.py check` reports 1 unpublished, `/api/dascore/utils/display/human_size.qmd`, and the manifest is refrozen in the same commit — which is the workflow that manifest exists for.

Stacked on #1068 for the refrozen baseline. Rebase to dev once that merges.

## Changelog

- none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved documentation build instructions with timing, indexing, rendering, validation, and summary steps.
  - Enhanced documentation link discovery across nested paths.

- **Bug Fixes**
  - Improved API documentation checks for unpublished pages, aliases, and moved entries.
  - Added clearer reporting for unpublished documentation and Quarto build timing.
  - Prevented documentation checks from using packages inside nested virtual environments.

- **Tests**
  - Expanded coverage for documentation links, API URL validation, reporting, and environment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->