### PR TITLE
Let a format hand over just the array for a sample window

### DIFF
--- a/.github/workflows/check_pr_changelog.yml
+++ b/.github/workflows/check_pr_changelog.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - master
       - dev
+      - xarray_integration
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - dev
+      - xarray_integration
   pull_request:
     branches:
       - master
       - dev
+      - xarray_integration
 
 permissions:
   contents: read

--- a/.github/workflows/run_min_dep_tests.yml
+++ b/.github/workflows/run_min_dep_tests.yml
@@ -5,10 +5,12 @@ on:
     branches:
     - master
     - dev
+    - xarray_integration
   pull_request:
     branches:
     - master
     - dev
+    - xarray_integration
     paths:
       - 'pyproject.toml'
       - '**.py'

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -6,10 +6,12 @@ on:
     branches:
     - master
     - dev
+    - xarray_integration
   pull_request:
     branches:
     - master
     - dev
+    - xarray_integration
     paths:
       - 'pyproject.toml'
       # The conda_env job exists to guard this file, so it has to run when

--- a/.github/workflows/test_free_threaded.yml
+++ b/.github/workflows/test_free_threaded.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - dev
+      - xarray_integration
   pull_request:
     branches:
       - master
       - dev
+      - xarray_integration
     paths:
       - 'dascore/**'
       - 'tests/**'

--- a/.github/workflows/test_wasm.yml
+++ b/.github/workflows/test_wasm.yml
@@ -8,11 +8,13 @@ on:
     branches:
       - master
       - dev
+      - xarray_integration
       - wasm
   pull_request:
     branches:
       - master
       - dev
+      - xarray_integration
     paths:
       - 'dascore/**'
       - 'tests/**'

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -963,6 +963,7 @@ class FiberIO:
     _automatic_type_casters = FrozenDict(
         {
             "read": 1,
+            "read_array": 1,
             "scan": 1,
             "write": 2,
             "get_format": 1,
@@ -980,6 +981,35 @@ class FiberIO:
         """
         msg = f"FiberIO: {self.name} has no read method"
         raise NotImplementedError(msg)
+
+    def read_array(
+        self, resource, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """
+        Return the raw data array for absolute sample windows.
+
+        A data-only fast path for callers which already know a resource's
+        structure (from an index) and need no Patch, no attrs, and no
+        coordinates back. ``windows`` maps dimension name to ``(start, stop)``,
+        half-open python indices on the resource's own sample grid;
+        dimensions absent from ``windows`` are returned whole. The array
+        comes back in the resource's stated dimension order (the order
+        ``scan`` reports), untransposed and uncast.
+
+        Multi-patch resources take ``source_patch_key`` (as ``read`` and
+        ``scan`` spell it) naming the one patch the windows index; without
+        it a multi-patch resource cannot be resolved and raises.
+
+        This default reads the whole resource through ``read`` and trims,
+        so every format is correct without overriding; formats override it
+        to slice storage directly.
+        """
+        source_patch_key = kwargs.pop("source_patch_key", "")
+        spool = self.read(resource, **kwargs)
+        patch = _resolve_read_spool(spool, source_patch_key)
+        if windows:
+            patch = patch.select(**dict(windows), samples=True)
+        return patch.data
 
     def scan(self, resource, *, snap: bool = True, **kwargs) -> list[ScanPayload]:
         """
@@ -1049,6 +1079,11 @@ class FiberIO:
     def implements_scan(self) -> bool:
         """Returns True if the subclass implements its own scan method else False."""
         return not _is_wrapped_func(self.scan, FiberIO.scan)
+
+    @property
+    def implements_read_array(self) -> bool:
+        """Return True if the subclass implements its own read_array method."""
+        return not _is_wrapped_func(self.read_array, FiberIO.read_array)
 
     @property
     def implements_get_format(self) -> bool:

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -989,20 +989,40 @@ class FiberIO:
         Return the raw data array for absolute sample windows.
 
         A data-only fast path for callers which already know a resource's
-        structure (from an index) and need no Patch, no attrs, and no
-        coordinates back. ``windows`` maps dimension name to ``(start, stop)``,
-        half-open python indices on the resource's own sample grid;
-        dimensions absent from ``windows`` are returned whole. The array
-        comes back in the resource's stated dimension order (the order
+        structure (from an index) and need no Patch, attrs, or
+        coordinates back. This default reads the whole resource through
+        ``read`` and trims — a Patch is still built internally, just not
+        returned — so every format is correct without overriding; formats
+        override it to slice storage directly and skip the Patch work.
+
+        Parameters
+        ----------
+        resource
+            The resource to read, as ``read`` takes it.
+        windows
+            Maps dimension name to ``(start, stop)`` half-open python
+            indices on the resource's own sample grid. Dimensions absent
+            from the mapping are returned whole.
+        **kwargs
+            Reader-specific options. Multi-patch resources take
+            ``source_patch_key`` (as ``read`` and ``scan`` spell it)
+            naming the one patch the windows index; without it an
+            ambiguous resource raises rather than guesses.
+
+        Returns
+        -------
+        The array in the resource's stated dimension order (the order
         ``scan`` reports), untransposed and uncast.
 
