### PR TITLE
Read what PyTables stored, and guard the gauge length

### DIFF
--- a/dascore/io/dasdae/_compat.py
+++ b/dascore/io/dasdae/_compat.py
@@ -182,21 +182,19 @@ def translate_legacy_attrs(attrs, coord_names: Iterable[str] = ()):
 # PyTables stored every attr value HDF5 had no native type for -- None,
 # tuples, lists -- as ``pickle.dumps(value, 0)`` and unpickled it on read.
 # A reader using h5py gets those bytes themselves, so the payload is read
-# here instead. It is parsed rather than unpickled: the loop below knows
-# the protocol-0 opcodes which build None, numbers, text, lists and
-# tuples, and no others. None of them can name a class, so a hostile
-# payload has nothing to reach, and anything outside the grammar is
-# reported as undecoded rather than guessed at. Mappings (``(d``/``s``)
-# are deliberately absent -- the one mapping DASCore ever stored is the
-# coord payload, which keeps its opt-in gate in translate_legacy_attrs.
+# here instead. decode_pytables_attr parses it rather than unpickling it:
+# it knows the protocol-0 opcodes which build None, numbers, text, lists
+# and tuples, and no others. None of them can name a class, so a hostile
+# payload has nothing to reach. Mappings (``(d``/``s``) are absent, which
+# is what leaves a pickled coord payload to the opt-in gate above.
 
-# Returned when a payload uses anything outside the grammar above.
+# Returned for a payload the grammar does not cover.
 NOT_DECODED = object()
 
 # Marks a stack position a list or tuple is later built from.
 _MARK = object()
 
-# Protocol 0 spells the two bools as ints.
+# Protocol 0 spells the two bools as ints, and suffixes a long with "L".
 _BOOL_ARGUMENTS = {b"00": False, b"01": True}
 
 
@@ -221,9 +219,9 @@ def decode_pytables_attr(payload: bytes):
 
     Returns
     -------
-    The decoded value, or ``NOT_DECODED`` when the payload is not one of
-    the shapes PyTables wrote for a DASCore attr, which leaves the caller
-    with the text it would have had anyway.
+    The decoded value, which may itself be None, or ``NOT_DECODED`` when
+    the payload is not one of the shapes PyTables wrote for a DASCore
+    attr, which leaves the caller with the text it would have had anyway.
     """
     stack: list = []
     memo: dict[bytes, object] = {}
@@ -231,8 +229,7 @@ def decode_pytables_attr(payload: bytes):
     while position < end:
         code, position = payload[position : position + 1], position + 1
         if code == b".":  # STOP
-            # A mark can only survive at the top of the stack, where it
-            # means the payload opened a container it never closed.
+            # A surviving mark means a container was opened and never closed.
             done = len(stack) == 1 and stack[0] is not _MARK
             return stack[0] if done else NOT_DECODED
         if code == b"(":  # MARK
@@ -248,9 +245,14 @@ def decode_pytables_attr(payload: bytes):
             stack.append(items if code == b"l" else tuple(items))
             continue
         if code == b"a":  # APPEND
-            if len(stack) < 2 or not isinstance(stack[-2], list):
+            if len(stack) < 2:
                 return NOT_DECODED
-            stack[-2].append(stack.pop())
+            item = stack.pop()
+            # A mark is an opened container rather than a value, and would
+            # otherwise be appended to the list as one.
+            if item is _MARK or not isinstance(stack[-1], list):
+                return NOT_DECODED
+            stack[-1].append(item)
             continue
         # Everything left takes a newline-terminated argument. Protocol 0
         # escapes newlines inside text, so the first one always ends it.
@@ -263,17 +265,25 @@ def decode_pytables_attr(payload: bytes):
                 return NOT_DECODED
             memo[argument] = stack[-1]
         elif code == b"g":  # GET
-            if argument not in memo:
+            shared = memo.get(argument, NOT_DECODED)
+            # Only a scalar may be shared. Sharing a container would let a
+            # short payload name one repeatedly and build a graph whose
+            # size is exponential in its length; refusing it keeps the
+            # result no larger than the bytes which asked for it.
+            if shared is NOT_DECODED or isinstance(shared, list | tuple):
                 return NOT_DECODED
-            stack.append(memo[argument])
+            stack.append(shared)
         elif code == b"V":  # UNICODE
-            stack.append(argument.decode("raw_unicode_escape"))
-        elif code == b"I":  # INT, which also spells the bools
+            try:
+                stack.append(argument.decode("raw_unicode_escape"))
+            except UnicodeDecodeError:  # a truncated escape
+                return NOT_DECODED
+        elif code in (b"I", b"L"):  # INT and LONG; INT also spells the bools
             if argument in _BOOL_ARGUMENTS:
                 stack.append(_BOOL_ARGUMENTS[argument])
                 continue
             try:
-                stack.append(int(argument))
+                stack.append(int(argument.removesuffix(b"L")))
             except ValueError:
                 return NOT_DECODED
         elif code == b"F":  # FLOAT

--- a/dascore/io/dasdae/_compat.py
+++ b/dascore/io/dasdae/_compat.py
@@ -175,3 +175,112 @@ def translate_legacy_attrs(attrs, coord_names: Iterable[str] = ()):
             continue
         convert_attr_units(out, name, to_units)
     return out
+
+
+# --- PyTables attr payloads
+#
+# PyTables stored every attr value HDF5 had no native type for -- None,
+# tuples, lists -- as ``pickle.dumps(value, 0)`` and unpickled it on read.
+# A reader using h5py gets those bytes themselves, so the payload is read
+# here instead. It is parsed rather than unpickled: the loop below knows
+# the protocol-0 opcodes which build None, numbers, text, lists and
+# tuples, and no others. None of them can name a class, so a hostile
+# payload has nothing to reach, and anything outside the grammar is
+# reported as undecoded rather than guessed at. Mappings (``(d``/``s``)
+# are deliberately absent -- the one mapping DASCore ever stored is the
+# coord payload, which keeps its opt-in gate in translate_legacy_attrs.
+
+# Returned when a payload uses anything outside the grammar above.
+NOT_DECODED = object()
+
+# Marks a stack position a list or tuple is later built from.
+_MARK = object()
+
+# Protocol 0 spells the two bools as ints.
+_BOOL_ARGUMENTS = {b"00": False, b"01": True}
+
+
+def _take_items_after_mark(stack: list) -> list | None:
+    """Remove and return everything pushed since the last mark."""
+    for index in range(len(stack) - 1, -1, -1):
+        if stack[index] is _MARK:
+            items = stack[index + 1 :]
+            del stack[index:]
+            return items
+    return None
+
+
+def decode_pytables_attr(payload: bytes):
+    """
+    Return the value a PyTables protocol-0 attr payload holds.
+
+    Parameters
+    ----------
+    payload
+        The raw bytes stored in the HDF5 attribute.
+
+    Returns
+    -------
+    The decoded value, or ``NOT_DECODED`` when the payload is not one of
+    the shapes PyTables wrote for a DASCore attr, which leaves the caller
+    with the text it would have had anyway.
+    """
+    stack: list = []
+    memo: dict[bytes, object] = {}
+    position, end = 0, len(payload)
+    while position < end:
+        code, position = payload[position : position + 1], position + 1
+        if code == b".":  # STOP
+            # A mark can only survive at the top of the stack, where it
+            # means the payload opened a container it never closed.
+            done = len(stack) == 1 and stack[0] is not _MARK
+            return stack[0] if done else NOT_DECODED
+        if code == b"(":  # MARK
+            stack.append(_MARK)
+            continue
+        if code == b"N":  # NONE
+            stack.append(None)
+            continue
+        if code in (b"l", b"t"):  # LIST, TUPLE
+            items = _take_items_after_mark(stack)
+            if items is None:
+                return NOT_DECODED
+            stack.append(items if code == b"l" else tuple(items))
+            continue
+        if code == b"a":  # APPEND
+            if len(stack) < 2 or not isinstance(stack[-2], list):
+                return NOT_DECODED
+            stack[-2].append(stack.pop())
+            continue
+        # Everything left takes a newline-terminated argument. Protocol 0
+        # escapes newlines inside text, so the first one always ends it.
+        stop = payload.find(b"\n", position)
+        if stop < 0:
+            return NOT_DECODED
+        argument, position = payload[position:stop], stop + 1
+        if code == b"p":  # PUT
+            if not stack:
+                return NOT_DECODED
+            memo[argument] = stack[-1]
+        elif code == b"g":  # GET
+            if argument not in memo:
+                return NOT_DECODED
+            stack.append(memo[argument])
+        elif code == b"V":  # UNICODE
+            stack.append(argument.decode("raw_unicode_escape"))
+        elif code == b"I":  # INT, which also spells the bools
+            if argument in _BOOL_ARGUMENTS:
+                stack.append(_BOOL_ARGUMENTS[argument])
+                continue
+            try:
+                stack.append(int(argument))
+            except ValueError:
+                return NOT_DECODED
+        elif code == b"F":  # FLOAT
+            try:
+                stack.append(float(argument))
+            except ValueError:
+                return NOT_DECODED
+        else:
+            return NOT_DECODED
+    return NOT_DECODED

--- a/dascore/io/dasdae/_compat.py
+++ b/dascore/io/dasdae/_compat.py
@@ -178,39 +178,19 @@ def translate_legacy_attrs(attrs, coord_names: Iterable[str] = ()):
 
 
 # --- PyTables attr payloads
-#
-# PyTables stored every attr value HDF5 had no native type for -- None,
-# tuples, lists -- as ``pickle.dumps(value, 0)`` and unpickled it on read.
-# A reader using h5py gets those bytes themselves, so the payload is read
-# here instead. decode_pytables_attr parses it rather than unpickling it:
-# it knows the protocol-0 opcodes which build None, numbers, text, lists
-# and tuples, and no others. None of them can name a class, so a hostile
-# payload has nothing to reach. Mappings (``(d``/``s``) are absent, which
-# is what leaves a pickled coord payload to the opt-in gate above.
 
-# Returned for a payload the grammar does not cover.
+# Returned for a payload this reader may not, or cannot, decode.
 NOT_DECODED = object()
-
-# Marks a stack position a list or tuple is later built from.
-_MARK = object()
-
-# Protocol 0 spells the two bools as ints, and suffixes a long with "L".
-_BOOL_ARGUMENTS = {b"00": False, b"01": True}
-
-
-def _take_items_after_mark(stack: list) -> list | None:
-    """Remove and return everything pushed since the last mark."""
-    for index in range(len(stack) - 1, -1, -1):
-        if stack[index] is _MARK:
-            items = stack[index + 1 :]
-            del stack[index:]
-            return items
-    return None
 
 
 def decode_pytables_attr(payload: bytes):
     """
