### PR TITLE
Match lane label ink to its box fill

### DIFF
--- a/dascore/viz/_lanes.py
+++ b/dascore/viz/_lanes.py
@@ -500,12 +500,19 @@ def _fit_labels(ax, placements, max_labels):
     scale = _MEASURED_DPI / figure.dpi
 
     size = plt.rcParams["font.size"] * 0.8
-    for text, x_mid, y_mid, width, height in placements:
+    for text, x_mid, y_mid, width, height, fill in placements:
         if not text:
             continue
         box = _box_points(transform, scale, x_mid, y_mid, width, height)
         room = (box[0] - _LABEL_PAD, box[1] - _LABEL_PAD)
         taken = _text_points(text, size)
+        # Black text carries a halo of the box's own lightness poorly, and
+        # a halo alone cannot rescue it: match the text to the fill instead,
+        # dark ink on a light box, white on a dark one, with the halo in
+        # the opposite tone so the letters keep an edge on their neighbours.
+        r, g, b = to_rgba_array(fill)[0][:3]
+        luminance = 0.299 * r + 0.587 * g + 0.114 * b
+        ink, halo = ("black", "white") if luminance > 0.5 else ("white", "black")
         for rotation in (0, 90):
             # Turning the text swaps which way it has to fit.
             if rotation:
@@ -520,10 +527,10 @@ def _fit_labels(ax, placements, max_labels):
                 va="center",
                 rotation=rotation,
                 fontsize=size,
+                color=ink,
                 zorder=4,
                 clip_on=True,
-                # A dark fill would otherwise swallow the text sitting on it.
-                path_effects=[pe.withStroke(linewidth=1.3, foreground="white")],
+                path_effects=[pe.withStroke(linewidth=1.5, foreground=halo)],
             )
             break
 
@@ -803,6 +810,7 @@ def plot_lanes(
                     low + height / 2,
                     width,
                     height,
+                    row_color,
                 )
             )
         if boxes:

--- a/dascore/viz/_lanes.py
+++ b/dascore/viz/_lanes.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.collections import PatchCollection
-from matplotlib.colors import BoundaryNorm, ListedColormap, to_rgba_array
+from matplotlib.colors import BoundaryNorm, ListedColormap, to_rgba, to_rgba_array
 from matplotlib.font_manager import FontProperties
 from matplotlib.layout_engine import ConstrainedLayoutEngine
 from matplotlib.patches import Patch as PatchArtist
@@ -481,6 +481,36 @@ def _text_points(text: str, size: float) -> tuple[float, float]:
     return width, height
 
 
