### PR TITLE
Slice the dim-discovering HDF5 formats directly in read_array

### DIFF
--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, slice_dataset
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
-from .utils import _get_cf_attrs, _get_cf_coords, _get_cf_version_str
+from .utils import (
+    _get_cf_attrs,
+    _get_cf_coords,
+    _get_cf_dims,
+    _get_cf_version_str,
+)
 
 
 class DASHDF5(FiberIO):
@@ -65,3 +73,15 @@ class DASHDF5(FiberIO):
             selection={"time": time, "channel": channel},
         )
         return dc.spool(patches)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """
+        Slice the ``das`` dataset directly.
+
+        The dimension order is the one the dataset's shape implies, which
+        is what `scan` reports.
+        """
+        raise_on_extra_kwargs(kwargs, "windows")
+        return slice_dataset(resource["das"], _get_cf_dims(resource), windows)

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -75,7 +75,11 @@ class DASHDF5(FiberIO):
         return dc.spool(patches)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
     ) -> np.ndarray:
         """
         Slice the ``das`` dataset directly.
@@ -83,5 +87,5 @@ class DASHDF5(FiberIO):
         The dimension order is the one the dataset's shape implies, which
         is what `scan` reports.
         """
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource["das"], _get_cf_dims(resource), windows)

--- a/dascore/io/dashdf5/utils.py
+++ b/dascore/io/dashdf5/utils.py
@@ -34,6 +34,9 @@ def _get_cf_version_str(hdf_fi) -> str | Literal[False]:
     return das_hdf_str[0].replace("DAS-HDF5-", "")
 
 
+_CF_DIMS = ("channel", "time")
+
+
 def _get_cf_coords(hdf_fi, minimal=False, snap=True) -> dc.core.CoordManager:
     """
     Get a coordinate manager of full file range.
@@ -72,16 +75,25 @@ def _get_cf_coords(hdf_fi, minimal=False, snap=True) -> dc.core.CoordManager:
         "y": ("channel",),
         "z": ("channel",),
     }
-    dims = ("channel", "time")
     cm = dc.core.CoordManager(
         coord_map=coords_map,
         dim_map=dim_map,
-        dims=dims,
+        dims=_CF_DIMS,
     )
-    # a bit of a hack to make sure data and coords align.
-    if cm.shape != hdf_fi["das"].shape:
+    if cm.dims != _get_cf_dims(hdf_fi):
         cm = cm.transpose()
     return cm
+
+
+def _get_cf_dims(hdf_fi) -> tuple[str, str]:
+    """
+    The stored dimension order of the ``das`` dataset.
+
+    The format does not state it, so it is read off the dataset's shape:
+    the channel-major order unless only the other one fits.
+    """
+    shape = (len(hdf_fi["channel"]), len(hdf_fi["t"]))
+    return _CF_DIMS if hdf_fi["das"].shape == shape else _CF_DIMS[::-1]
 
 
 def _get_cf_attrs(hdf_fi, coords=None, extras=None):

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -64,7 +64,8 @@ class H5Simple(FiberIO):
 
         The dimensions come from the file's ``dims`` attribute, or from
         which node's length matches each axis, exactly as `read` resolves
-        them; no coordinate values are read either way.
+        them. No coordinate values are read either way, and the axis no
+        node accounts for is named without building its index.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap")
         dims, data_node = _get_dims_and_data(resource)

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -62,8 +62,9 @@ class H5Simple(FiberIO):
         """
         Slice the data node directly.
 
-        The dimensions are resolved from node shapes alone, as `read`
-        resolves them; ``snap`` only changes coordinate values.
+        The dimensions come from the file's ``dims`` attribute, or from
+        which node's length matches each axis, exactly as `read` resolves
+        them; no coordinate values are read either way.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap")
         dims, data_node = _get_dims_and_data(resource)

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, slice_dataset
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
-from .utils import _get_attrs_coords_and_data, _is_h5simple
+from .utils import (
+    _get_attrs_coords_and_data,
+    _get_dims_and_data,
+    _is_h5simple,
+)
 
 
 class H5Simple(FiberIO):
@@ -44,6 +51,23 @@ class H5Simple(FiberIO):
         """
         attrs, cm, data = _get_attrs_coords_and_data(resource, snap)
         return dc.spool(build_patches(cm, data, attrs, selection=kwargs))
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the data node directly.
+
+        The dimensions are resolved from node shapes alone, as `read`
+        resolves them; ``snap`` only changes coordinate values.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        dims, data_node = _get_dims_and_data(resource)
+        return slice_dataset(data_node, dims, windows)
 
     def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[ScanPayload]:
         """Get the attributes of a h5simple file."""

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -51,9 +51,9 @@ def _get_coord(v, snap, name):
     return coord
 
 
-def _fill_coords(coord_shape_dict, other_nodes, data_node):
+def _name_missing_dim(coord_shape_dict, data_node) -> int:
     """
-    Fill missing coordinate with "channel".
+    Name the one axis no node accounts for "channel", and return its length.
 
     This is needed because the foresee data on pubdas only specify time;
     we have to fill in channel number.