-    Return the value a PyTables protocol-0 attr payload holds.
+    Return the value a PyTables attr payload holds.
+
+    PyTables stored every attr value HDF5 had no native type for -- None,
+    tuples, lists -- as a pickle, and unpickled it on read; a reader using
+    h5py gets the payload bytes instead. Decoding it is the same opt-in as
+    the coord payload above, and a file holding one usually holds both.
 
     Parameters
     ----------
@@ -220,77 +200,22 @@ def decode_pytables_attr(payload: bytes):
     Returns
     -------
     The decoded value, which may itself be None, or ``NOT_DECODED`` when
-    the payload is not one of the shapes PyTables wrote for a DASCore
-    attr, which leaves the caller with the text it would have had anyway.
+    the opt-in is off or the bytes do not decode. Unlike a coord payload,
+    which the patch cannot be built without, an attr is informational, so
+    a caller keeps the text it would have had rather than failing.
     """
-    stack: list = []
-    memo: dict[bytes, object] = {}
-    position, end = 0, len(payload)
-    while position < end:
-        code, position = payload[position : position + 1], position + 1
-        if code == b".":  # STOP
-            # A surviving mark means a container was opened and never closed.
-            done = len(stack) == 1 and stack[0] is not _MARK
-            return stack[0] if done else NOT_DECODED
-        if code == b"(":  # MARK
-            stack.append(_MARK)
-            continue
-        if code == b"N":  # NONE
-            stack.append(None)
-            continue
-        if code in (b"l", b"t"):  # LIST, TUPLE
-            items = _take_items_after_mark(stack)
-            if items is None:
-                return NOT_DECODED
-            stack.append(items if code == b"l" else tuple(items))
-            continue
-        if code == b"a":  # APPEND
-            if len(stack) < 2:
-                return NOT_DECODED
-            item = stack.pop()
-            # A mark is an opened container rather than a value, and would
-            # otherwise be appended to the list as one.
-            if item is _MARK or not isinstance(stack[-1], list):
-                return NOT_DECODED
-            stack[-1].append(item)
-            continue
-        # Everything left takes a newline-terminated argument. Protocol 0
-        # escapes newlines inside text, so the first one always ends it.
-        stop = payload.find(b"\n", position)
-        if stop < 0:
-            return NOT_DECODED
-        argument, position = payload[position:stop], stop + 1
-        if code == b"p":  # PUT
-            if not stack:
-                return NOT_DECODED
-            memo[argument] = stack[-1]
-        elif code == b"g":  # GET
-            shared = memo.get(argument, NOT_DECODED)
-            # Only a scalar may be shared. Sharing a container would let a
-            # short payload name one repeatedly and build a graph whose
-            # size is exponential in its length; refusing it keeps the
-            # result no larger than the bytes which asked for it.
-            if shared is NOT_DECODED or isinstance(shared, list | tuple):
-                return NOT_DECODED
-            stack.append(shared)
-        elif code == b"V":  # UNICODE
-            try:
-                stack.append(argument.decode("raw_unicode_escape"))
-            except UnicodeDecodeError:  # a truncated escape
-                return NOT_DECODED
-        elif code in (b"I", b"L"):  # INT and LONG; INT also spells the bools
-            if argument in _BOOL_ARGUMENTS:
-                stack.append(_BOOL_ARGUMENTS[argument])
-                continue
-            try:
-                stack.append(int(argument.removesuffix(b"L")))
-            except ValueError:
-                return NOT_DECODED
-        elif code == b"F":  # FLOAT
-            try:
-                stack.append(float(argument))
-            except ValueError:
-                return NOT_DECODED
-        else:
-            return NOT_DECODED
+    if not get_config().allow_dasdae_format_unpickle:
+        return NOT_DECODED
+    with contextlib.suppress(
+        AttributeError,
+        EOFError,
+        ImportError,
+        IndexError,
+        KeyError,
+        pickle.PickleError,
+        TypeError,
+        UnicodeError,
+        ValueError,
+    ):
+        return pickle.loads(payload)
     return NOT_DECODED

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -16,7 +16,12 @@ from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
 from dascore.io.core import STORED_PATCH_ID, make_scan_payload
-from dascore.io.dasdae._compat import strip_legacy_coord_fields, translate_legacy_attrs
+from dascore.io.dasdae._compat import (
+    NOT_DECODED,
+    decode_pytables_attr,
+    strip_legacy_coord_fields,
+    translate_legacy_attrs,
+)
 from dascore.io.utils import get_exact_coord
 from dascore.models.registry import get_model_tag, resolve_tagged_model
 from dascore.utils.array import (
@@ -172,13 +177,15 @@ def _save_patch(patch, wave_group, name):
 # --- Functions for reading
 
 
-def _get_attrs(patch_group):
+def _get_attrs(patch_group, legacy: bool = True):
     """Get the saved attributes from the group attrs."""
     out = {}
     attrs = [x for x in patch_group.attrs if x.startswith(_ATTR_PREFIX)]
     for attr_name in attrs:
         key = attr_name.replace(_ATTR_PREFIX, "")
-        val = _decode_attr_value(patch_group.attrs, key, patch_group.attrs[attr_name])
+        val = _decode_attr_value(
+            patch_group.attrs, key, patch_group.attrs[attr_name], legacy=legacy
+        )
         # need to unpack one value arrays
         if isinstance(val, np.ndarray) and not val.shape:
             val = np.asarray([val])[0]
@@ -305,7 +312,7 @@ def _matches_attr_filters(attrs, kwargs):
 
 def _get_patch_attrs(patch_group, legacy: bool) -> dict:
     """Get the true patch attrs, cleaning legacy coord metadata if needed."""
-    attrs = _get_attrs(patch_group)
+    attrs = _get_attrs(patch_group, legacy=legacy)
     if legacy:
         dims = _get_dims(patch_group)
         coord_names = _get_group_coord_names(patch_group)
@@ -317,7 +324,7 @@ def _get_patch_attrs(patch_group, legacy: bool) -> dict:
 
 def _read_patch(patch_group, legacy: bool = True, **kwargs):
     """Read a patch group, return Patch."""
-    attrs = _get_attrs(patch_group)
+    attrs = _get_attrs(patch_group, legacy=legacy)
     dims = _get_dims(patch_group)
     if legacy:
         attrs["dims"] = ",".join(dims)
@@ -374,7 +381,9 @@ def _get_scan_payload_from_group(group, legacy: bool = True, snap=True):
     for key in attrs:
         if not key.startswith(_ATTR_PREFIX):
             continue
-        value = _decode_attr_value(attrs, key.replace(_ATTR_PREFIX, ""), attrs[key])
+        value = _decode_attr_value(
+            attrs, key.replace(_ATTR_PREFIX, ""), attrs[key], legacy=legacy
+        )
         new_key = key.replace(_ATTR_PREFIX, "")
         # need to unpack 0 dim arrays.
         if isinstance(value, np.ndarray) and not value.shape:
@@ -432,11 +441,11 @@ def _encode_attr_value(key, value):
     return value, None
 
 
-def _decode_attr_value(attrs, key, value):
+def _decode_attr_value(attrs, key, value, legacy: bool = True):
     """Decode one stored attr value using saved type metadata when present."""
     attr_type = unbyte(attrs.get(f"{_ATTR_TYPE_PREFIX}{key}", None))
     if attr_type is None:
-        return _decode_legacy_attr_value(value)
+        return _decode_legacy_attr_value(attrs, key, value, legacy=legacy)
     if attr_type == "none":
         return None
     if attr_type == "datetime64[ns]":
@@ -448,12 +457,36 @@ def _decode_attr_value(attrs, key, value):
     return value
 
 
-def _decode_legacy_attr_value(value):
+def _holds_pytables_payload(attrs, key, value) -> bool:
+    """
+    Whether a legacy attr holds a PyTables pickle rather than text.
+
+    Nothing in the bytes separates the two -- a string attr of "N." is
+    byte-identical to a pickled None -- but PyTables wrote real strings as
+    UTF-8 and pickled payloads as raw bytes, which HDF5 records as the
+    attribute's character set.
+    """
+    if not isinstance(value, np.bytes_ | bytes):
+        return False
+    # Only an h5py attrs manager records the character set; a plain
+    # mapping of values cannot tell a payload from text.
+    get_id = getattr(attrs, "get_id", None)
+    if get_id is None:
+        return False
+    get_cset = getattr(get_id(f"{_ATTR_PREFIX}{key}").get_type(), "get_cset", None)
+    return get_cset is not None and get_cset() == 0
+
+
+def _decode_legacy_attr_value(attrs, key, value, legacy: bool = True):
     """Decode legacy DASDAE attrs still used by the shipped fixture files."""
     if value.__class__.__name__ == "Empty":
         return ""
     if isinstance(value, np.ndarray) and not value.shape:
         value = np.asarray([value])[0]
+    if legacy and _holds_pytables_payload(attrs, key, value):
+        decoded = decode_pytables_attr(bytes(value))
+        if decoded is not NOT_DECODED:
+            return decoded
     if isinstance(value, np.bytes_ | bytes):
         try:
             return unbyte(value)

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -182,7 +182,7 @@ def _get_attrs(patch_group, legacy: bool = True):
     out = {}
     attrs = [x for x in patch_group.attrs if x.startswith(_ATTR_PREFIX)]
     for attr_name in attrs:
-        key = attr_name.replace(_ATTR_PREFIX, "")
+        key = attr_name.removeprefix(_ATTR_PREFIX)
         val = _decode_attr_value(
             patch_group.attrs, key, patch_group.attrs[attr_name], legacy=legacy
         )
@@ -381,10 +381,8 @@ def _get_scan_payload_from_group(group, legacy: bool = True, snap=True):
     for key in attrs:
         if not key.startswith(_ATTR_PREFIX):
             continue
-        value = _decode_attr_value(
-            attrs, key.replace(_ATTR_PREFIX, ""), attrs[key], legacy=legacy
-        )
-        new_key = key.replace(_ATTR_PREFIX, "")
+        new_key = key.removeprefix(_ATTR_PREFIX)
+        value = _decode_attr_value(attrs, new_key, attrs[key], legacy=legacy)
         # need to unpack 0 dim arrays.
         if isinstance(value, np.ndarray) and not value.shape:
             value = np.atleast_1d(value)[0]
@@ -462,13 +460,13 @@ def _holds_pytables_payload(attrs, key, value) -> bool:
     Whether a legacy attr holds a PyTables pickle rather than text.
 
     Nothing in the bytes separates the two -- a string attr of "N." is
-    byte-identical to a pickled None -- but PyTables wrote real strings as
-    UTF-8 and pickled payloads as raw bytes, which HDF5 records as the
-    attribute's character set.
+    byte-identical to a pickled None. PyTables wrote real strings as UTF-8
+    and pickled payloads as raw bytes, and HDF5 stores which of the two an
+    attribute holds as its character set, so that is what decides here.
     """
     if not isinstance(value, np.bytes_ | bytes):
         return False
