### PR TITLE
Invert a plot's y axis only when it shows time

### DIFF
--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -12,6 +12,7 @@ import pandas as pd
 from dascore.units import Hz, get_quantity_str
 from dascore.units import s as seconds
 from dascore.utils.misc import suppress_warnings
+from dascore.utils.time import dtype_time_like
 
 
 def _get_dim_label(patch, dim):
@@ -50,6 +51,31 @@ def _get_ax(ax):
     if ax is None:
         _, ax = plt.subplots(1)
     return ax
+
+
+def _maybe_invert_yaxis(ax, patch, dim):
+    """
+    Invert the y axis if the dimension it displays is time-like.
+
+    Every patch plot uses this rule, so a patch is oriented the same way
+    however it is drawn. Seismic displays put time on a downward axis (shot
+    gathers, record sections), so a time-like y axis is flipped and any
+    other dimension is left alone. Distance in particular must not be
+    flipped: a wiggle plot draws its traces as offsets along the y axis, so
+    inverting it would point positive amplitudes down, which no wiggle
+    convention does.
+
+    Parameters
+    ----------
+    ax
+        The axis whose y axis may be inverted.
+    patch
+        The patch being plotted.
+    dim
+        The name of the dimension displayed on the y axis.
+    """
+    if dtype_time_like(patch.get_coord(dim).dtype):
+        ax.invert_yaxis()
 
 
 def _get_extents(dims_r, coords):

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -53,18 +53,18 @@ def _get_ax(ax):
     return ax
 
 
-def _maybe_invert_yaxis(ax, patch, dim):
+def _maybe_invert_yaxis(ax, patch, dim, ascending=True):
     """
-    Invert the y axis if the dimension it displays is time-like.
+    Orient the y axis so the dimension it displays runs the standard way.
 
     Plots which put a patch dimension on the y axis share this rule, so a
     dimension is oriented the same way whichever plot draws it. Seismic
     displays put time on a downward axis (shot gathers, record sections),
-    so a time-like y axis is flipped, taking the coordinate to ascend, and
-    any other dimension is left alone. Distance in particular must not be
-    flipped: a wiggle plot draws its traces as offsets along the y axis, so
-    flipping it would point positive amplitudes down as well, and distance
-    carries no convention which asks for that.
+    so a time-like dimension runs downward and any other runs upward.
+    Distance in particular must not run downward: a wiggle plot draws its
+    traces as offsets along the y axis, so flipping it would point positive
+    amplitudes down as well, and distance carries no convention which asks
+    for that.
 
     Parameters
     ----------
@@ -74,10 +74,16 @@ def _maybe_invert_yaxis(ax, patch, dim):
         The patch being plotted.
     dim
         The name of the dimension displayed on the y axis.
+    ascending
+        Whether the axis already places the dimension's values in ascending
+        order. False flips the decision, for a plot whose y positions follow
+        the array rather than the coordinate (wiggle offsets) and whose
+        coordinate is reverse sorted.
     """
+    invert = dtype_time_like(patch.get_coord(dim).dtype) != (not ascending)
     # invert_yaxis toggles, so check first; a caller can pass an axis which
     # is already time-down, and drawing on it must not flip it back.
-    if dtype_time_like(patch.get_coord(dim).dtype) and not ax.yaxis_inverted():
+    if invert and not ax.yaxis_inverted():
         ax.invert_yaxis()
 
 

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -57,13 +57,14 @@ def _maybe_invert_yaxis(ax, patch, dim):
     """
     Invert the y axis if the dimension it displays is time-like.
 
-    Every patch plot uses this rule, so a patch is oriented the same way
-    however it is drawn. Seismic displays put time on a downward axis (shot
-    gathers, record sections), so a time-like y axis is flipped and any
-    other dimension is left alone. Distance in particular must not be
+    Plots which put a patch dimension on the y axis share this rule, so a
+    dimension is oriented the same way whichever plot draws it. Seismic
+    displays put time on a downward axis (shot gathers, record sections),
+    so a time-like y axis is flipped, taking the coordinate to ascend, and
+    any other dimension is left alone. Distance in particular must not be
     flipped: a wiggle plot draws its traces as offsets along the y axis, so
-    inverting it would point positive amplitudes down, which no wiggle
-    convention does.
+    flipping it would point positive amplitudes down as well, and distance
+    carries no convention which asks for that.
 
     Parameters
     ----------

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -74,7 +74,9 @@ def _maybe_invert_yaxis(ax, patch, dim):
     dim
         The name of the dimension displayed on the y axis.
     """
