### PR TITLE
Apply a function to overlapping windows of a patch, and blend them back

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -464,6 +464,8 @@ class Patch(NodeRepr, NamespaceOwner):
     slope_filter = dascore.proc.slope_filter
     wiener_filter = dascore.proc.wiener_filter
     adaptive_spectral_filter = dascore.proc.adaptive_spectral_filter
+    tile_apply = dascore.proc.tile_apply
+    reassemble = dascore.proc.reassemble
     abs = dascore.proc.abs
     conj = dascore.proc.conj
     real = dascore.proc.real

--- a/dascore/proc/__init__.py
+++ b/dascore/proc/__init__.py
@@ -19,4 +19,5 @@ from .hampel import hampel_filter
 from .wiener import wiener_filter
 from .align import align_to_coord
 from .adaptive_spectral_filter import adaptive_spectral_filter
+from .tile_apply import reassemble, tile_apply
 from .inventory import enrich

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -223,6 +223,12 @@ class TileApply(PatchProcessor):
         if not selected:
             msg = "tile_apply needs a dimension and its window, e.g. time=0.5."
             raise ParameterError(msg)
+        # In the patch's axis order, whatever order they were named in, so a
+        # stack's tile and offset axes come out in that order too.
+        position = {dim: axis for axis, dim in enumerate(meta.dims)}
+        selected = dict(
+            sorted(selected.items(), key=lambda kv: position.get(kv[0], -1))
+        )
         return resolve_window(
             meta,
             selected,
@@ -238,7 +244,14 @@ class TileApply(PatchProcessor):
         window = self.window(meta)
         if self.mode == "overlap_add":
             return meta
-        return meta.update(coords=_stack_coords(meta, window))
+        assert window.stride is not None
+        # The stride the tiles were cut at travels in attrs, so a thinned
+        # stack still reassembles under the taper it was cut for.
+        strides = {
+            f"_tile_stride_{d}": int(s) for d, s in zip(window.dims, window.stride)
+        }
+        attrs = meta.attrs.update(**strides)
+        return meta.update(coords=_stack_coords(meta, window), attrs=attrs)
 
     def kernel(self, data, meta, out_meta):
         """Tile every batch over the windowed axes; blend or stack."""
@@ -261,12 +274,9 @@ class TileApply(PatchProcessor):
             stacks = np.stack([self.function(plan.extract(batch)) for batch in batches])
             out = stacks.reshape((*moved.shape[:-ndim], *plan.grid, *plan.size))
             # The tile axes go where the windowed dimensions were; the
-            # offsets within a tile go at the end, in the patch's axis order.
+            # offsets within a tile stay at the end, already in axis order.
             n_batch = moved.ndim - ndim
-            out = np.moveaxis(out, range(n_batch, n_batch + ndim), window.axes)
-            first = out.ndim - ndim
-            offsets = [first + int(i) for i in np.argsort(window.axes)]
-            return np.moveaxis(out, offsets, range(first, out.ndim))
+            return np.moveaxis(out, range(n_batch, n_batch + ndim), window.axes)
         taper = get_taper(self.taper, window.size, window.overlap)
         if engine == "numba":
             from dascore.utils._tiles_numba import apply_jit  # noqa: PLC0415
@@ -317,9 +327,7 @@ def _stack_coords(meta: PatchMeta, window: Window):
                     coords.get_coord(name),
                 )
         coords = coords.disassociate_coord(dim)
-    axis_of = dict(zip(window.dims, window.axes))
-    by_axis = sorted(window.dims, key=axis_of.__getitem__)
-    dims = (*meta.dims, *(f"{dim}_offset" for dim in by_axis))
+    dims = (*meta.dims, *(f"{dim}_offset" for dim in window.dims))
     # Coords given bare, or as (dims, values): the manager takes either.
     coord_map: dict[str, Any] = dict(coords.get_coord_tuple_map())
     coord_map.update(new_coords)
@@ -327,23 +335,6 @@ def _stack_coords(meta: PatchMeta, window: Window):
 
 
 register_implementation("tile_apply", TileApply)
-
-
-def _overlap_from_starts(
-    starts: list[np.ndarray], size: tuple[int, ...]
-) -> tuple[int, ...]:
-    """
-    Return how far the tiles overlapped when cut, from the gaps between starts.
-
-    The smallest gap between any two starts is the stride; a lone tile has
-    nothing to overlap with and gets a boxcar.
-    """
-    out = []
-    for start, z in zip(starts, size):
-        unique = np.unique(start)
-        stride = int(np.min(np.diff(unique))) if len(unique) > 1 else z
-        out.append(max(0, z - stride))
-    return tuple(out)
 
 
 @patch_function()
@@ -397,10 +388,11 @@ def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
     grid = moved.shape[-2 * ndim : -ndim]
     stacks = moved.reshape((-1, int(np.prod(grid)), *size))
     # Where each tile goes is what its start says, whatever order the tiles
-    # are in and whichever of them are still here; the taper's ramp length
-    # is what the tiles overlapped by when they were cut.
+    # are in and whichever of them are still here; the taper is the one the
+    # tiles were cut for, which the stride in attrs says.
     starts = [patch.get_coord(f"{dim}_start").values for dim in dims]
-    overlap = _overlap_from_starts(starts, size)
+    strides = tuple(int(patch.attrs[f"_tile_stride_{dim}"]) for dim in dims)
+    overlap = tuple(z - st for z, st in zip(size, strides))
     weights = get_taper(taper, size, overlap)
     origins = np.stack(np.meshgrid(*starts, indexing="ij"), axis=-1).reshape(-1, ndim)
     low = tuple(int(min(0, s.min())) for s in starts)
@@ -435,4 +427,5 @@ def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
         coord_map.pop(f"_tile_source_{key}")
     new_dims = tuple(d for d in patch.dims if d not in offset_dims)
     coords = get_coord_manager(coords=coord_map, dims=new_dims)
-    return patch.new(data=out, coords=coords)
+    attrs = {k: v for k, v in dict(patch.attrs).items() if not k.startswith("_tile_")}
+    return patch.new(data=out, coords=coords, attrs=dc.PatchAttrs(**attrs))

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -33,6 +33,7 @@ from dascore.exceptions import (
 )
 from dascore.utils.patch import patch_function
 from dascore.utils.signal import get_taper
+from dascore.utils.tiles import get_tile_plan
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.window import Window, resolve_window
 from dascore.workflow.meta import PatchMeta
@@ -337,6 +338,30 @@ def _stack_coords(meta: PatchMeta, window: Window):
 register_implementation("tile_apply", TileApply)
 
 
+def _place_each(stacks, starts, shape, size, weights):
+    """
+    Blend tiles by adding each where its start says, one tile at a time.
+
+    For a stack which is not every tile in the order it was cut -- thinned,
+    or reordered -- where the plan's colour classes no longer apply.
+    """
+    ndim = len(shape)
+    origins = np.stack(np.meshgrid(*starts, indexing="ij"), axis=-1).reshape(-1, ndim)
+    low = tuple(int(min(0, s.min())) for s in starts)
+    high = tuple(int(max(n, s.max() + z)) for n, s, z in zip(shape, starts, size))
+    out = np.zeros(
+        (stacks.shape[0], *(h - lo for lo, h in zip(low, high))),
+        dtype=np.result_type(stacks, weights),
+    )
+    for tile, origin in enumerate(origins):
+        place = tuple(
+            slice(int(o - lo), int(o - lo + z)) for o, lo, z in zip(origin, low, size)
+        )
+        out[(slice(None), *place)] += stacks[:, tile] * weights
+    inner = tuple(slice(-lo, -lo + n) for lo, n in zip(low, shape))
+    return out[(slice(None), *inner)]
+
+
 @patch_function()
 def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
     """
@@ -394,20 +419,17 @@ def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
     strides = tuple(int(patch.attrs[f"_tile_stride_{dim}"]) for dim in dims)
     overlap = tuple(z - st for z, st in zip(size, strides))
     weights = get_taper(taper, size, overlap)
-    origins = np.stack(np.meshgrid(*starts, indexing="ij"), axis=-1).reshape(-1, ndim)
-    low = tuple(int(min(0, s.min())) for s in starts)
-    high = tuple(int(max(n, s.max() + z)) for n, s, z in zip(shape, starts, size))
-    out = np.zeros(
-        (stacks.shape[0], *(h - lo for lo, h in zip(low, high))),
-        dtype=np.result_type(stacks, weights),
+    plan = get_tile_plan(shape, size, strides)
+    as_cut = all(
+        len(s) == count and np.array_equal(s, np.arange(count) * st - st)
+        for s, count, st in zip(starts, plan.grid, strides)
     )
-    for tile, origin in enumerate(origins):
-        place = tuple(
-            slice(int(o - lo), int(o - lo + z)) for o, lo, z in zip(origin, low, size)
-        )
-        out[(slice(None), *place)] += stacks[:, tile] * weights
-    inner = tuple(slice(-lo, -lo + n) for lo, n in zip(low, shape))
-    blended = out[(slice(None), *inner)]
+    if as_cut:
+        # Every tile, in the order it was cut: the plan blends the stack a
+        # colour class at a time rather than a tile at a time.
+        blended = np.stack([plan.overlap_add(stack, weights) for stack in stacks])
+    else:
+        blended = _place_each(stacks, starts, shape, size, weights)
     out = blended.reshape((*batch_shape, *shape))
     out = np.moveaxis(out, tuple(range(-ndim, 0)), tile_axes)
     # Put the source coordinates back, and drop everything the stack added.

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -33,7 +33,6 @@ from dascore.exceptions import (
 )
 from dascore.utils.patch import patch_function
 from dascore.utils.signal import get_taper
-from dascore.utils.tiles import get_tile_plan
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.window import Window, resolve_window
 from dascore.workflow.meta import PatchMeta
@@ -51,11 +50,16 @@ def _is_jitted(func) -> bool:
 
 
 def _offset_values(coord, offsets: np.ndarray):
-    """Return coordinate values `offsets` samples from the coordinate's start."""
-    step = coord.step
+    """
+    Return coordinate values `offsets` samples from the coordinate's first sample.
+
+    From the first sample, not the minimum: a descending coordinate steps
+    down from where it starts.
+    """
+    first, step = coord.values[0], coord.step
     if is_datetime64(coord.dtype) or is_timedelta64(coord.dtype):
