### PR TITLE
Share the colorbar scale and label helpers between map_fiber and waterfall

### DIFF
--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -9,9 +9,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from dascore.units import Hz, get_quantity_str
+from dascore.exceptions import ParameterError
+from dascore.units import Hz, get_quantity_str, maybe_convert_percent_to_fraction
 from dascore.units import s as seconds
-from dascore.utils.misc import suppress_warnings
+from dascore.utils.misc import suppress_warnings, tukey_fence
 from dascore.utils.time import dtype_time_like
 
 
@@ -20,9 +21,20 @@ def _get_dim_label(patch, dim):
     maybe_units = patch.get_coord(dim).units if dim in patch.coords else None
     if maybe_units == 1 / seconds:
         maybe_units = Hz
-    dim_str = string.capwords(str(dim))
-    unit_str = f" [{get_quantity_str(maybe_units)}]" if maybe_units else ""
-    return dim_str + unit_str
+    return _get_label(string.capwords(str(dim)), maybe_units)
+
+
+def _get_label(name, units, default=""):
+    """
+    Label a quantity as "name [units]", leaving out whichever part is unset.
+
+    Returns default if neither is set.
+    """
+    name = str(name) if name else ""
+    units = get_quantity_str(units) or ""
+    if name and units:
+        return f"{name} [{units}]"
+    return name or units or default
 
 
 def _get_data_label(patch, default=""):
@@ -31,10 +43,104 @@ def _get_data_label(patch, default=""):
 
     Returns default if the patch has neither a data_type nor data_units.
     """
-    data_type = str(patch.attrs.get("data_type", ""))
-    data_units = get_quantity_str(patch.attrs.data_units) or ""
-    dunits = f" [{data_units}]" if (data_type and data_units) else f"{data_units}"
-    return f"{data_type}{dunits}" or default
+    data_type = patch.attrs.get("data_type", "")
+    return _get_label(data_type, patch.attrs.data_units, default)
+
+
+def _validate_scale_type(scale_type):
+    """Validate that scale_type is either 'relative' or 'absolute'."""
+    valid_types = {"relative", "absolute"}
+    if scale_type not in valid_types:
+        msg = f"scale_type must be one of {valid_types}, but got '{scale_type}'"
+        raise ParameterError(msg)
+
+
+def _get_scale(scale, scale_type, data):
+    """
+    Calculate the colorbar limits based on scale and scale_type.
+    """
+    _validate_scale_type(scale_type)
+    # Whatever form scale was given in, this makes it a list.
+    scale = maybe_convert_percent_to_fraction(scale)
+    match (scale, scale_type):
+        # Case 1: Single value with relative scaling
+        # Scale is symmetric around the mean, using fraction of dynamic range
+        case (scale, "relative") if len(scale) == 1:
+            scale = scale[0]
+            if scale == 0:
+                msg = (
+                    "Relative scale value of 0 would produce degenerate colorbar limits"
+                )
+                raise ParameterError(msg)
+            mod = 0.5 * (np.nanmax(data) - np.nanmin(data))
+            if mod == 0:
+                # Constant data, use small epsilon to avoid degenerate limits
+                mod = 1e-10
+            mean = np.nanmean(data)
+            scale = np.asarray([mean - scale * mod, mean + scale * mod])
+        # Case 2: No scale specified with relative scaling
+        # Use Tukey's fence (C*IQR, C is normally 1.5) to exclude outliers.
+        # This prevents a few extreme values from obscuring the majority of the
+        # data at the cost of a slight performance penalty.
+        case ([], "relative"):
+            return tukey_fence(data)
+        # Case 3: Sequence with relative scaling
+        # Scale values represent fractions of the data range [0, 1]
+        # and are mapped to [data_min, data_max]
+        case (scale, "relative"):
+            scale = np.array(scale)
+            # Validate scale parameters
+            if len(scale) != 2:
+                msg = (
+                    "Relative scale must be a number or a length-2 sequence, "
+                    f"got {scale}"
+                )
+                raise ParameterError(msg)
+            if np.any(scale < 0) or scale[0] > scale[1]:
+                msg = (
+                    "Relative scale values cannot be negative and the first "
+                    f"value must be less than the second. You passed {scale}"
+                )
+                raise ParameterError(msg)
+            dmin, dmax = np.nanmin(data), np.nanmax(data)
+            data_range = dmax - dmin
+            # Map [0, 1] to [data_min, data_max]
+            scale = dmin + scale * data_range
+        # Case 4: Absolute scaling
+        case (scale, "absolute") if len(scale) == 1:
+            scale = np.array([-abs(scale[0]), abs(scale[0])])
+        # Case 5: Absolute scaling with a pair is used as the limits as is;
+        # anything longer cannot be.
+        case (scale, "absolute") if len(scale) > 2:
+            msg = f"scale must be a number or a length-2 sequence, got {scale}"
+            raise ParameterError(msg)
+
+    # Scale values are used directly as colorbar limits
+    return scale
+
+
+def _add_colorbar(ax, im, data, label, scale=None):
+    """
+    Add a colorbar with the given label to the plot.
+
+    When the limits leave data above or below them, extend triangles say so.
+    Only a finite pair of limits is ever applied, so only that can clip.
+    """
+    above, below = False, False
+    if scale is not None and len(scale) == 2 and np.all(np.isfinite(scale)):
+        mi, mx = np.nanmin(data), np.nanmax(data)
+        above = (mx > scale[1]) and not np.isclose(scale[1], mx)
+        below = (mi < scale[0]) and not np.isclose(scale[0], mi)
+    extend_map = {
+        (True, True): "both",
+        (True, False): "max",
+        (False, True): "min",
+    }
+    extend = extend_map.get((above, below), "neither")
+    cb = ax.get_figure().colorbar(
+        im, ax=ax, fraction=0.05, pad=0.025, extend=extend, extendfrac=0.025
+    )
+    cb.set_label(label)
 
 
 def _get_cmap(cmap):

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -67,10 +67,10 @@ def _get_scale(scale, scale_type, data):
         # Scale is symmetric around the mean, using fraction of dynamic range
         case (scale, "relative") if len(scale) == 1:
             scale = scale[0]
-            if scale == 0:
-                msg = (
-                    "Relative scale value of 0 would produce degenerate colorbar limits"
-                )
+            # Zero gives one limit twice, and less than zero puts them in the
+            # wrong order.
+            if scale <= 0:
+                msg = f"Relative scale value of {scale} must be greater than 0"
                 raise ParameterError(msg)
             mod = 0.5 * (np.nanmax(data) - np.nanmin(data))
             if mod == 0:

--- a/dascore/viz/map_fiber.py
+++ b/dascore/viz/map_fiber.py
@@ -26,11 +26,11 @@ def _get_position(patch, position):
     """
     The values drawn along one axis, and the coordinate they came from.
 
