### PR TITLE
A short-time transform over any number of dimensions

### DIFF
--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -460,6 +460,55 @@ def ricker_moveout(
     return dc.Patch(data=data, coords=coords, dims=dims)
 
 
+@register_func(EXAMPLE_PATCHES, key="plane_wave")
+def plane_wave(
+    frequency=20.0,
+    velocity=500.0,
+    duration=2.048,
+    time_step=0.002,
+    distance_step=4.0,
+    channel_count=128,
+    time_min="2020-01-01",
+):
+    """
+    A plane wave: one frequency crossing the array at one apparent velocity.
+
+    Every window of it has the same frequency-wavenumber content, a single
+    peak at ``(frequency, -frequency / velocity)``, which makes it a clean
+    input for spectral transforms and moveout filters.
+
+    Parameters
+    ----------
+    frequency
+        The wave's frequency in Hz.
+    velocity
+        The apparent velocity along the fibre in m/s; negative moves the
+        wave the other way.
+    duration
+        The duration of the time coordinate in seconds.
+    time_step
+        The time step in seconds.
+    distance_step
+        The distance step in metres.
+    channel_count
+        The number of distance channels.
+    time_min
+        The start time in the metadata.
+    """
+    distance = np.arange(channel_count) * distance_step
+    time = np.arange(round(duration / time_step)) * time_step
+    phase = 2 * np.pi * frequency * (time[None, :] - distance[:, None] / velocity)
+    patch = dc.Patch(
+        data=np.cos(phase).astype(np.float32),
+        coords={
+            "distance": distance,
+            "time": to_timedelta64(time) + np.datetime64(time_min),
+        },
+        dims=("distance", "time"),
+    )
+    return patch.set_units(distance="m", time="s")
+
+
 @register_func(EXAMPLE_PATCHES, key="delta_patch")
 def delta_patch(
     dim="time",

--- a/dascore/examples.py
+++ b/dascore/examples.py
@@ -429,6 +429,10 @@ def ricker_moveout(
     Notes
     -----
     Based on https://github.com/lijunzh/ricker/.
+
+    See Also
+    --------
+    `plane_wave`: one frequency at one apparent velocity, with no onset.
     """
 
     def _ricker(time, delay):
@@ -494,6 +498,11 @@ def plane_wave(
         The number of distance channels.
     time_min
         The start time in the metadata.
+
+    See Also
+    --------
+    `ricker_moveout`: a wavelet with an onset crossing the array at one
+    apparent velocity, for time-domain moveout.
     """
     distance = np.arange(channel_count) * distance_step
     time = np.arange(round(duration / time_step)) * time_step

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -7,7 +7,7 @@ implementation.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from math import prod
 from operator import mul, truediv
 from typing import Any, Literal
@@ -31,7 +31,7 @@ from dascore.utils.patch import (
     _get_dx_or_spacing_and_axes,
     patch_function,
 )
-from dascore.utils.signal import get_window
+from dascore.utils.signal import get_window_nd
 from dascore.utils.time import to_float
 from dascore.utils.transformatter import FourierTransformatter
 from dascore.utils.window import resolve_window
@@ -559,15 +559,16 @@ def _as_is(tiles: np.ndarray) -> np.ndarray:
     return tiles
 
 
-def _swap_window_axes(data: np.ndarray, axis: int) -> np.ndarray:
+def _swap_window_axes(data: np.ndarray, axes: tuple[int, ...]) -> np.ndarray:
     """
-    Move a stack's last axis to `axis` and what was there to the end.
+    Swap a stack's last axes, one per windowed dimension, with `axes`.
 
-    A stack keeps the windows within a tile as its last axis; an stft keeps
-    the frequencies where the transformed dimension was and the window
+    A stack keeps the samples within a tile as its last axes; an stft keeps
+    the frequencies where the transformed dimensions were and the window
     centres last. The swap is its own inverse.
     """
-    return np.moveaxis(data, (axis, -1), (-1, axis))
+    tail = tuple(range(-len(axes), 0))
+    return np.moveaxis(data, (*axes, *tail), (*tail, *axes))
 
 
 @patch_function(data_type="fourier_transform")
@@ -577,7 +578,7 @@ def stft(
     overlap: Quantity | int | None = 50 * percent,
     samples: bool = False,
     detrend: bool = False,
-    nfft: int | Quantity | np.timedelta64 | None = None,
+    nfft: int | Quantity | np.timedelta64 | Mapping[str, Any] | None = None,
     **kwargs,
 ):
     """
@@ -588,10 +589,9 @@ def stft(
     patch
         The patch to transform.
     taper_window
-        Parameter controlling the tapering of each time window before
-        fourier transform. Can either be the name of the window to use,
-        or an array, or a tuple of name and parameters passed to scipy.signal's
-        get_window function.
+        The taper each window is multiplied by before its transform: a name,
+        an array, or a ``(name, parameter)`` tuple `get_window` knows, for
+        every windowed dimension, or a list with one per dimension.
     overlap
         The overlap between windows. Can be a number (assumed to be in units of
         the transformed dimension if `samples`==False), a percent, or None for
@@ -605,13 +605,16 @@ def stft(
         no longer possible.
     nfft
         The length of the FFT taken of each window, in samples, or as a
-        quantity or timedelta in the transformed dimension's units. None, the default,
-        is the window length. A longer FFT zero pads each window, which
-        samples the same spectrum at more, closer frequencies; it adds no
-        resolution, since the window holds no more data. Must be at least
-        the window length.
+        quantity or timedelta in the transformed dimension's units; a mapping
+        gives each dimension its own. None, the default, is the window
+        length. A longer FFT zero pads each window, which samples the same
+        spectrum at more, closer frequencies; it adds no resolution, since
+        the window holds no more data. Must be at least the window length.
     **kwargs
-        Used to specify window length in data units, percent, or samples.
+        The dimensions to window and the window along each, in coordinate
+        units or, with `samples`, in samples. More than one dimension gives
+        each window's spectrum over all of them: ``distance=32, time=64``
+        is a local frequency-wavenumber spectrum.
 
     Examples
     --------
@@ -632,6 +635,9 @@ def stft(
     >>>
     >>> # Zero pad each 1000 sample window to a 4096 point FFT.
     >>> pa3 = patch.stft(time=1000, samples=True, nfft=4096)
+    >>>
+    >>> # Local f-k spectra: windows of 32 channels by 64 samples.
+    >>> fk = dc.get_example_patch().stft(distance=32, time=64, samples=True)
 
     Notes
     -----
@@ -642,11 +648,15 @@ def stft(
     - An array passed for taper_window must have as many samples as the
       window; one of another length is refused. To zero pad each window's
       FFT, give `nfft`.
+    - Real data is transformed one-sided along the last windowed dimension
+      and centred along the others, as [Patch.dft](`dascore.Patch.dft`) with
+      ``real=True`` is; complex data is centred along every one.
     - The output is a stack of windows as
       [Patch.tile_apply](`dascore.Patch.tile_apply`) makes one, transformed
       along the window: the transformed dimension becomes the window
       centres, ``{dim}_start`` and ``{dim}_stop`` say where each window came
-      from in samples, and the coordinates the stack carries for
+      from in samples, the frequencies sit where the dimension was and the
+      centres come last, and the coordinates the stack carries for
       [Patch.reassemble](`dascore.Patch.reassemble`) are what
       [Patch.istft](`dascore.Patch.istft`) blends the windows back with.
       Non-dimensional coordinates along the transformed dimension travel with
@@ -659,59 +669,75 @@ def stft(
     from dascore.proc.tile_apply import TileApply  # noqa: PLC0415
 
     resolved = resolve_window(
-        patch,
-        kwargs,
-        samples=samples,
-        overlap=overlap,
-        allow_multiple=False,
-        enforce_lt_coord=True,
+        patch, kwargs, samples=samples, overlap=overlap, enforce_lt_coord=True
     )
-    dim, axis, size = resolved.dims[0], resolved.axes[0], resolved.size[0]
-    coord = patch.get_coord(dim)
+    dims, axes, sizes = resolved.dims, resolved.axes, resolved.size
+    ndim = len(dims)
+    coords = [patch.get_coord(dim) for dim in dims]
     # No overlap given means none: the windows abut.
-    hop = size if resolved.stride is None else resolved.stride[0]
-    window = get_window(taper_window, size)
-    nfft = _resolve_nfft(nfft, coord, size)
-    fft_mode = "onesided" if np.isrealobj(patch.data) else "centered"
+    hops = sizes if resolved.stride is None else resolved.stride
+    nffts = tuple(
+        _resolve_nfft(nfft.get(dim) if isinstance(nfft, Mapping) else nfft, coord, size)
+        for dim, coord, size in zip(dims, coords, sizes)
+    )
+    real = np.isrealobj(patch.data)
     # A detrended window is tapered after the trend is removed, so the
     # stack is cut bare and the taper goes on here; an invertible one is
     # cut under the taper, which the stack then carries for istft.
     settings: dict[str, Any] = {
         "function": _as_is,
         "mode": "stack",
-        "analysis": None if detrend else window,
-        "overlap": size - hop,
+        "analysis": None if detrend else taper_window,
+        "overlap": {d: z - h for d, z, h in zip(dims, sizes, hops)},
         "samples": True,
-        dim: size,
+        **dict(zip(dims, sizes)),
     }
     stack = TileApply(**settings)._apply(patch)
     tiles = stack.data
+    tail = tuple(range(-ndim, 0))
     if detrend:
-        tiles = sp_detrend(tiles, axis=-1, type="linear") * window
-    step = to_float(coord.step)
-    if fft_mode == "onesided":
-        spectra = nft.rfft(tiles, n=nfft, axis=-1)
-        freqs = nft.rfftfreq(nfft, d=step)
-    else:
-        spectra = nft.fftshift(nft.fft(tiles, n=nfft, axis=-1), axes=-1)
-        freqs = nft.fftshift(nft.fftfreq(nfft, d=step))
+        for axis in tail:
+            tiles = sp_detrend(tiles, axis=axis, type="linear")
+        tiles = tiles * get_window_nd(taper_window, sizes)
+    steps = [to_float(coord.step) for coord in coords]
+    # Real data is transformed one-sided along the last windowed dimension
+    # and centred along the others, as dft does; complex data centred along
+    # every one.
+    fft = nft.rfftn if real else nft.fftn
+    spectra = fft(tiles, s=nffts, axes=tail)
+    centred = tail[:-1] if real else tail
+    if centred:
+        spectra = nft.fftshift(spectra, axes=centred)
+    freqs = [nft.fftshift(nft.fftfreq(n, d=step)) for n, step in zip(nffts, steps)]
+    if real:
+        freqs[-1] = nft.rfftfreq(nffts[-1], d=steps[-1])
     # One pass: the phase and, for compatibility with dft, the scale by step.
-    spectra *= _centre_phase(freqs * step, size) * spectra.dtype.type(step)
-    ft_dim = FourierTransformatter().rename_dims(patch.dims, index=axis)[axis]
-    new_dims = (*patch.dims[:axis], ft_dim, *patch.dims[axis + 1 :], dim)
+    factor = np.prod(steps).astype(spectra.dtype)
+    for axis, cycles, size, step in zip(tail, freqs, sizes, steps):
+        shape = [1] * ndim
+        shape[axis] = -1
+        factor = factor * _centre_phase(cycles * step, size).reshape(shape)
+    spectra *= factor
+    ft_dims = FourierTransformatter().rename_dims(dims)
+    new_dims = (
+        *(ft_dims[dims.index(d)] if d in dims else d for d in patch.dims),
+        *dims,
+    )
     coord_map = stack.coords.get_coord_tuple_map()
-    coord_map.pop(f"{dim}_offset")
-    freq_coord = get_coord(data=freqs, units=invert_quantity(coord.units))
-    coord_map[ft_dim] = ((ft_dim,), freq_coord)
+    for dim, ft_dim, values, coord in zip(dims, ft_dims, freqs, coords):
+        coord_map.pop(f"{dim}_offset")
+        freq_coord = get_coord(data=values, units=invert_quantity(coord.units))
+        coord_map[ft_dim] = ((ft_dim,), freq_coord)
     cm = get_coord_manager(coords=coord_map, dims=new_dims)
     attrs = stack.attrs.update(
         _stft_detrended=detrend,
-        _stft_fft_mode=fft_mode,
-        _stft_mfft=nfft,
+        _stft_real=dims[-1] if real else None,
         _pre_stft_data_type=patch.attrs.get("data_type"),
-        data_units=_get_data_units_from_dims(patch, dim, mul),
+        data_units=_get_data_units_from_dims(patch, dims, mul),
+        **{f"_stft_mfft_{dim}": n for dim, n in zip(dims, nffts)},
     )
-    return patch.new(data=_swap_window_axes(spectra, axis), coords=cm, attrs=attrs)
+    data = _swap_window_axes(spectra, axes)
+    return patch.new(data=data, coords=cm, attrs=attrs)
 
 
 @patch_function()
@@ -753,48 +779,65 @@ def istft(patch) -> dc.Patch:
 
     coord_map = patch.coords.get_coord_tuple_map()
     dims = [d for d in patch.dims if f"_tile_source_{d}" in coord_map]
-    if len(dims) != 1 or "_stft_mfft" not in dict(patch.attrs):
+    if not dims or "_stft_real" not in dict(patch.attrs):
         msg = (
             "Inverse short time fourier transform requires a patch that has"
             " undergone stft but this patch is missing required attrs. "
         )
         raise PatchError(msg)
-    if patch.attrs["_stft_detrended"] or f"_tile_analysis_{dims[0]}" not in coord_map:
+    windows = [f"_tile_analysis_{dim}" for dim in dims]
+    if patch.attrs["_stft_detrended"] or any(w not in coord_map for w in windows):
         msg = f"Inverse stft not possible for patch {patch}."
         raise PatchError(msg)
-    dim = dims[0]
-    ft_dim = FourierTransformatter().rename_dims([dim])[0]
-    axis = patch.get_axis(ft_dim)
-    source = coord_map[f"_tile_source_{dim}"][1]
-    size = len(coord_map[f"_tile_analysis_{dim}"][1])
-    nfft = int(patch.attrs["_stft_mfft"])
-    step = to_float(source.step)
-    cycles = patch.get_coord(ft_dim).values * step
-    spectra = _swap_window_axes(patch.data, axis)
-    spectra = spectra / (_centre_phase(cycles, size) * step)
-    if patch.attrs["_stft_fft_mode"] == "onesided":
-        tiles = nft.irfft(spectra, n=nfft, axis=-1)
-    else:
-        tiles = nft.ifft(nft.ifftshift(spectra, axes=-1), n=nfft, axis=-1)
+    # The dimension transformed one-sided, if any, is last, as it was cut.
+    real = patch.attrs["_stft_real"]
+    dims = [d for d in dims if d != real] + ([real] if real else [])
+    windows = [f"_tile_analysis_{dim}" for dim in dims]
+    ndim = len(dims)
+    ft_dims = FourierTransformatter().rename_dims(dims)
+    sizes = [len(coord_map[name][1]) for name in windows]
+    nffts = [int(patch.attrs[f"_stft_mfft_{dim}"]) for dim in dims]
+    steps = [to_float(coord_map[f"_tile_source_{dim}"][1].step) for dim in dims]
+    # The window centres go last, then the frequencies swap with them, so
+    # the windows' samples are the last axes whatever order the patch is in.
+    tail = tuple(range(-ndim, 0))
+    centres = tuple(patch.get_axis(dim) for dim in dims)
+    base_dims = [d for d in patch.dims if d not in dims]
+    axes = tuple(base_dims.index(ft_dim) for ft_dim in ft_dims)
+    spectra = _swap_window_axes(np.moveaxis(patch.data, centres, tail), axes)
+    factor = np.prod(steps).astype(spectra.dtype)
+    for axis, ft_dim, size, step in zip(tail, ft_dims, sizes, steps):
+        shape = [1] * ndim
+        shape[axis] = -1
+        cycles = patch.get_coord(ft_dim).values * step
+        factor = factor * _centre_phase(cycles, size).reshape(shape)
+    spectra = spectra / factor
+    centred = tail[:-1] if real else tail
+    if centred:
+        spectra = nft.ifftshift(spectra, axes=centred)
+    ifft = nft.irfftn if real else nft.ifftn
+    tiles = ifft(spectra, s=nffts, axes=tail)
     # The FFT was zero padded past the window; the window is its first samples.
-    tiles = tiles[..., :size]
-    offset = f"{dim}_offset"
-    # The frequency axis does not survive, nor does anything riding on it.
+    tiles = tiles[(..., *(slice(0, size) for size in sizes))]
+    offsets = [f"{dim}_offset" for dim in dims]
+    # The frequency axes do not survive, nor does anything riding on them.
     for name, cdims in patch.coords.dim_map.items():
-        if ft_dim in cdims:
+        if set(cdims) & set(ft_dims):
             coord_map.pop(name)
-    coord_map[offset] = ((offset,), get_coord(data=np.arange(size)))
-    others = [d for d in patch.dims[axis + 1 :] if d != dim]
-    stack_dims = (*patch.dims[:axis], dim, *others, offset)
-    attrs = {k: v for k, v in dict(patch.attrs).items() if not k.startswith("_stft")}
+    for offset, size in zip(offsets, sizes):
+        coord_map[offset] = ((offset,), get_coord(data=np.arange(size)))
+    renamed = (dims[ft_dims.index(d)] if d in ft_dims else d for d in base_dims)
+    stack_dims = (*renamed, *offsets)
+    data_type = patch.attrs.get("_pre_stft_data_type")
+    private = ("_stft", "_pre_stft")
+    attrs = {k: v for k, v in dict(patch.attrs).items() if not k.startswith(private)}
     stack = patch.new(
         data=tiles,
         coords=get_coord_manager(coords=coord_map, dims=stack_dims),
         attrs=dc.PatchAttrs(**attrs),
     )
     out = reassemble.func(stack)
-    new_attrs = dict(out.attrs)
-    if "_pre_stft_data_type" in new_attrs:
-        new_attrs["data_type"] = new_attrs.pop("_pre_stft_data_type")
-    new_attrs["data_units"] = _get_data_units_from_dims(patch, dim, truediv)
-    return out.update_attrs(**new_attrs)
+    return out.update_attrs(
+        data_type=data_type or "",
+        data_units=_get_data_units_from_dims(patch, dims, truediv),
+    )

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -683,7 +683,9 @@ def stft(
     strides = resolved.stride
     hops = sizes if strides is None else tuple(strides[i] for i in order)
     if isinstance(nfft, Mapping) and (extra := set(nfft) - set(dims)):
-        msg = f"nfft names dimensions which are not windowed: {sorted(extra)}."
+        msg = (
+            f"nfft names dimensions which are not windowed: {sorted(map(str, extra))}."
+        )
         raise ParameterError(msg)
     nffts = tuple(
         _resolve_nfft(nfft.get(dim) if isinstance(nfft, Mapping) else nfft, coord, size)

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -571,7 +571,7 @@ def _swap_window_axes(data: np.ndarray, axes: tuple[int, ...]) -> np.ndarray:
     return np.moveaxis(data, (*axes, *tail), (*tail, *axes))
 
 
-@patch_function(data_type="fourier_transform")
+@patch_function(data_type="fourier_transform", version="2.0")
 def stft(
     patch: PatchType,
     taper_window: str | ndarray | tuple[str | Any, ...] = "hann",
@@ -682,6 +682,9 @@ def stft(
     # No overlap given means none: the windows abut.
     strides = resolved.stride
     hops = sizes if strides is None else tuple(strides[i] for i in order)
+    if isinstance(nfft, Mapping) and (extra := set(nfft) - set(dims)):
+        msg = f"nfft names dimensions which are not windowed: {sorted(extra)}."
+        raise ParameterError(msg)
     nffts = tuple(
         _resolve_nfft(nfft.get(dim) if isinstance(nfft, Mapping) else nfft, coord, size)
         for dim, coord, size in zip(dims, coords, sizes)
@@ -746,7 +749,7 @@ def stft(
     return patch.new(data=data, coords=cm, attrs=attrs)
 
 
-@patch_function()
+@patch_function(version="2.0")
 def istft(patch) -> dc.Patch:
     """
     Invert a short-time fourier transform.

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -671,11 +671,17 @@ def stft(
     resolved = resolve_window(
         patch, kwargs, samples=samples, overlap=overlap, enforce_lt_coord=True
     )
-    dims, axes, sizes = resolved.dims, resolved.axes, resolved.size
+    # In the patch's axis order, whatever order they were named in: the
+    # stack's window axes come out in that order.
+    order = np.argsort(resolved.axes)
+    dims = tuple(resolved.dims[i] for i in order)
+    axes = tuple(resolved.axes[i] for i in order)
+    sizes = tuple(resolved.size[i] for i in order)
     ndim = len(dims)
     coords = [patch.get_coord(dim) for dim in dims]
     # No overlap given means none: the windows abut.
-    hops = sizes if resolved.stride is None else resolved.stride
+    strides = resolved.stride
+    hops = sizes if strides is None else tuple(strides[i] for i in order)
     nffts = tuple(
         _resolve_nfft(nfft.get(dim) if isinstance(nfft, Mapping) else nfft, coord, size)
         for dim, coord, size in zip(dims, coords, sizes)

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -765,6 +765,11 @@ class TestSTFTManyDims:
         assert out.attrs["_stft_mfft_distance"] == 64
         assert out.istft().equals(plane_wave, close=True)
 
+    def test_nfft_for_an_unwindowed_dimension_refused(self, plane_wave):
+        """A misspelt or unwindowed dimension in the mapping is not ignored."""
+        with pytest.raises(ParameterError, match="not windowed"):
+            plane_wave.stft(distance=32, time=64, samples=True, nfft={"tiem": 128})
+
     def test_window_per_dimension(self, plane_wave):
         """A list gives each dimension its own taper, in dimension order."""
         out = plane_wave.stft(

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -749,6 +749,13 @@ class TestSTFTManyDims:
         back = shuffled.istft()
         assert back.equals(plane_wave.transpose("time", "distance"), close=True)
 
+    def test_argument_order_does_not_matter(self, plane_wave):
+        """Dimensions are windowed in the patch's order however they are named."""
+        by_axis = plane_wave.stft(distance=32, time=64, samples=True)
+        by_name = plane_wave.stft(time=64, distance=32, samples=True)
+        assert by_name.equals(by_axis)
+        assert by_name.istft().equals(plane_wave, close=True)
+
     def test_nfft_per_dimension(self, plane_wave):
         """A mapping gives each dimension its own FFT length."""
         out = plane_wave.stft(

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -690,16 +690,7 @@ class TestSTFTManyDims:
     @pytest.fixture(scope="class")
     def plane_wave(self):
         """A plane wave of 20 Hz moving at 500 m/s: one (f, k) in every window."""
-        distance = np.arange(128, dtype=float) * 4.0
-        time = np.arange(1024, dtype=float) * 0.002
-        freq, velocity = 20.0, 500.0
-        data = np.cos(2 * np.pi * freq * (time[None, :] - distance[:, None] / velocity))
-        patch = dc.Patch(
-            data=data.astype(np.float32),
-            coords={"distance": distance, "time": time},
-            dims=("distance", "time"),
-        )
-        return patch.set_units(distance="m", time="s")
+        return dc.get_example_patch("plane_wave")
 
     def test_dims_and_coords(self, plane_wave):
         """Frequencies where the dimensions were, then the window centres."""

--- a/tests/test_transform/test_fourier.py
+++ b/tests/test_transform/test_fourier.py
@@ -620,26 +620,26 @@ class TestSTFT:
         # The window and hop are untouched; only the FFT of each window grew.
         assert padded.attrs["_tile_stride_time"] == plain.attrs["_tile_stride_time"]
         assert padded.get_coord("time") == plain.get_coord("time")
-        assert padded.attrs["_stft_mfft"] == 256
+        assert padded.attrs["_stft_mfft_time"] == 256
 
     def test_nfft_default_is_the_window(self, random_patch):
         """None means the window length, which is what stft always did."""
         plain = random_patch.stft(time=100, samples=True)
         explicit = random_patch.stft(time=100, samples=True, nfft=None)
-        assert plain.attrs["_stft_mfft"] == 100
+        assert plain.attrs["_stft_mfft_time"] == 100
         assert explicit.equals(plain)
 
     def test_nfft_in_units(self, random_patch):
         """A quantity is read through the coordinate, whatever samples says."""
         by_count = random_patch.stft(time=100, samples=True, nfft=256)
         by_units = random_patch.stft(time=100, samples=True, nfft=1.024 * second)
-        assert by_units.attrs["_stft_mfft"] == 256
+        assert by_units.attrs["_stft_mfft_time"] == 256
         assert by_units.equals(by_count)
 
     def test_nfft_as_a_timedelta(self, random_patch):
         """A native duration is read through the coordinate like a quantity."""
         out = random_patch.stft(time=100, samples=True, nfft=np.timedelta64(1024, "ms"))
-        assert out.attrs["_stft_mfft"] == 256
+        assert out.attrs["_stft_mfft_time"] == 256
 
     def test_fractional_nfft_refused(self, random_patch):
         """256.9 points is not an FFT length; it is not rounded quietly."""
@@ -666,7 +666,7 @@ class TestSTFT:
         freqs = out.get_coord("ft_time").values
         assert len(freqs) == 16
         assert freqs[0] < 0 < freqs[-1]
-        assert out.attrs["_stft_fft_mode"] == "centered"
+        assert out.attrs["_stft_real"] is None
         back = out.istft()
         assert back.equals(patch, close=True)
 
@@ -682,6 +682,100 @@ class TestSTFT:
         out = patch.stft(time=0.1)
         assert "aux_time" not in out.coords.coord_map
         assert "aux_dist" in out.coords.coord_map
+
+
+class TestSTFTManyDims:
+    """A short-time transform over more than one dimension: local f-k spectra."""
+
+    @pytest.fixture(scope="class")
+    def plane_wave(self):
+        """A plane wave of 20 Hz moving at 500 m/s: one (f, k) in every window."""
+        distance = np.arange(128, dtype=float) * 4.0
+        time = np.arange(1024, dtype=float) * 0.002
+        freq, velocity = 20.0, 500.0
+        data = np.cos(2 * np.pi * freq * (time[None, :] - distance[:, None] / velocity))
+        patch = dc.Patch(
+            data=data.astype(np.float32),
+            coords={"distance": distance, "time": time},
+            dims=("distance", "time"),
+        )
+        return patch.set_units(distance="m", time="s")
+
+    def test_dims_and_coords(self, plane_wave):
+        """Frequencies where the dimensions were, then the window centres."""
+        out = plane_wave.stft(distance=32, time=64, samples=True)
+        assert out.dims == ("ft_distance", "ft_time", "distance", "time")
+        # Real data: one-sided along the last windowed dimension, centred
+        # along the others, as dft does.
+        ft_time = out.get_coord("ft_time").values
+        ft_distance = out.get_coord("ft_distance").values
+        assert ft_time[0] == 0 and len(ft_time) == 33
+        assert ft_distance[0] < 0 < ft_distance[-1] and len(ft_distance) == 32
+        assert dc.get_quantity(out.get_coord("ft_distance").units) == dc.get_quantity(
+            "1/m"
+        )
+
+    def test_plane_wave_peaks_at_its_frequency_and_wavenumber(self, plane_wave):
+        """Every window's spectrum peaks at (20 Hz, 20 / 500 cycles per metre)."""
+        out = plane_wave.stft(distance=32, time=64, samples=True)
+        power = np.abs(out.data)
+        # The peak of every window, as an (ft_distance, ft_time) index.
+        peaks = np.array(
+            [
+                np.unravel_index(np.argmax(power[:, :, i, j]), power.shape[:2])
+                for i in range(power.shape[2])
+                for j in range(power.shape[3])
+            ]
+        )
+        ft_distance = out.get_coord("ft_distance").values
+        ft_time = out.get_coord("ft_time").values
+        expected_k, expected_f = -20 / 500, 20.0
+        assert np.allclose(ft_time[peaks[:, 1]], expected_f, atol=ft_time[1])
+        assert np.allclose(
+            ft_distance[peaks[:, 0]], expected_k, atol=ft_distance[1] - ft_distance[0]
+        )
+
+    def test_round_trip(self, plane_wave):
+        """The inverse runs along every dimension and restores the coordinates."""
+        out = plane_wave.stft(distance=32, time=64, samples=True)
+        back = out.istft()
+        assert back.equals(plane_wave, close=True)
+        assert not any(k.startswith("_") for k in dict(back.attrs))
+
+    def test_round_trip_transposed(self, plane_wave):
+        """The inverse finds its axes by name, whatever order they are in."""
+        out = plane_wave.stft(distance=32, time=64, samples=True)
+        shuffled = out.transpose("time", "ft_time", "distance", "ft_distance")
+        back = shuffled.istft()
+        assert back.equals(plane_wave.transpose("time", "distance"), close=True)
+
+    def test_nfft_per_dimension(self, plane_wave):
+        """A mapping gives each dimension its own FFT length."""
+        out = plane_wave.stft(
+            distance=32, time=64, samples=True, nfft={"distance": 64, "time": 64}
+        )
+        assert len(out.get_coord("ft_distance")) == 64
+        assert out.attrs["_stft_mfft_distance"] == 64
+        assert out.istft().equals(plane_wave, close=True)
+
+    def test_window_per_dimension(self, plane_wave):
+        """A list gives each dimension its own taper, in dimension order."""
+        out = plane_wave.stft(
+            distance=32, time=64, samples=True, taper_window=["boxcar", "hann"]
+        )
+        assert np.all(out.get_coord("_tile_analysis_distance").values == 1)
+        assert out.istft().equals(plane_wave, close=True)
+
+    def test_detrend_and_complex(self, plane_wave):
+        """Detrending runs along each dimension; complex data is centred on all."""
+        detrended = plane_wave.stft(distance=32, time=64, samples=True, detrend=True)
+        assert (
+            detrended.shape == plane_wave.stft(distance=32, time=64, samples=True).shape
+        )
+        complex_patch = plane_wave.new(data=plane_wave.data * (1 + 1j))
+        out = complex_patch.stft(distance=32, time=64, samples=True)
+        assert len(out.get_coord("ft_time")) == 64
+        assert out.istft().equals(complex_patch, close=True)
 
 
 class TestInverseSTFT:


### PR DESCRIPTION
## Description

PR 5 of the windowing plan (top-level `.scratch/windowing-unification-plan.md`), the optional one: `stft` over more than one dimension.

With `stft` built on the tile stack (#1088), transforming each window along every windowed dimension is the same code with `allow_multiple` on: `patch.stft(distance=32, time=64, samples=True)` is a local frequency-wavenumber spectrum, one per window, with `ft_distance` and `ft_time` where the dimensions were and the window centres last. Real data is transformed one-sided along the last windowed dimension and centred along the others, as `dft` with `real=True` is; complex data is centred along every one. `taper_window` takes a list with one window per dimension and `nfft` a mapping with one length per dimension. `istft` inverts along every dimension and finds its axes by name, so a transposed stft still comes back.

The one-dimensional path is the same code and its outputs are unchanged: the nine stft/istft and three spectrogram calls pinned for #1088 agree as they did (≤ 1e-8 where the grid matches scipy's), and 500 × 60000 times 547/560 ms against 530/540 before. Two things found on the way and fixed: `istft` left `_pre_stft_data_type` in the output's attrs (`update_attrs` does not drop a key), and a `fftshift` over no axes copies the whole array, so it is skipped.

The test is a plane wave at 20 Hz and 500 m/s: every window's spectrum peaks at (20 Hz, −0.04 cycles per metre), and it round-trips through `istft`, transposed too.

### Codex review

One P1, fixed: `resolve_window` keeps the keyword order while the stack sorts its dimensions into the patch's axis order, so `stft(time=16, distance=8)` labelled the axes the wrong way round and its inverse was wrong by 1.3 on unit data. `stft` now orders its dimensions by axis first; a test pins that the two spellings are equal and both invert. Codex checked and found no fault with the frequency conventions (8e-17 from numpy's), the per-axis phase and padding (1.5e-7 real, 2.1e-7 complex against direct numpy), the padded inverse crop, arbitrary transposition, a third un-windowed dimension, datetime coordinates, multi-axis data units, and sequential detrending (7e-14).

The GitHub review added two: an `nfft` mapping naming a dimension that is not windowed is refused rather than ignored, and `stft` and `istft` are at version 2.0, since their attrs and, at overlaps other than half, their window positions differ from 1.0's (the #1088 change and this one together), so an operation fingerprint tells the two apart.

## Changelog

- added: `Patch.stft` over more than one dimension, giving each window's spectrum over all of them (local f-k spectra); `taper_window` may be a list and `nfft` a mapping, one per dimension; `Patch.istft` inverts along every dimension.
- added: the `plane_wave` example patch, one frequency crossing the array at one apparent velocity, with the frequency, velocity, and geometry as parameters.
- changed: `Patch.stft` and `Patch.istft` are at operation version 2.0; `Patch.stft` records which dimension was transformed one-sided as `_stft_real`, and each dimension's FFT length as `_stft_mfft_{dim}`; `Patch.istft` no longer leaves `_pre_stft_data_type` behind.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable plane-wave example with distance and time coordinates, physical units, and adjustable signal parameters.
  - Enhanced short-time Fourier transforms to analyze multiple dimensions simultaneously, including distance and time.
  - Added per-dimension FFT lengths and windowing options.
- **Bug Fixes**
  - Improved inverse transforms for accurate reconstruction of multidimensional signals.
  - Improved handling of real-valued and complex multidimensional spectral data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->