### PR TITLE
State how wide an extent is, and say a coordinate's units on its values

### DIFF
--- a/dascore/core/annotations.py
+++ b/dascore/core/annotations.py
@@ -64,11 +64,11 @@ from dascore.utils.display import (
     Repr,
     RichRepr,
     counts_to_text,
-    duration_text,
     get_header_text,
     mapping_to_text,
     model_to_line,
     range_texts,
+    span_text,
     split_block,
     stated_fields,
 )
@@ -957,7 +957,7 @@ class AnnotationSet(NodeRepr, NamespaceOwner):
             base += near
             base += Text(" max: ", key_style)
             base += far
-            if (span := duration_text(low, high)) is not None:
+            if (span := span_text(low, high)) is not None:
                 base += Text(" ") + span
             kind = "point" if spelling.point else "range"
             base += Text(f" ({kind})", key_style)

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -633,9 +633,7 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         # them off the end of the line is not how it is read. A time
         # states its units in the way it is written -- an instant, a
         # step of "0.0005s" -- and says nothing here.
-        stated = None
-        if self.units is not None and not dtype_time_like(self.dtype):
-            stated = get_quantity_str(self.units)
+        stated = None if dtype_time_like(self.dtype) else self.unit_str
 
         def measured(value: Text) -> Text:
             """The value, and what it is measured in where it says."""

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -56,10 +56,10 @@ from dascore.utils.array import (
 )
 from dascore.utils.display import (
     RichRepr,
-    duration_text,
     get_nice_text,
     range_texts,
     rate_text,
+    span_text,
 )
 from dascore.utils.docs import compose_docstring, get_docstring
 from dascore.utils.misc import (
@@ -634,10 +634,11 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
             fields.append(("min", near, True))
         if not pd.isnull(self.max()):
             fields.append(("max", far, True))
-        # Only a time. Two instants say nothing about how far apart they
-        # are; a distance from 0 to 299 m already says 299 m.
-        if dtype_time_like(self.dtype) and not pd.isnull(self.min()):
-            if (span := duration_text(self.min(), self.max())) is not None:
+        # How far the two ends lie apart, which they do not otherwise
+        # say: a fiber run from 1212.4 m to 1636.7 m is 424.3 m of it.
+        # Said bare, since the units field below states them once.
+        if not (pd.isnull(self.min()) or pd.isnull(self.max())):
+            if (span := span_text(self.min(), self.max())) is not None:
                 # The brackets say what it is, so a line does not
                 # need the label a column heading gives it.
                 fields.append(("span", span, False))

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -627,31 +627,47 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         is held.
         """
         fields: list[tuple[str, Text, bool]] = []
+        # What the values are measured in, said on each of them rather
+        # than in a field of its own: how far the fiber runs and what
+        # that is measured in are one fact, and reading the second of
+        # them off the end of the line is not how it is read. A time
+        # states its units in the way it is written -- an instant, a
+        # step of "0.0005s" -- and says nothing here.
+        stated = None
+        if self.units is not None and not dtype_time_like(self.dtype):
+            stated = get_quantity_str(self.units)
+
+        def measured(value: Text) -> Text:
+            """The value, and what it is measured in where it says."""
+            if not stated:
+                return value
+            return value + Text(f" {stated}", dascore_styles["units"])
+
         # Drawn as one range: the two ends state the same blocks, and
         # the second states only what the first did not already.
         near, far = range_texts(self.min(), self.max())
         if not pd.isnull(self.min()):
-            fields.append(("min", near, True))
+            fields.append(("min", measured(near), True))
         if not pd.isnull(self.max()):
-            fields.append(("max", far, True))
+            fields.append(("max", measured(far), True))
         # How far the two ends lie apart, which they do not otherwise
         # say: a fiber run from 1212.4 m to 1636.7 m is 424.3 m of it.
-        # Said bare, since the units field below states them once.
         if not (pd.isnull(self.min()) or pd.isnull(self.max())):
-            if (span := span_text(self.min(), self.max())) is not None:
+            if (span := span_text(self.min(), self.max(), stated)) is not None:
                 # The brackets say what it is, so a line does not
                 # need the label a column heading gives it.
                 fields.append(("span", span, False))
         if not pd.isnull(self.step):
-            step = get_nice_text(self.step)
+            step = measured(get_nice_text(self.step))
             if (rate := rate_text(self.step)) is not None:
                 step = step + rate
             fields.append(("step", step, True))
+        # A coordinate which states no value has nothing to hang its
+        # units on, and they are a fact of it either way.
+        if stated and not fields:
+            fields.append(("units", get_nice_text(stated, style="units"), True))
         fields.append(("shape", get_nice_text(self.shape), True))
         fields.append(("dtype", get_nice_text(self.dtype), True))
-        if self.units is not None:
-            unit_str = get_quantity_str(self.units)
-            fields.append(("units", get_nice_text(unit_str, style="units"), True))
         return tuple(fields)
 
     def __rich__(self):

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -94,12 +94,12 @@ from dascore.utils.display import (
     ACQUISITION_ATTR,
     NodeRepr,
     Repr,
-    duration_text,
     elision_text,
     get_header_text,
     get_nice_text,
     group_names,
     range_texts,
+    span_text,
     split_block,
 )
 from dascore.utils.docs import compose_docstring
@@ -2493,14 +2493,15 @@ class Spool(NodeRepr, NamespaceOwner):
                 # in, so a min and a max from two of them are not two
                 # ends of one extent. Say so rather than imply otherwise.
                 base += Text(f"  (mixed units: {', '.join(units)})", key_style)
-            elif isinstance(low, _TIMES):
-                # A time is stated as an instant, so how long the two of
-                # them are apart is a fact the line does not yet carry.
-                # Any other dimension states its own magnitude already.
-                if (span := duration_text(low, high)) is not None:
-                    base += Text("  ") + span
-            elif units:
+                continue
+            # A time states its units in the way it is written; every
+            # other dimension is named in what it was measured in.
+            if units and not isinstance(low, _TIMES):
                 base += Text(" ") + Text(units[0], dascore_styles["units"])
+            # How far the two ends lie apart, said bare: the line has
+            # already named the units, and a width is in them.
+            if (span := span_text(low, high)) is not None:
+                base += Text("  ") + span
         return base
 
     @staticmethod
@@ -2520,19 +2521,12 @@ class Spool(NodeRepr, NamespaceOwner):
 
     def _span_text(self, low, high, units: tuple[str, ...]) -> Text | None:
         """How wide an extent is, measured in what the dimension is."""
-        # A time span is a duration. Any other dimension is as wide as
-        # its own units say, and calling that many seconds would be a
-        # different claim about a different quantity.
-        if isinstance(low, _TIMES):
-            return duration_text(low, high)
-        if isinstance(low, numbers.Number):
-            # A width is only in a unit where every patch agrees on one;
-            # stating the first of several would label a track in a unit
-            # it was not measured in.
-            stated = f" {units[0]}" if len(units) == 1 else ""
-            return Text(f"<{float(high - low):g}{stated}>", dascore_styles["keys"])
-        # A dimension of labels has two ends and no width between them.
-        return None
+        # A track states its units nowhere else, so the width carries
+        # them -- but only where every patch agrees on one, since
+        # stating the first of several would label a track in a unit it
+        # was not measured in.
+        stated = units[0] if len(units) == 1 else None
+        return span_text(low, high, stated)
 
     def _tracks_text(self, df, dim: str) -> Text | None:
         """

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -2498,9 +2498,11 @@ class Spool(NodeRepr, NamespaceOwner):
             # other dimension is named in what it was measured in.
             if units and not isinstance(low, _TIMES):
                 base += Text(" ") + Text(units[0], dascore_styles["units"])
-            # How far the two ends lie apart, said bare: the line has
-            # already named the units, and a width is in them.
-            if (span := span_text(low, high)) is not None:
+            # How far the two ends lie apart, in what they are measured
+            # in: a width said bare beside a max which names its units
+            # reads as if it were in others, and the tracks under this
+            # line state theirs.
+            if (span := span_text(low, high, units[0] if units else None)) is not None:
                 base += Text("  ") + span
         return base
 

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -1040,9 +1040,12 @@ def _measurable(value) -> bool:
     """Whether a value is a quantity two of which lie a width apart."""
     # A bool is an integer to Python and a quantity to nobody: a true
     # which is one more than a false is arithmetic, not a width. A
-    # complex pair has no width along one axis. Every other kind of
-    # number has one, a Decimal and a Fraction among them.
-    if isinstance(value, bool | complex):
+    # complex pair has no width along one axis, and numpy's own kinds
+    # are asked for by name -- only complex128 subclasses Python's,
+    # so complex64 came through as a number and stated the modulus of
+    # the difference. Every other kind of number has a width, a
+    # Decimal and a Fraction among them.
+    if isinstance(value, bool | complex | np.complexfloating):
         return False
     return isinstance(value, numbers.Number)
 

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -978,7 +978,22 @@ def span_text(low, high, units: str | None = None) -> Text | None:
     # a bool is not a quantity two of which are apart by anything.
     if not (isinstance(low, numbers.Real) and isinstance(high, numbers.Real)):
         return None
-    width = float(high) - float(low)
+    try:
+        if isinstance(low, numbers.Integral) and isinstance(high, numbers.Integral):
+            # Subtracted as integers, which is exact and does not wrap:
+            # two int64 ends one apart up near 2**60 are the same float,
+            # so a width of one would come back as no width at all.
+            width = float(int(high) - int(low))
+        else:
+            width = float(high) - float(low)
+    except (OverflowError, ValueError, TypeError):
+        # An end no float holds, a Python int of four hundred digits
+        # among them. A repr states nothing rather than raising out of
+        # the middle of itself.
+        return None
+    # A width, like a duration, is how far apart the two ends lie and
+    # not which of them was handed over first.
+    width = abs(width)
     if not np.isfinite(width) or width == 0:
         return None
     stated = f" {units}" if units else ""

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -932,23 +932,39 @@ def duration_text(low, high) -> Text | None:
     # of a repr in one order and gives an instant back in the other.
     if isinstance(low, _INSTANT_TYPES) != isinstance(high, _INSTANT_TYPES):
         return None
+    # Read from the two ends together, which is exact, and from each of
+    # them on its own where that cannot be done. An int64 of
+    # nanoseconds holds about 584 years and two instants can lie
+    # further apart than that: pandas raises over it, and numpy raises
+    # over it on some versions and wraps on others -- five centuries
+    # came back as 84.6 of them, pointing the other way from the ends
+    # they were read off.
+    seconds = None
     try:
         span = high - low
-    except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
-        # Two instants can lie further apart than a Timedelta holds. How
-        # long that is matters less than the extents it would otherwise
-        # take down with it.
-        return None
-    # Divided by a second rather than read with `to_float`, which counts
-    # nanoseconds: a span of centuries is more of those than an int64
-    # holds, and the wrap is silent. Ten thousand years read that way
-    # came back as sixty one.
-    try:
-        seconds = span / np.timedelta64(1, "s")
+    except (OutOfBoundsDatetime, OutOfBoundsTimedelta, OverflowError):
+        pass
     except TypeError:
-        # A span held in years or months is not a fixed number of
-        # seconds, so numpy refuses to say how many. Neither will this.
+        # Two times which do not agree on a timezone do not subtract at
+        # all, and neither end can be read as the other's clock.
         return None
+    else:
+        # Divided by a second rather than read with `to_float`, which
+        # counts nanoseconds: the same int64 the ends were held in, and
+        # ten thousand years read that way came back as sixty one.
+        try:
+            seconds = span / np.timedelta64(1, "s")
+        except TypeError:
+            # A span held in years or months is not a fixed number of
+            # seconds, so numpy refuses to say how many. Neither will
+            # this.
+            return None
+        if (seconds < 0) != (high < low):
+            seconds = None
+    if seconds is None:
+        # Each end on its own, which fits where the span between them
+        # does -- to a precision only a far shorter span would miss.
+        seconds = to_float(high) - to_float(low)
     if not (said := human_duration(seconds)):
         return None
     return Text(f"<{said}>", dascore_styles["keys"])

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -927,10 +927,10 @@ def duration_text(low, high) -> Text | None:
     """
     if not isinstance(low, _TIME_TYPES) or not isinstance(high, _TIME_TYPES):
         return None
-    # Both the same kind of time. An instant and a duration are not two
-    # ends of one extent, and subtracting them raises out of the middle
-    # of a repr in one order and gives an instant back in the other.
-    if isinstance(low, _INSTANT_TYPES) != isinstance(high, _INSTANT_TYPES):
+    # An end which is not a time is not an end: NaT compares against a
+    # Timestamp by raising, and how long an extent with one lasted is
+    # not a question with an answer.
+    if pd.isnull(low) or pd.isnull(high):
         return None
     # Read from the two ends together, which is exact, and from each of
     # them on its own where that cannot be done. An int64 of
@@ -964,6 +964,9 @@ def duration_text(low, high) -> Text | None:
     if seconds is None:
         # Each end on its own, which fits where the span between them
         # does -- to a precision only a far shorter span would miss.
+        # Held in nanoseconds itself, so a pair stated in a coarser unit
+        # and further apart than any instant a nanosecond can reach is
+        # read no better here than it was subtracted.
         seconds = to_float(high) - to_float(low)
     if not (said := human_duration(seconds)):
         return None
@@ -984,10 +987,9 @@ def span_text(low, high, units: str | None = None) -> Text | None:
     one in seconds would state a different quantity than the one
     measured.
 
-    ``units`` is what to say that width in, and is for a line which
-    states them nowhere else. A line which already names its units --
-    a coordinate row with a units field, a dimension with its unit
-    after it -- passes nothing rather than say them twice.
+    ``units`` is what to say that width in, and is stated wherever the
+    caller knows them: a width is a quantity, and one said bare beside
+    two ends which name their units reads as if it were in others.
 
     None where there is no width to state: two ends which meet, which
     is one sample and not a span of nothing, and a dimension of labels,
@@ -995,33 +997,43 @@ def span_text(low, high, units: str | None = None) -> Text | None:
     """
     if isinstance(low, _TIME_TYPES) or isinstance(high, _TIME_TYPES):
         return duration_text(low, high)
-    # Real, not Number: a complex pair has no width along one axis.
-    # Nor is a bool a quantity, though Python counts one as an integer;
-    # a true which is one more than a false is arithmetic, not a width.
-    if isinstance(low, bool) or isinstance(high, bool):
-        return None
-    if not (isinstance(low, numbers.Real) and isinstance(high, numbers.Real)):
+    if not (_measurable(low) and _measurable(high)):
         return None
     try:
         if isinstance(low, numbers.Integral) and isinstance(high, numbers.Integral):
             # Subtracted as integers, which is exact and does not wrap:
             # two int64 ends one apart up near 2**60 are the same float,
             # so a width of one would come back as no width at all.
-            width = float(int(high) - int(low))
+            width = abs(int(high) - int(low))
         else:
-            width = float(high) - float(low)
-    except (OverflowError, ValueError, TypeError):
-        # An end no float holds, a Python int of four hundred digits
-        # among them. A repr states nothing rather than raising out of
-        # the middle of itself.
+            # Subtracted in the kind they are held in, which a Decimal
+            # or a long double is exact in and a float is not.
+            width = abs(high - low)
+        # Read as a float only to ask whether there is a width to say,
+        # never to say it: an end no float holds, a Python int of four
+        # hundred digits among them, has no width a reader could read.
+        magnitude = float(width)
+    except (ArithmeticError, ValueError, TypeError):
+        # A repr states nothing rather than raising out of the middle
+        # of itself.
         return None
-    # A width, like a duration, is how far apart the two ends lie and
-    # not which of them was handed over first.
-    width = abs(width)
-    if not np.isfinite(width) or width == 0:
+    if not np.isfinite(magnitude) or magnitude == 0:
         return None
+    # Drawn the way the two ends it came from are drawn, so a reader
+    # who subtracts what the line says gets what the line says.
     stated = f" {units}" if units else ""
-    return Text(f"<{width:g}{stated}>", dascore_styles["keys"])
+    return Text(f"<{get_nice_text(width).plain}{stated}>", dascore_styles["keys"])
+
+
+def _measurable(value) -> bool:
+    """Whether a value is a quantity two of which lie a width apart."""
+    # A bool is an integer to Python and a quantity to nobody: a true
+    # which is one more than a false is arithmetic, not a width. A
+    # complex pair has no width along one axis. Every other kind of
+    # number has one, a Decimal and a Fraction among them.
+    if isinstance(value, bool | complex):
+        return False
+    return isinstance(value, numbers.Number)
 
 
 def _split_instant(rendered: str) -> tuple[str, str]:

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -927,6 +927,11 @@ def duration_text(low, high) -> Text | None:
     """
     if not isinstance(low, _TIME_TYPES) or not isinstance(high, _TIME_TYPES):
         return None
+    # Both the same kind of time. An instant and a duration are not two
+    # ends of one extent, and subtracting them raises out of the middle
+    # of a repr in one order and gives an instant back in the other.
+    if isinstance(low, _INSTANT_TYPES) != isinstance(high, _INSTANT_TYPES):
+        return None
     try:
         span = high - low
     except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
@@ -974,8 +979,11 @@ def span_text(low, high, units: str | None = None) -> Text | None:
     """
     if isinstance(low, _TIME_TYPES) or isinstance(high, _TIME_TYPES):
         return duration_text(low, high)
-    # Real, not Number: a complex pair has no width along one axis, and
-    # a bool is not a quantity two of which are apart by anything.
+    # Real, not Number: a complex pair has no width along one axis.
+    # Nor is a bool a quantity, though Python counts one as an integer;
+    # a true which is one more than a false is arithmetic, not a width.
+    if isinstance(low, bool) or isinstance(high, bool):
+        return None
     if not (isinstance(low, numbers.Real) and isinstance(high, numbers.Real)):
         return None
     try:

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numbers
 import re
 import textwrap
 from collections import Counter
@@ -154,9 +155,10 @@ class Table:
     """
     Records of one sort, drawn together.
 
-    They need not state the same fields -- only a time coordinate has a
-    span -- so a column exists for every field any row states and a row
-    with nothing for one leaves it empty.
+    They need not state the same fields -- a coordinate of one sample
+    has no span, and one read off a file may have no step -- so a
+    column exists for every field any row states and a row with
+    nothing for one leaves it empty.
 
     A terminal draws each record on its own line, which is what keeps
     `str()` unchanged; a panel draws them in columns, where each label
@@ -402,13 +404,13 @@ def _merge_columns(rows: Sequence[Row]) -> list[str]:
     """
     One column order which every row's own order agrees with.
 
-    Rows state different fields -- only a time coordinate has a span,
-    and a coordinate which selected nothing states neither a min nor a
-    max -- so the columns are the union. Sorted rather than merged by
-    hand: what each row states is an ordering constraint on part of the
-    whole, and reading them in as edges is what keeps a field which
-    appears late in one row and early in another from landing where no
-    row puts it.
+    Rows state different fields -- a coordinate of one sample has no
+    span, and a coordinate which selected nothing states neither a min
+    nor a max -- so the columns are the union. Sorted rather than
+    merged by hand: what each row states is an ordering constraint on
+    part of the whole, and reading them in as edges is what keeps a
+    field which appears late in one row and early in another from
+    landing where no row puts it.
 
     Two rows can disagree outright, which is a cycle and has no answer;
     the order they were first stated in is the one taken then.
@@ -918,14 +920,10 @@ def duration_text(low, high) -> Text | None:
     zero, which reads as a label on a gap and as an empty pair of
     brackets here.
 
-    Asked wherever a repr states two instants. A time is stated as an
-    instant, so how far apart two of them are is a fact the line does
-    not otherwise carry; every other kind of dimension states its own
-    magnitude already, and saying it twice is not saying more.
-
     Only of two times. A duration is read in seconds, so a distance of
     299 handed to this would come back as "5 m" -- five minutes, of a
-    span measured in metres.
+    span measured in metres. `span_text` is what an extent of any kind
+    is asked through; this is the arm of it which reads a clock.
     """
     if not isinstance(low, _TIME_TYPES) or not isinstance(high, _TIME_TYPES):
         return None
@@ -949,6 +947,42 @@ def duration_text(low, high) -> Text | None:
     if not (said := human_duration(seconds)):
         return None
     return Text(f"<{said}>", dascore_styles["keys"])
+
+
+def span_text(low, high, units: str | None = None) -> Text | None:
+    """
+    How wide an extent is, as a repr states it.
+
+    Asked wherever a repr states two ends. How far apart they lie is a
+    fact those two numbers do not carry: fiber running from 1212.4 m to
+    1636.7 m is 424.3 m of it, and the subtraction which says so is not
+    work a reader should be left to do.
+
+    A time span is a duration, said in the largest unit which fits.
+    Every other extent is as wide as its own numbers say, since reading
+    one in seconds would state a different quantity than the one
+    measured.
+
+    ``units`` is what to say that width in, and is for a line which
+    states them nowhere else. A line which already names its units --
+    a coordinate row with a units field, a dimension with its unit
+    after it -- passes nothing rather than say them twice.
+
+    None where there is no width to state: two ends which meet, which
+    is one sample and not a span of nothing, and a dimension of labels,
+    which has two ends and nothing measurable between them.
+    """
+    if isinstance(low, _TIME_TYPES) or isinstance(high, _TIME_TYPES):
+        return duration_text(low, high)
+    # Real, not Number: a complex pair has no width along one axis, and
+    # a bool is not a quantity two of which are apart by anything.
+    if not (isinstance(low, numbers.Real) and isinstance(high, numbers.Real)):
+        return None
+    width = float(high) - float(low)
+    if not np.isfinite(width) or width == 0:
+        return None
+    stated = f" {units}" if units else ""
+    return Text(f"<{width:g}{stated}>", dascore_styles["keys"])
 
 
 def _split_instant(rendered: str) -> tuple[str, str]:

--- a/dascore/utils/display.py
+++ b/dascore/utils/display.py
@@ -912,6 +912,29 @@ def human_duration(value: np.timedelta64 | pd.Timedelta | float) -> str:
     return f"{size:.3g} s"
 
 
+def _seconds_apart(seconds: float | None, low, high) -> float:
+    """
+    How far apart two times lie, from the span between them or the ends.
+
+    The span, where it is one: subtracting two instants is exact, and
+    nothing else says how far apart they are to the nanosecond.
+
+    Each end on its own where it is not. An int64 of nanoseconds holds
+    about 584 years and two instants can lie further apart than that:
+    pandas raises over it, numpy raises over it on some versions and
+    wraps on others, and a wrap shows as a span pointing the other way
+    from the ends it was read off -- five centuries came back as 84.6
+    of them. Reading the ends costs a precision only a far shorter span
+    would miss, and a span that short is never one of these. It is held
+    in nanoseconds itself, though, so a pair stated in a coarser unit
+    and further apart than any instant a nanosecond can reach is read
+    no better here than it was subtracted.
+    """
+    if seconds is not None and (seconds < 0) == (high < low):
+        return seconds
+    return to_float(high) - to_float(low)
+
+
 def duration_text(low, high) -> Text | None:
     """
     How long an extent lasted, as a repr states it.
@@ -932,17 +955,14 @@ def duration_text(low, high) -> Text | None:
     # not a question with an answer.
     if pd.isnull(low) or pd.isnull(high):
         return None
-    # Read from the two ends together, which is exact, and from each of
-    # them on its own where that cannot be done. An int64 of
-    # nanoseconds holds about 584 years and two instants can lie
-    # further apart than that: pandas raises over it, and numpy raises
-    # over it on some versions and wraps on others -- five centuries
-    # came back as 84.6 of them, pointing the other way from the ends
-    # they were read off.
     seconds = None
     try:
         span = high - low
     except (OutOfBoundsDatetime, OutOfBoundsTimedelta, OverflowError):
+        # Two instants can lie further apart than the int64 of
+        # nanoseconds holding them, which pandas raises over and numpy
+        # raises over on some versions. `_seconds_apart` says how far
+        # apart they are without them.
         pass
     except TypeError:
         # Two times which do not agree on a timezone do not subtract at
@@ -959,16 +979,7 @@ def duration_text(low, high) -> Text | None:
             # seconds, so numpy refuses to say how many. Neither will
             # this.
             return None
-        if (seconds < 0) != (high < low):
-            seconds = None
-    if seconds is None:
-        # Each end on its own, which fits where the span between them
-        # does -- to a precision only a far shorter span would miss.
-        # Held in nanoseconds itself, so a pair stated in a coarser unit
-        # and further apart than any instant a nanosecond can reach is
-        # read no better here than it was subtracted.
-        seconds = to_float(high) - to_float(low)
-    if not (said := human_duration(seconds)):
+    if not (said := human_duration(_seconds_apart(seconds, low, high))):
         return None
     return Text(f"<{said}>", dascore_styles["keys"])
 

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -2232,7 +2232,7 @@ class TestSpoolRepr:
         ]
         rendered = str(dc.spool(patches))
         assert "➤ Tracks (2 along distance)" in rendered