-    # Only an h5py attrs manager records the character set; a plain
+    # Only an h5py attrs manager exposes the character set; a plain
     # mapping of values cannot tell a payload from text.
     get_id = getattr(attrs, "get_id", None)
     if get_id is None:
@@ -478,7 +476,12 @@ def _holds_pytables_payload(attrs, key, value) -> bool:
 
 
 def _decode_legacy_attr_value(attrs, key, value, legacy: bool = True):
-    """Decode legacy DASDAE attrs still used by the shipped fixture files."""
+    """
+    Decode one attr value from a file written before attr types were stored.
+
+    A legacy file may hold the value as a PyTables payload, which only
+    ``legacy`` files are looked at for.
+    """
     if value.__class__.__name__ == "Empty":
         return ""
     if isinstance(value, np.ndarray) and not value.shape:

--- a/dascore/io/index/schema.py
+++ b/dascore/io/index/schema.py
@@ -33,9 +33,10 @@ from typing import NamedTuple, get_args, get_type_hints
 # Version of the index schema, independent of dascore's version. Bump it
 # when an index written by an older dascore would be read wrongly rather
 # than merely incompletely -- including when what a *stored value* means
-# changes, not only when a column does. 13 adds the patches table's
-# `data_size` column, which an index written by 12 has no column for.
-INDEX_VERSION = 13
+# changes, not only when a column does. 14 reads a legacy DASDAE file's
+# PyTables attr payloads, so 13 stored the payload text where a value
+# is now stored (`gauge_length` of "N." rather than nothing).
+INDEX_VERSION = 14
 # Identity string so any tool can sanity-check what it opened.
 WHAT_IS_THIS = "dascore_spool_index"
 

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -213,12 +213,15 @@ def _get_gauge_length(patch: PatchType, gauge_length) -> float:
     """
     Return the gauge length in meters, from the argument or the patch attrs.
 
-    Attrs read from a file carry whatever the file held, so a gauge length
-    which is not a positive number is rejected here rather than left to
-    fail on the arithmetic below.
+    Attrs read from a file carry whatever the file held, so every value
+    which is not a positive number is rejected here. A comparison against
+    zero is not enough on its own: text fails it outright, and nan and inf
+    pass it and go on to make a patch of nan or of zeros.
     """
     stored = getattr(patch.attrs, "gauge_length", None)
     gauge = convert_units(gauge_length if gauge_length is not None else stored, "m")