-        return coord.min() + dc.to_timedelta64(offsets * to_float(step))
-    return coord.min() + offsets * step
+        return first + dc.to_timedelta64(offsets * to_float(step))
+    return first + offsets * step
 
 
 def _engine_for(engine: str, func, ndim: int) -> str:
@@ -65,7 +69,7 @@ def _engine_for(engine: str, func, ndim: int) -> str:
         raise ParameterError(msg)
     jitted = _is_jitted(func)
     if engine == "auto":
-        engine = "numba" if jitted and ndim == 2 else "numpy"
+        engine = "numba" if jitted else "numpy"
     if engine == "numba":
         if not jitted:
             msg = (
@@ -74,7 +78,10 @@ def _engine_for(engine: str, func, ndim: int) -> str:
             )
             raise ParameterError(msg)
         if ndim != 2:
-            msg = "engine='numba' tiles exactly two dimensions."
+            msg = (
+                "A numba-compiled function is given one tile at a time over "
+                f"exactly two windowed dimensions; this call windows {ndim}."
+            )
             raise ParameterError(msg)
         # Deferred: the driver is optional, and importing it eagerly would
         # compile it whenever dascore is imported.
@@ -246,7 +253,13 @@ class TileApply(PatchProcessor):
         moved = np.moveaxis(data, window.axes, tail)
         batches = moved.reshape((-1, *moved.shape[-ndim:]))
         if self.mode == "stack":
-            stacks = np.stack([plan.extract(batch) for batch in batches])
+            if engine == "numba":
+                msg = (
+                    "mode='stack' hands the function the whole stack of tiles; "
+                    "a numba-compiled function of one tile cannot take it."
+                )
+                raise ParameterError(msg)
+            stacks = np.stack([self.function(plan.extract(batch)) for batch in batches])
             out = stacks.reshape((*moved.shape[:-ndim], *plan.grid, *plan.size))
             # The tile axes go where the windowed dimensions were; the
             # offsets within a tile go at the end, in the patch's axis order.
@@ -275,9 +288,15 @@ def _stack_coords(meta: PatchMeta, window: Window):
     for dim, size, stride, count in zip(
         window.dims, window.size, plan.stride, plan.grid
     ):
-        for suffix in ("_start", "_stop", "_offset"):
-            if f"{dim}{suffix}" in coords.coord_map:
-                msg = f"The patch already has a coordinate called {dim}{suffix}."
+        claimed = (
+            f"{dim}_start",
+            f"{dim}_stop",
+            f"{dim}_offset",
+            f"_tile_source_{dim}",
+        )
+        for name in claimed:
+            if name in coords.coord_map:
+                msg = f"The patch already has a coordinate called {name}."
                 raise ParameterError(msg)
         coord = coords.get_coord(dim)
         starts = np.arange(count) * stride - stride
@@ -301,6 +320,23 @@ def _stack_coords(meta: PatchMeta, window: Window):
 
 
 register_implementation("tile_apply", TileApply)
+
+
+def _overlap_from_starts(
+    starts: list[np.ndarray], size: tuple[int, ...]
+) -> tuple[int, ...]:
+    """
+    Return how far the tiles overlapped when cut, from the gaps between starts.
+
+    The smallest gap between any two starts is the stride; a lone tile has
+    nothing to overlap with and gets a boxcar.
+    """
+    out = []
+    for start, z in zip(starts, size):
+        unique = np.unique(start)
+        stride = int(np.min(np.diff(unique))) if len(unique) > 1 else z
+        out.append(max(0, z - stride))
+    return tuple(out)
 
 
 @patch_function()
@@ -338,10 +374,7 @@ def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
     dims = tuple(sources)
     offset_dims = tuple(f"{dim}_offset" for dim in dims)
     size = tuple(len(patch.get_coord(name)) for name in offset_dims)
-    starts = [patch.get_coord(f"{dim}_start").values for dim in dims]
-    stride = tuple(int(s[1] - s[0]) if len(s) > 1 else z for s, z in zip(starts, size))
     shape = tuple(len(coord) for coord in sources.values())
-    overlap = tuple(z - st for z, st in zip(size, stride))
     tile_axes = tuple(patch.get_axis(dim) for dim in dims)
     offset_axes = tuple(patch.get_axis(name) for name in offset_dims)
     ndim = len(dims)
@@ -352,15 +385,28 @@ def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
     batch_shape = moved.shape[: -2 * ndim]
     grid = moved.shape[-2 * ndim : -ndim]
     stacks = moved.reshape((-1, int(np.prod(grid)), *size))
-    plan = get_tile_plan(shape, size, stride)
-    if plan.grid != grid:
-        msg = f"The stack holds {grid} tiles but {shape} samples tile as {plan.grid}."
-        raise PatchError(msg)
+    # Where each tile goes is what its start says, whatever order the tiles
+    # are in and whichever of them are still here; the taper's ramp length
+    # is what the tiles overlapped by when they were cut.
+    starts = [patch.get_coord(f"{dim}_start").values for dim in dims]
+    overlap = _overlap_from_starts(starts, size)
     weights = get_taper(taper, size, overlap)
