### PR TITLE
Streamline inventory documentation

### DIFF
--- a/docs/_static/inventory_hierarchy.svg
+++ b/docs/_static/inventory_hierarchy.svg
@@ -1,0 +1,845 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="873.46014"
+   height="600"
+   viewBox="0 0 873.46014 600"
+   version="1.1"
+   id="svg56"
+   sodipodi:docname="inventory_hierarchy.svg"
+   inkscape:version="1.4.4 (1:1.4.4+202605061436+dcaf3e7d9e)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.75166667"
+     inkscape:cx="667.18403"
+     inkscape:cy="343.90244"
+     inkscape:window-width="1854"
+     inkscape:window-height="1011"
+     inkscape:window-x="66"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer-icons" />
+  <title
+     id="title1">Inventory hierarchy: SEED codes and DFOS codes</title>
+  <!--
+    Layout: one shared Network root, two parallel branches at identical row heights.
+    Seismic branch (blue #1f4e79 / #e3ecf6), fiber branch (rust #9a4a14 / #f7ece2),
+    shared root and structure lines in neutral grey (#555555).
+    Box = 240 x 108; icon cell = 64 x 40 at the top-left of each box.
+  -->
+  <defs
+     id="defs1">
+    <marker
+       id="arrow"
+       viewBox="0 0 10 10"
+       refX="9"
+       refY="5"
+       markerWidth="7"
+       markerHeight="7"
+       orient="auto-start-reverse">
+      <path
+         d="M 0,0 10,5 0,10 Z"
+         style="fill:#555555;stroke:none"
+         id="path1" />
+    </marker>
+    <pattern
+       id="hatch-blue"
+       patternUnits="userSpaceOnUse"
+       width="4"
+       height="4"
+       patternTransform="rotate(45)">
+      <path
+         d="M 0,0 V 4"
+         style="stroke:#1f4e79;stroke-width:0.8;opacity:0.55"
+         id="path2" />
+    </pattern>
+    <pattern
+       id="hatch-rust"
+       patternUnits="userSpaceOnUse"
+       width="4"
+       height="4"
+       patternTransform="rotate(45)">
+      <path
+         d="M 0,0 V 4"
+         style="stroke:#9a4a14;stroke-width:0.8;opacity:0.55"
+         id="path3" />
+    </pattern>
+  </defs>
+  <!-- ===================== background ===================== -->
+  <!-- ===================== titles (on the Network row) ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-40.687927,-18.303204)"
+     inkscape:label="titles"
+     id="layer-titles">
+    <text
+       x="218.58395"
+       y="186.57831"
+       style="font-weight:bold;font-size:20px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#1f4e79"
+       id="text1">Points</text>
+    <text
+       x="711.9101"
+       y="186.57831"
+       style="font-weight:bold;font-size:20px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#9a4a14"
+       id="text3">Fiber</text>
+    <text
+       x="462.577"
+       y="32.583179"
+       style="font-weight:bold;font-size:20px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#606060;fill-opacity:1"
+       id="text3-7">Inventory</text>
+  </g>
+  <!-- ===================== node boxes ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-40.687927,-18.303204)"
+     inkscape:label="nodes"
+     id="layer-nodes">
+    <g
+       id="node-network-0"
+       transform="matrix(0.59546922,0,0,0.62794221,-52.300615,31.450944)"
+       style="stroke-width:1.63535">
+      <rect
+         x="355"
+         y="40"
+         width="240"
+         height="108"
+         rx="4"
+         ry="4"
+         style="fill:#ffffff;stroke:#555555;stroke-width:2.45302"
+         id="rect4-9" />
+    </g>
+    <!-- shared root -->
+    <text
+       x="187.09528"
+       y="82.92662"
+       style="font-weight:bold;font-size:17px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#333333"
+       id="text5-8">Resources</text>
+    <!-- seismic branch -->
+    <rect
+       x="189.73392"
+       y="198.0238"
+       width="240"
+       height="108"
+       rx="4"
+       ry="4"
+       style="fill:#e3ecf6;stroke:#1f4e79;stroke-width:1.5"
+       id="rect6" />
+    <text
+       x="205.73392"
+       y="278.0238"
+       style="font-weight:bold;font-size:17px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#1f4e79"
+       id="text7">Station</text>
+    <text
+       x="413.73392"
+       y="278.0238"
+       style="font-size:18px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#1f4e79"
+       id="text8">S01</text>
+    <text
+       x="205.73392"
+       y="296.0238"
+       style="font-size:13px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+       id="desc-station">a site with point sensors</text>
+    <text
+       x="176.98079"
+       y="106.45135"
+       style="font-size:13px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+       id="desc-station-2">shareable objects</text>
+    <g
+       id="g64"
+       transform="translate(950.06009,67.320943)">
+      <g
+         id="node-network-0-3"
+         transform="matrix(0.59546922,0,0,0.62794221,-537.66122,-32.347511)"
+         style="stroke-width:1.63535">
+        <rect
+           x="355"
+           y="40"
+           width="240"
+           height="108"
+           rx="4"
+           ry="4"
+           style="fill:#ffffff;stroke:#555555;stroke-width:2.45302"
+           id="rect4-9-7" />
+      </g>
+      <text
+         x="-270.67435"
+         y="19.128166"
+         style="font-weight:bold;font-size:17px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#333333"
+         id="text5-8-5">CRS</text>
+      <text
+         x="-321.08081"
+         y="42.652893"
+         style="font-size:13px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+         id="desc-station-2-9">Coordinate Reference</text>
+    </g>
+    <g
+       id="node-location"
+       transform="translate(119.73392,-7.9762)">
+      <rect
+         x="70"
+         y="342"
+         width="240"
+         height="108"
+         rx="4"
+         ry="4"
+         style="fill:#e3ecf6;stroke:#1f4e79;stroke-width:1.5"
+         id="rect8" />
+      <text
+         x="86"
+         y="422"
+         style="font-weight:bold;font-size:17px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#1f4e79"
+         id="text9">Location</text>
+      <text
+         x="294"
+         y="422"
+         style="font-size:18px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#1f4e79"
+         id="text10">00</text>
+      <text
+         x="86"
+         y="440"
+         style="font-size:13px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+         id="desc-location">groups channels of one sensor</text>
+    </g>
+    <g
+       id="node-channel"
+       transform="translate(119.73392,-7.9762)">
+      <rect
+         x="70"
+         y="478"
+         width="240"
+         height="108"
+         rx="4"
+         ry="4"
+         style="fill:#e3ecf6;stroke:#1f4e79;stroke-width:1.5"
+         id="rect10" />
+      <text
+         x="86"
+         y="558"
+         style="font-weight:bold;font-size:17px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#1f4e79"
+         id="text11">Channel</text>
+      <text
+         x="294"
+         y="558"
+         style="font-size:18px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#1f4e79"
+         id="text12">HHZ</text>
+      <text
+         x="86"
+         y="576"
+         style="font-size:13px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+         id="desc-channel">one sensor stream</text>
+    </g>
+    <!-- fiber branch -->
+    <g
+       id="node-fiber-array"
+       transform="translate(-143.93991,-7.9762)">
+      <rect
+         x="640"
+         y="206"
+         width="240"
+         height="108"
+         rx="4"
+         ry="4"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:1.5"
+         id="rect12" />
+      <text
+         x="656"
+         y="286"
+         style="font-weight:bold;font-size:17px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#9a4a14"
+         id="text13">Fiber array</text>
+      <text
+         x="656"
+         y="304"
+         style="font-size:13px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+         id="text14">a site made of fibers</text>
+      <text
+         x="864"
+         y="286"
+         style="font-size:18px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#9a4a14"
+         id="text15">L01</text>
+    </g>
+    <g
+       id="node-optical-path"
+       transform="translate(-143.93991,-7.9762)">
+      <rect
+         x="640"
+         y="342"
+         width="240"
+         height="108"
+         rx="4"
+         ry="4"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:1.5"
+         id="rect15" />
+      <text
+         x="656"
+         y="422"
+         style="font-weight:bold;font-size:17px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#9a4a14"
+         id="text16">Optical path</text>
+      <text
+         x="656"
+         y="440"
+         style="font-size:13px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+         id="text17">one path through the array</text>
+      <text
+         x="864"
+         y="422"
+         style="font-size:18px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#9a4a14"
+         id="text18">04</text>
+    </g>
+    <g
+       id="node-acquisition"
+       transform="translate(-143.93991,-7.9762)">
+      <rect
+         x="640"
+         y="478"
+         width="240"
+         height="108"
+         rx="4"
+         ry="4"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:1.5"
+         id="rect18" />
+      <text
+         x="656"
+         y="558"
+         style="font-weight:bold;font-size:17px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#9a4a14"
+         id="text19">Acquisition</text>
+      <text
+         x="656"
+         y="576"
+         style="font-size:13px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+         id="text20">one interrogator stream</text>
+      <text
+         x="864"
+         y="558"
+         style="font-size:18px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#9a4a14"
+         id="text21">FSF</text>
+    </g>
+  </g>
+  <!-- ===================== concept icons ===================== -->
+  <!-- each icon lives in a 64 x 40 cell at (box.x + 16, box.y + 12); ink kept within x 10..54, y 6..34 -->
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-40.687927,-18.303204)"
+     inkscape:label="icons"
+     id="layer-icons">
+    <!-- network: several stations, joined -->
+    <g
+       id="g9"
+       transform="translate(-12.102997)">
+      <rect
+         x="355"
+         y="40"
+         width="240"
+         height="108"
+         rx="4"
+         ry="4"
+         style="fill:#ffffff;stroke:#555555;stroke-width:1.5"
+         id="rect4" />
+      <text
+         x="376.9455"
+         y="120.69434"
+         style="font-weight:bold;font-size:17px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#333333"
+         id="text5">Network</text>
+      <text
+         x="572.24756"
+         y="120.86432"
+         style="font-size:18px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#333333"
+         id="text6">XM</text>
+      <g
+         id="icon-network"
+         transform="translate(376.94551,52.694336)"
+         style="fill:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round">
+        <path
+           d="m 2,10 c 12,0 16,20 28,20 12,0 12,-16 20,-16 8,0 10,4 12,4"
+           style="fill:none;stroke:#9a4a14;stroke-width:1.75"
+           id="icon-network-fiber" />
+        <path
+           d="m 6,34 6,-10 6,10 z"
+           style="fill:#1f4e79;stroke:#1f4e79"
+           id="path22" />
+        <path
+           d="M 24,16 30,6 36,16 Z"
+           style="fill:#1f4e79;stroke:#1f4e79"
+           id="path23" />
+        <path
+           d="m 44,34 6,-10 6,10 z"
+           style="fill:#1f4e79;stroke:#1f4e79"
+           id="path24" />
+      </g>
+    </g>
+    <!-- station: the station symbol on the ground -->
+    <g
+       id="icon-station"
+       transform="translate(205.73392,210.0238)"
+       style="fill:none;stroke:#1f4e79;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round">
+      <g
+         id="station-region"
+         transform="matrix(1.1606512,0,0,1.1606512,-5.1408384,0.27343901)"
+         style="stroke-width:1.29238">
+        <path
+           d="M 32,4 C 42.5,4 49,10.5 49,21 49,31 42,38 32,38 21.5,38 15,31 15,20.5 15,10.5 22,4 32,4 Z"
+           style="fill:#1f4e79;fill-opacity:0.1;stroke:#1f4e79;stroke-width:0.689268;stroke-opacity:0.35"
+           id="path4" />
+        <path
+           d="M 32,4 C 42.5,4 49,10.5 49,21 49,31 42,38 32,38 21.5,38 15,31 15,20.5 15,10.5 22,4 32,4 Z"
+           style="fill:url(#hatch-blue);stroke:none;stroke-width:1.29238"
+           id="path5" />
+      </g>
+      <path
+         d="m 20.235179,33.765636 12.000001,-21.999999 12,21.999999 z"
+         style="fill:#1f4e79"
+         id="path26" />
+    </g>
+    <!-- location: a pin on a spot -->
+    <g
+       id="icon-location"
+       transform="translate(205.73392,355.19887)"
+       style="fill:none;stroke:#1f4e79;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round">
+      <path
+         d="m 32,32 c 0,0 -7.5,-12 -7.5,-18 a 7.5,7.5 0 1 1 15,0 c 0,6 -7.5,18 -7.5,18 z"
+         style="fill:#1f4e79"
+         id="path28" />
+      <circle
+         cx="32"
+         cy="14"
+         r="2.8"
+         style="fill:#ffffff;stroke:none"
+         id="circle28" />
+    </g>
+    <!-- channel: one trace -->
+    <g
+       id="icon-channel"
+       transform="translate(205.73392,482.0238)"
+       style="fill:none;stroke:#1f4e79;stroke-width:1.75;stroke-linecap:round;stroke-linejoin:round">
+      <path
+         d="M 10,28.7 L 15.5,28.7 L 21,18 L 26.5,38.5 L 32,17 L 37.5,36 L 43,22 L 48.5,31.5 L 54,28.7"
+         id="channel-trace" />
+      <g
+         style="fill:#1f4e79;stroke:none"
+         id="channel-samples">
+        <circle
+           cx="10"
+           cy="28.7"
+           r="1.7"
+           id="channel-sample-1" />
+        <circle
+           cx="15.5"
+           cy="28.7"
+           r="1.7"
+           id="channel-sample-2" />
+        <circle
+           cx="21"
+           cy="18"
+           r="1.7"
+           id="channel-sample-3" />
+        <circle
+           cx="26.5"
+           cy="38.5"
+           r="1.7"
+           id="channel-sample-4" />
+        <circle
+           cx="32"
+           cy="17"
+           r="1.7"
+           id="channel-sample-5" />
+        <circle
+           cx="37.5"
+           cy="36"
+           r="1.7"
+           id="channel-sample-6" />
+        <circle
+           cx="43"
+           cy="22"
+           r="1.7"
+           id="channel-sample-7" />
+        <circle
+           cx="48.5"
+           cy="31.5"
+           r="1.7"
+           id="channel-sample-8" />
+        <circle
+           cx="54"
+           cy="28.7"
+           r="1.7"
+           id="channel-sample-9" />
+      </g>
+    </g>
+    <!-- fiber array: a cable along the drift, down and back up each borehole -->
+    <g
+       id="icon-fiber-array"
+       transform="translate(512.06009,214.2238)"
+       style="fill:none;stroke:#9a4a14;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round">
+      <g
+         id="fiber-array-region">
+        <path
+           d="m 2,10 c 12,0 16,20 28,20 12,0 12,-16 20,-16 8,0 10,4 12,4"
+           style="fill:none;stroke:#9a4a14;stroke-width:15.6;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.13"
+           id="path6" />
+        <path
+           d="m 2,10 c 12,0 16,20 28,20 12,0 12,-16 20,-16 8,0 10,4 12,4"
+           style="fill:none;stroke:url(#hatch-rust);stroke-width:14;stroke-linecap:round;stroke-linejoin:round"
+           id="path7" />
+      </g>
+      <path
+         d="m 2,10 c 12,0 16,20 28,20 12,0 12,-16 20,-16 8,0 10,4 12,4"
+         style="stroke-width:1.75"
+         id="fiber-array-fiber" />
+    </g>
+    <!-- optical path: one fiber, addressed by distance from its start -->
+    <g
+       id="icon-optical-path"
+       transform="matrix(-1.4169094,0,0,-1.4409618,592.22334,402.55501)"
+       style="fill:none;stroke:#9a4a14;stroke-width:1.04977;stroke-linecap:round;stroke-linejoin:round">
+      <path
+         d="M 12,12 H 54 V 28 H 12 a 2,8 0 0 1 0,-16 z"
+         style="fill:#e2c4a6;stroke:#9a4a14;stroke-width:1.04977"
+         id="optical-path-cladding" />
+      <ellipse
+         cx="12"
+         cy="20"
+         rx="2"
+         ry="8"
+         style="fill:#e2c4a6;stroke:#9a4a14;stroke-width:1.04977"
+         id="optical-path-cladding-face" />
+      <path
+         d="m 12,17 h 42 v 6 H 12 a 0.9,3 0 0 1 0,-6 z"
+         style="fill:#ffffff;stroke:#9a4a14;stroke-width:0.769831"
+         id="optical-path-core" />
+      <ellipse
+         cx="12"
+         cy="20"
+         rx="0.89999998"
+         ry="3"
+         style="fill:#ffffff;stroke:#9a4a14;stroke-width:0.769831"
+         id="optical-path-core-face" />
+      <path
+         d="M 50,20 H 18 M 22.5,22.5 18,20 22.5,17.5"
+         style="stroke:#9a4a14;stroke-width:1.22473"
+         id="optical-path-light" />
+    </g>
+    <!-- acquisition: an interrogator sending a pulse down the fiber -->
+    <g
+       id="icon-acquisition"
+       transform="translate(512.06009,488.59899)"
+       style="fill:none;stroke:#9a4a14;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round">
+      <rect
+         x="4"
+         y="12"
+         width="16"
+         height="16"
+         rx="2"
+         ry="2"
+         style="fill:#ffffff;stroke:#9a4a14;stroke-width:1.5"
+         id="acquisition-interrogator" />
+      <rect
+         x="7"
+         y="15"
+         width="10"
+         height="5"
+         rx="1"
+         ry="1"
+         style="fill:none;stroke:#9a4a14;stroke-width:1.2"
+         id="acquisition-screen" />
+      <circle
+         cx="8.5"
+         cy="23.5"
+         r="1.1"
+         style="fill:#9a4a14;stroke:none"
+         id="acquisition-led-1" />
+      <circle
+         cx="12.5"
+         cy="23.5"
+         r="1.1"
+         style="fill:#9a4a14;stroke:none"
+         id="acquisition-led-2" />
+      <path
+         d="m 21.000017,20 h 17.355585 m -6.508344,-3 8.677792,3 -8.677792,3"
+         style="stroke:#9a4a14;stroke-width:1.75"
+         id="acquisition-arrow" />
+      <rect
+         x="42.14994"
+         y="8"
+         width="26"
+         height="24"
+         id="acquisition-waterfall-frame" />
+      <path
+         d="m 44.14994,31 q 2,-11 10,-22 m -3,22 q 2,-11 10,-22 m -3,22 q 2,-7 8,-14"
+         id="acquisition-waterfall-streaks" />
+    </g>
+  </g>
+  <!-- ===================== tree ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-40.687927,-18.303204)"
+     inkscape:label="arrows"
+     id="layer-arrows">
+    <!-- the root forks into both branches -->
+    <path
+       id="fork-seismic"
+       d="m 451.73392,148 v 20.6995 l -142,-0.40567 v 26.73662"
+       style="fill:none;stroke:#555555;stroke-width:2;marker-end:url(#arrow)"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="fork-fiber"
+       d="m 475,148 v 18.76828 l 142,0.52019 v 26.06822"
+       style="fill:none;stroke:#555555;stroke-width:2;marker-end:url(#arrow)"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="fork-fiber-3"
+       d="m 583.12735,94 h 38.53274"
+       style="fill:none;stroke:#555555;stroke-width:2;marker-end:url(#arrow)"
+       sodipodi:nodetypes="cc" />
+    <path
+       id="fork-fiber-3-1"
+       d="M 342.66666,94 H 304.13392"
+       style="fill:none;stroke:#555555;stroke-width:2;marker-end:url(#arrow)"
+       sodipodi:nodetypes="cc" />
+    <!-- within each branch -->
+    <path
+       d="m 309.73392,306.0238 v 28"
+       style="fill:none;stroke:#555555;stroke-width:1.5"
+       id="path37" />
+    <path
+       d="m 309.73392,442.0238 v 28"
+       style="fill:none;stroke:#555555;stroke-width:1.5"
+       id="path38" />
+    <path
+       d="m 616.06009,306.0238 v 28"
+       style="fill:none;stroke:#555555;stroke-width:1.5"
+       id="path39" />
+    <path
+       d="m 616.06009,442.0238 v 28"
+       style="fill:none;stroke:#555555;stroke-width:1.5"
+       id="path40" />
+  </g>
+  <!-- ===================== what the seismic levels carry ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-40.687927,-18.303204)"
+     inkscape:label="seismic-expansion"
+     id="layer-seismic-expansion">
+    <g
+       id="station-site">
+      <path
+         d="m 183.9,209 h -10 v 88 h 10"
+         style="fill:none;stroke:#1f4e79;stroke-width:1.5"
+         id="path8" />
+      <text
+         x="161.89999"
+         y="217"
+         style="font-style:italic;font-size:14px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:end;fill:#1f4e79"
+         id="text2">monitoring region</text>
+      <text
+         x="161.89999"
+         y="239"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text22">site</text>
+      <text
+         x="161.89999"
+         y="257"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text23">operator</text>
+      <text
+         x="161.89999"
+         y="274.65598"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text25">geology</text>
+    </g>
+    <g
+       id="location-position">
+      <path
+         d="m 183.9,345 h -10 v 88 h 10"
+         style="fill:none;stroke:#1f4e79;stroke-width:1.5"
+         id="path41" />
+      <text
+         x="161.89999"
+         y="353"
+         style="font-style:italic;font-size:14px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:end;fill:#1f4e79"
+         id="text41">measurement point</text>
+      <text
+         x="161.89999"
+         y="375"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text42">latitude</text>
+      <text
+         x="161.89999"
+         y="393"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text43">longitude</text>
+      <text
+         x="161.89999"
+         y="411"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text44">elevation</text>
+      <text
+         x="161.89999"
+         y="429"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text45">depth</text>
+    </g>
+    <g
+       id="channel-settings">
+      <path
+         d="m 183.9,479.5 h -10 v 88 h 10"
+         style="fill:none;stroke:#1f4e79;stroke-width:1.5"
+         id="path45" />
+      <text
+         x="161.89999"
+         y="487.5"
+         style="font-style:italic;font-size:14px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:end;fill:#1f4e79"
+         id="text46">Sensor Info</text>
+      <text
+         x="161.89999"
+         y="506.5"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text47">sensor</text>
+      <text
+         x="161.89999"
+         y="523.5"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text48">sampling(t)</text>
+      <text
+         x="161.89999"
+         y="540.73242"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="text49">response</text>
+    </g>
+  </g>
+  <!-- ===================== what the fiber levels carry ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-40.687927,-18.303204)"
+     inkscape:label="fiber-expansion"
+     id="layer-fiber-expansion">
+    <g
+       id="fiber-array-site">
+      <path
+         d="m 741.8,209 h 10 v 88 h -10"
+         style="fill:none;stroke:#9a4a14;stroke-width:1.5"
+         id="path49" />
+      <text
+         x="763.79999"
+         y="217"
+         style="font-style:italic;font-size:14px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#9a4a14"
+         id="text50">monitoring region</text>
+      <text
+         x="763.79999"
+         y="239"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text51">name</text>
+      <text
+         x="763.79999"
+         y="257"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text52">optical_paths</text>
+      <text
+         x="763.79999"
+         y="275"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text53">acquisitions</text>
+    </g>
+    <g
+       id="optical-path-tracks"
+       transform="translate(-144.18102,-7.0492038)">
+      <path
+         d="m 886,352 h 10 v 88 h -10"
+         style="fill:none;stroke:#9a4a14;stroke-width:1.5"
+         id="path46" />
+      <text
+         x="908"
+         y="360"
+         style="font-style:italic;font-size:14px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#9a4a14"
+         id="text54">measurement path</text>
+      <text
+         x="908"
+         y="382"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text55">optical_components</text>
+      <text
+         x="908"
+         y="400"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text56">geometry</text>
+      <text
+         x="908"
+         y="418"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text57">labels</text>
+      <text
+         x="908"
+         y="436"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text58">coupling</text>
+    </g>
+    <g
+       id="acquisition-settings"
+       transform="translate(-135.80829,-4.7035928)">
+      <path
+         d="m 876.44123,484.18931 h 10 v 88 h -10"
+         style="fill:none;stroke:#9a4a14;stroke-width:1.5"
+         id="path58" />
+      <text
+         x="898.44122"
+         y="492.1893"
+         style="font-style:italic;font-size:14px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#9a4a14"
+         id="text59">Sensor info</text>
+      <text
+         x="898.44122"
+         y="511.1893"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text60">interrogator</text>
+      <text
+         x="898.44122"
+         y="528.03552"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text61">sampling(t,d)</text>
+      <text
+         x="898.44122"
+         y="545.03552"
+         style="font-size:14px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#444444"
+         id="text62">distance_map</text>
+    </g>
+  </g>
+  <!-- ===================== keys ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-40.687927,-18.303204)"
+     inkscape:label="keys"
+     id="layer-keys">
+    <text
+       x="309.98099"
+       y="605.18195"
+       style="font-size:22px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#1f4e79"
+       id="text63"><tspan
+   style="fill:#333333"
+   id="tspan52">XM</tspan>.S01.00.HHZ</text>
+    <text
+       x="616.61334"
+       y="605.18195"
+       style="font-size:22px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#9a4a14"
+       id="text64"><tspan
+   style="fill:#333333"
+   id="tspan54">XM</tspan>.L01.04.FSF</text>
+  </g>
+  <metadata
+     id="metadata1">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>Inventory hierarchy: SEED codes and DFOS codes</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/docs/_static/optical_path_concept.svg
+++ b/docs/_static/optical_path_concept.svg
@@ -1,0 +1,855 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="900"
+   height="620"
+   viewBox="0 0 900 620"
+   version="1.1"
+   id="svg-optical-path-concept"
+   sodipodi:docname="optical_path_concept.svg"
+   inkscape:version="1.4.4 (1:1.4.4+202605061436+dcaf3e7d9e)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview-optical-path-concept"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:current-layer="layer-background"
+     inkscape:pagecheckerboard="0"
+     inkscape:zoom="1.0022222"
+     inkscape:cx="385.64302"
+     inkscape:cy="348.72506"
+     inkscape:window-width="1854"
+     inkscape:window-height="1011"
+     inkscape:window-x="66"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1" />
+  <title
+     id="title-optical-path-concept">What an optical path carries</title>
+  <!--
+    Conceptual companion to inventory_hierarchy.svg, which ends on an
+    Optical path node listing these four tracks. Hand-authored: it reads no
+    data and illustrates nothing real, only the SHAPE of each track. Model
+    vocabulary (optical_components, Splice, group, x/y/z) is genuine; every
+    example value is a placeholder.
+
+    Layout: spine panel 76-186, then a 2x2 card grid, cards 408 x 196 at
+    (30,196) (462,196) (30,408) (462,408). Rust family only, so the figure
+    stays in the fiber branch of the hierarchy drawing; the cards differ by
+    icon and by the shape of their schematic, never by hue.
+  -->
+  <defs
+     id="defs-concept">
+    <marker
+       id="arrow-neutral"
+       viewBox="0 0 10 10"
+       refX="9"
+       refY="5"
+       markerWidth="6"
+       markerHeight="6"
+       orient="auto-start-reverse">
+      <path
+         d="M 0,0 10,5 0,10 Z"
+         style="fill:#555555;stroke:none"
+         id="arrowhead-neutral" />
+    </marker>
+    <marker
+       id="arrow-faint"
+       viewBox="0 0 10 10"
+       refX="9"
+       refY="5"
+       markerWidth="5"
+       markerHeight="5"
+       orient="auto-start-reverse">
+      <path
+         d="M 0,0 10,5 0,10 Z"
+         style="fill:#c8c8c8;stroke:none"
+         id="arrowhead-faint" />
+    </marker>
+    <pattern
+       id="hatch-rust"
+       patternUnits="userSpaceOnUse"
+       width="4"
+       height="4"
+       patternTransform="rotate(45)">
+      <path
+         d="M 0,0 V 4"
+         style="stroke:#9a4a14;stroke-width:0.8;opacity:0.55"
+         id="hatch-rust-line" />
+    </pattern>
+  </defs>
+  <!-- ===================== background ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="background"
+     id="layer-background">
+    <rect
+       x="30"
+       y="76"
+       width="840"
+       height="110"
+       rx="4"
+       ry="4"
+       style="fill:#faf6f2;stroke:none"
+       id="spine-panel" />
+  </g>
+  <!-- ===================== title ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="title"
+     id="layer-title">
+    <text
+       x="450"
+       y="36"
+       style="font-weight:bold;font-size:22px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#333333"
+       id="fig-title">Optical path composition</text>
+    <text
+       x="450"
+       y="58"
+       style="font-size:13px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#5f5f5f"
+       id="fig-subtitle">four independent tracks, stated against distance along the same fiber</text>
+  </g>
+  <!-- ===================== spine ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="spine"
+     id="layer-spine">
+    <text
+       x="63.39257"
+       y="141.85388"
+       style="font-size:10.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#5f5f5f"
+       id="spine-interrogator-label">interrogator</text>
+    <line
+       x1="80"
+       y1="110"
+       x2="560"
+       y2="110"
+       style="stroke:#9a4a14;stroke-width:7;stroke-linecap:butt"
+       id="spine-run-1" />
+    <line
+       x1="560"
+       y1="110"
+       x2="830"
+       y2="110"
+       style="stroke:#c07a3a;stroke-width:7;stroke-linecap:butt"
+       id="spine-run-2" />
+    <!-- the core, drawn before the hardware glyphs so they sit over it -->
+    <line
+       x1="80"
+       y1="110"
+       x2="560"
+       y2="110"
+       style="stroke:#7d3b10;stroke-width:1.8;stroke-linecap:butt"
+       id="spine-core-1" />
+    <line
+       x1="560"
+       y1="110"
+       x2="830"
+       y2="110"
+       style="stroke:#7d3b10;stroke-width:1.8;stroke-linecap:butt"
+       id="spine-core-2" />
+    <!-- the cut end where the light goes in: core inside cladding -->
+    <ellipse
+       cx="79.957207"
+       cy="110.00297"
+       rx="1.3231971"
+       ry="2.9029665"
+       style="fill:#e2c4a6;stroke:#9a4a14;stroke-width:1.2"
+       id="spine-face-cladding" />
+    <ellipse
+       cx="79.994911"
+       cy="110.04056"
+       rx="0.4682945"
+       ry="1.1047094"
+       style="fill:#ffffff;stroke:#7d3b10;stroke-width:0.5;stroke-dasharray:none"
+       id="spine-face-core" />
+    <circle
+       cx="300"
+       cy="110"
+       r="7.4"
+       style="fill:#faf6f2;stroke:none"
+       id="spine-splice-halo" />
+    <path
+       d="M 295,105 L 305,115 M 295,115 L 305,105"
+       style="fill:none;stroke:#333333;stroke-width:1.8;stroke-linecap:round"
+       id="spine-splice" />
+    <circle
+       cx="560"
+       cy="110"
+       r="7.4"
+       style="fill:#faf6f2;stroke:none"
+       id="spine-connector-halo" />
+    <path
+       d="M 555,105 L 560,110 L 555,115 Z M 565,105 L 560,110 L 565,115 Z"
+       style="fill:#333333;stroke:none"
+       id="spine-connector" />
+    <line
+       x1="830"
+       y1="101"
+       x2="830"
+       y2="119"
+       style="stroke:#333333;stroke-width:2.2;stroke-linecap:round"
+       id="spine-terminator-bar" />
+    <path
+       d="M 828,105 L 821,110 L 828,115 Z"
+       style="fill:#333333;stroke:none"
+       id="spine-terminator-wedge" />
+    <text
+       x="300"
+       y="134"
+       style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#444444"
+       id="spine-label-splice">Splice</text>
+    <text
+       x="560"
+       y="134"
+       style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#444444"
+       id="spine-label-connector">Connector</text>
+    <text
+       x="830"
+       y="134"
+       style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+       id="spine-label-terminator">Terminator</text>
+    <line
+       x1="80"
+       y1="156"
+       x2="838"
+       y2="156"
+       style="fill:none;stroke:#555555;stroke-width:1.2"
+       marker-end="url(#arrow-neutral)"
+       id="spine-axis" />
+    <line
+       x1="80"
+       y1="156"
+       x2="80"
+       y2="163"
+       style="stroke:#555555;stroke-width:1.2"
+       id="spine-axis-zero-tick" />
+    <text
+       x="80"
+       y="177"
+       style="font-size:10.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#5f5f5f"
+       id="spine-axis-zero">0</text>
+    <text
+       x="459"
+       y="177"
+       style="font-style:italic;font-size:12px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#5f5f5f"
+       id="spine-axis-name">distance along the fiber</text>
+    <text
+       x="838"
+       y="177"
+       style="font-size:10.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#5f5f5f"
+       id="spine-axis-end">optical_length</text>
+  </g>
+  <!-- ===================== cards ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="cards"
+     id="layer-cards">
+    <rect
+       x="30"
+       y="196"
+       width="408"
+       height="196"
+       rx="4"
+       ry="4"
+       style="fill:#fdfaf7;stroke:#9a4a14;stroke-width:1.5"
+       id="card-components" />
+    <rect
+       x="462"
+       y="196"
+       width="408"
+       height="196"
+       rx="4"
+       ry="4"
+       style="fill:#fdfaf7;stroke:#9a4a14;stroke-width:1.5"
+       id="card-geometry" />
+    <rect
+       x="30"
+       y="408"
+       width="408"
+       height="196"
+       rx="4"
+       ry="4"
+       style="fill:#fdfaf7;stroke:#9a4a14;stroke-width:1.5"
+       id="card-labels" />
+    <rect
+       x="462"
+       y="408"
+       width="408"
+       height="196"
+       rx="4"
+       ry="4"
+       style="fill:#fdfaf7;stroke:#9a4a14;stroke-width:1.5"
+       id="card-coupling" />
+    <text
+       x="88"
+       y="233"
+       style="font-weight:bold;font-size:15px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#9a4a14"
+       id="name-components">optical_components</text>
+    <text
+       x="520"
+       y="233"
+       style="font-weight:bold;font-size:15px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#9a4a14"
+       id="name-geometry">geometry</text>
+    <text
+       x="88"
+       y="445"
+       style="font-weight:bold;font-size:15px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#9a4a14"
+       id="name-labels">labels</text>
+    <text
+       x="520"
+       y="445"
+       style="font-weight:bold;font-size:15px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#9a4a14"
+       id="name-coupling">coupling</text>
+    <text
+       x="48"
+       y="260"
+       style="font-size:12.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+       id="gloss-components">the fiber itself, part by part</text>
+    <text
+       x="480"
+       y="260"
+       style="font-size:12.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+       id="gloss-geometry">where the fiber is, as a function of distance</text>
+    <text
+       x="48"
+       y="472"
+       style="font-size:12.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+       id="gloss-labels">what a stretch of fiber is</text>
+    <text
+       x="480"
+       y="472"
+       style="font-size:12.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#5f5f5f"
+       id="gloss-coupling">how the cable couples to its surroundings</text>
+    <!-- the shared axis, restated faintly under every schematic -->
+    <line
+       x1="48"
+       y1="358"
+       x2="420"
+       y2="358"
+       style="fill:none;stroke:#d8d8d8;stroke-width:1"
+       marker-end="url(#arrow-faint)"
+       id="baseline-components" />
+    <line
+       x1="480"
+       y1="358"
+       x2="852"
+       y2="358"
+       style="fill:none;stroke:#d8d8d8;stroke-width:1"
+       marker-end="url(#arrow-faint)"
+       id="baseline-geometry" />
+    <line
+       x1="48"
+       y1="570"
+       x2="420"
+       y2="570"
+       style="fill:none;stroke:#d8d8d8;stroke-width:1"
+       marker-end="url(#arrow-faint)"
+       id="baseline-labels" />
+    <line
+       x1="480"
+       y1="570"
+       x2="852"
+       y2="570"
+       style="fill:none;stroke:#d8d8d8;stroke-width:1"
+       marker-end="url(#arrow-faint)"
+       id="baseline-coupling" />
+  </g>
+  <!-- ===================== schematics ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="schematics"
+     id="layer-schematics">
+    <!-- optical_components: a partition. parts abut, events sit between them -->
+    <g
+       id="schematic-components">
+      <text
+         x="158"
+         y="286"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#444444"
+         id="comp-label-splice">Splice</text>
+      <text
+         x="288"
+         y="286"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#444444"
+         id="comp-label-connector">Connector</text>
+      <text
+         x="420"
+         y="286"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#444444"
+         id="comp-label-terminator">Terminator</text>
+      <rect
+         x="48"
+         y="294"
+         width="110"
+         height="30"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:1.2"
+         id="comp-seg-1" />
+      <rect
+         x="158"
+         y="294"
+         width="130"
+         height="30"
+         style="fill:#e2c4a6;stroke:#9a4a14;stroke-width:1.2"
+         id="comp-seg-2" />
+      <rect
+         x="288"
+         y="294"
+         width="132"
+         height="30"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:1.2"
+         id="comp-seg-3" />
+      <text
+         x="223"
+         y="313"
+         style="font-size:9.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#7d3b10"
+         id="comp-seg-name">FiberSegment</text>
+      <circle
+         cx="158"
+         cy="309"
+         r="5.8"
+         style="fill:#ffffff;stroke:none"
+         id="comp-splice-halo" />
+      <path
+         d="M 154,305 L 162,313 M 154,313 L 162,305"
+         style="fill:none;stroke:#333333;stroke-width:1.7;stroke-linecap:round"
+         id="comp-splice" />
+      <circle
+         cx="288"
+         cy="309"
+         r="5.8"
+         style="fill:#ffffff;stroke:none"
+         id="comp-connector-halo" />
+      <path
+         d="M 284,305 L 288,309 L 284,313 Z M 292,305 L 288,309 L 292,313 Z"
+         style="fill:#333333;stroke:none"
+         id="comp-connector" />
+      <line
+         x1="420"
+         y1="297"
+         x2="420"
+         y2="321"
+         style="stroke:#333333;stroke-width:2.2;stroke-linecap:round"
+         id="comp-terminator-bar" />
+      <path
+         d="M 418,304.5 L 411,309 L 418,313.5 Z"
+         style="fill:#333333;stroke:none"
+         id="comp-terminator-wedge" />
+      <line
+         x1="48"
+         y1="354"
+         x2="48"
+         y2="362"
+         style="stroke:#9a9a9a;stroke-width:0.9"
+         id="comp-dim-tick-1" />
+      <line
+         x1="158"
+         y1="354"
+         x2="158"
+         y2="362"
+         style="stroke:#9a9a9a;stroke-width:0.9"
+         id="comp-dim-tick-2" />
+      <line
+         x1="288"
+         y1="354"
+         x2="288"
+         y2="362"
+         style="stroke:#9a9a9a;stroke-width:0.9"
+         id="comp-dim-tick-3" />
+      <line
+         x1="420"
+         y1="354"
+         x2="420"
+         y2="362"
+         style="stroke:#9a9a9a;stroke-width:0.9"
+         id="comp-dim-tick-4" />
+      <text
+         x="48"
+         y="348"
+         style="font-size:9.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#9a9a9a"
+         id="comp-dim-label">optical_length of each part</text>
+    </g>
+    <!-- geometry: a partial function of distance -->
+    <g
+       id="schematic-geometry">
+      <path
+         d="M 496,288 C 516,288 528,328 556,328 C 584,328 596,288 616,288"
+         style="fill:none;stroke:#9a4a14;stroke-width:2;stroke-linecap:round"
+         id="geom-piece-a" />
+      <path
+         d="M 700,288 C 718,288 730,326 752,326 C 774,326 786,288 804,288"
+         style="fill:none;stroke:#9a4a14;stroke-width:2;stroke-linecap:round"
+         id="geom-piece-b" />
+      <line
+         x1="616"
+         y1="288"
+         x2="700"
+         y2="288"
+         style="stroke:#c8c8c8;stroke-width:1.4;stroke-dasharray:2,4"
+         id="geom-gap" />
+      <text
+         x="658"
+         y="282.99557"
+         style="font-style:italic;font-size:10px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#9a9a9a"
+         id="geom-gap-label">unplaced</text>
+      <circle
+         cx="496"
+         cy="288"
+         r="2.6"
+         style="fill:#ffffff;stroke:#9a4a14;stroke-width:1.4"
+         id="geom-end-1" />
+      <circle
+         cx="616"
+         cy="288"
+         r="2.6"
+         style="fill:#ffffff;stroke:#9a4a14;stroke-width:1.4"
+         id="geom-end-2" />
+      <circle
+         cx="700"
+         cy="288"
+         r="2.6"
+         style="fill:#ffffff;stroke:#9a4a14;stroke-width:1.4"
+         id="geom-end-3" />
+      <circle
+         cx="804"
+         cy="288"
+         r="2.6"
+         style="fill:#ffffff;stroke:#9a4a14;stroke-width:1.4"
+         id="geom-end-4" />
+      <circle
+         cx="556"
+         cy="328"
+         r="2.8"
+         style="fill:#9a4a14;stroke:none"
+         id="geom-sample" />
+      <path
+         d="M 556,328 L 574,344"
+         style="fill:none;stroke:#9a9a9a;stroke-width:0.9"
+         id="geom-sample-leader" />
+      <text
+         x="578"
+         y="347"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#9a4a14"
+         id="geom-sample-label">(x, y, z)</text>
+    </g>
+    <!-- labels: independent groups of categorical spans -->
+    <g
+       id="schematic-labels">
+      <text
+         x="425.29153"
+         y="486"
+         style="font-size:9.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#9a9a9a"
+         id="labels-schema-hint">group · value</text>
+      <text
+         x="106"
+         y="505"
+         style="font-size:9.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#9a9a9a"
+         id="labels-group-1">group 1</text>
+      <text
+         x="106"
+         y="527"
+         style="font-size:9.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#9a9a9a"
+         id="labels-group-2">group 2</text>
+      <text
+         x="106"
+         y="549"
+         style="font-size:9.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#9a9a9a"
+         id="labels-group-3">group 3</text>
+      <rect
+         x="114"
+         y="492"
+         width="96"
+         height="18"
+         rx="2"
+         ry="2"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:0.9"
+         id="labels-1-a" />
+      <rect
+         x="234"
+         y="492"
+         width="96"
+         height="18"
+         rx="2"
+         ry="2"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:0.9"
+         id="labels-1-b" />
+      <rect
+         x="354"
+         y="492"
+         width="66"
+         height="18"
+         rx="2"
+         ry="2"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:0.9"
+         id="labels-1-c" />
+      <text
+         x="162"
+         y="505"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#9a4a14"
+         id="labels-1-a-t">A</text>
+      <text
+         x="282"
+         y="505"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#9a4a14"
+         id="labels-1-b-t">B</text>
+      <text
+         x="387"
+         y="505"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#9a4a14"
+         id="labels-1-c-t">C</text>
+      <rect
+         x="114"
+         y="514"
+         width="48"
+         height="18"
+         rx="2"
+         ry="2"
+         style="fill:#efdccb;stroke:#9a4a14;stroke-width:0.9"
+         id="labels-2-a" />
+      <rect
+         x="162"
+         y="514"
+         width="48"
+         height="18"
+         rx="2"
+         ry="2"
+         style="fill:#efdccb;stroke:#9a4a14;stroke-width:0.9"
+         id="labels-2-b" />
+      <rect
+         x="234"
+         y="514"
+         width="48"
+         height="18"
+         rx="2"
+         ry="2"
+         style="fill:#efdccb;stroke:#9a4a14;stroke-width:0.9"
+         id="labels-2-c" />
+      <rect
+         x="282"
+         y="514"
+         width="48"
+         height="18"
+         rx="2"
+         ry="2"
+         style="fill:#efdccb;stroke:#9a4a14;stroke-width:0.9"
+         id="labels-2-d" />
+      <text
+         x="138"
+         y="527"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#9a4a14"
+         id="labels-2-a-t">a</text>
+      <text
+         x="186"
+         y="527"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#9a4a14"
+         id="labels-2-b-t">b</text>
+      <text
+         x="258"
+         y="527"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#9a4a14"
+         id="labels-2-c-t">a</text>
+      <text
+         x="306"
+         y="527"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#9a4a14"
+         id="labels-2-d-t">b</text>
+      <rect
+         x="114"
+         y="536"
+         width="216"
+         height="18"
+         rx="2"
+         ry="2"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:0.9"
+         id="labels-3-a" />
+      <text
+         x="222"
+         y="549"
+         style="font-size:10px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#9a4a14"
+         id="labels-3-a-t">x</text>
+    </g>
+    <!-- coupling: sparse assertions, blank where nothing is claimed -->
+    <g
+       id="schematic-coupling">
+      <text
+         x="480"
+         y="490"
+         style="font-size:9.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;fill:#9a9a9a"
+         id="coupling-schema-hint">coupling_type · medium · attachment</text>
+      <rect
+         x="480"
+         y="500"
+         width="372"
+         height="28"
+         style="fill:#ffffff;stroke:#d8d8d8;stroke-width:0.9"
+         id="coupling-lane" />
+      <rect
+         x="494"
+         y="500"
+         width="106"
+         height="28"
+         style="fill:#f7ece2;stroke:none"
+         id="coupling-band-1-fill" />
+      <rect
+         x="494"
+         y="500"
+         width="106"
+         height="28"
+         style="fill:url(#hatch-rust);stroke:#9a4a14;stroke-width:1.1"
+         id="coupling-band-1" />
+      <rect
+         x="712"
+         y="500"
+         width="98"
+         height="28"
+         style="fill:#f7ece2;stroke:none"
+         id="coupling-band-2-fill" />
+      <rect
+         x="712"
+         y="500"
+         width="98"
+         height="28"
+         style="fill:url(#hatch-rust);stroke:#9a4a14;stroke-width:1.1"
+         id="coupling-band-2" />
+      <text
+         x="656"
+         y="518"
+         style="font-style:italic;font-size:10.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;text-anchor:middle;fill:#9a9a9a"
+         id="coupling-blank-label">no claim made</text>
+    </g>
+  </g>
+  <!-- ===================== icons ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="icons"
+     id="layer-icons">
+    <!-- interrogator: a box that launches light down a fiber -->
+    <g
+       id="icon-interrogator"
+       transform="matrix(1.0137816,0,0,1,49.362778,96.040962)"
+       style="fill:none;stroke:#9a4a14;stroke-width:1.48977;stroke-linecap:round;stroke-linejoin:round">
+      <rect
+         x="1"
+         y="6"
+         width="16"
+         height="16"
+         rx="2"
+         ry="2"
+         style="fill:#ffffff;stroke:#9a4a14;stroke-width:1.48977"
+         id="interrogator-body" />
+      <rect
+         x="4"
+         y="9"
+         width="10"
+         height="5"
+         rx="1"
+         ry="1"
+         style="fill:none;stroke:#9a4a14;stroke-width:1.19182"
+         id="interrogator-screen" />
+      <circle
+         cx="5.5"
+         cy="17.5"
+         r="1.1"
+         style="fill:#9a4a14;stroke:none;stroke-width:1.48977"
+         id="interrogator-led-1" />
+      <circle
+         cx="9.5"
+         cy="17.5"
+         r="1.1"
+         style="fill:#9a4a14;stroke:none;stroke-width:1.48977"
+         id="interrogator-led-2" />
+      <path
+         d="m 18.000002,14 h 9.718409 M 24.074008,10.303147 28.933212,14 24.074008,17.696852"
+         style="stroke:#9a4a14;stroke-width:1.73806"
+         id="interrogator-out" />
+    </g>
+    <!-- optical_components: parts laid end to end -->
+    <g
+       id="icon-components"
+       transform="translate(48,212)"
+       style="fill:none;stroke:#9a4a14;stroke-linecap:round">
+      <path
+         d="M 2,15 H 9.5 M 12.5,15 H 19.5 M 22.5,15 H 28"
+         style="stroke:#9a4a14;stroke-width:4.4;stroke-linecap:butt"
+         id="components-parts" />
+    </g>
+    <!-- geometry: a route through space, sampled -->
+    <g
+       id="icon-geometry"
+       transform="translate(480,212)"
+       style="fill:none;stroke:#9a4a14;stroke-linecap:round;stroke-linejoin:round">
+      <path
+         d="M 2,22 C 7,10 12,26 17,15 C 20,8 25,12 28,8"
+         style="stroke:#9a4a14;stroke-width:1.9"
+         id="geometry-route" />
+      <circle
+         cx="17"
+         cy="15"
+         r="2.6"
+         style="fill:#9a4a14;stroke:none"
+         id="geometry-sample" />
+    </g>
+    <!-- labels: tags on stretches of fiber -->
+    <g
+       id="icon-labels"
+       transform="translate(48,424)"
+       style="fill:none;stroke:#9a4a14;stroke-linecap:round;stroke-linejoin:round">
+      <path
+         d="M 3,7 H 17 L 23,11 L 17,15 H 3 Z"
+         style="fill:#f7ece2;stroke:#9a4a14;stroke-width:1.5"
+         id="labels-tag-1" />
+      <path
+         d="M 3,17 H 12 L 18,21 L 12,25 H 3 Z"
+         style="fill:#efdccb;stroke:#9a4a14;stroke-width:1.5"
+         id="labels-tag-2" />
+    </g>
+    <!-- coupling: the cable in contact with the ground -->
+    <g
+       id="icon-coupling"
+       transform="translate(480,424)"
+       style="fill:none;stroke:#9a4a14;stroke-linecap:round;stroke-linejoin:round">
+      <rect
+         x="2"
+         y="11"
+         width="26"
+         height="14"
+         style="fill:url(#hatch-rust);stroke:#9a4a14;stroke-width:1.3"
+         id="coupling-ground" />
+      <path
+         d="M 2,18 H 28"
+         style="stroke:#9a4a14;stroke-width:2.4"
+         id="coupling-cable" />
+    </g>
+  </g>
+  <!-- ===================== notes ===================== -->
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="notes"
+     id="layer-notes">
+    <text
+       x="48"
+       y="378"
+       style="font-style:italic;font-size:11.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#444444"
+       id="note-components">parts tile the axis in order; an event’s length is usually zero</text>
+    <text
+       x="480"
+       y="378"
+       style="font-style:italic;font-size:11.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#444444"
+       id="note-geometry">a partial function: a gap is unplaced, not missing</text>
+    <text
+       x="48"
+       y="590"
+       style="font-style:italic;font-size:11.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#444444"
+       id="note-labels">independent groups; they need not agree, or cover the whole fiber</text>
+    <text
+       x="480"
+       y="590"
+       style="font-style:italic;font-size:11.5px;font-family:'Source Sans 3', 'Noto Sans', 'DejaVu Sans', sans-serif;fill:#444444"
+       id="note-coupling">stated only where known; blank is not a claim of “uncoupled”</text>
+  </g>
+</svg>

