### PR TITLE
Filter each savgol dimension over the last pass's output

### DIFF
--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -388,7 +388,7 @@ def savgol_filter(
     size, axes = window.full_size(), window.axes
     for ax in axes:
         data = np_savgol_filter(
-            x=patch.data,
+            x=data,
             window_length=size[ax],
             polyorder=polyorder,
             mode=mode,

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -361,6 +361,17 @@ class TestSavgolFilter:
         assert out.shape == event_patch_2.shape
         assert not np.allclose(out.data, event_patch_2.data)
 
+    def test_each_dim_filtered_in_turn(self, random_patch):
+        """Each pass filters the last one's output, not the original data."""
+        kwargs = {"samples": True, "polyorder": 2}
+        out = random_patch.savgol_filter(time=5, distance=7, **kwargs)
+        chained = random_patch.savgol_filter(time=5, **kwargs).savgol_filter(
+            distance=7, **kwargs
+        )
+        assert np.allclose(out.data, chained.data)
+        one = random_patch.savgol_filter(time=5, **kwargs)
+        assert not np.allclose(out.data, one.data)
+
 
 class TestGaussianFilter:
     """Test the Gaussian Filter."""

--- a/tests/test_proc/test_filter.py
+++ b/tests/test_proc/test_filter.py
@@ -362,15 +362,23 @@ class TestSavgolFilter:
         assert not np.allclose(out.data, event_patch_2.data)
 
     def test_each_dim_filtered_in_turn(self, random_patch):
-        """Each pass filters the last one's output, not the original data."""
+        """
+        Each pass filters the last one's output, not the original data.
+
+        Every pass used to filter patch.data, so only the last keyword's
+        axis survived: the two dimension call equaled the last keyword's
+        alone, and swapping the keywords changed the answer.
+        """
         kwargs = {"samples": True, "polyorder": 2}
         out = random_patch.savgol_filter(time=5, distance=7, **kwargs)
         chained = random_patch.savgol_filter(time=5, **kwargs).savgol_filter(
             distance=7, **kwargs
         )
+        swapped = random_patch.savgol_filter(distance=7, time=5, **kwargs)
+        last_keyword = random_patch.savgol_filter(distance=7, **kwargs)
         assert np.allclose(out.data, chained.data)
-        one = random_patch.savgol_filter(time=5, **kwargs)
-        assert not np.allclose(out.data, one.data)
+        assert np.allclose(out.data, swapped.data)
+        assert not np.allclose(out.data, last_keyword.data)
 
 
 class TestGaussianFilter:

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -261,15 +261,7 @@ class TestChangedOnPurpose:
 
 
 class TestDimensionOrder:
-    """Which order the selected dimensions come back in no longer matters."""
-
-    def test_savgol_does_not_care_either(self, patch):
-        """Both keyword axes are filtered, so neither keyword order wins."""
-        both = patch.savgol_filter(time=5, distance=7, samples=True, polyorder=2)
-        other = patch.savgol_filter(distance=7, time=5, samples=True, polyorder=2)
-        last = patch.savgol_filter(distance=7, samples=True, polyorder=2)
-        assert np.allclose(both.data, other.data)
-        assert not np.allclose(both.data, last.data)
+    """Whether the order of the selected dimensions changes the answer."""
 
     def test_gaussian_does_not_care(self, patch):
         """Gaussian smoothing is separable, so order is nothing to it."""

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -261,22 +261,15 @@ class TestChangedOnPurpose:
 
 
 class TestDimensionOrder:
-    """Which order the selected dimensions come back in matters to savgol."""
+    """Which order the selected dimensions come back in no longer matters."""
 
-    def test_savgol_keeps_only_the_last_keyword(self, patch):
-        """
-        Each pass filters the original data, so the last keyword axis wins.
-
-        Pinned so the migration does not change it by accident; it is a
-        bug, and fixing it is a separate change with its own test.
-        """
+    def test_savgol_does_not_care_either(self, patch):
+        """Both keyword axes are filtered, so neither keyword order wins."""
         both = patch.savgol_filter(time=5, distance=7, samples=True, polyorder=2)
+        other = patch.savgol_filter(distance=7, time=5, samples=True, polyorder=2)
         last = patch.savgol_filter(distance=7, samples=True, polyorder=2)
-        reversed_both = patch.savgol_filter(
-            distance=7, time=5, samples=True, polyorder=2
-        )
-        assert np.allclose(both.data, last.data)
-        assert not np.allclose(both.data, reversed_both.data)
+        assert np.allclose(both.data, other.data)
+        assert not np.allclose(both.data, last.data)
 
     def test_gaussian_does_not_care(self, patch):
         """Gaussian smoothing is separable, so order is nothing to it."""


### PR DESCRIPTION
## Description

`savgol_filter` loops over the selected dimensions and says in its docstring that "the filter will be applied over each selected dimension sequentially", but every pass passed `x=patch.data` to scipy rather than the previous pass's output. Each pass therefore discarded the one before it and only the last keyword's axis survived: `patch.savgol_filter(time=5, distance=7, polyorder=2)` returned exactly `patch.savgol_filter(distance=7, polyorder=2)`, and reversing the keyword order changed the result.

The fix is one word, `x=data`. #1081 found this while unifying the window resolvers and pinned it there rather than changing results in a migration meant to be invisible; this is that separate change.

Two dimensions now compose: the two-dimension call equals the two single-dimension calls chained, and — savgol being linear, with `mode="interp"` at the edges — keyword order no longer matters, which is what the gaussian test beside it already asserted for gaussian.

`tests/test_utils/test_window_parity.py::TestDimensionOrder` held the pin describing the bug; it now asserts the order-independence instead. The regression test proper lives with the other savgol tests in `tests/test_proc/test_filter.py`, and it fails against the unfixed code.

## Changelog

- fixed: `Patch.savgol_filter` applied each dimension's pass to the original data, so only the last keyword's dimension was filtered. Passing more than one dimension now filters each in turn.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Savitzky–Golay filtering across multiple dimensions by applying each filter sequentially to the already-filtered result.
  - Corrected multi-dimensional filtering so results remain consistent regardless of dimension order.
  - Prevented multi-dimensional filtering from behaving like a single-dimension operation.

- **Tests**
  - Added regression coverage for sequential filtering across multiple dimensions and dimension-order consistency.
  - Updated test coverage to confirm filtering behavior matches expected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->