### PR TITLE
One way to resolve a window along a patch's dimensions

### DIFF
--- a/dascore/proc/adaptive_spectral_filter.py
+++ b/dascore/proc/adaptive_spectral_filter.py
@@ -457,14 +457,10 @@ class AdaptiveSpectralFilter(PatchProcessor):
         )
         # A default was given, so every dimension has an overlap.
         assert window.overlap is not None
-        dims, axes, windows, overlaps = (
-            window.dims,
-            window.axes,
-            window.size,
-            window.overlap,
+        _validate_window_and_overlap(
+            window.dims, window.size, window.overlap, float(self.exponent)
         )
-        _validate_window_and_overlap(dims, windows, overlaps, float(self.exponent))
-        return _Geometry(axes, windows, overlaps)
+        return _Geometry(window.axes, window.size, window.overlap)
 
     def kernel(self, data, meta, out_meta):
         """Filter every batch over the selected axes and stack the results."""

--- a/dascore/proc/adaptive_spectral_filter.py
+++ b/dascore/proc/adaptive_spectral_filter.py
@@ -24,7 +24,7 @@ so the two produce the same output.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from itertools import product
 from math import prod
 from typing import Any, Literal, NamedTuple
@@ -34,14 +34,11 @@ from pydantic import ConfigDict
 from scipy import fft as sp_fft
 
 from dascore.constants import PatchType
-from dascore.exceptions import (
-    MissingOptionalDependencyError,
-    ParameterError,
-    PatchCoordinateError,
-)
+from dascore.exceptions import MissingOptionalDependencyError, ParameterError
 from dascore.utils.misc import is_power_of_two
 from dascore.utils.patch import patch_function
 from dascore.utils.signal import _triangular_taper
+from dascore.utils.window import resolve_window
 from dascore.workflow.meta import PatchMeta
 from dascore.workflow.processor import PatchProcessor, register_implementation
 
@@ -291,63 +288,6 @@ class _Geometry(NamedTuple):
     overlaps: tuple[int, ...]
 
 
-def _axes(meta: PatchMeta, dims: tuple[str, ...]) -> tuple[int, ...]:
-    """Return the axis of each dimension named, refusing one the patch lacks."""
-    for dim in dims:
-        if dim not in meta.dims:
-            msg = f"Dimension {dim!r} not found in patch dimensions {meta.dims}."
-            raise PatchCoordinateError(msg)
-    return tuple(meta.get_axis(dim) for dim in dims)
-
-
-def _sample_counts(
-    meta: PatchMeta,
-    values: Mapping[str, Any],
-    *,
-    samples: bool,
-    name: str,
-    sample_dims: frozenset[str] = frozenset(),
-) -> tuple[int, ...]:
-    """Convert per-dimension values in samples or coordinate units to sample counts."""
-    out: list[int] = []
-    for dim, value in values.items():
-        if samples or dim in sample_dims:
-            count = int(value)
-        else:
-            count = meta.coords.get_coord(dim).get_sample_count(value)
-        invalid = count < 0 if name == "overlap" else count <= 0
-        if invalid:
-            requirement = "non-negative" if name == "overlap" else "positive"
-            msg = f"{name} for dimension {dim!r} must be {requirement}."
-            raise ParameterError(msg)
-        out.append(count)
-    return tuple(out)
-
-
-def _normalize_overlap(
-    overlap: Any,
-    dims: tuple[str, ...],
-    windows: tuple[int, ...],
-) -> tuple[dict[str, Any], frozenset[str]]:
-    """Return per-dimension overlap values and internally defaulted dimensions."""
-    # The largest overlap the window allows, which is what Lightguide uses.
-    defaults = {dim: window // 2 - 1 for dim, window in zip(dims, windows)}
-    if overlap is None:
-        return defaults, frozenset(dims)
-    if isinstance(overlap, Mapping):
-        extra = set(overlap) - set(dims)
-        if extra:
-            names = sorted(map(str, extra))
-            msg = f"overlap contains dimensions not being filtered: {names}"
-            raise ParameterError(msg)
-        return defaults | dict(overlap), frozenset(set(dims) - set(overlap))
-    # Uncoerced: the value the caller gave is read in coordinate units
-    # unless samples says otherwise, and int() of a timedelta64 or a
-    # fractional second is not the overlap they asked for. Only the
-    # defaults above are sample counts, which is what the returned set says.
-    return dict.fromkeys(dims, overlap), frozenset()
-
-
 def _get_engine(engine: str, selected_ndim: int) -> Callable:
     """Return the requested adaptive spectral array filter implementation."""
     if engine == "scipy" or (engine == "auto" and selected_ndim == 1):
@@ -504,16 +444,22 @@ class AdaptiveSpectralFilter(PatchProcessor):
                 "kwargs, e.g. patch.adaptive_spectral_filter(time=32, samples=True)."
             )
             raise ParameterError(msg)
-        dims = tuple(selected)
-        axes = _axes(meta, dims)
-        windows = _sample_counts(meta, selected, samples=self.samples, name="window")
-        overlap_values, sample_dims = _normalize_overlap(self.overlap, dims, windows)
-        overlaps = _sample_counts(
+        window = resolve_window(
             meta,
-            overlap_values,
+            selected,
             samples=self.samples,
-            name="overlap",
-            sample_dims=sample_dims,
+            overlap=self.overlap,
+            # The most the window allows, which is what Lightguide uses. A
+            # default is a sample count whatever `samples` says.
+            default_overlap=lambda size: size // 2 - 1,
+        )
+        # A default was given, so every dimension has an overlap.
+        assert window.overlap is not None
+        dims, axes, windows, overlaps = (
+            window.dims,
+            window.axes,
+            window.size,
+            window.overlap,
         )
         _validate_window_and_overlap(dims, windows, overlaps, float(self.exponent))
         return _Geometry(axes, windows, overlaps)

--- a/dascore/proc/adaptive_spectral_filter.py
+++ b/dascore/proc/adaptive_spectral_filter.py
@@ -449,6 +449,8 @@ class AdaptiveSpectralFilter(PatchProcessor):
             selected,
             samples=self.samples,
             overlap=self.overlap,
+            # Sample counts are read as given, whatever the coordinate is.
+            require_evenly_sampled=False,
             # The most the window allows, which is what Lightguide uses. A
             # default is a sample count whatever `samples` says.
             default_overlap=lambda size: size // 2 - 1,

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -249,7 +249,7 @@ def median_filter(
     Values specified with kwargs should be small, for example < 10 samples
     otherwise this can take a long time and use lots of memory.
     """
-    size = resolve_window(patch, kwargs, samples=samples).full_size()
+    size = resolve_window(patch, kwargs, samples=samples, min_samples=None).full_size()
     new_data = nd_median_filter(patch.data, size=size, mode=mode, cval=cval)
     return patch.update(data=new_data)
 
@@ -384,7 +384,7 @@ def savgol_filter(
     >>> filtered_pa_3 = pa.savgol_filter(distance=10, time=0.1, polyorder=4)
     """
     data = patch.data
-    window = resolve_window(patch, kwargs, samples=samples)
+    window = resolve_window(patch, kwargs, samples=samples, min_samples=None)
     size, axes = window.full_size(), window.axes
     for ax in axes:
         data = np_savgol_filter(
@@ -448,7 +448,7 @@ def gaussian_filter(
     See scipy.ndimage.gaussian_filter for more info on implementation
     and arguments.
     """
-    window = resolve_window(patch, kwargs, samples=samples)
+    window = resolve_window(patch, kwargs, samples=samples, min_samples=None)
     size, axes = window.full_size(), window.axes
     used_size = tuple(size[x] for x in axes)
     data = np_gauss(

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -39,6 +39,7 @@ from dascore.utils.patch import (
     patch_function,
 )
 from dascore.utils.time import to_float
+from dascore.utils.window import resolve_window
 
 filtfilt = lazy_import("scipy.signal", "filtfilt")
 iirfilter = lazy_import("scipy.signal", "iirfilter")
@@ -196,23 +197,6 @@ def sobel_filter(
     return patch.new(data=out)
 
 
-def _create_size_and_axes(patch, kwargs, samples):
-    """
-    Return a tuple of (size) and (axes).
-
-    Note: size will always have the same size as the patch, but
-    1s will be used if axis is not used.
-    """
-    dimfo = get_dim_axis_value(patch, kwargs=kwargs, allow_multiple=True)
-    axes = [x.axis for x in dimfo]
-    size = [1] * len(patch.dims)
-    for dim, axis, value in dimfo:
-        coord = patch.get_coord(dim)
-        window = coord.get_sample_count(value, samples=samples)
-        size[axis] = window
-    return tuple(size), tuple(axes)
-
-
 @patch_function()
 @compose_docstring(sample_explanation=samples_arg_description)
 def median_filter(
@@ -265,7 +249,7 @@ def median_filter(
     Values specified with kwargs should be small, for example < 10 samples
     otherwise this can take a long time and use lots of memory.
     """
-    size, _ = _create_size_and_axes(patch, kwargs, samples)
+    size = resolve_window(patch, kwargs, samples=samples).full_size()
     new_data = nd_median_filter(patch.data, size=size, mode=mode, cval=cval)
     return patch.update(data=new_data)
 
@@ -400,7 +384,8 @@ def savgol_filter(
     >>> filtered_pa_3 = pa.savgol_filter(distance=10, time=0.1, polyorder=4)
     """
     data = patch.data
-    size, axes = _create_size_and_axes(patch, kwargs, samples)
+    window = resolve_window(patch, kwargs, samples=samples)
+    size, axes = window.full_size(), window.axes
     for ax in axes:
         data = np_savgol_filter(
             x=patch.data,
@@ -463,7 +448,8 @@ def gaussian_filter(
     See scipy.ndimage.gaussian_filter for more info on implementation
     and arguments.
     """
-    size, axes = _create_size_and_axes(patch, kwargs, samples)
+    window = resolve_window(patch, kwargs, samples=samples)
+    size, axes = window.full_size(), window.axes
     used_size = tuple(size[x] for x in axes)
     data = np_gauss(
         input=patch.data,

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -10,7 +10,8 @@ from scipy.ndimage import median_filter
 from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
 from dascore.utils.moving import has_engine, move_median
-from dascore.utils.patch import get_patch_window_size, patch_function
+from dascore.utils.patch import patch_function
+from dascore.utils.window import resolve_window
 
 
 def _separable_median(data, size, mode, out):
@@ -193,9 +194,15 @@ def hampel_filter(
     # filter and scipy's median_filter both grow with the window.
     fast = approximate and has_engine("bottleneck")
     warn_above = None if fast else 100
-    size = get_patch_window_size(
-        patch, kwargs, samples, require_odd=True, warn_above=warn_above, min_samples=3
-    )
+    size = resolve_window(
+        patch,
+        kwargs,
+        samples=samples,
+        require_odd=True,
+        warn_above=warn_above,
+        min_samples=3,
+        allow_empty=True,
+    ).full_size()
     # Need to convert ints to float for calculations to avoid roundoff error.
     # There were issues using np.issubdtype not working so this uses kind.
     is_int = data.dtype.kind in {"i", "u"}

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -15,9 +15,9 @@ from dascore.utils.docs import compose_docstring
 from dascore.utils.patch import (
     _maybe_add_history_str,
     get_dim_axis_value,
-    get_window_axis_step,
 )
 from dascore.utils.pd import rolling_df
+from dascore.utils.window import resolve_window
 
 rolling_apply_description = """
 Apply a function over the specified moving window.
@@ -394,7 +394,19 @@ def rolling(
         return _NumpyPatchRoller
 
     dim, axis, value = get_dim_axis_value(patch, kwargs=kwargs)[0]
-    window, _, step = get_window_axis_step(patch, overlap, step, samples, **kwargs)
+    resolved = resolve_window(
+        patch,
+        kwargs,
+        samples=samples,
+        overlap=overlap,
+        step=step,
+        allow_multiple=False,
+        # No floor of its own: a zero window is refused below, by name.
+        min_samples=0,
+        enforce_lt_coord=True,
+    )
+    window = resolved.size[0]
+    step = None if resolved.stride is None else resolved.stride[0]
     # Handle default when no overlap/step specified and ensure window size
     step = 1 if step is None else step
     if window == 0 or step == 0:

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -14,7 +14,6 @@ from dascore.exceptions import ParameterError
 from dascore.utils.docs import compose_docstring
 from dascore.utils.patch import (
     _maybe_add_history_str,
-    get_dim_axis_value,
 )
 from dascore.utils.pd import rolling_df
 from dascore.utils.window import resolve_window
@@ -393,7 +392,6 @@ def rolling(
             return _PandasPatchRoller
         return _NumpyPatchRoller
 
-    dim, axis, value = get_dim_axis_value(patch, kwargs=kwargs)[0]
     resolved = resolve_window(
         patch,
         kwargs,
@@ -405,7 +403,8 @@ def rolling(
         min_samples=0,
         enforce_lt_coord=True,
     )
-    window = resolved.size[0]
+    dim, axis, window = resolved.dims[0], resolved.axes[0], resolved.size[0]
+    value = kwargs[dim]
     step = None if resolved.stride is None else resolved.stride[0]
     # Handle default when no overlap/step specified and ensure window size
     step = 1 if step is None else step

--- a/dascore/proc/wiener.py
+++ b/dascore/proc/wiener.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from dascore.constants import PatchType
 from dascore.exceptions import ParameterError
 from dascore.utils.imports import lazy_import
-from dascore.utils.patch import get_patch_window_size, patch_function
+from dascore.utils.patch import patch_function
+from dascore.utils.window import resolve_window
 
 wiener = lazy_import("scipy.signal", "wiener")
 
@@ -78,6 +79,6 @@ def wiener_filter(
         )
         raise ParameterError(msg)
 
-    size = get_patch_window_size(patch, kwargs, samples, min_samples=1)
+    size = resolve_window(patch, kwargs, samples=samples).full_size()
     filtered_data = wiener(patch.data, mysize=size, noise=noise)
     return patch.update(data=filtered_data)

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -30,7 +30,6 @@ from dascore.utils.misc import broadcast_for_index, iterate
 from dascore.utils.patch import (
     _get_data_units_from_dims,
     _get_dx_or_spacing_and_axes,
-    get_dim_axis_value,
     patch_function,
 )
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
@@ -624,9 +623,6 @@ def stft(
     [Patch.dft](`dascore.Patch.dft`), [Patch.istft](`dascore.Patch.istft`)
     """
     # Get coordinate information.
-    (dim, axis, _) = get_dim_axis_value(patch, kwargs=kwargs)[0]
-    coord = patch.get_coord(dim, require_evenly_sampled=True)
-    # Get window count/step in samples
     resolved = resolve_window(
         patch,
         kwargs,
@@ -637,7 +633,8 @@ def stft(
         min_samples=0,
         enforce_lt_coord=True,
     )
-    window_samples = resolved.size[0]
+    dim, axis, window_samples = resolved.dims[0], resolved.axes[0], resolved.size[0]
+    coord = patch.get_coord(dim)
     # No overlap given means none: the windows abut.
     hop = window_samples if resolved.stride is None else resolved.stride[0]
     sampling_rate = 1 / abs(dc.to_float(coord.step))

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -31,11 +31,11 @@ from dascore.utils.patch import (
     _get_data_units_from_dims,
     _get_dx_or_spacing_and_axes,
     get_dim_axis_value,
-    get_window_axis_step,
     patch_function,
 )
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.transformatter import FourierTransformatter
+from dascore.utils.window import resolve_window
 
 if TYPE_CHECKING:
     from scipy.signal import ShortTimeFFT
@@ -627,11 +627,19 @@ def stft(
     (dim, axis, _) = get_dim_axis_value(patch, kwargs=kwargs)[0]
     coord = patch.get_coord(dim, require_evenly_sampled=True)
     # Get window count/step in samples
-    window_samples, _, hop = get_window_axis_step(
-        patch, step=None, overlap=overlap, samples=samples, **kwargs
+    resolved = resolve_window(
+        patch,
+        kwargs,
+        samples=samples,
+        overlap=overlap,
+        allow_multiple=False,
+        # No floor of its own: a zero window is refused below, by name.
+        min_samples=0,
+        enforce_lt_coord=True,
     )
-    # Default step here is the same size as window (no overlap).
-    hop = hop if hop is not None else window_samples
+    window_samples = resolved.size[0]
+    # No overlap given means none: the windows abut.
+    hop = window_samples if resolved.stride is None else resolved.stride[0]
     sampling_rate = 1 / abs(dc.to_float(coord.step))
     # Create window.
     if isinstance(taper_window, ndarray):

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -629,8 +629,6 @@ def stft(
         samples=samples,
         overlap=overlap,
         allow_multiple=False,
-        # No floor of its own: a zero window is refused below, by name.
-        min_samples=0,
         enforce_lt_coord=True,
     )
     dim, axis, window_samples = resolved.dims[0], resolved.axes[0], resolved.size[0]

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -926,6 +926,71 @@ def get_dim_sampling_rate(patch: PatchType, dim: str) -> float:
     return 1.0 / d_dim
 
 
+@deprecate(
+    info=(
+        "get_patch_window_size is deprecated. Use "
+        "dascore.utils.window.resolve_window(...).full_size() instead."
+    ),
+    removed_in="0.2.0",
+)
+def get_patch_window_size(
+    patch: PatchType,
+    kwargs: dict,
+    samples: bool = False,
+    *,
+    require_odd: bool = False,
+    warn_above: int | None = None,
+    min_samples: int = 1,
+    enforce_lt_coord: bool = False,
+) -> tuple[int, ...]:
+    """Return the window along every patch axis; see `resolve_window`."""
+    # Deferred: dascore.utils.window imports this module.
+    from dascore.utils.window import resolve_window  # noqa: PLC0415
+
+    return resolve_window(
+        patch,
+        kwargs,
+        samples=samples,
+        allow_empty=True,
+        require_odd=require_odd,
+        warn_above=warn_above,
+        min_samples=min_samples,
+        enforce_lt_coord=enforce_lt_coord,
+    ).full_size()
+
+
+@deprecate(
+    info=(
+        "get_window_axis_step is deprecated. Use "
+        "dascore.utils.window.resolve_window instead."
+    ),
+    removed_in="0.2.0",
+)
+def get_window_axis_step(
+    patch,
+    overlap=None,
+    step=None,
+    samples=False,
+    **kwargs,
+) -> tuple[int, int, int | None]:
+    """Return one dimension's window, axis, and step; see `resolve_window`."""
+    # Deferred: dascore.utils.window imports this module.
+    from dascore.utils.window import resolve_window  # noqa: PLC0415
+
+    window = resolve_window(
+        patch,
+        kwargs,
+        samples=samples,
+        overlap=overlap,
+        step=step,
+        allow_multiple=False,
+        min_samples=0,
+        enforce_lt_coord=True,
+    )
+    stride = None if window.stride is None else window.stride[0]
+    return window.size[0], window.axes[0], stride
+
+
 # What a derivative along a dimension makes of the data. Read forward to
 # differentiate and backward to integrate; the same physics either way,
 # so one table states both.

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -178,6 +178,15 @@ def _maybe_add_history_str(attrs, hist_str):
     return attrs.update(history=new_history)
 
 
+class _HasDims(Protocol):
+    """Anything with dimension names in axis order: a patch, or its metadata."""
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        """The dimension names."""
+        ...
+
+
 class _PatchFunction(Protocol):
     """
     A function wrapped by `patch_function`.
@@ -809,7 +818,7 @@ def get_patch_names(
 
 
 def get_dim_axis_value(
-    patch: PatchType,
+    patch: _HasDims,
     *,
     args: tuple = tuple(),
     kwargs: Mapping = FrozenDict(),

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import functools
 import inspect
-import math
 import sys
-import warnings
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Literal, Protocol, cast, overload
@@ -33,7 +31,7 @@ from dascore.exceptions import (
     PatchCoordinateError,
     UnitError,
 )
-from dascore.units import carries_units, convert_units, get_quantity, is_percent
+from dascore.units import carries_units, convert_units, get_quantity
 from dascore.utils.array_api import (
     asarray_like,
     backend_name,
@@ -64,7 +62,7 @@ from dascore.utils.misc import (
     yield_sub_sequences,
 )
 from dascore.utils.paths import is_memory_uri
-from dascore.utils.time import is_timedelta64, to_float, to_timedelta64
+from dascore.utils.time import to_float
 from dascore.workflow.builtin import Concatenate, Stack
 from dascore.workflow.checks import attr_type, check_patch_attrs, check_patch_coords
 from dascore.workflow.identity import (
@@ -926,196 +924,6 @@ def get_dim_sampling_rate(patch: PatchType, dim: str) -> float:
         )
         raise CoordDataError(msg)
     return 1.0 / d_dim
-
-
-def get_patch_window_size(
-    patch: PatchType,
-    kwargs: dict,
-    samples: bool = False,
-    *,
-    require_odd: bool = False,
-    warn_above: int | None = None,
-    min_samples: int = 1,
-    enforce_lt_coord: bool = False,
-) -> tuple[int, ...]:
-    """
-    Get window sizes for patch processing operations.
-
-    Parameters
-    ----------
-    patch
-        The input patch.
-    kwargs
-        Keyword arguments specifying dimension names and their window sizes.
-    samples
-        If True, kwargs values are in samples; if False, in coordinate units.
-    require_odd
-        If True, require odd window sizes. When samples=False, even sizes
-        are adjusted to be odd. When samples=True, even sizes raise ParameterError.
-    warn_above
-        If specified, warn when the total window size (the product of the
-        sample counts of each dimension) exceeds this value.
-    min_samples
-        Minimum number of samples required per dimension.
-    enforce_lt_coord
-        If True, reject windows larger than coordinate length.
-
-    Returns
-    -------
-    Tuple of window sizes for each dimension of the patch data.
-
-    Raises
-    ------
-    ParameterError
-        If window sizes are too small, or if require_odd=True and samples=True
-        but window size is even.
-    """
-    # Handle empty kwargs case - return all ones
-    if not kwargs:
-        return tuple([1] * patch.data.ndim)
-
-    aggs = get_dim_axis_value(patch, kwargs=kwargs, allow_multiple=True)
-    size = [1] * patch.data.ndim
-
-    for name, axis, val in aggs:
-        coord = patch.get_coord(name, require_evenly_sampled=True)
-        samps = coord.get_sample_count(
-            val, samples=samples, enforce_lt_coord=enforce_lt_coord
-        )
-
-        # Check minimum samples requirement
-        if samps < min_samples:
-            if samples:
-                hint = "Try increasing its value."
-            else:
-                # in seconds, which is what a time value would be given in
-                step = coord.step
-                step = f"{to_float(step)} s" if is_timedelta64(step) else step
-                hint = (
-                    f"The value is in the units of {name}, which is sampled "
-                    f"every {step}; increase it, or use samples=True to give "
-                    "the window in samples."
-                )
-            msg = (
-                f"Window must have at least {min_samples} samples along each "
-                f"dimension. {name} has {samps} samples. {hint}"
-            )
-            raise ParameterError(msg)
-
-        # Handle odd number requirement
-        if require_odd and (samps % 2 != 1):
-            if not samples:
-                # Adjust even sizes to odd when samples=False
-                samps += 1
-            else:
-                # Raise error when samples=True and size is even
-                msg = (
-                    f"For clean median calculation, dimension windows must be odd "
-                    f"but {name} has a value of {samps} samples."
-                )
-                raise ParameterError(msg)
-
-        size[axis] = samps
-
-    # Warn on the total window, not each dimension: the cost of a windowed
-    # operation tracks the number of samples the window covers, so a 2D
-    # window is as expensive as its area.
-    total = math.prod(size)
-    if warn_above is not None and total > warn_above:
-        msg = (
-            f"Large window size ({total} samples) may result in slow "
-            "performance. Consider reducing the window size."
-        )
-        warnings.warn(msg, UserWarning, stacklevel=3)
-
-    return tuple(size)
-
-
-def get_window_axis_step(
-    patch,
-    overlap=None,
-    step=None,
-    samples=False,
-    **kwargs,
-) -> tuple[int, int, int | None]:
-    """
-    Get window size, axis, and step for a single patch dimension.
-
-    Parameters
-    ----------
-    patch
-        The patch with the dimension and coordinate.
-    overlap
-        Optional overlap between adjacent windows. Percent quantities are
-        interpreted relative to the window size.
-    step
-        Optional step between adjacent windows. Mutually exclusive with overlap.
-        Percent quantities are interpreted relative to the window size.
-    samples
-        If True, numeric window, overlap, and step values are interpreted as
-        sample counts. Quantities with explicit units keep their unit meaning.
-    **kwargs
-        Exactly one dimension name and window size.
-
-    Returns
-    -------
-    tuple
-        The window size in samples, the axis for the dimension, and the step in
-        samples. The step is None if neither step nor overlap was provided.
-    """
-
-    def _percent_to_window_samps(window, val):
-        """Convert any percentages to samples of the window."""
-        if is_per := is_percent(val):
-            mag = val.magnitude
-            if mag < 0 or mag > 100:
-                msg = f"Percentage must be between 0 and 100, not {val}"
-                raise ParameterError(msg)
-            val = int(np.round(val.magnitude / 100 * window))
-        return val, is_per
-
-    def _check_not_negative(val, name):
-        """Ensure a step or overlap value isn't negative."""
-        magnitude = val.magnitude if isinstance(val, dc.units.Quantity) else val
-        # A bare 0 would make numpy cast the timedelta to a generic unit.
-        zero = to_timedelta64(0) if is_timedelta64(magnitude) else 0
-        if magnitude is not None and magnitude < zero:
-            msg = f"{name} must be non-negative"
-            raise ParameterError(msg)
-
-    def quantity_to_samps(val, coord, samples=False):
-        """Convert quantity value to number of samples."""
-        # None just passes through
-        if val is None:
-            return None
-        # Specifying a quantity should overwrite samples parameter.
-        if isinstance(val, dc.units.Quantity):
-            samples = False
-        return coord.get_sample_count(val, samples=samples, enforce_lt_coord=True)
-
-    if overlap is not None and step is not None:
-        msg = "step and overlap are mutually exclusive."
-        raise ParameterError(msg)
-
-    dim, axis, win = get_dim_axis_value(patch, kwargs=kwargs, allow_multiple=False)[0]
-    coord = patch.get_coord(dim, require_evenly_sampled=True)
-    win_samp = coord.get_sample_count(win, samples=samples, enforce_lt_coord=True)
-    # Convert any percentages to win_samples
-    step, step_percent = _percent_to_window_samps(win_samp, step)
-    overlap, overlap_percent = _percent_to_window_samps(win_samp, overlap)
-    _check_not_negative(step, "step")
-    _check_not_negative(overlap, "overlap")
-    # Then convert to coordinate samples. This handles differing units and such.
-    step = quantity_to_samps(step, coord, samples=samples or step_percent)
-    overlap = quantity_to_samps(overlap, coord, samples=samples or overlap_percent)
-    # Convert overlap to step
-    if step is None and overlap is not None:
-        step = win_samp - overlap
-    if step is not None and step <= 0:
-        msg = "Window step must be greater than zero."
-        raise ParameterError(msg)
-    # Get window length/step in samples
-    return win_samp, axis, step
 
 
 # What a derivative along a dimension makes of the data. Read forward to

--- a/dascore/utils/window.py
+++ b/dascore/utils/window.py
@@ -1,0 +1,313 @@
+"""
+One way to say "a window of X, overlapping by Y" along a patch's dimensions.
+
+Every windowed patch function takes its windows as dimension keywords --
+``time=0.5``, ``distance=32 * m``, ``time=16`` with ``samples=True`` -- and
+some take an ``overlap`` or ``step`` between windows besides. Turning those
+into sample counts is one job, and :func:`resolve_window` does it for all of
+them, returning a :class:`Window`.
+
+What differs between functions is policy, not conversion: whether an even
+window is adjusted or refused, whether a window longer than the coordinate is
+refused, what a missing overlap means. Each of those is a keyword here, stated
+by the function which wants it.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from dascore.exceptions import CoordError, ParameterError
+from dascore.units import Quantity, is_percent
+from dascore.utils.misc import get_parent_code_name
+from dascore.utils.patch import get_dim_axis_value
+from dascore.utils.time import is_timedelta64, to_float, to_timedelta64
+
+# What a function means by an overlap nobody gave: a sample count, or a
+# rule for one from the window's size in samples.
+OverlapDefault = Callable[[int], int] | int | None
+
+
+@dataclass(frozen=True)
+class Window:
+    """
+    A window along some of a patch's dimensions, in samples.
+
+    Parameters
+    ----------
+    dims
+        The dimensions windowed, in the order the caller named them.
+    axes
+        The axis of each.
+    size
+        The window along each, in samples.
+    overlap
+        How far each window reaches into the next, in samples, or None if
+        the caller gave no overlap, no step, and no default -- which each
+        function reads its own way.
+    ndim
+        How many dimensions the patch has, so the window can be spelled
+        out for every axis.
+    """
+
+    dims: tuple[str, ...]
+    axes: tuple[int, ...]
+    size: tuple[int, ...]
+    overlap: tuple[int, ...] | None
+    ndim: int
+
+    @property
+    def stride(self) -> tuple[int, ...] | None:
+        """How far each window advances, in samples; None with no overlap."""
+        if self.overlap is None:
+            return None
+        return tuple(size - over for size, over in zip(self.size, self.overlap))
+
+    def full_size(self, fill: int = 1) -> tuple[int, ...]:
+        """Return the window along every patch axis, `fill` where none was given."""
+        out = [fill] * self.ndim
+        for axis, size in zip(self.axes, self.size):
+            out[axis] = size
+        return tuple(out)
+
+
+def _percent_to_samples(value: Any, size: int) -> tuple[Any, bool]:
+    """Turn a percent of the window into samples of it; say whether it was one."""
+    if not (was_percent := is_percent(value)):
+        return value, False
+    magnitude = value.magnitude
+    if magnitude < 0 or magnitude > 100:
+        msg = f"Percentage must be between 0 and 100, not {value}"
+        raise ParameterError(msg)
+    # Half rounds to even, as numpy rounds: 50% of 5 is 2 and of 7 is 4.
+    return int(np.round(magnitude / 100 * size)), was_percent
+
+
+def _check_not_negative(value: Any, name: str) -> None:
+    """Refuse a step or overlap which retreats."""
+    magnitude = value.magnitude if isinstance(value, Quantity) else value
+    # A bare 0 would make numpy cast the timedelta to a generic unit.
+    zero = to_timedelta64(0) if is_timedelta64(magnitude) else 0
+    if magnitude is not None and magnitude < zero:
+        msg = f"{name} must be non-negative"
+        raise ParameterError(msg)
+
+
+def _to_samples(coord, value: Any, *, samples: bool, enforce_lt_coord: bool) -> int:
+    """Return a value along a coordinate as a sample count."""
+    # A quantity carries its own units, whatever the call said about samples.
+    if isinstance(value, Quantity):
+        samples = False
+    return coord.get_sample_count(
+        value, samples=samples, enforce_lt_coord=enforce_lt_coord
+    )
+
+
+def _spread(value: Any, dims: tuple[str, ...], name: str) -> dict[str, Any]:
+    """Return one value per dimension from a scalar or a mapping."""
+    if isinstance(value, Mapping):
+        if extra := set(value) - set(dims):
+            names = sorted(map(str, extra))
+            msg = f"{name} contains dimensions not being windowed: {names}"
+            raise ParameterError(msg)
+        return {dim: value.get(dim) for dim in dims}
+    return dict.fromkeys(dims, value)
+
+
+def _too_small(name: str, coord, count: int, min_samples: int, samples: bool) -> str:
+    """Say why a window is too short, and what to do about it."""
+    if samples:
+        hint = "Try increasing its value."
+    else:
+        # in seconds, which is what a time value would be given in
+        step = coord.step
+        step = f"{to_float(step)} s" if is_timedelta64(step) else step
+        hint = (
+            f"The value is in the units of {name}, which is sampled "
+            f"every {step}; increase it, or use samples=True to give "
+            "the window in samples."
+        )
+    return (
+        f"Window must have at least {min_samples} samples along each "
+        f"dimension. {name} has {count} samples. {hint}"
+    )
+
+
+def resolve_window(
+    patch,
+    kwargs: Mapping[str, Any],
+    *,
+    samples: bool = False,
+    overlap: Any = None,
+    step: Any = None,
+    default_overlap: OverlapDefault = None,
+    allow_multiple: bool = True,
+    allow_empty: bool = False,
+    require_evenly_sampled: bool = True,
+    require_odd: bool = False,
+    min_samples: int = 1,
+    warn_above: int | None = None,
+    enforce_lt_coord: bool = False,
+) -> Window:
+    """
+    Return the window a call's dimension keywords describe, in samples.
+
+    Parameters
+    ----------
+    patch
+        The patch, or anything with its ``dims`` and ``coords`` -- a
+        `PatchMeta` serves, so a processor can resolve a window without data.
+    kwargs
+        Dimension names and the window along each, in coordinate units or,
+        with ``samples``, in samples. A `Quantity` keeps its units either way.
+    samples
+        If True, bare numbers are sample counts.
+    overlap
+        How far each window reaches into the next: one value for every
+        dimension, or a mapping of dimension to value. Read like the windows
+        are, except that a percent is a fraction of that dimension's window.
+    step
+        How far each window advances, spelled instead of ``overlap``; the
+        two are exclusive.
+    default_overlap
+        What a dimension given no overlap and no step gets: a sample count,
+        or a callable from the window's size in samples to one. None leaves
+        `Window.overlap` None when nothing was given.
+    allow_multiple
+        Whether more than one dimension may be windowed.
+    allow_empty
+        Whether no dimension at all may be, giving an empty window whose
+        `full_size` is all ones.
+    require_evenly_sampled
+        Whether a windowed coordinate must be evenly sampled. A window in
+        coordinate units cannot be converted without that anyway.
+    require_odd
+        Whether the window must have an odd number of samples. Given in
+        units, an even count is rounded up; given in samples, refused.
+    min_samples
+        The fewest samples a window may have along any dimension.
+    warn_above
+        Warn when the window's total sample count -- its area -- exceeds this.
+    enforce_lt_coord
+        Whether a window, step, or overlap longer than its coordinate is refused.
+
+    Raises
+    ------
+    ParameterError
+        For a window which is too small, even when it must be odd, longer
+        than its coordinate when that is refused, or an overlap or step which
+        is negative, leaves no advance, or is given alongside the other.
+    CoordError
+        For a coordinate which is not evenly sampled when that is required.
+    """
+    if not kwargs and allow_empty:
+        return Window((), (), (), None, len(patch.dims))
+    dim_axis_values = get_dim_axis_value(
+        patch, kwargs=kwargs, allow_multiple=allow_multiple
+    )
+    dims = tuple(x.dim for x in dim_axis_values)
+    axes = tuple(x.axis for x in dim_axis_values)
+    coords = {}
+    for dim in dims:
+        coord = patch.coords.get_coord(dim)
+        if require_evenly_sampled and coord.step is None:
+            extra = f"as required by {get_parent_code_name()}"
+            msg = f"Coordinate {dim} is not evenly sampled {extra}"
+            raise CoordError(msg)
+        coords[dim] = coord
+
+    sizes = []
+    for dim, _, value in dim_axis_values:
+        coord = coords[dim]
+        count = _to_samples(
+            coord, value, samples=samples, enforce_lt_coord=enforce_lt_coord
+        )
+        if count < min_samples:
+            raise ParameterError(_too_small(dim, coord, count, min_samples, samples))
+        if require_odd and count % 2 != 1:
+            if samples:
+                msg = (
+                    f"For clean median calculation, dimension windows must be odd "
+                    f"but {dim} has a value of {count} samples."
+                )
+                raise ParameterError(msg)
+            count += 1
+        sizes.append(count)
+    size = tuple(sizes)
+
+    # Warn on the total window, not each dimension: the cost of a windowed
+    # operation tracks the number of samples the window covers, so a 2D
+    # window is as expensive as its area.
+    total = math.prod(size)
+    if warn_above is not None and total > warn_above:
+        msg = (
+            f"Large window size ({total} samples) may result in slow "
+            "performance. Consider reducing the window size."
+        )
+        warnings.warn(msg, UserWarning, stacklevel=3)
+
+    overlaps = _resolve_overlap(
+        coords,
+        dims,
+        size,
+        overlap=overlap,
+        step=step,
+        default=default_overlap,
+        samples=samples,
+        enforce_lt_coord=enforce_lt_coord,
+    )
+    return Window(dims, axes, size, overlaps, len(patch.dims))
+
+
+def _resolve_overlap(
+    coords: Mapping[str, Any],
+    dims: tuple[str, ...],
+    size: tuple[int, ...],
+    *,
+    overlap: Any,
+    step: Any,
+    default: OverlapDefault,
+    samples: bool,
+    enforce_lt_coord: bool,
+) -> tuple[int, ...] | None:
+    """Return the overlap along each dimension in samples, or None if none was given."""
+    if overlap is not None and step is not None:
+        msg = "step and overlap are mutually exclusive."
+        raise ParameterError(msg)
+    name = "step" if step is not None else "overlap"
+    given = _spread(step if step is not None else overlap, dims, name)
+    out: list[int | None] = []
+    for dim, window in zip(dims, size):
+        value = given[dim]
+        if value is None:
+            if default is None:
+                out.append(None)
+                continue
+            out.append(default if isinstance(default, int) else default(window))
+            continue
+        value, was_percent = _percent_to_samples(value, window)
+        _check_not_negative(value, name)
+        count = _to_samples(
+            coords[dim],
+            value,
+            samples=samples or was_percent,
+            enforce_lt_coord=enforce_lt_coord,
+        )
+        advance = count if name == "step" else window - count
+        if advance <= 0:
+            msg = "Window step must be greater than zero."
+            raise ParameterError(msg)
+        out.append(window - advance)
+    if all(value is None for value in out):
+        return None
+    if any(value is None for value in out):
+        missing = [dim for dim, value in zip(dims, out) if value is None]
+        msg = f"{name} was given for some dimensions but not {missing}."
+        raise ParameterError(msg)
+    return tuple(out)  # ty: ignore[invalid-return-type]

--- a/dascore/utils/window.py
+++ b/dascore/utils/window.py
@@ -129,7 +129,9 @@ def _to_samples(
 
 
 def _spread(value: Any, dims: tuple[str, ...], name: str) -> dict[str, Any]:
-    """Return one value per dimension from a scalar or a mapping."""
+    """Return one value per dimension from a scalar or a mapping; ungiven where none."""
+    if value is None:
+        return dict.fromkeys(dims, _UNGIVEN)
     if not isinstance(value, Mapping):
         return dict.fromkeys(dims, value)
     if extra := set(value) - set(dims):
@@ -146,9 +148,9 @@ def _spread(value: Any, dims: tuple[str, ...], name: str) -> dict[str, Any]:
     return {dim: value.get(dim, _UNGIVEN) for dim in dims}
 
 
-def _too_small(name: str, coord, count: int, min_samples: int, samples: bool) -> str:
+def _too_small(name: str, coord, count: int, min_samples: int, in_samples: bool) -> str:
     """Say why a window is too short, and what to do about it."""
-    if samples:
+    if in_samples:
         hint = "Try increasing its value."
     else:
         # in seconds, which is what a time value would be given in
@@ -244,18 +246,13 @@ def resolve_window(
     )
     dims = tuple(x.dim for x in dim_axis_values)
     axes = tuple(x.axis for x in dim_axis_values)
-    coords = {}
-    for dim in dims:
-        coord = patch.coords.get_coord(dim)
+    coords, sizes = {}, []
+    for dim, _, value in dim_axis_values:
+        coord = coords[dim] = patch.coords.get_coord(dim)
         if require_evenly_sampled and coord.step is None:
             extra = f"as required by {get_parent_code_name()}"
             msg = f"Coordinate {dim} is not evenly sampled {extra}"
             raise CoordError(msg)
-        coords[dim] = coord
-
-    sizes = []
-    for dim, _, value in dim_axis_values:
-        coord = coords[dim]
         count, in_samples = _to_samples(
             coord,
             value,
@@ -317,36 +314,35 @@ def _resolve_overlap(
     """Return the overlap along each dimension in samples, or None if none was given."""
     name = "step" if step is not None else "overlap"
     given = _spread(step if step is not None else overlap, dims, name)
-    out: list[int | None] = []
+    out: list[int] = []
+    ungiven: list[str] = []
     for dim, window in zip(dims, size):
         value = given[dim]
-        kind, in_samples, via_coord = name, samples, through_coord
-        if value is _UNGIVEN or value is None:
+        if value is _UNGIVEN:
             if default is None:
-                out.append(None)
+                ungiven.append(dim)
                 continue
             # A default is a sample count already, and is checked like a
             # given one: it must not retreat, and must leave an advance.
-            value = default if isinstance(default, int) else default(window)
-            kind, in_samples, via_coord = "overlap", True, False
-        value, was_percent = _percent_to_samples(value, window)
-        _check_not_negative(value, kind)
-        count, _ = _to_samples(
-            coords[dim],
-            value,
-            samples=in_samples or was_percent,
-            enforce_lt_coord=enforce_lt_coord,
-            through_coord=via_coord,
-        )
-        advance = count if kind == "step" else window - count
+            count = default if isinstance(default, int) else default(window)
+            _check_not_negative(count, "overlap")
+            advance = window - count
+        else:
+            value, was_percent = _percent_to_samples(value, window)
+            _check_not_negative(value, name)
+            count, _ = _to_samples(
+                coords[dim],
+                value,
+                samples=samples or was_percent,
+                enforce_lt_coord=enforce_lt_coord,
+                through_coord=through_coord,
+            )
+            advance = count if name == "step" else window - count
         if advance <= 0:
             msg = "Window step must be greater than zero."
             raise ParameterError(msg)
         out.append(window - advance)
-    if all(value is None for value in out):
-        return None
-    if any(value is None for value in out):
-        missing = [dim for dim, value in zip(dims, out) if value is None]
-        msg = f"{name} was given for some dimensions but not {missing}."
+    if ungiven and out:
+        msg = f"{name} was given for some dimensions but not {ungiven}."
         raise ParameterError(msg)
-    return tuple(out)  # ty: ignore[invalid-return-type]
+    return None if ungiven else tuple(out)

--- a/dascore/utils/window.py
+++ b/dascore/utils/window.py
@@ -19,7 +19,7 @@ import math
 import warnings
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 import numpy as np
 
@@ -31,11 +31,25 @@ from dascore.utils.time import is_timedelta64, to_float, to_timedelta64
 
 # What a function means by an overlap nobody gave: a sample count, or a
 # rule for one from the window's size in samples.
-OverlapDefault = Callable[[int], int] | int | None
+OverlapDefault = Callable[[int], int] | int | np.integer | None
 
 # Marks a dimension a mapping left out, which is not the same as one it
 # set to None.
 _UNGIVEN = object()
+
+
+class Windowed(Protocol):
+    """What a window is resolved against: a patch, or its metadata alone."""
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        """The dimension names, in axis order."""
+        ...
+
+    @property
+    def coords(self) -> Any:
+        """The coordinate manager."""
+        ...
 
 
 @dataclass(frozen=True)
@@ -51,10 +65,10 @@ class Window:
         The axis of each.
     size
         The window along each, in samples.
-    overlap
-        How far each window reaches into the next, in samples, or None if
-        the caller gave no overlap, no step, and no default -- which each
-        function reads its own way.
+    stride
+        How far each window advances, in samples, or None if the caller
+        gave no overlap, no step, and no default -- which each function
+        reads its own way. A stride longer than the window leaves a gap.
     ndim
         How many dimensions the patch has, so the window can be spelled
         out for every axis.
@@ -63,15 +77,15 @@ class Window:
     dims: tuple[str, ...]
     axes: tuple[int, ...]
     size: tuple[int, ...]
-    overlap: tuple[int, ...] | None
+    stride: tuple[int, ...] | None
     ndim: int
 
     @property
-    def stride(self) -> tuple[int, ...] | None:
-        """How far each window advances, in samples; None with no overlap."""
-        if self.overlap is None:
+    def overlap(self) -> tuple[int, ...] | None:
+        """How far each window reaches into the next; negative across a gap."""
+        if self.stride is None:
             return None
-        return tuple(size - over for size, over in zip(self.size, self.overlap))
+        return tuple(size - step for size, step in zip(self.size, self.stride))
 
     def full_size(self, fill: int = 1) -> tuple[int, ...]:
         """Return the window along every patch axis, `fill` where none was given."""
@@ -168,7 +182,7 @@ def _too_small(name: str, coord, count: int, min_samples: int, in_samples: bool)
 
 
 def resolve_window(
-    patch,
+    patch: Windowed,
     kwargs: Mapping[str, Any],
     *,
     samples: bool = False,
@@ -285,7 +299,7 @@ def resolve_window(
         )
         warnings.warn(msg, UserWarning, stacklevel=3)
 
-    overlaps = _resolve_overlap(
+    strides = _resolve_stride(
         coords,
         dims,
         size,
@@ -296,10 +310,10 @@ def resolve_window(
         enforce_lt_coord=enforce_lt_coord,
         through_coord=require_evenly_sampled,
     )
-    return Window(dims, axes, size, overlaps, len(patch.dims))
+    return Window(dims, axes, size, strides, len(patch.dims))
 
 
-def _resolve_overlap(
+def _resolve_stride(
     coords: Mapping[str, Any],
     dims: tuple[str, ...],
     size: tuple[int, ...],
@@ -311,7 +325,7 @@ def _resolve_overlap(
     enforce_lt_coord: bool,
     through_coord: bool,
 ) -> tuple[int, ...] | None:
-    """Return the overlap along each dimension in samples, or None if none was given."""
+    """Return the stride along each dimension in samples, or None if none was given."""
     name = "step" if step is not None else "overlap"
     given = _spread(step if step is not None else overlap, dims, name)
     out: list[int] = []
@@ -324,7 +338,11 @@ def _resolve_overlap(
                 continue
             # A default is a sample count already, and is checked like a
             # given one: it must not retreat, and must leave an advance.
-            count = default if isinstance(default, int) else default(window)
+            count = (
+                int(default)
+                if isinstance(default, int | np.integer)
+                else default(window)
+            )
             _check_not_negative(count, "overlap")
             advance = window - count
         else:
@@ -341,7 +359,7 @@ def _resolve_overlap(
         if advance <= 0:
             msg = "Window step must be greater than zero."
             raise ParameterError(msg)
-        out.append(window - advance)
+        out.append(advance)
     if ungiven and out:
         msg = f"{name} was given for some dimensions but not {ungiven}."
         raise ParameterError(msg)

--- a/dascore/utils/window.py
+++ b/dascore/utils/window.py
@@ -33,6 +33,10 @@ from dascore.utils.time import is_timedelta64, to_float, to_timedelta64
 # rule for one from the window's size in samples.
 OverlapDefault = Callable[[int], int] | int | None
 
+# Marks a dimension a mapping left out, which is not the same as one it
+# set to None.
+_UNGIVEN = object()
+
 
 @dataclass(frozen=True)
 class Window:
@@ -99,25 +103,47 @@ def _check_not_negative(value: Any, name: str) -> None:
         raise ParameterError(msg)
 
 
-def _to_samples(coord, value: Any, *, samples: bool, enforce_lt_coord: bool) -> int:
-    """Return a value along a coordinate as a sample count."""
-    # A quantity carries its own units, whatever the call said about samples.
+def _to_samples(
+    coord,
+    value: Any,
+    *,
+    samples: bool,
+    enforce_lt_coord: bool,
+    through_coord: bool = True,
+) -> tuple[int, bool]:
+    """
+    Return a value along a coordinate as a sample count, and whether it was one.
+
+    A quantity carries its own units, whatever the call said about samples.
+    A bare sample count need not go through the coordinate at all, and a
+    function which does not require even sampling reads it directly.
+    """
     if isinstance(value, Quantity):
         samples = False
-    return coord.get_sample_count(
+    if samples and not through_coord:
+        return int(value), True
+    count = coord.get_sample_count(
         value, samples=samples, enforce_lt_coord=enforce_lt_coord
     )
+    return count, samples
 
 
 def _spread(value: Any, dims: tuple[str, ...], name: str) -> dict[str, Any]:
     """Return one value per dimension from a scalar or a mapping."""
-    if isinstance(value, Mapping):
-        if extra := set(value) - set(dims):
-            names = sorted(map(str, extra))
-            msg = f"{name} contains dimensions not being windowed: {names}"
+    if not isinstance(value, Mapping):
+        return dict.fromkeys(dims, value)
+    if extra := set(value) - set(dims):
+        names = sorted(map(str, extra))
+        msg = f"{name} contains dimensions not being windowed: {names}"
+        raise ParameterError(msg)
+    for dim, given in value.items():
+        if given is None:
+            msg = (
+                f"{name} for {dim!r} is None; leave it out of the mapping "
+                "to take the default."
+            )
             raise ParameterError(msg)
-        return {dim: value.get(dim) for dim in dims}
-    return dict.fromkeys(dims, value)
+    return {dim: value.get(dim, _UNGIVEN) for dim in dims}
 
 
 def _too_small(name: str, coord, count: int, min_samples: int, samples: bool) -> str:
@@ -151,7 +177,7 @@ def resolve_window(
     allow_empty: bool = False,
     require_evenly_sampled: bool = True,
     require_odd: bool = False,
-    min_samples: int = 1,
+    min_samples: int | None = 1,
     warn_above: int | None = None,
     enforce_lt_coord: bool = False,
 ) -> Window:
@@ -185,13 +211,15 @@ def resolve_window(
         Whether no dimension at all may be, giving an empty window whose
         `full_size` is all ones.
     require_evenly_sampled
-        Whether a windowed coordinate must be evenly sampled. A window in
-        coordinate units cannot be converted without that anyway.
+        Whether a windowed coordinate must be evenly sampled. When it need
+        not be, a window given in samples never consults the coordinate;
+        one in units cannot be converted without an even step anyway.
     require_odd
         Whether the window must have an odd number of samples. Given in
         units, an even count is rounded up; given in samples, refused.
     min_samples
-        The fewest samples a window may have along any dimension.
+        The fewest samples a window may have along any dimension, or None
+        for no floor at all.
     warn_above
         Warn when the window's total sample count -- its area -- exceeds this.
     enforce_lt_coord
@@ -206,6 +234,9 @@ def resolve_window(
     CoordError
         For a coordinate which is not evenly sampled when that is required.
     """
+    if overlap is not None and step is not None:
+        msg = "step and overlap are mutually exclusive."
+        raise ParameterError(msg)
     if not kwargs and allow_empty:
         return Window((), (), (), None, len(patch.dims))
     dim_axis_values = get_dim_axis_value(
@@ -225,13 +256,18 @@ def resolve_window(
     sizes = []
     for dim, _, value in dim_axis_values:
         coord = coords[dim]
-        count = _to_samples(
-            coord, value, samples=samples, enforce_lt_coord=enforce_lt_coord
+        count, in_samples = _to_samples(
+            coord,
+            value,
+            samples=samples,
+            enforce_lt_coord=enforce_lt_coord,
+            through_coord=require_evenly_sampled,
         )
-        if count < min_samples:
-            raise ParameterError(_too_small(dim, coord, count, min_samples, samples))
+        if min_samples is not None and count < min_samples:
+            msg = _too_small(dim, coord, count, min_samples, in_samples)
+            raise ParameterError(msg)
         if require_odd and count % 2 != 1:
-            if samples:
+            if in_samples:
                 msg = (
                     f"For clean median calculation, dimension windows must be odd "
                     f"but {dim} has a value of {count} samples."
@@ -261,6 +297,7 @@ def resolve_window(
         default=default_overlap,
         samples=samples,
         enforce_lt_coord=enforce_lt_coord,
+        through_coord=require_evenly_sampled,
     )
     return Window(dims, axes, size, overlaps, len(patch.dims))
 
@@ -275,31 +312,33 @@ def _resolve_overlap(
     default: OverlapDefault,
     samples: bool,
     enforce_lt_coord: bool,
+    through_coord: bool,
 ) -> tuple[int, ...] | None:
     """Return the overlap along each dimension in samples, or None if none was given."""
-    if overlap is not None and step is not None:
-        msg = "step and overlap are mutually exclusive."
-        raise ParameterError(msg)
     name = "step" if step is not None else "overlap"
     given = _spread(step if step is not None else overlap, dims, name)
     out: list[int | None] = []
     for dim, window in zip(dims, size):
         value = given[dim]
-        if value is None:
+        kind, in_samples, via_coord = name, samples, through_coord
+        if value is _UNGIVEN or value is None:
             if default is None:
                 out.append(None)
                 continue
-            out.append(default if isinstance(default, int) else default(window))
-            continue
+            # A default is a sample count already, and is checked like a
+            # given one: it must not retreat, and must leave an advance.
+            value = default if isinstance(default, int) else default(window)
+            kind, in_samples, via_coord = "overlap", True, False
         value, was_percent = _percent_to_samples(value, window)
-        _check_not_negative(value, name)
-        count = _to_samples(
+        _check_not_negative(value, kind)
+        count, _ = _to_samples(
             coords[dim],
             value,
-            samples=samples or was_percent,
+            samples=in_samples or was_percent,
             enforce_lt_coord=enforce_lt_coord,
+            through_coord=via_coord,
         )
-        advance = count if name == "step" else window - count
+        advance = count if kind == "step" else window - count
         if advance <= 0:
             msg = "Window step must be greater than zero."
             raise ParameterError(msg)

--- a/tests/test_proc/test_adaptive_spectral_filter.py
+++ b/tests/test_proc/test_adaptive_spectral_filter.py
@@ -125,7 +125,7 @@ class TestAdaptiveSpectralFilter:
         """Window sizes must resolve to positive sample counts."""
         patch = _patch((64, 64), ("distance", "time"), dtype=np.float32)
 
-        with pytest.raises(ParameterError, match=r"window.*must be positive"):
+        with pytest.raises(ParameterError, match="at least 1 samples"):
             patch.adaptive_spectral_filter(
                 distance=0, time=16, samples=True, engine="scipy"
             )

--- a/tests/test_utils/test_patch_utils.py
+++ b/tests/test_utils/test_patch_utils.py
@@ -14,14 +14,12 @@ import dascore as dc
 from dascore.config import config_context
 from dascore.constants import PatchType
 from dascore.exceptions import (
-    CoordError,
     CoordMergeError,
     IncompatiblePatchError,
     ParameterError,
     PatchAttributeError,
     PatchCoordinateError,
 )
-from dascore.units import percent
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch import (
     _force_patch_merge,
@@ -35,8 +33,6 @@ from dascore.utils.patch import (
     get_dim_axis_value,
     get_patch_kind,
     get_patch_names,
-    get_patch_window_size,
-    get_window_axis_step,
     merge_compatible_coords_attrs,
     merge_patches,
     patch_function,
@@ -1371,221 +1367,6 @@ class TestSwapKwargsDimToAxis:
 
         with pytest.raises(ParameterError, match="Dimension 'invalid_dim' not found"):
             swap_kwargs_dim_to_axis(random_patch, kwargs)
-
-
-class TestGetPatchWindowSize:
-    """Tests for the get_patch_window_size function."""
-
-    @pytest.fixture()
-    def simple_patch(self):
-        """Create a simple patch for testing."""
-        patch = dc.get_example_patch()
-        return patch.update_coords(time_step=0.2)  # Make windows reasonable
-
-    def test_basic_window_size(self, simple_patch):
-        """Test basic window size calculation."""
-        size = get_patch_window_size(simple_patch, {"time": 0.6})
-        assert isinstance(size, tuple)
-        assert len(size) == simple_patch.data.ndim
-        # Find which axis corresponds to time
-        time_axis = simple_patch.dims.index("time")
-        distance_axis = simple_patch.dims.index("distance")
-        assert size[time_axis] > 1  # time dimension should have window > 1
-        assert size[distance_axis] == 1  # distance dimension should be 1
-
-    def test_multiple_dimensions(self, simple_patch):
-        """Test window size with multiple dimensions."""
-        size = get_patch_window_size(simple_patch, {"time": 0.6, "distance": 3.0})
-        time_axis = simple_patch.dims.index("time")
-        distance_axis = simple_patch.dims.index("distance")
-        assert size[time_axis] > 1  # time dimension
-        assert size[distance_axis] > 1  # distance dimension
-
-    def test_samples_true(self, simple_patch):
-        """Test with samples=True parameter."""
-        size = get_patch_window_size(simple_patch, {"time": 5}, samples=True)
-        time_axis = simple_patch.dims.index("time")
-        assert size[time_axis] == 5
-
-    def test_require_odd_true_samples_false(self, simple_patch):
-        """Test require_odd=True with samples=False adjusts even sizes."""
-        # Use a value that would give even samples
-        coord = simple_patch.get_coord("time")
-        step = coord.step
-        even_value = step * 4  # Should give 4 samples
-
-        size = get_patch_window_size(
-            simple_patch, {"time": even_value}, samples=False, require_odd=True
-        )
-        # Should be adjusted to 5 (next odd number)
-        time_axis = simple_patch.dims.index("time")
-        assert size[time_axis] % 2 == 1
-
-    def test_require_odd_true_samples_true_even_raises(self, simple_patch):
-        """Test require_odd=True with samples=True raises for even sizes."""
-        with pytest.raises(ParameterError, match="windows must be odd"):
-            get_patch_window_size(
-                simple_patch, {"time": 4}, samples=True, require_odd=True
-            )
-
-    def test_require_odd_true_samples_true_odd_passes(self, simple_patch):
-        """Test require_odd=True with samples=True passes for odd sizes."""
-        size = get_patch_window_size(
-            simple_patch, {"time": 5}, samples=True, require_odd=True
-        )
-        time_axis = simple_patch.dims.index("time")
-        assert size[time_axis] == 5
-
-    def test_min_samples_validation(self, simple_patch):
-        """Test minimum samples validation."""
-        with pytest.raises(ParameterError, match="at least 3 samples"):
-            get_patch_window_size(
-                simple_patch, {"time": 2}, samples=True, min_samples=3
-            )
-
-    def test_warn_above_warning(self, simple_patch):
-        """Test warning for large window sizes."""
-        with pytest.warns(UserWarning, match="Large window size.*may result in slow"):
-            get_patch_window_size(
-                simple_patch, {"time": 15}, samples=True, warn_above=10
-            )
-
-    def test_warn_above_uses_total_window(self, simple_patch):
-        """The threshold applies to the window's total size, not each dim."""
-        kwargs = {"time": 5, "distance": 5}
-        with pytest.warns(UserWarning, match="Large window size \\(25 samples\\)"):
-            get_patch_window_size(simple_patch, kwargs, samples=True, warn_above=10)
-
-    def test_min_samples_message_suggests_samples(self, simple_patch):
-        """A too-small window in coord units should mention samples (#1046)."""
-        with pytest.raises(ParameterError, match="samples=True"):
-            get_patch_window_size(simple_patch, {"time": 0.2}, min_samples=3)
-        # When the value is already in samples there is nothing to suggest.
-        with pytest.raises(ParameterError, match="Try increasing"):
-            get_patch_window_size(
-                simple_patch, {"time": 2}, samples=True, min_samples=3
-            )
-
-    def test_no_warning_under_threshold(self, simple_patch):
-        """Test no warning for window sizes under threshold."""
-        with suppress_warnings(action="error"):
-            # This should not raise (no warning)
-            size = get_patch_window_size(
-                simple_patch, {"time": 5}, samples=True, warn_above=10
-            )
-            time_axis = simple_patch.dims.index("time")
-            assert size[time_axis] == 5
-
-    def test_empty_kwargs(self, simple_patch):
-        """Test with empty kwargs returns all ones."""
-        size = get_patch_window_size(simple_patch, {})
-        assert all(s == 1 for s in size)
-        assert len(size) == simple_patch.data.ndim
-
-    def test_invalid_dimension_raises(self, simple_patch):
-        """Test invalid dimension name raises error."""
-        with pytest.raises(ParameterError):
-            get_patch_window_size(simple_patch, {"invalid_dim": 5})
-
-    def test_non_evenly_sampled_raises(self, simple_patch):
-        """Test non-evenly sampled coordinate raises error."""
-        # Create a non-evenly sampled coordinate
-        time_size = simple_patch.data.shape[simple_patch.dims.index("time")]
-        time_vals = np.array([0.0, 0.1, 0.3, 0.7, 1.5])  # Non-uniform spacing
-        # Take enough values to match the patch size
-        if len(time_vals) < time_size:
-            # Extend with more irregular values
-            extra_vals = np.linspace(2.0, 10.0, time_size - len(time_vals))
-            time_vals = np.concatenate([time_vals, extra_vals])
-        irregular_patch = simple_patch.update_coords(time=time_vals[:time_size])
-
-        with pytest.raises(CoordError):
-            get_patch_window_size(irregular_patch, {"time": 0.5})
-
-
-class TestGetWindowAxisStep:
-    """Tests for getting window size, axis, and step."""
-
-    window = 16
-    step = 8
-
-    def test_apply_with_overlap(self, random_patch):
-        """Ensure overlap is converted to the correct step size."""
-        coord = random_patch.get_coord("distance")
-        window = self.window * coord.step
-        overlap = (self.window - self.step) * coord.step
-        out = get_window_axis_step(random_patch, distance=window, overlap=overlap)
-        assert out == (self.window, random_patch.get_axis("distance"), self.step)
-
-    def test_apply_with_percent_overlap(self, random_patch):
-        """Ensure percent overlap is supported."""
-        coord = random_patch.get_coord("distance")
-        window = self.window * coord.step
-        out = get_window_axis_step(random_patch, distance=window, overlap=50 * percent)
-        assert out == (self.window, random_patch.get_axis("distance"), self.step)
-
-    def test_apply_with_percent_overlap_and_samples(self, random_patch):
-        """Ensure percent overlap works when samples=True."""
-        out = get_window_axis_step(
-            random_patch, distance=self.window, overlap=50 * percent, samples=True
-        )
-        assert out == (self.window, random_patch.get_axis("distance"), self.step)
-
-    def test_negative_overlap_raises(self, random_patch):
-        """Ensure negative overlap is rejected."""
-        step = random_patch.get_coord("distance").step
-        msg = "overlap must be non-negative"
-        with pytest.raises(ParameterError, match=msg):
-            get_window_axis_step(
-                random_patch, distance=self.window * step, overlap=-step
-            )
-
-    def test_invalid_percent_overlap_raises(self, random_patch):
-        """Ensure percent overlap must be between 0 and 100."""
-        msg = "Percentage must be between 0 and 100"
-        with pytest.raises(ParameterError, match=msg):
-            get_window_axis_step(
-                random_patch, distance=self.window, overlap=101 * percent, samples=True
-            )
-
-    def test_complete_overlap_raises(self, random_patch):
-        """Ensure complete overlap is rejected."""
-        msg = "Window step must be greater than zero"
-        with pytest.raises(ParameterError, match=msg):
-            get_window_axis_step(
-                random_patch, distance=self.window, overlap=100 * percent, samples=True
-            )
-
-    def test_overlap_larger_than_window_raises(self, random_patch):
-        """Ensure overlap larger than window is rejected."""
-        msg = "Window step must be greater than zero"
-        with pytest.raises(ParameterError, match=msg):
-            get_window_axis_step(
-                random_patch,
-                distance=self.window,
-                overlap=self.window + 1,
-                samples=True,
-            )
-
-    def test_step_and_overlap_raises(self, random_patch):
-        """Ensure step and overlap are mutually exclusive."""
-        step = random_patch.get_coord("distance").step
-        msg = "step and overlap are mutually exclusive"
-        with pytest.raises(ParameterError, match=msg):
-            get_window_axis_step(
-                random_patch,
-                distance=self.window * step,
-                step=self.step * step,
-                overlap=50 * percent,
-            )
-
-    def test_none_overlap_matches_default(self, random_patch):
-        """Ensure overlap=None preserves default window/step behavior."""
-        step = random_patch.get_coord("distance").step
-        out = get_window_axis_step(
-            random_patch, distance=self.window * step, overlap=None
-        )
-        assert out == (self.window, random_patch.get_axis("distance"), None)
 
 
 class TestForcePatchMergeOverlap:

--- a/tests/test_utils/test_window.py
+++ b/tests/test_utils/test_window.py
@@ -432,7 +432,20 @@ class TestWindow:
         assert window.full_size() == (1, 5, 1)
         assert window.full_size(fill=0) == (0, 5, 0)
 
-    def test_stride(self):
-        """Stride is size less overlap."""
-        window = Window(("distance", "time"), (0, 1), (16, 8), (7, 3), 2)
-        assert window.stride == (9, 5)
+    def test_overlap_is_size_less_stride(self):
+        """Overlap is derived, so it and the stride can never disagree."""
+        window = Window(("distance", "time"), (0, 1), (16, 8), (9, 5), 2)
+        assert window.overlap == (7, 3)
+
+    def test_a_gap_is_a_negative_overlap(self, random_patch):
+        """A stride longer than the window is allowed, and says so."""
+        window = resolve_window(random_patch, {"distance": 5}, samples=True, step=8)
+        assert window.stride == (8,)
+        assert window.overlap == (-3,)
+
+    def test_default_overlap_takes_a_numpy_integer(self, random_patch):
+        """A sample count from numpy is a sample count."""
+        window = resolve_window(
+            random_patch, {"distance": 16}, samples=True, default_overlap=np.int64(2)
+        )
+        assert window.overlap == (2,)

--- a/tests/test_utils/test_window.py
+++ b/tests/test_utils/test_window.py
@@ -1,0 +1,351 @@
+"""Tests for resolving a window along a patch's dimensions."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import dascore as dc
+from dascore.exceptions import CoordError, ParameterError
+from dascore.units import percent
+from dascore.utils.misc import suppress_warnings
+from dascore.utils.window import Window, resolve_window
+from dascore.workflow.meta import PatchMeta
+
+
+@pytest.fixture()
+def simple_patch():
+    """The example patch resampled so that windows in seconds are reasonable."""
+    patch = dc.get_example_patch()
+    return patch.update_coords(time_step=0.2)
+
+
+class TestWindowSize:
+    """Windows given per dimension, in units or samples."""
+
+    def test_basic_window_size(self, simple_patch):
+        """A window along one dimension is one everywhere else."""
+        window = resolve_window(simple_patch, {"time": 0.6})
+        assert window.dims == ("time",)
+        assert window.axes == (simple_patch.get_axis("time"),)
+        assert window.size[0] > 1
+        assert window.overlap is None
+        size = window.full_size()
+        assert len(size) == simple_patch.data.ndim
+        assert size[simple_patch.get_axis("distance")] == 1
+
+    def test_multiple_dimensions(self, simple_patch):
+        """Two dimensions, in the order they were named."""
+        window = resolve_window(simple_patch, {"time": 0.6, "distance": 3.0})
+        assert window.dims == ("time", "distance")
+        assert all(size > 1 for size in window.size)
+
+    def test_samples_true(self, simple_patch):
+        """A bare number is a sample count when the call says so."""
+        window = resolve_window(simple_patch, {"time": 5}, samples=True)
+        assert window.size == (5,)
+
+    def test_quantity_overrides_samples(self, simple_patch):
+        """A quantity carries its units whatever the call says."""
+        by_units = resolve_window(simple_patch, {"time": 1.0 * dc.units.s})
+        under_samples = resolve_window(
+            simple_patch, {"time": 1.0 * dc.units.s}, samples=True
+        )
+        assert by_units.size == under_samples.size == (5,)
+
+    def test_require_odd_adjusts_units(self, simple_patch):
+        """Given in units, an even count is rounded up to odd."""
+        step = simple_patch.get_coord("time").step
+        window = resolve_window(simple_patch, {"time": step * 4}, require_odd=True)
+        assert window.size == (5,)
+
+    def test_require_odd_refuses_even_samples(self, simple_patch):
+        """Given in samples, an even count is the caller's to fix."""
+        with pytest.raises(ParameterError, match="windows must be odd"):
+            resolve_window(simple_patch, {"time": 4}, samples=True, require_odd=True)
+
+    def test_require_odd_passes_odd_samples(self, simple_patch):
+        """An odd count is left alone."""
+        window = resolve_window(
+            simple_patch, {"time": 5}, samples=True, require_odd=True
+        )
+        assert window.size == (5,)
+
+    def test_min_samples(self, simple_patch):
+        """A window below the floor is refused."""
+        with pytest.raises(ParameterError, match="at least 3 samples"):
+            resolve_window(simple_patch, {"time": 2}, samples=True, min_samples=3)
+
+    def test_min_samples_message_suggests_samples(self, simple_patch):
+        """A too-small window in coordinate units should mention samples (#1046)."""
+        with pytest.raises(ParameterError, match="samples=True"):
+            resolve_window(simple_patch, {"time": 0.2}, min_samples=3)
+        # When the value is already in samples there is nothing to suggest.
+        with pytest.raises(ParameterError, match="Try increasing"):
+            resolve_window(simple_patch, {"time": 2}, samples=True, min_samples=3)
+
+    def test_warn_above(self, simple_patch):
+        """A large window warns."""
+        with pytest.warns(UserWarning, match="Large window size.*may result in slow"):
+            resolve_window(simple_patch, {"time": 15}, samples=True, warn_above=10)
+
+    def test_warn_above_uses_total_window(self, simple_patch):
+        """The threshold applies to the window's area, not each dimension."""
+        kwargs = {"time": 5, "distance": 5}
+        with pytest.warns(UserWarning, match="Large window size \\(25 samples\\)"):
+            resolve_window(simple_patch, kwargs, samples=True, warn_above=10)
+
+    def test_no_warning_under_threshold(self, simple_patch):
+        """A small window says nothing."""
+        with suppress_warnings(action="error"):
+            window = resolve_window(
+                simple_patch, {"time": 5}, samples=True, warn_above=10
+            )
+        assert window.size == (5,)
+
+    def test_empty_kwargs_allowed(self, simple_patch):
+        """With nothing windowed, the window is one along every axis."""
+        window = resolve_window(simple_patch, {}, allow_empty=True)
+        assert window.dims == ()
+        assert window.full_size() == (1,) * simple_patch.data.ndim
+
+    def test_empty_kwargs_refused(self, simple_patch):
+        """Unless the function wants a dimension."""
+        with pytest.raises(ParameterError, match="at least one dimension"):
+            resolve_window(simple_patch, {})
+
+    def test_too_many_dimensions_refused(self, simple_patch):
+        """A function windowing one dimension refuses two."""
+        with pytest.raises(ParameterError, match="exactly one dimension"):
+            resolve_window(
+                simple_patch,
+                {"time": 5, "distance": 5},
+                samples=True,
+                allow_multiple=False,
+            )
+
+    def test_invalid_dimension_raises(self, simple_patch):
+        """A dimension the patch lacks is refused."""
+        with pytest.raises(ParameterError):
+            resolve_window(simple_patch, {"invalid_dim": 5})
+
+    def test_non_evenly_sampled_raises(self, simple_patch):
+        """A window in units needs a step to convert with."""
+        time_size = simple_patch.shape[simple_patch.get_axis("time")]
+        time_vals = np.concatenate(
+            [[0.0, 0.1, 0.3, 0.7, 1.5], np.linspace(2.0, 10.0, time_size - 5)]
+        )
+        irregular = simple_patch.update_coords(time=time_vals)
+        with pytest.raises(CoordError, match="not evenly sampled"):
+            resolve_window(irregular, {"time": 0.5})
+
+    def test_enforce_lt_coord(self, simple_patch):
+        """A window longer than its coordinate is refused when asked."""
+        with pytest.raises(ParameterError, match="results in a window"):
+            resolve_window(
+                simple_patch, {"time": 10_000}, samples=True, enforce_lt_coord=True
+            )
+        # Not by default: the dense filters hand one on to scipy.
+        window = resolve_window(simple_patch, {"time": 10_000}, samples=True)
+        assert window.size == (10_000,)
+
+    def test_from_meta(self, simple_patch):
+        """A patch's metadata is enough; no data need be in reach."""
+        meta = PatchMeta.from_patch(simple_patch)
+        from_meta = resolve_window(meta, {"time": 0.6, "distance": 3.0})
+        from_patch = resolve_window(simple_patch, {"time": 0.6, "distance": 3.0})
+        assert from_meta == from_patch
+
+
+class TestOverlap:
+    """Overlap and step between windows."""
+
+    window = 16
+    step = 8
+
+    def test_apply_with_overlap(self, random_patch):
+        """An overlap in units is converted to a stride."""
+        coord = random_patch.get_coord("distance")
+        window = self.window * coord.step
+        overlap = (self.window - self.step) * coord.step
+        out = resolve_window(random_patch, {"distance": window}, overlap=overlap)
+        assert out.size == (self.window,)
+        assert out.stride == (self.step,)
+        assert out.axes == (random_patch.get_axis("distance"),)
+
+    def test_apply_with_percent_overlap(self, random_patch):
+        """A percent is a fraction of the window."""
+        coord = random_patch.get_coord("distance")
+        window = self.window * coord.step
+        out = resolve_window(random_patch, {"distance": window}, overlap=50 * percent)
+        assert out.stride == (self.step,)
+
+    def test_apply_with_percent_overlap_and_samples(self, random_patch):
+        """Whatever `samples` says."""
+        out = resolve_window(
+            random_patch, {"distance": self.window}, overlap=50 * percent, samples=True
+        )
+        assert out.stride == (self.step,)
+
+    @pytest.mark.parametrize("window,overlap", [(5, 2), (7, 4), (9, 4)])
+    def test_percent_rounds_half_to_even(self, random_patch, window, overlap):
+        """50% of an odd window rounds as numpy rounds, which stft relied on."""
+        out = resolve_window(
+            random_patch, {"distance": window}, overlap=50 * percent, samples=True
+        )
+        assert out.overlap == (overlap,)
+
+    def test_step(self, random_patch):
+        """A step is the stride said directly."""
+        out = resolve_window(random_patch, {"distance": 16}, step=4, samples=True)
+        assert out.stride == (4,)
+        assert out.overlap == (12,)
+
+    def test_negative_overlap_raises(self, random_patch):
+        """An overlap cannot retreat."""
+        step = random_patch.get_coord("distance").step
+        with pytest.raises(ParameterError, match="overlap must be non-negative"):
+            resolve_window(
+                random_patch, {"distance": self.window * step}, overlap=-step
+            )
+
+    def test_invalid_percent_overlap_raises(self, random_patch):
+        """A percent is between 0 and 100."""
+        with pytest.raises(
+            ParameterError, match="Percentage must be between 0 and 100"
+        ):
+            resolve_window(
+                random_patch,
+                {"distance": self.window},
+                overlap=101 * percent,
+                samples=True,
+            )
+
+    def test_complete_overlap_raises(self, random_patch):
+        """A window which never advances is refused."""
+        with pytest.raises(
+            ParameterError, match="Window step must be greater than zero"
+        ):
+            resolve_window(
+                random_patch,
+                {"distance": self.window},
+                overlap=100 * percent,
+                samples=True,
+            )
+
+    def test_overlap_larger_than_window_raises(self, random_patch):
+        """As is one which retreats past the start."""
+        with pytest.raises(
+            ParameterError, match="Window step must be greater than zero"
+        ):
+            resolve_window(
+                random_patch,
+                {"distance": self.window},
+                overlap=self.window + 1,
+                samples=True,
+            )
+
+    def test_step_and_overlap_raises(self, random_patch):
+        """One hop, one spelling."""
+        step = random_patch.get_coord("distance").step
+        with pytest.raises(
+            ParameterError, match="step and overlap are mutually exclusive"
+        ):
+            resolve_window(
+                random_patch,
+                {"distance": self.window * step},
+                step=self.step * step,
+                overlap=50 * percent,
+            )
+
+    def test_none_overlap_is_none(self, random_patch):
+        """Nothing given and no default leaves the overlap unsaid."""
+        step = random_patch.get_coord("distance").step
+        out = resolve_window(random_patch, {"distance": self.window * step})
+        assert out.overlap is None
+        assert out.stride is None
+
+    def test_default_overlap_as_a_count(self, random_patch):
+        """A function may say what an unsaid overlap is."""
+        out = resolve_window(
+            random_patch, {"distance": 16}, samples=True, default_overlap=3
+        )
+        assert out.overlap == (3,)
+
+    def test_default_overlap_as_a_rule(self, random_patch):
+        """Or how to make one from the window."""
+        out = resolve_window(
+            random_patch,
+            {"distance": 16, "time": 8},
+            samples=True,
+            default_overlap=lambda size: size // 2 - 1,
+        )
+        assert out.overlap == (7, 3)
+
+    def test_default_is_in_samples_whatever_the_units(self, random_patch):
+        """A default is a sample count even when the windows are in units."""
+        coord = random_patch.get_coord("distance")
+        out = resolve_window(
+            random_patch, {"distance": 16 * coord.step}, default_overlap=7
+        )
+        assert out.overlap == (7,)
+
+    def test_mapping_per_dimension(self, random_patch):
+        """A mapping gives each dimension its own overlap."""
+        out = resolve_window(
+            random_patch,
+            {"distance": 16, "time": 8},
+            samples=True,
+            overlap={"distance": 4, "time": 50 * percent},
+        )
+        assert out.overlap == (4, 4)
+
+    def test_mapping_fills_missing_from_default(self, random_patch):
+        """A dimension the mapping leaves out takes the default."""
+        out = resolve_window(
+            random_patch,
+            {"distance": 16, "time": 8},
+            samples=True,
+            overlap={"time": 2},
+            default_overlap=lambda size: size // 2 - 1,
+        )
+        assert out.overlap == (7, 2)
+
+    def test_mapping_missing_without_default_refused(self, random_patch):
+        """Without one there is nothing to fill it with."""
+        with pytest.raises(ParameterError, match="not \\['time'\\]"):
+            resolve_window(
+                random_patch,
+                {"distance": 16, "time": 8},
+                samples=True,
+                overlap={"distance": 2},
+            )
+
+    def test_mapping_unknown_dimension_refused(self, random_patch):
+        """An overlap for a dimension not windowed is a mistake."""
+        with pytest.raises(ParameterError, match="not being windowed"):
+            resolve_window(
+                random_patch, {"distance": 16}, samples=True, overlap={"time": 2}
+            )
+
+    def test_scalar_applies_to_every_dimension(self, random_patch):
+        """One value, every dimension."""
+        out = resolve_window(
+            random_patch, {"distance": 16, "time": 8}, samples=True, overlap=2
+        )
+        assert out.overlap == (2, 2)
+
+
+class TestWindow:
+    """The resolved object itself."""
+
+    def test_full_size_fill(self):
+        """Unselected axes take the fill."""
+        window = Window(("time",), (1,), (5,), None, 3)
+        assert window.full_size() == (1, 5, 1)
+        assert window.full_size(fill=0) == (0, 5, 0)
+
+    def test_stride(self):
+        """Stride is size less overlap."""
+        window = Window(("distance", "time"), (0, 1), (16, 8), (7, 3), 2)
+        assert window.stride == (9, 5)

--- a/tests/test_utils/test_window.py
+++ b/tests/test_utils/test_window.py
@@ -336,6 +336,93 @@ class TestOverlap:
         assert out.overlap == (2, 2)
 
 
+class TestPolicies:
+    """The knobs a function turns."""
+
+    def test_min_samples_none_is_no_floor(self, simple_patch):
+        """A zero window passes when a function sets no floor."""
+        window = resolve_window(
+            simple_patch, {"time": 0}, samples=True, min_samples=None
+        )
+        assert window.size == (0,)
+
+    def test_uneven_coordinate_with_sample_counts(self):
+        """Without the even-sampling requirement, sample counts skip the coordinate."""
+        wacky = dc.get_example_patch("wacky_dim_coords_patch")
+        window = resolve_window(
+            wacky, {"time": 16}, samples=True, require_evenly_sampled=False
+        )
+        assert window.size == (16,)
+        # Units still need a step to convert with.
+        with pytest.raises(CoordError):
+            resolve_window(wacky, {"time": 1.0}, require_evenly_sampled=False)
+
+    def test_quantity_under_samples_adjusts_to_odd(self, simple_patch):
+        """A quantity is in units, so an even count is rounded up, not refused."""
+        window = resolve_window(
+            simple_patch, {"time": 0.8 * dc.units.s}, samples=True, require_odd=True
+        )
+        assert window.size == (5,)
+
+    def test_exclusivity_is_checked_first(self, simple_patch):
+        """Both hop spellings at once is the first thing said, before any size."""
+        with pytest.raises(ParameterError, match="mutually exclusive"):
+            resolve_window(
+                simple_patch,
+                {"time": 10_000},
+                samples=True,
+                step=2,
+                overlap=2,
+                enforce_lt_coord=True,
+            )
+
+    def test_default_overlap_is_checked(self, random_patch):
+        """A default which leaves no advance is refused like a given one."""
+        with pytest.raises(ParameterError, match="greater than zero"):
+            resolve_window(
+                random_patch, {"distance": 5}, samples=True, default_overlap=5
+            )
+        with pytest.raises(ParameterError, match="non-negative"):
+            resolve_window(
+                random_patch, {"distance": 5}, samples=True, default_overlap=-1
+            )
+
+    def test_explicit_none_in_mapping_refused(self, random_patch):
+        """None in a mapping is not the same as leaving the dimension out."""
+        with pytest.raises(ParameterError, match="leave it out"):
+            resolve_window(
+                random_patch,
+                {"distance": 16, "time": 8},
+                samples=True,
+                overlap={"time": None},
+                default_overlap=2,
+            )
+
+
+class TestDeprecatedResolvers:
+    """The two public utilities this replaces still answer, with a warning."""
+
+    def test_get_patch_window_size(self, simple_patch):
+        """The full-size tuple, as before."""
+        from dascore.utils.patch import get_patch_window_size  # noqa: PLC0415
+
+        with pytest.warns(DeprecationWarning, match="resolve_window"):
+            size = get_patch_window_size(simple_patch, {"time": 5}, samples=True)
+        assert (
+            size == resolve_window(simple_patch, {"time": 5}, samples=True).full_size()
+        )
+
+    def test_get_window_axis_step(self, random_patch):
+        """Window, axis, and step, as before."""
+        from dascore.utils.patch import get_window_axis_step  # noqa: PLC0415
+
+        with pytest.warns(DeprecationWarning, match="resolve_window"):
+            out = get_window_axis_step(
+                random_patch, distance=16, overlap=50 * percent, samples=True
+            )
+        assert out == (16, random_patch.get_axis("distance"), 8)
+
+
 class TestWindow:
     """The resolved object itself."""
 

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -11,6 +11,8 @@ one, so the merge can be checked against them rather than trusted.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -23,6 +25,12 @@ from dascore.units import percent, s
 def patch():
     """The example patch: 300 channels by 2000 samples at 4 ms."""
     return dc.get_example_patch()
+
+
+@pytest.fixture(scope="module")
+def wacky():
+    """A patch whose coordinates are not evenly sampled."""
+    return dc.get_example_patch("wacky_dim_coords_patch")
 
 
 class TestOddWindows:
@@ -149,8 +157,6 @@ class TestWarnings:
 
     def test_hampel_quiet_under_it(self, patch):
         """9 by 9 is 81."""
-        import warnings  # noqa: PLC0415
-
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             patch.hampel_filter(time=9, distance=9, samples=True, approximate=False)
@@ -173,11 +179,6 @@ class TestMinimumSamples:
 class TestUnevenCoordinates:
     """A window in coordinate units needs an evenly sampled coordinate."""
 
-    @pytest.fixture(scope="class")
-    def wacky(self):
-        """A patch whose coordinates are not evenly sampled."""
-        return dc.get_example_patch("wacky_dim_coords_patch")
-
     @pytest.mark.parametrize(
         "name", ["median_filter", "gaussian_filter", "hampel_filter", "wiener_filter"]
     )
@@ -189,11 +190,6 @@ class TestUnevenCoordinates:
 
 class TestUnevenCoordinatesInSamples:
     """A window in samples on an uneven coordinate: only AFK ever allowed it."""
-
-    @pytest.fixture(scope="class")
-    def wacky(self):
-        """A patch whose coordinates are not evenly sampled."""
-        return dc.get_example_patch("wacky_dim_coords_patch")
 
     def test_adaptive_spectral_filter_reads_the_count(self, wacky):
         """It never consulted the coordinate for a sample count, and still does not."""

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -1,0 +1,226 @@
+"""
+What every windowed patch function does today, pinned before the resolvers merge.
+
+Each windowed function used to turn "a window of X" into sample counts its own
+way, and the ways differed at the edges: whether an even window is adjusted or
+refused, whether a window longer than the coordinate is refused, what
+`overlap=None` means, how a percent rounds. The tests here pin those edges
+with literal values taken from the functions before the resolvers were made
+one, so the merge can be checked against them rather than trusted.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import dascore as dc
+from dascore.exceptions import CoordError, ParameterError
+from dascore.units import percent, s
+
+
+@pytest.fixture(scope="module")
+def patch():
+    """The example patch: 300 channels by 2000 samples at 4 ms."""
+    return dc.get_example_patch()
+
+
+class TestOddWindows:
+    """An even window is adjusted, refused, or accepted, depending on who asks."""
+
+    def test_hampel_adjusts_units_up_to_odd(self, patch):
+        """16 ms is 4 samples; hampel makes it 5 without saying so."""
+        by_units = patch.hampel_filter(time=0.016)
+        by_samples = patch.hampel_filter(time=5, samples=True)
+        assert np.allclose(by_units.data, by_samples.data)
+
+    def test_hampel_refuses_even_samples(self, patch):
+        """Given in samples, an even window is the caller's mistake."""
+        with pytest.raises(ParameterError, match="must be odd"):
+            patch.hampel_filter(time=4, samples=True)
+
+    def test_median_accepts_even_samples(self, patch):
+        """The median filter has never asked for an odd window."""
+        out = patch.median_filter(time=4, samples=True)
+        assert out.shape == patch.shape
+
+
+class TestOversizeWindows:
+    """A window longer than the coordinate is refused by some functions only."""
+
+    @pytest.mark.parametrize("name", ["rolling", "stft"])
+    def test_refused(self, patch, name):
+        """Rolling and stft check the window against the coordinate."""
+        func = getattr(patch, name)
+        with pytest.raises(ParameterError, match="results in a window"):
+            func(time=5000, samples=True)
+
+    @pytest.mark.parametrize("name", ["median_filter", "gaussian_filter"])
+    def test_accepted(self, patch, name):
+        """The dense filters hand an oversize window to scipy, which copes."""
+        out = getattr(patch, name)(time=5000, samples=True)
+        assert out.shape == patch.shape
+
+
+class TestOverlapNone:
+    """`overlap=None` means three different things."""
+
+    def test_rolling_means_a_stride_of_one(self, patch):
+        """Every sample gets a window."""
+        out = patch.rolling(time=5, samples=True).mean()
+        assert out.shape == patch.shape
+
+    def test_stft_omitted_means_half(self, patch):
+        """Stft's default is not None but 50%: windows of 8 hop by 4."""
+        out = patch.stft(time=8, samples=True)
+        assert out.attrs["_stft_hop"] == 4
+
+    def test_stft_none_means_no_overlap(self, patch):
+        """Given None outright, windows abut."""
+        out = patch.stft(time=8, samples=True, overlap=None)
+        assert out.attrs["_stft_hop"] == 8
+
+    def test_adaptive_spectral_filter_means_the_most_allowed(self, patch):
+        """Windows of 16 overlap by 7, which is window // 2 - 1."""
+        by_default = patch.adaptive_spectral_filter(time=16, distance=16, samples=True)
+        by_hand = patch.adaptive_spectral_filter(
+            time=16, distance=16, overlap=7, samples=True
+        )
+        assert np.allclose(by_default.data, by_hand.data)
+
+
+class TestPercentRounding:
+    """A percent of an odd window rounds half to even, as numpy does."""
+
+    @pytest.mark.parametrize("window,hop", [(5, 3), (7, 3), (9, 5)])
+    def test_stft_hop(self, patch, window, hop):
+        """50% of 5 is 2, of 7 is 4, of 9 is 4; the hop is what is left."""
+        out = patch.stft(time=window, samples=True, overlap=50 * percent)
+        assert out.attrs["_stft_hop"] == hop
+
+    def test_rolling_hop(self, patch):
+        """Rolling rounds the same way: 5 samples at 50% steps by 3."""
+        out = patch.rolling(time=5, samples=True, overlap=50 * percent).mean()
+        assert out.shape[patch.get_axis("time")] == 667
+
+
+class TestQuantitiesUnderSamples:
+    """A quantity keeps its units even when the call said samples."""
+
+    def test_rolling_overlap(self, patch):
+        """8 ms is two samples whatever `samples` says."""
+        by_quantity = patch.rolling(time=5, samples=True, overlap=0.008 * s).mean()
+        by_samples = patch.rolling(time=5, samples=True, overlap=2).mean()
+        assert by_quantity.shape == by_samples.shape
+        assert np.allclose(by_quantity.data, by_samples.data, equal_nan=True)
+
+
+class TestStepAndOverlap:
+    """The two spellings of a hop, and what is refused."""
+
+    def test_both_given_is_refused(self, patch):
+        """One hop, one spelling."""
+        with pytest.raises(ParameterError, match="mutually exclusive"):
+            patch.rolling(time=5, samples=True, step=2, overlap=2)
+
+    def test_complete_overlap_is_refused(self, patch):
+        """A window which never advances is not a window."""
+        with pytest.raises(ParameterError, match="greater than zero"):
+            patch.rolling(time=5, samples=True, overlap=5)
+
+    def test_negative_overlap_is_refused(self, patch):
+        """Nor is one which retreats."""
+        with pytest.raises(ParameterError, match="non-negative"):
+            patch.rolling(time=5, samples=True, overlap=-1)
+
+    def test_percent_out_of_range_is_refused(self, patch):
+        """A percent is between 0 and 100."""
+        with pytest.raises(ParameterError, match="between 0 and 100"):
+            patch.rolling(time=5, samples=True, overlap=150 * percent)
+
+
+class TestWarnings:
+    """Hampel warns on the area of the window, the others say nothing."""
+
+    def test_hampel_warns_on_a_large_area(self, patch):
+        """11 by 11 is 121 samples, above the threshold of 100."""
+        with pytest.warns(UserWarning, match="Large window"):
+            patch.hampel_filter(time=11, distance=11, samples=True, approximate=False)
+
+    def test_hampel_quiet_under_it(self, patch):
+        """9 by 9 is 81."""
+        import warnings  # noqa: PLC0415
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            patch.hampel_filter(time=9, distance=9, samples=True, approximate=False)
+
+
+class TestMinimumSamples:
+    """Each function has its own floor."""
+
+    def test_hampel_needs_three(self, patch):
+        """A window of one sample has no neighbours to compare against."""
+        with pytest.raises(ParameterError, match="at least 3 samples"):
+            patch.hampel_filter(time=1, samples=True)
+
+    def test_min_samples_message_names_the_step(self, patch):
+        """Given in units, the message says what a sample is worth."""
+        with pytest.raises(ParameterError, match="sampled every"):
+            patch.hampel_filter(time=0.001)
+
+
+class TestUnevenCoordinates:
+    """A window in coordinate units needs an evenly sampled coordinate."""
+
+    @pytest.fixture(scope="class")
+    def wacky(self):
+        """A patch whose coordinates are not evenly sampled."""
+        return dc.get_example_patch("wacky_dim_coords_patch")
+
+    @pytest.mark.parametrize(
+        "name", ["median_filter", "gaussian_filter", "hampel_filter", "wiener_filter"]
+    )
+    def test_refused_in_units(self, wacky, name):
+        """Nothing to convert with."""
+        with pytest.raises(CoordError):
+            getattr(wacky, name)(time=3)
+
+
+class TestDimensionOrder:
+    """Which order the selected dimensions come back in matters to savgol."""
+
+    def test_savgol_keeps_only_the_last_keyword(self, patch):
+        """
+        Each pass filters the original data, so the last keyword axis wins.
+
+        Pinned so the migration does not change it by accident; it is a
+        bug, and fixing it is a separate change with its own test.
+        """
+        both = patch.savgol_filter(time=5, distance=7, samples=True, polyorder=2)
+        last = patch.savgol_filter(distance=7, samples=True, polyorder=2)
+        reversed_both = patch.savgol_filter(
+            distance=7, time=5, samples=True, polyorder=2
+        )
+        assert np.allclose(both.data, last.data)
+        assert not np.allclose(both.data, reversed_both.data)
+
+    def test_gaussian_does_not_care(self, patch):
+        """Gaussian smoothing is separable, so order is nothing to it."""
+        one = patch.gaussian_filter(time=2, distance=3, samples=True)
+        other = patch.gaussian_filter(distance=3, time=2, samples=True)
+        assert np.allclose(one.data, other.data)
+
+
+class TestEmptySelection:
+    """What a call with no dimension does."""
+
+    def test_wiener_refuses(self, patch):
+        """Wiener asks for a window."""
+        with pytest.raises(ParameterError):
+            patch.wiener_filter()
+
+    def test_median_refuses_too(self, patch):
+        """So does every function which reads its dimensions from kwargs."""
+        with pytest.raises(ParameterError, match="at least one dimension"):
+            patch.median_filter()

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -187,6 +187,78 @@ class TestUnevenCoordinates:
             getattr(wacky, name)(time=3)
 
 
+class TestUnevenCoordinatesInSamples:
+    """A window in samples on an uneven coordinate: only AFK ever allowed it."""
+
+    @pytest.fixture(scope="class")
+    def wacky(self):
+        """A patch whose coordinates are not evenly sampled."""
+        return dc.get_example_patch("wacky_dim_coords_patch")
+
+    def test_adaptive_spectral_filter_reads_the_count(self, wacky):
+        """It never consulted the coordinate for a sample count, and still does not."""
+        out = wacky.adaptive_spectral_filter(time=16, samples=True, engine="scipy")
+        assert out.shape == wacky.shape
+
+    @pytest.mark.parametrize("name", ["median_filter", "hampel_filter"])
+    def test_dense_filters_refuse(self, wacky, name):
+        """They asked for an even coordinate whatever the units, and still do."""
+        with pytest.raises(CoordError):
+            getattr(wacky, name)(time=3, samples=True)
+
+    def test_rolling_refuses(self, wacky):
+        """As does rolling."""
+        with pytest.raises(CoordError):
+            wacky.rolling(time=3, samples=True)
+
+
+class TestNoFloor:
+    """The dense filters never had a minimum window."""
+
+    def test_gaussian_zero_is_the_identity(self, patch):
+        """A sigma of zero along an axis smooths nothing; scipy skips it."""
+        out = patch.gaussian_filter(time=0, samples=True)
+        assert np.allclose(out.data, patch.data)
+
+
+class TestChangedOnPurpose:
+    """
+    What the resolver does differently, each a call which used to fail.
+
+    Pinned so the difference is on record rather than discovered; each
+    is named in the pull request which made it.
+    """
+
+    def test_hampel_takes_a_quantity_under_samples(self, patch):
+        """Raised "must be integers" before; a quantity carries its units."""
+        by_quantity = patch.hampel_filter(time=0.016 * s, samples=True)
+        by_units = patch.hampel_filter(time=0.016)
+        assert np.allclose(by_quantity.data, by_units.data)
+
+    def test_rolling_takes_a_mapping(self, patch):
+        """Raised a TypeError before; a mapping is one value per dimension."""
+        mapped = patch.rolling(time=5, samples=True, overlap={"time": 2}).mean()
+        plain = patch.rolling(time=5, samples=True, overlap=2).mean()
+        assert np.allclose(mapped.data, plain.data, equal_nan=True)
+
+    def test_adaptive_spectral_filter_reads_a_percent(self, patch):
+        """Silently took int(25 * percent) == 0 before; 25% of 16 is 4."""
+        by_percent = patch.adaptive_spectral_filter(
+            time=16, distance=16, overlap=25 * percent, samples=True
+        )
+        by_count = patch.adaptive_spectral_filter(
+            time=16, distance=16, overlap=4, samples=True
+        )
+        assert np.allclose(by_percent.data, by_count.data)
+
+    def test_adaptive_spectral_filter_refuses_none_in_a_mapping(self, patch):
+        """Raised a TypeError before; now says what to do instead."""
+        with pytest.raises(ParameterError, match="leave it out"):
+            patch.adaptive_spectral_filter(
+                time=16, distance=16, overlap={"time": None}, samples=True
+            )
+
+
 class TestDimensionOrder:
     """Which order the selected dimensions come back in matters to savgol."""
 

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -247,6 +247,11 @@ class TestChangedOnPurpose:
         )
         assert np.allclose(by_percent.data, by_count.data)
 
+    def test_stft_refuses_a_zero_window(self, patch):
+        """Reached scipy and failed on the window's shape before; now says why."""
+        with pytest.raises(ParameterError, match="at least 1 samples"):
+            patch.stft(time=0, samples=True, overlap=None)
+
     def test_adaptive_spectral_filter_refuses_none_in_a_mapping(self, patch):
         """Raised a TypeError before; now says what to do instead."""
         with pytest.raises(ParameterError, match="leave it out"):


### PR DESCRIPTION
## Description

One way to turn "a window of X" into sample counts. DASCore had four: `get_patch_window_size` (hampel, wiener), `_create_size_and_axes` in `proc/filter.py` (median, gaussian, savgol), `get_window_axis_step` (rolling, stft — the only one that understood percent, and one dimension only), and `AdaptiveSpectralFilter.geometry`. They differed at the edges — whether an even window is adjusted or refused, whether a window longer than the coordinate is refused, what `overlap=None` means — and every new windowed operation re-derived all of it.

`dascore.utils.window.resolve_window` replaces all four and returns a `Window` (dims, axes, size, overlap, stride, in samples). What differs between functions is policy, not conversion, so each policy is a keyword the function states: `require_odd`, `min_samples`, `warn_above`, `enforce_lt_coord`, `allow_multiple`, `allow_empty`, `default_overlap`. It takes a `PatchMeta` as readily as a patch, so a `PatchProcessor` can resolve a window without data, and it accepts overlap as a scalar or a per-dimension mapping — which only the adaptive spectral filter uses yet.

This is the first PR of the windowing plan (top-level `.scratch/windowing-unification-plan.md`), and it is meant to change nothing a user can see. `tests/test_utils/test_window_parity.py` pins the edges of every migrated function with literal values taken from `dev` before the change — hampel rounding 4 samples up to 5 in units but refusing 4 in samples, median accepting even windows, rolling and stft refusing oversize windows while the dense filters pass them to scipy, stft's 50% of an odd window rounding half-to-even (5 → hop 3, 7 → 3, 9 → 5), a quantity keeping its units under `samples=True`, and savgol keeping only the last keyword's axis (a bug; pinned, not fixed — see below). Those tests passed on `dev` before the migration and pass after it.

What is deliberately not identical — each a call which used to fail and now works, pinned in `TestChangedOnPurpose`:

- A `Quantity` window under `samples=True` used to raise for the dense filters (`get_sample_count` refused it) while rolling and stft accepted it. Now a quantity carries its own units everywhere, and hampel rounds it up to odd as it would a value in units.
- `overlap={"time": 2}` used to raise a `TypeError` for rolling and stft; a mapping is now one value per dimension for every function.
- The adaptive spectral filter read `overlap=25 * percent` as `int(0.25) == 0` and filtered with no overlap; it now reads 25% of the window. `overlap={"time": None}` raised a `TypeError` and now says to leave the key out.
- `get_patch_window_size` and `get_window_axis_step` remain in `dascore.utils.patch` as deprecated wrappers over `resolve_window`, removed in 0.2.0.
- `stft(time=0, samples=True)` used to reach scipy and fail on the window's shape; it now raises the resolver's "at least 1 samples" `ParameterError`.
- Several adaptive spectral filter messages changed wording (the zero-window, negative-overlap, and unknown-dimension ones); they landed yesterday in #670.

Not migrated, on purpose: `kurtosis` (its own floor of 2 and a sorted-coordinate rule, with a message tests match), `whiten` (a smoothing length on a frequency coordinate, not a window), and `viz.spectrogram` (calls legacy `scipy.signal.spectrogram` with raw kwargs). Each is noted in the plan.

### A bug this PR pins rather than fixes

`savgol_filter` over two dimensions filters `patch.data` on every pass instead of the previous pass's output, so only the last keyword's axis survives: `savgol_filter(time=5, distance=7)` equals `savgol_filter(distance=7)`. The parity test documents it; the fix is one word (`x=data`) and its own PR, because it changes results.

### Codex review

Requested on the plan before this PR and on the code after it; both under `.scratch/`, untracked. The code review found the first commit less faithful than it claimed — two P1s (AFK on uneven coordinates with `samples=True` regressed to an error; its percent overlap changed from a silent 0) and five P2/P3s (dense-filter floors, oddness judged by the wrong flag, defaults unchecked, check precedence, the deleted utilities). All are fixed in the second commit and each has a pinned test. A third, cleanliness-focused review found a step longer than the window (which rolling allows) surfacing as a negative `overlap` in a field documented non-negative; `Window` now stores the stride and derives the overlap, negative across a gap and documented so. The plan review's P1s shaped this PR: per-call policies rather than a fixed signature, `overlap=None` left as None for the caller to read (rolling → stride 1, stft → windows abut, AFK → `window // 2 - 1`), stft's half-to-even rounding specified and pinned, no new public arguments, and characterization tests written first.

## Changelog

- none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent window and overlap handling across filters, rolling operations, and Fourier transforms.
  * Added support for dimension-aware windows, sample- or coordinate-based sizing, percentages, strides, and overlaps.
  * Added centralized validation for window sizes, sampling, dimensions, and coordinate limits.

* **Bug Fixes**
  * Improved handling of unevenly sampled coordinates and zero-sized windows.
  * Standardized validation and error reporting across windowed operations.

* **Tests**
  * Expanded coverage for window resolution, overlap, stride, validation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