+    if isinstance(gauge, np.ndarray) and gauge.size == 1:
+        gauge = gauge.item()  # a scalar a caller left in its array box
     # bool is a Real, and True would otherwise pass as a one meter gauge.
     if isinstance(gauge, Real) and not isinstance(gauge, bool):
         meters = float(gauge)

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import math
 import warnings
+from numbers import Real
 
 import numpy as np
 
@@ -207,6 +209,28 @@ def _get_strain_data_type(units) -> str:
     return "strain_rate" if units.dimensionality.get("[time]") == -1 else "strain"
 
 
+def _get_gauge_length(patch: PatchType, gauge_length) -> float:
+    """
+    Return the gauge length in meters, from the argument or the patch attrs.
+
+    Attrs read from a file carry whatever the file held, so a gauge length
+    which is not a positive number is rejected here rather than left to
+    fail on the arithmetic below.
+    """
+    stored = getattr(patch.attrs, "gauge_length", None)
+    gauge = convert_units(gauge_length if gauge_length is not None else stored, "m")
+    # bool is a Real, and True would otherwise pass as a one meter gauge.
+    if isinstance(gauge, Real) and not isinstance(gauge, bool):
+        meters = float(gauge)
+        if math.isfinite(meters) and meters > 0:
+            return meters
+    msg = (
+        f"Gauge length must be a positive number, got {gauge!r}. Pass it with "
+        "the gauge_length argument or set it in the patch attrs."
+    )
+    raise ParameterError(msg)
+
+
 @patch_function()
 def radians_to_strain(
     patch: PatchType,
@@ -254,14 +278,7 @@ def radians_to_strain(
     strain/s) and "strain" otherwise.
     """
     # First get gauge length, using gl passed into function or attached to attrs.
-    gl = getattr(patch.attrs, "gauge_length", None)
-    gauge = convert_units(gauge_length if gauge_length is not None else gl, "m")
-    if gauge is None or gauge <= 0:
-        msg = (
-            "Gauge length must be non-zero positive and provided "
-            "or defined in patch attrs."
-        )
-        raise ParameterError(msg)
+    gauge = _get_gauge_length(patch, gauge_length)
     # If units doesn't contain radians just return so function is idempotent
     quant = dc.get_quantity(patch.attrs.data_units)
     if str(dc.get_unit("radians")) not in str(quant):

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -17,11 +17,7 @@ from dascore.config import config_context
 from dascore.core.coords import CoordString
 from dascore.exceptions import InvalidFiberFileError
 from dascore.io.dasdae import utils as dasdae_utils
-from dascore.io.dasdae._compat import (
-    NOT_DECODED,
-    decode_pytables_attr,
-    translate_legacy_attrs,
-)
+from dascore.io.dasdae._compat import translate_legacy_attrs
 from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.dasdae.utils import (
     _ATTRS_CLASS_KEY,
@@ -444,91 +440,6 @@ class TestPyTablesAttrPayloads:
 
         return _read
 
-    @pytest.mark.parametrize(
-        "value",
-        [None, True, False, 3, 2.5, "text", (), ("a", "b"), [], [1, "x"], (1, (2, 3))],
-    )
-    def test_round_trip(self, value):
-        """Every shape PyTables wrote for a DASCore attr should decode."""
-        decoded = decode_pytables_attr(pickle.dumps(value, 0))
-        assert decoded == value
-        # 1 == True, so the bools need their type pinned as well.
-        assert type(decoded) is type(value)
-
-    def test_round_trip_long(self):
-        """Protocol 0 spells any int of 2**31 or more as a suffixed long."""
-        value = [2**100, 3_000_000_000]
-        payload = pickle.dumps(value, 0)
-        assert b"L" in payload, "payload must use the long opcode"
-        assert decode_pytables_attr(payload) == value
-
-    def test_text_with_escapes_round_trips(self):
-        """Protocol 0 escapes newlines and backslashes inside text."""
-        value = ("a\nb", "c\\d", "\u00b5\u03b5")
-        assert decode_pytables_attr(pickle.dumps(value, 0)) == value
-
-    @pytest.mark.parametrize(
-        "payload",
-        [
-            b"",
-            b"abc",
-            b"N",
-            b"V no newline",
-            b"Ibad\n.",
-            b"Fbad\n.",
-            b"g0\n.",
-            b"a.",
-            b"Nt.",
-            b"Nl.",
-            b"p0\n.",
-            b"(.",
-            b"(N.",
-            b"(l(a.",  # an opened container appended as if it were a value
-            b"V\\uZZZZ\n.",  # a truncated escape
-            b"IZZ\n.",
-            pickle.dumps({"a": 1}, 0),
-            pickle.dumps(np.float64(1.0), 0),
-        ],
-    )
-    def test_undecodable_payloads(self, payload):
-        """Anything outside the grammar is reported rather than guessed at."""
-        assert decode_pytables_attr(payload) is NOT_DECODED
-
-    def test_repeated_scalar_is_shared(self):
-        """A repeated string is stored once and referenced back."""
-        text = "repeated"
-        assert decode_pytables_attr(pickle.dumps((text, text), 0)) == (text, text)
-
-    def test_repeated_container_is_refused(self):
-        """A shared container could name a graph far larger than its bytes."""
-        shared = ("a", "b")
-        payload = pickle.dumps((shared, shared), 0)
-        assert b"g" in payload, "payload must reference the memo"
-        assert decode_pytables_attr(payload) is NOT_DECODED
-
-    def test_no_class_is_named(self):
-        """A payload naming a callable must not decode, let alone run it."""
-        payload = pickle.dumps(TestPyTablesAttrPayloads, 0)
-        assert decode_pytables_attr(payload) is NOT_DECODED
-
-    @pytest.mark.parametrize(
-        ("name", "expected"),
-        [
-            ("example_event_1", ()),
-            ("deformation_rate_event_1", ()),
-        ],
-    )
-    def test_shipped_file_history(self, name, expected):
-        """A shipped legacy file states its history, not its payload (#1078)."""
-        assert dc.get_example_patch(name).attrs.history == expected
-
-    def test_shipped_file_history_text(self):
-        """A shipped legacy file with real history states it as entries."""
-        history = dc.get_example_patch("febus_dss_mine_tight").attrs.history
-        assert isinstance(history, tuple)
-        assert history and all(isinstance(x, str) for x in history)
-        assert not history[0].startswith("(V")
-
     def test_read_decodes_none(self, pytables_attrs):
         """A pickled None should read back as None, not as its payload."""
         assert pytables_attrs(gauge_length=None)["gauge_length"] is None
@@ -537,6 +448,19 @@ class TestPyTablesAttrPayloads:
         """A pickled history tuple should read back as a tuple."""
         attrs = pytables_attrs(history=("first", "second"))
         assert attrs["history"] == ("first", "second")
+
+    def test_payload_needs_the_opt_in(self, pytables_attrs):
+        """Without the opt-in an attr payload stays the text it was."""
+        with config_context(allow_dasdae_format_unpickle=False):
+            assert pytables_attrs(gauge_length=None)["gauge_length"] == "N."
+
+    def test_undecodable_payload_stays_text(self, tmp_path):
+        """Bytes which are not a pickle keep the text they would have had."""
+        path = tmp_path / "not_a_pickle.h5"
+        with h5py.File(path, "w") as h5:
+            group = h5.create_group("waveforms").create_group("patch")
+            group.attrs["_attrs_station"] = np.bytes_(b"not a pickle.")
+            assert _get_attrs(group)["station"] == "not a pickle."
 
     def test_text_attr_is_not_decoded(self, tmp_path):
         """A real string which happens to be a valid payload stays text."""
@@ -569,6 +493,29 @@ class TestPyTablesAttrPayloads:
     def test_modern_file_is_not_decoded(self, pytables_attrs):
         """Only legacy files hold PyTables payloads."""
         assert pytables_attrs(legacy=False, note=None)["note"] == "N."
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("example_event_1", ()),
+            ("deformation_rate_event_1", ()),
+        ],
+    )
+    def test_shipped_file_history(self, name, expected):
+        """A shipped legacy file states its history, not its payload (#1078)."""
+        assert dc.get_example_patch(name).attrs.history == expected
+
+    def test_shipped_file_history_text(self):
+        """A shipped legacy file with real history states it as entries."""
+        history = dc.get_example_patch("febus_dss_mine_tight").attrs.history
+        assert isinstance(history, tuple)
+        assert history and all(isinstance(x, str) for x in history)
+        assert not history[0].startswith("(V")
+
+    def test_shipped_file_gauge_length(self):
+        """The example the strain docstrings use states no gauge length."""
+        patch = dc.get_example_patch("deformation_rate_event_1")
+        assert getattr(patch.attrs, "gauge_length", None) is None
 
 
 class TestLegacyUnitCompanions:

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -17,7 +17,11 @@ from dascore.config import config_context
 from dascore.core.coords import CoordString
 from dascore.exceptions import InvalidFiberFileError
 from dascore.io.dasdae import utils as dasdae_utils