+def _over(top, bottom) -> tuple[float, float, float]:
+    """The color `top` shows as when drawn over the opaque `bottom`."""
+    red, green, blue, alpha = to_rgba(top)
+    pairs = zip((red, green, blue), bottom, strict=True)
+    return tuple(alpha * x + (1 - alpha) * y for x, y in pairs)
+
+
+def _label_colors(fill, background) -> tuple[str, str]:
+    """The ink and halo a label takes on a box of this fill.
+
+    Black text on a dark box is unreadable whatever halo it carries, so
+    the ink follows the box: whichever of black and white holds more
+    contrast against it, with the halo in the other tone so the letters
+    keep an edge on their neighbours. The fill is judged as it renders,
+    since "none" and any partly transparent color show the background
+    rather than themselves.
+    """
+    channels = np.asarray(_over(fill, background))
+    # Contrast as sRGB defines it, over channels the display linearizes.
+    # An average of the coded channels instead calls a saturated green
+    # dark and gives it white text, which reads worse on it than black.
+    linear = np.where(
+        channels <= 0.04045, channels / 12.92, ((channels + 0.055) / 1.055) ** 2.4
+    )
+    light = float(np.array([0.2126, 0.7152, 0.0722]) @ linear)
+    white_ink = (1.0 + 0.05) / (light + 0.05)
+    black_ink = (light + 0.05) / (0.0 + 0.05)
+    return ("white", "black") if white_ink > black_ink else ("black", "white")
+
+
 def _fit_labels(ax, placements, max_labels):
     """Draw each label the way it fits its box, and drop what cannot.
 
@@ -500,19 +530,18 @@ def _fit_labels(ax, placements, max_labels):
     scale = _MEASURED_DPI / figure.dpi
 
     size = plt.rcParams["font.size"] * 0.8
+    # What a fill with any transparency lets through: the axes, and the
+    # figure behind an axes which is itself transparent. White under
+    # both, since a figure saved to show through would read as black.
+    over_figure = _over(figure.get_facecolor(), (1.0, 1.0, 1.0))
+    background = _over(ax.get_facecolor(), over_figure)
     for text, x_mid, y_mid, width, height, fill in placements:
         if not text:
             continue
         box = _box_points(transform, scale, x_mid, y_mid, width, height)
         room = (box[0] - _LABEL_PAD, box[1] - _LABEL_PAD)
         taken = _text_points(text, size)
-        # Black text carries a halo of the box's own lightness poorly, and
-        # a halo alone cannot rescue it: match the text to the fill instead,
-        # dark ink on a light box, white on a dark one, with the halo in
-        # the opposite tone so the letters keep an edge on their neighbours.
-        r, g, b = to_rgba_array(fill)[0][:3]
-        luminance = 0.299 * r + 0.587 * g + 0.114 * b
-        ink, halo = ("black", "white") if luminance > 0.5 else ("white", "black")
+        ink, halo = _label_colors(fill, background)
         for rotation in (0, 90):
             # Turning the text swaps which way it has to fit.
             if rotation:
@@ -673,7 +702,9 @@ def plot_lanes(
         default: text as itself, a number as its digits, and a row which
         states no value nothing, since its lane already names it. Text
         too wide for its box is turned on its side, and dropped only
-        when it does not fit that way either.
+        when it does not fit that way either. Each label is inked in
+        whichever of black and white reads better on its own box, so a
+        dark fill carries white text and a light one black.
     lanes
         The lanes to draw, in order. Names with no rows are kept as empty
         lanes, so two figures of different subjects still line up.

--- a/tests/test_viz/test_lanes.py
+++ b/tests/test_viz/test_lanes.py
@@ -304,6 +304,43 @@ class TestLayout:
         assert inks["coal"] == to_rgba("white")
         assert inks["chalk"] == to_rgba("black")
 
+    def test_label_ink_follows_contrast_not_the_midpoint(self):
+        """A saturated mid-tone reads better in black, and gets it."""
+        # The palette's green averages below half yet holds nearly twice
+        # the contrast with black as with white.
+        frame = pd.DataFrame({"start": [0.0], "end": [100.0], "v": ["moss"]})
+        ax = plot_lanes(frame, value="v", color="#009E73")
+        assert to_rgba(ax.texts[0].get_color()) == to_rgba("black")
+
+    @pytest.mark.parametrize(
+        ("figure_color", "axes_color", "expected"),
+        [
+            ("white", "white", "black"),
+            ("white", "black", "white"),
+            # A transparent axes shows the figure, not the white default.
+            ("black", "none", "white"),
+        ],
+    )
+    def test_a_transparent_fill_is_inked_for_what_shows(
+        self, figure_color, axes_color, expected
+    ):
+        """A see-through fill is judged by what is behind it, not itself."""
+        # The same nearly clear black renders pale over white and dark
+        # over black, so the ink has to follow what shows through.
+        frame = pd.DataFrame({"start": [0.0], "end": [100.0], "v": ["haze"]})
+        figure, ax = plt.subplots()
+        figure.set_facecolor(figure_color)
+        ax.set_facecolor(axes_color)
+        plot_lanes(frame, ax=ax, value="v", color={"haze": (0.0, 0.0, 0.0, 0.1)})
+        assert to_rgba(ax.texts[0].get_color()) == to_rgba(expected)
+
+    def test_an_unpainted_box_still_labels(self):
+        """color="none" paints nothing, and its label takes the background."""
+        frame = pd.DataFrame({"start": [0.0], "end": [100.0], "v": ["clear"]})
+        ax = plot_lanes(frame, value="v", color="none")
+        assert _texts(ax) == ["clear"]
+        assert to_rgba(ax.texts[0].get_color()) == to_rgba("black")
+
     def test_a_narrow_box_turns_its_label(self):
         """Text too wide for its box is stood on end rather than dropped."""
         # Boxes narrower than the text but far taller than it is tall.

--- a/tests/test_viz/test_lanes.py
+++ b/tests/test_viz/test_lanes.py
@@ -294,6 +294,16 @@ class TestLayout:
         ax = plot_lanes(frame, value="v")
         assert _texts(ax) == ["wide"]
 
+    def test_label_ink_matches_its_fill(self):
+        """White ink on a dark box, dark ink on a light one, so both read."""
+        frame = pd.DataFrame(
+            {"start": [0.0, 50.0], "end": [50.0, 100.0], "v": ["coal", "chalk"]}
+        )
+        ax = plot_lanes(frame, value="v", color={"coal": "black", "chalk": "white"})
+        inks = {x.get_text(): to_rgba(x.get_color()) for x in ax.texts}
+        assert inks["coal"] == to_rgba("white")
+        assert inks["chalk"] == to_rgba("black")
+
     def test_a_narrow_box_turns_its_label(self):
         """Text too wide for its box is stood on end rather than dropped."""
         # Boxes narrower than the text but far taller than it is tall.


### PR DESCRIPTION
## Description

Lane labels (`viz.path`, and anything else drawn through `plot_lanes`) were always black text with a thin white halo. On dark fills -- the fiber-segment blue, the borehole colors -- the halo smears into the glyphs at laptop sizes and the labels become hard to read (reported by a tutorial reviewer testing the Galileo 2026 notebooks).

The ink is now picked by contrast against what the box actually renders as: black text with a white halo on light boxes, white text with a black halo on dark ones, so the letters keep an edge either way.

Three details the review turned up, each now covered by a test:

- A fill of `none` is a valid color which paints nothing, and `to_rgba_array` returns no row for it, so indexing one raised `IndexError` and took the whole figure down. Such a box is inked against the background.
- A fill with any alpha shows the axes through it, so the fill is composited over the axes background (and the figure behind a transparent axes) before it is judged.
- A weighted average of the gamma-coded channels is not lightness. It calls the palette's `#009E73` dark and inks it white, where black holds nearly twice the contrast; it mis-picks on 5 of the 17 default `tab10` and `viridis` fills. The choice is now the better of the two sRGB contrast ratios.

Before / after at 3x zoom on `inv.viz.path`:

| before | after |
| --- | --- |
| black-on-dark smears | white ink with dark halo |

(Images attached in a comment since the CLI cannot embed them.)

## Changelog

- fixed: lane labels in `viz.path` and other lane plots now pick their text color for contrast with the box fill, so labels on dark boxes stay readable.
- fixed: a lane drawn with `color="none"` no longer raises `IndexError` when its boxes carry labels.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lane label readability by selecting contrasting text and halo colors based on the visible box fill and background.
  * Improved label contrast for transparent fills, dark or light backgrounds, and saturated colors.
  * Ensured labels remain readable for unpainted boxes.
  * Increased halo visibility around labels for clearer presentation.

* **Tests**
  * Added coverage for label contrast across transparent fills, figure and axes backgrounds, saturated colors, and unpainted boxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

