### PR TITLE
Read a channel axis in the units the distance map states

### DIFF
--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -49,10 +49,11 @@ from dascore.exceptions import (
     MissingOptionalDependencyError,
     ParameterError,
     PatchError,
+    UnitError,
     UnresolvedPatchError,
 )
 from dascore.models import values_equal
-from dascore.units import get_quantity_str
+from dascore.units import convert_units, get_quantity_str
 from dascore.utils.intervals import interval_masks, value_kind
 from dascore.utils.misc import iterate, validate_acquisition_key
 from dascore.utils.time import to_datetime64
@@ -685,6 +686,38 @@ def readable_on(dist_map) -> list[str]:
     return sorted({x for axis in dist_map.axes for x in AXIS_COORDS[axis]})
 
 
+# The units each map axis states its control points in. A channel number
+# counts channels and states no unit, while an instrument distance is the
+# interrogator's own meters, so a patch which carries feet must be
+# converted before the map can read it. Reading raw magnitudes instead
+# would place the channels somewhere else on the fiber, silently.
+AXIS_UNITS = {"channel": None, "instrument_distance": "m"}
+assert set(AXIS_UNITS) == set(DISTANCE_MAP_AXES)
+
+
+def to_axis_units(values, units, axis: str, name: str):
+    """
+    Return channel-like values in the units their map axis is written in.
+
+    Values which state no units are read as the axis's own, which is what
+    a patch that never mentioned units meant. Units the axis cannot be
+    expressed in are refused rather than silently taken as magnitudes.
+    """
+    to_units = AXIS_UNITS[axis]
+    if to_units is None or units is None or (isinstance(units, str) and not units):
+        return values
+    try:
+        return convert_units(values, to_units=to_units, from_units=units)
+    except UnitError as error:
+        msg = (
+            f"The patch's {name!r} coordinate is in "
+            f"{get_quantity_str(units)}, which the {axis!r} axis of the "
+            f"distance map cannot be read in; it states its control points "
+            f"in {to_units}. ({error})"
+        )
+        raise UnitError(msg) from error
+
+
 # Tracks whose fields enrich can project. The inventory names them, so a
 # track enrich can project and one selection can ask about are the same set.
 _TRACK_NAMES = tuple(TRACK_IDENTITY_FIELDS)
@@ -1254,6 +1287,18 @@ class PlacedRow(NamedTuple):
         return self.grid, self.low, self.high
 
 
+def _frame_units(frame, name: str) -> list:
+    """
+    Return each row's stated units for one coordinate, or None where it
+    states none. A planning frame keeps them private and a presented one
+    public, and either may answer here.
+    """
+    for column in (f"_{name}_units", f"{name}_units"):
+        if column in frame.columns:
+            return [None if pd.isnull(x) else x for x in frame[column]]
+    return [None] * len(frame)
+
+
 def _placed_rows(contexts, placements, frame, name: str):
     """
     Yield each row's channel grid and where it lands on the optical path.
@@ -1264,12 +1309,13 @@ def _placed_rows(contexts, placements, frame, name: str):
     """
     steps = frame[f"{name}_step"].to_numpy()
     bounds = zip(frame[f"{name}_min"], frame[f"{name}_max"], strict=True)
+    units = _frame_units(frame, name)
     # Keyed by identity because that is what is cheap: sibling epochs
     # resolve to one shared context object, and `__eq__` on an inventory
     # model dumps the whole subtree. A miss only recomputes.
     cache: dict[tuple, tuple] = {}