-    An array is drawn as given and belongs to no coordinate, so its axis
-    gets no label.
+    An array is drawn as given, masked points and all, and belongs to no
+    coordinate, so its axis gets no label.
     """
     if not isinstance(position, str):
-        return np.asarray(position), None
+        return np.asanyarray(position), None
     if position not in patch.coords:
         msg = f"{position} not found in patch coordinates"
         raise ParameterError(msg)
@@ -60,7 +60,7 @@ def _get_data_to_color(patch, x):
 def _get_color(patch, color, x):
     """The values to color by, and what the colorbar calls them."""
     if not isinstance(color, str):
-        return np.asarray(color), ""
+        return np.asanyarray(color), ""
     if color in patch.coords:
         units = patch.coords.coord_map[color].units
         return patch.coords.get_array(color), _get_label(color, units)

--- a/dascore/viz/map_fiber.py
+++ b/dascore/viz/map_fiber.py
@@ -1,4 +1,4 @@
-"""Module for waterfall plotting."""
+"""Module for drawing a fiber where it lies, colored by a per-channel value."""
 
 from __future__ import annotations
 
@@ -12,39 +12,29 @@ from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
 from dascore.utils.patch import patch_function
 from dascore.utils.plotting import (
+    _add_colorbar,
     _get_ax,
     _get_cmap,
+    _get_data_label,
     _get_dim_label,
+    _get_label,
+    _get_scale,
 )
 
 
-def _set_scale(im, scale, scale_type, color_coords):
-    """Set the scale of the color bar based on scale and scale_type."""
-    # check scale parameters
-    if scale_type not in {"absolute", "relative"}:
-        msg = f"scale_type must be 'absolute' or 'relative', got {scale_type!r}"
-        raise ParameterError(msg)
-    if not (isinstance(scale, float | int) or len(scale) == 2):
-        msg = "scale must be a number or a length-2 sequence"
-        raise ParameterError(msg)
-    # make sure we have a len two array
-    modifier = 1
-    if scale_type == "relative":
-        modifier = 0.5 * (np.nanmax(color_coords) - np.nanmin(color_coords))
-        # only one scale parameter provided, center around mean
-    if isinstance(scale, float):
-        mean = np.nanmean(color_coords)
-        scale = np.array([mean - scale * modifier, mean + scale * modifier])
-    im.set_clim(scale)
+def _get_position(patch, position):
+    """
+    The values drawn along one axis, and the coordinate they came from.
 