-    blended = np.stack([plan.overlap_add(stack, weights) for stack in stacks])
-    out = np.moveaxis(
-        blended.reshape((*batch_shape, *shape)), tuple(range(-ndim, 0)), tile_axes
+    origins = np.stack(np.meshgrid(*starts, indexing="ij"), axis=-1).reshape(-1, ndim)
+    low = tuple(int(min(0, s.min())) for s in starts)
+    high = tuple(int(max(n, s.max() + z)) for n, s, z in zip(shape, starts, size))
+    out = np.zeros(
+        (stacks.shape[0], *(h - lo for lo, h in zip(low, high))),
+        dtype=np.result_type(stacks, weights),
     )
+    for tile, origin in enumerate(origins):
+        place = tuple(
+            slice(int(o - lo), int(o - lo + z)) for o, lo, z in zip(origin, low, size)
+        )
+        out[(slice(None), *place)] += stacks[:, tile] * weights
+    inner = tuple(slice(-lo, -lo + n) for lo, n in zip(low, shape))
+    blended = out[(slice(None), *inner)]
+    out = blended.reshape((*batch_shape, *shape))
+    out = np.moveaxis(out, tuple(range(-ndim, 0)), tile_axes)
     # Put the source coordinates back, and drop everything the stack added.
     coord_map: dict[str, Any] = dict(patch.coords.get_coord_tuple_map())
     for dim, coord in sources.items():

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -302,7 +302,7 @@ def _stack_coords(meta: PatchMeta, window: Window):
         starts = np.arange(count) * stride - stride
         # The tile's middle sample, in the coordinate's units.
         centres = _offset_values(coord, starts + (size - 1) / 2)
-        offsets = _offset_values(coord, np.arange(size)) - coord.min()
+        offsets = _offset_values(coord, np.arange(size)) - coord.values[0]
         new_coords[dim] = get_coord(data=centres, units=coord.units)
         new_coords[f"{dim}_start"] = (dim, starts)
         new_coords[f"{dim}_stop"] = (dim, starts + size)

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -1,0 +1,377 @@
+"""
+Apply a function to overlapping windows of a patch, and blend them back.
+
+Many operations on DAS data are local: a window of the data is transformed,
+edited, and put back, and the windows overlap so that the seams do not
+show. The adaptive spectral filter is one; local normalization, a local
+f-k filter, and tile-wise rank reduction are others. What they share is
+everything but the function, and this module holds the everything.
+
+`tile_apply` cuts the patch into tiles along one or more dimensions, hands
+them to a function, and either blends them back under a taper into a patch
+shaped like the input (``mode="overlap_add"``) or returns them stacked, one
+tile axis per windowed dimension, for the caller to work on and put back
+with `reassemble` (``mode="stack"``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+from pydantic import ConfigDict
+
+import dascore as dc
+from dascore.constants import PatchType
+from dascore.core.coordmanager import get_coord_manager
+from dascore.core.coords import get_coord
+from dascore.exceptions import (
+    MissingOptionalDependencyError,
+    ParameterError,
+    PatchError,
+)
+from dascore.utils.patch import patch_function
+from dascore.utils.signal import get_taper
+from dascore.utils.tiles import get_tile_plan
+from dascore.utils.time import is_datetime64, is_timedelta64, to_float
+from dascore.utils.window import Window, resolve_window
+from dascore.workflow.meta import PatchMeta
+from dascore.workflow.processor import PatchProcessor, register_implementation
+
+__all__ = ("TileApply", "reassemble", "tile_apply")
+
+_MODES = ("overlap_add", "stack")
+_ENGINES = ("auto", "numpy", "numba")
+
+
+def _is_jitted(func) -> bool:
+    """Whether a function is a numba dispatcher, to be given a tile at a time."""
+    return hasattr(func, "py_func") and hasattr(func, "nopython_signatures")
+
+
+def _offset_values(coord, offsets: np.ndarray):
+    """Return coordinate values `offsets` samples from the coordinate's start."""
+    step = coord.step
+    if is_datetime64(coord.dtype) or is_timedelta64(coord.dtype):
+        return coord.min() + dc.to_timedelta64(offsets * to_float(step))
+    return coord.min() + offsets * step
+
+
+def _engine_for(engine: str, func, ndim: int) -> str:
+    """Return which engine runs `func`, or say why neither can."""
+    if engine not in _ENGINES:
+        msg = f"engine must be one of {_ENGINES}; got {engine!r}."
+        raise ParameterError(msg)
+    jitted = _is_jitted(func)
+    if engine == "auto":
+        engine = "numba" if jitted and ndim == 2 else "numpy"
+    if engine == "numba":
+        if not jitted:
+            msg = (
+                "engine='numba' takes a numba-compiled function of one tile; "
+                "a plain function takes the whole stack and runs on numpy."
+            )
+            raise ParameterError(msg)
+        if ndim != 2:
+            msg = "engine='numba' tiles exactly two dimensions."
+            raise ParameterError(msg)
+        # Deferred: the driver is optional, and importing it eagerly would
+        # compile it whenever dascore is imported.
+        from dascore.utils._tiles_numba import _JIT_AVAILABLE  # noqa: PLC0415
+
+        if not _JIT_AVAILABLE:
+            msg = "engine='numba' requires the optional dependency numba."
+            raise MissingOptionalDependencyError(msg)
+    elif jitted:
+        msg = (
+            "A numba-compiled function is given one tile at a time by "
+            "engine='numba'; the numpy engine hands the whole stack to a plain "
+            "function."
+        )
+        raise ParameterError(msg)
+    return engine
+
+
+@patch_function()
+def tile_apply(
+    patch: PatchType,
+    function: Callable,
+    *,
+    mode: str = "overlap_add",
+    overlap: Any = None,
+    taper: Any = "hann",
+    samples: bool = False,
+    engine: str = "auto",
+    **kwargs: Any,
+) -> PatchType:
+    """
+    Apply a function to overlapping windows of the patch.
+
+    Parameters
+    ----------
+    patch
+        The patch to window.
+    function
+        What to do to the tiles. On the numpy engine it is given the whole
+        stack at once, an array of ``[n_tiles, *window]``, and returns one of
+        the same shape: one vectorized call, not one per tile. A function
+        compiled with numba is given one tile at a time by the numba engine
+        and returns a tile of the same shape; it compiles the first time it
+        is used in each process, which takes a few seconds.
+    mode
+        ``"overlap_add"`` blends the tiles back under `taper` into a patch
+        shaped like the input. ``"stack"`` returns the tiles unblended: each
+        windowed dimension becomes an axis of tile centres, and the samples
+        within a tile become a new ``{dim}_offset`` dimension at the end.
+        `reassemble` blends a stack back.
+    overlap
+        How far each window reaches into the next, in coordinate units or,
+        with `samples`, in samples; a percent is a fraction of the window;
+        a mapping gives each dimension its own. Half the window when not
+        given. Never more than half: the taper's ramps would cross.
+    taper
+        The window whose edge the taper ramps take -- any name
+        `dascore.utils.signal.get_window` knows. The ramps are made
+        complementary, so blended tiles of an unchanged stack return the
+        input exactly. Not applied in ``"stack"`` mode.
+    samples
+        If True, windows and overlaps are sample counts.
+    engine
+        ``"numpy"``, ``"numba"``, or ``"auto"``, which is numba for a
+        numba-compiled `function` over two dimensions and numpy otherwise.
+    **kwargs
+        The dimensions to window and the window along each, such as
+        ``time=0.5`` (seconds) or ``time=64, distance=16, samples=True``.
+
+    Returns
+    -------
+    Patch
+        In ``"overlap_add"`` mode, a patch with the input's coordinates. In
+        ``"stack"`` mode, the tiles: the windowed dimensions carry the tile
+        centres, ``{dim}_start`` and ``{dim}_stop`` say where each tile came
+        from in samples, and ``{dim}_offset`` is the position within a tile.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch("example_event_2")
+    >>>
+    >>> # Automatic gain control: every window scaled to unit RMS, blended.
+    >>> def agc(tiles):
+    ...     rms = np.sqrt(np.mean(tiles**2, axis=(1, 2), keepdims=True))
+    ...     return tiles / np.where(rms > 0, rms, 1)
+    >>> normalized = patch.tile_apply(agc, time=0.05, distance=50)
+    >>>
+    >>> # The tiles themselves, to work on and put back.
+    >>> tiles = patch.tile_apply(lambda x: x, mode="stack", time=0.05, distance=50)
+    >>> back = tiles.reassemble()
+
+    Notes
+    -----
+    - Tiles start one stride before the data and are padded with zeros, so
+      every sample of the input is covered by tiles which see a full taper
+      ramp on both sides.
+    - The adaptive spectral filter is this with a spectral weighting as
+      `function`; see
+      [`Patch.adaptive_spectral_filter`](`dascore.Patch.adaptive_spectral_filter`).
+    """
+    return TileApply(
+        function=function,
+        mode=mode,
+        overlap=overlap,
+        taper=taper,
+        samples=samples,
+        engine=engine,
+        **kwargs,
+    )._apply(patch)
+
+
+class TileApply(PatchProcessor):
+    """
+    Apply a function to overlapping windows of a patch.
+
+    The dimensions to window arrive as extras carrying their window sizes,
+    as the patch function takes them; `window` turns them into sample
+    counts once the coordinates are known, and `derive_meta` says what a
+    stack's coordinates are without touching any data.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True, arbitrary_types_allowed=True)
+
+    function: Callable
+    mode: str = "overlap_add"
+    overlap: Any = None
+    taper: Any = "hann"
+    samples: bool = False
+    engine: str = "auto"
+
+    def window(self, meta: PatchMeta) -> Window:
+        """Return the window in samples."""
+        if self.mode not in _MODES:
+            msg = f"mode must be one of {_MODES}; got {self.mode!r}."
+            raise ParameterError(msg)
+        selected = self.model_extra or {}
+        if not selected:
+            msg = "tile_apply needs a dimension and its window, e.g. time=0.5."
+            raise ParameterError(msg)
+        return resolve_window(
+            meta,
+            selected,
+            samples=self.samples,
+            overlap=self.overlap,
+            # Half the window, the most the taper's ramps allow.
+            default_overlap=lambda size: size // 2,
+            min_samples=2,
+        )
+
+    def derive_meta(self, meta: PatchMeta) -> PatchMeta:
+        """Return the coordinates of a stack; a blend keeps the input's."""
+        window = self.window(meta)
+        if self.mode == "overlap_add":
+            return meta
+        return meta.update(coords=_stack_coords(meta, window))
+
+    def kernel(self, data, meta, out_meta):
+        """Tile every batch over the windowed axes; blend or stack."""
+        window = self.window(meta)
+        assert window.stride is not None and window.overlap is not None
+        engine = _engine_for(self.engine, self.function, len(window.axes))
+        plan = window.tiles(data.shape)
+        taper = get_taper(self.taper, window.size, window.overlap)
+        data = np.asarray(data)
+        ndim = len(window.axes)
+        tail = tuple(range(-ndim, 0))
+        moved = np.moveaxis(data, window.axes, tail)
+        batches = moved.reshape((-1, *moved.shape[-ndim:]))
+        if self.mode == "stack":
+            stacks = np.stack([plan.extract(batch) for batch in batches])
+            out = stacks.reshape((*moved.shape[:-ndim], *plan.grid, *plan.size))
+            # The tile axes go where the windowed dimensions were; the
+            # offsets within a tile go at the end, in the patch's axis order.
+            n_batch = moved.ndim - ndim
+            out = np.moveaxis(out, range(n_batch, n_batch + ndim), window.axes)
+            first = out.ndim - ndim
+            offsets = [first + int(i) for i in np.argsort(window.axes)]
+            return np.moveaxis(out, offsets, range(first, out.ndim))
+        if engine == "numba":
+            from dascore.utils._tiles_numba import apply_jit  # noqa: PLC0415
+
+            blended = [
+                apply_jit(plan, batch, self.function, taper) for batch in batches
+            ]
+        else:
+            blended = [plan.apply(batch, self.function, taper) for batch in batches]
+        out = np.stack(blended).reshape(moved.shape)
+        return np.moveaxis(out, tail, window.axes)
+
+
+def _stack_coords(meta: PatchMeta, window: Window):
+    """Return a stack's coordinate manager: tile centres, edges, and offsets."""
+    coords = meta.coords
+    plan = window.tiles(meta.shape)
+    new_coords = {}
+    for dim, size, stride, count in zip(
+        window.dims, window.size, plan.stride, plan.grid
+    ):
+        for suffix in ("_start", "_stop", "_offset"):
+            if f"{dim}{suffix}" in coords.coord_map:
+                msg = f"The patch already has a coordinate called {dim}{suffix}."
+                raise ParameterError(msg)
+        coord = coords.get_coord(dim)
+        starts = np.arange(count) * stride - stride
+        # The tile's middle sample, in the coordinate's units.
+        centres = _offset_values(coord, starts + (size - 1) / 2)
+        offsets = _offset_values(coord, np.arange(size)) - coord.min()
+        new_coords[dim] = get_coord(data=centres, units=coord.units)
+        new_coords[f"{dim}_start"] = (dim, starts)
+        new_coords[f"{dim}_stop"] = (dim, starts + size)
+        new_coords[f"{dim}_offset"] = get_coord(data=offsets, units=coord.units)
+        # The coordinate the tiles were cut from, for reassembly.
+        new_coords[f"_tile_source_{dim}"] = (None, coord)
+        coords = coords.disassociate_coord(dim)
+    axis_of = dict(zip(window.dims, window.axes))
+    by_axis = sorted(window.dims, key=axis_of.__getitem__)
+    dims = (*meta.dims, *(f"{dim}_offset" for dim in by_axis))
+    # Coords given bare, or as (dims, values): the manager takes either.
+    coord_map: dict[str, Any] = dict(coords.get_coord_tuple_map())
+    coord_map.update(new_coords)
+    return get_coord_manager(coords=coord_map, dims=dims)
+
+
+register_implementation("tile_apply", TileApply)
+
+
+@patch_function()
+def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
+    """
+    Blend a stack of tiles back into the patch they were cut from.
+
+    The inverse of [`tile_apply`](`dascore.Patch.tile_apply`) in
+    ``"stack"`` mode: each tile is multiplied by a taper with complementary
+    ramps and added where its ``{dim}_start`` says it came from, so a stack
+    which was not changed returns the original patch exactly.
+
+    Parameters
+    ----------
+    patch
+        A patch `tile_apply` stacked.
+    taper
+        The window whose edge the taper ramps take; see `tile_apply`.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> patch = dc.get_example_patch()
+    >>> tiles = patch.tile_apply(lambda x: x, mode="stack", time=0.2, samples=False)
+    >>> assert tiles.reassemble().equals(patch, close=True)
+    """
+    sources = {
+        name[len("_tile_source_") :]: coord
+        for name, coord in patch.coords.coord_map.items()
+        if name.startswith("_tile_source_")
+    }
+    if not sources:
+        msg = "reassemble takes a patch tile_apply stacked; this one has no tiles."
+        raise PatchError(msg)
+    dims = tuple(sources)
+    offset_dims = tuple(f"{dim}_offset" for dim in dims)
+    size = tuple(len(patch.get_coord(name)) for name in offset_dims)
+    starts = [patch.get_coord(f"{dim}_start").values for dim in dims]
+    stride = tuple(int(s[1] - s[0]) if len(s) > 1 else z for s, z in zip(starts, size))
+    shape = tuple(len(coord) for coord in sources.values())
+    overlap = tuple(z - st for z, st in zip(size, stride))
+    tile_axes = tuple(patch.get_axis(dim) for dim in dims)
+    offset_axes = tuple(patch.get_axis(name) for name in offset_dims)
+    ndim = len(dims)
+    # Batches first, then the tile grid, then the samples within a tile.
+    moved = np.moveaxis(
+        patch.data, (*tile_axes, *offset_axes), tuple(range(-2 * ndim, 0))
+    )
+    batch_shape = moved.shape[: -2 * ndim]
+    grid = moved.shape[-2 * ndim : -ndim]
+    stacks = moved.reshape((-1, int(np.prod(grid)), *size))
+    plan = get_tile_plan(shape, size, stride)
+    if plan.grid != grid:
+        msg = f"The stack holds {grid} tiles but {shape} samples tile as {plan.grid}."
+        raise PatchError(msg)
+    weights = get_taper(taper, size, overlap)
+    blended = np.stack([plan.overlap_add(stack, weights) for stack in stacks])
+    out = np.moveaxis(
+        blended.reshape((*batch_shape, *shape)), tuple(range(-ndim, 0)), tile_axes
+    )
+    # Put the source coordinates back, and drop everything the stack added.
+    coord_map: dict[str, Any] = dict(patch.coords.get_coord_tuple_map())
+    for dim, coord in sources.items():
+        coord_map[dim] = coord
+        for name in (
+            f"{dim}_start",
+            f"{dim}_stop",
+            f"{dim}_offset",
+            f"_tile_source_{dim}",
+        ):
+            coord_map.pop(name)
+    new_dims = tuple(d for d in patch.dims if d not in offset_dims)
+    coords = get_coord_manager(coords=coord_map, dims=new_dims)
+    return patch.new(data=out, coords=coords)

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -246,7 +246,6 @@ class TileApply(PatchProcessor):
         assert window.stride is not None and window.overlap is not None
         engine = _engine_for(self.engine, self.function, len(window.axes))
         plan = window.tiles(data.shape)
-        taper = get_taper(self.taper, window.size, window.overlap)
         data = np.asarray(data)
         ndim = len(window.axes)
         tail = tuple(range(-ndim, 0))
@@ -268,6 +267,7 @@ class TileApply(PatchProcessor):
             first = out.ndim - ndim
             offsets = [first + int(i) for i in np.argsort(window.axes)]
             return np.moveaxis(out, offsets, range(first, out.ndim))
+        taper = get_taper(self.taper, window.size, window.overlap)
         if engine == "numba":
             from dascore.utils._tiles_numba import apply_jit  # noqa: PLC0415
 
@@ -309,6 +309,13 @@ def _stack_coords(meta: PatchMeta, window: Window):
         new_coords[f"{dim}_offset"] = get_coord(data=offsets, units=coord.units)
         # The coordinate the tiles were cut from, for reassembly.
         new_coords[f"_tile_source_{dim}"] = (None, coord)
+        # And every coordinate which rode along it, a quality flag say.
+        for name, aux_dims in coords.dim_map.items():
+            if aux_dims == (dim,) and name != dim:
+                new_coords[f"_tile_source_{dim}__{name}"] = (
+                    None,
+                    coords.get_coord(name),
+                )
         coords = coords.disassociate_coord(dim)
     axis_of = dict(zip(window.dims, window.axes))
     by_axis = sorted(window.dims, key=axis_of.__getitem__)
@@ -363,11 +370,15 @@ def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
     >>> tiles = patch.tile_apply(lambda x: x, mode="stack", time=0.2, samples=False)
     >>> assert tiles.reassemble().equals(patch, close=True)
     """
-    sources = {
+    stashed = {
         name[len("_tile_source_") :]: coord
         for name, coord in patch.coords.coord_map.items()
         if name.startswith("_tile_source_")
     }
+    # `dim` for the coordinate the tiles were cut from; `dim__name` for one
+    # which rode along it.
+    sources = {name: coord for name, coord in stashed.items() if "__" not in name}
+    riders = {name: coord for name, coord in stashed.items() if "__" in name}
     if not sources:
         msg = "reassemble takes a patch tile_apply stacked; this one has no tiles."
         raise PatchError(msg)
@@ -418,6 +429,10 @@ def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
             f"_tile_source_{dim}",
         ):
             coord_map.pop(name)
+    for key, coord in riders.items():
+        dim, name = key.split("__", 1)
+        coord_map[name] = (dim, coord)
+        coord_map.pop(f"_tile_source_{key}")
     new_dims = tuple(d for d in patch.dims if d not in offset_dims)
     coords = get_coord_manager(coords=coord_map, dims=new_dims)
     return patch.new(data=out, coords=coords)

--- a/dascore/utils/_tiles_numba.py
+++ b/dascore/utils/_tiles_numba.py
@@ -1,0 +1,77 @@
+"""
+Optional numba driver which gives a compiled function one tile at a time.
+
+The module imports whether or not numba is installed; only `_JIT_AVAILABLE`
+says whether the driver can compile. The driver is specialized on the
+function it is handed, and numba cannot reuse such a specialization from
+disk, so it compiles the first time each function is used in a process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from dascore.utils.jit import maybe_numba_jit
+from dascore.utils.tiles import TilePlan
+
+
+@maybe_numba_jit(required=True, nopython=True, parallel=True)
+def _apply_colour_class(
+    padded: np.ndarray,
+    out: np.ndarray,
+    taper: np.ndarray,
+    window0: int,
+    window1: int,
+    stride0: int,
+    stride1: int,
+    n_tiles0: int,
+    n_tiles1: int,
+    colours0: int,
+    colours1: int,
+    colour0: int,
+    colour1: int,
+    func,
+) -> None:
+    """
+    Apply `func` to every tile of one colour class, adding into `out`.
+
+    Tiles of one class are `colours` strides apart, further than a tile
+    reaches, so no two iterations of the parallel loop write to the same
+    output sample.
+    """
+    count0 = (n_tiles0 - colour0 + colours0 - 1) // colours0
+    count1 = (n_tiles1 - colour1 + colours1 - 1) // colours1
+    for ind in numba.prange(count0 * count1):  # noqa: F821  # ty: ignore[unresolved-reference]
+        beg0 = (colour0 + colours0 * (ind // count1)) * stride0
+        beg1 = (colour1 + colours1 * (ind % count1)) * stride1
+        tile = func(padded[beg0 : beg0 + window0, beg1 : beg1 + window1])
+        out[beg0 : beg0 + window0, beg1 : beg1 + window1] += tile * taper
+
+
+_JIT_AVAILABLE = _apply_colour_class.jit_available
+
+
+def apply_jit(plan: TilePlan, array: np.ndarray, func, taper: np.ndarray) -> np.ndarray:
+    """
+    Return the array with `func` applied to every tile and the tiles blended.
+
+    `func` is a numba-compiled function of one tile returning a tile of the
+    same shape. Two dimensions only.
+    """
+    padded = plan.pad(array, dtype=np.result_type(array, np.float32))
+    out = np.zeros_like(padded)
+    for colour0 in range(plan.colours[0]):
+        for colour1 in range(plan.colours[1]):
+            _apply_colour_class(
+                padded,
+                out,
+                taper.astype(padded.dtype),
+                *plan.size,
+                *plan.stride,
+                *plan.grid,
+                *plan.colours,
+                colour0,
+                colour1,
+                func,
+            )
+    return plan.crop(out)

--- a/dascore/utils/_tiles_numba.py
+++ b/dascore/utils/_tiles_numba.py
@@ -59,7 +59,10 @@ def apply_jit(plan: TilePlan, array: np.ndarray, func, taper: np.ndarray) -> np.
     same shape. Two dimensions only.
     """
     padded = plan.pad(array, dtype=np.result_type(array, np.float32))
-    out = np.zeros_like(padded)
+    # One tile through the function first, to learn what it returns: the
+    # output takes that dtype, so a real tile made complex is kept complex.
+    probe = func(padded[tuple(slice(0, z) for z in plan.size)])
+    out = np.zeros(plan.extended, dtype=np.result_type(probe, padded, taper))
     for colour0 in range(plan.colours[0]):
         for colour1 in range(plan.colours[1]):
             _apply_colour_class(

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -103,6 +103,9 @@ def _format_values(val):
     elif isinstance(val, dc.Patch):
         # Truncate patch representations in history (issue #529)
         out = "Patch..."
+    elif callable(val):
+        # By name: a repr would carry an address which changes every run.
+        out = getattr(val, "__qualname__", None) or repr(val)
     else:
         out = str(val)
         if len(out) > _MAX_HISTORY_VALUE_LEN:

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -104,8 +104,14 @@ def _format_values(val):
         # Truncate patch representations in history (issue #529)
         out = "Patch..."
     elif callable(val):
-        # By name: a repr would carry an address which changes every run.
-        out = getattr(val, "__qualname__", None) or repr(val)
+        # By name: a repr would carry an address which changes every run. A
+        # partial is named by the function it wraps, an object by its class.
+        inner = getattr(val, "func", None)
+        out = (
+            getattr(val, "__qualname__", None)
+            or getattr(inner, "__qualname__", None)
+            or type(val).__qualname__
+        )
     else:
         out = str(val)
         if len(out) > _MAX_HISTORY_VALUE_LEN:

--- a/dascore/utils/tiles.py
+++ b/dascore/utils/tiles.py
@@ -22,7 +22,7 @@ from functools import lru_cache
 from itertools import product
 
 import numpy as np
-from numpy.lib.stride_tricks import sliding_window_view
+from numpy.lib.stride_tricks import as_strided
 
 from dascore.exceptions import ParameterError
 
@@ -107,14 +107,20 @@ class TilePlan:
         )
 
     def _tile_view(self, buffer: np.ndarray, writeable: bool = False) -> np.ndarray:
-        """A view of the buffer as the tile grid, ``[*grid, *size]``."""
-        view = sliding_window_view(buffer, self.size, writeable=writeable)
-        return view[
-            tuple(
-                slice(0, count * step, step)
-                for count, step in zip(self.grid, self.stride)
-            )
-        ]
+        """
+        A view of the buffer as the tile grid, ``[*grid, *size]``.
+
+        Strided directly rather than through `sliding_window_view`, whose
+        view spans every window position: on a 32-bit build that logical
+        size overflows for an ordinary patch, though nothing is allocated.
+        """
+        strides = (
+            *(step * s for step, s in zip(self.stride, buffer.strides)),
+            *buffer.strides,
+        )
+        return as_strided(
+            buffer, shape=(*self.grid, *self.size), strides=strides, writeable=writeable
+        )
 
     def pad(self, array: np.ndarray, dtype=None) -> np.ndarray:
         """

--- a/dascore/workflow/serialize.py
+++ b/dascore/workflow/serialize.py
@@ -279,7 +279,7 @@ def _encode(obj: Any, mode: EncodeMode) -> Any:
     if isinstance(obj, partial):
         return _encode_partial(obj, mode)
     if callable(obj):
-        return _encode_callable(obj)
+        return _encode_callable(obj, mode)
     return _encode_opaque(obj)
 
 
@@ -497,7 +497,7 @@ def _encode_partial(value: partial, mode: EncodeMode) -> Any:
     }
 
 
-def _encode_callable(func: Callable) -> Any:
+def _encode_callable(func: Callable, mode: EncodeMode = FINGERPRINT) -> Any:
     """
     Encode a callable by where it is defined.
 
@@ -507,6 +507,12 @@ def _encode_callable(func: Callable) -> Any:
     that source, and so are one parameter as far as a fingerprint is
     concerned.
     """
+    if mode == DOCUMENT:
+        msg = (
+            "A function parameter cannot be written to a document. Give the "
+            "task values it can carry, or keep the operation in code."
+        )
+        raise ParameterError(msg)
     module = getattr(func, "__module__", None) or "<unknown>"
     qualname = getattr(func, "__qualname__", None) or repr(func)
     out = {"path": f"{module}:{qualname}"}

--- a/docs/recipes/windowing.qmd
+++ b/docs/recipes/windowing.qmd
@@ -56,8 +56,10 @@ tiles = patch.tile_apply(lambda x: x, mode="stack", time=0.02, distance=40)
 print(tiles.dims, tiles.shape)
 
 # Drop every tile whose energy is in the lowest quarter, then blend back.
+# The mean keeps the offset axes at length one, so a per-tile flag
+# broadcasts back over every sample of its tile.
 energy = (tiles**2).mean(dim=("distance_offset", "time_offset"))
-quiet = energy.data < np.percentile(energy.data, 25)  # one flag per tile
+quiet = energy.data < np.percentile(energy.data, 25)
 kept = tiles.new(data=np.where(quiet, 0, tiles.data))
 denoised = kept.reassemble()
 assert denoised.shape == patch.shape

--- a/docs/recipes/windowing.qmd
+++ b/docs/recipes/windowing.qmd
@@ -1,0 +1,88 @@
+---
+title: Windows and Tiles
+execute:
+    warning: False
+---
+
+Much of what is done to DAS data is done to a window of it at a time. DASCore has three ways of windowing, and they answer different questions.
+
+| you want | use | what comes back |
+|---|---|---|
+| a value per sample, from the samples around it | [`Patch.rolling`](`dascore.Patch.rolling`) | a patch shaped like the input |
+| a transform of each window, kept as windows | [`Patch.stft`](`dascore.Patch.stft`), or [`Patch.tile_apply`](`dascore.Patch.tile_apply`) with `mode="stack"` | a patch with a window axis |
+| each window transformed and the windows blended back | [`Patch.tile_apply`](`dascore.Patch.tile_apply`) | a patch shaped like the input |
+
+All three take the window the same way: the dimension and its length, in coordinate units or with `samples=True` in samples, plus an `overlap` which may be a count, a duration, a percent of the window, or a mapping with one per dimension.
+
+## Tiles, blended
+
+`tile_apply` cuts the patch into overlapping tiles along one or more dimensions, hands them to a function, and blends the results back under a taper whose ramps sum to one, so a function which changes nothing returns the input exactly. The function is given the whole stack of tiles at once — an array of `[n_tiles, *window]` — and returns one of the same shape.
+
+Automatic gain control is the simplest example: every window scaled to unit RMS, so quiet and loud stretches draw alike.
+
+```{python}
+import numpy as np
+import matplotlib.pyplot as plt
+
+import dascore as dc
+
+patch = dc.get_example_patch("example_event_2").pass_filter(time=(1, 300))
+
+
+def agc(tiles):
+    """Scale every tile to unit RMS."""
+    rms = np.sqrt(np.mean(tiles**2, axis=(1, 2), keepdims=True))
+    return tiles / np.where(rms > 0, rms, 1)
+
+
+normalized = patch.tile_apply(agc, time=0.02, distance=40)
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
+for ax, pa, title in zip(axes, [patch, normalized], ["band-passed", "AGC, 20 ms by 40 m"]):
+    scale = np.percentile(np.abs(pa.data), 99)
+    pa.viz.waterfall(ax=ax, scale=scale, scale_type="absolute", cmap="bwr")
+    ax.set_title(title)
+fig.tight_layout()
+```
+
+The [adaptive spectral filter](adaptive_spectral_filter.qmd) is the same machinery with a spectral weighting as the function.
+
+## Tiles, kept
+
+With `mode="stack"` the tiles come back unblended. Each windowed dimension becomes an axis of tile centres, `{dim}_start` and `{dim}_stop` say where each tile came from in samples, and the samples within a tile become a `{dim}_offset` dimension at the end. Work on the stack as a patch — select tiles, transform along the offsets, threshold — and [`reassemble`](`dascore.Patch.reassemble`) blends it back.
+
+```{python}
+tiles = patch.tile_apply(lambda x: x, mode="stack", time=0.02, distance=40)
+print(tiles.dims, tiles.shape)
+
+# Drop every tile whose energy is in the lowest quarter, then blend back.
+energy = (tiles**2).mean(dim=("distance_offset", "time_offset"))
+quiet = energy.data < np.percentile(energy.data, 25)  # one flag per tile
+kept = tiles.new(data=np.where(quiet, 0, tiles.data))
+denoised = kept.reassemble()
+assert denoised.shape == patch.shape
+```
+
+A stack nobody changed reassembles to the patch it was cut from, coordinates and all.
+
+## A compiled function, one tile at a time
+
+A function compiled with numba is given one tile at a time rather than the stack, in parallel, which is faster for anything that cannot be written over the stack in one numpy call. It compiles the first time it is used in each process, which takes a few seconds; after that a 2000 by 6000 patch tiles in a fraction of a second.
+
+```{python}
+#| eval: false
+import numba
+
+
+@numba.njit
+def agc_tile(tile):
+    rms = np.sqrt(np.mean(tile * tile))
+    return tile / rms if rms > 0 else tile
+
+
+normalized = patch.tile_apply(agc_tile, time=0.02, distance=40)
+```
+
+## What a tile sees
+
+Tiles start one stride before the data and are padded with zeros, so every sample is covered by tiles which see a full taper ramp on both sides. Overlap defaults to half the window and cannot exceed it, since the ramps would cross. The taper's shape is any window [`get_window`](`dascore.utils.signal.get_window`) knows; its ramps are made complementary whatever the shape, which is what makes the blend exact.

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -169,6 +169,7 @@ website:
             - recipes/edge_effects.qmd
             - recipes/fk.qmd
             - recipes/adaptive_spectral_filter.qmd
+            - recipes/windowing.qmd
             - recipes/real_time_proc.qmd
             - recipes/parallelization.qmd
             - recipes/low_freq_proc.qmd

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -1,0 +1,313 @@
+"""Tests for applying a function to overlapping windows of a patch."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import dascore as dc
+from dascore.exceptions import ParameterError, PatchError
+from dascore.proc.tile_apply import TileApply
+from dascore.units import percent
+
+
+def identity(tiles):
+    """The stack as it came."""
+    return tiles
+
+
+def halve(tiles):
+    """Every tile at half amplitude."""
+    return tiles / 2
+
+
+def agc(tiles):
+    """Every tile scaled to unit RMS."""
+    axes = tuple(range(1, tiles.ndim))
+    rms = np.sqrt(np.mean(tiles**2, axis=axes, keepdims=True))
+    return tiles / np.where(rms > 0, rms, 1)
+
+
+def _jitted():
+    """Return a numba-compiled per-tile function, or skip."""
+    numba = pytest.importorskip("numba")
+    from dascore.utils._tiles_numba import _JIT_AVAILABLE  # noqa: PLC0415
+
+    if not _JIT_AVAILABLE:
+        pytest.skip("numba is not installed")
+
+    @numba.njit
+    def half_tile(tile):
+        return tile * 0.5
+
+    return half_tile
+
+
+@pytest.fixture(scope="module")
+def patch():
+    """The example patch: 300 channels by 2000 samples at 4 ms."""
+    return dc.get_example_patch()
+
+
+@pytest.fixture(scope="module")
+def cube():
+    """Three shots of 64 channels by 128 samples: one dimension to batch over."""
+    rng = np.random.default_rng(0)
+    coords = {
+        "shot": np.arange(3),
+        "distance": np.arange(64) * 2.0,
+        "time": dc.to_datetime64(np.arange(128) * 0.004),
+    }
+    data = rng.normal(size=(3, 64, 128)).astype(np.float32)
+    return dc.Patch(data=data, coords=coords, dims=("shot", "distance", "time"))
+
+
+class TestOverlapAdd:
+    """Tiles blended back under the taper."""
+
+    def test_identity(self, patch):
+        """An unchanged stack blends back to the input."""
+        out = patch.tile_apply(identity, time=0.064, distance=16)
+        assert out.dims == patch.dims
+        assert out.coords == patch.coords
+        np.testing.assert_allclose(out.data, patch.data, atol=1e-5)
+
+    def test_one_dimension(self, patch):
+        """One windowed dimension, every other one batched."""
+        out = patch.tile_apply(halve, time=0.064)
+        np.testing.assert_allclose(out.data, patch.data / 2, atol=1e-5)
+
+    @pytest.mark.parametrize("taper", ["hann", "triang", ("tukey", 0.5)])
+    def test_any_complementary_taper(self, patch, taper):
+        """The blend is exact for any taper shape, since the ramps are made so."""
+        out = patch.tile_apply(identity, taper=taper, time=32, distance=8, samples=True)
+        np.testing.assert_allclose(out.data, patch.data, atol=1e-5)
+
+    def test_overlap_forms(self, patch):
+        """A percent, a count, and a mapping all say the same overlap."""
+        by_percent = patch.tile_apply(
+            halve, overlap=25 * percent, time=64, samples=True
+        )
+        by_count = patch.tile_apply(halve, overlap=16, time=64, samples=True)
+        by_map = patch.tile_apply(halve, overlap={"time": 16}, time=64, samples=True)
+        assert by_percent.equals(by_count) and by_count.equals(by_map)
+
+    def test_agc_flattens_amplitude(self, patch):
+        """Normalized windows leave every region at about the same level."""
+        loud = patch.update(data=patch.data * np.linspace(1, 100, patch.shape[1]))
+        out = loud.tile_apply(agc, time=0.128, distance=32)
+        first = np.std(out.data[:, :200])
+        last = np.std(out.data[:, -200:])
+        assert 0.5 < first / last < 2
+        assert np.std(loud.data[:, :200]) / np.std(loud.data[:, -200:]) < 0.2
+
+    def test_batches_other_dimensions(self, cube):
+        """A dimension not windowed is an independent batch."""
+        out = cube.tile_apply(halve, distance=16, time=32, samples=True)
+        np.testing.assert_allclose(out.data, cube.data / 2, atol=1e-5)
+
+    def test_history_names_the_function(self, patch):
+        """History says which function, by name, not by address."""
+        out = patch.tile_apply(agc, time=64, samples=True)
+        assert "function='agc'" in list(out.attrs.history)[-1]
+
+
+class TestStack:
+    """The tiles themselves."""
+
+    @pytest.fixture(scope="class")
+    def stacked(self, patch):
+        """The example patch cut into 16 by 16 tiles."""
+        return patch.tile_apply(identity, mode="stack", time=0.064, distance=16)
+
+    def test_dims_and_shape(self, stacked, patch):
+        """Tile axes where the dimensions were, offsets at the end in axis order."""
+        assert stacked.dims == ("distance", "time", "distance_offset", "time_offset")
+        assert stacked.shape[2:] == (16, 16)
+
+    def test_centres_and_edges(self, stacked, patch):
+        """The tile axis is the centres; start and stop say where each came from."""
+        starts = stacked.get_coord("time_start").values
+        stops = stacked.get_coord("time_stop").values
+        assert starts[0] == -8 and stops[0] == 8  # one stride before the data
+        assert np.all(stops - starts == 16)
+        centres = stacked.get_coord("time").values
+        step = patch.get_coord("time").step
+        expected = patch.get_coord("time").min() + dc.to_timedelta64(
+            (starts + 7.5) * dc.to_float(step)
+        )
+        np.testing.assert_array_equal(centres, expected)
+
+    def test_offsets(self, stacked, patch):
+        """The offset within a tile, in the dimension's units from zero."""
+        offsets = stacked.get_coord("time_offset").values
+        assert len(offsets) == 16
+        assert offsets[0] == np.timedelta64(0, "ns")
+        assert offsets[1] == patch.get_coord("time").step
+
+    def test_source_is_kept(self, stacked, patch):
+        """The coordinate the tiles were cut from travels with them."""
+        assert stacked.get_coord("_tile_source_time") == patch.get_coord("time")
+
+    def test_float_coordinate(self, patch):
+        """A numeric dimension gets numeric centres and offsets."""
+        stacked = patch.tile_apply(identity, mode="stack", distance=16, samples=True)
+        assert stacked.get_coord("distance_offset").values[1] == 1.0
+        assert stacked.dims == ("distance", "time", "distance_offset")
+
+    def test_collision_refused(self, patch):
+        """A coordinate already called what a stack would call one is refused."""
+        clashing = patch.update_coords(time_offset=("time", np.zeros(2000)))
+        with pytest.raises(ParameterError, match="already has a coordinate"):
+            clashing.tile_apply(identity, mode="stack", time=64, samples=True)
+
+
+class TestReassemble:
+    """Blending a stack back."""
+
+    def test_round_trip_two_dimensions(self, patch):
+        """An unchanged stack reassembles to the patch, coordinates and all."""
+        stacked = patch.tile_apply(identity, mode="stack", time=0.064, distance=16)
+        back = stacked.reassemble()
+        assert back.equals(patch, close=True)
+        assert not any(k.startswith("_tile") for k in back.coords.coord_map)
+
+    def test_round_trip_one_dimension(self, patch):
+        """And with one dimension windowed."""
+        back = patch.tile_apply(
+            identity, mode="stack", time=64, samples=True
+        ).reassemble()
+        assert back.equals(patch, close=True)
+
+    def test_round_trip_batched(self, cube):
+        """A dimension not windowed is carried through both ways."""
+        stacked = cube.tile_apply(
+            identity, mode="stack", distance=16, time=32, samples=True
+        )
+        assert stacked.dims == (
+            "shot",
+            "distance",
+            "time",
+            "distance_offset",
+            "time_offset",
+        )
+        assert stacked.reassemble().equals(cube, close=True)
+
+    def test_edit_between(self, patch):
+        """Work done on the stack is what comes back: halve, then blend."""
+        stacked = patch.tile_apply(identity, mode="stack", time=64, samples=True)
+        back = stacked.update(data=stacked.data / 2).reassemble()
+        np.testing.assert_allclose(back.data, patch.data / 2, atol=1e-5)
+
+    def test_needs_a_stack(self, patch):
+        """A patch nobody tiled cannot be reassembled."""
+        with pytest.raises(PatchError, match="has no tiles"):
+            patch.reassemble()
+
+    def test_grid_must_match(self, patch):
+        """A stack with tiles missing does not reassemble."""
+        stacked = patch.tile_apply(identity, mode="stack", time=64, samples=True)
+        fewer = stacked.select(time=(0, 10), samples=True)
+        with pytest.raises(PatchError, match="tile as"):
+            fewer.reassemble()
+
+
+class TestEngines:
+    """numpy over the stack, numba over one tile at a time."""
+
+    def test_numba_matches_numpy(self, patch):
+        """The compiled per-tile function blends to what the stack function does."""
+        half_tile = _jitted()
+        by_numba = patch.tile_apply(half_tile, time=64, distance=16, samples=True)
+        by_numpy = patch.tile_apply(halve, time=64, distance=16, samples=True)
+        np.testing.assert_allclose(by_numba.data, by_numpy.data, atol=1e-5)
+        assert by_numba.dims == patch.dims
+
+    def test_driver_runs_in_python(self, patch):
+        """The driver gives the same answer uncompiled."""
+        half_tile = _jitted()
+        from dascore.utils._tiles_numba import _apply_colour_class  # noqa: PLC0415
+        from dascore.utils.signal import get_taper  # noqa: PLC0415
+        from dascore.utils.tiles import get_tile_plan  # noqa: PLC0415
+
+        data = np.asarray(patch.data[:40, :64], dtype=np.float32)
+        plan = get_tile_plan(data.shape, (8, 16), (5, 9))
+        taper = get_taper("hann", (8, 16), (3, 7))
+        padded, out = plan.pad(data), np.zeros(plan.extended, dtype=np.float32)
+        for c0 in range(plan.colours[0]):
+            for c1 in range(plan.colours[1]):
+                _apply_colour_class.func(
+                    padded,
+                    out,
+                    taper,
+                    *plan.size,
+                    *plan.stride,
+                    *plan.grid,
+                    *plan.colours,
+                    c0,
+                    c1,
+                    half_tile,
+                )
+        np.testing.assert_allclose(plan.crop(out), data / 2, atol=1e-5)
+
+    def test_jitted_function_on_numpy_engine_refused(self, patch):
+        """A per-tile function cannot take the stack."""
+        half_tile = _jitted()
+        with pytest.raises(ParameterError, match="one tile at a time"):
+            patch.tile_apply(half_tile, engine="numpy", time=64, samples=True)
+
+    def test_plain_function_on_numba_engine_refused(self, patch):
+        """And a stack function cannot be compiled."""
+        with pytest.raises(ParameterError, match="numba-compiled function"):
+            patch.tile_apply(halve, engine="numba", time=64, distance=16, samples=True)
+
+    def test_numba_engine_is_two_dimensional(self, patch):
+        """The driver tiles two dimensions."""
+        half_tile = _jitted()
+        with pytest.raises(ParameterError, match="exactly two dimensions"):
+            patch.tile_apply(half_tile, time=64, samples=True, engine="numba")
+
+    def test_numba_engine_without_numba(self, patch, monkeypatch):
+        """Asked for by name with numba absent, it says what is missing."""
+        import dascore.utils._tiles_numba as driver  # noqa: PLC0415
+
+        half_tile = _jitted()
+        monkeypatch.setattr(driver, "_JIT_AVAILABLE", False)
+        with pytest.raises(dc.exceptions.MissingOptionalDependencyError):
+            patch.tile_apply(half_tile, time=64, distance=16, samples=True)
+
+    def test_unknown_engine_refused(self, patch):
+        """A name which is not an engine."""
+        with pytest.raises(ParameterError, match="engine must be one of"):
+            patch.tile_apply(halve, engine="cuda", time=64, samples=True)
+
+
+class TestArguments:
+    """What the call refuses."""
+
+    def test_unknown_mode(self, patch):
+        """A mode which is not one."""
+        with pytest.raises(ParameterError, match="mode must be one of"):
+            patch.tile_apply(halve, mode="centre", time=64, samples=True)
+
+    def test_needs_a_dimension(self, patch):
+        """No window, nothing to tile."""
+        with pytest.raises(ParameterError, match="needs a dimension"):
+            patch.tile_apply(halve)
+
+    def test_overlap_past_half_refused(self, patch):
+        """The taper's ramps would cross."""
+        with pytest.raises(ParameterError, match="ramps would cross"):
+            patch.tile_apply(halve, overlap=40, time=64, samples=True)
+
+    def test_op_is_the_processor(self, patch):
+        """The seam: the call names the processor and the two routes agree."""
+        op = dc.proc.tile_apply.op(halve, time=64, samples=True)
+        assert isinstance(op, TileApply)
+        assert op(patch).equals(patch.tile_apply(halve, time=64, samples=True))
+
+    def test_cannot_be_written_to_a_document(self, patch):
+        """An operation holding a function is not one a document can hold."""
+        op = dc.proc.tile_apply.op(halve, time=64, samples=True)
+        with pytest.raises(ParameterError, match="cannot be written"):
+            op.to_dict()

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -229,6 +229,8 @@ class TestReassemble:
         back = stacked.reassemble()
         assert back.equals(patch, close=True)
         assert not any(k.startswith("_tile") for k in back.coords.coord_map)
+        assert not any(k.startswith("_tile") for k in dict(back.attrs))
+        assert "_tile_stride_time" in dict(stacked.attrs)
 
     def test_round_trip_one_dimension(self, patch):
         """And with one dimension windowed."""
@@ -287,6 +289,18 @@ class TestReassemble:
             back.data[:, 200:-200], patch.data[:, 200:-200], atol=1e-5
         )
         assert np.abs(back.data[:, :8]).max() == 0
+
+    def test_every_other_tile(self, patch):
+        """A stack thinned to alternate tiles blends under the taper it was cut for."""
+        stacked = patch.tile_apply(identity, mode="stack", time=64, samples=True)
+        n = stacked.shape[stacked.get_axis("time")]
+        thinned = stacked.select(time=np.arange(0, n, 2), samples=True)
+        back = thinned.reassemble()
+        assert back.shape == patch.shape
+        assert not any(k.startswith("_tile") for k in dict(back.attrs))
+        # Every other tile is gone, so no sample sees more than one: the
+        # blend is the kept tiles under their taper, nothing doubled.
+        assert np.abs(back.data).max() <= np.abs(patch.data).max() * 1.01
 
     def test_needs_a_stack(self, patch):
         """A patch nobody tiled cannot be reassembled."""

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -106,6 +106,31 @@ class TestOverlapAdd:
         out = cube.tile_apply(halve, distance=16, time=32, samples=True)
         np.testing.assert_allclose(out.data, cube.data / 2, atol=1e-5)
 
+    def test_history_names_a_partial_and_an_object(self, patch):
+        """A partial is named by its function, a callable object by its class."""
+        from functools import partial  # noqa: PLC0415
+
+        def scale(tiles, by):
+            return tiles * by
+
+        class Scaler:
+            def __call__(self, tiles):
+                return tiles * 3
+
+        by_partial = patch.tile_apply(partial(scale, by=2), time=64, samples=True)
+        by_object = patch.tile_apply(Scaler(), time=64, samples=True)
+        assert "scale'" in list(by_partial.attrs.history)[-1]
+        assert "0x" not in list(by_partial.attrs.history)[-1]
+        assert "function='" in list(by_object.attrs.history)[-1]
+        assert "0x" not in list(by_object.attrs.history)[-1]
+
+    def test_stack_needs_no_taper(self, patch):
+        """The taper is not built for a stack, so a name nothing knows is not asked."""
+        stacked = patch.tile_apply(
+            identity, mode="stack", taper="windowsXP", time=64, samples=True
+        )
+        assert stacked.dims[-1] == "time_offset"
+
     def test_history_names_the_function(self, patch):
         """History says which function, by name, not by address."""
         out = patch.tile_apply(agc, time=64, samples=True)
@@ -223,6 +248,17 @@ class TestReassemble:
         )
         assert stacked.reassemble().equals(cube, close=True)
 
