### PR TITLE
The windowing clean-up: one stack for stft and tile_apply, one numba driver, fewer rules

### DIFF
--- a/dascore/proc/adaptive_spectral_filter.py
+++ b/dascore/proc/adaptive_spectral_filter.py
@@ -34,7 +34,6 @@ from scipy import fft as sp_fft
 
 from dascore.constants import PatchType
 from dascore.exceptions import MissingOptionalDependencyError, ParameterError
-from dascore.utils.misc import is_power_of_two
 from dascore.utils.patch import patch_function
 from dascore.utils.signal import get_taper
 from dascore.utils.tiles import TilePlan, get_tile_plan
@@ -54,10 +53,8 @@ def _check_window(window: Any, overlap: Any, label: str) -> None:
     if not isinstance(overlap, int | np.integer):
         msg = f"overlap for {label} must be an integer; got {overlap!r}."
         raise ValueError(msg)
-    if window <= 4 or not is_power_of_two(window):
-        msg = (
-            f"window for {label} must be a power of two greater than 4; got {window!r}."
-        )
+    if window < 2:
+        msg = f"window for {label} must be at least 2 samples; got {window!r}."
         raise ValueError(msg)
     if overlap < 0:
         msg = f"overlap for {label} must be non-negative; got {overlap!r}."
