### PR TITLE
Raise on empty patches in waterfall plots

### DIFF
--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -45,7 +45,10 @@ def _validate_patch_dims(patch):
     """Validate that patch is 2D for waterfall plotting."""
     if patch.ndim != 2:
         # Try squeezing out degenerate dims to visualize.
-        patch = patch.squeeze()
+        singleton_dims = [
+            dim for dim, size in zip(patch.dims, patch.shape, strict=True) if size == 1
+        ]
+        patch = patch.squeeze(singleton_dims)
         if patch.ndim != 2:
             dims = patch.dims
             msg = (
@@ -291,6 +294,9 @@ def waterfall(
 
     Notes
     -----
+    - A Patch with an empty dimension returns an empty axes because it has no
+      cells to render.
+
     - The Y axis is automatically inverted if it is "time-like". This is to
       be consistent with standard seismic plotting convention. If you don't
       want this, simply invert the y axis of the returned axis object as
@@ -314,7 +320,8 @@ def waterfall(
     plan, runs = None, None
     if label_coord is not None:
         plan = label_plan(patch, label_coord, dims_r)
-        runs = label_runs(patch.coords.get_array(plan.name), plan.name)
+        if 0 not in patch.shape:
+            runs = label_runs(patch.coords.get_array(plan.name), plan.name)
     # Setup axes and data. A figure this call built is one whose room a
     # legend may take; any other belongs to the caller.
     owned = ax is None
@@ -326,6 +333,12 @@ def waterfall(
     dim_coords = {dim: patch.get_coord(dim) for dim in dims}
     coords = {dim: np.asarray(coord) for dim, coord in dim_coords.items()}
     cmap = _get_waterfall_colormap(patch, cmap)
+    if 0 in patch.shape:
+        _get_scale(scale, scale_type, np.zeros(1))
+        _format_axis_labels(ax, patch, dims_r)
+        if show:
+            plt.show()
+        return ax
     scale = _get_scale(scale, scale_type, data)
     label_edges = None
     use_image = all(coord.evenly_sampled for coord in dim_coords.values())

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -45,10 +45,7 @@ def _validate_patch_dims(patch):
     """Validate that patch is 2D for waterfall plotting."""
     if patch.ndim != 2:
         # Try squeezing out degenerate dims to visualize.
-        singleton_dims = [
-            dim for dim, size in zip(patch.dims, patch.shape, strict=True) if size == 1
-        ]
-        patch = patch.squeeze(singleton_dims)
+        patch = patch.squeeze()
         if patch.ndim != 2:
             dims = patch.dims
             msg = (
@@ -239,13 +236,11 @@ def waterfall(
         and the legend names them by the coordinate. Absent values (the empty
         string, NaN, or False) label nothing, and leave bare spine.
 
-        For a non-empty Patch, raises `ParameterError` for a coordinate which
-        is not a set of labels: one stating more than 20 distinct values, one
-        changing more than 200 times, one whose every value is absent, and one
-        which is a dimension or spans both of them. An empty Patch validates
-        the coordinate's dimensions but not its values when the labelled
-        dimension itself is empty because nothing can be labelled. All
-        refusals happen before a figure is created.
+        Raises `ParameterError` for a coordinate which is not a set of
+        labels: one stating more than 20 distinct values, one changing more
+        than 200 times, one whose every value is absent, and one which is a
+        dimension or spans both of them. All are judged before anything is
+        drawn, so a refusal leaves no figure behind.
 
     Examples
     --------
@@ -296,8 +291,8 @@ def waterfall(
 
     Notes
     -----
-    - A Patch with an empty dimension returns an empty axes because it has no
-      cells to render.
+    - A Patch with an empty dimension raises `ParameterError` immediately
+      because it has no cells to render.
 
     - The Y axis is automatically inverted if it is "time-like". This is to
       be consistent with standard seismic plotting convention. If you don't
@@ -311,6 +306,9 @@ def waterfall(
       the default behavior is to now use a statistical fence to avoid the
       problem. To get the old behavior, simply set scale=1.0.
     """
+    if 0 in patch.shape:
+        msg = "Cannot plot a Patch with an empty dimension."
+        raise ParameterError(msg)
     # Validate inputs
     patch = _validate_patch_dims(patch)
     _validate_gap_factor(gap_factor)
@@ -322,8 +320,7 @@ def waterfall(
     plan, runs = None, None
     if label_coord is not None:
         plan = label_plan(patch, label_coord, dims_r)
-        if len(patch.get_coord(plan.dim)):
-            runs = label_runs(patch.coords.get_array(plan.name), plan.name)
+        runs = label_runs(patch.coords.get_array(plan.name), plan.name)
     # Setup axes and data. A figure this call built is one whose room a
     # legend may take; any other belongs to the caller.
     owned = ax is None
@@ -335,12 +332,6 @@ def waterfall(
     dim_coords = {dim: patch.get_coord(dim) for dim in dims}
     coords = {dim: np.asarray(coord) for dim, coord in dim_coords.items()}
     cmap = _get_waterfall_colormap(patch, cmap)
-    if 0 in patch.shape:
-        _get_scale(scale, scale_type, np.zeros(1))
-        _format_axis_labels(ax, patch, dims_r)
-        if show:
-            plt.show()
-        return ax
     scale = _get_scale(scale, scale_type, data)
     label_edges = None
     use_image = all(coord.evenly_sampled for coord in dim_coords.values())

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -239,11 +239,13 @@ def waterfall(
         and the legend names them by the coordinate. Absent values (the empty
         string, NaN, or False) label nothing, and leave bare spine.
 
-        Raises `ParameterError` for a coordinate which is not a set of
-        labels: one stating more than 20 distinct values, one changing more
-        than 200 times, one whose every value is absent, and one which is a
-        dimension or spans both of them. All are judged before anything is
-        drawn, so a refusal leaves no figure behind.
+        For a non-empty Patch, raises `ParameterError` for a coordinate which
+        is not a set of labels: one stating more than 20 distinct values, one
+        changing more than 200 times, one whose every value is absent, and one
+        which is a dimension or spans both of them. An empty Patch validates
+        the coordinate's dimensions but not its values when the labelled
+        dimension itself is empty because nothing can be labelled. All
+        refusals happen before a figure is created.
 
     Examples
     --------
@@ -320,7 +322,7 @@ def waterfall(
     plan, runs = None, None
     if label_coord is not None:
         plan = label_plan(patch, label_coord, dims_r)
-        if 0 not in patch.shape:
+        if len(patch.get_coord(plan.dim)):
             runs = label_runs(patch.coords.get_array(plan.name), plan.name)
     # Setup axes and data. A figure this call built is one whose room a
     # legend may take; any other belongs to the caller.

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -249,6 +249,16 @@ class TestWaterfall:
         ax = patch.viz.waterfall(label_coord="zone", show=False)
         assert not ax.images
 
+    def test_empty_other_dimension_validates_labels(self):
+        """Labels remain validated when only the other dimension is empty."""
+        patch, inventory = inventory_patch_pair()
+        patch = patch.enrich(inventory)
+        empty_zone = np.full(patch.coord_shapes["distance"], "")
+        patch = patch.update_coords(zone=("distance", empty_zone))
+        patch = patch.select(time=(0, 0), samples=True)
+        with pytest.raises(ParameterError, match="no labels"):
+            patch.viz.waterfall(label_coord="zone", show=False)
+
     def test_y_axis_inverted_only_when_time_like(self, random_patch):
         """Time on the y axis increases downward; other dimensions do not."""
         ax = random_patch.viz.waterfall()  # distance on the y axis

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -222,42 +222,28 @@ class TestWaterfall:
         assert isinstance(ax, plt.Axes)
 
     @pytest.mark.parametrize("dim", ("distance", "time"))
-    def test_empty_dimension_returns_axes(self, random_patch, shown, dim):
-        """A patch with an empty dimension has nothing to draw. See #1089."""
+    @pytest.mark.parametrize("add_dimension", (False, True))
+    def test_empty_dimension_raises_immediately(
+        self, random_patch, shown, dim, add_dimension
+    ):
+        """An empty patch is rejected before any other processing. See #1089."""
         patch = random_patch.select(**{dim: (0, 0)}, samples=True)
+        if add_dimension:
+            patch = patch.append_dims("extra")
         assert 0 in patch.shape
-        _, supplied = plt.subplots()
+        figure_numbers = plt.get_fignums()
 
-        ax = patch.viz.waterfall(ax=supplied, show=True)
+        with pytest.raises(ParameterError, match="empty dimension"):
+            patch.viz.waterfall(
+                gap_factor=0,
+                scale_type="invalid",
+                label_coord="invalid",
+                cmap="invalid",
+                show=True,
+            )
 
-        assert ax is supplied
-        assert not ax.images
-        assert not ax.collections
-        assert ax.get_xlabel() and ax.get_ylabel()
-        assert shown
-
-    def test_empty_patch_squeezes_singleton_dimension(self, random_patch):
-        """A singleton dimension can be squeezed without dropping an empty one."""
-        patch = random_patch.select(distance=(0, 0), samples=True).append_dims("extra")
-        ax = patch.viz.waterfall(show=False)
-        assert not ax.images
-
-    def test_empty_labelled_dimension(self):
-        """An empty labelled dimension returns an empty axes."""
-        patch, inventory = inventory_patch_pair()
-        patch = patch.enrich(inventory).select(distance=(0, 0), samples=True)
-        ax = patch.viz.waterfall(label_coord="zone", show=False)
-        assert not ax.images
-
-    def test_empty_other_dimension_validates_labels(self):
-        """Labels remain validated when only the other dimension is empty."""
-        patch, inventory = inventory_patch_pair()
-        patch = patch.enrich(inventory)
-        empty_zone = np.full(patch.coord_shapes["distance"], "")
-        patch = patch.update_coords(zone=("distance", empty_zone))
-        patch = patch.select(time=(0, 0), samples=True)
-        with pytest.raises(ParameterError, match="no labels"):
-            patch.viz.waterfall(label_coord="zone", show=False)
+        assert plt.get_fignums() == figure_numbers
+        assert not shown
 
     def test_y_axis_inverted_only_when_time_like(self, random_patch):
         """Time on the y axis increases downward; other dimensions do not."""
@@ -408,9 +394,6 @@ class TestWaterfall:
         # Case sensitivity
         with pytest.raises(ParameterError, match=msg):
             random_patch.viz.waterfall(scale_type="Relative")
-        empty = random_patch.select(distance=(0, 0), samples=True)
-        with pytest.raises(ParameterError, match=msg):
-            empty.viz.waterfall(scale_type="invalid")
 
     def test_non_2d_patch_raises(self, random_patch):
         """Ensure non-2D patches raise ParameterError."""

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -221,6 +221,34 @@ class TestWaterfall:
         assert random_patch.dims[1] in ax.get_xlabel().lower()
         assert isinstance(ax, plt.Axes)
 
+    @pytest.mark.parametrize("dim", ("distance", "time"))
+    def test_empty_dimension_returns_axes(self, random_patch, shown, dim):
+        """A patch with an empty dimension has nothing to draw. See #1089."""
+        patch = random_patch.select(**{dim: (0, 0)}, samples=True)
+        assert 0 in patch.shape
+        _, supplied = plt.subplots()
+
+        ax = patch.viz.waterfall(ax=supplied, show=True)
+
+        assert ax is supplied
+        assert not ax.images
+        assert not ax.collections
+        assert ax.get_xlabel() and ax.get_ylabel()
+        assert shown
+
+    def test_empty_patch_squeezes_singleton_dimension(self, random_patch):
+        """A singleton dimension can be squeezed without dropping an empty one."""
+        patch = random_patch.select(distance=(0, 0), samples=True).append_dims("extra")
+        ax = patch.viz.waterfall(show=False)
+        assert not ax.images
+
+    def test_empty_labelled_dimension(self):
+        """An empty labelled dimension returns an empty axes."""
+        patch, inventory = inventory_patch_pair()
+        patch = patch.enrich(inventory).select(distance=(0, 0), samples=True)
+        ax = patch.viz.waterfall(label_coord="zone", show=False)
+        assert not ax.images
+
     def test_y_axis_inverted_only_when_time_like(self, random_patch):
         """Time on the y axis increases downward; other dimensions do not."""
         ax = random_patch.viz.waterfall()  # distance on the y axis
@@ -370,6 +398,9 @@ class TestWaterfall:
         # Case sensitivity
         with pytest.raises(ParameterError, match=msg):
             random_patch.viz.waterfall(scale_type="Relative")
+        empty = random_patch.select(distance=(0, 0), samples=True)
+        with pytest.raises(ParameterError, match=msg):
+            empty.viz.waterfall(scale_type="invalid")
 
     def test_non_2d_patch_raises(self, random_patch):
         """Ensure non-2D patches raise ParameterError."""


### PR DESCRIPTION
## Description

Closes #1089.

`Patch.viz.waterfall` raised an internal `TypeError` while calculating plot limits when either dimension was empty. Reject empty patches immediately with a clear `ParameterError`, before dimensionality checks, option validation, label planning, axes creation, or `show` handling.

## Changelog

- fixed: `Patch.viz.waterfall` now raises `ParameterError` immediately for patches with an empty dimension.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