-    for context, (dim, axis), (low, high), step in zip(
-        contexts, placements, bounds, steps, strict=True
+    for context, (dim, axis), (low, high), step, unit in zip(
+        contexts, placements, bounds, steps, units, strict=True
     ):
         if context is None or dim is None:
             yield PlacedRow(context, low, high, None, None, None)
@@ -1286,10 +1332,16 @@ def _placed_rows(contexts, placements, frame, name: str):
         # patch states a negative one, and counting samples with it would
         # give none at all.
         step = abs(step)
-        key = (id(context), axis, low, high, step)
+        # The units are part of the key because the envelope columns hold
+        # each row's native magnitudes: the same numbers in feet and in
+        # meters describe different channels.
+        key = (id(context), axis, low, high, step, unit)
         if (placed := cache.get(key)) is None:
             grid = np.arange(round((high - low) / step) + 1) * step + low
-            placed = (grid, context.acquisition.channel_to_distance(grid, axis=axis))
+            # The grid stays in the row's own units, which is what the
+            # pieces are cut in; only the map reads it in its own.
+            on_axis = to_axis_units(grid, unit, axis, name)
+            placed = (grid, context.acquisition.channel_to_distance(on_axis, axis=axis))
             cache[key] = placed
         grid, distances = placed
         yield PlacedRow(context, low, high, grid, distances, None)

--- a/dascore/core/inventory.py
+++ b/dascore/core/inventory.py
@@ -958,7 +958,7 @@ class DistanceMap(InventoryModel):
         Parameters
         ----------
         values
-            Channel numbers or instrument distances.
+            Channel numbers, or instrument distances in meters.
         axis
             The input axis ``values`` are on; the map's first axis by
             default.
@@ -1096,7 +1096,9 @@ class Acquisition(TimeRangedModel):
         Parameters
         ----------
         values
-            The interrogator-reported coordinate to place on the path.
+            The interrogator-reported coordinate to place on the path,
+            in the units of ``axis``: bare channel numbers on the channel
+            axis, and meters on the instrument_distance axis.
         axis
             Which of the map's input axes ``values`` are on; the map's
             first axis by default.

--- a/dascore/proc/inventory.py
+++ b/dascore/proc/inventory.py
@@ -27,6 +27,7 @@ from dascore.core._spool_inventory import (
     is_unset,
     map_axis_coords,
     readable_on,
+    to_axis_units,
     validate_enrich_conflict,
     validate_enrich_selection,
 )
@@ -266,7 +267,8 @@ def _get_channel_distances(patch, acquisition) -> tuple[str, str, np.ndarray]:
         if len(dims) != 1:
             msg = f"The {name!r} coordinate must belong to exactly one dimension."
             raise PatchError(msg)
-        values = patch.coords.coord_map[name].values
+        coord = patch.coords.coord_map[name]
+        values = to_axis_units(coord.values, coord.units, axis, name)
         try:
             distances = acquisition.channel_to_distance(values, axis=axis)
         except InvalidInventoryError as error:

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -272,6 +272,8 @@ assert patch_out.attrs.gauge_length == 10.0
 assert "zone" in patch_out.coords.coord_map
 ```
 
+The per-channel facts reach the patch by way of the acquisition's `distance_map`, which places each channel on the optical path. The map states its control points in meters on the `instrument_distance` axis, so a patch whose axis is written in another length — feet, kilometers — is converted before it is read, and one whose axis is not a length at all raises rather than being taken for meters. The `channel` axis counts channels and states no unit.
+
 Enrichment never removes a patch. One the inventory does not describe comes out unchanged rather than missing, with a warning, so an inventory that deliberately covers part of an archive needs no pruning first. Deciding membership is a separate step, below.
 
 What it copies follows one rule on each side. Every scalar fact the resolved acquisition states — and its interrogator's, under `interrogator.` — becomes an attr, and every per-channel fact the optical path states becomes a coordinate: the geometry axes, the label groups, and how each channel is coupled. Four names are left out of the blanket form: `data_type` and `data_units`, which describe the data as it now stands rather than the system that recorded it, and `sample_rate` and `spatial_interval`, which the patch's own coordinates already state and which a decimated patch would contradict. Naming one asks for it anyway.

--- a/tests/test_core/test_spool_inventory.py
+++ b/tests/test_core/test_spool_inventory.py
@@ -3170,6 +3170,48 @@ def _float_grid_pair(distance, span):
     ).check()
 
 
+class TestChannelUnits:
+    """Placing an index row's channels reads its stated units."""
+
+    def test_selection_is_invariant_to_the_axis_units(self, patch, inventory):
+        """The same channels answer whether the row is in meters or feet."""
+        shapes = []
+        for candidate in (patch, patch.convert_units(distance="ft")):
+            spool = dc.spool(candidate).attach_inventory(inventory).enrich()
+            shapes.append(spool.select(zone="north")[0].shape)
+        assert shapes[0] == shapes[1]
+
+    def test_expansion_is_invariant_to_the_axis_units(self, patch, inventory):
+        """As is expanding by a group, which places the same channels."""
+        expanded = []
+        for candidate in (patch, patch.convert_units(distance="ft")):
+            spool = dc.spool(candidate).attach_inventory(inventory).enrich()
+            expanded.append([x.shape for x in spool.expand_by("zone")])
+        assert expanded[0] == expanded[1]
+
+    def test_rows_in_different_units_are_placed_apart(self, patch, inventory):
+        """
+        Envelope columns hold each row's own magnitudes, so two rows
+        stating the same numbers in different units are different
+        channels and may not share a cached placement.
+        """
+        feet = patch.set_units(distance="ft").update_attrs(tag="feet")
+        spool = dc.spool([patch, feet]).attach_inventory(inventory).enrich()
+        out = spool.select(zone="north")
+        assert len(out) == 2
+        # The whole feet patch is north: 299 feet is 91 meters.
+        shapes = {x.attrs.tag: x.shape for x in out}
+        assert shapes["feet"] == patch.shape
+        assert shapes["random"] == (100, patch.shape[1])
+
+    def test_incompatible_units_raise(self, patch, inventory):
+        """A coordinate which is not a length cannot be a distance."""
+        seconds = patch.set_units(distance="s")
+        spool = dc.spool(seconds).attach_inventory(inventory)
+        with pytest.raises(UnitError, match="instrument_distance"):
+            spool.select(zone="north")
+
+
 class TestChannelSelectContracts:
     """Contracts channel selection keeps with enrichment, plans, and flags."""
 

--- a/tests/test_core/test_spool_inventory.py
+++ b/tests/test_core/test_spool_inventory.py
@@ -32,7 +32,12 @@ from dascore.constants import (
     enrich_coords_description,
     enrich_on_missing_description,
 )
-from dascore.core._spool_inventory import InventoryRef, is_unset, resolve_row_epochs
+from dascore.core._spool_inventory import (
+    InventoryRef,
+    _frame_units,
+    is_unset,
+    resolve_row_epochs,
+)
 from dascore.core.inventory import (
     _SYSTEM_FACT_NAMES,
     Acquisition,
@@ -3168,6 +3173,34 @@ def _float_grid_pair(distance, span):
             ),
         )
     ).check()
+
+
+class TestFrameUnits:
+    """Reading a frame's stated units under either spelling."""
+
+    def test_private_column(self):
+        """A planning frame keeps the units private."""
+        frame = pd.DataFrame({"_distance_units": ["m", "ft"]})
+
+        assert _frame_units(frame, "distance") == ["m", "ft"]
+
+    def test_public_column(self):
+        """A presented one makes them public."""
+        frame = pd.DataFrame({"distance_units": ["m", "ft"]})
+
+        assert _frame_units(frame, "distance") == ["m", "ft"]
+
+    def test_unstated_units_are_none(self):
+        """A row which states no units answers None, not NaN."""
+        frame = pd.DataFrame({"_distance_units": ["m", None]})
+
+        assert _frame_units(frame, "distance") == ["m", None]
+
+    def test_no_units_column(self):
+        """A frame with neither spelling states units for no row."""
+        frame = pd.DataFrame({"distance_min": [0.0, 0.0]})
+
+        assert _frame_units(frame, "distance") == [None, None]
 
 
 class TestChannelUnits:

--- a/tests/test_proc/test_proc_inventory.py
+++ b/tests/test_proc/test_proc_inventory.py
@@ -24,6 +24,7 @@ from dascore.exceptions import (
     InvalidInventoryError,
     ParameterError,
     PatchError,
+    UnitError,
     UnresolvedPatchError,
 )
 
@@ -357,6 +358,41 @@ class TestChannelResolution:
         """Overwriting the mapped axis would break the next resolution."""
         with pytest.raises(PatchError, match="will not overwrite"):
             patch.enrich(inventory, attrs=False, coords=("distance",))
+
+
+class TestCoordinateUnits:
+    """The map reads its axis in its own units, not the patch's."""
+
+    def test_feet_place_the_same_channels(self, patch, inventory):
+        """Restating the axis in feet moves no channel along the fiber."""
+        in_meters = patch.enrich(inventory)
+        in_feet = patch.convert_units(distance="ft").enrich(inventory)
+        for name in ("zone", "x", "y", "z"):
+            first = in_meters.get_array(name)
+            second = in_feet.get_array(name)
+            if np.issubdtype(first.dtype, np.floating):
+                assert np.allclose(first, second, equal_nan=True)
+            else:
+                assert np.array_equal(first, second)
+
+    def test_incompatible_units_raise(self, patch, inventory):
+        """A coordinate which is not a length cannot be a distance."""
+        seconds = patch.set_units(distance="s")
+        with pytest.raises(UnitError, match="instrument_distance"):
+            seconds.enrich(inventory, attrs=False, coords=("zone",))
+
+    def test_a_channel_axis_ignores_units(self, patch, inventory):
+        """Channel numbers count channels, so they state no unit."""
+        channel_map = _replace_acquisition(
+            inventory, distance_map=DistanceMap(channel=(0.0,), distance=(100.0,))
+        )
+        channels = np.arange(len(patch.get_coord("distance")))
+        with_channel = patch.update_coords(channel=("distance", channels))
+        bare = with_channel.enrich(channel_map, attrs=False, coords=("zone",))
+        with_units = with_channel.set_units(channel="ft").enrich(
+            channel_map, attrs=False, coords=("zone",)
+        )
+        assert np.array_equal(bare.get_array("zone"), with_units.get_array("zone"))
 
 
 class TestGeometryColumns:


### PR DESCRIPTION
## Description

Fixes #1073.

An `Acquisition`'s `distance_map` states its `instrument_distance` control points in the interrogator's own meters, but both places that read a patch onto the path handed it the coordinate's raw magnitudes:

- `dascore/proc/inventory.py::_get_channel_distances`, which `Patch.enrich` projects through, and
- `dascore/core/_spool_inventory.py::_placed_rows`, which the spool planner rebuilds each index row's channel grid in.

So a patch whose distance axis had been converted to feet was placed somewhere else on the fiber, and enrichment, inventory-backed selection, and `expand_by` all silently answered about different channels. On the example pair, `zone` went from 100 north / 200 south channels to 208 uncovered / 31 north / 61 south.

Both paths now convert the values into the units the axis they are read on is written in — meters for `instrument_distance`, and nothing at all for `channel`, which counts channels and states no unit. A coordinate stating no units is still read as the axis's own, so nothing changes for patches that never mentioned units, and a coordinate which is not a length raises `UnitError` rather than being taken for meters.

Two details worth naming:

- The planner keeps the grid in the row's own units, since that is what the kept pieces are cut in; only the map reads it converted.
- The row's units join the placement cache key. Envelope columns hold each row's native magnitudes, so two rows stating the same numbers in different units are different channels and must not share a placement.

## Changelog

- fixed: `Patch.enrich` and inventory-backed spool selection now read a channel axis in the units the acquisition's `distance_map` states, so a patch whose distance coordinate was converted to another length places the same channels; a coordinate which is not a length raises instead of being read as meters.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
