### PR TITLE
Condense tutorial documentation

### DIFF
--- a/docs/tutorial/concepts.qmd
+++ b/docs/tutorial/concepts.qmd
@@ -4,133 +4,83 @@ execute:
   warning: false
 ---
 
-This page highlights some concepts helpful for working with DASCore.
-
 # Data structures
 
-For most uses of DASCore, only two data structures are directly involved.
-These are the [Patch](patch.qmd) and the [Spool](spool.qmd).
+Most DASCore work uses two objects: a [Patch](patch.qmd), which holds one n-dimensional array with coordinates and metadata, and a [Spool](spool.qmd), which manages patches in memory, on disk, or remotely.
 
-The `Patch` contains a contiguous block of N dimensional data and metadata.
-The `Spool` manages a group of `Patch`es. These can be in memory, on
-disk, or a remote resource.
+Patch operations are eager once a patch is loaded. Spool operations generally build lazy selections and chunking plans, loading patch arrays only when indexed, iterated, or mapped.
 
 ![Patch (blue) and Spool (red)](../_static/patch_n_spool.png){#fig-patch_n_spool}
 
-You will read more about Patches and Spools later on in the tutorial.
-
 # Time
 
-Any expression of time should use [numpy](https://numpy.org/doc/stable/reference/arrays.datetime.html) time constructs, which include [datetime64](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.datetime64) and [timedelta64](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.timedelta64).
-
-For example:
+DASCore represents absolute and relative time with NumPy [`datetime64`](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.datetime64) and [`timedelta64`](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.timedelta64).
 
 ```{python}
 import numpy as np
 
-# Create a datetime64 with an iso8601 time string.
-time_1 = np.datetime64('2022-01-01T15:12:11.172455')
-
-# Create a new time by adding some time to time_1.
-time_2 = time_1 + np.timedelta64(60, 's')
-
-# Get the number of hours separating them:
-delta_1 = (time_2 - time_1) / np.timedelta64(1, 'h')
+start = np.datetime64("2022-01-01T15:12:11")
+end = start + np.timedelta64(60, "s")
+minutes = (end - start) / np.timedelta64(1, "m")
 ```
 
-DASCore provides two convenience functions for working with times:
-
-- [to_datetime64](`dascore.utils.time.to_datetime64`) converts different inputs to numpy datetime64 arrays or instances.
-- [to_timedelta64](`dascore.utils.time.to_timedelta64`) converts different inputs to numpy timedelta64 arrays or instances.
-
-For example:
+[`dc.to_datetime64`](`dascore.utils.time.to_datetime64`) and [`dc.to_timedelta64`](`dascore.utils.time.to_timedelta64`) normalize common inputs:
 
 ```{python}
 import dascore as dc
 
-# Convert a time string to a datetime64 object.
-time_1 = dc.to_datetime64('2022-01-01T12:12:12.1212')
-
-# Convert a timestamp (seconds from 1970-01-01) to a datetime object
-time_2 = dc.to_datetime64(610243200)
+time = dc.to_datetime64("2022-01-01T12:12:12.1212")
+duration = dc.to_timedelta64(1.5)
 ```
 
+Numeric values passed to `to_datetime64` are Unix timestamps in seconds. Numeric values passed to `to_timedelta64` are durations in seconds.
 
-# Dimension Selection
+# Dimension arguments
 
-Most of DASCore's processing methods can be applied along any dimension. Typically, the dimension is selected with keyword, and the method specific data are passed as values. For example, applying [pass_filter](`dascore.proc.filter.pass_filter`) to a patch with `distance` and `time` dimensions works like this:
+Most processing methods name a dimension as a keyword:
 
 ```{python}
-import dascore as dc
 patch = dc.get_example_patch()
-
-filtered_time = patch.pass_filter(time=(1, 5))
-filtered_distance = patch.pass_filter(distance=(0.1, 0.2))
+temporal = patch.pass_filter(time=(1, 5))
+spatial = patch.pass_filter(distance=(0.1, 0.2))
 ```
 
-However, the meaning of the values depends on the function, e.g. both frequency and period might make sense in the example above. For [pass_filter](`dascore.proc.filter.pass_filter`), bare numbers mean frequency along `time` and wavenumber along `distance`. In both cases the number is the inverse of *that coordinate's own units*, so it is Hz and 1/m only while the coordinates are in seconds and meters. The example patch's distance is in meters, so `distance=(0.1, 0.2)` above keeps spatial wavelengths of 5 m to 10 m.
+The function determines what the values mean. For `pass_filter`, bare numbers are inverse coordinate units: frequency for time and wavenumber for distance. Datetime coordinates always use seconds; numeric coordinates use their declared units.
 
-Datetime and timedelta coordinates are always in seconds, so a `time` coordinate of that dtype always takes Hz. A numeric `time` coordinate does not: `example_event_2` stores time as float seconds, and converting it to milliseconds makes bare numbers mean 1/ms.
+For a distance coordinate in metres, `distance=(0.1, 0.2)` means wavenumbers from 0.1 to 0.2 per metre, corresponding to wavelengths from 5 to 10 metres. If the coordinate is converted to feet, the same bare numbers instead mean inverse feet.
 
-Attaching units removes the guesswork, and lets the same band be stated as a wavelength instead:
+Attach quantities to make the intended band independent of coordinate units:
 
 ```{python}
-import dascore as dc
-import numpy as np
 from dascore.units import m
 
-patch = dc.get_example_patch()
-
-# This patch's distance is in meters, so bare numbers are 1/m.
-# Wavenumbers of 0.01 to 0.1 and wavelengths of 10 m to 100 m are two
-# ways of describing the same band.
 by_wavenumber = patch.pass_filter(distance=(0.01, 0.1))
 by_wavelength = patch.pass_filter(distance=(10 * m, 100 * m))
-
 assert np.allclose(by_wavenumber.data, by_wavelength.data)
+```
 
-# With units attached the query means the same thing regardless of what
-# units the coordinate happens to be in.
+```{python}
 in_feet = patch.convert_units(distance="ft")
-assert np.allclose(in_feet.pass_filter(distance=(10 * m, 100 * m)).data, by_wavelength.data)
-
-# The time axis behaves the same way when its coordinate is numeric.
-# example_event_2 stores time as float seconds, so bare numbers are Hz,
-# but in milliseconds the same band needs numbers 1000 times smaller.
-event = dc.get_example_patch("example_event_2")
-in_ms = event.convert_units(time="ms")
-
 assert np.allclose(
-    in_ms.pass_filter(time=(0.01, 0.05)).data,
-    event.pass_filter(time=(10, 50)).data,
+    in_feet.pass_filter(distance=(10 * m, 100 * m)).data,
+    by_wavelength.data,
 )
 ```
 
-When in doubt, be explicit with units and read the docs for the function in question!
-
 # Units
 
-DASCore provides first class support for units through the [`units`](`dascore.units`) module. Units (or rather quantities) can be imported directly or can be created with the [get_quantity](`dascore.units.get_quantity`) function.
+DASCore uses [Pint](https://pint.readthedocs.io/) quantities. Import common units or parse them with [`get_quantity`](`dascore.units.get_quantity`):
 
 ```{python}
-from dascore.units import get_quantity, m, ft
+from dascore.units import ft, get_quantity, m
 
-meters = get_quantity("meters")
-
-# Now meters should be equal to 1 meter.
-assert meters == 1 * m
-
-# Convert 10 meters to ft.
-ten_m = meters * 10
-print(ten_m.to(ft))
-
-# get_quantity can handle a lot of complexity!
-quantity = get_quantity("10 * (PI / 10^3) (millifurlongs)/(tesla)")
-print(quantity)
+distance = 10 * m
+print(distance.to(ft))
+assert get_quantity("meters") == 1 * m
 ```
 
-Many of DASCore's Patch methods support units/quantities as shown above. See the [units section](patch.qmd#units) in the Patch tutorial for examples.
+Patch selection, processing, and conversion methods accept quantities directly. See [Patch units](patch.qmd#units) for examples.
 
-:::{.callout-note}
-DASCore uses the unit library [Pint](https://github.com/hgrecco/pint) for unit parsing/conversions. See its documentation for more info on units and quantities.
-:::
+Use explicit quantities whenever code may encounter the same coordinate expressed in different units. Bare values are most appropriate when the coordinate convention is fixed and documented.
+
+Unit-aware operations preserve physical meaning through coordinate conversion and patch arithmetic. `set_units` changes labels only; `convert_units` changes values to preserve the same quantity.

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -1,92 +1,67 @@
 # Runtime Configuration
 
-DASCore exposes a small runtime configuration surface through `dascore.config`.
+Runtime settings live in `dascore.config` and affect subsequent operations.
 
-```python
-from pathlib import Path
-
-from dascore.config import get_config, config_context
-
-print(get_config().remote_cache_dir)
-
-with config_context(remote_cache_dir=Path("/tmp/dascore-remote-cache")):
-    ...
-```
-
-Configuration changes affect subsequent operations only. For example, changing `remote_cache_dir` changes where future remote-file materializations are cached.
-
-## Two configuration tiers
-
-Config can be changed in two ways:
-
-- `set_config(...)` changes the process-wide base permanently. The change is visible from every thread and task and is not restored automatically; `reset_config()` returns to defaults. Use it for application-level settings applied once at startup.
-- `config_context(...)` overrides the config only for the current thread or task. The override is restored when the block exits, and concurrent blocks in different threads never clobber one another.
-
-```python
+```{python}
 import dascore as dc
 
-dc.set_config(display_float_precision=5)  # permanent
+print(dc.get_config().display_float_precision)
+```
 
-with dc.config_context(display_float_precision=8):  # scoped to this block
+# Scope
+
+| Function | Scope | Restoration |
+|---|---|---|
+| `set_config(...)` | Process-wide base | Until `reset_config()` |
+| `config_context(...)` | Current thread or task | When the block exits |
+
+```{python}
+dc.set_config(display_float_precision=5)
+
+with dc.config_context(display_float_precision=8):
     ...
 
-dc.reset_config()  # drop the permanent change
+dc.reset_config()
 ```
 
-[`Spool.map`](`dascore.core.spool.Spool.map`) binds the config active when `map` is called and re-applies it in each worker, so overrides also reach thread- and process-pool workers.
+Concurrent contexts do not overwrite one another. `Spool.map` captures the active configuration and reapplies it in workers.
 
-History recording is also configurable:
+`set_config` is intended for application startup. Prefer `config_context` in libraries, tests, notebooks, and any operation that should restore the caller's settings.
 
-- `patch_history="standard"` preserves the default behavior and appends new entries to `Patch.attrs.history`.
-- `patch_history="disabled"` preserves any existing history but stops DASCore from appending new entries inside that config context.
+# Common settings
 
-```python
-from dascore.config import config_context
+- `patch_history="disabled"` preserves existing history but stops appending entries.
+- `patch_kind_attrs` selects metadata fields that determine whether patches are compatible; see [Patch compatibility](../notes/patch_compatibility.qmd).
+- `display_float_precision` controls displayed decimals.
+- `display_array_threshold` limits printed array values.
+- `display_max_items` limits children shown at each representation level.
+- `display_max_patches` disables expensive spool summaries above a threshold.
+- `display_html` switches notebook output to text.
+- `display_html_open_lines` sets when HTML sections start folded; `0` folds all sections.
 
-with config_context(patch_history="disabled"):
-    ...
+`patch_kind_attrs` affects operators and spool partitioning. Conflicting values prevent combination; missing values act as wildcards for operators but form their own partition in spool operations.
+
+```{python}
+with dc.config_context(patch_kind_attrs=("acquisition_key",)):
+    ...  # tag and data_category no longer separate patch kinds
 ```
 
-Which patches may be combined is configurable too: `patch_kind_attrs` names the attributes that decide whether two patches are the same kind (patches with differing values for any of them are never combined; a missing value is a wildcard for operators and a value of its own where patches are partitioned). See the [Patch Compatibility](../notes/patch_compatibility.qmd) note.
-
-```python
-with config_context(patch_kind_attrs=("acquisition_key",)):
-    ...  # tag and data_category no longer separate patches
+```{python}
+with dc.config_context(patch_history="disabled", display_max_items=3):
+    patch = dc.get_example_patch().abs()
+    display(patch)
 ```
 
-How objects print is configurable as well: `display_float_precision` sets the decimals shown for floats (a value smaller than the last of them is shown in that many significant figures instead, so it reads as a number rather than as 0.000), `display_array_threshold` how much of an array is printed before it is elided, `display_max_items` how many children a repr lists per level before saying how many it left out, and `display_max_patches` how large a spool may be before its repr stops summarizing what it covers and names the limit it exceeded instead.
+HTML output uses collapsible sections in notebooks and rendered documentation. Text output contains the same underlying summary and is suitable for terminals and logs.
 
-```python
-with config_context(display_max_items=3):
-    display(inventory)  # at most three networks, arrays or paths per level
+```{python}
+with dc.config_context(display_html=False):
+    display(patch)
 
-with config_context(display_max_patches=100):
-    display(spool)  # a bigger spool names the limit rather than its extents
+with dc.config_context(display_html_open_lines=0):
+    display(patch)
 ```
 
-Where a display can render HTML -- a notebook, or this documentation --
-an object draws a panel whose sections fold, rather than the text above.
-`display_html` turns that off and sends every display back to the text,
-which says the same words. `display_html_open_lines` (12 by default) is
-how many lines a section may hold and still open on its own; a longer
-one, such as a patch's data, starts folded, and `0` folds every section.
+For `allow_remote_cache`, HDF5 block-cache settings, and metadata-versus-read behavior, see [Working with remote patches](remote_patches.qmd).
 
-A setting only holds while its block does, and a notebook echoes the
-last thing a cell states rather than anything inside a block, so these
-ask for the display while the setting is still in force. `display` is a
-name Jupyter puts in the namespace; elsewhere it comes from
-`IPython.display`.
-
-```python
-with config_context(display_html=False):
-    display(patch)  # the text repr, even in a notebook
-
-with config_context(display_html_open_lines=0):
-    display(patch)  # every section folded until it is asked for
-```
-
-For remote IO settings such as `allow_remote_cache`,
-`allow_remote_cache_for_metadata`, `warn_on_remote_cache`,
-`remote_hdf5_block_size`, `remote_hdf5_max_blocks`, and `warn_on_gc_pause`,
-plus examples of metadata-only vs read-time behavior, see
-[Working with Remote Patches](remote_patches.qmd).
+Remote settings include the cache directory, separate permissions for metadata and data materialization, first-download warnings, HDF5 block size, block count, and garbage-collection warnings. Keep conservative metadata defaults unless a workflow explicitly accepts downloads.

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -47,19 +47,29 @@ with dc.config_context(patch_kind_attrs=("acquisition_key",)):
 ```
 
 ```{python}
+from IPython.display import HTML
+
 with dc.config_context(patch_history="disabled", display_max_items=3):
     patch = dc.get_example_patch().abs()
-    patch
+    compact_html = HTML(patch._repr_html_())
+
+compact_html
 ```
 
 HTML output uses collapsible sections in notebooks and rendered documentation. Text output contains the same underlying summary and is suitable for terminals and logs.
 
 ```{python}
 with dc.config_context(display_html=False):
-    patch
+    text_output = repr(patch)
 
+print(text_output)
+```
+
+```{python}
 with dc.config_context(display_html_open_lines=0):
-    patch
+    folded_html = HTML(patch._repr_html_())
+
+folded_html
 ```
 
 For `allow_remote_cache`, HDF5 block-cache settings, and metadata-versus-read behavior, see [Working with remote patches](remote_patches.qmd).

--- a/docs/tutorial/configuration.qmd
+++ b/docs/tutorial/configuration.qmd
@@ -15,7 +15,7 @@ print(dc.get_config().display_float_precision)
 | `set_config(...)` | Process-wide base | Until `reset_config()` |
 | `config_context(...)` | Current thread or task | When the block exits |
 
-```{python}
+```python
 dc.set_config(display_float_precision=5)
 
 with dc.config_context(display_float_precision=8):
@@ -49,17 +49,17 @@ with dc.config_context(patch_kind_attrs=("acquisition_key",)):
 ```{python}
 with dc.config_context(patch_history="disabled", display_max_items=3):
     patch = dc.get_example_patch().abs()
-    display(patch)
+    patch
 ```
 
 HTML output uses collapsible sections in notebooks and rendered documentation. Text output contains the same underlying summary and is suitable for terminals and logs.
 
 ```{python}
 with dc.config_context(display_html=False):
-    display(patch)
+    patch
 
 with dc.config_context(display_html_open_lines=0):
-    display(patch)
+    patch
 ```
 
 For `allow_remote_cache`, HDF5 block-cache settings, and metadata-versus-read behavior, see [Working with remote patches](remote_patches.qmd).

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -5,444 +5,204 @@ execute:
 ---
 
 :::{.callout-warning}
-This page covers advanced DASCore features. Most users will be fine with only the coordinate material presented in the [patch tutorial](patch.qmd#coords).
+This page covers advanced features. Most users should work through the [Patch coordinate interface](patch.qmd#data-and-coordinates).
 :::
 
-In order to manage coordinate labels and array manipulations, DASCore implements two classes, [`BaseCoord`](`dascore.core.coords.BaseCoord`), which has several associated subclasses corresponding to different types of coordinates, and [CoordManager](`dascore.core.coordmanager.CoordManager`) which manages a group of coordinates. Much like the [`Patch`](`dascore.core.patch.Patch`), instances of both of these classes are immutable (to the extent possible), so they cannot be modified in place but have methods which return new instances.  
+[`BaseCoord`](`dascore.core.coords.BaseCoord`) represents one coordinate. [`CoordManager`](`dascore.core.coordmanager.CoordManager`) groups coordinates and keeps their associated arrays aligned. Both return new objects rather than modifying themselves.
 
 # Coordinates
 
-Coordinates usually keep track of labels along an associated dimension of an array, but they can also be independent of array data. They provide methods for slicing, re-ordering, filtering etc. and are used internally by DASCore for such operations.
+## Creation
 
-Coordinates are a collection of classes which implement a common interface. 
-
-
-:::{.callout-note}
-Coordinates are very similar (in concept) to Pandas' indices, with some significant differences in implementation.
-:::
-
-## Coordinate Creation
-
-### Get Coord
-
-[`get_coord`](`dascore.core.coords.get_coord`) returns an instance of a subclass of [`BaseCoord`](`dascore.core.coords.BaseCoord`) appropriate for the input values. Here are a few examples:
+[`get_coord`](`dascore.core.coords.get_coord`) chooses the appropriate coordinate type from a range or array.
 
 ```{python}
+import re
+
 import numpy as np
 
-from dascore.core import get_coord
+from dascore.core import get_coord, get_coord_manager
 
-# Get monotonic, evenly sampled coords from start, stop, step.
-range_coord = get_coord(start=0, stop=10, step=1)
+regular = get_coord(start=0, stop=10, step=1, units="m")
+same = get_coord(data=np.arange(10), units="m")
+irregular = get_coord(data=np.array([0.0, 1.0, 2.2, 4.0]))
 
-# Do the same as above but using an evenly sampled sorted array.
-array = np.arange(0, 10, step=1)
-array_coord = get_coord(data=array)
-
-# Assert the type and values of the resulting coordinates are the same.
-assert range_coord == array_coord
-
-# the Arrays don't have to be evenly sampled, or sorted.
-sorted_array = np.sort(np.random.rand(10))
-sorted_coord = get_coord(data=sorted_array)
-
-random_array = np.random.rand(10) 
-random_coord = get_coord(data=random_array)
+assert regular == same
 ```
 
-String arrays create string-backed coordinates.
+Coordinates expose values, units, data type, ordering, sampling regularity, limits, and length through their attributes and methods.
+
+| Attribute | Meaning |
+|---|---|
+| `sorted`, `reverse_sorted` | Coordinate order |
+| `evenly_sampled` | Whether one step describes every value |
+| `dtype` | NumPy data type |
+| `units` | Physical units, if present |
+| `min()`, `max()` | Coordinate limits |
+
+## Segmented coordinates
+
+[`CoordSegmented`](`dascore.core.coords.CoordSegmented`) preserves monotonic blocks and their discontinuities. Use [`concat_coords(...)`](`dascore.core.coords.concat_coords`) when the blocks are known:
 
 ```{python}
-import numpy as np
-
-from dascore.core import get_coord
-
-coord = get_coord(data=np.array(["sensor_001", "sensor_002", "sensor_003"]))
-print(type(coord).__name__)
-print(coord.values)
-```
-
-### Segmented Coordinates
-
-[`CoordSegmented`](`dascore.core.coords.CoordSegmented`) preserves monotonic coordinate blocks and the discontinuities between them. It is useful when a logical coordinate contains dropped samples, acquisition gaps, or a sampling-rate change but the corresponding data should remain in one in-memory patch.
-
-Use [`concat_coords(...)`](`dascore.core.coords.concat_coords`) when the blocks are already known:
-
-```{python}
-from dascore.core.coords import concat_coords, get_coord
+from dascore.core.coords import concat_coords
 
 first = get_coord(start=0.0, stop=5.0, step=1.0, units="m")
 second = get_coord(start=8.0, stop=13.0, step=1.0, units="m")
 segmented = concat_coords(first, second)
 
-print(type(segmented).__name__)
 print(segmented.get_discontinuities("gaps"))
 ```
 
-Use [`CoordSegmented.from_array(...)`](`dascore.core.coords.CoordSegmented.from_array`) for an exact, strictly monotonic stored array. The constructor preserves every value and returns the simplest truthful coordinate, so an exactly uniform input becomes a normal `CoordRange` and a wholly irregular input may become a `CoordMonotonicArray`.
+Use [`CoordSegmented.from_array(...)`](`dascore.core.coords.CoordSegmented.from_array`) to preserve an exact monotonic array. Segmented coordinates have `step=None`. `simplify(tolerance=...)` may reduce their segments within an error bound; `snap()` always replaces values with one evenly sampled range. Split patches with segmented dimension coordinates before writing to formats that cannot represent gaps.
 
 ```{python}
-import numpy as np
-
 from dascore.core.coords import CoordSegmented
 
 values = np.array([0.0, 1.0, 2.0, 7.0, 8.0, 9.0])
-exact_coord = CoordSegmented.from_array(values, tolerance=0, units="m")
-
-assert np.array_equal(exact_coord.values, values)
-assert len(exact_coord.get_discontinuities("gaps")) == 1
+exact = CoordSegmented.from_array(values, tolerance=0, units="m")
+assert np.array_equal(exact.values, values)
 ```
 
-Segmented coordinates have `step=None` because one step cannot describe the entire coordinate. `coord.simplify(tolerance=...)` may replace segments with a simpler fit while bounding how far values move; `coord.snap()` always forces one evenly sampled range and can move interior values without a bound. Use `patch.split_gaps()` to turn a patch with segmented dimensional coordinates into contiguous patches before writing it to a format that cannot store gaps.
+## Updating and units
 
-### Update
-
-Update uses the existing coordinate as a template and returns a coordinate with some part modified. 
+`update` uses an existing coordinate as a template:
 
 ```{python}
-import numpy as np
+start = np.datetime64("2023-01-01")
+coord = get_coord(start=start, stop=start + np.timedelta64(1, "h"), step=np.timedelta64(1, "m"))
 
-import dascore as dc
-from dascore.core import get_coord
-
-# Create example coordinate.
-start, stop = np.datetime64("2023-01-01"), np.datetime64("2023-01-01T01")
-step = np.timedelta64(60, 's')
-coord = get_coord(start=start, stop=stop, step=step)
-
-# Update entire array, adding 10s to each element.
-new_data = coord.values + np.timedelta64(10, "s")
-coord_new_data = coord.update(data=new_data)
-
-# Update step, keeping length and start but shortening end time.
-coord_new_step = coord.update(step=np.timedelta64(1800, 's'))
-
-# Change maximum value, keeping length the same and changing step.
-coord_new_max = coord.update(max=stop + 10 * step)
+shifted = coord.update(data=coord.values + np.timedelta64(10, "s"))
+coarser = coord.update(step=np.timedelta64(30, "m"))
 ```
 
+Updating `min`, `max`, or `step` retains the coordinate length and derives the remaining range values. Updating `data` instead lets DASCore choose the simplest coordinate class that represents the new array.
 
-## Coordinate Attributes
-
-The following tables shows some of the commonly used coordinate attributes:
-
-| Attribute        | Description                                             |
-|------------------|---------------------------------------------------------|
-| `sorted`         | `True` if the coordinate is sorted in ascending order.  |
-| `reverse_sorted` | `True` if the coordinate is sorted in descending order. |
-| `evenly_sampled` | `True` if the coordinate has uniform step sizes.        |
-| `dtype`          | The numpy data type of the coordinate.                  | 
-| `data`           | Return an array of coordinate values.                   | 
-| `units`          | Coordinate units.                                       |
-| `degenerate`     | `True` if the coordinate has a zero length dimension.   |
-| `min()`          | Return the minimum value in the coordinate.             |
-| `max()`          | Return the maximum value in the coordinate.             |
-
-: Coordinate attributes {.striped .hover}
-
-## Coordinate Methods
-This section highlights some of the coordinate methods. The methods which would cause changes to a data array return a new coordinate and an object that can be used for indexing an array. This can either be a `slice` instance or another array which uses numpy's advanced indexing features for sorting or selection.
-
-
-### Sort
-[`sort`](`dascore.core.coords.BaseCoord.sort`) sorts the values of the coordinate. 
+`set_units` changes the label without changing values; `convert_units` converts both.
 
 ```{python}
-import numpy as np
-
-from dascore.core import get_coord
-
-random_array = np.random.rand(10) 
-random_coord = get_coord(data=random_array)
-
-# Returns a new array and indexer that can be used to apply the sorting
-# operation to a dimension of an array.
-sorted_coord, indexer = random_coord.sort()
-
-# The array could then be updated as follows.
-data = np.random.rand(10, 20)
-sorted_data = data[indexer, :] 
+relabeled = regular.set_units("ft")
+converted = regular.convert_units("ft")
 ```
 
-### Snap
+## Sorting, snapping, and selecting
 
-[`snap`](`dascore.core.coords.BaseCoord.snap`) replaces coordinate values with an evenly sampled range spanning the same minimum and maximum. This intentionally loses interior precision and should be used only when that idealization is acceptable. Unlike [`sort`](`dascore.core.coords.BaseCoord.sort`), it returns only a new coordinate and no indexer, because it replaces the values rather than permuting them, so for an unsorted coordinate the snapped values no longer label the samples they used to. When data alignment matters, use [`CoordManager.snap`](`dascore.core.coordmanager.CoordManager.snap`), which sorts the coordinate and its associated array together before snapping, or [`Patch.snap_coords(...)`](`dascore.Patch.snap_coords`), which does the same across the selected dimensions of a patch.
+Methods that reorder or remove samples return both a coordinate and an indexer for the associated array.
 
 ```{python}
-import numpy as np
+unsorted = get_coord(data=np.array([3, 1, 2]))
+sorted_coord, indexer = unsorted.sort()
 
-from dascore.core import get_coord
+data = np.arange(6).reshape(3, 2)
+sorted_data = data[indexer, :]
 
-values = np.array([0.0, 1.0, 2.2, 3.0])
-irregular_coord = get_coord(data=values)
-snapped_coord = irregular_coord.snap()
-
-assert snapped_coord.evenly_sampled
-assert snapped_coord.min() == irregular_coord.min()
-assert snapped_coord.max() == irregular_coord.max()
+selected_coord, indexer = regular.select((3, 7))
+selected_data = np.arange(len(regular))[indexer]
 ```
 
-Use `simplify(tolerance=...)` instead when the maximum allowed coordinate movement must be explicit. Most coordinate types are already in their simplest form; this distinction is most useful for segmented coordinates.
-
-
-### Select
-[`select`](`dascore.core.coords.BaseCoord.select`) is used for slicing/sub-selecting.
+Selections accept compatible quantities and convert them before comparison:
 
 ```{python}
-import numpy as np
-
-from dascore.core import get_coord
-
-coord = get_coord(start=0, stop=21, step=1)
-
-new_coord, indexer = coord.select((3, 14))
-
-data = np.random.rand(10, 20)
-selected_data = data[:, indexer] 
-```
-
-Most coordinate methods also support units.
-
-```{python}
-import numpy as np
-
-from dascore.core import get_coord
 from dascore.units import ft
 
-coord = get_coord(start=0, stop=21, step=1, units='m')
-
-new_coord, indexer = coord.select((14*ft, 50 * ft))
-print(new_coord) 
+selected_in_feet, _ = regular.select((3 * ft, 20 * ft))
 ```
 
-## String Coordinates
+`sort` permutes existing values and returns the matching permutation. `snap` changes values, while `simplify(tolerance=...)` chooses a simpler representation only within the requested displacement bound. The distinction is important whenever coordinate values are measurements rather than ideal labels.
 
-String coordinates support exact matching, wildcard matching with `*` and `?`,
-compiled regular expressions, boolean-mask selection, and sorting. They are
-useful for channel names, sensor identifiers, and other categorical labels that
-do not have meaningful numeric spacing.
+`snap()` returns only a coordinate because it replaces values rather than permuting them. Use `CoordManager.snap` or `Patch.snap_coords` when data must be sorted with the coordinate before snapping.
+
+## String coordinates
+
+String coordinates support exact matches, `*` and `?` wildcards, compiled regular expressions, boolean masks, and sorting. They do not support units, relative selection, or numeric ranges.
 
 ```{python}
-import numpy as np
-import re
+labels = get_coord(data=np.array(["ch_a", "ch_b", "aux_1", "aux_2"]))
 
-from dascore.core import get_coord
-
-coord = get_coord(data=np.array(["ch_a", "ch_b", "aux_1", "aux_2"]))
-
-selected, indexer = coord.select("ch_b")
-print(selected.values)
-print(indexer)
-
-matched, matched_indexer = coord.select("ch_*")
-print(matched.values)
-print(matched_indexer)
-
-regex_matched, regex_indexer = coord.select(re.compile(r"^aux_\d$"))
-print(regex_matched.values)
-print(regex_indexer)
-
-sorted_coord, sort_indexer = coord.sort()
-print(sorted_coord.values)
-print(sort_indexer)
+exact, _ = labels.select("ch_b")
+channels, _ = labels.select("ch_*")
+aux, _ = labels.select(re.compile(r"^aux_\d$"))
+sorted_labels, sort_indexer = labels.sort()
 ```
 
-Unlike numeric, datetime, or timedelta coordinates, string coordinates do not
-support:
+Strings containing `*` or `?` are treated as wildcard patterns, so avoid those characters in labels which must be matched literally. Boolean masks are the unambiguous choice for arbitrary sets.
 
-- units
-- range-style selection such as `(start, stop)`
-- relative selection
-- range calculations such as `coord_range()`
+## Finding insertion positions
 
-Selection for string coordinates should use exact values, wildcard patterns,
-compiled regular expressions, or boolean masks. Strings containing `*` or `?`
-are treated as wildcard patterns, so avoid those characters in labels you
-intend to select literally.
-
-### Units
-
-[`convert_units`](`dascore.core.coords.BaseCoord.convert_units`) and [`set_units`](`dascore.core.coords.BaseCoord.set_units`) are used to change/set the units associated with a coordinate.
+[`get_next_index`](`dascore.core.coords.BaseCoord.get_next_index`) returns where a value is or would be inserted in a sorted coordinate:
 
 ```{python}
-import numpy as np
-
-from dascore.core import get_coord
-from dascore.units import ft
-
-coord = get_coord(start=0, stop=21, step=1, units='m')
-
-# Convert coords to ft.
-coord_ft_converted = coord.convert_units("ft")
-
-# Simply change unit label (values remain the same).
-coord_ft_set = coord.set_units("ft")
-
-# Create coord with silly units.
-silly_units = "10*PI*m/ft * furlongs * fortnight"
-coord_silly_units = get_coord(start=10, stop=21, step=1, units=silly_units)
-
-# Simplify the coordinates and modify coordinate values accordingly.
-simple_coord = coord_silly_units.simplify_units()
-print(f"Simplified units are: {simple_coord.units}")
-print(f"New coord lims are: {simple_coord.limits}") 
+assert regular.get_next_index(2) == 2
+assert regular.get_next_index(2.1) == 3
 ```
 
-### Get Next Index
-[`get_next_index`](`dascore.core.coords.BaseCoord.get_next_index`) returns the index value (an integer) for where a value would be inserted into the coordinate. It can only be used on a sorted coordinate.
+# Coordinate managers
+
+## Creation and association
+
+[`get_coord_manager`](`dascore.core.coordmanager.get_coord_manager`) creates a manager from coordinates and ordered dimensions. Tuple values specify `(associated_dimensions, coordinate)`; use `None` for an independent coordinate.
 
 ```{python}
-from dascore.core import get_coord
-coord = get_coord(start=0, stop=10, step=1)
-# Find the index for a value contained by the coordinate.
-assert coord.get_next_index(1) == 1
-# The next (not closest) index is return for value not in coord.
-assert coord.get_next_index(2.000001) == 3
+distance = get_coord(start=0, stop=10, step=1)
+time = get_coord(start=0, stop=1, step=0.1)
+latitude = get_coord(data=np.linspace(41.5, 41.6, len(distance)))
+
+manager = get_coord_manager(
+    coords={
+        "distance": distance,
+        "time": time,
+        "latitude": ("distance", latitude),
+        "deployment": (None, get_coord(data=np.array(["A"]))),
+    },
+    dims=("distance", "time"),
+)
 ```
 
-# CoordManager
-
-The [`CoordManager`](`dascore.core.coordmanager.CoordManager`) handles a group of coordinates and provides methods for updating managed data arrays. 
-
-
-## Coordinate Manager Creation
-[`CoordManager`](`dascore.core.coordmanager.CoordManager`) instances can be created from a dictionary of coordinates via the [`get_coord_manager`](`dascore.core.coordmanager.get_coord_manager`) function.
+`manager.dims` stores dimension order, `coord_map` maps names to coordinates, and `dim_map` records dimensional associations.
 
 ```{python}
-from dascore.core import get_coord, get_coord_manager
-
-coord_dict = {
-    "dim1": get_coord(start=1, stop=10, step=1),
-    "dim2": get_coord(start=0.001, stop=1, step=.1),
-}
-
-cm = get_coord_manager(coords=coord_dict, dims=("dim1", "dim2"))
-
-# dims are the dimension names (in order).
-print(f"dimensions are {cm.dims}")
-
-# coord_map is a mapping of {coord_name: coordinate}.
-print(dict(cm.coord_map))
-
-# dim_map is a mapping of {coord_name: (associated_dimensions...)}.
-print(dict(cm.dim_map))
+print(manager.dims)
+print(dict(manager.dim_map))
 ```
 
-`CoordManager`s can have non-dimensional coordinates which may or may not be associated with a coordinate dimension.
+## Updating
+
+`CoordManager.update` replaces, adds, disassociates, or drops coordinates:
 
 ```{python}
-from dascore.core import get_coord, get_coord_manager
-
-coord_dict = {
-    "dim1": get_coord(start=0, stop=10, step=1),
-    "dim2": get_coord(start=0.001, stop=1, step=.1),
-    # "dim_coord" is a non-dimensional coordinate associated with
-    # dim1, so it must have the same shape. Notice how the associated
-    # dimension and coordinate values can be specified in a tuple. 
-    "dim_coord": ("dim1", get_coord(start=10, stop=20, step=1)),
-    # Non-dimensional coordinates are not associated with a dimension
-    # and must use None as the first argument in the tuple.
-    "non_dim_coord": (None, get_coord(start=1, stop=100, step=1)),
-}
-
-cm_many_coords = get_coord_manager(coords=coord_dict, dims=("dim1", "dim2"))
-print(cm_many_coords)
+new_distance = distance.update(data=distance.values + 10)
+updated = manager.update(distance=new_distance)
+detached = updated.update(latitude=(None, latitude))
+without_latitude = detached.update(latitude=None)
 ```
 
-### Update
-
-[`update`](`dascore.core.coordmanager.CoordManager.update`) uses an existing `CoordinateManager` as a template and updates some aspect in the returned coordinate. 
+New coordinates use the same update form:
 
 ```{python}
-import dascore as dc
-
-# Get coordinate manager from default patch.
-patch = dc.get_example_patch()
-cm = patch.coords
-
-# Add 10 to each distance values create new coord.
-dist_coord = cm.get_coord("distance") 
-new_dist_array = dist_coord.data + 10
-new_dist_coord = dist_coord.update(data=new_dist_array)
-
-# Create new coordinate manager with new distance coord.
-new_cm = cm.update(distance=new_dist_coord)
+quality = get_coord(data=np.linspace(0, 1, len(distance)))
+with_quality = manager.update(quality=("distance", quality))
+independent = manager.update(run=(None, get_coord(data=np.array([1]))))
 ```
 
-It can also be used to add new coordinates,
+Setting a dimension coordinate to `None` drops that dimension and every coordinate depending on it. Dropping a missing non-dimensional coordinate is a no-op.
 
-```{python}
-distance_length = len(cm.get_coord("distance"))
+## Methods with data
 
-# Create a new coordinate. 
-new_coord = get_coord(data=np.random.rand(distance_length))
-
-# Add it to the coord manager associated with distance dimension.
-new_cm_1 = cm.update(new_coord=("distance", new_coord))
-
-# Add the coordinate but don't associate it with any dimension.
-new_cm_2 = cm.update(new_coord=(None, new_coord))
-```
-
-and drop or disassociate coordinates.
-
-```{python}
-# Disassociate "new_coord" from dimension distance.
-new_cm_3 = new_cm_1.update(new_coord=(None, new_coord))
-
-# Drop coordinate "new_coord". Note this must be done on a coord manager
-# which actually has "new_coord"; dropping a missing coord is a no-op.
-new_cm_4 = new_cm_1.update(new_coord=None)
-assert "new_coord" not in new_cm_4.coord_map
-
-# Drop dimension "time".
-new_cm_5 = cm.update(time=None)
-assert "time" not in new_cm_5.dims
-```
-
-## Coordinate Manager Methods
-Much like `BaseCoord`, the `CoordinateManager` class implements a variety of methods for filtering, sorting, modifying units, etc. However, there are some difference. Unlike coordinates, when an operation would change the data array associated with the coordinates, the `CoordManager` method accepts the array as an argument and returns a new array. Like the `Patch` methods, `CoordManager` methods use keyword arguments to specify coordinates by name.
-
-
-### Select
-
-[select](`dascore.core.coordmanager.CoordManager.select`) trims the coordinate manager and, optionally, an associated array.
+Operations that change array alignment accept the array and return an updated manager and array. Coordinate names are keyword arguments, as on `Patch`.
 
 ```{python}
 import dascore as dc
 
 patch = dc.get_example_patch()
-cm, data = patch.coords, patch.data
+manager, data = patch.coords, patch.data
 
-new_cm, new_data = cm.select(data=data, distance=(..., 100))
+selected_manager, selected_data = manager.select(data=data, distance=(..., 100))
+sorted_manager, sorted_data = manager.sort("time", "distance", array=data, reverse=True)
+renamed = manager.rename_coord(time="elapsed_time")
 ```
 
+When several dimensions are sorted together, the returned data reflects each permutation in dimension order. Renaming a dimension also updates every coordinate association that refers to it.
 
-### Sort
+`sort`, `snap`, unit conversion, and other alignment-changing methods follow the same `(manager, array)` return pattern. Passing no array updates coordinates alone; when data alignment matters, always pass the associated array.
 
-[sort](`dascore.core.coordmanager.CoordManager.sort`) sorts along one or more axes. 
-
-```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-cm, data = patch.coords, patch.data
-
-# Sort along both dimensions in descending order.
-new_cm, new_data = cm.sort("time", "distance", reverse=True)
-```
-
-### Rename Coord
-
-[rename_coord](`dascore.core.coordmanager.CoordManager.rename_coord`) renames a coordinate or dimension.
-
-```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-cm = patch.coords
-
-# Rename time to money.
-renamed_cm = cm.rename_coord(time="money")
-print(renamed_cm)
-```
+Prefer the corresponding Patch methods when operating on a patch; they keep data, coordinates, metadata, and provenance together.

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -203,6 +203,6 @@ renamed = manager.rename_coord(time="elapsed_time")
 
 When several dimensions are sorted together, the returned data reflects each permutation in dimension order. Renaming a dimension also updates every coordinate association that refers to it.
 
-`sort`, `snap`, unit conversion, and other alignment-changing methods follow the same `(manager, array)` return pattern. Passing no array updates coordinates alone; when data alignment matters, always pass the associated array.
+`select`, `order`, `sort`, and `snap` accept an associated array and return `(manager, array)`. Methods that do not change alignment, such as unit conversion, return only a manager.
 
 Prefer the corresponding Patch methods when operating on a patch; they keep data, coordinates, metadata, and provenance together.

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -54,7 +54,7 @@ segmented = concat_coords(first, second)
 print(segmented.get_discontinuities("gaps"))
 ```
 
-Use [`CoordSegmented.from_array(...)`](`dascore.core.coords.CoordSegmented.from_array`) to preserve an exact monotonic array. Segmented coordinates have `step=None`. `simplify(tolerance=...)` may reduce their segments within an error bound; `snap()` always replaces values with one evenly sampled range. Split patches with segmented dimension coordinates before writing to formats that cannot represent gaps.
+Use [`CoordSegmented.from_array(...)`](`dascore.core.coords.CoordSegmented.from_array`) to preserve an exact monotonic array. It returns the simplest truthful coordinate, so uniform input becomes `CoordRange`; segmented output has `step=None`. `simplify(tolerance=...)` may reduce segments within an error bound, while `snap()` replaces values with one evenly sampled range. Use `patch.split_gaps()` before writing segmented dimensions to formats that cannot represent gaps.
 
 ```{python}
 from dascore.core.coords import CoordSegmented

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -4,182 +4,109 @@ execute:
   warning: false
 ---
 
-The following highlights some DASCore features for working with IO.
+DASCore reads and writes local `pathlib.Path` objects and remote [`UPath`](https://pypi.org/project/universal-pathlib/) resources supported by each format. See [Working with remote patches](remote_patches.qmd) for cache policy.
 
-:::{.callout-note}
-If you are working with remote `UPath` resources, especially HTTP or object
-store backends, see the [Working with Remote Patches](remote_patches.qmd)
-tutorial for examples, cache settings, and metadata-vs-read behavior.
-:::
+# Writing and reading
 
-## Using UPath Resources
-
-DASCore accepts both `pathlib.Path` and [`UPath`](https://pypi.org/project/universal-pathlib/) inputs for many file-backed workflows. This is useful when your data lives on a non-local backend supported by `fsspec`.
-
-The example below uses `memory://` so it can run without any external network access.
-
-```{python}
-from upath import UPath
-import dascore as dc
-
-source = dc.get_example_patch()
-remote_path = UPath("memory://dascore/tutorial/example_patch.h5")
-
-dc.write(source, remote_path, "DASDAE")
-
-summary = dc.scan(remote_path)[0]
-loaded = dc.read(remote_path)[0]
-
-print(summary.source_path)
-print(loaded.dims)
-```
-
-## Writing Patches to Disk
-
-Patches can be written to disk using the `io` namespace. The following shows how to write a Patch to disk in the [DASDAE format](`dascore.io.dasdae`)
+Write through `Patch.io`, then open the result with `dc.read` or `dc.spool`:
 
 ```{python}
 from pathlib import Path
+
 import dascore as dc
 
-write_path = Path("output_file.h5")
 patch = dc.get_example_patch()
-
-patch.io.write(write_path, "dasdae")
+path = Path("output_file.h5")
+patch.io.write(path, "DASDAE")
+round_trip = dc.read(path)[0]
 ```
 
 ```{python}
 #| echo: false
-if write_path.exists():
-    write_path.unlink()
+path.unlink(missing_ok=True)
 ```
 
-Remote-style `UPath` destinations also work for supported formats.
+Remote-style destinations use the same interface:
 
 ```{python}
 from upath import UPath
-import dascore as dc
 
-patch = dc.get_example_patch()
-remote_write_path = UPath("memory://dascore/tutorial/output_file.pkl")
-
-patch.io.write(remote_write_path, "pickle")
-
-round_trip = dc.read(remote_write_path)[0]
-print(round_trip.dims)
+remote_path = UPath("memory://dascore/tutorial/output.pkl")
+patch.io.write(remote_path, "pickle")
+remote_patch = dc.read(remote_path)[0]
 ```
 
-## Scan Metadata Without Loading Data
+Format support varies by backend: a formatter that requires a local seekable file may use the remote cache, while formats built on fsspec-compatible stores can operate directly.
 
-[`dascore.scan`](`dascore.scan`) returns [`PatchSummary`](`dascore.PatchSummary`) objects. These results expose patch metadata, coordinate-summary envelopes, and source information without loading the data array into memory.
+# Scanning metadata
+
+[`dc.scan`](`dascore.scan`) returns [`PatchSummary`](`dascore.PatchSummary`) objects without loading patch arrays.
 
 ```{python}
-import dascore as dc
 from dascore.utils.downloader import fetch
 
-path = fetch("terra15_das_1_trimmed.hdf5")
-scan_patch = dc.scan(path)[0]
+source = fetch("terra15_das_1_trimmed.hdf5")
+summary = dc.scan(source)[0]
 
-print(scan_patch.source_path)
-print(scan_patch.get_coord_summary("time").min)
+print(summary.source_path)
+print(summary.get_coord_summary("time").min)
 ```
 
-Scan results are useful for listing contents, building dataframes, and deciding which patches to load.
+Scanning also reports `source_format`, `source_version`, and `source_patch_key`, which together identify the formatter and patch inside a multi-patch file.
+
+Use source fields from the summary to load a specific patch. For compact directory listings, use `scan` or `scan_to_df`.
 
 ```{python}
-loaded_patch = dc.read(
-    scan_patch.source_path,
-    file_format=scan_patch.source_format,
-    file_version=scan_patch.source_version,
-    source_patch_key=scan_patch.source_patch_key or None,
+loaded = dc.read(
+    summary.source_path,
+    file_format=summary.source_format,
+    file_version=summary.source_version,
+    source_patch_key=summary.source_patch_key or None,
 )[0]
-print(loaded_patch.data.shape)
 ```
 
-When a coordinate-summary envelope is insufficient, [`dascore.scan_payloads(...)`](`dascore.scan_payloads`) exposes each formatter's full `CoordManager` without loading the patch data array. Pass `snap=False` to request the exact stored coordinate values from formats that store per-sample arrays.
+[`dc.scan_payloads(...)`](`dascore.scan_payloads`) also returns each formatter's `CoordManager`. With `snap=False`, formats that store per-sample coordinates expose their exact values:
 
 ```{python}
-payload = dc.scan_payloads(path, snap=False)[0]
-time_coord = payload["coords"].get_coord("time")
-
-print(payload["source_path"])
-print(type(time_coord).__name__)
-print(time_coord.get_discontinuities("gaps"))
+payload = dc.scan_payloads(source, snap=False)[0]
+time = payload["coords"].get_coord("time")
 ```
 
-`scan_payloads` may read and retain large coordinate arrays, so prefer a specific file over an entire directory and discard each result promptly. Use `dc.scan` or `dc.scan_to_df` for compact directory indexing.
+Payload scans still may read and retain large coordinate arrays, so reserve them for targeted files.
 
-:::{.callout-note}
-`Patch.attrs` stores non-coordinate metadata only. Coordinate summaries such as `time_min`, `time_max`, and `distance_step` are accessed through [`PatchSummary.get_coord_summary(...)`](`dascore.PatchSummary.get_coord_summary`) or via `patch.summary.get_coord_summary(...)`.
-:::
+`Patch.attrs` contains non-coordinate metadata. Access coordinate bounds and steps from `Patch.summary`, `PatchSummary.get_coord_summary(...)`, or the flattened summary returned by `flat_dump()`.
 
-## Directory spools
+# Directory spools
 
-A spool over a directory of dascore-readable files is created with the [`dascore.spool`](`dascore.spool`) function. It is the same class as any other spool; the only difference is how it was constructed.
-
-For example:
+`dc.spool(directory)` creates a lazy, indexed view of every supported file below that directory:
 
 ```{python}
-#| output: false
+from dascore import examples
 
-import dascore
-from dascore import examples as ex
-
-# Get a directory with several files
-diverse_spool = dascore.get_example_spool('diverse_das')
-path = ex.spool_to_directory(diverse_spool)
-
-# Create a spool for interacting with the files in the directory.
+directory = examples.spool_to_directory(dc.get_example_spool("diverse_das"))
 spool = (
-  dascore.spool(path)
-  .select(acquisition_key='DAS2.*')  # sub-select one data source
-  .select(time=(..., '2022-01-01'))  # unselect anything after 2022
-  .chunk(time=2, overlap=0.5)  # change the chunking of the patches
+    dc.spool(directory)
+    .select(acquisition_key="DAS2.*")
+    .select(time=(..., "2022-01-01"))
+    .chunk(time=2, overlap=0.5)
 )
+```
 
-# Iterate each patch and do something with it
+Iteration is where patch arrays are loaded:
+
+```{python}
 for patch in spool:
-  ...
+    processed = patch.detrend("time")
 ```
 
-## Converting Patches to Other Library Formats
+The hidden `.dascore_index.sqlite3` stores file metadata and enables selections before patch data is loaded. Opening a new directory creates the index; call `spool.update()` after files change. See the [spool tutorial](spool.qmd) and [index note](../notes/spool_index.qmd) for path attributes and index lifecycle.
 
-The `Patch.io` namespace also includes functionality for converting `Patch` instances to datastructures used by other libraries including Pandas, Xarray, and ObsPy. See the [external conversion recipe](../recipes/external_conversion.qmd) for examples.
+`update()` scans new or modified files, removes rows for deleted files, and leaves unchanged rows alone. File size and modification time identify candidates for rescanning.
 
+An optional `.inventory` companion describes the observing system and is not scanned as data.
 
-## Directory Indexer
-The `DBDirectoryIndexer` tracks the contents of a directory which contains fiber data. It creates a small, hidden SQLite index named `.dascore_index.sqlite3` at the top of the directory. Directory spools use this index internally and push metadata selections into SQLite before loading patch data. See the [spool index note](../notes/spool_index.qmd) for the schema and lifecycle.
+The index and inventory are companions to the archive rather than data sources themselves, so both use reserved hidden names and are excluded from formatter discovery.
 
-`.dascore_index.sqlite3` is one of two hidden names DASCore gives a meaning at the top of a data directory. The other is `.inventory`, which is where a directory may keep the [inventory](inventory.qmd) describing the observing system its data was recorded through. Both are companions the directory keeps rather than content it holds, which is why both are hidden and neither is scanned as data.
+# External formats
 
-
-```{python}
-#| output: false
-import dascore
-from dascore.io.index.indexer import DBDirectoryIndexer
-from dascore import examples as ex
-
-# Get a directory with several files
-diverse_spool = dascore.get_example_spool('diverse_das')
-path = ex.spool_to_directory(diverse_spool)
-
-# Create an indexer and update the index. This scans new or changed files
-# (detected by per-file modification time and size), removes entries of
-# deleted files, and creates the index if one does not yet exist.
-DBDirectoryIndexer(path).update()
-
-# The index is queried through a spool. Opening one indexes the directory
-# if it has not been indexed yet, but does not rescan afterwards: call
-# spool.update() (or the indexer's, above) when the files change.
-df = dascore.spool(path).get_contents()
-
-# This dataframe can be used to ascertain data availability, detect gaps, etc.
-```
-
-```{python}
-#| echo: false
-
-from IPython.display import display
-
-display(df.head())
-```
+`Patch.io` also converts patches to structures used by Pandas, Xarray, and ObsPy. See the [external conversion recipe](../recipes/external_conversion.qmd).

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -77,21 +77,7 @@ A coordinate may be associated with one or more dimensions, such as latitude alo
 
 Dimension coordinates usually share a dimension's name, but that is not required. Auxiliary coordinates such as latitude commonly depend on `distance`; a quality grid may depend on both `distance` and `time`; deployment metadata can be independent of every dimension.
 
-String coordinates support exact matches, wildcards, compiled regular expressions, masks, and sorting. They do not support units or numeric range selection.
-
-```{python}
-import re
-
-labeled = patch.select(distance=slice(0, 4), samples=True).new(dims=("channel", "time"))
-labeled = labeled.update_coords(channel=np.array(["ch_a", "ch_b", "aux_1", "aux_2"]))
-
-exact = labeled.select(channel="ch_b")
-channels = labeled.select(channel="ch_*")
-aux = labeled.select(channel=re.compile(r"^aux_\d$"))
-reverse = labeled.sort_coords("channel", reverse=True)
-```
-
-Wildcards use Unix-style `*` and `?`. Use a compiled expression for regular-expression matching, and avoid wildcard characters in labels that must be selected literally.
+String coordinates support exact matches, wildcards, compiled regular expressions, masks, and sorting, but not units or numeric ranges. See [String coordinates](coords.qmd#string-coordinates) for examples and literal-label caveats.
 
 ## Attributes and summaries
 
@@ -107,7 +93,7 @@ print(row["time_min"], row["distance_step"])
 
 `Patch.summary` is read-only. `flat_dump()` is intended for tabular rows and produces the same coordinate-summary column names used by spool indexes, including `time_min`, `time_max`, and `distance_step`. The optional `data_type` attribute is a display hint; interpret data through its units, coordinates, and history.
 
-The complete validated attribute schema is available programmatically:
+A preview of the validated attribute schema is available programmatically:
 
 ```{python}
 attribute_fields = dc.PatchAttrs.get_summary_df()
@@ -239,7 +225,7 @@ window = patch.select(
 )
 ```
 
-Slices are accepted anywhere a `(minimum, maximum)` tuple is accepted. They remain range shorthand, so sample slices still require `samples=True`. Processing functions such as `pass_filter` and `taper` use tuples rather than slices.
+`select` and `order` accept slices as range shorthand; sample slices still require `samples=True`. Processing functions such as `pass_filter` and `taper` require tuples.
 
 ## Unselect and order
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -4,1045 +4,418 @@ execute:
   warning: false
 ---
 
-A [`Patch`](`dascore.core.patch.Patch`) manages an array and its associated coordinate labels and metadata.
-
-:::{.callout-note}
-The `Patch` design was inspired by [Xarray's `DataArray`](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html)
-:::
-
-# Patch creation
-
-Patches can be created in several different ways.
-
-## Load an example patch
-
-DASCore includes several example datasets. They are mostly used for simple demonstrations and testing.
+A [`Patch`](`dascore.core.patch.Patch`) couples an array with coordinate labels and metadata. Patch methods return new patches instead of modifying the original.
 
 ```{python}
-import dascore as dc
-from dascore import print
+import numpy as np
 
-pa1 = dc.get_example_patch("random_das")
-pa2 = dc.get_example_patch("example_event_1")
+import dascore as dc
+
+patch = dc.get_example_patch()
 ```
 
-See [`get_example_patch`](`dascore.examples.get_example_patch`) for supported patches.
+# Creating patches
 
-## Load a file
+## Examples and files
 
-A single file can be loaded like this:
-
+DASCore includes example patches for tutorials and tests:
 
 ```{python}
-#| code-fold: true
-# This code block is only here to create a usable path for the next cell.
-import dascore as dc
-# Import fetch to read DASCore example files.
+event = dc.get_example_patch("example_event_1")
+```
+
+Use [`dc.spool(...)`](`dascore.spool`) to open DAS files and take a patch by indexing the spool:
+
+```{python}
 from dascore.utils.downloader import fetch
 
-
 path = fetch("terra15_das_1_trimmed.hdf5")
-# To read DAS data stored locally on your machine, simply replace the above line with:
-# path = "/path/to/data/directory/data.EXT"
+file_patch = dc.spool(path)[0]
 ```
 
+See the [spool tutorial](spool.qmd) for directories, archives, and remote resources.
+
+## Arrays
+
+To build a patch directly, supply the data, its dimension names, and coordinates. Attributes are optional.
 
 ```{python}
-import dascore as dc
+rng = np.random.default_rng(13)
+data = rng.random((300, 2_000))
+time = dc.to_datetime64("2017-09-18") + np.arange(2_000) * dc.to_timedelta64(1 / 250)
+distance = np.arange(300)
 
-# path should point to your file, e.g.
-# path = mydata.hdf5
-
-pa = dc.spool(path)[0]
-```
-
-Spools are covered in more detail in the [next section](spool.qmd).
-
-
-## Manually create a patch
-
-Patches can be created from:
-
-- A data array
-- Coordinates for labeling each axis
-- Attributes (optional)
-
-```{python}
-import numpy as np
-
-import dascore as dc
-from dascore.utils.time import to_timedelta64
-
-# Create the patch data
-array = np.random.random(size=(300, 2_000))
-
-# Create attributes, or metadata
-attrs = dict(
-    category="DAS",
-    id="test_data1",
-    data_units="um/(m * s)"
+manual_patch = dc.Patch(
+    data=data,
+    dims=("distance", "time"),
+    coords={"distance": distance, "time": time},
+    attrs={"data_units": "um/(m * s)"},
 )
-
-# Create coordinates, labels for each axis in the array.
-time_start = dc.to_datetime64("2017-09-18")
-time_step = to_timedelta64(1 / 250)
-time = time_start + np.arange(array.shape[1]) * time_step
-
-distance_start = 0
-distance_step = 1
-distance = distance_start + np.arange(array.shape[0]) * distance_step
-
-coords = dict(time=time, distance=distance)
-
-# Define dimensions (first label corresponds to data axis 0)
-dims = ('distance', 'time')
-
-pa = dc.Patch(data=array, coords=coords, attrs=attrs, dims=dims)
 ```
 
-# Patch anatomy
+# Anatomy
 
-## Data
+## Data and coordinates
 
-The data is simply an n-dimensional array which is accessed with the `data` attribute.
+`Patch.data` is a read-only n-dimensional array. Copy it before changing values directly.
 
 ```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-
-print(f"Data shape is {patch.data.shape}")
-
-print(f"Data contents are\n{patch.data}")
+data_copy = np.array(patch.data)
+data_copy[:10] = 0
 ```
 
-:::{.callout-note}
-The data arrays are read-only. This means you can't modify them in place; you must make a copy first.
-
-```python
-import numpy as np
-
-patch.data[:10] = 12  # won't work
-
-array = np.array(patch.data)  # this makes a copy
-array[:10] = 12  # then this works
-```
-:::
-
-
-## Coords
-
-DASCore implements a class called [CoordManager](`dascore.core.coordmanager.CoordManager`) which manages dimension names, coordinate labels, selecting, sorting, etc. `CoordManager` has several convenience methods for accessing contained information:
+`Patch.coords` manages dimension names and coordinates. The common accessors are available on the patch itself:
 
 ```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-coords = patch.coords
-
-# Get an array of time values
-time_array = coords.get_array("time")
-
-# Get the maximum distance value
-distance_max = coords.max("distance")
-
-# Get the time step (NaN if time isn't evenly sampled)
-time_step = coords.step("time")
+time_coord = patch.get_coord("time")
+time_values = patch.get_array("time")
+distance_max = patch.coords.max("distance")
+time_step = patch.coords.step("time")
 ```
 
-For convenience, coordinates and their corresponding arrays can be accessed from the patch level as well.
+A coordinate may be associated with one or more dimensions, such as latitude along `distance`, or be independent of the data. See the advanced [coordinates tutorial](coords.qmd) for direct `BaseCoord` and `CoordManager` use.
+
+Dimension coordinates usually share a dimension's name, but that is not required. Auxiliary coordinates such as latitude commonly depend on `distance`; a quality grid may depend on both `distance` and `time`; deployment metadata can be independent of every dimension.
+
+String coordinates support exact matches, wildcards, compiled regular expressions, masks, and sorting. They do not support units or numeric range selection.
 
 ```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-
-# Get the coordinate object for distance
-distance_coord = patch.get_coord("distance")
-
-# Get the array of values corresponding to time
-time_array = patch.get_array("time")
-```
-
-Coords also have an expressive string representation:
-
-```{python}
-print(coords)
-```
-
-:::{.callout-note}
-
- - Patch dimensions may have an associated coordinate with the same name but this is not required.
-
- - Coordinates are often (but not always) associated with one or more dimensions. For example, coordinates "latitude" and "longitude" are often associated with dimension "distance". 
-
-:::
-
-Most of the other `CoordManager` features are primarily used internally by DASCore, but you can read more about them in the [Coordinate Tutorial](coords.qmd).
-
-String dimension labels are also supported. These are useful when a dimension
-is identified by names or channel labels rather than numeric positions.
-
-```{python}
-import numpy as np
 import re
 
-import dascore as dc
+labeled = patch.select(distance=slice(0, 4), samples=True).new(dims=("channel", "time"))
+labeled = labeled.update_coords(channel=np.array(["ch_a", "ch_b", "aux_1", "aux_2"]))
 
-patch = dc.get_example_patch().select(distance=slice(0, 4), samples=True)
-patch = patch.new(dims=("channel", "time"))
-labels = np.array(["ch_a", "ch_b", "aux_1", "aux_2"])
-patch = patch.update_coords(channel=labels)
-
-# Exact-match selection works on string coordinates.
-selected = patch.select(channel="ch_b")
-print(selected.get_coord("channel").values)
-
-# Unix-style wildcards also work.
-matched = patch.select(channel="ch_*")
-print(matched.get_coord("channel").values)
-
-# Compiled regular expressions are also supported.
-regex_matched = patch.select(channel=re.compile(r"^aux_\d$"))
-print(regex_matched.get_coord("channel").values)
-
-# Sorting also works.
-sorted_patch = patch.sort_coords("channel", reverse=True)
-print(sorted_patch.get_coord("channel").values)
+exact = labeled.select(channel="ch_b")
+channels = labeled.select(channel="ch_*")
+aux = labeled.select(channel=re.compile(r"^aux_\d$"))
+reverse = labeled.sort_coords("channel", reverse=True)
 ```
 
-String coordinates support exact matching, wildcard matching with `*` and `?`,
-compiled regular expressions, boolean-mask selection, and sorting, but they do
-not support units or numeric range selection. Avoid using `*` or `?` in labels
-you intend to select literally.
+Wildcards use Unix-style `*` and `?`. Use a compiled expression for regular-expression matching, and avoid wildcard characters in labels that must be selected literally.
 
-## Attrs
+## Attributes and summaries
 
-The metadata stored in `Patch.attrs` is a [pydantic model](https://docs.pydantic.dev/usage/models/) which enforces a schema and provides validation. [`PatchAttrs.get_summary_df`](`dascore.models.base.DascoreBaseModel.get_summary_df`) generates a table of the attribute descriptions:
-
+`Patch.attrs` contains validated, non-coordinate metadata such as `data_units`, `acquisition_key`, `gauge_length`, and processing history. Coordinate bounds and steps are derived through `Patch.summary` rather than duplicated in `attrs`.
 
 ```{python}
-#| echo: false
+print(patch.attrs.data_units)
+print(patch.summary.get_coord_summary("time").min)
 
-import dascore as dc
-from IPython.display import Markdown
-
-df_str = (
-    dc.PatchAttrs.get_summary_df()
-    .reset_index()
-    .to_markdown(index=False, stralign="center")
-)
-Markdown(df_str)
+row = patch.flat_dump()
+print(row["time_min"], row["distance_step"])
 ```
 
+`Patch.summary` is read-only. `flat_dump()` is intended for tabular rows and produces the same coordinate-summary column names used by spool indexes, including `time_min`, `time_max`, and `distance_step`. The optional `data_type` attribute is a display hint; interpret data through its units, coordinates, and history.
 
-Specific data formats may also add attributes (e.g. "gauge_length", "pulse_width"), but this depends on the parser.
-
-### Patch History
-
-Patch-processing methods append entries to `Patch.attrs.history` by default so downstream steps remain traceable.
+The complete validated attribute schema is available programmatically:
 
 ```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-filtered = patch.pass_filter(time=(1, 10))
-
-print(filtered.attrs.history[-1])
+attribute_fields = dc.PatchAttrs.get_summary_df()
+attribute_fields.head()
 ```
 
-If you want to suppress new history entries for a block of operations, use `config_context(patch_history="disabled")`. Existing history is preserved, but DASCore will stop appending new entries until that config context exits.
+Patch functions append to `attrs.history`. Disable new entries temporarily when provenance is not needed:
 
 ```{python}
 from dascore.config import config_context
 
-patch = dc.get_example_patch().pass_filter(time=(1, 10))
-old_history = patch.attrs.history
-
 with config_context(patch_history="disabled"):
-    out = patch.abs()
-
-assert out.attrs.history == old_history
+    without_new_history = patch.abs()
 ```
 
-`Patch.attrs` only stores non-coordinate metadata. This includes things like the acquisition key, data units, and observing-system fields such as `gauge_length` or `pulse_width`.
+Existing history remains intact while recording is disabled. This is useful for tight processing loops where a full operation log is unnecessary; leave the default enabled when results must be audited later.
 
 ### Patch identity
 
-Two ids answer two different questions, and they move independently.
+Two attributes track identity:
 
-`patch_id` says **which data** this is. It survives every operation which does not change what the data is *of* — filtering, decimating, transposing, changing units — and changes only when data from more than one source is combined.
-
-`processing_id` says **what was done**. It advances on every operation, by folding that operation's fingerprint into the id the input carried.
+| Attribute | Meaning | Changes when |
+|---|---|---|
+| `patch_id` | Which source data this is | Multiple sources are combined |
+| `processing_id` | Which operations produced it | A patch function changes the patch |
 
 ```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
 filtered = patch.pass_filter(time=(1, 10))
-
-# Same data, so the same patch_id.
 assert filtered.attrs.patch_id == patch.attrs.patch_id
-# Something was done to it, so a new processing_id.
 assert filtered.attrs.processing_id != patch.attrs.processing_id
 ```
 
-Neither is a random number after the first, so the same data processed the same way arrives at the same `processing_id` — in another process, on another machine, next year:
+The processing route matters. Repeating the same operations produces the same `processing_id`, while changing their order does not:
 
 ```{python}
-one = patch.pass_filter(time=(1, 10)).decimate(time=2)
-two = patch.pass_filter(time=(1, 10)).decimate(time=2)
-assert one.attrs.processing_id == two.attrs.processing_id
-
-# And a different route is a different answer, order included.
+first = patch.pass_filter(time=(1, 10)).decimate(time=2)
+same = patch.pass_filter(time=(1, 10)).decimate(time=2)
 other = patch.decimate(time=2).pass_filter(time=(1, 10))
-assert other.attrs.processing_id != one.attrs.processing_id
+
+assert first.attrs.processing_id == same.attrs.processing_id
+assert first.attrs.processing_id != other.attrs.processing_id
 ```
 
-A patch read from a file derives its `patch_id` from what it was read from — the format and version, the path, which patch it is within the file, and the file's size and modification time — so two processes reading the same file agree on which data it is, and so does scanning it without reading it at all:
+File-backed patches derive `patch_id` from format, version, path, patch key, file size, and modification time. Repeated reads and metadata scans therefore agree without hashing the data array. Copying the same bytes to another path produces a different derived ID; overwriting a path also changes it. DASDAE files store both IDs and restore the stored values when read elsewhere.
 
-```{python}
-import tempfile
-from pathlib import Path
-
-path = Path(tempfile.mkdtemp()) / "patch.h5"
-patch.io.write(path, "dasdae")
-
-assert dc.read(path)[0].attrs.patch_id == dc.read(path)[0].attrs.patch_id
-```
-
-Those fields are the ones the spool index already keeps, and they are the ones it already uses to decide whether a file changed: data written over a path is a new datum rather than the old one wearing its id. The price is the other way round — the same bytes copied to a second path, or re-fetched over the first, are a new datum too. A missed match is the safe failure; two different data claiming to be one is not.
-
-`patch_id` is indexed by the spool, so a spool hands back the patch an id names without loading anything to look for it — see [Finding a patch by its id](spool.qmd#finding-a-patch-by-its-id). `processing_id` is not: it advances on every operation, including the ones a spool runs as it loads.
-
-The path is part of the id, so a derived id is not stable across machines. A stored one is: DASDAE writes both ids into the file, and a patch read back from it keeps the id it was written with rather than deriving a new one. A patch built in memory names no source, so its `patch_id` is minted, and stable only within the process which built it.
-
-An operation which hands the patch straight back did nothing, and records nothing. Neither id is part of `Patch.equals`: two patches holding the same data are equal however they were made.
-
-### What builds a patch, and what operates on one
-
-`new`, `update` and `update_attrs` carry both ids through, unless you name one and set it yourself. They are not operations — they are how a patch function assembles its own result — so stamping there would count every operation twice.
-
-That has a consequence worth knowing: changing data through `new` yourself leaves the ids saying the data is unchanged and the route is the same one.
+In-memory patches receive process-local IDs. Direct calls to `new`, `update`, and `update_attrs` preserve both IDs because patch functions use them to assemble results. Changing data through these low-level methods does not describe a processing step:
 
 ```{python}
 doubled = patch.new(data=patch.data * 2)
-
-# It says it is the same data by the same route, because nothing told it otherwise.
 assert doubled.attrs.patch_id == patch.attrs.patch_id
 assert doubled.attrs.processing_id == patch.attrs.processing_id
 ```
 
-The ids describe what DASCore was asked to do. Work done through [patch functions](processing.qmd) is described; work done by reaching past them is not. Building a patch from arrays rather than from another patch is the honest case, and mints a new `patch_id`:
+Use patch functions when processing should advance provenance. A function that returns the input unchanged advances neither ID, and IDs do not participate in `Patch.equals`. Set `patch_provenance="disabled"` only when IDs are not needed. See [Finding a patch by its ID](spool.qmd#finding-a-patch-by-id) and [Workflow](workflow.qmd) for lookup and operation fingerprints.
+
+## Display and shortcuts
+
+Displaying a patch summarizes its data, coordinates, attributes, and history. HTML displays use collapsible sections; [`display_html`](configuration.qmd) selects the text representation instead.
 
 ```{python}
-import numpy as np
-
-built = dc.Patch(data=np.asarray(patch.data), coords=patch.coords, dims=patch.dims)
-assert built.attrs.patch_id != patch.attrs.patch_id
-```
-
-Set `patch_provenance="disabled"` to stop maintaining them:
-
-```{python}
-with config_context(patch_provenance="disabled"):
-    plain = dc.Patch(data=patch.data, coords=patch.coords, dims=patch.dims)
-
-assert plain.attrs.patch_id == ""
-```
-
-## Summary
-
-`Patch.summary` provides a read-only combined view of:
-
-- `Patch.attrs` for non-coordinate metadata
-- coordinate summaries derived from `Patch.coords`
-
-Use `Patch.summary` when you need fields such as `time_min`, `time_max`, `distance_step`, or coordinate units.
-
-```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-
-print(patch.attrs.tag)
-print(patch.get_coord("time").min())
-print(patch.get_coord("distance").step)
-```
-
-For tabular use, [`PatchSummary.flat_dump()`](`dascore.PatchSummary.flat_dump`) returns a flat dictionary combining attrs with coordinate summary fields.
-
-```{python}
-row = patch.flat_dump()
-print(row["time_min"])
-print(row["distance_max"])
-```
-
-The `data_type` attribute is an optional label for the kind of data in the patch. It is useful for display defaults and quick inspection, but physical interpretation should come from `data_units`, coordinate units, and `history`. See the [PatchAttrs note](../notes/patch_attrs.qmd) for more detail.
-
-## Seeing a patch
-
-A patch says what it holds. Where a display can render HTML — a notebook, or this page — it draws a panel whose sections fold; everywhere else, and with `display_html` off, it says the same words as text.
-
-A time range is drawn as a range rather than as two values: both ends state the same fields, and the far one states only what differs, with `…` standing for whatever it repeats of the near one. A patch inside one day says that day once.
-
-```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
 patch
 ```
 
-## Shortcuts
-
-DASCore Patches offer a few shortcuts for quickly accessing commonly used information:
+For time-distance patches, `seconds` and `channel_count` provide quick size information. `get_patch_name()` returns the default filename for a patch.
 
 ```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-print(patch.seconds)  # number of seconds in the patch
-print(patch.channel_count)  # number of channels in the patch
+print(patch.seconds, patch.channel_count)
+print(patch.get_patch_name())
 ```
 
-These shortcuts only work for patches with dimensions "time" and "distance", but they can help new users who may be unfamiliar with datetimes and coordinates.
+`Spool.get_patch_names()` applies the same naming convention to every managed patch. Display precision, truncation, and folding are controlled by the [runtime configuration](configuration.qmd).
 
-The "name" of a patch (the filename DASCore would use if the patch were saved to disk) can be generated with [`Patch.get_patch_name`](`dascore.Patch.get_patch_name`). For a spool, use [`Spool.get_patch_names`](`dascore.Spool.get_patch_names`) to get the names of its managed patches.
-
-```python 
-import dascore as dc
-
-patch = dc.get_example_patch()
-spool = dc.get_example_spool()
-
-patch_name = patch.get_patch_name()
-patch_names = spool.get_patch_names()
-```
-
-# Trim and Reshape
-
-The following methods help trim, reshape, and manipulate coordinates.
+# Selecting and reshaping
 
 ## Select
 
-Patches are trimmed using the [`Patch.select`](`dascore.Patch.select`) method. Unlike [`Patch.order`](`dascore.Patch.order`), `select` will not change the order of the affected dimensions, it will only remove elements. Most commonly, `select` takes the coordinate name and a tuple of (lower_limit, upper_limit) as the values. Either limit can be `...` or `None`, indicating an open interval, as can an infinite bound pointing away from the data, such as `(lower_limit, np.inf)`. 
+[`Patch.select`](`dascore.Patch.select`) keeps coordinate values inside a range without reordering them. Use `...` or `None` for an open bound.
 
 ```{python}
-import numpy as np
-
-import dascore as dc
-
-patch = dc.get_example_patch()
-attrs = patch.attrs
-
-# Select 1 sec after current start time to 1 sec before end time.
 time = patch.get_coord("time")
-one_sec = dc.to_timedelta64(1)
-select_tuple = (time.min() + one_sec, time.max() - one_sec)
-new = patch.select(time=select_tuple)
+one_second = dc.to_timedelta64(1)
 
-# Select only the first half of the distance channels.
-distance_max = np.mean(patch.coords.get_array('distance'))
-new = patch.select(distance=(..., distance_max))
+trimmed = patch.select(time=(time.min() + one_second, time.max() - one_second))
+first_half = patch.select(distance=(..., np.mean(patch.get_array("distance"))))
 ```
 
-The `relative` keyword is used to trim coordinates based on the start (positive) and end (negative).
+With `relative=True`, positive bounds are measured from the start and negative bounds from the end:
 
 ```{python}
-import dascore as dc
+trimmed = patch.select(time=(1, -1), relative=True)
+```
+
+Relative quantities are converted before measuring from an endpoint:
+
+```{python}
 from dascore.units import ft
 
-patch = dc.get_example_patch()
-
-# We can make the example above simpler with relative selection
-new = patch.select(time=(1, -1), relative=True)
-
-# select 2 seconds from end to 1 second from end
-new = patch.select(time=(-2, -1), relative=True)
-
-# select last 100 ft of distance channels
-new = patch.select(distance=(-100 * ft, ...), relative=True)
+last_hundred_feet = patch.select(distance=(-100 * ft, ...), relative=True)
 ```
 
-The `samples` keyword tells `select` the meaning of the query is in samples rather than the units of the selected dimension. Unlike absolute selections, sample selections are **always** relative to the data contained in the patch: a single index of 0 is the first sample along the dimension and -1 is the last.
+With `samples=True`, values are array indices. Sample ranges follow Python slicing, while coordinate-value ranges include both endpoints.
 
-:::{.callout-warning}
-Sample ranges and value ranges do not have the same end behavior. A value range includes both of its endpoints, but a sample range excludes its upper bound, like Python's slicing and `range`.
-
-A consequence worth remembering: `-1` used as the end of a range excludes the last sample, even though `-1` on its own selects it.
-
-| query | selects |
+| Query | Result |
 |---|---|
-| `select(distance=(0, 10))` | values 0 through 10, **both included** (11 channels) |
-| `select(time=(0, 10), samples=True)` | samples 0 through 9 (10 samples) |
-| `select(time=(0, -1), samples=True)` | every sample **except** the last |
-| `select(time=-1, samples=True)` | only the last sample |
-
-: Range endpoints in values vs samples {.striped .hover}
-
-`select` also accepts a slice wherever it accepts a `(min, max)` tuple, which is worth preferring for sample ranges since `slice(0, -1)` reads exactly like `x[0:-1]`. Note this is specific to `select` and `order`; processing functions such as `pass_filter` and `taper` require a tuple. Note also that the slice is still only shorthand for a range, so it needs `samples=True` just as a tuple does — without it, `-1` is a coordinate value rather than an index.
-:::
+| `select(distance=(0, 10))` | Coordinate values 0 through 10, inclusive |
+| `select(time=(0, 10), samples=True)` | Samples 0 through 9 |
+| `select(time=(0, -1), samples=True)` | Every sample except the last |
+| `select(time=-1, samples=True)` | Only the last sample |
 
 ```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-sample_count = len(patch.get_array("time"))
-
-# Trim patch to only include first 10 time rows (or columns).
-new = patch.select(time=(..., 10), samples=True)
-assert len(new.get_array("time")) == 10
-
-# Only include the last distance column or row.
-new = patch.select(distance=-1, samples=True)
-
-# But as the end of a range, -1 excludes the last sample.
-new = patch.select(time=(0, -1), samples=True)
-assert len(new.get_array("time")) == sample_count - 1
-
-# A slice means the same thing, and makes that more obvious.
-assert len(patch.select(time=slice(0, -1), samples=True).get_array("time")) == sample_count - 1
+first_ten = patch.select(time=slice(0, 10), samples=True)
+last_channel = patch.select(distance=-1, samples=True)
 ```
 
-Arrays can also be passed as values in which case they will be treated like sets, meaning only coordinate elements in the array will be selected.
+Arrays select a set of coordinate values or sample positions:
 
 ```{python}
-import numpy as np
-
-import dascore as dc
-
-patch = dc.get_example_patch()
-
-# Create an array of desired distances.
-dist_to_select = np.array([10., 18., 12.])
-sub_patch = patch.select(distance=dist_to_select)
-# Test that select worked.
-assert set(sub_patch.get_array('distance')) == set(dist_to_select)
-
-# Samples also work
-sub_patch = patch.select(distance=np.array([0, 12, 10, 9]), samples=True)
-assert len(sub_patch.get_array('distance')) == 4
+chosen = patch.select(distance=np.array([10, 18, 12]))
+chosen_samples = patch.select(distance=np.array([0, 12, 10, 9]), samples=True)
 ```
 
-## Unselect
-
-[`Patch.unselect`](`dascore.Patch.unselect`) is the complement of `select`: it takes the same selectors and removes the samples `select` would have kept. Naming one coordinate gives exactly the complement; naming several complements each on its own, as below.
+Multiple keywords apply one selection per coordinate in the same call. The resulting array is the intersection of those selections:
 
 ```{python}
-import dascore as dc
+window = patch.select(
+    time=(1, -1),
+    distance=(0, 100),
+    relative=True,
+)
+```
 
-patch = dc.get_example_patch()
+Slices are accepted anywhere a `(minimum, maximum)` tuple is accepted. They remain range shorthand, so sample slices still require `samples=True`. Processing functions such as `pass_filter` and `taper` use tuples rather than slices.
 
-# Everything outside meters 50 to 200.
+## Unselect and order
+
+[`Patch.unselect`](`dascore.Patch.unselect`) removes what `select` would keep. Removing an interior range creates a segmented coordinate.
+
+```{python}
 outside = patch.unselect(distance=(50, 200))
-
-# Together the two account for every channel, and share none.
-inside = patch.select(distance=(50, 200))
-assert len(outside.get_array("distance")) + len(inside.get_array("distance")) == 300
-```
-
-Removing a range from the middle leaves a hole, so the coordinate is no longer evenly sampled:
-
-```{python}
-assert patch.get_coord("distance").step is not None
 assert outside.get_coord("distance").step is None
 ```
 
-That is why [`Spool.unselect`](`dascore.core.spool.Spool.unselect`) refuses the patches' own coordinates. A patch can have samples removed from its middle; at spool level the complement of a range would be a hole in every patch rather than a choice between patches. The coordinates an attached DASDAE [inventory](inventory.qmd) defines along the fiber are a separate case, and are accepted: removing one of those chooses which channels a patch holds. When several coordinates are named, each is complemented on its own — the true complement of a block is a frame around it, which no array can hold.
+Each named coordinate is complemented independently. At spool level, patch coordinates cannot be unselected because removing an interior interval could turn one patch into two; use `Patch.unselect` when subdivision is intended.
 
-## Order
- Order is similar to [`Patch.select`](`dascore.Patch.select`), but will re-arrange data to the order specified by a value array. This may also cause parts of the patch to be duplicated.
-
-```{python}
-import numpy as np
-
-import dascore as dc
-
-patch = dc.get_example_patch()
-
-# Get a patch with a new distance ordering
-dist_order1 = np.array([20., 10., 15.])
-patch_dist1 = patch.order(distance=dist_order1)
-assert np.all(dist_order1 == patch_dist1.get_array("distance"))
-
-# Get a patch with duplicate entries for distance
-dist_order2 = np.array([20., 20., 20.])
-patch_dist2 = patch.order(distance=dist_order2)
-assert np.all(dist_order2 == patch_dist2.get_array("distance"))
-```
-
-## New dimensions
-
-Sometimes it can be useful to add new (empty) dimensions to a Patch.
-[`Patch.append_dims`](`dascore.Patch.append_dims`) does this.
-
-```python
-import dascore as dc
-
-patch = dc.get_example_patch()
-
-# Create a new patch with a single empty dimension called "nothing"
-patch_dims = patch.append_dims("nothing")
-
-# Create a new patch with a length two dimension called "money".
-# The contents of the patch are repeated along the new dimension to fill
-# the required length.
-patch_extended_dims = patch.append_dims(money=2)
-
-# Transpose can then be used to re-arrange the dims
-patch_extended = patch_extended_dims.transpose("time", "money", "distance")
-
-# And update coords to add coordinate values to the new dim
-patch_extended_coord = patch_extended.update_coords(money=[10, 30])
-```
-
-Although these examples are quite contrived, these functions are very useful for transforms which create high dimensional patches. 
-
-# Processing
-
-The patch has several methods which are intended to be chained together via a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface), meaning each method returns a new `Patch` instance.
+[`Patch.order`](`dascore.Patch.order`) instead follows the supplied order and may duplicate samples.
 
 ```{python}
-import dascore as dc
-pa = dc.get_example_patch()
+ordered = patch.order(distance=np.array([20, 10, 20]))
+```
 
-out = (
-    # Decimate to reduce data volume by 8 along time dimension
-    pa.decimate(time=8)  
-    # Detrend along distance dimension
-    .detrend(dim='distance')
-    # Apply a low-pass 10 Hz butterworth filter along time dimension
+[`Patch.append_dims`](`dascore.Patch.append_dims`) adds a dimension and optionally repeats the data along it:
+
+```{python}
+expanded = patch.append_dims(realization=2).update_coords(realization=[0, 1])
+```
+
+The new dimension is appended to the array. Use `transpose` to place it elsewhere:
+
+```{python}
+expanded = expanded.transpose("distance", "realization", "time")
+```
+
+# Processing and visualization
+
+Patch methods form a fluent interface, so processing steps can be chained:
+
+```{python}
+processed = (
+    patch.decimate(time=8)
+    .detrend(dim="distance")
     .pass_filter(time=(..., 10))
 )
 ```
-The processing methods are located in the [dascore.proc](`dascore.proc`) module. The [patch processing tutorial](processing.qmd) provides more information about processing routines.
 
-# Visualization
+See [Patch processing](processing.qmd) and the [`dascore.proc`](`dascore.proc`) API for available operations.
 
-DASCore provides some visualization functions in the [dascore.viz](`dascore.viz`) module or using the `Patch.viz` namespace. DASCore generally only implements simple, matplotlib based visualizations but other DASDAE packages will likely do more interesting visualizations.
+Plots are available through `Patch.viz`:
 
 ```{python}
-import dascore as dc
+event.taper(time=0.05).pass_filter(time=(..., 300)).viz.waterfall(show=True);
+```
 
-patch = (
-    dc.get_example_patch('example_event_1')
-    .taper(time=0.05)
-    .pass_filter(time=(..., 300))
+See the [visualization tutorial](visualization.qmd) for plot options.
+
+# Updating patches
+
+[`Patch.update`](`dascore.Patch.update`) replaces data, coordinates, or the complete attribute model. [`Patch.update_attrs`](`dascore.Patch.update_attrs`) changes selected metadata fields.
+
+```{python}
+scaled = patch.update(data=patch.data * 10)
+retagged = patch.update_attrs(tag="processed")
+```
+
+[`Patch.update_coords`](`dascore.Patch.update_coords`) modifies or adds coordinates. Tuple values specify `(associated_dimensions, values)`.
+
+```{python}
+shifted = patch.update_coords(time_min=patch.coords.min("time") + one_second)
+
+latitude = np.linspace(41.5, 41.8, patch.shape[0])
+located = patch.update_coords(latitude=("distance", latitude))
+
+quality = np.ones_like(patch.data)
+with_quality = located.update_coords(quality=(patch.dims, quality))
+```
+
+Several coordinates can be attached in one call, and the associated dimension determines the required shape:
+
+```{python}
+longitude = np.linspace(-109.9, -109.6, patch.shape[0])
+located = patch.update_coords(
+    latitude=("distance", latitude),
+    longitude=("distance", longitude),
 )
-
-patch.viz.waterfall(show=True);
 ```
 
-# Modifying patches
-
-Because patches should be treated as immutable objects, they can't be modified with normal attribute assignment. However, DASCore provides several methods that return new patches with modifications. 
-
-## Update
-
-[`Patch.update`](`dascore.core.patch.Patch.update`) uses the `Patch` instances as a template and returns a new `Patch` instances with one or more aspects modified.
+The same tuple syntax works during construction:
 
 ```{python}
-import dascore as dc
-pa = dc.get_example_patch()
-
-# Create a copy of patch with new data but coords and attrs stay the same.
-new_data_patch = pa.update(data=pa.data * 10)
-
-# Completely replace the attributes.
-new_attrs_patch = pa.update(attrs=dict(tag="TMU"))
-```
-
-## Update attrs
-
-[`Patch.update_attrs`](`dascore.core.patch.Patch.update_attrs`) is for making changes to the attrs (metadata) while keeping the unaffected metadata (`Patch.update` would completely replace the old attrs).
-
-```{python}
-import dascore as dc
-pa = dc.get_example_patch()
-
-# Update existing attribute 'acquisition_key' and create new attr 'new_attr'
-pa1 = pa.update_attrs(acquisition_key='EXP1.R2D1..RAW', new_attr=42)
-```
-
-```{python}
-#| echo: false
-assert pa1.attrs.acquisition_key == "EXP1.R2D1..RAW"
-assert pa1.attrs.new_attr == 42
-```
-
-
-## Update coords
-
-[`Patch.update_coords`](`dascore.core.patch.Patch.update_coords`) returns a new patch with the coordinates changed in some way. These changes can include:
- - Modifying (updating) existing coordinates
- - Adding new coordinates
- - Changing coordinate dimensional association
-
-
-### Modifying coordinates
-
-Coordinates can be updated by specifying a new array which should take the place of the old one:
-
-```{python}
-import dascore as dc
-
-pa = dc.get_example_patch()
-
-# Add one second to all values in the time array.
-one_second = dc.to_timedelta64(1)
-old_time = pa.coords.get_array('time')
-new = pa.update_coords(time=old_time + one_second)
-```
-
-Or by specifying new min, max, or step values for a coordinate.
-
-```{python}
-import dascore as dc
-
-pa = dc.get_example_patch()
-one_second = dc.to_timedelta64(1)
-
-# Change the starting time of the array.
-new_time = pa.coords.min('time') + one_second
-new = pa.update_coords(time_min=new_time)
-```
-
-### Adding coordinates
-
-Commonly, additional coordinates, such as latitude/longitude, are attached to a particular dimension such as distance. It is also possible to include coordinates that are not associated with any dimensions.
-
-
-```{python}
-import numpy as np
-
-import dascore as dc
-
-pa = dc.get_example_patch()
-coords = pa.coords
-dist = coords.get_array('distance')
-time = coords.get_array('time')
-
-# Add a single coordinate associated with distance dimension.
-lat = np.arange(0, len(dist)) * .001 -109.857952
-# Note the tuple form: (associated_dimension, value)
-out_1 = pa.update_coords(latitude=('distance', lat))
-
-# Add multiple coordinates associated with distance dimension.
-lon = np.arange(0, len(dist)) *.001 + 41.544654
-out_2 = pa.update_coords(
-    latitude=('distance', lat),
-    longitude=('distance', lon),
+rebuilt = dc.Patch(
+    data=patch.data,
+    dims=patch.dims,
+    coords={
+        "distance": patch.get_array("distance"),
+        "time": patch.get_array("time"),
+        "latitude": ("distance", latitude),
+        "quality": (patch.dims, quality),
+    },
+    attrs=patch.attrs,
 )
-
-# Add coordinate associated with multiple dimensions.
-quality = np.ones_like(pa.data)
-out_3 = pa.update_coords(
-    quality=(pa.dims, quality)
-)
-
-# Add coordinate which isn't associated with a dimension.
-no_dim_coord = pa.update_coords(non_dim=(None, np.arange(10)))
 ```
 
-### Changing coordinate dimensional association
+To change an association, pass the same values with a new dimension tuple. This changes coordinate metadata without reshaping the patch.
 
-The dimensions each coordinate is associated with can be changed. For example, to remove a coordinate's dimension association:
+Coordinates not associated with a dimension use `(None, values)`. [`Patch.drop_coords`](`dascore.Patch.drop_coords`) removes non-dimensional coordinates; dimension coordinates cannot be dropped.
 
 ```{python}
-import dascore as dc
-
-# Load a patch which has latitude and longitude coordinates.
-patch = dc.get_example_patch("random_patch_with_lat_lon")
-
-# Disassociate latitude from distance.
-lat = patch.coords.get_array('latitude')
-patch_detached_lat = patch.update_coords(latitude=(None, lat))
+detached = located.update_coords(latitude=(None, latitude))
+without_latitude = detached.drop_coords("latitude")
 ```
-
-## Dropping coordinates
-
-Non-dimensional coordinates can be dropped using [`Patch.drop_coords`](`dascore.proc.coords.drop_coords`). Dimensional coordinates, however, cannot be dropped since doing so would force the patch data to become degenerate.
-
-```{python}
-import dascore as dc
-
-# This patch has latitude and longitude coordinates
-patch = dc.get_example_patch("random_patch_with_lat_lon")
-
-# Drop latitude, this won't affect the data or other coordinates
-patch_dropped_lat = patch.drop_coords("latitude")
-print(patch_dropped_lat.coords)
-```
-
-### Coords in patch initialization
-
-Any number of coordinates can also be assigned when the patch is initiated. For coordinates other than those of the patch dimensions, the associated dimensions must be specified. For example:
-
-```{python}
-import dascore as dc
-import numpy as np
-
-# Create data for patch
-rand = np.random.RandomState(13)
-array = rand.random(size=(20, 100))
-time1 = np.datetime64("2020-01-01")
-
-# Create patch attrs
-attrs = dict(dx=1, d_time=1 / 250.0, category="DAS", id="test_data1")
-time_deltas = dc.to_timedelta64(np.arange(array.shape[1]) * attrs["d_time"])
-
-# Create coordinate data
-distance = np.arange(array.shape[0]) * attrs["dx"]
-time = time1 + time_deltas
-quality = np.ones_like(array)
-latitude = np.arange(array.shape[0]) * .001 - 111.00
-
-# Create coord dict
-coords = dict(
-    distance=distance,
-    time=time,
-    latitude=("distance", latitude),  # Note distance is attached dimension
-    quality=(("distance", "time"), quality),  # Two attached dimensions here
-)
-
-# Define dimensions of array and init Patch
-dims = ("distance", "time")
-out = dc.Patch(data=array, coords=coords, attrs=attrs, dims=dims)
-```
-
 
 # Units
 
-As mentioned in the [units section of the concept page](concepts.qmd#units), DASCore provides first-class support for units. 
-
-## Patch units
-
-There are two methods for configuring the units associated with a `Patch`.
-
-[`Patch.set_units`](`dascore.Patch.set_units`) sets the units on a patch or its coordinates. Old units are simply overwritten without performing any conversions. The first argument sets the data units and the keywords set the coordinate units.
-
-[`Patch.convert_units`](`dascore.Patch.convert_units`) converts data or coordinates units by appropriately transforming the data or coordinates arrays. If no units exist they will simply be set.
+[`Patch.set_units`](`dascore.Patch.set_units`) changes unit labels without converting values. [`Patch.convert_units`](`dascore.Patch.convert_units`) converts the data or coordinate values.
 
 ```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-
-# Set data units and distance units; don't do any conversions
-patch_set_units = patch.set_units("m/s", distance="ft")
-
-# Convert data units and distance units; will modify data/coords
-# to correctly do the conversion.
-patch_conv_units = patch_set_units.convert_units("ft/s", distance='m')
+with_units = patch.set_units("m/s", distance="ft")
+converted = with_units.convert_units("ft/s", distance="m")
 ```
 
-The data or coordinate units attributes are [Pint Quantity](https://pint.readthedocs.io/en/stable/getting/tutorial.html#defining-a-quantity), but they can be converted to strings with [`get_quantity_str`](`dascore.units.get_quantity_str`).
+Use `set_units` only when values are already expressed in the new unit or when correcting a missing label. Use `convert_units` when numeric values must preserve the same physical quantity. Data units are stored as Pint quantities and can be formatted with [`get_quantity_str`](`dascore.units.get_quantity_str`).
+
+Quantities may be passed directly to selection and processing functions:
 
 ```{python}
-import dascore as dc
-from dascore.units import get_quantity_str
+from dascore.units import ft, m
 
-patch = dc.get_example_patch().set_units("m/s")
-
-print(type(patch.attrs.data_units))
-print(get_quantity_str(patch.attrs.data_units))
+selected = patch.select(distance=(10 * ft, 10 * m))
+filtered = patch.pass_filter(distance=(10 * m, 100 * m))
 ```
 
-## Units in processing functions
+Quantities are converted to the coordinate's units before selection or processing, so the same expression works after a coordinate is converted from metres to feet.
+
+# Arithmetic and NumPy
+
+Scalar and NumPy-array operations broadcast over patch data. Patch-to-patch operations require compatible metadata and align coordinates on their intersection; units participate in the calculation. See [Patch compatibility](../notes/patch_compatibility.qmd) for the shared rules.
 
 ```{python}
-import dascore as dc
-from dascore.units import m, ft
+scaled = patch / 10
+offset = patch + np.ones(patch.shape)
+combined = patch + patch
 
-pa = dc.get_example_patch()
-
-# Sub-select a patch to only include distance from 10ft to 10m.
-sub_selected = pa.select(distance=(10*ft, 10*m))
-
-# Filter patch for spatial wavelengths from 10m to 100m.
-dist_filtered = pa.pass_filter(distance=(10*m, 100*m))
+assert np.allclose(scaled.data, patch.data / 10)
+assert np.allclose(combined.data, patch.data * 2)
 ```
 
-See the documentation on [`Patch.select`](`dascore.Patch.select`) and [`Patch.pass_filter`](`dascore.Patch.pass_filter`) for more details.
-
-# Patch operations
-
-Patches implement many numpy-like functions which are applied directly to a patch using built-in python operators.
-
-In the case of scalars and numpy arrays, the operations are broadcast over the patch data. In the case of two patches, the patches must be the same kind (no conflicting values for the attributes named by the config option `patch_kind_attrs`, such as `acquisition_key` and `tag`), their coordinates are aligned on the intersection of their values, then the operator is applied to both patches' data. Data units take part in the operation rather than having to match. Here are a few examples:
-
-:::{.callout-note}
-See the [Patch Compatibility](../notes/patch_compatibility.qmd) note for the rules shared by operators, `where`, `concatenate`, `stack`, and `chunk`.
-:::
-
-## Patch operations with scalars
+Operations between patches first reject conflicting values in the configured `patch_kind_attrs`, then align shared coordinate values. Broadcast-compatible shapes are supported:
 
 ```{python}
-import numpy as np
-
-import dascore as dc
-
-patch = dc.get_example_patch()
-
-out1 = patch / 10
-assert np.allclose(patch.data / 10, out1.data)
-
-out2 = patch ** 2.3
-assert np.allclose(patch.data ** 2.3, out2.data)
-
-out3 = patch - 3
-assert np.allclose(patch.data - 3, out3.data)
+one_channel = patch.select(distance=0, samples=True).squeeze()
+broadcast_sum = patch + one_channel
+assert broadcast_sum.shape == patch.shape
 ```
 
-Units are also fully supported.
+Quantities update `data_units` as part of the arithmetic:
 
 ```{python}
-import dascore as dc
-from dascore.units import m, s
+from dascore.units import s
 
-patch = dc.get_example_patch().set_units("m/s")
-
-# Multiplying patches by a quantity with units updates the data_units.
-new = patch * 10 * m/s
-
-print(f"units before operation {patch.attrs.data_units}")
-print(f"units after operation {new.attrs.data_units}")
+velocity = patch.set_units("m/s")
+displacement = velocity * (2 * s)
+print(displacement.attrs.data_units)
 ```
 
-## Patch operations with numpy arrays
+Array operands must broadcast against patch data. Coordinate-aware alignment occurs only for another Patch; a bare NumPy array contributes no coordinate or metadata information.
 
-`Patch` implements the numpy array protocol, meaning you can use numpy functions on patches
+NumPy ufuncs operate directly on patches, and DASCore patch ufuncs support named-dimension reduction and accumulation.
 
 ```{python}
-import numpy as np
-
-import dascore as dc
-
-patch = dc.get_example_patch()
-ones = np.ones(patch.shape)
-
-out1 = patch + ones
-assert np.allclose(patch.data + ones, out1.data)
+absolute = np.abs(patch)
+cumulative = patch.add.accumulate("time")
+summed = patch.add.reduce("distance")
 ```
 
-Units also work with numpy arrays.
+`Patch.apply_ufunc` also accepts a NumPy ufunc explicitly. DASCore maps named dimensions to NumPy axes and preserves compatible coordinates:
 
 ```{python}
-import numpy as np
-
-import dascore as dc
-from dascore.units import furlongs
-
-patch = dc.get_example_patch()
-ones = np.ones(patch.shape) * furlongs
-
-out1 = patch * ones
-print(f"units before operation {patch.attrs.data_units}")
-print(f"units after operation {out1.attrs.data_units}")
+same_absolute = patch.apply_ufunc(np.abs)
+scaled = patch.apply_ufunc(np.multiply, 10)
 ```
 
-## Patch operations with other patches
-
-### Identically shaped patches
-
-When patches are shaped the same, the operations can simply be applied on the data arrays, then coords and attrs merged.
-
-```{python}
-import numpy as np
-
-import dascore as dc
-from dascore.units import furlongs
-
-patch = dc.get_example_patch()
-
-# Adding two patches together simply adds their data their
-# and checks/merges coords and attrs.
-out = patch + patch
-
-assert np.allclose(patch.data * 2, out.data)
-```
-
-### Broadcastable patches
-
-If the arrays are not shaped the same, but they can be broadcasted to compatible shapes, these operations work as well.
-
-```{python}
-import numpy as np
-
-import dascore as dc
-from dascore.units import furlongs
-
-patch = dc.get_example_patch()
-sub_patch = patch.select(distance=1, samples=True)
-print(sub_patch.shape)
-
-# The sub patch is broadcasted over the patch along appropriate dimension.
-sum_patch = patch + sub_patch
-print(sum_patch.shape)
-```
-
-### Numpy Functions
-
-DASCore uses [apply_array_ufunc](`dascore.utils.array.apply_ufunc`) and [array_function](`dascore.utils.array.apply_array_func`) for applying numpy functions to `Patch` instances.
-
-For NumPy's [ufuncs](https://numpy.org/doc/stable/reference/ufuncs.html) DASCore implements `Patch` universal functions. You can use numpy ufuncs directly on patches or create patch-specific ufuncs with dimension support.
-
-```{python}
-import numpy as np
-import dascore as dc
-
-patch = dc.get_example_patch()
-
-# Use numpy ufuncs directly on patches
-abs_patch = np.abs(patch)
-sin_patch = np.sin(patch)
-
-# Add patches together using numpy ufuncs
-sum_patch = np.add(patch, patch)
-
-# Or name the ufunc, with the patch as its first operand
-same_abs_patch = patch.apply_ufunc(np.abs)
-scaled_patch = patch.apply_ufunc(np.multiply, 10)
-```
-
-Some of the Patch methods are ufuncs which means they support accumulation and reduction along specified dimensions.
-
-```{python}
-from dascore.utils.array import PatchUFunc
-import numpy as np
-import dascore as dc
-
-patch = dc.get_example_patch()
-added_patch = patch.add(patch)
-patch_cum_sum = patch.add.accumulate("time")
-patch_reduced = patch.add.reduce("distance")
-```
-
-
-:::{.callout-note}
-`PatchUFunc.reduce`/`accumulate` accept `dim` (mapped internally to `axis`), while numpy ufuncs accept `axis`.
-:::
-
-For more advanced usage, you can create patch ufuncs.
-
-```{python}
-from dascore.utils.array import PatchUFunc
-import numpy as np
-import dascore as dc
-
-# Create a patch ufunc wrapper
-add_ufunc = PatchUFunc(np.add)
-patch = dc.get_example_patch()
-
-# Use accumulate to compute cumulative sum along time dimension
-cumsum_patch = add_ufunc.accumulate(patch, dim="time")
-
-# Use reduce to sum all values along distance dimension
-sum_patch = add_ufunc.reduce(patch, dim="distance")
-
-# Bind to patch for cleaner syntax
-bound_add = add_ufunc.__get__(patch, type(patch))
-result = bound_add.reduce(dim="time")  # No need to pass patch
-```
-
-The patch ufunc system automatically handles dimension-to-axis conversion and preserves patch coordinates appropriately.
+Named reduction removes the reduced dimension and coordinates which depend on it. Accumulation retains the original shape and dimension coordinates.

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -76,7 +76,7 @@ A scalar applies the same fraction at both ends. Tuple values let asymmetric rec
 
 See the [edge-effects recipe](../recipes/edge_effects.qmd) for tapering before filters.
 
-# Rolling windows
+# Rolling windows {#rolling}
 
 [`Patch.rolling`](`dascore.Patch.rolling`) provides moving-window reductions. Incomplete windows produce NaNs, which can be removed with `dropna`.
 

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -3,48 +3,8 @@ title: Patch Processing
 execute:
   warning: false
 ---
-The following shows some simple examples of patch processing. See the
-[proc module](`dascore.proc`) for a list of all processing functions.
 
-# Basic
-
-There are several "basic" processing functions which manipulate the patch metadata, shape, etc. Many of these are covered in the [patch tutorial](patch.qmd), but here are a few that aren't:
-
-## Transpose
-The [`transpose` patch function](`dascore.Patch.transpose`) patch function simply transposes the dimensions of the patch, either by rotating the dimensions or to a new specified dimension.
-
-```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-print(f"dims before transpose: {patch.dims}")
-
-transposed = patch.transpose()
-print(f"dims after transpose: {transposed.dims}")
-
-# Dimension order can be manually specified as well.
-transposed = patch.transpose("time", "distance")
-```
-
-## Squeeze
-[`squeeze`](`dascore.Patch.squeeze`) removes dimensions which have a single value (see also `numpy.squeeze`).
-
-```{python}
-import dascore as dc
-
-patch = dc.get_example_patch()
-# Select first distance value to make distance dim flat.
-
-flat_patch = patch.select(distance=0, samples=True)
-print(f"Pre-squeeze shape: {flat_patch.shape}")
-
-squeezed = flat_patch.squeeze()
-print(f"Post-squeeze shape: {squeezed.shape}")
-```
-
-## Dropna
-
-The [`dropna` patch function](`dascore.Patch.dropna`) patch function drops "nullish" values from a given label.
+Patch-processing methods return new patches and are listed in the [`dascore.proc`](`dascore.proc`) API.
 
 ```{python}
 import numpy as np
@@ -52,274 +12,141 @@ import numpy as np
 import dascore as dc
 
 patch = dc.get_example_patch()
-
-# Create a patch with nan values
-data = np.array(patch.data)
-data[:, 0] = np.nan
-patch_with_nan = patch.new(data=data)
-
-# Drop Nan along axis 1
-dim = patch_with_nan.dims[1]
-no_na_patch = patch_with_nan.dropna(dim)
-
-assert not np.any(np.isnan(no_na_patch.data))
 ```
 
+# Shape and missing values
+
+`transpose` changes dimension order, `squeeze` removes length-one dimensions, and `dropna` removes labels containing null values.
+
+```{python}
+transposed = patch.transpose("time", "distance")
+
+flat = patch.select(distance=0, samples=True)
+squeezed = flat.squeeze()
+
+data = np.array(patch.data)
+data[:, 0] = np.nan
+without_nan = patch.new(data=data).dropna("time")
+```
+
+`transpose()` with no arguments rotates dimension order. `squeeze()` can name dimensions to remove and rejects any named dimension whose length is not one. `dropna` keeps coordinate and data indexing synchronized.
 
 # Decimate
 
-[decimate](`dascore.Patch.decimate`) decimates a `Patch` along a given axis while by default performing low-pass filtering to avoid [aliasing](https://en.wikipedia.org/wiki/Aliasing).
-
-## Data creation
-
-First, we create a patch composed of two sine waves; one above the new
-decimation frequency and one below.
+[`Patch.decimate`](`dascore.Patch.decimate`) downsamples a dimension and applies an anti-aliasing filter by default.
 
 ```{python}
-import dascore as dc
-
-patch = dc.examples.get_example_patch(
+waves = dc.examples.get_example_patch(
     "sin_wav",
     sample_rate=1000,
     frequency=[200, 10],
     channel_count=2,
 )
-patch.viz.wiggle(show=True);
+
+iir = waves.decimate(time=10, filter_type="iir")
+fir = waves.decimate(time=10, filter_type="fir")
+aliased = waves.decimate(time=10, filter_type=None)
 ```
 
-## IIR filter
-
-Next we decimate by 10x using IIR filter
+Use `filter_type=None` only when aliasing is intentional or filtering has already been performed.
 
 ```{python}
-decimated_iir = patch.decimate(time=10, filter_type='iir')
-decimated_iir.viz.wiggle(show=True);
+iir.viz.wiggle(show=True);
+aliased.viz.wiggle(show=True);
 ```
 
-Notice the lowpass filter removed the 200 Hz signal and only
-the 10Hz wave remains.
-
-## FIR filter
-
-Next we decimate by 10x using FIR filter.
-
-```{python}
-decimated_fir = patch.decimate(time=10, filter_type='fir')
-decimated_fir.viz.wiggle(show=True);
-```
-
-## No Filter
-
-Next, we decimate without a filter to purposely induce aliasing.
-
-```{python}
-decimated_no_filt = patch.decimate(time=10, filter_type=None)
-decimated_no_filt.viz.wiggle(show=True);
-```
+Here the filtered result removes the 200 Hz component before reducing the 1,000 Hz sample rate. The unfiltered result folds that energy into a lower apparent frequency.
 
 # Taper
 
-[taper](`dascore.Patch.taper`) is used to taper the edges of a patch dimension to zero. To see this, let's create a patch of all 1s and apply the taper function
+[`Patch.taper`](`dascore.Patch.taper`) applies a cosine taper to a fraction of a dimension. A tuple controls the two ends; `None` leaves one end unchanged.
 
 ```{python}
-import numpy as np
-import dascore as dc
-
-_patch = dc.get_example_patch()
-patch_ones = _patch.new(data=np.ones_like(_patch.data))
+ones = patch.new(data=np.ones_like(patch.data))
+both_ends = ones.taper(time=0.1)
+different_ends = ones.taper(distance=(0.1, 0.3))
+end_only = ones.taper(distance=(None, 0.1))
 ```
-
-The following code will apply a 10% taper, meaning a cosine taper is applied along the first and last 10% of the specified dimension.
 
 ```{python}
-patch_ones.taper(time=0.1).viz.waterfall();
+different_ends.viz.waterfall(show=True);
 ```
 
-Passing a tuple of values enables different amounts of tapering for each end of the dimension.
+A scalar applies the same fraction at both ends. Tuple values let asymmetric records taper more strongly at one boundary, and may also be expressed with compatible units where supported.
 
+See the [edge-effects recipe](../recipes/edge_effects.qmd) for tapering before filters.
+
+# Rolling windows
+
+[`Patch.rolling`](`dascore.Patch.rolling`) provides moving-window reductions. Incomplete windows produce NaNs, which can be removed with `dropna`.
 
 ```{python}
-# Apply a 10% taper to the start and 30% to the end of distance dimension.
-patch_ones.taper(distance=(0.1, 0.3)).viz.waterfall();
+event = dc.get_example_patch("example_event_1")
+smoothed = event.rolling(time=50, samples=True).mean().dropna("time")
 ```
-
-Either element of the tuple can be `None` which indicates no tapering is applied.
 
 ```{python}
-# Only apply 10% taper to the end of the distance dimension.
-patch_ones.taper(distance=(None, 0.1)).viz.waterfall();
+smoothed.viz.waterfall(show=True);
 ```
 
-See also the [edge effects recipe](../recipes/edge_effects.qmd) for using tapering to help filtering.
-
-# Rolling
-The [rolling patch function](`dascore.Patch.rolling`) implements moving window operators similar to [pandas rolling](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.rolling.html). It is useful for smoothing, calculating aggregated statistics, etc.
-
-Here is an example of using a rolling mean to smooth along the time axis:
-
-```{python}
-import dascore as dc
-
-patch = dc.get_example_patch("example_event_1")
-# Apply moving mean window over every 50 samples
-dt = patch.get_coord('time').step
-
-smoothed = patch.rolling(time=50*dt).mean()
-smoothed.viz.waterfall();
-```
-
-Notice the nan values at the start of the time axis. These can be trimmed with [`Patch.dropna`](`dascore.Patch.dropna`).
-
+Rolling objects provide reductions such as `mean`, `median`, `min`, `max`, `std`, and `sum`. Specify a coordinate-unit window or set `samples=True` for an exact sample count.
 
 # Gain
 
-Amplitudes recorded far from a source, or late in a record, are weaker than the ones near it. Two patch functions bring them back up.
-
 ## Automatic gain control
 
-Passing a `window` to [`Patch.normalize`](`dascore.Patch.normalize`) divides each sample by the norm of a window centered on it, rather than by one norm of the whole trace. That is automatic gain control: weak late arrivals come up to the amplitude of the strong early ones, at the cost of no longer being able to compare amplitudes across the record.
+Passing `window` to [`Patch.normalize`](`dascore.Patch.normalize`) divides every sample by a centered local norm. This raises weak arrivals but removes amplitude comparability across the record.
 
 ```{python}
-import dascore as dc
-
-patch = dc.get_example_patch("example_event_1")
-patch.viz.waterfall(scale=0.2);
+gained = event.normalize("time", norm="l2", window=0.1)
 ```
 
 ```{python}
-# Divide each sample by the RMS of a 0.1 second window around it.
-gained = patch.normalize("time", norm="l2", window=0.1)
-gained.viz.waterfall(scale=0.5);
+gained.viz.waterfall(scale=0.5, show=True);
 ```
 
-The `norm` argument picks what the window is divided by, exactly as it does without a window: `l2` for the RMS, `l1` for the mean absolute value, `max` for the largest absolute value. The window length is in units of the dimension unless `samples=True`, and is centered on the sample it scales.
+`norm` may be `l2` (RMS), `l1` (mean absolute value), or `max`. Window length uses coordinate units unless `samples=True`. Reflected edge values keep the output shape and avoid the incomplete-window NaNs produced by `rolling`.
 
-Every sample is scaled, the ends included. Where a centered window runs off the end of the dimension, the coordinate is reflected about its last sample to fill it, so the output keeps the shape it was given and gains no NaN values. That is deliberately unlike [`rolling`](`dascore.Patch.rolling`), which returns one value per *window* rather than one per sample and so leaves NaN where a window was not full. Here a NaN edge would throw away half a window at each end of every trace -- with a one second window on a record sampled at 250 Hz, an eighth of an eight second record, first arrivals and all.
+Without `window`, `normalize` uses one norm for the complete trace. With a window, every sample receives its own local scale. This distinction matters when amplitudes themselves carry scientific meaning.
 
 ## Power gain
 
-[`Patch.pow_coord`](`dascore.Patch.pow_coord`) multiplies the data by a coordinate raised to a power. Unlike gain control, the curve depends only on where a sample sits, never on the amplitudes around it, so amplitudes stay comparable from trace to trace. Raising time to a power of one or two is the usual correction for geometric spreading.
+[`Patch.pow_coord`](`dascore.Patch.pow_coord`) multiplies data by a coordinate raised to a power. Because the curve depends only on position, relative amplitudes remain comparable between traces.
 
 ```{python}
-spread_corrected = patch.pow_coord(time=2)
-spread_corrected.viz.waterfall(scale=0.5);
+spread_corrected = event.pow_coord(time=2)
+both_dimensions = event.pow_coord(time=2, distance=1)
 ```
 
-The gain counts from the start of the coordinate: the curve is one, two, three ... raised to the power, so the first sample keeps its amplitude rather than being multiplied by zero. Any dimension can carry a power, and several can at once:
+The coordinate count begins at one rather than zero, so the first sample retains its amplitude. Time powers of one or two are common geometric-spreading corrections; other dimensions can be corrected in the same call.
+
+# Spectral whitening
+
+[`Patch.whiten`](`dascore.Patch.whiten`) balances spectral amplitudes while largely preserving phase. It is commonly used before ambient-noise correlation.
 
 ```{python}
-# Correct along the fiber as well as in time.
-both = patch.pow_coord(time=2, distance=1)
-```
+signal = dc.get_example_patch(
+    "sin_wav",
+    frequency=[1, 10, 20, 54, 66],
+    amplitude=[1, 2, 3, 4, 9],
+    duration=1,
+    sample_rate=200,
+)
 
-
-# Whiten
-
-The [`Patch.whiten`](`dascore.Patch.whiten`) function performs spectral whitening by balancing the amplitude spectra of the patch while leaving the phase (largely) unchanged. Spectral whitening is often a pre-processing step in ambient noise correlation workflows.
-
-To demonstrate, we create some plotting code and an example patch.
-
-```{python}
-
-import matplotlib.pyplot as plt
-import numpy as np
-
-import dascore as dc
-from dascore.utils.time import to_float
-
-
-rng = np.random.default_rng()
-
-
-def plot_time_and_frequency(patch, channel=0):
-    """ Make plots of time and frequency of patch with single channel."""
-    sq_patch = patch.select(distance=channel, samples=True).squeeze()
-    time_array = to_float(patch.get_array("time"))
-    time = time_array - np.min(time_array)
-
-    fig, (td_ax, fd_ax, phase_ax) = plt.subplots(1, 3, figsize=(9, 2.5))
-
-    # Plot in time domain
-    td_ax.plot(time, sq_patch.data, color="tab:blue")
-    td_ax.set_title("Time Domain")
-    td_ax.set_xlabel("time (s)")
-
-    # Plot freq amplitude
-    ft_patch = sq_patch.dft("time", real=True)
-    freq = ft_patch.get_array("ft_time")
-    fd_ax.plot(freq, ft_patch.abs().data, color="tab:red")
-    fd_ax.set_xlabel("Frequency (Hz)")
-    fd_ax.set_title("Amplitude Spectra")
-
-    # plot freq phase
-    phase_ax.plot(freq, np.angle(ft_patch.data), color="tab:cyan")
-    phase_ax.set_xlabel("Frequency (Hz)")
-    phase_ax.set_title("Phase Angle")
-
-    # fd_ax.set_xlim(0, 1000)
-    return fig
-
-
-def make_noisy_sine_patch():
-    """Make a noisy sine wave patch."""
-    patch = dc.get_example_patch(
-        "sin_wav",
-        frequency=[1, 10, 20, 54, 66],
-        amplitude=[1, 2, 3, 4, 9],
-        duration=1,
-        sample_rate=200,
-    )
-    rand_noise = (rng.random(patch.data.shape) - 0.5) * 10
-    patch = patch.new(data = patch.data + rand_noise)
-    return patch
+white = signal.whiten(time=(20, 80), smooth_size=1)
 ```
 
 ```{python}
-patch = make_noisy_sine_patch()
-plot_time_and_frequency(patch);
+white.viz.wiggle(show=True);
 ```
-
-The default whitening makes all spectral amplitudes equal.
 
 ```{python}
-white_patch = patch.whiten()
-plot_time_and_frequency(white_patch);
+hard_band = signal.whiten(time=(20, 40, 60, 80))
+frequency_patch = signal.dft("time", real=True)
+frequency_white = frequency_patch.whiten(time=(20, 40, 60, 80))
+time_white = frequency_white.idft()
 ```
 
-The whitening can be restricted to certain frequency bands by specifying the dimension and a frequency range.
+A four-value band controls the taper around the whitened interval. Frequency-domain patches are accepted and remain in that domain; use `idft()` when a time-domain result is needed. `water_level` stabilizes frequencies with near-zero amplitude.
 
-```{python}
-white_patch = patch.whiten(time=(20, 80))
-plot_time_and_frequency(white_patch);
-```
-
-Four values can be used to control the start/end of the taper.
-
-```{python}
-white_patch = patch.whiten(time=(20, 40, 60, 80))
-plot_time_and_frequency(white_patch);
-```
-
-Whiten also supports using a smoothed amplitude for normalization which causes less drastic changes to the amplitude spectrum.
-
-```{python}
-white_patch = patch.whiten(smooth_size=1)
-_ = plot_time_and_frequency(white_patch)
-```
-
-
-```{python}
-white_patch = patch.whiten(smooth_size=2, time=(10, 20, 80, 90))
-_ = plot_time_and_frequency(white_patch)
-```
-
-`Whiten` also accepts patches in the frequency domain, in which case frequency patches are returned. This might be useful if whiten is only a part of a frequency domain workflow.
-
-```{python}
-fft_patch = patch.dft("time", real=True)
-dft_white = fft_patch.whiten(smooth_size=1, time=(20, 40, 60, 80))
-td_patch = dft_white.idft()
-plot_time_and_frequency(td_patch);
-```
-
-The `water_level` parameter can be useful for stabilizing frequencies that may have near-zero values.
+`smooth_size` divides by a smoothed spectrum rather than forcing every bin to equal amplitude. This usually preserves broad spectral shape while suppressing narrow peaks.

--- a/docs/tutorial/processing.qmd
+++ b/docs/tutorial/processing.qmd
@@ -120,7 +120,7 @@ both_dimensions = event.pow_coord(time=2, distance=1)
 
 The coordinate count begins at one rather than zero, so the first sample retains its amplitude. Time powers of one or two are common geometric-spreading corrections; other dimensions can be corrected in the same call.
 
-# Spectral whitening
+# Spectral whitening {#whiten}
 
 [`Patch.whiten`](`dascore.Patch.whiten`) balances spectral amplitudes while largely preserving phase. It is commonly used before ambient-noise correlation.
 

--- a/docs/tutorial/remote_patches.qmd
+++ b/docs/tutorial/remote_patches.qmd
@@ -90,7 +90,7 @@ Only cyclic garbage accumulates during the pause, and only until the final remot
 
 ```python
 with config_context(warn_on_gc_pause=False):
-    patch = dc.read("http://example.com/data/prodml_2.1.h5")[0]
+    patch = dc.read(http_path)[0]
 ```
 
 # Transfer tuning
@@ -108,7 +108,7 @@ Small blocks reduce over-fetch during metadata scans but increase network round 
 
 ```python
 with config_context(remote_hdf5_block_size=262_144, remote_hdf5_max_blocks=4):
-    summaries = dc.scan_to_df(urls)
+    summaries = dc.scan_to_df([http_path])
 ```
 
 HTTP and HTTPS use both settings. S3 uses its own read-ahead cache and takes the block size only.

--- a/docs/tutorial/remote_patches.qmd
+++ b/docs/tutorial/remote_patches.qmd
@@ -61,6 +61,8 @@ with config_context(
 When a metadata query would require a full download and metadata caching is disabled, DASCore raises [`RemoteCacheError`](`dascore.exceptions.RemoteCacheError`). Opt in only for a known operation:
 
 ```python
+http_path = UPath("https://raw.githubusercontent.com/dasdae/test_data/master/das/example_dasdae_event_1.h5")
+
 with config_context(allow_remote_cache_for_metadata=True):
     summary = dc.scan(http_path)[0]
 ```

--- a/docs/tutorial/remote_patches.qmd
+++ b/docs/tutorial/remote_patches.qmd
@@ -4,197 +4,109 @@ execute:
   warning: false
 ---
 
-DASCore can work directly with remote resources exposed through [`UPath`](https://pypi.org/project/universal-pathlib/), and is currently tested with backends such as `memory://`, `s3://`, and `http://`.
+DASCore accepts remote resources through [`UPath`](https://pypi.org/project/universal-pathlib/) and tests backends including `memory://`, `s3://`, and `http://`.
 
-The main distinction is simple:
+| Operation | Default behavior |
+|---|---|
+| `scan`, `get_format` | Avoid downloading a complete file |
+| `scan_payloads` | Same cache policy, but may transfer full coordinate arrays |
+| `read`, spool indexing/iteration | Perform the heavier I/O needed to load data |
 
-- metadata operations such as [`dc.scan(...)`](`dascore.scan`) and [`dc.get_format(...)`](`dascore.get_format`) stay conservative by default
-- [`dc.scan_payloads(...)`](`dascore.scan_payloads`) uses the metadata cache policy too, but may read complete coordinate arrays and retain more memory than `dc.scan(...)`
-- data-loading operations such as [`dc.read(...)`](`dascore.read`) and patch access through [`dc.spool(...)`](`dascore.spool`) are allowed to do heavier IO when needed
+# Basic example
 
-## Basic Remote Example
-
-The example below uses `memory://` so it can run without external network access.
+`memory://` demonstrates the remote interface without network access:
 
 ```{python}
 from upath import UPath
+
 import dascore as dc
 
-patch = dc.get_example_patch()
 remote_path = UPath("memory://dascore/tutorial/remote_patch.h5")
-
-dc.write(patch, remote_path, "DASDAE")
+dc.write(dc.get_example_patch(), remote_path, "DASDAE")
 
 summary = dc.scan(remote_path)[0]
 payload = dc.scan_payloads(remote_path, snap=False)[0]
 loaded = dc.read(remote_path)[0]
 spool = dc.spool(remote_path)
-
-print(summary.source_path)
-print(payload["coords"].dims)
-print(loaded.dims)
-print(len(spool))
 ```
 
-For backends that support direct remote access, DASCore can often scan and read without creating a local cached copy.
+Backends that support direct access may require no local cached copy.
 
-## Remote Cache Settings
+The summary contains compact coordinate envelopes and source fields. The payload includes the formatter's coordinate manager, and indexing the spool loads the patch array.
 
-The relevant runtime config values live in `dascore.config`.
+# Cache policy
+
+Remote behavior is controlled through `dascore.config`:
+
+| Setting | Purpose |
+|---|---|
+| `remote_cache_dir` | Directory for materialized remote files |
+| `allow_remote_cache` | Permit caching for data reads |
+| `allow_remote_cache_for_metadata` | Permit caching for metadata operations |
+| `warn_on_remote_cache` | Warn on the first download into the cache |
 
 ```{python}
 from pathlib import Path
 
-from dascore.config import get_config, config_context
-
-config = get_config()
-
-print(config.remote_cache_dir)
-print(config.allow_remote_cache)
-print(config.allow_remote_cache_for_metadata)
-print(config.warn_on_remote_cache)
+from dascore.config import config_context
 
 with config_context(
     remote_cache_dir=Path("/tmp/dascore-remote-cache"),
     allow_remote_cache=True,
     allow_remote_cache_for_metadata=False,
-    warn_on_remote_cache=True,
 ):
-    ...
+    patch = dc.read(remote_path)[0]
 ```
 
-- `remote_cache_dir` is the local directory DASCore uses when it has to materialize a remote file.
-- `allow_remote_cache=True` allows local materialization for real read operations.
-- `allow_remote_cache_for_metadata=False` keeps metadata operations predictable by default.
-- `warn_on_remote_cache=True` emits a warning the first time DASCore downloads a remote file into the local cache.
-
-## Metadata By Default
-
-When a backend can satisfy metadata access directly, `dc.scan(...)`, `dc.scan_payloads(...)`, and `dc.get_format(...)` work as usual.
-
-```{python}
-print(dc.get_format(remote_path))
-print(dc.scan(remote_path)[0].source_format)
-print(dc.scan_payloads(remote_path, snap=False)[0]["source_format"])
-```
-
-`scan_payloads` does not load the patch data array, but exact scans can still transfer every stored coordinate value. Use it for targeted coordinate probes rather than broad remote directory listings.
-
-If answering a metadata query would require downloading the file first, DASCore raises [`RemoteCacheError`](`dascore.exceptions.RemoteCacheError`) instead of silently materializing it.
+When a metadata query would require a full download and metadata caching is disabled, DASCore raises [`RemoteCacheError`](`dascore.exceptions.RemoteCacheError`). Opt in only for a known operation:
 
 ```python
-from dascore.exceptions import RemoteCacheError
-from upath import UPath
-import dascore as dc
-
-http_path = UPath("http://example.com/data/prodml_2.1.h5")
-
-try:
-    dc.get_format(http_path)
-except RemoteCacheError as exc:
-    print(exc)
-```
-
-## Opt In When Metadata Caching Is Acceptable
-
-If you know a metadata operation may need local caching, opt in explicitly.
-
-```python
-from dascore.config import config_context
-from upath import UPath
-import dascore as dc
-
-http_path = UPath("http://example.com/data/prodml_2.1.h5")
-
 with config_context(allow_remote_cache_for_metadata=True):
-    fmt = dc.get_format(http_path)
     summary = dc.scan(http_path)[0]
-    payload = dc.scan_payloads(http_path, snap=False)[0]
-
-print(fmt)
-print(summary.source_path)
-print(payload["coords"].dims)
 ```
 
-When metadata-time caching is enabled, DASCore may warn on the first download if `warn_on_remote_cache=True`.
+`scan_payloads` avoids the data array but may still transfer and retain exact coordinate arrays. Prefer `scan` or `scan_to_df` for broad directory listings.
 
-## Reads And Spools
+Warnings occur on the first materialization when `warn_on_remote_cache=True`, making an unexpected local download visible without repeating the message for every file.
 
-[`dc.read(...)`](`dascore.read`) remains the escape hatch for remote data that genuinely needs heavier IO. If a backend requires a local cached file to complete the read, DASCore may materialize it locally when `allow_remote_cache=True`.
+# Reads and spools
+
+`dc.read(...)` may materialize a remote file when `allow_remote_cache=True`. For a spool, `get_contents()` uses metadata while indexing and iteration load patch data. If a backend cannot provide spool metadata directly, enable metadata caching explicitly.
 
 ```python
-from upath import UPath
-import dascore as dc
-
-http_path = UPath("http://example.com/data/prodml_2.1.h5")
-patch = dc.read(http_path)[0]
-print(patch.data.shape)
+remote_spool = dc.spool(http_path)
+metadata = remote_spool.get_contents()
+with config_context(allow_remote_cache=True):
+    patch = remote_spool[0]
 ```
 
-The same distinction applies to spools:
+# Remote HDF5 and garbage collection
 
-- `spool.get_contents()` relies on summary metadata
-- `spool[0]` or iteration loads patch data
-- if a remote backend cannot answer the metadata side without a download, use `allow_remote_cache_for_metadata=True`
+Remote HDF5 file-like reads can deadlock if cyclic garbage collection runs on fsspec's event-loop thread while h5py holds its global lock. DASCore therefore pauses cyclic garbage collection while remote HDF5 handles are open, restores it after the last handle closes, and warns once per process. Reference counting and local-file reads are unaffected.
 
-## Garbage Collection During Remote HDF5 Reads
-
-While a remote HDF5 handle is open, DASCore pauses Python's automatic garbage collection for the whole process, then restores it when the last such handle closes.
-
-This avoids a deadlock which h5py documents under [Python file-like objects](https://docs.h5py.org/en/stable/high/file.html#python-file-like-objects): h5py serializes its low-level calls behind a process-global lock, holds that lock while a file-like object services a read, and needs the same lock to deallocate a dead h5py object. A remote read is serviced by the event loop thread [fsspec](https://filesystem-spec.readthedocs.io/) runs for each async backend, so a cyclic collection landing on that thread waits for a lock the reader will not release until the read completes.
-
-Of the mitigations h5py suggests, DASCore takes the second: temporarily disabling collection. The first, avoiding reference cycles which keep h5py objects alive, is not something a library can guarantee, since the cycle may be anywhere in the process.
-
-Reference counting is unaffected, so most objects are still freed immediately; only cyclic garbage accumulates, and only until the handle closes. Reads of local files and of synchronous backends such as `memory://` are unaffected.
-
-DASCore warns the first time it pauses collection in a process, since the effect is otherwise invisible. Silence it with `warn_on_gc_pause=False` once you know it applies to your workflow.
+Only cyclic garbage accumulates during the pause, and only until the final remote HDF5 handle closes. Objects reclaimed through normal reference counting are still released immediately.
 
 ```python
-import dascore as dc
-from dascore.config import config_context
-
 with config_context(warn_on_gc_pause=False):
     patch = dc.read("http://example.com/data/prodml_2.1.h5")[0]
 ```
 
-## Tuning Remote HDF5 Transfers
+# Transfer tuning
 
-Opening an HDF5 file over HTTP is dominated by h5py's metadata probe, which alternates between the file's header and footer. DASCore reads through a block cache so both ends stay resident rather than being refetched on every jump. Two settings control it:
+Two settings control the remote HDF5 block cache:
 
-- `remote_hdf5_block_size` — bytes fetched per block (5 MiB by default)
-- `remote_hdf5_max_blocks` — blocks one open handle may keep (8 by default)
+| Setting | Default | Trade-off |
+|---|---:|---|
+| `remote_hdf5_block_size` | 5 MiB | Larger blocks reduce requests but may over-fetch |
+| `remote_hdf5_max_blocks` | 8 | More blocks retain more data per open handle |
 
-Their product is roughly the memory one open handle retains, so ~40 MiB by default. The cache fetches one block per request, so the block size trades bytes against round trips. Which way to move it depends on what you are doing, because scanning and reading pull in opposite directions.
+Their product approximates memory retained per handle: about 40 MiB by default. For metadata scans, reduce both values; for sequential patch reads, use larger blocks and fewer of them. Concurrent handles multiply this memory. When reading complete files, local materialization is usually more efficient than repeated range requests.
 
-### Scanning many files
-
-Scanning reads only metadata — kilobytes, from two distant regions of each file, which is then closed before the cache is reused. Big blocks spend megabytes to deliver kilobytes, so shrink both:
+Small blocks reduce over-fetch during metadata scans but increase network round trips. Large blocks favor contiguous reads. Lower `remote_hdf5_max_blocks` first when many handles are open concurrently.
 
 ```python
-import dascore as dc
-from dascore.config import config_context
-
-urls = [f"http://example.com/data/file_{i}.h5" for i in range(100)]
-
 with config_context(remote_hdf5_block_size=262_144, remote_hdf5_max_blocks=4):
-    df = dc.scan_to_df(urls)
+    summaries = dc.scan_to_df(urls)
 ```
 
-That retains 1 MiB per handle rather than 40 MiB. Do not shrink too far: on a high-latency link the extra round trips cost more than the bytes saved.
-
-### Reading whole patches
-
-Reading pulls large contiguous ranges, so bigger blocks mean fewer requests for the same bytes. The LRU earns little on a single pass, so trade blocks for size:
-
-```python
-with config_context(remote_hdf5_block_size=16_777_216, remote_hdf5_max_blocks=2):
-    patch = dc.read("http://example.com/data/prodml_2.1.h5")[0]
-```
-
-If you read whole files, especially more than once, let DASCore materialize them locally instead — see [Remote Cache Settings](#remote-cache-settings). One sequential download beats any streaming pattern.
-
-### Many handles at once
-
-The figure is per *open* handle, so concurrent reads multiply it: eight files in parallel at the defaults holds ~320 MiB. Lower `remote_hdf5_max_blocks` first, since evictions cost nothing for a scan or a single pass.
-
-Both settings apply to the protocols DASCore tunes; `remote_hdf5_max_blocks` reaches only HTTP and HTTPS, as S3 uses a read-ahead cache which takes the block size alone.
+HTTP and HTTPS use both settings. S3 uses its own read-ahead cache and takes the block size only.

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -50,7 +50,7 @@ index_path = Path(tempfile.mkdtemp()) / "index.h5"
 external_index = dc.spool(directory, index_path=index_path).update()
 ```
 
-Pass `index_path=` when the data directory is not writable. The path is normally discovered automatically; when supplying one explicitly, reuse it when reopening the archive. Remote `UPath` resources also work; see [Working with remote patches](remote_patches.qmd) for cache policy.
+Pass `index_path=` when the data directory is not writable. New spools normally rediscover an external index; an index inside the data directory takes precedence. Remote `UPath` resources also work; see [Working with remote patches](remote_patches.qmd) for cache policy.
 
 ## Path attributes
 
@@ -185,11 +185,6 @@ merged = spool.chunk(time=None)
 bounded = spool.chunk(time=1 * megabytes)
 ```
 
-```{python}
-partial_windows = spool.chunk(time=3, overlap=1, keep_partial=True)
-all_contiguous = spool.chunk(time=None)
-```
-
 `overlap` accepts the same coordinate-unit, quantity, or data-size forms as the chunk length. `keep_partial=True` retains a shorter final window. Passing `time=None` asks DASCore to merge every contiguous compatible segment.
 
 Data-size limits cover the array only, not coordinates, metadata, or later processing copies. `MB` is decimal and `MiB` is binary.
@@ -211,7 +206,7 @@ coverage = gappy.get_coverage()
 second_scale_gaps = gappy.get_gaps(tolerance=1 * s)
 ```
 
-`gap_size` spans from the last sample before a gap to the first after it, so subtract one sample step for the missing extent. The `tolerance` argument, shared with `chunk`, controls which boundaries count. Coverage uses patch envelopes; holes inside a patch are not visible. `group_id` links coverage rows to their gaps.
+`gap_size` spans from the last sample before a gap to the first after it, so subtract one sample step for the missing extent. The `tolerance` argument, shared with `chunk`, controls which boundaries count. Pass another dimension as in `get_gaps("distance")`; `time` is only the default. Coverage uses patch envelopes; holes inside a patch are not visible. `group_id` links coverage rows to their gaps.
 
 At the default tolerance of 1.5 samples, one missing sample counts as a gap. A quantity or timedelta expresses the limit in coordinate units instead. Overlaps are not gaps; coverage calculates the union of available spans.
 
@@ -233,7 +228,7 @@ joined = dc.spool([patch, later]).concatenate(time=None)
 
 `concatenate` can also create a new dimension when given a name not already present. Use this to stack compatible patches whose samples should remain distinct rather than merging along an existing axis.
 
-Patches that cannot concatenate remain in separate output groups. Values are ordered along the concatenated dimension when it has a step; otherwise spool order is retained. Other coordinates must agree, while coordinates along the concatenated dimension are joined.
+Patches that cannot concatenate remain in separate output groups. Values are ordered along the concatenated dimension when it has a step; otherwise spool order is retained. Other coordinates must agree, while coordinates along the concatenated dimension are joined. For conflicting non-coordinate attributes, `conflict=` can raise (the default), drop them, or keep the first value.
 
 # Mapping
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -232,7 +232,7 @@ Patches that cannot concatenate remain in separate output groups. Values are ord
 
 # Mapping
 
-[`Spool.map`](`dascore.core.spool.Spool.map`) applies a function lazily to every patch. Chunk first to control work size.
+[`Spool.map`](`dascore.core.spool.Spool.map`) eagerly applies a function to every patch. Chunk first to control work size.
 
 ```{python}
 def distance_max(patch):

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -4,423 +4,263 @@ execute:
   warning: false
 ---
 
-Spools are containers/managers of [patches](patch.qmd). The spool interface is designed to manage a variety of data sources, including a group of patches loaded into memory, archives of local files, and a variety of remote resources.
-
-For file-backed spools, DASCore first scans metadata and coordinate summaries, then loads patch data only when you access a patch from the spool. This means methods like `get_contents()` work from patch summary metadata, while `spool[0]` or iteration materializes loaded patches.
-
-# Data Sources
-
-The simplest way to get the appropriate spool for a specified input is to use the [`spool`](`dascore.spool`) function, which knows about many different input types and returns a [`Spool`](`dascore.core.spool.Spool`) instance.
-
-## Patches (in-memory)
+A [`Spool`](`dascore.core.spool.Spool`) manages patches from memory, files, directories, or remote resources. File-backed spools scan metadata first and load arrays only when patches are accessed.
 
 ```{python}
 import dascore as dc
 
-patch_list = [dc.get_example_patch()]
-
-spool1 = dc.spool(patch_list)
+spool = dc.get_example_spool()
 ```
 
-## A Single file
+# Data sources
+
+Use [`dc.spool(...)`](`dascore.spool`) for any supported input:
 
 ```{python}
-import dascore as dc
+from dascore.utils.downloader import fetch
+
+memory_spool = dc.spool([dc.get_example_patch()])
+file_spool = dc.spool(fetch("terra15_das_1_trimmed.hdf5"))
+```
+
+Remote paths use the same constructor:
+
+```{python}
 from upath import UPath
-# Import fetch to read DASCore example files 
-from dascore.utils.downloader import fetch
 
-path_to_das_file = fetch("terra15_das_1_trimmed.hdf5")
-# To read DAS data stored locally on your machine, simply replace the above line with:
-# path_to_das_file = "/path/to/data/directory/data.EXT"
-
-spool2 = dc.spool(path_to_das_file)
-
-# UPath-backed resources also work for file-backed spools.
-remote_file = UPath("memory://dascore/tutorial/spool_file.h5")
+remote_file = UPath("memory://dascore/tutorial/spool-file.h5")
 dc.write(dc.get_example_patch(), remote_file, "DASDAE")
-spool2_remote = dc.spool(remote_file)
+remote_spool = dc.spool(remote_file)
 ```
 
-## A directory of DAS files
+Directory spools maintain an index for fast metadata queries. Call `update()` after files change.
 
 ```{python}
-import dascore as dc
-# Import fetch to read DASCore example files 
-from dascore.utils.downloader import fetch
-
-# Fetch a sample file path from DASCore (just to get a usable path for the rest of the cell)
-directory_path = fetch('terra15_das_1_trimmed.hdf5').parent
-# To read a directory of DAS data stored locally on your machine, 
-# simply replace the above line with:
-# directory_path = "/path/to/data/directory/"
-
-# Update will create an index of the contents for fast querying/access
-spool3 = dc.spool(directory_path).update()
+directory = fetch("terra15_das_1_trimmed.hdf5").parent
+directory_spool = dc.spool(directory).update()
 ```
 
-An indexed directory summarizes itself when printed, the same as any other spool; see [what a spool says of itself](#what-a-spool-says-of-itself).
-
-If you want the index file to exist somewhere else, for example if you can't write to the data directory, you can specify an index path.
+To place the index outside the data directory:
 
 ```{python}
-#| warning: false
-#| output: false
 import tempfile
 from pathlib import Path
 
 index_path = Path(tempfile.mkdtemp()) / "index.h5"
-
-# Update will create an index of the contents for fast querying/access.
-spool = dc.spool(directory_path, index_path=index_path).update()
+external_index = dc.spool(directory, index_path=index_path).update()
 ```
 
-A new spool created for the same directory will find this index file automatically. The exception is when a valid index file already exists inside the data directory itself, which takes precedence.
+Pass `index_path=` when the data directory is not writable. The path is normally discovered automatically; when supplying one explicitly, reuse it when reopening the archive. Remote `UPath` resources also work; see [Working with remote patches](remote_patches.qmd) for cache policy.
 
-:::{.callout-warning}
-If you remove files from a directory that has already been indexed, you should delete the index file and then call `update` again on the spool like this:
+## Path attributes
 
-```python
-spool.indexer.index_path.unlink()
-spool.update()
-```
-
-It is best not to delete files once added to a directory managed by DASCore.
-:::
-
-### Path attributes (hive-style directories)
-
-Directory spools parse `key=value` pairs out of the directories inside the spool, in the style of [Hive partitioning](https://hive.apache.org/). Each directory segment can hold one pair (`acquisition_key=XX.R2D1..RAW/`), or several separated by `__` (the same separator DASCore's default patch names use), as in `cable=north__tag=raw/`. The parsed values become string attributes: they show up in `get_contents()`, work with `select`, and are set on loaded patches. When a path attribute and an attribute stored inside the file share a name, the path wins — renaming a directory is how you attach or correct metadata without rewriting data.
+Directory names written as `key=value` become string attributes on index rows and loaded patches. Multiple pairs in one segment use `__`; path values override attributes stored in the file.
 
 ```{python}
-import tempfile
-from pathlib import Path
-
-import dascore as dc
-
-# Build a small hive-partitioned directory of DAS files.
-data_path = Path(tempfile.mkdtemp()) / "experiment=demo" / "cable=north"
+root = Path(tempfile.mkdtemp())
+data_path = root / "experiment=demo" / "cable=north"
 data_path.mkdir(parents=True)
-dc.get_example_patch().io.write(data_path / "das_file.h5", "DASDAE")
+dc.get_example_patch().io.write(data_path / "patch.h5", "DASDAE")
 
-spool = dc.spool(data_path.parent.parent).update()
-df = spool.get_contents()
-assert df["experiment"].iloc[0] == "demo"
-assert len(spool.select(cable="north")) == 1
-
-# The loaded patch carries the path attributes too.
-patch = spool[0]
-assert patch.attrs["experiment"] == "demo"
-assert patch.attrs["cable"] == "north"
+partitioned = dc.spool(root).update()
+assert partitioned.get_contents()["experiment"].iloc[0] == "demo"
+assert partitioned[0].attrs["cable"] == "north"
 ```
 
-Renaming a partition directory and calling `update()` refreshes the affected attributes by rewriting index rows — file contents are not re-read, so this stays fast even for very large directories.
+Renaming a partition directory and calling `update()` refreshes path attributes without rereading file contents. Removing a path attribute may require rescanning the affected file so its stored value can be restored.
 
-```{python}
-root = data_path.parent.parent
-(root / "experiment=demo").rename(root / "experiment=final")
-spool = spool.update()
-assert spool.get_contents()["experiment"].iloc[0] == "final"
-```
-
-A few details worth knowing:
-
-- Only the directories *containing* a source are parsed. The source's own name is opaque, whether it names a file or a directory-format unit: an extension cannot be told apart from a value ending in one, so `acquisition_key=XX.R2D1..RAW` would be ambiguous. The spool's own root is outside the spool and contributes nothing either, so `dc.spool(".../experiment=demo")` does not pick up `experiment` — point the spool at a parent to keep that partition.
-- Values are always strings; `select` supports equality, collections, unix-style globs, and regular expressions on them.
-- Removing a `key=value` pair from a path triggers a rescan of the affected files (the file's own value has to be recovered), while adding or changing pairs does not.
-- A path key that matches a coordinate name (e.g. `distance=...`) resolves attrs-first in bare `select` kwargs; use the `_coords` argument to target the coordinate explicitly.
-
-However they were constructed, all spools are the same class and share the same behavior and methods.
-
-:::{.callout-note}
-Remote file resources work with `dc.spool(...)`, `dc.read(...)`, `dc.scan(...)`, and `dc.scan_payloads(...)`.
-:::
-
-:::{.callout-note}
-For remote `UPath` resources, DASCore treats metadata operations differently
-from full reads. See the [Working with Remote Patches](remote_patches.qmd)
-tutorial for the remote-cache policy, spool implications, and examples.
-:::
+Only directories below the spool root are parsed; the root and source filename are not. Values remain strings and support the normal attribute selectors. When a path key matches a coordinate, bare `select` targets the attribute; use `_coords` for the coordinate. See the [directory index note](../notes/spool_index.qmd) for update and indexing details.
 
 # Accessing patches
 
-Patches are extracted from the spool via simple iteration or indexing. New
-spools are returned via slicing.
+Indexing and iteration load patches. Slicing, integer arrays, and boolean masks return a new spool.
 
 ```{python}
-import dascore as dc
-
-spool = dc.get_example_spool()
-
-# Extract first patch in the spool.
 patch = spool[0]
+subset = spool[1:]
 
-# Iterate patches in spool.
 for patch in spool:
     ...
-
-# Slice spool to create new spool which excludes first patch.
-new_spool = spool[1:]
 ```
 
-For file-backed spools, indexing or iteration is the point where DASCore loads the underlying patch data. Metadata-only operations such as `get_contents()` and `select(...)` can usually run without loading full patch arrays.
-
-An array can also be used (just like numpy) to select/re-arrange spool contents. For example, a boolean array can be used to de-select patches:
+Integer arrays reorder patches and may repeat them; boolean arrays keep positions marked `True`:
 
 ```{python}
-import dascore as dc
 import numpy as np
 
-spool = dc.get_example_spool()
-
-# Get bool array, true values indicate patch is kept, false is discarded.
-bool_array = np.ones(len(spool), dtype=np.bool_)
-bool_array[1] = False
-
-# Remove patch at position 1 from spool.
-new = spool[bool_array]
+reordered = spool[np.array([2, 0])]
+mask = np.ones(len(spool), dtype=bool)
+mask[1] = False
+without_second = spool[mask]
 ```
 
-and an integer array can be used to deselect/rearrange patches
+Lists and Pandas Series follow the same positional rules. Slicing remains lazy: it narrows the spool plan without loading selected arrays.
+
+Rows from `get_contents()` align with spool positions, so a dataframe condition can select the same patches. Do not reuse a mask from a differently ordered spool.
 
 ```{python}
-import dascore as dc
-import numpy as np
-
-spool = dc.get_example_spool()
-
-# Get an array of integers which indicate the index of included patches
-index_array = np.array([2, 0])
-
-# create a new spool with patch 2 and patch 0.
-new = spool[index_array]
+diverse = dc.get_example_spool("diverse_das")
+contents = diverse.get_contents()
+tagged = diverse[contents["tag"] == "some_tag"]
 ```
 
-A pandas Series or a list works the same way. Since the rows of [`get_contents`](`dascore.core.spool.Spool.get_contents`) line up with the patches, a filter on that dataframe is a boolean selector for the spool:
+# Inspecting and selecting
+
+Displaying a spool shows its patch count, coordinate extents, and tracks for distinct patch kinds. Large spools omit the expensive summary according to [`display_max_patches`](configuration.qmd).
+
+A track groups patches with the same configured kind attributes and measures their span along time, or another available dimension. Single-kind spools omit redundant tracks because their overall extent already carries the same information. Tracks describe extents, not coverage; use `get_coverage` for missing-data statistics.
 
 ```{python}
-import dascore as dc
-
-spool = dc.get_example_spool("diverse_das")
-df = spool.get_contents()
-
-# Keep the patches whose tag is "some_tag" (the same as a select).
-new = spool[df["tag"] == "some_tag"]
-assert len(new) == (df["tag"] == "some_tag").sum()
-```
-
-A boolean mask is applied by position, so it must come from the contents of the spool it selects; build it from that spool's `get_contents` rather than from a differently ordered or already filtered view.
-
-# What a spool says of itself
-
-A spool states how many patches it holds, the extent it covers along each dimension its patches have, and one *track* per kind of patch. A track is named by the values which tell its kind apart from the others, by the same rule the [coverage plot](visualization.qmd#spool) names its lanes. Tracks are measured along one dimension — time where the patches have it — and patches which do not have that dimension are left out of them. A spool of a single kind states no tracks at all, since the extents above already state what its one track would.
-
-```{python}
-import dascore as dc
-
 dc.get_example_spool("diverse_das")
 ```
 
-Summarizing realizes the whole index relation, which is more work than a glance is worth on a very large archive. The `display_max_patches` [configuration option](configuration.qmd) says where that line is, and it holds however the spool got here: past it a spool states its count, its path, and a line naming the limit it exceeded — never the extents — whether or not the relation was already realized. Nothing here measures coverage — that runs a chunk plan, and is what `get_coverage` below is for.
-
-# get_contents
-
-The [`get_contents`](`dascore.core.spool.Spool.get_contents`) method returns a dataframe listing the spool contents. It realizes the whole relation, so it can be expensive over a large remote archive.
+[`Spool.get_contents`](`dascore.core.spool.Spool.get_contents`) returns one metadata row per patch without loading its data array. File-backed rows include `source_path`, `source_format`, and `source_patch_key`.
 
 ```{python}
-import dascore as dc
-spool = dc.get_example_spool()
-
-# Return dataframe with contents of spool (each row has metadata of a patch)
-contents = spool.get_contents()
-contents
+contents = diverse.get_contents()
+contents[["time_min", "time_max", "source_format"]].head()
 ```
 
-The columns returned by `get_contents()` come from the same patch summary metadata exposed by `Patch.summary`, so fields such as `time_min`, `time_max`, and `distance_step` are available without loading the underlying patch data. Source metadata such as `source_path`, `source_format`, and `source_patch_key` are also available for file-backed spools.
+The dataframe is a realized relation, so requesting every row can be expensive for a very large remote archive. Apply `select` first whenever the index backend can push down the predicate.
 
-# select
-
-The [select](`dascore.core.spool.Spool.select`) method selects a subset of a spool and returns a new spool. [`get_contents`](`dascore.core.spool.Spool.get_contents`) will now reflect a subset of the original data requested by the select operation.
+[`Spool.select`](`dascore.core.spool.Spool.select`) filters metadata and trims matching patches along coordinates.
 
 ```{python}
-import dascore as dc
-spool = dc.get_example_spool()
-
-# Select a spool with data after Jan 3rd, 2020.
-subspool = spool.select(time=('2020-01-03T00:00:09', ...))
+recent = diverse.select(time=("2020-01-03", ...))
+sources = diverse.select(acquisition_key={"DAS2.R2D1..RAW", "DAS3.R2D1..RAW"})
+tagged = diverse.select(tag="some*")
 ```
 
-In addition to trimming the data along a specified dimension (as shown above), `select` can be used to filter patches that meet a specified criteria.
-
+Coordinate selections both discard patches outside the range and trim intersecting patches. Attribute selections only filter rows. Collections, Unix-style globs, and compiled regular expressions are accepted for string metadata.
 
 ```{python}
-import dascore as dc
-# Load a spool which has many diverse patches.
-spool = dc.get_example_spool('diverse_das')
+import re
 
-# Only include patches from two named data sources.
-subspool = spool.select(acquisition_key={'DAS2.R2D1..RAW', 'DAS3.R2D1..RAW'})
-
-# Only include spools which match some unix-style query on their tags.
-subspool = spool.select(tag='some*')
+regex_tags = diverse.select(tag=re.compile(r"^some"))
 ```
 
-## Finding a patch by its id
+## Finding a patch by ID
 
-`patch_id` — which data a patch is, described in [Patch identity](patch.qmd#patch-identity) — is indexed like any other attribute. A spool can therefore hand back the patch an id names without loading anything to look for it, which is how a result written down somewhere else finds its way back to the data it came from.
+File-backed `patch_id` values are indexed, so a recorded ID can locate its source without loading every patch:
 
 ```{python}
-import dascore as dc
-spool = dc.get_example_spool()
-
-wanted = spool.get_contents()["patch_id"].iloc[1]
+wanted = spool.get_contents()["patch_id"].iloc[0]
 found = spool.select(patch_id=wanted)
-
-assert len(found) == 1
 assert found[0].attrs.patch_id == wanted
 ```
 
-An id is the same on every read of the same file, so one written down today still names the same data next year — see [Patch identity](patch.qmd#patch-identity) for what an id is derived from and when it changes.
+`processing_id` is not indexed because loading advances processing provenance. Built or chunked spools may have no `patch_id`, and moving a source invalidates its derived ID until the directory is rescanned. See [Patch identity](patch.qmd#patch-identity) for the identity rules.
 
-Two things do not carry an id. `processing_id` is not indexed at all: it advances whenever an operation runs, and a spool runs one as it loads, so what the index recorded would not be what came back. And a spool whose patches are built rather than read — a chunked one, most of all — has no `patch_id` column, because a merged patch folds its members' ids rather than inheriting any one of them; selecting by id there says the spool has no such attribute rather than quietly matching nothing.
+An empty ID after a file move is intentional: retaining the path-derived value would point at a source which no longer exists. Calling `update()` rebuilds the row from its new location.
 
-An id names a path, so a file which moves — including the directory rename that attaches metadata to an archive — is no longer the row the index derived an id for. The index clears the id rather than keeping a stale one, so a moved source has an empty `patch_id` until the archive is scanned again; the patches themselves still carry theirs.
+## Unselect
 
-# unselect
-
-[`unselect`](`dascore.core.spool.Spool.unselect`) is the complement of `select`: it returns the patches the same selection would have removed. Each keyword means what it means in `select`, so this is how to name what a spool does *not* want without spelling out the rest of the archive.
+[`Spool.unselect`](`dascore.core.spool.Spool.unselect`) returns patches rejected by the same attribute selection.
 
 ```{python}
-import dascore as dc
-spool = dc.get_example_spool('diverse_das')
-
-# Everything except the patches tagged 'some_tag'.
-subspool = spool.unselect(tag='some_tag')
-assert len(subspool) + len(spool.select(tag='some_tag')) == len(spool)
+not_tagged = diverse.unselect(tag="some_tag")
 ```
 
-The patches' own coordinates are not accepted. Selecting on one trims each patch to the range as well as dropping the patches which miss it entirely, so the complement of `time=(t1, t2)` is the part of every patch *before* `t1` together with the part *after* `t2` — one patch becoming two. That is subdivision rather than filtering; select the ranges to keep instead, or use [`Patch.unselect`](`dascore.Patch.unselect`) on each patch.
-
-The coordinates an attached [inventory](inventory.qmd) defines along the fiber are different, and *are* accepted: removing one of those chooses which channels a patch holds. A patch may then be cut into the pieces the query did not match, so `len` can grow here as well.
-
-# chunk
-
-The [`chunk`](`dascore.core.spool.Spool.chunk`) method controls how data are grouped together in patches within the spool. It can be used to merge contiguous patches together, specify the size of patches for processing, specify overlap with previous patches, etc.
+Patch coordinates are excluded because complementing an interior range would split every patch. Inventory coordinates are allowed and may increase the number of resulting patches.
 
 ```{python}
-import dascore as dc
-spool = dc.get_example_spool()
+from dascore.examples import inventory_patch_pair
 
-# Chunk spool for 3 s increments with 1 s overlaps
-# and keep any segments at the end that don't have the full 3 s.
-subspool = spool.chunk(time=3, overlap=1, keep_partial=True)
-
-# Merge all contiguous segments along time dimension.
-merged_spool = spool.chunk(time=None)
+inventory_patch, inventory = inventory_patch_pair()
+inventory_spool = dc.spool(inventory_patch).attach_inventory(inventory)
+outside_zone = inventory_spool.unselect(zone="zone_1")
 ```
 
-The chunk length can also be a quantity, either in the coordinate's own units or as a data size. A data size chunks so that each patch's data array is about that large, which is the usual way to keep patches inside a memory budget without working out the sample arithmetic by hand.
+Inventory complements may cut one input patch into several retained pieces, so an `unselect` result can contain more patches than its input.
+
+# Chunking and coverage
+
+[`Spool.chunk`](`dascore.core.spool.Spool.chunk`) lazily changes patch boundaries. It can merge contiguous patches, create fixed windows with overlap, or limit array size.
 
 ```{python}
-from dascore.units import s, megabytes
+from dascore.units import megabytes, s
 
-# The same 3 second chunk, with the units stated explicitly.
-unit_chunked = spool.chunk(time=3 * s)
-
-# Chunk so each patch's data array is at most ~1 MB.
-size_chunked = spool.chunk(time=1 * megabytes)
+windowed = spool.chunk(time=3 * s, overlap=1 * s, keep_partial=True)
+merged = spool.chunk(time=None)
+bounded = spool.chunk(time=1 * megabytes)
 ```
 
-A data size measures the data array only; coordinates, attrs, and any copies made later during processing are extra, so the patch as a whole is somewhat larger. The sample count is rounded down, so the patch's data never exceeds the requested size, and `MB` is 10^6^ bytes while `MiB` is 2^20^. `overlap` accepts the same forms.
+```{python}
+partial_windows = spool.chunk(time=3, overlap=1, keep_partial=True)
+all_contiguous = spool.chunk(time=None)
+```
 
-# get_gaps
+`overlap` accepts the same coordinate-unit, quantity, or data-size forms as the chunk length. `keep_partial=True` retains a shorter final window. Passing `time=None` asks DASCore to merge every contiguous compatible segment.
 
-Merging tells you what a spool *has*; [`get_gaps`](`dascore.core.spool.Spool.get_gaps`) tells you what it is missing. It applies the same rules `chunk` merges by, so every row it returns is a boundary `chunk` refuses to close.
+Data-size limits cover the array only, not coordinates, metadata, or later processing copies. `MB` is decimal and `MiB` is binary.
+
+## Gaps and coverage
+
+[`Spool.get_gaps`](`dascore.core.spool.Spool.get_gaps`) reports boundaries that `chunk` will not merge. [`Spool.get_coverage`](`dascore.core.spool.Spool.get_coverage`) summarizes the same compatible groups.
 
 ```{python}
 import numpy as np
 from dascore.examples import random_spool
 
-# Three patches separated by one second holes.
 gappy = random_spool(time_gap=np.timedelta64(1, "s"), length=3)
-
-gappy.get_gaps()
+gaps = gappy.get_gaps()
+coverage = gappy.get_coverage()
 ```
-
-`time_min` is the last sample before the gap and `time_max` the first sample after it, so `gap_size` is one step wider than the extent actually missing; subtract the magnitude of the `time_step` column for the extent itself. Overlapping patches are never a gap, and neither is a hole the `tolerance` covers — a boundary is a gap once it exceeds `tolerance` samples, so at the default 1.5 a single missing sample already counts. A quantity or timedelta states the same limit in the coordinate's own units instead — `get_gaps(tolerance=1 * s)` reports every boundary wider than a second, whatever the sampling rate — and never reports one narrower than a single sample, so contiguous patches stay contiguous. It is the same `tolerance` `chunk` takes, so widening it here predicts exactly which merges will succeed.
-
-Pass another dimension to ask about it instead; `time` is only the default.
-
-# get_coverage
-
-[`get_coverage`](`dascore.core.spool.Spool.get_coverage`) summarizes the same groups, one row each, which is the quicker way to see whether an archive is worth loading at all.
 
 ```{python}
-gappy.get_coverage()
+second_scale_gaps = gappy.get_gaps(tolerance=1 * s)
 ```
 
-`gap_total` is the sum of that group's `get_gaps` rows, `span` is the extent it covers end to end, and `coverage` is the fraction of that span the patches cover. It is measured between patches, from the index's envelopes, so a hole *inside* a patch does not show up. Patches divide into groups the way `chunk` divides them — on the kind attributes, but also on sampling rate and coordinate structure — so a single tag can span several rows. `group_id` names the group in both frames, which is how a gap is traced back to the row that counts it.
+`gap_size` spans from the last sample before a gap to the first after it, so subtract one sample step for the missing extent. The `tolerance` argument, shared with `chunk`, controls which boundaries count. Coverage uses patch envelopes; holes inside a patch are not visible. `group_id` links coverage rows to their gaps.
 
-Both frames are drawn by [`Spool.viz.coverage`](`dascore.viz.spool.coverage`), and a long archive by [`Spool.viz.calendar`](`dascore.viz.spool.calendar`); see the [visualization tutorial](visualization.qmd#spool). Those lanes and the [tracks a spool states](#what-a-spool-says-of-itself) are named by one rule, with the coverage each group measured appended here; because the groups above are the finer partition, a lane is a track or a part of one.
+At the default tolerance of 1.5 samples, one missing sample counts as a gap. A quantity or timedelta expresses the limit in coordinate units instead. Overlaps are not gaps; coverage calculates the union of available spans.
 
-# concatenate
-Similar to `chunk`, [`Spool.concatenate`](`dascore.Spool.concatenate`) is used to combine patches together. However, `concatenate` ignores gaps and overlaps along the concatenation axis — it joins each group's patches in the order of that dimension (spool order when the dimension has no step to tell its orientation) — and can even be used to create new patch dimensions. It partitions patches as `chunk` does (by kind, dimensions, the other dimensions' identities, and the concatenated dimension's units), so patches which cannot be concatenated together simply land in separate outputs, and it polices the remaining attributes with the same `conflict` argument (coordinates are not policed: they are joined along the concatenated dimension, or must agree). Like `chunk`, it produces a lazy, plan-backed result.
+Coverage groups use patch kind, dimensions, sampling rate, and coordinate structure. One metadata tag can therefore produce several rows when its patches cannot be combined safely.
 
-```python 
-import dascore as dc
+Use [`Spool.viz.coverage`](`dascore.viz.spool.coverage`) or [`Spool.viz.calendar`](`dascore.viz.spool.calendar`) to plot these summaries.
 
+## Concatenate
+
+[`Spool.concatenate`](`dascore.Spool.concatenate`) joins each compatible group even across gaps or overlaps. Unlike `chunk`, it does not require continuity.
+
+```{python}
 patch = dc.get_example_patch()
-
-# Create a spool with patches that have a large gap
-time = patch.get_coord("time")
 one_hour = dc.to_timedelta64(3600)
-patch2 = patch.update_coords(time_min=time.max() + one_hour)
-spool = dc.spool([patch, patch2])
+later = patch.update_coords(time_min=patch.get_coord("time").max() + one_hour)
 
-# chunk rightfully wouldn't merge these patches, but concatenate will.
-merged = spool.concatenate(time=None)
-print(merged[0].coords)
+joined = dc.spool([patch, later]).concatenate(time=None)
 ```
 
-# map
+`concatenate` can also create a new dimension when given a name not already present. Use this to stack compatible patches whose samples should remain distinct rather than merging along an existing axis.
 
-The [`map`](`dascore.core.spool.Spool.map`) method applies a function to all patches in the spool. It provides an efficient way to process large datasets, especially when combined with clients (aka executors).
+Patches that cannot concatenate remain in separate output groups. Values are ordered along the concatenated dimension when it has a step; otherwise spool order is retained. Other coordinates must agree, while coordinates along the concatenated dimension are joined.
 
-For example, calculating the maximum value for each channel (distance) for 5 second increments with 1 second overlap can be done like so:
+# Mapping
+
+[`Spool.map`](`dascore.core.spool.Spool.map`) applies a function lazily to every patch. Chunk first to control work size.
 
 ```{python}
-import dascore as dc
-spool = dc.get_example_spool()
-
-# define function for mapping to each patch
-def get_dist_max(patch):
-    """Function which will be mapped to each patch in spool."""
+def distance_max(patch):
+    """Return each channel's maximum."""
     return patch.aggregate("time", "max")
 
-# chunk and apply function
-map_out = spool.chunk(time=5, overlap=1).map(get_dist_max)
 
-# combine output back into a single patch
-agg_patch = dc.spool(map_out).concatenate(time=None)[0]
-
-agg_patch
+mapped = spool.chunk(time=5, overlap=1).map(distance_max)
+result = dc.spool(mapped).concatenate(time=None)[0]
 ```
 
-See the [parallel processing recipe](../recipes/parallelization.qmd) for more examples with `map`.
+`map` returns a list by default. Wrap it with `dc.spool(...)` to continue using spool operations, as above. Active runtime configuration is propagated to thread and process workers.
+
+See the [parallel processing recipe](../recipes/parallelization.qmd) for executors and larger workflows.
 
 # Inventory
 
-A spool can carry a DASDAE [inventory](inventory.qmd): a description of the observing system its data was recorded through — the fiber, where it goes, and how the interrogator was configured over time. Attaching one adds nothing to the patches, but makes the names the inventory defines along the fiber available to `select` and [`expand_by`](`dascore.core.spool.Spool.expand_by`), and lets [`enrich`](`dascore.core.spool.Spool.enrich`) copy that metadata onto patches as they are extracted.
+A spool can attach a DASDAE [inventory](inventory.qmd). Inventory labels become available to `select` and [`expand_by`](`dascore.core.spool.Spool.expand_by`); [`enrich`](`dascore.core.spool.Spool.enrich`) copies observing-system metadata onto extracted patches.
 
 ```{python}
-import dascore as dc
-from dascore.examples import inventory_patch_pair
-
 patch, inventory = inventory_patch_pair()
-spool = dc.spool(patch).attach_inventory(inventory)
-
-# The inventory annotates two zones along the fiber, so they can be selected.
-assert len(spool.expand_by("zone")) == 2
+with_inventory = dc.spool(patch).attach_inventory(inventory)
+assert len(with_inventory.expand_by("zone")) == 2
 ```
 
-A spool opened on a directory which carries an inventory under the name `.inventory` — as a directory, or as `.inventory.yaml`, `.inventory.yml`, or `.inventory.json` — starts out attached to it.
+Directory spools automatically load `.inventory`, `.inventory.yaml`, `.inventory.yml`, or `.inventory.json` stored beside the data.

--- a/docs/tutorial/transformations.qmd
+++ b/docs/tutorial/transformations.qmd
@@ -4,84 +4,58 @@ execute:
   warning: false
 ---
 
-In DASCore, transformations are operations which change the domain of a patch, and usually its units and dimension names along with it. Transforms can be found in the [transform module](`dascore.transform`) or accessed as `Patch` methods.
+Transforms change a patch's domain and usually its dimension names and units. They are available as Patch methods and in [`dascore.transform`](`dascore.transform`).
 
-# Discrete Fourier Transforms
+# Fourier transform
 
-The [Discrete Fourier Transform](https://en.wikipedia.org/wiki/Discrete_Fourier_transform) (dft) is commonly used in many signal processing workflows. DASCore implements this as the [dft](`dascore.transform.fourier.dft`) patch method.
+[`Patch.dft`](`dascore.transform.fourier.dft`) changes a dimension such as `time` to its Fourier-domain counterpart, `ft_time`. `real=True` keeps only the nonnegative frequencies of real input.
 
 ```{python}
 import numpy as np
+
 import dascore as dc
 
-# Get example patch, set unit to velocity (for demonstration)
 patch = dc.get_example_patch().set_units("m/s")
+transformed = patch.dft(dim="time", real=True)
 
-transformed = patch.dft(dim="time")
-
-# Note how the dimension name has changed
-print(f"old_dims: {patch.dims} new dims: {transformed.dims}")
-
-# As have the units
-old_units = patch.attrs.data_units
-new_units = transformed.attrs.data_units
-print(f"old units: {old_units}, new units: {new_units}")
+print(transformed.dims)
+print(transformed.attrs.data_units)
 ```
 
-:::{.callout-note}
-The transformed dimension names change; "time" becomes "ft_time" indicating the domain of the dimension has changed. The units are also updated. See the [note on Fourier transforms in DASCore](../notes/dft_notes.qmd) for more details.
-:::
-
-In many cases, it is advantageous to only calculate the fourier transform corresponding to the positive frequencies (since the Fourier transform of a real signal is symmetric).
+The transformed coordinate uses inverse units and the data units change according to the transform normalization. Transform several dimensions by naming each one.
 
 ```{python}
-# Transform distance axis to Fourier domain using real fourier transform
-real_transform = patch.dft(dim='distance', real=True)
-print(real_transform.get_coord("ft_distance"))
+spatial_spectrum = patch.dft(dim="distance", real=True)
+print(spatial_spectrum.get_coord("ft_distance"))
 ```
 
-The Inverse Discrete Fourier Transform [idft](`dascore.transform.fourier.idft`) undoes the transformation.
+[`Patch.idft`](`dascore.transform.fourier.idft`) performs the inverse transform:
 
 ```{python}
-import numpy as np
-
-# A round trip recovers the original patch.
 round_trip = patch.dft(dim="time").idft()
-
-print(f"dims after round trip: {round_trip.dims}")
 assert np.allclose(round_trip.data.real, patch.data)
 ```
 
-# Short Time Fourier Transform
+Real transforms remember the information needed for their inverse. Numerical round trips may contain tiny floating-point differences, so compare them with a tolerance rather than exact equality.
 
-Related to the Discrete Fourier Transform, the [Short Term Fourier Transform](https://en.wikipedia.org/wiki/Short-time_Fourier_transform) is useful for analyzing the time-dependent frequency content. DASCore implements this as [stft](`dascore.transform.fourier.stft`) and the corresponding [istft](`dascore.transform.fourier.istft`).
+See [Fourier transforms in DASCore](../notes/dft_notes.qmd) for naming, units, and normalization.
 
-```{python}
-import numpy as np
-import dascore as dc
-from dascore.units import second, percent
+# Short-time Fourier transform
 
-# Get example patch, set unit to velocity (for demonstration)
-patch = (
-    dc.get_example_patch("chirp", channel_count=3)
-    .set_units("m/s")
-)
-
-patch.viz.waterfall();
-```
+[`Patch.stft`](`dascore.transform.fourier.stft`) shows frequency content through time; [`Patch.istft`](`dascore.transform.fourier.istft`) inverts it.
 
 ```{python}
-# Perform the transform, visualize the amplitude spectra, for the first
-# channel then invert.
-transformed = (
-    patch.stft(time=1*second, overlap=50*percent)
-)
-inverse =  transformed.istft()
+from dascore.units import percent, second
 
-transformed.abs().select(distance=0, samples=True).squeeze().viz.waterfall();
+chirp = dc.get_example_patch("chirp", channel_count=3).set_units("m/s")
+spectrogram = chirp.stft(time=1 * second, overlap=50 * percent)
+inverse = spectrogram.istft()
+
+spectrogram.abs().select(distance=0, samples=True).squeeze().viz.waterfall();
 ```
 
-:::{.callout-note}
-`stft` drops non-dimensional coordinates associated with the transformed
-dimension, matching `dft` behavior.
-:::
+The window length uses the selected coordinate's units. `overlap` may be expressed as a percentage, coordinate quantity, or supported numeric form. The inverse uses the transform metadata to reconstruct the original dimension.
+
+Inspect the transformed coordinate to obtain frequency bins; select or filter in the transformed domain exactly as with other patch dimensions.
+
+Like `dft`, `stft` drops non-dimensional coordinates associated with the transformed dimension.

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -121,7 +121,7 @@ spool.viz.coverage(show=True);
 
 Lane names contain the metadata that separates compatible groups and append that group's coverage. A spool representation uses the same kind attributes for tracks, but coverage lanes may split a track further by sampling rate or coordinate structure.
 
-Time is the default dimension. Select a smaller spool before plotting when coverage percentages should describe a smaller window; change only the axes to zoom without changing the statistics.
+Time is the default dimension; pass another one as in `spool.viz.coverage("distance")`. Select a smaller spool before plotting when coverage percentages should describe a smaller window; change only the axes to zoom without changing the statistics.
 
 ```{python}
 spool.select(time=("2024-01-15", "2024-01-25")).viz.coverage(show=True);

--- a/docs/tutorial/visualization.qmd
+++ b/docs/tutorial/visualization.qmd
@@ -4,176 +4,130 @@ execute:
   warning: false
 ---
 
-The [viz module](`dascore.viz`) holds DASCore's plots, and they hang off the object they are of: `Patch.viz` for data, `Spool.viz` for what an archive holds, `Inventory.viz` for the observing system which recorded it.
+DASCore plots are available from the object they describe: `Patch.viz`, `Spool.viz`, and `Inventory.viz`.
 
 # Patch
-The following provides some examples of patch visualization.
 
 ## Waterfall
-The [`waterfall patch function`](`dascore.viz.waterfall`) creates a waterfall plot of the patch data.
+
+[`Patch.viz.waterfall`](`dascore.viz.waterfall`) plots patch data as an image. Its default 1.5×IQR color limits reduce the influence of outliers.
 
 ```{python}
 import dascore as dc
 
-patch = dc.get_example_patch('example_event_2')
-
-# Default scaling uses IQR-based fence to handle outliers
+patch = dc.get_example_patch("example_event_2")
 patch.viz.waterfall(show=True);
 ```
 
-### Controlling color scaling
-
-The `scale` parameter controls the colorbar saturation. By default, waterfall uses a statistical fence (1.5×IQR) to exclude outliers and show the majority of the data clearly.
+`scale_type="relative"` interprets `scale` as a fraction of the dynamic range around the mean. `scale_type="absolute"` accepts explicit limits.
 
 ```{python}
 import matplotlib.pyplot as plt
-import dascore as dc
-
-patch = dc.get_example_patch('example_event_2')
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
-
-# Relative scaling: 0.2 means ±20% of dynamic range around mean
 patch.viz.waterfall(scale=0.2, scale_type="relative", ax=ax1)
-ax1.set_title("Relative scaling (scale=0.2)")
-
-# Absolute scaling: directly set colorbar limits
 patch.viz.waterfall(scale=(-50, 50), scale_type="absolute", ax=ax2)
-ax2.set_title("Absolute scaling (scale=(-50, 50))")
-
+ax1.set_title("Relative")
+ax2.set_title("Absolute")
 plt.tight_layout()
 plt.show()
 ```
 
-### Marking where labels change
+Pass an existing Matplotlib axis to compose the plot with other panels. The returned axis can be customized with the normal Matplotlib API.
 
-An [inventory](inventory.qmd) states its label groups over stretches of the fiber, and [`Patch.enrich`](`dascore.proc.inventory.enrich`) projects each group onto the patch as its own coordinate. Naming one with `label_coord` marks off each stretch and names it in a legend beyond the colorbar, so the plot reads in the vocabulary the inventory uses rather than in metres alone.
+### Inventory labels
+
+After [`Patch.enrich`](`dascore.proc.inventory.enrich`) adds inventory labels as coordinates, `label_coord` marks their ranges along the plot edges. Boolean coordinates mark membership under their coordinate name.
 
 ```{python}
 from dascore.examples import inventory_patch_pair
 
 zoned, inventory = inventory_patch_pair()
-
 zoned.enrich(inventory).viz.waterfall(label_coord="zone", show=True);
 ```
 
-Each zone is a bar along the left and right spines, covering the channels it applies to. The bars sit on the spines rather than over the image, because a wash over the data would have to be strong enough to see, and a wash that strong has recolored the data under it — which on a diverging colormap is the measurement itself.
-
-Joining the two bars wherever the value changes is a hairline, so a boundary can still be traced through the image rather than only read off its edges. It is drawn faint, over a white stroke which keeps it visible on a busy image without letting it compete with the data.
-
-Where a group says nothing the spine is left bare, so what a group covers and what it merely passes over are read off the same edge. A coordinate over `time` rather than `distance` puts its bars on the bottom and top spines instead; which dimension the coordinate belongs to is what decides, and nothing needs to be passed.
-
-A boolean coordinate is a membership group: only the stretches it holds are marked, and the legend calls them by the coordinate's own name.
+Labels are drawn on both spines of their associated dimension, with faint lines across the image at value changes. Missing labels leave the spine bare. Coordinates associated with `time` use the top and bottom spines; distance coordinates use the left and right.
 
 ```{python}
 zoned.enrich(inventory).viz.waterfall(label_coord="noisy", show=True);
 ```
 
 ## Wiggle
-The [`wiggle patch function`](`dascore.viz.wiggle`) creates a wiggle plot of the patch data. Each trace is drawn as an offset along the y axis, which, as in the waterfall plot, is only inverted when it is time-like. Traces stacked along distance, the default, therefore leave positive amplitudes pointing up, just as they point right in a conventional (time down) wiggle display. We'll use the same patch as above to model this function.
+
+[`Patch.viz.wiggle`](`dascore.viz.wiggle`) draws offset traces. Time-like stacking axes are inverted; other axes retain their normal direction.
+
+The default stacks traces along distance, leaving positive amplitudes upward. If traces are stacked along time, the time axis is inverted and positive amplitudes point right in the conventional display.
 
 ```{python}
-import dascore as dc
-
-patch = (
-    dc.get_example_patch('example_event_1')
-    .set_units("mm/(m*s)", distance='m', time='s')
+event = (
+    dc.get_example_patch("example_event_1")
     .taper(time=0.05)
     .pass_filter(time=(..., 300))
 )
-patch.viz.wiggle(scale = .5)
-```
-
-Another example using wiggle to plot a sine wave is demonstrated below.
-
-```{python}
-import dascore as dc
-
-patch = dc.examples.get_example_patch(
-    "sin_wav",
-    sample_rate=60,
-    frequency=[60, 10],
-    channel_count=1,
-)
-patch.viz.wiggle(show=True);
+event.viz.wiggle(scale=0.5, show=True);
 ```
 
 # Inventory
 
-An [inventory](inventory.qmd) plots what it knows about the fiber, with no data present. The examples below use the tunnel deployment the [tunnel recipe](../recipes/tunnel_inventory.qmd) builds.
+Inventory plots show the observing system without loading patch data. These examples use the deployment from the [tunnel inventory recipe](../recipes/tunnel_inventory.qmd).
 
 ```{python}
-import dascore as dc
-
 inventory = dc.get_example_inventory("tunnel")
 ```
 
-## Path
+## Path and map
 
-The [`path plot`](`dascore.viz.inventory.path`) draws every track along the fiber against optical distance. `distance=` is the window to draw, in the same coordinate; this deployment starts with 1.5 km of telemetry lead-in, which would otherwise crush the instrumented part into a corner.
+[`Inventory.viz.path`](`dascore.viz.inventory.path`) draws each track against optical distance. Use `distance=` to focus on part of the fiber.
 
 ```{python}
 inventory.viz.path(time="2024-07-01", distance=(1495, 1780), show=True);
 ```
 
-The boreholes label themselves 3, 2, 1 — the fiber works back through them — and the splices are ticks rather than zero-width boxes.
+Tracks are drawn in optical order. Point features such as splices appear as ticks, while intervals such as boreholes occupy their measured spans.
 
-## Map
-
-The [`map plot`](`dascore.viz.inventory.map_path`) draws where the fiber physically goes, in two axes of the inventory's coordinate reference system. `x` and `y` choose them: a borehole runs straight down, so the default plan view collapses it to a point.
+[`Inventory.viz.map`](`dascore.viz.inventory.map_path`) draws two physical coordinates. `color=` accepts optical distance, coupling, geometry columns, or label groups. Unsurveyed fiber is left as a gap.
 
 ```{python}
 inventory.viz.map(x="x", y="z", color="section", time="2024-07-01", show=True);
 ```
 
-The break near the middle of the trench is the slack coil, which nobody surveyed. Unplaced fiber is left out rather than bridged, since a made-up polyline would be worse than a gap.
-
-`color=` also takes a geometry column, a label group, or `"coupling"`. Its default is optical distance, which is how a distance read off a waterfall is found on the ground:
-
-```{python}
-inventory.viz.map(x="x", y="z", time="2024-07-01", show=True);
-```
+The default color is optical distance, which links a distance read from a waterfall to its physical location. Choose `x` and `y` for the useful view; a vertical borehole collapses to a point in plan view.
 
 ## Timeline
 
-The [`timeline plot`](`dascore.viz.inventory.timeline`) draws when each acquisition and each optical path was valid. An epoch which states no start or no end is unbounded, and runs off that side of the axis hatched.
+[`Inventory.viz.timeline`](`dascore.viz.inventory.timeline`) shows when acquisitions and optical paths are valid. Hatched ends indicate unbounded epochs.
 
 ```{python}
 inventory.viz.timeline(show=True);
 ```
 
-The path lane splits on the first of September, which is the day the trench cable was repaired.
-
+Open-ended validity intervals continue beyond the corresponding side of the axis. Use the timeline before selecting a `time=` for the path or map when an inventory contains several configurations.
 
 # Spool
 
-A [spool](spool.qmd) plots what it has and what it is missing, reading its index rather than its data, so these work on an archive far too large to load. The examples use a sparsely sampled deployment example: two months of a temperature and a strain acquisition, sampled once an hour.
+Spool plots use index metadata, so they do not load patch arrays.
 
 ```{python}
-import dascore as dc
-
 spool = dc.get_example_spool("sparse_dss")
 ```
 
 ## Coverage
 
-The [`coverage plot`](`dascore.viz.spool.coverage`) gives each group of patches which could combine a lane, drawn as the runs it holds and the holes between them. The holes are the ones [`get_gaps`](`dascore.core.spool.Spool.get_gaps`) reports and the percentage is that lane's [`get_coverage`](`dascore.core.spool.Spool.get_coverage`), so the picture and the numbers cannot disagree.
+[`Spool.viz.coverage`](`dascore.viz.spool.coverage`) gives each compatible patch group a lane showing its runs, gaps, and coverage percentage. It uses the same grouping and gaps as [`get_coverage`](`dascore.core.spool.Spool.get_coverage`) and [`get_gaps`](`dascore.core.spool.Spool.get_gaps`).
 
 ```{python}
 spool.viz.coverage(show=True);
 ```
 
-Both acquisitions lose the four days in the middle of January, which is the site's own outage; the strain acquisition started later and was pulled out earlier, which is why its lane is shorter rather than gappy at the ends.
+Lane names contain the metadata that separates compatible groups and append that group's coverage. A spool representation uses the same kind attributes for tracks, but coverage lanes may split a track further by sampling rate or coordinate structure.
 
-A lane is named by the values which tell its group apart from the others, with that group's coverage appended. The [spool's own repr](spool.qmd#what-a-spool-says-of-itself) names its tracks by the same rule, so the two can be read against each other. A track is one kind of patch, which is where the grouping here starts; a lane can be finer, because sampling rate and coordinate structure part two lanes of one kind.
-
-Time is measured by default; any other dimension the spool states can be named instead, as `spool.viz.coverage("distance")`. The whole of it is drawn, because part of a spool is a smaller spool: select the window first and the lanes, and the percentages on them, are of that window rather than of a window drawn over percentages of everything.
+Time is the default dimension. Select a smaller spool before plotting when coverage percentages should describe a smaller window; change only the axes to zoom without changing the statistics.
 
 ```{python}
 spool.select(time=("2024-01-15", "2024-01-25")).viz.coverage(show=True);
 ```
 
-The lanes end where the selection does, which is what a spool of those ten days holds. Keeping the whole picture and looking at part of it is a different question, and one for the axes rather than the spool: a lane which runs off the edge there says the data does not stop at it.
+Setting axis limits instead keeps the full-spool percentages and only changes the viewport. A line continuing beyond an axis edge then correctly indicates data outside the visible window.
 
 ```{python}
 import numpy as np
@@ -184,26 +138,22 @@ ax.set_xlim(np.datetime64("2024-01-15"), np.datetime64("2024-01-25"));
 
 ## Calendar
 
-Over months, one lane per group runs out of room. The [`calendar plot`](`dascore.viz.spool.calendar`) gives each day a cell instead, colored by how much of that day the spool covers:
+[`Spool.viz.calendar`](`dascore.viz.spool.calendar`) summarizes long time ranges by day. Each cell is the union of all selected patch groups and cannot exceed 100%; grey cells are invalid calendar dates.
 
 ```{python}
 spool.viz.calendar(show=True);
 ```
 
-A cell has no room for a lane per group, so it asks whether *anything* was recording: a day is the union of what every group covers. Two acquisitions running at once therefore cover one day between them, not two, and a cell never exceeds 100%. A grey cell is a day the calendar has no room for — there is no thirtieth of February — which is a different claim from a day covered by nothing.
+Because each day is a union, simultaneous acquisitions do not count twice. Empty valid dates represent no coverage; grey cells represent dates which do not exist, such as February 30.
 
-That also means `group` is not a way to pick one acquisition here; it only decides which boundaries count as gaps. Select the patches you mean first, and the calendar is of them alone:
+Select an acquisition before plotting it alone. Use `method="gap"` to emphasize short gaps or `method="count"` to show overlapping patch counts.
 
 ```{python}
 spool.select(tag="temperature").viz.calendar(show=True);
 ```
 
-The four days in the middle of January are still empty, since that outage took the whole site, but the strain acquisition no longer fills in the days temperature was down on its own.
-
-`method="gap"` asks the opposite question on a log scale, which is the one to use when the holes are short enough that a percentage rounds them away:
-
 ```{python}
 spool.viz.calendar(method="gap", show=True);
 ```
 
-`method="count"` colors each day by how many patches overlap it, which is how an archive's file layout shows itself.
+The `group` argument controls which boundaries count as gaps; it does not select an acquisition. Filter the spool first when the calendar should describe only part of the archive.

--- a/docs/tutorial/workflow.qmd
+++ b/docs/tutorial/workflow.qmd
@@ -3,24 +3,23 @@ title: Workflow
 execute:
   warning: false
 ---
-A workflow is processing written down as an object rather than as a script. Its piece is a [Task](`dascore.workflow.task.Task`): one operation and the parameters it was given. A task is immutable, knows its own fingerprint, and can be written to a file and read back, so an operation can be compared, stored, shared, and run later against other data.
 
-DASCore stops there. Arranging tasks into a graph, scheduling them and streaming data through them is what Dask, Ray and friends already do; what DASCore adds is that each step names itself the same way every time, and that a patch carries two ids saying where it came from.
+A workflow records processing as objects rather than only as a script. Its basic unit is an immutable [`Task`](`dascore.workflow.task.Task`): one operation and its parameters. DASCore records tasks and fingerprints; graph construction and scheduling belong to tools such as Dask and Ray.
 
 ::: {.callout-note}
-The workflow module is new. Every patch function already builds one — see [Patch functions are tasks](#patch-functions-are-tasks) — but DASCore's own processing does not route through it yet.
+The workflow module is new. Patch functions expose task objects, but DASCore processing does not yet route through a workflow graph.
 :::
 
 # Tasks
 
-A task is a frozen model whose fields are the parameters of the operation, plus a `run` which does it.
+Subclass `Task`, declare operation parameters as fields, and implement `run`:
 
 ```{python}
 from dascore.workflow import Task
 
 
 class Scale(Task):
-    """Multiply data by a factor."""
+    """Multiply patch data by a factor."""
 
     factor: float = 1.0
 
@@ -29,47 +28,29 @@ class Scale(Task):
         return patch.update(data=patch.data * self.factor)
 
 
-task = Scale(factor=2)
-task
+scale = Scale(factor=2)
 ```
 
-Because the parameters are the object, a task holds its parameters for good: an array given to one is marked read-only in place, so a task cannot come to report a fingerprint of values it no longer holds. Nothing is copied, so pass a copy of a buffer you are still writing to.
+Task parameters are frozen. Arrays are marked read-only without being copied, so copy a buffer before passing it if other code will continue writing to it.
 
-Because the parameters are the object, two tasks which would do the same thing are the same task:
-
-```{python}
-assert Scale(factor=2) == Scale(factor=2)
-assert Scale(factor=2) != Scale(factor=3)
-```
+Because parameters are the model fields, task equality describes the operation rather than object identity. Calling a task supplies only its runtime inputs; stored parameters remain unchanged.
 
 ## Fingerprints
 
-Every task has a `fingerprint`: a short digest of which task it is, which version of it, and what it was given. The same call gives the same fingerprint in another process, on another machine, and in a later release, barring a change in how pandas or pint hash their own objects.
+Each task has a deterministic fingerprint derived from its package, class, version, and parameters. Equivalent tasks compare equal and share a fingerprint.
 
 ```{python}
-Scale(factor=2).fingerprint
+assert Scale(factor=2) == Scale(factor=2)
+assert Scale(factor=2).fingerprint == scale.fingerprint
 ```
 
-The fingerprint names the package, the class and its parameters, not the module inside the package nor the source of the body. Moving `Scale` to another module of the same package does not change it; changing what the same parameters *mean* should, which is what `__version__` is for:
+Set a task class's `__version__` when the same parameters acquire different behavior. Module paths and function source are not fingerprinted, so moving code within a package does not change existing identities.
 
-```{python}
-class Scale(Task):
-    """Multiply data by a factor, differently."""
-
-    __version__ = "2.0"
-    factor: float = 1.0
-
-    def run(self, patch):
-        """Scale a patch."""
-        return patch.update(data=patch.data * self.factor)
-
-
-Scale(factor=2).fingerprint
-```
+Fingerprints are stable across processes and machines for supported parameter types. Packages are responsible for increasing `__version__` when behavior changes without a parameter change.
 
 ## Tasks from functions
 
-A function can become a task class without being rewritten. The decorator reads its signature: the first parameter is what the task is given when it runs, and the rest become its fields.
+The [`task`](`dascore.workflow.task.task`) decorator converts a function signature into a task class. Leading parameters are runtime inputs; remaining parameters become stored fields.
 
 ```{python}
 from dascore.workflow import task
@@ -81,110 +62,70 @@ def scale_number(number, factor=1):
     return number * factor
 
 
-scale_number(factor=3).run(2)
+operation = scale_number(factor=3)
+assert operation.run(2) == 6
+assert operation(2) == 6
 ```
 
-`inputs=` says how many leading parameters are inputs — `inputs=0` makes a task which is handed nothing and produces a value of its own, and `inputs=2` one which takes a pair. A function which packs its arguments (`def merge(*patches)`) can be asked for any number, which is what a task joining two branches needs.
-
-A task is callable, so it can stand anywhere a function of its inputs can:
+Use `inputs=` when a function takes zero or multiple runtime inputs.
 
 ```{python}
-scale_number(factor=3)(2)
+@task(inputs=2)
+def add_numbers(left, right, offset=0):
+    """Add two runtime inputs and a stored offset."""
+    return left + right + offset
+
+
+assert add_numbers(offset=1)(2, 3) == 6
 ```
 
-## Patch functions are tasks
+# Patch operations
 
-Every function decorated with `dc.patch_function` — which is most, though not all, of DASCore's patch methods — builds the operation a call to it is, with `.op`. The arguments are bound against the function's signature and the defaults filled in, so what comes back says which call was made rather than how it was spelled.
+Functions decorated with `dc.patch_function` expose `.op(...)`, which binds arguments and defaults into a [`PatchOp`](`dascore.workflow.PatchOp`).
 
 ```{python}
 import dascore as dc
 
 patch = dc.get_example_patch()
 normalize = dc.proc.normalize.op("time")
-normalize
-```
 
-That is the operation `patch.normalize("time")` performs, reached the other way round — history and all:
-
-```{python}
 assert normalize(patch).equals(patch.normalize("time"))
-normalize.fingerprint
+print(normalize.fingerprint)
 ```
 
-One class stands for every patch function, not one class each. An operation is a name and some arguments, and a name is a string:
-
-```{python}
-from dascore.workflow import PatchOp
-
-PatchOp(name="pass_filter", kwargs={"time": (10, 100)})
-```
-
-Because it is a task, it writes itself down:
-
-```{python}
-normalize.to_dict()
-```
-
-A call has a fingerprint whether or not anyone builds an operation for it. `fingerprint_call` answers for a call written as arguments, and `PatchOp.fingerprint` asks it for the operation built from the same call, so the two agree by construction rather than by test. Nothing is fingerprinted while an ordinary call runs — the decorator does not hash your arguments behind your back:
+Registry names distinguish DASCore operations from similarly named plugin operations. [`fingerprint_call`](`dascore.workflow.fingerprint_call`) computes the same identity without constructing an operation. Ordinary patch calls do not fingerprint arguments unless provenance recording needs the operation.
 
 ```{python}
 from dascore.workflow import fingerprint_call
 
-fingerprint_call(dc.proc.normalize, (), {"dim": "time"}) == normalize.fingerprint
+assert fingerprint_call(dc.proc.normalize, (), {"dim": "time"}) == normalize.fingerprint
+print(normalize.to_dict())
 ```
 
-An operation is named by a registry tag, not by where a patch keeps it. DASCore's own are bare; anything else is named by the package which defines it, so a plugin's `normalize` can never be read back as DASCore's — and a function you have only just written, bound to nothing, is nameable too:
+Advanced operations may use [`PatchProcessor`](`dascore.workflow.processor.PatchProcessor`) to separate metadata derivation from the array kernel or register kernels for other array libraries; these details are documented in the workflow API.
 
-```{python}
-import dascore.viz
+Separating `derive_meta` from `kernel` lets planners inspect coordinate and metadata changes without touching an array. Registered kernels can then execute the same named operation on another array implementation without changing its fingerprint.
 
-dc.viz.waterfall.op(show=False).name
-```
+# Saving and loading
 
-The document also records which module the function came from. It is informational — what an error message uses to tell you what to import — and deliberately not part of the fingerprint, so moving a function between modules does not make it a different operation:
-
-```{python}
-dc.proc.detrend.op("time").to_dict()["params"]["module"]
-```
-
-## Operations written out by hand
-
-A few operations are not `PatchOp` at all. Where an operation wants a seam — a kernel another array library can supply, a metadata step something can read without touching the data — it is written as a [PatchProcessor](`dascore.workflow.processor.PatchProcessor`) instead, and the patch function delegates to it.
-
-```{python}
-type(normalize)
-```
-
-It is the same operation either way: the same name, the same arguments, and the same fingerprint, so an id recorded before the class existed still matches. What the class adds is that the two halves can be asked for separately — `derive_meta` says what happens to the coordinates and never sees an array, `kernel` does the arithmetic and never sees a coordinate.
-
-```{python}
-from dascore.workflow import PatchMeta
-
-meta = PatchMeta.from_patch(patch)
-# What normalizing does to the metadata: nothing, which is why it fuses.
-normalize.derive_meta(meta) is meta
-```
-
-`register_kernel` is how a package which brings its own arrays says how one of them runs; nothing else about the operation changes.
-
-## Saving and loading
-
-A task can be written to JSON or YAML — `.yaml` and `.yml` write YAML, `.json` or a bare name write JSON, and any other suffix is refused rather than guessed at — and read back into the same task. It names its class by the registered tag rather than by an import path, so reading a file never imports whatever the file happens to name. The other side of that is that a task class has to live at module level, under a name no other class in its package claims, and that whatever defines it has to be imported before the file is loaded.
+Tasks serialize to JSON or YAML and load through registered task names. Loading does not import arbitrary paths from the file, so the package defining a custom task must already be imported.
 
 ```{python}
 import tempfile
 from pathlib import Path
 
-from dascore.workflow import Task
-
-path = Path(tempfile.mkdtemp()) / "run.yaml"
+path = Path(tempfile.mkdtemp()) / "operation.yaml"
 normalize.save(path)
-assert Task.load(path) == normalize
-print(path.read_text())
+loaded = Task.load(path)
+assert loaded == normalize
 ```
 
-# What a patch carries
+`.yaml` and `.yml` select YAML; `.json` and suffixless paths select JSON. Unsupported suffixes are rejected rather than guessed. Custom task classes must live at module level under a unique package registry name.
 
-A task says what an operation is; the two ids on `Patch.attrs` say what happened to a particular patch. `patch_id` names which data it is — derived from the file it was read out of — and `processing_id` folds each operation's fingerprint into the one before it, so a route through the data has a name of its own. Both are covered in [Patch identity](patch.qmd#patch-identity).
+# Patch provenance
 
-Nothing here schedules work. Composing tasks into a graph, running them over many patches and streaming results belong to the tools which already do that — `spool.map`, Dask, Ray — and DASCore's part is that each step, and each patch, names itself the same way every time.
+Tasks describe operations; `Patch.attrs` records their effect on data. `patch_id` identifies source data, while `processing_id` incorporates each operation fingerprint. See [Patch identity](patch.qmd#patch-identity) for persistence and lookup rules.
+
+Workflow objects do not schedule execution. Use `Spool.map`, Dask, Ray, or another executor to run operations over many patches.
+
+This boundary keeps saved operations portable: orchestration tools decide when and where work runs, while DASCore provides stable operation and patch identities.


### PR DESCRIPTION
## Description

Condense the tutorial documentation while retaining the API examples, behavioral caveats, and cross-references readers need. The full tutorial is about 50% shorter, with duplicated examples and repetitive prose removed across 11 pages.

The revision also restores the existing rolling-window anchor, keeps configuration examples safe in generated doc tests, and makes important non-default options explicit for segmented coordinates, coverage, gaps, and concatenation.

## Changelog

- changed: Condensed the tutorial documentation while preserving essential examples and usage guidance.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked and streamlined tutorials covering concepts, configuration, coordinates, file I/O, patches, processing, remote data, spools, transformations, visualization, and workflows.
  * Added clearer guidance on lazy operations, configuration scopes, units, remote access, caching, inventories, Fourier transforms, and provenance.
  * Updated examples and terminology throughout, with redundant advanced material and lengthy explanations removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->