-
-def _get_colorbar_label(data_type, data_units):
-    """Label the colorbar, leaving out whichever part is unset."""
-    name = str(data_type) if data_type else ""
-    units = str(data_units) if data_units else ""
-    if name and units:
-        return f"{name} ({units})"
-    return name or units
+    An array is drawn as given and belongs to no coordinate, so its axis
+    gets no label.
+    """
+    if not isinstance(position, str):
+        return np.asarray(position), None
+    if position not in patch.coords:
+        msg = f"{position} not found in patch coordinates"
+        raise ParameterError(msg)
+    return patch.coords.get_array(position), position
 
 
 def _get_data_to_color(patch, x):
@@ -65,6 +55,22 @@ def _get_data_to_color(patch, x):
         )
         raise ParameterError(msg)
     return data.reshape(points)
+
+
+def _get_color(patch, color, x):
+    """The values to color by, and what the colorbar calls them."""
+    if not isinstance(color, str):
+        return np.asarray(color), ""
+    if color in patch.coords:
+        units = patch.coords.coord_map[color].units
+        return patch.coords.get_array(color), _get_label(color, units)
+    if color == "data":
+        return _get_data_to_color(patch, x), _get_data_label(patch)
+    msg = (
+        f"{color} not found in patch coordinates. Use 'data' to "
+        "color by the patch's own data."
+    )
+    raise ParameterError(msg)
 
 
 @patch_function()
@@ -100,11 +106,14 @@ def map_fiber(
         A matplotlib colormap string or instance. Set to None to not plot the
         colorbar.
     scale
-        If not None, controls the saturation level of the colorbar.
-        Values can either be a float, to set upper and lower limit to the same
-        value centered around the mean of the data, or a length 2 tuple
-        specifying upper and lower limits. See `scale_type` for controlling how
-        values are scaled.
+        If not None, controls the saturation level of the colorbar. A single
+        number is symmetric: with `scale_type="relative"` the limits sit that
+        fraction of half the data range either side of the mean, and with
+        `scale_type="absolute"` they are -abs(scale) and abs(scale). A pair
+        of numbers gives the lower and upper limits: fractions of the data
+        range, from 0 to 1, when relative, or the values themselves when
+        absolute. Percent quantities, such as `10 * dc.units.percent`, are
+        converted to fractions.
     scale_type
         Controls the type of scaling specified by `scale` parameter. Options
         are:
@@ -125,55 +134,26 @@ def map_fiber(
     >>> reduced = patch.std("time").squeeze()
     >>> _ = reduced.viz.map_fiber("latitude", "longitude", "data")
     """
-    dims = []
-    if isinstance(x, str):
-        if x not in patch.coords:
-            msg = f"{x} not found in patch coordinates"
-            raise ParameterError(msg)
-        dims.append(x)
-        x = patch.coords.get_array(x)
-    if isinstance(y, str):
-        if y not in patch.coords:
-            msg = f"{y} not found in patch coordinates"
-            raise ParameterError(msg)
-        dims.append(y)
-        y = patch.coords.get_array(y)
-    if isinstance(color, str):
-        if color in patch.coords:
-            data_type = color
-            data_units = patch.coords.coord_map[color].units
-            color = patch.coords.get_array(color)
-        elif color == "data":
-            data_type = patch.attrs.data_type
-            data_units = patch.attrs.data_units
-            color = _get_data_to_color(patch, x)
-        else:
-            msg = (
-                f"{color} not found in patch coordinates. Use 'data' to "
-                "color by the patch's own data."
-            )
-            raise ParameterError(msg)
-    else:
-        data_type = ""
-        data_units = ""
+    x, x_dim = _get_position(patch, x)
+    y, y_dim = _get_position(patch, y)
+    color, label = _get_color(patch, color, x)
 
     ax = _get_ax(ax)