+    def test_coordinates_riding_a_windowed_dimension_come_back(self, patch):
+        """A per-sample coordinate along a windowed dimension round-trips."""
+        flagged = patch.update_coords(quality=("time", np.arange(2000) % 3))
+        stacked = flagged.tile_apply(identity, mode="stack", time=64, samples=True)
+        assert "quality" not in stacked.dims
+        back = stacked.reassemble()
+        assert back.equals(flagged, close=True)
+        np.testing.assert_array_equal(
+            back.get_coord("quality").values, np.arange(2000) % 3
+        )
+
     def test_edit_between(self, patch):
         """Work done on the stack is what comes back: halve, then blend."""
         stacked = patch.tile_apply(identity, mode="stack", time=64, samples=True)
@@ -265,6 +301,19 @@ class TestEngines:
         by_numpy = patch.tile_apply(halve, time=64, distance=16, samples=True)
         np.testing.assert_allclose(by_numba.data, by_numpy.data, atol=1e-5)
         assert by_numba.dims == patch.dims
+
+    def test_numba_keeps_the_function_s_dtype(self, patch):
+        """A compiled function which makes a real tile complex keeps it complex."""
+        numba = pytest.importorskip("numba")
+        _jitted()
+
+        @numba.njit
+        def to_complex(tile):
+            return tile * (1 + 1j)
+
+        out = patch.tile_apply(to_complex, time=64, distance=16, samples=True)
+        assert np.iscomplexobj(out.data)
+        np.testing.assert_allclose(out.data.imag, patch.data, atol=1e-4)
 
     def test_driver_runs_in_python(self, patch):
         """The driver gives the same answer uncompiled."""

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -120,6 +120,20 @@ class TestStack:
         """The example patch cut into 16 by 16 tiles."""
         return patch.tile_apply(identity, mode="stack", time=0.064, distance=16)
 