-from dascore.io.dasdae._compat import translate_legacy_attrs
+from dascore.io.dasdae._compat import (
+    NOT_DECODED,
+    decode_pytables_attr,
+    translate_legacy_attrs,
+)
 from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.dasdae.utils import (
     _ATTRS_CLASS_KEY,
@@ -409,16 +413,104 @@ class TestLegacyFixtureCompatibility:
 
     def test_decode_legacy_attr_bytes_falls_back_to_text(self):
         """Undecodable legacy bytes should fall back to plain text."""
-        assert _decode_legacy_attr_value(b"abc") == "abc"
+        assert _decode_legacy_attr_value({}, "key", b"abc") == "abc"
 
-    def test_decode_legacy_attr_pickled_bytes_fall_back_to_text(self):
-        """Legacy pickled attrs should no longer be unpickled."""
-        payload = pickle.dumps(("a", "b"))
-        assert isinstance(_decode_legacy_attr_value(payload), str)
+    def test_decode_legacy_attr_pickled_bytes_need_the_attrs(self):
+        """A payload can only be told from text by the stored attribute."""
+        payload = pickle.dumps(("a", "b"), 0)
+        assert isinstance(_decode_legacy_attr_value({}, "history", payload), str)
 
     def test_decode_legacy_attr_unboxes_scalar_arrays(self):
         """Scalar legacy arrays should be unpacked back to scalars."""
-        assert _decode_legacy_attr_value(np.asarray(5)) == 5
+        assert _decode_legacy_attr_value({}, "key", np.asarray(5)) == 5
+
+
+class TestPyTablesAttrPayloads:
+    """PyTables pickled attr values HDF5 had no native type for."""
+
+    @pytest.fixture
+    def pytables_attrs(self, tmp_path):
+        """Read attrs back from a group whose attrs mimic PyTables output."""
+
+        def _read(legacy=True, **values):
+            path = tmp_path / "pytables_attrs.h5"
+            with h5py.File(path, "w") as h5:
+                group = h5.create_group("waveforms").create_group("patch")
+                for name, value in values.items():
+                    # PyTables wrote payloads as bytes, which HDF5 records
+                    # with the ASCII character set, and text as UTF-8.
+                    group.attrs[f"_attrs_{name}"] = np.bytes_(pickle.dumps(value, 0))
+                return _get_attrs(group, legacy=legacy)
+
+        return _read
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, True, False, 3, 2.5, "text", (), ("a", "b"), [], [1, "x"], (1, (2, 3))],
+    )
+    def test_round_trip(self, value):
+        """Every shape PyTables wrote for a DASCore attr should decode."""
+        assert decode_pytables_attr(pickle.dumps(value, 0)) == value
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            b"",
+            b"abc",
+            b"N",
+            b"V no newline",
+            b"Ibad\n.",
+            b"Fbad\n.",
+            b"g0\n.",
+            b"a.",
+            b"Nt.",
+            b"Nl.",
+            b"p0\n.",
+            b"(.",
+            b"(N.",
+            pickle.dumps({"a": 1}, 0),
+            pickle.dumps(np.float64(1.0), 0),
+        ],
+    )
+    def test_undecodable_payloads(self, payload):
+        """Anything outside the grammar is reported rather than guessed at."""
+        assert decode_pytables_attr(payload) is NOT_DECODED
+
+    def test_repeated_value_is_shared(self):
+        """A repeated object is stored once and referenced, and must decode."""
+        shared = ("a", "b")
+        assert decode_pytables_attr(pickle.dumps((shared, shared), 0)) == (
+            shared,
+            shared,
+        )
+
+    def test_no_class_is_named(self):
+        """A payload naming a callable must not decode, let alone run it."""
+        payload = pickle.dumps(TestPyTablesAttrPayloads, 0)
+        assert decode_pytables_attr(payload) is NOT_DECODED
+
+    def test_read_decodes_none(self, pytables_attrs):
+        """A pickled None should read back as None, not as its payload."""
+        assert pytables_attrs(gauge_length=None)["gauge_length"] is None
+
+    def test_read_decodes_history(self, pytables_attrs):
+        """A pickled history tuple should read back as a tuple."""
+        attrs = pytables_attrs(history=("first", "second"))
+        assert attrs["history"] == ("first", "second")
+
+    def test_text_attr_is_not_decoded(self, tmp_path):
+        """A real string which happens to be a valid payload stays text."""
+        path = tmp_path / "text_attr.h5"
+        with h5py.File(path, "w") as h5:
+            group = h5.create_group("waveforms").create_group("patch")
+            # PyTables stored real strings as UTF-8; "N." is byte-identical
+            # to a pickled None and only the character set separates them.
+            group.attrs["_attrs_station"] = "N."
+            assert _get_attrs(group)["station"] == "N."
+
+    def test_modern_file_is_not_decoded(self, pytables_attrs):
+        """Only legacy files hold PyTables payloads."""
+        assert pytables_attrs(legacy=False, note=None)["note"] == "N."
 
 
 class TestLegacyUnitCompanions:

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -450,6 +450,21 @@ class TestPyTablesAttrPayloads:
     )
     def test_round_trip(self, value):
         """Every shape PyTables wrote for a DASCore attr should decode."""