-    cmap = _get_cmap(cmap)
+    im = ax.scatter(x, y, c=color, cmap=_get_cmap(cmap))
 
-    im = ax.scatter(x, y, c=color, cmap=cmap)
-
-    # scale colorbar
     if scale is not None:
-        _set_scale(im, scale, scale_type, color)
+        scale = _get_scale(scale, scale_type, color)
+    # As in waterfall: limits are applied only where they are a finite pair.
+    if scale is not None and len(scale) == 2 and np.all(np.isfinite(scale)):
+        im.set_clim(np.asarray(scale))
 
-    # set axis labels
-    for dim, x in zip(dims, ["x", "y"]):
-        getattr(ax, f"set_{x}label")(_get_dim_label(patch, dim))
+    if x_dim is not None:
+        ax.set_xlabel(_get_dim_label(patch, x_dim))
+    if y_dim is not None:
+        ax.set_ylabel(_get_dim_label(patch, y_dim))
 
-    # add color bar with title
     if cmap is not None:
-        cb = ax.get_figure().colorbar(im, ax=ax, fraction=0.05, pad=0.025)
-        cb.set_label(_get_colorbar_label(data_type, data_units))
+        _add_colorbar(ax, im, color, label, scale)
 
     if show:
         plt.show()

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -11,17 +11,17 @@ import numpy as np
 
 from dascore.constants import DEFAULT_COLORMAPS, PatchType
 from dascore.exceptions import ParameterError
-from dascore.units import maybe_convert_percent_to_fraction
 from dascore.utils.gaps import get_gap_edges, is_monotonic_and_finite
-from dascore.utils.misc import tukey_fence
 from dascore.utils.patch import patch_function
 from dascore.utils.plotting import (
+    _add_colorbar,
     _format_time_axis,
     _get_ax,
     _get_cmap,
     _get_data_label,
     _get_dim_label,
     _get_extents,
+    _get_scale,
     _maybe_invert_yaxis,
 )
 from dascore.utils.time import is_datetime64
@@ -32,14 +32,6 @@ from dascore.viz._labels import (
     label_runs,
     mesh_cell_edges,
 )
-
-
-def _validate_scale_type(scale_type):
-    """Validate that scale_type is either 'relative' or 'absolute'."""
-    valid_types = {"absolute", "relative"}
-    if scale_type not in valid_types:
-        msg = f"scale_type must be one of {valid_types}, but got '{scale_type}'"
-        raise ParameterError(msg)
 
 
 def _validate_gap_factor(gap_factor):
@@ -64,60 +56,6 @@ def _validate_patch_dims(patch):
     return patch
 
 