@@ -62,8 +62,7 @@ def _fill_coords(coord_shape_dict, other_nodes, data_node):
     assert len(missing_shape) == 1, "can only fill one missing coord."
     shape = next(iter(missing_shape))
     coord_shape_dict[shape] = "channel"
-    other_nodes["channel"] = np.arange(shape)
-    return other_nodes, coord_shape_dict
+    return shape
 
 
 def _get_dims(data_node, time_node, other_nodes, dims=None):
@@ -85,11 +84,7 @@ def _get_dims(data_node, time_node, other_nodes, dims=None):
     coord_shape_dict[len(time_node)] = "time"
     # need to fill some dims
     if len(coord_shape_dict) != len(data_node.shape):
-        other_nodes, coord_shape_dict = _fill_coords(
-            coord_shape_dict,
-            other_nodes,
-            data_node,
-        )
+        _name_missing_dim(coord_shape_dict, data_node)
     return tuple(coord_shape_dict[x] for x in data_node.shape), other_nodes
 
 
@@ -97,6 +92,10 @@ def _get_coords_and_dims(data_node, time_node, other_nodes, snap=True, dims=None
     """Get dims tuple and coord dict."""
     dims, other_nodes = _get_dims(data_node, time_node, other_nodes, dims)
     other_nodes["time"] = time_node
+    # the filled axis is named but not built: only coordinates need it
+    if "channel" in dims and "channel" not in other_nodes:
+        length = data_node.shape[dims.index("channel")]
+        other_nodes["channel"] = np.arange(length)
     coords = {i: _get_coord(v, snap=snap, name=i) for i, v in other_nodes.items()}
     return dims, coords
 

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -66,35 +66,43 @@ def _fill_coords(coord_shape_dict, other_nodes, data_node):
     return other_nodes, coord_shape_dict
 
 
+def _get_dims(data_node, time_node, other_nodes, dims=None):
+    """
+    Get the dims tuple, and the coord nodes any filling added.
+
+    The format does not have to state its dimensions; when it does not,
+    each is named by the node whose length matches that axis. Only node
+    shapes are read here, never their values.
+    """
+    if dims:
+        stated = tuple(dims.split(",")) if isinstance(dims, str) else tuple(dims)
+        return stated, other_nodes
+    can_guess_shape = len(data_node.shape) == len(set(data_node.shape))
+    assert can_guess_shape, "Cant determine dims; shape values not unique!"
+    assert len(time_node.shape) == 1, "time node has more than one dimension!"
+    # get a dict of {coord_name: shape} for 1d coords.
+    coord_shape_dict = {len(v): x for x, v in other_nodes.items() if len(v.shape) == 1}
+    coord_shape_dict[len(time_node)] = "time"
+    # need to fill some dims
+    if len(coord_shape_dict) != len(data_node.shape):
+        other_nodes, coord_shape_dict = _fill_coords(
+            coord_shape_dict,
+            other_nodes,
+            data_node,
+        )
+    return tuple(coord_shape_dict[x] for x in data_node.shape), other_nodes
+
+
 def _get_coords_and_dims(data_node, time_node, other_nodes, snap=True, dims=None):
     """Get dims tuple and coord dict."""
-    if dims:
-        dims = dims if not isinstance(dims, str) else dims.split(",")
-    else:  # ascertain dims from shape
-        can_guess_shape = len(data_node.shape) == len(set(data_node.shape))
-        assert can_guess_shape, "Cant determine dims; shape values not unique!"
-        assert len(time_node.shape) == 1, "time node has more than one dimension!"
-        # get a dict of {coord_name: shape} for 1d coords.
-        coord_shape_dict = {
-            len(v): x for x, v in other_nodes.items() if len(v.shape) == 1
-        }
-        coord_shape_dict[len(time_node)] = "time"
-        # need to fill some dims
-        if len(coord_shape_dict) != len(data_node.shape):
-            other_nodes, coord_shape_dict = _fill_coords(
-                coord_shape_dict,
-                other_nodes,
-                data_node,
-            )
-
-        dims = tuple(coord_shape_dict[x] for x in data_node.shape)
+    dims, other_nodes = _get_dims(data_node, time_node, other_nodes, dims)
     other_nodes["time"] = time_node
     coords = {i: _get_coord(v, snap=snap, name=i) for i, v in other_nodes.items()}
     return dims, coords
 
 
-def _get_cm_and_data(h5, snap=False, dims=None):
-    """Extract coordinate manager and data node."""
+def _get_nodes(h5):
+    """Return the file's data node, time node, and other array nodes."""
     root_nodes = {name: node for name, node in h5.items() if hasattr(node, "shape")}
     array_names = set(root_nodes)
     data_node_name = array_names & DATA_ARRAY_NAMES
@@ -104,10 +112,24 @@ def _get_cm_and_data(h5, snap=False, dims=None):
     assert len(data_node_name) == 1, f"{h5} doesn't have exactly one data node."
     assert len(time_node_name) == 1, f"{h5} doesn't have exactly one time node"
 
-    data_node = root_nodes[next(iter(data_node_name))]
-    time_node = root_nodes[next(iter(time_node_name))]
-    other_nodes = {x: root_nodes[x] for x in other_node_names}
+    return (
+        root_nodes[next(iter(data_node_name))],
+        root_nodes[next(iter(time_node_name))],
+        {x: root_nodes[x] for x in other_node_names},
+    )
 
+
+def _get_dims_and_data(h5):
+    """Return the data node's dims and the node itself, reading no values."""
+    dims_attr = unbyte(h5.attrs["dims"]) if "dims" in h5.attrs else None
+    data_node, time_node, other_nodes = _get_nodes(h5)
+    dims, _ = _get_dims(data_node, time_node, other_nodes, dims_attr)
+    return dims, data_node
+
+
+def _get_cm_and_data(h5, snap=False, dims=None):
+    """Extract coordinate manager and data node."""
+    data_node, time_node, other_nodes = _get_nodes(h5)
     dims, coords = _get_coords_and_dims(data_node, time_node, other_nodes, snap, dims)
     return dc.core.get_coord_manager(coords, dims=dims), data_node
 

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -61,6 +61,7 @@ class Terra15FormatterV4(FiberIO):
         time: tuple[timeable_types, timeable_types] | None = None,
         distance: tuple[float, float] | None = None,
         snap_dims: bool = True,
+        snap: bool | None = None,
         **kwargs,
     ) -> dc.Spool:
         """
@@ -78,7 +79,11 @@ class Terra15FormatterV4(FiberIO):
             If True, ensure the coordinates are evenly sampled monotonic.
             This will cause some loss in precision but it is usually
             negligible.
+        snap
+            The name `scan` gives ``snap_dims``, so a caller can forward
+            what it gave `scan`; it wins when both are given.
         """