--- a/docs/_static/optical_path_concept.svg
+++ b/docs/_static/optical_path_concept.svg
@@ -233,7 +233,7 @@
        x="80"
        y="177"
        style="font-size:10.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:middle;fill:#5f5f5f"
-       id="spine-axis-zero">0</text>
+       id="spine-axis-start">distance_min</text>
     <text
        x="459"
        y="177"
@@ -243,7 +243,7 @@
        x="838"
        y="177"
        style="font-size:10.5px;font-family:'Source Code Pro', 'DejaVu Sans Mono', Menlo, Consolas, monospace;text-anchor:end;fill:#5f5f5f"
-       id="spine-axis-end">optical_length</text>
+       id="spine-axis-end">distance_max</text>
   </g>
   <!-- ===================== cards ===================== -->
   <g

--- a/docs/tutorial/inventory.qmd
+++ b/docs/tutorial/inventory.qmd
@@ -4,382 +4,236 @@ execute:
   warning: false
 ---
 
-A DASDAE **inventory** describes the observing system a fiber archive was recorded through: the cables and fibers the light travelled down, the interrogators that lit them, where the fiber physically goes, and how all of it was configured over time. It plays the role StationXML plays in seismology, extended to the things a fiber deployment has and a seismic station does not — an optical path with components along it, and channels whose meaning is a position on that path.
+A DASDAE **inventory** describes the observing system behind a fiber archive: the optical path, interrogator settings, deployment geometry, coupling, and labels. It plays the role StationXML plays for point sensors while leaving the data files unchanged.
 