+    def test_function_is_applied(self, patch):
+        """The stack is what the function made of the tiles, not the raw tiles."""
+        raw = patch.tile_apply(identity, mode="stack", time=64, samples=True)
+        halved = patch.tile_apply(halve, mode="stack", time=64, samples=True)
+        np.testing.assert_allclose(halved.data, raw.data / 2)
+
+    def test_compiled_function_refused(self, patch):
+        """A per-tile function has no stack to take."""
+        half_tile = _jitted()
+        with pytest.raises(ParameterError, match="cannot take it"):
+            patch.tile_apply(
+                half_tile, mode="stack", time=64, distance=16, samples=True
+            )
+
     def test_dims_and_shape(self, stacked, patch):
         """Tile axes where the dimensions were, offsets at the end in axis order."""
         assert stacked.dims == ("distance", "time", "distance_offset", "time_offset")
@@ -154,6 +168,22 @@ class TestStack:
         stacked = patch.tile_apply(identity, mode="stack", distance=16, samples=True)
         assert stacked.get_coord("distance_offset").values[1] == 1.0
         assert stacked.dims == ("distance", "time", "distance_offset")
+
+    def test_descending_coordinate(self, patch):
+        """Centres step down a descending coordinate from its first sample."""
+        flipped = patch.flip("distance", flip_coords=True)
+        stacked = flipped.tile_apply(identity, mode="stack", distance=16, samples=True)
+        centres = stacked.get_coord("distance").values
+        assert centres[0] > centres[1]
+        first = flipped.get_coord("distance").values[0]
+        assert centres[0] == first + (-8 + 7.5) * flipped.get_coord("distance").step
+        assert stacked.reassemble().equals(flipped, close=True)
+
+    def test_source_name_collision_refused(self, patch):
+        """The coordinate the source travels under is claimed too."""
+        clashing = patch.update_coords(_tile_source_time=("time", np.zeros(2000)))
+        with pytest.raises(ParameterError, match="_tile_source_time"):
+            clashing.tile_apply(identity, mode="stack", time=64, samples=True)
 
     def test_collision_refused(self, patch):
         """A coordinate already called what a stack would call one is refused."""
