### PR TITLE
Stop doing timedelta arithmetic numpy has deprecated

### DIFF
--- a/dascore/units.py
+++ b/dascore/units.py
@@ -243,8 +243,8 @@ def convert_units(
         follows the input rather than matching it (an int in yields a float
         out) and callers legitimately pass values the checker only knows as
         `object`. Note that data is returned untouched whenever from_units
-        is None, so None survives that path but raises a TypeError once
-        there are real factors to apply.
+        is None or already names to_units, so None survives those paths but
+        raises a TypeError once there are real factors to apply.
     to_units
         The desired units after the conversion
     from_units
@@ -264,6 +264,9 @@ def convert_units(
     elif to_units is None:
         msg = "Cannot convert units to_units are not specified"
         raise UnitError(msg)
+    # Factors of one aren't free: they round a timedelta64 through float.
+    if units_match(from_units, to_units):
+        return data
     try:
         mult1, add, mult2 = _get_conversion_factors(from_units, to_units)
     except DimensionalityError as e:

--- a/dascore/utils/chunk_plan.py
+++ b/dascore/utils/chunk_plan.py
@@ -304,7 +304,9 @@ def _check_tolerance_value(value, name, shown=None, *, allow_infinite=False):
         raise ParameterError(msg)
     try:
         null = bool(pd.isnull(value))
-        negative = not null and value < 0
+        # A bare 0 would make numpy cast the timedelta to a generic unit.
+        zero = to_timedelta64(0) if is_timedelta64(value) else 0
+        negative = not null and value < zero
     except TypeError:
         msg = (
             f"The tolerance for {name!r} must be a sample count, a quantity, "

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -64,7 +64,7 @@ from dascore.utils.misc import (
     yield_sub_sequences,
 )
 from dascore.utils.paths import is_memory_uri
-from dascore.utils.time import is_timedelta64, to_float
+from dascore.utils.time import is_timedelta64, to_float, to_timedelta64
 from dascore.workflow.builtin import Concatenate, Stack
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
 from dascore.workflow.identity import (
@@ -1077,7 +1077,9 @@ def get_window_axis_step(
     def _check_not_negative(val, name):
         """Ensure a step or overlap value isn't negative."""
         magnitude = val.magnitude if isinstance(val, dc.units.Quantity) else val
-        if magnitude is not None and magnitude < 0:
+        # A bare 0 would make numpy cast the timedelta to a generic unit.
+        zero = to_timedelta64(0) if is_timedelta64(magnitude) else 0
+        if magnitude is not None and magnitude < zero:
             msg = f"{name} must be non-negative"
             raise ParameterError(msg)
 


### PR DESCRIPTION
## Description

Closes #1074.

Merging contiguous datetime patches ran arithmetic NumPy has deprecated for `np.timedelta64`. NumPy says the implicit generic-unit cast of a bare number will become an error, so operations that succeed today are on a path to failure.

The reported site is one of three, all reached by ordinary use:

- `dascore/units.py::convert_units` applied its affine factors as `(data * mult1 + add) * mult2`. `_middle_step` expresses each member's step in the merged coordinate's units, and a time-like coordinate may only carry seconds, so the conversion is always an identity — but adding the bare zero to a `timedelta64` is the deprecated cast, and it fires once per input patch. Fixed by returning the data untouched when the units already match, using the `units_match` helper written for exactly this.

  Skipping only the zero offset would have silenced the warning while leaving a second, quieter bug in place: `mult2` is a float `1.0`, so the identity conversion rounds a `timedelta64`'s integer payload through float64. `convert_units(np.timedelta64(2**53 + 1, "ns"), "s", "s")` came back one nanosecond short on every NumPy version. The fast path is exact.

- `dascore/utils/chunk_plan.py::_check_tolerance_value` tested `value < 0`, comparing a `timedelta64` against a bare integer. Every timedelta tolerance passes through it, so `spool.chunk(time=None, tolerance=to_timedelta64(10))` — the spelling added in #1065 — warns too.

- `dascore/utils/patch.py::_check_not_negative` did the same for a rolling window or step, so `patch.rolling(time=<timedelta>, step=<timedelta>)` warns.

Both comparisons now use the `to_timedelta64(0) if is_timedelta64(value) else 0` idiom `chunk_plan.py` already uses for the chunk value.

### Behavior notes

A conversion to the units already held now returns the input object rather than a float copy, so `convert_units(1, "m", "m")` is `1`, not `1.0`. Conversions that actually convert are untouched, offsets included.

One degenerate input changes: a `Quantity` whose *magnitude* is `pd.NA`, passed as units, previously propagated `<NA>` and now raises `TypeError` from the magnitude comparison. `get_quantity(pd.NA)` already raises, so such a value can only arrive by constructing the `Quantity` by hand; nothing in the repo does.

### Verification

The deprecation exists only on NumPy >= 2.4, so I built a second environment on NumPy 2.5.2 (the reporter's version) to check against. The issue's reproduction is warning-free there after the change, and I confirmed each of the three sites warned before it and does not after. The full suite passes on both 2.3.5 and 2.5.2, and coverage stays at 100% on all three changed files.

I found the second and third sites by sweeping the whole suite under 2.5.2 for this warning, not from the issue.

No tests added — these are deprecation fixes, and the existing suite already covers the changed lines.

### Follow-up, not in this PR

That sweep also found about a dozen test-only spellings that trip the same deprecation — `np.timedelta64("NaT")` with no unit, and `time_array + 10` on a `datetime64` array — across `test_display`, `test_file_spool`, `test_directory_spool`, `test_spool_inventory`, `test_dasdae`, `test_prodml_write` and `test_patch_chunk`. None is a library defect, but they will fail once NumPy promotes the deprecation, and they want one mechanical sweep rather than a partial fix here.

## Changelog

- fixed: Merging patches with a datetime coordinate, chunking with a timedelta tolerance, and rolling over a timedelta window no longer perform arithmetic NumPy has deprecated for `timedelta64`.
- fixed: `dascore.units.convert_units` no longer rounds a `timedelta64` through floating point when the units already match.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unit conversions now preserve data unchanged when the source and destination units are identical.
  - Improved validation for time-based tolerances, steps, and overlaps.
  - Prevented deprecated NumPy time comparison behavior and related warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->