### PR TITLE
Slice Terra15 and TDMS storage directly in read_array

### DIFF
--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -9,16 +9,11 @@ import numpy as np
 import pandas as pd
 
 import dascore as dc
-from dascore.exceptions import ParameterError
 from dascore.io import FiberIO
+from dascore.io.utils import windows_to_slices
 from dascore.utils.hdf5 import H5Reader, H5Writer
 from dascore.utils.io import _normalize_source_patch_keys
-from dascore.utils.misc import (
-    _to_slice,
-    _validate_sample_values,
-    raise_on_extra_kwargs,
-    unbyte,
-)
+from dascore.utils.misc import raise_on_extra_kwargs, unbyte
 from dascore.utils.patch import get_patch_names
 
 from .utils import (
@@ -166,17 +161,8 @@ class DASDAEV1(FiberIO):
         """
         raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
         group = _get_patch_group(resource, source_patch_key)
-        dims = _get_dims(group)
-        if unknown := sorted(set(windows) - set(dims)):
-            msg = f"Window dimensions {unknown} are not among patch dims {dims}."
-            raise ParameterError(msg)
-        # the same validation and (start, stop) reading as select(samples=True)
-        for window in windows.values():
-            _validate_sample_values(window)
-        index = tuple(
-            _to_slice(windows[dim]) if dim in windows else slice(None) for dim in dims
-        )
-        return group["data"][index]
+        data = group["data"]
+        return data[windows_to_slices(windows, _get_dims(group), data.shape)]
 
     def scan(self, resource: H5Reader, snap: bool = True, **kwargs):
         """

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -9,10 +9,19 @@ import numpy as np
 import dascore as dc
 from dascore.constants import timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, windows_to_slices
 from dascore.utils.io import BinaryReader, LocalBinaryReader
+from dascore.utils.misc import raise_on_extra_kwargs
 
-from .utils import _get_all_attrs, _get_data, _get_default_attrs, _get_version_str
+from .utils import (
+    _get_all_attrs,
+    _get_data,
+    _get_default_attrs,
+    _get_fileinfo,
+    _get_sample_count,
+    _get_version_str,
+    _read_sample_range,
+)
 
 
 class TDMSFormatterV4713(FiberIO):
@@ -74,3 +83,23 @@ class TDMSFormatterV4713(FiberIO):
             coords, data, attrs, selection={"time": time, "distance": distance}
         )
         return dc.spool(patches)
