### PR TITLE
Slice storage directly in read_array for every remaining format

### DIFF
--- a/dascore/io/ai4eps/core.py
+++ b/dascore/io/ai4eps/core.py
@@ -83,8 +83,12 @@ class AI4EPSV1(FiberIO):
         return dc.spool(patches)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
     ) -> np.ndarray:
         """Slice the ``data`` dataset directly."""
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource["data"], ("distance", "time"), windows)

--- a/dascore/io/ai4eps/core.py
+++ b/dascore/io/ai4eps/core.py
@@ -9,8 +9,10 @@ import numpy as np
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import slice_dataset
 from dascore.models import DateTime64, OptionalFiniteFloat
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import _get_attrs_dict, _get_coords, _get_patches, _is_ai4eps
 
@@ -79,3 +81,10 @@ class AI4EPSV1(FiberIO):
             resource, time=time, distance=distance, attr_cls=AI4EPSPatchAttrs
         )
         return dc.spool(patches)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """Slice the ``data`` dataset directly."""
+        raise_on_extra_kwargs(kwargs, "windows")
+        return slice_dataset(resource["data"], ("distance", "time"), windows)

--- a/dascore/io/ap_sensing/core.py
+++ b/dascore/io/ap_sensing/core.py
@@ -75,8 +75,12 @@ class APSensingV10(FiberIO):
         return dc.spool(patches)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
     ) -> np.ndarray:
         """Slice the ``DAS`` dataset directly."""
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource["DAS"], ("time", "distance"), windows)

--- a/dascore/io/ap_sensing/core.py
+++ b/dascore/io/ap_sensing/core.py
@@ -6,11 +6,15 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import slice_dataset
 from dascore.models import OptionalFiniteFloat
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import _get_attrs_dict, _get_coords, _get_patches, _get_version_string
 
@@ -69,3 +73,10 @@ class APSensingV10(FiberIO):
             resource, time=time, distance=distance, attr_cls=APSensingPatchAttrs
         )
         return dc.spool(patches)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """Slice the ``DAS`` dataset directly."""
+        raise_on_extra_kwargs(kwargs, "windows")
+        return slice_dataset(resource["DAS"], ("time", "distance"), windows)

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -1007,11 +1007,12 @@ class FiberIO:
             Reader-specific options. Multi-patch resources take
             ``source_patch_key`` (as ``read`` and ``scan`` spell it)
             naming the one patch the windows index; without it an
-            ambiguous resource raises rather than guesses. An option
-            which only labels samples, such as most formats' ``snap``,
-            is accepted and ignored, since the windows are indices on a
-            grid it cannot move; one which changes how many samples the
-            resource has (Terra15's ``snap_dims``) is honored.
+            ambiguous resource raises rather than guesses. A labelling
+            option is spelled as that format's ``read`` spells it, since
+            this default forwards to ``read``: usually ``snap``, which
+            only labels samples and so cannot move a window and is
+            ignored; where such an option decides how many samples the
+            resource has, it is honored.
 
         Returns
         -------

--- a/dascore/io/core.py
+++ b/dascore/io/core.py
@@ -1007,12 +1007,18 @@ class FiberIO:
             Reader-specific options. Multi-patch resources take
             ``source_patch_key`` (as ``read`` and ``scan`` spell it)
             naming the one patch the windows index; without it an
-            ambiguous resource raises rather than guesses.
+            ambiguous resource raises rather than guesses. An option
+            which only labels samples, such as most formats' ``snap``,
+            is accepted and ignored, since the windows are indices on a
+            grid it cannot move; one which changes how many samples the
+            resource has (Terra15's ``snap_dims``) is honored.
 
         Returns
         -------
         The array in the resource's stated dimension order (the order
-        ``scan`` reports), untransposed and uncast.
+        ``scan`` reports), untransposed and uncast. A resource whose
+        array is empty returns that empty array, where this default
+        raises instead, having no patch to build.
 
         Examples
         --------

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -148,6 +148,7 @@ class DASDAEV1(FiberIO):
         resource: H5Reader,
         windows: dict[str, tuple[int, int]],
         source_patch_key="",
+        snap: bool = True,
         **kwargs,
     ) -> np.ndarray:
         """
@@ -159,7 +160,7 @@ class DASDAEV1(FiberIO):
         is the waveform group name `scan` reports; a positional index is
         not accepted, because DASDAE never synthesizes one.
         """
-        raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
+        raise_on_extra_kwargs(kwargs, "windows, source_patch_key and snap")
         group = _get_patch_group(resource, source_patch_key)
         return slice_dataset(group["data"], _get_dims(group), windows)
 

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -9,16 +9,11 @@ import numpy as np
 import pandas as pd
 
 import dascore as dc
-from dascore.exceptions import ParameterError
 from dascore.io import FiberIO
+from dascore.io.utils import windows_to_slices
 from dascore.utils.hdf5 import H5Reader, H5Writer
 from dascore.utils.io import _normalize_source_patch_keys