-def _get_scale(scale, scale_type, data):
-    """
-    Calculate the color bar scale limits based on scale and scale_type.
-    """
-    _validate_scale_type(scale_type)
-    # This ensures we have a list of the previous scale parameters.
-    scale = maybe_convert_percent_to_fraction(scale)
-    match (scale, scale_type):
-        # Case 1: Single value with relative scaling
-        # Scale is symmetric around the mean, using fraction of dynamic range
-        case (scale, "relative") if len(scale) == 1:
-            scale = scale[0]
-            if scale == 0:
-                msg = (
-                    "Relative scale value of 0 would produce degenerate colorbar limits"
-                )
-                raise ParameterError(msg)
-            mod = 0.5 * (np.nanmax(data) - np.nanmin(data))
-            if mod == 0:
-                # Constant data, use small epsilon to avoid degenerate limits
-                mod = 1e-10
-            mean = np.nanmean(data)
-            scale = np.asarray([mean - scale * mod, mean + scale * mod])
-        # Case 2: No scale specified with relative scaling
-        # Use Tukey's fence (C*IQR, C is normally 1.5) to exclude outliers.
-        # This prevents a few extreme values from obscuring the majority of the
-        # data at the cost of a slight performance penalty.
-        case ([], "relative"):
-            return tukey_fence(data)
-        # Case 3: Sequence with relative scaling
-        # Scale values represent fractions of the data range [0, 1]
-        # and are mapped to [data_min, data_max]
-        case (scale, "relative"):
-            scale = np.array(scale)
-            # Validate scale parameters
-            if len(scale) != 2 or np.any(scale < 0) or scale[0] > scale[1]:
-                msg = (
-                    "Relative scale values cannot be negative and the first "
-                    f"value must be less than the second. You passed {scale}"
-                )
-                raise ParameterError(msg)
-            dmin, dmax = np.nanmin(data), np.nanmax(data)
-            data_range = dmax - dmin
-            # Map [0, 1] to [data_min, data_max]
-            scale = dmin + scale * data_range
-        # Case 4: Absolute scaling
-        case (scale, "absolute") if len(scale) == 1:
-            scale = np.array([-abs(scale[0]), abs(scale[0])])
-        # Case 5: Absolute scaling with sequence: no match needed.
-
-    # Scale values are used directly as colorbar limits
-    return scale
-
-
 def _format_axis_labels(ax, patch, dims_r):
     """
     Format axis labels and handle time-like axes.
@@ -130,33 +68,6 @@ def _format_axis_labels(ax, patch, dims_r):
             _format_time_axis(ax, dim, x)
         if x == "y":
             _maybe_invert_yaxis(ax, patch, dim)
-
-
-def _add_colorbar(ax, im, data, patch, log, scale):
-    """
-    Add a colorbar with appropriate labels to the plot.
-    When auto-scaling, extend-triangles are added if data above or below limits exist
-    """
-    mi = np.nanmin(data)
-    mx = np.nanmax(data)
-
-    above, below = False, False
-    if scale is not None and len(scale) == 2:
-        above = (mx > scale[1]) and not np.isclose(scale[1], mx)
-        below = (mi < scale[0]) and not np.isclose(scale[0], mi)
-    extend_map = {
-        (True, True): "both",
-        (True, False): "max",
-        (False, True): "min",
-    }
-    extend = extend_map.get((above, below), "neither")
-    cb = ax.get_figure().colorbar(
-        im, ax=ax, fraction=0.05, pad=0.025, extend=extend, extendfrac=0.025
-    )
-    label = _get_data_label(patch)
-    if log:
-        label = f"{label} - log_10"
-    cb.set_label(label)
 
 
 def _get_waterfall_colormap(patch, cmap=None):
@@ -255,12 +166,14 @@ def waterfall(
         A matplotlib colormap string or instance. If `None`, a colormap will be
         chosen automatically, depending on the data_type of the patch.
     scale
-        If not None, controls the saturation level of the colorbar.
-        Values can either be a float, to set upper and lower limit to the same
-        value centered around the mean of the data, a length 2 tuple
-        specifying upper and lower limits, or None, which will automatically
-        determine limits based on a quartile fence. (uses q1 - 1.5 * (q3 - q1)
-        and q3 + 1.5 * (q3 - q1)).
+        If not None, controls the saturation level of the colorbar. A single
+        number is symmetric: with `scale_type="relative"` the limits sit that
+        fraction of half the data range either side of the mean, and with
+        `scale_type="absolute"` they are -abs(scale) and abs(scale). A pair
+        of numbers gives the lower and upper limits: fractions of the data
+        range, from 0 to 1, when relative, or the values themselves when
+        absolute. Percent quantities, such as `10 * dc.units.percent`, are
+        converted to fractions.
     scale_type
         Controls the type of scaling specified by `scale` parameter. Options
         are:
@@ -450,7 +363,10 @@ def waterfall(
     _format_axis_labels(ax, patch, dims_r)
     # Add colorbar if requested
     if cbar:
-        _add_colorbar(ax, im, data, patch, log, scale)
+        label = _get_data_label(patch)
+        if log:
+            label = f"{label} - log_10"
+        _add_colorbar(ax, im, data, label, scale)
     # Label lines come last so the legend is placed beyond a colorbar which
     # has already taken its room.
     if plan is not None and runs is not None:

--- a/tests/test_viz/test_map_fiber.py
+++ b/tests/test_viz/test_map_fiber.py
@@ -70,6 +70,21 @@ class TestPlotMap:
 
         assert isinstance(ax, plt.Axes)
 
+    def test_masked_arrays_keep_their_mask(self, random_patch_with_lat_lon):
+        """A masked point stays out of the drawing, as scatter would leave it."""
+        patch = random_patch_with_lat_lon
+        lats = patch.coords.get_array("latitude")
+        lons = patch.coords.get_array("longitude")
+        mask = np.zeros(len(lats), dtype=bool)
+        mask[::3] = True
+        color = np.ma.array(np.arange(len(lats), dtype=float), mask=mask)
+        ax = patch.viz.map_fiber(np.ma.array(lats, mask=mask), lons, color)
+        drawn = ax.collections[0].get_array()
+        assert np.array_equal(np.ma.getmaskarray(drawn), mask)
+        assert np.array_equal(
+            np.ma.getmaskarray(ax.collections[0].get_offsets())[:, 0], mask
+        )
+
     def test_default_parameters(self, random_patch):
         """Call map_fiber plot, return."""
         ax = random_patch.viz.map_fiber()

--- a/tests/test_viz/test_map_fiber.py
+++ b/tests/test_viz/test_map_fiber.py
@@ -1,4 +1,4 @@
-"""Tests for waterfall plots."""
+"""Tests for map_fiber plots."""
 
 from __future__ import annotations
 
@@ -126,6 +126,62 @@ class TestPlotMap:
         random_patch.viz.map_fiber(show=True)
         assert shown
 
+    def test_array_x_named_y_labels_y_axis(self, random_patch_with_lat_lon):
+        """A named coordinate labels its own axis, whatever the other one is."""
+        lats = random_patch_with_lat_lon.coords.get_array("latitude")
+        ax = random_patch_with_lat_lon.viz.map_fiber(lats, "longitude")
+        assert "longitude" in ax.get_ylabel().lower()
+        assert ax.get_xlabel() == ""
+
+    def test_coord_label_has_no_magnitude(self, random_patch_with_lat_lon):
+        """The bar reads "distance [m]", not the "1 m" a pint quantity prints as."""
+        patch = random_patch_with_lat_lon.set_units(distance="m")
+        ax = patch.viz.map_fiber("latitude", "longitude", "distance")
+        assert ax.get_figure().axes[-1].get_ylabel() == "distance [m]"
+
+    def test_int_scale(self, random_patch):
+        """An integer scale is read like the same float, not as one limit."""
+        from_int = random_patch.viz.map_fiber(scale=2).collections[0].get_clim()
+        from_float = random_patch.viz.map_fiber(scale=2.0).collections[0].get_clim()
+        assert from_int == from_float
+        # Twice half the range either side of the mean is wider than the data.
+        values = random_patch.coords.get_array("distance")
+        assert from_int[0] < values.min() and from_int[1] > values.max()
+
+    def test_relative_pair_is_a_fraction_of_the_range(self, random_patch):
+        """A relative pair reads as fractions of the color range, as in waterfall."""
+        ax = random_patch.viz.map_fiber(scale=[0, 0.5])
+        values = ax.collections[0].get_array()
+        low, high = ax.collections[0].get_clim()
+        assert np.isclose(low, values.min())
+        assert np.isclose(high, values.min() + 0.5 * np.ptp(values))
+
+    def test_absolute_number_is_symmetric_about_zero(self, random_patch):
+        """A single absolute value is a limit either side of zero, as in waterfall."""
+        ax = random_patch.viz.map_fiber(scale=10, scale_type="absolute")
+        assert ax.collections[0].get_clim() == (-10, 10)
+
+    def test_unusable_absolute_scale_leaves_autoscale(self, random_patch):
+        """An empty or non-finite pair applies no limits rather than failing."""
+        expected = random_patch.viz.map_fiber().collections[0].get_clim()
+        for scale in ([], (np.nan, 1)):
+            ax = random_patch.viz.map_fiber(scale=scale, scale_type="absolute")
+            assert ax.collections[0].get_clim() == expected
+            assert ax.collections[0].colorbar.extend == "neither"
+
+    def test_empty_arrays_draw_an_empty_map(self):
+        """Nothing to draw is still a plot, with its colorbar."""
+        empty = np.array([])
+        ax = dc.get_example_patch().viz.map_fiber(empty, empty, empty)
+        assert len(ax.collections[0].get_offsets()) == 0
+
+    def test_clipped_scale_extends_colorbar(self, random_patch):
+        """Limits inside the data range get extend triangles, as in waterfall."""
+        values = random_patch.coords.get_array("distance")
+        mid = np.mean(values)
+        ax = random_patch.viz.map_fiber(scale=(mid - 1, mid + 1), scale_type="absolute")
+        assert ax.collections[0].colorbar.extend == "both"
+
 
 class TestMapFiberColorByData:
     """Tests for coloring the fiber by the patch's own data."""
