### PR TITLE
Run the tests that sit next to the scripts

### DIFF
--- a/.github/test_code.sh
+++ b/.github/test_code.sh
@@ -14,7 +14,12 @@ export COVERAGE_CORE=sysmon
 parallel=(-n logical --dist loadfile)
 cov_args=(--cov dascore --cov-append --cov-report=)
 
-args=(tests -m "not network" "${parallel[@]}" "${cov_args[@]}")
+# The doc tooling keeps its tests next to the scripts they test rather than
+# under tests/, which mirrors the package. Named here so they are collected:
+# without this the only thing running them is someone remembering to.
+suite=(tests scripts docs/filters)
+
+args=("${suite[@]}" -m "not network" "${parallel[@]}" "${cov_args[@]}")
 if [[ "$1" == "network" ]]; then
   args=(tests -m network "${parallel[@]}" "${cov_args[@]}")
 fi

--- a/scripts/_doc_report.py
+++ b/scripts/_doc_report.py
@@ -241,7 +241,7 @@ def measure_qmd(api_path: Path = API_DOC_PATH) -> dict:
         kind = classify_page(path.read_text())
         kinds[kind] += 1
         if kind != "static":
-            executable[str(path.relative_to(api_path.parent))] = kind
+            executable[path.relative_to(api_path.parent).as_posix()] = kind
     return {
         "sizes": _size_stats(sizes),
         "kinds": dict(kinds),
@@ -297,7 +297,7 @@ def find_case_collisions(api_path: Path = API_DOC_PATH) -> list[list[str]]:
     """
     groups = defaultdict(list)
     for path in api_path.rglob("*.qmd"):
-        relative = str(path.relative_to(api_path))
+        relative = path.relative_to(api_path).as_posix()
         groups[relative.lower()].append(relative)
     return sorted(sorted(x) for x in groups.values() if len(x) > 1)
 
@@ -346,11 +346,13 @@ _QUIET_KINDS = frozenset({"static", "source_only"})
 
 def _record_surprise(surprises, relative, executable, has_output) -> None:
     """Note a page whose rendered output disagrees with its classification."""
-    kind = executable.get(str(relative.with_suffix(".qmd")), "static")
+    # Posix throughout: these are keys into the index the build wrote and
+    # names printed in a report read next to it, not paths on this disk.
+    kind = executable.get(relative.with_suffix(".qmd").as_posix(), "static")
     if has_output and kind in _QUIET_KINDS:
-        surprises["unexpected"].append(str(relative))
+        surprises["unexpected"].append(relative.as_posix())
     elif not has_output and kind not in _QUIET_KINDS:
-        surprises["missing"].append(str(relative))
+        surprises["missing"].append(relative.as_posix())
 
 
 def _archive_bytes(site_path: Path) -> int:

--- a/scripts/_index_api.py
+++ b/scripts/_index_api.py
@@ -50,10 +50,12 @@ def _get_base_address(path, base_path):
     if _is_environment_path(path):
         return ""
     try:
-        out = Path(path).relative_to(Path(base_path))
+        out = Path(path).relative_to(Path(base_path)).as_posix()
     except ValueError:
         return ""
-    new = str(out).replace("/__init__.py", "").replace(".py", "")
+    # as_posix, not str: a module address is dotted, and on windows str
+    # would hand back backslashes for the separator this then replaces.
+    new = out.replace("/__init__.py", "").replace(".py", "")
     return new.replace("/", ".")
 
 

--- a/scripts/_qmd_builder.py
+++ b/scripts/_qmd_builder.py
@@ -22,7 +22,8 @@ def _build_content_string(path, api_path):
     """Build a content string."""
     out = [
         f"- text: {path.with_suffix('').name}",
-        f"  href: {path.relative_to(api_path)}",
+        # as_posix: an href is a URL, whatever separator the OS writes.
+        f"  href: {path.relative_to(api_path).as_posix()}",
     ]
     return out
 

--- a/scripts/test_differential_check.py
+++ b/scripts/test_differential_check.py
@@ -17,6 +17,7 @@ from differential_check import (
 )
 
 import dascore as dc
+from dascore.exceptions import ParameterError
 
 
 @pytest.fixture(scope="module")
@@ -65,6 +66,18 @@ class TestCompare:
         assert compare({"a": digest(patch)}, {}) == ["a: only in before"]
 
 
+# dump() records the error instead of the fingerprint when a call raises,
+# so the comparison covers what each version says about a bad argument --
+# the class included, since it names the error it writes. Naming them here
+# keeps a fourth from joining quietly, which would drop that call from the
+# comparison.
+RAISERS = {
+    "norm_bad": ValueError,
+    "transpose_bad_dim": ParameterError,
+    "rename_missing": KeyError,
+}
+
+
 class TestCalls:
     """Tests for the calls which get compared."""
 
@@ -76,19 +89,12 @@ class TestCalls:
 
     def test_calls_run(self):
         """Every call fingerprints, save the ones which exist to raise."""
-        # dump() records the error instead of the fingerprint when a call
-        # raises, so the comparison covers what each version says about a
-        # bad argument. Naming them here keeps a fourth from joining
-        # quietly, which would drop that call from the comparison.
-        raised = set()
         for name, call in get_calls().items():
-            try:
-                patch = call()
-            except Exception:
-                raised.add(name)
+            if (error := RAISERS.get(name)) is not None:
+                with pytest.raises(error):
+                    call()
                 continue
-            assert digest(patch), f"{name} returned nothing"
-        assert raised == {"norm_bad", "transpose_bad_dim", "rename_missing"}
+            assert digest(call()), f"{name} returned nothing"
 
 
 class TestMatrix:

--- a/scripts/test_differential_check.py
+++ b/scripts/test_differential_check.py
@@ -75,9 +75,20 @@ class TestCalls:
         assert {"add_scalar", "agg_mean", "pad_tuple"}.issubset(set(calls))
 
     def test_calls_run(self):
-        """Every call runs and returns something which can be fingerprinted."""
+        """Every call fingerprints, save the ones which exist to raise."""
+        # dump() records the error instead of the fingerprint when a call
+        # raises, so the comparison covers what each version says about a
+        # bad argument. Naming them here keeps a fourth from joining
+        # quietly, which would drop that call from the comparison.
+        raised = set()
         for name, call in get_calls().items():
-            assert digest(call()), f"{name} returned nothing"
+            try:
+                patch = call()
+            except Exception:
+                raised.add(name)
+                continue
+            assert digest(patch), f"{name} returned nothing"
+        assert raised == {"norm_bad", "transpose_bad_dim", "rename_missing"}
 
 
 class TestMatrix:

--- a/scripts/test_doc_report.py
+++ b/scripts/test_doc_report.py
@@ -85,7 +85,11 @@ class TestTimeCommand:
         assert timing["page_count"] == 3
         # The last page has no next page to bound it; it lands in finalize.
         assert set(timing["pages"]) == {"a.qmd", "b.qmd"}
-        assert timing["page_phase"] == pytest.approx(0.1, abs=0.1)
+        # Bounded, not pinned: a loaded runner takes as long as it takes.
+        # The two sleeps between the three progress lines are the floor, and
+        # the sleep after the last one has to land outside the page phase.
+        assert timing["page_phase"] >= 0.1
+        assert timing["page_phase"] < timing["wall"]
         assert timing["startup"] + timing["page_phase"] + timing["finalize"] == (
             pytest.approx(timing["wall"], abs=0.01)
         )


### PR DESCRIPTION
## Description

The doc tooling keeps its tests beside the scripts they test — `scripts/test_*.py`, and now `docs/filters/` — rather than under `tests/`, which mirrors the package. But `.github/test_code.sh` collects `tests` and nothing else, so none of those seven files has ever run in CI. Codex caught this on #1068 and #1069.

Turning collection on needed one fix first and found three more.

**The fix it needed.** `scripts/test_differential_check.py::TestCalls::test_calls_run` has been failing on `dev`: it asserts every call in the differential check fingerprints, but three of them — `norm_bad`, `transpose_bad_dim`, `rename_missing` — exist to raise, because `dump()` records the error instead and the comparison covers what each version says about a bad argument. The test now names those three, so a fourth cannot join quietly and drop that call from the comparison.

**What it found.** Six failures on the windows cell, all one root cause: a module address, a quarto href, and the keys of the page index are each built by stringifying a relative path, which on windows comes back with backslashes. A dotted address kept the separator (`dascore\core\patch`), an href became `api\dascore\core.qmd`, and a rendered page could not be looked up in the index the build wrote. Now `as_posix()` in the four places that make a name rather than open a file. The doc build only runs on linux, so nothing shipped was wrong — but a contributor on windows could not have built the docs.

One flake of my own too: `test_doc_report.py` pinned a measured page phase to 0.1 s ± 0.1 and the macos runner took 0.216. It now bounds the phase instead of timing the runner.

`docs/filters` is named in the collection as well. It holds no tests on `dev`, so it collects nothing today and picks up `test_fill_links.py` when #1068 lands.

## Changelog

- none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