@@ -199,17 +229,30 @@ class TestReassemble:
         back = stacked.update(data=stacked.data / 2).reassemble()
         np.testing.assert_allclose(back.data, patch.data / 2, atol=1e-5)
 
+    def test_reordered_tiles_go_back_where_they_came_from(self, patch):
+        """Each tile is placed by its start, whatever order the stack is in."""
+        stacked = patch.tile_apply(identity, mode="stack", time=64, samples=True)
+        n = stacked.shape[stacked.get_axis("time")]
+        reversed_stack = stacked.order(time=np.arange(n)[::-1], samples=True)
+        assert reversed_stack.reassemble().equals(patch, close=True)
+
+    def test_dropped_tiles_leave_their_region_quiet(self, patch):
+        """A stack with tiles removed blends what is left; the gap stays silent."""
+        stacked = patch.tile_apply(identity, mode="stack", time=64, samples=True)
+        n = stacked.shape[stacked.get_axis("time")]
+        kept = stacked.select(time=(2, n - 2), samples=True)
+        back = kept.reassemble()
+        assert back.shape == patch.shape
+        # The middle is untouched; the ends, whose tiles are gone, are not.
+        np.testing.assert_allclose(
+            back.data[:, 200:-200], patch.data[:, 200:-200], atol=1e-5
+        )
+        assert np.abs(back.data[:, :8]).max() == 0
+
     def test_needs_a_stack(self, patch):
         """A patch nobody tiled cannot be reassembled."""
         with pytest.raises(PatchError, match="has no tiles"):
             patch.reassemble()