-from dascore.utils.misc import (
-    _to_slice,
-    _validate_sample_values,
-    raise_on_extra_kwargs,
-    unbyte,
-)
+from dascore.utils.misc import raise_on_extra_kwargs, unbyte
 from dascore.utils.patch import get_patch_names
 
 from .utils import (
@@ -166,17 +161,8 @@ class DASDAEV1(FiberIO):
         """
         raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
         group = _get_patch_group(resource, source_patch_key)
-        dims = _get_dims(group)
-        if unknown := sorted(set(windows) - set(dims)):
-            msg = f"Window dimensions {unknown} are not among patch dims {dims}."
-            raise ParameterError(msg)
-        # the same validation and (start, stop) reading as select(samples=True)
-        for window in windows.values():
-            _validate_sample_values(window)
-        index = tuple(
-            _to_slice(windows[dim]) if dim in windows else slice(None) for dim in dims
-        )
-        return group["data"][index]
+        data = group["data"]
+        return data[windows_to_slices(windows, _get_dims(group), data.shape)]
 
     def scan(self, resource: H5Reader, snap: bool = True, **kwargs):
         """

--- a/dascore/io/dasdae/core.py
+++ b/dascore/io/dasdae/core.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 import dascore as dc
 from dascore.io import FiberIO
-from dascore.io.utils import windows_to_slices
+from dascore.io.utils import slice_dataset
 from dascore.utils.hdf5 import H5Reader, H5Writer
 from dascore.utils.io import _normalize_source_patch_keys
 from dascore.utils.misc import raise_on_extra_kwargs, unbyte
@@ -161,8 +161,7 @@ class DASDAEV1(FiberIO):
         """
         raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
         group = _get_patch_group(resource, source_patch_key)
-        data = group["data"]
-        return data[windows_to_slices(windows, _get_dims(group), data.shape)]
+        return slice_dataset(group["data"], _get_dims(group), windows)
 
     def scan(self, resource: H5Reader, snap: bool = True, **kwargs):
         """

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -16,7 +16,7 @@ from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
 from dascore.core.summary import normalize_source_patch_key
-from dascore.exceptions import MissingPatchError, PatchAttributeError
+from dascore.exceptions import PatchAttributeError
 from dascore.io.core import STORED_PATCH_ID, make_scan_payload
 from dascore.io.dasdae._compat import (
     NOT_DECODED,
@@ -24,7 +24,7 @@ from dascore.io.dasdae._compat import (
     strip_legacy_coord_fields,
     translate_legacy_attrs,
 )
-from dascore.io.utils import get_exact_coord
+from dascore.io.utils import get_exact_coord, resolve_keyed_source
 from dascore.models.registry import get_model_tag, resolve_tagged_model
 from dascore.utils.array import (
     convert_bytes_to_strings,
@@ -297,29 +297,14 @@ def _get_patch_group(h5, source_patch_key=""):
     """
     Return the one waveform group a source patch key names.
 
-    Without a key, a file holding exactly one patch resolves to it. An
-    empty file raises MissingPatchError; several patches without a key,
-    or a key naming no group, raise PatchAttributeError, the types the
-    default `read_array` raises.
+    A key names a direct child of the waveform group, never an h5py path.
     """
-    key = normalize_source_patch_key(source_patch_key)
     waveforms = h5.get("waveforms", {})
-    if not len(waveforms):
-        msg = f"No patches in {h5.filename}."
-        raise MissingPatchError(msg)
-    if key:
-        # h5py reads a key as a path, so "<name>/data" or "/waveforms"
-        # would resolve to something; only a direct child by that name,
-        # which never holds a separator, is a patch
-        group = waveforms.get(key) if "/" not in key and key in waveforms else None
-        if group is None or group.name != f"{waveforms.name}/{key}":
-            msg = f"No patch named '{key}' in {h5.filename}."
-            raise PatchAttributeError(msg)
-        return group
-    if len(waveforms) > 1:
-        msg = f"{h5.filename} holds several patches; pass source_patch_key."
-        raise PatchAttributeError(msg)
-    return next(iter(waveforms.values()))
+    key = normalize_source_patch_key(source_patch_key)
+    if "/" in key:
+        # h5py would read the key as a path; a patch is a direct child
+        raise PatchAttributeError(f"No patch named '{key}' in {h5.filename}.")
+    return resolve_keyed_source(waveforms, key, where=str(h5.filename))
 
 
 def _matches_attr_filters(attrs, kwargs):

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, slice_dataset
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
-from .utils import _get_cf_attrs, _get_cf_coords, _get_cf_version_str
+from .utils import (
+    _get_cf_attrs,
+    _get_cf_coords,
+    _get_cf_dims,
+    _get_cf_version_str,
+)
 
 
 class DASHDF5(FiberIO):
@@ -65,3 +73,19 @@ class DASHDF5(FiberIO):
             selection={"time": time, "channel": channel},
         )
         return dc.spool(patches)
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the ``das`` dataset directly.
+
+        The dimension order is the one the dataset's shape implies, which
+        is what `scan` reports.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        return slice_dataset(resource["das"], _get_cf_dims(resource), windows)

--- a/dascore/io/dashdf5/utils.py
+++ b/dascore/io/dashdf5/utils.py
@@ -34,6 +34,9 @@ def _get_cf_version_str(hdf_fi) -> str | Literal[False]:
     return das_hdf_str[0].replace("DAS-HDF5-", "")
 
 
+_CF_DIMS = ("channel", "time")
+
+
 def _get_cf_coords(hdf_fi, minimal=False, snap=True) -> dc.core.CoordManager:
     """
     Get a coordinate manager of full file range.
@@ -72,16 +75,25 @@ def _get_cf_coords(hdf_fi, minimal=False, snap=True) -> dc.core.CoordManager:
         "y": ("channel",),
         "z": ("channel",),
     }
-    dims = ("channel", "time")
     cm = dc.core.CoordManager(
         coord_map=coords_map,
         dim_map=dim_map,
-        dims=dims,
+        dims=_CF_DIMS,
     )
-    # a bit of a hack to make sure data and coords align.
-    if cm.shape != hdf_fi["das"].shape:
+    if cm.dims != _get_cf_dims(hdf_fi):
         cm = cm.transpose()
     return cm
+
+
+def _get_cf_dims(hdf_fi) -> tuple[str, str]:
+    """
+    The stored dimension order of the ``das`` dataset.
+
+    The format does not state it, so it is read off the dataset's shape:
+    the channel-major order unless only the other one fits.
+    """
+    shape = (len(hdf_fi["channel"]), len(hdf_fi["t"]))
+    return _CF_DIMS if hdf_fi["das"].shape == shape else _CF_DIMS[::-1]
 
 
 def _get_cf_attrs(hdf_fi, coords=None, extras=None):

--- a/dascore/io/dasvader/core.py
+++ b/dascore/io/dasvader/core.py
@@ -4,16 +4,21 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import resolve_keyed_source, slice_dataset
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import (
     DATA_NAMES,
     _dereference,
     _get_attr_dict,
     _get_coord_manager,
+    _get_data_and_dims,
     _get_reference_names,
     _is_dasvader_jld2,
     _read_dasvader,
@@ -83,3 +88,23 @@ class DASVaderV1(FiberIO):
         """Read a DASVader spool of patches."""
         patches = _read_dasvader(resource, time=time, distance=distance)
         return dc.spool(patches)
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        source_patch_key="",
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the data reference's dataset directly.
+
+        Only the ``dDAS`` record, which names the reference, is read
+        besides the requested block. A file holds one patch, so the key
+        `scan` reports is empty; any other is refused.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
+        dataset, dims = _get_data_and_dims(resource)
+        where = str(getattr(resource, "filename", "the resource"))
+        resolve_keyed_source({"": dataset}, source_patch_key, where=where)
+        return slice_dataset(dataset, dims, windows)

--- a/dascore/io/dasvader/utils.py
+++ b/dascore/io/dasvader/utils.py
@@ -158,11 +158,25 @@ def _get_coord_manager(h5, rec):
     dist = _get_distance_coord(rec)
     # The data axis is transposed based on if they are stored in "strainrate"
     # or "data" reference.
-    dims = ("distance", "time") if "data" in names else ("time", "distance")
     return dc.get_coord_manager(
         {"time": time, "distance": dist},
-        dims=dims,
+        dims=_get_dims(names),
     )
+
+
+def _get_dims(names) -> tuple[str, str]:
+    """The stored dimension order, which the data reference's name says."""
+    # The data axis is transposed based on if they are stored in
+    # "strainrate" or "data" reference.
+    return ("distance", "time") if "data" in names else ("time", "distance")
+
+
+def _get_data_and_dims(h5, rec=None):
+    """Resolve the data reference to its dataset, with its dimension order."""
+    rec = h5["dDAS"][()] if rec is None else rec
+    names = set(_get_reference_names(h5))
+    data_name = "data" if "data" in names else next(iter(DATA_NAMES & names))
+    return _dereference(h5, rec[data_name], data_name), _get_dims(names)
 
 
 # --- Reading
@@ -195,12 +209,8 @@ def _read_dasvader(h5, distance=None, time=None):
     """Read DASVader data into a Patch."""
     rec = h5["dDAS"][()]
     cm = _get_coord_manager(h5, rec)
-    # First, figure out what the data name is (this changes in different
-    # dasvader iterations), but if we get to here it has at least one.
     ref_names = set(_get_reference_names(h5))
-    data_name = "data" if "data" in ref_names else next(iter(DATA_NAMES & ref_names))
-    # data is a reference here; need to resolve it with h5 File.
-    data = _dereference(h5, rec[data_name], data_name)
+    data, _ = _get_data_and_dims(h5, rec)
     attrs = (
         _get_attr_dict(_dereference(h5, rec["atrib"], "atrib"))
         if "atrib" in ref_names

--- a/dascore/io/febus/a1utils.py
+++ b/dascore/io/febus/a1utils.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 from collections import namedtuple
 from collections.abc import Iterator
-from functools import cache
 
 import numpy as np
 
 import dascore as dc
 from dascore.core import get_coord, get_coord_manager
 from dascore.core.coordmanager import CoordManager
-from dascore.io.utils import drop_blank_attrs
+from dascore.io.utils import drop_blank_attrs, windows_to_slices
 from dascore.utils.io import _normalize_source_patch_keys
 from dascore.utils.misc import (
     _maybe_unpack,
@@ -118,7 +117,6 @@ def _get_zone_time(feb):
     return _FebusTime(block_time, dt, idx_start, idx_stop)
 
 
-@cache
 def _get_block_time(feb):
     """Get the block time (time in seconds between each block)."""
     # Some files have this set. We haven't yet seen any files where this
@@ -386,6 +384,36 @@ def _get_data_new_cm(cm, febus, distance=None, time=None):
             data = data_3d.reshape(-1, data_3d.shape[2])
     cm = get_coord_manager({"time": time_coord, "distance": dist_coord}, dims=cm.dims)
     return data, cm
+
+
+def _read_febus_array(febus: _FebusSlice, windows) -> np.ndarray:
+    """
+    Read a window of one zone's data as a (time, distance) array.
+
+    The zone stores a 3-D cube of ``(block, row, distance)`` whose rows
+    outside ``idx_start`` to ``idx_stop`` are the blocks' padding. The
+    time axis `scan` reports is what is left, flattened, so a time window
+    names a range of blocks and an offset into the first of them; only
+    those blocks are read.
+    """
+    time_info = _get_zone_time(febus)
+    data = febus.zone[febus.data_name]
+    rows = time_info.idx_stop - time_info.idx_start + 1
+    shape = (rows * data.shape[0], data.shape[2])
+    time_slice, dist_slice = windows_to_slices(windows, ("time", "distance"), shape)
+    length = time_slice.stop - time_slice.start
+    width = dist_slice.stop - dist_slice.start
+    if not length or not width:
+        return np.empty((length, width), dtype=data.dtype)
+    first = time_slice.start // rows
+    # the last block the window touches, counted from its last sample
+    last = (time_slice.stop - 1) // rows
+    block = data[
+        first : last + 1, time_info.idx_start : time_info.idx_stop + 1, dist_slice
+    ]
+    flat = block.reshape(-1, block.shape[2])
+    offset = time_slice.start - first * rows
+    return flat[offset : offset + length]
 
 
 def _read_febus(

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -264,8 +264,6 @@ class FebusMTXH5V1(FiberIO):
     ) -> np.ndarray:
         """
         Slice the ``mtx`` dataset directly.
-
-        ``snap`` only changes coordinate values, never the grid.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource["mtx"], _MTX_DIMS, windows)
@@ -338,8 +336,6 @@ class FebusBSLH5V1(FiberIO):
     ) -> np.ndarray:
         """
         Slice the ``bsl_data`` dataset directly.
-
-        ``snap`` only changes coordinate values, never the grid.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource["bsl_data"], _BSL_DIMS, windows)
@@ -409,8 +405,6 @@ class FebusT1V1(FiberIO):
     ) -> np.ndarray:
         """
         Slice the ``Data/Temperature`` dataset directly.
-
-        ``snap`` only changes coordinate values, never the grid.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -18,16 +18,18 @@ from dascore.constants import (
 )
 from dascore.io import FiberIO, ScanPayload
 from dascore.io.core import make_scan_payload
-from dascore.io.utils import slice_dataset
+from dascore.io.utils import resolve_keyed_source, slice_dataset
 from dascore.models import OptionalFiniteFloat, UTF8Str
 from dascore.utils.hdf5 import H5Reader
 from dascore.utils.io import TextReader
 from dascore.utils.misc import raise_on_extra_kwargs
 
 from .a1utils import (
+    _flatten_febus_info,
     _get_febus_version_str,
     _get_source_patch_key,
     _read_febus,
+    _read_febus_array,
     _yield_attrs_coords,
 )
 from .g1utils import (
@@ -145,6 +147,30 @@ class Febus2(FiberIO):
             attr_cls=FebusPatchAttrs,
         )
         return dc.spool(patches)
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        source_patch_key="",
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Read one zone's window out of its block-structured data cube.
+
+        ``source_patch_key`` is the ``group:source:zone`` name `scan`
+        reports; a file holding several zones needs one.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
+        # pairs, not a mapping: two zones can generate one name, and the
+        # default read refuses such a key rather than picking one
+        zones = [
+            (_get_source_patch_key(zone), zone)
+            for zone in _flatten_febus_info(resource)
+        ]
+        where = str(getattr(resource, "filename", "the resource"))
+        febus = resolve_keyed_source(zones, source_patch_key, where=where)
+        return _read_febus_array(febus, windows)
 
 
 class Febus1(Febus2):

--- a/dascore/io/febus/core.py
+++ b/dascore/io/febus/core.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import (
     float_select_type,
@@ -16,9 +18,11 @@ from dascore.constants import (
 )
 from dascore.io import FiberIO, ScanPayload
 from dascore.io.core import make_scan_payload
+from dascore.io.utils import slice_dataset
 from dascore.models import OptionalFiniteFloat, UTF8Str
 from dascore.utils.hdf5 import H5Reader
 from dascore.utils.io import TextReader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .a1utils import (
     _get_febus_version_str,
@@ -27,6 +31,8 @@ from .a1utils import (
     _yield_attrs_coords,
 )
 from .g1utils import (
+    _BSL_DIMS,
+    _MTX_DIMS,
     _bsl_version,
     _get_bsl_attrs,
     _get_bsl_coords,
@@ -249,6 +255,21 @@ class FebusMTXH5V1(FiberIO):
         )
         return dc.spool([] if patch is None else [patch])
 
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the ``mtx`` dataset directly.
+
+        ``snap`` only changes coordinate values, never the grid.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        return slice_dataset(resource["mtx"], _MTX_DIMS, windows)
+
 
 class FebusBSLH5V1(FiberIO):
     """
@@ -308,6 +329,21 @@ class FebusBSLH5V1(FiberIO):
         )
         return dc.spool([] if patch is None else [patch])
 
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the ``bsl_data`` dataset directly.
+
+        ``snap`` only changes coordinate values, never the grid.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        return slice_dataset(resource["bsl_data"], _BSL_DIMS, windows)
+
 
 class FebusT1V1(FiberIO):
     """
@@ -363,3 +399,20 @@ class FebusT1V1(FiberIO):
         if not pa.data.size:
             return dc.spool([])
         return dc.spool([pa])
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the ``Data/Temperature`` dataset directly.
+
+        ``snap`` only changes coordinate values, never the grid.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        return slice_dataset(
+            resource["Data/Temperature"], ("time", "distance"), windows
+        )

--- a/dascore/io/gdr/core.py
+++ b/dascore/io/gdr/core.py
@@ -10,12 +10,17 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
 from dascore.io.gdr.utils_das import _get_attrs_coords_and_data, _get_version
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, slice_dataset
 from dascore.models import OptionalFiniteFloat
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
+
+from .utils_das import _get_dims
 
 
 class GDRPatchAttrs(dc.PatchAttrs):
@@ -68,6 +73,25 @@ class GDR_V1(FiberIO):  # noqa
             selection={"time": time, "distance": distance},
         )
         return dc.spool(patches)
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the ``DasRawData/RawData`` dataset directly.
+
+        ``snap`` only changes coordinate values, never the grid.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        return slice_dataset(
+            resource["DasRawData/RawData"],
+            _get_dims(resource["DasRawData/RawData"]),
+            windows,
+        )
 
     def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[ScanPayload]:
         """Get the attributes of a resource belong to this type."""

--- a/dascore/io/gdr/core.py
+++ b/dascore/io/gdr/core.py
@@ -83,8 +83,6 @@ class GDR_V1(FiberIO):  # noqa
     ) -> np.ndarray:
         """
         Slice the ``DasRawData/RawData`` dataset directly.
-
-        ``snap`` only changes coordinate values, never the grid.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(

--- a/dascore/io/gdr/utils_das.py
+++ b/dascore/io/gdr/utils_das.py
@@ -45,6 +45,19 @@ def _get_version(h5fi):
     return "GDR_DAS", _COMPOSITE_VERSIONS[(meta_fmt, data_fmt)]
 
 
+def _get_dims(dataset) -> tuple[str, ...]:
+    """The dimension names, from the dataset's DasDimensions attribute."""
+    das_dims = dataset.attrs["DasDimensions"]
+    out = [""] * 2
+    for num, dim in enumerate(das_dims):
+        if dim.startswith("time"):
+            out[num] = "time"
+        elif dim == "locus":
+            out[num] = "distance"
+    assert all(out)
+    return tuple(out)
+
+
 def _get_attrs_coords_and_data(resource, snap):
     """
     Get attributes, coordinates, and data from the file.
@@ -84,21 +97,9 @@ def _get_coord_manager(resource, snap=True):
         units = unbyte(group.attrs["SpatialSamplingIntervalUnit"])
         return get_coord(start=0, step=dx, shape=(length,), units=units)
 
-    def get_dims(dataset):
-        """Get the dimension names."""
-        das_dims = dataset.attrs["DasDimensions"]
-        out = [""] * 2
-        for num, dim in enumerate(das_dims):
-            if dim.startswith("time"):
-                out[num] = "time"
-            elif dim == "locus":
-                out[num] = "distance"
-        assert all(out)
-        return tuple(out)
-
     time_coord = get_time_coord(resource, snap)
     dataset = resource["DasRawData/RawData"]
-    dims = get_dims(dataset)
+    dims = _get_dims(dataset)
     # Get distance coord.
     dist_axis = dims.index("distance")
     dist_length = dataset.shape[dist_axis]

--- a/dascore/io/gdr/utils_das.py
+++ b/dascore/io/gdr/utils_das.py
@@ -4,6 +4,8 @@ Utilities functions for GDR DAS format.
 See: https://gdr.openei.org/das_data_standard for more info.
 """
 
+from __future__ import annotations
+
 import numpy as np
 
 import dascore as dc

--- a/dascore/io/gdr/utils_das.py
+++ b/dascore/io/gdr/utils_das.py
@@ -46,15 +46,21 @@ def _get_version(h5fi):
 
 
 def _get_dims(dataset) -> tuple[str, ...]:
-    """The dimension names, from the dataset's DasDimensions attribute."""
+    """
+    The dataset's dimension names, in DASCore's spelling.
+
+    The file states them in ``DasDimensions``, where the distance axis is
+    called ``locus``.
+    """
     das_dims = dataset.attrs["DasDimensions"]
     out = [""] * 2
     for num, dim in enumerate(das_dims):
+        dim = unbyte(dim)
         if dim.startswith("time"):
             out[num] = "time"
         elif dim == "locus":
             out[num] = "distance"
-    assert all(out)
+    assert all(out), f"unexpected DasDimensions {das_dims}"
     return tuple(out)
 
 

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, slice_dataset
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
-from .utils import _get_attrs_coords_and_data, _is_h5simple
+from .utils import (
+    _get_attrs_coords_and_data,
+    _get_dims_and_data,
+    _is_h5simple,
+)
 
 
 class H5Simple(FiberIO):
@@ -44,6 +51,25 @@ class H5Simple(FiberIO):
         """
         attrs, cm, data = _get_attrs_coords_and_data(resource, snap)
         return dc.spool(build_patches(cm, data, attrs, selection=kwargs))
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the data node directly.
+
+        The dimensions come from the file's ``dims`` attribute, or from
+        which node's length matches each axis, exactly as `read` resolves
+        them. No coordinate values are read either way, and the axis no
+        node accounts for is named without building its index.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        dims, data_node = _get_dims_and_data(resource)
+        return slice_dataset(data_node, dims, windows)
 
     def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[ScanPayload]:
         """Get the attributes of a h5simple file."""

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -51,9 +51,9 @@ def _get_coord(v, snap, name):
     return coord
 
 
-def _fill_coords(coord_shape_dict, other_nodes, data_node):
+def _name_missing_dim(coord_shape_dict, data_node) -> int:
     """
-    Fill missing coordinate with "channel".
+    Name the one axis no node accounts for "channel", and return its length.
 
     This is needed because the foresee data on pubdas only specify time;
     we have to fill in channel number.
@@ -62,39 +62,46 @@ def _fill_coords(coord_shape_dict, other_nodes, data_node):
     assert len(missing_shape) == 1, "can only fill one missing coord."
     shape = next(iter(missing_shape))
     coord_shape_dict[shape] = "channel"
-    other_nodes["channel"] = np.arange(shape)
-    return other_nodes, coord_shape_dict
+    return shape
+
+
+def _get_dims(data_node, time_node, other_nodes, dims=None):
+    """
+    Get the dims tuple, and the coord nodes any filling added.
+
+    The format does not have to state its dimensions; when it does not,
+    each is named by the node whose length matches that axis. Only node
+    shapes are read here, never their values.
+    """
+    if dims:
+        stated = tuple(dims.split(",")) if isinstance(dims, str) else tuple(dims)
+        return stated, other_nodes
+    can_guess_shape = len(data_node.shape) == len(set(data_node.shape))
+    assert can_guess_shape, "Cant determine dims; shape values not unique!"
+    assert len(time_node.shape) == 1, "time node has more than one dimension!"
+    # get a dict of {coord_name: shape} for 1d coords.
+    coord_shape_dict = {len(v): x for x, v in other_nodes.items() if len(v.shape) == 1}
+    coord_shape_dict[len(time_node)] = "time"
+    # need to fill some dims
+    if len(coord_shape_dict) != len(data_node.shape):
+        _name_missing_dim(coord_shape_dict, data_node)
+    return tuple(coord_shape_dict[x] for x in data_node.shape), other_nodes
 
 
 def _get_coords_and_dims(data_node, time_node, other_nodes, snap=True, dims=None):
     """Get dims tuple and coord dict."""
-    if dims:
-        dims = dims if not isinstance(dims, str) else dims.split(",")
-    else:  # ascertain dims from shape
-        can_guess_shape = len(data_node.shape) == len(set(data_node.shape))
-        assert can_guess_shape, "Cant determine dims; shape values not unique!"
-        assert len(time_node.shape) == 1, "time node has more than one dimension!"
-        # get a dict of {coord_name: shape} for 1d coords.
-        coord_shape_dict = {
-            len(v): x for x, v in other_nodes.items() if len(v.shape) == 1
-        }
-        coord_shape_dict[len(time_node)] = "time"
-        # need to fill some dims
-        if len(coord_shape_dict) != len(data_node.shape):
-            other_nodes, coord_shape_dict = _fill_coords(
-                coord_shape_dict,
-                other_nodes,
-                data_node,
-            )
-
-        dims = tuple(coord_shape_dict[x] for x in data_node.shape)
+    dims, other_nodes = _get_dims(data_node, time_node, other_nodes, dims)
     other_nodes["time"] = time_node
+    # the filled axis is named but not built: only coordinates need it
+    if "channel" in dims and "channel" not in other_nodes:
+        length = data_node.shape[dims.index("channel")]
+        other_nodes["channel"] = np.arange(length)
     coords = {i: _get_coord(v, snap=snap, name=i) for i, v in other_nodes.items()}
     return dims, coords
 
 
-def _get_cm_and_data(h5, snap=False, dims=None):
-    """Extract coordinate manager and data node."""
+def _get_nodes(h5):
+    """Return the file's data node, time node, and other array nodes."""
     root_nodes = {name: node for name, node in h5.items() if hasattr(node, "shape")}
     array_names = set(root_nodes)
     data_node_name = array_names & DATA_ARRAY_NAMES
@@ -104,10 +111,24 @@ def _get_cm_and_data(h5, snap=False, dims=None):
     assert len(data_node_name) == 1, f"{h5} doesn't have exactly one data node."
     assert len(time_node_name) == 1, f"{h5} doesn't have exactly one time node"
 
-    data_node = root_nodes[next(iter(data_node_name))]
-    time_node = root_nodes[next(iter(time_node_name))]
-    other_nodes = {x: root_nodes[x] for x in other_node_names}
+    return (
+        root_nodes[next(iter(data_node_name))],
+        root_nodes[next(iter(time_node_name))],
+        {x: root_nodes[x] for x in other_node_names},
+    )
 
+
+def _get_dims_and_data(h5):
+    """Return the data node's dims and the node itself, reading no values."""
+    dims_attr = unbyte(h5.attrs["dims"]) if "dims" in h5.attrs else None
+    data_node, time_node, other_nodes = _get_nodes(h5)
+    dims, _ = _get_dims(data_node, time_node, other_nodes, dims_attr)
+    return dims, data_node
+
+
+def _get_cm_and_data(h5, snap=False, dims=None):
+    """Extract coordinate manager and data node."""
+    data_node, time_node, other_nodes = _get_nodes(h5)
     dims, coords = _get_coords_and_dims(data_node, time_node, other_nodes, snap, dims)
     return dc.core.get_coord_manager(coords, dims=dims), data_node
 

--- a/dascore/io/netcdf/core.py
+++ b/dascore/io/netcdf/core.py
@@ -12,10 +12,14 @@ import dascore as dc
 from dascore.exceptions import MissingOptionalDependencyError
 from dascore.io import FiberIO
 from dascore.io.core import ScanPayload, make_scan_payload
-from dascore.io.utils import get_exact_coord
+from dascore.io.utils import (
+    get_exact_coord,
+    resolve_keyed_source,
+    windows_to_slices,
+)
 from dascore.utils.hdf5 import H5Reader, get_h5py_file
 from dascore.utils.io import patch_to_xarray, xarray_to_patch
-from dascore.utils.misc import optional_import
+from dascore.utils.misc import optional_import, raise_on_extra_kwargs
 
 from .utils import (
     XDAS_PAYLOAD_VARIABLE,
@@ -129,6 +133,33 @@ class NetCDFCFV18(FiberIO):
         if not patch.data.size:
             return dc.spool([])
         return dc.spool([patch])
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        source_patch_key="",
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the payload variable through xarray.
+
+        The selection goes through xarray rather than the stored dataset
+        so CF decoding (scaling, offsets, fill values) applies exactly as
+        it does in `read`.
+        """
+        raise_on_extra_kwargs(kwargs, "windows, source_patch_key and snap")
+        with _open_xarray_dataset(resource) as dataset:
+            data_var_name = get_xarray_data_var_name(dataset)
+            resolve_keyed_source(
+                {self._get_source_patch_key(data_var_name): data_var_name},
+                source_patch_key,
+                where=str(getattr(resource, "filename", "the resource")),
+            )
+            data_array = dataset[data_var_name]
+            slices = windows_to_slices(windows, data_array.dims, data_array.shape)
+            return data_array[slices].to_numpy()
 
     def _get_write_encoding(self, **kwargs):
         """Translate explicit write options into xarray encoding hints."""

--- a/dascore/io/neubrex/core.py
+++ b/dascore/io/neubrex/core.py
@@ -12,9 +12,10 @@ import dascore as dc
 import dascore.io.neubrex.utils_das as das_utils
 import dascore.io.neubrex.utils_rfs as rfs_utils
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, slice_dataset
 from dascore.models import OptionalFiniteFloat
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 
 class NeubrexRFSPatchAttrs(dc.PatchAttrs):
@@ -87,6 +88,21 @@ class NeubrexRFSV1(FiberIO):
         )
         return dc.spool(patches)
 
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the ``data`` dataset directly.
+
+        ``snap`` only changes coordinate values, never the grid.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        return slice_dataset(resource["data"], ("time", "distance"), windows)
+
     def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[ScanPayload]:
         """Get the attributes of a resource belong to this type."""
         cm = rfs_utils._get_coord_manager(resource, snap)
@@ -137,6 +153,13 @@ class NeubrexDASV1(FiberIO):
             selection={"time": time, "distance": distance},
         )
         return dc.spool(patches)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """Slice the ``Acoustic`` dataset directly."""
+        raise_on_extra_kwargs(kwargs, "windows")
+        return slice_dataset(resource["Acoustic"], ("time", "distance"), windows)
 
     def scan(self, resource: H5Reader, **kwargs) -> list[ScanPayload]:
         """Get the attributes of this format from File."""

--- a/dascore/io/neubrex/core.py
+++ b/dascore/io/neubrex/core.py
@@ -97,8 +97,6 @@ class NeubrexRFSV1(FiberIO):
     ) -> np.ndarray:
         """
         Slice the ``data`` dataset directly.
-
-        ``snap`` only changes coordinate values, never the grid.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource["data"], ("time", "distance"), windows)
@@ -155,10 +153,14 @@ class NeubrexDASV1(FiberIO):
         return dc.spool(patches)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
     ) -> np.ndarray:
         """Slice the ``Acoustic`` dataset directly."""
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource["Acoustic"], ("time", "distance"), windows)
 
     def scan(self, resource: H5Reader, **kwargs) -> list[ScanPayload]:

--- a/dascore/io/odh4/core.py
+++ b/dascore/io/odh4/core.py
@@ -80,8 +80,12 @@ class ODH4V1(FiberIO):
         return dc.spool(patches)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
     ) -> np.ndarray:
         """Slice the ``raw_data`` dataset directly."""
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource["raw_data"], ("distance", "time"), windows)

--- a/dascore/io/odh4/core.py
+++ b/dascore/io/odh4/core.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import slice_dataset
 from dascore.models import OptionalFiniteFloat
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import _get_attrs_dict, _get_coords, _get_patches, _is_odh4, _read_attrs
 
@@ -74,3 +78,10 @@ class ODH4V1(FiberIO):
             resource, time=time, distance=distance, attr_cls=ODH4PatchAttrs
         )
         return dc.spool(patches)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """Slice the ``raw_data`` dataset directly."""
+        raise_on_extra_kwargs(kwargs, "windows")
+        return slice_dataset(resource["raw_data"], ("distance", "time"), windows)

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -81,10 +81,7 @@ class OptoDASV8(FiberIO):
         snap: bool = True,
         **kwargs,
     ) -> np.ndarray:
-        """Slice the ``data`` dataset directly, in the header's dimension order.
-
-        ``snap`` only changes coordinate values, never the grid.
-        """
+        """Slice the ``data`` dataset directly, in the header's dimension order."""
         raise_on_extra_kwargs(kwargs, "windows and snap")
         dims = tuple(unbyte(x) for x in resource["header"]["dimensionNames"])
         return slice_dataset(resource["data"], dims, windows)

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import slice_dataset
 from dascore.models import OptionalFiniteFloat, UTF8Str
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs, unbyte
 
 from .utils import _get_opto_das_attrs, _get_opto_das_version_str, _read_opto_das
 
@@ -69,6 +73,21 @@ class OptoDASV8(FiberIO):
             resource, time=time, distance=distance, attr_cls=OptoDASPatchAttrs
         )
         return dc.spool(patches)
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """Slice the ``data`` dataset directly, in the header's dimension order.
+
+        ``snap`` only changes coordinate values, never the grid.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        dims = tuple(unbyte(x) for x in resource["header"]["dimensionNames"])
+        return slice_dataset(resource["data"], dims, windows)
 
 
 class OptoDASV9(OptoDASV8):

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import slice_dataset
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from ...utils.hdf5 import H5Reader, H5Writer
 from .utils import (
+    _get_data_node,
     _get_prodml_version_str,
     _read_prodml,
     _write_prodml,
@@ -77,6 +82,25 @@ class ProdMLV2_0(FiberIO):  # noqa
             source_patch_key=source_patch_key,
         )
         return dc.spool(patches)
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        source_patch_key="",
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice one acquisition node's data array directly.
+
+        ``source_patch_key`` is the node name `scan` reports (for example
+        ``Raw[0]`` or ``FbeData[0]``); a file holding several nodes needs
+        one.
+        """
+        raise_on_extra_kwargs(kwargs, "windows, source_patch_key and snap")
+        dataset, dims = _get_data_node(resource, source_patch_key)
+        return slice_dataset(dataset, dims, windows)
 
 
 class ProdMLV2_1(ProdMLV2_0):  # noqa

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -14,7 +14,7 @@ import dascore as dc
 from dascore.constants import VALID_DATA_TYPES
 from dascore.core.coords import get_coord
 from dascore.exceptions import InvalidSpoolError, PatchError
-from dascore.io.utils import convert_attr_units, get_exact_coord
+from dascore.io.utils import convert_attr_units, get_exact_coord, resolve_keyed_source
 from dascore.models import OptionalFiniteFloat, UTF8Str
 from dascore.units import get_quantity_str
 from dascore.utils.hdf5 import encode_h5_strings
@@ -483,6 +483,31 @@ def _write_prodml(spool, resource):
     raw_time.attrs.update(time_attrs)
 
 
+def _get_node_dims(node_info) -> tuple[str, ...]:
+    """
+    The stored dimension order of a data node, as `scan` reports it.
+
+    A node states its own ``Dimensions`` where it has them; a raw node
+    states them on its data array, and a processed one which states none
+    falls back to its parent's.
+    """
+    if node_info.patch_type == "raw":
+        return _get_dims_from_attrs(node_info.node["RawData"].attrs)
+    attrs = node_info.node.attrs
+    if "Dimensions" not in attrs:
+        attrs = node_info.parent_node.attrs
+    return _get_dims_from_attrs(attrs)
+
+
+def _get_data_node(h5, source_patch_key=""):
+    """Return the (dataset, dims) the key names, keyed as `scan` keys them."""
+    # pairs, not a mapping: a file may name two nodes alike, and the
+    # default read refuses such a key rather than picking one
+    nodes = [(info.name, info) for info in _yield_data_nodes(h5)]
+    info = resolve_keyed_source(nodes, source_patch_key, where=str(h5.filename))
+    return _NODE_DATA_PROCESSORS[info.patch_type](info), _get_node_dims(info)
+
+
 @register_func(_NODE_ATTRS_PROCESSORS, key="raw")
 def _get_raw_node_attr_coords(node_info, d_coord, base_info, snap=True):
     """Get the raw data information."""
@@ -493,7 +518,7 @@ def _get_raw_node_attr_coords(node_info, d_coord, base_info, snap=True):
     info["_source_patch_key"] = node_info.name
     coords = dc.get_coord_manager(
         coords={"time": t_coord, "distance": d_coord},
-        dims=_get_dims_from_attrs(node_info.node["RawData"].attrs),
+        dims=_get_node_dims(node_info),
     )
     return ProdMLRawPatchAttrs(**info), coords
 
@@ -520,7 +545,7 @@ def _get_processed_node_attr_coords(node_info, d_coord, base_info, snap=True):
     distance = d_coord[ind_1 : ind_1 + count]
     coords = dc.get_coord_manager(
         coords={"time": t_coord, "distance": distance},
-        dims=_get_dims_from_attrs(node_info.parent_node.attrs),
+        dims=_get_node_dims(node_info),
     )
     return ProdMLFbePatchAttrs.from_dict(out), coords
 

--- a/dascore/io/silixah5/core.py
+++ b/dascore/io/silixah5/core.py
@@ -6,11 +6,15 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import slice_dataset
 from dascore.models import OptionalFiniteFloat
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import (
     _get_attr,
@@ -80,6 +84,16 @@ class SilixaH5V1(FiberIO):
             resource, time=time, distance=distance, attr_cls=SilixaPatchAttrs
         )
         return dc.spool(patches)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """Slice the ``Acoustic`` dataset directly.
+
+        Version 2 files hold the array under ``Fiber``; ``_data_name`` says which.
+        """
+        raise_on_extra_kwargs(kwargs, "windows")
+        return slice_dataset(resource[self._data_name], ("time", "distance"), windows)
 
 
 class SilixaH5V2(SilixaH5V1):

--- a/dascore/io/silixah5/core.py
+++ b/dascore/io/silixah5/core.py
@@ -86,13 +86,14 @@ class SilixaH5V1(FiberIO):
         return dc.spool(patches)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
     ) -> np.ndarray:
-        """Slice the ``Acoustic`` dataset directly.
-
-        Version 2 files hold the array under ``Fiber``; ``_data_name`` says which.
-        """
-        raise_on_extra_kwargs(kwargs, "windows")
+        """Slice the version's data dataset (``Acoustic`` or ``Fiber``)."""
+        raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource[self._data_name], ("time", "distance"), windows)
 
 

--- a/dascore/io/sintela/core.py
+++ b/dascore/io/sintela/core.py
@@ -11,16 +11,22 @@ import numpy as np
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import windows_to_slices
 from dascore.models import OptionalFiniteFloat
 from dascore.utils.io import BinaryReader, LocalBinaryReader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .protobuf_utils import get_supported_family_tag, read_payload, scan_payload
 from .utils import (
     _HEADER_SIZES,
+    DIMS,
     SYNC_WORD,
     _get_attrs_coords_header,
+    _get_complete_header,
+    _get_data_shape,
     _get_patches,
     _read_base_header,
+    _read_sample_range,
 )
 
 
@@ -84,6 +90,22 @@ class SintelaBinaryV3(FiberIO):
         )
 
         return dc.spool(patch)
+
+    def read_array(
+        self, resource: LocalBinaryReader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """
+        Slice the memory-mapped packet payloads.
+
+        Only the header and the requested block leave the file; the map
+        skips each packet's header, so the window indexes samples.
+        """
+        raise_on_extra_kwargs(kwargs, "windows")
+        header = _get_complete_header(resource)
+        shape = _get_data_shape(header)
+        time_slice, dist_slice = windows_to_slices(windows, DIMS, shape)
+        data = _read_sample_range(resource, header, time_slice.start, time_slice.stop)
+        return np.asarray(data[:, dist_slice])
 
 
 class SintelaProtobufV1(FiberIO):

--- a/dascore/io/sintela/utils.py
+++ b/dascore/io/sintela/utils.py
@@ -10,6 +10,8 @@ Notes
   start for version 4 support.
 """
 
+from __future__ import annotations
+
 import numpy as np
 
 import dascore as dc

--- a/dascore/io/sintela/utils.py
+++ b/dascore/io/sintela/utils.py
@@ -188,8 +188,20 @@ def _get_attr_dict(header, extras=None):
     return out
 
 
-def _load_data(fid, header):
-    """Use numpy's memmap to get array information."""
+def _get_data_shape(header) -> tuple[int, int]:
+    """The (time, channel) shape the file's packets hold."""
+    return header["num_packets"] * header["num_samples"], header["num_channels"]
+
+
+def _read_sample_range(fid, header, start=0, stop=None):
+    """
+    Read time samples ``start`` to ``stop`` (half-open) as (samples, channels).
+
+    Each packet carries a header the samples must skip, so stripping them
+    leaves a view numpy cannot stride over and any read copies. A packet
+    is therefore the smallest unit read: only those the range touches
+    are.
+    """
     header_size = header["header_size"]
     num_channels = header["num_channels"]
     num_samples = header["num_samples"]
@@ -200,10 +212,22 @@ def _load_data(fid, header):
     raw = maybe_mem_map(fid)
     # Compute how many blocks
     block_count = raw.size // packet_size
+    total, _ = _get_data_shape(header)
+    start = max(start, 0)
+    stop = total if stop is None else min(stop, total)
+    if stop <= start:
+        return np.empty((0, num_channels), dtype=dtype)
+    first, last = start // num_samples, (stop - 1) // num_samples
     # Create a view that skips headers
-    data = raw.reshape(block_count, packet_size)[:, header_size:]
-    data = data.view(dtype).reshape(-1, num_channels)
-    return data
+    packets = raw.reshape(block_count, packet_size)[first : last + 1, header_size:]
+    data = packets.view(dtype).reshape(-1, num_channels)
+    offset = start - first * num_samples
+    return data[offset : offset + (stop - start)]
+
+
+def _load_data(fid, header):
+    """Use numpy's memmap to get array information."""
+    return _read_sample_range(fid, header)
 
 
 def _get_attrs_coords_header(rid, attr_class=PatchAttrs, extras=None):

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -9,10 +9,19 @@ import numpy as np
 import dascore as dc
 from dascore.constants import timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, windows_to_slices
 from dascore.utils.io import BinaryReader, LocalBinaryReader
+from dascore.utils.misc import raise_on_extra_kwargs
 
-from .utils import _get_all_attrs, _get_data, _get_default_attrs, _get_version_str
+from .utils import (
+    _get_all_attrs,
+    _get_data,
+    _get_default_attrs,
+    _get_fileinfo,
+    _get_sample_count,
+    _get_version_str,
+    _read_sample_range,
+)
 
 
 class TDMSFormatterV4713(FiberIO):
@@ -74,3 +83,23 @@ class TDMSFormatterV4713(FiberIO):
             coords, data, attrs, selection={"time": time, "distance": distance}
         )
         return dc.spool(patches)
