### PR TITLE
Address tutorial review follow-ups

### DIFF
--- a/docs/tutorial/concepts.qmd
+++ b/docs/tutorial/concepts.qmd
@@ -83,4 +83,4 @@ Patch selection, processing, and conversion methods accept quantities directly. 
 
 Use explicit quantities whenever code may encounter the same coordinate expressed in different units. Bare values are most appropriate when the coordinate convention is fixed and documented.
 
-Unit-aware operations preserve physical meaning through coordinate conversion and patch arithmetic. `set_units` changes labels only; `convert_units` changes values to preserve the same quantity.
+Unit-aware operations preserve physical meaning through coordinate conversion and patch arithmetic. [`Patch.set_units`](`dascore.Patch.set_units`) changes labels only; [`Patch.convert_units`](`dascore.Patch.convert_units`) changes values to preserve the same quantity.

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -34,10 +34,13 @@ Coordinates expose values, units, data type, ordering, sampling regularity, limi
 
 | Attribute | Meaning |
 |---|---|
-| `sorted`, `reverse_sorted` | Coordinate order |
+| `sorted` | Whether values are strictly increasing |
+| `reverse_sorted` | Whether values are strictly decreasing |
 | `evenly_sampled` | Whether one step describes every value |
 | `dtype` | NumPy data type |
+| `data` | Array of coordinate values |
 | `units` | Physical units, if present |
+| `degenerate` | Whether the coordinate has zero length |
 | `min()`, `max()` | Coordinate limits |
 
 ## Segmented coordinates

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -34,13 +34,13 @@ Coordinates expose values, units, data type, ordering, sampling regularity, limi
 
 | Attribute | Meaning |
 |---|---|
-| `sorted` | Whether values are strictly increasing |
-| `reverse_sorted` | Whether values are strictly decreasing |
+| `sorted` | Whether the coordinate reports ascending ordering |
+| `reverse_sorted` | Whether the coordinate reports descending ordering |
 | `evenly_sampled` | Whether one step describes every value |
 | `dtype` | NumPy data type |
 | `data` | Array of coordinate values |
 | `units` | Physical units, if present |
-| `degenerate` | Whether the coordinate has zero length |
+| `degenerate` | Whether the coordinate is empty or zero-dimensional |
 | `min()`, `max()` | Coordinate limits |
 
 ## Segmented coordinates

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -46,7 +46,8 @@ Format support varies by backend: a formatter that requires a local seekable fil
 from dascore.utils.downloader import fetch
 
 source = fetch("terra15_das_1_trimmed.hdf5")
-summary = dc.scan(source)[0]
+summary_index = 0
+summary = dc.scan(source)[summary_index]
 
 print(summary.source_path)
 print(summary.get_coord_summary("time").min)
@@ -54,7 +55,7 @@ print(summary.get_coord_summary("time").min)
 
 Scanning also reports `source_format`, `source_version`, and `source_patch_key`, which together identify the formatter and patch inside a multi-patch file.
 