+
+    def read_array(
+        self,
+        resource: LocalBinaryReader,
+        windows: dict[str, tuple[int, int]],
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Decode only the segments a time window touches.
+
+        A segment interleaves its channels, so it is the finest unit read;
+        the distance window is applied after decoding. The file holds one
+        patch, so no ``source_patch_key`` is taken.
+        """
+        raise_on_extra_kwargs(kwargs, "windows")
+        fileinfo, _ = _get_fileinfo(resource)
+        shape = (_get_sample_count(resource, fileinfo), int(fileinfo["n_channels"]))
+        time_slice, dist_slice = windows_to_slices(windows, ("time", "distance"), shape)
+        data = _read_sample_range(resource, fileinfo, time_slice.start, time_slice.stop)
+        return data[:, dist_slice]

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -18,7 +18,6 @@ from .utils import (
     _get_data,
     _get_default_attrs,
     _get_fileinfo,
-    _get_sample_count,
     _get_version_str,
     _read_sample_range,
 )
@@ -93,13 +92,12 @@ class TDMSFormatterV4713(FiberIO):
         """
         Decode only the segments a time window touches.
 
-        A segment interleaves its channels, so it is the finest unit read;
-        the distance window is applied after decoding. The file holds one
-        patch, so no ``source_patch_key`` is taken.
+        The distance window is applied after decoding, since a segment
+        interleaves its channels.
         """
         raise_on_extra_kwargs(kwargs, "windows")
-        fileinfo, _ = _get_fileinfo(resource)
-        shape = (_get_sample_count(resource, fileinfo), int(fileinfo["n_channels"]))
+        fileinfo, attrs = _get_fileinfo(resource)
+        shape = (len(attrs["coords"]["time"]), int(fileinfo["n_channels"]))
         time_slice, dist_slice = windows_to_slices(windows, ("time", "distance"), shape)
         data = _read_sample_range(resource, fileinfo, time_slice.start, time_slice.stop)
         return data[:, dist_slice]

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -201,10 +201,14 @@ def _iter_segment_bounds(tdms_file, fileinfo, lead_in_length=28):
         nso = min(file_size, start + next_seg_nso)
 
 
+def _segment_sample_count(fileinfo, rdo, nso) -> int:
+    """How many samples per channel the segment at these byte bounds holds."""
+    per_sample = int(fileinfo["n_channels"]) * np.dtype(fileinfo["data_type"]).itemsize
+    return (nso - rdo) // per_sample
+
+
 def _get_sample_count(tdms_file, fileinfo, lead_in_length=28):
     """Return how many samples per channel the whole file holds."""
-    itemsize = np.dtype(fileinfo["data_type"]).itemsize
-    per_sample = fileinfo["n_channels"] * itemsize
     position = tdms_file.tell()
     try:
         bounds = list(_iter_segment_bounds(tdms_file, fileinfo, lead_in_length))
@@ -212,7 +216,7 @@ def _get_sample_count(tdms_file, fileinfo, lead_in_length=28):
         tdms_file.seek(position, 0)
     # Counting bytes to the end of the file instead would count every
     # segment's lead-in and metadata as data.
-    return sum((nso - rdo) // per_sample for rdo, nso in bounds)
+    return sum(_segment_sample_count(fileinfo, rdo, nso) for rdo, nso in bounds)
 
 
 def _get_all_attrs(tdms_file, lead_in_length=28):
@@ -288,10 +292,8 @@ def _get_fileinfo(tdms_file, lead_in_length=28):
 
 def _get_segment_data(fileinfo, nch, dmap, nso, rdo):
     """Decode one segment of the mapped file as a (samples, channels) array."""
-    # seg1_length: length of recording indicated as raw_data in metadata for
-    # each channel in bytes
-    seg_length = int((nso - rdo) / nch / np.dtype(fileinfo["data_type"]).itemsize)
-    channel_length = seg_length
+    # samples per channel in this segment
+    seg_length = _segment_sample_count(fileinfo, rdo, nso)
 
     if fileinfo["decimated"]:
         # number of completely full chunks
@@ -332,34 +334,37 @@ def _get_segment_data(fileinfo, nch, dmap, nso, rdo):
         data_node = np.append(data_node, raw_last_chunk, axis=0)
     # Outside the branch: a decimated segment whose chunks all happen to
     # be full has nothing left over, and still has its data.
-    return data_node, channel_length
+    return data_node
 
 
 def _read_sample_range(tdms_file, fileinfo, start=0, stop=None, lead_in_length=28):
     """
     Read time samples ``start`` to ``stop`` (half-open) as (samples, channels).
 
-    A segment interleaves its channels, so it is the finest unit decoded;
-    only the segments the range touches are.
+    ``start`` and ``stop`` are resolved, non-negative sample indices (or
+    ``stop`` None for the end). Only the segments the range touches are
+    decoded.
     """
     dmap = mmap.mmap(tdms_file.fileno(), 0, access=mmap.ACCESS_READ)
     nch = int(fileinfo["n_channels"])
-    per_sample = nch * np.dtype(fileinfo["data_type"]).itemsize
     parts, offset = [], 0
     for rdo, nso in _iter_segment_bounds(tdms_file, fileinfo, lead_in_length):
-        seg_start, seg_stop = offset, offset + (nso - rdo) // per_sample
+        seg_len = _segment_sample_count(fileinfo, rdo, nso)
+        seg_start, seg_stop = offset, offset + seg_len
         offset = seg_stop
         if stop is not None and seg_start >= stop:
             break
         if seg_stop <= start:
             continue
-        segment, _ = _get_segment_data(fileinfo, nch, dmap, nso, rdo)
-        seg_len = seg_stop - seg_start
+        segment = _get_segment_data(fileinfo, nch, dmap, nso, rdo)
         low = max(start - seg_start, 0)
         high = seg_len if stop is None else min(stop - seg_start, seg_len)
         parts.append(segment[low:high])
     if not parts:
         return np.empty((0, nch), dtype=fileinfo["data_type"])
+    if len(parts) == 1:
+        # a decoded segment owns its data, so one part needs no copy
+        return parts[0]
     # segments stack along time, the first axis of (samples, channels)
     return np.concatenate(parts, axis=0)
 

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -286,75 +286,86 @@ def _get_fileinfo(tdms_file, lead_in_length=28):
     return fileinfo, attrs
 
 
-def _get_data(tdms_file, lead_in_length=28):
-    """Get all the data saved in the current file."""
+def _get_segment_data(fileinfo, nch, dmap, nso, rdo):
+    """Decode one segment of the mapped file as a (samples, channels) array."""
+    # seg1_length: length of recording indicated as raw_data in metadata for
+    # each channel in bytes
+    seg_length = int((nso - rdo) / nch / np.dtype(fileinfo["data_type"]).itemsize)
+    channel_length = seg_length
 
-    def get_segment_data(fileinfo, nch, dmap, nso, rdo):
-        # seg1_length: length of recording indicated as raw_data in metadata for
-        # each channel in bytes
-        seg_length = int((nso - rdo) / nch / np.dtype(fileinfo["data_type"]).itemsize)
-        channel_length = seg_length
-
-        if fileinfo["decimated"]:
-            # number of completely full chunks
-            n_complete_blk = int(seg_length / fileinfo["chunk_size"])
-            ax_ord = "C"
-        else:
-            n_complete_blk = 0
-            ax_ord = "F"
-        # use data from mapped file to fill variable raw_data
-        raw_data = np.ndarray(
-            (n_complete_blk, nch, fileinfo["chunk_size"]),
+    if fileinfo["decimated"]:
+        # number of completely full chunks
+        n_complete_blk = int(seg_length / fileinfo["chunk_size"])
+        ax_ord = "C"
+    else:
+        n_complete_blk = 0
+        ax_ord = "F"
+    # use data from mapped file to fill variable raw_data
+    raw_data = np.ndarray(
+        (n_complete_blk, nch, fileinfo["chunk_size"]),
+        dtype=fileinfo["data_type"],
+        buffer=dmap,
+        offset=rdo,
+    )
+    # Rotate the axes to [chunk_size, nblk, nch]
+    raw_data = np.rollaxis(raw_data, 2)
+    data_node = np.reshape(raw_data, (n_complete_blk * fileinfo["chunk_size"], nch))
+    if n_complete_blk != seg_length / fileinfo["chunk_size"]:
+        # If the last chunk isn't full there is some data left
+        additional_samples = int(seg_length - n_complete_blk * fileinfo["chunk_size"])
+        additional_samples_offset = (
+            rdo
+            + n_complete_blk
+            * nch
+            * fileinfo["chunk_size"]
+            * np.dtype(fileinfo["data_type"]).itemsize
+        )
+        raw_last_chunk = np.ndarray(
+            (nch, additional_samples),
             dtype=fileinfo["data_type"],
             buffer=dmap,
-            offset=rdo,
+            offset=additional_samples_offset,
+            order=ax_ord,
         )
-        # Rotate the axes to [chunk_size, nblk, nch]
-        raw_data = np.rollaxis(raw_data, 2)
-        data_node = np.reshape(raw_data, (n_complete_blk * fileinfo["chunk_size"], nch))
-        if n_complete_blk != seg_length / fileinfo["chunk_size"]:
-            # If the last chunk isn't full there is some data left
-            additional_samples = int(
-                seg_length - n_complete_blk * fileinfo["chunk_size"]
-            )
-            additional_samples_offset = (
-                rdo
-                + n_complete_blk
-                * nch
-                * fileinfo["chunk_size"]
-                * np.dtype(fileinfo["data_type"]).itemsize
-            )
-            raw_last_chunk = np.ndarray(
-                (nch, additional_samples),
-                dtype=fileinfo["data_type"],
-                buffer=dmap,
-                offset=additional_samples_offset,
-                order=ax_ord,
-            )
-            # Rotate the axes to [samples, nch]
-            raw_last_chunk = np.rollaxis(raw_last_chunk, 1)
-            data_node = np.append(data_node, raw_last_chunk, axis=0)
-        # Outside the branch: a decimated segment whose chunks all happen to
-        # be full has nothing left over, and still has its data.
-        return data_node, channel_length
+        # Rotate the axes to [samples, nch]
+        raw_last_chunk = np.rollaxis(raw_last_chunk, 1)
+        data_node = np.append(data_node, raw_last_chunk, axis=0)
+    # Outside the branch: a decimated segment whose chunks all happen to
+    # be full has nothing left over, and still has its data.
+    return data_node, channel_length
 
-    fileinfo, attrs = _get_fileinfo(tdms_file)
 
-    # map file contents to a variable dmap
+def _read_sample_range(tdms_file, fileinfo, start=0, stop=None, lead_in_length=28):
+    """
+    Read time samples ``start`` to ``stop`` (half-open) as (samples, channels).
+
+    A segment interleaves its channels, so it is the finest unit decoded;
+    only the segments the range touches are.
+    """
     dmap = mmap.mmap(tdms_file.fileno(), 0, access=mmap.ACCESS_READ)
-    # nch: number of channels
     nch = int(fileinfo["n_channels"])
-
-    data_node = None
-    channel_length = 0
+    per_sample = nch * np.dtype(fileinfo["data_type"]).itemsize
+    parts, offset = [], 0
     for rdo, nso in _iter_segment_bounds(tdms_file, fileinfo, lead_in_length):
-        segment, seg_length = get_segment_data(fileinfo, nch, dmap, nso, rdo)
-        # A segment holds every channel for a stretch of time, so segments
-        # stack along time, which is the first axis of (samples, channels).
-        if data_node is None:
-            data_node = segment
-        else:
-            data_node = np.append(data_node, segment, axis=0)
-        channel_length += seg_length
+        seg_start, seg_stop = offset, offset + (nso - rdo) // per_sample
+        offset = seg_stop
+        if stop is not None and seg_start >= stop:
+            break
+        if seg_stop <= start:
+            continue
+        segment, _ = _get_segment_data(fileinfo, nch, dmap, nso, rdo)
+        seg_len = seg_stop - seg_start
+        low = max(start - seg_start, 0)
+        high = seg_len if stop is None else min(stop - seg_start, seg_len)
+        parts.append(segment[low:high])
+    if not parts:
+        return np.empty((0, nch), dtype=fileinfo["data_type"])
+    # segments stack along time, the first axis of (samples, channels)
+    return np.concatenate(parts, axis=0)
 
-    return data_node, channel_length, attrs
+
+def _get_data(tdms_file, lead_in_length=28):
+    """Get all the data saved in the current file."""
+    fileinfo, attrs = _get_fileinfo(tdms_file)
+    data = _read_sample_range(tdms_file, fileinfo, lead_in_length=lead_in_length)
+    return data, len(data), attrs

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import timeable_types
 from dascore.io import FiberIO, ScanPayload
+from dascore.io.utils import windows_to_slices
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import (
+    _get_scanned_time_info,
     _get_terra15_version_str,
     _get_version_data_node,
     _read_terra15,
@@ -77,6 +82,25 @@ class Terra15FormatterV4(FiberIO):
         if not patch.data.size:
             return dc.spool([])
         return dc.spool(patch)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """
+        Slice the data node directly.
+
+        Only the time node's ends (to count the samples a file actually
+        finished writing) and the requested block leave the file. The file
+        holds one patch, so no ``source_patch_key`` is taken.
+        """
+        raise_on_extra_kwargs(kwargs, "windows")
+        _, data_node = _get_version_data_node(resource)
+        _, _, time_len, _ = _get_scanned_time_info(data_node)
+        data = data_node["data"]
+        # an unfinished file has zero-filled rows past the last written
+        # sample; the scan grid stops at time_len, so the slices must too
+        shape = (time_len, data.shape[1])
+        return data[windows_to_slices(windows, ("time", "distance"), shape)]
 
 
 class Terra15FormatterV5(Terra15FormatterV4):

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -14,6 +14,7 @@ from dascore.utils.hdf5 import H5Reader
 from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import (
+    _get_distance_coord,
     _get_scanned_time_info,
     _get_terra15_version_str,
     _get_version_data_node,
@@ -84,22 +85,29 @@ class Terra15FormatterV4(FiberIO):
         return dc.spool(patch)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap_dims: bool = True,
+        **kwargs,
     ) -> np.ndarray:
         """
         Slice the data node directly.
 