-The data files stay as they are. An inventory is written once, beside the archive, and DASCore joins the two on demand: patches carry an `acquisition_key` (`network.fiber_array.location.acquisition`) which, together with the time they cover, resolves to exactly one entry in the inventory.
-
-Nothing here changes patch data. Everything an inventory contributes is metadata — attributes on a patch, coordinates along the fiber, and names you can select and group by.
+Patches join to the inventory through `acquisition_key` (`network.fiber_array.location.acquisition`) and time. The result is metadata: patch attributes, coordinates along the fiber, and names available for selection and grouping.
 
 # The model
 
-An inventory is a tree of DASCore models. Its spine is containment, and each edge below is labelled with the field that holds the thing it points at.
+![Point-sensor and fiber inventory concepts.](../_static/inventory_hierarchy.svg){width="100%" style="background-color: white" fig-alt="Conceptual comparison of observing-system identifiers: point sensors progress from network and station through location to channel, while fiber systems progress from network and fiber array through optical path to acquisition; both share resources and a coordinate reference system."}
 
-```{mermaid}
-flowchart TD
-  Inventory -->|networks| Network
-  Network -->|fiber_arrays| FiberArray
-  Network -->|stations| Station
-  FiberArray -->|acquisitions| Acquisition
-  FiberArray -->|optical_paths| OpticalPath
-  Station -->|channels| Channel
+This is a conceptual comparison with StationXML, not a literal containment diagram. In DASCore, acquisitions and optical paths are sibling collections on a fiber array. There is no `Location` model: a [`Channel`](`dascore.core.inventory.Channel`) carries a `location_code`, and a station holds its channels directly.
+
+An [`Inventory`](`dascore.core.inventory.Inventory`) contains [`Network`](`dascore.core.inventory.Network`) objects. A network may hold conventional stations and [`FiberArray`](`dascore.core.inventory.FiberArray`) objects. Each fiber array holds:
+
+- [`Acquisition`](`dascore.core.inventory.Acquisition`) objects, which describe an interrogator stream and map instrument distance onto an optical path.
+- [`OpticalPath`](`dascore.core.inventory.OpticalPath`) objects, which describe what the light travelled through.
+
+Shared objects such as interrogators, cables, enclosures, and measurements live under `Inventory.resources`. Other objects refer to them by `resource_id`, avoiding duplicate metadata; model constructors also accept the object itself.
+
+![Optical-path track concepts.](../_static/optical_path_concept.svg){width="100%" style="background-color: white" fig-alt="Four tracks share optical distance: contiguous optical components tile the complete fiber, geometry is a partially defined function, labels form independent interval groups, and coupling is stated only where known."}
+
+An optical path has four independent tracks along optical distance:
+
+- `optical_components`: fiber segments, splices, connectors, and terminators. These tile the complete path and define its extent.
+- `geometry`: measured quantities along the fiber, including coordinates named by the inventory's coordinate reference system.
+- `coupling`: how each interval of cable meets its surroundings.
+- `labels`: interval names such as borehole, drift, or zone.
+
+Geometry, coupling, and labels may cover only part of the path. Missing coverage means “not stated,” not that the fiber or channel is absent.
+
+Acquisitions and optical paths may have time-bounded epochs. Resolving a patch therefore uses both its acquisition key and time: hardware or geometry can change without changing the durable fiber-array identity.
+
+# Authoring an inventory
+
+Inventories can be written as one YAML or JSON document, but a directory is easier to maintain: models use YAML or JSON, while long tracks use CSV.
+
+```text
+inventory/
+├── inventory.yaml
+├── resources/
+│   └── interrogator-1.yaml
+├── acquisitions/
+│   └── DAS.R2D1..RAW.yaml
+└── fiber_arrays/
+    └── DAS.R2D1/
+        ├── attrs.yaml
+        └── path/
+            ├── attrs.yaml
+            ├── optical_components.csv
+            ├── geometry.csv
+            ├── coupling.csv
+            └── labels.csv
 ```
 
-An [`Inventory`](`dascore.core.inventory.Inventory`) holds networks; a [`Network`](`dascore.core.inventory.Network`) holds fiber arrays, and stations for the conventional instruments recorded alongside them; a [`FiberArray`](`dascore.core.inventory.FiberArray`) is the durable observing identity, which holds both [`Acquisition`](`dascore.core.inventory.Acquisition`) objects — how an interrogator was set up — and [`OpticalPath`](`dascore.core.inventory.OpticalPath`) objects — what the light actually travelled through.
+Each object file declares its `object_type`. An acquisition filename gives its full identity, and its `distance_map` connects the interrogator's axis to optical distance:
 
-The optical path is the part with no seismological analog. It is described by four independent tracks along optical distance.
-
-```{mermaid}
-flowchart LR
-  OpticalPath -->|optical_components| Components["FiberSegment · Splice · Connector · Terminator"]
-  OpticalPath -->|geometry| Geometry
-  OpticalPath -->|coupling| CouplingCondition
-  OpticalPath -->|labels| OpticalPathLabel
+```yaml
+object_type: Acquisition
+data_category: DAS
+data_type: velocity
+gauge_length: 10.0
+interrogator: interrogator-1
+distance_map:
+  instrument_distance: [0.0, 299.0]
+  distance: [100.0, 399.0]
 ```
 
