### PR TITLE
Give stft an FFT length, and draw the spectrogram with it

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -855,13 +855,6 @@ class CoordManager(RichRepr, DascoreBaseModel):
             name: (self.dim_map[name], coord) for name, coord in self.coord_map.items()
         }
 
-    def _get_dim_array_dict(self) -> dict[str, tuple[tuple[str, ...], ArrayLike]]:
-        """Get the coord map in the form {coord_name: ((dims,), array)}."""
-        return {
-            name: (dims, coord.data)
-            for name, (dims, coord) in self._get_dim_coord_dict().items()
-        }
-
     def _replace_coords(self, new_coords: dict) -> Self:
         """
         Return a manager with these coords replaced, or self if none are.

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -585,8 +585,8 @@ def stft(
     taper_window: str | ndarray | tuple[str | Any, ...] = "hann",
     overlap: Quantity | int | None = 50 * percent,
     samples: bool = False,
-    nfft: int | Quantity | np.timedelta64 | None = None,
     detrend: bool = False,
+    nfft: int | Quantity | np.timedelta64 | None = None,
     **kwargs,
 ):
     """
@@ -608,6 +608,10 @@ def stft(
     samples
         If True, the window length (provided in kwargs) and overlap parameters
         are in samples (or explicit units).
+    detrend
+        If True, detrend each time window before performing fourier transform.
+        This can lead to nicer looking spectrograms, but means the istft is
+        no longer possible.
     nfft
         The length of the FFT taken of each window, in samples, or as a
         quantity or timedelta in the transformed dimension's units. None, the default,
@@ -615,10 +619,6 @@ def stft(
         samples the same spectrum at more, closer frequencies; it adds no
         resolution, since the window holds no more data. Must be at least
         the window length.
-    detrend
-        If True, detrend each time window before performing fourier transform.
-        This can lead to nicer looking spectrograms, but means the istft is
-        no longer possible.
     **kwargs
         Used to specify window length in data units, percent, or samples.
 

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -563,7 +563,13 @@ def _resolve_nfft(nfft, coord, window_samples: int) -> int:
     """
     if nfft is None:
         return window_samples
-    count = coord.get_sample_count(nfft) if isinstance(nfft, Quantity) else int(nfft)
+    if isinstance(nfft, Quantity | np.timedelta64):
+        count = coord.get_sample_count(nfft)
+    elif isinstance(nfft, int | np.integer):
+        count = int(nfft)
+    else:
+        msg = f"nfft must be a whole number of samples or a quantity; got {nfft!r}."
+        raise ParameterError(msg)
     if count < window_samples:
         msg = (
             f"nfft must be at least the window length; a {count} point FFT of "
@@ -579,7 +585,7 @@ def stft(
     taper_window: str | ndarray | tuple[str | Any, ...] = "hann",
     overlap: Quantity | int | None = 50 * percent,
     samples: bool = False,
-    nfft: int | Quantity | None = None,
+    nfft: int | Quantity | np.timedelta64 | None = None,
     detrend: bool = False,
     **kwargs,
 ):
@@ -604,7 +610,7 @@ def stft(
         are in samples (or explicit units).
     nfft
         The length of the FFT taken of each window, in samples, or as a
-        quantity with units of the transformed dimension. None, the default,
+        quantity or timedelta in the transformed dimension's units. None, the default,
         is the window length. A longer FFT zero pads each window, which
         samples the same spectrum at more, closer frequencies; it adds no
         resolution, since the window holds no more data. Must be at least

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -554,12 +554,32 @@ def _get_stft_coords(patch, dim, axis, coord, stft, window):
     return out
 
 
+def _resolve_nfft(nfft, coord, window_samples: int) -> int:
+    """
+    Return the FFT length in samples: the window's, or a longer one to pad to.
+
+    A bare number is a sample count whatever `samples` said; a quantity is
+    read through the coordinate.
+    """
+    if nfft is None:
+        return window_samples
+    count = coord.get_sample_count(nfft) if isinstance(nfft, Quantity) else int(nfft)
+    if count < window_samples:
+        msg = (
+            f"nfft must be at least the window length; a {count} point FFT of "
+            f"a {window_samples} sample window would drop data."
+        )
+        raise ParameterError(msg)
+    return count
+
+
 @patch_function(data_type="fourier_transform")
 def stft(
     patch: PatchType,
     taper_window: str | ndarray | tuple[str | Any, ...] = "hann",
     overlap: Quantity | int | None = 50 * percent,
     samples: bool = False,
+    nfft: int | Quantity | None = None,
     detrend: bool = False,
     **kwargs,
 ):
@@ -582,6 +602,13 @@ def stft(
     samples
         If True, the window length (provided in kwargs) and overlap parameters
         are in samples (or explicit units).
+    nfft
+        The length of the FFT taken of each window, in samples, or as a
+        quantity with units of the transformed dimension. None, the default,
+        is the window length. A longer FFT zero pads each window, which
+        samples the same spectrum at more, closer frequencies; it adds no
+        resolution, since the window holds no more data. Must be at least
+        the window length.
     detrend
         If True, detrend each time window before performing fourier transform.
         This can lead to nicer looking spectrograms, but means the istft is
@@ -605,6 +632,9 @@ def stft(
     >>> # Using a custom window array and specifying window/overlap in samples.
     >>> window = get_window(("tukey", 0.1), 1000)
     >>> pa2 = patch.stft(time=1000, taper_window=window, overlap=100, samples=True)
+    >>>
+    >>> # Zero pad each 1000 sample window to a 4096 point FFT.
+    >>> pa3 = patch.stft(time=1000, samples=True, nfft=4096)
 
     Notes
     -----
@@ -613,7 +643,8 @@ def stft(
       (unless a boxcar window is used) because the taper window changes the time
       series signal before the transformation.
     - An array passed for taper_window must have as many samples as the
-      window; one of another length is refused.
+      window; one of another length is refused. To zero pad each window's
+      FFT, give `nfft`.
     - Non-dimensional coordinates associated with transformed coordinates
       are dropped in the output.
 
@@ -636,6 +667,7 @@ def stft(
     hop = window_samples if resolved.stride is None else resolved.stride[0]
     sampling_rate = 1 / abs(dc.to_float(coord.step))
     window = get_window(taper_window, window_samples)
+    nfft = _resolve_nfft(nfft, coord, window_samples)
     # Perform stft
     fft_mode = "onesided" if np.isrealobj(patch.data) else "centered"
     stft = ShortTimeFFT(
@@ -643,7 +675,7 @@ def stft(
         hop=hop,
         fs=sampling_rate,
         fft_mode=fft_mode,
-        mfft=window_samples,
+        mfft=nfft,
     )
     func = stft.stft if not detrend else partial(stft.stft_detrend, detr="linear")
     # For compatibility with dft, we scale by step. See the DFT note for why.
@@ -659,7 +691,7 @@ def stft(
         "_stft_sampling_rate": sampling_rate,
         "_stft_detrended": detrend,
         "_stft_fft_mode": fft_mode,
-        "_stft_mfft": window_samples,
+        "_stft_mfft": nfft,
         "_stft_performed": True,
         "_pre_stft_data_type": patch.attrs.get("data_type"),
         "data_units": _get_data_units_from_dims(patch, dim, mul),

--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -1,26 +1,16 @@
-"""A spectrogram visualization."""
+"""A spectrogram visualization: a short-time Fourier transform, drawn."""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Literal
+from typing import Any, Literal
 
 import matplotlib.pyplot as plt
-import numpy as np
-from scipy.signal import spectrogram as scipy_spectrogram
 
 from dascore.constants import PatchType
-from dascore.core.attrs import PatchAttrs
-from dascore.core.coordmanager import get_coord_manager
-from dascore.core.coords import get_compatible_values, get_coord
-from dascore.units import invert_quantity
-from dascore.utils.misc import iterate
-from dascore.utils.patch import (
-    _get_data_units_from_dims,
-    _get_dx_or_spacing_and_axes,
-    patch_function,
-)
-from dascore.utils.transformatter import FourierTransformatter
+from dascore.exceptions import ParameterError
+from dascore.units import Quantity, percent
+from dascore.utils.patch import patch_function
 
 
 def _get_other_dim(dim, dims):
@@ -34,47 +24,28 @@ def _get_other_dim(dim, dims):
         return dims[0] if dims[1] == dim else dims[1]
 
 
-def _get_new_original_coord(old_coord, array):
-    """Get a new coordinate for original axis (eg time)."""
-    old_min = get_compatible_values(old_coord.min(), array.dtype)
-    is_dt = np.issubdtype(old_coord.dtype, np.datetime64)
-    val_dtype = np.timedelta64 if is_dt else old_coord.dtype
-    vals = get_compatible_values(array, val_dtype)
-    return get_coord(data=old_min + vals, units=old_coord.units)
+def _spectrogram_patch(patch: PatchType, dim: str, aggr_domain: str, **stft_kwargs):
+    """
+    Return the power the spectrogram draws: |STFT|², one other dimension averaged.
 
-
-def _get_transformed_coord(coord, freqs):
-    """Get the transformed coordinates."""
-    return get_coord(data=freqs, units=invert_quantity(coord.units))
-
-
-def _get_new_dims(patch, dim, new_coord_name):
-    """Get the new dimension tuple."""
-    dims = list(patch.dims)
-    dims[dims.index(dim)] = new_coord_name
-    return tuple([*dims, dim])
-
-
-def _spectrogram_patch(patch: PatchType, dim: str = "time", **kwargs) -> PatchType:
-    """Create a spectrogram patch for visualization."""
-    assert len(iterate(dim)) == 1, "only one dimension allowed."
-    coord = patch.get_coord(dim)
-    dxs, axes = _get_dx_or_spacing_and_axes(patch, dim, require_evenly_spaced=True)
-    new_coord_name = FourierTransformatter().rename_dims(dim)[0]
-    out_coords = patch.coords._get_dim_array_dict()
-    freqs, original, spec = scipy_spectrogram(
-        patch.data,
-        fs=1 / dxs[0],
-        axis=axes[0],
-        **kwargs,
-    )
-    out_coords[dim] = _get_new_original_coord(coord, original)
-    out_coords[new_coord_name] = _get_transformed_coord(coord, freqs)
-    new_dims = _get_new_dims(patch, dim, new_coord_name)
-    cm = get_coord_manager(out_coords, dims=tuple(new_dims))
-    attrs = dict(patch.attrs)
-    attrs["data_units"] = _get_data_units_from_dims(patch, dim, np.multiply)
-    return patch.__class__(data=spec, attrs=PatchAttrs(**attrs), coords=cm)
+    The other dimension is averaged before the transform (`aggr_domain="time"`)
+    or after it (`"frequency"`); a one-sample dimension is squeezed either way.
+    """
+    other_dim = _get_other_dim(dim, patch.dims)
+    if other_dim is None:
+        return patch.stft(**stft_kwargs).abs() ** 2
+    if aggr_domain == "time":
+        averaged = patch.aggregate(other_dim, method="mean", dim_reduce="squeeze")
+        return averaged.stft(**stft_kwargs).abs() ** 2
+    if aggr_domain == "frequency":
+        power = (patch.stft(**stft_kwargs).abs() ** 2).squeeze()
+        # A length one other_dim is squeezed out above, and a dimension
+        # of one sample has nothing to average over anyway.
+        if other_dim in power.dims:
+            power = power.aggregate(other_dim, method="mean").squeeze()
+        return power
+    msg = f"The aggr_domain '{aggr_domain}' should be 'time' or 'frequency'."
+    raise ValueError(msg)
 
 
 @patch_function()
@@ -88,6 +59,11 @@ def spectrogram(
     scale_type: Literal["relative", "absolute"] = "relative",
     log=False,
     show=False,
+    *,
+    taper_window: Any = "hann",
+    overlap: Quantity | int | None = 50 * percent,
+    nfft: int | Quantity | None = None,
+    samples: bool = False,
     **kwargs,
 ) -> plt.Axes:
     """
@@ -122,9 +98,13 @@ def spectrogram(
         If True, visualize the common logarithm of the absolute values of patch data.
     show : bool, optional
         If True, show the plot. Otherwise, just return the axis.
-    **kwargs : dict, optional
-        Passed to `scipy.signal.spectrogram` to control spectrogram options.
-        See its documentation for options.
+    taper_window, overlap, nfft, samples
+        Passed to [Patch.stft](`dascore.Patch.stft`), and read as it reads them.
+    **kwargs
+        The window, as [Patch.stft](`dascore.Patch.stft`) takes it: the
+        dimension and its length, such as ``time=0.5`` (seconds) or
+        ``time=256, samples=True``. With none given, a 256 sample window along
+        `dim`.
 
     Examples
     --------
@@ -133,29 +113,42 @@ def spectrogram(
     >>>
     >>> # Create a spectrogram plot
     >>> ax = patch.viz.spectrogram(show=False)
+    >>>
+    >>> # Half second windows, zero padded to 512 point FFTs, log colours.
+    >>> ax = patch.viz.spectrogram(time=0.5, nfft=512, log=True)
+
+    Notes
+    -----
+    This is [Patch.stft](`dascore.Patch.stft`) followed by
+    [Patch.viz.waterfall](`dascore.Patch.viz.waterfall`), with one other
+    dimension averaged away. The values drawn are |STFT|² in the scaling
+    `stft` uses, which is `dft`'s; an earlier version called
+    `scipy.signal.spectrogram` directly, whose power spectral density differs
+    from this by a constant and which took scipy's own argument names
+    (`nperseg`, `noverlap`). Window, overlap, taper and FFT length are now
+    spelled as `stft` spells them.
     """
     dims = patch.dims
     if len(dims) > 2 or len(dims) < 1:
         raise ValueError("Can only make spectrogram of 1D or 2D patches.")
-
-    other_dim = _get_other_dim(dim, dims)
-    if other_dim is not None:
-        if aggr_domain == "time":
-            patch_aggr = patch.aggregate(other_dim, method="mean", dim_reduce="squeeze")
-            spec = _spectrogram_patch(patch_aggr, dim, **kwargs)
-        elif aggr_domain == "frequency":
-            _spec = _spectrogram_patch(patch, dim, **kwargs).squeeze()
-            # A length one other_dim is squeezed out above, and a dimension
-            # of one sample has nothing to average over anyway.
-            if other_dim in _spec.dims:
-                _spec = _spec.aggregate(other_dim, method="mean").squeeze()
-            spec = _spec
-        else:
-            raise ValueError(
-                f"The aggr_domain '{aggr_domain}' should be 'time' or 'frequency'."
-            )
-    else:
-        spec = _spectrogram_patch(patch, dim, **kwargs)
+    if not kwargs:
+        kwargs, samples = {dim: 256}, True
+    elif dim not in kwargs:
+        msg = (
+            f"The window is given along {sorted(kwargs)} but the spectrogram is "
+            f"of {dim!r}; give the window as {dim}=..."
+        )
+        raise ParameterError(msg)
+    spec = _spectrogram_patch(
+        patch,
+        dim,
+        aggr_domain,
+        taper_window=taper_window,
+        overlap=overlap,
+        nfft=nfft,
+        samples=samples,
+        **kwargs,
+    )
     return spec.viz.waterfall(
         ax=ax, cmap=cmap, scale=scale, scale_type=scale_type, log=log, show=show
     )

--- a/dascore/viz/spectrogram.py
+++ b/dascore/viz/spectrogram.py
@@ -24,14 +24,15 @@ def _get_other_dim(dim, dims):
         return dims[0] if dims[1] == dim else dims[1]
 
 
-def _spectrogram_patch(patch: PatchType, dim: str, aggr_domain: str, **stft_kwargs):
+def _spectrogram_patch(
+    patch: PatchType, dim: str, other_dim: str | None, aggr_domain: str, **stft_kwargs
+):
     """
     Return the power the spectrogram draws: |STFT|², one other dimension averaged.
 
     The other dimension is averaged before the transform (`aggr_domain="time"`)
     or after it (`"frequency"`); a one-sample dimension is squeezed either way.
     """
-    other_dim = _get_other_dim(dim, patch.dims)
     if other_dim is None:
         return patch.stft(**stft_kwargs).abs() ** 2
     if aggr_domain == "time":
@@ -64,6 +65,7 @@ def spectrogram(
     overlap: Quantity | int | None = 50 * percent,
     nfft: int | Quantity | None = None,
     samples: bool = False,
+    detrend: bool = False,
     **kwargs,
 ) -> plt.Axes:
     """
@@ -98,7 +100,7 @@ def spectrogram(
         If True, visualize the common logarithm of the absolute values of patch data.
     show : bool, optional
         If True, show the plot. Otherwise, just return the axis.
-    taper_window, overlap, nfft, samples
+    taper_window, overlap, nfft, samples, detrend
         Passed to [Patch.stft](`dascore.Patch.stft`), and read as it reads them.
     **kwargs
         The window, as [Patch.stft](`dascore.Patch.stft`) takes it: the
@@ -121,18 +123,24 @@ def spectrogram(
     -----
     This is [Patch.stft](`dascore.Patch.stft`) followed by
     [Patch.viz.waterfall](`dascore.Patch.viz.waterfall`), with one other
-    dimension averaged away. The values drawn are |STFT|² in the scaling
-    `stft` uses, which is `dft`'s; an earlier version called
-    `scipy.signal.spectrogram` directly, whose power spectral density differs
-    from this by a constant and which took scipy's own argument names
-    (`nperseg`, `noverlap`). Window, overlap, taper and FFT length are now
-    spelled as `stft` spells them.
+    dimension averaged away, and the values drawn are |STFT|² in the scaling
+    `stft` uses. Before DASCore 0.1.22 it called `scipy.signal.spectrogram`
+    directly, which differed in more than scaling: it removed the mean of
+    each window (`detrend="constant"`), tapered with a ``("tukey", 0.25)``
+    window, overlapped by an eighth of the window, took no windows past the
+    ends of the data, and spelled its arguments as scipy does (`nperseg`,
+    `noverlap`). Now the taper is hann, the overlap half, windows reach the
+    ends as `stft`'s do, nothing is detrended unless `detrend=True` is
+    passed through, and the window, overlap, taper and FFT length are given
+    as `stft` takes them.
     """
     dims = patch.dims
     if len(dims) > 2 or len(dims) < 1:
         raise ValueError("Can only make spectrogram of 1D or 2D patches.")
+    other_dim = _get_other_dim(dim, dims)
     if not kwargs:
-        kwargs, samples = {dim: 256}, True
+        # scipy's old default, or the whole of a shorter patch.
+        kwargs, samples = {dim: min(256, len(patch.get_coord(dim)))}, True
     elif dim not in kwargs:
         msg = (
             f"The window is given along {sorted(kwargs)} but the spectrogram is "
@@ -142,11 +150,13 @@ def spectrogram(
     spec = _spectrogram_patch(
         patch,
         dim,
+        other_dim,
         aggr_domain,
         taper_window=taper_window,
         overlap=overlap,
         nfft=nfft,
         samples=samples,
+        detrend=detrend,
         **kwargs,
     )
     return spec.viz.waterfall(

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -612,6 +612,45 @@ class TestSTFT:
         out = random_patch.stft(time=1, overlap=None)
         assert isinstance(out, dc.Patch)
 
+    def test_nfft_adds_bins(self, random_patch):
+        """A longer FFT samples the spectrum at more, closer frequencies."""
+        plain = random_patch.stft(time=100, samples=True)
+        padded = random_patch.stft(time=100, samples=True, nfft=256)
+        assert len(padded.get_coord("ft_time")) == 256 // 2 + 1
+        rate = padded.attrs["_stft_sampling_rate"]
+        assert float(padded.get_coord("ft_time").step) == pytest.approx(rate / 256)
+        # The window and hop are untouched; only the FFT of each window grew.
+        assert padded.attrs["_stft_hop"] == plain.attrs["_stft_hop"]
+        assert padded.get_coord("time") == plain.get_coord("time")
+        assert padded.attrs["_stft_mfft"] == 256
+
+    def test_nfft_default_is_the_window(self, random_patch):
+        """None means the window length, which is what stft always did."""
+        plain = random_patch.stft(time=100, samples=True)
+        explicit = random_patch.stft(time=100, samples=True, nfft=None)
+        assert plain.attrs["_stft_mfft"] == 100
+        assert explicit.equals(plain)
+
+    def test_nfft_in_units(self, random_patch):
+        """A quantity is read through the coordinate, whatever samples says."""
+        by_count = random_patch.stft(time=100, samples=True, nfft=256)
+        by_units = random_patch.stft(time=100, samples=True, nfft=1.024 * second)
+        assert by_units.attrs["_stft_mfft"] == 256
+        assert by_units.equals(by_count)
+
+    def test_nfft_below_window_refused(self, random_patch):
+        """A shorter FFT would drop data, which is not a transform."""
+        with pytest.raises(ParameterError, match="at least the window length"):
+            random_patch.stft(time=100, samples=True, nfft=50)
+
+    def test_nfft_is_interpolation(self, random_patch):
+        """Padding adds bins between the old ones; the old ones are unchanged."""
+        plain = random_patch.stft(time=100, samples=True)
+        padded = random_patch.stft(time=100, samples=True, nfft=200)
+        axis = padded.get_axis("ft_time")
+        every_other = np.take(padded.data, np.arange(0, 101, 2), axis=axis)
+        assert np.allclose(every_other, plain.data)
+
     def test_non_dim_coord_associated_with_transform(self):
         """See #611."""
         patch = dc.get_example_patch("random_das", shape=(10, 200))
@@ -659,6 +698,13 @@ class TestInverseSTFT:
         stft = patch.stft(time=1)
         istft = stft.istft()
         assert patch.equals(istft, close=True)
+
+    def test_round_trip_with_nfft(self, random_patch):
+        """A padded FFT inverts to the same data; the padding is dropped."""
+        pa1 = random_patch.stft(time=100, samples=True, nfft=256)
+        pa2 = pa1.istft()
+        assert pa2.equals(random_patch, close=True)
+        assert not any(k.startswith("_stft") for k in dict(pa2.attrs))
 
     def test_non_transformed_raises(self, random_patch):
         """Test that a patch that hasn't undergone stft can't be used."""

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -638,6 +638,16 @@ class TestSTFT:
         assert by_units.attrs["_stft_mfft"] == 256
         assert by_units.equals(by_count)
 
+    def test_nfft_as_a_timedelta(self, random_patch):
+        """A native duration is read through the coordinate like a quantity."""
+        out = random_patch.stft(time=100, samples=True, nfft=np.timedelta64(1024, "ms"))
+        assert out.attrs["_stft_mfft"] == 256
+
+    def test_fractional_nfft_refused(self, random_patch):
+        """256.9 points is not an FFT length; it is not rounded quietly."""
+        with pytest.raises(ParameterError, match="whole number of samples"):
+            random_patch.stft(time=100, samples=True, nfft=256.9)
+
     def test_nfft_below_window_refused(self, random_patch):
         """A shorter FFT would drop data, which is not a transform."""
         with pytest.raises(ParameterError, match="at least the window length"):

--- a/tests/test_viz/test_spectrogram.py
+++ b/tests/test_viz/test_spectrogram.py
@@ -126,6 +126,17 @@ class TestPlotSpectrogram:
         padded = random_patch.viz.spectrogram(time=64, samples=True, nfft=256)
         assert self._image_shape(padded)[0] > self._image_shape(plain)[0]
 
+    def test_short_patch_takes_the_whole_of_itself(self, random_patch):
+        """A patch shorter than the 256 sample default is one window."""
+        short = random_patch.select(time=(0, 100), samples=True)
+        axis = short.viz.spectrogram()
+        assert isinstance(axis, plt.Axes)
+
+    def test_detrend_passes_through(self, random_patch):
+        """Detrending each window is stft's, reached from here."""
+        axis = random_patch.viz.spectrogram(time=64, samples=True, detrend=True)
+        assert isinstance(axis, plt.Axes)
+
     def test_scipy_spelling_refused(self, random_patch):
         """Scipy's nperseg is not a dimension; the window is time=..."""
         with pytest.raises(ParameterError, match="give the window as time="):
@@ -135,7 +146,7 @@ class TestPlotSpectrogram:
     def test_is_stft_squared(self, random_patch, aggr_domain):
         """What is drawn is |stft|² with the other dimension averaged."""
         power = _spectrogram_patch(
-            random_patch, "time", aggr_domain, time=64, samples=True
+            random_patch, "time", "distance", aggr_domain, time=64, samples=True
         )
         if aggr_domain == "time":
             averaged = random_patch.aggregate("distance", method="mean")

--- a/tests/test_viz/test_spectrogram.py
+++ b/tests/test_viz/test_spectrogram.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
-from dascore.viz.spectrogram import _get_other_dim
+from dascore.exceptions import ParameterError
+from dascore.viz.spectrogram import _get_other_dim, _spectrogram_patch
 
 
 def test_get_other_dim_valid():
@@ -103,17 +105,43 @@ class TestPlotSpectrogram:
         return axis.collections[0].get_array().shape
 
     @pytest.mark.parametrize("aggr_domain", ["frequency", "time"])
-    def test_kwargs_passed_to_spectrogram_2d(self, random_patch, aggr_domain):
-        """Ensure kwargs (e.g. nperseg) reach scipy for 2D patches. See #661."""
+    def test_window_reaches_stft_2d(self, random_patch, aggr_domain):
+        """The window is stft's, and changes the picture. See #661."""
         default = random_patch.viz.spectrogram(dim="time", aggr_domain=aggr_domain)
         windowed = random_patch.viz.spectrogram(
-            dim="time", aggr_domain=aggr_domain, nperseg=64
+            dim="time", aggr_domain=aggr_domain, time=64, samples=True
         )
         assert self._image_shape(default) != self._image_shape(windowed)
 
-    def test_kwargs_passed_to_spectrogram_1d(self, random_patch):
-        """Ensure kwargs reach scipy for 1D patches as well. See #661."""
+    def test_window_reaches_stft_1d(self, random_patch):
+        """And for a single trace. See #661."""
         patch = random_patch.select(distance=0, samples=True).squeeze()
         default = patch.viz.spectrogram(dim="time")
-        windowed = patch.viz.spectrogram(dim="time", nperseg=64)
+        windowed = patch.viz.spectrogram(dim="time", time=64, samples=True)
         assert self._image_shape(default) != self._image_shape(windowed)
+
+    def test_nfft_adds_frequency_rows(self, random_patch):
+        """A longer FFT draws more frequency rows for the same window."""
+        plain = random_patch.viz.spectrogram(time=64, samples=True)
+        padded = random_patch.viz.spectrogram(time=64, samples=True, nfft=256)
+        assert self._image_shape(padded)[0] > self._image_shape(plain)[0]
+
+    def test_scipy_spelling_refused(self, random_patch):
+        """Scipy's nperseg is not a dimension; the window is time=..."""
+        with pytest.raises(ParameterError, match="give the window as time="):
+            random_patch.viz.spectrogram(nperseg=64)
+
+    @pytest.mark.parametrize("aggr_domain", ["frequency", "time"])
+    def test_is_stft_squared(self, random_patch, aggr_domain):
+        """What is drawn is |stft|² with the other dimension averaged."""
+        power = _spectrogram_patch(
+            random_patch, "time", aggr_domain, time=64, samples=True
+        )
+        if aggr_domain == "time":
+            averaged = random_patch.aggregate("distance", method="mean")
+            expected = averaged.stft(time=64, samples=True).abs() ** 2
+        else:
+            power_2d = random_patch.stft(time=64, samples=True).abs() ** 2
+            expected = power_2d.aggregate("distance", method="mean")
+        expected = expected.squeeze()
+        assert np.allclose(power.data, expected.data)


### PR DESCRIPTION
## Description

Two things, one reason.

**`nfft` on `Patch.stft`.** Until #1083 the only way to zero pad each window's FFT was to pass an array `taper_window` shorter than the window: scipy took the array's length as the real window, shortened it, removed the overlap, and padded the FFT to the length DASCore had computed — silently. #1083 refused the mismatched array; this gives the padding an honest spelling. `nfft` is the FFT length of each window: a bare number is a sample count whatever `samples` says, a quantity (`1.024 * s`) is read through the coordinate, `None` is the window length as before. It goes to scipy as `mfft` and into `_stft_mfft`, so `istft` round-trips unchanged. Shorter than the window is refused — that would drop data. The docstring says what it buys: more, closer frequency bins of the same spectrum, not more resolution; the test `test_nfft_is_interpolation` pins that (every other bin of `nfft=200` is `nfft=100`).

**`Patch.viz.spectrogram` is now `stft` followed by `waterfall`.** It called legacy `scipy.signal.spectrogram` directly — the one window path left that took scipy's argument names (`nperseg`, `noverlap`, `nfft`, sample counts only) rather than DASCore's, and whose values differed from `stft`'s by a scaling constant. Derrick asked (2026-08-28) that it be kept as the one-call plot but built on `stft`, in this PR. It now takes the window as `stft` does (`time=0.5`, or `time=256, samples=True`; a 256-sample window along `dim` when none is given, scipy's old default), plus `taper_window`, `overlap`, `nfft`, and `samples` passed straight through; `aggr_domain` and the plotting arguments are unchanged. The values drawn are `|STFT|²` in `stft`'s scaling. A note in the docstring says this is what was done and what else changed with it, because it is more than scaling: scipy's spectrogram removed each window's mean (`detrend="constant"`), tapered with `("tukey", 0.25)`, overlapped by an eighth of the window, and took no windows past the ends; now the taper is hann, the overlap half, windows reach the ends as `stft`'s do, and nothing is detrended unless `detrend=True` is passed through. A patch shorter than the 256-sample default is one window. The private scipy-shaped helpers are deleted; `test_is_stft_squared` asserts the drawn power equals `patch.stft(...).abs() ** 2` averaged the same way, so the two can never disagree again.

Not touched, and why: `dft` pads to the next fast length and composes with `Patch.pad` for a specific length; `dispersion_phase_shift` has `approx_resolution`, the same idea in Hz.

### Codex review

No P1s. Fixed: a patch shorter than 256 samples could not use the default window (now `min(256, len)`); a fractional `nfft` was truncated by `int()` (now refused); a `np.timedelta64` `nfft` raised a `TypeError` (now read through the coordinate like a quantity); and the docstring's claim that the old spectrogram differed "by a constant" understated it — the detrending, taper, overlap and boundary differences above are now stated, and `detrend` is passed through.

## Changelog

- added: `nfft` argument on `Patch.stft`, the FFT length of each window in samples (or a quantity in the dimension's units); longer than the window zero pads.
- changed: `Patch.viz.spectrogram` is built on `Patch.stft` and takes its window, `taper_window`, `overlap`, `nfft`, and `samples` arguments; the values drawn are `|STFT|²`; scipy's `nperseg`/`noverlap` are no longer accepted.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Spectrograms now support configurable taper windows, overlap, FFT length, sample-based windows, and detrending.
  - Added support for specifying FFT length using durations, timedeltas, or integer values.
  - Spectrogram aggregation and visualization now provide consistent results across time and frequency dimensions.
  - Short signals and padded FFTs are handled more reliably.

- **Bug Fixes**
  - Invalid FFT and aggregation values now produce clear parameter errors.
  - Inverse STFT processing preserves original data after padded transforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