-        Only the time node's ends (to count the samples a file actually
-        finished writing) and the requested block leave the file. The file
-        holds one patch, so no ``source_patch_key`` is taken.
+        Besides the requested block, only the time node's ends and the
+        header are read (the whole time node for an unfinished file, to
+        count the rows it actually wrote). ``snap_dims`` selects the same
+        grid ``read`` and ``scan`` use: snapped, the rows stop at the last
+        written sample; raw, every row counts, as the raw time coordinate
+        does.
         """
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and snap_dims")
         _, data_node = _get_version_data_node(resource)
-        _, _, time_len, _ = _get_scanned_time_info(data_node)
         data = data_node["data"]
-        # an unfinished file has zero-filled rows past the last written
-        # sample; the scan grid stops at time_len, so the slices must too
-        shape = (time_len, data.shape[1])
+        time_len = data.shape[0]
+        if snap_dims:
+            _, _, time_len, _ = _get_scanned_time_info(data_node)
+        shape = (time_len, len(_get_distance_coord(resource)))
         return data[windows_to_slices(windows, ("time", "distance"), shape)]
 
 

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -160,8 +160,8 @@ def windows_to_slices(
 
     Each window is validated as `Patch.select` validates ``samples=True``
     values and resolved against its dimension's length, so every slice
-    comes back with explicit non-negative bounds; a dimension without a
-    window is taken whole.
+    comes back with explicit non-negative bounds and ``start <= stop`` (a
+    reversed window is empty); a dimension without a window is taken whole.
 
     Parameters
     ----------

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 import numpy as np
@@ -12,10 +12,10 @@ import dascore as dc
 from dascore.constants import INVENTORY_ATTRS
 from dascore.core.coordmanager import CoordManager
 from dascore.core.coords import BaseCoord, CoordSegmented, get_coord
-from dascore.exceptions import CoordError, UnitError
+from dascore.exceptions import CoordError, ParameterError, UnitError
 from dascore.models import ArrayLike
 from dascore.units import convert_units, get_quantity_str
-from dascore.utils.misc import unbyte
+from dascore.utils.misc import _to_slice, _validate_sample_values, unbyte
 
 # Stored coordinate arrays often carry sub-step jitter (e.g. GPS-stamped DAS
 # time). ``CoordSegmented.from_array`` treats every isolated sampling change as
@@ -150,6 +150,40 @@ def build_patches(
         return []
     # Ellipsis rather than a slice so 0d data (a scalar patch) also loads.
     return [dc.Patch(data=data[...], coords=coords, attrs=patch_attrs)]
+
+
+def windows_to_slices(
+    windows: Mapping[str, Any], dims: Sequence[str], shape: Sequence[int]
+) -> tuple[slice, ...]:
+    """
+    Turn `FiberIO.read_array` windows into one slice per dimension.
+
+    Each window is validated as `Patch.select` validates ``samples=True``
+    values and resolved against its dimension's length, so every slice
+    comes back with explicit non-negative bounds; a dimension without a
+    window is taken whole.
+
+    Parameters
+    ----------
+    windows
+        Dimension name to ``(start, stop)`` half-open sample indices.
+    dims
+        The dimensions in the array's stored order.
+    shape
+        The array's shape, in the same order.
+    """
+    if unknown := sorted(set(windows) - set(dims)):
+        msg = f"Window dimensions {unknown} are not among patch dims {tuple(dims)}."
+        raise ParameterError(msg)
+    out = []
+    for dim, size in zip(dims, shape, strict=True):
+        if dim not in windows:
+            out.append(slice(0, size))
+            continue
+        _validate_sample_values(windows[dim])
+        span = range(size)[_to_slice(windows[dim])]
+        out.append(slice(span.start, max(span.stop, span.start)))
+    return tuple(out)
 
 
 def get_gridded_coord(values, units=None) -> BaseCoord:

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -313,7 +313,9 @@ class TestReadArray:
         with pytest.raises(ParameterError, match="Unexpected keyword"):
             DASDAEV1().read_array(written_dascore_v1_random, {}, time_min=1)
 
-    def test_reads_only_the_window(self, written_dascore_v1_random, monkeypatch):
+    def test_reads_only_the_window(
+        self, written_dascore_v1_random, random_patch, monkeypatch
+    ):
         """The dataset is sliced in the file, not read whole then trimmed."""
         seen = []
         original = h5py.Dataset.__getitem__
@@ -324,7 +326,7 @@ class TestReadArray:
 
         monkeypatch.setattr(h5py.Dataset, "__getitem__", spy)
         DASDAEV1().read_array(written_dascore_v1_random, {"time": (2, 6)})
-        assert seen == [(slice(None), slice(2, 6))]
+        assert seen == [(slice(0, random_patch.shape[0]), slice(2, 6))]
 
 
 class TestScanDASDAE:

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -51,7 +51,12 @@ from dascore.io.core import (
     make_scan_payload,
 )
 from dascore.io.dasdae.core import DASDAEV1
-from dascore.io.utils import build_patches, convert_attr_units, get_exact_coord
+from dascore.io.utils import (
+    build_patches,
+    convert_attr_units,
+    get_exact_coord,
+    windows_to_slices,
+)
 from dascore.utils.downloader import fetch
 from dascore.utils.hdf5 import H5Writer
 from dascore.utils.io import (
@@ -2321,3 +2326,34 @@ class TestFiberIOReadArray:
         finally:
             del PlainFormat.read_array
         assert not plain.implements_read_array
+
+
+class TestWindowsToSlices:
+    """Tests for turning read_array windows into per-dimension slices."""
+
+    def test_absent_dimension_is_whole(self):
+        """A dimension without a window spans its whole length."""
+        out = windows_to_slices({"time": (2, 5)}, ("distance", "time"), (7, 9))
+        assert out == (slice(0, 7), slice(2, 5))
+
+    def test_open_negative_and_overlong_bounds_resolve(self):
+        """None, ..., negative, and past-the-end bounds resolve like numpy."""
+        out = windows_to_slices(
+            {"time": (..., 3), "distance": (-2, 50)}, ("time", "distance"), (9, 7)
+        )
+        assert out == (slice(0, 3), slice(5, 7))
+        assert windows_to_slices({"time": (4, None)}, ("time",), (9,)) == (slice(4, 9),)
+
+    def test_empty_window_stays_empty(self):
+        """A reversed window is empty, never negative-length."""
+        assert windows_to_slices({"time": (6, 2)}, ("time",), (9,)) == (slice(6, 6),)
+
+    def test_unknown_dimension_raises(self):
+        """A window on a dimension the array lacks raises."""
+        with pytest.raises(ParameterError, match="not among patch dims"):
+            windows_to_slices({"bob": (0, 1)}, ("time",), (9,))
+
+    def test_non_integer_bounds_raise(self):
+        """Bounds are sample indices, never values."""
+        with pytest.raises(ParameterError, match="integers"):
+            windows_to_slices({"time": (1.5, 3)}, ("time",), (9,))

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -246,16 +246,28 @@ class TestReadArray:
             return original(fileinfo, nch, dmap, nso, rdo)
 
         single = dc.spool(fetch("iDAS005_tdms_example.626.tdms"))[0]
+        with open(two_segment_path, "rb") as fi:
+            fileinfo, _ = tdms_utils._get_fileinfo(fi)
+            first, second = (
+                rdo for rdo, _ in tdms_utils._iter_segment_bounds(fi, fileinfo)
+            )
         monkeypatch.setattr(tdms_utils, "_get_segment_data", spy)
         io = TDMSFormatterV4713()
-        out = io.read_array(two_segment_path, {"time": (1200, 1300)})
-        assert len(decoded) == 1
-        assert np.array_equal(out, single.data[200:300])
-        # a window inside the first segment stops the walk before the second
-        decoded.clear()
-        out = io.read_array(two_segment_path, {"time": (100, 200)})
-        assert len(decoded) == 1
-        assert np.array_equal(out, single.data[100:200])
+        # windows and the segment each should decode; the boundary is 1000
+        cases = {
+            (1200, 1300): [second],
+            (100, 200): [first],
+            (0, 1000): [first],
+            (1000, 1100): [second],
+            (990, 1010): [first, second],
+        }
+        for (start, stop), expected in cases.items():
+            decoded.clear()
+            out = io.read_array(two_segment_path, {"time": (start, stop)})
+            assert decoded == expected, (start, stop)
+            # both segments hold the example's samples
+            rows = np.concatenate([single.data, single.data])[start:stop]
+            assert np.array_equal(out, rows)
 
     def test_empty_window(self, two_segment_path):
         """A window past the end is empty with the right width and dtype."""

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -11,8 +11,10 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.io.core import FiberIO
 from dascore.io.silixah5.utils import _ATTR_MAP as _SILIXA_ATTR_MAP
 from dascore.io.tdms import utils as tdms_utils
+from dascore.io.tdms.core import TDMSFormatterV4713
 from dascore.io.tdms.utils import parse_time_stamp, type_not_supported
 from dascore.utils.downloader import fetch
 
@@ -209,6 +211,58 @@ class TestMultiSegment:
         assert summary.coords["time"].len == 2000
         assert summary.coords["time"].min == time.min()
         assert summary.coords["time"].max == time.max()
+
+
+class TestReadArray:
+    """Tests for reading only the segments a window touches."""
+
+    @pytest.fixture(scope="class")
+    def two_segment_path(self, tmp_path_factory):
+        """The example file's segment written twice (see TestMultiSegment)."""
+        raw = Path(fetch("iDAS005_tdms_example.626.tdms")).read_bytes()
+        path = tmp_path_factory.mktemp("tdms_read_array") / "two_segment.tdms"
+        path.write_bytes(raw + raw)
+        return path
+
+    def test_matches_default_across_segments(self, two_segment_path):
+        """A window spanning the segment boundary matches the default."""
+        io = TDMSFormatterV4713()
+        windows = {"time": (990, 1010), "distance": (5, 9)}
+        out = io.read_array(two_segment_path, windows)
+        expected = FiberIO.read_array(io, two_segment_path, windows)
+        assert out.dtype == expected.dtype
+        assert np.array_equal(out, expected)
+        assert out.shape == (20, 4)
+
+    def test_only_touched_segments_are_decoded(self, two_segment_path, monkeypatch):
+        """A window inside the second segment decodes that segment alone."""
+        from dascore.io.tdms import utils as tdms_utils  # noqa: PLC0415
+
+        decoded = []
+        original = tdms_utils._get_segment_data
+
+        def spy(fileinfo, nch, dmap, nso, rdo):
+            decoded.append(rdo)
+            return original(fileinfo, nch, dmap, nso, rdo)
+
+        single = dc.spool(fetch("iDAS005_tdms_example.626.tdms"))[0]
+        monkeypatch.setattr(tdms_utils, "_get_segment_data", spy)
+        io = TDMSFormatterV4713()
+        out = io.read_array(two_segment_path, {"time": (1200, 1300)})
+        assert len(decoded) == 1
+        assert np.array_equal(out, single.data[200:300])
+        # a window inside the first segment stops the walk before the second
+        decoded.clear()
+        out = io.read_array(two_segment_path, {"time": (100, 200)})
+        assert len(decoded) == 1
+        assert np.array_equal(out, single.data[100:200])
+
+    def test_empty_window(self, two_segment_path):
+        """A window past the end is empty with the right width and dtype."""
+        io = TDMSFormatterV4713()
+        out = io.read_array(two_segment_path, {"time": (5000, 6000)})
+        assert out.shape == (0, 1152)
+        assert out.dtype == FiberIO.read_array(io, two_segment_path, {}).dtype
 
 
 class TestTDMSInterrogator:

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -112,22 +112,6 @@ class TestTerra15Unfinished:
 class TestReadArray:
     """Tests for slicing the data node directly."""
 