+        snap_dims = snap_dims if snap is None else snap
         patch = _read_terra15(resource, time, distance, snap_dims=snap_dims)
         if not patch.data.size:
             return dc.spool([])
@@ -88,7 +93,8 @@ class Terra15FormatterV4(FiberIO):
         self,
         resource: H5Reader,
         windows: dict[str, tuple[int, int]],
-        snap_dims: bool = True,
+        snap: bool = True,
+        snap_dims: bool | None = None,
         **kwargs,
     ) -> np.ndarray:
         """
@@ -96,16 +102,18 @@ class Terra15FormatterV4(FiberIO):
 
         Besides the requested block, only the time node's ends and the
         header are read (the whole time node for an unfinished file, to
-        count the rows it actually wrote). ``snap_dims`` selects the grid,
-        spelled as ``read`` spells it (``scan`` calls the same option
-        ``snap``): snapped, the rows stop at the last written sample; raw,
-        every stored row counts, as the raw time coordinate does.
+        count the rows it actually wrote). ``snap`` selects the grid, and
+        unlike other formats it decides how many rows there are: snapped,
+        they stop at the last written sample; raw, every stored row
+        counts, as the raw time coordinate does. ``read`` calls the same
+        option ``snap_dims``, so both spellings are taken.
         """
-        raise_on_extra_kwargs(kwargs, "windows and snap_dims")
+        raise_on_extra_kwargs(kwargs, "windows, snap and snap_dims")
+        snap = snap if snap_dims is None else snap_dims
         _, data_node = _get_version_data_node(resource)
         data = data_node["data"]
         time_len = data.shape[0]
-        if snap_dims:
+        if snap:
             _, _, time_len, _ = _get_scanned_time_info(data_node)
         shape = (time_len, len(_get_distance_coord(resource)))
         return slice_dataset(data, ("time", "distance"), windows, shape)

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -594,9 +594,9 @@ class TestRead:
         io, path = io_path_tuple
         if not io.implements_read_array:
             pytest.skip(f"{io.name} inherits the default read_array")
-        params = inspect.signature(io.read_array).parameters
-        if "snap" not in params:
-            pytest.skip(f"{io.name}.read_array takes no labelling option")
+        # what scan takes, read_array must take: the caller forwards it
+        if "snap" not in inspect.signature(io.scan).parameters:
+            pytest.skip(f"{io.name}.scan takes no labelling option")
         with skip_missing():
             payloads = {x: dc.scan_payloads(path, snap=x)[0] for x in (True, False)}
         key = payloads[True].get("source_patch_key", "")


### PR DESCRIPTION
## Description

`read_array` overrides for the two HDF5 formats that discover their dimension order rather than fixing it.

- **DASHDF5** stores `das` either channel-major or time-major; the reader already decided by comparing the coordinate manager's shape to the dataset's. That decision moves into `_get_cf_dims`, which reads only the channel and time array lengths, so `read` and the override cannot disagree.
- **H5Simple** names its dimensions from a root attribute when it has one and otherwise from which node's length matches each axis. That resolution is split out of coordinate building into `_get_dims`, so the override resolves dims from node shapes alone, reading no coordinate values.

Both are covered by the common-IO parity and in-file slicing tests.

Stacked on #1112.

## Changelog

- added: `read_array` slices storage directly for the DASHDF5 and H5Simple formats.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