-    if dtype_time_like(patch.get_coord(dim).dtype):
+    # invert_yaxis toggles, so check first; a caller can pass an axis which
+    # is already time-down, and drawing on it must not flip it back.
+    if dtype_time_like(patch.get_coord(dim).dtype) and not ax.yaxis_inverted():
         ax.invert_yaxis()
 
 

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -22,8 +22,9 @@ from dascore.utils.plotting import (
     _get_data_label,
     _get_dim_label,
     _get_extents,
+    _maybe_invert_yaxis,
 )
-from dascore.utils.time import dtype_time_like, is_datetime64
+from dascore.utils.time import is_datetime64
 from dascore.viz._labels import (
     draw_labels,
     image_cell_edges,
@@ -127,10 +128,8 @@ def _format_axis_labels(ax, patch, dims_r):
         dtype = patch.get_coord(dim).dtype
         if is_datetime64(dtype):
             _format_time_axis(ax, dim, x)
-        # Invert the y axis so origin is at the top. This follows the
-        # convention for seismic shot gathers where time increases downward.
-        if x == "y" and dtype_time_like(dtype):
-            ax.invert_yaxis()
+        if x == "y":
+            _maybe_invert_yaxis(ax, patch, dim)
 
 
 def _add_colorbar(ax, im, data, patch, log, scale):

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -231,13 +231,16 @@ def wiggle(
 
     Notes
     -----
-    - Traces are offset along the y axis and positive amplitudes point up,
-      as they point right in a conventional (time down) wiggle display.
+    - Traces are drawn as offsets along the y axis, so which way that axis
+      runs also decides which way positive amplitudes point.
 
-    - As in [waterfall](`dascore.viz.waterfall`), the y axis is
-      inverted only when it is "time-like", meaning when the traces are
-      stacked along time rather than along distance. If you don't want that,
-      invert the y axis of the returned axis object.
+    - As in [waterfall](`dascore.viz.waterfall`), the y axis is inverted
+      only when it is "time-like". Traces stacked along distance (the
+      default) therefore leave it alone, and positive amplitudes point up
+      just as they point right in a conventional (time down) wiggle
+      display. Traces stacked along time (`dim="distance"`) invert it to
+      keep time increasing downward, and the amplitudes follow it down. To
+      undo either, invert the y axis of the returned axis object.
     """
     # A length one dimension has nothing to connect, so drop it rather than
     # drawing a separate (one-sample) wiggle for every sample along the other.

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -17,6 +17,7 @@ from dascore.utils.plotting import (
     _get_ax,
     _get_data_label,
     _get_dim_label,
+    _maybe_invert_yaxis,
 )
 from dascore.utils.time import dtype_time_like
 
@@ -169,7 +170,8 @@ def _wiggle_2d(patch, ax, dim, scale, alpha, color, shade):
     # formatter there would overwrite them.
     if np.issubdtype(patch.get_coord(dim).dtype, np.datetime64):
         _format_time_axis(ax, dim, "x")
-    ax.invert_yaxis()  # invert y so it's consistent with waterfall
+    # The y axis holds the trace offsets, so it is other_dim which decides.
+    _maybe_invert_yaxis(ax, patch, other_dim)
     return ax
 
 
@@ -226,6 +228,16 @@ def wiggle(
     >>> # A single trace plots as one line
     >>> trace = patch.select(distance=0, samples=True)
     >>> _ = trace.viz.wiggle()
+
+    Notes
+    -----
+    - Traces are offset along the y axis and positive amplitudes point up,
+      as they point right in a conventional (time down) wiggle display.
+
+    - As in [waterfall](`dascore.viz.waterfall`), the y axis is
+      inverted only when it is "time-like", meaning when the traces are
+      stacked along time rather than along distance. If you don't want that,
+      invert the y axis of the returned axis object.
     """
     # A length one dimension has nothing to connect, so drop it rather than
     # drawing a separate (one-sample) wiggle for every sample along the other.

--- a/dascore/viz/wiggle.py
+++ b/dascore/viz/wiggle.py
@@ -171,7 +171,10 @@ def _wiggle_2d(patch, ax, dim, scale, alpha, color, shade):
     if np.issubdtype(patch.get_coord(dim).dtype, np.datetime64):
         _format_time_axis(ax, dim, "x")
     # The y axis holds the trace offsets, so it is other_dim which decides.
-    _maybe_invert_yaxis(ax, patch, other_dim)
+    # The offsets follow the array, so a reverse sorted coordinate already
+    # runs the other way and the axis must be flipped back.
+    other_coord = patch.get_coord(other_dim)
+    _maybe_invert_yaxis(ax, patch, other_dim, ascending=not other_coord.reverse_sorted)
     return ax
 
 

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -70,7 +70,7 @@ zoned.enrich(inventory).viz.waterfall(label_coord="noisy", show=True);
 ```
 
 ## Wiggle
-The [`wiggle patch function`](`dascore.viz.wiggle`) creates a wiggle plot of the patch data. We'll use the same patch as above to model this function.
+The [`wiggle patch function`](`dascore.viz.wiggle`) creates a wiggle plot of the patch data. Each trace is drawn as an offset along the y axis and positive amplitudes point up, just as they point right in a conventional (time down) wiggle display. Like the waterfall plot, the y axis is only inverted when it is time-like, which for a wiggle means the traces are stacked along time rather than along distance. We'll use the same patch as above to model this function.
 
 ```{python}
 import dascore as dc

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -70,7 +70,7 @@ zoned.enrich(inventory).viz.waterfall(label_coord="noisy", show=True);
 ```
 
 ## Wiggle
-The [`wiggle patch function`](`dascore.viz.wiggle`) creates a wiggle plot of the patch data. Each trace is drawn as an offset along the y axis and positive amplitudes point up, just as they point right in a conventional (time down) wiggle display. Like the waterfall plot, the y axis is only inverted when it is time-like, which for a wiggle means the traces are stacked along time rather than along distance. We'll use the same patch as above to model this function.
+The [`wiggle patch function`](`dascore.viz.wiggle`) creates a wiggle plot of the patch data. Each trace is drawn as an offset along the y axis, which, as in the waterfall plot, is only inverted when it is time-like. Traces stacked along distance, the default, therefore leave positive amplitudes pointing up, just as they point right in a conventional (time down) wiggle display. We'll use the same patch as above to model this function.
 
 ```{python}
 import dascore as dc

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -221,6 +221,13 @@ class TestWaterfall:
         assert random_patch.dims[1] in ax.get_xlabel().lower()
         assert isinstance(ax, plt.Axes)
 
+    def test_y_axis_inverted_only_when_time_like(self, random_patch):
+        """Time on the y axis increases downward; other dimensions do not."""
+        ax = random_patch.viz.waterfall()  # distance on the y axis
+        assert not ax.yaxis_inverted()
+        ax = random_patch.transpose("time", "distance").viz.waterfall()
+        assert ax.yaxis_inverted()
+
     def test_colorbar_scale(self, random_patch):
         """Tests for the scaling parameter."""
         ax_scalar = random_patch.viz.waterfall(scale=0.2)

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -284,3 +284,46 @@ class TestWiggle:
         patch = patch_1d + 10  # everything well above zero
         ax = patch.viz.wiggle(shade=True)
         assert min(ax.get_ylim()) <= 0
+
+
+class TestWiggleOrientation:
+    """Tests for which direction the wiggle plot's y axis runs."""
+
+    @pytest.fixture()
+    def small_patch(self, random_patch):
+        """A small patch to cut back on plot time."""
+        return random_patch.select(distance=(10, 15), samples=True).select(
+            time=(0, 20), samples=True
+        )
+
+    def test_distance_traces_not_inverted(self, small_patch):
+        """Traces stacked along distance leave distance increasing upward."""
+        ax = small_patch.viz.wiggle()
+        assert not ax.yaxis_inverted()
+
+    def test_time_traces_inverted(self, small_patch):
+        """Traces stacked along time keep the time increases downward convention."""
+        ax = small_patch.viz.wiggle(dim="distance")
+        assert ax.yaxis_inverted()
+
+    def test_positive_data_deflects_up(self, small_patch):
+        """An all positive patch, like an envelope, must deflect up."""
+        patch = small_patch.envelope("time")
+        assert np.all(patch.data >= 0)
+        ax = patch.viz.wiggle()
+        trace = _get_traces(ax)[0]
+        x = trace[0, 0]
+        offset, peak = trace[:, 1].min(), trace[:, 1].max()
+        assert peak > offset
+        # Display coordinates grow upward on the screen, whatever the axis does.
+        (_, offset_y), (_, peak_y) = ax.transData.transform([(x, offset), (x, peak)])
+        assert peak_y > offset_y
+
+    @pytest.mark.parametrize("trace_dim", ["distance", "time"])
+    def test_agrees_with_waterfall(self, small_patch, trace_dim):
+        """Both plots invert the y axis under the same conditions."""
+        connected_dim = next(iter(set(small_patch.dims) - {trace_dim}))
+        wiggle_ax = small_patch.viz.wiggle(dim=connected_dim)
+        # Waterfall puts the patch's first dimension on the y axis.
+        water_ax = small_patch.transpose(trace_dim, connected_dim).viz.waterfall()
+        assert wiggle_ax.yaxis_inverted() == water_ax.yaxis_inverted()

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -24,6 +24,15 @@ def _get_shade_vertices(ax):
     return poly, np.concatenate([x.vertices for x in poly.get_paths()])
 
 
+def _peak_is_above_offset(ax):
+    """Return True if the first trace's peak is drawn above its offset line."""
+    trace = _get_traces(ax)[0]
+    x, low, high = trace[0, 0], trace[:, 1].min(), trace[:, 1].max()
+    # Display coordinates grow upward on the screen, whatever the axis does.
+    (_, low_y), (_, high_y) = ax.transData.transform([(x, low), (x, high)])
+    return high_y > low_y
+
+
 class TestWiggle:
     """Tests for wiggle plot."""
 
@@ -310,14 +319,16 @@ class TestWiggleOrientation:
         """An all positive patch, like an envelope, must deflect up."""
         patch = small_patch.envelope("time")
         assert np.all(patch.data >= 0)
-        ax = patch.viz.wiggle()
-        trace = _get_traces(ax)[0]
-        x = trace[0, 0]
-        offset, peak = trace[:, 1].min(), trace[:, 1].max()
-        assert peak > offset
-        # Display coordinates grow upward on the screen, whatever the axis does.
-        (_, offset_y), (_, peak_y) = ax.transData.transform([(x, offset), (x, peak)])
-        assert peak_y > offset_y
+        assert _peak_is_above_offset(patch.viz.wiggle())
+
+    def test_time_traces_deflect_with_their_axis(self, small_patch):
+        """
+        Stacking traces along time inverts the axis they are offset along,
+        so their amplitudes point down with it. Documented, not desirable;
+        a time axis running upward would be the greater surprise.
+        """
+        patch = small_patch.envelope("time")
+        assert not _peak_is_above_offset(patch.viz.wiggle(dim="distance"))
 
     def test_inversion_is_idempotent(self, small_patch):
         """Drawing on an already time-down axis must not flip it back."""

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -319,6 +319,13 @@ class TestWiggleOrientation:
         (_, offset_y), (_, peak_y) = ax.transData.transform([(x, offset), (x, peak)])
         assert peak_y > offset_y
 
+    def test_inversion_is_idempotent(self, small_patch):
+        """Drawing on an already time-down axis must not flip it back."""
+        _, ax = plt.subplots(1)
+        for _ in range(2):
+            small_patch.viz.wiggle(dim="distance", ax=ax)
+            assert ax.yaxis_inverted()
+
     @pytest.mark.parametrize("trace_dim", ["distance", "time"])
     def test_agrees_with_waterfall(self, small_patch, trace_dim):
         """Both plots invert the y axis under the same conditions."""

--- a/tests/test_viz/test_wiggle.py
+++ b/tests/test_viz/test_wiggle.py
@@ -33,6 +33,12 @@ def _peak_is_above_offset(ax):
     return high_y > low_y
 
 
+def _trace_display_y(ax, index):
+    """Where a trace is drawn, in display coordinates, which grow upward."""
+    trace = _get_traces(ax)[index]
+    return ax.transData.transform([(trace[0, 0], trace[:, 1].mean())])[0][1]
+
+
 class TestWiggle:
     """Tests for wiggle plot."""
 
@@ -305,16 +311,6 @@ class TestWiggleOrientation:
             time=(0, 20), samples=True
         )
 
-    def test_distance_traces_not_inverted(self, small_patch):
-        """Traces stacked along distance leave distance increasing upward."""
-        ax = small_patch.viz.wiggle()
-        assert not ax.yaxis_inverted()
-
-    def test_time_traces_inverted(self, small_patch):
-        """Traces stacked along time keep the time increases downward convention."""
-        ax = small_patch.viz.wiggle(dim="distance")
-        assert ax.yaxis_inverted()
-
     def test_positive_data_deflects_up(self, small_patch):
         """An all positive patch, like an envelope, must deflect up."""
         patch = small_patch.envelope("time")
@@ -329,6 +325,26 @@ class TestWiggleOrientation:
         """
         patch = small_patch.envelope("time")
         assert not _peak_is_above_offset(patch.viz.wiggle(dim="distance"))
+
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_distance_runs_upward(self, small_patch, reverse):
+        """Distance increases upward however its coordinate is sorted."""
+        patch = small_patch.sort_coords("distance", reverse=reverse)
+        distance = patch.get_array("distance")
+        ax = patch.viz.wiggle()
+        far = _trace_display_y(ax, int(np.argmax(distance)))
+        near = _trace_display_y(ax, int(np.argmin(distance)))
+        assert far > near
+
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_time_runs_downward(self, small_patch, reverse):
+        """Time increases downward however its coordinate is sorted."""
+        patch = small_patch.sort_coords("time", reverse=reverse)
+        time = patch.get_array("time")
+        ax = patch.viz.wiggle(dim="distance")
+        late = _trace_display_y(ax, int(np.argmax(time)))
+        early = _trace_display_y(ax, int(np.argmin(time)))
+        assert late < early
 
     def test_inversion_is_idempotent(self, small_patch):
         """Drawing on an already time-down axis must not flip it back."""


### PR DESCRIPTION
## Description

`Patch.viz.wiggle` ended `_wiggle_2d` with an unconditional `ax.invert_yaxis()`, commented as keeping it "consistent with waterfall". That y axis holds the trace offsets, not a coordinate axis, so for the usual patch (traces stacked along distance) the flip did two things it shouldn't:

- Positive amplitudes pointed **down**. It is invisible on data that swings both ways, but obvious on positive-only data — `patch.envelope("time").viz.wiggle()` draws every envelope hanging below its trace line, and `shade=True`, documented as shading values "greater than the trace offset", fills downward.
- Distance ran **opposite** to `viz.waterfall` of the same patch, which is the consistency the inversion was there to provide. On the example patch, waterfall's distance axis goes `(0, 299)` while wiggle's went `(315, -15)`.

Waterfall never had this problem because it inverts conditionally: `_format_axis_labels` flips y only when the y dimension is time-like, which is the seismic "time increases downward" convention. Wiggle applied that rule to whatever happened to be on y.

The convention itself is the wider one. In ObsPy's record section, Fatiando's `seismic_wiggle`, and the usual matplotlib wiggle recipes, the axis that gets flipped is always *time*; the amplitude/offset axis never is. ObsPy's `orientation="horizontal"` section is the direct analogue of DASCore's default layout (time connected on x, traces stacked on y) and leaves the offset axis alone, so positive points up.

So the rule now lives in one place, `_maybe_invert_yaxis` in `dascore.utils.plotting`, and both plots use it: invert y only when the dimension shown there is time-like. For wiggle that means the y axis is inverted when the traces are stacked along time (`wiggle(dim="distance")`) and left alone when they are stacked along distance, which also puts positive amplitudes up. `viz.spectrogram` and `viz.specplot` route through waterfall and pick it up for free.

One wrinkle the rule has to account for: a wiggle's offsets follow the array, not the coordinate, so a reverse sorted dimension already runs backwards on the axis. `_maybe_invert_yaxis` therefore takes an `ascending` argument which flips the decision, and wiggle passes `not coord.reverse_sorted`. Distance increases upward and time increases downward whichever way the coordinate is sorted.

The one place positive amplitudes still point down is `wiggle(dim="distance")`, where the traces are stacked along time and share their axis with the amplitude. A time axis running upward seemed the greater surprise, so the inversion wins there; the docstring says so and a test pins it.

Tests cover both plots' orientation for both sort orders, the positive-only (envelope) case, drawing onto an axis a caller already inverted, and that the two plots agree on the same patch.

## Changelog

- fixed: `Patch.viz.wiggle` no longer inverts its y axis when the traces are stacked along distance, so positive amplitudes point up and distance runs the same way it does in `Patch.viz.waterfall`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plot orientations now automatically follow scientific conventions: time-based axes run downward, while distance-based axes run upward.
  * Wiggle plots consistently orient traces based on the stacked dimension and coordinate order.
  * Positive wiggle amplitudes now point in the expected direction for both time- and distance-based displays.
* **Documentation**
  * Updated visualization guidance to explain automatic trace orientation and override behavior.
* **Bug Fixes**
  * Prevented repeated axis inversion from changing plot orientation unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->