-    @pytest.fixture(
-        params=["terra15_das_example_path", "terra15_v5_path", "terra15_v6_path"]
-    )
-    def terra15_path(self, request):
-        """Each Terra15 version's example file."""
-        return request.getfixturevalue(request.param)
-
-    def test_matches_default(self, terra15_path):
-        """The override returns what the read-and-trim default returns."""
-        io = Terra15FormatterV4()
-        windows = {"time": (3, 11), "distance": (2, 6)}
-        out = io.read_array(terra15_path, windows)
-        expected = FiberIO.read_array(io, terra15_path, windows)
-        assert out.dtype == expected.dtype
-        assert np.array_equal(out, expected)
-
     def test_unfinished_file_stops_at_written_samples(
         self, terra15_das_unfinished_path
     ):
@@ -140,6 +124,18 @@ class TestReadArray:
         # a window past the end clips to the written samples, as select does
         tail = io.read_array(terra15_das_unfinished_path, {"time": (-3, 10**6)})
         assert np.array_equal(tail, patch.data[-3:])
+
+    def test_raw_grid_counts_every_row(self, terra15_das_unfinished_path):
+        """With snap_dims=False the window lives on the raw grid, as in read."""
+        io = Terra15FormatterV4()
+        path = terra15_das_unfinished_path
+        out = io.read_array(path, {"time": (-5, None)}, snap_dims=False)
+        expected = FiberIO.read_array(io, path, {"time": (-5, None)}, snap_dims=False)
+        assert np.array_equal(out, expected)
+        assert len(out) == 5
+        assert len(io.read_array(path, {}, snap_dims=False)) > len(
+            io.read_array(path, {})
+        )
 
     def test_reads_only_the_window(self, terra15_v6_path, monkeypatch):
         """The data node is sliced in the file, not read whole then trimmed."""

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -11,6 +11,8 @@ import pandas as pd
 import pytest
 
 import dascore as dc