+        decoded = decode_pytables_attr(pickle.dumps(value, 0))
+        assert decoded == value
+        # 1 == True, so the bools need their type pinned as well.
+        assert type(decoded) is type(value)
+
+    def test_round_trip_long(self):
+        """Protocol 0 spells any int of 2**31 or more as a suffixed long."""
+        value = [2**100, 3_000_000_000]
+        payload = pickle.dumps(value, 0)
+        assert b"L" in payload, "payload must use the long opcode"
+        assert decode_pytables_attr(payload) == value
+
+    def test_text_with_escapes_round_trips(self):
+        """Protocol 0 escapes newlines and backslashes inside text."""
+        value = ("a\nb", "c\\d", "\u00b5\u03b5")
         assert decode_pytables_attr(pickle.dumps(value, 0)) == value
 
     @pytest.mark.parametrize(
@@ -468,6 +483,9 @@ class TestPyTablesAttrPayloads:
             b"p0\n.",
             b"(.",
             b"(N.",
+            b"(l(a.",  # an opened container appended as if it were a value
+            b"V\\uZZZZ\n.",  # a truncated escape
+            b"IZZ\n.",
             pickle.dumps({"a": 1}, 0),
             pickle.dumps(np.float64(1.0), 0),
         ],
@@ -476,18 +494,40 @@ class TestPyTablesAttrPayloads:
         """Anything outside the grammar is reported rather than guessed at."""
         assert decode_pytables_attr(payload) is NOT_DECODED
 
