### PR TITLE
Cut and blend tiles in one place, and write the filter on it

### DIFF
--- a/dascore/proc/_adaptive_spectral_filter_numba.py
+++ b/dascore/proc/_adaptive_spectral_filter_numba.py
@@ -16,12 +16,11 @@ from __future__ import annotations
 import numpy as np
 
 from dascore.proc.adaptive_spectral_filter import (
+    _plan_and_taper,
     _restore_dtype,
     _validate_filter_inputs,
 )
 from dascore.utils.jit import maybe_numba_jit
-from dascore.utils.signal import get_taper
-from dascore.utils.tiles import get_tile_plan
 
 
 # fastmath is intentional: the weighting is approximate, and tests allow small
@@ -102,13 +101,10 @@ def _adaptive_spectral_filter_numba(
     if data.ndim != 2:
         msg = "The numba engine filters two-dimensional arrays only."
         raise ValueError(msg)
-    stride = tuple(win - over for win, over in zip(window_size, overlap))
-    plan = get_tile_plan(data.shape, window_size, stride)
-    taper = get_taper("triang", window_size, overlap)
+    plan, taper = _plan_and_taper(data, window_size, overlap)
     # The buffer is long enough for every tile to be whole, so the kernel
     # slices without checking the edges.
-    padded = np.zeros(plan.extended, dtype=np.float32)
-    padded[plan._inner()] = data
+    padded = plan.pad(data, dtype=np.float32)
     filtered = np.zeros_like(padded)
     for colour0 in range(plan.colours[0]):
         for colour1 in range(plan.colours[1]):
@@ -117,7 +113,7 @@ def _adaptive_spectral_filter_numba(
                 filtered,
                 taper,
                 *window_size,
-                *stride,
+                *plan.stride,
                 *plan.grid,
                 *plan.colours,
                 colour0,
@@ -125,4 +121,4 @@ def _adaptive_spectral_filter_numba(
                 float(exponent),
                 bool(normalize_power),
             )
-    return _restore_dtype(filtered[plan._inner()], data.dtype)
+    return _restore_dtype(plan.crop(filtered), data.dtype)

--- a/dascore/proc/_adaptive_spectral_filter_numba.py
+++ b/dascore/proc/_adaptive_spectral_filter_numba.py
@@ -3,6 +3,12 @@ Optional Numba/rocket-fft engine for the two-dimensional adaptive spectral filte
 
 The module imports whether or not numba and rocket-fft are installed; only
 ``_NUMBA_ENGINE_AVAILABLE`` says whether the kernel can actually compile.
+
+The kernel is the filter with its tile loop written out, rather than the
+plan's vectorized one, because it can then be compiled once and cached on
+disk; a kernel taking the filter as an argument would compile again in
+every process. It takes its geometry -- padding, grid, colour classes --
+from the same `TilePlan` the numpy engine uses.
 """
 
 from __future__ import annotations
@@ -10,11 +16,12 @@ from __future__ import annotations
 import numpy as np
 
 from dascore.proc.adaptive_spectral_filter import (
-    _finalize_output,
-    _prepare_work_arrays,
+    _restore_dtype,
     _validate_filter_inputs,
 )
 from dascore.utils.jit import maybe_numba_jit
+from dascore.utils.signal import get_taper
+from dascore.utils.tiles import get_tile_plan
 
 
 # fastmath is intentional: the weighting is approximate, and tests allow small
@@ -27,7 +34,7 @@ from dascore.utils.jit import maybe_numba_jit
     fastmath=True,
     parallel=True,
 )
-def _filter_tile_group(
+def _filter_colour_class(
     padded: np.ndarray,
     filtered: np.ndarray,
     taper: np.ndarray,
@@ -37,27 +44,26 @@ def _filter_tile_group(
     stride1: int,
     n_tiles0: int,
     n_tiles1: int,
-    parity0: int,
-    parity1: int,
+    colours0: int,
+    colours1: int,
+    colour0: int,
+    colour1: int,
     exponent: float,
     normalize_power: bool,
 ) -> None:
     """
-    Filter every tile whose grid indices share a parity, adding into filtered.
+    Filter every tile of one colour class, adding into filtered.
 
-    Same-parity tiles start two strides apart, and an overlap under half the
-    window keeps a window shorter than two strides, so no two iterations of
-    the parallel loop write to the same output sample.
+    Tiles of one class are `colours` strides apart, further than a tile
+    reaches, so no two iterations of the parallel loop write to the same
+    output sample.
     """
-    count0 = (n_tiles0 - parity0 + 1) // 2
-    count1 = (n_tiles1 - parity1 + 1) // 2
+    count0 = (n_tiles0 - colour0 + colours0 - 1) // colours0
+    count1 = (n_tiles1 - colour1 + colours1 - 1) // colours1
     for ind in numba.prange(count0 * count1):  # noqa: F821  # ty: ignore[unresolved-reference]
-        beg0 = (parity0 + 2 * (ind // count1)) * stride0
-        beg1 = (parity1 + 2 * (ind % count1)) * stride1
-        n0 = min(window0, padded.shape[0] - beg0)
-        n1 = min(window1, padded.shape[1] - beg1)
-        tile = np.zeros((window0, window1), dtype=np.float32)
-        tile[:n0, :n1] = padded[beg0 : beg0 + n0, beg1 : beg1 + n1]
+        beg0 = (colour0 + colours0 * (ind // count1)) * stride0
+        beg1 = (colour1 + colours1 * (ind % count1)) * stride1
+        tile = padded[beg0 : beg0 + window0, beg1 : beg1 + window1]
         spec = np.fft.rfft2(tile)
         if exponent != 0.0:
             power = np.abs(spec)
@@ -67,11 +73,11 @@ def _filter_tile_group(
                 power = power / max_power if max_power > 0.0 else power
             # float32 so the weighted spectrum keeps rfft2's complex64 type.
             spec = spec * (power**exponent).astype(np.float32)
-        tile = np.fft.irfft2(spec, s=(window0, window1))
-        filtered[beg0 : beg0 + n0, beg1 : beg1 + n1] += tile[:n0, :n1] * taper[:n0, :n1]
+        out = np.fft.irfft2(spec, s=(window0, window1))
+        filtered[beg0 : beg0 + window0, beg1 : beg1 + window1] += out * taper
 
 
-_NUMBA_ENGINE_AVAILABLE = _filter_tile_group.jit_available
+_NUMBA_ENGINE_AVAILABLE = _filter_colour_class.jit_available
 
 
 def _adaptive_spectral_filter_numba(
@@ -96,22 +102,27 @@ def _adaptive_spectral_filter_numba(
     if data.ndim != 2:
         msg = "The numba engine filters two-dimensional arrays only."
         raise ValueError(msg)
-    padded, taper, stride, n_tiles = _prepare_work_arrays(
-        data, window_size=window_size, overlap=overlap
-    )
+    stride = tuple(win - over for win, over in zip(window_size, overlap))
+    plan = get_tile_plan(data.shape, window_size, stride)
+    taper = get_taper("triang", window_size, overlap)
+    # The buffer is long enough for every tile to be whole, so the kernel
+    # slices without checking the edges.
+    padded = np.zeros(plan.extended, dtype=np.float32)
+    padded[plan._inner()] = data
     filtered = np.zeros_like(padded)
-    for parity0 in range(2):
-        for parity1 in range(2):
-            _filter_tile_group(
+    for colour0 in range(plan.colours[0]):
+        for colour1 in range(plan.colours[1]):
+            _filter_colour_class(
                 padded,
                 filtered,
                 taper,
                 *window_size,
                 *stride,
-                *n_tiles,
-                parity0,
-                parity1,
+                *plan.grid,
+                *plan.colours,
+                colour0,
+                colour1,
                 float(exponent),
                 bool(normalize_power),
             )
-    return _finalize_output(filtered, data.shape, data.dtype, stride)
+    return _restore_dtype(filtered[plan._inner()], data.dtype)

--- a/dascore/proc/adaptive_spectral_filter.py
+++ b/dascore/proc/adaptive_spectral_filter.py
@@ -37,7 +37,7 @@ from dascore.exceptions import MissingOptionalDependencyError, ParameterError
 from dascore.utils.misc import is_power_of_two
 from dascore.utils.patch import patch_function
 from dascore.utils.signal import get_taper
-from dascore.utils.tiles import get_tile_plan
+from dascore.utils.tiles import TilePlan, get_tile_plan
 from dascore.utils.window import Window, resolve_window
 from dascore.workflow.meta import PatchMeta
 from dascore.workflow.processor import PatchProcessor, register_implementation
@@ -125,6 +125,15 @@ def _restore_dtype(out: np.ndarray, dtype: np.dtype) -> np.ndarray:
     return out
 
 
+def _plan_and_taper(
+    data: np.ndarray, window_size: tuple[int, ...], overlap: tuple[int, ...]
+) -> tuple[TilePlan, np.ndarray]:
+    """Validate the filter's inputs and return where its tiles sit and their taper."""
+    stride = tuple(win - over for win, over in zip(window_size, overlap))
+    plan = get_tile_plan(data.shape, window_size, stride)
+    return plan, get_taper("triang", window_size, overlap)
+
+
 def _weight_spectra(
     tiles: np.ndarray, *, exponent: float, normalize_power: bool
 ) -> np.ndarray:
@@ -196,13 +205,13 @@ def _adaptive_spectral_filter_scipy(
     _validate_filter_inputs(
         data, window_size=window_size, overlap=overlap, exponent=float(exponent)
     )
-    stride = tuple(win - over for win, over in zip(window_size, overlap))
-    plan = get_tile_plan(data.shape, window_size, stride)
-    taper = get_taper("triang", window_size, overlap)
+    plan, taper = _plan_and_taper(data, window_size, overlap)
     weight = partial(
         _weight_spectra, exponent=float(exponent), normalize_power=normalize_power
     )
-    return _restore_dtype(plan.apply(data, weight, taper), data.dtype)
+    # The filter works in float32 whatever it is given.
+    out = plan.apply(np.asarray(data, dtype=np.float32), weight, taper)
+    return _restore_dtype(out, data.dtype)
 
 
 def _get_engine(engine: str, selected_ndim: int) -> Callable:

--- a/dascore/proc/adaptive_spectral_filter.py
+++ b/dascore/proc/adaptive_spectral_filter.py
@@ -25,9 +25,8 @@ so the two produce the same output.
 from __future__ import annotations
 
 from collections.abc import Callable
-from itertools import product
-from math import prod
-from typing import Any, Literal, NamedTuple
+from functools import partial
+from typing import Any, Literal
 
 import numpy as np
 from pydantic import ConfigDict
@@ -38,7 +37,8 @@ from dascore.exceptions import MissingOptionalDependencyError, ParameterError
 from dascore.utils.misc import is_power_of_two
 from dascore.utils.patch import patch_function
 from dascore.utils.signal import get_taper
-from dascore.utils.window import resolve_window
+from dascore.utils.tiles import get_tile_plan
+from dascore.utils.window import Window, resolve_window
 from dascore.workflow.meta import PatchMeta
 from dascore.workflow.processor import PatchProcessor, register_implementation
 
@@ -112,44 +112,6 @@ def _validate_window_and_overlap(
         raise ParameterError(str(exc)) from exc
 
 
-def _prepare_work_arrays(
-    data: np.ndarray,
-    *,
-    window_size: tuple[int, ...],
-    overlap: tuple[int, ...],
-) -> tuple[np.ndarray, np.ndarray, tuple[int, ...], tuple[int, ...]]:
-    """
-    Return the padded float32 input, the taper, the stride, and the tile grid.
-
-    The input is padded by one stride of zeros on every side so the tiles
-    which straddle its edges see a full taper ramp.
-    """
-    working = np.ascontiguousarray(data, dtype=np.float32)
-    stride = tuple(win - over for win, over in zip(window_size, overlap))
-    taper = get_taper("triang", window_size, overlap)
-    padded_shape = tuple(
-        length + 2 * step for length, step in zip(working.shape, stride)
-    )
-    padded = np.zeros(padded_shape, dtype=np.float32)
-    inner = tuple(
-        slice(step, length + step) for length, step in zip(working.shape, stride)
-    )
-    padded[inner] = working
-    n_tiles = tuple(pad_len // step for pad_len, step in zip(padded.shape, stride))
-    return padded, taper, stride, n_tiles
-
-
-def _finalize_output(
-    filtered: np.ndarray,
-    shape: tuple[int, ...],
-    dtype: np.dtype,
-    stride: tuple[int, ...],
-) -> np.ndarray:
-    """Crop the padding away and restore the input dtype where that is safe."""
-    inner = tuple(slice(step, length + step) for length, step in zip(shape, stride))
-    return _restore_dtype(filtered[inner], dtype)
-
-
 def _restore_dtype(out: np.ndarray, dtype: np.dtype) -> np.ndarray:
     """
     Return float32 output in the input's dtype, if that is a wide enough float.
@@ -163,51 +125,29 @@ def _restore_dtype(out: np.ndarray, dtype: np.dtype) -> np.ndarray:
     return out
 
 
-def _extract_tiles(
-    padded: np.ndarray,
-    window_size: tuple[int, ...],
-    stride: tuple[int, ...],
-    n_tiles: tuple[int, ...],
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Copy every window into a dense tile stack for batched FFTs."""
-    ndim = len(window_size)
-    tiles = np.zeros((prod(n_tiles), *window_size), dtype=np.float32)
-    begins = np.zeros((*n_tiles, ndim), dtype=np.int64)
-    sizes = np.zeros((*n_tiles, ndim), dtype=np.int64)
-    for tile_index, tile_inds in enumerate(product(*(range(num) for num in n_tiles))):
-        beg = tuple(ind * step for ind, step in zip(tile_inds, stride))
-        end = tuple(
-            min(start + win, size)
-            for start, win, size in zip(beg, window_size, padded.shape)
-        )
-        valid_shape = tuple(stop - start for start, stop in zip(beg, end))
-        begins[tile_inds] = beg
-        sizes[tile_inds] = valid_shape
-        data_slices = tuple(slice(start, stop) for start, stop in zip(beg, end))
-        tile_slices = tuple(slice(0, size) for size in valid_shape)
-        tiles[(tile_index, *tile_slices)] = padded[data_slices]
-    return tiles, begins, sizes
+def _weight_spectra(
+    tiles: np.ndarray, *, exponent: float, normalize_power: bool
+) -> np.ndarray:
+    """
+    Return every tile with its spectrum weighted by a power of its magnitude.
 
-
-def _overlap_add_tiles(
-    out: np.ndarray,
-    tiles: np.ndarray,
-    taper: np.ndarray,
-    begins: np.ndarray,
-    sizes: np.ndarray,
-) -> None:
-    """Add every tapered tile back into the padded output."""
-    grid_shape = begins.shape[:-1]
-    for tile_index, tile_inds in enumerate(
-        product(*(range(num) for num in grid_shape))
-    ):
-        beg = tuple(begins[tile_inds])
-        valid_shape = tuple(sizes[tile_inds])
-        out_slices = tuple(
-            slice(start, start + size) for start, size in zip(beg, valid_shape)
-        )
-        tile_slices = tuple(slice(0, size) for size in valid_shape)
-        out[out_slices] += tiles[(tile_index, *tile_slices)] * taper[tile_slices]
+    The filter itself, on a stack of tiles: one FFT over the stack, one
+    weighting, one inverse.
+    """
+    axes = tuple(range(1, tiles.ndim))
+    size = tiles.shape[1:]
+    spec = sp_fft.rfftn(tiles, s=size, axes=axes, workers=-1)
+    if exponent != 0.0:
+        power = np.abs(spec).astype(np.float32, copy=False)
+        if normalize_power:
+            max_power = power.max(axis=axes, keepdims=True)
+            power = np.divide(
+                power, max_power, out=np.zeros_like(power), where=max_power != 0
+            )
+        spec *= power**exponent
+    return sp_fft.irfftn(spec, s=size, axes=axes, workers=-1).astype(
+        np.float32, copy=False
+    )
 
 
 def _adaptive_spectral_filter_scipy(
@@ -256,35 +196,13 @@ def _adaptive_spectral_filter_scipy(
     _validate_filter_inputs(
         data, window_size=window_size, overlap=overlap, exponent=float(exponent)
     )
-    padded, taper, stride, n_tiles = _prepare_work_arrays(
-        data, window_size=window_size, overlap=overlap
+    stride = tuple(win - over for win, over in zip(window_size, overlap))
+    plan = get_tile_plan(data.shape, window_size, stride)
+    taper = get_taper("triang", window_size, overlap)
+    weight = partial(
+        _weight_spectra, exponent=float(exponent), normalize_power=normalize_power
     )
-    tiles, begins, sizes = _extract_tiles(padded, window_size, stride, n_tiles)
-    axes = tuple(range(-data.ndim, 0))
-
-    spec = sp_fft.rfftn(tiles, s=window_size, axes=axes, workers=-1)
-    if exponent != 0.0:
-        power = np.abs(spec).astype(np.float32, copy=False)
-        if normalize_power:
-            max_power = power.max(axis=axes, keepdims=True)
-            power = np.divide(
-                power, max_power, out=np.zeros_like(power), where=max_power != 0
-            )
-        spec *= power**exponent
-    tiles = sp_fft.irfftn(spec, s=window_size, axes=axes, workers=-1).astype(
-        np.float32, copy=False
-    )
-    filtered = np.zeros_like(padded)
-    _overlap_add_tiles(filtered, tiles, taper, begins, sizes)
-    return _finalize_output(filtered, data.shape, data.dtype, stride)
-
-
-class _Geometry(NamedTuple):
-    """The selected axes and their windows and overlaps, all in samples."""
-
-    axes: tuple[int, ...]
-    windows: tuple[int, ...]
-    overlaps: tuple[int, ...]
+    return _restore_dtype(plan.apply(data, weight, taper), data.dtype)
 
 
 def _get_engine(engine: str, selected_ndim: int) -> Callable:
@@ -434,8 +352,8 @@ class AdaptiveSpectralFilter(PatchProcessor):
     # `_get_engine` as a ParameterError like every other bad argument.
     engine: str = "auto"
 
-    def geometry(self, meta: PatchMeta) -> _Geometry:
-        """Return the selected axes and their windows and overlaps, in samples."""
+    def geometry(self, meta: PatchMeta) -> Window:
+        """Return the window in samples: the selected axes, sizes, and overlaps."""
         selected = self.model_extra or {}
         if len(selected) not in {1, 2}:
             msg = (
@@ -459,11 +377,12 @@ class AdaptiveSpectralFilter(PatchProcessor):
         _validate_window_and_overlap(
             window.dims, window.size, window.overlap, float(self.exponent)
         )
-        return _Geometry(window.axes, window.size, window.overlap)
+        return window
 
     def kernel(self, data, meta, out_meta):
         """Filter every batch over the selected axes and stack the results."""
-        axes, windows, overlaps = self.geometry(meta)
+        window = self.geometry(meta)
+        axes, windows, overlaps = window.axes, window.size, window.overlap
         engine = _get_engine(self.engine, len(axes))
         data = np.asarray(data)
         tail = tuple(range(-len(axes), 0))

--- a/dascore/utils/tiles.py
+++ b/dascore/utils/tiles.py
@@ -1,0 +1,176 @@
+"""
+Cut an array into overlapping tiles, and blend them back.
+
+A :class:`TilePlan` is the geometry: where every tile of a given size and
+stride sits over an array of a given shape, with one stride of zeros padded
+on every side so the tiles at the edges see a full taper ramp. It cuts the
+array into a dense stack of tiles, ``[n_tiles, *size]``, which one call to a
+vectorized function can transform, and adds a stack back under a taper so
+that, with a taper whose ramps are complementary, tiles of an untouched
+stack sum to the array they were cut from.
+
+The plan is the part of a windowed operation which has nothing to do with
+the operation. The adaptive spectral filter is the first thing written on
+it; anything which transforms, edits, and reassembles windows is the next.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from itertools import product
+
+import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view
+
+from dascore.exceptions import ParameterError
+
+
+@dataclass(frozen=True)
+class TilePlan:
+    """
+    Where every tile sits over an array.
+
+    Parameters
+    ----------
+    shape
+        The array's shape along the tiled axes.
+    size
+        The tile's shape.
+    stride
+        How far each tile advances along each axis. Never longer than the
+        tile: a gap between tiles is nothing to blend.
+
+    Notes
+    -----
+    Build one with :func:`get_tile_plan`, which caches, rather than directly.
+    """
+
+    shape: tuple[int, ...]
+    size: tuple[int, ...]
+    stride: tuple[int, ...]
+
+    def __post_init__(self):
+        """Refuse a geometry which cannot tile."""
+        if not len(self.shape) == len(self.size) == len(self.stride):
+            msg = "shape, size, and stride must have the same length."
+            raise ParameterError(msg)
+        if any(step < 1 for step in self.stride) or any(z < 1 for z in self.size):
+            msg = "tile size and stride must be positive."
+            raise ParameterError(msg)
+        if any(step > z for step, z in zip(self.stride, self.size)):
+            msg = "a stride longer than the tile leaves gaps no tile covers."
+            raise ParameterError(msg)
+
+    @property
+    def pad(self) -> tuple[int, ...]:
+        """Zeros added at each end of every axis: one stride, for a full ramp."""
+        return self.stride
+
+    @property
+    def grid(self) -> tuple[int, ...]:
+        """How many tiles along each axis."""
+        return tuple(
+            (length + 2 * step) // step for length, step in zip(self.shape, self.stride)
+        )
+
+    @property
+    def n_tiles(self) -> int:
+        """How many tiles there are."""
+        return math.prod(self.grid)
+
+    @property
+    def extended(self) -> tuple[int, ...]:
+        """The padded buffer's shape, long enough for the last tile to fit whole."""
+        return tuple(
+            max(length + 2 * step, (count - 1) * step + z)
+            for length, step, count, z in zip(
+                self.shape, self.stride, self.grid, self.size
+            )
+        )
+
+    @property
+    def colours(self) -> tuple[int, ...]:
+        """
+        Tiles per axis between two which cannot overlap.
+
+        Tiles whose grid indices agree modulo this never share a sample, so
+        each colour class of tiles can be added into the output at once.
+        """
+        return tuple(math.ceil(z / step) for z, step in zip(self.size, self.stride))
+
+    def _inner(self) -> tuple[slice, ...]:
+        """The array's place inside the padded buffer."""
+        return tuple(
+            slice(step, step + length) for step, length in zip(self.pad, self.shape)
+        )
+
+    def _tile_view(self, buffer: np.ndarray, writeable: bool = False) -> np.ndarray:
+        """A view of the buffer as the tile grid, ``[*grid, *size]``."""
+        view = sliding_window_view(buffer, self.size, writeable=writeable)
+        return view[
+            tuple(
+                slice(0, count * step, step)
+                for count, step in zip(self.grid, self.stride)
+            )
+        ]
+
+    def extract(self, array: np.ndarray) -> np.ndarray:
+        """Return the tiles as a float32 stack, ``[n_tiles, *size]``."""
+        buffer = np.zeros(self.extended, dtype=np.float32)
+        buffer[self._inner()] = array
+        return self._tile_view(buffer).reshape((self.n_tiles, *self.size))
+
+    def overlap_add(self, tiles: np.ndarray, taper: np.ndarray) -> np.ndarray:
+        """
+        Return the array the tapered tiles sum to, cropped to the array's shape.
+
+        Parameters
+        ----------
+        tiles
+            A stack as `extract` returns, ``[n_tiles, *size]``.
+        taper
+            The weights each tile is multiplied by, of the tile's shape; see
+            `dascore.utils.signal.get_taper`.
+        """
+        buffer = np.zeros(self.extended, dtype=np.float32)
+        grid = tiles.reshape((*self.grid, *self.size)) * taper
+        view = self._tile_view(buffer, writeable=True)
+        # One colour class at a time: its tiles never overlap, so adding
+        # them through the strided view touches each sample once.
+        for colour in product(*(range(k) for k in self.colours)):
+            pick = tuple(
+                slice(c, count, k)
+                for c, count, k in zip(colour, self.grid, self.colours)
+            )
+            view[pick] += grid[pick]
+        return buffer[self._inner()]
+
+    def apply(self, array: np.ndarray, func, taper: np.ndarray) -> np.ndarray:
+        """
+        Return the array with `func` applied to every tile and the tiles blended.
+
+        Parameters
+        ----------
+        array
+            The array to tile, of this plan's shape.
+        func
+            Takes the whole stack, ``[n_tiles, *size]``, and returns one of the
+            same shape: one vectorized call, not one per tile.
+        taper
+            The weights the tiles are blended under.
+        """
+        return self.overlap_add(func(self.extract(array)), taper)
+
+
+@lru_cache(maxsize=128)
+def get_tile_plan(
+    shape: tuple[int, ...], size: tuple[int, ...], stride: tuple[int, ...]
+) -> TilePlan:
+    """
+    Return the plan for tiles of `size` at `stride` over an array of `shape`.
+
+    Cached: a spool of patches of one shape shares a plan.
+    """
+    return TilePlan(tuple(shape), tuple(size), tuple(stride))

--- a/dascore/utils/tiles.py
+++ b/dascore/utils/tiles.py
@@ -133,7 +133,10 @@ class TilePlan:
     def extract(self, array: np.ndarray, dtype=None) -> np.ndarray:
         """Return the tiles as a stack, ``[n_tiles, *size]``, in the array's dtype."""
         buffer = self.pad(array, dtype)
-        return self._tile_view(buffer).reshape((self.n_tiles, *self.size))
+        tiles = self._tile_view(buffer).reshape((self.n_tiles, *self.size))
+        # A one-dimensional plan reshapes without copying, which would hand
+        # out the read-only window view; a stack is for writing to.
+        return tiles if tiles.flags.writeable else tiles.copy()
 
     def overlap_add(self, tiles: np.ndarray, taper: np.ndarray) -> np.ndarray:
         """

--- a/dascore/utils/tiles.py
+++ b/dascore/utils/tiles.py
@@ -64,7 +64,7 @@ class TilePlan:
             raise ParameterError(msg)
 
     @property
-    def pad(self) -> tuple[int, ...]:
+    def margin(self) -> tuple[int, ...]:
         """Zeros added at each end of every axis: one stride, for a full ramp."""
         return self.stride
 
@@ -103,7 +103,7 @@ class TilePlan:
     def _inner(self) -> tuple[slice, ...]:
         """The array's place inside the padded buffer."""
         return tuple(
-            slice(step, step + length) for step, length in zip(self.pad, self.shape)
+            slice(step, step + length) for step, length in zip(self.margin, self.shape)
         )
 
     def _tile_view(self, buffer: np.ndarray, writeable: bool = False) -> np.ndarray:
@@ -116,10 +116,23 @@ class TilePlan:
             )
         ]
 
-    def extract(self, array: np.ndarray) -> np.ndarray:
-        """Return the tiles as a float32 stack, ``[n_tiles, *size]``."""
-        buffer = np.zeros(self.extended, dtype=np.float32)
+    def pad(self, array: np.ndarray, dtype=None) -> np.ndarray:
+        """
+        Return the array inside a zeroed buffer every tile fits in whole.
+
+        The buffer takes the array's dtype unless one is given.
+        """
+        buffer = np.zeros(self.extended, dtype=dtype or np.asarray(array).dtype)
         buffer[self._inner()] = array
+        return buffer
+
+    def crop(self, buffer: np.ndarray) -> np.ndarray:
+        """Return the array's part of a buffer `pad` made."""
+        return buffer[self._inner()]
+
+    def extract(self, array: np.ndarray, dtype=None) -> np.ndarray:
+        """Return the tiles as a stack, ``[n_tiles, *size]``, in the array's dtype."""
+        buffer = self.pad(array, dtype)
         return self._tile_view(buffer).reshape((self.n_tiles, *self.size))
 
     def overlap_add(self, tiles: np.ndarray, taper: np.ndarray) -> np.ndarray:
@@ -134,18 +147,20 @@ class TilePlan:
             The weights each tile is multiplied by, of the tile's shape; see
             `dascore.utils.signal.get_taper`.
         """
-        buffer = np.zeros(self.extended, dtype=np.float32)
-        grid = tiles.reshape((*self.grid, *self.size)) * taper
+        dtype = np.result_type(tiles, taper)
+        buffer = np.zeros(self.extended, dtype=dtype)
+        grid = tiles.reshape((*self.grid, *self.size))
         view = self._tile_view(buffer, writeable=True)
         # One colour class at a time: its tiles never overlap, so adding
-        # them through the strided view touches each sample once.
+        # them through the strided view touches each sample once. The
+        # taper goes on here, a class at a time, rather than on the stack.
         for colour in product(*(range(k) for k in self.colours)):
             pick = tuple(
                 slice(c, count, k)
                 for c, count, k in zip(colour, self.grid, self.colours)
             )
-            view[pick] += grid[pick]
-        return buffer[self._inner()]
+            view[pick] += grid[pick] * taper
+        return self.crop(buffer)
 
     def apply(self, array: np.ndarray, func, taper: np.ndarray) -> np.ndarray:
         """

--- a/dascore/utils/window.py
+++ b/dascore/utils/window.py
@@ -27,6 +27,7 @@ from dascore.exceptions import CoordError, ParameterError
 from dascore.units import Quantity, is_percent
 from dascore.utils.misc import get_parent_code_name
 from dascore.utils.patch import get_dim_axis_value
+from dascore.utils.tiles import TilePlan, get_tile_plan
 from dascore.utils.time import is_timedelta64, to_float, to_timedelta64
 
 # What a function means by an overlap nobody gave: a sample count, or a
@@ -93,6 +94,18 @@ class Window:
         for axis, size in zip(self.axes, self.size):
             out[axis] = size
         return tuple(out)
+
+    def tiles(self, shape: tuple[int, ...]) -> TilePlan:
+        """
+        Return the plan for tiling an array of `shape` along the windowed axes.
+
+        `shape` is the array's extent along `dims`, in that order. A window
+        with no stride cannot tile.
+        """
+        if self.stride is None:
+            msg = "A window with no overlap or step given does not tile."
+            raise ParameterError(msg)
+        return get_tile_plan(tuple(shape), self.size, self.stride)
 
 
 def _percent_to_samples(value: Any, size: int) -> tuple[Any, bool]:

--- a/dascore/utils/window.py
+++ b/dascore/utils/window.py
@@ -99,13 +99,14 @@ class Window:
         """
         Return the plan for tiling an array of `shape` along the windowed axes.
 
-        `shape` is the array's extent along `dims`, in that order. A window
-        with no stride cannot tile.
+        `shape` is the whole array's; the plan covers the windowed axes in
+        the order the window names them. A window with no stride cannot tile.
         """
         if self.stride is None:
             msg = "A window with no overlap or step given does not tile."
             raise ParameterError(msg)
-        return get_tile_plan(tuple(shape), self.size, self.stride)
+        selected = tuple(shape[axis] for axis in self.axes)
+        return get_tile_plan(selected, self.size, self.stride)
 
 
 def _percent_to_samples(value: Any, size: int) -> tuple[Any, bool]:

--- a/tests/test_proc/test_adaptive_spectral_filter.py
+++ b/tests/test_proc/test_adaptive_spectral_filter.py
@@ -697,8 +697,7 @@ class TestAdaptiveSpectralCore:
         window, overlap = (8, 16), (3, 7)
         plan = get_tile_plan(data.shape, window, (5, 9))
         taper = get_taper("triang", window, overlap)
-        padded = np.zeros(plan.extended, dtype=np.float32)
-        padded[plan._inner()] = data
+        padded = plan.pad(data)
         filtered = np.zeros_like(padded)
         for colour0 in range(plan.colours[0]):
             for colour1 in range(plan.colours[1]):
@@ -715,7 +714,7 @@ class TestAdaptiveSpectralCore:
                     0.8,
                     True,
                 )
-        out = filtered[plan._inner()]
+        out = plan.crop(filtered)
         expected = _adaptive_spectral_filter_scipy(
             data,
             window_size=window,

--- a/tests/test_proc/test_adaptive_spectral_filter.py
+++ b/tests/test_proc/test_adaptive_spectral_filter.py
@@ -21,6 +21,8 @@ from dascore.proc.adaptive_spectral_filter import (
     _get_engine,
     _validate_window_and_overlap,
 )
+from dascore.utils.signal import get_taper
+from dascore.utils.tiles import get_tile_plan
 
 
 def _numba_engine():
@@ -692,26 +694,34 @@ class TestAdaptiveSpectralCore:
         numba_mod = _numba_engine()
         rng = np.random.default_rng(20260511)
         data = rng.normal(size=(24, 40)).astype(np.float32)
-        kwargs = dict(window_size=(8, 16), overlap=(3, 7))
-        padded, taper, stride, n_tiles = numba_mod._prepare_work_arrays(data, **kwargs)
+        window, overlap = (8, 16), (3, 7)
+        plan = get_tile_plan(data.shape, window, (5, 9))
+        taper = get_taper("triang", window, overlap)
+        padded = np.zeros(plan.extended, dtype=np.float32)
+        padded[plan._inner()] = data
         filtered = np.zeros_like(padded)
-        for parity0, parity1 in [(0, 0), (0, 1), (1, 0), (1, 1)]:
-            numba_mod._filter_tile_group.func(
-                padded,
-                filtered,
-                taper,
-                8,
-                16,
-                *stride,
-                *n_tiles,
-                parity0,
-                parity1,
-                0.8,
-                True,
-            )
-        out = numba_mod._finalize_output(filtered, data.shape, data.dtype, stride)
+        for colour0 in range(plan.colours[0]):
+            for colour1 in range(plan.colours[1]):
+                numba_mod._filter_colour_class.func(
+                    padded,
+                    filtered,
+                    taper,
+                    *window,
+                    *plan.stride,
+                    *plan.grid,
+                    *plan.colours,
+                    colour0,
+                    colour1,
+                    0.8,
+                    True,
+                )
+        out = filtered[plan._inner()]
         expected = _adaptive_spectral_filter_scipy(
-            data, exponent=0.8, normalize_power=True, **kwargs
+            data,
+            window_size=window,
+            overlap=overlap,
+            exponent=0.8,
+            normalize_power=True,
         )
 
         np.testing.assert_allclose(out, expected, rtol=1e-5, atol=1e-5)

--- a/tests/test_utils/test_tiles.py
+++ b/tests/test_utils/test_tiles.py
@@ -1,0 +1,129 @@
+"""Tests for cutting an array into tiles and blending them back."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dascore.exceptions import ParameterError
+from dascore.utils.signal import get_taper
+from dascore.utils.tiles import TilePlan, get_tile_plan
+
+# Shapes which are not multiples of anything, so the edge tiles are ragged.
+CASES = [
+    ((33,), (8,), (3,)),
+    ((64, 64), (16, 16), (7, 7)),
+    ((100, 257), (16, 16), (7, 7)),
+    ((100, 257), (8, 32), (0, 15)),
+    ((20, 30, 40), (8, 8, 16), (3, 3, 7)),
+    ((5,), (16,), (7,)),
+]
+
+
+def _stride(size, overlap):
+    return tuple(z - o for z, o in zip(size, overlap))
+
+
+class TestGeometry:
+    """What the plan says about where tiles sit."""
+
+    def test_grid_and_extension(self):
+        """Two strides of padding, tiles every stride, room for the last one."""
+        plan = get_tile_plan((100,), (16,), (9,))
+        assert plan.pad == (9,)
+        assert plan.grid == (118 // 9,)
+        assert plan.extended[0] >= (plan.grid[0] - 1) * 9 + 16
+        assert plan.n_tiles == plan.grid[0]
+
+    def test_colours(self):
+        """Tiles two strides apart cannot overlap when the stride is over half."""
+        assert get_tile_plan((64, 64), (16, 16), (9, 9)).colours == (2, 2)
+        assert get_tile_plan((64,), (16,), (16,)).colours == (1,)
+        assert get_tile_plan((64,), (16,), (5,)).colours == (4,)
+
+    def test_cached(self):
+        """One plan per geometry."""
+        assert get_tile_plan((64,), (16,), (9,)) is get_tile_plan((64,), (16,), (9,))
+
+    @pytest.mark.parametrize(
+        "shape,size,stride,match",
+        [
+            ((64, 64), (16,), (9, 9), "same length"),
+            ((64,), (16,), (0,), "positive"),
+            ((64,), (0,), (1,), "positive"),
+            ((64,), (16,), (17,), "leaves gaps"),
+        ],
+    )
+    def test_refused(self, shape, size, stride, match):
+        """A geometry which cannot tile says why."""
+        with pytest.raises(ParameterError, match=match):
+            TilePlan(shape, size, stride)
+
+
+class TestExtract:
+    """Cutting the stack."""
+
+    def test_stack_shape(self):
+        """One tile per grid cell, each the tile's size."""
+        plan = get_tile_plan((100, 257), (16, 16), (9, 9))
+        tiles = plan.extract(np.ones((100, 257)))
+        assert tiles.shape == (plan.n_tiles, 16, 16)
+        assert tiles.dtype == np.float32
+
+    def test_edges_are_zero_padded(self):
+        """The first tile starts one stride before the data, in zeros."""
+        plan = get_tile_plan((100,), (16,), (9,))
+        tiles = plan.extract(np.ones(100))
+        assert np.all(tiles[0, :9] == 0) and np.all(tiles[0, 9:] == 1)
+
+    def test_first_tile_is_the_padded_start(self):
+        """A tile is a plain slice of the padded buffer."""
+        rng = np.random.default_rng(0)
+        array = rng.normal(size=(40, 50)).astype(np.float32)
+        plan = get_tile_plan(array.shape, (8, 8), (5, 5))
+        tiles = plan.extract(array).reshape((*plan.grid, 8, 8))
+        # Tile (1, 1) starts one stride in on each axis, which is where the
+        # data starts: its top-left corner is the array's top-left corner.
+        np.testing.assert_array_equal(tiles[1, 1], array[:8, :8])
+
+
+class TestOverlapAdd:
+    """Blending the stack back."""
+
+    @pytest.mark.parametrize("shape,size,overlap", CASES)
+    def test_identity(self, shape, size, overlap):
+        """An untouched stack under a complementary taper is the array."""
+        rng = np.random.default_rng(1)
+        array = rng.normal(size=shape).astype(np.float32)
+        plan = get_tile_plan(shape, size, _stride(size, overlap))
+        taper = get_taper("hann", size, overlap)
+        out = plan.overlap_add(plan.extract(array), taper)
+        np.testing.assert_allclose(out, array, atol=1e-5)
+        assert out.shape == array.shape
+
+    def test_matches_a_loop(self):
+        """The colour-class adds equal adding every tile one by one."""
+        rng = np.random.default_rng(2)
+        array = rng.normal(size=(50, 70)).astype(np.float32)
+        size, overlap = (16, 8), (7, 3)
+        plan = get_tile_plan(array.shape, size, _stride(size, overlap))
+        taper = get_taper("triang", size, overlap)
+        tiles = plan.extract(array) * rng.normal(size=(plan.n_tiles, 1, 1))
+        expected = np.zeros(plan.extended, dtype=np.float32)
+        grid = tiles.reshape((*plan.grid, *size))
+        for i in range(plan.grid[0]):
+            for j in range(plan.grid[1]):
+                b0, b1 = i * plan.stride[0], j * plan.stride[1]
+                expected[b0 : b0 + 16, b1 : b1 + 8] += grid[i, j] * taper
+        expected = expected[plan._inner()]
+        # float32, summed in a different order.
+        np.testing.assert_allclose(plan.overlap_add(tiles, taper), expected, atol=1e-6)
+
+    def test_apply_is_extract_func_blend(self):
+        """`apply` is the three steps in one."""
+        rng = np.random.default_rng(3)
+        array = rng.normal(size=(64, 64)).astype(np.float32)
+        plan = get_tile_plan(array.shape, (16, 16), (9, 9))
+        taper = get_taper("triang", (16, 16), (7, 7))
+        doubled = plan.apply(array, lambda tiles: tiles * 2, taper)
+        np.testing.assert_allclose(doubled, 2 * array, atol=1e-5)

--- a/tests/test_utils/test_tiles.py
+++ b/tests/test_utils/test_tiles.py
@@ -30,7 +30,7 @@ class TestGeometry:
     def test_grid_and_extension(self):
         """Two strides of padding, tiles every stride, room for the last one."""
         plan = get_tile_plan((100,), (16,), (9,))
-        assert plan.pad == (9,)
+        assert plan.margin == (9,)
         assert plan.grid == (118 // 9,)
         assert plan.extended[0] >= (plan.grid[0] - 1) * 9 + 16
         assert plan.n_tiles == plan.grid[0]
@@ -64,17 +64,46 @@ class TestExtract:
     """Cutting the stack."""
 
     def test_stack_shape(self):
-        """One tile per grid cell, each the tile's size."""
+        """One tile per grid cell, each the tile's size, in the array's dtype."""
         plan = get_tile_plan((100, 257), (16, 16), (9, 9))
-        tiles = plan.extract(np.ones((100, 257)))
+        tiles = plan.extract(np.ones((100, 257), dtype=np.float32))
         assert tiles.shape == (plan.n_tiles, 16, 16)
         assert tiles.dtype == np.float32
+
+    def test_dtype_is_kept_or_given(self):
+        """Complex tiles for a complex array; a dtype asked for is used."""
+        plan = get_tile_plan((40,), (8,), (5,))
+        assert plan.extract(np.ones(40, dtype=np.complex64)).dtype == np.complex64
+        assert (
+            plan.extract(np.ones(40, dtype=np.int16), dtype=np.float32).dtype
+            == np.float32
+        )
+
+    def test_pad_and_crop_round_trip(self):
+        """`crop` undoes `pad`."""
+        plan = get_tile_plan((40, 30), (8, 8), (5, 5))
+        array = np.arange(1200, dtype=np.float64).reshape(40, 30)
+        buffer = plan.pad(array)
+        assert buffer.shape == plan.extended and buffer.dtype == np.float64
+        np.testing.assert_array_equal(plan.crop(buffer), array)
 
     def test_edges_are_zero_padded(self):
         """The first tile starts one stride before the data, in zeros."""
         plan = get_tile_plan((100,), (16,), (9,))
         tiles = plan.extract(np.ones(100))
         assert np.all(tiles[0, :9] == 0) and np.all(tiles[0, 9:] == 1)
+
+    def test_complex_round_trip(self):
+        """A complex stack blends back to the complex array."""
+        rng = np.random.default_rng(4)
+        array = (rng.normal(size=(30, 40)) + 1j * rng.normal(size=(30, 40))).astype(
+            np.complex64
+        )
+        plan = get_tile_plan(array.shape, (8, 8), (5, 5))
+        taper = get_taper("hann", (8, 8), (3, 3))
+        out = plan.overlap_add(plan.extract(array), taper)
+        assert out.dtype == np.complex64
+        np.testing.assert_allclose(out, array, atol=1e-5)
 
     def test_first_tile_is_the_padded_start(self):
         """A tile is a plain slice of the padded buffer."""
@@ -115,7 +144,7 @@ class TestOverlapAdd:
             for j in range(plan.grid[1]):
                 b0, b1 = i * plan.stride[0], j * plan.stride[1]
                 expected[b0 : b0 + 16, b1 : b1 + 8] += grid[i, j] * taper
-        expected = expected[plan._inner()]
+        expected = plan.crop(expected)
         # float32, summed in a different order.
         np.testing.assert_allclose(plan.overlap_add(tiles, taper), expected, atol=1e-6)
 

--- a/tests/test_utils/test_tiles.py
+++ b/tests/test_utils/test_tiles.py
@@ -79,6 +79,16 @@ class TestExtract:
             == np.float32
         )
 
+    @pytest.mark.parametrize(
+        "shape,size,stride", [((40,), (8,), (5,)), ((40, 30), (8, 8), (5, 5))]
+    )
+    def test_stack_is_writeable(self, shape, size, stride):
+        """A stack is for transforming, in place if the caller likes."""
+        plan = get_tile_plan(shape, size, stride)
+        tiles = plan.extract(np.ones(shape, dtype=np.float32))
+        tiles /= 2
+        assert tiles.flags.writeable
+
     def test_pad_and_crop_round_trip(self):
         """`crop` undoes `pad`."""
         plan = get_tile_plan((40, 30), (8, 8), (5, 5))

--- a/tests/test_utils/test_window.py
+++ b/tests/test_utils/test_window.py
@@ -423,6 +423,23 @@ class TestDeprecatedResolvers:
 class TestWindow:
     """The resolved object itself."""
 
+    def test_tiles(self, random_patch):
+        """A window with a stride plans tiles over the axes it selects."""
+        window = resolve_window(
+            random_patch, {"distance": 16, "time": 8}, samples=True, overlap=2
+        )
+        shape = tuple(random_patch.shape[axis] for axis in window.axes)
+        plan = window.tiles(shape)
+        assert plan.size == (16, 8)
+        assert plan.stride == (14, 6)
+        assert plan.shape == shape
+
+    def test_tiles_need_a_stride(self, random_patch):
+        """With no overlap or step given there is no stride to tile at."""
+        window = resolve_window(random_patch, {"time": 8}, samples=True)
+        with pytest.raises(ParameterError, match="does not tile"):
+            window.tiles((2000,))
+
     def test_full_size_fill(self):
         """Unselected axes take the fill."""
         window = Window(("time",), (1,), (5,), None, 3)

--- a/tests/test_utils/test_window.py
+++ b/tests/test_utils/test_window.py
@@ -428,17 +428,16 @@ class TestWindow:
         window = resolve_window(
             random_patch, {"distance": 16, "time": 8}, samples=True, overlap=2
         )
-        shape = tuple(random_patch.shape[axis] for axis in window.axes)
-        plan = window.tiles(shape)
+        plan = window.tiles(random_patch.shape)
         assert plan.size == (16, 8)
         assert plan.stride == (14, 6)
-        assert plan.shape == shape
+        assert plan.shape == tuple(random_patch.shape[axis] for axis in window.axes)
 
     def test_tiles_need_a_stride(self, random_patch):
         """With no overlap or step given there is no stride to tile at."""
         window = resolve_window(random_patch, {"time": 8}, samples=True)
         with pytest.raises(ParameterError, match="does not tile"):
-            window.tiles((2000,))
+            window.tiles(random_patch.shape)
 
     def test_full_size_fill(self):
         """Unselected axes take the fill."""


### PR DESCRIPTION
## Description

PR 3 of the windowing plan (top-level `.scratch/windowing-unification-plan.md`): the tile machinery the adaptive spectral filter carried privately becomes `dascore.utils.tiles`, and the filter is the first thing written on it.

`TilePlan` is the geometry — where every tile of a given size and stride sits over an array of a given shape, padded by one stride of zeros on each side so edge tiles see a full taper ramp. It is N-dimensional, cached by `get_tile_plan(shape, size, stride)` so a spool of same-shaped patches shares one, and reached from a `Window` by `Window.tiles(shape)`. Three operations:

- `extract(array)` → a dense float32 stack `[n_tiles, *size]`, cut in one `sliding_window_view` rather than a Python loop.
- `overlap_add(tiles, taper)` → the array the tapered tiles sum to. Tiles are added a colour class at a time — tiles `ceil(size / stride)` grid steps apart never share a sample — so each class is one strided `+=`, no loop over tiles.
- `apply(array, func, taper)` — the two around a function over the whole stack.

The invariant it is tested on: an untouched stack under a complementary taper (`get_taper`, PR 2) sums back to the array, to float32 rounding, in 1, 2, and 3 dimensions and for ragged edges.

**The filter on it.** `_adaptive_spectral_filter_scipy` is now `plan.apply(data, weight_spectra, taper)` where `_weight_spectra` is the six lines that were ever the filter: one `rfftn` over the stack, the weighting, one `irfftn`. `_prepare_work_arrays`, `_extract_tiles`, `_overlap_add_tiles`, `_finalize_output`, and `_Geometry` are gone (`geometry()` returns the `Window`). The numba engine keeps its own tile loop — a kernel compiled once and cached on disk — but takes padding, grid, and colour classes from the same plan; a kernel taking the filter as an argument would recompile in every process (measured: 2.9 s in a fresh process even with `cache=True`), which is why the injected-`f` driver waits for a public consumer.

Numbers, 2000 × 6000 float32, 16-sample windows overlapping by 7:

| engine | before | after |
|---|---|---|
| numpy/scipy | 1.48 s | 0.35 s |
| numba | 0.14 s | 0.14 s |

Output unchanged: both engines match Lightguide's `afk_filter` to 3.5e-7 over 96 window/overlap/exponent/normalization cases, as before. Every existing filter test passes untouched except the one which exercised the deleted helpers by name, rewritten against the plan.

### Reviews

Codex's GitHub review raised one thread — a one-dimensional plan handed back the read-only window view from `extract` — fixed in `5b690548` with an in-place test. Its CLI review was requested with the usual 25-minute window and had not returned when this was tagged; if it lands I'll address it here. My own pass fixed five warts before that: `pad`/`crop` on the plan instead of a private slice, the array's dtype kept in `extract` (complex stacks blend back complex), one setup function for both engines, `Window.tiles` taking the whole array's shape, and the taper applied a colour class at a time rather than to a copy of the stack.

## Changelog

- none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reusable windowed tiling support for processing arrays in overlapping tiles.
  - Windows can now generate tile plans from shape, size, and overlap settings.
  - Added utilities for extracting, padding, blending, and applying operations across tiles.
- **Improvements**
  - Adaptive spectral filtering now uses consistent tiling and tapering across processing engines.
  - Improved handling of padded edges, overlapping regions, data types, and multidimensional inputs.
  - Results are blended and cropped more reliably, including for irregular edge sizes.
- **Bug Fixes**
  - Improved tile validation and handling of writable tile data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