+
+    def read_array(
+        self,
+        resource: LocalBinaryReader,
+        windows: dict[str, tuple[int, int]],
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Decode only the segments a time window touches.
+
+        A segment interleaves its channels, so it is the finest unit read;
+        the distance window is applied after decoding. The file holds one
+        patch, so no ``source_patch_key`` is taken.
+        """
+        raise_on_extra_kwargs(kwargs, "windows")
+        fileinfo, _ = _get_fileinfo(resource)
+        shape = (_get_sample_count(resource, fileinfo), int(fileinfo["n_channels"]))
+        time_slice, dist_slice = windows_to_slices(windows, ("time", "distance"), shape)
+        data = _read_sample_range(resource, fileinfo, time_slice.start, time_slice.stop)
+        return data[:, dist_slice]

--- a/dascore/io/tdms/core.py
+++ b/dascore/io/tdms/core.py
@@ -18,7 +18,6 @@ from .utils import (
     _get_data,
     _get_default_attrs,
     _get_fileinfo,
-    _get_sample_count,
     _get_version_str,
     _read_sample_range,
 )
@@ -93,13 +92,12 @@ class TDMSFormatterV4713(FiberIO):
         """
         Decode only the segments a time window touches.
 
-        A segment interleaves its channels, so it is the finest unit read;
-        the distance window is applied after decoding. The file holds one
-        patch, so no ``source_patch_key`` is taken.
+        The distance window is applied after decoding, since a segment
+        interleaves its channels.
         """
         raise_on_extra_kwargs(kwargs, "windows")
-        fileinfo, _ = _get_fileinfo(resource)
-        shape = (_get_sample_count(resource, fileinfo), int(fileinfo["n_channels"]))
+        fileinfo, attrs = _get_fileinfo(resource)
+        shape = (len(attrs["coords"]["time"]), int(fileinfo["n_channels"]))
         time_slice, dist_slice = windows_to_slices(windows, ("time", "distance"), shape)
         data = _read_sample_range(resource, fileinfo, time_slice.start, time_slice.stop)
         return data[:, dist_slice]

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -201,10 +201,14 @@ def _iter_segment_bounds(tdms_file, fileinfo, lead_in_length=28):
         nso = min(file_size, start + next_seg_nso)
 
 
+def _segment_sample_count(fileinfo, rdo, nso) -> int:
+    """How many samples per channel the segment at these byte bounds holds."""
+    per_sample = int(fileinfo["n_channels"]) * np.dtype(fileinfo["data_type"]).itemsize
+    return (nso - rdo) // per_sample
+
+
 def _get_sample_count(tdms_file, fileinfo, lead_in_length=28):
     """Return how many samples per channel the whole file holds."""
-    itemsize = np.dtype(fileinfo["data_type"]).itemsize
-    per_sample = fileinfo["n_channels"] * itemsize
     position = tdms_file.tell()
     try:
         bounds = list(_iter_segment_bounds(tdms_file, fileinfo, lead_in_length))
@@ -212,7 +216,7 @@ def _get_sample_count(tdms_file, fileinfo, lead_in_length=28):
         tdms_file.seek(position, 0)
     # Counting bytes to the end of the file instead would count every
     # segment's lead-in and metadata as data.
-    return sum((nso - rdo) // per_sample for rdo, nso in bounds)
+    return sum(_segment_sample_count(fileinfo, rdo, nso) for rdo, nso in bounds)
 
 
 def _get_all_attrs(tdms_file, lead_in_length=28):
@@ -288,10 +292,8 @@ def _get_fileinfo(tdms_file, lead_in_length=28):
 
 def _get_segment_data(fileinfo, nch, dmap, nso, rdo):
     """Decode one segment of the mapped file as a (samples, channels) array."""
-    # seg1_length: length of recording indicated as raw_data in metadata for
-    # each channel in bytes
-    seg_length = int((nso - rdo) / nch / np.dtype(fileinfo["data_type"]).itemsize)
-    channel_length = seg_length
+    # samples per channel in this segment
+    seg_length = _segment_sample_count(fileinfo, rdo, nso)
 
     if fileinfo["decimated"]:
         # number of completely full chunks
@@ -332,34 +334,37 @@ def _get_segment_data(fileinfo, nch, dmap, nso, rdo):
         data_node = np.append(data_node, raw_last_chunk, axis=0)
     # Outside the branch: a decimated segment whose chunks all happen to
     # be full has nothing left over, and still has its data.
-    return data_node, channel_length
+    return data_node
 
 
 def _read_sample_range(tdms_file, fileinfo, start=0, stop=None, lead_in_length=28):
     """
     Read time samples ``start`` to ``stop`` (half-open) as (samples, channels).
 
-    A segment interleaves its channels, so it is the finest unit decoded;
-    only the segments the range touches are.
+    ``start`` and ``stop`` are resolved, non-negative sample indices (or
+    ``stop`` None for the end). Only the segments the range touches are
+    decoded.
     """
     dmap = mmap.mmap(tdms_file.fileno(), 0, access=mmap.ACCESS_READ)
     nch = int(fileinfo["n_channels"])
-    per_sample = nch * np.dtype(fileinfo["data_type"]).itemsize
     parts, offset = [], 0
     for rdo, nso in _iter_segment_bounds(tdms_file, fileinfo, lead_in_length):
-        seg_start, seg_stop = offset, offset + (nso - rdo) // per_sample
+        seg_len = _segment_sample_count(fileinfo, rdo, nso)
+        seg_start, seg_stop = offset, offset + seg_len
         offset = seg_stop
         if stop is not None and seg_start >= stop:
             break
         if seg_stop <= start:
             continue
-        segment, _ = _get_segment_data(fileinfo, nch, dmap, nso, rdo)
-        seg_len = seg_stop - seg_start
+        segment = _get_segment_data(fileinfo, nch, dmap, nso, rdo)
         low = max(start - seg_start, 0)
         high = seg_len if stop is None else min(stop - seg_start, seg_len)
         parts.append(segment[low:high])
     if not parts:
         return np.empty((0, nch), dtype=fileinfo["data_type"])
+    if len(parts) == 1:
+        # a decoded segment owns its data, so one part needs no copy
+        return parts[0]
     # segments stack along time, the first axis of (samples, channels)
     return np.concatenate(parts, axis=0)
 

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -286,75 +286,86 @@ def _get_fileinfo(tdms_file, lead_in_length=28):
     return fileinfo, attrs
 
 
-def _get_data(tdms_file, lead_in_length=28):
-    """Get all the data saved in the current file."""
+def _get_segment_data(fileinfo, nch, dmap, nso, rdo):
+    """Decode one segment of the mapped file as a (samples, channels) array."""
+    # seg1_length: length of recording indicated as raw_data in metadata for
+    # each channel in bytes
+    seg_length = int((nso - rdo) / nch / np.dtype(fileinfo["data_type"]).itemsize)
+    channel_length = seg_length
 
-    def get_segment_data(fileinfo, nch, dmap, nso, rdo):
-        # seg1_length: length of recording indicated as raw_data in metadata for
-        # each channel in bytes
-        seg_length = int((nso - rdo) / nch / np.dtype(fileinfo["data_type"]).itemsize)
-        channel_length = seg_length
-
-        if fileinfo["decimated"]:
-            # number of completely full chunks
-            n_complete_blk = int(seg_length / fileinfo["chunk_size"])
-            ax_ord = "C"
-        else:
-            n_complete_blk = 0
-            ax_ord = "F"
-        # use data from mapped file to fill variable raw_data
-        raw_data = np.ndarray(
-            (n_complete_blk, nch, fileinfo["chunk_size"]),
+    if fileinfo["decimated"]:
+        # number of completely full chunks
+        n_complete_blk = int(seg_length / fileinfo["chunk_size"])
+        ax_ord = "C"
+    else:
+        n_complete_blk = 0
+        ax_ord = "F"
+    # use data from mapped file to fill variable raw_data
+    raw_data = np.ndarray(
+        (n_complete_blk, nch, fileinfo["chunk_size"]),
+        dtype=fileinfo["data_type"],
+        buffer=dmap,
+        offset=rdo,
+    )
+    # Rotate the axes to [chunk_size, nblk, nch]
+    raw_data = np.rollaxis(raw_data, 2)
+    data_node = np.reshape(raw_data, (n_complete_blk * fileinfo["chunk_size"], nch))
+    if n_complete_blk != seg_length / fileinfo["chunk_size"]:
+        # If the last chunk isn't full there is some data left
+        additional_samples = int(seg_length - n_complete_blk * fileinfo["chunk_size"])
+        additional_samples_offset = (
+            rdo
+            + n_complete_blk
+            * nch
+            * fileinfo["chunk_size"]
+            * np.dtype(fileinfo["data_type"]).itemsize
+        )
+        raw_last_chunk = np.ndarray(
+            (nch, additional_samples),
             dtype=fileinfo["data_type"],
             buffer=dmap,
-            offset=rdo,
+            offset=additional_samples_offset,
+            order=ax_ord,
         )
-        # Rotate the axes to [chunk_size, nblk, nch]
-        raw_data = np.rollaxis(raw_data, 2)
-        data_node = np.reshape(raw_data, (n_complete_blk * fileinfo["chunk_size"], nch))
-        if n_complete_blk != seg_length / fileinfo["chunk_size"]:
-            # If the last chunk isn't full there is some data left
-            additional_samples = int(
-                seg_length - n_complete_blk * fileinfo["chunk_size"]
-            )
-            additional_samples_offset = (
-                rdo
-                + n_complete_blk
-                * nch
-                * fileinfo["chunk_size"]
-                * np.dtype(fileinfo["data_type"]).itemsize
-            )
-            raw_last_chunk = np.ndarray(
-                (nch, additional_samples),
-                dtype=fileinfo["data_type"],
-                buffer=dmap,
-                offset=additional_samples_offset,
-                order=ax_ord,
-            )
-            # Rotate the axes to [samples, nch]
-            raw_last_chunk = np.rollaxis(raw_last_chunk, 1)
-            data_node = np.append(data_node, raw_last_chunk, axis=0)
-        # Outside the branch: a decimated segment whose chunks all happen to
-        # be full has nothing left over, and still has its data.
-        return data_node, channel_length
+        # Rotate the axes to [samples, nch]
+        raw_last_chunk = np.rollaxis(raw_last_chunk, 1)
+        data_node = np.append(data_node, raw_last_chunk, axis=0)
+    # Outside the branch: a decimated segment whose chunks all happen to
+    # be full has nothing left over, and still has its data.
+    return data_node, channel_length
 
-    fileinfo, attrs = _get_fileinfo(tdms_file)
 
-    # map file contents to a variable dmap
+def _read_sample_range(tdms_file, fileinfo, start=0, stop=None, lead_in_length=28):
+    """
+    Read time samples ``start`` to ``stop`` (half-open) as (samples, channels).
+
+    A segment interleaves its channels, so it is the finest unit decoded;
+    only the segments the range touches are.
+    """
     dmap = mmap.mmap(tdms_file.fileno(), 0, access=mmap.ACCESS_READ)
-    # nch: number of channels
     nch = int(fileinfo["n_channels"])
-
-    data_node = None
-    channel_length = 0
+    per_sample = nch * np.dtype(fileinfo["data_type"]).itemsize
+    parts, offset = [], 0
     for rdo, nso in _iter_segment_bounds(tdms_file, fileinfo, lead_in_length):
-        segment, seg_length = get_segment_data(fileinfo, nch, dmap, nso, rdo)
-        # A segment holds every channel for a stretch of time, so segments
-        # stack along time, which is the first axis of (samples, channels).
-        if data_node is None:
-            data_node = segment
-        else:
-            data_node = np.append(data_node, segment, axis=0)
-        channel_length += seg_length
+        seg_start, seg_stop = offset, offset + (nso - rdo) // per_sample
+        offset = seg_stop
+        if stop is not None and seg_start >= stop:
+            break
+        if seg_stop <= start:
+            continue
+        segment, _ = _get_segment_data(fileinfo, nch, dmap, nso, rdo)
+        seg_len = seg_stop - seg_start
+        low = max(start - seg_start, 0)
+        high = seg_len if stop is None else min(stop - seg_start, seg_len)
+        parts.append(segment[low:high])
+    if not parts:
+        return np.empty((0, nch), dtype=fileinfo["data_type"])
+    # segments stack along time, the first axis of (samples, channels)
+    return np.concatenate(parts, axis=0)
 
-    return data_node, channel_length, attrs
+
+def _get_data(tdms_file, lead_in_length=28):
+    """Get all the data saved in the current file."""
+    fileinfo, attrs = _get_fileinfo(tdms_file)
+    data = _read_sample_range(tdms_file, fileinfo, lead_in_length=lead_in_length)
+    return data, len(data), attrs

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -9,7 +9,7 @@ import numpy as np
 import dascore as dc
 from dascore.constants import timeable_types
 from dascore.io import FiberIO, ScanPayload
-from dascore.io.utils import windows_to_slices
+from dascore.io.utils import slice_dataset
 from dascore.utils.hdf5 import H5Reader
 from dascore.utils.misc import raise_on_extra_kwargs
 
@@ -108,7 +108,7 @@ class Terra15FormatterV4(FiberIO):
         if snap_dims:
             _, _, time_len, _ = _get_scanned_time_info(data_node)
         shape = (time_len, len(_get_distance_coord(resource)))
-        return data[windows_to_slices(windows, ("time", "distance"), shape)]
+        return slice_dataset(data, ("time", "distance"), windows, shape)
 
 
 class Terra15FormatterV5(Terra15FormatterV4):

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import timeable_types
 from dascore.io import FiberIO, ScanPayload
+from dascore.io.utils import windows_to_slices
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import (
+    _get_scanned_time_info,
     _get_terra15_version_str,
     _get_version_data_node,
     _read_terra15,
@@ -77,6 +82,25 @@ class Terra15FormatterV4(FiberIO):
         if not patch.data.size:
             return dc.spool([])
         return dc.spool(patch)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """
+        Slice the data node directly.
+
+        Only the time node's ends (to count the samples a file actually
+        finished writing) and the requested block leave the file. The file
+        holds one patch, so no ``source_patch_key`` is taken.
+        """
+        raise_on_extra_kwargs(kwargs, "windows")
+        _, data_node = _get_version_data_node(resource)
+        _, _, time_len, _ = _get_scanned_time_info(data_node)
+        data = data_node["data"]
+        # an unfinished file has zero-filled rows past the last written
+        # sample; the scan grid stops at time_len, so the slices must too
+        shape = (time_len, data.shape[1])
+        return data[windows_to_slices(windows, ("time", "distance"), shape)]
 
 
 class Terra15FormatterV5(Terra15FormatterV4):

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -61,6 +61,7 @@ class Terra15FormatterV4(FiberIO):
         time: tuple[timeable_types, timeable_types] | None = None,
         distance: tuple[float, float] | None = None,
         snap_dims: bool = True,
+        snap: bool | None = None,
         **kwargs,
     ) -> dc.Spool:
         """
@@ -78,7 +79,11 @@ class Terra15FormatterV4(FiberIO):
             If True, ensure the coordinates are evenly sampled monotonic.
             This will cause some loss in precision but it is usually
             negligible.
+        snap
+            The name `scan` gives ``snap_dims``, so a caller can forward
+            what it gave `scan`; it wins when both are given.
         """
+        snap_dims = snap_dims if snap is None else snap
         patch = _read_terra15(resource, time, distance, snap_dims=snap_dims)
         if not patch.data.size:
             return dc.spool([])
@@ -88,7 +93,8 @@ class Terra15FormatterV4(FiberIO):
         self,
         resource: H5Reader,
         windows: dict[str, tuple[int, int]],
-        snap_dims: bool = True,
+        snap: bool = True,
+        snap_dims: bool | None = None,
         **kwargs,
     ) -> np.ndarray:
         """
@@ -96,16 +102,18 @@ class Terra15FormatterV4(FiberIO):
 
         Besides the requested block, only the time node's ends and the
         header are read (the whole time node for an unfinished file, to
-        count the rows it actually wrote). ``snap_dims`` selects the grid,
-        spelled as ``read`` spells it (``scan`` calls the same option
-        ``snap``): snapped, the rows stop at the last written sample; raw,
-        every stored row counts, as the raw time coordinate does.
+        count the rows it actually wrote). ``snap`` selects the grid, and
+        unlike other formats it decides how many rows there are: snapped,
+        they stop at the last written sample; raw, every stored row
+        counts, as the raw time coordinate does. ``read`` calls the same
+        option ``snap_dims``, so both spellings are taken.
         """
-        raise_on_extra_kwargs(kwargs, "windows and snap_dims")
+        raise_on_extra_kwargs(kwargs, "windows, snap and snap_dims")
+        snap = snap if snap_dims is None else snap_dims
         _, data_node = _get_version_data_node(resource)
         data = data_node["data"]
         time_len = data.shape[0]
-        if snap_dims:
+        if snap:
             _, _, time_len, _ = _get_scanned_time_info(data_node)
         shape = (time_len, len(_get_distance_coord(resource)))
         return slice_dataset(data, ("time", "distance"), windows, shape)

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -96,10 +96,10 @@ class Terra15FormatterV4(FiberIO):
 
         Besides the requested block, only the time node's ends and the
         header are read (the whole time node for an unfinished file, to
-        count the rows it actually wrote). ``snap_dims`` selects the same
-        grid ``read`` and ``scan`` use: snapped, the rows stop at the last
-        written sample; raw, every row counts, as the raw time coordinate
-        does.
+        count the rows it actually wrote). ``snap_dims`` selects the grid,
+        spelled as ``read`` spells it (``scan`` calls the same option
+        ``snap``): snapped, the rows stop at the last written sample; raw,
+        every stored row counts, as the raw time coordinate does.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap_dims")
         _, data_node = _get_version_data_node(resource)

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -23,6 +23,18 @@ from .utils import (
 )
 
 
+def _resolve_snap(snap, snap_dims, default=True):
+    """
+    Read the option Terra15 spells two ways.
+
+    `scan` calls it ``snap`` and `read` calls it ``snap_dims``; a caller
+    may forward either, so both are taken and ``snap`` wins.
+    """
+    if snap is not None:
+        return snap
+    return default if snap_dims is None else snap_dims
+
+
 class Terra15FormatterV4(FiberIO):
     """Support for Terra15 data format, version 4."""
 
@@ -60,7 +72,7 @@ class Terra15FormatterV4(FiberIO):
         resource: H5Reader,
         time: tuple[timeable_types, timeable_types] | None = None,
         distance: tuple[float, float] | None = None,
-        snap_dims: bool = True,
+        snap_dims: bool | None = None,
         snap: bool | None = None,
         **kwargs,
     ) -> dc.Spool:
@@ -83,7 +95,7 @@ class Terra15FormatterV4(FiberIO):
             The name `scan` gives ``snap_dims``, so a caller can forward
             what it gave `scan`; it wins when both are given.
         """
