### PR TITLE
Build every window, ramp, and tile taper in one place

### DIFF
--- a/dascore/proc/adaptive_spectral_filter.py
+++ b/dascore/proc/adaptive_spectral_filter.py
@@ -37,7 +37,7 @@ from dascore.constants import PatchType
 from dascore.exceptions import MissingOptionalDependencyError, ParameterError
 from dascore.utils.misc import is_power_of_two
 from dascore.utils.patch import patch_function
-from dascore.utils.signal import _triangular_taper
+from dascore.utils.signal import get_taper
 from dascore.utils.window import resolve_window
 from dascore.workflow.meta import PatchMeta
 from dascore.workflow.processor import PatchProcessor, register_implementation
@@ -126,8 +126,7 @@ def _prepare_work_arrays(
     """
     working = np.ascontiguousarray(data, dtype=np.float32)
     stride = tuple(win - over for win, over in zip(window_size, overlap))
-    plateau = tuple(win - 2 * over for win, over in zip(window_size, overlap))
-    taper = _triangular_taper(window_size, plateau)
+    taper = get_taper("triang", window_size, overlap)
     padded_shape = tuple(
         length + 2 * step for length, step in zip(working.shape, stride)
     )

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -201,7 +201,6 @@ def hampel_filter(
         require_odd=True,
         warn_above=warn_above,
         min_samples=3,
-        allow_empty=True,
     ).full_size()
     # Need to convert ints to float for calculations to avoid roundoff error.
     # There were issues using np.issubdtype not working so this uses kind.

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -399,18 +399,13 @@ def rolling(
         overlap=overlap,
         step=step,
         allow_multiple=False,
-        # No floor of its own: a zero window is refused below, by name.
-        min_samples=0,
         enforce_lt_coord=True,
     )
     dim, axis, window = resolved.dims[0], resolved.axes[0], resolved.size[0]
     value = kwargs[dim]
     step = None if resolved.stride is None else resolved.stride[0]
-    # Handle default when no overlap/step specified and ensure window size
+    # No overlap or step given means every sample gets a window.
     step = 1 if step is None else step
-    if window == 0 or step == 0:
-        msg = "Window or step size can't be zero. Use any positive values."
-        raise ParameterError(msg)
     cls = _get_engine(step, engine, patch)
     roll_hist = (
         f"rolling({dim}={value}, step={step}, overlap={overlap}, "

--- a/dascore/proc/taper.py
+++ b/dascore/proc/taper.py
@@ -14,7 +14,7 @@ from dascore.units import Quantity
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import broadcast_for_index
 from dascore.utils.patch import get_dim_axis_value, patch_function
-from dascore.utils.signal import WINDOW_FUNCTIONS, _get_window_function
+from dascore.utils.signal import WINDOW_FUNCTIONS, get_ramp, get_window
 from dascore.utils.time import to_float
 
 
@@ -111,7 +111,6 @@ def taper(
     >>> from dascore.units import m
     >>> patch_taper4 = patch.taper(distance=15 * m)
     """
-    func = _get_window_function(window_type)
     # get taper values in samples.
     out = np.array(patch.data)  # Need to make a copy here.
     shape = out.shape
@@ -120,14 +119,16 @@ def taper(
     _validate_windows(samps, start_slice, end_slice, shape, axis)
     if samps[0] is not None:
         val = start_slice.stop
-        window = func(2 * val)[:val]
+        # The first half of a window of 2n, as this function has always cut
+        # it; taper_range and the tile tapers take the first n of 2n + 1.
+        window = get_window(window_type, 2 * val)[:val]
         # get indices window (which will broadcast) and data
         data_inds = broadcast_for_index(n_dims, axis, start_slice)
         window_inds = broadcast_for_index(n_dims, axis, slice(None), fill=None)
         out[data_inds] = out[data_inds] * window[window_inds]
     if samps[1] is not None:
         val = shape[axis] - end_slice.start
-        window = func(2 * val)[val:]
+        window = get_window(window_type, 2 * val)[val:]
         data_inds = broadcast_for_index(n_dims, axis, end_slice)
         window_inds = broadcast_for_index(n_dims, axis, slice(None), fill=None)
         out[data_inds] = out[data_inds] * window[window_inds]
@@ -164,9 +165,7 @@ def _get_taper_coord_inds(coord, values, relative, samples):
 
 def _get_taper_curve(coord, ind_1, ind_2, window_type, reverse=False):
     """Get the taper curve between index1 and index2."""
-    func = _get_window_function(window_type)
-    samps = ind_2 - ind_1
-    taper = func(samps * 2 + 1)[:samps]
+    taper = get_ramp(window_type, ind_2 - ind_1)
     if reverse:
         taper = taper[::-1]
     # Need to extrapolate to get correct values for non evenly sampled coords.

--- a/dascore/proc/taper.py
+++ b/dascore/proc/taper.py
@@ -14,7 +14,7 @@ from dascore.units import Quantity
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import broadcast_for_index
 from dascore.utils.patch import get_dim_axis_value, patch_function
-from dascore.utils.signal import WINDOW_FUNCTIONS, get_ramp, get_window
+from dascore.utils.signal import WINDOW_FUNCTIONS, get_ramp
 from dascore.utils.time import to_float
 
 
@@ -119,16 +119,14 @@ def taper(
     _validate_windows(samps, start_slice, end_slice, shape, axis)
     if samps[0] is not None:
         val = start_slice.stop
-        # The first half of a window of 2n, as this function has always cut
-        # it; taper_range and the tile tapers take the first n of 2n + 1.
-        window = get_window(window_type, 2 * val)[:val]
+        window = get_ramp(window_type, val)
         # get indices window (which will broadcast) and data
         data_inds = broadcast_for_index(n_dims, axis, start_slice)
         window_inds = broadcast_for_index(n_dims, axis, slice(None), fill=None)
         out[data_inds] = out[data_inds] * window[window_inds]
     if samps[1] is not None:
         val = shape[axis] - end_slice.start
-        window = get_window(window_type, 2 * val)[val:]
+        window = get_ramp(window_type, val)[::-1]
         data_inds = broadcast_for_index(n_dims, axis, end_slice)
         window_inds = broadcast_for_index(n_dims, axis, slice(None), fill=None)
         out[data_inds] = out[data_inds] * window[window_inds]

--- a/dascore/proc/taper.py
+++ b/dascore/proc/taper.py
@@ -14,7 +14,7 @@ from dascore.units import Quantity
 from dascore.utils.docs import compose_docstring
 from dascore.utils.misc import broadcast_for_index
 from dascore.utils.patch import get_dim_axis_value, patch_function
-from dascore.utils.signal import WINDOW_FUNCTIONS, get_ramp
+from dascore.utils.signal import WINDOW_NAMES, get_ramp
 from dascore.utils.time import to_float
 
 
@@ -61,7 +61,7 @@ def _validate_windows(samps, start_slice, end_slice, shape, axis):
 
 
 @patch_function()
-@compose_docstring(taper_type=sorted(WINDOW_FUNCTIONS))
+@compose_docstring(taper_type=sorted(WINDOW_NAMES))
 def taper(
     patch: PatchType,
     window_type: str = "hann",
@@ -195,7 +195,7 @@ def _get_range_envelope(coord, inds, window_type, invert):
 
 
 @patch_function()
-@compose_docstring(taper_type=sorted(WINDOW_FUNCTIONS))
+@compose_docstring(taper_type=sorted(WINDOW_NAMES))
 def taper_range(
     patch: PatchType,
     window_type: str = "hann",

--- a/dascore/proc/taper.py
+++ b/dascore/proc/taper.py
@@ -64,7 +64,7 @@ def _validate_windows(samps, start_slice, end_slice, shape, axis):
 @compose_docstring(taper_type=sorted(WINDOW_NAMES))
 def taper(
     patch: PatchType,
-    window_type: str = "hann",
+    window_type: str | tuple = "hann",
     **kwargs,
 ) -> PatchType:
     """
@@ -75,8 +75,10 @@ def taper(
     patch
         The patch instance.
     window_type
-        The type of window to use For tapering. Supported Options are:
-            {taper_type}.
+        The window whose edge the taper takes. Supported options are:
+            {taper_type}
+        or any name or ``(name, parameter)`` tuple `scipy.signal.get_window`
+        accepts, such as ``("tukey", 0.5)``.
     **kwargs
         Used to specify the dimension along which to taper and the percentage
         of total length of the dimension (if a decimal or percent, see examples),
@@ -198,7 +200,7 @@ def _get_range_envelope(coord, inds, window_type, invert):
 @compose_docstring(taper_type=sorted(WINDOW_NAMES))
 def taper_range(
     patch: PatchType,
-    window_type: str = "hann",
+    window_type: str | tuple = "hann",
     invert=False,
     relative=False,
     samples=False,
@@ -212,8 +214,10 @@ def taper_range(
     patch
         A patch instance.
     window_type
-        The type of window to use For tapering. Supported Options are:
-            {taper_type}.
+        The window whose edge the taper takes. Supported options are:
+            {taper_type}
+        or any name or ``(name, parameter)`` tuple `scipy.signal.get_window`
+        accepts, such as ``("tukey", 0.5)``.
     invert
         If True, the values inside the specified range are set to zero
         and gradually tapered to 1.

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -32,6 +32,7 @@ from dascore.utils.patch import (
     _get_dx_or_spacing_and_axes,
     patch_function,
 )
+from dascore.utils.signal import get_window
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.transformatter import FourierTransformatter
 from dascore.utils.window import resolve_window
@@ -40,7 +41,6 @@ if TYPE_CHECKING:
     from scipy.signal import ShortTimeFFT
 else:
     ShortTimeFFT = lazy_import("scipy.signal", "ShortTimeFFT")
-get_window = lazy_import("scipy.signal.windows", "get_window")
 
 DFT_OUTPUT_DATA_TYPE_MAP = {
     "AS": "amplitude_spectrum",
@@ -640,7 +640,7 @@ def stft(
     if isinstance(taper_window, ndarray):
         window = taper_window
     else:
-        window = get_window(taper_window, window_samples, fftbins=False)
+        window = get_window(taper_window, window_samples)
     # Perform stft
     fft_mode = "onesided" if np.isrealobj(patch.data) else "centered"
     stft = ShortTimeFFT(

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -612,9 +612,8 @@ def stft(
       For a given sliding window, Parseval's theorem doesn't hold exactly
       (unless a boxcar window is used) because the taper window changes the time
       series signal before the transformation.
-    - If an array is passed for taper_window that has a different length
-      than specified in kwargs, artificial enriching of frequency resolution
-      (equivalent to zero padding in time domain) can occur.
+    - An array passed for taper_window must have as many samples as the
+      window; one of another length is refused.
     - Non-dimensional coordinates associated with transformed coordinates
       are dropped in the output.
 
@@ -636,11 +635,7 @@ def stft(
     # No overlap given means none: the windows abut.
     hop = window_samples if resolved.stride is None else resolved.stride[0]
     sampling_rate = 1 / abs(dc.to_float(coord.step))
-    # Create window.
-    if isinstance(taper_window, ndarray):
-        window = taper_window
-    else:
-        window = get_window(taper_window, window_samples)
+    window = get_window(taper_window, window_samples)
     # Perform stft
     fft_mode = "onesided" if np.isrealobj(patch.data) else "centered"
     stft = ShortTimeFFT(

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -956,11 +956,12 @@ def get_patch_window_size(
     # Deferred: dascore.utils.window imports this module.
     from dascore.utils.window import resolve_window  # noqa: PLC0415
 
+    if not kwargs:
+        return (1,) * len(patch.dims)
     return resolve_window(
         patch,
         kwargs,
         samples=samples,
-        allow_empty=True,
         require_odd=require_odd,
         warn_above=warn_above,
         min_samples=min_samples,

--- a/dascore/utils/signal.py
+++ b/dascore/utils/signal.py
@@ -23,24 +23,25 @@ from dascore.utils.imports import lazy_import
 
 _scipy_get_window = lazy_import("scipy.signal", "get_window")
 
-# DASCore's own names for windows, including two which scipy does not
-# spell: `cos` for hann and `ramp` for triang. Anything not here is handed
-# to scipy, which knows the rest and takes `(name, parameter)` tuples.
-WINDOW_FUNCTIONS = dict(
-    barthann=lazy_import("scipy.signal.windows", "barthann"),
-    bartlett=lazy_import("scipy.signal.windows", "bartlett"),
-    blackman=lazy_import("scipy.signal.windows", "blackman"),
-    blackmanharris=lazy_import("scipy.signal.windows", "blackmanharris"),
-    bohman=lazy_import("scipy.signal.windows", "bohman"),
-    hamming=lazy_import("scipy.signal.windows", "hamming"),
-    hann=lazy_import("scipy.signal.windows", "hann"),
-    cos=lazy_import("scipy.signal.windows", "hann"),
-    nuttall=lazy_import("scipy.signal.windows", "nuttall"),
-    parzen=lazy_import("scipy.signal.windows", "parzen"),
-    triang=lazy_import("scipy.signal.windows", "triang"),
-    ramp=lazy_import("scipy.signal.windows", "triang"),
-    boxcar=lazy_import("scipy.signal.windows", "boxcar"),
-)
+# The names DASCore documents for windows, each the scipy name it means.
+# Two are DASCore's own: `cos` for hann and `ramp` for triang. Anything not
+# here is handed to scipy as given, which knows more names and takes
+# `(name, parameter)` tuples.
+WINDOW_NAMES = {
+    "barthann": "barthann",
+    "bartlett": "bartlett",
+    "blackman": "blackman",
+    "blackmanharris": "blackmanharris",
+    "bohman": "bohman",
+    "boxcar": "boxcar",
+    "cos": "hann",
+    "hamming": "hamming",
+    "hann": "hann",
+    "nuttall": "nuttall",
+    "parzen": "parzen",
+    "ramp": "triang",
+    "triang": "triang",
+}
 
 
 def get_window(window: Any, size: int, *, fftbins: bool = False) -> np.ndarray:
@@ -50,7 +51,7 @@ def get_window(window: Any, size: int, *, fftbins: bool = False) -> np.ndarray:
     Parameters
     ----------
     window
-        A name from `WINDOW_FUNCTIONS`, any name or ``(name, parameter)``
+        A name from `WINDOW_NAMES`, any name or ``(name, parameter)``
         tuple `scipy.signal.get_window` accepts, or an array, which is
         returned as it is if it has `size` samples.
     size
@@ -69,18 +70,19 @@ def get_window(window: Any, size: int, *, fftbins: bool = False) -> np.ndarray:
             msg = f"The window has {len(window)} samples, not {size}."
             raise ParameterError(msg)
         return window
-    if isinstance(window, str) and window in WINDOW_FUNCTIONS:
-        return WINDOW_FUNCTIONS[window](size, sym=not fftbins)
+    name = WINDOW_NAMES.get(window, window) if isinstance(window, str) else window
     try:
-        return _scipy_get_window(window, size, fftbins=fftbins)
+        return _scipy_get_window(name, size, fftbins=fftbins)
     except ValueError as exc:
-        # scipy says "Unknown window type" for a name it lacks; its other
-        # complaints -- a parameter out of range -- are its own to make.
-        if "Unknown window type" not in str(exc):
+        # A bare name scipy refuses is one it does not know, or one which
+        # needs a parameter it was not given; either way the caller named
+        # a window they cannot have. A tuple's complaint is about its
+        # parameters, and is scipy's to make.
+        if not isinstance(window, str):
             raise
         msg = (
-            f"'{window}' is not a known window type. Options are: "
-            f"{sorted(WINDOW_FUNCTIONS)}, or any name scipy.signal.get_window takes."
+            f"'{window}' is not a known window type ({exc}). Options are: "
+            f"{sorted(WINDOW_NAMES)}, or any name scipy.signal.get_window takes."
         )
         raise ParameterError(msg) from exc
 

--- a/dascore/utils/signal.py
+++ b/dascore/utils/signal.py
@@ -1,16 +1,31 @@
 """
-Utilities for signal processing.
+Windows, ramps, and tile tapers, built one way.
+
+A *window* is a whole array of weights, the thing a spectral transform
+multiplies a tile by. A *ramp* is the rising edge of one, which an edge
+taper multiplies the first samples of a patch by. A *taper* is a tile of
+ones with ramps down every edge, which overlapping tiles are blended with.
+All three come from one place, so a name means the same shape wherever it
+is used, and a ramp can be made complementary -- adjacent ramps summing to
+one -- when a blend has to invert exactly.
 """
 
 from __future__ import annotations
 
+import math
 from functools import lru_cache
+from typing import Any
 
 import numpy as np
 
 from dascore.exceptions import ParameterError
 from dascore.utils.imports import lazy_import
 
+_scipy_get_window = lazy_import("scipy.signal", "get_window")
+
+# DASCore's own names for windows, including two which scipy does not
+# spell: `cos` for hann and `ramp` for triang. Anything not here is handed
+# to scipy, which knows the rest and takes `(name, parameter)` tuples.
 WINDOW_FUNCTIONS = dict(
     barthann=lazy_import("scipy.signal.windows", "barthann"),
     bartlett=lazy_import("scipy.signal.windows", "bartlett"),
@@ -28,97 +43,130 @@ WINDOW_FUNCTIONS = dict(
 )
 
 
-def _get_window_function(window_type):
-    """Get the window function to use for taper."""
-    # get taper function or raise if it isn't known.
-    if window_type not in WINDOW_FUNCTIONS:
-        msg = (
-            f"'{window_type}' is not a known window type. "
-            f"Options are: {sorted(WINDOW_FUNCTIONS)}"
-        )
-        raise ParameterError(msg)
-    func = WINDOW_FUNCTIONS[window_type]
-    return func
-
-
-def _triangular_taper_1d(size: int, plateau: int) -> np.ndarray:
-    """Return a one-dimensional triangular plateau taper."""
-    ramp_size = (size - plateau) // 2
-    taper = np.ones(size, dtype=np.float32)
-    if ramp_size:
-        ramp = _get_window_function("triang")(ramp_size * 2 + 1)[:ramp_size]
-        taper[:ramp_size] = ramp
-        taper[size - ramp_size :] = ramp[::-1]
-    return taper
-
-
-@lru_cache(maxsize=64)
-def _cached_triangular_taper(
-    window_size: tuple[int, ...], plateau: tuple[int, ...]
-) -> np.ndarray:
-    """Build the cached taper array used by :func:`_triangular_taper`."""
-    if len(window_size) != len(plateau):
-        msg = "window_size and plateau must have the same length."
-        raise ValueError(msg)
-    if len(window_size) not in {1, 2}:
-        msg = "Only one- and two-dimensional tapers are supported."
-        raise ValueError(msg)
-    if any(plat > win for win, plat in zip(window_size, plateau)):
-        msg = "Plateau cannot be larger than window size."
-        raise ValueError(msg)
-    if any(plat < 0 for plat in plateau):
-        msg = "Plateau sizes must be non-negative."
-        raise ValueError(msg)
-    if any(win % 2 for win in window_size):
-        msg = "Window sizes must be even."
-        raise ValueError(msg)
-    tapers = [
-        _triangular_taper_1d(win, plat) for win, plat in zip(window_size, plateau)
-    ]
-    if len(tapers) == 1:
-        return tapers[0].astype(np.float32)
-    return (tapers[0][:, None] * tapers[1][None, :]).astype(np.float32)
-
-
-def _triangular_taper(
-    window_size: tuple[int, ...], plateau: tuple[int, ...]
-) -> np.ndarray:
+def get_window(window: Any, size: int, *, fftbins: bool = False) -> np.ndarray:
     """
-    Return a one- or two-dimensional triangular plateau taper.
+    Return a window of `size` samples.
 
     Parameters
     ----------
-    window_size
-        Number of samples in the window dimensions. Values must be even.
-    plateau
-        Number of central samples with unit weight in each dimension. Values
-        must be non-negative and no larger than the corresponding window size.
+    window
+        A name from `WINDOW_FUNCTIONS`, any name or ``(name, parameter)``
+        tuple `scipy.signal.get_window` accepts, or an array, which is
+        returned as it is if it has `size` samples.
+    size
+        How many samples the window has.
+    fftbins
+        If True, the window is periodic, as for a spectral estimate; the
+        default is symmetric, as for a taper.
+
+    Raises
+    ------
+    ParameterError
+        For a name nothing knows, or an array of the wrong length.
+    """
+    if isinstance(window, np.ndarray):
+        if len(window) != size:
+            msg = f"The window has {len(window)} samples, not {size}."
+            raise ParameterError(msg)
+        return window
+    if isinstance(window, str) and window in WINDOW_FUNCTIONS:
+        return WINDOW_FUNCTIONS[window](size, sym=not fftbins)
+    try:
+        return _scipy_get_window(window, size, fftbins=fftbins)
+    except ValueError as exc:
+        msg = (
+            f"'{window}' is not a known window type. Options are: "
+            f"{sorted(WINDOW_FUNCTIONS)}, or any name scipy.signal.get_window takes."
+        )
+        raise ParameterError(msg) from exc
+
+
+def get_ramp(window: Any, length: int, *, complementary: bool = False) -> np.ndarray:
+    """
+    Return the rising edge of a window: `length` samples climbing towards one.
+
+    The ramp is the first `length` samples of a symmetric window of
+    ``2 * length + 1``, so its peak, which the window holds at the middle,
+    is the sample just past the ramp.
+
+    Parameters
+    ----------
+    window
+        The window whose edge this is; see `get_window`.
+    length
+        How many samples the ramp has.
+    complementary
+        If True, scale the ramp so that it and its reverse sum to one at
+        every sample. Two tiles whose ramps overlap then blend to exactly
+        the signal between them, whatever the window's shape.
+    """
+    ramp = get_window(window, 2 * length + 1)[:length]
+    if complementary and length:
+        total = ramp + ramp[::-1]
+        ramp = np.divide(ramp, total, out=np.full_like(ramp, 0.5), where=total > 0)
+        # A window such as blackman touches zero from below by rounding; a
+        # weight is never negative.
+        ramp = np.clip(ramp, 0.0, 1.0)
+    return ramp
+
+
+@lru_cache(maxsize=64)
+def _cached_taper(
+    window: Any, size: tuple[int, ...], overlap: tuple[int, ...]
+) -> np.ndarray:
+    """Build the taper `get_taper` hands out copies of."""
+    if len(size) != len(overlap):
+        msg = "size and overlap must have the same length."
+        raise ParameterError(msg)
+    if any(over < 0 for over in overlap):
+        msg = "overlap must be non-negative."
+        raise ParameterError(msg)
+    if any(2 * over > length for length, over in zip(size, overlap)):
+        msg = "overlap cannot exceed half the tile: the ramps would cross."
+        raise ParameterError(msg)
+    edges = []
+    for length, over in zip(size, overlap):
+        edge = np.ones(length, dtype=np.float64)
+        if over:
+            ramp = get_ramp(window, over, complementary=True)
+            edge[:over] = ramp
+            edge[length - over :] = ramp[::-1]
+        edges.append(edge)
+    # Separable: the taper is the outer product of its edges.
+    taper = math.prod(np.ix_(*edges)) if len(edges) > 1 else edges[0]
+    return np.asarray(taper, dtype=np.float32)
+
+
+def get_taper(
+    window: Any, size: tuple[int, ...], overlap: tuple[int, ...]
+) -> np.ndarray:
+    """
+    Return a tile of ones with complementary ramps of `overlap` down every edge.
+
+    Tiles of this `size` laid at a stride of ``size - overlap`` and
+    multiplied by this taper sum to exactly one everywhere they cover, so
+    an overlap-add of them returns the signal they were cut from.
+
+    Parameters
+    ----------
+    window
+        The window whose edge the ramps take; see `get_window`.
+    size
+        The tile's shape.
+    overlap
+        How many samples each edge ramps over, per axis. Zero is a boxcar
+        along that axis.
 
     Returns
     -------
     numpy.ndarray
-        A ``float32`` array with shape ``window_size``. The returned array is a
-        copy, so callers can mutate it without corrupting the internal cache.
-
-    Raises
-    ------
-    ValueError
-        If the inputs have different lengths, if the taper dimensionality is
-        not one or two, if any plateau is negative, if any plateau is greater
-        than the corresponding window size, or if any window size is odd.
-
-    Notes
-    -----
-    The taper is separable in 2D. Each axis contains a central unit-weight
-    plateau and triangular ramps on both sides generated from DASCore's
-    registered ``"triang"`` window function. When plateau equals window size,
-    the result is all ones along that axis.
+        A ``float32`` array of shape `size`; a copy, so it may be written to.
 
     Examples
     --------
-    >>> from dascore.utils.signal import _triangular_taper
-    >>> taper = _triangular_taper((8, 8), (2, 2))
+    >>> from dascore.utils.signal import get_taper
+    >>> taper = get_taper("triang", (8, 8), (3, 3))
     >>> taper.shape
     (8, 8)
     """
-    return _cached_triangular_taper(window_size, plateau).copy()
+    return _cached_taper(window, tuple(size), tuple(overlap)).copy()

--- a/dascore/utils/signal.py
+++ b/dascore/utils/signal.py
@@ -74,6 +74,10 @@ def get_window(window: Any, size: int, *, fftbins: bool = False) -> np.ndarray:
     try:
         return _scipy_get_window(window, size, fftbins=fftbins)
     except ValueError as exc:
+        # scipy says "Unknown window type" for a name it lacks; its other
+        # complaints -- a parameter out of range -- are its own to make.
+        if "Unknown window type" not in str(exc):
+            raise
         msg = (
             f"'{window}' is not a known window type. Options are: "
             f"{sorted(WINDOW_FUNCTIONS)}, or any name scipy.signal.get_window takes."
@@ -102,6 +106,8 @@ def get_ramp(window: Any, length: int, *, complementary: bool = False) -> np.nda
     """
     ramp = get_window(window, 2 * length + 1)[:length]
     if complementary and length:
+        # Weights, whatever the window was given as.
+        ramp = np.asarray(ramp, dtype=np.float64)
         total = ramp + ramp[::-1]
         ramp = np.divide(ramp, total, out=np.full_like(ramp, 0.5), where=total > 0)
         # A window such as blackman touches zero from below by rounding; a
@@ -110,11 +116,10 @@ def get_ramp(window: Any, length: int, *, complementary: bool = False) -> np.nda
     return ramp
 
 
-@lru_cache(maxsize=64)
-def _cached_taper(
+def _build_taper(
     window: Any, size: tuple[int, ...], overlap: tuple[int, ...]
 ) -> np.ndarray:
-    """Build the taper `get_taper` hands out copies of."""
+    """Build a taper; see `get_taper`."""
     if len(size) != len(overlap):
         msg = "size and overlap must have the same length."
         raise ParameterError(msg)
@@ -126,15 +131,34 @@ def _cached_taper(
         raise ParameterError(msg)
     edges = []
     for length, over in zip(size, overlap):
-        edge = np.ones(length, dtype=np.float64)
+        # float32 throughout, edges and product alike, so the taper is the
+        # one the filter has always used to the last bit.
+        edge = np.ones(length, dtype=np.float32)
+        # Built even when the overlap is zero, so a window nothing knows is
+        # refused rather than never asked for.
+        ramp = get_ramp(window, over, complementary=True).astype(np.float32)
         if over:
-            ramp = get_ramp(window, over, complementary=True)
             edge[:over] = ramp
             edge[length - over :] = ramp[::-1]
         edges.append(edge)
     # Separable: the taper is the outer product of its edges.
     taper = math.prod(np.ix_(*edges)) if len(edges) > 1 else edges[0]
     return np.asarray(taper, dtype=np.float32)
+
+
+@lru_cache(maxsize=64)
+def _cached_taper(
+    window: Any, size: tuple[int, ...], overlap: tuple[int, ...]
+) -> np.ndarray:
+    """The tapers named by something hashable, built once each."""
+    return _build_taper(window, size, overlap)
+
+
+def _hashable(value: Any) -> bool:
+    """Whether a window can key the cache: a name, or a tuple of such."""
+    if isinstance(value, tuple):
+        return all(_hashable(item) for item in value)
+    return isinstance(value, str | int | float)
 
 
 def get_taper(
@@ -169,4 +193,8 @@ def get_taper(
     >>> taper.shape
     (8, 8)
     """
-    return _cached_taper(window, tuple(size), tuple(overlap)).copy()
+    size, overlap = tuple(size), tuple(overlap)
+    if _hashable(window):
+        return _cached_taper(window, size, overlap).copy()
+    # An array, or a tuple carrying a list: built each time, uncached.
+    return _build_taper(window, size, overlap)

--- a/dascore/utils/window.py
+++ b/dascore/utils/window.py
@@ -190,7 +190,6 @@ def resolve_window(
     step: Any = None,
     default_overlap: OverlapDefault = None,
     allow_multiple: bool = True,
-    allow_empty: bool = False,
     require_evenly_sampled: bool = True,
     require_odd: bool = False,
     min_samples: int | None = 1,
@@ -223,9 +222,6 @@ def resolve_window(
         `Window.overlap` None when nothing was given.
     allow_multiple
         Whether more than one dimension may be windowed.
-    allow_empty
-        Whether no dimension at all may be, giving an empty window whose
-        `full_size` is all ones.
     require_evenly_sampled
         Whether a windowed coordinate must be evenly sampled. When it need
         not be, a window given in samples never consults the coordinate;
@@ -253,8 +249,6 @@ def resolve_window(
     if overlap is not None and step is not None:
         msg = "step and overlap are mutually exclusive."
         raise ParameterError(msg)
-    if not kwargs and allow_empty:
-        return Window((), (), (), None, len(patch.dims))
     dim_axis_values = get_dim_axis_value(
         patch, kwargs=kwargs, allow_multiple=allow_multiple
     )

--- a/tests/test_proc/test_adaptive_spectral_filter.py
+++ b/tests/test_proc/test_adaptive_spectral_filter.py
@@ -21,7 +21,6 @@ from dascore.proc.adaptive_spectral_filter import (
     _get_engine,
     _validate_window_and_overlap,
 )
-from dascore.utils.signal import _triangular_taper
 
 
 def _numba_engine():
@@ -535,58 +534,6 @@ class TestAdaptiveSpectralFilter:
 
 class TestAdaptiveSpectralCore:
     """Tests for plain array adaptive spectral helpers."""
-
-    def test_triangular_taper_values(self) -> None:
-        """The shared taper should match the overlap-add ramp geometry."""
-        taper = _triangular_taper((8, 8), (2, 2))
-        expected_1d = np.array([0.25, 0.5, 0.75, 1.0, 1.0, 0.75, 0.5, 0.25])
-
-        np.testing.assert_allclose(taper, expected_1d[:, None] * expected_1d[None, :])
-        assert taper.dtype == np.float32
-
-    def test_triangular_taper_all_ones_when_plateau_matches_window(self) -> None:
-        """A full-window plateau should support zero-overlap reconstruction."""
-        taper = _triangular_taper((8, 8), (8, 8))
-
-        np.testing.assert_array_equal(taper, np.ones((8, 8), dtype=np.float32))
-
-    def test_triangular_taper_one_dimensional(self) -> None:
-        """The shared taper should also support 1D reconstruction."""
-        taper = _triangular_taper((8,), (2,))
-        expected = np.array([0.25, 0.5, 0.75, 1.0, 1.0, 0.75, 0.5, 0.25])
-
-        np.testing.assert_allclose(taper, expected)
-        assert taper.dtype == np.float32
-
-    def test_triangular_taper_cache_is_not_mutated_by_callers(self) -> None:
-        """Callers should receive a copy of the cached taper."""
-        taper = _triangular_taper((16, 16), (2, 2))
-        expected = taper.copy()
-
-        taper[...] = -1.0
-        actual = _triangular_taper((16, 16), (2, 2))
-
-        np.testing.assert_array_equal(actual, expected)
-
-    @pytest.mark.parametrize(
-        "window_size,plateau,match",
-        [
-            ((16, 16), (17, 2), "Plateau cannot"),
-            ((16, 16), (-1, 2), "non-negative"),
-            ((15, 16), (2, 2), "Window sizes must be even"),
-            ((16, 16), (2,), "same length"),
-            ((16, 16, 16), (2, 2, 2), "one- and two-dimensional"),
-        ],
-    )
-    def test_triangular_taper_rejects_invalid_geometry(
-        self,
-        window_size: tuple[int, int],
-        plateau: tuple[int, int],
-        match: str,
-    ) -> None:
-        """Invalid taper geometry should raise."""
-        with pytest.raises(ValueError, match=match):
-            _triangular_taper(window_size, plateau)
 
     @pytest.mark.parametrize(
         "window_size,overlap,match",

--- a/tests/test_proc/test_rolling.py
+++ b/tests/test_proc/test_rolling.py
@@ -129,7 +129,7 @@ class TestRolling:
     def test_window_zero_raises(self, random_patch):
         """When the window or step is entered 0 it should raise."""
         random_patch.get_coord("time")
-        msg = "Window or step size can't be zero"
+        msg = "at least 1 samples"
         with pytest.raises(ParameterError, match=msg):
             random_patch.rolling(time=0)
 

--- a/tests/test_proc/test_taper.py
+++ b/tests/test_proc/test_taper.py
@@ -11,7 +11,7 @@ from dascore.exceptions import ParameterError
 from dascore.proc.taper import taper
 from dascore.units import m, percent
 from dascore.utils.misc import broadcast_for_index
-from dascore.utils.signal import WINDOW_FUNCTIONS
+from dascore.utils.signal import WINDOW_NAMES, get_window
 
 gen = np.random.default_rng(32)
 
@@ -38,18 +38,18 @@ def time_tapered_patch(request, patch_ones):
 
 
 def test_every_window_tapers():
-    """Each name in the table reaches the window scipy has for it.
-
-    The entries are lazy imports, and two of them are aliases (`cos` for
-    hann, `ramp` for triang), so a name pointing at the wrong scipy symbol
-    resolves fine and returns an array of the right length. Asserting the
-    shape of the window is what catches that: every one of them tapers to
-    near zero at both ends, hamming's 0.08 being the highest, and boxcar
-    is the one which does not taper at all.
     """
-    assert set(TAPER_WINDOWS) <= set(WINDOW_FUNCTIONS)
-    for name, func in WINDOW_FUNCTIONS.items():
-        window = np.asarray(func(64))
+    Each documented name builds the window scipy has for it.
+
+    Two of them are aliases (`cos` for hann, `ramp` for triang), so a name
+    pointing at the wrong scipy symbol would still return an array of the
+    right length. Asserting the shape of the window is what catches that:
+    every one of them tapers to near zero at both ends, hamming's 0.08 being
+    the highest, and boxcar is the one which does not taper at all.
+    """
+    assert set(TAPER_WINDOWS) <= set(WINDOW_NAMES)
+    for name in WINDOW_NAMES:
+        window = np.asarray(get_window(name, 64))
         assert window.shape == (64,), name
         assert np.max(window) <= 1.0 + 1e-9, name
         if name == "boxcar":

--- a/tests/test_utils/test_signal.py
+++ b/tests/test_utils/test_signal.py
@@ -7,7 +7,7 @@ import pytest
 from scipy.signal.windows import hann, triang
 
 from dascore.exceptions import ParameterError
-from dascore.utils.signal import WINDOW_FUNCTIONS, get_ramp, get_taper, get_window
+from dascore.utils.signal import WINDOW_NAMES, get_ramp, get_taper, get_window
 
 # The shapes a blend might be asked for, from flat to bell.
 SHAPES = ["boxcar", "triang", "hann", "hamming", "blackman", ("tukey", 0.5)]
@@ -51,14 +51,19 @@ class TestGetWindow:
         with pytest.raises(ValueError, match="NW"):
             get_window(("dpss", 2.5), 3)
 
+    def test_a_name_needing_a_parameter_is_refused_by_name(self):
+        """Kaiser without its beta is a window the caller cannot have."""
+        with pytest.raises(ParameterError, match="not a known window"):
+            get_window("kaiser", 8)
+
     def test_unknown_name_refused(self):
         """A name nobody knows says what the options are."""
         with pytest.raises(ParameterError, match="not a known window"):
             get_window("windowsXP", 8)
 
     def test_every_registered_name_builds(self):
-        """The registry is not decorative."""
-        for name in WINDOW_FUNCTIONS:
+        """The name table is not decorative."""
+        for name in WINDOW_NAMES:
             assert get_window(name, 8).shape == (8,)
 
 

--- a/tests/test_utils/test_signal.py
+++ b/tests/test_utils/test_signal.py
@@ -1,0 +1,179 @@
+"""Tests for windows, ramps, and tile tapers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.signal.windows import hann, triang
+
+from dascore.exceptions import ParameterError
+from dascore.utils.signal import WINDOW_FUNCTIONS, get_ramp, get_taper, get_window
+
+# The shapes a blend might be asked for, from flat to bell.
+SHAPES = ["boxcar", "triang", "hann", "hamming", "blackman", ("tukey", 0.5)]
+
+
+class TestGetWindow:
+    """One name, one window."""
+
+    def test_dascore_name(self):
+        """A registered name gives scipy's symmetric window."""
+        np.testing.assert_allclose(get_window("hann", 9), hann(9, sym=True))
+
+    def test_alias(self):
+        """DASCore's own spellings are honoured."""
+        np.testing.assert_allclose(get_window("cos", 9), hann(9))
+        np.testing.assert_allclose(get_window("ramp", 9), triang(9))
+
+    def test_scipy_name_and_tuple(self):
+        """What scipy knows, this knows."""
+        assert get_window(("tukey", 0.25), 16).shape == (16,)
+        assert get_window("flattop", 16).shape == (16,)
+
+    def test_periodic(self):
+        """A periodic window, for a spectral estimate."""
+        np.testing.assert_allclose(
+            get_window("hann", 8, fftbins=True), hann(8, sym=False)
+        )
+
+    def test_array_passes_through(self):
+        """An array of the right length is the window."""
+        array = np.linspace(0, 1, 7)
+        assert get_window(array, 7) is array
+
+    def test_array_of_the_wrong_length_refused(self):
+        """Of the wrong length, it is refused by count."""
+        with pytest.raises(ParameterError, match="7 samples, not 8"):
+            get_window(np.ones(7), 8)
+
+    def test_unknown_name_refused(self):
+        """A name nobody knows says what the options are."""
+        with pytest.raises(ParameterError, match="not a known window"):
+            get_window("windowsXP", 8)
+
+    def test_every_registered_name_builds(self):
+        """The registry is not decorative."""
+        for name in WINDOW_FUNCTIONS:
+            assert get_window(name, 8).shape == (8,)
+
+
+class TestGetRamp:
+    """The rising edge of a window."""
+
+    def test_triangle_values(self):
+        """Four samples of triangle from a window of nine: 0.2, 0.4, 0.6, 0.8."""
+        np.testing.assert_allclose(get_ramp("triang", 4), [0.2, 0.4, 0.6, 0.8])
+
+    def test_zero_length(self):
+        """No ramp is no samples."""
+        assert get_ramp("hann", 0).shape == (0,)
+        assert get_ramp("hann", 0, complementary=True).shape == (0,)
+
+    def test_triangle_is_already_complementary(self):
+        """A triangle's ramp and its reverse sum to one as built."""
+        ramp = get_ramp("triang", 5)
+        np.testing.assert_allclose(ramp + ramp[::-1], 1)
+        np.testing.assert_allclose(get_ramp("triang", 5, complementary=True), ramp)
+
+    @pytest.mark.parametrize("shape", SHAPES)
+    @pytest.mark.parametrize("length", [1, 2, 3, 7, 16])
+    def test_complementary(self, shape, length):
+        """Asked for, any shape's ramp and its reverse sum to one."""
+        ramp = get_ramp(shape, length, complementary=True)
+        np.testing.assert_allclose(ramp + ramp[::-1], 1, atol=1e-12)
+        assert np.all(ramp >= 0) and np.all(ramp <= 1)
+
+    def test_complementary_keeps_the_shape_monotone(self):
+        """Scaling does not turn a rise into a wobble."""
+        ramp = get_ramp("hann", 16, complementary=True)
+        assert np.all(np.diff(ramp) >= 0)
+
+
+class TestGetTaper:
+    """A tile of ones with ramps down every edge."""
+
+    def test_values(self):
+        """The one-dimensional taper is the ramp, ones, and the ramp reversed."""
+        taper = get_taper("triang", (8,), (3,))
+        expected = [0.25, 0.5, 0.75, 1.0, 1.0, 0.75, 0.5, 0.25]
+        np.testing.assert_allclose(taper, expected)
+        assert taper.dtype == np.float32
+
+    def test_two_dimensional_is_separable(self):
+        """The 2-D taper is the outer product of its edges."""
+        taper = get_taper("triang", (8, 8), (3, 3))
+        edge = np.array([0.25, 0.5, 0.75, 1.0, 1.0, 0.75, 0.5, 0.25])
+        np.testing.assert_allclose(taper, edge[:, None] * edge[None, :])
+
+    def test_three_dimensional(self):
+        """And so for any number of axes."""
+        taper = get_taper("hann", (6, 4, 8), (2, 1, 3))
+        assert taper.shape == (6, 4, 8)
+        assert taper[3, 2, 4] == 1.0
+
+    def test_zero_overlap_is_all_ones(self):
+        """No ramp along an axis is a boxcar along it."""
+        np.testing.assert_array_equal(
+            get_taper("hann", (8, 8), (0, 0)), np.ones((8, 8))
+        )
+
+    def test_odd_sizes_are_fine(self):
+        """A tile need not be even."""
+        assert get_taper("triang", (7, 9), (3, 4)).shape == (7, 9)
+
+    def test_copies_are_handed_out(self):
+        """Writing to one taper does not change the next."""
+        taper = get_taper("triang", (16, 16), (2, 2))
+        expected = taper.copy()
+        taper[...] = -1.0
+        np.testing.assert_array_equal(get_taper("triang", (16, 16), (2, 2)), expected)
+
+    @pytest.mark.parametrize(
+        "size,overlap,match",
+        [
+            ((16, 16), (2,), "same length"),
+            ((16, 16), (-1, 2), "non-negative"),
+            ((16, 16), (9, 2), "ramps would cross"),
+        ],
+    )
+    def test_invalid_geometry_refused(self, size, overlap, match):
+        """A taper which cannot be built says why."""
+        with pytest.raises(ParameterError, match=match):
+            get_taper("triang", size, overlap)
+
+    @pytest.mark.parametrize("shape", SHAPES)
+    @pytest.mark.parametrize(
+        "size,overlap", [(16, 7), (16, 4), (8, 1), (9, 4), (32, 15)]
+    )
+    def test_tiles_sum_to_one(self, shape, size, overlap):
+        """
+        The invariant: tiles at a stride of size - overlap blend to exactly one.
+
+        This is what lets an overlap-add of tapered tiles return the signal
+        they were cut from, and it holds for every shape, not only the
+        triangle, because the ramps are complementary.
+        """
+        taper = get_taper(shape, (size,), (overlap,))
+        stride = size - overlap
+        n_tiles = 6
+        total = np.zeros(stride * (n_tiles - 1) + size)
+        for tile in range(n_tiles):
+            total[tile * stride : tile * stride + size] += taper
+        # Away from the two ends, where no neighbour reaches.
+        np.testing.assert_allclose(total[overlap:-overlap], 1, atol=1e-6)
+
+    def test_two_dimensional_tiles_sum_to_one(self):
+        """The same in two dimensions, where the corners see four tiles."""
+        size, overlap = (8, 16), (3, 7)
+        taper = get_taper("hann", size, overlap)
+        stride = tuple(s - o for s, o in zip(size, overlap))
+        n = 4
+        total = np.zeros(tuple(st * (n - 1) + s for st, s in zip(stride, size)))
+        for i in range(n):
+            for j in range(n):
+                total[
+                    i * stride[0] : i * stride[0] + size[0],
+                    j * stride[1] : j * stride[1] + size[1],
+                ] += taper
+        inner = total[overlap[0] : -overlap[0], overlap[1] : -overlap[1]]
+        np.testing.assert_allclose(inner, 1, atol=1e-6)

--- a/tests/test_utils/test_signal.py
+++ b/tests/test_utils/test_signal.py
@@ -46,6 +46,11 @@ class TestGetWindow:
         with pytest.raises(ParameterError, match="7 samples, not 8"):
             get_window(np.ones(7), 8)
 
+    def test_scipy_parameter_errors_are_scipy_errors(self):
+        """A window scipy knows but cannot build with those parameters says why."""
+        with pytest.raises(ValueError, match="NW"):
+            get_window(("dpss", 2.5), 3)
+
     def test_unknown_name_refused(self):
         """A name nobody knows says what the options are."""
         with pytest.raises(ParameterError, match="not a known window"):
@@ -82,6 +87,11 @@ class TestGetRamp:
         ramp = get_ramp(shape, length, complementary=True)
         np.testing.assert_allclose(ramp + ramp[::-1], 1, atol=1e-12)
         assert np.all(ramp >= 0) and np.all(ramp <= 1)
+
+    def test_integer_array_ramp(self):
+        """An integer array is weights too, once complementary."""
+        ramp = get_ramp(np.arange(7), 3, complementary=True)
+        np.testing.assert_allclose(ramp + ramp[::-1], 1)
 
     def test_complementary_keeps_the_shape_monotone(self):
         """Scaling does not turn a rise into a wobble."""
@@ -120,6 +130,28 @@ class TestGetTaper:
     def test_odd_sizes_are_fine(self):
         """A tile need not be even."""
         assert get_taper("triang", (7, 9), (3, 4)).shape == (7, 9)
+
+    def test_array_window(self):
+        """An array window builds a taper, uncached."""
+        taper = get_taper(np.hanning(7), (8,), (3,))
+        assert taper.shape == (8,)
+        assert taper[4] == 1.0
+
+    def test_tuple_with_a_list_parameter(self):
+        """A scipy tuple carrying a list is not hashable, and still builds."""
+        taper = get_taper(("general_cosine", [0.5, 0.5]), (8,), (3,))
+        assert taper.shape == (8,)
+
+    def test_unknown_window_refused_even_at_zero_overlap(self):
+        """No ramp is needed, and the name is still checked."""
+        with pytest.raises(ParameterError, match="not a known window"):
+            get_taper("windowsXP", (8,), (0,))
+
+    def test_two_dimensional_is_float32_throughout(self):
+        """Edges multiply in float32, so the corner is the float32 product."""
+        taper = get_taper("triang", (8, 8), (2, 2))
+        corner = np.float32(1 / 3) * np.float32(1 / 3)
+        assert taper[0, 0] == corner
 
     def test_copies_are_handed_out(self):
         """Writing to one taper does not change the next."""

--- a/tests/test_utils/test_window.py
+++ b/tests/test_utils/test_window.py
@@ -9,6 +9,7 @@ import dascore as dc
 from dascore.exceptions import CoordError, ParameterError
 from dascore.units import percent
 from dascore.utils.misc import suppress_warnings
+from dascore.utils.patch import get_patch_window_size, get_window_axis_step
 from dascore.utils.window import Window, resolve_window
 from dascore.workflow.meta import PatchMeta
 
@@ -398,8 +399,6 @@ class TestDeprecatedResolvers:
 
     def test_get_patch_window_size(self, simple_patch):
         """The full-size tuple, as before."""
-        from dascore.utils.patch import get_patch_window_size  # noqa: PLC0415
-
         with pytest.warns(DeprecationWarning, match="resolve_window"):
             size = get_patch_window_size(simple_patch, {"time": 5}, samples=True)
         assert (
@@ -408,16 +407,12 @@ class TestDeprecatedResolvers:
 
     def test_get_patch_window_size_with_no_window(self, simple_patch):
         """As before, no dimension gives one along every axis."""
-        from dascore.utils.patch import get_patch_window_size  # noqa: PLC0415
-
         with pytest.warns(DeprecationWarning, match="resolve_window"):
             size = get_patch_window_size(simple_patch, {})
         assert size == (1,) * simple_patch.data.ndim
 
     def test_get_window_axis_step(self, random_patch):
         """Window, axis, and step, as before."""
-        from dascore.utils.patch import get_window_axis_step  # noqa: PLC0415
-
         with pytest.warns(DeprecationWarning, match="resolve_window"):
             out = get_window_axis_step(
                 random_patch, distance=16, overlap=50 * percent, samples=True

--- a/tests/test_utils/test_window.py
+++ b/tests/test_utils/test_window.py
@@ -103,14 +103,8 @@ class TestWindowSize:
             )
         assert window.size == (5,)
 
-    def test_empty_kwargs_allowed(self, simple_patch):
-        """With nothing windowed, the window is one along every axis."""
-        window = resolve_window(simple_patch, {}, allow_empty=True)
-        assert window.dims == ()
-        assert window.full_size() == (1,) * simple_patch.data.ndim
-
     def test_empty_kwargs_refused(self, simple_patch):
-        """Unless the function wants a dimension."""
+        """A windowed function wants a window."""
         with pytest.raises(ParameterError, match="at least one dimension"):
             resolve_window(simple_patch, {})
 

--- a/tests/test_utils/test_window.py
+++ b/tests/test_utils/test_window.py
@@ -406,6 +406,14 @@ class TestDeprecatedResolvers:
             size == resolve_window(simple_patch, {"time": 5}, samples=True).full_size()
         )
 
+    def test_get_patch_window_size_with_no_window(self, simple_patch):
+        """As before, no dimension gives one along every axis."""
+        from dascore.utils.patch import get_patch_window_size  # noqa: PLC0415
+
+        with pytest.warns(DeprecationWarning, match="resolve_window"):
+            size = get_patch_window_size(simple_patch, {})
+        assert size == (1,) * simple_patch.data.ndim
+
     def test_get_window_axis_step(self, random_patch):
         """Window, axis, and step, as before."""
         from dascore.utils.patch import get_window_axis_step  # noqa: PLC0415

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -252,6 +252,21 @@ class TestChangedOnPurpose:
         with pytest.raises(ParameterError, match="at least 1 samples"):
             patch.stft(time=0, samples=True, overlap=None)
 
+    def test_rolling_zero_window_is_the_resolver_s_floor(self, patch):
+        """Rolling had its own "can't be zero" check; the shared floor says it now."""
+        with pytest.raises(ParameterError, match="at least 1 samples"):
+            patch.rolling(time=0, samples=True)
+
+    def test_hampel_with_no_window_refuses(self, patch):
+        """Given no dimension, hampel used to return the data untouched."""
+        with pytest.raises(ParameterError, match="at least one dimension"):
+            patch.hampel_filter()
+
+    def test_stft_array_window_of_the_wrong_length_refused(self, patch):
+        """A 90-sample array for a 100-sample window used to be zero padded."""
+        with pytest.raises(ParameterError, match="90 samples, not 100"):
+            patch.stft(time=100, taper_window=np.ones(90), samples=True)
+
     def test_adaptive_spectral_filter_refuses_none_in_a_mapping(self, patch):
         """Raised a TypeError before; now says what to do instead."""
         with pytest.raises(ParameterError, match="leave it out"):

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -297,3 +297,64 @@ class TestEmptySelection:
         """So does every function which reads its dimensions from kwargs."""
         with pytest.raises(ParameterError, match="at least one dimension"):
             patch.median_filter()
+
+
+class TestTaperRamps:
+    """
+    The ramp each edge-tapering function builds today, pinned by value.
+
+    `Patch.taper` takes the first half of a window of 2n samples;
+    `taper_range` and the adaptive spectral filter take the first n of a
+    window of 2n + 1. The two are not the same ramp, and which one a
+    function uses is part of what it returns.
+    """
+
+    @pytest.fixture(scope="class")
+    def ones(self):
+        """A patch of ones, so the taper is the output."""
+        patch = dc.get_example_patch()
+        return patch.new(data=np.ones_like(patch.data))
+
+    def test_taper_uses_a_2n_window(self, ones):
+        """16 ms is five samples; the ramp is the first five of a triangle of ten."""
+        out = ones.taper(time=(np.timedelta64(16, "ms"), None), window_type="triang")
+        np.testing.assert_allclose(out.data[0, :5], [0.1, 0.3, 0.5, 0.7, 0.9])
+        assert out.data[0, 5] == 1.0
+
+    def test_taper_hann_uses_a_2n_window(self, ones):
+        """The same construction for hann: the first five of a hann of ten."""
+        from scipy.signal.windows import hann  # noqa: PLC0415
+
+        out = ones.taper(time=(np.timedelta64(16, "ms"), None), window_type="hann")
+        np.testing.assert_allclose(out.data[0, :5], hann(10)[:5], rtol=1e-6)
+        assert out.data[0, 5] == 1.0
+
+    def test_taper_range_uses_a_2n_plus_1_window(self, ones):
+        """Four samples of triangle from a window of nine: 0.2, 0.4, 0.6, 0.8."""
+        out = ones.taper_range(
+            time=(0, 4, 100, 104), samples=True, window_type="triang"
+        )
+        np.testing.assert_allclose(out.data[0, :5], [0.2, 0.4, 0.6, 0.8, 1.0])
+
+    def test_taper_range_hann_uses_a_2n_plus_1_window(self, ones):
+        """And for hann."""
+        out = ones.taper_range(time=(0, 4, 100, 104), samples=True, window_type="hann")
+        expected = [0.0, 0.14644661, 0.5, 0.85355339, 1.0]
+        np.testing.assert_allclose(out.data[0, :5], expected, rtol=1e-6)
+
+    def test_stft_window_is_scipy_symmetric(self, patch):
+        """Stft's whole-tile window is scipy's symmetric one."""
+        from scipy.signal.windows import hann  # noqa: PLC0415
+
+        out = patch.stft(time=8, samples=True, overlap=None)
+        # The window travels as a coordinate for istft; it is the symmetric hann.
+        np.testing.assert_allclose(
+            out.get_coord("_stft_window").values, hann(8, sym=True)
+        )
+
+    def test_adaptive_spectral_filter_ramp(self, ones):
+        """The tile taper's ramp is the 2n + 1 triangle, complementary by nature."""
+        from dascore.utils.signal import get_taper  # noqa: PLC0415
+
+        taper = get_taper("triang", (8,), (3,))
+        np.testing.assert_allclose(taper, [0.25, 0.5, 0.75, 1, 1, 0.75, 0.5, 0.25])

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -301,12 +301,12 @@ class TestEmptySelection:
 
 class TestTaperRamps:
     """
-    The ramp each edge-tapering function builds today, pinned by value.
+    The ramp each edge-tapering function builds, pinned by value.
 
-    `Patch.taper` takes the first half of a window of 2n samples;
-    `taper_range` and the adaptive spectral filter take the first n of a
-    window of 2n + 1. The two are not the same ramp, and which one a
-    function uses is part of what it returns.
+    All take the first n samples of a window of 2n + 1, so a five-sample
+    triangle is 1/6, 2/6, ... 5/6 and the plateau follows. `Patch.taper`
+    used to take the first half of a window of 2n instead (1/10, 3/10,
+    ...), and moved here on purpose: one ramp, everywhere.
     """
 
     @pytest.fixture(scope="class")
@@ -315,19 +315,23 @@ class TestTaperRamps:
         patch = dc.get_example_patch()
         return patch.new(data=np.ones_like(patch.data))
 
-    def test_taper_uses_a_2n_window(self, ones):
-        """16 ms is five samples; the ramp is the first five of a triangle of ten."""
+    def test_taper_uses_a_2n_plus_1_window(self, ones):
+        """16 ms is five samples; the ramp is the first five of a triangle of 11."""
         out = ones.taper(time=(np.timedelta64(16, "ms"), None), window_type="triang")
-        np.testing.assert_allclose(out.data[0, :5], [0.1, 0.3, 0.5, 0.7, 0.9])
-        assert out.data[0, 5] == 1.0
+        np.testing.assert_allclose(out.data[0, :6], np.arange(1, 7) / 6)
 
-    def test_taper_hann_uses_a_2n_window(self, ones):
-        """The same construction for hann: the first five of a hann of ten."""
+    def test_taper_hann_uses_a_2n_plus_1_window(self, ones):
+        """The same construction for hann: the first five of a hann of 11."""
         from scipy.signal.windows import hann  # noqa: PLC0415
 
         out = ones.taper(time=(np.timedelta64(16, "ms"), None), window_type="hann")
-        np.testing.assert_allclose(out.data[0, :5], hann(10)[:5], rtol=1e-6)
+        np.testing.assert_allclose(out.data[0, :5], hann(11)[:5], rtol=1e-6)
         assert out.data[0, 5] == 1.0
+
+    def test_taper_end_is_the_start_reversed(self, ones):
+        """The end ramp is the mirror of the start ramp."""
+        out = ones.taper(time=np.timedelta64(16, "ms"), window_type="triang")
+        np.testing.assert_allclose(out.data[0, -5:], (np.arange(1, 6) / 6)[::-1])
 
     def test_taper_range_uses_a_2n_plus_1_window(self, ones):
         """Four samples of triangle from a window of nine: 0.2, 0.4, 0.6, 0.8."""

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -15,10 +15,12 @@ import warnings
 
 import numpy as np
 import pytest
+from scipy.signal.windows import hann
 
 import dascore as dc
 from dascore.exceptions import CoordError, ParameterError
 from dascore.units import percent, s
+from dascore.utils.signal import get_taper
 
 
 @pytest.fixture(scope="module")
@@ -337,8 +339,6 @@ class TestTaperRamps:
 
     def test_taper_hann_uses_a_2n_plus_1_window(self, ones):
         """The same construction for hann: the first five of a hann of 11."""
-        from scipy.signal.windows import hann  # noqa: PLC0415
-
         out = ones.taper(time=(np.timedelta64(16, "ms"), None), window_type="hann")
         np.testing.assert_allclose(out.data[0, :5], hann(11)[:5], rtol=1e-6)
         assert out.data[0, 5] == 1.0
@@ -363,8 +363,6 @@ class TestTaperRamps:
 
     def test_stft_window_is_scipy_symmetric(self, patch):
         """Stft's whole-tile window is scipy's symmetric one."""
-        from scipy.signal.windows import hann  # noqa: PLC0415
-
         out = patch.stft(time=8, samples=True, overlap=None)
         # The window travels as a coordinate for istft; it is the symmetric hann.
         np.testing.assert_allclose(
@@ -373,7 +371,5 @@ class TestTaperRamps:
 
     def test_adaptive_spectral_filter_ramp(self, ones):
         """The tile taper's ramp is the 2n + 1 triangle, complementary by nature."""
-        from dascore.utils.signal import get_taper  # noqa: PLC0415
-
         taper = get_taper("triang", (8,), (3,))
         np.testing.assert_allclose(taper, [0.25, 0.5, 0.75, 1, 1, 0.75, 0.5, 0.25])


### PR DESCRIPTION
## Description

One place to build a window, the rising edge of one, and a tile of ones with those edges ramped down every side. DASCore had three: `Patch.taper` cut the first half of a window of `2n` through a private name registry; `taper_range` cut the first `n` of a window of `2n + 1` through the same registry; the adaptive spectral filter built its own triangular plateau taper in `utils/signal.py`; and `stft` went straight to `scipy.signal.get_window`, so a `(name, parameter)` tuple worked there and nowhere else, and DASCore's own names (`cos`, `ramp`) worked everywhere but there.

`dascore.utils.signal` now has three functions and everything builds from them:

- `get_window(window, size, *, fftbins=False)` — a DASCore name, any scipy name or `(name, parameter)` tuple, or an array of the right length. Unknown names still raise the "not a known window type" `ParameterError`, now naming scipy's names as options too.
- `get_ramp(window, length, *, complementary=False)` — the first `length` samples of a symmetric window of `2 * length + 1`. With `complementary=True` the ramp is scaled so that it and its reverse sum to one at every sample, for any shape, so overlapping tiles blend to exactly the signal between them.
- `get_taper(window, size, overlap)` — an N-dimensional tile of ones with complementary ramps of `overlap` samples down every edge; cached, copies handed out. This is the adaptive spectral filter's taper, generalized from "triangle, one or two dimensions, even sizes" to any shape, any number of axes, any size. `_triangular_taper` is deleted.

This is PR 2 of the windowing plan (top-level `.scratch/windowing-unification-plan.md`), and it changes one output, on purpose (below). `TestTaperRamps` in `tests/test_utils/test_window_parity.py` pins what each function returns — `taper_range`'s four-sample triangle from a window of nine (`0.2, 0.4, …`), `stft`'s symmetric hann, the filter's `0.25, 0.5, 0.75`, all unchanged and passed on `dev` first — and `Patch.taper`'s new ramp. The adaptive spectral filter still matches Lightguide to 3.5e-7 over 96 window/overlap/exponent cases on both engines.

The invariant the new builder is tested on: for six shapes from boxcar to blackman and five window/overlap pairs, tiles laid at a stride of `size - overlap` and multiplied by the taper sum to one everywhere they cover, in one and two dimensions. A triangle's ramp is complementary as built, which is why the filter's output is unchanged; every other shape becomes so by `r / (r + r[::-1])`.

### One change on purpose

`Patch.taper` cut its ramp from a window of `2n`; `taper_range` and the tile tapers cut theirs from `2n + 1`. For a five-sample triangle that was `0.1, 0.3, 0.5, 0.7, 0.9` against `0.2, 0.4, 0.6, 0.8, 1.0`. `Patch.taper` now cuts as the others do — one ramp, everywhere — and the largest change to any result is the first tapered sample, about one part in `2n` of full scale, at the end of the data the taper exists to quiet. `TestTaperRamps` pins the new values and says what the old ones were.

### Codex review

No P1s. Fixed: an array window or a scipy tuple carrying a list could not key the taper cache and raised as unhashable (now built uncached); an integer array could not be made complementary; a misspelled window was accepted whenever the overlap was zero (the ramp is now built regardless, so the name is checked); scipy's own parameter errors (`("dpss", 2.5)` at 3 samples) were relabelled as unknown windows; and the 2-D taper multiplied its edges in float64 where the old one used float32, a one-ulp difference the filter can now see nowhere. Not changed: `Patch.taper` given both a bad range and a bad window name used to complain about the name first and now the range — both are still refused, and the order on doubly-invalid input is not worth a throwaway window build to preserve.

### Four small breaks, on purpose

The branch is `dev`, so the warts this work exposed are fixed rather than preserved, each pinned in `TestChangedOnPurpose`:

- `hampel_filter()` with no dimension returned the data untouched; it now refuses like every other windowed function, and `resolve_window` loses the `allow_empty` policy which existed for that case alone.
- `rolling(time=0)` had its own "can't be zero" check; the shared floor's message says it now.
- `stft` given an array window of the wrong length zero padded it (documented as "artificial enriching of frequency resolution"); it is now refused by count.
- `WINDOW_FUNCTIONS`, a table of lazy scipy imports, is `WINDOW_NAMES`, a map of the documented names to scipy's. A bare name scipy refuses for any reason — unknown, or needing a parameter — is a `ParameterError` naming the options and carrying scipy's reason; a `(name, parameter)` tuple's error stays scipy's. This is what fixes CI: scipy 1.16 and newer word the unknown-name error differently, and the first cut told them apart by the words.

## Changelog

- changed: `Patch.taper` cuts its ramp from a window of `2n + 1` samples like `taper_range`, rather than `2n`; results differ by at most about one part in `2n` at the first tapered sample.
- changed: `hampel_filter` with no dimension keyword raises `ParameterError` instead of returning the data unchanged.
- changed: `stft` refuses an array `taper_window` whose length is not the window's, rather than zero padding it.
- removed: `dascore.utils.signal.WINDOW_FUNCTIONS`; `WINDOW_NAMES` lists the documented window names.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.