-        assert "<5>" in rendered
+        assert "<5.000>" in rendered
         assert " s>" not in rendered
 
     def test_a_track_states_the_unit_its_dimension_agrees_on(self):
@@ -2247,7 +2247,18 @@ class TestSpoolRepr:
             ).convert_units(distance="m")
             for tag in ("a", "b")
         ]
-        assert "<5 m>" in str(dc.spool(patches))
+        assert "<5.000 m>" in str(dc.spool(patches))
+
+    def test_a_dimension_states_how_wide_it_is(self):
+        """
+        A dimension line states its width the way its coordinates do.
+
+        Two ends do not carry it, and the same width read off the
+        tracks under the line is said the same way there.
+        """
+        rendered = str(dc.get_example_spool())
+        assert "distance: 0.000 to 299.000 m  <299.000 m>" in rendered
+        assert "<24 s>" in rendered
 
     def test_a_dimension_of_labels_has_ends_and_no_width(self):
         """A string dimension cannot be subtracted, and must not be."""

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import re
 import time
+from decimal import Decimal
+from fractions import Fraction
 from html import unescape
 from importlib.resources import files
 from pathlib import Path
@@ -1042,6 +1044,24 @@ class TestDurationText:
         """
         assert duration_text(low, high) is None
 
+    @pytest.mark.parametrize(
+        ("low", "high"),
+        [
+            (pd.Timestamp("2020-01-01"), np.datetime64("NaT")),
+            (np.datetime64("NaT"), pd.Timestamp("2020-01-01")),
+            (pd.NaT, pd.Timestamp("2020-01-01")),
+        ],
+        ids=["high_null", "low_null", "pandas_null"],
+    )
+    def test_an_end_which_is_not_a_time(self, low, high):
+        """
+        NaT compares against a Timestamp by raising.
+
+        How long an extent with one end unstated lasted is not a
+        question with an answer, and not one to raise a repr over.
+        """
+        assert duration_text(low, high) is None
+
     def test_further_apart_than_a_timedelta_holds(self):
         """
         Two instants can lie further apart than a Timedelta holds.