@@ -175,8 +172,7 @@ def _adaptive_spectral_filter_scipy(
     data
         One- or two-dimensional input array. The filter computes in ``float32``.
     window_size
-        Power-of-two window lengths, one per array axis. Values must be greater
-        than 4.
+        Window lengths in samples, one per array axis, of at least 2.
     overlap
         Number of samples each neighboring window overlaps on each axis. Values
         must be non-negative and smaller than half the matching window.
@@ -198,7 +194,7 @@ def _adaptive_spectral_filter_scipy(
     ValueError
         If ``data`` is not one- or two-dimensional, ``exponent`` is not finite,
         ``window_size`` and ``overlap`` do not match ``data.ndim``, any window
-        size is not a power of two greater than 4, or any overlap is negative or
+        size is under 2 samples, or any overlap is negative or
         at least half the matching window size.
     """
     data = np.asarray(data)
@@ -326,9 +322,9 @@ def adaptive_spectral_filter(
       its own magnitude to the power of ``exponent``, so the output's units
       are not the input's and its amplitudes grow with the input's; compare
       arrivals within one output rather than across inputs.
-    - Windows must be powers of two greater than 4 samples. A window should
-      hold a few cycles of the arrivals to keep and be short against the
-      distance over which their moveout changes.
+    - A window should hold a few cycles of the arrivals to keep and be short
+      against the distance over which their moveout changes. Any length of
+      at least 2 samples serves; a power of two transforms fastest.
     """
     return AdaptiveSpectralFilter(
         overlap=overlap,
@@ -377,6 +373,7 @@ class AdaptiveSpectralFilter(PatchProcessor):
             overlap=self.overlap,
             # Sample counts are read as given, whatever the coordinate is.
             require_evenly_sampled=False,
+            min_samples=2,
             # The most the window allows, which is what Lightguide uses. A
             # default is a sample count whatever `samples` says.
             default_overlap=lambda size: size // 2 - 1,

--- a/dascore/proc/adaptive_spectral_filter.py
+++ b/dascore/proc/adaptive_spectral_filter.py
@@ -1,25 +1,14 @@
 """
-Adaptive spectral filtering for DASCore patches.
-
-The filter walks a patch in overlapping windows along one or two dimensions.
-Each window is transformed to the spectral domain, every coefficient is
-weighted by a power of its own magnitude, and the window is transformed back
-and added into the output under a tapered overlap-add. Energy which is
-coherent within a window concentrates in a few large coefficients, which the
-weighting keeps; energy spread across the spectrum is suppressed.
+The adaptive spectral (AFK) filter: every window's spectrum weighted by a
+power of its own magnitude, so coherent energy is kept and the rest suppressed.
 
 Over two dimensions this is the adaptive frequency-wavenumber filter of
 @isken2022denoising as implemented by Pyrocko
 [Lightguide](https://github.com/pyrocko/lightguide), which the SciPy engine
-here matches to floating-point precision. Over one dimension it is the same
-weighting applied to each trace on its own.
-
-The public patch function converts dimension names and coordinate units to
-axes and sample counts and batches over every dimension not selected. The
-engines work on raw one- or two-dimensional arrays; the optional
-Numba/rocket-fft engine in `_adaptive_spectral_filter_numba` handles the
-two-dimensional case and shares this module's validation, padding, and taper
-so the two produce the same output.
+matches to floating-point precision. The engines take one- or
+two-dimensional arrays; the patch function resolves windows and batches over
+every other dimension. The optional numba engine in
+`_adaptive_spectral_filter_numba` shares this module's validation and taper.
 """
 
 from __future__ import annotations
@@ -165,37 +154,31 @@ def _adaptive_spectral_filter_scipy(
     normalize_power: bool = False,
 ) -> np.ndarray:
     """
-    Filter a 1D or 2D array with the SciPy adaptive spectral implementation.
+    Filter a 1D or 2D array with the SciPy engine.
 
     Parameters
     ----------
     data
-        One- or two-dimensional input array. The filter computes in ``float32``.
+        A one- or two-dimensional array; the filter computes in ``float32``.
     window_size
-        Window lengths in samples, one per array axis, of at least 2.
+        Window lengths in samples, one per axis, of at least 2.
     overlap
-        Number of samples each neighboring window overlaps on each axis. Values
-        must be non-negative and smaller than half the matching window.
+        Samples each window shares with the next along each axis: at least 0
+        and under half the window.
     exponent
-        Spectral magnitude exponent used as the adaptive weighting power. ``0``
-        leaves the spectrum unweighted before overlap-add reconstruction.
+        The weighting power; ``0`` leaves the spectrum unweighted.
     normalize_power
-        If ``True``, normalize each tile's spectral magnitudes by that tile's
-        maximum magnitude before applying ``exponent``.
+        If True, scale each window's magnitudes by their maximum first.
 
     Returns
     -------
-    numpy.ndarray
-        The filtered array with the same shape as ``data``. Floating input
-        dtypes are restored; non-floating inputs return ``float32`` output.
+    The filtered array, in the input's floating dtype or ``float32``.
 
     Raises
     ------
     ValueError
-        If ``data`` is not one- or two-dimensional, ``exponent`` is not finite,
-        ``window_size`` and ``overlap`` do not match ``data.ndim``, any window
-        size is under 2 samples, or any overlap is negative or
-        at least half the matching window size.
+        For an array of another dimensionality, or a window, overlap, or
+        exponent outside the ranges above.
     """
     data = np.asarray(data)
     _validate_filter_inputs(
@@ -250,62 +233,42 @@ def adaptive_spectral_filter(
     **kwargs: Any,
 ) -> PatchType:
     """
-    Apply adaptive spectral filtering over one or two patch dimensions.
+    Suppress energy which is not coherent within a window: the AFK filter.
 
     Parameters
     ----------
     patch
-        DASCore patch whose data should be filtered.
+        The patch to filter.
     overlap
-        Window overlap in samples when ``samples=True`` or in coordinate units
-        otherwise. A single value applies to all selected dimensions; a mapping
-        can specify dimensions independently. When omitted, each dimension
-        defaults to ``window // 2 - 1`` samples, the largest overlap allowed.
+        How far each window reaches into the next, in coordinate units or,
+        with `samples`, in samples; a mapping gives each dimension its own.
+        Default is ``window // 2 - 1`` samples, the most allowed.
     exponent
-        Spectral magnitude exponent used as the adaptive weighting power.
-        Larger values suppress incoherent energy harder; ``0`` leaves the
-        spectrum unweighted, and values above 1 begin to remove weak coherent
-        arrivals along with the noise. Must be non-negative.
+        The weighting power. ``0`` leaves the spectrum unweighted; above 1
+        weak coherent arrivals go with the noise. Non-negative.
     normalize_power
-        If ``True``, normalize each tile's spectral magnitudes by that tile's
-        maximum magnitude before applying ``exponent``. This keeps the
-        amplitude of every window near its input level, at the cost of
-        suppressing much less noise in windows which hold no signal.
+        If True, scale each window's magnitudes by their maximum before the
+        exponent, which keeps every window near its input amplitude at the
+        cost of suppressing much less noise where there is no signal.
     samples
-        If ``True``, dimension kwargs and overlap values are interpreted as
-        sample counts. If ``False``, values are converted through evenly sampled
-        patch coordinates.
+        If True, windows and overlaps are sample counts.
     engine
-        ``"auto"`` uses SciPy for one selected dimension and the optional
-        Numba/rocket-fft implementation for two selected dimensions when
-        available. ``"numba"`` requires two selected dimensions and the optional
-        fast engine. ``"scipy"`` always uses the SciPy FFT implementation.
+        ``"scipy"``, ``"numba"`` (two dimensions, needs numba and rocket-fft),
+        or ``"auto"``, which is numba when it can be.
     **kwargs
-        One or two dimension names and their window sizes, such as ``time=32``
-        or ``time=32, distance=32``.
+        One or two dimensions and their windows, such as ``time=32`` or
+        ``time=32, distance=32``.
 
     Returns
     -------
-    Patch
-        A new patch with filtered data and original dimensions and coordinates.
-        The data are ``float32``, or ``float64`` for ``float64`` input.
-
-    Raises
-    ------
-    ParameterError
-        If one or two dimensions are not selected, if selected window or overlap
-        values are invalid, if ``exponent`` is not finite and non-negative, or
-        if an invalid engine name is requested.
-    MissingOptionalDependencyError
-        If ``engine="numba"`` is requested for two selected dimensions but the
-        optional fast-engine dependencies are not installed.
+    A patch with the input's shape and coordinates, in ``float32`` unless the
+    input is ``float64``.
 
     Examples
     --------
     >>> import dascore as dc
     >>> patch = dc.get_example_patch("example_event_2").pass_filter(time=(1, 300))
-    >>> # Suppress energy which is not coherent across both time and distance,
-    >>> # in windows of 16 samples along each.
+    >>> # Keep what is coherent across both time and distance.
     >>> filtered = patch.adaptive_spectral_filter(
     ...     time=16, distance=16, samples=True
     ... )
@@ -314,17 +277,16 @@ def adaptive_spectral_filter(
 
     Notes
     -----
-    - With two selected dimensions this is the adaptive frequency-wavenumber
-      (AFK) filter of @isken2022denoising, and matches Pyrocko
-      [Lightguide](https://github.com/pyrocko/lightguide)'s `afk_filter`,
-      whose defaults are ``window_size=16, overlap=7, exponent=0.8``.
-    - The filter is not amplitude preserving. Each coefficient is scaled by
-      its own magnitude to the power of ``exponent``, so the output's units
-      are not the input's and its amplitudes grow with the input's; compare
-      arrivals within one output rather than across inputs.
+    - Over two dimensions this is the adaptive frequency-wavenumber filter of
+      @isken2022denoising, matching Pyrocko
+      [Lightguide](https://github.com/pyrocko/lightguide)'s `afk_filter` and
+      its defaults, ``window_size=16, overlap=7, exponent=0.8``.
+    - Not amplitude preserving: each coefficient is scaled by its own
+      magnitude to the power of ``exponent``, so compare arrivals within one
+      output rather than across inputs.
     - A window should hold a few cycles of the arrivals to keep and be short
-      against the distance over which their moveout changes. Any length of
-      at least 2 samples serves; a power of two transforms fastest.
+      against the distance over which their moveout changes; a power of two
+      transforms fastest.
     """
     return AdaptiveSpectralFilter(
         overlap=overlap,

--- a/dascore/proc/adaptive_spectral_filter.py
+++ b/dascore/proc/adaptive_spectral_filter.py
@@ -49,7 +49,9 @@ def _check_window(window: Any, overlap: Any, label: str) -> None:
         msg = f"overlap for {label} must be non-negative; got {overlap!r}."
         raise ValueError(msg)
     if overlap >= window / 2:
-        msg = f"overlap for {label} is too large; maximum is {window // 2 - 1} samples."
+        msg = (
+            f"overlap for {label} is too large; maximum is {(window - 1) // 2} samples."
+        )
         raise ValueError(msg)
 
 
@@ -242,7 +244,7 @@ def adaptive_spectral_filter(
     overlap
         How far each window reaches into the next, in coordinate units or,
         with `samples`, in samples; a mapping gives each dimension its own.
-        Default is ``window // 2 - 1`` samples, the most allowed.
+        Default is ``(window - 1) // 2`` samples, the most allowed.
     exponent
         The weighting power. ``0`` leaves the spectrum unweighted; above 1
         weak coherent arrivals go with the noise. Non-negative.
@@ -338,7 +340,7 @@ class AdaptiveSpectralFilter(PatchProcessor):
             min_samples=2,
             # The most the window allows, which is what Lightguide uses. A
             # default is a sample count whatever `samples` says.
-            default_overlap=lambda size: size // 2 - 1,
+            default_overlap=lambda size: (size - 1) // 2,
         )
         # A default was given, so every dimension has an overlap.
         assert window.overlap is not None

--- a/dascore/proc/filter.py
+++ b/dascore/proc/filter.py
@@ -249,7 +249,7 @@ def median_filter(
     Values specified with kwargs should be small, for example < 10 samples
     otherwise this can take a long time and use lots of memory.
     """
-    size = resolve_window(patch, kwargs, samples=samples, min_samples=None).full_size()
+    size = resolve_window(patch, kwargs, samples=samples, min_samples=0).full_size()
     new_data = nd_median_filter(patch.data, size=size, mode=mode, cval=cval)
     return patch.update(data=new_data)
 
@@ -384,7 +384,7 @@ def savgol_filter(
     >>> filtered_pa_3 = pa.savgol_filter(distance=10, time=0.1, polyorder=4)
     """
     data = patch.data
-    window = resolve_window(patch, kwargs, samples=samples, min_samples=None)
+    window = resolve_window(patch, kwargs, samples=samples, min_samples=0)
     size, axes = window.full_size(), window.axes
     for ax in axes:
         data = np_savgol_filter(
@@ -448,7 +448,7 @@ def gaussian_filter(
     See scipy.ndimage.gaussian_filter for more info on implementation
     and arguments.
     """
-    window = resolve_window(patch, kwargs, samples=samples, min_samples=None)
+    window = resolve_window(patch, kwargs, samples=samples, min_samples=0)
     size, axes = window.full_size(), window.axes
     used_size = tuple(size[x] for x in axes)
     data = np_gauss(

--- a/dascore/proc/hampel.py
+++ b/dascore/proc/hampel.py
@@ -4,6 +4,9 @@ Functionality for Hampel despiking.
 
 from __future__ import annotations
 
+import math
+import warnings
+
 import numpy as np
 from scipy.ndimage import median_filter
 
@@ -193,15 +196,17 @@ def hampel_filter(
     # Only bottleneck's moving median is flat in window size; the exact
     # filter and scipy's median_filter both grow with the window.
     fast = approximate and has_engine("bottleneck")
-    warn_above = None if fast else 100
     size = resolve_window(
-        patch,
-        kwargs,
-        samples=samples,
-        require_odd=True,
-        warn_above=warn_above,
-        min_samples=3,
+        patch, kwargs, samples=samples, require_odd=True, min_samples=3
     ).full_size()
+    # The cost tracks the window's area, so a 2D window is as expensive as
+    # its samples multiplied.
+    if not fast and math.prod(size) > 100:
+        msg = (
+            f"Large window size ({math.prod(size)} samples) may result in slow "
+            "performance. Consider reducing the window size."
+        )
+        warnings.warn(msg, UserWarning, stacklevel=2)
     # Need to convert ints to float for calculations to avoid roundoff error.
     # There were issues using np.issubdtype not working so this uses kind.
     is_int = data.dtype.kind in {"i", "u"}

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -17,6 +17,7 @@ with `reassemble` (``mode="stack"``).
 from __future__ import annotations
 
 from collections.abc import Callable
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -63,7 +64,7 @@ def _offset_values(coord, offsets: np.ndarray):
     return first + offsets * step
 
 
-def _engine_for(engine: str, func, ndim: int) -> str:
+def _engine_for(engine: str, func) -> str:
     """Return which engine runs `func`, or say why neither can."""
     if engine not in _ENGINES:
         msg = f"engine must be one of {_ENGINES}; got {engine!r}."
@@ -76,12 +77,6 @@ def _engine_for(engine: str, func, ndim: int) -> str:
             msg = (
                 "engine='numba' takes a numba-compiled function of one tile; "
                 "a plain function takes the whole stack and runs on numpy."
-            )
-            raise ParameterError(msg)
-        if ndim != 2:
-            msg = (
-                "A numba-compiled function is given one tile at a time over "
-                f"exactly two windowed dimensions; this call windows {ndim}."
             )
             raise ParameterError(msg)
         # Deferred: the driver is optional, and importing it eagerly would
@@ -125,9 +120,9 @@ def tile_apply(
         What to do to the tiles. On the numpy engine it is given the whole
         stack at once, an array of ``[n_tiles, *window]``, and returns one of
         the same shape: one vectorized call, not one per tile. A function
-        compiled with numba is given one tile at a time by the numba engine
-        and returns a tile of the same shape; it compiles the first time it
-        is used in each process, which takes a few seconds.
+        compiled with numba is given one tile at a time by the numba engine,
+        in parallel, and returns a tile of the same shape; it compiles the
+        first time it is used in each process, which takes a few seconds.
     mode
         ``"overlap_add"`` blends the tiles back under `taper` into a patch
         shaped like the input. ``"stack"`` returns the tiles unblended: each
@@ -157,7 +152,7 @@ def tile_apply(
         If True, windows and overlaps are sample counts.
     engine
         ``"numpy"``, ``"numba"``, or ``"auto"``, which is numba for a
-        numba-compiled `function` over two dimensions and numpy otherwise.
+        numba-compiled `function` and numpy otherwise.
     **kwargs
         The dimensions to window and the window along each, such as
         ``time=0.5`` (seconds) or ``time=64, distance=16, samples=True``.
@@ -286,7 +281,7 @@ class TileApply(PatchProcessor):
         """Tile every batch over the windowed axes; blend or stack."""
         window = self.window(meta)
         assert window.stride is not None and window.overlap is not None
-        engine = _engine_for(self.engine, self.function, len(window.axes))
+        engine = _engine_for(self.engine, self.function)
         plan = window.tiles(data.shape)
         data = np.asarray(data)
         ndim = len(window.axes)
@@ -294,22 +289,18 @@ class TileApply(PatchProcessor):
         moved = np.moveaxis(data, window.axes, tail)
         batches = moved.reshape((-1, *moved.shape[-ndim:]))
         if self.mode == "stack":
-            if engine == "numba":
-                msg = (
-                    "mode='stack' hands the function the whole stack of tiles; "
-                    "a numba-compiled function of one tile cannot take it."
-                )
-                raise ParameterError(msg)
             analysis = (
                 None
                 if self.analysis is None
                 else get_dual_taper(self.analysis, plan.size, plan.stride)[0]
             )
+            apply = self.function
+            if engine == "numba":
+                from dascore.utils._tiles_numba import stack_jit  # noqa: PLC0415
+
+                apply = partial(stack_jit, func=self.function)
             stacks = np.stack(
-                [
-                    self.function(_windowed(plan.extract(batch), analysis))
-                    for batch in batches
-                ]
+                [apply(_windowed(plan.extract(batch), analysis)) for batch in batches]
             )
             out = stacks.reshape((*moved.shape[:-ndim], *plan.grid, *plan.size))
             # The tile axes go where the windowed dimensions were; the

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -34,7 +34,12 @@ from dascore.exceptions import (
 )
 from dascore.utils.misc import iterate
 from dascore.utils.patch import patch_function
-from dascore.utils.signal import get_dual_taper, get_taper, get_window, get_window_nd
+from dascore.utils.signal import (
+    get_dual_taper,
+    get_taper,
+    get_window_edges,
+    get_window_nd,
+)
 from dascore.utils.tiles import get_tile_plan
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.window import Window, resolve_window
@@ -143,10 +148,12 @@ def tile_apply(
         return the input exactly. Not applied in ``"stack"`` mode.
     analysis
         A window each tile is multiplied by before `function` sees it -- any
-        name or ``(name, parameter)`` tuple `get_window` knows, applied along
-        every windowed dimension. Given one, the tiles are blended back under
-        its dual, computed by scipy along each axis, so the blend is still
-        exact; a spectral `function` then sees a properly windowed tile.
+        name, ``(name, parameter)`` tuple, or one-dimensional array
+        `get_window` knows, applied along every windowed dimension, or a
+        list with one per windowed dimension in the patch's dimension
+        order. Given one, the tiles are blended back under its dual,
+        computed by scipy along each axis, so the blend is still exact; a
+        spectral `function` then sees a properly windowed tile.
         Exclusive with `taper`, and the overlap may then exceed half the
         window. None, the default, gives `function` the raw tile.
     samples
@@ -349,6 +356,7 @@ def _stack_coords(meta: PatchMeta, window: Window, analysis: Any):
     """Return a stack's coordinate manager: tile centres, edges, and offsets."""
     coords = meta.coords
     plan = window.tiles(meta.shape)
+    edges = None if analysis is None else get_window_edges(analysis, plan.size)
     new_coords = {}
     for dim, size, stride, margin, count in zip(
         window.dims, window.size, plan.stride, plan.margin, plan.grid
@@ -376,8 +384,8 @@ def _stack_coords(meta: PatchMeta, window: Window, analysis: Any):
         # The coordinate the tiles were cut from, for reassembly, and the
         # window the tiles were cut under, whose dual blends them back.
         new_coords[f"_tile_source_{dim}"] = (None, coord)
-        if analysis is not None:
-            edge = np.asarray(get_window(analysis, size), dtype=np.float32)
+        if edges is not None:
+            edge = edges[window.dims.index(dim)].astype(np.float32)
             new_coords[f"_tile_analysis_{dim}"] = (None, edge)
         # And every coordinate which rode along it, a quality flag say.
         for name, aux_dims in coords.dim_map.items():

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -32,8 +32,9 @@ from dascore.exceptions import (
     ParameterError,
     PatchError,
 )
+from dascore.utils.misc import iterate
 from dascore.utils.patch import patch_function
-from dascore.utils.signal import get_dual_taper, get_taper
+from dascore.utils.signal import get_dual_taper, get_taper, get_window, get_window_nd
 from dascore.utils.tiles import get_tile_plan
 from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.window import Window, resolve_window
@@ -183,11 +184,10 @@ def tile_apply(
 
     Notes
     -----
-    - Tiles start before the data and are padded with zeros: one stride
-      before, so every sample of the input is covered by tiles which see a
-      full taper ramp on both sides, or under an analysis window as many
-      whole strides as it takes for every tile which would reach a sample to
-      exist, which its dual relies on.
+    - Tiles start before the data and are padded with zeros, as many whole
+      strides before as it takes for every tile which reaches a sample to
+      exist: none when tiles abut, one stride up to half overlap, more
+      beyond it, which an analysis window's dual relies on.
     - The adaptive spectral filter is this with a spectral weighting as
       `function`; see
       [`Patch.adaptive_spectral_filter`](`dascore.Patch.adaptive_spectral_filter`).
@@ -239,10 +239,11 @@ class TileApply(PatchProcessor):
                 "a taper cannot be given as well."
             )
             raise ParameterError(msg)
-        if self.analysis is not None and not isinstance(self.analysis, str | tuple):
+        if isinstance(self.analysis, np.ndarray) and self.analysis.ndim != 1:
             msg = (
-                "An analysis window is given by name, or as a (name, parameter) "
-                "tuple, so that its dual can be built along each axis."
+                "An analysis window given as an array is one-dimensional, an "
+                "edge applied along every windowed dimension, so that its dual "
+                "can be built along each axis."
             )
             raise ParameterError(msg)
         # In the patch's axis order, whatever order they were named in, so a
@@ -272,10 +273,9 @@ class TileApply(PatchProcessor):
         strides = {
             f"_tile_stride_{d}": int(s) for d, s in zip(window.dims, window.stride)
         }
-        if self.analysis is not None:
-            strides["_tile_analysis"] = self.analysis
         attrs = meta.attrs.update(**strides)
-        return meta.update(coords=_stack_coords(meta, window), attrs=attrs)
+        coords = _stack_coords(meta, window, self.analysis)
+        return meta.update(coords=coords, attrs=attrs)
 
     def kernel(self, data, meta, out_meta):
         """Tile every batch over the windowed axes; blend or stack."""
@@ -292,7 +292,7 @@ class TileApply(PatchProcessor):
             analysis = (
                 None
                 if self.analysis is None
-                else get_dual_taper(self.analysis, plan.size, plan.stride)[0]
+                else get_window_nd(self.analysis, plan.size)
             )
             apply = self.function
             if engine == "numba":
@@ -345,7 +345,7 @@ def _windowed(tiles: np.ndarray, analysis: np.ndarray | None) -> np.ndarray:
     return tiles if analysis is None else tiles * analysis
 
 
-def _stack_coords(meta: PatchMeta, window: Window):
+def _stack_coords(meta: PatchMeta, window: Window, analysis: Any):
     """Return a stack's coordinate manager: tile centres, edges, and offsets."""
     coords = meta.coords
     plan = window.tiles(meta.shape)
@@ -358,6 +358,7 @@ def _stack_coords(meta: PatchMeta, window: Window):
             f"{dim}_stop",
             f"{dim}_offset",
             f"_tile_source_{dim}",
+            f"_tile_analysis_{dim}",
         )
         for name in claimed:
             if name in coords.coord_map:
@@ -366,14 +367,18 @@ def _stack_coords(meta: PatchMeta, window: Window):
         coord = coords.get_coord(dim)
         starts = np.arange(count) * stride - margin
         # The tile's middle sample, in the coordinate's units.
-        centres = _offset_values(coord, starts + (size - 1) / 2)
+        centres = _offset_values(coord, starts + size // 2)
         offsets = _offset_values(coord, np.arange(size)) - coord.values[0]
         new_coords[dim] = get_coord(data=centres, units=coord.units)
         new_coords[f"{dim}_start"] = (dim, starts)
         new_coords[f"{dim}_stop"] = (dim, starts + size)
         new_coords[f"{dim}_offset"] = get_coord(data=offsets, units=coord.units)
-        # The coordinate the tiles were cut from, for reassembly.
+        # The coordinate the tiles were cut from, for reassembly, and the
+        # window the tiles were cut under, whose dual blends them back.
         new_coords[f"_tile_source_{dim}"] = (None, coord)
+        if analysis is not None:
+            edge = np.asarray(get_window(analysis, size), dtype=np.float32)
+            new_coords[f"_tile_analysis_{dim}"] = (None, edge)
         # And every coordinate which rode along it, a quality flag say.
         for name, aux_dims in coords.dim_map.items():
             if aux_dims == (dim,) and name != dim:
@@ -473,15 +478,16 @@ def reassemble(patch: PatchType, *, taper: Any = None) -> PatchType:
     # tiles were cut for, which the stride in attrs says.
     starts = [patch.get_coord(f"{dim}_start").values for dim in dims]
     strides = tuple(int(patch.attrs[f"_tile_stride_{dim}"]) for dim in dims)
-    analysis = patch.attrs.get("_tile_analysis")
-    if analysis is not None:
+    windows = [f"_tile_analysis_{dim}" for dim in dims]
+    if all(name in patch.coords.coord_map for name in windows):
         if taper is not None:
             msg = (
                 "This stack was cut with an analysis window and is blended under "
                 "its dual; a taper cannot be given."
             )
             raise ParameterError(msg)
-        weights = get_dual_taper(analysis, size, strides)[1]
+        edges = [patch.get_coord(name).values for name in windows]
+        weights = get_dual_taper(edges, size, strides)[1]
     else:
         overlap = tuple(z - st for z, st in zip(size, strides))
         weights = get_taper("hann" if taper is None else taper, size, overlap)
@@ -498,8 +504,15 @@ def reassemble(patch: PatchType, *, taper: Any = None) -> PatchType:
         blended = _place_each(stacks, starts, shape, size, weights)
     out = blended.reshape((*batch_shape, *shape))
     out = np.moveaxis(out, tuple(range(-ndim, 0)), tile_axes)
-    # Put the source coordinates back, and drop everything the stack added.
-    coord_map: dict[str, Any] = dict(patch.coords.get_coord_tuple_map())
+    # Put the source coordinates back, and drop everything the stack added,
+    # along with any coordinate on a tile or offset axis, which has no
+    # sample to go back to.
+    consumed = set(dims) | set(offset_dims)
+    coord_map: dict[str, Any] = {
+        name: (cdims, values)
+        for name, (cdims, values) in patch.coords.get_coord_tuple_map().items()
+        if not consumed & set(iterate(cdims))
+    }
     for dim, coord in sources.items():
         coord_map[dim] = coord
         for name in (
@@ -507,8 +520,9 @@ def reassemble(patch: PatchType, *, taper: Any = None) -> PatchType:
             f"{dim}_stop",
             f"{dim}_offset",
             f"_tile_source_{dim}",
+            f"_tile_analysis_{dim}",
         ):
-            coord_map.pop(name)
+            coord_map.pop(name, None)
     for key, coord in riders.items():
         dim, name = key.split("__", 1)
         coord_map[name] = (dim, coord)

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -551,7 +551,7 @@ def _centre_phase(cycles: np.ndarray, size: int) -> np.ndarray:
     there, as scipy's `ShortTimeFFT` does. `cycles` is each frequency in
     cycles per sample.
     """
-    return np.exp(2j * np.pi * cycles * (size // 2))
+    return np.exp(2j * np.pi * cycles * (size // 2)).astype(np.complex64)
 
 
 def _as_is(tiles: np.ndarray) -> np.ndarray:
@@ -688,7 +688,6 @@ def stft(
     tiles = stack.data
     if detrend:
         tiles = sp_detrend(tiles, axis=-1, type="linear") * window
-    # For compatibility with dft, we scale by step. See the DFT note for why.
     step = to_float(coord.step)
     if fft_mode == "onesided":
         spectra = nft.rfft(tiles, n=nfft, axis=-1)
@@ -696,7 +695,8 @@ def stft(
     else:
         spectra = nft.fftshift(nft.fft(tiles, n=nfft, axis=-1), axes=-1)
         freqs = nft.fftshift(nft.fftfreq(nfft, d=step))
-    spectra *= _centre_phase(freqs * step, size)
+    # One pass: the phase and, for compatibility with dft, the scale by step.
+    spectra *= _centre_phase(freqs * step, size) * spectra.dtype.type(step)
     ft_dim = FourierTransformatter().rename_dims(patch.dims, index=axis)[axis]
     new_dims = (*patch.dims[:axis], ft_dim, *patch.dims[axis + 1 :], dim)
     coord_map = stack.coords.get_coord_tuple_map()
@@ -711,9 +711,7 @@ def stft(
         _pre_stft_data_type=patch.attrs.get("data_type"),
         data_units=_get_data_units_from_dims(patch, dim, mul),
     )
-    return patch.new(
-        data=_swap_window_axes(spectra * step, axis), coords=cm, attrs=attrs
-    )
+    return patch.new(data=_swap_window_axes(spectra, axis), coords=cm, attrs=attrs)
 
 
 @patch_function()
@@ -772,8 +770,8 @@ def istft(patch) -> dc.Patch:
     nfft = int(patch.attrs["_stft_mfft"])
     step = to_float(source.step)
     cycles = patch.get_coord(ft_dim).values * step
-    spectra = _swap_window_axes(patch.data, axis) / step
-    spectra = spectra / _centre_phase(cycles, size)
+    spectra = _swap_window_axes(patch.data, axis)
+    spectra = spectra / (_centre_phase(cycles, size) * step)
     if patch.attrs["_stft_fft_mode"] == "onesided":
         tiles = nft.irfft(spectra, n=nfft, axis=-1)
     else:

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -8,10 +8,9 @@ implementation.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from functools import partial
 from math import prod
 from operator import mul, truediv
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import numpy as np
 import numpy.fft as nft
@@ -26,21 +25,18 @@ from dascore.core.coords import get_coord
 from dascore.exceptions import ParameterError, PatchError
 from dascore.units import Quantity, invert_quantity, percent
 from dascore.utils.imports import lazy_import
-from dascore.utils.misc import broadcast_for_index, iterate
+from dascore.utils.misc import iterate
 from dascore.utils.patch import (
     _get_data_units_from_dims,
     _get_dx_or_spacing_and_axes,
     patch_function,
 )
 from dascore.utils.signal import get_window
-from dascore.utils.time import is_datetime64, is_timedelta64, to_float
+from dascore.utils.time import to_float
 from dascore.utils.transformatter import FourierTransformatter
 from dascore.utils.window import resolve_window
 
-if TYPE_CHECKING:
-    from scipy.signal import ShortTimeFFT
-else:
-    ShortTimeFFT = lazy_import("scipy.signal", "ShortTimeFFT")
+sp_detrend = lazy_import("scipy.signal", "detrend")
 
 DFT_OUTPUT_DATA_TYPE_MAP = {
     "AS": "amplitude_spectrum",
@@ -521,39 +517,6 @@ def idft(patch: PatchType, dim: str | Sequence[str] | None = None) -> PatchType:
     return out
 
 
-def _get_stft_coords(patch, dim, axis, coord, stft, window):
-    """Get the new coordinate manager following stft."""
-
-    def _get_stft_dims(dim, dims, axis):
-        """Get the output dimensions after stft."""
-        ft = FourierTransformatter()
-        new_dims = list(ft.rename_dims(dims, index=axis, forward=True))
-        new_dims.append(dim)
-        return tuple(new_dims)
-
-    # Get new coordinate. Just called time here because that is most common.
-    time = stft.t(len(coord))
-    if is_datetime64(coord.dtype) or is_timedelta64(coord.dtype):
-        time = dc.to_timedelta64(time)
-    # Get new dimensions
-    new_dims = list(_get_stft_dims(dim, patch.dims, axis))
-    # Match dft behavior by removing coords associated with transformed dim,
-    # while keeping the transformed dim itself as a non-dimensional coord.
-    coord_map = patch.coords.disassociate_coord(dim).get_coord_tuple_map()
-    new_units = invert_quantity(coord.units)
-    coord_map.update(
-        {
-            dim: get_coord(data=time + coord.min(), units=coord.units),
-            new_dims[axis]: get_coord(data=stft.f, units=new_units),
-            # Add window array for inverse stft.
-            "_stft_window": (None, window),
-            "_stft_old_coord": (None, patch.get_coord(dim)),
-        }
-    )
-    out = get_coord_manager(coords=coord_map, dims=tuple(new_dims))
-    return out
-
-
 def _resolve_nfft(nfft, coord, window_samples: int) -> int:
     """
     Return the FFT length in samples: the window's, or a longer one to pad to.
@@ -577,6 +540,34 @@ def _resolve_nfft(nfft, coord, window_samples: int) -> int:
         )
         raise ParameterError(msg)
     return count
+
+
+def _centre_phase(cycles: np.ndarray, size: int) -> np.ndarray:
+    """
+    Return the phase which refers each window's spectrum to its centre sample.
+
+    An FFT refers phase to the window's first sample; the window's time
+    coordinate is its centre, so the spectrum is rotated to say the phase
+    there, as scipy's `ShortTimeFFT` does. `cycles` is each frequency in
+    cycles per sample.
+    """
+    return np.exp(2j * np.pi * cycles * (size // 2))
+
+
+def _as_is(tiles: np.ndarray) -> np.ndarray:
+    """The stack, untouched: `stft` transforms it once it has coordinates."""
+    return tiles
+
+
+def _swap_window_axes(data: np.ndarray, axis: int) -> np.ndarray:
+    """
+    Move a stack's last axis to `axis` and what was there to the end.
+
+    A stack keeps the windows within a tile as its last axis; an stft keeps
+    the frequencies where the transformed dimension was and the window
+    centres last. The swap is its own inverse.
+    """
+    return np.moveaxis(data, (axis, -1), (-1, axis))
 
 
 @patch_function(data_type="fourier_transform")
@@ -651,14 +642,22 @@ def stft(
     - An array passed for taper_window must have as many samples as the
       window; one of another length is refused. To zero pad each window's
       FFT, give `nfft`.
-    - Non-dimensional coordinates associated with transformed coordinates
-      are dropped in the output.
+    - The output is a stack of windows as
+      [Patch.tile_apply](`dascore.Patch.tile_apply`) makes one, transformed
+      along the window: the transformed dimension becomes the window
+      centres, ``{dim}_start`` and ``{dim}_stop`` say where each window came
+      from in samples, and the coordinates the stack carries for
+      [Patch.reassemble](`dascore.Patch.reassemble`) are what
+      [Patch.istft](`dascore.Patch.istft`) blends the windows back with.
+      Non-dimensional coordinates along the transformed dimension travel with
+      the stack and come back on the inverse.
 
     See Also
     --------
     [Patch.dft](`dascore.Patch.dft`), [Patch.istft](`dascore.Patch.istft`)
     """
-    # Get coordinate information.
+    from dascore.proc.tile_apply import TileApply  # noqa: PLC0415
+
     resolved = resolve_window(
         patch,
         kwargs,
@@ -667,93 +666,54 @@ def stft(
         allow_multiple=False,
         enforce_lt_coord=True,
     )
-    dim, axis, window_samples = resolved.dims[0], resolved.axes[0], resolved.size[0]
+    dim, axis, size = resolved.dims[0], resolved.axes[0], resolved.size[0]
     coord = patch.get_coord(dim)
     # No overlap given means none: the windows abut.
-    hop = window_samples if resolved.stride is None else resolved.stride[0]
-    sampling_rate = 1 / abs(dc.to_float(coord.step))
-    window = get_window(taper_window, window_samples)
-    nfft = _resolve_nfft(nfft, coord, window_samples)
-    # Perform stft
+    hop = size if resolved.stride is None else resolved.stride[0]
+    window = get_window(taper_window, size)
+    nfft = _resolve_nfft(nfft, coord, size)
     fft_mode = "onesided" if np.isrealobj(patch.data) else "centered"
-    stft = ShortTimeFFT(
-        win=window,
-        hop=hop,
-        fs=sampling_rate,
-        fft_mode=fft_mode,
-        mfft=nfft,
-    )
-    func = stft.stft if not detrend else partial(stft.stft_detrend, detr="linear")
-    # For compatibility with dft, we scale by step. See the DFT note for why.
-    coord_step = dc.to_float(coord.step)
-    new_data = func(patch.data, axis=axis) * coord_step
-    # Get new coordinate manager
-    cm = _get_stft_coords(patch, dim, axis, coord, stft, window)
-    # Update attrs with metadata needed to invert stft
-    new_attrs = {
-        "_stft_time_dimension": dim,
-        "_stft_frequency_dimension": cm.dims[axis],
-        "_stft_hop": hop,
-        "_stft_sampling_rate": sampling_rate,
-        "_stft_detrended": detrend,
-        "_stft_fft_mode": fft_mode,
-        "_stft_mfft": nfft,
-        "_stft_performed": True,
-        "_pre_stft_data_type": patch.attrs.get("data_type"),
-        "data_units": _get_data_units_from_dims(patch, dim, mul),
+    # A detrended window is tapered after the trend is removed, so the
+    # stack is cut bare and the taper goes on here; an invertible one is
+    # cut under the taper, which the stack then carries for istft.
+    settings: dict[str, Any] = {
+        "function": _as_is,
+        "mode": "stack",
+        "analysis": None if detrend else window,
+        "overlap": size - hop,
+        "samples": True,
+        dim: size,
     }
-    attrs = patch.attrs.update(**new_attrs)
-    return patch.new(data=new_data, coords=cm, attrs=attrs)
-
-
-def _get_inverse_axes(patch):
-    """Get the inverse dimension and axes."""
-    time_dimension = patch.attrs.get("_stft_time_dimension")
-    frequency_dimension = patch.attrs.get("_stft_frequency_dimension")
-    if time_dimension is None or frequency_dimension is None:
-        msg = (
-            "Inverse short time fourier transform requires a patch that has"
-            " undergone stft but this patch is missing required attrs. "
-        )
-        raise PatchError(msg)
-    time_axis = patch.get_axis(time_dimension)
-    frequency_axis = patch.get_axis(frequency_dimension)
-    return time_axis, frequency_axis
-
-
-def _get_istft_coord(coords, frequency_axis, time_axis):
-    """
-    Get the coordinate manager for the inverse of the short time fourier transform.
-    """
-    dims = coords.dims
-    freq_name, time_name = dims[frequency_axis], dims[time_axis]
-    # Drop the transformed dims and any coords associated with them; those
-    # coords are indexed by frequency or window and cannot survive the inverse.
-    stripped = coords.drop_coords(freq_name, time_name)[0]
-    # Use the tuple map so associated coords keep their dimensions.
-    coord_map = stripped.get_coord_tuple_map()
-    coord_map.pop("_stft_window")
-    time = coord_map.pop("_stft_old_coord")[1]
-    coord_map[time_name] = (time_name, time)
-    # Get new dimensions
-    new_dims = list(dims)
-    new_dims[frequency_axis] = time_name
-    new_dims.pop(time_axis)
-    return get_coord_manager(coords=coord_map, dims=tuple(new_dims)), time
-
-
-def _get_short_time_fft(patch) -> ShortTimeFFT:
-    """Reconstruct the short time fft from the attrs/coords in patch."""
-    sr = patch.attrs.get("_stft_sampling_rate")
-    # Recreate STFFT class based on saved coords/attrs.
-    stft = ShortTimeFFT(
-        win=patch.get_coord("_stft_window").values,
-        hop=patch.attrs.get("_stft_hop"),
-        fs=sr,
-        fft_mode=patch.attrs.get("_stft_fft_mode"),
-        mfft=patch.attrs.get("_stft_mfft"),
+    stack = TileApply(**settings)._apply(patch)
+    tiles = stack.data
+    if detrend:
+        tiles = sp_detrend(tiles, axis=-1, type="linear") * window
+    # For compatibility with dft, we scale by step. See the DFT note for why.
+    step = to_float(coord.step)
+    if fft_mode == "onesided":
+        spectra = nft.rfft(tiles, n=nfft, axis=-1)
+        freqs = nft.rfftfreq(nfft, d=step)
+    else:
+        spectra = nft.fftshift(nft.fft(tiles, n=nfft, axis=-1), axes=-1)
+        freqs = nft.fftshift(nft.fftfreq(nfft, d=step))
+    spectra *= _centre_phase(freqs * step, size)
+    ft_dim = FourierTransformatter().rename_dims(patch.dims, index=axis)[axis]
+    new_dims = (*patch.dims[:axis], ft_dim, *patch.dims[axis + 1 :], dim)
+    coord_map = stack.coords.get_coord_tuple_map()
+    coord_map.pop(f"{dim}_offset")
+    freq_coord = get_coord(data=freqs, units=invert_quantity(coord.units))
+    coord_map[ft_dim] = ((ft_dim,), freq_coord)
+    cm = get_coord_manager(coords=coord_map, dims=new_dims)
+    attrs = stack.attrs.update(
+        _stft_detrended=detrend,
+        _stft_fft_mode=fft_mode,
+        _stft_mfft=nfft,
+        _pre_stft_data_type=patch.attrs.get("data_type"),
+        data_units=_get_data_units_from_dims(patch, dim, mul),
     )
-    return stft
+    return patch.new(
+        data=_swap_window_axes(spectra * step, axis), coords=cm, attrs=attrs
+    )
 
 
 @patch_function()
@@ -779,44 +739,64 @@ def istft(patch) -> dc.Patch:
 
     Notes
     -----
-    - Non-dimensional coordinates associated with un-transformed dimensions
-      are preserved. Those associated with the transformed dimension are
-      already dropped by [stft](`dascore.transform.fourier.stft`) so they
-      cannot be restored.
-    - Coordinates associated with the frequency or window dimensions the
-      stft created are dropped, since neither dimension survives the
-      inverse. [idft](`dascore.Patch.idft`) behaves the same way.
+    - Each window's spectrum is inverted and the windows are blended back
+      by [Patch.reassemble](`dascore.Patch.reassemble`), under the dual of
+      the taper they were cut with, so the coordinates the stft carried
+      come back with them -- those along the transformed dimension included.
+    - Coordinates associated with the frequency dimension the stft created
+      are dropped, since it does not survive the inverse.
+      [idft](`dascore.Patch.idft`) behaves the same way.
 
     See Also
     --------
     [Patch.stft](`dascore.Patch.stft`), [Patch.idft](`dascore.Patch.idft`)
     """
-    time_axis, frequency_axis = _get_inverse_axes(patch)
-    detrended = patch.attrs.get("_stft_detrended")
-    # Instantiate the transformer.
-    stft = _get_short_time_fft(patch)
-    # Raise if inverse not possible.
-    if detrended or not stft.invertible:
+    from dascore.proc.tile_apply import reassemble  # noqa: PLC0415
+
+    coord_map = patch.coords.get_coord_tuple_map()
+    dims = [d for d in patch.dims if f"_tile_source_{d}" in coord_map]
+    if len(dims) != 1 or "_stft_mfft" not in dict(patch.attrs):
+        msg = (
+            "Inverse short time fourier transform requires a patch that has"
+            " undergone stft but this patch is missing required attrs. "
+        )
+        raise PatchError(msg)
+    if patch.attrs["_stft_detrended"] or f"_tile_analysis_{dims[0]}" not in coord_map:
         msg = f"Inverse stft not possible for patch {patch}."
         raise PatchError(msg)
-    # Get coord manager and perform inverse transform.
-    cm, coord = _get_istft_coord(patch.coords, frequency_axis, time_axis)
-    data_untrimmed = stft.istft(
-        patch.data / dc.to_float(coord.step), t_axis=time_axis, f_axis=frequency_axis
+    dim = dims[0]
+    ft_dim = FourierTransformatter().rename_dims([dim])[0]
+    axis = patch.get_axis(ft_dim)
+    source = coord_map[f"_tile_source_{dim}"][1]
+    size = len(coord_map[f"_tile_analysis_{dim}"][1])
+    nfft = int(patch.attrs["_stft_mfft"])
+    step = to_float(source.step)
+    cycles = patch.get_coord(ft_dim).values * step
+    spectra = _swap_window_axes(patch.data, axis) / step
+    spectra = spectra / _centre_phase(cycles, size)
+    if patch.attrs["_stft_fft_mode"] == "onesided":
+        tiles = nft.irfft(spectra, n=nfft, axis=-1)
+    else:
+        tiles = nft.ifft(nft.ifftshift(spectra, axes=-1), n=nfft, axis=-1)
+    # The FFT was zero padded past the window; the window is its first samples.
+    tiles = tiles[..., :size]
+    offset = f"{dim}_offset"
+    # The frequency axis does not survive, nor does anything riding on it.
+    for name, cdims in patch.coords.dim_map.items():
+        if ft_dim in cdims:
+            coord_map.pop(name)
+    coord_map[offset] = ((offset,), get_coord(data=np.arange(size)))
+    others = [d for d in patch.dims[axis + 1 :] if d != dim]
+    stack_dims = (*patch.dims[:axis], dim, *others, offset)
+    attrs = {k: v for k, v in dict(patch.attrs).items() if not k.startswith("_stft")}
+    stack = patch.new(
+        data=tiles,
+        coords=get_coord_manager(coords=coord_map, dims=stack_dims),
+        attrs=dc.PatchAttrs(**attrs),
     )
-    # Trim data array to remove effect of padding.
-    # Note: after ISTFT, `frequency_axis` now indexes the restored time axis.
-    index = broadcast_for_index(
-        data_untrimmed.ndim, frequency_axis, slice(0, len(coord))
-    )
-    new_data = data_untrimmed[index]
-    assert new_data.shape == cm.shape
-    # Re-assemble and return new patch.
-    patch_attrs = dict(patch.attrs)
-    new_attrs = {i: v for i, v in patch_attrs.items() if not i.startswith("_stft")}
-    if "_pre_stft_data_type" in patch_attrs:
+    out = reassemble.func(stack)
+    new_attrs = dict(out.attrs)
+    if "_pre_stft_data_type" in new_attrs:
         new_attrs["data_type"] = new_attrs.pop("_pre_stft_data_type")
-    dim = patch.dims[time_axis]
     new_attrs["data_units"] = _get_data_units_from_dims(patch, dim, truediv)
-    attrs = dc.PatchAttrs(**new_attrs)
-    return patch.new(data=new_data, coords=cm, attrs=attrs)
+    return out.update_attrs(**new_attrs)

--- a/dascore/utils/_tiles_numba.py
+++ b/dascore/utils/_tiles_numba.py
@@ -1,13 +1,15 @@
 """
-Optional numba driver which gives a compiled function one tile at a time.
+Optional numba drivers which give a compiled function one tile at a time.
 
 The module imports whether or not numba is installed; only `_JIT_AVAILABLE`
-says whether the driver can compile. The driver is specialized on the
+says whether the drivers can compile. A driver is specialized on the
 function it is handed, and numba cannot reuse such a specialization from
 disk, so it compiles the first time each function is used in a process.
 """
 
 from __future__ import annotations
+
+import itertools
 
 import numpy as np
 
@@ -16,40 +18,29 @@ from dascore.utils.tiles import TilePlan
 
 
 @maybe_numba_jit(required=True, nopython=True, parallel=True)
-def _apply_colour_class(
-    padded: np.ndarray,
-    out: np.ndarray,
-    taper: np.ndarray,
-    window0: int,
-    window1: int,
-    stride0: int,
-    stride1: int,
-    n_tiles0: int,
-    n_tiles1: int,
-    colours0: int,
-    colours1: int,
-    colour0: int,
-    colour1: int,
-    func,
-    analysis: np.ndarray | None = None,
-) -> None:
+def _blend_class(tiles, out, taper, rest, func, analysis) -> None:
     """
     Apply `func` to every tile of one colour class, adding into `out`.
 
-    Tiles of one class are `colours` strides apart, further than a tile
-    reaches, so no two iterations of the parallel loop write to the same
-    output sample.
+    `tiles` and `out` are views of that class, ``[*counts, *size]``, and
+    `rest` is ``counts[1:]``. Tiles of one class are further apart than a
+    tile reaches, so no two iterations of the parallel loop write to the
+    same output sample.
     """
-    count0 = (n_tiles0 - colour0 + colours0 - 1) // colours0
-    count1 = (n_tiles1 - colour1 + colours1 - 1) // colours1
-    for ind in numba.prange(count0 * count1):  # noqa: F821  # ty: ignore[unresolved-reference]
-        beg0 = (colour0 + colours0 * (ind // count1)) * stride0
-        beg1 = (colour1 + colours1 * (ind % count1)) * stride1
-        tile = func(padded[beg0 : beg0 + window0, beg1 : beg1 + window1] * analysis)
-        out[beg0 : beg0 + window0, beg1 : beg1 + window1] += tile * taper
+    for first in numba.prange(tiles.shape[0]):  # noqa: F821  # ty: ignore[unresolved-reference]
+        for other in np.ndindex(rest):
+            index = (first,) + other  # noqa: RUF005  # numba joins tuples this way
+            out[index] += func(tiles[index] * analysis) * taper
 
 
-_JIT_AVAILABLE = _apply_colour_class.jit_available
+@maybe_numba_jit(required=True, nopython=True, parallel=True)
+def _stack_each(tiles, out, func) -> None:
+    """Apply `func` to every tile of a stack, in parallel."""
+    for ind in numba.prange(tiles.shape[0]):  # noqa: F821  # ty: ignore[unresolved-reference]
+        out[ind] = func(tiles[ind])
+
+
+_JIT_AVAILABLE = _blend_class.jit_available
 
 
 def apply_jit(
@@ -63,8 +54,8 @@ def apply_jit(
     Return the array with `func` applied to every tile and the tiles blended.
 
     `func` is a numba-compiled function of one tile returning a tile of the
-    same shape. Two dimensions only. `analysis` multiplies each tile before
-    `func` sees it; None is a window of ones.
+    same shape. `analysis` multiplies each tile before `func` sees it; None
+    is a window of ones.
     """
     padded = plan.pad(array, dtype=np.result_type(array, np.float32))
     if analysis is None:
@@ -74,19 +65,26 @@ def apply_jit(
     # output takes that dtype, so a real tile made complex is kept complex.
     probe = func(padded[tuple(slice(0, z) for z in plan.size)] * analysis)
     out = np.zeros(plan.extended, dtype=np.result_type(probe, padded, taper))
-    for colour0 in range(plan.colours[0]):
-        for colour1 in range(plan.colours[1]):
-            _apply_colour_class(
-                padded,
-                out,
-                taper.astype(padded.dtype),
-                *plan.size,
-                *plan.stride,
-                *plan.grid,
-                *plan.colours,
-                colour0,
-                colour1,
-                func,
-                analysis,
-            )
+    tiles_in = plan._tile_view(padded)
+    tiles_out = plan._tile_view(out, writeable=True)
+    ndim = len(plan.size)
+    for colour in itertools.product(*(range(c) for c in plan.colours)):
+        sub = tuple(slice(c, None, k) for c, k in zip(colour, plan.colours))
+        tiles = tiles_in[sub]
+        _blend_class(
+            tiles,
+            tiles_out[sub],
+            taper.astype(out.dtype),
+            tiles.shape[1:ndim],
+            func,
+            analysis,
+        )
     return plan.crop(out)
+
+
+def stack_jit(tiles: np.ndarray, func) -> np.ndarray:
+    """Return a stack of tiles with `func` applied to each, in parallel."""
+    probe = func(tiles[0])
+    out = np.empty(tiles.shape, dtype=np.result_type(probe, tiles))
+    _stack_each(tiles, out, func)
+    return out

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -1402,23 +1402,6 @@ def tukey_fence(data, fence_multiplier=1.5) -> np.ndarray:
     return lower_and_top
 
 
-def is_power_of_two(value: int) -> bool:
-    """
-    Return ``True`` when *value* is a positive power of two.
-
-    Powers of two have exactly one set bit in their binary representation.
-    Subtracting one flips that bit and all lower bits, so ``value & (value - 1)``
-    is zero only when ``value`` had a single set bit. The ``value > 0`` check
-    excludes zero and negative values.
-
-    Parameters
-    ----------
-    value
-        The value to test.
-    """
-    return value > 0 and (value & (value - 1) == 0)
-
-
 def is_strictly_monotonic(values, increasing: bool | None = None) -> bool:
     """
     Return True if a 1D sequence is strictly monotonic.

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import functools
 import inspect
+import math
 import sys
+import warnings
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Literal, Protocol, cast, overload
@@ -967,15 +969,21 @@ def get_patch_window_size(
 
     if not kwargs:
         return (1,) * len(patch.dims)
-    return resolve_window(
+    size = resolve_window(
         patch,
         kwargs,
         samples=samples,
         require_odd=require_odd,
-        warn_above=warn_above,
         min_samples=min_samples,
         enforce_lt_coord=enforce_lt_coord,
     ).full_size()
+    if warn_above is not None and math.prod(size) > warn_above:
+        msg = (
+            f"Large window size ({math.prod(size)} samples) may result in slow "
+            "performance. Consider reducing the window size."
+        )
+        warnings.warn(msg, UserWarning, stacklevel=2)
+    return size
 
 
 @deprecate(

--- a/dascore/utils/signal.py
+++ b/dascore/utils/signal.py
@@ -217,7 +217,8 @@ def get_dual_taper(
     Parameters
     ----------
     window
-        The analysis window; see `get_window`. One name for every axis.
+        The analysis window; see `get_window`. One for every axis, or a
+        list with one per axis.
     size
         The tile's shape.
     stride
@@ -239,6 +240,8 @@ def get_dual_taper(
         msg = "size and stride must have the same length."
         raise ParameterError(msg)
     size, stride = tuple(size), tuple(stride)
+    if isinstance(window, list):
+        return _build_dual_taper(window, size, stride)
     if _hashable(window):
         analysis, synthesis = _cached_dual_taper(window, size, stride)
         return analysis.copy(), synthesis.copy()
@@ -251,11 +254,51 @@ def _cached_dual_taper(window, size, stride):
 
 
 def _build_dual_taper(window, size, stride):
-    analyses, duals = [], []
-    for length, step in zip(size, stride):
-        edge = np.asarray(get_window(window, length), dtype=np.float64)
-        duals.append(_ShortTimeFFT(edge, hop=step, fs=1.0).dual_win)
-        analyses.append(edge)
-    analysis = math.prod(np.ix_(*analyses)) if len(size) > 1 else analyses[0]
-    synthesis = math.prod(np.ix_(*duals)) if len(size) > 1 else duals[0]
-    return np.asarray(analysis, np.float32), np.asarray(synthesis, np.float32)
+    edges = _edges(window, size)
+    duals = []
+    for edge, step in zip(edges, stride):
+        try:
+            duals.append(_ShortTimeFFT(edge, hop=step, fs=1.0).dual_win)
+        except ValueError as exc:
+            msg = (
+                f"A {len(edge)} sample window cannot be inverted at a stride of "
+                f"{step}: the tiles leave gaps no tile weights. Overlap more."
+            )
+            raise ParameterError(msg) from exc
+    return _outer(edges), _outer(duals)
+
+
+def get_window_nd(window: Any, size: tuple[int, ...]) -> np.ndarray:
+    """
+    Return a window along every axis of a tile: the outer product of its edges.
+
+    Parameters
+    ----------
+    window
+        The window; see `get_window`. One for every axis, or a list with
+        one per axis.
+    size
+        The tile's shape.
+
+    Examples
+    --------
+    >>> from dascore.utils.signal import get_window_nd
+    >>> get_window_nd("hann", (8, 16)).shape
+    (8, 16)
+    """
+    return _outer(_edges(window, tuple(size)))
+
+
+def _edges(window: Any, size: tuple[int, ...]) -> list[np.ndarray]:
+    """Return the window along each axis, as float64 arrays."""
+    windows = window if isinstance(window, list) else [window] * len(size)
+    return [
+        np.asarray(get_window(spec, n), dtype=np.float64)
+        for spec, n in zip(windows, size)
+    ]
+
+
+def _outer(edges: list[np.ndarray]) -> np.ndarray:
+    """Return the outer product of the edges, in float32."""
+    out = math.prod(np.ix_(*edges)) if len(edges) > 1 else edges[0]
+    return np.asarray(out, np.float32)

--- a/dascore/utils/signal.py
+++ b/dascore/utils/signal.py
@@ -254,7 +254,7 @@ def _cached_dual_taper(window, size, stride):
 
 
 def _build_dual_taper(window, size, stride):
-    edges = _edges(window, size)
+    edges = get_window_edges(window, size)
     duals = []
     for edge, step in zip(edges, stride):
         try:
@@ -286,15 +286,28 @@ def get_window_nd(window: Any, size: tuple[int, ...]) -> np.ndarray:
     >>> get_window_nd("hann", (8, 16)).shape
     (8, 16)
     """
-    return _outer(_edges(window, tuple(size)))
+    return _outer(get_window_edges(window, tuple(size)))
 
 
-def _edges(window: Any, size: tuple[int, ...]) -> list[np.ndarray]:
-    """Return the window along each axis, as float64 arrays."""
+def get_window_edges(window: Any, size: tuple[int, ...]) -> list[np.ndarray]:
+    """
+    Return a window along each axis of a tile, as float64 arrays.
+
+    Parameters
+    ----------
+    window
+        The window; see `get_window`. One for every axis, or a list with
+        one per axis.
+    size
+        The tile's shape.
+    """
     windows = window if isinstance(window, list) else [window] * len(size)
+    if len(windows) != len(size):
+        msg = f"{len(windows)} windows were given for {len(size)} axes."
+        raise ParameterError(msg)
     return [
         np.asarray(get_window(spec, n), dtype=np.float64)
-        for spec, n in zip(windows, size)
+        for spec, n in zip(windows, size, strict=True)
     ]
 
 

--- a/dascore/utils/tiles.py
+++ b/dascore/utils/tiles.py
@@ -2,8 +2,8 @@
 Cut an array into overlapping tiles, and blend them back.
 
 A :class:`TilePlan` is the geometry: where every tile of a given size and
-stride sits over an array of a given shape, with one stride of zeros padded
-on every side so the tiles at the edges see a full taper ramp. It cuts the
+stride sits over an array of a given shape, zero padded so that every tile
+which reaches the array exists whole. It cuts the
 array into a dense stack of tiles, ``[n_tiles, *size]``, which one call to a
 vectorized function can transform, and adds a stack back under a taper so
 that, with a taper whose ramps are complementary, tiles of an untouched
@@ -66,23 +66,19 @@ class TilePlan:
     @property
     def margin(self) -> tuple[int, ...]:
         """
-        Zeros added at each end of every axis, in whole strides.
+        Zeros before the array along each axis, in whole strides.
 
-        Enough that every sample of the array is reached by every tile which
-        would reach it in an unbounded grid: one stride when tiles overlap
-        by no more than half, more when they overlap deeper, which a
-        synthesis window computed as a dual relies on.
+        As many as it takes for every tile which reaches the array to exist:
+        none when tiles abut, one stride up to half overlap, more beyond it,
+        which a synthesis window computed as a dual relies on.
         """
-        return tuple(
-            max(step, math.ceil((z - step) / step) * step)
-            for z, step in zip(self.size, self.stride)
-        )
+        return tuple((c - 1) * step for c, step in zip(self.colours, self.stride))
 
     @property
     def grid(self) -> tuple[int, ...]:
-        """How many tiles along each axis."""
+        """How many tiles along each axis: every one which reaches the array."""
         return tuple(
-            (length + 2 * m) // step
+            (length - 1 + m) // step + 1
             for length, m, step in zip(self.shape, self.margin, self.stride)
         )
 
@@ -95,7 +91,7 @@ class TilePlan:
     def extended(self) -> tuple[int, ...]:
         """The padded buffer's shape, long enough for the last tile to fit whole."""
         return tuple(
-            max(length + 2 * m, (count - 1) * step + z)
+            max(length + m, (count - 1) * step + z)
             for length, m, step, count, z in zip(
                 self.shape, self.margin, self.stride, self.grid, self.size
             )

--- a/dascore/utils/window.py
+++ b/dascore/utils/window.py
@@ -15,8 +15,6 @@ by the function which wants it.
 
 from __future__ import annotations
 
-import math
-import warnings
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -206,8 +204,7 @@ def resolve_window(
     allow_multiple: bool = True,
     require_evenly_sampled: bool = True,
     require_odd: bool = False,
-    min_samples: int | None = 1,
-    warn_above: int | None = None,
+    min_samples: int = 1,
     enforce_lt_coord: bool = False,
 ) -> Window:
     """
@@ -244,10 +241,8 @@ def resolve_window(
         Whether the window must have an odd number of samples. Given in
         units, an even count is rounded up; given in samples, refused.
     min_samples
-        The fewest samples a window may have along any dimension, or None
-        for no floor at all.
-    warn_above
-        Warn when the window's total sample count -- its area -- exceeds this.
+        The fewest samples a window may have along any dimension; 0 is no
+        floor at all.
     enforce_lt_coord
         Whether a window, step, or overlap longer than its coordinate is refused.
 
@@ -282,7 +277,7 @@ def resolve_window(
             enforce_lt_coord=enforce_lt_coord,
             through_coord=require_evenly_sampled,
         )
-        if min_samples is not None and count < min_samples:
+        if count < min_samples:
             msg = _too_small(dim, coord, count, min_samples, in_samples)
             raise ParameterError(msg)
         if require_odd and count % 2 != 1:
@@ -295,18 +290,6 @@ def resolve_window(
             count += 1
         sizes.append(count)
     size = tuple(sizes)
-
-    # Warn on the total window, not each dimension: the cost of a windowed
-    # operation tracks the number of samples the window covers, so a 2D
-    # window is as expensive as its area.
-    total = math.prod(size)
-    if warn_above is not None and total > warn_above:
-        msg = (
-            f"Large window size ({total} samples) may result in slow "
-            "performance. Consider reducing the window size."
-        )
-        warnings.warn(msg, UserWarning, stacklevel=3)
-
     strides = _resolve_stride(
         coords,
         dims,

--- a/docs/recipes/adaptive_spectral_filter.qmd
+++ b/docs/recipes/adaptive_spectral_filter.qmd
@@ -31,7 +31,7 @@ fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
 show(axes, [patch, filtered], ["band-passed", "filtered"])
 ```
 
-Only the window sizes were given; `overlap` defaults to the largest the window allows and `exponent` to 0.8, the settings Lightguide uses. Windows must be powers of two greater than 4 samples and can also be given in coordinate units, as in `patch.adaptive_spectral_filter(time=1.6e-3 * s, distance=16 * m)`. Selecting a single dimension weights each trace's spectrum on its own, which favours the strong arrivals but cannot see coherence across the fiber.
+Only the window sizes were given; `overlap` defaults to the largest the window allows and `exponent` to 0.8, the settings Lightguide uses. Windows can also be given in coordinate units, as in `patch.adaptive_spectral_filter(time=1.6e-3 * s, distance=16 * m)`. Selecting a single dimension weights each trace's spectrum on its own, which favours the strong arrivals but cannot see coherence across the fiber.
 
 ## Choosing the exponent
 

--- a/docs/recipes/adaptive_spectral_filter.qmd
+++ b/docs/recipes/adaptive_spectral_filter.qmd
@@ -4,9 +4,7 @@ execute:
     warning: False
 ---
 
-[`Patch.adaptive_spectral_filter`](`dascore.Patch.adaptive_spectral_filter`) suppresses energy which is not coherent within a small window of the data. Over time and distance together it is the adaptive frequency-wavenumber (AFK) filter of @isken2022denoising, as implemented in Pyrocko's [Lightguide](https://github.com/pyrocko/lightguide), and it is a good first tool for pulling arrivals out of DAS data whose noise is not organized along any particular moveout.
-
-The filter walks the patch in overlapping windows. Each window is Fourier transformed, every coefficient is multiplied by its own magnitude raised to `exponent`, and the window is transformed back and blended into the output. An arrival which is coherent across the window concentrates its energy in a few large coefficients, which the weighting favours over everything spread thinly across the spectrum.
+[`Patch.adaptive_spectral_filter`](`dascore.Patch.adaptive_spectral_filter`) is the adaptive frequency-wavenumber (AFK) filter of @isken2022denoising, as in Pyrocko's [Lightguide](https://github.com/pyrocko/lightguide). Each window of the data is Fourier transformed, every coefficient is scaled by its own magnitude to the power `exponent`, and the windows are blended back. A coherent arrival concentrates in a few large coefficients, which the weighting favours over noise spread across the spectrum.
 
 ```{python}
 import numpy as np
@@ -19,7 +17,7 @@ filtered = patch.adaptive_spectral_filter(time=16, distance=16, samples=True)
 
 
 def show(axes, patches, titles):
-    """Draw each patch on its own colour scale; the filter does not keep amplitude."""
+    """Each patch on its own colour scale: the filter does not keep amplitude."""
     for ax, patch, title in zip(axes, patches, titles):
         scale = np.percentile(np.abs(patch.data), 99)
         patch.viz.waterfall(ax=ax, scale=scale, scale_type="absolute", cmap="bwr")
@@ -31,11 +29,11 @@ fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
 show(axes, [patch, filtered], ["band-passed", "filtered"])
 ```
 
-Only the window sizes were given; `overlap` defaults to the largest the window allows and `exponent` to 0.8, the settings Lightguide uses. Windows can also be given in coordinate units, as in `patch.adaptive_spectral_filter(time=1.6e-3 * s, distance=16 * m)`. Selecting a single dimension weights each trace's spectrum on its own, which favours the strong arrivals but cannot see coherence across the fiber.
+`overlap` defaults to the most the window allows and `exponent` to 0.8, Lightguide's settings. Windows may be given in coordinate units. A single dimension weights each trace on its own.
 
 ## Choosing the exponent
 
-`exponent` is the filter's strength. At 0 the data pass through unchanged; near 1 the weighting is the magnitude itself, and above 1 weak but coherent arrivals start to go with the noise.
+0 passes the data unchanged; above 1, weak coherent arrivals go with the noise.
 
 ```{python}
 exponents = [0.2, 0.5, 0.8, 1.2]
@@ -54,6 +52,6 @@ show(
 
 ## What it does not do
 
-The filter is not amplitude preserving: every coefficient is scaled by a power of its own magnitude, so the output's units are not the input's and its amplitudes grow with the input's. Compare arrivals within one filtered patch, not across patches, and do not read the output as strain.
+It does not preserve amplitude: compare arrivals within one filtered patch, not across patches.
 
-Nor does it remove coherent noise. Energy which is organized within a window is kept whatever its origin, so per-channel offsets, instrument ringing, or a strong surface wave must be removed first. The first example event carries low-frequency per-channel striping which the filter keeps as faithfully as the arrivals; a band-pass above 50 Hz before filtering is what leaves the event alone.
+Nor does it remove coherent noise: per-channel striping, ringing, or a strong surface wave are kept like arrivals, so remove them first, as the band-pass above does.

--- a/docs/recipes/windowing.qmd
+++ b/docs/recipes/windowing.qmd
@@ -70,7 +70,7 @@ A stack nobody changed reassembles to the patch it was cut from, coordinates and
 
 ## A compiled function, one tile at a time
 
-A function compiled with numba is given one tile at a time rather than the stack, in parallel, which is faster for anything that cannot be written over the stack in one numpy call. It compiles the first time it is used in each process, which takes a few seconds; after that a 2000 by 6000 patch tiles in a fraction of a second.
+A function compiled with numba is given one tile at a time rather than the stack, in parallel, which is faster for anything that cannot be written over the stack in one numpy call. It works over any number of dimensions and in `mode="stack"` too. It compiles the first time it is used in each process, which takes a few seconds; after that a 2000 by 6000 patch tiles in a fraction of a second.
 
 ```{python}
 #| eval: false

--- a/docs/recipes/windowing.qmd
+++ b/docs/recipes/windowing.qmd
@@ -68,6 +68,8 @@ assert denoised.shape == patch.shape
 
 A stack nobody changed reassembles to the patch it was cut from, coordinates and all.
 
+`stft` is this stack with each window transformed along its offsets: the same `{dim}_start`, `{dim}_stop`, and rider coordinates, so `istft` is an inverse FFT of each window followed by `reassemble`, under the dual of the taper the windows were cut with.
+
 ## A compiled function, one tile at a time
 
 A function compiled with numba is given one tile at a time rather than the stack, in parallel, which is faster for anything that cannot be written over the stack in one numpy call. It works over any number of dimensions and in `mode="stack"` too. It compiles the first time it is used in each process, which takes a few seconds; after that a 2000 by 6000 patch tiles in a fraction of a second.
@@ -104,4 +106,4 @@ assert local_fk.shape == patch.shape
 
 ## What a tile sees
 
-Tiles start before the data and are padded with zeros: one stride before, so every sample is covered by tiles which see a full taper ramp on both sides, or under an analysis window as many whole strides as it takes for every tile which would reach a sample to exist, which the dual relies on. Overlap defaults to half the window; under a taper it cannot exceed half, since the ramps would cross, and under an analysis window it may go as deep as scipy can invert the window at. The taper's shape is any window [`get_window`](`dascore.utils.signal.get_window`) knows; its ramps are made complementary whatever the shape, which is what makes the blend exact.
+Tiles start before the data and are padded with zeros, as many whole strides before as it takes for every tile which reaches a sample to exist: none when tiles abut, one stride up to half overlap, more beyond it, which an analysis window's dual relies on. Overlap defaults to half the window; under a taper it cannot exceed half, since the ramps would cross, and under an analysis window it may go as deep as scipy can invert the window at. The taper's shape is any window [`get_window`](`dascore.utils.signal.get_window`) knows; its ramps are made complementary whatever the shape, which is what makes the blend exact.

--- a/tests/test_proc/test_adaptive_spectral_filter.py
+++ b/tests/test_proc/test_adaptive_spectral_filter.py
@@ -123,10 +123,10 @@ class TestAdaptiveSpectralFilter:
             patch.adaptive_spectral_filter(samples=True, engine="scipy")
 
     def test_rejects_non_positive_window(self) -> None:
-        """Window sizes must resolve to positive sample counts."""
+        """Window sizes must resolve to at least two samples."""
         patch = _patch((64, 64), ("distance", "time"), dtype=np.float32)
 
-        with pytest.raises(ParameterError, match="at least 1 samples"):
+        with pytest.raises(ParameterError, match="at least 2 samples"):
             patch.adaptive_spectral_filter(
                 distance=0, time=16, samples=True, engine="scipy"
             )
@@ -432,11 +432,25 @@ class TestAdaptiveSpectralFilter:
         with pytest.raises(ParameterError, match="two selected dimensions"):
             patch.adaptive_spectral_filter(time=16, samples=True, engine="numba")
 
+    def test_any_window_length(self):
+        """A window need not be a power of two: 15 by 300 samples filters."""
+        patch = _patch((32, 600), ("distance", "time"), dtype=np.float32)
+        out = patch.adaptive_spectral_filter(distance=15, time=300, samples=True)
+        assert out.shape == patch.shape
+        assert np.all(np.isfinite(out.data))
+
+    def test_window_in_units_need_not_be_a_power_of_two(self):
+        """0.3 s at 4 ms is 75 samples, and works like any other length."""
+        patch = _patch((8, 1000), ("distance", "time"), dtype=np.float32)
+        by_units = patch.adaptive_spectral_filter(time=0.3)
+        by_samples = patch.adaptive_spectral_filter(time=75, samples=True)
+        assert np.allclose(by_units.data, by_samples.data)
+
     @pytest.mark.parametrize(
         "kwargs,match",
         [
             ({"exponent": np.nan}, "exponent must be finite"),
-            ({"distance": 15}, "power of two"),
+            ({"distance": 1}, "at least 2 samples"),
             ({"overlap": {"distance": 8}}, "too large"),
             ({"overlap": {"distance": -1}}, "non-negative"),
         ],
@@ -540,8 +554,7 @@ class TestAdaptiveSpectralCore:
     @pytest.mark.parametrize(
         "window_size,overlap,match",
         [
-            ((15, 16), (7, 7), "power of two"),
-            ((4, 16), (1, 7), "greater than 4"),
+            ((1, 16), (0, 7), "at least 2 samples"),
             ((16, 16), (-1, 7), "non-negative"),
             ((16, 16), (8, 7), "too large"),
             ((16.0, 16), (7, 7), "must be an integer"),

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -256,6 +256,26 @@ class TestAnalysisWindow:
         assert by_array.equals(by_name, close=True)
         assert by_array.equals(patch, close=True)
 
+    def test_one_window_per_dimension(self, patch):
+        """A list gives each windowed dimension its own, in dimension order."""
+        windows = ["hann", "boxcar"]  # distance, then time: the patch's order
+        blended = patch.tile_apply(
+            identity, analysis=windows, time=16, distance=8, samples=True
+        )
+        assert blended.equals(patch, close=True)
+        stacked = patch.tile_apply(
+            identity, mode="stack", analysis=windows, time=16, distance=8, samples=True
+        )
+        assert np.all(stacked.get_coord("_tile_analysis_time").values == 1)
+        assert stacked.reassemble().equals(patch, close=True)
+
+    def test_wrong_number_of_windows_refused(self, patch):
+        """One window per windowed dimension, no more and no fewer."""
+        with pytest.raises(ParameterError, match="windows were given"):
+            patch.tile_apply(
+                identity, analysis=["hann"], time=16, distance=8, samples=True
+            )
+
     def test_two_dimensional_array_refused(self, patch):
         """A dual is built along each axis, which an N-D array cannot give."""
         with pytest.raises(ParameterError, match="one-dimensional"):

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -11,6 +11,7 @@ import dascore as dc
 from dascore.exceptions import ParameterError, PatchError
 from dascore.proc.tile_apply import TileApply
 from dascore.units import percent
+from dascore.utils.signal import get_window
 
 
 def identity(tiles):
@@ -219,10 +220,11 @@ class TestAnalysisWindow:
         stacked = patch.tile_apply(
             identity, mode="stack", analysis="hann", overlap=12, time=16, samples=True
         )
-        assert stacked.attrs["_tile_analysis"] == "hann"
+        edge = stacked.get_coord("_tile_analysis_time").values
+        np.testing.assert_allclose(edge, get_window("hann", 16), atol=1e-7)
         back = stacked.reassemble()
         assert back.equals(patch, close=True)
-        assert "_tile_analysis" not in dict(back.attrs)
+        assert "_tile_analysis_time" not in back.coords.coord_map
 
     def test_stack_refuses_a_taper(self, patch):
         """The dual is the only blend a windowed stack has."""
@@ -246,10 +248,20 @@ class TestAnalysisWindow:
                 lambda x: x, analysis="hann", taper="hann", time=16, samples=True
             )
 
-    def test_array_refused(self, patch):
-        """A dual is built along each axis, which needs a name."""
-        with pytest.raises(ParameterError, match="given by name"):
-            patch.tile_apply(identity, analysis=np.ones((16,)), time=16, samples=True)
+    def test_array_window(self, patch):
+        """A one-dimensional array is an edge for every windowed dimension."""
+        edge = get_window("hamming", 16)
+        by_array = patch.tile_apply(identity, analysis=edge, time=16, samples=True)
+        by_name = patch.tile_apply(identity, analysis="hamming", time=16, samples=True)
+        assert by_array.equals(by_name, close=True)
+        assert by_array.equals(patch, close=True)
+
+    def test_two_dimensional_array_refused(self, patch):
+        """A dual is built along each axis, which an N-D array cannot give."""
+        with pytest.raises(ParameterError, match="one-dimensional"):
+            patch.tile_apply(
+                identity, analysis=np.ones((16, 16)), time=16, samples=True
+            )
 
     def test_numba_engine(self, patch):
         """The compiled path windows each tile before the function too."""
@@ -300,7 +312,7 @@ class TestStack:
         centres = stacked.get_coord("time").values
         step = patch.get_coord("time").step
         expected = patch.get_coord("time").min() + dc.to_timedelta64(
-            (starts + 7.5) * dc.to_float(step)
+            (starts + 8) * dc.to_float(step)
         )
         np.testing.assert_array_equal(centres, expected)
 
@@ -328,7 +340,7 @@ class TestStack:
         centres = stacked.get_coord("distance").values
         assert centres[0] > centres[1]
         first = flipped.get_coord("distance").values[0]
-        assert centres[0] == first + (-8 + 7.5) * flipped.get_coord("distance").step
+        assert centres[0] == first + (-8 + 8) * flipped.get_coord("distance").step
         # Offsets count from the tile's first sample, in the coordinate's direction.
         offsets = stacked.get_coord("distance_offset").values
         assert offsets[0] == 0 and offsets[1] == flipped.get_coord("distance").step
@@ -349,6 +361,15 @@ class TestStack:
 
 class TestReassemble:
     """Blending a stack back."""
+
+    def test_coordinate_on_a_tile_axis_is_dropped(self, patch):
+        """A per-tile coordinate has no sample to go back to."""
+        tiles = patch.tile_apply(lambda x: x, mode="stack", time=16, samples=True)
+        n_tiles = tiles.shape[tiles.dims.index("time")]
+        marked = tiles.update_coords(energy=("time", np.arange(n_tiles, dtype=float)))
+        back = marked.reassemble()
+        assert "energy" not in back.coords.coord_map
+        assert back.equals(patch, close=True)
 
     def test_array_taper(self, patch):
         """A taper given as an array is a window like any other."""

--- a/tests/test_proc/test_tile_apply.py
+++ b/tests/test_proc/test_tile_apply.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import itertools
+
 import numpy as np
 import pytest
 
@@ -272,13 +274,17 @@ class TestStack:
         halved = patch.tile_apply(halve, mode="stack", time=64, samples=True)
         np.testing.assert_allclose(halved.data, raw.data / 2)
 
-    def test_compiled_function_refused(self, patch):
-        """A per-tile function has no stack to take."""
+    def test_compiled_function_stacks(self, patch):
+        """A per-tile function is run over every tile of the stack, in parallel."""
         half_tile = _jitted()
-        with pytest.raises(ParameterError, match="cannot take it"):
-            patch.tile_apply(
-                half_tile, mode="stack", time=64, distance=16, samples=True
-            )
+        by_numba = patch.tile_apply(
+            half_tile, mode="stack", time=64, distance=16, samples=True
+        )
+        by_numpy = patch.tile_apply(
+            halve, mode="stack", time=64, distance=16, samples=True
+        )
+        np.testing.assert_allclose(by_numba.data, by_numpy.data, atol=1e-6)
+        assert by_numba.dims == by_numpy.dims
 
     def test_dims_and_shape(self, stacked, patch):
         """Tile axes where the dimensions were, offsets at the end in axis order."""
@@ -469,10 +475,13 @@ class TestEngines:
         assert np.iscomplexobj(out.data)
         np.testing.assert_allclose(out.data.imag, patch.data, atol=1e-4)
 
-    def test_driver_runs_in_python(self, patch):
-        """The driver gives the same answer uncompiled."""
+    def test_drivers_run_in_python(self, patch):
+        """The drivers give the same answer uncompiled."""
         half_tile = _jitted()
-        from dascore.utils._tiles_numba import _apply_colour_class  # noqa: PLC0415
+        from dascore.utils._tiles_numba import (  # noqa: PLC0415
+            _blend_class,
+            _stack_each,
+        )
         from dascore.utils.signal import get_taper  # noqa: PLC0415
         from dascore.utils.tiles import get_tile_plan  # noqa: PLC0415
 
@@ -480,22 +489,23 @@ class TestEngines:
         plan = get_tile_plan(data.shape, (8, 16), (5, 9))
         taper = get_taper("hann", (8, 16), (3, 7))
         padded, out = plan.pad(data), np.zeros(plan.extended, dtype=np.float32)
-        for c0 in range(plan.colours[0]):
-            for c1 in range(plan.colours[1]):
-                _apply_colour_class.func(
-                    padded,
-                    out,
-                    taper,
-                    *plan.size,
-                    *plan.stride,
-                    *plan.grid,
-                    *plan.colours,
-                    c0,
-                    c1,
-                    half_tile,
-                    np.ones(plan.size, np.float32),
-                )
+        tiles_in, tiles_out = plan._tile_view(padded), plan._tile_view(out, True)
+        for colour in itertools.product(*(range(c) for c in plan.colours)):
+            sub = tuple(slice(c, None, k) for c, k in zip(colour, plan.colours))
+            tiles = tiles_in[sub]
+            _blend_class.func(
+                tiles,
+                tiles_out[sub],
+                taper,
+                tiles.shape[1:2],
+                half_tile,
+                np.ones(plan.size, np.float32),
+            )
         np.testing.assert_allclose(plan.crop(out), data / 2, atol=1e-5)
+        stack = plan.extract(data)
+        stacked = np.empty_like(stack)
+        _stack_each.func(stack, stacked, half_tile)
+        np.testing.assert_allclose(stacked, stack / 2)
 
     def test_jitted_function_on_numpy_engine_refused(self, patch):
         """A per-tile function cannot take the stack."""
@@ -508,12 +518,44 @@ class TestEngines:
         with pytest.raises(ParameterError, match="numba-compiled function"):
             patch.tile_apply(halve, engine="numba", time=64, distance=16, samples=True)
 
-    @pytest.mark.parametrize("engine", ["auto", "numba"])
-    def test_compiled_function_needs_two_dimensions(self, patch, engine):
-        """The driver tiles two dimensions, and says so however it was reached."""
+    def test_compiled_function_in_one_dimension(self, patch):
+        """The driver tiles one dimension as readily as two."""
         half_tile = _jitted()
-        with pytest.raises(ParameterError, match="exactly two windowed dimensions"):
-            patch.tile_apply(half_tile, time=64, samples=True, engine=engine)
+        by_numba = patch.tile_apply(half_tile, time=64, samples=True)
+        by_numpy = patch.tile_apply(halve, time=64, samples=True)
+        np.testing.assert_allclose(by_numba.data, by_numpy.data, atol=1e-5)
+
+    def test_compiled_function_in_three_dimensions(self):
+        """And three, with a dimension that is not windowed batched over."""
+        half_tile = _jitted()
+        rng = np.random.default_rng(3)
+        patch = dc.Patch(
+            data=rng.normal(size=(3, 24, 30, 40)).astype(np.float32),
+            coords={
+                "a": np.arange(3),
+                "x": np.arange(24),
+                "y": np.arange(30),
+                "z": np.arange(40),
+            },
+            dims=("a", "x", "y", "z"),
+        )
+        by_numba = patch.tile_apply(half_tile, x=8, y=6, z=10, samples=True)
+        by_numpy = patch.tile_apply(halve, x=8, y=6, z=10, samples=True)
+        np.testing.assert_allclose(by_numba.data, by_numpy.data, atol=1e-5)
+        np.testing.assert_allclose(by_numba.data, patch.data / 2, atol=1e-5)
+
+    def test_compiled_function_under_an_analysis_window(self, patch):
+        """The window goes on inside the driver, and the dual brings it back."""
+        half_tile = _jitted()
+        out = patch.tile_apply(
+            half_tile,
+            analysis="hann",
+            overlap={"time": 48, "distance": 12},
+            time=64,
+            distance=16,
+            samples=True,
+        )
+        np.testing.assert_allclose(out.data, patch.data / 2, atol=1e-4)
 
     def test_numba_engine_without_numba(self, patch, monkeypatch):
         """Asked for by name with numba absent, it says what is missing."""

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -585,14 +585,12 @@ class TestSTFT:
             .select(time=0, samples=True)
             .squeeze()
         )
-        # The first slice should have 50 padded 0s on the right, and the first
-        # 51 samples in the signal.
-        padded = patch.pad(time=(50, 0), samples=True).select(
-            time=(0, 101), samples=True
-        )
-        padded_fft = padded.dft("time", real=True, pad=False).squeeze()
+        # With no overlap the first window is the first 101 samples; the stft
+        # refers phase to the window's centre, so magnitudes are compared.
+        first = patch.select(time=(0, 101), samples=True)
+        first_fft = first.dft("time", real=True, pad=False).squeeze()
         ar1 = stft.data
-        ar2 = padded_fft.data
+        ar2 = first_fft.data
 
         factor = np.abs(ar1) / np.abs(ar2)
         assert np.allclose(factor, 1.0)
@@ -617,10 +615,10 @@ class TestSTFT:
         plain = random_patch.stft(time=100, samples=True)
         padded = random_patch.stft(time=100, samples=True, nfft=256)
         assert len(padded.get_coord("ft_time")) == 256 // 2 + 1
-        rate = padded.attrs["_stft_sampling_rate"]
+        rate = 1 / dc.to_float(random_patch.get_coord("time").step)
         assert float(padded.get_coord("ft_time").step) == pytest.approx(rate / 256)
         # The window and hop are untouched; only the FFT of each window grew.
-        assert padded.attrs["_stft_hop"] == plain.attrs["_stft_hop"]
+        assert padded.attrs["_tile_stride_time"] == plain.attrs["_tile_stride_time"]
         assert padded.get_coord("time") == plain.get_coord("time")
         assert padded.attrs["_stft_mfft"] == 256
 
@@ -660,6 +658,17 @@ class TestSTFT:
         axis = padded.get_axis("ft_time")
         every_other = np.take(padded.data, np.arange(0, 101, 2), axis=axis)
         assert np.allclose(every_other, plain.data)
+
+    def test_complex_input_round_trips(self, random_patch):
+        """Complex data is transformed two-sided, centred, and comes back."""
+        patch = random_patch.new(data=random_patch.data * (1 + 1j))
+        out = patch.stft(time=16, samples=True)
+        freqs = out.get_coord("ft_time").values
+        assert len(freqs) == 16
+        assert freqs[0] < 0 < freqs[-1]
+        assert out.attrs["_stft_fft_mode"] == "centered"
+        back = out.istft()
+        assert back.equals(patch, close=True)
 
     def test_non_dim_coord_associated_with_transform(self):
         """See #611."""
@@ -722,6 +731,12 @@ class TestInverseSTFT:
         with pytest.raises(PatchError, match=msg):
             random_patch.istft()
 
+    def test_uninvertible_window_raises(self, random_patch):
+        """Abutting hann windows leave gaps: the stft is not invertible."""
+        out = random_patch.stft(time=16, samples=True, overlap=None)
+        with pytest.raises(ParameterError, match="cannot be inverted"):
+            out.istft()
+
     def test_detrended_raise(self, chirp_stft_detrend_patch):
         """Since detrended stft can't be inverted it should raise."""
         msg = "Inverse stft not possible"
@@ -753,22 +768,22 @@ class TestInverseSTFTAssociatedCoords:
         assert np.allclose(out.data, patch.data)
 
     def test_coord_on_transformed_dim(self, patch_with_coords):
-        """A coord on the transformed dim is dropped by stft, not restored."""
+        """A coord on the transformed dim rides with the windows and comes back."""
         patch = patch_with_coords.drop_coords("depth", "note")
         stft_patch = patch.stft(time=0.1)
         assert "tlabel" not in stft_patch.coords.coord_map
+        assert "_tile_source_time__tlabel" in stft_patch.coords.coord_map
         out = stft_patch.istft()
-        assert "tlabel" not in out.coords.coord_map
         assert out.dims == patch.dims
+        assert out.coords == patch.coords
         assert np.allclose(out.data, patch.data)
 
     def test_multiple_associated_coords(self, patch_with_coords):
-        """Several associated coords round trip, minus the transformed one."""
+        """Several associated coords round trip, the transformed one included."""
         patch = patch_with_coords
         out = patch.stft(time=0.1).istft()
-        expected = patch.drop_coords("tlabel")
         assert out.dims == patch.dims
-        assert out.coords == expected.coords
+        assert out.coords == patch.coords
         assert np.allclose(out.data, patch.data)
 
     def test_coord_on_untransformed_time(self, patch_with_coords):
@@ -776,7 +791,7 @@ class TestInverseSTFTAssociatedCoords:
         patch = patch_with_coords
         out = patch.stft(distance=4).istft()
         assert out.dims == patch.dims
-        assert out.coords == patch.drop_coords("depth").coords
+        assert out.coords == patch.coords
         assert np.allclose(out.data, patch.data)
 
     def test_coords_on_stft_dims_dropped(self, patch_with_coords):

--- a/tests/test_utils/test_signal.py
+++ b/tests/test_utils/test_signal.py
@@ -226,6 +226,17 @@ class TestGetTaper:
 class TestGetDualTaper:
     """An analysis window and the synthesis window which inverts it."""
 
+    def test_uninvertible_window_refused(self):
+        """A hann at a stride of its own length leaves gaps; scipy has no dual."""
+        with pytest.raises(ParameterError, match="cannot be inverted"):
+            get_dual_taper("hann", (8,), (8,))
+
+    def test_one_window_per_axis(self):
+        """A list gives each axis its own window."""
+        analysis, _ = get_dual_taper(["hann", "boxcar"], (8, 6), (4, 3))
+        np.testing.assert_allclose(analysis[:, 0], get_window("hann", 8) * 1.0)
+        np.testing.assert_allclose(analysis[4, :], np.ones(6) * analysis[4, 0])
+
     def test_unhashable_window_builds(self):
         """A scipy tuple carrying a list is not hashable, and still builds."""
         analysis, synthesis = get_dual_taper(("general_cosine", [0.5, 0.5]), (8,), (2,))

--- a/tests/test_utils/test_tiles.py
+++ b/tests/test_utils/test_tiles.py
@@ -35,6 +35,14 @@ class TestGeometry:
         assert plan.extended[0] >= (plan.grid[0] - 1) * 9 + 16
         assert plan.n_tiles == plan.grid[0]
 
+    def test_abutting_tiles_need_no_margin(self):
+        """With no overlap the first tile starts at the array, and none is wasted."""
+        plan = get_tile_plan((10,), (4,), (4,))
+        assert plan.margin == (0,)
+        assert plan.grid == (3,)
+        plan = get_tile_plan((8,), (4,), (4,))
+        assert plan.grid == (2,)
+
     def test_margin_grows_with_overlap(self):
         """One stride of margin up to half overlap; whole strides beyond it."""
         assert get_tile_plan((64,), (16,), (9,)).margin == (9,)

--- a/tests/test_utils/test_window.py
+++ b/tests/test_utils/test_window.py
@@ -8,7 +8,6 @@ import pytest
 import dascore as dc
 from dascore.exceptions import CoordError, ParameterError
 from dascore.units import percent
-from dascore.utils.misc import suppress_warnings
 from dascore.utils.patch import get_patch_window_size, get_window_axis_step
 from dascore.utils.window import Window, resolve_window
 from dascore.workflow.meta import PatchMeta
@@ -84,25 +83,6 @@ class TestWindowSize:
         # When the value is already in samples there is nothing to suggest.
         with pytest.raises(ParameterError, match="Try increasing"):
             resolve_window(simple_patch, {"time": 2}, samples=True, min_samples=3)
-
-    def test_warn_above(self, simple_patch):
-        """A large window warns."""
-        with pytest.warns(UserWarning, match="Large window size.*may result in slow"):
-            resolve_window(simple_patch, {"time": 15}, samples=True, warn_above=10)
-
-    def test_warn_above_uses_total_window(self, simple_patch):
-        """The threshold applies to the window's area, not each dimension."""
-        kwargs = {"time": 5, "distance": 5}
-        with pytest.warns(UserWarning, match="Large window size \\(25 samples\\)"):
-            resolve_window(simple_patch, kwargs, samples=True, warn_above=10)
-
-    def test_no_warning_under_threshold(self, simple_patch):
-        """A small window says nothing."""
-        with suppress_warnings(action="error"):
-            window = resolve_window(
-                simple_patch, {"time": 5}, samples=True, warn_above=10
-            )
-        assert window.size == (5,)
 
     def test_empty_kwargs_refused(self, simple_patch):
         """A windowed function wants a window."""
@@ -334,11 +314,9 @@ class TestOverlap:
 class TestPolicies:
     """The knobs a function turns."""
 
-    def test_min_samples_none_is_no_floor(self, simple_patch):
+    def test_min_samples_zero_is_no_floor(self, simple_patch):
         """A zero window passes when a function sets no floor."""
-        window = resolve_window(
-            simple_patch, {"time": 0}, samples=True, min_samples=None
-        )
+        window = resolve_window(simple_patch, {"time": 0}, samples=True, min_samples=0)
         assert window.size == (0,)
 
     def test_uneven_coordinate_with_sample_counts(self):
@@ -404,6 +382,14 @@ class TestDeprecatedResolvers:
         assert (
             size == resolve_window(simple_patch, {"time": 5}, samples=True).full_size()
         )
+
+    def test_get_patch_window_size_warns_above(self, simple_patch):
+        """The deprecated helper still warns on a large window."""
+        with pytest.warns(UserWarning, match="Large window"):
+            with pytest.warns(DeprecationWarning):
+                get_patch_window_size(
+                    simple_patch, {"time": 5}, samples=True, warn_above=4
+                )
 
     def test_get_patch_window_size_with_no_window(self, simple_patch):
         """As before, no dimension gives one along every axis."""

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -83,12 +83,12 @@ class TestOverlapNone:
     def test_stft_omitted_means_half(self, patch):
         """Stft's default is not None but 50%: windows of 8 hop by 4."""
         out = patch.stft(time=8, samples=True)
-        assert out.attrs["_stft_hop"] == 4
+        assert out.attrs["_tile_stride_time"] == 4
 
     def test_stft_none_means_no_overlap(self, patch):
         """Given None outright, windows abut."""
         out = patch.stft(time=8, samples=True, overlap=None)
-        assert out.attrs["_stft_hop"] == 8
+        assert out.attrs["_tile_stride_time"] == 8
 
     def test_adaptive_spectral_filter_means_the_most_allowed(self, patch):
         """Windows of 16 overlap by 7, which is window // 2 - 1."""
@@ -106,7 +106,7 @@ class TestPercentRounding:
     def test_stft_hop(self, patch, window, hop):
         """50% of 5 is 2, of 7 is 4, of 9 is 4; the hop is what is left."""
         out = patch.stft(time=window, samples=True, overlap=50 * percent)
-        assert out.attrs["_stft_hop"] == hop
+        assert out.attrs["_tile_stride_time"] == hop
 
     def test_rolling_hop(self, patch):
         """Rolling rounds the same way: 5 samples at 50% steps by 3."""
@@ -351,7 +351,7 @@ class TestTaperRamps:
         out = patch.stft(time=8, samples=True, overlap=None)
         # The window travels as a coordinate for istft; it is the symmetric hann.
         np.testing.assert_allclose(
-            out.get_coord("_stft_window").values, hann(8, sym=True)
+            out.get_coord("_tile_analysis_time").values, hann(8, sym=True), rtol=1e-6
         )
 
     def test_adaptive_spectral_filter_ramp(self, ones):

--- a/tests/test_utils/test_window_parity.py
+++ b/tests/test_utils/test_window_parity.py
@@ -91,12 +91,17 @@ class TestOverlapNone:
         assert out.attrs["_tile_stride_time"] == 8
 
     def test_adaptive_spectral_filter_means_the_most_allowed(self, patch):
-        """Windows of 16 overlap by 7, which is window // 2 - 1."""
+        """Windows of 16 overlap by 7 and of 15 by 7: the most under half."""
         by_default = patch.adaptive_spectral_filter(time=16, distance=16, samples=True)
         by_hand = patch.adaptive_spectral_filter(
             time=16, distance=16, overlap=7, samples=True
         )
         assert np.allclose(by_default.data, by_hand.data)
+        odd = patch.adaptive_spectral_filter(time=15, distance=15, samples=True)
+        odd_by_hand = patch.adaptive_spectral_filter(
+            time=15, distance=15, overlap=7, samples=True
+        )
+        assert np.allclose(odd.data, odd_by_hand.data)
 
 
 class TestPercentRounding:


### PR DESCRIPTION
## Description

The last PR of the windowing plan (top-level `.scratch/windowing-unification-plan.md`): the clean-up. One commit per item.

**One windowed stack.** `stft` no longer has its own vocabulary. It cuts its windows with the tile machinery (`TileApply` in stack mode, the taper as the analysis window), transforms each window along its offsets, and carries what any stack carries: `{dim}_start`, `{dim}_stop`, `_tile_source_{dim}`, `_tile_stride_{dim}`, and the window as `_tile_analysis_{dim}`. `istft` is an inverse FFT of each window followed by `reassemble`, which blends under scipy's dual of that window — so `_get_stft_coords`, `_get_inverse_axes`, `_get_istft_coord`, `_get_short_time_fft`, the `ShortTimeFFT` object and six private attrs are gone, and a coordinate along the transformed dimension now rides with the windows and comes back on the inverse instead of being dropped. The output layout (`(…, ft_time, …, time)`) is unchanged.

What moved, measured against outputs pinned before the rewrite (nine `stft`/`istft` calls, three `spectrogram` calls): at the default half overlap the window grid, the `time` coordinate, and the spectra are identical to scipy's (`|Δ|` ≤ 1e-8; `viz.spectrogram` ≤ 1e-11), because phase is referred to each window's centre sample as scipy does, and detrended windows agree to 1e-15. At other overlaps the windows sit on the tile grid — the first starts a whole number of strides before the data rather than centred on its first sample — so a 40 % or 10 % overlap stft has its windows at different positions than before; `istft` is exact either way (≤ 6e-8). A window scipy cannot invert (Hann with no overlap) is refused at `istft` with a `ParameterError` saying to overlap more, where it used to be a `PatchError`.

**Tile geometry.** A tile exists only where it reaches the data: the margin before the array is `(colours − 1)` strides, so abutting tiles start at the array and no all-padding tile is cut at either end; the grid is every tile which reaches a sample. At overlap ≤ half this is the old geometry minus the wasted tiles, and the adaptive spectral filter's output is bit-identical. A tile's centre is its sample `size // 2`, scipy's convention, rather than the half-sample `(size − 1) / 2`. An analysis window may be a one-dimensional array, one edge for every windowed dimension, as a taper may; a stack stores the window's samples along each dimension, so a name, a tuple, and an array all travel the same way.

**One numba driver, any dimensionality, both modes.** The driver walks each colour class through strided views of the tile grid (`np.ndindex` over the class), so it no longer spells out two axes; a compiled function now runs over one, two, or three windowed dimensions and in `mode="stack"` (a three-line second driver). 2000 × 6000 AGC on the numba engine: 100 ms before, 71–127 ms after across runs (machine noise; the numpy engine varied 513–756 ms in the same runs). Compile on first use rose from 2.6 s to 4.8 s.

**Not one numba loop.** The adaptive spectral filter keeps its own cached colour-class loop. Measured: a driver specialized through a module-level closure over its tile function recompiles in every process (2.0, 2.5, 2.0 s over three fresh processes, cache files written but not reused), where the same driver naming the tile function as a global loads from disk in 0.74 s. The plan's item 3 is closed by measurement rather than by code; the two loops are now the AFK's eight lines of FFT math and the driver's one line.

**The adaptive spectral filter takes any window length.** The power-of-two rule was Lightguide's; both engines' FFTs take any length, so `time=0.3` works like every other windowed call. The floor is two samples. `is_power_of_two` had no other caller and is removed.

**Two fewer resolver knobs.** `warn_above` was Hampel's alone, so Hampel warns itself; `min_samples` is an `int`, 0 for no floor, rather than `int | None`. The five that remain — `allow_multiple`, `require_evenly_sampled`, `require_odd`, `enforce_lt_coord`, `default_overlap` — each encode a policy the parity tests pin as genuinely different between functions (a dense filter accepts a window longer than its coordinate, `rolling` refuses one; Hampel rounds a window in units up to odd; the adaptive filter reads sample counts without a coordinate step), so they stay.

**Timing.** On a 500 × 60000 patch `stft` is 530 ms and `istft` 540 ms, against 568 and 620 on the scipy path they replace, once the centre phase is built in the spectra's dtype and folded with the `dft` scaling into one pass. Batching every row through one `TilePlan` call instead of the per-row loop was built and measured: `extract` gained (61 vs 136 ms) but the strided blend lost twice over (224 vs 100 ms float32, 429 vs 207 float64 — a row's buffer stays in cache, a 500-row one does not), so the per-row loop stays.

**AFK docs halved.** The recipe's prose goes from 343 to 163 words and the patch function's docstring from 460 to 296, saying the same things once.

## Changelog

- changed: `Patch.stft` produces the windowed stack `Patch.tile_apply` does, with its coordinates, and `Patch.istft` blends it back with `Patch.reassemble`; coordinates along the transformed dimension now survive the round trip; windows sit on the tile grid (unchanged at the default half overlap); a window that cannot be inverted is refused with a `ParameterError`.
- changed: `Patch.tile_apply` and `Patch.reassemble` cut no all-padding tiles, put a tile's centre at its sample `size // 2`, accept a one-dimensional array as `analysis`, and run a numba-compiled function over any number of dimensions and in stack mode.
- changed: `Patch.adaptive_spectral_filter` takes windows of any length of at least two samples.
- removed: `warn_above` from `dascore.utils.window.resolve_window` (the deprecated `get_patch_window_size` still warns); `dascore.utils.misc.is_power_of_two`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