@@ -206,6 +262,8 @@ class TestMapFiberErrors:
             random_patch.viz.map_fiber(scale_type="nope", scale=10)
 
     def test_bad_scale_length(self, random_patch):
-        """A scale that is neither a number nor a length-2 sequence should raise."""
+        """Three values are limits for nothing, whichever way they are read."""
         with pytest.raises(ParameterError, match="scale must be"):
             random_patch.viz.map_fiber(scale=(1, 2, 3))
+        with pytest.raises(ParameterError, match="scale must be"):
+            random_patch.viz.map_fiber(scale=(1, 2, 3), scale_type="absolute")

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -398,6 +398,11 @@ class TestWaterfall:
         clim = ax.images[0].get_clim()
         assert clim[0] != clim[1], "Colorbar limits should not be identical"
 
+    def test_negative_relative_scale_raises(self, random_patch):
+        """A negative relative scale would put the limits in the wrong order."""
+        with pytest.raises(ParameterError, match="greater than 0"):
+            random_patch.viz.waterfall(scale=-0.5, scale_type="relative")
+
     def test_scale_zero_raises(self, random_patch):
         """Ensure scale=0 with relative scaling raises ParameterError."""
         msg = "Relative scale value of 0"

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -353,6 +353,11 @@ class TestWaterfall:
         with pytest.raises(ParameterError, match=msg):
             random_patch.viz.waterfall(scale=(0.1, 0.2, 0.9), scale_type="relative")
 
