### PR TITLE
Warn when resampling drops associated coordinates

### DIFF
--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -106,6 +106,25 @@ def decimate(
     return patch.new(data=data, coords=coords)
 
 
+def _relative_coord_values(coord_num, samples_num):
+    """Return interpolation coordinates relative to their first sample."""
+    if not len(coord_num):
+        return coord_num, samples_num
+    offset = coord_num[0]
+    return coord_num - offset, samples_num - offset
+
+
+def _apply_coord_updates(cm, updates):
+    """Apply coordinate updates without parsing coordinate names as kwargs."""
+    coord_map = dict(cm.get_coord_tuple_map())
+    for name, value in updates.items():
+        if value is None:
+            coord_map.pop(name, None)
+        else:
+            coord_map[name] = value
+    return dc.core.get_coord_manager(coords=coord_map, dims=cm.dims)
+
+
 def _interpolate_associated(cm, dim, coord_num, samples_num, kind) -> dict:
     """
     Interpolate the coordinates which ride the interpolated dimension.
@@ -120,6 +139,7 @@ def _interpolate_associated(cm, dim, coord_num, samples_num, kind) -> dict:
     would otherwise leave the old values sitting on the new ones.
     """
     out = {}
+    coord_num, samples_num = _relative_coord_values(coord_num, samples_num)
     for name, coord_dims in cm.dim_map.items():
         coord = cm.coord_map[name]
         if name == dim or dim not in coord_dims:
@@ -203,16 +223,17 @@ def interpolate(patch: PatchType, kind: str | int = "linear", **kwargs) -> Patch
     # datetime64 yet.
     coord_num = to_int(patch.coords.get_array(dim))
     samples_num = to_int(samples)
+    interp_coord, interp_samples = _relative_coord_values(coord_num, samples_num)
     func = compat.interp1d(
-        coord_num, patch.data, axis=axis, kind=kind, fill_value="extrapolate"
+        interp_coord, patch.data, axis=axis, kind=kind, fill_value="extrapolate"
     )
-    out = func(samples_num)
+    out = func(interp_samples)
     cm = patch.coords
     associated_dims = cm.dim_map[dim]
     coord_new = dc.core.get_coord(data=samples)
     updates = {dim: (associated_dims, coord_new)}
     updates |= _interpolate_associated(cm, dim, coord_num, samples_num, kind)
-    cm_new = cm.update(**updates)
+    cm_new = _apply_coord_updates(cm, updates)
     return patch.new(data=out, coords=cm_new)
 
 
@@ -257,6 +278,9 @@ def resample(
     -----
     - Unless `samples` is `True`, this function requires a sampling_period.
     - The resulting Patch can be slightly shorter than the input Patch.
+    - Numeric coordinates measured on the resampled dimension are interpolated
+      onto its new samples. Time-like and non-numeric coordinates measured on
+      that dimension are dropped, as they are by [`Patch.interpolate`].
 
     Examples
     --------
@@ -306,11 +330,18 @@ def resample(
     data, new_coord = compat.resample(
         patch.data, int(np.round(new_len)), t=coord, axis=axis, window=window
     )
-    cm = patch.coords.update(**{dim: new_coord})
-    out = patch.new(data=data, coords=cm)
+    cm = patch.coords
+    coord_num = to_int(cm.get_array(dim))
+    out = patch.new(data=data, coords=cm.update(**{dim: new_coord}))
     # Interpolate if new sampling rate is not very close to desired sampling rate.
+    associated_kind = "linear"
     if not samples and not np.isclose(new_len, np.round(new_len)):
         start, stop, step = get_start_stop_step(out, dim)
         new_coord = np.arange(start, stop, new_step)
         out = interpolate(out, kind=interp_kind, **{dim: new_coord})
-    return out
+        associated_kind = interp_kind
+    updates = _interpolate_associated(
+        cm, dim, coord_num, to_int(out.coords.get_array(dim)), associated_kind
+    )
+    coords = _apply_coord_updates(out.coords, updates)
+    return out.new(coords=coords)

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -108,9 +108,13 @@ def decimate(
 
 def _relative_coord_values(coord_num, samples_num):
     """Return interpolation coordinates relative to their first sample."""
-    if not len(coord_num):
-        return coord_num, samples_num
     offset = coord_num[0]
+    if np.issubdtype(coord_num.dtype, np.unsignedinteger) or np.issubdtype(
+        samples_num.dtype, np.unsignedinteger
+    ):
+        coord_num = np.asarray(np.asarray(coord_num, dtype=object) - int(offset))
+        samples_num = np.asarray(np.asarray(samples_num, dtype=object) - int(offset))
+        return coord_num.astype(np.float64), samples_num.astype(np.float64)
     return coord_num - offset, samples_num - offset
 
 
@@ -230,7 +234,7 @@ def interpolate(patch: PatchType, kind: str | int = "linear", **kwargs) -> Patch
     out = func(interp_samples)
     cm = patch.coords
     associated_dims = cm.dim_map[dim]
-    coord_new = dc.core.get_coord(data=samples)
+    coord_new = dc.core.get_coord(data=samples, units=cm.coord_map[dim].units)
     updates = {dim: (associated_dims, coord_new)}
     updates |= _interpolate_associated(cm, dim, coord_num, samples_num, kind)
     cm_new = _apply_coord_updates(cm, updates)
@@ -330,6 +334,7 @@ def resample(
     data, new_coord = compat.resample(
         patch.data, int(np.round(new_len)), t=coord, axis=axis, window=window
     )
+    new_coord = dc.core.get_coord(data=new_coord, units=coord.units)
     cm = patch.coords
     coord_num = to_int(cm.get_array(dim))
     out = patch.new(data=data, coords=cm.update(**{dim: new_coord}))

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Literal
 
 import numpy as np
@@ -18,6 +19,7 @@ from dascore.utils.patch import (
     patch_function,
 )
 from dascore.utils.time import dtype_time_like, to_int, to_timedelta64
+from dascore.warnings import DASCoreWarning
 
 scipy_decimate = lazy_import("scipy.signal", "decimate")
 
@@ -106,29 +108,6 @@ def decimate(
     return patch.new(data=data, coords=coords)
 
 
-def _relative_coord_values(coord_num, samples_num):
-    """Return interpolation coordinates relative to their first sample."""
-    offset = coord_num[0]
-    if np.issubdtype(coord_num.dtype, np.unsignedinteger) or np.issubdtype(
-        samples_num.dtype, np.unsignedinteger
-    ):
-        coord_num = np.asarray(np.asarray(coord_num, dtype=object) - int(offset))
-        samples_num = np.asarray(np.asarray(samples_num, dtype=object) - int(offset))
-        return coord_num.astype(np.float64), samples_num.astype(np.float64)
-    return coord_num - offset, samples_num - offset
-
-
-def _apply_coord_updates(cm, updates):
-    """Apply coordinate updates without parsing coordinate names as kwargs."""
-    coord_map = dict(cm.get_coord_tuple_map())
-    for name, value in updates.items():
-        if value is None:
-            coord_map.pop(name, None)
-        else:
-            coord_map[name] = value
-    return dc.core.get_coord_manager(coords=coord_map, dims=cm.dims)
-
-
 def _interpolate_associated(cm, dim, coord_num, samples_num, kind) -> dict:
     """
     Interpolate the coordinates which ride the interpolated dimension.
@@ -143,7 +122,6 @@ def _interpolate_associated(cm, dim, coord_num, samples_num, kind) -> dict:
     would otherwise leave the old values sitting on the new ones.
     """
     out = {}
-    coord_num, samples_num = _relative_coord_values(coord_num, samples_num)
     for name, coord_dims in cm.dim_map.items():
         coord = cm.coord_map[name]
         if name == dim or dim not in coord_dims:
@@ -227,17 +205,16 @@ def interpolate(patch: PatchType, kind: str | int = "linear", **kwargs) -> Patch
     # datetime64 yet.
     coord_num = to_int(patch.coords.get_array(dim))
     samples_num = to_int(samples)
-    interp_coord, interp_samples = _relative_coord_values(coord_num, samples_num)
     func = compat.interp1d(
-        interp_coord, patch.data, axis=axis, kind=kind, fill_value="extrapolate"
+        coord_num, patch.data, axis=axis, kind=kind, fill_value="extrapolate"
     )
-    out = func(interp_samples)
+    out = func(samples_num)
     cm = patch.coords
     associated_dims = cm.dim_map[dim]
-    coord_new = dc.core.get_coord(data=samples, units=cm.coord_map[dim].units)
+    coord_new = dc.core.get_coord(data=samples)
     updates = {dim: (associated_dims, coord_new)}
     updates |= _interpolate_associated(cm, dim, coord_num, samples_num, kind)
-    cm_new = _apply_coord_updates(cm, updates)
+    cm_new = cm.update(**updates)
     return patch.new(data=out, coords=cm_new)
 
 
@@ -282,9 +259,9 @@ def resample(
     -----
     - Unless `samples` is `True`, this function requires a sampling_period.
     - The resulting Patch can be slightly shorter than the input Patch.
-    - Numeric coordinates measured on the resampled dimension are interpolated
-      onto its new samples. Time-like and non-numeric coordinates measured on
-      that dimension are dropped, as they are by [`Patch.interpolate`].
+    - Coordinates associated with the resampled dimension are dropped because
+      resampling cannot safely infer their new values. A `DASCoreWarning` names
+      any coordinates which were dropped.
 
     Examples
     --------
@@ -334,19 +311,22 @@ def resample(
     data, new_coord = compat.resample(
         patch.data, int(np.round(new_len)), t=coord, axis=axis, window=window
     )
-    new_coord = dc.core.get_coord(data=new_coord, units=coord.units)
+    associated = sorted(
+        name
+        for name, coord_dims in patch.coords.dim_map.items()
+        if name != dim and dim in coord_dims
+    )
     cm = patch.coords
-    coord_num = to_int(cm.get_array(dim))
-    out = patch.new(data=data, coords=cm.update(**{dim: new_coord}))
+    if associated:
+        names = ", ".join(associated)
+        msg = f"Resampling dimension {dim!r} dropped associated coordinates: {names}."
+        warnings.warn(msg, DASCoreWarning, stacklevel=2)
+        cm, _ = cm.drop_coords(*associated)
+    cm = cm.update(**{dim: new_coord})
+    out = patch.new(data=data, coords=cm)
     # Interpolate if new sampling rate is not very close to desired sampling rate.
-    associated_kind = "linear"
     if not samples and not np.isclose(new_len, np.round(new_len)):
         start, stop, step = get_start_stop_step(out, dim)
         new_coord = np.arange(start, stop, new_step)
         out = interpolate(out, kind=interp_kind, **{dim: new_coord})
-        associated_kind = interp_kind
-    updates = _interpolate_associated(
-        cm, dim, coord_num, to_int(out.coords.get_array(dim)), associated_kind
-    )
-    coords = _apply_coord_updates(out.coords, updates)
-    return out.new(coords=coords)
+    return out

--- a/dascore/proc/resample.py
+++ b/dascore/proc/resample.py
@@ -320,7 +320,7 @@ def resample(
     if associated:
         names = ", ".join(associated)
         msg = f"Resampling dimension {dim!r} dropped associated coordinates: {names}."
-        warnings.warn(msg, DASCoreWarning, stacklevel=2)
+        warnings.warn(msg, DASCoreWarning, stacklevel=3)
         cm, _ = cm.drop_coords(*associated)
     cm = cm.update(**{dim: new_coord})
     out = patch.new(data=data, coords=cm)

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -81,6 +81,7 @@ class TestInterpolate:
         out = patch.interpolate(distance=new_coord)
         assert out.coords.dim_map["lat"] == ("distance",)
         assert out.get_coord("lat").units == patch.get_coord("lat").units
+        assert out.get_coord("distance").units == patch.get_coord("distance").units
         assert len(out.get_array("lat")) == len(new_coord)
         # The samples which did not move keep the values they had.
         kept = out.get_array("lat")[::2]
@@ -115,6 +116,22 @@ class TestInterpolate:
         out = patch.interpolate(distance=new_coord)
         assert out.coords.dim_map["quality"] == ("distance", "time")
         assert out.get_array("quality").shape == out.shape
+
+    def test_unsigned_coords_do_not_wrap(self):
+        """Rebasing unsigned interpolation coordinates avoids wraparound."""
+        coord = np.array([3, 4, 5], dtype=np.uint64)
+        samples = np.array([2, 3, 4], dtype=np.uint64)
+        values = coord.astype(float)
+        patch = dc.Patch(
+            data=values,
+            coords={"x": coord, "aux": ("x", values)},
+            dims=("x",),
+        )
+
+        out = patch.interpolate(x=samples)
+
+        assert np.allclose(out.data, samples)
+        assert np.allclose(out.get_array("aux"), samples)
 
 
 class TestDecimate:
@@ -233,6 +250,7 @@ class TestResample:
             return expected
 
         assert out.coords.dim_map == patch.coords.dim_map
+        assert out.get_coord("distance").units == patch.get_coord("distance").units
         expected_lat = _linear_extrapolate(patch.get_array("lat"))
         assert np.allclose(out.get_array("lat"), expected_lat)
         expected_quality = np.apply_along_axis(

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -222,9 +222,10 @@ class TestResample:
         distance = patch.get_coord("distance")
         value = len(distance) * 2 if samples else distance.step * 1.232132323222
 
-        with pytest.warns(DASCoreWarning, match="lat, quality"):
+        with pytest.warns(DASCoreWarning, match="lat, quality") as warning_records:
             out = patch.resample(distance=value, samples=samples)
 
+        assert warning_records[0].filename == __file__
         assert {"lat", "quality"}.isdisjoint(out.coords.coord_map)
         assert np.allclose(out.get_array("time2"), patch.get_array("time2"))
 

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -13,6 +13,7 @@ from dascore.compat import random_state
 from dascore.exceptions import FilterValueError, ParameterError
 from dascore.units import Hz, m, s
 from dascore.utils.patch import get_start_stop_step
+from dascore.warnings import DASCoreWarning
 
 resample_mod = importlib.import_module("dascore.proc.resample")
 
@@ -81,7 +82,6 @@ class TestInterpolate:
         out = patch.interpolate(distance=new_coord)
         assert out.coords.dim_map["lat"] == ("distance",)
         assert out.get_coord("lat").units == patch.get_coord("lat").units
-        assert out.get_coord("distance").units == patch.get_coord("distance").units
         assert len(out.get_array("lat")) == len(new_coord)
         # The samples which did not move keep the values they had.
         kept = out.get_array("lat")[::2]
@@ -116,22 +116,6 @@ class TestInterpolate:
         out = patch.interpolate(distance=new_coord)
         assert out.coords.dim_map["quality"] == ("distance", "time")
         assert out.get_array("quality").shape == out.shape
-
-    def test_unsigned_coords_do_not_wrap(self):
-        """Rebasing unsigned interpolation coordinates avoids wraparound."""
-        coord = np.array([3, 4, 5], dtype=np.uint64)
-        samples = np.array([2, 3, 4], dtype=np.uint64)
-        values = coord.astype(float)
-        patch = dc.Patch(
-            data=values,
-            coords={"x": coord, "aux": ("x", values)},
-            dims=("x",),
-        )
-
-        out = patch.interpolate(x=samples)
-
-        assert np.allclose(out.data, samples)
-        assert np.allclose(out.get_array("aux"), samples)
 
 
 class TestDecimate:
@@ -230,87 +214,33 @@ class TestResample:
     """Tests for resampling along a given dimension."""
 
     @pytest.mark.parametrize("samples", (False, True))
-    def test_associated_coords_resampled(self, random_patch_many_coords, samples):
-        """Numeric coordinates on the resampled dimension follow it. See #1090."""
+    def test_associated_coords_dropped_with_warning(
+        self, random_patch_many_coords, samples
+    ):
+        """Coords on the resampled dimension are deliberately dropped. See #1090."""
         patch = random_patch_many_coords
         distance = patch.get_coord("distance")
         value = len(distance) * 2 if samples else distance.step * 1.232132323222
 
-        out = patch.resample(distance=value, samples=samples)
-        old_distance = patch.get_array("distance")
-        new_distance = out.get_array("distance")
+        with pytest.warns(DASCoreWarning, match="lat, quality"):
+            out = patch.resample(distance=value, samples=samples)
 
-        def _linear_extrapolate(values):
-            expected = np.interp(new_distance, old_distance, values)
-            above = new_distance > old_distance[-1]
-            slope = (values[-1] - values[-2]) / (old_distance[-1] - old_distance[-2])
-            expected[above] = values[-1] + slope * (
-                new_distance[above] - old_distance[-1]
-            )
-            return expected
-
-        assert out.coords.dim_map == patch.coords.dim_map
-        assert out.get_coord("distance").units == patch.get_coord("distance").units
-        expected_lat = _linear_extrapolate(patch.get_array("lat"))
-        assert np.allclose(out.get_array("lat"), expected_lat)
-        expected_quality = np.apply_along_axis(
-            _linear_extrapolate,
-            patch.get_axis("distance"),
-            patch.get_array("quality"),
-        )
-        assert np.allclose(out.get_array("quality"), expected_quality)
+        assert {"lat", "quality"}.isdisjoint(out.coords.coord_map)
         assert np.allclose(out.get_array("time2"), patch.get_array("time2"))
 
-    def test_datetime_dim_associated_coord(self):
-        """Large epoch nanoseconds retain fine interpolation precision."""
-        size = 8
-        time = np.datetime64("2026-01-01", "ns") + np.arange(size) * np.timedelta64(
-            100, "ns"
-        )
-        patch = dc.Patch(
-            data=np.arange(size, dtype=float),
-            coords={"time": time, "clock": ("time", np.arange(size, dtype=float))},
-            dims=("time",),
-        )
-
-        out = patch.resample(time=16, samples=True)
-
-        assert np.allclose(out.get_array("clock"), np.arange(16) / 2)
-
-        samples = time[0] + np.arange(11) * np.timedelta64(70, "ns")
-        out = patch.interpolate(time=samples)
-        assert np.allclose(out.data, out.get_array("clock"))
-
-    def test_associated_coord_name_like_dim_attr(self):
-        """A legal coordinate name is not parsed as dimension metadata."""
-        distance = np.arange(8, dtype=float)
+    def test_same_length_resample_drops_associated_coords(self):
+        """Associated coordinates are dropped even when their shape still fits."""
+        distance = np.arange(8.0)
         patch = dc.Patch(
             data=distance,
-            coords={"distance": distance, "distance_min": ("distance", distance * 10)},
+            coords={"distance": distance, "aux": ("distance", distance)},
             dims=("distance",),
         )
 
-        out = patch.resample(distance=16, samples=True)
+        with pytest.warns(DASCoreWarning, match="aux"):
+            out = patch.resample(distance=len(distance), samples=True)
 
-        assert np.allclose(out.get_array("distance_min"), np.arange(16) * 5)
-
-        out = patch.resample(distance=1.02)
-        assert np.allclose(
-            out.get_array("distance_min"), out.get_array("distance") * 10
-        )
-
-    def test_exact_resample_ignores_interp_kind_for_coords(self):
-        """Fourier-only resampling does not apply the fallback interpolation kind."""
-        values = np.arange(3, dtype=float)
-        patch = dc.Patch(
-            data=values,
-            coords={"x": values, "aux": ("x", values)},
-            dims=("x",),
-        )
-
-        out = patch.resample(x=6, samples=True, interp_kind="cubic")
-
-        assert np.allclose(out.get_array("aux"), np.arange(6) / 2)
+        assert "aux" not in out.coords.coord_map
 
     def test_missing_period_raises(self, random_patch):
         """A null sampling period is rejected rather than producing NaN."""

--- a/tests/test_proc/test_resample.py
+++ b/tests/test_proc/test_resample.py
@@ -212,6 +212,88 @@ class TestDecimate:
 class TestResample:
     """Tests for resampling along a given dimension."""
 
+    @pytest.mark.parametrize("samples", (False, True))
+    def test_associated_coords_resampled(self, random_patch_many_coords, samples):
+        """Numeric coordinates on the resampled dimension follow it. See #1090."""
+        patch = random_patch_many_coords
+        distance = patch.get_coord("distance")
+        value = len(distance) * 2 if samples else distance.step * 1.232132323222
+
+        out = patch.resample(distance=value, samples=samples)
+        old_distance = patch.get_array("distance")
+        new_distance = out.get_array("distance")
+
+        def _linear_extrapolate(values):
+            expected = np.interp(new_distance, old_distance, values)
+            above = new_distance > old_distance[-1]
+            slope = (values[-1] - values[-2]) / (old_distance[-1] - old_distance[-2])
+            expected[above] = values[-1] + slope * (
+                new_distance[above] - old_distance[-1]
+            )
+            return expected
+
+        assert out.coords.dim_map == patch.coords.dim_map
+        expected_lat = _linear_extrapolate(patch.get_array("lat"))
+        assert np.allclose(out.get_array("lat"), expected_lat)
+        expected_quality = np.apply_along_axis(
+            _linear_extrapolate,
+            patch.get_axis("distance"),
+            patch.get_array("quality"),
+        )
+        assert np.allclose(out.get_array("quality"), expected_quality)
+        assert np.allclose(out.get_array("time2"), patch.get_array("time2"))
+
+    def test_datetime_dim_associated_coord(self):
+        """Large epoch nanoseconds retain fine interpolation precision."""
+        size = 8
+        time = np.datetime64("2026-01-01", "ns") + np.arange(size) * np.timedelta64(
+            100, "ns"
+        )
+        patch = dc.Patch(
+            data=np.arange(size, dtype=float),
+            coords={"time": time, "clock": ("time", np.arange(size, dtype=float))},
+            dims=("time",),
+        )
+
+        out = patch.resample(time=16, samples=True)
+
+        assert np.allclose(out.get_array("clock"), np.arange(16) / 2)
+
+        samples = time[0] + np.arange(11) * np.timedelta64(70, "ns")
+        out = patch.interpolate(time=samples)
+        assert np.allclose(out.data, out.get_array("clock"))
+
+    def test_associated_coord_name_like_dim_attr(self):
+        """A legal coordinate name is not parsed as dimension metadata."""
+        distance = np.arange(8, dtype=float)
+        patch = dc.Patch(
+            data=distance,
+            coords={"distance": distance, "distance_min": ("distance", distance * 10)},
+            dims=("distance",),
+        )
+
+        out = patch.resample(distance=16, samples=True)
+
+        assert np.allclose(out.get_array("distance_min"), np.arange(16) * 5)
+
+        out = patch.resample(distance=1.02)
+        assert np.allclose(
+            out.get_array("distance_min"), out.get_array("distance") * 10
+        )
+
+    def test_exact_resample_ignores_interp_kind_for_coords(self):
+        """Fourier-only resampling does not apply the fallback interpolation kind."""
+        values = np.arange(3, dtype=float)
+        patch = dc.Patch(
+            data=values,
+            coords={"x": values, "aux": ("x", values)},
+            dims=("x",),
+        )
+
+        out = patch.resample(x=6, samples=True, interp_kind="cubic")
+
+        assert np.allclose(out.get_array("aux"), np.arange(6) / 2)
+
     def test_missing_period_raises(self, random_patch):
         """A null sampling period is rejected rather than producing NaN."""
         match = "requires a sampling period"


### PR DESCRIPTION
## Description

Closes #1090.

`Patch.resample` silently dropped coordinates associated with the resampled dimension. Deliberately drop every associated coordinate before resampling and emit a `DASCoreWarning` naming the removed coordinates, including when the requested output has the same length and stale coordinates would otherwise still fit.

## Changelog

- fixed: `Patch.resample` now warns when it drops coordinates associated with the resampled dimension.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [x] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Resampling now removes coordinates associated with the resampled dimension instead of interpolating or extrapolating them.
  * A warning identifies any associated coordinates that are dropped, including when the resampled dimension retains the same length.
  * Unrelated coordinates remain preserved during resampling.

* **Documentation**
  * Clarified that associated coordinates are dropped with a warning during resampling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->