-    def test_repeated_value_is_shared(self):
-        """A repeated object is stored once and referenced, and must decode."""
+    def test_repeated_scalar_is_shared(self):
+        """A repeated string is stored once and referenced back."""
+        text = "repeated"
+        assert decode_pytables_attr(pickle.dumps((text, text), 0)) == (text, text)
+
+    def test_repeated_container_is_refused(self):
+        """A shared container could name a graph far larger than its bytes."""
         shared = ("a", "b")
-        assert decode_pytables_attr(pickle.dumps((shared, shared), 0)) == (
-            shared,
-            shared,
-        )
+        payload = pickle.dumps((shared, shared), 0)
+        assert b"g" in payload, "payload must reference the memo"
+        assert decode_pytables_attr(payload) is NOT_DECODED
 
     def test_no_class_is_named(self):
         """A payload naming a callable must not decode, let alone run it."""
         payload = pickle.dumps(TestPyTablesAttrPayloads, 0)
         assert decode_pytables_attr(payload) is NOT_DECODED
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("example_event_1", ()),
+            ("deformation_rate_event_1", ()),
+        ],
+    )
+    def test_shipped_file_history(self, name, expected):
+        """A shipped legacy file states its history, not its payload (#1078)."""
+        assert dc.get_example_patch(name).attrs.history == expected
+
+    def test_shipped_file_history_text(self):
+        """A shipped legacy file with real history states it as entries."""
+        history = dc.get_example_patch("febus_dss_mine_tight").attrs.history
+        assert isinstance(history, tuple)
+        assert history and all(isinstance(x, str) for x in history)
+        assert not history[0].startswith("(V")
 
     def test_read_decodes_none(self, pytables_attrs):
         """A pickled None should read back as None, not as its payload."""
@@ -503,10 +543,28 @@ class TestPyTablesAttrPayloads:
         path = tmp_path / "text_attr.h5"
         with h5py.File(path, "w") as h5:
             group = h5.create_group("waveforms").create_group("patch")
-            # PyTables stored real strings as UTF-8; "N." is byte-identical
-            # to a pickled None and only the character set separates them.
-            group.attrs["_attrs_station"] = "N."
+            # PyTables stored a real string as fixed-length UTF-8 and a
+            # payload as raw bytes. "N." is byte-identical to a pickled
+            # None, so only the character set separates the two, and the
+            # value has to be written the way PyTables wrote text for the
+            # test to reach that comparison at all.
+            group.attrs.create(
+                "_attrs_station",
+                np.bytes_(b"N."),
+                dtype=h5py.string_dtype(encoding="utf-8", length=2),
+            )
+            attrs = group.attrs
+            assert isinstance(attrs["_attrs_station"], np.bytes_ | bytes)
+            assert attrs.get_id("_attrs_station").get_type().get_cset() == 1
             assert _get_attrs(group)["station"] == "N."
+
+    def test_attr_name_repeating_the_prefix(self, tmp_path):
+        """The stored name must be recovered exactly, not by substitution."""
+        path = tmp_path / "repeated_prefix.h5"
+        with h5py.File(path, "w") as h5:
+            group = h5.create_group("waveforms").create_group("patch")
+            group.attrs["_attrs_my_attrs_thing"] = np.bytes_(pickle.dumps(None, 0))
+            assert _get_attrs(group)["my_attrs_thing"] is None
 
     def test_modern_file_is_not_decoded(self, pytables_attrs):
         """Only legacy files hold PyTables payloads."""

--- a/tests/test_transform/test_strain.py
+++ b/tests/test_transform/test_strain.py
@@ -258,12 +258,21 @@ class TestRadianToStrain:
         out = patch.radians_to_strain(gauge_length=1)
         assert isinstance(out, dc.Patch)
 
-    @pytest.mark.parametrize("bad", ["N.", b"10", float("nan"), float("inf"), 0, -5])
+    @pytest.mark.parametrize(
+        "bad", ["N.", b"10", float("nan"), float("inf"), 0, -5, True]
+    )
     def test_non_positive_gauge_length_in_attrs(self, rad_patch, bad):
         """A gauge length which is not a positive number should be rejected."""
         patch = rad_patch.update_attrs(gauge_length=bad)
         with pytest.raises(ParameterError, match="Gauge length must"):
             patch.radians_to_strain()
+
+    @pytest.mark.parametrize("boxed", [np.array(10.0), np.array([10.0])])
+    def test_gauge_length_in_an_array_box(self, rad_patch, boxed):
+        """A scalar left in an array should still be a gauge length."""
+        patch = rad_patch.update_attrs(gauge_length=None)
+        out = patch.radians_to_strain(gauge_length=boxed)
+        assert out.equals(rad_patch.radians_to_strain(gauge_length=10))
 
     def test_gauge_length_quantity(self, rad_patch):
         """A gauge length with units should convert to meters."""

--- a/tests/test_transform/test_strain.py
+++ b/tests/test_transform/test_strain.py
@@ -283,7 +283,6 @@ class TestRadianToStrain:
     def test_example_patch_without_gauge_length(self):
         """The example patch the docstrings use states no gauge length (#1078)."""
         patch = dc.get_example_patch("deformation_rate_event_1")
-        assert getattr(patch.attrs, "gauge_length", None) is None
         with pytest.raises(ParameterError, match="Gauge length must"):
             patch.update_attrs(data_units="rad").radians_to_strain()
 

--- a/tests/test_transform/test_strain.py
+++ b/tests/test_transform/test_strain.py
@@ -258,6 +258,26 @@ class TestRadianToStrain:
         out = patch.radians_to_strain(gauge_length=1)
         assert isinstance(out, dc.Patch)
 