@@ -1104,8 +1124,18 @@ class TestSpanText:
         assert str(span_text(low, high)) == "<24 s>"
 
     def test_a_width_is_said_in_the_units_asked_for(self):
-        """A line which names its units nowhere else names them here."""
-        assert str(span_text(0.0, 5.0, "m")) == "<5 m>"
+        """A width said bare reads as if it were in other units."""
+        assert str(span_text(0.0, 5.0, "m")) == "<5.000 m>"
+
+    def test_a_width_is_drawn_as_the_ends_it_came_from_are(self):
+        """
+        A reader who subtracts what the line says gets what it says.
+
+        The same formatter the two ends are drawn with, so a float
+        states its decimals and an integer states none.
+        """
+        assert str(span_text(360.663, 362.119)) == "<1.456>"
+        assert str(span_text(0, 299)) == "<299>"
 
     def test_ends_which_meet_have_no_width(self):
         """One sample spans an instant, which is not a span of nothing."""
@@ -1141,10 +1171,11 @@ class TestSpanText:
         Two int64 ends can lie further apart than an int64 holds.
 
         Subtracted as they are stored the width wraps and comes back
-        negative, so each end is read as a float first.
+        negative, so both ends are read as Python integers first, which
+        have no width they do not fit in.
         """
         low, high = np.int64(-(2**63)), np.int64(2**63 - 1)
-        assert str(span_text(low, high)) == "<1.84467e+19>"
+        assert str(span_text(low, high)) == "<18446744073709551615>"
 
     def test_a_width_finer_than_a_float_resolves(self):
         """
