### PR TITLE
Let dc.spool open an example file by name

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -103,6 +103,7 @@ from dascore.utils.display import (
     split_block,
 )
 from dascore.utils.docs import compose_docstring
+from dascore.utils.downloader import resolve_example_uri
 from dascore.utils.misc import (
     _spool_map,
     deep_equality_check,
@@ -2633,14 +2634,13 @@ def spool(obj: path_types | Spool | Sequence[PatchType], **kwargs) -> Spool:
     Examples
     --------
     >>> import dascore as dc
-    >>> from dascore.utils.downloader import fetch
     >>>
-    >>> # Get a spool from a single file
-    >>> single_file_path = fetch("example_dasdae_event_1.h5")
-    >>> file_spool = dc.spool(single_file_path)
+    >>> # Get a spool from a single file. An examples:// name refers to a
+    >>> # file in DASCore's example data registry; use your own path here.
+    >>> file_spool = dc.spool("examples://example_dasdae_event_1.h5")
     >>>
     >>> # get a spool from a directory of files
-    >>> directory_path = fetch("example_dasdae_event_1.h5").parent
+    >>> directory_path = dc.examples.spool_to_directory(dc.get_example_spool())
     >>> directory_spool = dc.spool(directory_path)
     >>>
     >>> # get a spool from a single patch
@@ -2656,7 +2656,7 @@ def spool(obj: path_types | Spool | Sequence[PatchType], **kwargs) -> Spool:
 @spool.register(UPath)
 def _spool_from_str(path, **kwargs):
     """Get a spool from a path."""
-    path = coerce_to_upath(path)
+    path = coerce_to_upath(resolve_example_uri(path))
     # A directory was passed; index it.
     if path.is_dir():
         requires_local_directory(path, label="Directory spool")

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -445,6 +445,9 @@ def _get_reloadable_source_path(
             continue
         if isinstance(candidate, IOResourceManager):
             candidate = candidate.source
+        # A reloadable path names the file, never the examples:// name,
+        # which no filesystem knows how to reopen.
+        candidate = resolve_example_uri(candidate)
         if isinstance(candidate, str | Path | UPath):
             return coerce_to_upath(candidate)
     return ""

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -60,6 +60,7 @@ from dascore.exceptions import (
     RemoteCacheError,
     UnknownFiberFormatError,
 )
+from dascore.utils.downloader import resolve_example_uri
 from dascore.utils.io import (
     IOResourceManager,
     _normalize_source_patch_keys,
@@ -77,7 +78,12 @@ from dascore.utils.misc import (
     iterate,
     warn_or_raise,
 )
-from dascore.utils.paths import coerce_to_local_path, coerce_to_upath, is_local_path
+from dascore.utils.paths import (
+    coerce_to_local_path,
+    coerce_to_upath,
+    is_example_uri,
+    is_local_path,
+)
 from dascore.utils.plugins import FIBER_IO_GROUP, get_entry_point_loaders
 from dascore.utils.progress import track
 from dascore.utils.remote_io import (
@@ -763,7 +769,9 @@ class _FiberIOManager:
         # would be caught by the robustness handler below and read as
         # "wrong format", silently skipping the reader which does match.
         with IOResourceManager(path) as man, suppress_gc_pause_warning():
-            path = man.source
+            # The source may still be an examples:// name if a manager was
+            # handed in already wrapping one; the checks below need a path.
+            path = resolve_example_uri(man.source)
             if isinstance(path, UPath):
                 exists = path.exists()
                 suffix = path.suffix
@@ -1203,6 +1211,8 @@ def _source_path_string(source) -> str:
     """
     if isinstance(source, IOResourceManager):
         source = source.source
+    # An id names the file an examples:// name resolves to, not the name.
+    source = resolve_example_uri(source)
     if isinstance(source, str | Path | UPath):
         return _canonical_path(source)
     for attribute in ("_dascore_source_path", "name", "filename"):
@@ -1350,15 +1360,13 @@ def read(
     --------
     >>> import numpy as np
     >>> import dascore as dc
-    >>> from dascore.utils.downloader import fetch
     >>>
-    >>> file_path = fetch("terra15_das_1_trimmed.hdf5")
-    >>>
-    >>> patch = dc.read(file_path)
+    >>> patch = dc.read("examples://terra15_das_1_trimmed.hdf5")
     """
     # Held because `path` is reassigned to whatever the reader wanted; the
     # id names the source the caller asked for, not the handle it became.
-    source = path
+    # An examples:// name resolves first so the id names the file, not the URI.
+    source = path = resolve_example_uri(path)
     with remote_cache_scope("read"):
         with IOResourceManager(path) as man:
             inferred_format = not file_format or not file_version
@@ -1436,11 +1444,8 @@ def scan_to_df(
     Examples
     --------
     >>> import dascore as dc
-    >>> from dascore.utils.downloader import fetch
     >>>
-    >>> file_path = fetch("terra15_das_1_trimmed.hdf5")
-    >>>
-    >>> df = dc.scan_to_df(file_path)
+    >>> df = dc.scan_to_df("examples://terra15_das_1_trimmed.hdf5")
     """
     if isinstance(path, pd.DataFrame):
         return path
@@ -1466,6 +1471,7 @@ def scan_to_df(
 def _iterate_scan_inputs(patch_source, ext, mtime, include_directories=True, **kwargs):
     """Yield scan candidates."""
     for el in iterate(patch_source):
+        el = resolve_example_uri(el)
         if isinstance(el, str | Path | UPath):
             path = (
                 coerce_to_local_path(el) if is_local_path(el) else coerce_to_upath(el)
@@ -1835,10 +1841,8 @@ def scan(
     Examples
     --------
     >>> import dascore as dc
-    >>> from dascore.utils.downloader import fetch
     >>>
-    >>> file_path = fetch("terra15_das_1_trimmed.hdf5")
-    >>> summary = dc.scan(file_path)[0]
+    >>> summary = dc.scan("examples://terra15_das_1_trimmed.hdf5")[0]
 
     See Also
     --------
@@ -1978,12 +1982,10 @@ def get_format(
     Examples
     --------
     >>> import dascore as dc
-    >>> from dascore.utils.downloader import fetch
     >>>
-    >>> file_path = fetch("prodml_2.1.h5")
-    >>>
-    >>> file_format, file_version = dc.get_format(file_path)
+    >>> file_format, file_version = dc.get_format("examples://prodml_2.1.h5")
     """
+    path = resolve_example_uri(path)
     scope = get_remote_cache_scope()
     if scope == "read":
         return FiberIO.manager._get_format(
@@ -2111,6 +2113,8 @@ def write(
     ------
     [`UnknownFiberFormatError`](`dascore.exceptions.UnknownFiberFormatError`)
         - Could not determine the fiber format.
+    [`ParameterError`](`dascore.exceptions.ParameterError`)
+        - The path is an ``examples://`` name, which is read-only.
 
     Examples
     --------
@@ -2124,6 +2128,16 @@ def write(
     >>> assert path.exists()
     >>> path.unlink()
     """
+    # Example files are read-only; writing to one would land on top of the
+    # downloader's cached copy. A manager is unwrapped first so wrapping the
+    # uri is not a way around this.
+    target = path.source if isinstance(path, IOResourceManager) else path
+    if is_example_uri(target):
+        msg = (
+            f"Cannot write to {target}; examples:// names are read-only. "
+            f"Give a path to write to instead."
+        )
+        raise ParameterError(msg)
     fiber_io = FiberIO.manager.get_fiberio(format=file_format, version=file_version)
     if not isinstance(patch_or_spool, dc.Spool):
         patch_or_spool = dc.spool([patch_or_spool])

--- a/dascore/io/segy/__init__.py
+++ b/dascore/io/segy/__init__.py
@@ -16,12 +16,8 @@ segy v2.1 spec: seg_y_rev2_1-oct2023-1701361639333.pdf
 Examples
 --------
 import dascore as dc
-from dascore.utils.downloader import fetch
 
-# get the path to a segy file.
-path = fetch("conoco_segy_1.sgy")
-
-segy_patch = dc.spool(path)[0]
+segy_patch = dc.spool("examples://conoco_segy_1.sgy")[0]
 """
 
 from .core import SegyV1_0, SegyV2_0, SegyV2_1

--- a/dascore/io/sentek/__init__.py
+++ b/dascore/io/sentek/__init__.py
@@ -5,9 +5,7 @@ Examples
 --------
 
 import dascore as dc
-from dascore.utils.downloader import fetch
 
-path_to_sentek_file = fetch("DASDMSShot00_20230328155653619.das")
-sentek_patch = dc.spool(path_to_sentek_file)[0]
+sentek_patch = dc.spool("examples://DASDMSShot00_20230328155653619.das")[0]
 """
 from .core import SentekV5

--- a/dascore/io/uptech/__init__.py
+++ b/dascore/io/uptech/__init__.py
@@ -6,9 +6,7 @@ Examples
 Read a registered test file:
 
 >>> import dascore as dc
->>> from dascore.utils.downloader import fetch
->>> path = fetch("uptech_as1000_1.hdf5")
->>> spool = dc.read(path)
+>>> spool = dc.read("examples://uptech_as1000_1.hdf5")
 
 The reader expects ``Acquisition/StrainRate`` and ``Acquisition/Time``
 datasets. Format metadata is read from attributes on the strain-rate dataset;

--- a/dascore/utils/downloader.py
+++ b/dascore/utils/downloader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from functools import cache
 from importlib.resources import files
 from pathlib import Path
+from typing import TypeVar
 
 import pandas as pd
 import pooch
@@ -15,6 +16,9 @@ from dascore.exceptions import UnknownExampleError
 from dascore.utils.paths import EXAMPLE_SCHEME, is_example_uri
 
 REGISTRY_PATH = Path(str(files("dascore").joinpath("data_registry.txt")))
+
+# An example uri becomes a Path; anything else is handed back as it came.
+_T = TypeVar("_T")
 
 
 @cache
@@ -91,7 +95,7 @@ def fetch(name: Path | str, **kwargs) -> Path:
     )
 
 
-def resolve_example_uri(resource):
+def resolve_example_uri(resource: _T) -> _T | Path:
     """
     Resolve an ``examples://{name}`` URI to a local path.
 

--- a/dascore/utils/downloader.py
+++ b/dascore/utils/downloader.py
@@ -11,6 +11,8 @@ import pooch
 
 from dascore.config import get_config
 from dascore.constants import DATA_VERSION
+from dascore.exceptions import UnknownExampleError
+from dascore.utils.paths import EXAMPLE_SCHEME, is_example_uri
 
 REGISTRY_PATH = Path(str(files("dascore").joinpath("data_registry.txt")))
 
@@ -87,3 +89,59 @@ def fetch(name: Path | str, **kwargs) -> Path:
     return _fetch_cached(
         name=str(name), cache_dir=str(get_config().downloader_cache_dir)
     )
+
+
+def resolve_example_uri(resource):
+    """
+    Resolve an ``examples://{name}`` URI to a local path.
+
+    Parameters
+    ----------
+    resource
+        Any resource. Anything which is not an example URI is returned
+        unchanged so call sites need no branch of their own.
+
+    Returns
+    -------
+    A path to the downloaded file, or the unmodified resource.
+
+    Raises
+    ------
+    [`UnknownExampleError`](`dascore.exceptions.UnknownExampleError`) if the
+    name is not a file in the data registry.
+
+    Examples
+    --------
+    >>> from dascore.utils.downloader import resolve_example_uri
+    >>> path = resolve_example_uri("examples://terra15_das_1_trimmed.hdf5")
+    >>> path.exists()
+    True
+    """
+    if not is_example_uri(resource):
+        return resource
+    name = str(resource)[len(EXAMPLE_SCHEME) :]
+    if name in set(get_registry_df()["name"]):
+        # Deliberately not fetch: it returns a same-named file in the working
+        # directory in preference to the registry entry, and an examples://
+        # name asked for the registry entry.
+        return _fetch_cached(
+            name=name, cache_dir=str(get_config().downloader_cache_dir)
+        )
+    # Imported here rather than at module top because dascore.examples
+    # imports fetch from this module.
+    from dascore.examples import EXAMPLE_PATCHES, EXAMPLE_SPOOLS  # noqa: PLC0415
+
+    if name in EXAMPLE_PATCHES or name in EXAMPLE_SPOOLS:
+        msg = (
+            f"'{name}' is a generated example, not a file in the data "
+            f"registry, so it has no path to open. Use "
+            f"dc.get_example_patch('{name}') or "
+            f"dc.get_example_spool('{name}') instead."
+        )
+    else:
+        msg = (
+            f"No example file named '{name}'. Names come from the data "
+            f"registry; see dascore.utils.downloader.get_registry_df for "
+            f"the full list."
+        )
+    raise UnknownExampleError(msg)

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -17,6 +17,7 @@ import dascore as dc
 from dascore.compat import UPath
 from dascore.constants import PatchType
 from dascore.exceptions import PatchConversionError
+from dascore.utils.downloader import resolve_example_uri
 from dascore.utils.misc import (
     _maybe_make_parent_directory,
     iterate,
@@ -50,6 +51,12 @@ def ensure_local_file(resource) -> Path:
 
 def _normalize_resource_identity(resource):
     """Normalize one pathlike input to a local Path or remote UPath."""
+    # An examples:// name has no filesystem behind it, so it becomes a real
+    # path before anything asks what protocol it speaks. It happens here,
+    # when a handle is actually wanted, rather than when a manager is built:
+    # constructing one must not reach the network, and the manager's source
+    # must keep naming the uri so a write of it can still be refused.
+    resource = resolve_example_uri(resource)
     if is_local_path(resource):
         return coerce_to_local_path(resource)
     return coerce_to_upath(resource)

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -16,7 +16,7 @@ import numpy as np
 import dascore as dc
 from dascore.compat import UPath
 from dascore.constants import PatchType
-from dascore.exceptions import PatchConversionError
+from dascore.exceptions import ParameterError, PatchConversionError
 from dascore.utils.downloader import resolve_example_uri
 from dascore.utils.misc import (
     _maybe_make_parent_directory,
@@ -26,6 +26,7 @@ from dascore.utils.misc import (
 from dascore.utils.paths import (
     coerce_to_local_path,
     coerce_to_upath,
+    is_example_uri,
     is_local_path,
     is_pathlike,
 )
@@ -231,6 +232,24 @@ def release_handle(handle, abort: bool = False):
         getattr(handle, "close", lambda: None)()
 
 
+# Handle classes name the mode they open in. Everything else truncates or
+# appends, so an example file must not be opened through one.
+_READ_MODES = frozenset({"r", "rb"})
+
+
+def _refuse_example_write(source, required_type) -> None:
+    """Refuse a handle which would write over a downloaded example file."""
+    if not is_example_uri(source):
+        return
+    if getattr(required_type, "mode", "r") in _READ_MODES:
+        return
+    msg = (
+        f"Cannot open {source} for writing; examples:// names are read-only. "
+        f"Give a path to write to instead."
+    )
+    raise ParameterError(msg)
+
+
 class IOResourceManager:
     """
     A class for managing opening/closing files.
@@ -269,6 +288,7 @@ class IOResourceManager:
         if isinstance(self._source, self.__class__):
             return self._source.get_resource(required_type)
         required_type = _get_required_type(required_type)
+        _refuse_example_write(self._source, required_type)
         with self._lock:
             if required_type not in self._cache:
                 source = _resolve_resource(self._source, required_type)

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -241,7 +241,17 @@ def _refuse_example_write(source, required_type) -> None:
     """Refuse a handle which would write over a downloaded example file."""
     if not is_example_uri(source):
         return
-    if getattr(required_type, "mode", "r") in _READ_MODES:
+    # A type with no get_handle opens nothing: the resolved path is handed
+    # through as it is. LocalPath has one, but it returns a filename rather
+    # than an open file, so neither can truncate anything by itself.
+    if not hasattr(required_type, "get_handle"):
+        return
+    if isinstance(required_type, type) and issubclass(required_type, LocalPath):
+        return
+    # Any other handle must say it opens to read. A missing mode is refused
+    # rather than assumed harmless: every reader here declares one, so
+    # silence is more likely an unknown writer than a safe default.
+    if getattr(required_type, "mode", None) in _READ_MODES:
         return
     msg = (
         f"Cannot open {source} for writing; examples:// names are read-only. "

--- a/dascore/utils/paths.py
+++ b/dascore/utils/paths.py
@@ -57,7 +57,7 @@ def is_memory_uri(path) -> bool:
     return str(path).startswith(_MEMORY_SCHEMES)
 
 
-def is_example_uri(path) -> bool:
+def is_example_uri(path: object) -> bool:
     """
     Return True if a path names a file in the example data registry.
 

--- a/dascore/utils/paths.py
+++ b/dascore/utils/paths.py
@@ -18,6 +18,10 @@ _HIVE_NULL = "__HIVE_DEFAULT_PARTITION__"
 # dascore.io.index.catalog); such paths dispatch to in-memory registries
 # and are never treated as file names.
 _MEMORY_SCHEMES = ("memorypatch://", "memory://")
+# Synthetic URI scheme naming a file in the example data registry
+# (dascore/data_registry.txt); resolved to a local path by
+# dascore.utils.downloader.resolve_example_uri.
+EXAMPLE_SCHEME = "examples://"
 
 
 def is_pathlike(resource) -> TypeIs[str | Path | UPath]:
@@ -51,6 +55,24 @@ def is_memory_uri(path) -> bool:
     named e.g. ``memory_notes.h5`` is not misclassified.
     """
     return str(path).startswith(_MEMORY_SCHEMES)
+
+
+def is_example_uri(path) -> bool:
+    """
+    Return True if a path names a file in the example data registry.
+
+    Matches the exact ``examples://`` scheme, so a real file named e.g.
+    ``examples_notes.h5`` is not misclassified.
+
+    Examples
+    --------
+    >>> from dascore.utils.paths import is_example_uri
+    >>> is_example_uri("examples://terra15_das_1_trimmed.hdf5")
+    True
+    >>> is_example_uri("examples_notes.h5")
+    False
+    """
+    return str(path).startswith(EXAMPLE_SCHEME)
 
 
 def directory_writable(path) -> bool:

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -28,15 +28,11 @@ DASCore is part of the [DAS Data Analysis Ecosystem (DASDAE)](https://dasdae.org
 
 ```{python}
 import dascore as dc
-# Import fetch to read DASCore example files 
-from dascore.utils.downloader import fetch 
 
-# Fetch a sample file path from DASCore
-file_path = fetch('terra15_das_1_trimmed.hdf5')
-# To read DAS data stored locally on your machine, simply replace the above line with:
-# file_path = "/path/to/data/directory/data.EXT"
-
-spool = dc.spool(file_path)
+# An examples:// name refers to one of DASCore's example files.
+# To read DAS data stored locally on your machine, simply replace it with:
+# spool = dc.spool("/path/to/data/directory/data.EXT")
+spool = dc.spool("examples://terra15_das_1_trimmed.hdf5")
 patch = spool[0]
 ```
 

--- a/docs/recipes/add_spatial_coordinates_to_patch.qmd
+++ b/docs/recipes/add_spatial_coordinates_to_patch.qmd
@@ -16,10 +16,10 @@ Here, we:
 import pandas as pd
 
 import dascore as dc
-from dascore.utils.downloader import fetch
 
-# Get path for example coordinates.
-path = fetch("brady_hs_DAS_DTS_coords.csv")
+# Get path for example coordinates. Pandas needs a path, so the example
+# file is fetched rather than named with an examples:// uri.
+path = dc.examples.fetch("brady_hs_DAS_DTS_coords.csv")
 
 # Read coordinates data from csv file.
 coord_table = pd.read_csv(path).rename(columns={"Channel": "distance"})

--- a/docs/tutorial/file_io.qmd
+++ b/docs/tutorial/file_io.qmd
@@ -43,11 +43,8 @@ Format support varies by backend: a formatter that requires a local seekable fil
 [`dc.scan`](`dascore.scan`) returns [`PatchSummary`](`dascore.PatchSummary`) objects without loading patch arrays.
 
 ```{python}
-from dascore.utils.downloader import fetch
-
-source = fetch("terra15_das_1_trimmed.hdf5")
 summary_index = 0
-summary = dc.scan(source)[summary_index]
+summary = dc.scan("examples://terra15_das_1_trimmed.hdf5")[summary_index]
 
 print(summary.source_path)
 print(summary.get_coord_summary("time").min)
@@ -69,7 +66,7 @@ loaded = source_spool[summary_index]
 [`dc.scan_payloads(...)`](`dascore.scan_payloads`) also returns each formatter's `CoordManager`. With `snap=False`, formats that store per-sample coordinates expose their exact values:
 
 ```{python}
-payload = dc.scan_payloads(source, snap=False)[0]
+payload = dc.scan_payloads(summary.source_path, snap=False)[0]
 time = payload["coords"].get_coord("time")
 ```
 

--- a/docs/tutorial/patch.qmd
+++ b/docs/tutorial/patch.qmd
@@ -27,11 +27,12 @@ event = dc.get_example_patch("example_event_1")
 Use [`dc.spool(...)`](`dascore.spool`) to open DAS files and take a patch by indexing the spool:
 
 ```{python}
-from dascore.utils.downloader import fetch
-
-path = fetch("terra15_das_1_trimmed.hdf5")
-file_patch = dc.spool(path)[0]
+file_patch = dc.spool("examples://terra15_das_1_trimmed.hdf5")[0]
 ```
+
+:::{.callout-note}
+An `examples://` name refers to a file in DASCore's [example data registry](`dascore.utils.downloader.get_registry_df`); it is downloaded and cached the first time it is used. Anywhere it appears in these docs, a path to your own data works just as well. Generated examples, which have no file behind them, come from [`dc.get_example_patch`](`dascore.examples.get_example_patch`) and [`dc.get_example_spool`](`dascore.examples.get_example_spool`) instead.
+:::
 
 See the [spool tutorial](spool.qmd) for directories, archives, and remote resources.
 

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -17,10 +17,8 @@ spool = dc.get_example_spool()
 Use [`dc.spool(...)`](`dascore.spool`) for any supported input:
 
 ```{python}
-from dascore.utils.downloader import fetch
-
 memory_spool = dc.spool([dc.get_example_patch()])
-file_spool = dc.spool(fetch("terra15_das_1_trimmed.hdf5"))
+file_spool = dc.spool("examples://terra15_das_1_trimmed.hdf5")
 ```
 
 Remote paths use the same constructor:
@@ -36,7 +34,8 @@ remote_spool = dc.spool(remote_file)
 Directory spools maintain an index for fast metadata queries. Call `update()` after files change.
 
 ```{python}
-directory = fetch("terra15_das_1_trimmed.hdf5").parent
+# Write example patches to a directory to get a usable path.
+directory = dc.examples.spool_to_directory(dc.get_example_spool())
 directory_spool = dc.spool(directory).update()
 ```
 

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -28,6 +28,7 @@ from dascore.exceptions import (
     MissingOptionalDependencyError,
     MissingPatchError,
     ParameterError,
+    UnknownExampleError,
 )
 from dascore.io.index.planned import PlanResolver
 from dascore.io.segy import SegyV1_0
@@ -952,6 +953,19 @@ class TestGetSpool:
         """A path that doesn't exist should raise."""
         with pytest.raises(Exception, match="get spool from"):
             dc.spool("here_or_there?")
+
+    def test_spool_from_example_uri(self, terra15_das_example_path):
+        """An examples:// name should behave like the path it names."""
+        out = dc.spool("examples://terra15_das_1_trimmed.hdf5")
+        expected = dc.spool(terra15_das_example_path)
+        assert isinstance(out, BaseSpool)
+        assert len(out) == len(expected)
+        assert out[0].equals(expected[0])
+
+    def test_generated_example_uri_raises(self):
+        """A generated example has no file, so the error says where to look."""
+        with pytest.raises(UnknownExampleError, match="get_example_spool"):
+            dc.spool("examples://random_das")
 
     def test_non_supported_type_raises(self):
         """A type that can't contain patches should raise."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -53,6 +53,7 @@ from dascore.io.core import (
 from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.utils import build_patches, convert_attr_units, get_exact_coord
 from dascore.utils.downloader import fetch
+from dascore.utils.hdf5 import H5Writer
 from dascore.utils.io import BinaryReader, BinaryWriter, IOResourceManager
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.time import to_datetime64
@@ -1095,6 +1096,24 @@ class TestExampleUri:
         """Payload scans accept the uri too."""
         payload = dc.scan_payloads(example_uri, snap=False)[0]
         assert "coords" in payload
+
+    def test_scan_through_manager_names_the_file(self, example_uri, example_path):
+        """A manager wrapping a uri still reports a reloadable source path."""
+        summary = dc.scan(IOResourceManager(example_uri))[0]
+        assert str(summary.source_path) == str(example_path)
+
+    def test_writer_handle_refused(self, example_uri, example_path):
+        """A writer handle would truncate the example, so it is refused."""
+        before = example_path.read_bytes()
+        for required_type in (BinaryWriter, H5Writer):
+            with pytest.raises(ParameterError, match="read-only"):
+                IOResourceManager(example_uri).get_resource(required_type)
+        assert example_path.read_bytes() == before
+
+    def test_reader_handle_allowed(self, example_uri):
+        """Reading through a manager is unaffected by the write refusal."""
+        with IOResourceManager(example_uri) as man:
+            assert man.get_resource(BinaryReader).read(4)
 
     def test_ids_name_the_file(self, example_uri, example_path):
         """A patch read by uri has the id of one read by path."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -54,7 +54,12 @@ from dascore.io.dasdae.core import DASDAEV1
 from dascore.io.utils import build_patches, convert_attr_units, get_exact_coord
 from dascore.utils.downloader import fetch
 from dascore.utils.hdf5 import H5Writer
-from dascore.utils.io import BinaryReader, BinaryWriter, IOResourceManager
+from dascore.utils.io import (
+    BinaryReader,
+    BinaryWriter,
+    IOResourceManager,
+    LocalPath,
+)
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.time import to_datetime64
 from dascore.workflow.identity import source_patch_id
@@ -1109,6 +1114,28 @@ class TestExampleUri:
             with pytest.raises(ParameterError, match="read-only"):
                 IOResourceManager(example_uri).get_resource(required_type)
         assert example_path.read_bytes() == before
+
+    def test_modeless_handle_refused(self, example_uri, example_path):
+        """A handle which declares no mode is refused rather than trusted."""
+
+        class _ModelessWriter:
+            """A writer which forgot to say which mode it opens in."""
+
+            @classmethod
+            def get_handle(cls, resource):
+                """Truncate the resource, as an undeclared writer would."""
+                return open(resource, mode="wb")
+
+        before = example_path.read_bytes()
+        with pytest.raises(ParameterError, match="read-only"):
+            IOResourceManager(example_uri).get_resource(_ModelessWriter)
+        assert example_path.read_bytes() == before
+
+    def test_path_handles_allowed(self, example_uri, example_path):
+        """Types which name the file rather than open it stay allowed."""
+        for required_type in (Path, UPath, LocalPath):
+            resource = IOResourceManager(example_uri).get_resource(required_type)
+            assert str(resource) == str(example_path)
 
     def test_reader_handle_allowed(self, example_uri):
         """Reading through a manager is unaffected by the write refusal."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -26,6 +26,7 @@ from dascore.exceptions import (
     InvalidFiberIOError,
     MissingOptionalDependencyError,
     MissingPatchError,
+    ParameterError,
     PatchAttributeError,
     RemoteCacheError,
     UnknownFiberFormatError,
@@ -1030,6 +1031,77 @@ class TestFileUri:
     def test_read(self, file_uri, dasdae_path):
         """Read via file:// URI should equal read via plain path."""
         assert dc.read(file_uri)[0] == dc.read(dasdae_path)[0]
+
+
+class TestExampleUri:
+    """The examples:// scheme names a file in the data registry."""
+
+    name = "terra15_das_1_trimmed.hdf5"
+
+    @pytest.fixture(scope="class")
+    def example_path(self):
+        """The local path the example uri resolves to."""
+        return fetch(self.name)
+
+    @pytest.fixture(scope="class")
+    def example_uri(self):
+        """The uri form of the same file."""
+        return f"examples://{self.name}"
+
+    def test_get_format(self, example_uri, example_path):
+        """get_format should agree for uri and path."""
+        assert dc.get_format(example_uri) == dc.get_format(example_path)
+
+    def test_scan(self, example_uri, example_path):
+        """Scanning a uri names the resolved file, not the uri."""
+        summary = dc.scan(example_uri)[0]
+        assert summary == dc.scan(example_path)[0]
+        assert str(summary.source_path) == str(example_path)
+
+    def test_scan_to_df(self, example_uri, example_path):
+        """scan_to_df should accept the uri."""
+        df = dc.scan_to_df(example_uri)
+        assert str(df["source_path"].iloc[0]) == str(example_path)
+
+    def test_read(self, example_uri, example_path):
+        """Read via uri should equal read via path."""
+        assert dc.read(example_uri)[0] == dc.read(example_path)[0]
+
+    def test_write_refused(self, example_uri, example_path):
+        """Writing to a uri must not overwrite the cached example file."""
+        before = example_path.read_bytes()
+        with pytest.raises(ParameterError, match="read-only"):
+            dc.write(dc.get_example_patch(), example_uri, "dasdae")
+        assert example_path.read_bytes() == before
+
+    def test_write_refused_through_manager(self, example_uri, example_path):
+        """Wrapping the uri in a manager is not a way around the refusal."""
+        before = example_path.read_bytes()
+        with pytest.raises(ParameterError, match="read-only"):
+            dc.write(dc.get_example_patch(), IOResourceManager(example_uri), "pickle")
+        assert example_path.read_bytes() == before
+
+    def test_manager_construction_is_lazy(self, monkeypatch, example_uri):
+        """Building a manager must not reach the network."""
+
+        def _no_fetch(*args, **kwargs):
+            raise AssertionError("the manager resolved its source eagerly")
+
+        monkeypatch.setattr("dascore.utils.downloader._fetch_cached", _no_fetch)
+        manager = IOResourceManager(example_uri)
+        assert manager.source == example_uri
+
+    def test_scan_payloads(self, example_uri):
+        """Payload scans accept the uri too."""
+        payload = dc.scan_payloads(example_uri, snap=False)[0]
+        assert "coords" in payload
+
+    def test_ids_name_the_file(self, example_uri, example_path):
+        """A patch read by uri has the id of one read by path."""
+        by_uri = dc.read(example_uri)[0]
+        by_path = dc.read(example_path)[0]
+        assert by_uri.attrs.patch_id == by_path.attrs.patch_id
+        assert by_uri.attrs.history == by_path.attrs.history
 
 
 class TestScan:

--- a/tests/test_utils/test_downloader.py
+++ b/tests/test_utils/test_downloader.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from dascore.config import config_context
+from dascore.exceptions import UnknownExampleError
 from dascore.utils.downloader import (
     REGISTRY_PATH,
     _fetch_cached,
@@ -16,6 +17,7 @@ from dascore.utils.downloader import (
     fetcher,
     get_fetcher,
     get_registry_df,
+    resolve_example_uri,
 )
 
 
@@ -109,3 +111,39 @@ class TestFetch:
         out = _fetch_cached(name="example.dat", cache_dir=str(tmp_path))
 
         assert out == tmp_path / "example.dat"
+
+
+class TestResolveExampleUri:
+    """The examples:// scheme names a file in the data registry."""
+
+    def test_registry_name(self):
+        """A registry name resolves to the downloaded file."""
+        name = "terra15_das_1_trimmed.hdf5"
+        path = resolve_example_uri(f"examples://{name}")
+        assert path.exists()
+        assert path.name == name
+        assert path.parent == get_fetcher().path
+
+    def test_working_directory_file_does_not_shadow(self, tmp_path, monkeypatch):
+        """A same-named local file must not stand in for the registry entry."""
+        name = "terra15_das_1_trimmed.hdf5"
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / name).write_bytes(b"not the registered file")
+        path = resolve_example_uri(f"examples://{name}")
+        assert path.parent == get_fetcher().path
+        assert path.read_bytes()[:4] != b"not "
+
+    def test_non_uri_passes_through(self, tmp_path):
+        """Anything which is not an example uri is returned unchanged."""
+        for resource in (tmp_path, str(tmp_path), 42):
+            assert resolve_example_uri(resource) is resource
+
+    def test_unknown_name_raises(self):
+        """An unregistered name names the registry in the error."""
+        with pytest.raises(UnknownExampleError, match="registry"):
+            resolve_example_uri("examples://not_a_real_file.h5")
+
+    def test_generated_example_points_to_example_functions(self):
+        """A generated example has no file, so the error says where to look."""
+        with pytest.raises(UnknownExampleError, match="get_example_spool"):
+            resolve_example_uri("examples://random_das")

--- a/tests/test_utils/test_paths.py
+++ b/tests/test_utils/test_paths.py
@@ -13,6 +13,7 @@ from dascore.utils.paths import (
     coerce_to_upath,
     directory_writable,
     get_path_protocol,
+    is_example_uri,
     is_local_path,
     is_pathlike,
     requires_local_directory,
@@ -124,3 +125,20 @@ class TestRequiresLocalDirectory:
                 UPath("memory://dascore/testdir"),
                 label="Directory spool",
             )
+
+
+class TestIsExampleUri:
+    """The examples:// scheme is matched exactly."""
+
+    def test_example_uri(self):
+        """A name with the scheme is an example uri."""
+        assert is_example_uri("examples://terra15_das_1_trimmed.hdf5")
+
+    def test_similar_name_is_not_matched(self):
+        """A real file whose name merely starts with examples is not."""
+        assert not is_example_uri("examples_notes.h5")
+        assert not is_example_uri("example://not_the_scheme.h5")
+
+    def test_path_is_not_matched(self, tmp_path):
+        """Ordinary paths are not example uris."""
+        assert not is_example_uri(tmp_path / "data.h5")


### PR DESCRIPTION
## Description

New users met this before they met any DASCore API:

```python
from dascore.utils.downloader import fetch
path = fetch('terra15_das_1_trimmed.hdf5')
spool = dc.spool(path)
```

Three lines, a private-looking module path, and a function whose job — download and cache a registry file — is incidental to what the page is teaching. It reads as required setup rather than the scaffolding it is.

This adds an `examples://` URI scheme so an example file is named where the reader already looks, inside the call that opens it:

```python
spool = dc.spool("examples://terra15_das_1_trimmed.hdf5")
```

`examples://<name>` resolves to the local path of that entry in `dascore/data_registry.txt`, downloading and caching it on first use. Because it resolves to a real path before anything else happens, it works in every path-taking reader — `dc.spool`, `dc.read`, `dc.scan`, `dc.scan_to_df`, `dc.get_format` — and patch ids, source paths and index rows name the resolved file exactly as they did before, not the URI.

It is read-only in both directions it could be misread:

- `dc.write` (and `Patch.io.write`) refuses an `examples://` target rather than landing on top of the downloader's cached copy. A resource manager wrapping one is unwrapped first, so that is not a way around it.
- a generated example name, which has no file behind it, is refused with a pointer to `dc.get_example_patch` / `dc.get_example_spool`.

An `examples://` name always means the registry entry: unlike `fetch`, it does not defer to a same-named file in the working directory.

Resolution happens at the entry points and when a handle is actually wanted, not in `IOResourceManager.__init__` — constructing a manager must not reach the network, and its `source` must keep naming the URI so a write of it can still be refused.

`fetch` is unchanged and still public. `docs/contributing/*` deliberately keeps using it: those pages are about registering test data, where `fetch` is the right API.

## Changelog

- added: `dc.spool`, `dc.read`, `dc.scan`, `dc.scan_to_df` and `dc.get_format` accept `examples://<name>` to open a file from DASCore's example data registry.
- changed: the tutorials name example files with `examples://` rather than importing `fetch`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Load registered example files directly with `examples://` URIs for reading, scanning, and spool workflows.
  - Example files download and cache automatically on first access.
  - Added clear errors for unknown or generated example names.
  - Prevented writing data to read-only example URIs.
  - Preserved lazy access so creating a resource does not download data unnecessarily.

- **Documentation**
  - Updated guides, recipes, and examples to demonstrate direct example URI usage.
  - Clarified when a local file path is required and how to create example-data directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->