-The components are the physical pieces the light passes through, and they are what gives the path its extent: each one states the stretch of optical distance it occupies, and they tile — each begins where the last ended — so the path runs from the first to the last. They are read in distance order whatever order the rows are written in, so a component states where it is rather than being counted through to it. The other three describe intervals of that extent — the geometry holds the measured curves along the fiber, of which the columns the coordinate reference system names are position; the coupling says how the fiber is attached to the ground there; and the labels name anything else worth recording per interval. Each of those covers what it covers, and none of them has to cover the whole path.
+Track files are ordinary tables. For example:
 
-Objects reused in several places — interrogators, cables, enclosures, measurements — are written once under the inventory's `resources` and referred to elsewhere by their `resource_id`. Such a field accepts either the object itself or that string, which is what the dashed edges below mean.
-
-```{mermaid}
-flowchart LR
-  Acquisition -.->|interrogator| Interrogator
-  FiberSegment -.->|container| Cable
-  Cable -.->|container| Enclosure
-  OpticalPath -.->|measurements| OpticalMeasurement
+```csv
+object_type,distance_min,distance_max,name
+FiberSegment,0,100,lead-in
+Splice,100,,wellhead splice
+FiberSegment,100,500,trench cable
 ```
 
-These three diagrams are the shape of the model, not the whole of it; each class's own API page lists every field it has.
+A point component leaves `distance_max` blank; a fiber segment states both bounds. Rows are ordered by distance when loaded, regardless of file order.
 
-# Writing an inventory
+The main authoring rules are:
 
-An inventory can be a single YAML file, but the format it is usually authored in is a **directory**, which splits the metadata along its natural grain: small heterogeneous objects as YAML (or JSON) files matching the models, and long row-shaped track data as CSV files a field crew can maintain in a spreadsheet.
+- File and directory names state identity. If the file repeats an identity field, the values must agree.
+- `path` is the reserved optical-path directory. `attrs` and `inventory` are reserved file stems.
+- Files outside reserved object slots are ignored unless they declare a recognized inventory object; files inside reserved slots must follow the conventions. Field notes and photographs may live elsewhere in the inventory tree.
+- CSV columns beginning with `_` are also ignored. Use `description` for notes that should survive serialization.
+- Quantities that interpolate belong in `geometry.csv`; interval values belong in `labels.csv`. Units may appear in geometry headers, for example `chainage (m)`.
+
+A dated entity uses an `@time` suffix, such as `path@2025-01-01/`, to begin a new epoch. The directory loader validates identities, object types, references, track coverage, and epoch ranges when [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads it.
+
+Position is ordinary geometry whose column names match the coordinate reference system, or the canonical aliases `x`, `y`, and `z`. Positional axes must be stated together and use the CRS units; a geometry segment may omit all of them and record another quantity such as chainage instead.
+
+The [tunnel inventory recipe](../recipes/tunnel_inventory.qmd) builds a complete directory, including resources, geometry, repairs, and multiple optical paths.
+
+# Track semantics
+
+Tracks use three shapes:
+
+| shape | tracks | coverage | overlap | value outside coverage |
+|---|---|---|---|---|
+| tiling | `optical_components` | complete | none | — |
+| function | geometry columns, coupling, labels with values | partial | none | `""` or `NaN` |
+| membership | labels without values | partial | allowed | `False` |
+
+A label with an empty `value` states membership; a label with a value defines an interval coordinate. Literal `true` and `false` values are refused because an empty value already spells membership. One label group must consistently contain text, numbers, or membership. Numeric groups use `NaN` outside coverage and therefore project as floating-point coordinates.
+
+Intervals are half-open, `[start, end)`, so adjacent rows can tile without overlap. Projection still includes the final channel at the end of a covered run.
+
+Geometry columns, label groups, and typed tracks become coordinates. Label group names cannot use structural names, track names, or recognized coordinate labels; see `RESERVED_GROUP_NAMES` in `dascore.core.inventory`. Geometry columns may use coordinate labels—that is how a segment states an axis—but cannot share a name with a label group.
+
+# Inspecting and visualizing
+
+The examples below use an inventory and patch designed to resolve together:
 
 ```{python}
 import tempfile
 from pathlib import Path
 
 import dascore as dc