@@ -1177,6 +1208,23 @@ class TestSpanText:
         and give an instant back in the other.
         """
         assert span_text(low, high) is None
+
+    @pytest.mark.parametrize(
+        ("low", "high", "expected"),
+        [
+            (Decimal("1.5"), Decimal("4.5"), "<3.0>"),
+            (Fraction(2**60), Fraction(2**60 + 1), "<1>"),
+        ],
+        ids=["decimal", "fraction"],
+    )
+    def test_a_width_held_in_a_kind_a_float_cannot_hold(self, low, high, expected):
+        """
+        Every kind of number has a width, not only the ones numpy has.
+
+        Read as two floats these come back as no width at all: 2**60
+        and one past it are the same float.
+        """
+        assert str(span_text(low, high)) == expected
 
     def test_a_pair_of_bools_has_no_width(self):
         """
@@ -1483,7 +1531,7 @@ class TestValuesAReaderCanRead:
         """
         frame = pd.DataFrame({"distance_min": [0.0], "distance_max": [299.0]})
         rendered = str(AnnotationSet(frame, dims=("distance",)))
-        assert "<299>" in rendered
+        assert "<299.000>" in rendered
         assert " m>" not in rendered
 
     def test_an_annotation_set_states_its_span(self):
@@ -2155,8 +2203,9 @@ class TestTableColumns:
         """
         It belongs where the row stating it puts it.
 