-        Multi-patch resources take ``source_patch_key`` (as ``read`` and
-        ``scan`` spell it) naming the one patch the windows index; without
-        it a multi-patch resource cannot be resolved and raises.
-
-        This default reads the whole resource through ``read`` and trims,
-        so every format is correct without overriding; formats override it
-        to slice storage directly.
+        Examples
+        --------
+        >>> from dascore.io.dasdae.core import DASDAEV1
+        >>> from dascore.utils.downloader import fetch
+        >>>
+        >>> path = fetch("example_dasdae_event_1.h5")
+        >>> array = DASDAEV1().read_array(path, {"time": (0, 50)})
+        >>> array.shape
+        (601, 50)
         """
         source_patch_key = kwargs.pop("source_patch_key", "")
         spool = self.read(resource, **kwargs)

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -235,14 +235,21 @@ class FileResolver(PatchResolver):
             kwargs["file_version"] = row["source_version"]
         return dc.read(**kwargs, **id_kwargs, **trim)
 
-    def resolve(self, row: Mapping, **trim) -> dc.Patch:
-        """Read the patch, passing range trims down as read hints."""
-        path = row["source_path"]
-        # relative paths resolve against the catalog root; URIs and
-        # absolute paths pass through untouched.
+    def resolve_path(self, path):
+        """
+        Resolve a row's source path against the catalog root.
+
+        Relative paths resolve against the root; URIs and absolute paths
+        pass through untouched.
+        """
         if self._root is not None and "://" not in str(path):
             if not Path(path).is_absolute():
-                path = self._root / path
+                return self._root / path
+        return path
+
+    def resolve(self, row: Mapping, **trim) -> dc.Patch:
+        """Read the patch, passing range trims down as read hints."""
+        path = self.resolve_path(row["source_path"])
         source_patch_key = _row_source_patch_key(row)
         if source_patch_key.isdigit():
             # Positional (synthesized) ids index the full source read; a

--- a/dascore/io/index/catalog.py
+++ b/dascore/io/index/catalog.py
@@ -235,7 +235,7 @@ class FileResolver(PatchResolver):
             kwargs["file_version"] = row["source_version"]
         return dc.read(**kwargs, **id_kwargs, **trim)
 
-    def resolve_path(self, path):
+    def resolve_path(self, path: str | Path) -> str | Path:
         """
         Resolve a row's source path against the catalog root.
 

--- a/dascore/io/index/planned.py
+++ b/dascore/io/index/planned.py
@@ -24,9 +24,12 @@ import pandas as pd
 
 import dascore as dc
 from dascore.core.coords import CoordSummary