-
-    def test_grid_must_match(self, patch):
-        """A stack with tiles missing does not reassemble."""
-        stacked = patch.tile_apply(identity, mode="stack", time=64, samples=True)
-        fewer = stacked.select(time=(0, 10), samples=True)
-        with pytest.raises(PatchError, match="tile as"):
-            fewer.reassemble()
 
 
 class TestEngines:
@@ -261,11 +304,12 @@ class TestEngines:
         with pytest.raises(ParameterError, match="numba-compiled function"):
             patch.tile_apply(halve, engine="numba", time=64, distance=16, samples=True)
 
-    def test_numba_engine_is_two_dimensional(self, patch):
-        """The driver tiles two dimensions."""
+    @pytest.mark.parametrize("engine", ["auto", "numba"])
+    def test_compiled_function_needs_two_dimensions(self, patch, engine):
+        """The driver tiles two dimensions, and says so however it was reached."""
         half_tile = _jitted()
-        with pytest.raises(ParameterError, match="exactly two dimensions"):
-            patch.tile_apply(half_tile, time=64, samples=True, engine="numba")
+        with pytest.raises(ParameterError, match="exactly two windowed dimensions"):
+            patch.tile_apply(half_tile, time=64, samples=True, engine=engine)
 
     def test_numba_engine_without_numba(self, patch, monkeypatch):
         """Asked for by name with numba absent, it says what is missing."""

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -202,6 +202,9 @@ class TestStack:
         assert centres[0] > centres[1]
         first = flipped.get_coord("distance").values[0]
         assert centres[0] == first + (-8 + 7.5) * flipped.get_coord("distance").step
