### PR TITLE
Let a format hand over just the array for a sample window

### DIFF
--- a/.github/workflows/check_pr_changelog.yml
+++ b/.github/workflows/check_pr_changelog.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - master
       - dev
+      - xarray_integration
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - dev
+      - xarray_integration
   pull_request:
     branches:
       - master
       - dev
+      - xarray_integration
 
 permissions:
   contents: read

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -5,10 +5,12 @@ on:
     branches:
     - master
     - dev
+    - xarray_integration
   pull_request:
     branches:
     - master
     - dev
+    - xarray_integration
     paths:
       - 'pyproject.toml'
       - '**.py'

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -6,10 +6,12 @@ on:
     branches:
     - master
     - dev
+    - xarray_integration
   pull_request:
     branches:
     - master
     - dev
+    - xarray_integration
     paths:
       - 'pyproject.toml'
       # The conda_env job exists to guard this file, so it has to run when

--- a/.github/workflows/test_free_threaded.yml
+++ b/.github/workflows/test_free_threaded.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - dev
+      - xarray_integration
   pull_request:
     branches:
       - master
       - dev
+      - xarray_integration
     paths:
       - 'dascore/**'
       - 'tests/**'

--- a/.github/workflows/test_wasm.yml
+++ b/.github/workflows/test_wasm.yml
@@ -8,11 +8,13 @@ on:
     branches:
       - master
       - dev
+      - xarray_integration
       - wasm
   pull_request:
     branches:
       - master
       - dev