+from dascore.exceptions import UnknownFiberFormatError
+from dascore.io.core import FiberIO, _required_resource_type
 from dascore.io.index.backend import get_backend
 from dascore.io.index.catalog import (
     CompositeResolver,
+    FileResolver,
     PatchCatalog,
     PatchResolver,
     _adjust_unit_segments,
@@ -46,9 +49,11 @@ from dascore.utils.chunk_plan import (
     _concatenated_steps,
     _ensure_patch_id,
 )
+from dascore.utils.io import IOResourceManager
 from dascore.utils.misc import _CanonicalRange, is_range
 from dascore.utils.patch import concatenate_planned
 from dascore.utils.patch_assembly import PatchAssembler
+from dascore.utils.paths import is_memory_uri
 from dascore.utils.pd import adjust_segments
 
 # Row columns which name dc.read's own keyword arguments; passing one along
@@ -111,8 +116,8 @@ def _num(value) -> float | None:
     return float(value)
 
 
-def _dtype_str(value) -> str:
-    """Convert a stored element dtype to its string, "" when unknown."""
+def _row_str(value) -> str:
+    """A row cell as a string, with the frame's nulls (None/NaN) as ""."""
     return "" if value is None or pd.isnull(value) else str(value)
 
 
@@ -443,7 +448,7 @@ def _output_records(
             # chunk can still size patches by their memory footprint.
             # NaN is truthy, so `or ""` alone would store the string
             # "nan" and poison every later np.dtype() of this column.
-            dtype=_dtype_str(row.get("_dtype")),
+            dtype=_row_str(row.get("_dtype")),
             data_size=sizes.get(output_id),
             time_min=_ns(row.get("time_min")),
             time_max=_ns(row.get("time_max")),
@@ -555,6 +560,71 @@ class PlanResolver(PatchResolver):
         patch = self.loader.resolve(kwargs, **trim)
         patch = apply_exact_residuals(patch, self.parent_residuals)
         return self._in_plan_units(patch, kwargs)
+
+    def _load_member_array(self, row: Mapping, windows: Mapping) -> np.ndarray | None:
+        """
+        Load one member's raw array through the format's `read_array`.
+
+        ``windows`` maps dimension name to a half-open ``(start, stop)``
+        sample window on the member source's own grid; absent dimensions
+        load whole. The array comes back in the source's stated dimension
+        order, untransposed and uncast.
+
+        The caller must anchor the windows on the raw file grid — a
+        window computed against a trimmed or residual-adjusted envelope
+        is not a window on that grid. Returns None when the row cannot
+        take the data-only path, and the caller falls back to
+        `_load_member`, which is exact for every row. The fast path
+        requires a plain file-backed row with a concrete format and
+        version, a natively keyed patch (a synthesized digit key means
+        "the nth patch of the full read", which only the whole-read
+        default honors), a format which overrides ``read_array``, and no
+        parent residuals — a residual re-trims the loaded patch, and a
+        data-only read would skip that trim. The fast path trusts the
+        index about the grid itself: the caller's shape guard catches a
+        resized file, not a shifted one.
+        """
+        if self.parent_residuals:
+            return None
+        path = _row_str(row.get("source_path"))
+        if not path:
+            return None
+        if is_memory_uri(path) or path.startswith(PLAN_SCHEME):
+            return None
+        fmt = _row_str(row.get("source_format"))
+        version = _row_str(row.get("source_version"))
+        if not fmt or not version:
+            return None
+        loader = self.loader
+        if not isinstance(loader, FileResolver):
+            loader = getattr(loader, "file", None)
+        if not isinstance(loader, FileResolver):
+            return None
+        try:
+            # An exact version is required: without one the manager hands
+            # back the newest reader, which may not match this file.
+            fiber_io = FiberIO.manager.get_fiberio(format=fmt, version=version)
+        except UnknownFiberFormatError:
+            return None
+        if not fiber_io.implements_read_array:
+            return None
+        key = _row_source_patch_key(row)
+        if key.isdigit():
+            # A synthesized positional key binds against the full source
+            # read (see FileResolver.resolve); an override which resolves
+            # keys natively could match the wrong patch, or nothing.
+            return None
+        kwargs = {"source_patch_key": key} if key else {}
+        # The resource manager resolves remote paths and opens the handle
+        # type the override's annotation asks for, exactly as dc.read
+        # provisions its reader; _pre_cast says the work is already done.
+        with IOResourceManager(loader.resolve_path(path)) as manager:
+            resource = manager.get_resource(
+                _required_resource_type(fiber_io.read_array)
+            )
+            return fiber_io.read_array(
+                resource, dict(windows), _pre_cast=True, **kwargs
+            )
 
     def _in_plan_units(self, patch: dc.Patch, kwargs: Mapping) -> dc.Patch:
         """

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -355,11 +355,18 @@ def _get_min_max_query(kwargs, df):
     to_kill = []
     for key, val in kwargs.items():
         val = None if val is ... else val  # handle ...
+        # Claim a min/max key only when the bare column exists; otherwise
+        # leave it for the bad-kwarg policy (claiming it used to KeyError
+        # deep in the range filter under its bare name).
         if key.endswith("_max") and key not in col_set:
-            out[key.replace("_max", "")][1] = val
+            if key.removesuffix("_max") not in col_set:
+                continue
+            out[key.removesuffix("_max")][1] = val
             to_kill.append(key)
         elif key.endswith("_min") and key not in col_set:
-            out[key.replace("_min", "")][0] = val
+            if key.removesuffix("_min") not in col_set:
+                continue
+            out[key.removesuffix("_min")][0] = val
             to_kill.append(key)
     # remove keys with min/max suffix
     for key in to_kill:

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -166,6 +166,18 @@ The rule is simple:
 
 For some formats, a numeric patch index is enough if patch ordering is stable. For others, a native identifier such as a group name, node name, or source/zone tuple is better. If your format only ever produces one patch per file, you usually do not need to set `source_patch_key`.
 
+## `read_array`: a data-only fast path
+
+[`FiberIO.read_array`](`dascore.io.core.FiberIO.read_array`) returns the raw data array for absolute sample windows, without building a `Patch`. Callers that already know a file's structure from a spool index (for example the lazy `Spool.io.to_xarray` blocks) use it to skip attribute and coordinate parsing on every read.
+
+You never have to implement it: the default reads the whole resource through `read` and trims, so it is correct for every format. Overriding pays off for formats that can slice storage directly (an HDF5 dataset, a memory-mapped binary). The contract for an override:
+
+- `windows` maps dimension name to `(start, stop)` half-open python indices on the file's own sample grid; dimensions absent from `windows` are returned whole.
+- Return the array in the file's stated dimension order (the order `scan` reports), untransposed and uncast. The caller transposes and casts.
+- Multi-patch formats receive `source_patch_key` naming the one patch the windows index; a multi-patch resource without a key should raise rather than guess. DASCore's own machinery only forwards native keys (ones your format emitted); for a synthesized positional key it bypasses `read_array` entirely and loads the patch the ordinary way.
+- The `resource` parameter participates in the same type coercion as `read`: annotate it (e.g. an HDF5 reader type) and DASCore hands you that handle.
+- Windows arrive as indices, never values: value-to-index conversion (including rounding) is the caller's job, done once through the coordinate machinery.
+
 ## What Belongs in `attrs`
 
 Every attr a reader emits is one of four kinds, and the kind decides both its

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -168,7 +168,7 @@ For some formats, a numeric patch index is enough if patch ordering is stable. F
 
 ## `read_array`: a data-only fast path
 
-[`FiberIO.read_array`](`dascore.io.core.FiberIO.read_array`) returns the raw data array for absolute sample windows, without building a `Patch`. Callers that already know a file's structure from a spool index (for example the lazy `Spool.io.to_xarray` blocks) use it to skip attribute and coordinate parsing on every read.
+[`FiberIO.read_array`](`dascore.io.core.FiberIO.read_array`) returns the raw data array for absolute sample windows, without building a `Patch`. Callers that already know a file's structure from a spool index use it to skip attribute and coordinate parsing on every read.
 
 You never have to implement it: the default reads the whole resource through `read` and trims, so it is correct for every format. Overriding pays off for formats that can slice storage directly (an HDF5 dataset, a memory-mapped binary). The contract for an override:
 

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -168,7 +168,7 @@ For some formats, a numeric patch index is enough if patch ordering is stable. F
 
 ## `read_array`: a data-only fast path
 
-[`FiberIO.read_array`](`dascore.io.core.FiberIO.read_array`) returns the raw data array for absolute sample windows, without building a `Patch`. Callers that already know a file's structure from a spool index use it to skip attribute and coordinate parsing on every read.
+[`FiberIO.read_array`](`dascore.io.core.FiberIO.read_array`) returns the raw data array for absolute sample windows, without returning a `Patch` (the default still builds one internally; direct-storage overrides skip it). Callers that already know a file's structure from a spool index use it to skip attribute and coordinate parsing on every read.
 
 You never have to implement it: the default reads the whole resource through `read` and trims, so it is correct for every format. Overriding pays off for formats that can slice storage directly (an HDF5 dataset, a memory-mapped binary). The contract for an override:
 

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -13,7 +13,9 @@ import pytest
 
 import dascore as dc
 from dascore.exceptions import MissingPatchError, ParameterError
+from dascore.io.core import FiberIO
 from dascore.io.index.planned import (
+    PLAN_SCHEME,
     PlanResolver,
     _aux_coord_info,
     _coord_record_from_row,
@@ -397,3 +399,145 @@ class TestStatedUnits:
     def test_stated_units_pass_through(self):
         """A real spelling survives as a string."""
         assert _stated_units("ft") == "ft"
+
+
+class TestLoadMemberArray:
+    """Tests for the resolver's read_array fast path and its gates."""
+
+    @pytest.fixture(scope="class")
+    def file_spool(self, tmp_path_factory):
+        """A directory spool of single-patch DASDAE files."""
+        path = tmp_path_factory.mktemp("load_member_array")
+        for num, patch in enumerate(dc.get_example_spool()):
+            patch.io.write(path / f"patch_{num}.h5", "dasdae")
+        return dc.spool(path).update()
+
+    @pytest.fixture
+    def resolver(self, file_spool):
+        """The plan resolver of the chunked file spool."""
+        return file_spool.chunk(time=None)._catalog.resolver
+
+    @pytest.fixture
+    def row(self, resolver):
+        """One member row of the plan."""
+        return resolver.member_rows.iloc[0].to_dict()
+
+    @pytest.fixture
+    def override(self, row):
+        """Give the row's format a counting read_array override."""
+        fiber_io = FiberIO.manager.get_fiberio(
+            format=row["source_format"], version=row["source_version"]
+        )
+        calls = []
+
+        def read_array(self, resource, windows, **kwargs):
+            # a real override's caster wrapper consumes _pre_cast; this
+            # raw function sees it and must not forward it to read
+            kwargs.pop("_pre_cast", None)
+            calls.append((windows, kwargs))
+            return FiberIO.read_array(self, resource, windows, **kwargs)
+
+        # set and delete by hand: monkeypatch would restore the inherited
+        # method as an own class attribute rather than remove it
+        type(fiber_io).read_array = read_array
+        yield calls
+        del type(fiber_io).read_array
+
+    def test_no_override_returns_none(self, resolver, row):
+        """A format without an override takes the patch path."""
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+
+    def test_override_loads_window(self, resolver, row, override):
+        """The override gets the windows and its array matches the patch path."""
+        out = resolver._load_member_array(row, {"time": (2, 9)})
+        expected = resolver._load_member(row).select(time=(2, 9), samples=True).data
+        assert np.array_equal(out, expected)
+        assert out.dtype == expected.dtype
+        # the row's own patch key rides along so multi-patch files resolve
+        expected_kwargs = {"source_patch_key": row["source_patch_key"]}
+        assert override == [({"time": (2, 9)}, expected_kwargs)]
+
+    def test_digit_key_returns_none(self, resolver, row, override):
+        """A synthesized positional key only binds against a full read."""
+        row = dict(row, source_patch_key="3")
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_null_row_cells_return_none(self, resolver, row, override):
+        """NaN cells (a left merge's misses) refuse like absent ones."""
+        for column in ("source_path", "source_format", "source_version"):
+            bad = dict(row, **{column: float("nan")})
+            assert resolver._load_member_array(bad, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_residuals_return_none(self, file_spool, override):
+        """A residual selection re-trims patches; windows cannot compose."""
+        sub = file_spool.select(time=(2, 100), samples=True).chunk(time=None)
+        resolver = sub._catalog.resolver
+        assert resolver.parent_residuals
+        row = resolver.member_rows.iloc[0].to_dict()
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_missing_version_returns_none(self, resolver, row, override):
+        """Without an exact version the reader cannot be resolved."""
+        row = dict(row, source_version="")
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_unknown_format_returns_none(self, resolver, row, override):
+        """An unknown format falls back rather than raising here."""
+        row = dict(row, source_format="not_a_real_format", source_version="1")
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_plan_path_returns_none(self, resolver, row, override):
+        """A nested plan row loads through its own resolver."""
+        row = dict(row, source_path=f"{PLAN_SCHEME}deadbeef/0")
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_memory_row_returns_none(self, override):
+        """An in-memory patch has no file to slice.
+
+        The scheme gate is defense in depth: a memory row's "memory"
+        format is unregistered, so a later gate would refuse it too.
+        """
+        resolver = dc.get_example_spool().chunk(time=None)._catalog.resolver
+        row = resolver.member_rows.iloc[0].to_dict()
+        row["source_version"] = "1"
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_non_file_loader_returns_none(self, resolver, row, override, monkeypatch):
+        """A loader with no file leg cannot resolve a path."""
+        monkeypatch.setattr(resolver, "loader", object())
+        assert resolver._load_member_array(row, {"time": (0, 5)}) is None
+        assert override == []
+
+    def test_override_gets_annotated_handle(self, resolver, row):
+        """The override receives the handle type it declares, like read.
+
+        The resource manager provisions it, so a remote path resolves the
+        same way dc.read's own reading does instead of arriving as a raw
+        URL string.
+        """
+        from dascore.utils.io import BinaryReader  # noqa: PLC0415
+
+        fiber_io = FiberIO.manager.get_fiberio(
+            format=row["source_format"], version=row["source_version"]
+        )
+        seen = {}
+
+        def read_array(self, resource, windows, **kwargs):
+            seen["resource"] = resource
+            return np.zeros(2)
+
+        read_array._required_type = BinaryReader
+        type(fiber_io).read_array = read_array
+        try:
+            out = resolver._load_member_array(row, {"time": (0, 2)})
+        finally:
+            del type(fiber_io).read_array
+        assert np.array_equal(out, np.zeros(2))
+        assert hasattr(seen["resource"], "read")  # a handle, not a path

--- a/tests/test_io/test_index/test_planned.py
+++ b/tests/test_io/test_index/test_planned.py
@@ -26,6 +26,7 @@ from dascore.io.index.planned import (
 )
 from dascore.units import m
 from dascore.utils.chunk_plan import ChunkPlan, samples_adjusted_envelopes
+from dascore.utils.io import BinaryReader
 
 
 @pytest.fixture(scope="module")
@@ -522,8 +523,6 @@ class TestLoadMemberArray:
         same way dc.read's own reading does instead of arriving as a raw
         URL string.
         """
-        from dascore.utils.io import BinaryReader  # noqa: PLC0415
-
         fiber_io = FiberIO.manager.get_fiberio(
             format=row["source_format"], version=row["source_version"]
         )

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -2202,3 +2202,102 @@ class TestSourceIds:
         """The config which turns the ids off turns this off too."""
         with config_context(patch_provenance="disabled"):
             assert dc.read(terra15_path)[0].attrs.patch_id == ""
+
+
+class TestFiberIOReadArray:
+    """Tests for the read_array data-only contract and its default."""
+
+    @pytest.fixture(scope="class")
+    def single_patch_path(self, tmp_path_factory):
+        """One patch written to a DASDAE file."""
+        path = tmp_path_factory.mktemp("read_array") / "single.h5"
+        dc.write(dc.get_example_patch(), path, "dasdae")
+        return path
+
+    @pytest.fixture(scope="class")
+    def multi_patch_path(self, tmp_path_factory):
+        """Two patches with distinct data written to one DASDAE file."""
+        path = tmp_path_factory.mktemp("read_array") / "multi.h5"
+        spool = dc.examples.get_example_spool("random_das", length=2)
+        # distinct arrays, or a wrong-patch resolution could pass parity
+        patches = [patch.new(data=patch.data + num) for num, patch in enumerate(spool)]
+        assert not np.array_equal(patches[0].data, patches[1].data)
+        dc.write(dc.spool(patches), path, "dasdae")
+        return path
+
+    @pytest.fixture(scope="class")
+    def dasdae_io(self, single_patch_path):
+        """The FiberIO which read the file, resolved exactly."""
+        fmt, version = dc.get_format(single_patch_path)
+        return FiberIO.manager.get_fiberio(format=fmt, version=version)
+
+    def test_default_matches_read_then_select(self, dasdae_io, single_patch_path):
+        """Windows are half-open python indices: plain numpy slicing."""
+        patch = dc.read(single_patch_path)[0]
+        assert patch.dims == ("distance", "time")
+        windows = {"time": (5, 50), "distance": (2, 9)}
+        out = dasdae_io.read_array(single_patch_path, windows)
+        expected = patch.data[2:9, 5:50]
+        assert np.array_equal(out, expected)
+        # untransposed and uncast: the file's own order and dtype
+        assert out.dtype == patch.data.dtype
+
+    def test_absent_dimensions_load_whole(self, dasdae_io, single_patch_path):
+        """A dimension missing from windows comes back whole."""
+        patch = dc.read(single_patch_path)[0]
+        out = dasdae_io.read_array(single_patch_path, {"time": (0, 10)})
+        expected = patch.select(time=(0, 10), samples=True).data
+        assert np.array_equal(out, expected)
+        assert np.array_equal(dasdae_io.read_array(single_patch_path, {}), patch.data)
+
+    def test_multi_patch_selects_keyed_patch(self, dasdae_io, multi_patch_path):
+        """The key names which patch of the file the windows index."""
+        for payload in dc.scan(multi_patch_path):
+            key = payload.source_patch_key
+            wanted = dc.read(multi_patch_path, source_patch_key=key)[0]
+            out = dasdae_io.read_array(
+                multi_patch_path, {"time": (3, 17)}, source_patch_key=key
+            )
+            expected = wanted.select(time=(3, 17), samples=True).data
+            assert np.array_equal(out, expected)
+
+    def test_multi_patch_without_key_raises(self, dasdae_io, multi_patch_path):
+        """Windows on an ambiguous grid never guess a patch."""
+        with pytest.raises(PatchAttributeError, match="uniquely resolved"):
+            dasdae_io.read_array(multi_patch_path, {"time": (0, 5)})
+
+    def test_override_resource_coercion(self, single_patch_path):
+        """An override's resource annotation is honored like read's.
+
+        The type-casting layer promises FiberIO authors that a method's
+        resource parameter arrives as the annotated handle type; that
+        must hold for read_array or an override written like a read
+        method fails on the raw path it is handed.
+        """
+        seen = {}
+
+        class ReadArrayCastFormat(FiberIO):
+            name = "_test_read_array_cast"
+            version = "1"
+
+            def read_array(self, resource: BinaryReader, windows, **kwargs):
+                seen["resource"] = resource
+                return np.zeros(2)
+
+        fiber_io = ReadArrayCastFormat()
+        out = fiber_io.read_array(single_patch_path, {})
+        assert np.array_equal(out, np.zeros(2))
+        assert hasattr(seen["resource"], "read")  # a handle, not a path
+
+    def test_implements_flag(self, dasdae_io):
+        """The flag says whether a format overrides the default."""
+        assert not dasdae_io.implements_read_array
+        cls = type(dasdae_io)
+        # set and delete by hand: monkeypatch would restore the inherited
+        # method as an own class attribute rather than remove it
+        cls.read_array = lambda self, resource, windows, **kw: np.empty(0)
+        try:
+            assert dasdae_io.implements_read_array
+        finally:
+            del cls.read_array
+        assert not dasdae_io.implements_read_array

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -250,6 +250,31 @@ class TestFilterDfAdvanced:
         out = filter_df(example_df_2, time=None)
         assert np.all(out)
 
+    def test_min_max_query_without_column(self, example_df_2):
+        """A {name}_min query whose bare column is absent is a bad kwarg.
+
+        It used to KeyError deep in the range filter, which broke readers
+        forwarding read hints (e.g. dc.read(dasdae_file, time_min=...)).
+        """
+        df = example_df_2.drop(columns=["time"], errors="ignore")
+        assert "time" not in df.columns
+        value = df["time_min"].iloc[0]
+        with pytest.raises(ParameterError, match="Bad filter parameter"):
+            filter_df(df.drop(columns=["time_min", "time_max"]), time_min=value)
+        out = filter_df(
+            df.drop(columns=["time_min", "time_max"]),
+            time_min=value,
+            ignore_bad_kwargs=True,
+        )
+        assert np.all(out)
+        # the _max spelling walks the sibling branch
+        out = filter_df(
+            df.drop(columns=["time_min", "time_max"]),
+            time_max=value,
+            ignore_bad_kwargs=True,
+        )
+        assert np.all(out)
+
     def test_timedelta_columns(self, example_df_timedeltas):
         """Ensure timedelta columns work when specifying ranges of single col."""
         df = example_df_timedeltas


### PR DESCRIPTION
## Description

Adds `FiberIO.read_array`: a data-only fast path returning the raw array for absolute sample windows, without building a Patch. Split out of #1106 (which now carries only the `to_xarray` wiring) so the generally useful core lands on dev directly: the contract is published for plugin authors, and the per-format overrides (DASDAE, Terra15, TDMS) plus `chunk`-assembly adoption can proceed on dev independent of the xarray series.

The contract keeps readers dumb and the machinery honest:

- `windows` maps dimension name to half-open `(start, stop)` sample indices on the file's own grid; absent dimensions load whole. Value-to-index conversion (and its rounding) happens once, in the caller, through the coordinate machinery — readers never round.
- The array returns in the file's stated dims order, untransposed and uncast; the caller transposes, casts, and keeps its own shape guard.
- Multi-patch files take `source_patch_key`; without it an ambiguous file raises rather than guessing (`_resolve_read_spool` is reused, not re-spelled).
- `resource` participates in the same type-coercion layer as `read` (a registered test format pins it), so an override annotated like a `read` method gets the handle it declares.
- The default implementation reads through `read` and trims with `select(samples=True)`, so every existing format — third-party plugins included — is correct on day one. Overriding is opt-in per format; no overrides ship here.

Machinery: `PlanResolver._load_member_array(row, windows)` gates the data-only path — a plain file-backed row with a concrete format and version, a native (non-synthesized) patch key, a format that actually overrides `read_array`, no parent residuals, and windows the caller anchored on the raw file grid. Ineligible rows return None and the caller falls back to the exact `_load_member` patch path. The override's resource is provisioned through `IOResourceManager`, exactly as `dc.read` provisions its reader, so remote paths resolve to the annotated handle type.

Two base fixes ride along because the machinery needs them: `filter_df` reports a `{name}_min`/`{name}_max` kwarg whose bare column is absent as a bad filter parameter instead of `KeyError`-ing deep in the range filter (reader-forwarded trim hints crashed on this), and the CI workflows gain `xarray_integration` in their branch filters — pull requests into that branch previously ran no test matrix at all.

Review provenance: this content shipped through #1106's full cycle — three blind internal reviewers plus a cross-model adversarial round (11 findings addressed, including a live wrong-samples bug in plan-collapsed spools), Codex PR review threads answered, and a green run of the complete CI matrix.

## Changelog

- added: `FiberIO.read_array` lets a format return the raw data array for absolute sample windows, with a default built on `read` so every format works without changes.
- fixed: `filter_df` reports a `{name}_min`/`{name}_max` query whose bare column is absent as a bad filter parameter instead of raising `KeyError`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added data-only array loading for supported storage formats, with automatic fallback when unavailable.
  - Improved derived catalog handling and loading performance for planned data.

- **Bug Fixes**
  - Invalid min/max filters now return a clear parameter error instead of an internal key error.

- **Documentation**
  - Documented the data-only array-loading contract, fallback behavior, window selection, and format requirements.

- **Tests**
  - Expanded coverage for array loading, derived catalogs, filtering, and fallback scenarios.

- **Chores**
  - Extended automated checks and test workflows to the `xarray_integration` branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->