-        Only a time coordinate has a span, and it states it between its
-        max and its step rather than after everything a distance says.
+        A coordinate of one sample has no span, and the one beside it
+        states its own between its max and its step rather than after
+        everything the shorter row says.
         """
         assert self._columns([("a", "xz"), ("b", "xyz")]) == ["kind", "x", "y", "z"]
 

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -1166,10 +1166,26 @@ class TestSpanText:
             (None, None),
             (np.bool_(False), np.bool_(True)),
             (complex(0, 0), complex(1, 1)),
+            # Only complex128 subclasses Python's complex, so the rest
+            # came through as numbers and stated the modulus of the
+            # difference as though it were a width.
+            (np.complex64(0), np.complex64(3 + 4j)),
+            (np.complex128(0), np.complex128(3 + 4j)),
+            (np.clongdouble(0), np.clongdouble(3 + 4j)),
             (0.0, float("nan")),
             (0.0, float("inf")),
         ],
-        ids=["strings", "none", "bools", "complex", "nan", "infinite"],
+        ids=[
+            "strings",
+            "none",
+            "bools",
+            "complex",
+            "complex64",
+            "complex128",
+            "clongdouble",
+            "nan",
+            "infinite",
+        ],
     )
     def test_what_has_no_width_states_none(self, low, high):
         """

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -1140,6 +1140,32 @@ class TestSpanText:
         """How far apart two ends lie, the way a duration is read."""
         assert str(span_text(5, 2)) == "<3>"
 