+    def test_long_absolute_scale_raises(self, random_patch):
+        """Three absolute values are limits for nothing, so say so."""
+        with pytest.raises(ParameterError, match="scale must be"):
+            random_patch.viz.waterfall(scale=(0.1, 0.2, 0.9), scale_type="absolute")
+
     def test_invalid_scale_type_raises(self, random_patch):
         """Ensure invalid scale_type values raise ParameterError."""
         msg = "scale_type must be one of"


### PR DESCRIPTION
## Description

`map_fiber` grew up beside `waterfall` and kept its own copies of what the two share: a colorbar scale routine, a colorbar, and a label builder. This tidies that, starting from the module docstring, which still said "Module for waterfall plotting."

- `_get_scale`, `_validate_scale_type` and `_add_colorbar` move from `viz/waterfall.py` to `utils/plotting.py`, and `map_fiber` uses them in place of its own `_set_scale`. `map_fiber` therefore reads `scale` the way `waterfall` does: a relative pair is a fraction of the color range rather than raw limits, a single absolute value is symmetric about zero rather than about the mean, an integer works like a float (the old code only matched `float`, so `scale=5` was handed to `set_clim` as a lone value), and percent quantities are accepted. Its colorbar now gets the extend triangles when the limits clip the data.
- `_add_colorbar` takes the label rather than the patch, so it can label a coordinate as well as data; `_get_label(name, units)` builds "name [units]" for `_get_data_label`, `_get_dim_label` and the `map_fiber` colorbar alike. A coordinate-colored `map_fiber` bar reads `distance [m]` where it read `distance (1 m)`.
- `map_fiber(x=<array>, y="longitude")` used to label the x axis with the y coordinate's name, because the labels were zipped over whichever names were given. Each axis now labels itself.
- A `scale` of more than two values with `scale_type="absolute"` raises a `ParameterError` in both plots; `waterfall` used to ignore it silently. A wrong-length relative `scale` now says so rather than complaining about sign and order.

The `scale` docstring, which described neither plot accurately, is rewritten on both.

## Changelog

- fixed: `Patch.viz.map_fiber` labels each axis with its own coordinate when only one of `x` and `y` is a coordinate name.
- fixed: `Patch.viz.map_fiber` accepts an integer `scale`, and a coordinate-colored bar reads `distance [m]` rather than `distance (1 m)`.
- changed: `Patch.viz.map_fiber` reads `scale` and `scale_type` the way `Patch.viz.waterfall` does: a relative pair is a fraction of the color range, a single absolute value is symmetric about zero, percent quantities are accepted, and the colorbar shows extend triangles where the limits clip the data.
- changed: `Patch.viz.waterfall` and `Patch.viz.map_fiber` raise a `ParameterError` for an absolute `scale` of more than two values instead of ignoring it.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved fiber map and waterfall visualizations with consistent scale handling.
  * Added relative, absolute, percentage-based, and symmetric color scale options.
  * Enhanced colorbars with clearer labels, units, limits, and outlier handling.
  * Added support for more flexible coordinate and color selections in fiber maps.

* **Bug Fixes**
  * Improved handling of empty data, invalid scales, and degenerate value ranges.
  * Corrected axis labeling and colorbar extensions for clipped data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->