-
-files = {
-    # The envelope: the document's own facts. Optional.
-    "inventory.yaml": "object_type: Inventory\n",
-    # Shared objects, named by the resource_id others refer to them by.
-    "resources/fi-1.yaml": (
-        "object_type: Interrogator\n"
-        "manufacturer: Fake Interrogators\n"
-        "model: FI-1\n"
-    ),
-    # A file's name states the identity: network.fiber_array.location.code
-    "acquisitions/DAS.R2D1..RAW.yaml": (
-        "object_type: Acquisition\n"
-        "data_category: DAS\n"
-        "data_type: velocity\n"
-        "gauge_length: 10.0\n"
-        "spatial_interval: 1.0\n"
-        "interrogator: fi-1\n"
-        # Where the interrogator's own axis lands on the optical path.
-        "distance_map:\n"
-        "  instrument_distance: [0.0, 299.0]\n"
-        "  distance: [100.0, 399.0]\n"
-    ),
-    # An entity is a file until it needs tracks, and then a directory.
-    "fiber_arrays/DAS.R2D1/attrs.yaml": (
-        "object_type: FiberArray\nname: the north array\n"
-    ),
-    "fiber_arrays/DAS.R2D1/path/attrs.yaml": (
-        "object_type: OpticalPath\nname: main\n"
-    ),
-    # The tracks along the path, as tables.
-    "fiber_arrays/DAS.R2D1/path/optical_components.csv": (
-        "object_type,distance_min,distance_max,name\n"
-        "FiberSegment,0,100,lead-in\n"
-        "Splice,100,,wellhead splice\n"
-        "FiberSegment,100,500,trench cable\n"
-    ),
-    "fiber_arrays/DAS.R2D1/path/coupling.csv": (
-        "distance_min,distance_max,coupling_type,medium\n"
-        "100,400,trench,soil\n"
-    ),
-    # A geometry column is any number measured along the fiber. This one
-    # is the trench's own chainage, and the middle segment is a coil: the
-    # chainage stands still while ten meters of fiber goes by.
-    "fiber_arrays/DAS.R2D1/path/geometry.csv": (
-        "name,distance,chainage (m)\n"
-        "to the coil,100,1200\n"
-        "to the coil,240,1340\n"
-        "slack coil,240,1340\n"
-        "slack coil,250,1340\n"
-        "past the coil,250,1340\n"
-        "past the coil,400,1490\n"
-    ),
-    "fiber_arrays/DAS.R2D1/path/labels.csv": (
-        "distance_min,distance_max,group,value\n"
-        "100,250,zone,north\n"
-        "250,400,zone,south\n"
-        "150,300,noisy,\n"
-    ),
-}
-
-inventory_path = Path(tempfile.mkdtemp()) / "north_array"
-for name, text in files.items():
-    path = inventory_path / name
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text)
-
-inventory = dc.inventory(inventory_path)
-```
-
-A point component — a splice, a connector, a terminator — occupies no measurable length, so it states one distance and leaves `distance_max` blank; the wellhead splice above is one. A fiber segment states both, since one silently collapsing to a point would lose the fiber it stands for.
-
-A few rules make that directory readable without a schema in front of you:
-
-- **The file declares what it is.** Every object file states its `object_type`, and its container checks that statement rather than supplying it.
-- **The name states the identity.** `acquisitions/DAS.R2D1..RAW.yaml` *is* the acquisition `DAS.R2D1..RAW` — network `DAS`, fiber array `R2D1`, blank location code, code `RAW`. Restating a part of it inside the file is allowed, as long as the two agree; there is never a precedence rule between two spellings of one fact.
-- **`path` is the one reserved *container* name.** A directory called `path` addresses an optical path rather than serializing an attribute named "path". (`attrs` and `inventory` are reserved as file stems — an entity's own object file, and the envelope — and the top-level directory names above are fixed.)
-- **Files that participate in no convention are ignored.** Photos, field notes, and deployment logs can live in the inventory directory undisturbed.
-- **Columns that participate in no convention are ignored too.** A CSV header beginning with an underscore — `_crew`, `_drawing` — is the crew's own record keeping, and nothing reads it. It stays in the file it was written in, so a note which should travel with the inventory goes in a `description` column instead, which every object has.
-
-Two tracks can hold something that varies along the fiber, and which one to use is decided by how a value behaves between the points which state it. **A quantity which interpolates goes in `geometry.csv`**, one column per quantity, read as a curve through its control points; a column may name its units in its header, `chainage (m)`. **A value which holds over a stretch and then stops goes in `labels.csv`**, a set of intervals rather than a curve — a zone name has no meaning between two of them, and neither does a borehole number. Labels are usually words, then, but a number which identifies rather than measures is a label too. A column of text in a geometry table is refused, and says so.
-
-Position is not a separate kind of thing: a column whose name the coordinate reference system declares — or its canonical `x`, `y`, `z` alias — *is* that axis, takes its units from the CRS, and must be stated with all its siblings, since half a position is not a position. A segment which names none of them, like the chainage above, states no position at all and is perfectly valid. The segment `name`s themselves are for humans; what a channel gets is the columns.
-
-# The shape of a track
-
-Every track is a set of intervals of optical distance, and the rules a track is checked against follow from which of three shapes it has:
-
-| shape | tracks | coverage | overlap | an uncovered channel gets |
-|---|---|---|---|---|
-| tiling | `optical_components` | the whole path | none | — |
-| function | geometry columns, `coupling`, label groups with values | partial | none | `""` for text, `NaN` for numbers |
-| membership | label groups without values | partial | free: a channel belongs if any interval includes it | `False` |
-
-A label states membership by leaving its `value` empty, as `noisy` does above, and states a function by giving one. `true` and `false` are refused as values, since membership already has a spelling. A group holds one kind of value throughout — text or numbers — and a group which states membership in one row cannot hold a value in another. Because a numeric group spells absence as `NaN`, it projects onto a patch as floats, so a borehole numbered `3` reads back as `3.0`; a number which must stay exact is text, `BH3`.
-
-A group, a geometry column, and a typed track each become a coordinate under their own name, so one name is one coordinate: a group may not take the name of a structural coordinate (`time`, `distance`, `channel`, `instrument_distance`, `acquisition_key`), of a track (`optical_components`, `geometry`, `coupling`, or `labels` itself), or of any recognised coordinate label, whether or not this inventory's coordinate reference system declares it; the full set is `RESERVED_GROUP_NAMES` in `dascore.core.inventory`. A group and a geometry column cannot share a name either.
-
-Intervals are half-open, `[start, end)`, which is what lets adjacent intervals tile without overlapping. When a track is projected onto channels, the end of each run of coverage belongs to the interval ending there, so the last channel of a run is not left out by an interval which ends exactly on it.
-
-Loading checks the document, so a directory that is not a valid inventory says so at the point it is read:
-
-```{python}
-from dascore.exceptions import InvalidInventoryError
-
-try:
-    dc.inventory(inventory_path / "acquisitions")
-except InvalidInventoryError as error:
-    print(error)
-else:
-    raise AssertionError("a directory of acquisitions is no inventory")
-```
-
-Inventories can also be built in memory from the model classes directly, which is how the tests build theirs. The examples below take one already built that way, along with a patch it describes:
-
-```{python}
 from dascore.examples import inventory_patch_pair
 