+    @pytest.mark.parametrize(
+        ("low", "high"),
+        [
+            (np.datetime64("2020-01-01"), np.timedelta64(1, "D")),
+            (np.timedelta64(1, "D"), np.datetime64("2020-01-01")),
+            (pd.Timestamp("2020-01-01"), pd.Timedelta("1D")),
+        ],
+        ids=["numpy", "numpy_reversed", "pandas"],
+    )
+    def test_an_instant_and_a_duration_are_not_one_extent(self, low, high):
+        """
+        Two kinds of time do not make two ends.
+
+        Subtracted they raise out of the middle of a repr in one order,
+        and give an instant back in the other.
+        """
+        assert span_text(low, high) is None
+
+    def test_a_pair_of_bools_has_no_width(self):
+        """
+        A true which is one more than a false is arithmetic.
+
+        Python counts a bool as an integer, so nothing else refuses it.
+        """
+        assert span_text(False, True) is None
+
     def test_a_mixed_pair_is_not_read_as_a_duration(self):
         """
         One end a time and the other not is not an extent at all.

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -24,6 +24,7 @@ from dascore.core.annotations import (
     AnnotationSet,
     AnnotationSetAttrs,
 )
+from dascore.core.coords import get_coord
 from dascore.core.inventory import Acquisition, Cable, Network
 from dascore.utils import display
 from dascore.utils.display import (
@@ -1111,6 +1112,34 @@ class TestSpanText:
         """
         assert span_text(low, high) is None
 
+    def test_ends_no_float_holds_state_nothing(self):
+        """A repr says nothing rather than raising out of the middle of itself."""
+        assert span_text(0, 10**400) is None
+
+    def test_a_width_wider_than_its_own_dtype_holds(self):
+        """
+        Two int64 ends can lie further apart than an int64 holds.
+
+        Subtracted as they are stored the width wraps and comes back
+        negative, so each end is read as a float first.
+        """
+        low, high = np.int64(-(2**63)), np.int64(2**63 - 1)
+        assert str(span_text(low, high)) == "<1.84467e+19>"
+
+    def test_a_width_finer_than_a_float_resolves(self):
+        """
+        Two int64 ends one apart up near 2**60 are the same float.
+
+        Subtracted as floats their width reads as zero, which states no
+        span at all for two ends which really do lie apart.
+        """
+        low = np.int64(2**60)
+        assert str(span_text(low, low + 1)) == "<1>"
+
+    def test_a_width_is_not_which_end_came_first(self):
+        """How far apart two ends lie, the way a duration is read."""
+        assert str(span_text(5, 2)) == "<3>"
+
     def test_a_mixed_pair_is_not_read_as_a_duration(self):
         """
         One end a time and the other not is not an extent at all.
@@ -1340,7 +1369,7 @@ class TestValuesAReaderCanRead:
         subtraction the reader should not be left to do.
         """
         rendered = str(dc.get_example_patch().coords.coord_map["distance"])
-        assert "<299>" in rendered
+        assert "<299 m>" in rendered
 
     def test_a_distance_coord_states_no_rate(self):
         """One over a distance is not a quantity anyone quotes."""
@@ -1349,7 +1378,29 @@ class TestValuesAReaderCanRead:
     def test_a_span_off_the_time_axis_is_not_read_in_seconds(self):
         """299 metres read as a duration is "5 m", which is five minutes."""
         rendered = str(dc.get_example_patch().coords.coord_map["distance"])
-        assert " s>" not in rendered and " m>" not in rendered
+        assert " s>" not in rendered
+
+    def test_a_coord_states_its_units_on_its_values(self):
+        """
+        What a value is measured in is part of reading it.
+
+        Said in a field of its own it sat at the end of the line, a
+        column away from every number it applied to.
+        """
+        rendered = str(dc.get_example_patch().coords.coord_map["distance"])
+        assert "min: 0 m max: 299 m" in rendered
+        assert "step: 1 m" in rendered
+        assert "units: " not in rendered
+
+    def test_a_time_coord_states_no_units_of_its_own(self):
+        """An instant, and a step of "0.004s", say it in the writing."""
+        rendered = str(dc.get_example_patch().coords.coord_map["time"])
+        assert "units" not in rendered
+
+    def test_a_coord_with_no_values_still_states_its_units(self):
+        """Nothing is left to hang them on, and they are a fact of it."""
+        coord = get_coord(shape=(10,), units="m")
+        assert "units: m" in str(coord)
 
     def test_a_coord_of_one_sample_states_no_span(self):
         """Two ends which meet lie no distance apart."""