+    @pytest.mark.parametrize("bad", ["N.", b"10", float("nan"), float("inf"), 0, -5])
+    def test_non_positive_gauge_length_in_attrs(self, rad_patch, bad):
+        """A gauge length which is not a positive number should be rejected."""
+        patch = rad_patch.update_attrs(gauge_length=bad)
+        with pytest.raises(ParameterError, match="Gauge length must"):
+            patch.radians_to_strain()
+
+    def test_gauge_length_quantity(self, rad_patch):
+        """A gauge length with units should convert to meters."""
+        patch = rad_patch.update_attrs(gauge_length=None)
+        out = patch.radians_to_strain(gauge_length=10_000 * dc.get_quantity("mm"))
+        assert out.equals(rad_patch.radians_to_strain(gauge_length=10))
+
+    def test_example_patch_without_gauge_length(self):
+        """The example patch the docstrings use states no gauge length (#1078)."""
+        patch = dc.get_example_patch("deformation_rate_event_1")
+        assert getattr(patch.attrs, "gauge_length", None) is None
+        with pytest.raises(ParameterError, match="Gauge length must"):
+            patch.update_attrs(data_units="rad").radians_to_strain()
+
     def test_no_radians(self, random_patch):
         """Ensure no radians in units returns same patch."""
         patch = random_patch.update_attrs(gauge_length=10)


### PR DESCRIPTION
## Description

Fixes #1078.

`radians_to_strain` raised `TypeError` instead of `ParameterError` on DASCore's own example patch, because `deformation_rate_event_1` reported `gauge_length == 'N.'`. Two things, and the second turned out to be the interesting one.

### The file was never wrong; the reader was

`b'N.'` is not garbage. It is `pickle.dumps(None, 0)`.

PyTables stored every attr value HDF5 has no native type for — `None`, tuples, lists — as a pickle, and unpickled it again on read. DASDAE files were written with PyTables until the reader moved to h5py, and h5py hands back the payload bytes themselves. So the value round-tripped correctly for years and started reading as its own pickle text.

`gauge_length` is the visible symptom. `history` is the quieter one — on `dev`, every legacy file reports it as pickle text:

```python
dc.get_example_patch("example_event_1").attrs.history
# dev:  '(lp0\n.'                                  <- pickled []
# here: ()
dc.get_example_patch("febus_dss_mine_tight").attrs.history
# dev:  "(Vupdate_coords(distance='CoordRange( min: 0.0 max: 2e+03 ...
# here: ("update_coords(distance='CoordRange( min: 0.0 max: 2e+03 ...",)
```

### Decoding it under the gate that already exists

`_compat.py` already unpickles the legacy **coord** payload behind `allow_dasdae_format_unpickle`, off by default. An attr payload is the same kind of thing from the same writer, so it goes through the same gate, and `decode_pytables_attr` is a `pickle.loads` beside the one two functions up.

Nothing new is being trusted here. Four of the five shipped legacy files **already refuse to read** without the opt-in, because they carry a coord payload too:

```python
with dc.config_context(allow_dasdae_format_unpickle=False):
    dc.read(fetch("deformation_rate_event_1.hdf5"))   # InvalidFiberFileError, on dev and here
```

So anyone who can open the file in this issue at all has already opted in. `dc.get_example_patch` and the test suite both turn the gate on, which is why the examples work.

The one difference from the coord path is what a refusal costs. A patch cannot be built without its coords, so that path raises; an attr is informational, so this one leaves the caller the text it would have had.

### Telling a payload from a string

Nothing in the bytes separates them — a string attr of `"N."` is byte-identical to a pickled `None`. HDF5 records the difference as the attribute's character set: PyTables wrote real strings as UTF-8 (`cset=1`) and pickled payloads as raw bytes (`cset=0`). That is the same discriminator PyTables itself relies on when reading, and it is checked only on legacy files.

### The guard

`transform/strain.py` compared `gauge <= 0` after a `gauge is None` check, so any non-numeric gauge length walked into the comparison. It now requires a positive, finite, real number and names the offending value:

```
ParameterError: Gauge length must be a positive number, got 'N.'. Pass it with
the gauge_length argument or set it in the patch attrs.
```

Worth keeping independently of the reader fix, and not only for the exception type: `nan <= 0` and `inf <= 0` are both `False`, so either passed the old check and produced a full patch of `nan` or of zeros with no error at all. Readers hand attrs through from files DASCore did not write, and `dasjax` mirrors this code.

### What is not here

No change to `dasdae/test_data`. The stored value is a correctly pickled `None`, which is what the acquisition recorded; rewriting the six affected files would bump every hash, bust every cache, delete the only shipped fixtures for the legacy format, and still leave real users' legacy files misread.

### Review notes

An earlier revision of this PR decoded the payloads with a hand-written protocol-0 opcode reader rather than `pickle`, to avoid unpickling at all. It was 117 lines, and six blind reviewers found four ways into it — a sentinel that could reach `PatchAttrs`, a shared container that let a 289-byte payload name a 1.9 GB graph, an uncaught `UnicodeDecodeError`, and a missing opcode for any int of 2\*\*31 or more. It is gone; the gate was the answer. What survives from that round:

- **`str.replace` is not `removeprefix`.** The stored attr name was rebuilt from the stripped key, and `.replace` strips every occurrence, so an attr named `_attrs_my_attrs_thing` looked up a name no file has. Both this and the pre-existing `_attr_type_` lookup now use `removeprefix`.
- **`INDEX_VERSION` needed the bump.** Its own comment mandates one when what a *stored value* means changes: an index written by 13 over `deformation_rate_event_1.hdf5` holds `gauge_length='N.'` forever, since rescan is mtime/size-only, and would then disagree with the patch it points at.
- **The guard narrowed what it accepted.** `np.array(10.0)` and `np.array([10.0])` worked under the old `gauge <= 0` and now unwrap rather than raise.
- **The character-set discriminator had no coverage.** The test wrote a Python `str`, which h5py hands back as `str`, so it never reached the comparison at all.

## Changelog

- fixed: Legacy DASDAE files written by PyTables report their attrs again when `allow_dasdae_format_unpickle` is set, the same opt-in their coord metadata already needs; `None` and history tuples were reading back as their own pickle text (e.g. `gauge_length` on the `deformation_rate_event_1` example was the string `'N.'`).
- fixed: `Patch.radians_to_strain` raises `ParameterError` for a gauge length which is not a positive number, rather than `TypeError` for text and a silent patch of `nan` for `nan`.
- changed: The spool index version is 14, so an index built by an earlier version is rebuilt rather than serving the attr values it stored for a legacy DASDAE file.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when reading legacy DASDAE files with PyTables-encoded attributes.
  - Correctly recovers legacy gauge-length values instead of treating them as missing.
  - Rejects invalid gauge lengths, including non-positive, non-finite, boolean, and text values.
  - Supports scalar and unit-based gauge-length inputs, converting values to meters.
  - Provides clearer handling when legacy attribute values cannot be decoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->