-patch, example_inventory = inventory_patch_pair()
+patch, inventory = inventory_patch_pair()
 ```
 
-Where a patch is not needed, [`dc.get_example_inventory`](`dascore.examples.get_example_inventory`) returns a registered inventory on its own, the same way `dc.get_example_patch` returns a patch. `dc.get_example_inventory("tunnel")` is the whole deployment the [tunnel recipe](../recipes/tunnel_inventory.qmd) builds, read from the same files that page shows.
-
-# What an inventory can contribute
-
-[`Inventory.get_names`](`dascore.core.inventory.Inventory.get_names`) lists the names an inventory could put on a patch, split by where each one lands. `attrs` are the observing-system facts, which are one value per patch; `coords` take a value per channel, because they describe somewhere along the fiber.
+[`Inventory.get_names`](`dascore.core.inventory.Inventory.get_names`) separates scalar attributes from per-channel coordinates:
 
 ```{python}
 names = inventory.get_names()
-
-print("attrs:", names.attrs[:4], "...")
-print("coords:", [x for x in names.coords if "." not in x])
-
-# The label groups and the geometry column named in the CSVs.
-assert {"zone", "noisy", "chainage"} <= set(names.coords)
 assert "gauge_length" in names.attrs
+assert {"zone", "noisy", "coupling"} <= set(names.coords)
 ```
 
-`zone` and `noisy` are there because the labels CSV named them, and `chainage` because the geometry CSV did: a group and a column each become a coordinate under their own name. `coupling`, `geometry`, and `optical_components` are there for the same reason — a track contributes its name only where a path actually describes it. `distance` is where each channel sits on the optical path, and `x`/`y`/`z` and `longitude`/`latitude`/`elevation` are the two spellings of the axes the inventory's coordinate reference system declares.
+The result lists what the inventory *can* contribute, not what every channel will receive. A partially covered path may list a coordinate whose value is blank for some channels.
 
-Listing a name is not promising a value for it. This example's geometry states chainage and no position, so the spatial names resolve to nothing until some segment states them.
-
-# Seeing an inventory
-
-An inventory summarizes what it holds. Each object in the tree states one line, so the line you see nested here is the line that network, fiber array or optical path leads with when you show it on its own:
-
-```{python}
-inventory
-```
-
-Only what an object states is shown, so a field left at its default does not take up a line. `Networks` lists at most `display_max_items` children per level (see the [configuration](configuration.qmd) page) and says how many it left out.
-
-An inventory also draws itself through its `viz` namespace, and each of the three plots looks along one coordinate.
-
-[`Inventory.viz.path`](`dascore.viz.inventory.path`) looks along **optical distance**, which is the coordinate the data is in. Every track becomes a lane, so the distances each acquisition's channels cover, the components, the coupling, and each label group line up against the same axis:
+`Inventory.viz.path` aligns acquisitions, components, coupling, labels, and geometry along optical distance:
 
 ```{python}
 inventory.viz.path(show=True);
 ```
 
-A geometry column is a curve rather than a set of intervals, so it is drawn as a panel beneath. Here the chainage stands still through the slack coil while ten meters of fiber goes by:
+Use `tracks=` to select lanes and `columns=` to select geometry columns. [`Inventory.viz.map`](`dascore.viz.inventory.map_path`) plots geometry in space, while [`Inventory.viz.timeline`](`dascore.viz.inventory.timeline`) plots acquisition and path epochs through time.
+
+# Using an inventory with a spool
+
+[`Spool.attach_inventory`](`dascore.core.spool.Spool.attach_inventory`) stores an inventory reference without changing patches or loading data. It is the only way a spool gets an inventory; `enrich` and `conform_to_inventory` always use the attached one.
 
 ```{python}
-inventory.viz.path(columns="chainage", show=True);
-```
-
-`tracks=` picks the lanes, in the order given, when the whole picture is more than the question needs:
-
-```{python}
-inventory.viz.path(tracks=("coupling", "zone"), show=True);
-```
-
-The other two plots need something this small example does not have. [`Inventory.viz.map`](`dascore.viz.inventory.map_path`) looks along **space**, and needs geometry which states the CRS's axes; this path states chainage and no position. [`Inventory.viz.timeline`](`dascore.viz.inventory.timeline`) looks along **time**, and is worth reading where the epochs are real. The [tunnel recipe](../recipes/tunnel_inventory.qmd) has both.
-
-# Attaching an inventory to a spool
-
-[`Spool.attach_inventory`](`dascore.core.spool.Spool.attach_inventory`) carries an inventory on a spool, and touches no data. No patch gains a field, no row moves, `len` does not change. It costs nothing per patch, which is what makes it safe to do early and decide later what to use it for. Attaching a *different* inventory does clear any enrichment set up from the old one, since applying the old instructions to new metadata would rewrite every patch behind your back.
-
-It is also the only way a spool gets an inventory: `enrich` and `conform_to_inventory` read the attached one rather than taking their own, so the spool has one answer to which inventory it means.
-
-```{python}
-spool = dc.spool(patch).attach_inventory(example_inventory)
-
-# Attaching alone adds nothing to the patches.
+spool = dc.spool(patch).attach_inventory(inventory)
 assert "gauge_length" not in dict(spool[0].attrs)
 ```
 
-What attaching *does* change is which names resolve. The coordinates the inventory defines along the fiber become selectable, and [`Spool.expand_by`](`dascore.core.spool.Spool.expand_by`) can expand the spool by the values of one:
+Once attached, inventory coordinates can drive selection and expansion:
 
 ```{python}
-# Keep only the channels the inventory places in the northern zone.
 northern = spool.select(zone="north")
-
-# Or get one patch per zone, each holding that zone's channels.
 zones = spool.expand_by("zone")