@@ -2005,7 +2056,6 @@ class TestCoordinatesAreStated:
             # Asked of the coordinate rather than stated: an integer is
             # 32 bits where the suite runs in WebAssembly and 64 here.
             ("dtype", None),
-            ("units", "m"),
         ],
     )
     def test_the_facts_a_coordinate_states(self, patch, label, value):

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -62,6 +62,7 @@ from dascore.utils.display import (
     range_texts,
     rate_text,
     render_text,
+    span_text,
     split_block,
     stated_fields,
 )
@@ -1068,6 +1069,58 @@ class TestDurationText:
         assert expected in str(said)
 
 
+class TestSpanText:
+    """Tests for how wide an extent is, whatever it is measured in."""
+
+    def test_two_numbers_state_how_far_apart_they_lie(self):
+        """The fact a min and a max do not carry on their own."""
+        assert str(span_text(1212.381, 1636.714)) == "<424.333>"
+
+    def test_two_instants_are_a_duration(self):
+        """A time is the one kind of extent said in units of its own."""
+        low = np.datetime64("2020-01-01T00:00:00")
+        high = np.datetime64("2020-01-01T00:00:24")
+        assert str(span_text(low, high)) == "<24 s>"
+
+    def test_a_width_is_said_in_the_units_asked_for(self):
+        """A line which names its units nowhere else names them here."""
+        assert str(span_text(0.0, 5.0, "m")) == "<5 m>"
+
+    def test_ends_which_meet_have_no_width(self):
+        """One sample spans an instant, which is not a span of nothing."""
+        assert span_text(5.0, 5.0) is None
+
+    @pytest.mark.parametrize(
+        ("low", "high"),
+        [
+            ("a", "c"),
+            (None, None),
+            (np.bool_(False), np.bool_(True)),
+            (complex(0, 0), complex(1, 1)),
+            (0.0, float("nan")),
+            (0.0, float("inf")),
+        ],
+        ids=["strings", "none", "bools", "complex", "nan", "infinite"],
+    )
+    def test_what_has_no_width_states_none(self, low, high):
+        """
+        A dimension of labels has two ends and nothing between them.
+
+        Neither has a pair which cannot be subtracted into one real
+        number, or whose difference is not a number a reader can read.
+        """
+        assert span_text(low, high) is None
+
+    def test_a_mixed_pair_is_not_read_as_a_duration(self):
+        """
+        One end a time and the other not is not an extent at all.
+
+        Without the guard numpy raises out of the middle of a repr.
+        """
+        assert span_text(np.datetime64("2020-01-01"), 1) is None
+        assert span_text(1, np.datetime64("2020-01-01")) is None
+
+
 class TestRangeTexts:
     """Tests for the two ends of a range, drawn as one range."""
 
@@ -1281,13 +1334,27 @@ class TestValuesAReaderCanRead:
         coord = dc.get_example_patch().coords.coord_map["time"]
         assert "250 Hz" in str(coord)
 
-    def test_a_distance_coord_states_neither(self):
+    def test_a_distance_coord_states_its_span(self):
         """
-        A distance from 0 to 299 m already says how wide it is, and a
-        rate over it is not a quantity anyone quotes.
+        A run of fiber is as long as its two ends lie apart, which is a
+        subtraction the reader should not be left to do.
         """
         rendered = str(dc.get_example_patch().coords.coord_map["distance"])
-        assert "Hz" not in rendered
+        assert "<299>" in rendered
+
+    def test_a_distance_coord_states_no_rate(self):
+        """One over a distance is not a quantity anyone quotes."""
+        assert "Hz" not in str(dc.get_example_patch().coords.coord_map["distance"])
+
+    def test_a_span_off_the_time_axis_is_not_read_in_seconds(self):
+        """299 metres read as a duration is "5 m", which is five minutes."""
+        rendered = str(dc.get_example_patch().coords.coord_map["distance"])
+        assert " s>" not in rendered and " m>" not in rendered
+
+    def test_a_coord_of_one_sample_states_no_span(self):
+        """Two ends which meet lie no distance apart."""
+        patch = dc.get_example_patch().select(distance=(0, 1), samples=True)
+        rendered = str(patch.coords.coord_map["distance"])
         assert "<" not in rendered
 
     def test_the_data_states_how_much_room_it_takes(self):
@@ -1310,16 +1377,17 @@ class TestValuesAReaderCanRead:
         rendered = str(AnnotationSet(frame, dims=("time",)))
         assert "min: 2020-01-01T00:00:00 max: …:09" in rendered
 
-    def test_an_annotation_set_over_distance_states_no_span(self):
+    def test_an_annotation_set_over_distance_states_its_width(self):
         """
-        A distance annotation is not measured in time.
+        A distance annotation is as wide as distance is.
 
-        299 metres read as a duration is "5 m", which is five minutes.
+        Not as many seconds: 299 metres read as a duration is "5 m",
+        which is five minutes.
         """
         frame = pd.DataFrame({"distance_min": [0.0], "distance_max": [299.0]})
         rendered = str(AnnotationSet(frame, dims=("distance",)))