-        snap_dims = snap_dims if snap is None else snap
+        snap_dims = _resolve_snap(snap, snap_dims)
         patch = _read_terra15(resource, time, distance, snap_dims=snap_dims)
         if not patch.data.size:
             return dc.spool([])
@@ -93,7 +105,7 @@ class Terra15FormatterV4(FiberIO):
         self,
         resource: H5Reader,
         windows: dict[str, tuple[int, int]],
-        snap: bool = True,
+        snap: bool | None = None,
         snap_dims: bool | None = None,
         **kwargs,
     ) -> np.ndarray:
@@ -106,10 +118,11 @@ class Terra15FormatterV4(FiberIO):
         unlike other formats it decides how many rows there are: snapped,
         they stop at the last written sample; raw, every stored row
         counts, as the raw time coordinate does. ``read`` calls the same
-        option ``snap_dims``, so both spellings are taken.
+        option ``snap_dims``, so both spellings are taken, and ``snap``
+        wins when both are given, as it does in `read`.
         """
         raise_on_extra_kwargs(kwargs, "windows, snap and snap_dims")
-        snap = snap if snap_dims is None else snap_dims
+        snap = _resolve_snap(snap, snap_dims)
         _, data_node = _get_version_data_node(resource)
         data = data_node["data"]
         time_len = data.shape[0]

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -14,6 +14,7 @@ from dascore.utils.hdf5 import H5Reader
 from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import (
+    _get_distance_coord,
     _get_scanned_time_info,
     _get_terra15_version_str,
     _get_version_data_node,
@@ -84,22 +85,29 @@ class Terra15FormatterV4(FiberIO):
         return dc.spool(patch)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap_dims: bool = True,
+        **kwargs,
     ) -> np.ndarray:
         """
         Slice the data node directly.
 