+from dascore.io.core import FiberIO
+from dascore.io.terra15.core import Terra15FormatterV4
 from dascore.io.terra15.utils import _get_version_data_node
 
 
@@ -105,3 +107,51 @@ class TestTerra15Unfinished:
         """Ensure the time is increasing."""
         time = patch_unfinished.coords.get_array("time")
         assert np.all(np.diff(time) >= np.timedelta64(0, "s"))
+
+
+class TestReadArray:
+    """Tests for slicing the data node directly."""
+
+    @pytest.fixture(
+        params=["terra15_das_example_path", "terra15_v5_path", "terra15_v6_path"]
+    )
+    def terra15_path(self, request):
+        """Each Terra15 version's example file."""
+        return request.getfixturevalue(request.param)
+
+    def test_matches_default(self, terra15_path):
+        """The override returns what the read-and-trim default returns."""
+        io = Terra15FormatterV4()
+        windows = {"time": (3, 11), "distance": (2, 6)}
+        out = io.read_array(terra15_path, windows)
+        expected = FiberIO.read_array(io, terra15_path, windows)
+        assert out.dtype == expected.dtype
+        assert np.array_equal(out, expected)
+
+    def test_unfinished_file_stops_at_written_samples(
+        self, terra15_das_unfinished_path
+    ):
+        """Zero-filled rows past the last written sample are never returned."""
+        io = Terra15FormatterV4()
+        patch = dc.spool(terra15_das_unfinished_path)[0]
+        out = io.read_array(terra15_das_unfinished_path, {})
+        assert out.shape == patch.shape
+        assert np.array_equal(out, patch.data)
+        # a window past the end clips to the written samples, as select does
+        tail = io.read_array(terra15_das_unfinished_path, {"time": (-3, 10**6)})
+        assert np.array_equal(tail, patch.data[-3:])
+
+    def test_reads_only_the_window(self, terra15_v6_path, monkeypatch):
+        """The data node is sliced in the file, not read whole then trimmed."""
+        seen = []
+        original = h5py.Dataset.__getitem__
+
+        def spy(self, index):
+            if self.name.endswith("/data"):
+                seen.append(index)
+            return original(self, index)
+
+        monkeypatch.setattr(h5py.Dataset, "__getitem__", spy)
+        Terra15FormatterV4().read_array(terra15_v6_path, {"time": (2, 6)})
+        assert len(seen) == 1
+        assert seen[0][0] == slice(2, 6)