-        assert "299" in rendered
-        assert "<" not in rendered
+        assert "<299>" in rendered
+        assert " m>" not in rendered
 
     def test_an_annotation_set_states_its_span(self):
         """The same fact a spool and a patch coordinate state."""

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -42,6 +42,7 @@ from dascore.utils.display import (
     _indent_text,
     _limit_items,
     _render_html,
+    _seconds_apart,
     _section_title,
     _storage_quantum,
     _strip_css_comments,
@@ -1070,6 +1071,23 @@ class TestDurationText:
         the whole of what pandas can say is 584.6 years wide.
         """
         assert "584.6 y" in str(duration_text(pd.Timestamp.min, pd.Timestamp.max))
+
+    def test_a_span_which_points_the_other_way_from_its_ends(self):
+        """
+        A wrap is a span whose sign its two ends disagree with.
+
+        Asked of `_seconds_apart` directly: whether numpy wraps here or
+        raises is a version away either way, and the reading which
+        rescues the wrap has to hold on both.
+        """
+        low = np.datetime64("1700-01-01", "ns")
+        high = np.datetime64("2200-01-01", "ns")
+        # What the wrapped subtraction says: 84.6 years, and negative.
+        wrapped = -2.668289673709552e9
+        assert _seconds_apart(wrapped, low, high) > 1.5e10
+        assert _seconds_apart(None, low, high) > 1.5e10
+        # A span its ends agree with is the span, to the nanosecond.
+        assert _seconds_apart(0.5, low, high) == 0.5
 
     def test_a_span_wider_than_the_nanoseconds_it_is_held_in(self):
         """

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -1046,10 +1046,30 @@ class TestDurationText:
         """
         Two instants can lie further apart than a Timedelta holds.
 
-        How long that is matters less than the extents it would
-        otherwise take down with it.
+        Subtracting them raises, so each is read on its own instead --
+        the whole of what pandas can say is 584.6 years wide.
         """
-        assert duration_text(pd.Timestamp.min, pd.Timestamp.max) is None
+        assert "584.6 y" in str(duration_text(pd.Timestamp.min, pd.Timestamp.max))
+
+    def test_a_span_wider_than_the_nanoseconds_it_is_held_in(self):
+        """
+        An int64 of nanoseconds holds about 584 years.
+
+        numpy wraps past that without saying so, and five centuries
+        came back as 84.6 of them.
+        """
+        low = np.datetime64("1700-01-01", "ns")
+        high = np.datetime64("2200-01-01", "ns")
+        assert "500 y" in str(duration_text(low, high))
+
+    def test_two_times_which_do_not_share_a_timezone(self):
+        """
+        One aware and one naive do not subtract.
+
+        Which matters less than the repr they would raise out of.
+        """
+        low = pd.Timestamp("2020-01-01", tz="UTC")
+        assert duration_text(low, pd.Timestamp("2020-01-02")) is None
 
     @pytest.mark.parametrize(
         ("low", "high", "expected"),


### PR DESCRIPTION
## Description

Two things a coordinate's repr made the reader work out for themselves.

**A span was stated for time and for nothing else.** The reasoning was that two instants say nothing about how far apart they are, while a distance from 0 to 299 m already says 299 m — which holds only for an axis starting at zero. A real fiber run does not:

```
*distance: CoordRange( min: 1212.381 max: 1636.714 step: 1.595 shape: (267,) dtype: float64 units: m )
```

That is 424.3 m of fiber, and the subtraction which says so was left to the reader.

**The units sat in a field of their own**, at the end of the line and a column away from every number they applied to.

So this adds `span_text`, which says how far apart two ends lie in whatever they are measured in — a duration for two times, the numbers' own difference otherwise, and nothing for a pair which is not two ends of one extent (labels, complex, bools, a mixed pair, an unstated end, or an end no float holds). Every repr which states two ends asks it: a coordinate row, an annotation set, and a spool's dimensions. `Spool._span_text`, which already worked this way for track widths, delegates to it rather than holding a second copy. A width is drawn by the same formatter its two ends are drawn with, so subtracting what a line says gives what the line says.

A coordinate now says its units on each value which has them — the two ends, the width between them, and the step — keeping the field only for a coordinate which states no value to hang them on. A time says nothing there: an instant, and a step of `0.004s`, state their units in the way they are written.

Before:

```
➤ Dimensions (time, distance)
    time:     2020-01-03T00:00:00 to …:23.996  <24 s>
    distance: 0.000 to 299.000 m
➤ Coordinates (distance: 300, time: 2000)
    *distance: CoordRange( min: 0 max: 299 step: 1 shape: (300,) dtype: int64 units: m )
    *time: CoordRange( min: 2017-09-18T00:00:00 max: …:07.996 <8 s> step: 0.004s · 250 Hz shape: (2000,) dtype: datetime64[ns] units: s )
```

After:

```
➤ Dimensions (time, distance)
    time:     2020-01-03T00:00:00 to …:23.996  <24 s>
    distance: 0.000 to 299.000 m  <299.000 m>
➤ Coordinates (distance: 300, time: 2000)
    *distance: CoordRange( min: 0 m max: 299 m <299 m> step: 1 m shape: (300,) dtype: int64 )
    *time: CoordRange( min: 2017-09-18T00:00:00 max: …:07.996 <8 s> step: 0.004s · 250 Hz shape: (2000,) dtype: datetime64[ns] )
```

Two ends which meet still state no span: one sample spans an instant, not a span of nothing.

`duration_text` was hardened along the way, since every extent now asks through it. An int64 of nanoseconds holds about 584 years and two instants can lie further apart than that — pandas raises over it, and numpy raises over it on some versions and wraps silently on others, so a coordinate running from 1700 to 2200 stated 84.6 years of a span which is five hundred. Both are now read one end at a time instead. A pair which does not agree on a timezone, and a pair with an unstated end, state nothing rather than raising out of the middle of a repr.

## Changelog

- changed: Coordinate, annotation, and spool dimension reprs state how wide an extent is for every dimension, not only for time.
- changed: A coordinate's repr states its units on the values they measure rather than in a field of its own.
- fixed: A repr states the true length of a span too wide for the nanoseconds holding it, rather than the wrapped one, and states nothing rather than raising where two times do not agree on a timezone or where one end is unstated.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Coordinate, dimension, and track displays now show spans consistently for numeric and time-based values.
  * Non-time coordinates display units alongside their values for clearer context.
  * Numeric widths use consistent precision.
  * Added support for displaying measurable spans across additional numeric types.

* **Bug Fixes**
  * Improved handling of very large, null, invalid, or timezone-mismatched time ranges.
  * Prevented display errors when calculating durations outside supported ranges or with incompatible timezones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->