+        # Offsets count from the tile's first sample, in the coordinate's direction.
+        offsets = stacked.get_coord("distance_offset").values
+        assert offsets[0] == 0 and offsets[1] == flipped.get_coord("distance").step
         assert stacked.reassemble().equals(flipped, close=True)
 
     def test_source_name_collision_refused(self, patch):

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -264,6 +264,16 @@ class TestReassemble:
             back.get_coord("quality").values, np.arange(2000) % 3
         )
 
+    def test_three_dimensions_windowed(self, cube):
+        """Every dimension windowed at once: the plan is not two-dimensional."""
+        stacked = cube.tile_apply(
+            halve, mode="stack", shot=2, distance=16, time=32, samples=True
+        )
+        assert stacked.dims[-3:] == ("shot_offset", "distance_offset", "time_offset")
+        np.testing.assert_allclose(stacked.reassemble().data, cube.data / 2, atol=1e-5)
+        blended = cube.tile_apply(identity, shot=2, distance=16, time=32, samples=True)
+        np.testing.assert_allclose(blended.data, cube.data, atol=1e-5)
+
     def test_edit_between(self, patch):
         """Work done on the stack is what comes back: halve, then blend."""
         stacked = patch.tile_apply(identity, mode="stack", time=64, samples=True)

--- a/tests/test_workflow/_calls.py
+++ b/tests/test_workflow/_calls.py
@@ -104,12 +104,22 @@ def get_patch(name: str):
         small = patch.select(distance=(0, 50))
         shifts = np.arange(len(small.get_array("distance"))) * np.timedelta64(1, "ms")
         return small.update_coords(shift_times=("distance", shifts))
+    if name == "tiled":
+        # A stack of tiles, which `reassemble` blends back.
+        return patch.tile_apply(
+            _halve, mode="stack", time=64, distance=16, samples=True
+        )
     if name == "inventory":
         from dascore.examples import inventory_patch_pair  # noqa: PLC0415
 
         return inventory_patch_pair()[0]
     msg = f"no example patch called {name!r}"
     raise LookupError(msg)
+
+
+def _halve(tiles):
+    """A function over a stack of tiles, for `tile_apply`."""
+    return tiles / 2
 
 
 def _slope_filter():
@@ -206,6 +216,8 @@ CALLS: tuple[tuple[str, str, tuple, dict], ...] = (
     ("wiener_filter", "default", (), {"time": 5, "samples": True}),
     ("hampel_filter", "default", (), {"time": 5, "samples": True}),
     ("adaptive_spectral_filter", "default", (), {"time": 32, "samples": True}),
+    ("tile_apply", "default", (_halve,), {"time": 64, "distance": 16, "samples": True}),
+    ("reassemble", "tiled", (), {"taper": "triang"}),
     ("select", "default", (), {"distance": (10, 40)}),
     ("unselect", "default", (), {"distance": (10, 40)}),
     ("order", "default", (), {"distance": (30, 10, 20), "samples": True}),

--- a/tests/test_workflow/test_patch_op.py
+++ b/tests/test_workflow/test_patch_op.py
@@ -44,7 +44,7 @@ IDS = [x[0] for x in CALLS]
 # The operations whose arguments the serializer refuses. A frame is data,
 # not a parameter; the serializer says so, and this records which calls in
 # the catalogue land on it.
-_NOT_WRITABLE = {"coords_from_df", "add_distance_to"}
+_NOT_WRITABLE = {"coords_from_df", "add_distance_to", "tile_apply"}
 
 
 def _drawn(axes) -> tuple[int, ...]:

--- a/tests/test_workflow/test_serialize.py
+++ b/tests/test_workflow/test_serialize.py
@@ -447,10 +447,15 @@ class TestOddballs:
         """A function is encoded by where it is defined."""
         assert encode(np.mean) == {"$callable": {"path": "numpy:mean"}}
 
-    def test_callable_cannot_round_trip(self):
-        """A document does not import whatever it names."""
+    def test_callable_cannot_be_written(self):
+        """A document does not import whatever it names, so it is not written."""
+        with pytest.raises(ParameterError, match="cannot be written"):
+            encode(np.mean, mode=DOCUMENT)
+
+    def test_callable_document_cannot_be_read(self):
+        """One written elsewhere is refused on the way in as well."""
         with pytest.raises(ParameterError, match="cannot be rebuilt"):
-            decode(encode(np.mean, mode=DOCUMENT))
+            decode({"$callable": {"path": "numpy:mean"}})
 
     def test_lambdas_differ_by_source(self):
         """Two lambdas which do different things are different parameters."""
@@ -480,8 +485,8 @@ class TestOddballs:
 
     def test_partial_round_trip_refused(self):
         """A partial holds a function, so a document cannot carry it."""
-        with pytest.raises(ParameterError, match="cannot be rebuilt"):
-            decode(encode(partial(np.mean, axis=0), mode=DOCUMENT))
+        with pytest.raises(ParameterError, match="cannot be written"):
+            encode(partial(np.mean, axis=0), mode=DOCUMENT)
 
     def test_opaque_value(self):
         """A value nothing else describes is named by its class."""


### PR DESCRIPTION
## Description

PR 4 of the windowing plan (top-level `.scratch/windowing-unification-plan.md`): the tile machinery goes public.

**`Patch.tile_apply(function, *, mode, overlap, taper, samples, engine, **dims)`** cuts the patch into overlapping tiles along one or more dimensions, hands them to a function, and either blends them back under a taper (`mode="overlap_add"`, the default) or returns them as a stack (`mode="stack"`). The window is spelled as every windowed function now spells it (PR 1); the taper is any `get_window` name with its ramps made complementary (PR 2), so a function which changes nothing returns the input exactly; the geometry is `TilePlan` (PR 3). Dimensions not windowed are batched.

Two function contracts, by engine:

- numpy (default): `function(tiles)` takes the whole stack, `[n_tiles, *window]`, and returns one of the same shape — one vectorized call.
- numba: a numba-compiled function of one tile, run in parallel by a driver which is specialized on it. This is the injected-`f` driver deferred from PR 3; here it is a documented cost — it compiles the first time each function is used in a process — rather than a regression to a default engine. `engine="auto"` picks it for a compiled function over two dimensions.

**`mode="stack"`** returns the tiles with the coordinates the plan settled on: each windowed dimension becomes an axis of tile centres; `{dim}_start` and `{dim}_stop` carry each tile's source samples; `{dim}_offset` is the position within a tile, a new dimension at the end in the patch's axis order; the coordinate the tiles were cut from travels as `_tile_source_{dim}`. **`Patch.reassemble(taper=...)`** blends a stack back and restores the source coordinates; an unchanged stack round-trips exactly, in 1-D, 2-D, and batched.

**The seam.** `TileApply` is a `PatchProcessor`: `derive_meta` states a stack's coordinates without touching data, `kernel` runs it. Two things the framework needed for a function-valued argument: history now names a callable (`function='agc'`) instead of printing its address, and a document refuses a function at write time — the same standing as a dataframe — rather than writing a name it could never import. `tile_apply` joins `_NOT_WRITABLE` in the every-patch-function contracts. One framework wart met on the way: a patch function cannot call a parameter `func`, because the history helper inside `patch_function` has one; hence `function`.

**The second consumer** is the recipe, `docs/recipes/windowing.qmd`: it names the three windowing regimes (rolling, stack, tile-and-blend) and when each applies, and shows automatic gain control on the numpy engine, a stack thresholded by tile energy and reassembled, and the compiled per-tile form. The adaptive spectral filter is the first consumer and is unchanged.

### Codex review

One P1: `mode="stack"` extracted the tiles and never called the function. Fixed, with a test that a halving function halves the stack; a compiled per-tile function is refused in stack mode, having no stack to take. Four P2s, all fixed with tests: `reassemble` inferred one stride from the first two starts, so a reordered or thinned stack was refused — it now places every tile by its own `{dim}_start`, so tiles go back in any order and a removed tile leaves its region silent; tile centres were stepped from `coord.min()` rather than the first sample, wrong for a descending coordinate; `engine="auto"` routed a compiled 1-D function to numpy and then refused it as compiled — it now says the driver needs two windowed dimensions; and `_tile_source_{dim}` was not in the collision check.

The GitHub review then raised four more, all fixed in `7e6e30bb` with tests: a coordinate riding along a windowed dimension (a per-sample quality flag) was dropped by the stack and lost by the round trip — it now travels as `_tile_source_{dim}__{name}` and comes back; a `partial` or callable object was still named by a repr with an address — a partial is named by the function it wraps, an object by its class; the taper was built for a stack, which never applies it, so an unknown taper name refused a valid stack; and the numba driver fixed its output dtype to the input's, so a compiled function making a real tile complex was refused — one tile goes through first to learn what comes back.

### Self-review

After the reviews: the dimensions are windowed in the patch's axis order whatever order they were named in, so a stack's axes fall out in order without the shuffle that used to put them there; the stride a stack was cut at travels in its attrs (`_tile_stride_{dim}`) so `reassemble` blends under the taper the tiles were cut for instead of inferring it from whichever starts remain (a stack thinned to every other tile used to read as cut at twice the stride), and strips the stack's attrs as it does its coordinates. The 32-bit WASM cell also caught `sliding_window_view` addressing every window position — 2.4 GB of logical view for an ordinary patch — so `TilePlan` strides the tile grid directly.

## Changelog

- added: `Patch.tile_apply`, which applies a function to overlapping windows of a patch and blends them back or returns them stacked, and `Patch.reassemble`, which blends a stack back.
- changed: a patch function's history names a function argument rather than printing its address; an operation holding a function is refused when written to a document.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added windowed tile processing for patches, including overlapping tiles, tapered blending, stacked outputs, and reassembly.
  - Exposed tile processing and reassembly through the patch API.
  - Added optional accelerated processing for compatible tile operations.

- **Documentation**
  - Added a windowing guide with examples for blended tiles, stacked workflows, denoising, padding, tapering, and overlap settings.

- **Validation**
  - Improved handling and messaging for callable operations that cannot be saved in documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