### PR DESCRIPTION
## Description

Second and third `read_array` overrides, on the contract #1107 published and the pattern #1110 set.

- **Terra15** slices the HDF5 data node. The only other bytes read are the time node's ends, which say how many rows an unfinished file actually wrote; the slices are capped there so zero-filled rows never come back.
- **TDMS** decodes only the segments a time window touches. A segment interleaves its channels, so it is the finest unit read; the distance window is applied after decoding. `_get_data` now delegates to the same segment walker, so `read` and `read_array` share one decoder.
- **`windows_to_slices`** in `dascore/io/utils.py` turns windows into per-dimension slices with the validation `select(samples=True)` uses, resolved against the array's shape. DASDAE's override uses it too; the next overrides will.

Median of alternated repeats. `read(select)` is `read` with coordinate kwargs; the override saves the per-call attrs, coords, and Patch cost.

| file | window | read + trim | read(select) | override |
| --- | --- | --- | --- | --- |
| Terra15 v6 (280 x 5203, 6 MB) | 50 x 5203 | 3.0 ms | 1.8 ms | 0.69 ms |
| Terra15 v6 (280 x 5203, 6 MB) | 50 x 20 | 3.1 ms | 1.8 ms | 0.62 ms |
| TDMS (1000 x 1152, 2.4 MB) | 100 x 1152 | 0.91 ms | 0.81 ms | 0.44 ms |
| TDMS, two segments (2000 x 1152, 4.7 MB) | 100 x 1152 | 1.1 ms | 1.1 ms | 0.43 ms |

Review: five blind reviewers plus a Codex leg, 10 correctness findings addressed in f4c12f60 (`snap_dims` honored on the raw grid, distance width from the header, one fewer copy on single-segment TDMS reads, exact segment-boundary tests). Declined: accepting `time=`/`distance=` value filters in `read_array`; the windows are the trim, as the DASDAE override settled.

## Changelog

- added: Terra15 `read_array` slices the HDF5 data node directly, stopping at the last written sample of an unfinished file.
- added: TDMS `read_array` decodes only the segments a time window touches.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