-        Only the time node's ends (to count the samples a file actually
-        finished writing) and the requested block leave the file. The file
-        holds one patch, so no ``source_patch_key`` is taken.
+        Besides the requested block, only the time node's ends and the
+        header are read (the whole time node for an unfinished file, to
+        count the rows it actually wrote). ``snap_dims`` selects the same
+        grid ``read`` and ``scan`` use: snapped, the rows stop at the last
+        written sample; raw, every row counts, as the raw time coordinate
+        does.
         """
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and snap_dims")
         _, data_node = _get_version_data_node(resource)
-        _, _, time_len, _ = _get_scanned_time_info(data_node)
         data = data_node["data"]
-        # an unfinished file has zero-filled rows past the last written
-        # sample; the scan grid stops at time_len, so the slices must too
-        shape = (time_len, data.shape[1])
+        time_len = data.shape[0]
+        if snap_dims:
+            _, _, time_len, _ = _get_scanned_time_info(data_node)
+        shape = (time_len, len(_get_distance_coord(resource)))
         return data[windows_to_slices(windows, ("time", "distance"), shape)]
 
 

--- a/dascore/io/uptech/core.py
+++ b/dascore/io/uptech/core.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, slice_dataset
 from dascore.models import OptionalFiniteFloat
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import _DATASET, _get_attrs_dict, _get_coords, _is_uptech
 
@@ -62,3 +65,10 @@ class UptechH5V1(FiberIO):
             selection={"time": time, "distance": distance},
         )
         return dc.spool(patches)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """Slice the ``Acquisition/StrainRate`` dataset directly."""
+        raise_on_extra_kwargs(kwargs, "windows")
+        return slice_dataset(resource[_DATASET], ("time", "distance"), windows)

--- a/dascore/io/uptech/core.py
+++ b/dascore/io/uptech/core.py
@@ -67,8 +67,12 @@ class UptechH5V1(FiberIO):
         return dc.spool(patches)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
     ) -> np.ndarray:
         """Slice the ``Acquisition/StrainRate`` dataset directly."""
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource[_DATASET], ("time", "distance"), windows)

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -188,7 +188,11 @@ def windows_to_slices(
             out.append(slice(0, size))
             continue
         _validate_sample_values(windows[dim])
-        span = range(size)[_to_slice(windows[dim])]
+        window = _to_slice(windows[dim])
+        if window.step not in (None, 1):
+            msg = f"A window is a contiguous range; {dim!r} asked for {windows[dim]!r}."
+            raise ParameterError(msg)
+        span = range(size)[window]
         out.append(slice(span.start, max(span.stop, span.start)))
     return tuple(out)
 

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -12,7 +12,14 @@ import dascore as dc
 from dascore.constants import INVENTORY_ATTRS
 from dascore.core.coordmanager import CoordManager
 from dascore.core.coords import BaseCoord, CoordSegmented, get_coord
-from dascore.exceptions import CoordError, ParameterError, UnitError
+from dascore.core.summary import normalize_source_patch_key
+from dascore.exceptions import (
+    CoordError,
+    MissingPatchError,
+    ParameterError,
+    PatchAttributeError,
+    UnitError,
+)
 from dascore.models import ArrayLike
 from dascore.units import convert_units, get_quantity_str
 from dascore.utils.misc import _to_slice, _validate_sample_values, unbyte
@@ -184,6 +191,57 @@ def windows_to_slices(
         span = range(size)[_to_slice(windows[dim])]
         out.append(slice(span.start, max(span.stop, span.start)))
     return tuple(out)
+
+
+def resolve_keyed_source(
+    sources: Mapping[str, Any] | Iterable[tuple[str, Any]],
+    key,
+    where: str = "the resource",
+):
+    """
+    Return the one source a ``source_patch_key`` names.
+
+    Resolves a native key as the default `FiberIO.read_array` does: an
+    empty resource is missing data, and an unknown key, an ambiguous
+    keyless one, or a key naming more than one source cannot be
+    resolved. Unlike the default it takes no positional key, since a
+    format which states its own keys never synthesizes one.
+
+    ``sources`` maps each native key to whatever the caller needs back,
+    and is read lazily, so an h5py group can be passed as it is. Pass
+    ``(key, value)`` pairs instead where a resource can state one key
+    twice, so the ambiguity is seen rather than silently resolved.
+    """
+    key = normalize_source_patch_key(key)
+    if isinstance(sources, Mapping):
+        # a mapping cannot hold a name twice, so it is read as it is: an
+        # h5py group resolves a name without opening its siblings
+        mapping = cast("Mapping[str, Any]", sources)
+        if not len(mapping):
+            raise MissingPatchError(f"No patches in {where}.")
+        if key:
+            if key not in mapping:
+                raise PatchAttributeError(f"No patch named '{key}' in {where}.")
+            return mapping[key]
+        if len(mapping) > 1:
+            msg = f"{where} holds several patches; pass source_patch_key."
+            raise PatchAttributeError(msg)
+        return next(iter(mapping.values()))
+    pairs = list(sources)
+    if not pairs:
+        raise MissingPatchError(f"No patches in {where}.")
+    if key:
+        found = [value for name, value in pairs if name == key]
+        if not found:
+            raise PatchAttributeError(f"No patch named '{key}' in {where}.")
+        if len(found) > 1:
+            msg = f"{where} names '{key}' more than once; it cannot be resolved."
+            raise PatchAttributeError(msg)
+        return found[0]
+    if len(pairs) > 1:
+        msg = f"{where} holds several patches; pass source_patch_key."
+        raise PatchAttributeError(msg)
+    return pairs[0][1]
 
 
 def slice_dataset(

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -160,8 +160,8 @@ def windows_to_slices(
 
     Each window is validated as `Patch.select` validates ``samples=True``
     values and resolved against its dimension's length, so every slice
-    comes back with explicit non-negative bounds; a dimension without a
-    window is taken whole.
+    comes back with explicit non-negative bounds and ``start <= stop`` (a
+    reversed window is empty); a dimension without a window is taken whole.
 
     Parameters
     ----------

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -186,7 +186,12 @@ def windows_to_slices(
     return tuple(out)
 
 
-def slice_dataset(dataset, dims: Sequence[str], windows: Mapping[str, Any], shape=None):
+def slice_dataset(
+    dataset: ArrayLike,
+    dims: Sequence[str],
+    windows: Mapping[str, Any],
+    shape: Sequence[int] | None = None,
+) -> np.ndarray:
     """
     Read the sample windows of an array stored in ``dims`` order.
 

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -190,8 +190,9 @@ def slice_dataset(dataset, dims: Sequence[str], windows: Mapping[str, Any], shap
     """
     Read the sample windows of an array stored in ``dims`` order.
 
-    ``shape`` defaults to the dataset's own; pass it when the scan grid
-    is shorter than the stored array (see `windows_to_slices`).
+    ``shape`` defaults to the dataset's own; pass it when an axis of the
+    grid `scan` reports is shorter than the stored one, as it is for a
+    Terra15 file whose trailing rows were never written.
     """
     shape = dataset.shape if shape is None else shape
     return dataset[windows_to_slices(windows, dims, shape)]

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 import numpy as np
@@ -12,10 +12,10 @@ import dascore as dc
 from dascore.constants import INVENTORY_ATTRS
 from dascore.core.coordmanager import CoordManager
 from dascore.core.coords import BaseCoord, CoordSegmented, get_coord
-from dascore.exceptions import CoordError, UnitError
+from dascore.exceptions import CoordError, ParameterError, UnitError
 from dascore.models import ArrayLike
 from dascore.units import convert_units, get_quantity_str
-from dascore.utils.misc import unbyte
+from dascore.utils.misc import _to_slice, _validate_sample_values, unbyte
 
 # Stored coordinate arrays often carry sub-step jitter (e.g. GPS-stamped DAS
 # time). ``CoordSegmented.from_array`` treats every isolated sampling change as
@@ -150,6 +150,40 @@ def build_patches(
         return []
     # Ellipsis rather than a slice so 0d data (a scalar patch) also loads.
     return [dc.Patch(data=data[...], coords=coords, attrs=patch_attrs)]
+
+
+def windows_to_slices(
+    windows: Mapping[str, Any], dims: Sequence[str], shape: Sequence[int]
+) -> tuple[slice, ...]:
+    """
+    Turn `FiberIO.read_array` windows into one slice per dimension.
+
+    Each window is validated as `Patch.select` validates ``samples=True``
+    values and resolved against its dimension's length, so every slice
+    comes back with explicit non-negative bounds; a dimension without a
+    window is taken whole.
+
+    Parameters
+    ----------
+    windows
+        Dimension name to ``(start, stop)`` half-open sample indices.
+    dims
+        The dimensions in the array's stored order.
+    shape
+        The array's shape, in the same order.
+    """
+    if unknown := sorted(set(windows) - set(dims)):
+        msg = f"Window dimensions {unknown} are not among patch dims {tuple(dims)}."
+        raise ParameterError(msg)
+    out = []
+    for dim, size in zip(dims, shape, strict=True):
+        if dim not in windows:
+            out.append(slice(0, size))
+            continue
+        _validate_sample_values(windows[dim])
+        span = range(size)[_to_slice(windows[dim])]
+        out.append(slice(span.start, max(span.stop, span.start)))
+    return tuple(out)
 
 
 def get_gridded_coord(values, units=None) -> BaseCoord:

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -186,6 +186,17 @@ def windows_to_slices(
     return tuple(out)
 
 
+def slice_dataset(dataset, dims: Sequence[str], windows: Mapping[str, Any], shape=None):
+    """
+    Read the sample windows of an array stored in ``dims`` order.
+
+    ``shape`` defaults to the dataset's own; pass it when the scan grid
+    is shorter than the stored array (see `windows_to_slices`).
+    """
+    shape = dataset.shape if shape is None else shape
+    return dataset[windows_to_slices(windows, dims, shape)]
+
+
 def get_gridded_coord(values, units=None) -> BaseCoord:
     """
     Return a stored coordinate array forced onto an even grid.

--- a/docs/contributing/new_format.qmd
+++ b/docs/contributing/new_format.qmd
@@ -103,6 +103,8 @@ return dc.spool(
 - Annotate `resource` with the same managed-resource type used by `read()`.
 - Accept indices, not coordinate values; callers perform value-to-index conversion.
 
+Accept the labelling options your `read` takes, usually `snap`, even when they change nothing: the default forwards them, so refusing one would make the same call work for one format and fail for another.
+
 The caller bypasses `read_array` for synthesized positional keys.
 
 ## Accept managed resources

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -18,6 +18,7 @@ from io import BufferedIOBase, BytesIO, UnsupportedOperation
 from operator import eq, ge, le
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pandas as pd
 import pytest
@@ -28,6 +29,7 @@ from dascore.exceptions import CoordError, UnknownFiberFormatError
 from dascore.io import BinaryReader, FiberIO
 from dascore.io.ai4eps import AI4EPSV1
 from dascore.io.ap_sensing import APSensingV10
+from dascore.io.core import _required_resource_type
 from dascore.io.dasdae import DASDAEV1
 from dascore.io.dashdf5 import DASHDF5
 from dascore.io.febus import Febus1, Febus2, FebusBSLH5V1, FebusMTXH5V1, FebusT1V1
@@ -53,6 +55,7 @@ from dascore.io.terra15 import (
 )
 from dascore.io.uptech import UptechH5V1
 from dascore.utils.downloader import fetch, get_registry_df
+from dascore.utils.hdf5 import H5Reader
 from dascore.utils.misc import all_close, iterate, order_range_tuple
 from tests.test_io._common_io_test_utils import (
     get_flat_io_test,
@@ -575,6 +578,38 @@ class TestRead:
         expected = FiberIO.read_array(io, path, windows, **kwargs)
         assert out.dtype == expected.dtype
         assert np.array_equal(out, expected)
+
+    def test_hdf5_read_array_never_reads_the_array_whole(
+        self, io_path_tuple, monkeypatch
+    ):
+        """An HDF5 override slices its data array in the file."""
+        io, path = io_path_tuple
+        if not io.implements_read_array or not issubclass(
+            _required_resource_type(io.read_array), H5Reader
+        ):
+            pytest.skip(f"{io.name} has no HDF5 read_array override")
+        with skip_missing():
+            payload = dc.scan(path)[0]
+        key = payload.source_patch_key
+        kwargs = {"source_patch_key": key} if key else {}
+        sized = [
+            (d, n) for d, n in zip(payload.dims, payload.shape, strict=True) if n > 2
+        ]
+        assert sized, "no dimension long enough to window"
+        dim, size = sized[0]
+        reads = []
+        original = h5py.Dataset.__getitem__
+
+        def spy(self, index):
+            if self.ndim >= 2:
+                reads.append(index)
+            return original(self, index)
+
+        monkeypatch.setattr(h5py.Dataset, "__getitem__", spy)
+        io.read_array(path, {dim: (1, size - 1)}, **kwargs)
+        assert reads, "the data array was never read"
+        for index in reads:
+            assert isinstance(index, tuple) and slice(1, size - 1) in index, index
 
     def test_slice_single_dim_both_ends(self, io_path_tuple):
         """

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -583,29 +583,27 @@ class TestRead:
             assert out.dtype == expected.dtype
             assert np.array_equal(out, expected), windows
 
-    def test_read_array_ignores_labelling_options(self, io_path_tuple):
-        """An option which only labels samples cannot move the window."""
+    def test_read_array_honors_labelling_options(self, io_path_tuple):
+        """A labelling option selects the grid `scan` reports under it.
+
+        Most formats' `snap` only labels samples, so it cannot move the
+        window; where it decides how many samples the resource has, the
+        array follows it. Either way the caller may forward what it gave
+        `scan`, and the shapes have to agree.
+        """
         io, path = io_path_tuple
         if not io.implements_read_array:
             pytest.skip(f"{io.name} inherits the default read_array")
         params = inspect.signature(io.read_array).parameters
-        labelling = [x for x in ("snap", "snap_dims") if x in params]
-        if not labelling:
+        if "snap" not in params:
             pytest.skip(f"{io.name}.read_array takes no labelling option")
         with skip_missing():
-            payload = dc.scan(path)[0]
-        key = payload.source_patch_key
+            payloads = {x: dc.scan_payloads(path, snap=x)[0] for x in (True, False)}
+        key = payloads[True].get("source_patch_key", "")
         kwargs = {"source_patch_key": key} if key else {}
-        dim = payload.dims[0]
-        windows = {dim: (0, max(payload.shape[0] - 1, 1))}
-        out = io.read_array(path, windows, **kwargs)
-        for name in labelling:
-            # Terra15's snap_dims is the exception: it says how many rows
-            # an unfinished file wrote, so it is allowed to change the count
-            other = io.read_array(path, windows, **{name: False}, **kwargs)
-            if name == "snap_dims":
-                continue
-            assert np.array_equal(out, other), name
+        for snap, payload in payloads.items():
+            out = io.read_array(path, {}, snap=snap, **kwargs)
+            assert out.shape == tuple(payload["shape"]), snap
 
     def test_hdf5_read_array_never_reads_the_array_whole(
         self, io_path_tuple, monkeypatch

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -594,9 +594,9 @@ class TestRead:
         io, path = io_path_tuple
         if not io.implements_read_array:
             pytest.skip(f"{io.name} inherits the default read_array")
-        params = inspect.signature(io.read_array).parameters
-        if "snap" not in params:
-            pytest.skip(f"{io.name}.read_array takes no labelling option")
+        # what scan takes, read_array must take: the caller forwards it
+        if "snap" not in inspect.signature(io.scan).parameters:
+            pytest.skip(f"{io.name}.scan takes no labelling option")
         with skip_missing():
             payloads = {x: dc.scan_payloads(path, snap=x)[0] for x in (True, False)}
         key = payloads[True].get("source_patch_key", "")

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -581,7 +581,9 @@ class TestRead:
             out = io.read_array(path, windows, **kwargs)
             expected = FiberIO.read_array(io, path, windows, **kwargs)
             assert out.dtype == expected.dtype
-            assert np.array_equal(out, expected), windows
+            # a gap is stored as nan, which is never equal to itself
+            nan = np.issubdtype(out.dtype, np.inexact)
+            assert np.array_equal(out, expected, equal_nan=nan), windows
 
     def test_read_array_honors_labelling_options(self, io_path_tuple):
         """A labelling option selects the grid `scan` reports under it.
@@ -619,35 +621,46 @@ class TestRead:
             payload = dc.scan(path)[0]
         key = payload.source_patch_key
         kwargs = {"source_patch_key": key} if key else {}
-        sized = {
-            dim: size
+        # a small window, so reading the array whole is never mistaken
+        # for reading what was asked for
+        windows = {
+            dim: (1, min(size - 1, 4))
             for dim, size in zip(payload.dims, payload.shape, strict=True)
             if size > 2
         }
-        assert sized, "no dimension long enough to window"
-        windows = {dim: (1, size - 1) for dim, size in sized.items()}
-        # every axis is windowed, so a two-step read (whole axis, then
-        # trim) is visible as a slice this does not expect
-        wanted = tuple(
-            (1, size - 1) if dim in sized else (0, size)
-            for dim, size in zip(payload.dims, payload.shape, strict=True)
-        )
+        assert windows, "no dimension long enough to window"
         reads = []
         original = h5py.Dataset.__getitem__
 
+        patch_size = int(np.prod(payload.shape))
+
         def spy(self, index):
-            # a coordinate array has fewer dimensions than the data
-            if self.ndim == len(payload.dims):
-                reads.append(index)
-            return original(self, index)
+            out = original(self, index)
+            # the data array holds at least a sample per patch value;
+            # a coordinate or metadata array is smaller
+            if self.ndim > 1 and self.size >= patch_size:
+                reads.append((self.shape, np.shape(out), index))
+            return out
 
         monkeypatch.setattr(h5py.Dataset, "__getitem__", spy)
         io.read_array(path, windows, **kwargs)
-        assert len(reads) == 1, reads
-        index = reads[0]
-        assert isinstance(index, tuple) and len(index) == len(wanted), index
-        # xarray spells the same slice with an explicit unit step
-        assert tuple((x.start, x.stop) for x in index) == wanted, index
+        assert reads, "the data array was never read"
+        stored = reads[0][0]
+        if len(stored) == len(payload.dims):
+            # the plain case: one read, sliced on every windowed axis
+            assert len(reads) == 1, reads
+            wanted = tuple(
+                (1, min(size - 1, 4)) if dim in windows else (0, size)
+                for dim, size in zip(payload.dims, payload.shape, strict=True)
+            )
+            index = reads[0][2]
+            assert isinstance(index, tuple) and len(index) == len(wanted), index
+            # xarray spells the same slice with an explicit unit step
+            assert tuple((x.start, x.stop) for x in index) == wanted, index
+        else:
+            # a cube of blocks reads more than the window, never all of it
+            for shape, got, _ in reads:
+                assert got != shape, (shape, got)
 
     def test_slice_single_dim_both_ends(self, io_path_tuple):
         """

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -569,47 +569,87 @@ class TestRead:
             payload = dc.scan(path)[0]
         key = payload.source_patch_key
         kwargs = {"source_patch_key": key} if key else {}
-        windows = {
-            dim: (1, size - 1)
+        sized = [
+            (dim, size)
             for dim, size in zip(payload.dims, payload.shape, strict=True)
             if size > 2
-        }
+        ]
+        every = {dim: (1, size - 1) for dim, size in sized}
+        # the partial and empty cases pin the other half of the contract:
+        # a dimension absent from windows comes back whole
+        for windows in (every, {sized[0][0]: every[sized[0][0]]}, {}):
+            out = io.read_array(path, windows, **kwargs)
+            expected = FiberIO.read_array(io, path, windows, **kwargs)
+            assert out.dtype == expected.dtype
+            assert np.array_equal(out, expected), windows
+
+    def test_read_array_ignores_labelling_options(self, io_path_tuple):
+        """An option which only labels samples cannot move the window."""
+        io, path = io_path_tuple
+        if not io.implements_read_array:
+            pytest.skip(f"{io.name} inherits the default read_array")
+        params = inspect.signature(io.read_array).parameters
+        labelling = [x for x in ("snap", "snap_dims") if x in params]
+        if not labelling:
+            pytest.skip(f"{io.name}.read_array takes no labelling option")
+        with skip_missing():
+            payload = dc.scan(path)[0]
+        key = payload.source_patch_key
+        kwargs = {"source_patch_key": key} if key else {}
+        dim = payload.dims[0]
+        windows = {dim: (0, max(payload.shape[0] - 1, 1))}
         out = io.read_array(path, windows, **kwargs)
-        expected = FiberIO.read_array(io, path, windows, **kwargs)
-        assert out.dtype == expected.dtype
-        assert np.array_equal(out, expected)
+        for name in labelling:
+            # Terra15's snap_dims is the exception: it says how many rows
+            # an unfinished file wrote, so it is allowed to change the count
+            other = io.read_array(path, windows, **{name: False}, **kwargs)
+            if name == "snap_dims":
+                continue
+            assert np.array_equal(out, other), name
 
     def test_hdf5_read_array_never_reads_the_array_whole(
         self, io_path_tuple, monkeypatch
     ):
         """An HDF5 override slices its data array in the file."""
         io, path = io_path_tuple
-        if not io.implements_read_array or not issubclass(
-            _required_resource_type(io.read_array), H5Reader
-        ):
+        resource_type = (
+            _required_resource_type(io.read_array) if io.implements_read_array else None
+        )
+        if resource_type is None or not issubclass(resource_type, H5Reader):
             pytest.skip(f"{io.name} has no HDF5 read_array override")
         with skip_missing():
             payload = dc.scan(path)[0]
         key = payload.source_patch_key
         kwargs = {"source_patch_key": key} if key else {}
-        sized = [
-            (d, n) for d, n in zip(payload.dims, payload.shape, strict=True) if n > 2
-        ]
+        sized = {
+            dim: size
+            for dim, size in zip(payload.dims, payload.shape, strict=True)
+            if size > 2
+        }
         assert sized, "no dimension long enough to window"
-        dim, size = sized[0]
+        windows = {dim: (1, size - 1) for dim, size in sized.items()}
+        # every axis is windowed, so a two-step read (whole axis, then
+        # trim) is visible as a slice this does not expect
+        wanted = tuple(
+            (1, size - 1) if dim in sized else (0, size)
+            for dim, size in zip(payload.dims, payload.shape, strict=True)
+        )
         reads = []
         original = h5py.Dataset.__getitem__
 
         def spy(self, index):
-            if self.ndim >= 2:
+            # a coordinate array has fewer dimensions than the data
+            if self.ndim == len(payload.dims):
                 reads.append(index)
             return original(self, index)
 
         monkeypatch.setattr(h5py.Dataset, "__getitem__", spy)
-        io.read_array(path, {dim: (1, size - 1)}, **kwargs)
-        assert reads, "the data array was never read"
-        for index in reads:
-            assert isinstance(index, tuple) and slice(1, size - 1) in index, index
+        io.read_array(path, windows, **kwargs)
+        assert len(reads) == 1, reads
+        index = reads[0]
+        assert isinstance(index, tuple) and len(index) == len(wanted), index
+        # xarray spells the same slice with an explicit unit step
+        assert tuple((x.start, x.stop) for x in index) == wanted, index
 
     def test_slice_single_dim_both_ends(self, io_path_tuple):
         """

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -313,7 +313,9 @@ class TestReadArray:
         with pytest.raises(ParameterError, match="Unexpected keyword"):
             DASDAEV1().read_array(written_dascore_v1_random, {}, time_min=1)
 
-    def test_reads_only_the_window(self, written_dascore_v1_random, monkeypatch):
+    def test_reads_only_the_window(
+        self, written_dascore_v1_random, random_patch, monkeypatch
+    ):
         """The dataset is sliced in the file, not read whole then trimmed."""
         seen = []
         original = h5py.Dataset.__getitem__
@@ -324,7 +326,7 @@ class TestReadArray:
 
         monkeypatch.setattr(h5py.Dataset, "__getitem__", spy)
         DASDAEV1().read_array(written_dascore_v1_random, {"time": (2, 6)})
-        assert seen == [(slice(None), slice(2, 6))]
+        assert seen == [(slice(0, random_patch.shape[0]), slice(2, 6))]
 
 
 class TestScanDASDAE:

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -288,6 +288,13 @@ class TestReadArray:
         expected = DASDAEV1().read_array(written_dascore_v1_random, {})
         assert np.array_equal(out, expected)
 
+    def test_path_like_key_raises(self, multi_patch_path):
+        """A key h5py would read as a path names no patch."""
+        name = dc.scan(multi_patch_path)[0].source_patch_key
+        for key in ("/waveforms", f"{name}/data", f"./{name}"):
+            with pytest.raises(PatchAttributeError, match="No patch named"):
+                DASDAEV1().read_array(multi_patch_path, {}, source_patch_key=key)
+
     def test_keyless_multi_patch_raises(self, multi_patch_path):
         """Several patches and no key cannot be resolved."""
         with pytest.raises(PatchAttributeError, match="source_patch_key"):

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -21,6 +21,8 @@ from dascore.exceptions import (
     DependencyError,
     UnknownFiberFormatError,
 )
+from dascore.io.core import FiberIO
+from dascore.io.dasvader.core import DASVaderV1
 from dascore.io.dasvader.utils import (
     EXPECTED,
     _dereference,
@@ -364,3 +366,34 @@ class TestDASVader:
         # `is False` rather than a truthiness check: the empty intersection
         # used to be returned directly, so the answer was the empty set.
         assert _is_dasvader_jld2(_Resource()) is False
+
+    @pytest.fixture(
+        params=["dasvader_modern_path", "das_vader_strainrate_no_attrib_path"]
+    )
+    def read_array_path(self, request):
+        """Each readable layout: the `data` and `strainrate` references."""
+        return request.getfixturevalue(request.param)
+
+    def test_read_array_matches_default(self, read_array_path):
+        """The override returns what the read-and-trim default returns.
+
+        DASVader is kept out of the common IO tests, so its parity with
+        the default is checked here.
+        """
+        io = DASVaderV1()
+        patch = dc.spool(read_array_path)[0]
+        windows = {
+            dim: (1, size - 1)
+            for dim, size in zip(patch.dims, patch.shape, strict=True)
+        }
+        out = io.read_array(read_array_path, windows)
+        expected = FiberIO.read_array(io, read_array_path, windows)
+        assert out.dtype == expected.dtype
+        assert np.array_equal(out, expected)
+        assert out.shape == tuple(size - 2 for size in patch.shape)
+
+    def test_read_array_whole(self, read_array_path):
+        """No windows returns the array the patch holds."""
+        patch = dc.spool(read_array_path)[0]
+        out = DASVaderV1().read_array(read_array_path, {})
+        assert np.array_equal(out, patch.data)

--- a/tests/test_io/test_febus/test_febusa1.py
+++ b/tests/test_io/test_febus/test_febusa1.py
@@ -9,8 +9,14 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.exceptions import ParameterError, PatchAttributeError
+from dascore.io.core import FiberIO
 from dascore.io.febus import Febus2
-from dascore.io.febus.a1utils import _flatten_febus_info
+from dascore.io.febus.a1utils import (
+    _flatten_febus_info,
+    _get_source_patch_key,
+    _get_zone_time,
+)
 from dascore.utils.downloader import fetch
 from dascore.utils.misc import unbyte
 from dascore.utils.time import to_float
@@ -93,6 +99,108 @@ class TestFebus:
         """A non-matching source_patch_key should filter out Febus patches."""
         out = dc.read(febus_path, source_patch_key="not-a-real-febus-patch")
         assert len(out) == 0
+
+    @staticmethod
+    def _rows_per_block(path, key):
+        """How many time rows of each block survive its padding."""
+        with h5py.File(path, "r") as h5:
+            zones = {_get_source_patch_key(z): z for z in _flatten_febus_info(h5)}
+            info = _get_zone_time(zones[key])
+        return info.idx_stop - info.idx_start + 1
+
+    def test_read_array_spans_blocks(self, febus_path):
+        """A window crossing a block boundary matches the default."""
+        io = Febus2()
+        payload = dc.scan(febus_path)[0]
+        key = payload.source_patch_key
+        rows = self._rows_per_block(febus_path, key)
+        # one window straddling a block boundary, one wholly inside a
+        # later block, one at the start: the offset arithmetic both ways
+        cases = [(rows - 2, rows + 3), (2 * rows + 1, 2 * rows + 4), (0, 3)]
+        cases = [x for x in cases if x[1] <= payload.shape[0]]
+        # the first case straddles a block boundary; without it the test
+        # would pass on arithmetic it never exercised
+        assert len(cases) > 1, cases
+        for start, stop in cases:
+            windows = {"time": (start, stop)}
+            out = io.read_array(febus_path, windows, source_patch_key=key)
+            expected = FiberIO.read_array(io, febus_path, windows, source_patch_key=key)
+            assert out.shape == expected.shape == (stop - start, payload.shape[1])
+            assert np.array_equal(out, expected, equal_nan=True), (start, stop)
+
+    def test_read_array_empty_window(self, febus_path):
+        """A reversed or zero-width window is empty, with the right width."""
+        io = Febus2()
+        payload = dc.scan(febus_path)[0]
+        key = payload.source_patch_key
+        out = io.read_array(febus_path, {"time": (5, 5)}, source_patch_key=key)
+        assert out.shape == (0, payload.shape[1])
+        out = io.read_array(febus_path, {"distance": (4, 2)}, source_patch_key=key)
+        assert out.shape == (payload.shape[0], 0)
+
+    @pytest.fixture(scope="class")
+    def two_zone_path(self, febus_path, tmp_path_factory):
+        """A copy of the example file carrying a second, distinct zone."""
+        path = tmp_path_factory.mktemp("febus_two_zone") / "two_zone.h5"
+        shutil.copy(febus_path, path)
+        with h5py.File(path, "a") as h5:
+            zone = _flatten_febus_info(h5)[0]
+            source = zone.source
+            source.copy(zone.zone_name, "Zone_copy")
+            copied = source["Zone_copy"]
+            copied[zone.data_name][...] = -copied[zone.data_name][...]
+        return path
+
+    def test_read_array_reads_the_named_zone(self, two_zone_path):
+        """Each zone's key reads that zone, never its neighbor."""
+        io = Febus2()
+        payloads = dc.scan(two_zone_path)
+        assert len(payloads) == 2
+        arrays = [
+            io.read_array(two_zone_path, {}, source_patch_key=x.source_patch_key)
+            for x in payloads
+        ]
+        # the copy holds the negated data, so a wrong zone is visible
+        assert np.allclose(arrays[0], -arrays[1], equal_nan=True)
+        for payload, array in zip(payloads, arrays, strict=True):
+            expected = FiberIO.read_array(
+                io, two_zone_path, {}, source_patch_key=payload.source_patch_key
+            )
+            assert np.array_equal(array, expected, equal_nan=True)
+
+    def test_read_array_without_key_raises(self, two_zone_path):
+        """A file holding several zones cannot resolve a keyless read."""
+        with pytest.raises(PatchAttributeError, match="source_patch_key"):
+            Febus2().read_array(two_zone_path, {})
+
+    def test_read_array_reads_only_touched_blocks(self, febus_path, monkeypatch):
+        """A one-block window decodes one block, not the whole cube."""
+        io = Febus2()
+        payload = dc.scan(febus_path)[0]
+        key = payload.source_patch_key
+        rows = self._rows_per_block(febus_path, key)
+        blocks = payload.shape[0] // rows
+        if blocks < 2:
+            pytest.skip("file holds one block")
+        reads = []
+        original = h5py.Dataset.__getitem__
+
+        def spy(self, index):
+            if self.ndim == 3:
+                reads.append(index[0])
+            return original(self, index)
+
+        monkeypatch.setattr(h5py.Dataset, "__getitem__", spy)
+        io.read_array(febus_path, {"time": (rows, rows + 2)}, source_patch_key=key)
+        assert reads == [slice(1, 2)], reads
+
+    def test_read_array_refuses_a_stepped_window(self, febus_path):
+        """A window is a contiguous range; a stride is not part of it."""
+        key = dc.scan(febus_path)[0].source_patch_key
+        with pytest.raises(ParameterError, match="contiguous"):
+            Febus2().read_array(
+                febus_path, {"time": slice(0, 10, 2)}, source_patch_key=key
+            )
 
 
 class TestFebusA1Interrogator:

--- a/tests/test_io/test_gdr/test_gdr.py
+++ b/tests/test_io/test_gdr/test_gdr.py
@@ -1,9 +1,12 @@
 """Tests for the GDR file format."""
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
 from dascore.io.gdr import GDR_V1
+from dascore.io.gdr.utils_das import _get_dims
 from dascore.utils.downloader import fetch
 
 
@@ -25,3 +28,26 @@ class TestGDR:
         time_2 = patch2.get_coord("time")
         assert len(time_1) == len(time_2)
         assert np.all(time_1.values == time_2.values)
+
+
+class TestGetDims:
+    """Tests for reading the dimension names the file states."""
+
+    @staticmethod
+    def _dataset(dimensions):
+        """A stand-in dataset stating these DasDimensions."""
+        return SimpleNamespace(attrs={"DasDimensions": dimensions})
+
+    @pytest.mark.parametrize("locus", ["locus", b"locus", np.bytes_("locus")])
+    def test_locus_is_distance(self, locus):
+        """The file's locus axis is DASCore's distance, however it is stored."""
+        assert _get_dims(self._dataset(["time", locus])) == ("time", "distance")
+
+    def test_order_follows_the_file(self):
+        """A distance-major file is reported distance-major."""
+        assert _get_dims(self._dataset(["locus", "time"])) == ("distance", "time")
+
+    def test_unknown_dimension_raises(self):
+        """A dimension name the reader cannot map is not guessed at."""
+        with pytest.raises(AssertionError, match="DasDimensions"):
+            _get_dims(self._dataset(["time", "bob"]))

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -51,7 +51,12 @@ from dascore.io.core import (
     make_scan_payload,
 )
 from dascore.io.dasdae.core import DASDAEV1
-from dascore.io.utils import build_patches, convert_attr_units, get_exact_coord
+from dascore.io.utils import (
+    build_patches,
+    convert_attr_units,
+    get_exact_coord,
+    windows_to_slices,
+)
 from dascore.utils.downloader import fetch
 from dascore.utils.hdf5 import H5Writer
 from dascore.utils.io import (
@@ -2321,3 +2326,34 @@ class TestFiberIOReadArray:
         finally:
             del PlainFormat.read_array
         assert not plain.implements_read_array
+
+
+class TestWindowsToSlices:
+    """Tests for turning read_array windows into per-dimension slices."""
+
+    def test_absent_dimension_is_whole(self):
+        """A dimension without a window spans its whole length."""
+        out = windows_to_slices({"time": (2, 5)}, ("distance", "time"), (7, 9))
+        assert out == (slice(0, 7), slice(2, 5))
+
+    def test_open_negative_and_overlong_bounds_resolve(self):
+        """None, ..., negative, and past-the-end bounds resolve like numpy."""
+        out = windows_to_slices(
+            {"time": (..., 3), "distance": (-2, 50)}, ("time", "distance"), (9, 7)
+        )
+        assert out == (slice(0, 3), slice(5, 7))
+        assert windows_to_slices({"time": (4, None)}, ("time",), (9,)) == (slice(4, 9),)
+
+    def test_empty_window_stays_empty(self):
+        """A reversed window is empty, never negative-length."""
+        assert windows_to_slices({"time": (6, 2)}, ("time",), (9,)) == (slice(6, 6),)
+
+    def test_unknown_dimension_raises(self):
+        """A window on a dimension the array lacks raises."""
+        with pytest.raises(ParameterError, match="not among patch dims"):
+            windows_to_slices({"bob": (0, 1)}, ("time",), (9,))
+
+    def test_non_integer_bounds_raise(self):
+        """Bounds are sample indices, never values."""
+        with pytest.raises(ParameterError, match="integers"):
+            windows_to_slices({"time": (1.5, 3)}, ("time",), (9,))

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -55,6 +55,7 @@ from dascore.io.utils import (
     build_patches,
     convert_attr_units,
     get_exact_coord,
+    resolve_keyed_source,
     slice_dataset,
     windows_to_slices,
 )
@@ -2385,3 +2386,40 @@ class TestSliceDataset:
         # a window past the shortened grid clips to it, not to the file
         tail = slice_dataset(dataset, dims, {"time": (2, 50)}, short)
         assert np.array_equal(tail, dataset[2:4, :])
+
+
+class TestResolveKeyedSource:
+    """Tests for resolving which source a key names."""
+
+    def test_mapping_resolves_by_key(self):
+        """A mapping is read as it is; a lone source needs no key."""
+        assert resolve_keyed_source({"a": 1, "b": 2}, "b") == 2
+        assert resolve_keyed_source({"a": 1}, "") == 1
+
+    def test_pairs_resolve_by_key(self):
+        """Pairs resolve like a mapping when the names are distinct."""
+        assert resolve_keyed_source([("a", 1), ("b", 2)], "b") == 2
+        assert resolve_keyed_source([("a", 1)], "") == 1
+
+    def test_empty_is_missing(self):
+        """Nothing to resolve is missing data, not a bad key."""
+        for empty in ({}, []):
+            with pytest.raises(MissingPatchError, match="No patches"):
+                resolve_keyed_source(empty, "a")
+
+    def test_unknown_key(self):
+        """A key naming nothing is refused either way."""
+        for sources in ({"a": 1}, [("a", 1)]):
+            with pytest.raises(PatchAttributeError, match="No patch named"):
+                resolve_keyed_source(sources, "b")
+
+    def test_keyless_ambiguous(self):
+        """Several sources and no key cannot be resolved."""
+        for sources in ({"a": 1, "b": 2}, [("a", 1), ("b", 2)]):
+            with pytest.raises(PatchAttributeError, match="source_patch_key"):
+                resolve_keyed_source(sources, "")
+
+    def test_repeated_name_in_pairs(self):
+        """A resource naming one key twice is ambiguous, never the last one."""
+        with pytest.raises(PatchAttributeError, match="more than once"):
+            resolve_keyed_source([("a", 1), ("a", 2)], "a")

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -55,6 +55,7 @@ from dascore.io.utils import (
     build_patches,
     convert_attr_units,
     get_exact_coord,
+    slice_dataset,
     windows_to_slices,
 )
 from dascore.utils.downloader import fetch
@@ -2357,3 +2358,30 @@ class TestWindowsToSlices:
         """Bounds are sample indices, never values."""
         with pytest.raises(ParameterError, match="integers"):
             windows_to_slices({"time": (1.5, 3)}, ("time",), (9,))
+
+
+class TestSliceDataset:
+    """Tests for reading the windows of a stored array."""
+
+    @pytest.fixture
+    def dataset(self, tmp_path):
+        """A 2-D HDF5 dataset of known values."""
+        path = tmp_path / "array.h5"
+        with h5py.File(path, "w") as h5:
+            h5.create_dataset("data", data=np.arange(60).reshape(10, 6))
+        with h5py.File(path, "r") as h5:
+            yield h5["data"]
+
+    def test_windows_read_in_the_file(self, dataset):
+        """Only the window's values come back, in the dataset's order."""
+        out = slice_dataset(dataset, ("time", "distance"), {"time": (2, 5)})
+        assert np.array_equal(out, dataset[2:5, :])
+
+    def test_shape_caps_a_shorter_grid(self, dataset):
+        """A grid shorter than the stored array never reads past its end."""
+        dims, short = ("time", "distance"), (4, 6)
+        whole = slice_dataset(dataset, dims, {}, short)
+        assert np.array_equal(whole, dataset[:4, :])
+        # a window past the shortened grid clips to it, not to the file
+        tail = slice_dataset(dataset, dims, {"time": (2, 50)}, short)
+        assert np.array_equal(tail, dataset[2:4, :])

--- a/tests/test_io/test_optodas/test_optodas.py
+++ b/tests/test_io/test_optodas/test_optodas.py
@@ -2,6 +2,10 @@
 Tests for optoDAS files.
 """
 
+import h5py
+import numpy as np
+import pytest
+
 import dascore as dc
 from dascore.io.optodas import OptoDASV8
 from dascore.utils.downloader import fetch
@@ -19,3 +23,35 @@ class TestOptoDASIssues:
             payload = fiber_io.scan(path, snap=snap)[0]
             distance = payload["coords"].get_coord("distance")
             assert distance.units == dc.get_quantity("m")
+
+
+class TestReadArray:
+    """Tests for slicing the data dataset directly."""
+
+    @pytest.fixture(scope="class")
+    def transposed_path(self, tmp_path_factory):
+        """An OptoDAS file whose header states the other dimension order."""
+        source = fetch("opto_das_1.hdf5")
+        path = tmp_path_factory.mktemp("optodas_transposed") / "transposed.hdf5"
+        with h5py.File(source, "r") as src, h5py.File(path, "w") as dest:
+            for name in src:
+                src.copy(name, dest)
+            names = [x.decode() for x in dest["header"]["dimensionNames"][:]]
+            del dest["header"]["dimensionNames"]
+            dest["header"]["dimensionNames"] = np.array(
+                [x.encode() for x in names[::-1]]
+            )
+            data = dest["data"][:]
+            del dest["data"]
+            dest["data"] = data.T
+        return path
+
+    def test_dimension_order_follows_the_header(self, transposed_path):
+        """The header names the stored order; a hardcoded one would transpose."""
+        io = OptoDASV8()
+        with h5py.File(transposed_path, "r") as h5:
+            stored = h5["data"][:]
+        out = io.read_array(transposed_path, {"time": (1, 4)})
+        # the header now calls the first axis distance, so a time window
+        # takes columns rather than rows
+        assert np.array_equal(out, stored[:, 1:4])

--- a/tests/test_io/test_prodml/test_prodml_source_patch_key.py
+++ b/tests/test_io/test_prodml/test_prodml_source_patch_key.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import shutil
+
+import h5py
+import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.exceptions import PatchAttributeError
+from dascore.io.core import FiberIO
+from dascore.io.prodml.core import ProdMLV2_0
 from dascore.utils.downloader import fetch
 
 
@@ -46,3 +53,68 @@ class TestProdMLSourcePatchId:
             summaries[0].get_coord_summary("time").min,
             summaries[1].get_coord_summary("time").min,
         }
+
+
+class TestReadArrayKeys:
+    """The key names which of a file's several nodes is read."""
+
+    @pytest.fixture(scope="class")
+    def prodml_fbe_path(self):
+        """A ProdML file holding several FBE nodes."""
+        return fetch("prodml_fbe_1.h5")
+
+    def test_each_key_reads_its_own_node(self, prodml_fbe_path):
+        """Every node is reachable, and none stands in for another."""
+        io = ProdMLV2_0()
+        payloads = dc.scan(prodml_fbe_path)
+        assert len(payloads) > 1
+        arrays = {}
+        for payload in payloads:
+            key = payload.source_patch_key
+            out = io.read_array(prodml_fbe_path, {}, source_patch_key=key)
+            expected = FiberIO.read_array(io, prodml_fbe_path, {}, source_patch_key=key)
+            assert np.array_equal(out, expected, equal_nan=True), key
+            arrays[key] = out
+        # the nodes share a shape, so only their values tell them apart
+        first = next(iter(arrays.values()))
+        assert any(
+            not np.array_equal(first, x, equal_nan=True) for x in arrays.values()
+        )
+
+    def test_unknown_key_raises(self, prodml_fbe_path):
+        """A key naming no node is not silently resolved to one."""
+        with pytest.raises(PatchAttributeError, match="No patch named"):
+            ProdMLV2_0().read_array(prodml_fbe_path, {}, source_patch_key="nope")
+
+    def test_keyless_multi_node_raises(self, prodml_fbe_path):
+        """Several nodes and no key cannot be resolved."""
+        with pytest.raises(PatchAttributeError, match="source_patch_key"):
+            ProdMLV2_0().read_array(prodml_fbe_path, {})
+
+
+class TestNodeDims:
+    """Where a node's stored dimension order comes from."""
+
+    @pytest.fixture
+    def fbe_without_dimensions(self, tmp_path):
+        """A copy of the FBE file whose nodes state no Dimensions."""
+        path = tmp_path / "no_dims.h5"
+        shutil.copy(fetch("prodml_fbe_1.h5"), path)
+        with h5py.File(path, "a") as h5:
+            for group in h5["Acquisition"].values():
+                for node in getattr(group, "values", dict)():
+                    for name, dataset in getattr(node, "items", dict)():
+                        if name.lower().startswith("fbedata["):
+                            dataset.attrs.pop("Dimensions", None)
+        return path
+
+    def test_missing_dimensions_falls_back(self, fbe_without_dimensions):
+        """A node stating nothing takes its parent's order, as scan does."""
+        io = ProdMLV2_0()
+        payload = dc.scan(fbe_without_dimensions)[0]
+        key = payload.source_patch_key
+        out = io.read_array(fbe_without_dimensions, {}, source_patch_key=key)
+        expected = FiberIO.read_array(
+            io, fbe_without_dimensions, {}, source_patch_key=key
+        )
+        assert out.shape == expected.shape == payload.shape

--- a/tests/test_io/test_sintela/test_binary.py
+++ b/tests/test_io/test_sintela/test_binary.py
@@ -5,10 +5,14 @@ Tests for sintela binary format.
 import shutil
 from pathlib import Path
 
+import numpy as np
 import pytest
 
+import dascore as dc
 from dascore.exceptions import InvalidFiberFileError
+from dascore.io.core import FiberIO
 from dascore.io.sintela import SintelaBinaryV3
+from dascore.io.sintela.utils import _get_complete_header
 from dascore.utils.downloader import fetch
 
 
@@ -33,3 +37,52 @@ class TestScanSintelaBinary:
         fiber_io = SintelaBinaryV3()
         with pytest.raises(InvalidFiberFileError):
             fiber_io.scan(extra_bytes_file)
+
+
+class TestReadArray:
+    """Tests for slicing the mapped packet payloads."""
+
+    @pytest.fixture(scope="class")
+    def binary_path(self):
+        """The example Sintela binary recording."""
+        return fetch("sintela_binary_v3_test_1.raw")
+
+    def test_matches_default(self, binary_path):
+        """The override returns what the read-and-trim default returns."""
+        io = SintelaBinaryV3()
+        patch = dc.spool(binary_path)[0]
+        windows = {"time": (3, 11), "distance": (2, 6)}
+        out = io.read_array(binary_path, windows)
+        expected = FiberIO.read_array(io, binary_path, windows)
+        assert out.dtype == expected.dtype
+        assert np.array_equal(out, expected)
+        assert np.array_equal(out, patch.data[3:11, 2:6])
+
+    def test_reads_only_touched_packets(self, binary_path):
+        """A window inside one packet copies that packet, not the file."""
+        io = SintelaBinaryV3()
+        with open(binary_path, "rb") as fi:
+            header = _get_complete_header(fi)
+        samples, channels = header["num_samples"], header["num_channels"]
+        packets = header["num_packets"]
+        if packets < 2:
+            pytest.skip("file holds one packet")
+        # a window wholly inside the last packet, so a whole-file read is
+        # visible in what the returned view is backed by
+        start = (packets - 1) * samples
+        out = io.read_array(binary_path, {"time": (start, start + 3)})
+        assert out.shape == (3, channels)
+        assert out.base is not None
+        whole = packets * samples * channels * np.dtype(header["dtype"]).itemsize
+        assert out.base.nbytes < whole
+        # and it is the right packet
+        expected = FiberIO.read_array(io, binary_path, {"time": (start, start + 3)})
+        assert np.array_equal(out, expected)
+
+    def test_empty_window(self, binary_path):
+        """A window past the end is empty, with the right width and dtype."""
+        io = SintelaBinaryV3()
+        whole = io.read_array(binary_path, {})
+        out = io.read_array(binary_path, {"time": (10**9, 10**9 + 5)})
+        assert out.shape == (0, whole.shape[1])
+        assert out.dtype == whole.dtype

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -246,16 +246,28 @@ class TestReadArray:
             return original(fileinfo, nch, dmap, nso, rdo)
 
         single = dc.spool(fetch("iDAS005_tdms_example.626.tdms"))[0]
+        with open(two_segment_path, "rb") as fi:
+            fileinfo, _ = tdms_utils._get_fileinfo(fi)
+            first, second = (
+                rdo for rdo, _ in tdms_utils._iter_segment_bounds(fi, fileinfo)
+            )
         monkeypatch.setattr(tdms_utils, "_get_segment_data", spy)
         io = TDMSFormatterV4713()
-        out = io.read_array(two_segment_path, {"time": (1200, 1300)})
-        assert len(decoded) == 1
-        assert np.array_equal(out, single.data[200:300])
-        # a window inside the first segment stops the walk before the second
-        decoded.clear()
-        out = io.read_array(two_segment_path, {"time": (100, 200)})
-        assert len(decoded) == 1
-        assert np.array_equal(out, single.data[100:200])
+        # windows and the segment each should decode; the boundary is 1000
+        cases = {
+            (1200, 1300): [second],
+            (100, 200): [first],
+            (0, 1000): [first],
+            (1000, 1100): [second],
+            (990, 1010): [first, second],
+        }
+        for (start, stop), expected in cases.items():
+            decoded.clear()
+            out = io.read_array(two_segment_path, {"time": (start, stop)})
+            assert decoded == expected, (start, stop)
+            # both segments hold the example's samples
+            rows = np.concatenate([single.data, single.data])[start:stop]
+            assert np.array_equal(out, rows)
 
     def test_empty_window(self, two_segment_path):
         """A window past the end is empty with the right width and dtype."""

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -11,8 +11,10 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.io.core import FiberIO
 from dascore.io.silixah5.utils import _ATTR_MAP as _SILIXA_ATTR_MAP
 from dascore.io.tdms import utils as tdms_utils
+from dascore.io.tdms.core import TDMSFormatterV4713
 from dascore.io.tdms.utils import parse_time_stamp, type_not_supported
 from dascore.utils.downloader import fetch
 
@@ -209,6 +211,58 @@ class TestMultiSegment:
         assert summary.coords["time"].len == 2000
         assert summary.coords["time"].min == time.min()
         assert summary.coords["time"].max == time.max()
+
+
+class TestReadArray:
+    """Tests for reading only the segments a window touches."""
+
+    @pytest.fixture(scope="class")
+    def two_segment_path(self, tmp_path_factory):
+        """The example file's segment written twice (see TestMultiSegment)."""
+        raw = Path(fetch("iDAS005_tdms_example.626.tdms")).read_bytes()
+        path = tmp_path_factory.mktemp("tdms_read_array") / "two_segment.tdms"
+        path.write_bytes(raw + raw)
+        return path
+
+    def test_matches_default_across_segments(self, two_segment_path):
+        """A window spanning the segment boundary matches the default."""
+        io = TDMSFormatterV4713()
+        windows = {"time": (990, 1010), "distance": (5, 9)}
+        out = io.read_array(two_segment_path, windows)
+        expected = FiberIO.read_array(io, two_segment_path, windows)
+        assert out.dtype == expected.dtype
+        assert np.array_equal(out, expected)
+        assert out.shape == (20, 4)
+
+    def test_only_touched_segments_are_decoded(self, two_segment_path, monkeypatch):
+        """A window inside the second segment decodes that segment alone."""
+        from dascore.io.tdms import utils as tdms_utils  # noqa: PLC0415
+
+        decoded = []
+        original = tdms_utils._get_segment_data
+
+        def spy(fileinfo, nch, dmap, nso, rdo):
+            decoded.append(rdo)
+            return original(fileinfo, nch, dmap, nso, rdo)
+
+        single = dc.spool(fetch("iDAS005_tdms_example.626.tdms"))[0]
+        monkeypatch.setattr(tdms_utils, "_get_segment_data", spy)
+        io = TDMSFormatterV4713()
+        out = io.read_array(two_segment_path, {"time": (1200, 1300)})
+        assert len(decoded) == 1
+        assert np.array_equal(out, single.data[200:300])
+        # a window inside the first segment stops the walk before the second
+        decoded.clear()
+        out = io.read_array(two_segment_path, {"time": (100, 200)})
+        assert len(decoded) == 1
+        assert np.array_equal(out, single.data[100:200])
+
+    def test_empty_window(self, two_segment_path):
+        """A window past the end is empty with the right width and dtype."""
+        io = TDMSFormatterV4713()
+        out = io.read_array(two_segment_path, {"time": (5000, 6000)})
+        assert out.shape == (0, 1152)
+        assert out.dtype == FiberIO.read_array(io, two_segment_path, {}).dtype
 
 
 class TestTDMSInterrogator:

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -136,6 +136,25 @@ class TestReadArray:
         raw = io.read_array(path, {}, snap_dims=False)
         assert len(raw) > len(io.read_array(path, {}))
 
+    def test_both_spellings_agree(self, terra15_das_unfinished_path):
+        """`scan` calls it snap and `read` snap_dims; both are taken here.
+
+        The unfinished file is the one where the option changes how many
+        rows there are, so the two grids differ and a mix-up shows.
+        """
+        io = Terra15FormatterV4()
+        path = terra15_das_unfinished_path
+        snapped = io.read_array(path, {})
+        raw = io.read_array(path, {}, snap=False)
+        assert len(raw) > len(snapped)
+        # either spelling alone selects the same grid
+        assert len(io.read_array(path, {}, snap_dims=False)) == len(raw)
+        assert len(io.read_array(path, {}, snap=True)) == len(snapped)
+        # given both, snap wins, in read_array and in read alike
+        assert len(io.read_array(path, {}, snap=True, snap_dims=False)) == len(snapped)
+        both = io.read(path, snap=True, snap_dims=False)[0]
+        assert len(both.get_coord("time")) == len(snapped)
+
     def test_reads_only_the_window(self, terra15_v6_path, monkeypatch):
         """The data node is sliced in the file, not read whole then trimmed."""
         seen = []

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -133,9 +133,8 @@ class TestReadArray:
         expected = FiberIO.read_array(io, path, {"time": (-5, None)}, snap_dims=False)
         assert np.array_equal(out, expected)
         assert len(out) == 5
-        assert len(io.read_array(path, {}, snap_dims=False)) > len(
-            io.read_array(path, {})
-        )
+        raw = io.read_array(path, {}, snap_dims=False)
+        assert len(raw) > len(io.read_array(path, {}))
 
     def test_reads_only_the_window(self, terra15_v6_path, monkeypatch):
         """The data node is sliced in the file, not read whole then trimmed."""

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -112,22 +112,6 @@ class TestTerra15Unfinished:
 class TestReadArray:
     """Tests for slicing the data node directly."""
 
-    @pytest.fixture(
-        params=["terra15_das_example_path", "terra15_v5_path", "terra15_v6_path"]
-    )
-    def terra15_path(self, request):
-        """Each Terra15 version's example file."""
-        return request.getfixturevalue(request.param)
-
-    def test_matches_default(self, terra15_path):
-        """The override returns what the read-and-trim default returns."""
-        io = Terra15FormatterV4()
-        windows = {"time": (3, 11), "distance": (2, 6)}
-        out = io.read_array(terra15_path, windows)
-        expected = FiberIO.read_array(io, terra15_path, windows)
-        assert out.dtype == expected.dtype
-        assert np.array_equal(out, expected)
-
     def test_unfinished_file_stops_at_written_samples(
         self, terra15_das_unfinished_path
     ):
@@ -140,6 +124,18 @@ class TestReadArray:
         # a window past the end clips to the written samples, as select does
         tail = io.read_array(terra15_das_unfinished_path, {"time": (-3, 10**6)})
         assert np.array_equal(tail, patch.data[-3:])
+
+    def test_raw_grid_counts_every_row(self, terra15_das_unfinished_path):
+        """With snap_dims=False the window lives on the raw grid, as in read."""
+        io = Terra15FormatterV4()
+        path = terra15_das_unfinished_path
+        out = io.read_array(path, {"time": (-5, None)}, snap_dims=False)
+        expected = FiberIO.read_array(io, path, {"time": (-5, None)}, snap_dims=False)
+        assert np.array_equal(out, expected)
+        assert len(out) == 5
+        assert len(io.read_array(path, {}, snap_dims=False)) > len(
+            io.read_array(path, {})
+        )
 
     def test_reads_only_the_window(self, terra15_v6_path, monkeypatch):
         """The data node is sliced in the file, not read whole then trimmed."""

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -11,6 +11,8 @@ import pandas as pd
 import pytest
 
 import dascore as dc
+from dascore.io.core import FiberIO
+from dascore.io.terra15.core import Terra15FormatterV4
 from dascore.io.terra15.utils import _get_version_data_node
 
 
@@ -105,3 +107,51 @@ class TestTerra15Unfinished:
         """Ensure the time is increasing."""
         time = patch_unfinished.coords.get_array("time")
         assert np.all(np.diff(time) >= np.timedelta64(0, "s"))
+
+
+class TestReadArray:
+    """Tests for slicing the data node directly."""
+
+    @pytest.fixture(
+        params=["terra15_das_example_path", "terra15_v5_path", "terra15_v6_path"]
+    )
+    def terra15_path(self, request):
+        """Each Terra15 version's example file."""
+        return request.getfixturevalue(request.param)
+
+    def test_matches_default(self, terra15_path):
+        """The override returns what the read-and-trim default returns."""
+        io = Terra15FormatterV4()
+        windows = {"time": (3, 11), "distance": (2, 6)}
+        out = io.read_array(terra15_path, windows)
+        expected = FiberIO.read_array(io, terra15_path, windows)
+        assert out.dtype == expected.dtype
+        assert np.array_equal(out, expected)
+
+    def test_unfinished_file_stops_at_written_samples(
+        self, terra15_das_unfinished_path
+    ):
+        """Zero-filled rows past the last written sample are never returned."""
+        io = Terra15FormatterV4()
+        patch = dc.spool(terra15_das_unfinished_path)[0]
+        out = io.read_array(terra15_das_unfinished_path, {})
+        assert out.shape == patch.shape
+        assert np.array_equal(out, patch.data)
+        # a window past the end clips to the written samples, as select does
+        tail = io.read_array(terra15_das_unfinished_path, {"time": (-3, 10**6)})
+        assert np.array_equal(tail, patch.data[-3:])
+
+    def test_reads_only_the_window(self, terra15_v6_path, monkeypatch):
+        """The data node is sliced in the file, not read whole then trimmed."""
+        seen = []
+        original = h5py.Dataset.__getitem__
+
+        def spy(self, index):
+            if self.name.endswith("/data"):
+                seen.append(index)
+            return original(self, index)
+
+        monkeypatch.setattr(h5py.Dataset, "__getitem__", spy)
+        Terra15FormatterV4().read_array(terra15_v6_path, {"time": (2, 6)})
+        assert len(seen) == 1
+        assert seen[0][0] == slice(2, 6)


### PR DESCRIPTION
## Description

`read_array` overrides for every remaining format whose storage can be sliced, following the contract #1107 published and the pattern #1110 and #1111 set. Originally four stacked PRs (#1113, #1114, #1115 merged into this branch), so this carries all of them.

**Fixed-layout HDF5, one dataset per patch** — APSensing, AI4EPS, ODH4, Uptech, Silixa H5 (v1 and v2), Neubrex DAS and RFS, OptoDAS (8 to 11), GDR, and Febus MTX, BSL and T1. Each is a few lines: refuse stray kwargs, name the dataset and its stored dimension order, slice. Febus MTX and T1 loaded their whole array before trimming, so a windowed read there now moves only the window.

**Dimension order discovered rather than fixed** — DASHDF5 stores `das` either channel-major or time-major, and H5Simple names its axes from a root attribute or from which node's length matches each one. Both decisions move into helpers shared with `read`, so the two paths cannot disagree, and the override resolves dims from node shapes without reading coordinate values.

**Keyed and xarray-backed** — ProdML resolves the acquisition node its `source_patch_key` names, DASVader resolves the JLD2 object reference whose name also fixes the dimension order, and NetCDF-CF selects through xarray so CF decoding applies exactly as in `read`. `resolve_keyed_source` now carries the keyed-resolution error contract (missing, unknown, ambiguous, and a name a resource states twice); DASDAE, ProdML, NetCDF and Febus A1 share it.

**Binary** — Sintela slices its memory map by packet, and Febus A1 reads only the blocks a window touches out of its `(block, row, distance)` cube, whose padding rows are dropped and whose blocks flatten into one time axis.

Shared machinery lives in `dascore/io/utils.py`: `windows_to_slices` validates a window as `select(samples=True)` validates it and resolves it against the grid `scan` reports, and `slice_dataset` wraps that for the common single-dataset case. Three formats pass an explicit grid because it is not the stored shape: Terra15's unwritten trailing rows, Febus's block cube, Sintela's packet headers.

Two common-IO tests cover every override against every example file: parity with the default read-then-trim path (windowing every axis, one axis, and none), and a spy proving the data array is sliced in the file rather than read whole.

Formats deliberately left on the default, with reasons: mseed and Sintela protobuf (patches are stitched from decoded records), SR4731 (scaling needs a global maximum), Febus G1 CSV and pickle (no random access), sentek (small files, and the reader transposes), segy (per-trace reads already, so only header parsing is saved), and XMLBinary, which cannot benefit until it emits a native `source_patch_key`, since the resolver refuses the synthesized positional keys it gets today.

Two things the reviews turned up that are **not** fixed here. Febus `read` raises `ValueError` when time and distance are selected together, because the block reshape uses the stored width rather than the width the distance selection leaves; the obvious repair returns wrongly ordered samples, so it needs its own change. And `windows_to_slices` refuses a window carrying a stride, which the default honors through `select`; refusing is the safer half of that pair until a caller needs strides.

## Changelog

- added: `read_array` slices storage directly for APSensing, AI4EPS, ODH4, Uptech, Silixa H5, Neubrex, OptoDAS, GDR, Febus (MTX, BSL, T1 and A1), DASHDF5, H5Simple, ProdML, DASVader, NetCDF and Sintela binary.
- fixed: reading a Sintela binary file no longer copies the whole payload before trimming.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added efficient windowed array reading across supported DAS file formats.
  * Reads now load only requested time and distance ranges, including partial and empty windows.
  * Added source selection for files containing multiple patches or zones.
  * Improved handling of stored dimension order for more reliable results.
  * Standardized support for window labeling and snapping options, including `snap` and `snap_dims`.

* **Bug Fixes**
  * Improved validation and error reporting for invalid windows, source keys, and unexpected options.

* **Documentation**
  * Clarified expected labeling-option behavior for format integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->