-assert len(zones) == 2
 assert set(zones.get_contents()["zone"]) == {"north", "south"}
 ```
 
-Selecting on an inventory coordinate trims channels rather than cutting the patch at the spool level, since the inventory is what says which channel is which. A patch left with no matching channels at all drops out, there being nothing to keep.
+Selection trims channels; a patch with no matching channels drops out.
 
-# Enriching patches
+Attaching a replacement inventory clears enrichment configured from the old one, preventing stale instructions from being applied to new metadata.
 
-[`Spool.enrich`](`dascore.core.spool.Spool.enrich`) is how the inventory's metadata actually reaches the patches. It is set up once and applied as each patch is extracted, so it stays cheap on a large spool.
+## Enriching patches
 
-```{python}
-enriched = spool.enrich()
-
-patch_out = enriched[0]
-assert patch_out.attrs.gauge_length == 10.0
-assert "zone" in patch_out.coords.coord_map
-```
-
-The per-channel facts reach the patch by way of the acquisition's `distance_map`, which places each channel on the optical path. The map states its control points in meters on the `instrument_distance` axis, so a patch whose axis is written in another length — feet, kilometers — is converted before it is read, and one whose axis is not a length at all raises rather than being taken for meters. The `channel` axis counts channels and states no unit.
-
-Enrichment never removes a patch. One the inventory does not describe comes out unchanged rather than missing, with a warning, so an inventory that deliberately covers part of an archive needs no pruning first. Deciding membership is a separate step, below.
-
-What it copies follows one rule on each side. Every scalar fact the resolved acquisition states — and its interrogator's, under `interrogator.` — becomes an attr, and every per-channel fact the optical path states becomes a coordinate: the geometry axes, the label groups, and how each channel is coupled. Four names are left out of the blanket form: `data_type` and `data_units`, which describe the data as it now stands rather than the system that recorded it, and `sample_rate` and `spatial_interval`, which the patch's own coordinates already state and which a decimated patch would contradict. Naming one asks for it anyway.
+[`Spool.enrich`](`dascore.core.spool.Spool.enrich`) copies resolved metadata as patches are loaded. Acquisition and interrogator facts become attributes; optical-path facts become per-channel coordinates.
 
 ```{python}
-enriched_patch = spool.enrich()[0]
-
-# A fact about the acquisition, and one about each channel.
-assert enriched_patch.attrs.data_category == "DAS"
-assert set(enriched_patch.get_array("coupling")) == {"trench", ""}
-
-# Which makes the comparison everyone wants a selection.
-trenched = enriched_patch.select(coupling="trench")
+enriched = spool.enrich()[0]
+assert enriched.attrs.gauge_length == 10.0
+assert "zone" in enriched.coords.coord_map
+assert set(enriched.get_array("coupling")) == {"trench", ""}
 ```
 
-Where the patch and the inventory both state an attr and disagree, `conflict` decides. The default `keep_first` keeps what the file said, because it said it first; `keep_last` lets the inventory correct it; `drop` leaves neither; and `raise` treats the disagreement as the misresolution it usually is — a header contradicting the resolved acquisition normally means the `acquisition_key` resolved to the wrong place. Filling an attr the patch leaves unset is not a disagreement, and happens under every policy.
+The acquisition's `distance_map` performs the projection. Compatible distance units are converted; incompatible axes raise. An unresolved patch is returned unchanged with a warning, so enrichment never silently removes data.
+
+By default, scalar acquisition fields and `interrogator.*` fields become attributes, while geometry, coupling, and labels become coordinates. `data_type` and `data_units` are excluded because processing may have changed the data; `sample_rate` and `spatial_interval` are excluded because the patch coordinates already state them. They can still be requested explicitly.
+
+If a patch attribute conflicts with the inventory, `conflict` chooses the result: `keep_first` (default) keeps the patch value, `keep_last` uses the inventory, `drop` removes both, and `raise` reports the contradiction.
 
 ```{python}
 stale = patch.update_attrs(gauge_length=99.0)
-
-assert stale.enrich(example_inventory).attrs.gauge_length == 99.0
-assert stale.enrich(example_inventory, conflict="keep_last").attrs.gauge_length == 10.0
+assert stale.enrich(inventory).attrs.gauge_length == 99.0
+assert stale.enrich(inventory, conflict="keep_last").attrs.gauge_length == 10.0
 ```
 
-A single patch can be enriched directly with [`Patch.enrich`](`dascore.proc.inventory.enrich`), which takes the same arguments apart from `on_unresolved` — one patch either resolves or raises, so there is no policy to state. It takes the inventory as an argument, since only a spool carries one:
+[`Patch.enrich`](`dascore.proc.inventory.enrich`) performs the same operation directly on one patch, but an unresolved patch raises instead of using the spool's `on_unresolved` policy.
+
+## Conforming a spool
+
+[`Spool.conform_to_inventory`](`dascore.core.spool.Spool.conform_to_inventory`) eagerly resolves every row, rejects or drops unresolved patches, and subdivides patches at optical-path changes. Unlike attachment and enrichment, it can change spool length.
 
 ```{python}
-one = patch.enrich(example_inventory)
-assert one.attrs.gauge_length == 10.0
-```
-
-# Conforming a spool
-
-[`Spool.conform_to_inventory`](`dascore.core.spool.Spool.conform_to_inventory`) is the one eager step of the workflow, and the only one that changes what the spool contains. It resolves every row now, refuses patches the inventory does not describe, and *subdivides* a patch whose span crosses a change of optical path — so the spool can grow as well as shrink. Pass `on_unresolved="ignore"` (or `"warn"`) to drop the undescribed patches instead of raising, which is what an inventory deliberately covering part of an archive wants.
-
-```{python}
-# A second patch this inventory says nothing about.
 stranger = dc.get_example_patch("random_das", acquisition_key="XX.NOPE..RAW")
-mixed = dc.spool([patch, stranger]).attach_inventory(example_inventory)
-assert len(mixed) == 2
+mixed = dc.spool([patch, stranger]).attach_inventory(inventory)
 
-# Conforming keeps only what the inventory describes.
 conformed = mixed.conform_to_inventory(on_unresolved="ignore")
 assert len(conformed) == 1
 assert conformed[0].attrs.acquisition_key == "DAS.R2D1..RAW"
 ```
 
-Subdivision is exact: each piece begins at the first sample at or after the change that opens it, so together the pieces hold every sample the patch held and hold none of them twice. `len` and `get_contents` describe the pieces.
+Subdivision preserves every sample exactly once. Use `on_unresolved="warn"` or `"ignore"` when an inventory intentionally covers only part of an archive.
 
-This is why attaching an inventory never implies conforming to one. Attaching is inert; conforming changes `len`, moves rows, raises by default on a patch the inventory does not describe, and raises, whatever the policy, when a patch straddles a change of acquisition. A spool that quietly changed its own length would be a bad thing to get by default.
+Conforming raises when one patch straddles an acquisition change, since a patch cannot carry two acquisition configurations. This is why attachment remains inert: conforming can remove, split, or reject data and must be requested explicitly.
 
-# An inventory a directory carries
+# Inventory files beside data
 
-A directory of data can keep the inventory that describes it, under the name `.inventory`, and a spool opened on that directory starts out attached to it. The metadata is then found where it lies, rather than named again by every script that reads the archive.
+A data directory may carry its inventory as `.inventory/`, `.inventory.yaml`, `.inventory.yml`, or `.inventory.json`. A spool opened on that directory attaches it automatically:
 
 ```{python}
 data_path = Path(tempfile.mkdtemp()) / "archive"
 data_path.mkdir()
 patch.io.write(data_path / "patch.h5", "DASDAE")
-
-# Either form works: the directory .inventory/, or a serialized file
-# naming its format -- .inventory.yaml, .inventory.yml, or .inventory.json.
-example_inventory.io.to_yaml(data_path / ".inventory.yaml")
+inventory.io.to_yaml(data_path / ".inventory.yaml")
 
 carrying = dc.spool(data_path).update()
 assert carrying.enrich()[0].attrs.gauge_length == 10.0
 ```
 
-The name is hidden for the same reason `.dascore_index.sqlite3` is: it is a companion the directory keeps rather than content it holds, so the file scanner skips it. Both forms present at once is two spellings of one fact, and is refused. The visible spelling `inventory.yaml` is deliberately *not* it — in the authoring format that name is the envelope, so a data directory holding one would be claiming to be an inventory directory itself.
+Discovery happens when the spool opens, but parsing waits until an inventory-backed operation. Ordinary `len`, sorting, chunking, patch loading, and selection using only indexed names do not parse it; selection on an inventory coordinate does. The inventory is then cached. After editing it, call `attach_inventory()` with no argument to reread the directory's copy.
 
-Three things happen at three different times, and keeping them apart is the point:
-
-- **Discovery is eager.** Whether the directory carries an inventory is settled when the spool is opened, by a stat of each spelling and nothing more.
-- **Reading is lazy.** The file is read at the first question only an inventory can answer — never for `len`, `get_contents`, `sort`, `chunk`, extracting a patch, or a selection on names the index already knows. A malformed inventory therefore cannot stop you loading data; only the inventory-backed calls fail, and they name the directory the inventory came from and say that the spool picked it up on opening.
-- **Refreshing is explicit.** An inventory is an input, not a cache, so it is read once and held with no modification-time check. `attach_inventory()` with no argument means "the one this directory carries, read it again", which is the whole authoring loop:
-
-```{python}
-# Correct the gauge length in the file the directory carries.
-old_acquisition = example_inventory.networks[0].fiber_arrays[0].acquisitions[0]
-corrected = example_inventory.replace(
-    old_acquisition, old_acquisition.new(gauge_length=12.0)
-)
-corrected.io.to_yaml(data_path / ".inventory.yaml")
-
-# The spool which already read it still reports what it read.
-assert carrying.enrich()[0].attrs.gauge_length == 10.0
-
-# Asking again is what picks the correction up.
-refreshed = carrying.attach_inventory()
-assert refreshed.enrich()[0].attrs.gauge_length == 12.0
-```
-
-`attach_inventory` accepts a path as well as an `Inventory`, read on the same terms — and it is the only one of the three that takes either, since `enrich` and `conform_to_inventory` read what it attached.
+Two `.inventory` spellings in one directory are refused as ambiguous. The visible name `inventory.yaml` is not a companion file: in the authoring format it is the inventory envelope.
 
 # Serializing
 
-[`Inventory.io.to_yaml`](`dascore.core.inventory.inventory_to_yaml`) writes the single-file interchange form — the artifact to ship beside a data archive — and [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads any of the forms back.
+[`Inventory.io.to_yaml`](`dascore.core.inventory.inventory_to_yaml`) produces the single-file interchange form. [`dc.inventory`](`dascore.core.inventory_loader.inventory`) reads directory, YAML, JSON, model, or serialized text inputs.
 
 ```{python}
 text = inventory.io.to_yaml()
 assert dc.inventory(text) == inventory
 
