### PR TITLE
Harden degenerate patch operations

### DIFF
--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -889,6 +889,13 @@ def squeeze(self: PatchType, dim=None) -> PatchType:
         is selected with length greater than one, an error is raised.
         If None, all length one dimensions are squeezed.
 
+    Raises
+    ------
+    CoordError
+        If a selected dimension does not exist or has more than one sample.
+    ParameterError
+        If squeezing would remove every dimension from the patch.
+
     Examples
     --------
     >>> import dascore as dc
@@ -906,6 +913,9 @@ def squeeze(self: PatchType, dim=None) -> PatchType:
     # Nothing to squeeze; the coord manager returned self, so reuse this patch.
     if coords is self.coords:
         return self
+    if not coords.dims:
+        msg = "Cannot squeeze all dimensions; at least one dimension must remain."
+        raise ParameterError(msg)
     if dim is None:
         axes = tuple(i for i, x in enumerate(self.shape) if x == 1)
     else:

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -1393,6 +1393,8 @@ def tukey_fence(data, fence_multiplier=1.5) -> np.ndarray:
     """
     Apply Tukey's fence to determine data range without outliers.
     """
+    if np.all(pd.isnull(data)):
+        return np.asarray([np.nan, np.nan])
     q1, q3 = np.nanpercentile(data, [25, 75])
     dmin, dmax = np.nanmin(data), np.nanmax(data)
     diff = q3 - q1  # Interquartile range (IQR)

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -1393,13 +1393,14 @@ def tukey_fence(data, fence_multiplier=1.5) -> np.ndarray:
     """
     Apply Tukey's fence to determine data range without outliers.
     """
-    if np.all(pd.isnull(data)):
-        return np.asarray([np.nan, np.nan])
-    q1, q3 = np.nanpercentile(data, [25, 75])
-    dmin, dmax = np.nanmin(data), np.nanmax(data)
-    diff = q3 - q1  # Interquartile range (IQR)
-    q_lower = np.nanmax([q1 - diff * fence_multiplier, dmin])
-    q_upper = np.nanmin([q3 + diff * fence_multiplier, dmax])
+    with suppress_warnings(
+        category=RuntimeWarning, message="All-NaN (?:slice|axis) encountered"
+    ):
+        q1, q3 = np.nanpercentile(data, [25, 75])
+        dmin, dmax = np.nanmin(data), np.nanmax(data)
+        diff = q3 - q1  # Interquartile range (IQR)
+        q_lower = np.nanmax([q1 - diff * fence_multiplier, dmin])
+        q_upper = np.nanmin([q3 + diff * fence_multiplier, dmax])
     lower_and_top = np.asarray([q_lower, q_upper])
     return lower_and_top
 

--- a/tests/test_proc/test_proc_coords.py
+++ b/tests/test_proc/test_proc_coords.py
@@ -879,6 +879,14 @@ class TestSqueeze:
         coords = random_patch.coords
         assert coords.squeeze() is coords
 
+    @pytest.mark.parametrize("dim", [None, ("distance", "time")])
+    def test_squeeze_all_dimensions_raises(self, random_patch, dim):
+        """Squeeze should not create an unsupported scalar patch."""
+        patch = random_patch.select(distance=0, time=0, samples=True)
+        msg = "at least one dimension"
+        with pytest.raises(ParameterError, match=msg):
+            patch.squeeze(dim)
+
 
 class TestGetCoord:
     """Tests for the get_coord convenience function."""

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -542,9 +542,9 @@ class TestTukeyFence:
         assert np.allclose(result, [1.0, 5.0])
 
     def test_all_nan(self):
-        """All-NaN data should return NaN bounds."""
+        """All-NaN data should return NaN bounds without warnings."""
         data = np.array([np.nan, np.nan, np.nan])
-        with suppress_warnings():
+        with suppress_warnings(action="error"):
             result = tukey_fence(data)
         assert np.isnan(result[0])
         assert np.isnan(result[1])

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -16,6 +16,7 @@ import dascore as dc
 from dascore.examples import inventory_patch_pair
 from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, percent
+from dascore.utils.misc import suppress_warnings
 from dascore.utils.time import is_datetime64, to_timedelta64
 from dascore.viz._labels import BAR_GID, MAX_LABELS, MAX_RUNS, SEAM_GID
 from dascore.viz._lanes import string_colors
@@ -385,6 +386,14 @@ class TestWaterfall:
         data = np.ones(random_patch.shape)
         patch = random_patch.update(data=data)
         ax = patch.viz.waterfall()
+        assert isinstance(ax, plt.Axes)
+
+    def test_all_nan_patch(self, random_patch):
+        """All-NaN data should plot without leaking scaling warnings."""
+        data = np.full(random_patch.shape, np.nan)
+        patch = random_patch.update(data=data)
+        with suppress_warnings(action="error"):
+            ax = patch.viz.waterfall()
         assert isinstance(ax, plt.Axes)
 
     def test_constant_data_with_relative_scale(self, random_patch):

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -392,7 +392,7 @@ class TestWaterfall:
         """All-NaN data should plot without leaking scaling warnings."""
         data = np.full(random_patch.shape, np.nan)
         patch = random_patch.update(data=data)
-        with suppress_warnings(action="error"):
+        with suppress_warnings(category=RuntimeWarning, action="error"):
             ax = patch.viz.waterfall()
         assert isinstance(ax, plt.Axes)
 


### PR DESCRIPTION
## Description

Harden two degenerate patch workflows found while exercising tutorial-style user stories:

- Raise a clear `ParameterError` when `Patch.squeeze()` would remove every dimension instead of leaking an internal coordinate-shape error.
- Return NaN Tukey bounds for all-null data without runtime warnings, allowing all-NaN waterfall patches to render quietly.

The assumptions are that DASCore continues not to support scalar patches and that an all-NaN visualization should render with undefined color bounds rather than emit scaling warnings.

## Changelog

- fixed: `Patch.squeeze` raises a clear error when squeezing would remove every dimension.
- fixed: Waterfall plots of all-NaN patches no longer emit runtime warnings while determining color bounds.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented squeezing operations from removing all dimensions without a clear error.
  * Improved handling of entirely null data by returning NaN bounds without warnings.
  * Ensured waterfall visualizations work correctly with patches containing only NaN values.

* **Tests**
  * Added coverage for invalid all-dimension squeezing and all-NaN data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->