### PR TITLE
Name the path plot's first lane for the acquisition

### DIFF
--- a/dascore/viz/inventory.py
+++ b/dascore/viz/inventory.py
@@ -289,7 +289,7 @@ def _select_tracks(frame, tracks, path):
     for name in wanted:
         if name == "acquisition":
             keep.extend(
-                x for x in dict.fromkeys(frame["lane"]) if x.startswith("acquisition")
+                x for x in dict.fromkeys(frame["lane"]) if x.startswith("acquisition (")
             )
         elif name in TRACKS or name in groups:
             keep.append(name)
@@ -348,9 +348,9 @@ def path(
     """
     Plot what lies along one optical path, against optical distance.
 
-    Every track the path describes becomes a lane: the channels each
-    acquisition places on it, the optical components which give it its
-    length, how it is coupled to the ground, and one lane per label
+    Every track the path describes becomes a lane: the stretch each
+    acquisition places channels on, the optical components which give it
+    its length, how it is coupled to the ground, and one lane per label
     group. A geometry column such as chainage or depth can be drawn as a
     line panel beneath, sharing the distance axis; it breaks wherever the
     path states no value rather than bridging the gap. Where the fiber

--- a/dascore/viz/inventory.py
+++ b/dascore/viz/inventory.py
@@ -195,7 +195,12 @@ def _path_acquisitions(array, path, time=None):
 
 
 def _track_frame(path, acquisitions) -> pd.DataFrame:
-    """Flatten a path's tracks into one frame of intervals."""
+    """Flatten a path's tracks into one frame of intervals.
+
+    Each row states the track it came from as well as the lane it draws
+    in, since a label group may be named for a track and the two are
+    then told apart by nothing a lane name carries.
+    """
     rows = []
     for acquisition in acquisitions:
         dist_map = acquisition.distance_map
@@ -205,6 +210,7 @@ def _track_frame(path, acquisitions) -> pd.DataFrame:
         rows.append(
             {
                 "lane": f"acquisition ({acquisition.code})",
+                "track": "acquisition",
                 "start": float(distances[0]),
                 "end": float(distances[-1]),
                 "value": acquisition.code,
@@ -215,6 +221,7 @@ def _track_frame(path, acquisitions) -> pd.DataFrame:
         rows.append(
             {
                 "lane": "components",
+                "track": "components",
                 "start": component.distance_min,
                 "end": component.distance_max,
                 "value": type(component).__name__,
@@ -225,6 +232,7 @@ def _track_frame(path, acquisitions) -> pd.DataFrame:
         rows.append(
             {
                 "lane": "coupling",
+                "track": "coupling",
                 "start": coupling.distance_min,
                 "end": coupling.distance_max,
                 "value": coupling.coupling_type,
@@ -235,6 +243,10 @@ def _track_frame(path, acquisitions) -> pd.DataFrame:
         rows.append(
             {
                 "lane": item.group,
+                # Label groups are their own track, whatever they are
+                # named: a group which takes a track's name is still a
+                # group, and the track has no claim on its lane.
+                "track": "labels",
                 "start": item.distance_min,
                 "end": item.distance_max,
                 "value": item.value,
@@ -287,23 +299,32 @@ def _select_tracks(frame, tracks, path):
     wanted = [tracks] if isinstance(tracks, str) else list(tracks)
     keep = []
     for name in wanted:
-        if name == "acquisition":
-            keep.extend(
-                x for x in dict.fromkeys(frame["lane"]) if x.startswith("acquisition (")
+        if name not in TRACKS and name not in groups:
+            # The acquisition lanes are the only ones whose name is not
+            # the name they are asked for, so they are the only ones a
+            # caller can read off the plot and type back in vain.
+            hint = (
+                " The lanes one draws are named for their acquisitions, "
+                "and are asked for by the track's name."
+                if name.startswith("acquisition (")
+                else ""
             )
-            # A label group may be named for the track, since the name is
-            # not reserved. The two lanes are then both meant, rather than
-            # the track's reading putting the group out of reach.
-            if name in groups:
-                keep.append(name)
-        elif name in TRACKS or name in groups:
-            keep.append(name)
-        else:
             msg = (
                 f"{name!r} is not a track of this optical path; the tracks are "
-                f"{TRACKS} and the label groups are {groups}."
+                f"{TRACKS} and the label groups are {groups}.{hint}"
             )
             raise ParameterError(msg)
+        if name in TRACKS:
+            # A track draws a lane per acquisition and one otherwise.
+            keep.extend(frame.loc[frame["track"] == name, "lane"])
+        if name in groups:
+            # A group may take a track's name, since what an inventory
+            # reserves are the coordinate names. Both lanes are then
+            # meant: the track has no claim on the group's.
+            keep.append(name)
+    # First mention wins, so a lane named twice is drawn where it was
+    # first asked for rather than where it was last.
+    keep = list(dict.fromkeys(keep))
     out = frame[frame["lane"].isin(keep)]
     if out.empty:
         msg = f"This optical path has nothing to draw for tracks={tracks!r}."
@@ -353,13 +374,14 @@ def path(
     """
     Plot what lies along one optical path, against optical distance.
 
-    Every track the path describes becomes a lane: the stretch each
-    acquisition places channels on, the optical components which give it
-    its length, how it is coupled to the ground, and one lane per label
-    group. A geometry column such as chainage or depth can be drawn as a
-    line panel beneath, sharing the distance axis; it breaks wherever the
-    path states no value rather than bridging the gap. Where the fiber
-    physically is belongs to map().
+    Every track becomes a lane: one per acquisition recording through
+    the path, spanning the distances its channels cover, the optical
+    components which give the path its length, how it is coupled to the
+    ground, and one lane per label group. A geometry column such as
+    chainage or depth can be drawn as a line panel beneath, sharing the
+    distance axis; it breaks wherever the path states no value rather
+    than bridging the gap. Where the fiber physically is belongs to
+    map().
 
     Parameters
     ----------
@@ -381,8 +403,10 @@ def path(
     tracks
         Which lanes to draw, in order: any of "acquisition", "components",
         "coupling", and the path's label group names. None draws all.
-        "acquisition" draws a lane per acquisition, and also the label
-        group of that name where a path states one.
+        "acquisition" draws one lane per acquisition, named with its
+        code. A label group may take a track's name, since what an
+        inventory reserves are the coordinate names; both lanes are then
+        drawn, and neither can be asked for on its own.
     columns
         Geometry columns to draw as line panels beneath the lanes. The
         CRS's position axes are refused, since they belong on a map.
@@ -435,7 +459,7 @@ def path(
     frame = _track_frame(chosen, _path_acquisitions(array, chosen, time))
     # The palette is the path's, not this figure's, so drawing some of the
     # tracks colors them as drawing all of them does.
-    vocabulary = list(frame.loc[frame["lane"] != "components", "value"])
+    vocabulary = list(frame.loc[frame["track"] != "components", "value"])
     frame = _select_tracks(frame, tracks, chosen)
     lanes = list(dict.fromkeys(frame["lane"]))
     if ax is None:

--- a/dascore/viz/inventory.py
+++ b/dascore/viz/inventory.py
@@ -291,6 +291,11 @@ def _select_tracks(frame, tracks, path):
             keep.extend(
                 x for x in dict.fromkeys(frame["lane"]) if x.startswith("acquisition (")
             )
+            # A label group may be named for the track, since the name is
+            # not reserved. The two lanes are then both meant, rather than
+            # the track's reading putting the group out of reach.
+            if name in groups:
+                keep.append(name)
         elif name in TRACKS or name in groups:
             keep.append(name)
         else:
@@ -376,6 +381,8 @@ def path(
     tracks
         Which lanes to draw, in order: any of "acquisition", "components",
         "coupling", and the path's label group names. None draws all.
+        "acquisition" draws a lane per acquisition, and also the label
+        group of that name where a path states one.
     columns
         Geometry columns to draw as line panels beneath the lanes. The
         CRS's position axes are refused, since they belong on a map.

--- a/dascore/viz/inventory.py
+++ b/dascore/viz/inventory.py
@@ -204,7 +204,7 @@ def _track_frame(path, acquisitions) -> pd.DataFrame:
         distances = dist_map.distance
         rows.append(
             {
-                "lane": f"channels ({acquisition.code})",
+                "lane": f"acquisition ({acquisition.code})",
                 "start": float(distances[0]),
                 "end": float(distances[-1]),
                 "value": acquisition.code,
@@ -245,7 +245,7 @@ def _track_frame(path, acquisitions) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-TRACKS = ("channels", "components", "coupling")
+TRACKS = ("acquisition", "components", "coupling")
 
 
 def _column_panels(path, columns, crs) -> list[str]:
@@ -287,9 +287,9 @@ def _select_tracks(frame, tracks, path):
     wanted = [tracks] if isinstance(tracks, str) else list(tracks)
     keep = []
     for name in wanted:
-        if name == "channels":
+        if name == "acquisition":
             keep.extend(
-                x for x in dict.fromkeys(frame["lane"]) if x.startswith("channels")
+                x for x in dict.fromkeys(frame["lane"]) if x.startswith("acquisition")
             )
         elif name in TRACKS or name in groups:
             keep.append(name)
@@ -374,7 +374,7 @@ def path(
         end may be None, or ..., to run to the path's own bound. A long
         lead-in otherwise crushes the instrumented part into a corner.
     tracks
-        Which lanes to draw, in order: any of "channels", "components",
+        Which lanes to draw, in order: any of "acquisition", "components",
         "coupling", and the path's label group names. None draws all.
     columns
         Geometry columns to draw as line panels beneath the lanes. The

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -213,7 +213,7 @@ Only what an object states is shown, so a field left at its default does not tak
 
 An inventory also draws itself through its `viz` namespace, and each of the three plots looks along one coordinate.
 
-[`Inventory.viz.path`](`dascore.viz.inventory.path`) looks along **optical distance**, which is the coordinate the data is in. Every track the path describes becomes a lane, so the stretch an acquisition places channels on, the components, the coupling, and each label group line up against the same axis:
+[`Inventory.viz.path`](`dascore.viz.inventory.path`) looks along **optical distance**, which is the coordinate the data is in. Every track becomes a lane, so the distances each acquisition's channels cover, the components, the coupling, and each label group line up against the same axis:
 
 ```{python}
 inventory.viz.path(show=True);

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -213,7 +213,7 @@ Only what an object states is shown, so a field left at its default does not tak
 
 An inventory also draws itself through its `viz` namespace, and each of the three plots looks along one coordinate.
 
-[`Inventory.viz.path`](`dascore.viz.inventory.path`) looks along **optical distance**, which is the coordinate the data is in. Every track the path describes becomes a lane, so the channels an acquisition places, the components, the coupling, and each label group line up against the same axis:
+[`Inventory.viz.path`](`dascore.viz.inventory.path`) looks along **optical distance**, which is the coordinate the data is in. Every track the path describes becomes a lane, so the stretch an acquisition places channels on, the components, the coupling, and each label group line up against the same axis:
 
 ```{python}
 inventory.viz.path(show=True);

--- a/tests/test_viz/test_inventory_viz.py
+++ b/tests/test_viz/test_inventory_viz.py
@@ -389,10 +389,10 @@ class TestPath:
         assert list(zip(lane["start"], lane["end"])) == [(100.0, 200.0), (200.0, 350.0)]
 
     def test_all_tracks(self, site):
-        """Every track becomes a lane, channels first."""
+        """Every track becomes a lane, the acquisition first."""
         ax = path(site, "DAS.L1.00", time="2026-06-10")
         assert _lanes(ax) == [
-            "channels (RAW)",
+            "acquisition (RAW)",
             "components",
             "coupling",
             "zone",
@@ -504,8 +504,8 @@ class TestPath:
         """tracks= picks lanes and orders them."""
         ax = path(site, "DAS.L1.00", time="2026-06-10", tracks=("zone", "coupling"))
         assert _lanes(ax) == ["zone", "coupling"]
-        ax = path(site, "DAS.L1.00", time="2026-06-10", tracks="channels")
-        assert _lanes(ax) == ["channels (RAW)"]
+        ax = path(site, "DAS.L1.00", time="2026-06-10", tracks="acquisition")
+        assert _lanes(ax) == ["acquisition (RAW)"]
 
     def test_unknown_track(self, site):
         """A track which is not a track nor a label group is refused."""
@@ -515,16 +515,16 @@ class TestPath:
     def test_tracks_with_nothing(self, site):
         """Asking for a lane the path has no rows for is an error."""
         with pytest.raises(ParameterError, match="nothing to draw for tracks"):
-            path(site, "spur", tracks="channels")
+            path(site, "spur", tracks="acquisition")
 
     def test_acquisition_not_effective(self, site):
         """An acquisition which overlaps the path but not the time is left out."""
         ax = path(site, "DAS.L1.00", time="2026-06-20")
-        assert not any(x.startswith("channels") for x in _lanes(ax))
+        assert not any(x.startswith("acquisition") for x in _lanes(ax))
 
     def test_point_distance_map(self, site):
         """A single-point distance map draws as a tick, not a guessed span."""
-        ax = path(site, "DAS.L1.00", time="2026-08-01", tracks="channels")
+        ax = path(site, "DAS.L1.00", time="2026-08-01", tracks="acquisition")
         assert ax.lines
         assert ax.lines[0].get_xdata()[0] == 100.0
 

--- a/tests/test_viz/test_inventory_viz.py
+++ b/tests/test_viz/test_inventory_viz.py
@@ -206,6 +206,51 @@ def build_labeled_inventory(values: int, crs, lines: int = 1) -> inv.Inventory:
     ).check()
 
 
+# The address of the one path build_grouped_inventory draws.
+PATH = "DAS.L3.00"
+
+
+def build_grouped_inventory(group: str, codes=("RAW",)) -> inv.Inventory:
+    """One path of one label group, interrogated by an acquisition per code."""
+    optical_path = inv.OpticalPath(
+        name="main",
+        location_code="00",
+        optical_components=(
+            inv.FiberSegment(name="run", distance_min=0.0, distance_max=300.0),
+        ),
+        labels=(
+            inv.OpticalPathLabel(
+                distance_min=0.0, distance_max=150.0, group=group, value="dark"
+            ),
+        ),
+    )
+    acquisitions = tuple(
+        inv.Acquisition(
+            code=code,
+            location_code="00",
+            data_category="DAS",
+            sample_rate=100.0,
+            gauge_length=10.0,
+            distance_map=inv.DistanceMap(channel=(0.0, 300.0), distance=(0.0, 300.0)),
+        )
+        for code in codes
+    )
+    return inv.Inventory(
+        networks=(
+            inv.Network(
+                code="DAS",
+                fiber_arrays=(
+                    inv.FiberArray(
+                        code="L3",
+                        acquisitions=acquisitions,
+                        optical_paths=(optical_path,),
+                    ),
+                ),
+            ),
+        )
+    ).check()
+
+
 @pytest.fixture(scope="module")
 def site():
     """The inventory most tests draw."""
@@ -509,43 +554,62 @@ class TestPath:
 
     def test_track_name_shared_with_label_group(self):
         """A group named for the track is drawn, not shadowed by it."""
-        labels = (
-            inv.OpticalPathLabel(
-                distance_min=0.0, distance_max=150.0, group="acquisition", value="dark"
-            ),
-        )
-        optical_path = inv.OpticalPath(
-            name="main",
-            location_code="00",
-            optical_components=(
-                inv.FiberSegment(name="run", distance_min=0.0, distance_max=300.0),
-            ),
-            labels=labels,
-        )
-        acquisition = inv.Acquisition(
-            code="RAW",
-            location_code="00",
-            data_category="DAS",
-            sample_rate=100.0,
-            gauge_length=10.0,
-            distance_map=inv.DistanceMap(channel=(0.0, 300.0), distance=(0.0, 300.0)),
-        )
-        inventory = inv.Inventory(
-            networks=(
-                inv.Network(
-                    code="DAS",
-                    fiber_arrays=(
-                        inv.FiberArray(
-                            code="L3",
-                            acquisitions=(acquisition,),
-                            optical_paths=(optical_path,),
-                        ),
-                    ),
-                ),
-            )
-        ).check()
-        ax = path(inventory, "DAS.L3.00", tracks="acquisition")
+        ax = path(build_grouped_inventory("acquisition"), PATH, tracks="acquisition")
         assert _lanes(ax) == ["acquisition (RAW)", "acquisition"]
+
+    def test_track_name_only_prefixed(self):
+        """A group whose name merely starts with the track's is its own."""
+        inventory = build_grouped_inventory("acquisition zone")
+        assert _lanes(path(inventory, PATH, tracks="acquisition")) == [
+            "acquisition (RAW)"
+        ]
+        assert _lanes(path(inventory, PATH, tracks="acquisition zone")) == [
+            "acquisition zone"
+        ]
+
+    def test_track_does_not_claim_a_lane_shaped_group(self):
+        """A group named like a lane is a group, not an acquisition."""
+        inventory = build_grouped_inventory("acquisition (FOO)")
+        assert _lanes(path(inventory, PATH, tracks="acquisition")) == [
+            "acquisition (RAW)"
+        ]
+        assert _lanes(path(inventory, PATH, tracks="acquisition (FOO)")) == [
+            "acquisition (FOO)"
+        ]
+        # With no acquisition to draw, the track finds nothing rather
+        # than answering with the group which looks like one.
+        bare = build_grouped_inventory("acquisition (FOO)", codes=())
+        with pytest.raises(ParameterError, match="nothing to draw for tracks"):
+            path(bare, PATH, tracks="acquisition")
+
+    def test_one_lane_per_acquisition(self):
+        """Acquisitions of different codes are a lane each, and select together."""
+        inventory = build_grouped_inventory("zone", codes=("RAW", "AUX"))
+        assert _lanes(path(inventory, PATH, tracks="acquisition")) == [
+            "acquisition (RAW)",
+            "acquisition (AUX)",
+        ]
+
+    def test_shared_name_keeps_the_track_position(self):
+        """A group named for a track travels with it, not to the end."""
+        inventory = build_grouped_inventory("acquisition")
+        ax = path(inventory, PATH, tracks=("components", "acquisition"))
+        assert _lanes(ax) == ["components", "acquisition (RAW)", "acquisition"]
+
+    def test_lane_name_is_not_a_track_name(self, site):
+        """Typing the lane read off the plot says which name to use."""
+        with pytest.raises(ParameterError, match="asked for by the track's name"):
+            path(site, "DAS.L1.00", time="2026-06-10", tracks="acquisition (RAW)")
+
+    def test_repeated_track_drawn_where_first_asked(self, site):
+        """A lane named twice keeps the position of its first mention."""
+        ax = path(
+            site,
+            "DAS.L1.00",
+            time="2026-06-10",
+            tracks=("coupling", "zone", "coupling"),
+        )
+        assert _lanes(ax) == ["coupling", "zone"]
 
     def test_unknown_track(self, site):
         """A track which is not a track nor a label group is refused."""

--- a/tests/test_viz/test_inventory_viz.py
+++ b/tests/test_viz/test_inventory_viz.py
@@ -507,6 +507,46 @@ class TestPath:
         ax = path(site, "DAS.L1.00", time="2026-06-10", tracks="acquisition")
         assert _lanes(ax) == ["acquisition (RAW)"]
 
+    def test_track_name_shared_with_label_group(self):
+        """A group named for the track is drawn, not shadowed by it."""
+        labels = (
+            inv.OpticalPathLabel(
+                distance_min=0.0, distance_max=150.0, group="acquisition", value="dark"
+            ),
+        )
+        optical_path = inv.OpticalPath(
+            name="main",
+            location_code="00",
+            optical_components=(
+                inv.FiberSegment(name="run", distance_min=0.0, distance_max=300.0),
+            ),
+            labels=labels,
+        )
+        acquisition = inv.Acquisition(
+            code="RAW",
+            location_code="00",
+            data_category="DAS",
+            sample_rate=100.0,
+            gauge_length=10.0,
+            distance_map=inv.DistanceMap(channel=(0.0, 300.0), distance=(0.0, 300.0)),
+        )
+        inventory = inv.Inventory(
+            networks=(
+                inv.Network(
+                    code="DAS",
+                    fiber_arrays=(
+                        inv.FiberArray(
+                            code="L3",
+                            acquisitions=(acquisition,),
+                            optical_paths=(optical_path,),
+                        ),
+                    ),
+                ),
+            )
+        ).check()
+        ax = path(inventory, "DAS.L3.00", tracks="acquisition")
+        assert _lanes(ax) == ["acquisition (RAW)", "acquisition"]
+
     def test_unknown_track(self, site):
         """A track which is not a track nor a label group is refused."""
         with pytest.raises(ParameterError, match="'nope' is not a track"):


### PR DESCRIPTION
## Description

`Inventory.viz.path` drew its first lane as `channels (DAS)`. The lane is one acquisition, named with its code, and the bar spans the distances that acquisition's channels cover — so it names the acquisition, and now says so: `acquisition (DAS)`.

The lane string doubles as the key `tracks=` selects on, so the track name follows the lane's: `tracks="acquisition"` where it used to be `tracks="channels"`. Leaving them apart would mean selecting a lane by a name the plot never shows.

That rename turned out to expose a real fault in how lanes were selected. `_select_tracks` decided which track drew a lane by matching the lane's *name*, which is only ever approximately true: a label group may be named for a track, since what an inventory reserves are the coordinate names, and a group called `acquisition (FOO)` is as legal as any other. The prefix scan drew such a group as though an acquisition had placed it — typographically indistinguishable from a real acquisition lane — and, with no acquisitions on the path, answered `tracks="acquisition"` with the group's lane instead of saying nothing was there.

Each row of the track frame now states the track it came from, and selection reads that instead of the lane's name. A group is a group whatever it is named; a group sharing a track's name is drawn alongside it and keeps the track's position in `tracks=`; and asking for a track that drew nothing says so.

Two fixes fall out of the same code:

- A lane named twice in `tracks=` keeps the position of its **first** mention. `tracks=("coupling", "zone", "coupling")` drew `coupling` last, because the order map handed a repeated lane its last index, while the docstring promises "in order". Pre-existing, reachable without the rename.
- The palette skips the components *track* rather than every lane named `components`, so a label group of that name keeps stable colors.

Finally, the lane a caller reads off the plot — `acquisition (RAW)` — is the one name `tracks=` does not take. Typing it back now says which name to use rather than only listing the tokens.

### Not fixed here

A label group named `components` merges into the components track's lane: both get the literal lane name `components` in `_track_frame`, so the group's intervals are drawn inside the track's lane and cannot be selected alone. That is a lane-*naming* collision rather than a selection one, it predates this branch, and separating them means changing a displayed lane name for a track this PR does not otherwise touch. Happy to open an issue, or fold it in if you would rather it went with this.

`Inventory.viz.path` is not in v0.1.21 — it lands with #952 in the upcoming release — so nothing written against the last release breaks, and there is nothing to warn users about renaming.

## Changelog

- none

<!-- viz.path itself is new in this same unreleased cycle (#952), so a bullet
     saying a lane was renamed would tell users about a name they never saw.
     Say the word and I will add a `changed:` bullet instead. -->

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed the inventory visualization track from “channels” to “acquisition.”
  * Improved track selection so acquisition lanes, label groups, and repeated selections are handled consistently.
  * Added clearer validation and guidance for invalid track names.
  * Ensured each acquisition is displayed in its own lane.

* **Documentation**
  * Updated inventory visualization terminology and tutorial descriptions to reflect the new acquisition track naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->