### PR TITLE
Window a tile on the way in and blend it back under the dual

### DIFF
--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -32,7 +32,7 @@ from dascore.exceptions import (
     PatchError,
 )
 from dascore.utils.patch import patch_function
-from dascore.utils.signal import get_taper
+from dascore.utils.signal import get_dual_taper, get_taper
 from dascore.utils.tiles import get_tile_plan
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.window import Window, resolve_window
@@ -109,6 +109,7 @@ def tile_apply(
     mode: str = "overlap_add",
     overlap: Any = None,
     taper: Any = "hann",
+    analysis: Any = None,
     samples: bool = False,
     engine: str = "auto",
     **kwargs: Any,
@@ -143,6 +144,14 @@ def tile_apply(
         `dascore.utils.signal.get_window` knows. The ramps are made
         complementary, so blended tiles of an unchanged stack return the
         input exactly. Not applied in ``"stack"`` mode.
+    analysis
+        A window each tile is multiplied by before `function` sees it -- any
+        name or ``(name, parameter)`` tuple `get_window` knows, applied along
+        every windowed dimension. Given one, the tiles are blended back under
+        its dual, computed by scipy along each axis, so the blend is still
+        exact; a spectral `function` then sees a properly windowed tile.
+        Exclusive with `taper`, and the overlap may then exceed half the
+        window. None, the default, gives `function` the raw tile.
     samples
         If True, windows and overlaps are sample counts.
     engine
@@ -190,6 +199,7 @@ def tile_apply(
         mode=mode,
         overlap=overlap,
         taper=taper,
+        analysis=analysis,
         samples=samples,
         engine=engine,
         **kwargs,
@@ -212,6 +222,7 @@ class TileApply(PatchProcessor):
     mode: str = "overlap_add"
     overlap: Any = None
     taper: Any = "hann"
+    analysis: Any = None
     samples: bool = False
     engine: str = "auto"
 
@@ -223,6 +234,18 @@ class TileApply(PatchProcessor):
         selected = self.model_extra or {}
         if not selected:
             msg = "tile_apply needs a dimension and its window, e.g. time=0.5."
+            raise ParameterError(msg)
+        if self.analysis is not None and self.taper != "hann":
+            msg = (
+                "Given an analysis window, the tiles are blended under its dual; "
+                "a taper cannot be given as well."
+            )
+            raise ParameterError(msg)
+        if self.analysis is not None and not isinstance(self.analysis, str | tuple):
+            msg = (
+                "An analysis window is given by name, or as a (name, parameter) "
+                "tuple, so that its dual can be built along each axis."
+            )
             raise ParameterError(msg)
         # In the patch's axis order, whatever order they were named in, so a
         # stack's tile and offset axes come out in that order too.
@@ -251,6 +274,8 @@ class TileApply(PatchProcessor):
         strides = {
             f"_tile_stride_{d}": int(s) for d, s in zip(window.dims, window.stride)
         }
+        if self.analysis is not None:
+            strides["_tile_analysis"] = self.analysis
         attrs = meta.attrs.update(**strides)
         return meta.update(coords=_stack_coords(meta, window), attrs=attrs)
 
@@ -272,23 +297,44 @@ class TileApply(PatchProcessor):
                     "a numba-compiled function of one tile cannot take it."
                 )
                 raise ParameterError(msg)
-            stacks = np.stack([self.function(plan.extract(batch)) for batch in batches])
+            analysis = _analysis(self.analysis, plan)
+            stacks = np.stack(
+                [self.function(plan.extract(batch) * analysis) for batch in batches]
+            )
             out = stacks.reshape((*moved.shape[:-ndim], *plan.grid, *plan.size))
             # The tile axes go where the windowed dimensions were; the
             # offsets within a tile stay at the end, already in axis order.
             n_batch = moved.ndim - ndim
             return np.moveaxis(out, range(n_batch, n_batch + ndim), window.axes)
-        taper = get_taper(self.taper, window.size, window.overlap)
+        analysis = _analysis(self.analysis, plan)
+        synthesis = (
+            get_taper(self.taper, plan.size, window.overlap)
+            if self.analysis is None
+            else get_dual_taper(self.analysis, plan.size, plan.stride)[1]
+        )
         if engine == "numba":
             from dascore.utils._tiles_numba import apply_jit  # noqa: PLC0415
 
             blended = [
-                apply_jit(plan, batch, self.function, taper) for batch in batches
+                apply_jit(plan, batch, self.function, synthesis, analysis)
+                for batch in batches
             ]
         else:
-            blended = [plan.apply(batch, self.function, taper) for batch in batches]
+            blended = [
+                plan.overlap_add(
+                    self.function(plan.extract(batch) * analysis), synthesis
+                )
+                for batch in batches
+            ]
         out = np.stack(blended).reshape(moved.shape)
         return np.moveaxis(out, tail, window.axes)
+
+
+def _analysis(analysis: Any, plan) -> np.ndarray:
+    """Return what every tile is multiplied by on the way in: ones by default."""
+    if analysis is None:
+        return np.ones(plan.size, dtype=np.float32)
+    return get_dual_taper(analysis, plan.size, plan.stride)[0]
 
 
 def _stack_coords(meta: PatchMeta, window: Window):
@@ -363,7 +409,7 @@ def _place_each(stacks, starts, shape, size, weights):
 
 
 @patch_function()
-def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
+def reassemble(patch: PatchType, *, taper: Any = None) -> PatchType:
     """
     Blend a stack of tiles back into the patch they were cut from.
 
@@ -377,7 +423,9 @@ def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
     patch
         A patch `tile_apply` stacked.
     taper
-        The window whose edge the taper ramps take; see `tile_apply`.
+        The window whose edge the taper ramps take; see `tile_apply`. Hann
+        when not given. A stack cut with an analysis window is blended under
+        that window's dual instead, and takes no taper.
 
     Examples
     --------
@@ -417,8 +465,18 @@ def reassemble(patch: PatchType, *, taper: Any = "hann") -> PatchType:
     # tiles were cut for, which the stride in attrs says.
     starts = [patch.get_coord(f"{dim}_start").values for dim in dims]
     strides = tuple(int(patch.attrs[f"_tile_stride_{dim}"]) for dim in dims)
-    overlap = tuple(z - st for z, st in zip(size, strides))
-    weights = get_taper(taper, size, overlap)
+    analysis = patch.attrs.get("_tile_analysis")
+    if analysis is not None:
+        if taper is not None:
+            msg = (
+                "This stack was cut with an analysis window and is blended under "
+                "its dual; a taper cannot be given."
+            )
+            raise ParameterError(msg)
+        weights = get_dual_taper(analysis, size, strides)[1]
+    else:
+        overlap = tuple(z - st for z, st in zip(size, strides))
+        weights = get_taper(taper or "hann", size, overlap)
     plan = get_tile_plan(shape, size, strides)
     as_cut = all(
         len(s) == count and np.array_equal(s, np.arange(count) * st - st)

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -108,7 +108,7 @@ def tile_apply(
     *,
     mode: str = "overlap_add",
     overlap: Any = None,
-    taper: Any = "hann",
+    taper: Any = None,
     analysis: Any = None,
     samples: bool = False,
     engine: str = "auto",
@@ -138,12 +138,13 @@ def tile_apply(
         How far each window reaches into the next, in coordinate units or,
         with `samples`, in samples; a percent is a fraction of the window;
         a mapping gives each dimension its own. Half the window when not
-        given. Never more than half: the taper's ramps would cross.
+        given, and never more than half under a taper, whose ramps would
+        cross; under an analysis window, as deep as scipy can invert it.
     taper
         The window whose edge the taper ramps take -- any name
-        `dascore.utils.signal.get_window` knows. The ramps are made
-        complementary, so blended tiles of an unchanged stack return the
-        input exactly. Not applied in ``"stack"`` mode.
+        `dascore.utils.signal.get_window` knows; Hann when not given. The
+        ramps are made complementary, so blended tiles of an unchanged stack
+        return the input exactly. Not applied in ``"stack"`` mode.
     analysis
         A window each tile is multiplied by before `function` sees it -- any
         name or ``(name, parameter)`` tuple `get_window` knows, applied along
@@ -187,9 +188,11 @@ def tile_apply(
 
     Notes
     -----
-    - Tiles start one stride before the data and are padded with zeros, so
-      every sample of the input is covered by tiles which see a full taper
-      ramp on both sides.
+    - Tiles start before the data and are padded with zeros: one stride
+      before, so every sample of the input is covered by tiles which see a
+      full taper ramp on both sides, or under an analysis window as many
+      whole strides as it takes for every tile which would reach a sample to
+      exist, which its dual relies on.
     - The adaptive spectral filter is this with a spectral weighting as
       `function`; see
       [`Patch.adaptive_spectral_filter`](`dascore.Patch.adaptive_spectral_filter`).
@@ -221,7 +224,7 @@ class TileApply(PatchProcessor):
     function: Callable
     mode: str = "overlap_add"
     overlap: Any = None
-    taper: Any = "hann"
+    taper: Any = None
     analysis: Any = None
     samples: bool = False
     engine: str = "auto"
@@ -235,7 +238,7 @@ class TileApply(PatchProcessor):
         if not selected:
             msg = "tile_apply needs a dimension and its window, e.g. time=0.5."
             raise ParameterError(msg)
-        if self.analysis is not None and self.taper != "hann":
+        if self.analysis is not None and self.taper is not None:
             msg = (
                 "Given an analysis window, the tiles are blended under its dual; "
                 "a taper cannot be given as well."
@@ -297,21 +300,23 @@ class TileApply(PatchProcessor):
                     "a numba-compiled function of one tile cannot take it."
                 )
                 raise ParameterError(msg)
-            analysis = _analysis(self.analysis, plan)
+            analysis = (
+                None
+                if self.analysis is None
+                else get_dual_taper(self.analysis, plan.size, plan.stride)[0]
+            )
             stacks = np.stack(
-                [self.function(plan.extract(batch) * analysis) for batch in batches]
+                [
+                    self.function(_windowed(plan.extract(batch), analysis))
+                    for batch in batches
+                ]
             )
             out = stacks.reshape((*moved.shape[:-ndim], *plan.grid, *plan.size))
             # The tile axes go where the windowed dimensions were; the
             # offsets within a tile stay at the end, already in axis order.
             n_batch = moved.ndim - ndim
             return np.moveaxis(out, range(n_batch, n_batch + ndim), window.axes)
-        analysis = _analysis(self.analysis, plan)
-        synthesis = (
-            get_taper(self.taper, plan.size, window.overlap)
-            if self.analysis is None
-            else get_dual_taper(self.analysis, plan.size, plan.stride)[1]
-        )
+        analysis, synthesis = _windows(self.analysis, self.taper, plan, window.overlap)
         if engine == "numba":
             from dascore.utils._tiles_numba import apply_jit  # noqa: PLC0415
 
@@ -322,7 +327,7 @@ class TileApply(PatchProcessor):
         else:
             blended = [
                 plan.overlap_add(
-                    self.function(plan.extract(batch) * analysis), synthesis
+                    self.function(_windowed(plan.extract(batch), analysis)), synthesis
                 )
                 for batch in batches
             ]
@@ -330,11 +335,23 @@ class TileApply(PatchProcessor):
         return np.moveaxis(out, tail, window.axes)
 
 
-def _analysis(analysis: Any, plan) -> np.ndarray:
-    """Return what every tile is multiplied by on the way in: ones by default."""
+def _windows(
+    analysis: Any, taper: Any, plan, overlap
+) -> tuple[np.ndarray | None, np.ndarray]:
+    """
+    Return what tiles are multiplied by on the way in and on the way out.
+
+    Without an analysis window the tiles go in as they are and come out
+    under a taper with complementary ramps; with one, under its dual.
+    """
     if analysis is None:
-        return np.ones(plan.size, dtype=np.float32)
-    return get_dual_taper(analysis, plan.size, plan.stride)[0]
+        return None, get_taper("hann" if taper is None else taper, plan.size, overlap)
+    return get_dual_taper(analysis, plan.size, plan.stride)
+
+
+def _windowed(tiles: np.ndarray, analysis: np.ndarray | None) -> np.ndarray:
+    """Return the tiles under the analysis window, or as they are without one."""
+    return tiles if analysis is None else tiles * analysis
 
 
 def _stack_coords(meta: PatchMeta, window: Window):
@@ -342,8 +359,8 @@ def _stack_coords(meta: PatchMeta, window: Window):
     coords = meta.coords
     plan = window.tiles(meta.shape)
     new_coords = {}
-    for dim, size, stride, count in zip(
-        window.dims, window.size, plan.stride, plan.grid
+    for dim, size, stride, margin, count in zip(
+        window.dims, window.size, plan.stride, plan.margin, plan.grid
     ):
         claimed = (
             f"{dim}_start",
@@ -356,7 +373,7 @@ def _stack_coords(meta: PatchMeta, window: Window):
                 msg = f"The patch already has a coordinate called {name}."
                 raise ParameterError(msg)
         coord = coords.get_coord(dim)
-        starts = np.arange(count) * stride - stride
+        starts = np.arange(count) * stride - margin
         # The tile's middle sample, in the coordinate's units.
         centres = _offset_values(coord, starts + (size - 1) / 2)
         offsets = _offset_values(coord, np.arange(size)) - coord.values[0]
@@ -476,11 +493,11 @@ def reassemble(patch: PatchType, *, taper: Any = None) -> PatchType:
         weights = get_dual_taper(analysis, size, strides)[1]
     else:
         overlap = tuple(z - st for z, st in zip(size, strides))
-        weights = get_taper(taper or "hann", size, overlap)
+        weights = get_taper("hann" if taper is None else taper, size, overlap)
     plan = get_tile_plan(shape, size, strides)
     as_cut = all(
-        len(s) == count and np.array_equal(s, np.arange(count) * st - st)
-        for s, count, st in zip(starts, plan.grid, strides)
+        len(s) == count and np.array_equal(s, np.arange(count) * st - m)
+        for s, count, st, m in zip(starts, plan.grid, strides, plan.margin)
     )
     if as_cut:
         # Every tile, in the order it was cut: the plan blends the stack a

--- a/dascore/utils/_tiles_numba.py
+++ b/dascore/utils/_tiles_numba.py
@@ -31,7 +31,7 @@ def _apply_colour_class(
     colour0: int,
     colour1: int,
     func,
-    analysis: np.ndarray,
+    analysis: np.ndarray | None = None,
 ) -> None:
     """
     Apply `func` to every tile of one colour class, adding into `out`.
@@ -57,16 +57,18 @@ def apply_jit(
     array: np.ndarray,
     func,
     taper: np.ndarray,
-    analysis: np.ndarray,
+    analysis: np.ndarray | None = None,
 ) -> np.ndarray:
     """
     Return the array with `func` applied to every tile and the tiles blended.
 
     `func` is a numba-compiled function of one tile returning a tile of the
     same shape. Two dimensions only. `analysis` multiplies each tile before
-    `func` sees it.
+    `func` sees it; None is a window of ones.
     """
     padded = plan.pad(array, dtype=np.result_type(array, np.float32))
+    if analysis is None:
+        analysis = np.ones(plan.size, dtype=padded.dtype)
     analysis = analysis.astype(padded.dtype)
     # One tile through the function first, to learn what it returns: the
     # output takes that dtype, so a real tile made complex is kept complex.

--- a/dascore/utils/_tiles_numba.py
+++ b/dascore/utils/_tiles_numba.py
@@ -31,6 +31,7 @@ def _apply_colour_class(
     colour0: int,
     colour1: int,
     func,
+    analysis: np.ndarray,
 ) -> None:
     """
     Apply `func` to every tile of one colour class, adding into `out`.
@@ -44,24 +45,32 @@ def _apply_colour_class(
     for ind in numba.prange(count0 * count1):  # noqa: F821  # ty: ignore[unresolved-reference]
         beg0 = (colour0 + colours0 * (ind // count1)) * stride0
         beg1 = (colour1 + colours1 * (ind % count1)) * stride1
-        tile = func(padded[beg0 : beg0 + window0, beg1 : beg1 + window1])
+        tile = func(padded[beg0 : beg0 + window0, beg1 : beg1 + window1] * analysis)
         out[beg0 : beg0 + window0, beg1 : beg1 + window1] += tile * taper
 
 
 _JIT_AVAILABLE = _apply_colour_class.jit_available
 
 
-def apply_jit(plan: TilePlan, array: np.ndarray, func, taper: np.ndarray) -> np.ndarray:
+def apply_jit(
+    plan: TilePlan,
+    array: np.ndarray,
+    func,
+    taper: np.ndarray,
+    analysis: np.ndarray,
+) -> np.ndarray:
     """
     Return the array with `func` applied to every tile and the tiles blended.
 
     `func` is a numba-compiled function of one tile returning a tile of the
-    same shape. Two dimensions only.
+    same shape. Two dimensions only. `analysis` multiplies each tile before
+    `func` sees it.
     """
     padded = plan.pad(array, dtype=np.result_type(array, np.float32))
+    analysis = analysis.astype(padded.dtype)
     # One tile through the function first, to learn what it returns: the
     # output takes that dtype, so a real tile made complex is kept complex.
-    probe = func(padded[tuple(slice(0, z) for z in plan.size)])
+    probe = func(padded[tuple(slice(0, z) for z in plan.size)] * analysis)
     out = np.zeros(plan.extended, dtype=np.result_type(probe, padded, taper))
     for colour0 in range(plan.colours[0]):
         for colour1 in range(plan.colours[1]):
@@ -76,5 +85,6 @@ def apply_jit(plan: TilePlan, array: np.ndarray, func, taper: np.ndarray) -> np.
                 colour0,
                 colour1,
                 func,
+                analysis,
             )
     return plan.crop(out)

--- a/dascore/utils/signal.py
+++ b/dascore/utils/signal.py
@@ -22,6 +22,7 @@ from dascore.exceptions import ParameterError
 from dascore.utils.imports import lazy_import
 
 _scipy_get_window = lazy_import("scipy.signal", "get_window")
+_ShortTimeFFT = lazy_import("scipy.signal", "ShortTimeFFT")
 
 # The names DASCore documents for windows, each the scipy name it means.
 # Two are DASCore's own: `cos` for hann and `ramp` for triang. Anything not
@@ -200,3 +201,61 @@ def get_taper(
         return _cached_taper(window, size, overlap).copy()
     # An array, or a tuple carrying a list: built each time, uncached.
     return _build_taper(window, size, overlap)
+
+
+def get_dual_taper(
+    window: Any, size: tuple[int, ...], stride: tuple[int, ...]
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Return an analysis window and the synthesis window which inverts it.
+
+    Tiles multiplied by the analysis window on the way in and by the
+    synthesis window on the way out sum to exactly what they were cut from,
+    at any stride the window can be inverted at: the synthesis window is
+    scipy's canonical dual, built per axis and multiplied across them.
+
+    Parameters
+    ----------
+    window
+        The analysis window; see `get_window`. One name for every axis.
+    size
+        The tile's shape.
+    stride
+        How far tiles advance along each axis.
+
+    Returns
+    -------
+    A pair of ``float32`` arrays of shape `size`: the analysis window and
+    its dual.
+
+    Examples
+    --------
+    >>> from dascore.utils.signal import get_dual_taper
+    >>> analysis, synthesis = get_dual_taper("hann", (16, 16), (4, 4))
+    >>> analysis.shape == synthesis.shape == (16, 16)
+    True
+    """
+    if len(size) != len(stride):
+        msg = "size and stride must have the same length."
+        raise ParameterError(msg)
+    size, stride = tuple(size), tuple(stride)
+    if _hashable(window):
+        analysis, synthesis = _cached_dual_taper(window, size, stride)
+        return analysis.copy(), synthesis.copy()
+    return _build_dual_taper(window, size, stride)
+
+
+@lru_cache(maxsize=64)
+def _cached_dual_taper(window, size, stride):
+    return _build_dual_taper(window, size, stride)
+
+
+def _build_dual_taper(window, size, stride):
+    analyses, duals = [], []
+    for length, step in zip(size, stride):
+        edge = np.asarray(get_window(window, length), dtype=np.float64)
+        duals.append(_ShortTimeFFT(edge, hop=step, fs=1.0).dual_win)
+        analyses.append(edge)
+    analysis = math.prod(np.ix_(*analyses)) if len(size) > 1 else analyses[0]
+    synthesis = math.prod(np.ix_(*duals)) if len(size) > 1 else duals[0]
+    return np.asarray(analysis, np.float32), np.asarray(synthesis, np.float32)

--- a/dascore/utils/tiles.py
+++ b/dascore/utils/tiles.py
@@ -65,14 +65,25 @@ class TilePlan:
 
     @property
     def margin(self) -> tuple[int, ...]:
-        """Zeros added at each end of every axis: one stride, for a full ramp."""
-        return self.stride
+        """
+        Zeros added at each end of every axis, in whole strides.
+
+        Enough that every sample of the array is reached by every tile which
+        would reach it in an unbounded grid: one stride when tiles overlap
+        by no more than half, more when they overlap deeper, which a
+        synthesis window computed as a dual relies on.
+        """
+        return tuple(
+            max(step, math.ceil((z - step) / step) * step)
+            for z, step in zip(self.size, self.stride)
+        )
 
     @property
     def grid(self) -> tuple[int, ...]:
         """How many tiles along each axis."""
         return tuple(
-            (length + 2 * step) // step for length, step in zip(self.shape, self.stride)
+            (length + 2 * m) // step
+            for length, m, step in zip(self.shape, self.margin, self.stride)
         )
 
     @property
@@ -84,9 +95,9 @@ class TilePlan:
     def extended(self) -> tuple[int, ...]:
         """The padded buffer's shape, long enough for the last tile to fit whole."""
         return tuple(
-            max(length + 2 * step, (count - 1) * step + z)
-            for length, step, count, z in zip(
-                self.shape, self.stride, self.grid, self.size
+            max(length + 2 * m, (count - 1) * step + z)
+            for length, m, step, count, z in zip(
+                self.shape, self.margin, self.stride, self.grid, self.size
             )
         )
 

--- a/docs/recipes/windowing.qmd
+++ b/docs/recipes/windowing.qmd
@@ -25,6 +25,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 import dascore as dc
+from dascore.units import percent
 
 patch = dc.get_example_patch("example_event_2").pass_filter(time=(1, 300))
 
@@ -83,6 +84,22 @@ def agc_tile(tile):
 
 
 normalized = patch.tile_apply(agc_tile, time=0.02, distance=40)
+```
+
+## A window on the way in
+
+By default the function sees raw, rectangular tiles and the blend alone is tapered. A function which takes a spectrum of each tile may want the tile windowed first. Give `analysis` a window name and each tile is multiplied by it before the function sees it; the blend then uses that window's dual, computed by scipy along each axis, so an unchanged stack still returns the input exactly — and the overlap may go past half the window.
+
+```{python}
+def keep_strongest(tiles):
+    """Keep the largest quarter of each tile's f-k coefficients."""
+    spectra = np.fft.rfft2(tiles)
+    cutoff = np.percentile(np.abs(spectra), 75, axis=(1, 2), keepdims=True)
+    return np.fft.irfft2(np.where(np.abs(spectra) < cutoff, 0, spectra), s=tiles.shape[1:])
+
+
+local_fk = patch.tile_apply(keep_strongest, analysis="hann", overlap=75 * percent, time=0.02, distance=40)
+assert local_fk.shape == patch.shape
 ```
 
 ## What a tile sees

--- a/docs/recipes/windowing.qmd
+++ b/docs/recipes/windowing.qmd
@@ -104,4 +104,4 @@ assert local_fk.shape == patch.shape
 
 ## What a tile sees
 
-Tiles start one stride before the data and are padded with zeros, so every sample is covered by tiles which see a full taper ramp on both sides. Overlap defaults to half the window and cannot exceed it, since the ramps would cross. The taper's shape is any window [`get_window`](`dascore.utils.signal.get_window`) knows; its ramps are made complementary whatever the shape, which is what makes the blend exact.
+Tiles start before the data and are padded with zeros: one stride before, so every sample is covered by tiles which see a full taper ramp on both sides, or under an analysis window as many whole strides as it takes for every tile which would reach a sample to exist, which the dual relies on. Overlap defaults to half the window; under a taper it cannot exceed half, since the ramps would cross, and under an analysis window it may go as deep as scipy can invert the window at. The taper's shape is any window [`get_window`](`dascore.utils.signal.get_window`) knows; its ramps are made complementary whatever the shape, which is what makes the blend exact.

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -140,6 +140,52 @@ class TestOverlapAdd:
 class TestAnalysisWindow:
     """A window on the way in, its dual on the way out."""
 
+    def test_deep_overlap_stack_starts_where_the_tiles_do(self, patch):
+        """At 12 of 16 the first tile starts three strides before the data."""
+        tiles = patch.tile_apply(
+            lambda x: x,
+            mode="stack",
+            analysis="hann",
+            overlap=12,
+            time=16,
+            samples=True,
+        )
+        starts = tiles.get_coord("time_start").values
+        assert starts[0] == -12
+        assert starts[1] - starts[0] == 4
+
+    def test_deep_overlap_thinned_stack_is_placed_by_its_starts(self, patch):
+        """Every other tile of a deep stack lands where the full stack put it."""
+        tiles = patch.tile_apply(
+            lambda x: x,
+            mode="stack",
+            analysis="hann",
+            overlap=12,
+            time=16,
+            samples=True,
+        )
+        keep = np.arange(0, tiles.shape[tiles.dims.index("time")], 2)
+        thinned = tiles.select(time=keep, samples=True).reassemble()
+        zeroed = tiles.data.copy()
+        zeroed[:, 1::2] = 0
+        expected = tiles.new(data=zeroed).reassemble()
+        np.testing.assert_allclose(thinned.data, expected.data, atol=1e-6)
+
+    @pytest.mark.parametrize("mode", ["overlap_add", "stack"])
+    def test_without_a_window_the_function_sees_the_dtype(self, mode):
+        """No analysis window, no promotion: an integer tile stays integer."""
+        seen = []
+        patch = dc.Patch(
+            data=np.arange(32, dtype=np.int32), coords={"x": np.arange(32)}, dims=("x",)
+        )
+
+        def parity(tiles):
+            seen.append(tiles.dtype)
+            return tiles & 1
+
+        patch.tile_apply(parity, mode=mode, x=8, samples=True)
+        assert seen == [np.dtype(np.int32)]
+
     @pytest.mark.parametrize("window", ["hann", "hamming", ("tukey", 0.5)])
     def test_identity_under_a_dual(self, patch, window):
         """Windowed tiles blended under the dual return the input exactly."""
@@ -189,6 +235,13 @@ class TestAnalysisWindow:
         with pytest.raises(ParameterError, match="cannot be given as well"):
             patch.tile_apply(
                 identity, analysis="hann", taper="triang", time=16, samples=True
+            )
+
+    def test_an_explicit_default_taper_is_still_a_taper(self, patch):
+        """Spelling out the default does not slip past the exclusivity rule."""
+        with pytest.raises(ParameterError, match="cannot be given as well"):
+            patch.tile_apply(
+                lambda x: x, analysis="hann", taper="hann", time=16, samples=True
             )
 
     def test_array_refused(self, patch):
@@ -290,6 +343,12 @@ class TestStack:
 
 class TestReassemble:
     """Blending a stack back."""
+
+    def test_array_taper(self, patch):
+        """A taper given as an array is a window like any other."""
+        tiles = patch.tile_apply(lambda x: x, mode="stack", time=16, samples=True)
+        back = tiles.reassemble(taper=np.hanning(17))
+        assert back.equals(patch, close=True)
 
     def test_round_trip_two_dimensions(self, patch):
         """An unchanged stack reassembles to the patch, coordinates and all."""

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -137,6 +137,74 @@ class TestOverlapAdd:
         assert "function='agc'" in list(out.attrs.history)[-1]
 
 
+class TestAnalysisWindow:
+    """A window on the way in, its dual on the way out."""
+
+    @pytest.mark.parametrize("window", ["hann", "hamming", ("tukey", 0.5)])
+    def test_identity_under_a_dual(self, patch, window):
+        """Windowed tiles blended under the dual return the input exactly."""
+        out = patch.tile_apply(
+            identity, analysis=window, time=32, distance=8, samples=True
+        )
+        np.testing.assert_allclose(out.data, patch.data, atol=1e-5)
+
+    def test_deep_overlap(self, patch):
+        """With a dual the overlap may pass half the window: hop 4 of 16."""
+        out = patch.tile_apply(
+            identity, analysis="hann", overlap=12, time=16, samples=True
+        )
+        np.testing.assert_allclose(out.data, patch.data, atol=1e-5)
+
+    def test_function_sees_the_window(self, patch):
+        """The function receives windowed tiles, not raw ones."""
+        seen = {}
+
+        def peek(tiles):
+            seen["edge"] = float(np.abs(tiles[:, :, 0]).max())
+            return tiles
+
+        patch.tile_apply(peek, analysis="hann", time=32, distance=8, samples=True)
+        assert seen["edge"] == 0.0  # a hann window is zero at its first sample
+
+    def test_stack_round_trip(self, patch):
+        """A stack cut with an analysis window reassembles under its dual."""
+        stacked = patch.tile_apply(
+            identity, mode="stack", analysis="hann", overlap=12, time=16, samples=True
+        )
+        assert stacked.attrs["_tile_analysis"] == "hann"
+        back = stacked.reassemble()
+        assert back.equals(patch, close=True)
+        assert "_tile_analysis" not in dict(back.attrs)
+
+    def test_stack_refuses_a_taper(self, patch):
+        """The dual is the only blend a windowed stack has."""
+        stacked = patch.tile_apply(
+            identity, mode="stack", analysis="hann", time=16, samples=True
+        )
+        with pytest.raises(ParameterError, match="cannot be given"):
+            stacked.reassemble(taper="triang")
+
+    def test_taper_and_analysis_exclusive(self, patch):
+        """One or the other."""
+        with pytest.raises(ParameterError, match="cannot be given as well"):
+            patch.tile_apply(
+                identity, analysis="hann", taper="triang", time=16, samples=True
+            )
+
+    def test_array_refused(self, patch):
+        """A dual is built along each axis, which needs a name."""
+        with pytest.raises(ParameterError, match="given by name"):
+            patch.tile_apply(identity, analysis=np.ones((16,)), time=16, samples=True)
+
+    def test_numba_engine(self, patch):
+        """The compiled path windows each tile before the function too."""
+        half_tile = _jitted()
+        by_numba = patch.tile_apply(
+            half_tile, analysis="hann", time=32, distance=8, samples=True
+        )
+        np.testing.assert_allclose(by_numba.data, patch.data / 2, atol=1e-4)
+
+
 class TestStack:
     """The tiles themselves."""
 
@@ -366,6 +434,7 @@ class TestEngines:
                     c0,
                     c1,
                     half_tile,
+                    np.ones(plan.size, np.float32),
                 )
         np.testing.assert_allclose(plan.crop(out), data / 2, atol=1e-5)
 

--- a/tests/test_utils/test_signal.py
+++ b/tests/test_utils/test_signal.py
@@ -7,7 +7,14 @@ import pytest
 from scipy.signal.windows import hann, triang
 
 from dascore.exceptions import ParameterError
-from dascore.utils.signal import WINDOW_NAMES, get_ramp, get_taper, get_window
+from dascore.utils.signal import (
+    WINDOW_NAMES,
+    get_dual_taper,
+    get_ramp,
+    get_taper,
+    get_window,
+)
+from dascore.utils.tiles import get_tile_plan
 
 # The shapes a blend might be asked for, from flat to bell.
 SHAPES = ["boxcar", "triang", "hann", "hamming", "blackman", ("tukey", 0.5)]
@@ -214,3 +221,37 @@ class TestGetTaper:
                 ] += taper
         inner = total[overlap[0] : -overlap[0], overlap[1] : -overlap[1]]
         np.testing.assert_allclose(inner, 1, atol=1e-6)
+
+
+class TestGetDualTaper:
+    """An analysis window and the synthesis window which inverts it."""
+
+    def test_unhashable_window_builds(self):
+        """A scipy tuple carrying a list is not hashable, and still builds."""
+        analysis, synthesis = get_dual_taper(("general_cosine", [0.5, 0.5]), (8,), (2,))
+        assert analysis.shape == synthesis.shape == (8,)
+
+    @pytest.mark.parametrize("shape", SHAPES)
+    @pytest.mark.parametrize(
+        "size,stride",
+        [((8,), (3,)), ((8,), (2,)), ((16, 16), (9, 9)), ((16, 16), (4, 4))],
+    )
+    def test_analysis_times_dual_sums_to_one(self, shape, size, stride):
+        """Tiles cut, windowed, and blended under the dual return the array."""
+        rng = np.random.default_rng(5)
+        array = rng.normal(size=tuple(4 * z for z in size)).astype(np.float32)
+        plan = get_tile_plan(array.shape, size, stride)
+        analysis, synthesis = get_dual_taper(shape, size, stride)
+        out = plan.overlap_add(plan.extract(array) * analysis, synthesis)
+        np.testing.assert_allclose(out, array, atol=1e-5)
+
+    def test_shapes_and_dtype(self):
+        """Both windows are float32 arrays of the tile's shape."""
+        analysis, synthesis = get_dual_taper("hann", (8, 16), (4, 8))
+        assert analysis.shape == synthesis.shape == (8, 16)
+        assert analysis.dtype == synthesis.dtype == np.float32
+
+    def test_mismatched_lengths_refused(self):
+        """A stride per axis."""
+        with pytest.raises(ParameterError, match="same length"):
+            get_dual_taper("hann", (8, 16), (4,))

--- a/tests/test_utils/test_tiles.py
+++ b/tests/test_utils/test_tiles.py
@@ -35,6 +35,14 @@ class TestGeometry:
         assert plan.extended[0] >= (plan.grid[0] - 1) * 9 + 16
         assert plan.n_tiles == plan.grid[0]
 
+    def test_margin_grows_with_overlap(self):
+        """One stride of margin up to half overlap; whole strides beyond it."""
+        assert get_tile_plan((64,), (16,), (9,)).margin == (9,)
+        assert get_tile_plan((64,), (16,), (8,)).margin == (8,)
+        # Hop 3 of 8: a sample is reached by three tiles, two strides back.
+        assert get_tile_plan((33,), (8,), (3,)).margin == (6,)
+        assert get_tile_plan((64,), (16,), (4,)).margin == (12,)
+
     def test_colours(self):
         """Tiles two strides apart cannot overlap when the stride is over half."""
         assert get_tile_plan((64, 64), (16, 16), (9, 9)).colours == (2, 2)


### PR DESCRIPTION
## Description

PR 7 of the windowing plan (top-level `.scratch/windowing-unification-plan.md`): a window on the way in.

**`Patch.tile_apply(function, analysis="hann", ...)`** multiplies every tile by a window before `function` sees it. Until now a spectral function got a raw, rectangular tile, and the only window available was the taper on the way *out*; a Hann on the way in — what any FFT of a tile wants — was not possible, because the blend would no longer sum to one. Now the synthesis window is not a taper with complementary ramps but the **dual** of the analysis window, computed per axis by scipy's `ShortTimeFFT(...).dual_win` and multiplied across the windowed dimensions (`get_dual_taper` in `dascore.utils.signal`, cached like `get_taper`). `Σₖ w(n−kH)·g(n−kH) = 1` holds for any window scipy can invert at that hop, so an unchanged tile still round-trips to the input exactly, and the overlap may exceed half the window — 75 % is the natural choice with a Hann.

One geometry change makes that possible: `TilePlan.margin` is now `max(stride, ceil((size − stride) / stride) · stride)` rather than one stride, so at a deep overlap every sample of the array is reached by every tile which would reach it in an unbounded grid, which the dual relies on. At an overlap of half or less it is the one stride it was, so nothing cut before this PR moves: the adaptive spectral filter's output is bit-identical to `windowing-4`.

The analysis window is given by name or `(name, parameter)` tuple only, since a dual is built per axis and an arbitrary array need not be separable; it is exclusive with `taper`. In `mode="stack"` the tiles come back windowed and the name travels as `_tile_analysis`, so `reassemble` blends under the dual and refuses a taper. The numba driver takes the same window and applies it per tile.

The recipe gains a section, "A window on the way in", keeping the strongest 2-D Fourier components of each tile under `analysis="hann", overlap=75 * percent`.

### Codex review

One P1: a stack's `{dim}_start` coordinates and `reassemble`'s as-cut check still assumed one stride of margin, so at a deep overlap every tile was labelled `margin − stride` samples late — a full stack round-tripped only because the as-cut fast path ignores the starts, and a thinned or reordered deep stack was placed wrong. Both now read `plan.margin`, with tests that a 12-of-16 stack starts at −12 and that every other tile of it lands where the full stack put it. One P2: a function given no analysis window was still handed `tiles * ones`, promoting an integer patch to float before the function saw it; without a window the tiles now go in as they are, with a test that an `int32` patch's function sees `int32` in both modes. Two P3s: the docs still said tiles start one stride before the data and overlap cannot exceed half — now qualified for the analysis-window case in the docstring, the notes, and the recipe; and the analysis/dual pair was fetched twice per call — once now.

The GitHub review added two: `reassemble` chose its default with `taper or "hann"`, which an array taper cannot be asked, and an explicit `taper="hann"` next to `analysis` passed the exclusivity check because it equalled the default. `taper` now defaults to `None`, meaning Hann, in both places, with tests for an array taper and for the spelled-out default.

## Changelog

- added: `analysis` on `Patch.tile_apply`, a window each tile is multiplied by before the function, blended back under its scipy dual so the reconstruction stays exact at any overlap the window can be inverted at; `get_dual_taper` in `dascore.utils.signal`.
- changed: `TilePlan` pads by more than one stride when tiles overlap by more than half.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional analysis windows for tile processing, allowing each tile to be windowed before processing and reconstructed accurately with dual-window blending.
  - Supports overlaps greater than half a tile while preserving exact reconstruction.
  - Added dual-window generation for multidimensional signals.

- **Bug Fixes**
  - Improved padding and tile placement for deep-overlap workflows.
  - Preserved data types when no analysis window is used.

- **Documentation**
  - Added guidance and examples for analysis-window processing and high-overlap configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->