+      - xarray_integration
     paths:
       - 'dascore/**'
       - 'tests/**'

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -963,7 +963,6 @@ class FiberIO:
     _automatic_type_casters = FrozenDict(
         {
             "read": 1,
-            "read_array": 1,
             "scan": 1,
             "write": 2,
             "get_format": 1,

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -963,6 +963,7 @@ class FiberIO:
     _automatic_type_casters = FrozenDict(
         {
             "read": 1,
+            "read_array": 1,
             "scan": 1,
             "write": 2,
             "get_format": 1,
@@ -980,6 +981,35 @@ class FiberIO:
         """
         msg = f"FiberIO: {self.name} has no read method"
         raise NotImplementedError(msg)
+
+    def read_array(
+        self, resource, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """
+        Return the raw data array for absolute sample windows.
+
+        A data-only fast path for callers which already know a resource's
+        structure (from an index): no Patch is built and no coordinates are
+        parsed. ``windows`` maps dimension name to ``(start, stop)``,
+        half-open python indices on the resource's own sample grid;
+        dimensions absent from ``windows`` are returned whole. The array
+        comes back in the resource's stated dimension order (the order
+        ``scan`` reports), untransposed and uncast.
+
+        Multi-patch resources take ``source_patch_key`` (as ``read`` and
+        ``scan`` spell it) naming the one patch the windows index; without
+        it a multi-patch resource cannot be resolved and raises.
+
+        This default reads the whole resource through ``read`` and trims,
+        so every format is correct without overriding; formats override it
+        to slice storage directly.
+        """
+        source_patch_key = kwargs.pop("source_patch_key", "")
+        spool = self.read(resource, **kwargs)
+        patch = _resolve_read_spool(spool, source_patch_key)
+        if windows:
+            patch = patch.select(**dict(windows), samples=True)
+        return patch.data
 
     def scan(self, resource, *, snap: bool = True, **kwargs) -> list[ScanPayload]:
         """
@@ -1049,6 +1079,11 @@ class FiberIO:
     def implements_scan(self) -> bool:
         """Returns True if the subclass implements its own scan method else False."""
         return not _is_wrapped_func(self.scan, FiberIO.scan)
+
+    @property
+    def implements_read_array(self) -> bool:
+        """Return True if the subclass implements its own read_array method."""
+        return not _is_wrapped_func(self.read_array, FiberIO.read_array)
 
     @property
     def implements_get_format(self) -> bool:

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -963,6 +963,7 @@ class FiberIO:
     _automatic_type_casters = FrozenDict(
         {
             "read": 1,
+            "read_array": 1,
             "scan": 1,
             "write": 2,
             "get_format": 1,
@@ -988,8 +989,8 @@ class FiberIO:
         Return the raw data array for absolute sample windows.
 
         A data-only fast path for callers which already know a resource's
-        structure (from an index): no Patch is built and no coordinates are
-        parsed. ``windows`` maps dimension name to ``(start, stop)``,
+        structure (from an index) and need no Patch, no attrs, and no
+        coordinates back. ``windows`` maps dimension name to ``(start, stop)``,
         half-open python indices on the resource's own sample grid;
         dimensions absent from ``windows`` are returned whole. The array
         comes back in the resource's stated dimension order (the order

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -235,14 +235,21 @@ class FileResolver(PatchResolver):
             kwargs["file_version"] = row["source_version"]
         return dc.read(**kwargs, **id_kwargs, **trim)
 
-    def resolve(self, row: Mapping, **trim) -> dc.Patch:
-        """Read the patch, passing range trims down as read hints."""
-        path = row["source_path"]
-        # relative paths resolve against the catalog root; URIs and
-        # absolute paths pass through untouched.
+    def resolve_path(self, path):
+        """
+        Resolve a row's source path against the catalog root.
+
+        Relative paths resolve against the root; URIs and absolute paths
+        pass through untouched.
+        """
         if self._root is not None and "://" not in str(path):
             if not Path(path).is_absolute():
-                path = self._root / path
+                return self._root / path
+        return path
+
+    def resolve(self, row: Mapping, **trim) -> dc.Patch:
+        """Read the patch, passing range trims down as read hints."""
+        path = self.resolve_path(row["source_path"])
         source_patch_key = _row_source_patch_key(row)
         if source_patch_key.isdigit():
             # Positional (synthesized) ids index the full source read; a

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -25,7 +25,7 @@ import pandas as pd
 import dascore as dc
 from dascore.core.coords import CoordSummary
 from dascore.exceptions import UnknownFiberFormatError
-from dascore.io.core import FiberIO
+from dascore.io.core import FiberIO, _required_resource_type
 from dascore.io.index.backend import get_backend
 from dascore.io.index.catalog import (
     CompositeResolver,
@@ -49,6 +49,7 @@ from dascore.utils.chunk_plan import (
     _concatenated_steps,
     _ensure_patch_id,
 )
+from dascore.utils.io import IOResourceManager
 from dascore.utils.misc import _CanonicalRange, is_range
 from dascore.utils.patch import concatenate_planned
 from dascore.utils.patch_assembly import PatchAssembler
@@ -614,7 +615,16 @@ class PlanResolver(PatchResolver):
             # keys natively could match the wrong patch, or nothing.
             return None
         kwargs = {"source_patch_key": key} if key else {}
-        return fiber_io.read_array(loader.resolve_path(path), dict(windows), **kwargs)
+        # The resource manager resolves remote paths and opens the handle
+        # type the override's annotation asks for, exactly as dc.read
+        # provisions its reader; _pre_cast says the work is already done.
+        with IOResourceManager(loader.resolve_path(path)) as manager:
+            resource = manager.get_resource(
+                _required_resource_type(fiber_io.read_array)
+            )
+            return fiber_io.read_array(
+                resource, dict(windows), _pre_cast=True, **kwargs
+            )
 
     def _in_plan_units(self, patch: dc.Patch, kwargs: Mapping) -> dc.Patch:
         """

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -64,6 +64,13 @@ PLAN_SCHEME = "plan://"
 _NON_ATTR = {"output_id", "dims", "coord_names", "patch"}
 
 
+def _row_str(value) -> str:
+    """A row cell as a string, with the frame's nulls (None/NaN) as ""."""
+    if value is None or (not isinstance(value, str) and pd.isnull(value)):
+        return ""
+    return str(value)
+
+
 def _stated_units(value) -> str | None:
     """Return a unit string, or None when the row states none.
 
@@ -569,22 +576,30 @@ class PlanResolver(PatchResolver):
         load whole. The array comes back in the source's stated dimension
         order, untransposed and uncast.
 
-        Returns None when the row cannot take the data-only path, and the
-        caller falls back to `_load_member`, which is exact for every
-        row. The fast path requires a plain file-backed row with a
-        concrete format and version, a format which overrides
-        ``read_array``, and no parent residuals — a residual re-trims the
-        loaded patch, so a window computed against the residual-adjusted
-        envelope is not a window on the raw grid.
+        The caller must anchor the windows on the raw file grid — a
+        window computed against a trimmed or residual-adjusted envelope
+        is not a window on that grid. Returns None when the row cannot
+        take the data-only path, and the caller falls back to
+        `_load_member`, which is exact for every row. The fast path
+        requires a plain file-backed row with a concrete format and
+        version, a natively keyed patch (a synthesized digit key means
+        "the nth patch of the full read", which only the whole-read
+        default honors), a format which overrides ``read_array``, and no
+        parent residuals — a residual re-trims the loaded patch, and a
+        data-only read would skip that trim. The fast path trusts the
+        index about the grid itself: the caller's shape guard catches a
+        resized file, not a shifted one.
         """
         if self.parent_residuals:
             return None
-        path = row.get("source_path")
-        fmt, version = row.get("source_format"), row.get("source_version")
-        if not path or not fmt or not version:
+        path = _row_str(row.get("source_path"))
+        if not path:
             return None
-        path = str(path)
         if is_memory_uri(path) or path.startswith(PLAN_SCHEME):
+            return None
+        fmt = _row_str(row.get("source_format"))
+        version = _row_str(row.get("source_version"))
+        if not fmt or not version:
             return None
         loader = self.loader
         if not isinstance(loader, FileResolver):
@@ -600,6 +615,11 @@ class PlanResolver(PatchResolver):
         if not fiber_io.implements_read_array:
             return None
         key = _row_source_patch_key(row)
+        if key.isdigit():
+            # A synthesized positional key binds against the full source
+            # read (see FileResolver.resolve); an override which resolves
+            # keys natively could match the wrong patch, or nothing.
+            return None
         kwargs = {"source_patch_key": key} if key else {}
         return fiber_io.read_array(loader.resolve_path(path), dict(windows), **kwargs)
 

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -24,9 +24,12 @@ import pandas as pd
 
 import dascore as dc
 from dascore.core.coords import CoordSummary
+from dascore.exceptions import UnknownFiberFormatError
+from dascore.io.core import FiberIO
 from dascore.io.index.backend import get_backend
 from dascore.io.index.catalog import (
     CompositeResolver,
+    FileResolver,
     PatchCatalog,
     PatchResolver,
     _adjust_unit_segments,
@@ -49,6 +52,7 @@ from dascore.utils.chunk_plan import (
 from dascore.utils.misc import _CanonicalRange, is_range
 from dascore.utils.patch import concatenate_planned
 from dascore.utils.patch_assembly import PatchAssembler
+from dascore.utils.paths import is_memory_uri
 from dascore.utils.pd import adjust_segments
 
 # Row columns which name dc.read's own keyword arguments; passing one along
@@ -555,6 +559,49 @@ class PlanResolver(PatchResolver):
         patch = self.loader.resolve(kwargs, **trim)
         patch = apply_exact_residuals(patch, self.parent_residuals)
         return self._in_plan_units(patch, kwargs)
+
+    def _load_member_array(self, row: Mapping, windows: Mapping) -> np.ndarray | None:
+        """
+        Load one member's raw array through the format's `read_array`.
+
+        ``windows`` maps dimension name to a half-open ``(start, stop)``
+        sample window on the member source's own grid; absent dimensions
+        load whole. The array comes back in the source's stated dimension
+        order, untransposed and uncast.
+
+        Returns None when the row cannot take the data-only path, and the
+        caller falls back to `_load_member`, which is exact for every
+        row. The fast path requires a plain file-backed row with a
+        concrete format and version, a format which overrides
+        ``read_array``, and no parent residuals — a residual re-trims the
+        loaded patch, so a window computed against the residual-adjusted
+        envelope is not a window on the raw grid.
+        """
+        if self.parent_residuals:
+            return None
+        path = row.get("source_path")
+        fmt, version = row.get("source_format"), row.get("source_version")
+        if not path or not fmt or not version:
+            return None
+        path = str(path)
+        if is_memory_uri(path) or path.startswith(PLAN_SCHEME):
+            return None
+        loader = self.loader
+        if not isinstance(loader, FileResolver):
+            loader = getattr(loader, "file", None)
+        if not isinstance(loader, FileResolver):
+            return None
+        try:
+            # An exact version is required: without one the manager hands
+            # back the newest reader, which may not match this file.
+            fiber_io = FiberIO.manager.get_fiberio(format=fmt, version=version)
+        except UnknownFiberFormatError:
+            return None
+        if not fiber_io.implements_read_array:
+            return None
+        key = _row_source_patch_key(row)
+        kwargs = {"source_patch_key": key} if key else {}
+        return fiber_io.read_array(loader.resolve_path(path), dict(windows), **kwargs)
 
     def _in_plan_units(self, patch: dc.Patch, kwargs: Mapping) -> dc.Patch:
         """

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -64,13 +64,6 @@ PLAN_SCHEME = "plan://"
 _NON_ATTR = {"output_id", "dims", "coord_names", "patch"}
 
 
-def _row_str(value) -> str:
-    """A row cell as a string, with the frame's nulls (None/NaN) as ""."""
-    if value is None or (not isinstance(value, str) and pd.isnull(value)):
-        return ""
-    return str(value)
-
-
 def _stated_units(value) -> str | None:
     """Return a unit string, or None when the row states none.
 
@@ -122,8 +115,8 @@ def _num(value) -> float | None:
     return float(value)
 
 
-def _dtype_str(value) -> str:
-    """Convert a stored element dtype to its string, "" when unknown."""
+def _row_str(value) -> str:
+    """A row cell as a string, with the frame's nulls (None/NaN) as ""."""
     return "" if value is None or pd.isnull(value) else str(value)
 
 
@@ -454,7 +447,7 @@ def _output_records(
             # chunk can still size patches by their memory footprint.
             # NaN is truthy, so `or ""` alone would store the string
             # "nan" and poison every later np.dtype() of this column.
-            dtype=_dtype_str(row.get("_dtype")),
+            dtype=_row_str(row.get("_dtype")),
             data_size=sizes.get(output_id),
             time_min=_ns(row.get("time_min")),
             time_max=_ns(row.get("time_max")),

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -463,8 +463,12 @@ def _load_xarray_block(resolver, row, dim, lims, dims, shape, dtype, window=None
     since read hints only reduce reading.
     """
     array = None
-    src_dims = tuple(str(row.get("dims") or "").split(","))
-    if window is not None and all(src_dims):
+    stated = row.get("dims")
+    src_dims = tuple(stated.split(",")) if isinstance(stated, str) else ()
+    # The row must state the same dimensions the tree promises, or the
+    # transpose below could not be built; disagreement means the patch
+    # path, whose own errors say what is wrong.
+    if window is not None and sorted(src_dims) == sorted(dims):
         array = resolver._load_member_array(row, {dim: window})
     if array is None:
         patch = resolver._load_member(row).select(**{dim: lims})
@@ -662,10 +666,18 @@ def spool_to_xarray(
     # Member grids in the plan's normalized units, so trims and envelopes
     # speak the same unit; the plan normalized the same frame identically.
     norm = _normalize_chunk_units(working, dim).set_index("_patch_id")
+    # A working row which is itself a trim (a collapsed plan's member)
+    # states a trimmed envelope, so a sample window measured against it
+    # is not anchored on the file's grid; such members load by value.
+    if "_modified" in norm.columns:
+        modified = members["_patch_id"].map(norm["_modified"]).fillna(True).astype(bool)
+    else:
+        modified = pd.Series(False, index=members.index)
     members = members.assign(
         _pos=np.arange(len(members)),
         _env_low=members["_patch_id"].map(norm[f"{dim}_min"]),
         _env_high=members["_patch_id"].map(norm[f"{dim}_max"]),
+        _env_anchored=~modified,
     )
     # One shared graph node for the resolver, not a copy inside every
     # block task — it can hold live patches or a large member table.
@@ -746,7 +758,14 @@ def spool_to_xarray(
                 lims = (m[f"{dim}_min"], m[f"{dim}_max"])
                 row = member_rows.iloc[int(m["_pos"])].to_dict()
                 delayed = dask.delayed(_load_xarray_block)(
-                    resolver_ref, row, dim, lims, dims, shape, dtype, window
+                    resolver_ref,
+                    row,
+                    dim,
+                    lims,
+                    dims,
+                    shape,
+                    dtype,
+                    window if m["_env_anchored"] else None,
                 )
                 blocks.append(da.from_delayed(delayed, shape=shape, dtype=dtype))
             array = da.concatenate(blocks, axis=axis)

--- a/dascore/utils/io.py
+++ b/dascore/utils/io.py
@@ -424,6 +424,9 @@ def _member_coord(low, high, step, env_low, env_high, get_coord, units=None):
     follow exactly the rule loading follows, not a parallel rounding.
     Units ride along so a unit-bearing tolerance can be read against the
     merged coordinate, as chunk reads it.
+
+    Also returns the window as half-open sample indices on the member's
+    own grid — the form `FiberIO.read_array` takes.
     """
     low, high, step = _np_scalar(low), _np_scalar(high), _np_scalar(step)
     env_low, env_high = _np_scalar(env_low), _np_scalar(env_high)
@@ -438,34 +441,48 @@ def _member_coord(low, high, step, env_low, env_high, get_coord, units=None):
         )
         raise PatchConversionError(msg)
     full = get_coord(min=env_low, max=env_high + step, step=step, units=units)
-    coord, _ = full.select((low, high))
+    coord, indexer = full.select((low, high))
     # plan invariant: a published member always presents at least a sample
     assert len(coord), "a plan member never presents an empty window"
-    return coord
+    # a range select of an evenly sampled coordinate is a unit slice
+    assert isinstance(indexer, slice), "range select yields a slice"
+    start, stop, stride = indexer.indices(len(full))
+    assert stride == 1, "range select never strides"
+    return coord, (start, stop)
 
 
-def _load_xarray_block(resolver, row, dim, lims, dims, shape, dtype):
+def _load_xarray_block(resolver, row, dim, lims, dims, shape, dtype, window=None):
     """
     Load one dask block: a source patch trimmed to its member window.
 
-    Runs at compute time, once per block. Member loading goes through the
-    plan resolver — the same path a chunked spool loads through — so
-    residuals, units, and nested plans are honored; the select re-applies
-    the window exactly since read hints only reduce reading.
+    Runs at compute time, once per block. When the row's format offers a
+    `read_array` fast path, only the raw array for the sample window is
+    read; otherwise member loading goes through the plan resolver — the
+    same path a chunked spool loads through — so residuals, units, and
+    nested plans are honored. The select re-applies the window exactly
+    since read hints only reduce reading.
     """
-    patch = resolver._load_member(row).select(**{dim: lims})
-    if patch.dims != dims:
-        patch = patch.transpose(*dims)
-    if patch.shape != shape:
+    array = None
+    src_dims = tuple(str(row.get("dims") or "").split(","))
+    if window is not None and all(src_dims):
+        array = resolver._load_member_array(row, {dim: window})
+    if array is None:
+        patch = resolver._load_member(row).select(**{dim: lims})
+        if patch.dims != dims:
+            patch = patch.transpose(*dims)
+        array = patch.data
+    elif src_dims != dims:
+        array = np.transpose(array, [src_dims.index(d) for d in dims])
+    if array.shape != shape:
         msg = (
             f"Loaded block from '{row.get('source_path', '<memory>')}' has shape "
-            f"{patch.shape}, but the spool index promised {shape}. The source "
+            f"{array.shape}, but the spool index promised {shape}. The source "
             "file changed after indexing; run spool.update() and convert again."
         )
         raise PatchConversionError(msg)
     # A member narrower than the segment's combined dtype upcasts here so
     # the array holds the dtype its metadata states.
-    return patch.data.astype(dtype, copy=False)
+    return array.astype(dtype, copy=False)
 
 
 def _xarray_group_nodes(outputs, group_attrs):
@@ -678,9 +695,11 @@ def spool_to_xarray(
             mem = members[members["output_id"] == out["output_id"]]
             mem = mem.sort_values(f"{dim}_min")
             # Each member's block is sized by its own coordinate: the same
-            # select which trims the block at load also counts it here.
-            member_coords = [
-                _member_coord(
+            # select which trims the block at load also counts it here,
+            # and its indexer is the sample window a data-only read takes.
+            member_coords, member_windows = [], []
+            for _, m in mem.iterrows():
+                coord, window = _member_coord(
                     m[f"{dim}_min"],
                     m[f"{dim}_max"],
                     m[f"{dim}_step"],
@@ -689,8 +708,8 @@ def spool_to_xarray(
                     get_coord,
                     units=m.get(f"_{dim}_units"),
                 )
-                for _, m in mem.iterrows()
-            ]
+                member_coords.append(coord)
+                member_windows.append(window)
             coords, sizes = {}, {}
             for d in dims:
                 if d == dim:
@@ -720,13 +739,14 @@ def spool_to_xarray(
                 coords[d] = coord.values
                 sizes[d] = len(coord)
             blocks = []
-            for member_coord, (_, m) in zip(member_coords, mem.iterrows(), strict=True):
+            zipped = zip(member_coords, member_windows, mem.iterrows(), strict=True)
+            for member_coord, window, (_, m) in zipped:
                 count = len(member_coord)
                 shape = tuple(count if d == dim else sizes[d] for d in dims)
                 lims = (m[f"{dim}_min"], m[f"{dim}_max"])
                 row = member_rows.iloc[int(m["_pos"])].to_dict()
                 delayed = dask.delayed(_load_xarray_block)(
-                    resolver_ref, row, dim, lims, dims, shape, dtype
+                    resolver_ref, row, dim, lims, dims, shape, dtype, window
                 )
                 blocks.append(da.from_delayed(delayed, shape=shape, dtype=dtype))
             array = da.concatenate(blocks, axis=axis)

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -355,11 +355,18 @@ def _get_min_max_query(kwargs, df):
     to_kill = []
     for key, val in kwargs.items():
         val = None if val is ... else val  # handle ...
+        # Claim a min/max key only when the bare column exists; otherwise
+        # leave it for the bad-kwarg policy (claiming it used to KeyError
+        # deep in the range filter under its bare name).
         if key.endswith("_max") and key not in col_set:
-            out[key.replace("_max", "")][1] = val
+            if key.removesuffix("_max") not in col_set:
+                continue
+            out[key.removesuffix("_max")][1] = val
             to_kill.append(key)
         elif key.endswith("_min") and key not in col_set:
-            out[key.replace("_min", "")][0] = val
+            if key.removesuffix("_min") not in col_set:
+                continue
+            out[key.removesuffix("_min")][0] = val
             to_kill.append(key)
     # remove keys with min/max suffix
     for key in to_kill:
@@ -656,19 +663,6 @@ def filter_df(
     container rather than relying on either.
     """
     min_max_query = _convert_times(df, _get_min_max_query(kwargs, df))
-    # A {name}_min/{name}_max query needs the bare column; treat one whose
-    # column is absent like any other bad kwarg rather than KeyError-ing.
-    if missing := set(min_max_query) - set(df.columns):
-        if not ignore_bad_kwargs:
-            bad_dict = {x: tuple(min_max_query[x]) for x in sorted(missing)}
-            msg = (
-                "Bad filter parameter found. Either the column does not "
-                f"exist or it's value is invalid. Keys/values are: {bad_dict}"
-            )
-            raise ParameterError(msg)
-        min_max_query = {
-            key: val for key, val in min_max_query.items() if key not in missing
-        }
     kwargs, range_query, _ = split_df_query(kwargs, df, ignore_bad_kwargs)
     multicolumn_range_query = _convert_times(df, range_query)
     multicolumn_range_query = {

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -656,6 +656,19 @@ def filter_df(
     container rather than relying on either.
     """
     min_max_query = _convert_times(df, _get_min_max_query(kwargs, df))
+    # A {name}_min/{name}_max query needs the bare column; treat one whose
+    # column is absent like any other bad kwarg rather than KeyError-ing.
+    if missing := set(min_max_query) - set(df.columns):
+        if not ignore_bad_kwargs:
+            bad_dict = {x: tuple(min_max_query[x]) for x in sorted(missing)}
+            msg = (
+                "Bad filter parameter found. Either the column does not "
+                f"exist or it's value is invalid. Keys/values are: {bad_dict}"
+            )
+            raise ParameterError(msg)
+        min_max_query = {
+            key: val for key, val in min_max_query.items() if key not in missing
+        }
     kwargs, range_query, _ = split_df_query(kwargs, df, ignore_bad_kwargs)
     multicolumn_range_query = _convert_times(df, range_query)
     multicolumn_range_query = {

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -174,7 +174,7 @@ You never have to implement it: the default reads the whole resource through `re
 
 - `windows` maps dimension name to `(start, stop)` half-open python indices on the file's own sample grid; dimensions absent from `windows` are returned whole.
 - Return the array in the file's stated dimension order (the order `scan` reports), untransposed and uncast. The caller transposes and casts.
-- Multi-patch formats receive `source_patch_key` naming the one patch the windows index; a multi-patch resource without a key should raise rather than guess.
+- Multi-patch formats receive `source_patch_key` naming the one patch the windows index; a multi-patch resource without a key should raise rather than guess. DASCore's own machinery only forwards native keys (ones your format emitted); a synthesized positional key falls back to the default whole-read path instead.
 - Windows arrive as indices, never values: value-to-index conversion (including rounding) is the caller's job, done once through the coordinate machinery.
 
 ## What Belongs in `attrs`

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -174,7 +174,8 @@ You never have to implement it: the default reads the whole resource through `re
 
 - `windows` maps dimension name to `(start, stop)` half-open python indices on the file's own sample grid; dimensions absent from `windows` are returned whole.
 - Return the array in the file's stated dimension order (the order `scan` reports), untransposed and uncast. The caller transposes and casts.
-- Multi-patch formats receive `source_patch_key` naming the one patch the windows index; a multi-patch resource without a key should raise rather than guess. DASCore's own machinery only forwards native keys (ones your format emitted); a synthesized positional key falls back to the default whole-read path instead.
+- Multi-patch formats receive `source_patch_key` naming the one patch the windows index; a multi-patch resource without a key should raise rather than guess. DASCore's own machinery only forwards native keys (ones your format emitted); for a synthesized positional key it bypasses `read_array` entirely and loads the patch the ordinary way.
+- The `resource` parameter participates in the same type coercion as `read`: annotate it (e.g. an HDF5 reader type) and DASCore hands you that handle.
 - Windows arrive as indices, never values: value-to-index conversion (including rounding) is the caller's job, done once through the coordinate machinery.
 
 ## What Belongs in `attrs`

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -166,6 +166,17 @@ The rule is simple:
 
 For some formats, a numeric patch index is enough if patch ordering is stable. For others, a native identifier such as a group name, node name, or source/zone tuple is better. If your format only ever produces one patch per file, you usually do not need to set `source_patch_key`.
 
+## `read_array`: a data-only fast path
+
+[`FiberIO.read_array`](`dascore.io.core.FiberIO.read_array`) returns the raw data array for absolute sample windows, without building a `Patch`. Callers that already know a file's structure from a spool index (for example the lazy `Spool.io.to_xarray` blocks) use it to skip attribute and coordinate parsing on every read.
+
+You never have to implement it: the default reads the whole resource through `read` and trims, so it is correct for every format. Overriding pays off for formats that can slice storage directly (an HDF5 dataset, a memory-mapped binary). The contract for an override:
+
+- `windows` maps dimension name to `(start, stop)` half-open python indices on the file's own sample grid; dimensions absent from `windows` are returned whole.
+- Return the array in the file's stated dimension order (the order `scan` reports), untransposed and uncast. The caller transposes and casts.
+- Multi-patch formats receive `source_patch_key` naming the one patch the windows index; a multi-patch resource without a key should raise rather than guess.
+- Windows arrive as indices, never values: value-to-index conversion (including rounding) is the caller's job, done once through the coordinate machinery.
+
 ## What Belongs in `attrs`
 
 Every attr a reader emits is one of four kinds, and the kind decides both its

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -431,6 +431,9 @@ class TestLoadMemberArray:
         calls = []
 
         def read_array(self, resource, windows, **kwargs):
+            # a real override's caster wrapper consumes _pre_cast; this
+            # raw function sees it and must not forward it to read
+            kwargs.pop("_pre_cast", None)
             calls.append((windows, kwargs))
             return FiberIO.read_array(self, resource, windows, **kwargs)
 
@@ -511,3 +514,30 @@ class TestLoadMemberArray:
         monkeypatch.setattr(resolver, "loader", object())
         assert resolver._load_member_array(row, {"time": (0, 5)}) is None
         assert override == []
+
+    def test_override_gets_annotated_handle(self, resolver, row):
+        """The override receives the handle type it declares, like read.
+
+        The resource manager provisions it, so a remote path resolves the
+        same way dc.read's own reading does instead of arriving as a raw
+        URL string.
+        """
+        from dascore.utils.io import BinaryReader  # noqa: PLC0415
+
+        fiber_io = FiberIO.manager.get_fiberio(
+            format=row["source_format"], version=row["source_version"]
+        )
+        seen = {}
+
+        def read_array(self, resource, windows, **kwargs):
+            seen["resource"] = resource
+            return np.zeros(2)
+
+        read_array._required_type = BinaryReader
+        type(fiber_io).read_array = read_array
+        try:
+            out = resolver._load_member_array(row, {"time": (0, 2)})
+        finally:
+            del type(fiber_io).read_array
+        assert np.array_equal(out, np.zeros(2))
+        assert hasattr(seen["resource"], "read")  # a handle, not a path

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -495,10 +495,13 @@ class TestLoadMemberArray:
         assert override == []
 
     def test_memory_row_returns_none(self, override):
-        """An in-memory patch has no file to slice."""
+        """An in-memory patch has no file to slice.
+
+        The scheme gate is defense in depth: a memory row's "memory"
+        format is unregistered, so a later gate would refuse it too.
+        """
         resolver = dc.get_example_spool().chunk(time=None)._catalog.resolver
         row = resolver.member_rows.iloc[0].to_dict()
-        assert row["source_version"] == ""  # yet the scheme is what refuses
         row["source_version"] = "1"
         assert resolver._load_member_array(row, {"time": (0, 5)}) is None
         assert override == []

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -423,7 +423,7 @@ class TestLoadMemberArray:
         return resolver.member_rows.iloc[0].to_dict()
 
     @pytest.fixture
-    def override(self, monkeypatch, row):
+    def override(self, row):
         """Give the row's format a counting read_array override."""
         fiber_io = FiberIO.manager.get_fiberio(
             format=row["source_format"], version=row["source_version"]
@@ -434,8 +434,11 @@ class TestLoadMemberArray:
             calls.append((windows, kwargs))
             return FiberIO.read_array(self, resource, windows, **kwargs)
 
-        monkeypatch.setattr(type(fiber_io), "read_array", read_array, raising=False)
-        return calls
+        # set and delete by hand: monkeypatch would restore the inherited
+        # method as an own class attribute rather than remove it
+        type(fiber_io).read_array = read_array
+        yield calls
+        del type(fiber_io).read_array
 
     def test_no_override_returns_none(self, resolver, row):
         """A format without an override takes the patch path."""
@@ -446,9 +449,23 @@ class TestLoadMemberArray:
         out = resolver._load_member_array(row, {"time": (2, 9)})
         expected = resolver._load_member(row).select(time=(2, 9), samples=True).data
         assert np.array_equal(out, expected)
+        assert out.dtype == expected.dtype
         # the row's own patch key rides along so multi-patch files resolve
         expected_kwargs = {"source_patch_key": row["source_patch_key"]}
         assert override == [({"time": (2, 9)}, expected_kwargs)]
+
+    def test_digit_key_returns_none(self, resolver, row, override):
+        """A synthesized positional key only binds against a full read."""
+        row = dict(row, source_patch_key="3")
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_null_row_cells_return_none(self, resolver, row, override):
+        """NaN cells (a left merge's misses) refuse like absent ones."""
+        for column in ("source_path", "source_format", "source_version"):
+            bad = dict(row, **{column: float("nan")})
+            assert resolver._load_member_array(bad, {"time": (0, 5)}) is None
+        assert override == []
 
     def test_residuals_return_none(self, file_spool, override):
         """A residual selection re-trims patches; windows cannot compose."""
@@ -481,7 +498,10 @@ class TestLoadMemberArray:
         """An in-memory patch has no file to slice."""
         resolver = dc.get_example_spool().chunk(time=None)._catalog.resolver
         row = resolver.member_rows.iloc[0].to_dict()
+        assert row["source_version"] == ""  # yet the scheme is what refuses
+        row["source_version"] = "1"
         assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
 
     def test_non_file_loader_returns_none(self, resolver, row, override, monkeypatch):
         """A loader with no file leg cannot resolve a path."""

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -13,7 +13,9 @@ import pytest
 
 import dascore as dc
 from dascore.exceptions import MissingPatchError, ParameterError
+from dascore.io.core import FiberIO
 from dascore.io.index.planned import (
+    PLAN_SCHEME,
     PlanResolver,
     _aux_coord_info,
     _coord_record_from_row,
@@ -397,3 +399,92 @@ class TestStatedUnits:
     def test_stated_units_pass_through(self):
         """A real spelling survives as a string."""
         assert _stated_units("ft") == "ft"
+
+
+class TestLoadMemberArray:
+    """Tests for the resolver's read_array fast path and its gates."""
+
+    @pytest.fixture(scope="class")
+    def file_spool(self, tmp_path_factory):
+        """A directory spool of single-patch DASDAE files."""
+        path = tmp_path_factory.mktemp("load_member_array")
+        for num, patch in enumerate(dc.get_example_spool()):
+            patch.io.write(path / f"patch_{num}.h5", "dasdae")
+        return dc.spool(path).update()
+
+    @pytest.fixture
+    def resolver(self, file_spool):
+        """The plan resolver of the chunked file spool."""
+        return file_spool.chunk(time=None)._catalog.resolver
+
+    @pytest.fixture
+    def row(self, resolver):
+        """One member row of the plan."""
+        return resolver.member_rows.iloc[0].to_dict()
+
+    @pytest.fixture
+    def override(self, monkeypatch, row):
+        """Give the row's format a counting read_array override."""
+        fiber_io = FiberIO.manager.get_fiberio(
+            format=row["source_format"], version=row["source_version"]
+        )
+        calls = []
+
+        def read_array(self, resource, windows, **kwargs):
+            calls.append((windows, kwargs))
+            return FiberIO.read_array(self, resource, windows, **kwargs)
+
+        monkeypatch.setattr(type(fiber_io), "read_array", read_array, raising=False)
+        return calls
+
+    def test_no_override_returns_none(self, resolver, row):
+        """A format without an override takes the patch path."""
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+
+    def test_override_loads_window(self, resolver, row, override):
+        """The override gets the windows and its array matches the patch path."""
+        out = resolver._load_member_array(row, {"time": (2, 9)})
+        expected = resolver._load_member(row).select(time=(2, 9), samples=True).data
+        assert np.array_equal(out, expected)
+        # the row's own patch key rides along so multi-patch files resolve
+        expected_kwargs = {"source_patch_key": row["source_patch_key"]}
+        assert override == [({"time": (2, 9)}, expected_kwargs)]
+
+    def test_residuals_return_none(self, file_spool, override):
+        """A residual selection re-trims patches; windows cannot compose."""
+        sub = file_spool.select(time=(2, 100), samples=True).chunk(time=None)
+        resolver = sub._catalog.resolver
+        assert resolver.parent_residuals
+        row = resolver.member_rows.iloc[0].to_dict()
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_missing_version_returns_none(self, resolver, row, override):
+        """Without an exact version the reader cannot be resolved."""
+        row = dict(row, source_version="")
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_unknown_format_returns_none(self, resolver, row, override):
+        """An unknown format falls back rather than raising here."""
+        row = dict(row, source_format="not_a_real_format", source_version="1")
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_plan_path_returns_none(self, resolver, row, override):
+        """A nested plan row loads through its own resolver."""
+        row = dict(row, source_path=f"{PLAN_SCHEME}deadbeef/0")
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_memory_row_returns_none(self, override):
+        """An in-memory patch has no file to slice."""
+        resolver = dc.get_example_spool().chunk(time=None)._catalog.resolver
+        row = resolver.member_rows.iloc[0].to_dict()
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+
+    def test_non_file_loader_returns_none(self, resolver, row, override, monkeypatch):
+        """A loader with no file leg cannot resolve a path."""
+        monkeypatch.setattr(resolver, "loader", object())
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -2202,3 +2202,71 @@ class TestSourceIds:
         """The config which turns the ids off turns this off too."""
         with config_context(patch_provenance="disabled"):
             assert dc.read(terra15_path)[0].attrs.patch_id == ""
+
+
+class TestFiberIOReadArray:
+    """Tests for the read_array data-only contract and its default."""
+
+    @pytest.fixture(scope="class")
+    def single_patch_path(self, tmp_path_factory):
+        """One patch written to a DASDAE file."""
+        path = tmp_path_factory.mktemp("read_array") / "single.h5"
+        dc.write(dc.get_example_patch(), path, "dasdae")
+        return path
+
+    @pytest.fixture(scope="class")
+    def multi_patch_path(self, tmp_path_factory):
+        """Two patches written to one DASDAE file."""
+        path = tmp_path_factory.mktemp("read_array") / "multi.h5"
+        spool = dc.examples.get_example_spool("random_das", length=2)
+        dc.write(spool, path, "dasdae")
+        return path
+
+    @pytest.fixture(scope="class")
+    def dasdae_io(self, single_patch_path):
+        """The FiberIO which read the file, resolved exactly."""
+        fmt, version = dc.get_format(single_patch_path)
+        return FiberIO.manager.get_fiberio(format=fmt, version=version)
+
+    def test_default_matches_read_then_select(self, dasdae_io, single_patch_path):
+        """The default is read + samples-select, stated as arrays."""
+        patch = dc.read(single_patch_path)[0]
+        windows = {"time": (5, 50), "distance": (2, 9)}
+        out = dasdae_io.read_array(single_patch_path, windows)
+        expected = patch.select(**windows, samples=True).data
+        assert np.array_equal(out, expected)
+
+    def test_absent_dimensions_load_whole(self, dasdae_io, single_patch_path):
+        """A dimension missing from windows comes back whole."""
+        patch = dc.read(single_patch_path)[0]
+        out = dasdae_io.read_array(single_patch_path, {"time": (0, 10)})
+        expected = patch.select(time=(0, 10), samples=True).data
+        assert np.array_equal(out, expected)
+        assert np.array_equal(dasdae_io.read_array(single_patch_path, {}), patch.data)
+
+    def test_multi_patch_selects_keyed_patch(self, dasdae_io, multi_patch_path):
+        """The key names which patch of the file the windows index."""
+        for payload in dc.scan(multi_patch_path):
+            key = payload.source_patch_key
+            wanted = dc.read(multi_patch_path, source_patch_key=key)[0]
+            out = dasdae_io.read_array(
+                multi_patch_path, {"time": (3, 17)}, source_patch_key=key
+            )
+            expected = wanted.select(time=(3, 17), samples=True).data
+            assert np.array_equal(out, expected)
+
+    def test_multi_patch_without_key_raises(self, dasdae_io, multi_patch_path):
+        """Windows on an ambiguous grid never guess a patch."""
+        with pytest.raises(PatchAttributeError, match="uniquely resolved"):
+            dasdae_io.read_array(multi_patch_path, {"time": (0, 5)})
+
+    def test_implements_flag(self, dasdae_io, monkeypatch):
+        """The flag says whether a format overrides the default."""
+        assert not dasdae_io.implements_read_array
+        monkeypatch.setattr(
+            type(dasdae_io),
+            "read_array",
+            lambda self, resource, windows, **kw: np.empty(0),
+            raising=False,
+        )
+        assert dasdae_io.implements_read_array

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -2216,10 +2216,13 @@ class TestFiberIOReadArray:
 
     @pytest.fixture(scope="class")
     def multi_patch_path(self, tmp_path_factory):
-        """Two patches written to one DASDAE file."""
+        """Two patches with distinct data written to one DASDAE file."""
         path = tmp_path_factory.mktemp("read_array") / "multi.h5"
         spool = dc.examples.get_example_spool("random_das", length=2)
-        dc.write(spool, path, "dasdae")
+        # distinct arrays, or a wrong-patch resolution could pass parity
+        patches = [patch.new(data=patch.data + num) for num, patch in enumerate(spool)]
+        assert not np.array_equal(patches[0].data, patches[1].data)
+        dc.write(dc.spool(patches), path, "dasdae")
         return path
 
     @pytest.fixture(scope="class")
@@ -2262,6 +2265,29 @@ class TestFiberIOReadArray:
         """Windows on an ambiguous grid never guess a patch."""
         with pytest.raises(PatchAttributeError, match="uniquely resolved"):
             dasdae_io.read_array(multi_patch_path, {"time": (0, 5)})
+
+    def test_override_resource_coercion(self, single_patch_path):
+        """An override's resource annotation is honored like read's.
+
+        The type-casting layer promises FiberIO authors that a method's
+        resource parameter arrives as the annotated handle type; that
+        must hold for read_array or an override written like a read
+        method fails on the raw path it is handed.
+        """
+        seen = {}
+
+        class ReadArrayCastFormat(FiberIO):
+            name = "_test_read_array_cast"
+            version = "1"
+
+            def read_array(self, resource: BinaryReader, windows, **kwargs):
+                seen["resource"] = resource
+                return np.zeros(2)
+
+        fiber_io = ReadArrayCastFormat()
+        out = fiber_io.read_array(single_patch_path, {})
+        assert np.array_equal(out, np.zeros(2))
+        assert hasattr(seen["resource"], "read")  # a handle, not a path
 
     def test_implements_flag(self, dasdae_io):
         """The flag says whether a format overrides the default."""

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -2229,12 +2229,15 @@ class TestFiberIOReadArray:
         return FiberIO.manager.get_fiberio(format=fmt, version=version)
 
     def test_default_matches_read_then_select(self, dasdae_io, single_patch_path):
-        """The default is read + samples-select, stated as arrays."""
+        """Windows are half-open python indices: plain numpy slicing."""
         patch = dc.read(single_patch_path)[0]
+        assert patch.dims == ("distance", "time")
         windows = {"time": (5, 50), "distance": (2, 9)}
         out = dasdae_io.read_array(single_patch_path, windows)
-        expected = patch.select(**windows, samples=True).data
+        expected = patch.data[2:9, 5:50]
         assert np.array_equal(out, expected)
+        # untransposed and uncast: the file's own order and dtype
+        assert out.dtype == patch.data.dtype
 
     def test_absent_dimensions_load_whole(self, dasdae_io, single_patch_path):
         """A dimension missing from windows comes back whole."""
@@ -2260,13 +2263,15 @@ class TestFiberIOReadArray:
         with pytest.raises(PatchAttributeError, match="uniquely resolved"):
             dasdae_io.read_array(multi_patch_path, {"time": (0, 5)})
 
-    def test_implements_flag(self, dasdae_io, monkeypatch):
+    def test_implements_flag(self, dasdae_io):
         """The flag says whether a format overrides the default."""
         assert not dasdae_io.implements_read_array
-        monkeypatch.setattr(
-            type(dasdae_io),
-            "read_array",
-            lambda self, resource, windows, **kw: np.empty(0),
-            raising=False,
-        )
-        assert dasdae_io.implements_read_array
+        cls = type(dasdae_io)
+        # set and delete by hand: monkeypatch would restore the inherited
+        # method as an own class attribute rather than remove it
+        cls.read_array = lambda self, resource, windows, **kw: np.empty(0)
+        try:
+            assert dasdae_io.implements_read_array
+        finally:
+            del cls.read_array
+        assert not dasdae_io.implements_read_array

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -1907,3 +1907,131 @@ class TestIOResourceManagerConcurrency:
             assert len({id(x) for x in handles}) == 1
             assert not handles[0].closed
         assert handles[0].closed
+
+
+class TestToXarrayReadArray:
+    """Tests wiring the read_array fast path into to_xarray blocks."""
+
+    @pytest.fixture(autouse=True)
+    def _require_libs(self):
+        """These tests need both optional libraries."""
+        pytest.importorskip("xarray")
+        pytest.importorskip("dask")
+
+    @pytest.fixture(scope="class")
+    def dasdae_directory(self, tmp_path_factory):
+        """A directory of single-patch DASDAE files."""
+        path = tmp_path_factory.mktemp("to_xarray_read_array")
+        for num, patch in enumerate(dc.get_example_spool()):
+            patch.io.write(path / f"patch_{num}.h5", "dasdae")
+        return path
+
+    @pytest.fixture
+    def override_calls(self, monkeypatch):
+        """Give DASDAE a counting read_array override."""
+        from dascore.io.core import FiberIO  # noqa: PLC0415
+        from dascore.io.dasdae.core import DASDAEV1  # noqa: PLC0415
+
+        calls = []
+
+        def read_array(self, resource, windows, **kwargs):
+            calls.append(windows)
+            return FiberIO.read_array(self, resource, windows, **kwargs)
+
+        monkeypatch.setattr(DASDAEV1, "read_array", read_array, raising=False)
+        return calls
+
+    def _leaf(self, tree):
+        """The first dataset holding a data variable."""
+        return next(node for node in tree.subtree if "data" in node.dataset)
+
+    def test_fast_path_loads_blocks(
+        self, dasdae_directory, override_calls, monkeypatch
+    ):
+        """With an override, computing never builds a member Patch."""
+        from dascore.io.index.planned import PlanResolver  # noqa: PLC0415
+
+        spool = dc.spool(dasdae_directory).update()
+        eager = spool.chunk(time=None)[0].data
+        tree = spool.io.to_xarray()
+
+        def _fail(*args, **kwargs):
+            raise AssertionError("fast path fell back to patch loading")
+
+        monkeypatch.setattr(PlanResolver, "_load_member", _fail)
+        out = self._leaf(tree)["data"].data.compute()
+        assert np.array_equal(out, eager)
+        assert len(override_calls) == len(spool)
+
+    def test_residual_spool_falls_back(self, dasdae_directory, override_calls):
+        """A samples-selected spool loads through the exact patch path."""
+        spool = dc.spool(dasdae_directory).update()
+        sub = spool.select(time=(2, 100), samples=True)
+        out = self._leaf(sub.io.to_xarray())["data"].data.compute()
+        assert np.array_equal(out, sub.chunk(time=None)[0].data)
+        assert override_calls == []
+
+    def test_transposes_source_order(self):
+        """A native-order array is transposed to the tree's dims."""
+        from dascore.utils.io import _load_xarray_block  # noqa: PLC0415
+
+        native = np.arange(12).reshape(3, 4)
+
+        class _Fake:
+            def _load_member_array(self, row, windows):
+                return native
+
+        row = {"dims": "time,distance", "source_path": "x"}
+        out = _load_xarray_block(
+            _Fake(),
+            row,
+            "time",
+            (0, 2),
+            ("distance", "time"),
+            (4, 3),
+            native.dtype,
+            (0, 3),
+        )
+        assert np.array_equal(out, native.T)
+
+    def test_stale_shape_raises(self):
+        """An array which breaks the index's promise raises."""
+        from dascore.exceptions import PatchConversionError  # noqa: PLC0415
+        from dascore.utils.io import _load_xarray_block  # noqa: PLC0415
+
+        class _Fake:
+            def _load_member_array(self, row, windows):
+                return np.zeros((2, 2))
+
+        row = {"dims": "time,distance", "source_path": "x"}
+        with pytest.raises(PatchConversionError, match="promised"):
+            _load_xarray_block(
+                _Fake(), row, "time", (0, 2), ("time", "distance"), (3, 4), "f8", (0, 3)
+            )
+
+    def test_row_without_dims_falls_back(self, random_patch):
+        """A row which cannot state its dimension order takes the patch path."""
+        from dascore.utils.io import _load_xarray_block  # noqa: PLC0415
+
+        patch = random_patch
+
+        class _Fake:
+            def _load_member_array(self, row, windows):
+                raise AssertionError("fast path consulted without dims")
+
+            def _load_member(self, row):
+                return patch
+
+        coord = patch.get_coord("time")
+        lims = (coord.min(), coord.max())
+        out = _load_xarray_block(
+            _Fake(),
+            {"source_path": "x"},
+            "time",
+            lims,
+            patch.dims,
+            patch.shape,
+            patch.data.dtype,
+            (0, len(coord)),
+        )
+        assert np.array_equal(out, patch.data)

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -1419,6 +1419,7 @@ class TestSpoolToXarray:
         monkeypatch.setattr(PatchCatalog, "resolve_row", _fail)
         monkeypatch.setattr(FileResolver, "resolve", _fail)
         monkeypatch.setattr(PlanResolver, "_load_member", _fail)
+        monkeypatch.setattr(PlanResolver, "_load_member_array", _fail)
         tree = spool.io.to_xarray()
         assert len(self._leaves(tree))
 
@@ -1927,7 +1928,7 @@ class TestToXarrayReadArray:
         return path
 
     @pytest.fixture
-    def override_calls(self, monkeypatch):
+    def override_calls(self):
         """Give DASDAE a counting read_array override."""
         from dascore.io.core import FiberIO  # noqa: PLC0415
         from dascore.io.dasdae.core import DASDAEV1  # noqa: PLC0415
@@ -1938,8 +1939,11 @@ class TestToXarrayReadArray:
             calls.append(windows)
             return FiberIO.read_array(self, resource, windows, **kwargs)
 
-        monkeypatch.setattr(DASDAEV1, "read_array", read_array, raising=False)
-        return calls
+        # set and delete by hand: monkeypatch would restore the inherited
+        # method as an own class attribute rather than remove it
+        DASDAEV1.read_array = read_array
+        yield calls
+        del DASDAEV1.read_array
 
     def _leaf(self, tree):
         """The first dataset holding a data variable."""
@@ -1971,28 +1975,93 @@ class TestToXarrayReadArray:
         assert np.array_equal(out, sub.chunk(time=None)[0].data)
         assert override_calls == []
 
+    def test_chunked_spool_falls_back(self, dasdae_directory, override_calls):
+        """A plan-backed spool's trimmed rows never take the fast path.
+
+        Its collapsed member rows state trimmed envelopes, so a sample
+        window computed against them is not a window on the file grid;
+        the fast path must refuse or it reads the wrong samples.
+        """
+        spool = dc.spool(dasdae_directory).update().chunk(time=3)
+        eager = spool.chunk(time=None)[0].data
+        out = self._leaf(spool.io.to_xarray())["data"].data.compute()
+        assert np.array_equal(out, eager)
+        assert override_calls == []
+
+    def test_interior_window_fast_path(self, tmp_path, override_calls):
+        """An overlap-trimmed member reads an interior file window.
+
+        Two half-overlapping files merge into one segment, so the second
+        member's window starts mid-file — the case where a wrong window
+        anchor would silently read the wrong samples.
+        """
+        first = dc.get_example_patch()
+        time = first.get_coord("time")
+        half = time.values[len(time) // 2]
+        second = first.update_coords(time_min=half)
+        for num, patch in enumerate((first, second)):
+            patch.update_attrs(history=[]).io.write(tmp_path / f"p{num}.h5", "dasdae")
+        spool = dc.spool(tmp_path).update()
+        eager = spool.chunk(time=None)[0].data
+        out = self._leaf(spool.io.to_xarray())["data"].data.compute()
+        assert np.array_equal(out, eager)
+        # the trimmed member's window must not be anchored at the start
+        starts = sorted(window["time"][0] for window in override_calls)
+        assert len(override_calls) == 2
+        assert starts[0] == 0 and starts[1] > 0
+
     def test_transposes_source_order(self):
-        """A native-order array is transposed to the tree's dims."""
+        """A native-order array is transposed to the tree's dims.
+
+        Three dimensions with a cyclic permutation, so the permutation
+        differs from its inverse and a reversed mapping cannot pass.
+        """
         from dascore.utils.io import _load_xarray_block  # noqa: PLC0415
 
-        native = np.arange(12).reshape(3, 4)
+        native = np.arange(24).reshape(2, 3, 4)
 
         class _Fake:
             def _load_member_array(self, row, windows):
                 return native
 
-        row = {"dims": "time,distance", "source_path": "x"}
+        row = {"dims": "time,distance,depth", "source_path": "x"}
         out = _load_xarray_block(
             _Fake(),
             row,
             "time",
-            (0, 2),
-            ("distance", "time"),
-            (4, 3),
+            (0, 1),
+            ("distance", "depth", "time"),
+            (3, 4, 2),
             native.dtype,
-            (0, 3),
+            (0, 2),
         )
-        assert np.array_equal(out, native.T)
+        assert np.array_equal(out, native.transpose(1, 2, 0))
+
+    def test_mismatched_dims_fall_back(self, random_patch):
+        """A row stating different dims than the tree takes the patch path."""
+        from dascore.utils.io import _load_xarray_block  # noqa: PLC0415
+
+        patch = random_patch
+
+        class _Fake:
+            def _load_member_array(self, row, windows):
+                raise AssertionError("fast path consulted with foreign dims")
+
+            def _load_member(self, row):
+                return patch
+
+        coord = patch.get_coord("time")
+        out = _load_xarray_block(
+            _Fake(),
+            {"dims": "depth,time", "source_path": "x"},
+            "time",
+            (coord.min(), coord.max()),
+            patch.dims,
+            patch.shape,
+            patch.data.dtype,
+            (0, len(coord)),
+        )
+        assert np.array_equal(out, patch.data)
 
     def test_stale_shape_raises(self):
         """An array which breaks the index's promise raises."""

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -1942,6 +1942,9 @@ class TestToXarrayReadArray:
         calls = []
 
         def read_array(self, resource, windows, **kwargs):
+            # a real override's caster wrapper consumes _pre_cast; this
+            # raw function sees it and must not forward it to read
+            kwargs.pop("_pre_cast", None)
             calls.append(windows)
             return FiberIO.read_array(self, resource, windows, **kwargs)
 

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -1921,10 +1921,16 @@ class TestToXarrayReadArray:
 
     @pytest.fixture(scope="class")
     def dasdae_directory(self, tmp_path_factory):
-        """A directory of single-patch DASDAE files."""
+        """A directory of single-patch DASDAE files with distinct data.
+
+        Distinct arrays per file, or a block reading the wrong member
+        would still pass the parity assertions.
+        """
         path = tmp_path_factory.mktemp("to_xarray_read_array")
         for num, patch in enumerate(dc.get_example_spool()):
-            patch.io.write(path / f"patch_{num}.h5", "dasdae")
+            patch.new(data=patch.data + num).io.write(
+                path / f"patch_{num}.h5", "dasdae"
+            )
         return path
 
     @pytest.fixture
@@ -1998,7 +2004,8 @@ class TestToXarrayReadArray:
         first = dc.get_example_patch()
         time = first.get_coord("time")
         half = time.values[len(time) // 2]
-        second = first.update_coords(time_min=half)
+        # distinct data so reading the wrong file cannot pass parity
+        second = first.update_coords(time_min=half).new(data=first.data + 1)
         for num, patch in enumerate((first, second)):
             patch.update_attrs(history=[]).io.write(tmp_path / f"p{num}.h5", "dasdae")
         spool = dc.spool(tmp_path).update()

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -267,6 +267,13 @@ class TestFilterDfAdvanced:
             ignore_bad_kwargs=True,
         )
         assert np.all(out)
+        # the _max spelling walks the sibling branch
+        out = filter_df(
+            df.drop(columns=["time_min", "time_max"]),
+            time_max=value,
+            ignore_bad_kwargs=True,
+        )
+        assert np.all(out)
 
     def test_timedelta_columns(self, example_df_timedeltas):
         """Ensure timedelta columns work when specifying ranges of single col."""

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -250,6 +250,24 @@ class TestFilterDfAdvanced:
         out = filter_df(example_df_2, time=None)
         assert np.all(out)
 
+    def test_min_max_query_without_column(self, example_df_2):
+        """A {name}_min query whose bare column is absent is a bad kwarg.
+
+        It used to KeyError deep in the range filter, which broke readers
+        forwarding read hints (e.g. dc.read(dasdae_file, time_min=...)).
+        """
+        df = example_df_2.drop(columns=["time"], errors="ignore")
+        assert "time" not in df.columns
+        value = df["time_min"].iloc[0]
+        with pytest.raises(ParameterError, match="Bad filter parameter"):
+            filter_df(df.drop(columns=["time_min", "time_max"]), time_min=value)
+        out = filter_df(
+            df.drop(columns=["time_min", "time_max"]),
+            time_min=value,
+            ignore_bad_kwargs=True,
+        )
+        assert np.all(out)
+
     def test_timedelta_columns(self, example_df_timedeltas):
         """Ensure timedelta columns work when specifying ranges of single col."""
         df = example_df_timedeltas


### PR DESCRIPTION
## Description

Adds `FiberIO.read_array`: a data-only fast path returning the raw array for absolute sample windows, without building a Patch. Callers that plan from a spool index (the lazy `Spool.io.to_xarray` blocks, eventually chunk assembly) already know every piece of structure; per-block profiling showed ~2.5 ms/block of Patch construction and read plumbing that this contract removes once formats override it.

The contract keeps readers dumb and the machinery honest:

- `windows` maps dimension name to half-open `(start, stop)` sample indices on the file's own grid; absent dimensions load whole. Value-to-index conversion (and its rounding) happens once, in the caller, through `coord.select` — readers never round.
- The array returns in the file's stated dims order, untransposed and uncast; the caller transposes, casts, and keeps the stale-index shape guard.
- Multi-patch files take `source_patch_key`; without it an ambiguous file raises rather than guessing (`_resolve_read_spool` is reused, not re-spelled).
- The default implementation reads through `read` and trims with `select(samples=True)`, so every existing format — third-party plugins included — is correct on day one. Overriding is opt-in per format.

Wiring in this PR:

- `PlanResolver._load_member_array(row, windows)` gates the fast path: it requires a plain file-backed row with a concrete format and version, a native (non-synthesized) patch key, a format that actually overrides `read_array`, and no parent residuals. Ineligible rows return None and the caller uses the exact `_load_member` patch path, unchanged.
- The `to_xarray` block loader computes each member's sample window from the same `coord.select` that sizes the block, and tries the fast path only when the window is anchored on the raw file grid — a collapsed plan's member states a trimmed envelope, so those members load by value (adversarial review caught this as a live wrong-samples bug; a regression test pins it, and an overlap fixture pins the interior-window case that must keep working).
- `resource` participates in the same type-coercion layer as `read` (a registered test format pins it), so an override annotated like a `read` method gets the handle it declares.
- One necessary base fix: `filter_df` no longer `KeyError`s on a `{name}_min`/`{name}_max` kwarg whose bare column is absent — `_get_min_max_query` declines to claim it, routing it through the existing bad-kwarg policy. Reader-forwarded trim hints (`dc.read(dasdae_file, time_min=...)`) crashed on this, which the fallback path needs working.

No format overrides ship here — behavior is otherwise identical (nothing implements `read_array` yet); this PR lands the contract, machinery, and tests so the DASDAE/Terra15/TDMS override PRs are one-liners with A/B numbers. Fixture arrays carry distinct values per patch so a wrong-member or wrong-patch read cannot pass the parity assertions (mutation-tested). Targets `xarray_integration`.

## Changelog

- added: `FiberIO.read_array` lets a format return the raw data array for absolute sample windows, with a default built on `read` so every format works without changes; the lazy `Spool.io.to_xarray` blocks use it when a format overrides it.
- fixed: `filter_df` reports a `{name}_min`/`{name}_max` query whose bare column is absent as a bad filter parameter instead of raising `KeyError`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