-Use the source path and patch ID to load the specific scanned patch through its spool. The spool uses its indexed `source_patch_key` when materializing that row. For compact directory listings, use `scan` or `scan_to_df`.
+Use the source path and the summary's position to load the same patch through its spool. Scan results and file-spool rows have the same order, and the spool uses each row's `source_patch_key` when materializing it. For compact directory listings, use `scan` or `scan_to_df`.
 
 ```{python}
 source_spool = dc.spool(
@@ -62,7 +63,7 @@ source_spool = dc.spool(
     file_format=summary.source_format,
     file_version=summary.source_version,
 )
-loaded = source_spool.select(patch_id=summary.attrs.patch_id)[0]
+loaded = source_spool[summary_index]
 ```
 
 [`dc.scan_payloads(...)`](`dascore.scan_payloads`) also returns each formatter's `CoordManager`. With `snap=False`, formats that store per-sample coordinates expose their exact values:

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -8,7 +8,7 @@ DASCore reads and writes local `pathlib.Path` objects and remote [`UPath`](https
 
 # Writing and reading
 
-Write through `Patch.io`, then open the result with `dc.read` or `dc.spool`:
+Write through `Patch.io`, then open the result as a spool:
 
 ```{python}
 from pathlib import Path
@@ -18,7 +18,7 @@ import dascore as dc
 patch = dc.get_example_patch()
 path = Path("output_file.h5")
 patch.io.write(path, "DASDAE")
-round_trip = dc.read(path)[0]
+round_trip = dc.spool(path)[0]
 ```
 
 ```{python}
@@ -26,14 +26,14 @@ round_trip = dc.read(path)[0]
 path.unlink(missing_ok=True)
 ```
 
-Remote-style destinations use the same interface:
+Remote destinations use the same interface through [universal-pathlib](https://pypi.org/project/universal-pathlib/), whose `UPath` objects support URLs implemented by [fsspec](https://filesystem-spec.readthedocs.io/):
 
 ```{python}
 from upath import UPath
 
 remote_path = UPath("memory://dascore/tutorial/output.pkl")
 patch.io.write(remote_path, "pickle")
-remote_patch = dc.read(remote_path)[0]
+remote_patch = dc.spool(remote_path)[0]
 ```
 
 Format support varies by backend: a formatter that requires a local seekable file may use the remote cache, while formats built on fsspec-compatible stores can operate directly.
@@ -54,15 +54,15 @@ print(summary.get_coord_summary("time").min)
 
 Scanning also reports `source_format`, `source_version`, and `source_patch_key`, which together identify the formatter and patch inside a multi-patch file.
 
-Use source fields from the summary to load a specific patch. For compact directory listings, use `scan` or `scan_to_df`.
+Use the source path and patch ID to load the specific scanned patch through its spool. The spool uses its indexed `source_patch_key` when materializing that row. For compact directory listings, use `scan` or `scan_to_df`.
 
 ```{python}
-loaded = dc.read(
+source_spool = dc.spool(
     summary.source_path,
     file_format=summary.source_format,
     file_version=summary.source_version,
-    source_patch_key=summary.source_patch_key or None,
-)[0]
+)
+loaded = source_spool.select(patch_id=summary.attrs.patch_id)[0]
 ```
 
 [`dc.scan_payloads(...)`](`dascore.scan_payloads`) also returns each formatter's `CoordManager`. With `snap=False`, formats that store per-sample coordinates expose their exact values:
@@ -103,7 +103,7 @@ The hidden `.dascore_index.sqlite3` stores file metadata and enables selections 
 
 `update()` scans new or modified files, removes rows for deleted files, and leaves unchanged rows alone. File size and modification time identify candidates for rescanning.
 
-An optional `.inventory` companion describes the observing system and is not scanned as data.
+An optional [`.inventory` companion](inventory.qmd) describes the observing system and is not scanned as data.
 
 The index and inventory are companions to the archive rather than data sources themselves, so both use reserved hidden names and are excluded from formatter discovery.
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -57,7 +57,7 @@ manual_patch = dc.Patch(
 
 ## Data and coordinates
 
-`Patch.data` is a read-only n-dimensional array. Copy it before changing values directly.
+`Patch.data` is an immutable n-dimensional array and must be treated as such; it generally cannot be changed in place. Copy it before changing values directly.
 
 ```{python}
 data_copy = np.array(patch.data)
@@ -137,7 +137,7 @@ assert first.attrs.processing_id == same.attrs.processing_id
 assert first.attrs.processing_id != other.attrs.processing_id
 ```
 
-File-backed patches derive `patch_id` from format, version, path, patch key, file size, and modification time. Repeated reads and metadata scans therefore agree without hashing the data array. Copying the same bytes to another path produces a different derived ID; overwriting a path also changes it. DASDAE files store both IDs and restore the stored values when read elsewhere.
+When a file does not contain a `patch_id`, DASCore derives one from the format, version, path, patch key, file size, and modification time. Repeated reads and metadata scans therefore agree without hashing the data array. Copying the same bytes to another path produces a different derived ID, and overwriting a path also changes it. When a file contains stored IDs, DASCore restores those values when the file is read elsewhere.
 
 In-memory patches receive process-local IDs. Direct calls to `new`, `update`, and `update_attrs` preserve both IDs because patch functions use them to assemble results. Changing data through these low-level methods does not describe a processing step:
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -137,7 +137,7 @@ assert first.attrs.processing_id == same.attrs.processing_id
 assert first.attrs.processing_id != other.attrs.processing_id
 ```
 
-When a file does not contain a `patch_id`, DASCore derives one from the format, version, path, patch key, file size, and modification time. Repeated reads and metadata scans therefore agree without hashing the data array. Copying the same bytes to another path produces a different derived ID, and overwriting a path also changes it. When a file contains stored IDs, DASCore restores those values when the file is read elsewhere.
+When a file does not contain a `patch_id`, DASCore derives one from the format, version, path, patch key, file size, and modification time. Repeated reads and metadata scans therefore agree without hashing the data array. Copying the same bytes to another path produces a different derived ID, and overwriting a path also changes it. Formats that support stored lineage IDs restore those values when the file is read elsewhere.
 
 In-memory patches receive process-local IDs. Direct calls to `new`, `update`, and `update_attrs` preserve both IDs because patch functions use them to assemble results. Changing data through these low-level methods does not describe a processing step:
 

--- a/docs/tutorial/remote_patches.qmd
+++ b/docs/tutorial/remote_patches.qmd
@@ -84,7 +84,7 @@ with config_context(allow_remote_cache=True):
 
 # Remote HDF5 and garbage collection
 
-Remote HDF5 file-like reads can deadlock if cyclic garbage collection runs on fsspec's event-loop thread while h5py holds its global lock. DASCore therefore pauses cyclic garbage collection while remote HDF5 handles are open, restores it after the last handle closes, and warns once per process. Reference counting and local-file reads are unaffected.
+Remote HDF5 file-like reads can deadlock if cyclic garbage collection runs on fsspec's event-loop thread while h5py holds its global lock, as described in [h5py's file-like object documentation](https://docs.h5py.org/en/stable/high/file.html#python-file-like-objects). DASCore therefore pauses cyclic garbage collection while remote HDF5 handles are open, restores it after the last handle closes, and warns once per process. Reference counting and local-file reads are unaffected.
 
 Only cyclic garbage accumulates during the pause, and only until the final remote HDF5 handle closes. Objects reclaimed through normal reference counting are still released immediately.
 


### PR DESCRIPTION
## Description

Address the pending follow-up review left on #1097 after it merged. This restores the requested tutorial links and coordinate details, routes file-loading examples through spools, and clarifies patch immutability, patch identity, and remote HDF5 behavior.

The file-loading example preserves format/version hints and selects the scanned patch by `patch_id`, so it remains correct for ambiguous formats and multi-patch files.

## Changelog

- changed: Tutorial guidance now uses spools for file access and clarifies coordinate, inventory, provenance, and remote HDF5 behavior.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved API links for unit-setting and unit-conversion methods.
  * Clarified coordinate attribute semantics, including sorting and degenerate coordinates.
  * Updated file-loading examples to use spools and clarified remote storage support, scanned-patch ordering, and inventory references.
  * Clarified patch data immutability and lineage identifier behavior across supported formats.
  * Added a reference explaining remote HDF5 garbage-collection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->