-# JSON works everywhere YAML does, and needs no YAML library installed.
 json_path = data_path / "inventory.json"
 json_path.write_text(inventory.model_dump_json())
 assert dc.inventory(json_path) == inventory
 ```
 
-A document that cannot be parsed, cannot be decoded, or keys a field with something that is not a name (`1: 2` is legal YAML) raises `InvalidInventoryError` rather than whatever the parser happened to raise, wherever it is read from.
+Invalid documents consistently raise [`InvalidInventoryError`](`dascore.exceptions.InvalidInventoryError`).

--- a/tests/test_inventory_diagrams.py
+++ b/tests/test_inventory_diagrams.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 from pathlib import Path
 from xml.etree import ElementTree
@@ -61,6 +62,20 @@ def _page_text() -> str:
     return _PAGE_PATH.read_text(encoding="utf-8")
 
 
+def _parse_view_box(value: str) -> list[float]:
+    """Parse and validate an SVG viewBox."""
+    values = [float(item) for item in re.split(r"[\s,]+", value.strip())]
+    valid = (
+        len(values) == 4
+        and all(math.isfinite(item) for item in values)
+        and values[2] > 0
+        and values[3] > 0
+    )
+    if not valid:
+        raise ValueError(f"Invalid SVG viewBox: {value!r}")
+    return values
+
+
 @pytest.mark.parametrize("name", _DIAGRAMS)
 def test_page_references_each_diagram(name):
     """Each shipped diagram is used exactly once by the inventory page."""
@@ -75,9 +90,7 @@ def test_diagram_is_valid_svg(name):
     assert root.tag == "{http://www.w3.org/2000/svg}svg"
     view_box = root.get("viewBox")
     assert view_box
-    values = [float(value) for value in re.split(r"[\s,]+", view_box.strip())]
-    assert len(values) == 4
-    assert values[2] > 0 and values[3] > 0
+    _parse_view_box(view_box)
     namespace = "{http://www.w3.org/2000/svg}"
     definitions = {
         element
@@ -90,6 +103,12 @@ def test_diagram_is_valid_svg(name):
         if element not in definitions
     }
     assert tags & _GRAPHIC_ELEMENTS
+
+
+def test_non_finite_view_box_is_invalid():
+    """SVG viewBox values cannot contain floating-point infinities."""
+    with pytest.raises(ValueError, match="Invalid SVG viewBox"):
+        _parse_view_box("0 0 inf 100")
 
 
 @pytest.mark.parametrize(("name", "model_fields"), _MODEL_FIELDS.items())

--- a/tests/test_inventory_diagrams.py
+++ b/tests/test_inventory_diagrams.py
@@ -8,7 +8,7 @@ from xml.etree import ElementTree
 
 import pytest
 
-from dascore.core.inventory import Acquisition, FiberArray, Inventory, OpticalPath
+from dascore.core.inventory import Acquisition, FiberArray, OpticalPath
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _DOC_PATH = _REPO_ROOT / "docs"
@@ -32,13 +32,18 @@ _GRAPHIC_ELEMENTS = {
 }
 _MODEL_FIELDS = {
     "inventory_hierarchy.svg": {
-        Inventory: {"resources"},
-        FiberArray: {"optical_paths", "acquisitions"},
-        OpticalPath: {"optical_components", "geometry", "labels", "coupling"},
-        Acquisition: {"interrogator", "distance_map"},
+        "fiber-array-site": (FiberArray, {"optical_paths", "acquisitions"}),
+        "optical-path-tracks": (
+            OpticalPath,
+            {"optical_components", "geometry", "labels", "coupling"},
+        ),
+        "acquisition-settings": (Acquisition, {"interrogator", "distance_map"}),
     },
     "optical_path_concept.svg": {
-        OpticalPath: {"optical_components", "geometry", "labels", "coupling"},
+        "layer-cards": (
+            OpticalPath,
+            {"optical_components", "geometry", "labels", "coupling"},
+        ),
     },
 }
 
@@ -68,8 +73,11 @@ def test_diagram_is_valid_svg(name):
     """A missing, empty, or malformed image must fail before the docs build."""
     root = ElementTree.parse(_STATIC_PATH / name).getroot()
     assert root.tag == "{http://www.w3.org/2000/svg}svg"
-    assert root.get("viewBox")
-    assert all(float(value) > 0 for value in root.get("viewBox").split()[2:])
+    view_box = root.get("viewBox")
+    assert view_box
+    values = [float(value) for value in re.split(r"[\s,]+", view_box.strip())]
+    assert len(values) == 4
+    assert values[2] > 0 and values[3] > 0
     namespace = "{http://www.w3.org/2000/svg}"
     definitions = {
         element
@@ -88,8 +96,10 @@ def test_diagram_is_valid_svg(name):
 def test_diagram_model_fields(name, model_fields):
     """Field names shown in the diagrams stay aligned with the models."""
     root = ElementTree.parse(_STATIC_PATH / name).getroot()
-    text = " ".join(root.itertext()).lower()
-    for model, fields in model_fields.items():
+    for group_id, (model, fields) in model_fields.items():
+        group = root.find(f".//*[@id='{group_id}']")
+        assert group is not None
+        text = " ".join(group.itertext()).lower()
         assert fields <= model.model_fields.keys()
         assert all(field in text for field in fields)
 

--- a/tests/test_inventory_diagrams.py
+++ b/tests/test_inventory_diagrams.py
@@ -1,133 +1,107 @@
-"""
-Tests which keep the inventory tutorial's mermaid diagrams honest.
-
-The diagrams are hand-written, so nothing stops them describing a model that no
-longer looks like that. These tests read the diagrams back out of the page and
-check each edge against the models: that the source is a model, that the field
-labelling the edge exists on it, that the target is a model that field can
-actually hold, and that a dashed edge is drawn exactly where the field accepts a
-resource_id string in place of the object.
-"""
+"""Tests for the inventory tutorial's explanatory diagrams."""
 
 from __future__ import annotations
 
 import re
-import types
 from pathlib import Path
-from typing import Union, get_args, get_origin, get_type_hints
+from xml.etree import ElementTree
 
 import pytest
 
-import dascore.core.inventory as inventory_module
-from dascore.core.inventory import InventoryModel
+from dascore.core.inventory import Acquisition, FiberArray, Inventory, OpticalPath
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _DOC_PATH = _REPO_ROOT / "docs"
 _PAGE_PATH = _DOC_PATH / "tutorial" / "inventory.qmd"
+_STATIC_PATH = _DOC_PATH / "_static"
+_DIAGRAMS = {
+    "inventory_hierarchy.svg": {"station", "channel", "fiber", "acquisition"},
+    "optical_path_concept.svg": {"components", "geometry", "labels", "coupling"},
+}
+_GRAPHIC_ELEMENTS = {
+    "circle",
+    "ellipse",
+    "image",
+    "line",
+    "path",
+    "polygon",
+    "polyline",
+    "rect",
+    "text",
+    "use",
+}
+_MODEL_FIELDS = {
+    "inventory_hierarchy.svg": {
+        Inventory: {"resources"},
+        FiberArray: {"optical_paths", "acquisitions"},
+        OpticalPath: {"optical_components", "geometry", "labels", "coupling"},
+        Acquisition: {"interrogator", "distance_map"},
+    },
+    "optical_path_concept.svg": {
+        OpticalPath: {"optical_components", "geometry", "labels", "coupling"},
+    },
+}
 
-# Run wherever the docs are, skip where they are not, on the same terms as
-# test_changelog.py: the sdist grafts tests but ships only docs/LICENSE, so the
-# directory existing does not mean the real docs tree is there. Deliberately not
-# keyed on the tutorial itself, or deleting the page would skip rather than fail.
+# The sdist grafts tests but ships only docs/LICENSE. Key this on a page the
+# full documentation tree always contains, not on the files under test.
 _DOCS_PRESENT = (_DOC_PATH / "index.qmd").is_file()
 
 pytestmark = pytest.mark.skipif(
     not _DOCS_PRESENT, reason="the documentation tree is not installed"
 )
 
-_BLOCK = re.compile(r"^```\{mermaid\}\n(.*?)^```", re.MULTILINE | re.DOTALL)
-# `Source -->|field| Target` or its dashed form, where a target may carry a
-# label: `Components["FiberSegment · Splice"]`.
-_EDGE = re.compile(
-    r"^\s*(\w+)\s*(-->|-\.->)\s*\|(\w+)\|\s*(\w+)(?:\[\"([^\"]+)\"\])?\s*$"
-)
-_ARROW = re.compile(r"-\.?->")
+
+def _page_text() -> str:
+    """Return the inventory tutorial source."""
+    return _PAGE_PATH.read_text(encoding="utf-8")
 
 
-def _read_diagrams():
-    """Return the page's edges, and the edge lines which could not be read.
-
-    The unread lines matter as much as the edges: an edge this module cannot
-    parse is an edge it cannot check, and dropping it silently is how the whole
-    file goes vacuous one arrow at a time.
-    """
-    if not _DOCS_PRESENT:  # nothing to read; every test here is skipped
-        return (), ()
-    edges, unread = [], []
-    # Explicitly utf-8: the page is, and the separator this splits labels on is
-    # not ascii, so reading it under a locale which is not utf-8 -- windows --
-    # decodes the separator to something else and quietly stops splitting.
-    for block in _BLOCK.findall(_PAGE_PATH.read_text(encoding="utf-8")):
-        for line in block.splitlines():
-            if (match := _EDGE.match(line)) is None:
-                if _ARROW.search(line):
-                    unread.append(line.strip())
-                continue
-            source, arrow, field, node, label = match.groups()
-            # A labelled node stands for the several types its label names.
-            targets = tuple(label.split(" · ")) if label else (node,)
-            edges.append((source, arrow == "-.->", field, targets))
-    return tuple(edges), tuple(unread)
+@pytest.mark.parametrize("name", _DIAGRAMS)
+def test_page_references_each_diagram(name):
+    """Each shipped diagram is used exactly once by the inventory page."""
+    pattern = rf"^!\[[^]]+\]\(\.\./_static/{re.escape(name)}\)"
+    assert len(re.findall(pattern, _page_text(), re.MULTILINE)) == 1
 
 
-def _accepted_models(model, field):
-    """Return the models the field holds, and whether it accepts a reference.
-
-    A reference is a `str` in the same union as a model, which is how the
-    inventory spells "this may be a resource_id instead of the object".
-    """
-    annotation = get_type_hints(model)[field]
-    found, referenced = set(), False
-
-    def _walk(node, in_reference_union):
-        nonlocal referenced
-        origin = get_origin(node)
-        if origin in (Union, types.UnionType):
-            args = get_args(node)
-            in_reference_union = str in args
-            for arg in args:
-                _walk(arg, in_reference_union)
-        elif origin is not None:
-            for arg in get_args(node):
-                _walk(arg, in_reference_union)
-        elif isinstance(node, type) and issubclass(node, InventoryModel):
-            found.add(node)
-            referenced = referenced or in_reference_union
-
-    _walk(annotation, False)
-    return found, referenced
+@pytest.mark.parametrize("name", _DIAGRAMS)
+def test_diagram_is_valid_svg(name):
+    """A missing, empty, or malformed image must fail before the docs build."""
+    root = ElementTree.parse(_STATIC_PATH / name).getroot()
+    assert root.tag == "{http://www.w3.org/2000/svg}svg"
+    assert root.get("viewBox")
+    assert all(float(value) > 0 for value in root.get("viewBox").split()[2:])
+    namespace = "{http://www.w3.org/2000/svg}"
+    definitions = {
+        element
+        for defs in root.findall(f".//{namespace}defs")
+        for element in defs.iter()
+    }
+    tags = {
+        element.tag.rsplit("}", 1)[-1]
+        for element in root.iter()
+        if element not in definitions
+    }
+    assert tags & _GRAPHIC_ELEMENTS
 
 
-_EDGES, _UNREAD = _read_diagrams()
+@pytest.mark.parametrize(("name", "model_fields"), _MODEL_FIELDS.items())
+def test_diagram_model_fields(name, model_fields):
+    """Field names shown in the diagrams stay aligned with the models."""
+    root = ElementTree.parse(_STATIC_PATH / name).getroot()
+    text = " ".join(root.itertext()).lower()
+    for model, fields in model_fields.items():
+        assert fields <= model.model_fields.keys()
+        assert all(field in text for field in fields)
 
 
-class TestDiagramEdges:
-    """Every edge drawn in the tutorial has to be a field the models have."""
-
-    def test_the_page_draws_edges(self):
-        """A regex which quietly matched nothing would pass every test below."""
-        assert len(_EDGES) >= 12
-
-    def test_every_edge_line_is_read(self):
-        """An arrow this module cannot parse is an arrow it cannot check."""
-        assert not _UNREAD, f"Unparsed mermaid edges: {_UNREAD}"
-
-    @pytest.mark.parametrize(("source", "dashed", "field", "targets"), _EDGES)
-    def test_an_edge_matches_the_models(self, source, dashed, field, targets):
-        """The source, the field, the targets, and the arrow all have to agree."""
-        model = getattr(inventory_module, source, None)
-        assert isinstance(model, type) and issubclass(model, InventoryModel), (
-            f"{source} is not an inventory model."
-        )
-        assert field in model.model_fields, f"{source} has no field {field!r}."
-
-        accepted, referenced = _accepted_models(model, field)
-        names = {x.__name__ for x in accepted}
-        for target in targets:
-            assert target in names, f"{source}.{field} cannot hold a {target}."
-
-        arrow = "dashed" if dashed else "solid"
-        assert dashed == referenced, (
-            f"{source}.{field} is drawn {arrow}, which says the wrong thing "
-            "about whether it accepts a resource_id in place of the object."
-        )
+@pytest.mark.parametrize(("name", "required_terms"), _DIAGRAMS.items())
+def test_diagram_has_alt_text(name, required_terms):
+    """The page gives each visual a useful text alternative."""
+    pattern = rf"^!\[[^]]+\]\(\.\./_static/{re.escape(name)}\)\{{(?P<attrs>[^}}]+)\}}"
+    match = re.search(pattern, _page_text(), re.MULTILINE)
+    assert match is not None
+    alt_match = re.search(r'fig-alt="(?P<alt>[^"]+)"', match["attrs"])
+    assert alt_match is not None
+    alt = alt_match["alt"].lower()
+    assert len(alt.split()) >= 20
+    assert all(term in alt for term in required_terms)


### PR DESCRIPTION
## Description

Replace the inventory tutorial's Mermaid diagrams with local copies of the deployment figures from the Galileo 2026 repository. Condense the surrounding explanation from 3,639 to 1,605 words while retaining the model, authoring rules, track semantics, enrichment, conformance, discovery, and serialization workflows.

The diagram tests now verify that both shipped SVGs are valid, referenced once, and accompanied by useful alt text.

## Changelog

- changed: Streamlined the inventory tutorial and added diagrams comparing point-sensor and fiber inventory structures and explaining optical-path tracks.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reworked the inventory tutorial with clearer sections, updated examples, and more concise explanations.
  - Replaced Mermaid diagrams with static SVG illustrations.
  - Expanded guidance on modeling, enrichment, conforming, companion inventory files, serialization, and visualization.
  - Updated inventory and patch examples to reflect the current workflow.

- **Tests**
  - Added validation for diagram structure, model field references, page references, dimensions, and descriptive alternative text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->